### PR TITLE
feat: add configuration update events

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,23 @@ Rotate Merkle roots when membership changes or an allowlist leak is suspected. U
 
 Control these owner functions with a multisig or timelock, and watch the event logs for unexpected modifications. Continuous monitoring helps detect unauthorized updates before they affect job flow.
 
+### General Configuration Events
+
+Several operational parameters are adjustable by the owner. Each setter emits an event for on‑chain transparency:
+
+- `updateAGITokenAddress(address newToken)` → `AGITokenAddressUpdated`
+- `setBaseIpfsUrl(string newUrl)` → `BaseIpfsUrlUpdated`
+- `setRequiredValidatorApprovals(uint256 count)` → `RequiredValidatorApprovalsUpdated`
+- `setRequiredValidatorDisapprovals(uint256 count)` → `RequiredValidatorDisapprovalsUpdated`
+- `setPremiumReputationThreshold(uint256 newThreshold)` → `PremiumReputationThresholdUpdated`
+- `setMaxJobPayout(uint256 newMax)` → `MaxJobPayoutUpdated`
+- `setJobDurationLimit(uint256 newLimit)` → `JobDurationLimitUpdated`
+- `updateTermsAndConditionsIpfsHash(string newHash)` → `TermsAndConditionsIpfsHashUpdated`
+- `updateContactEmail(string newEmail)` → `ContactEmailUpdated`
+- `updateAdditionalText1(string newText)` → `AdditionalText1Updated`
+- `updateAdditionalText2(string newText)` → `AdditionalText2Updated`
+- `updateAdditionalText3(string newText)` → `AdditionalText3Updated`
+
 ### Validator Incentives
 
 - **Staking & withdrawals** – validators deposit $AGI via `stake()` and must maintain at least `stakeRequirement`. Stakes can be withdrawn with `withdrawStake` only after all participated jobs are finalized and undisputed.
@@ -161,6 +178,8 @@ await agiJobManager.resolveDispute(jobId, 1); // 1 = DisputeOutcome.EmployerWin
 - [Project Purpose](#project-purpose)
 - [Features](#features)
 - [Burn Mechanism](#burn-mechanism)
+- [Allowlist and ENS Management](#allowlist-and-ens-management)
+- [General Configuration Events](#general-configuration-events)
 - [Validator Incentives](#validator-incentives)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -257,6 +257,18 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     event ValidatorBlacklisted(address indexed validator, bool status);
     event ModeratorAdded(address indexed moderator);
     event ModeratorRemoved(address indexed moderator);
+    event AGITokenAddressUpdated(address indexed newTokenAddress);
+    event BaseIpfsUrlUpdated(string newUrl);
+    event RequiredValidatorApprovalsUpdated(uint256 newApprovals);
+    event RequiredValidatorDisapprovalsUpdated(uint256 newDisapprovals);
+    event PremiumReputationThresholdUpdated(uint256 newThreshold);
+    event MaxJobPayoutUpdated(uint256 newMaxPayout);
+    event JobDurationLimitUpdated(uint256 newLimit);
+    event TermsAndConditionsIpfsHashUpdated(string newHash);
+    event ContactEmailUpdated(string newEmail);
+    event AdditionalText1Updated(string newText);
+    event AdditionalText2Updated(string newText);
+    event AdditionalText3Updated(string newText);
     event BurnAddressUpdated(address indexed newBurnAddress);
     /// @notice Emitted when the burn percentage is updated.
     event BurnPercentageUpdated(uint256 newPercentage);
@@ -473,50 +485,62 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     function updateAGITokenAddress(address _newTokenAddress) external onlyOwner {
         agiToken = IERC20(_newTokenAddress);
+        emit AGITokenAddressUpdated(_newTokenAddress);
     }
 
     function setBaseIpfsUrl(string calldata _url) external onlyOwner {
         baseIpfsUrl = _url;
+        emit BaseIpfsUrlUpdated(_url);
     }
 
     function setRequiredValidatorApprovals(uint256 _approvals) external onlyOwner {
         requiredValidatorApprovals = _approvals;
+        emit RequiredValidatorApprovalsUpdated(_approvals);
     }
 
     function setRequiredValidatorDisapprovals(uint256 _disapprovals) external onlyOwner {
         requiredValidatorDisapprovals = _disapprovals;
+        emit RequiredValidatorDisapprovalsUpdated(_disapprovals);
     }
 
     function setPremiumReputationThreshold(uint256 _threshold) external onlyOwner {
         premiumReputationThreshold = _threshold;
+        emit PremiumReputationThresholdUpdated(_threshold);
     }
 
     function setMaxJobPayout(uint256 _maxPayout) external onlyOwner {
         maxJobPayout = _maxPayout;
+        emit MaxJobPayoutUpdated(_maxPayout);
     }
 
     function setJobDurationLimit(uint256 _limit) external onlyOwner {
         jobDurationLimit = _limit;
+        emit JobDurationLimitUpdated(_limit);
     }
 
     function updateTermsAndConditionsIpfsHash(string calldata _hash) external onlyOwner {
         termsAndConditionsIpfsHash = _hash;
+        emit TermsAndConditionsIpfsHashUpdated(_hash);
     }
 
     function updateContactEmail(string calldata _email) external onlyOwner {
         contactEmail = _email;
+        emit ContactEmailUpdated(_email);
     }
 
     function updateAdditionalText1(string calldata _text) external onlyOwner {
         additionalText1 = _text;
+        emit AdditionalText1Updated(_text);
     }
 
     function updateAdditionalText2(string calldata _text) external onlyOwner {
         additionalText2 = _text;
+        emit AdditionalText2Updated(_text);
     }
 
     function updateAdditionalText3(string calldata _text) external onlyOwner {
         additionalText3 = _text;
+        emit AdditionalText3Updated(_text);
     }
 
     function setClubRootNode(bytes32 newClubRootNode) external onlyOwner {


### PR DESCRIPTION
## Summary
- add events for all configurable parameters
- emit events from each setter
- document new events in README

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`
- `grep -n "passing" /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_6890d0729a5883338d4b9a3b7fcf1983