### PR TITLE
chore: pin Solidity 0.8.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## v1
-- Updated Solidity compiler to version 0.8.30 across contracts, configuration, and docs.
+- Updated Solidity compiler to version 0.8.21 across contracts, configuration, and docs.
 - Updated dependencies: Node.js 22.x LTS, Hardhat 2.26.1, @nomicfoundation/hardhat-toolbox 6.1.0, and OpenZeppelin Contracts 5.4.0.
 - Introduced AGIJobManagerV1 contract and updated deployment script.
 - Expanded README with security notice and toolchain verification steps.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 - [AGIJobs NFT contract on Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code) / [Blockscout](https://blockscout.com/eth/mainnet/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477/contracts) – cross-check the address on multiple explorers before trading.
 - [$AGI token contract on Etherscan](https://etherscan.io/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D#code) / [Blockscout](https://eth.blockscout.com/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D?tab=contract) – cross-verify the token address before transacting.
 - [AGIJobManager v0 Source](legacy/AGIJobManagerv0.sol)
-- [AGIJobManager v1 Source](contracts/AGIJobManagerv1.sol) – experimental upgrade using Solidity 0.8.30; includes an automatic token burn on final validation via the `JobFinalizedAndBurned` event and configurable burn parameters. Not deployed; treat any address claiming to be v1 as unverified until announced through official channels.
+- [AGIJobManager v1 Source](contracts/AGIJobManagerv1.sol) – experimental upgrade using Solidity 0.8.21; includes an automatic token burn on final validation via the `JobFinalizedAndBurned` event and configurable burn parameters. Not deployed; treat any address claiming to be v1 as unverified until announced through official channels.
 
 > **Warning**: Links above are provided for reference only. Always validate contract addresses and metadata on multiple block explorers before interacting.
 
@@ -55,7 +55,7 @@ All addresses should be independently verified before use.
 ## Versions
 
 - **v0 – Legacy:** Immutable code deployed at [0x0178b6bad606aaf908f72135b8ec32fc1d5ba477](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477).
-- **v1 – Development:** Uses Solidity 0.8.30 (pinned) with custom errors and gas‑optimized loops; deployment address: _TBA_. Any contract advertised as v1 prior to an official release should be regarded as untrusted.
+- **v1 – Development:** Uses Solidity 0.8.21 (pinned) with custom errors and gas‑optimized loops; deployment address: _TBA_. Any contract advertised as v1 prior to an official release should be regarded as untrusted.
 
 > **Caution:** v0 is frozen and must not be modified. All new work should target v1.
 
@@ -241,7 +241,7 @@ await agiJobManager.resolveDispute(jobId, AGIJobManager.DisputeOutcome.EmployerW
 ## Prerequisites
 - **Node.js & npm** – Node.js ≥ 20.x LTS (tested with v20.19.4; check with `node --version`).
 - **Hardhat 2.26.1** or **Foundry** – choose either development toolkit and use its respective commands (`npx hardhat` or `forge`).
-- **Solidity Compiler** – version 0.8.30 (pinned).
+- **Solidity Compiler** – version 0.8.21 (pinned).
 - **OpenZeppelin Contracts** – version 5.4.0 with `SafeERC20` for secure token transfers.
 
 Confirm toolchain versions:
@@ -319,7 +319,7 @@ module.exports = {
     },
   },
   solidity: {
-    version: "0.8.30",
+    version: "0.8.21",
     settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true },
   },
   paths: { sources: "./contracts" },

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.30;
+pragma solidity 0.8.21;
 // AGIJobManagerV1 supersedes AGIJobManager v0
 
 /*

--- a/contracts/mocks/MockENS.sol
+++ b/contracts/mocks/MockENS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.30;
+pragma solidity 0.8.21;
 
 contract MockENS {
     function resolver(bytes32) external pure returns (address) {

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.30;
+pragma solidity 0.8.21;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/MockNameWrapper.sol
+++ b/contracts/mocks/MockNameWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.30;
+pragma solidity 0.8.21;
 
 contract MockNameWrapper {
     function ownerOf(uint256) external pure returns (address) {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,7 +2,7 @@ require('@nomicfoundation/hardhat-toolbox');
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: { version: '0.8.30', settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true } },
+  solidity: { version: '0.8.21', settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true } },
   paths: {
     sources: './contracts'
   },


### PR DESCRIPTION
## Summary
- pin AGIJobManagerV1 and mocks to Solidity 0.8.21
- configure Hardhat and docs for the same compiler version

## Testing
- `npx hardhat compile --force`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890ee075c94833384497fc97be29968