### PR TITLE
docs: clarify burn disable option

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -456,6 +456,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         validationRewardPercentage = _percentage;
     }
 
+    /// @notice Update burn rate in basis points.
+    /// @dev Setting `newPercentage` to 0 disables burning.
     function setBurnPercentage(uint256 newPercentage) external onlyOwner {
         require(newPercentage <= PERCENTAGE_DENOMINATOR, "Invalid percentage");
         burnPercentage = newPercentage;


### PR DESCRIPTION
## Summary
- document that setting `burnPercentage` to 0 disables burning

## Testing
- `npm run compile`
- `npm run lint` (fails: ✖ 403 problems (0 errors, 403 warnings))
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68903aa0254c833381ac6396b03294fe