### PR TITLE
docs: warn about ignoring env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ PRIVATE_KEY="0xabc123..."                # Private key of the deploying wallet
 ETHERSCAN_API_KEY="your-etherscan-api-key"
 ```
 
+Remember to add `.env` to your `.gitignore` and never commit private keys.
+
+```gitignore
+.env
+```
+
 ### Hardhat
 Load these variables in `hardhat.config.ts`:
 


### PR DESCRIPTION
## Summary
- caution to add `.env` to `.gitignore` and keep private keys out of version control
- show `.gitignore` snippet for `.env`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f9757f8508333a686f88ede1570b2