### PR TITLE
ci: run lint and tests on Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint
+        run: npm run lint
       - name: Run tests
-        run: echo "No tests specified"
+        run: npm test


### PR DESCRIPTION
## Summary
- install Node.js 22.x and project dependencies
- run linting and tests in CI

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688feda6a4f083338f71db5a3811d82d