### PR TITLE
docs: note v1 solidity version

### DIFF
--- a/AGIJobManagerv1.sol
+++ b/AGIJobManagerv1.sol
@@ -103,7 +103,7 @@ OVERRIDING AUTHORITY: AGI.ETH
    
 */
 
-pragma solidity ^0.8.30;
+pragma solidity 0.8.30;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
@@ -126,6 +126,9 @@ interface NameWrapper {
     function ownerOf(uint256 id) external view returns (address);
 }
 
+/// @title AGIJobManagerV1
+/// @notice Experimental upgrade of the immutable AGIJobManager v0. This contract
+///         is a work in progress and has not been deployed on any network.
 contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
     using ECDSA for bytes32;
     using MerkleProof for bytes32[];

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [AGIJobManager v0 on Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code)
 - [AGIJobs NFT Collection on OpenSea](https://opensea.io/collection/agijobs) – confirm the collection contract on a block explorer before trading.
 - [AGIJobManager v0 Source](AGIJobManagerv0.sol)
-- [AGIJobManager v1 Source](AGIJobManagerv1.sol)
+- [AGIJobManager v1 Source](AGIJobManagerv1.sol) – experimental upgrade pinned to Solidity 0.8.30; not deployed.
 
 > Verify every address independently before sending transactions. Cross-check on multiple block explorers (e.g., Etherscan, Blockscout) and official channels.
 
@@ -28,7 +28,7 @@ All addresses should be independently verified before use.
 ## Versions
 
 - **v0 – Legacy:** Immutable code deployed at [0x0178b6bad606aaf908f72135b8ec32fc1d5ba477](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477).
-- **v1 – Development:** Current target; deployment address: _TBA_.
+- **v1 – Development:** Current target pinned to Solidity 0.8.30; deployment address: _TBA_.
 
 > **Caution:** v0 is frozen and must not be modified. All new work should target v1.
 


### PR DESCRIPTION
## Summary
- document v1 solidity 0.8.30 requirement
- annotate AGIJobManagerV1 with NatSpec and pinned compiler version

## Testing
- `npm run lint` *(fails: Failed to load a solhint's config file)*
- `npm run compile` *(fails: You are not inside a Hardhat project)*
- `npm test` *(fails: You are not inside a Hardhat project)*

------
https://chatgpt.com/codex/tasks/task_e_688fd48ae3388333a80c392bead371b5