### PR TITLE
feat: enforce job existence before finalization

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -535,6 +535,9 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     function _finalizeJob(uint256 _jobId) internal {
         Job storage job = jobs[_jobId];
+        // Explicit existence and completion checks per best practices
+        require(job.employer != address(0), "Job does not exist");
+        require(!job.completed, "Already finalized");
         // Ensure burning and payouts occur only after the job meets validation requirements
         require(
             job.validatorApprovals >= requiredValidatorApprovals || job.disputed,


### PR DESCRIPTION
## Summary
- ensure `_finalizeJob` only runs on existing, unfinished jobs before burning tokens and distributing payouts
- document burn flow and owner controls in README

## Testing
- `npm run compile`
- `npm run lint`
- `npm run test`
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68904164e5c48333b3e1ac9e33c501d1