### PR TITLE
chore: upgrade to solidity 0.8.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## v1
-- Bumped Solidity compiler to version 0.8.30.
+- Updated Solidity compiler to version 0.8.30 across contracts, configuration, and docs.
 - Updated dependencies: Node.js 22.x LTS, Hardhat 2.26.1, @nomicfoundation/hardhat-toolbox 6.1.0, and OpenZeppelin Contracts 5.4.0.
 - Introduced AGIJobManagerV1 contract and updated deployment script.
 - Expanded README with security notice and toolchain verification steps.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - [AGIJobs NFT contract on Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code) / [Blockscout](https://blockscout.com/eth/mainnet/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477/contracts) – cross-check the address on multiple explorers before trading.
 - [$AGI token contract on Etherscan](https://etherscan.io/address/0x8eb24319393716668d768dcec29356ae9cffe285#code) / [Blockscout](https://eth.blockscout.com/address/0x8eb24319393716668d768dcec29356ae9cffe285?tab=contract) – cross-verify the token address before transacting.
 - [AGIJobManager v0 Source](legacy/AGIJobManagerv0.sol)
-- [AGIJobManager v1 Source](contracts/AGIJobManagerv1.sol) – experimental upgrade using Solidity ^0.8.24; not deployed.
+- [AGIJobManager v1 Source](contracts/AGIJobManagerv1.sol) – experimental upgrade using Solidity ^0.8.30; not deployed.
 
 > Verify every address independently before sending transactions. Cross-check on multiple block explorers (e.g., Etherscan, Blockscout) and official channels.
 
@@ -31,7 +31,7 @@ All addresses should be independently verified before use.
 ## Versions
 
 - **v0 – Legacy:** Immutable code deployed at [0x0178b6bad606aaf908f72135b8ec32fc1d5ba477](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477).
-- **v1 – Development:** Current target pinned to Solidity ^0.8.24; deployment address: _TBA_.
+- **v1 – Development:** Current target pinned to Solidity ^0.8.30; deployment address: _TBA_.
 
 > **Caution:** v0 is frozen and must not be modified. All new work should target v1.
 
@@ -103,7 +103,7 @@ For a standalone diagram, see [docs/architecture.md](docs/architecture.md).
 ## Prerequisites
 - **Node.js & npm** – Node.js ≥ 22.x LTS (tested with v22.18.0; check with `node --version`).
 - **Hardhat 2.26.1** or **Foundry** – choose either development toolkit and use its respective commands (`npx hardhat` or `forge`).
-- **Solidity Compiler** – version 0.8.24.
+- **Solidity Compiler** – version 0.8.30.
 - **OpenZeppelin Contracts** – version 5.4.0 with `SafeERC20` for secure token transfers.
 
 Confirm toolchain versions:
@@ -179,7 +179,7 @@ module.exports = {
     },
   },
   solidity: {
-    version: "0.8.24",
+    version: "0.8.30",
     settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true },
   },
   paths: { sources: "./contracts" },

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -103,7 +103,7 @@ OVERRIDING AUTHORITY: AGI.ETH
    
 */
 
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.30;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,7 +2,7 @@ require('@nomicfoundation/hardhat-toolbox');
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: { version: '0.8.24', settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true } },
+  solidity: { version: '0.8.30', settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true } },
   paths: {
     sources: './contracts'
   }


### PR DESCRIPTION
## Summary
- target Solidity ^0.8.30 in AGIJobManager V1
- align Hardhat config and documentation with the new compiler
- note the compiler upgrade in the changelog

## Testing
- `npm run compile`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688feb43486083339a254f352dbded91