### PR TITLE
feat: enforce single validator vote

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Incorrect validator votes lose stake according to `slashingPercentage`. Slashed 
 - **Aligned rewards** – when a job finalizes, only validators whose votes match the outcome split `validationRewardPercentage` basis points of the remaining escrow along with any slashed stake. If no votes are correct, the slashed tokens are sent to `slashedStakeRecipient`.
 - **Slashing & reputation penalties** – incorrect votes lose `slashingPercentage` basis points of staked tokens and incur a reputation deduction.
 - **Owner‑tunable parameters** – the contract owner can adjust `stakeRequirement`, `slashingPercentage` (basis points), `validationRewardPercentage` (basis points), `minValidatorReputation`, and `slashedStakeRecipient`; each `onlyOwner` update emits a dedicated event.
+- **Single-shot voting** – validators cannot change their vote once cast; a validator address may approve *or* disapprove a job, but never both. Attempts to vote twice revert.
 
 #### Employer-Win Dispute Path
 

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -372,7 +372,12 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         require(reputation[msg.sender] >= minValidatorReputation, "Insufficient reputation");
         Job storage job = jobs[_jobId];
         require(job.completionRequested, "Completion not requested");
-        require(!job.completed && !job.approvals[msg.sender], "Job completed or already approved");
+        require(
+            !job.completed &&
+                !job.approvals[msg.sender] &&
+                !job.disapprovals[msg.sender],
+            "Job completed or already reviewed"
+        );
         job.validatorApprovals++;
         job.approvals[msg.sender] = true;
         job.validators.push(msg.sender);


### PR DESCRIPTION
## Summary
- prevent validators from switching sides on a job
- document single-shot validator voting

## Testing
- `npm test`
- `npm run lint` *(fails: 567 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_6891020e68048333beb8350162a45f97