### PR TITLE
docs: add deployed contract section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ AGIJob Manager v0 is a foundational smart-contract component for the emerging Ec
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Quick Start](#quick-start)
+- [Deployed Contract](#deployed-contract)
 - [Example interactions](#example-interactions)
 - [Testing](#testing)
 - [Linting](#linting)
@@ -139,6 +140,10 @@ forge verify-contract <DEPLOYED_CONTRACT_ADDRESS> AGIJobManagerv0 --chain sepoli
 ```
 
 Set the `ETHERSCAN_API_KEY` (or a network-specific variant such as `SEPOLIA_ETHERSCAN_API_KEY`) as described in the [Foundry verification documentation](https://book.getfoundry.sh/reference/forge/verify-contract) to allow Foundry to authenticate with the block explorer API.
+
+### Deployed Contract
+
+The contract is currently deployed on Ethereum mainnet at [0x0178b6bad606aaf908f72135b8ec32fc1d5ba477](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477). This address may change with future releases.
 
 ### Example interactions
 


### PR DESCRIPTION
## Summary
- document mainnet deployment address with Etherscan link
- update README table of contents for new Deployed Contract section

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx hardhat test` *(fails: requires installing hardhat@2.26.1)*
- `forge test` *(fails: command not found)*
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688f9ff7ea0c83339f9f9182be7f7cae