### PR TITLE
feat: use custom error for missing burn address

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -255,6 +255,9 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     /// @dev Thrown when the supplied amount is zero or exceeds the contract balance.
     error InvalidAmount();
 
+    /// @dev Thrown when the burn address has not been configured.
+    error BurnAddressNotSet();
+
     constructor(
         address _agiTokenAddress,
         string memory _baseIpfsUrl,
@@ -568,7 +571,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         uint256 remainingEscrow = job.payout - burnAmount;
 
         if (burnAmount > 0) {
-            require(burnAddress != address(0), "Burn address not set");
+            if (burnAddress == address(0)) revert BurnAddressNotSet();
             agiToken.safeTransfer(burnAddress, burnAmount);
         }
 


### PR DESCRIPTION
## Summary
- add `BurnAddressNotSet` custom error
- use custom error instead of revert string when burn address is unset

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890a95b8bf4833387f70ab979fa4ad0