### PR TITLE
Block validator votes on disputed jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Incorrect validator votes lose stake according to `slashingPercentage`. Slashed 
 - **Aligned rewards** – when a job finalizes, only validators whose votes match the outcome split `validationRewardPercentage` basis points of the remaining escrow along with any slashed stake. If no votes are correct, the slashed tokens are sent to `slashedStakeRecipient`.
 - **Slashing & reputation penalties** – incorrect votes lose `slashingPercentage` basis points of staked tokens and incur a reputation deduction.
 - **Owner‑tunable parameters** – the contract owner can adjust `stakeRequirement`, `slashingPercentage` (basis points), `validationRewardPercentage` (basis points), `minValidatorReputation`, and `slashedStakeRecipient`; each `onlyOwner` update emits a dedicated event.
+- **Dispute lock** – once a job is disputed, no additional validator votes are accepted until a moderator resolves the dispute.
 - **Single-shot voting** – validators cannot change their vote once cast; a validator address may approve *or* disapprove a job, but never both. Attempts to vote twice revert.
 
 #### Employer-Win Dispute Path

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -372,6 +372,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         require(reputation[msg.sender] >= minValidatorReputation, "Insufficient reputation");
         Job storage job = jobs[_jobId];
         require(job.completionRequested, "Completion not requested");
+        require(!job.disputed, "Job disputed");
         require(
             !job.completed &&
                 !job.approvals[msg.sender] &&
@@ -395,14 +396,12 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         require(reputation[msg.sender] >= minValidatorReputation, "Insufficient reputation");
         Job storage job = jobs[_jobId];
         require(job.completionRequested, "Completion not requested");
+        require(!job.disputed, "Job disputed");
         require(!job.completed && !job.disapprovals[msg.sender], "Job completed or already disapproved");
         require(!job.approvals[msg.sender], "Validator already approved");
-        bool isNewValidator = !job.approvals[msg.sender] && !job.disapprovals[msg.sender];
         job.validatorDisapprovals++;
         job.disapprovals[msg.sender] = true;
-        if (isNewValidator) {
-            job.validators.push(msg.sender);
-        }
+        job.validators.push(msg.sender);
         _addValidatorDisapprovedJob(msg.sender, _jobId);
         emit JobDisapproved(_jobId, msg.sender);
         if (job.validatorDisapprovals >= requiredValidatorDisapprovals) {


### PR DESCRIPTION
## Summary
- stop validators from approving or rejecting jobs after a dispute is opened
- document dispute lock in validator incentives section

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891035b90488333b4ed79599cac3def