### PR TITLE
Clarify validator incentives and compiler version

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
 - **Transparent moderation** – emits `AgentBlacklisted`, `ValidatorBlacklisted`, `ModeratorAdded`, and `ModeratorRemoved` events for on-chain auditability.
 - **Gas-efficient validations** – v1 replaces string `require` messages with custom errors and prefix increments.
 - **Enum-based dispute resolution** – moderators settle conflicts with a typed `DisputeOutcome` enum instead of fragile string comparisons.
-- **Stake-based validator incentives** – validators must stake $AGI and maintain a minimum reputation. Misaligned votes are slashed, reputation drops can auto-blacklist validators, and the owner tunes requirements and rewards.
+- **Stake-based validator incentives**
+  - Validators must stake $AGI and maintain a minimum reputation.
+  - Only validators voting with the final outcome earn rewards.
+  - Misaligned votes incur stake slashing and reputation penalties.
+  - All validator parameters (reward %, slashing %, stake requirement,
+    approval thresholds, etc.) are owner-configurable.
 - **Basis-point standardization** – percentage parameters like burns, slashing, and rewards are expressed in basis points for deterministic math.
 - **Configurable slashed stake recipient** – if no validator votes correctly, all slashed stake is sent to `slashedStakeRecipient` (initially the owner but adjustable, e.g. to the burn address).
 - **Automatic finalization & configurable token burn** – the last validator approval triggers `_finalizeJobAndBurn`, minting the completion NFT, releasing the payout, and burning the configured portion of escrow. The `JobFinalizedAndBurned` event records agent payouts and burn amounts.


### PR DESCRIPTION
## Summary
- detail validator reward and slashing rules in README
- ensure README references the pinned Solidity 0.8.21 compiler

## Testing
- `npx --yes markdownlint-cli README.md` (fails: line-length and formatting warnings)
- `npm run lint` (solhint warnings)
- `npx eslint .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890effe0074833390acf1eabcb649c2