### PR TITLE
docs: clarify setup and verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [AGIJobs NFT Collection on OpenSea](https://opensea.io/collection/agijobs)
 - [AGIJobManager v1 Source](AGIJobManagerv1.sol)
 
-> Verify every address independently before sending transactions.
+> Verify every address independently before sending transactions. Cross-check on multiple block explorers and official channels.
 
 > **Audit Status:** _Unaudited – use at your own risk._
 
@@ -119,8 +119,9 @@ AGIJob Manager is a foundational smart-contract component for the emerging Econo
 4. **Install dependencies**
    ```bash
    npm install solc@0.8.30 @openzeppelin/contracts@5.4.0
+   npm ci
    ```
-   > For reproducible builds, `npm ci` installs the exact versions pinned in `package-lock.json`.
+   `npm install` adds the required packages while `npm ci` performs a clean, reproducible install using `package-lock.json`.
 
 ## Configuration
 Set the following environment variables in a local `.env` file so deployment tools can access your RPC endpoint and signer:
@@ -224,13 +225,14 @@ Set the `ETHERSCAN_API_KEY` (or a network-specific variant such as `SEPOLIA_ETHE
 
 ## Contract Verification
 
-The **v0** contract is verified on [Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code) for transparency.  To reproduce the verification yourself:
+The **v0** contract is verified on [Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code) for transparency. To reproduce the verification yourself:
 
 ```bash
+export ETHERSCAN_API_KEY="your-etherscan-api-key"
 npx hardhat verify --network mainnet 0x0178b6bad606aaf908f72135b8ec32fc1d5ba477
 ```
 
-Compare the compiler settings and bytecode against the deployed address before interacting with any contract instance.
+Compare the compiler settings and bytecode against the deployed address on multiple explorers before interacting with any contract instance.
 
 ### Example Interactions
 


### PR DESCRIPTION
## Summary
- document reproducible dependency installation with `npm ci`
- note `ETHERSCAN_API_KEY` requirement and suggest cross-checking addresses on multiple explorers

## Testing
- `npm run compile` (fails: HH1 not inside Hardhat project)
- `npm run lint` (fails: solhint config missing)
- `npm test` (fails: HH1 not inside Hardhat project)


------
https://chatgpt.com/codex/tasks/task_e_688fcfce5050833399828412db15ace7