### PR TITLE
feat: make burn address configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
 The v1 prototype sends a slice of each finalized job's payout to a burn address, permanently reducing token supply.
 
 - **Default burn percentage:** `0` (no burn until set).
-- **Burn address:** `BURN_ADDRESS` (`0x000000000000000000000000000000000000dEaD`).
-- **Owner controls:** `setBurnPercentage` (0–10,000 bps) adjusts the rate; `JobFinalizedAndBurned` logs agent payouts and tokens destroyed.
+- **Burn address:** `burnAddress` (`0x000000000000000000000000000000000000dEaD`).
+- **Owner controls:** `setBurnPercentage` (0–10,000 bps) adjusts the rate; `setBurnAddress` updates the burn destination; `JobFinalizedAndBurned` logs agent payouts and tokens destroyed.
 
 ## Table of Contents
 - [Quick Links](#quick-links)

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -157,7 +157,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     ENS public ens;
     NameWrapper public nameWrapper;
 
-    address public constant BURN_ADDRESS = 0x000000000000000000000000000000000000dEaD;
+    address public burnAddress;
     uint256 public burnPercentage;
     uint256 public constant PERCENTAGE_DENOMINATOR = 10_000;
 
@@ -236,6 +236,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     event ValidatorBlacklisted(address indexed validator, bool status);
     event ModeratorAdded(address indexed moderator);
     event ModeratorRemoved(address indexed moderator);
+    event BurnAddressUpdated(address indexed newBurnAddress);
 
     /// @dev Thrown when an AGI type is added with invalid parameters.
     error InvalidAGITypeParameters();
@@ -261,6 +262,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         agentRootNode = _agentRootNode;
         validatorMerkleRoot = _validatorMerkleRoot;
         agentMerkleRoot = _agentMerkleRoot;
+        burnAddress = 0x000000000000000000000000000000000000dEaD;
     }
 
     modifier onlyModerator() {
@@ -468,6 +470,12 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         burnPercentage = newPercentage;
     }
 
+    function setBurnAddress(address newBurnAddress) external onlyOwner {
+        require(newBurnAddress != address(0), "invalid address");
+        burnAddress = newBurnAddress;
+        emit BurnAddressUpdated(newBurnAddress);
+    }
+
     function calculateReputationPoints(uint256 _payout, uint256 _duration) internal pure returns (uint256) {
         uint256 scaledPayout = _payout / 1e18;
         uint256 payoutPoints = scaledPayout ** 3 / 1e5;
@@ -551,7 +559,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         }
 
         if (burnAmount > 0) {
-            agiToken.safeTransfer(BURN_ADDRESS, burnAmount);
+            agiToken.safeTransfer(burnAddress, burnAmount);
         }
 
         uint256 tokenId = nextTokenId++;


### PR DESCRIPTION
## Summary
- allow updating burn address at runtime
- emit event when burn address changes
- document configurable burn address

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890164968048333b1c302ebe6c6b1fe