### PR TITLE
refine burn defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
 
 The v1 prototype destroys a slice of each finalized job's escrow, permanently reducing total supply. Burning occurs automatically when the last validator approval triggers `_finalizeJob` to mint the NFT, release payment and burn tokens—no separate call is required.
 
-- **burnPercentage** – basis points of escrow destroyed on finalization. Defaults to `5%` (500 basis points) and can be updated only by the contract owner via `setBurnPercentage(newBps)`. This call emits `BurnPercentageUpdated(newBps)`.
-- **burnAddress** – destination for burned tokens. Initially `0x000000000000000000000000000000000000dEaD`; the owner may redirect burns with `setBurnAddress(newAddress)`, emitting `BurnAddressUpdated(newAddress)`.
+- **BURN_ADDRESS / burnAddress** – `BURN_ADDRESS` is the canonical dead wallet (`0x000000000000000000000000000000000000dEaD`). The mutable `burnAddress` variable starts at this value but the owner may redirect burns via `setBurnAddress(newAddress)`, emitting `BurnAddressUpdated(newAddress)`.
+- **BURN_PERCENTAGE / burnPercentage** – `BURN_PERCENTAGE` (500 basis points) seeds the mutable `burnPercentage` variable. The owner may change or disable burning with `setBurnPercentage(newBps)`; setting `0` halts burning. Each update emits `BurnPercentageUpdated(newBps)`.
 - **setBurnConfig(newAddress, newBps)** – convenience method for owners to update both settings atomically. Emits `BurnAddressUpdated(newAddress)` and `BurnPercentageUpdated(newBps)` in a single transaction.
 - **Automatic finalization** – the final validator approval executes `_finalizeJob`, minting the completion NFT, releasing payment and burning `burnPercentage` of the escrow to `burnAddress`. `JobFinalizedAndBurned(jobId, agent, employer, payoutToAgent, tokensBurned)` records the transfer.
 - **Caution:** Tokens sent to the burn address are irrecoverable; monitor `BurnPercentageUpdated` and `BurnAddressUpdated` events when changing parameters.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -157,15 +157,15 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     ENS public ens;
     NameWrapper public nameWrapper;
 
-    /// @notice Default address used to irretrievably burn tokens.
-    address public constant DEFAULT_BURN_ADDRESS =
+    /// @notice Canonical address used to irretrievably burn tokens.
+    address public constant BURN_ADDRESS =
         0x000000000000000000000000000000000000dEaD;
     /// @notice Default portion of a job's payout to burn (5% = 500 basis points).
-    uint256 public constant DEFAULT_BURN_PERCENTAGE = 500;
+    uint256 public constant BURN_PERCENTAGE = 500;
     /// @notice Destination for burned tokens. Owner may update if needed.
-    address public burnAddress = DEFAULT_BURN_ADDRESS;
+    address public burnAddress = BURN_ADDRESS;
     /// @notice Portion of a job's payout (in basis points) to destroy on completion.
-    uint256 public burnPercentage = DEFAULT_BURN_PERCENTAGE;
+    uint256 public burnPercentage = BURN_PERCENTAGE;
     /// @notice Denominator used for percentage calculations (100% = 10_000).
     uint256 public constant PERCENTAGE_DENOMINATOR = 10_000;
 


### PR DESCRIPTION
## Summary
- rename default burn constants to `BURN_ADDRESS` and `BURN_PERCENTAGE`
- document burn defaults and owner controls in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68909b72d8fc833392ad8653de804fa7