### PR TITLE
feat: add configurable burn settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The v1 prototype destroys a slice of each finalized job's escrow, permanently re
 
 - **burnPercentage** – basis points of escrow destroyed on finalization. Defaults to `5%` (500 basis points) and can be updated only by the contract owner via `setBurnPercentage(newBps)`. This call emits `BurnPercentageUpdated(newBps)`.
 - **burnAddress** – destination for burned tokens. Initially `0x000000000000000000000000000000000000dEaD`; the owner may redirect burns with `setBurnAddress(newAddress)`, emitting `BurnAddressUpdated(newAddress)`.
+- **setBurnConfig(newAddress, newBps)** – convenience method for owners to update both settings atomically. Emits `BurnAddressUpdated(newAddress)` and `BurnPercentageUpdated(newBps)` in a single transaction.
 - **Automatic finalization** – the final validator approval executes `_finalizeJob`, minting the completion NFT, releasing payment and burning `burnPercentage` of the escrow to `burnAddress`. `JobFinalizedAndBurned(jobId, agent, employer, payoutToAgent, tokensBurned)` records the transfer.
 - **Caution:** Tokens sent to the burn address are irrecoverable; monitor `BurnPercentageUpdated` and `BurnAddressUpdated` events when changing parameters.
 
@@ -95,9 +96,8 @@ The v1 prototype destroys a slice of each finalized job's escrow, permanently re
 
 **Setup checklist**
 
-1. `setBurnPercentage(newBps)` – define the portion of escrow to destroy.
-2. `setBurnAddress(newAddress)` – choose where burned tokens go.
-3. On final validator approval, watch for `JobFinalizedAndBurned` to confirm payout and burn amounts.
+1. `setBurnConfig(newAddress, newBps)` – set burn destination and rate in one call, or use `setBurnAddress`/`setBurnPercentage` individually.
+2. On final validator approval, watch for `JobFinalizedAndBurned` to confirm payout and burn amounts.
 
 **Example finalization**
 

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -475,6 +475,21 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         emit BurnAddressUpdated(newBurnAddress);
     }
 
+    /// @notice Atomically update burn address and percentage.
+    /// @param newBurnAddress Destination for burned tokens.
+    /// @param newPercentage Portion of payout (in basis points) to burn.
+    function setBurnConfig(
+        address newBurnAddress,
+        uint256 newPercentage
+    ) external onlyOwner {
+        require(newBurnAddress != address(0), "invalid address");
+        require(newPercentage <= PERCENTAGE_DENOMINATOR, "Invalid percentage");
+        burnAddress = newBurnAddress;
+        burnPercentage = newPercentage;
+        emit BurnAddressUpdated(newBurnAddress);
+        emit BurnPercentageUpdated(newPercentage);
+    }
+
     function calculateReputationPoints(uint256 _payout, uint256 _duration) internal pure returns (uint256) {
         uint256 scaledPayout = _payout / 1e18;
         uint256 payoutPoints = scaledPayout ** 3 / 1e5;
@@ -551,6 +566,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         uint256 remainingEscrow = job.payout - burnAmount;
 
         if (burnAmount > 0) {
+            require(burnAddress != address(0), "Burn address not set");
             agiToken.safeTransfer(burnAddress, burnAmount);
         }
 

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -129,6 +129,23 @@ describe("AGIJobManagerV1 payouts", function () {
       .withArgs(newPercentage);
   });
 
+  it("allows owner to update burn config atomically", async function () {
+    const { manager } = await deployFixture();
+    const newAddress = ethers.getAddress(
+      "0x000000000000000000000000000000000000BEEF"
+    );
+    const newPercentage = 750;
+
+    await expect(manager.setBurnConfig(newAddress, newPercentage))
+      .to.emit(manager, "BurnAddressUpdated")
+      .withArgs(newAddress)
+      .and.to.emit(manager, "BurnPercentageUpdated")
+      .withArgs(newPercentage);
+
+    expect(await manager.burnAddress()).to.equal(newAddress);
+    expect(await manager.burnPercentage()).to.equal(newPercentage);
+  });
+
   it("emits JobFinalizedAndBurned with correct payouts", async function () {
     const { token, manager, employer, agent, validator } = await deployFixture();
     const payout = ethers.parseEther("1000");


### PR DESCRIPTION
## Summary
- allow owner to update burn destination and rate atomically
- require burn address to be set before burning
- document burn configuration workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68907204d41483338821dd5e46e766a6