### PR TITLE
docs: add architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ For version details, see the [changelog](CHANGELOG.md).
 ## Project Purpose
 AGIJob Manager is a foundational smart-contract component for the emerging Economy of AGI. The v0 contract coordinates work between **AGI Agents** and **AGI Nodes**, using the $AGI utility token as the medium of exchange. Agents perform computational jobs, Nodes supply the processing power, and $AGI rewards flow through the system to fuel a decentralized network of autonomous services.
 
+```mermaid
+sequenceDiagram
+    participant Employer
+    participant Agent
+    participant Validator
+    participant AGI as "AGI Token"
+
+    Employer->>Agent: Post job & escrow AGI
+    Agent->>Validator: Submit work
+    Validator->>Employer: Approve work
+    Employer->>AGI: Release payment
+    AGI-->>Agent: Payout
+    AGI-->>Validator: Validation reward
+```
+
+For a standalone diagram, see [docs/architecture.md](docs/architecture.md).
+
 ## Features
 
 - **On-chain job board** – employers escrow $AGI and assign tasks to approved agents.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Diagram
+
+```mermaid
+sequenceDiagram
+    participant Employer
+    participant Agent
+    participant Validator
+    participant AGI as "AGI Token"
+
+    Employer->>Agent: Post job & escrow AGI
+    Agent->>Validator: Submit work
+    Validator->>Employer: Approve work
+    Employer->>AGI: Release payment
+    AGI-->>Agent: Payout
+    AGI-->>Validator: Validation reward
+```
+


### PR DESCRIPTION
## Summary
- add mermaid diagram showing employer, agent, validator, and AGI token interactions
- embed diagram in Project Purpose section of README and link to standalone docs/architecture.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fe15f13588333a3734d009c3c9b6b