### PR TITLE
Align validator rewards when no correct votes

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -436,8 +436,10 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
                 (job.payout * validationRewardPercentage) /
                 PERCENTAGE_DENOMINATOR;
             uint256 completionTime = block.timestamp - job.assignedAt;
-            uint256 reputationPoints = calculateReputationPoints(job.payout, completionTime);
-            uint256 validatorReputationChange = calculateValidatorReputationPoints(reputationPoints);
+            uint256 reputationPoints =
+                calculateReputationPoints(job.payout, completionTime);
+            uint256 validatorReputationChange =
+                calculateValidatorReputationPoints(reputationPoints);
             uint256 correctValidatorCount = 0;
             uint256 totalSlashed = 0;
 
@@ -460,12 +462,18 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
                 }
             }
 
-            uint256 validatorPayout = correctValidatorCount > 0
-                ? validatorPayoutTotal / correctValidatorCount
-                : 0;
-            uint256 slashedReward = correctValidatorCount > 0
-                ? totalSlashed / correctValidatorCount
-                : 0;
+            if (correctValidatorCount == 0) {
+                validatorPayoutTotal = 0;
+            }
+
+            uint256 validatorPayout =
+                correctValidatorCount > 0
+                    ? validatorPayoutTotal / correctValidatorCount
+                    : 0;
+            uint256 slashedReward =
+                correctValidatorCount > 0
+                    ? totalSlashed / correctValidatorCount
+                    : 0;
 
             if (correctValidatorCount == 0 && totalSlashed > 0) {
                 agiToken.safeTransfer(slashedStakeRecipient, totalSlashed);
@@ -846,7 +854,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         uint256 validatorPayoutTotal =
             (job.payout * validationRewardPercentage) /
             PERCENTAGE_DENOMINATOR;
-        uint256 validatorReputationChange = calculateValidatorReputationPoints(reputationPoints);
+        uint256 validatorReputationChange =
+            calculateValidatorReputationPoints(reputationPoints);
         uint256 correctValidatorCount = 0;
         uint256 totalSlashed = 0;
 
@@ -869,12 +878,18 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
             }
         }
 
-        uint256 validatorPayout = correctValidatorCount > 0
-            ? validatorPayoutTotal / correctValidatorCount
-            : 0;
-        uint256 slashedReward = correctValidatorCount > 0
-            ? totalSlashed / correctValidatorCount
-            : 0;
+        if (correctValidatorCount == 0) {
+            validatorPayoutTotal = 0;
+        }
+
+        uint256 validatorPayout =
+            correctValidatorCount > 0
+                ? validatorPayoutTotal / correctValidatorCount
+                : 0;
+        uint256 slashedReward =
+            correctValidatorCount > 0
+                ? totalSlashed / correctValidatorCount
+                : 0;
 
         if (correctValidatorCount == 0 && totalSlashed > 0) {
             agiToken.safeTransfer(slashedStakeRecipient, totalSlashed);


### PR DESCRIPTION
## Summary
- prevent validator reward from being orphaned when no votes align with the outcome
- clarify README: reward portion returns to agent or employer; only slashed stake goes to slashedStakeRecipient

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68910f2609b08333bc95ff1ef7ef9f44