### PR TITLE
feat: add configurable roots and ENS addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,19 @@ export AGENT_MERKLE_ROOT=0xAgentRoot
 npx hardhat run scripts/deploy.ts --network sepolia
 ```
 
+After deployment the contract owner may adjust these values if needed:
+
+```ts
+await agiJobManager.setClubRootNode(0xNewClubRoot);
+await agiJobManager.setAgentRootNode(0xNewAgentRoot);
+await agiJobManager.setValidatorMerkleRoot(0xNewValidatorRoot);
+await agiJobManager.setAgentMerkleRoot(0xNewAgentMerkleRoot);
+await agiJobManager.setENS(0xNewEnsRegistry);
+await agiJobManager.setNameWrapper(0xNewNameWrapper);
+```
+
+Each setter emits a corresponding `*Updated` event for off‑chain tracking.
+
 Always deploy to a public test network first and independently verify the resulting address on at least one block explorer before handling real assets.
 
 ### Deployed Contracts

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -234,8 +234,12 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     event JobCancelled(uint256 jobId);
     event DisputeResolved(uint256 jobId, address resolver, string resolution);
     event JobDisputed(uint256 jobId, address disputant);
-    event RootNodeUpdated(bytes32 indexed newRootNode);
-    event MerkleRootUpdated(bytes32 indexed newMerkleRoot);
+    event ClubRootNodeUpdated(bytes32 indexed newClubRootNode);
+    event AgentRootNodeUpdated(bytes32 indexed newAgentRootNode);
+    event ValidatorMerkleRootUpdated(bytes32 indexed newValidatorMerkleRoot);
+    event AgentMerkleRootUpdated(bytes32 indexed newAgentMerkleRoot);
+    event ENSAddressUpdated(address indexed newEnsAddress);
+    event NameWrapperAddressUpdated(address indexed newNameWrapperAddress);
     event OwnershipVerified(address claimant, string subdomain);
     event RecoveryInitiated(string reason);
     event AGITypeUpdated(address indexed nftAddress, uint256 payoutPercentage);
@@ -508,6 +512,38 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     function updateAdditionalText3(string calldata _text) external onlyOwner {
         additionalText3 = _text;
+    }
+
+    function setClubRootNode(bytes32 newClubRootNode) external onlyOwner {
+        clubRootNode = newClubRootNode;
+        emit ClubRootNodeUpdated(newClubRootNode);
+    }
+
+    function setAgentRootNode(bytes32 newAgentRootNode) external onlyOwner {
+        agentRootNode = newAgentRootNode;
+        emit AgentRootNodeUpdated(newAgentRootNode);
+    }
+
+    function setValidatorMerkleRoot(bytes32 newValidatorMerkleRoot) external onlyOwner {
+        validatorMerkleRoot = newValidatorMerkleRoot;
+        emit ValidatorMerkleRootUpdated(newValidatorMerkleRoot);
+    }
+
+    function setAgentMerkleRoot(bytes32 newAgentMerkleRoot) external onlyOwner {
+        agentMerkleRoot = newAgentMerkleRoot;
+        emit AgentMerkleRootUpdated(newAgentMerkleRoot);
+    }
+
+    function setENS(address newEnsAddress) external onlyOwner {
+        require(newEnsAddress != address(0), "invalid address");
+        ens = ENS(newEnsAddress);
+        emit ENSAddressUpdated(newEnsAddress);
+    }
+
+    function setNameWrapper(address newNameWrapperAddress) external onlyOwner {
+        require(newNameWrapperAddress != address(0), "invalid address");
+        nameWrapper = NameWrapper(newNameWrapperAddress);
+        emit NameWrapperAddressUpdated(newNameWrapperAddress);
     }
 
     function getJobStatus(uint256 _jobId) external view returns (bool, bool, string memory) {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -5,5 +5,10 @@ module.exports = {
   solidity: { version: '0.8.30', settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true } },
   paths: {
     sources: './contracts'
+  },
+  networks: {
+    hardhat: {
+      allowUnlimitedContractSize: true
+    }
   }
 };


### PR DESCRIPTION
## Summary
- allow owner to update ENS, NameWrapper, and all merkle/ENS roots
- emit dedicated events for each configuration change
- document new admin functions and enable tests to deploy large contract

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c61a82ec83338947e3e660dd1e22