### PR TITLE
docs: add hardhat toolbox setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ AGIJob Manager v0 is a foundational smart-contract component for the emerging Ec
    - Hardhat
      ```bash
      npm install --save-dev hardhat@2.26.1
+     npm install --save-dev @nomicfoundation/hardhat-toolbox@6.1.0
      npx hardhat init
      ```
+     *`@nomicfoundation/hardhat-toolbox` bundles the `hardhat-ethers` plugin required by [`scripts/deploy.ts`](scripts/deploy.ts).*
    - Foundry
      ```bash
      curl -L https://foundry.paradigm.xyz | bash
@@ -80,6 +82,7 @@ Load these variables in `hardhat.config.ts`:
 ```ts
 import { config as dotenvConfig } from "dotenv";
 import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-toolbox";
 
 dotenvConfig();
 


### PR DESCRIPTION
## Summary
- document installing Hardhat toolbox
- import Hardhat toolbox plugin in example config

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx hardhat test` *(fails: Need to install the following packages: hardhat@2.26.1)*

------
https://chatgpt.com/codex/tasks/task_e_688f9efa74248333a13bdf9bd72d74f3