### PR TITLE
docs: document allowlist rotation and ENS updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ await manager.connect(validator).validateJob(jobId, "", []);
 // employer receives the completion NFT
 ```
 
+### Allowlist and ENS Management
+
+Owners can refresh allowlists and name-service references without redeploying the contract.
+
+- `setValidatorMerkleRoot(bytes32 newValidatorMerkleRoot)` – rotates the validator allowlist and emits `ValidatorMerkleRootUpdated`.
+- `setAgentMerkleRoot(bytes32 newAgentMerkleRoot)` – updates the agent allowlist and emits `AgentMerkleRootUpdated`.
+- `setClubRootNode(bytes32 newClubRootNode)` – changes the ENS root node used for validator proofs, emitting `ClubRootNodeUpdated`.
+- `setAgentRootNode(bytes32 newAgentRootNode)` – replaces the agent ENS root node and emits `AgentRootNodeUpdated`.
+- `setENS(address newEnsAddress)` / `setNameWrapper(address newNameWrapperAddress)` – refresh external contract references and emit `ENSAddressUpdated` / `NameWrapperAddressUpdated`.
+
+**When to update**
+
+Rotate Merkle roots when membership changes or an allowlist leak is suspected. Update ENS or NameWrapper addresses if the registry or wrapper contracts are redeployed. After each change, monitor the emitted events to confirm the new values.
+
+**Security considerations**
+
+Control these owner functions with a multisig or timelock, and watch the event logs for unexpected modifications. Continuous monitoring helps detect unauthorized updates before they affect job flow.
+
 ### Validator Incentives
 
 - **Staking & withdrawals** – validators deposit $AGI via `stake()` and must maintain at least `stakeRequirement`. Stakes can be withdrawn with `withdrawStake` only after all participated jobs are finalized and undisputed.


### PR DESCRIPTION
## Summary
- explain owner functions for rotating validator/agent allowlists and ENS root nodes
- note when to update allowlists or ENS/NameWrapper references and watch for emitted events
- add security guidance for multi-sig control and event monitoring

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890cc0d213c833387c796ed592c4250