### PR TITLE
Use enum for dispute resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ When validators disapprove a job and the employer prevails:
 await agiJobManager.connect(v1).validateJob(jobId); // incorrect approval; will be slashed
 await agiJobManager.connect(v2).disapproveJob(jobId, "", []);
 await agiJobManager.connect(v3).disapproveJob(jobId, "", []); // employer wins, v2 & v3 rewarded
+await agiJobManager.resolveDispute(jobId, 1); // 1 = DisputeOutcome.EmployerWin
 ```
 
 ## Table of Contents

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -274,7 +274,7 @@ describe("AGIJobManagerV1 payouts", function () {
     await manager.connect(validator2).disapproveJob(jobId, "", []);
 
     await manager.addModerator(owner.address);
-    await manager.resolveDispute(jobId, "employer win");
+    await manager.resolveDispute(jobId, 1); // 1 = DisputeOutcome.EmployerWin
 
     const validatorPayoutTotal = (payout * 8n) / 100n;
     const slashAmount = (stakeAmount * 50n) / 100n;


### PR DESCRIPTION
## Summary
- introduce `DisputeOutcome` enum to represent agent/employer win states
- update `resolveDispute` to take enum and emit typed outcome
- adjust tests and docs to pass numeric enum values

## Testing
- `npm test`
- `npm run lint` (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_6890ce6eade08333b701770ec5c5e3b7