### PR TITLE
Use GitHub Actions CI badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: echo "No tests specified"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AGIJob Manager v0
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) ![Build Status](https://img.shields.io/badge/build-passing-brightgreen)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
 > **Audit Status:** _Unaudited – use at your own risk._
 


### PR DESCRIPTION
## Summary
- replace static build badge with GitHub Actions status badge
- add minimal CI workflow so the badge reflects real runs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f9aaeefac8333a4cee062841f0ec7