### PR TITLE
Emit events for blacklisting and moderator management

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ For a standalone diagram, see [docs/architecture.md](docs/architecture.md).
 - **NFT marketplace** – completed jobs mint NFTs that can be listed, purchased, or delisted.
 - **ENS & Merkle verification** – subdomain ownership and allowlists guard access to jobs and validation.
 - **Pausable and owner‑controlled** – emergency stop, moderator management, and tunable parameters.
+- **Transparent moderation** – emits `AgentBlacklisted`, `ValidatorBlacklisted`, `ModeratorAdded`, and `ModeratorRemoved` events for on-chain auditability.
 
 ## Table of Contents
 - [Quick Links](#quick-links)

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -220,6 +220,10 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     event NFTPurchased(uint256 indexed tokenId, address indexed buyer, uint256 price);
     event NFTDelisted(uint256 indexed tokenId);
     event RewardPoolContribution(address indexed contributor, uint256 amount);
+    event AgentBlacklisted(address indexed agent, bool status);
+    event ValidatorBlacklisted(address indexed validator, bool status);
+    event ModeratorAdded(address indexed moderator);
+    event ModeratorRemoved(address indexed moderator);
 
     constructor(
         address _agiTokenAddress,
@@ -335,10 +339,12 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     function blacklistAgent(address _agent, bool _status) external onlyOwner {
         blacklistedAgents[_agent] = _status;
+        emit AgentBlacklisted(_agent, _status);
     }
 
     function blacklistValidator(address _validator, bool _status) external onlyOwner {
         blacklistedValidators[_validator] = _status;
+        emit ValidatorBlacklisted(_validator, _status);
     }
 
     function delistJob(uint256 _jobId) external onlyOwner {
@@ -351,10 +357,12 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     function addModerator(address _moderator) external onlyOwner {
         moderators[_moderator] = true;
+        emit ModeratorAdded(_moderator);
     }
 
     function removeModerator(address _moderator) external onlyOwner {
         moderators[_moderator] = false;
+        emit ModeratorRemoved(_moderator);
     }
 
     function updateAGITokenAddress(address _newTokenAddress) external onlyOwner {


### PR DESCRIPTION
## Summary
- add AgentBlacklisted, ValidatorBlacklisted, ModeratorAdded, and ModeratorRemoved events to `AGIJobManagerV1`
- emit events in blacklist and moderator management functions
- document these moderation events in the README

## Testing
- `npm run compile`
- `npm run lint` (solhint: 385 warnings, 0 errors)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fe2e95e50833393b64e1b6afbd5c3