### PR TITLE
Ensure job completion request before validation

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -320,6 +320,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         require(_verifyOwnership(msg.sender, subdomain, proof, clubRootNode) || additionalValidators[msg.sender], "Not authorized validator");
         require(!blacklistedValidators[msg.sender], "Blacklisted validator");
         Job storage job = jobs[_jobId];
+        require(job.completionRequested, "Completion not requested");
         require(!job.completed && !job.approvals[msg.sender], "Job completed or already approved");
         job.validatorApprovals++;
         job.approvals[msg.sender] = true;
@@ -335,6 +336,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         require(_verifyOwnership(msg.sender, subdomain, proof, clubRootNode) || additionalValidators[msg.sender], "Not authorized validator");
         require(!blacklistedValidators[msg.sender], "Blacklisted validator");
         Job storage job = jobs[_jobId];
+        require(job.completionRequested, "Completion not requested");
         require(!job.completed && !job.disapprovals[msg.sender], "Job completed or already disapproved");
         job.validatorDisapprovals++;
         job.disapprovals[msg.sender] = true;

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -81,4 +81,19 @@ describe("AGIJobManagerV1 payouts", function () {
 
     expect(await token.balanceOf(agent.address)).to.equal(agentExpected);
   });
+
+  it("rejects validation before completion is requested", async function () {
+    const { token, manager, employer, agent, validator } = await deployFixture();
+    const payout = ethers.parseEther("1000");
+
+    await token.connect(employer).approve(await manager.getAddress(), payout);
+    await manager.connect(employer).createJob("jobhash", payout, 1000, "details");
+
+    const jobId = 0;
+    await manager.connect(agent).applyForJob(jobId, "", []);
+
+    await expect(
+      manager.connect(validator).validateJob(jobId, "", [])
+    ).to.be.revertedWith("Completion not requested");
+  });
 });


### PR DESCRIPTION
## Summary
- guard `validateJob` and `disapproveJob` so they revert when completion was not requested
- add test ensuring validation fails without a completion request

## Testing
- `npm test`
- `npm run lint` *(fails: 402 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6890256d7b248333858dce3d87392bfa