### PR TITLE
docs: update Node.js instructions to 22 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ AGIJob Manager v0 is a foundational smart-contract component for the emerging Ec
 - [License](#license)
 
 ## Prerequisites
-- **Node.js & npm** – Node.js ≥ 20.x LTS (bundled with a matching npm version).
+- **Node.js & npm** – Node.js ≥ 22.x LTS (bundled with a matching npm version).
 - **Hardhat 2.26.1** or **Foundry** – choose either development toolkit and use its respective commands (`npx hardhat` or `forge`).
 - **Solidity Compiler** – version 0.8.30.
 - **OpenZeppelin Contracts** – version 5.4.0.
 
 ## Installation
-1. **Install Node.js 20.x LTS and npm**
+1. **Install Node.js 22.x LTS and npm**
    Using [`nvm`](https://github.com/nvm-sh/nvm):
 
    ```bash
    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
    source ~/.nvm/nvm.sh
-   nvm install 20
+   nvm install 22
    ```
 
    > For platform-specific installation details, see the [official Node.js documentation](https://nodejs.org/en/download/package-manager).


### PR DESCRIPTION
## Summary
- update Node.js prerequisite to 22.x LTS and adjust installation snippet

## Testing
- `npm view hardhat@2.26.1 engines; echo done`
- `npm view @openzeppelin/contracts@5.4.0 engines; echo done`
- `npm view solc@0.8.30 engines; echo done`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f9ddbade48333a4630b291b86ab4e