### PR TITLE
Add configurable validator staking and incentive updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
   - Misaligned votes incur stake slashing and reputation penalties.
   - All validator parameters (reward %, slashing %, stake requirement,
     approval thresholds, etc.) are owner-configurable.
+  - Setting the stake requirement or slashing percentage to `0` disables those mechanisms.
 - **Basis-point standardization** – percentage parameters like burns, slashing, and rewards are expressed in basis points for deterministic math.
 - **Configurable slashed stake recipient** – if no validator votes correctly, all slashed stake is sent to `slashedStakeRecipient` (initially the owner but adjustable, e.g. to the burn address) while the validator reward portion reverts to the agent or employer.
 - **Automatic finalization & configurable token burn** – the last validator approval triggers `_finalizeJobAndBurn`, minting the completion NFT, releasing the payout, and burning the configured portion of escrow. The `JobFinalizedAndBurned` event records agent payouts and burn amounts.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -675,14 +675,16 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         emit SlashedStakeRecipientUpdated(newRecipient);
     }
 
+    /// @notice Update the minimum stake validators must maintain.
+    /// @dev Setting `amount` to 0 removes the staking requirement entirely.
     function setStakeRequirement(uint256 amount) external onlyOwner {
-        require(amount > 0, "Invalid amount");
         stakeRequirement = amount;
         emit StakeRequirementUpdated(amount);
     }
 
     /// @notice Update the slashing rate applied to incorrect validator stakes.
     /// @param percentage Portion of staked tokens to slash in basis points.
+    /// @dev Setting `percentage` to 0 disables slashing.
     function setSlashingPercentage(uint256 percentage) external onlyOwner {
         require(percentage <= PERCENTAGE_DENOMINATOR, "Invalid percentage");
         slashingPercentage = percentage;
@@ -694,6 +696,13 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         emit MinValidatorReputationUpdated(minimum);
     }
 
+    /// @notice Atomically update validator incentive parameters.
+    /// @param rewardPercentage Portion of job payout allocated to correct validators (basis points).
+    /// @param stakeReq Minimum stake required to validate (0 disables staking).
+    /// @param slashPercentage Portion of incorrect stake to slash (basis points; 0 disables).
+    /// @param minRep Minimum reputation required to validate.
+    /// @param approvals Validator approvals needed to finalize a job.
+    /// @param disapprovals Validator disapprovals needed to dispute a job.
     function setValidatorConfig(
         uint256 rewardPercentage,
         uint256 stakeReq,
@@ -704,7 +713,6 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     ) external onlyOwner {
         require(rewardPercentage <= PERCENTAGE_DENOMINATOR, "Invalid percentage");
         require(slashPercentage <= PERCENTAGE_DENOMINATOR, "Invalid percentage");
-        require(stakeReq > 0, "Invalid stake");
         require(approvals > 0, "Invalid approvals");
         require(disapprovals > 0, "Invalid disapprovals");
         validationRewardPercentage = rewardPercentage;


### PR DESCRIPTION
## Summary
- allow contract owner to disable validator staking by setting the requirement to 0
- document slashing and validator config options
- note in README that staking and slashing can be turned off

## Testing
- `npx hardhat test`
- `forge test` *(no tests found)*
- `npx solhint 'contracts/**/*.sol'` *(warnings only)*
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68911d46fe808333be934d3b4cfafdf7