### PR TITLE
feat: prevent duplicate validator disapproval

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -340,9 +340,13 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         Job storage job = jobs[_jobId];
         require(job.completionRequested, "Completion not requested");
         require(!job.completed && !job.disapprovals[msg.sender], "Job completed or already disapproved");
+        require(!job.approvals[msg.sender], "Validator already approved");
+        bool isNewValidator = !job.approvals[msg.sender] && !job.disapprovals[msg.sender];
         job.validatorDisapprovals++;
         job.disapprovals[msg.sender] = true;
-        job.validators.push(msg.sender);
+        if (isNewValidator) {
+            job.validators.push(msg.sender);
+        }
         validatorApprovedJobs[msg.sender].push(_jobId);
         emit JobDisapproved(_jobId, msg.sender);
         if (job.validatorDisapprovals >= requiredValidatorDisapprovals) {


### PR DESCRIPTION
## Summary
- guard disapproveJob against validators who already approved
- add check to avoid pushing a validator twice to the validators list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68903c6a78148333ba558e8dce214420