### PR TITLE
docs: detail employer-win validator flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,23 @@ await manager.connect(validator).validateJob(jobId, "", []);
 - **Staking & withdrawals** – validators deposit $AGI via `stake()` and must maintain at least `stakeRequirement`. Stakes can be withdrawn with `withdrawStake` only after all participated jobs are finalized and undisputed.
 - **Aligned rewards** – when a job finalizes, only validators whose votes match the outcome split `validationRewardPercentage` of the remaining escrow along with any slashed stake.
 - **Slashing & reputation penalties** – incorrect votes lose `slashingPercentage` of staked tokens and incur a reputation deduction.
-- **Owner‑tunable parameters** – the contract owner can adjust `stakeRequirement`, `slashingPercentage`, and `validationRewardPercentage` to calibrate incentives.
+- **Owner‑tunable parameters** – the contract owner can adjust `stakeRequirement`, `slashingPercentage`, and `validationRewardPercentage`; each `onlyOwner` update emits a dedicated event.
+
+#### Employer-Win Dispute Path
+
+When validators disapprove a job and the employer prevails:
+
+- Disapproving validators split `validationRewardPercentage` of the escrow along with any slashed stake.
+- Approving validators are slashed and receive no reward.
+- The remaining escrow returns to the employer.
+
+**Example employer-win dispute**
+
+```ts
+await agiJobManager.connect(v1).validateJob(jobId); // incorrect approval; will be slashed
+await agiJobManager.connect(v2).disapproveJob(jobId, "", []);
+await agiJobManager.connect(v3).disapproveJob(jobId, "", []); // employer wins, v2 & v3 rewarded
+```
 
 ## Table of Contents
 - [Quick Links](#quick-links)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,3 +15,19 @@ sequenceDiagram
     AGI-->>Validator: Validation reward
 ```
 
+## Employer-Win Dispute Flow
+
+```mermaid
+sequenceDiagram
+    participant Employer
+    participant Agent
+    participant Validator
+    participant AGI as "AGI Token"
+
+    Employer->>Agent: Post job & escrow AGI
+    Agent->>Validator: Submit work
+    Validator-->>Employer: Reject work
+    AGI-->>Validator: Split reward & slashed stake
+    AGI-->>Employer: Return remaining escrow
+```
+

--- a/docs/project-purpose.md
+++ b/docs/project-purpose.md
@@ -17,4 +17,20 @@ sequenceDiagram
     AGI-->>Validator: Validation reward
 ```
 
+## Employer-Win Dispute Flow
+
+```mermaid
+sequenceDiagram
+    participant Employer
+    participant Agent
+    participant Validator
+    participant AGI as "AGI Token"
+
+    Employer->>Agent: Post job & escrow AGI
+    Agent->>Validator: Submit work
+    Validator-->>Employer: Reject work
+    AGI-->>Validator: Split reward & slashed stake
+    AGI-->>Employer: Return remaining escrow
+```
+
 For a standalone diagram, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary
- document employer-win dispute rewards and slashing in validator incentives
- mention owner-adjustable incentive parameters and event emissions
- add diagrams and examples illustrating employer-win flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c2897af083339841de96e9ae9315