### PR TITLE
docs: expand README and fix v1 imports

### DIFF
--- a/AGIJobManagerv1.sol
+++ b/AGIJobManagerv1.sol
@@ -105,13 +105,14 @@ OVERRIDING AUTHORITY: AGI.ETH
 
 pragma solidity ^0.8.30;
 
-import "@openzeppelin/contracts@5.4.0/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts@5.4.0/token/ERC721/extensions/ERC721URIStorage.sol";
-import "@openzeppelin/contracts@5.4.0/utils/ReentrancyGuard.sol";
-import "@openzeppelin/contracts@5.4.0/utils/Pausable.sol";
-import "@openzeppelin/contracts@5.4.0/access/Ownable.sol";
-import "@openzeppelin/contracts@5.4.0/utils/cryptography/ECDSA.sol";
-import "@openzeppelin/contracts@5.4.0/utils/cryptography/MerkleProof.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 
 interface ENS {
     function resolver(bytes32 node) external view returns (address);
@@ -225,7 +226,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         bytes32 _agentRootNode,
         bytes32 _validatorMerkleRoot,
         bytes32 _agentMerkleRoot
-    ) ERC721("AGIJobs", "Job") {
+    ) ERC721("AGIJobs", "Job") Ownable(msg.sender) {
         agiToken = IERC20(_agiTokenAddress);
         baseIpfsUrl = _baseIpfsUrl;
         ens = ENS(_ensAddress);

--- a/README.md
+++ b/README.md
@@ -29,11 +29,20 @@ For version details, see the [changelog](CHANGELOG.md).
 ## Project Purpose
 AGIJob Manager v0 is a foundational smart-contract component for the emerging Economy of AGI. It coordinates work between **AGI Agents** and **AGI Nodes**, using the $AGI utility token as the medium of exchange. Agents perform computational jobs, Nodes supply the processing power, and $AGI rewards flow through the system to fuel a decentralized network of autonomous services.
 
+## Features
+
+- **On-chain job board** – employers escrow $AGI and assign tasks to approved agents.
+- **Reputation system** – agents and validators earn points that unlock premium capabilities.
+- **NFT marketplace** – completed jobs mint NFTs that can be listed, purchased, or delisted.
+- **ENS & Merkle verification** – subdomain ownership and allowlists guard access to jobs and validation.
+- **Pausable and owner‑controlled** – emergency stop, moderator management, and tunable parameters.
+
 ## Table of Contents
 - [Quick Links](#quick-links)
 - [Versions](#versions)
 - [Repository Structure](#repository-structure)
 - [Project Purpose](#project-purpose)
+- [Features](#features)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
 - [Configuration](#configuration)


### PR DESCRIPTION
## Summary
- document core features and repository layout in README
- align AGIJobManagerV1 imports with standard OpenZeppelin paths and ensure constructor sets deployer as owner

## Testing
- `npm run lint` *(fails: Failed to load a solhint's config file)*
- `npx solcjs --bin AGIJobManagerv1.sol --base-path . --include-path node_modules` *(fails: Stack too deep)*
- `npm run test` *(fails: Compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_688fc602e558833383653932d5376b77