### PR TITLE
feat: include stake recipient in validator config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
   - Only validators voting with the final outcome earn rewards.
   - Misaligned votes incur stake slashing and reputation penalties.
   - All validator parameters (reward %, slashing %, stake requirement,
-    approval thresholds, etc.) are owner-configurable.
+    approval thresholds, slashed-stake recipient, etc.) are owner-configurable.
   - Setting the stake requirement or slashing percentage to `0` disables those mechanisms.
 - **Basis-point standardization** – percentage parameters like burns, slashing, and rewards are expressed in basis points for deterministic math.
 - **Configurable slashed stake recipient** – if no validator votes correctly, all slashed stake is sent to `slashedStakeRecipient` (initially the owner but adjustable, e.g. to the burn address) while the validator reward portion reverts to the agent or employer.
@@ -164,7 +164,7 @@ Several operational parameters are adjustable by the owner. Every update emits a
 
 Validator staking economics are owner‑configurable as well:
 
-- `setValidatorConfig(uint256 rewardPct, uint256 stakeReq, uint256 slashPct, uint256 minRep, uint256 approvals, uint256 disapprovals)` → `ValidatorConfigUpdated`
+- `setValidatorConfig(uint256 rewardPct, uint256 stakeReq, uint256 slashPct, uint256 minRep, uint256 approvals, uint256 disapprovals, address slashRecipient)` → `ValidatorConfigUpdated`
 - `setStakeRequirement(uint256 amount)` → `StakeRequirementUpdated`
 - `setSlashingPercentage(uint256 percentage)` → `SlashingPercentageUpdated`
 - `setValidationRewardPercentage(uint256 percentage)` → `ValidationRewardPercentageUpdated` (set to `0` to disable rewards)
@@ -193,7 +193,7 @@ Incorrect validator votes lose stake according to `slashingPercentage`. Slashed 
 - **Staking & withdrawals** – validators deposit $AGI via `stake()` and may top up incrementally. Validation is only permitted once their total stake meets `stakeRequirement`. Stakes can be withdrawn with `withdrawStake` only after all participated jobs are finalized and undisputed.
 - **Aligned rewards** – when a job finalizes, only validators whose votes match the outcome split `validationRewardPercentage` basis points of the remaining escrow along with any slashed stake. If no votes are correct, slashed tokens go to `slashedStakeRecipient` and the reserved validator reward portion is returned to the job's agent or employer.
 - **Slashing & reputation penalties** – incorrect votes lose `slashingPercentage` basis points of staked tokens and incur a reputation deduction.
-- **Owner‑tunable parameters** – the contract owner can adjust `stakeRequirement` (must be greater than zero), `slashingPercentage` (basis points), `validationRewardPercentage` (basis points), `minValidatorReputation`, and `slashedStakeRecipient` individually. Approval and disapproval thresholds are also owner‑set and must remain greater than zero. All of these values can be updated atomically via `setValidatorConfig`; each `onlyOwner` update emits a dedicated event.
+- **Owner‑tunable parameters** – the contract owner can adjust `stakeRequirement` (must be greater than zero), `slashingPercentage` (basis points), `validationRewardPercentage` (basis points), `minValidatorReputation`, `slashedStakeRecipient`, and approval/disapproval thresholds. All of these values can be updated atomically via `setValidatorConfig`, which also sets `slashedStakeRecipient`; each `onlyOwner` update emits a dedicated event.
 - **Dispute lock** – once a job is disputed, no additional validator votes are accepted until a moderator resolves the dispute.
 - **Single-shot voting** – validators cannot change their vote once cast; a validator address may approve *or* disapprove a job, but never both. Attempts to vote twice revert.
 

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -298,7 +298,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         uint256 slashingPercentage,
         uint256 minValidatorReputation,
         uint256 requiredApprovals,
-        uint256 requiredDisapprovals
+        uint256 requiredDisapprovals,
+        address slashedStakeRecipient
     );
 
     /// @dev Thrown when an AGI type is added with invalid parameters.
@@ -703,31 +704,36 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     /// @param minRep Minimum reputation required to validate.
     /// @param approvals Validator approvals needed to finalize a job.
     /// @param disapprovals Validator disapprovals needed to dispute a job.
+    /// @param slashRecipient Address receiving slashed stake when no validator votes correctly.
     function setValidatorConfig(
         uint256 rewardPercentage,
         uint256 stakeReq,
         uint256 slashPercentage,
         uint256 minRep,
         uint256 approvals,
-        uint256 disapprovals
+        uint256 disapprovals,
+        address slashRecipient
     ) external onlyOwner {
         require(rewardPercentage <= PERCENTAGE_DENOMINATOR, "Invalid percentage");
         require(slashPercentage <= PERCENTAGE_DENOMINATOR, "Invalid percentage");
         require(approvals > 0, "Invalid approvals");
         require(disapprovals > 0, "Invalid disapprovals");
+        require(slashRecipient != address(0), "invalid address");
         validationRewardPercentage = rewardPercentage;
         stakeRequirement = stakeReq;
         slashingPercentage = slashPercentage;
         minValidatorReputation = minRep;
         requiredValidatorApprovals = approvals;
         requiredValidatorDisapprovals = disapprovals;
+        slashedStakeRecipient = slashRecipient;
         emit ValidatorConfigUpdated(
             rewardPercentage,
             stakeReq,
             slashPercentage,
             minRep,
             approvals,
-            disapprovals
+            disapprovals,
+            slashRecipient
         );
     }
 

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -346,7 +346,7 @@ describe("AGIJobManagerV1 payouts", function () {
   });
 
   it("allows owner to update validator incentive parameters atomically", async function () {
-    const { manager, employer } = await deployFixture();
+    const { manager, employer, validator } = await deployFixture();
     const cfg = {
       rewardPct: 500,
       stakeReq: 123n,
@@ -354,6 +354,7 @@ describe("AGIJobManagerV1 payouts", function () {
       minRep: 42n,
       approvals: 2,
       disapprovals: 3,
+      recipient: validator.address,
     };
 
     await expect(
@@ -365,7 +366,8 @@ describe("AGIJobManagerV1 payouts", function () {
           cfg.slashPct,
           cfg.minRep,
           cfg.approvals,
-          cfg.disapprovals
+          cfg.disapprovals,
+          cfg.recipient
         )
     )
       .to.be.revertedWithCustomError(manager, "OwnableUnauthorizedAccount")
@@ -378,7 +380,8 @@ describe("AGIJobManagerV1 payouts", function () {
         cfg.slashPct,
         cfg.minRep,
         cfg.approvals,
-        cfg.disapprovals
+        cfg.disapprovals,
+        cfg.recipient
       )
     )
       .to.emit(manager, "ValidatorConfigUpdated")
@@ -388,7 +391,8 @@ describe("AGIJobManagerV1 payouts", function () {
         cfg.slashPct,
         cfg.minRep,
         cfg.approvals,
-        cfg.disapprovals
+        cfg.disapprovals,
+        cfg.recipient
       );
 
     expect(await manager.validationRewardPercentage()).to.equal(cfg.rewardPct);
@@ -399,6 +403,7 @@ describe("AGIJobManagerV1 payouts", function () {
     expect(await manager.requiredValidatorDisapprovals()).to.equal(
       cfg.disapprovals
     );
+    expect(await manager.slashedStakeRecipient()).to.equal(cfg.recipient);
   });
 
   it("cleans up validator history enabling stake withdrawal after many jobs", async function () {


### PR DESCRIPTION
## Summary
- allow setting `slashedStakeRecipient` in `setValidatorConfig`
- document new validator config parameter in README

## Testing
- `npx hardhat compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68912840ce2c83338f42f5d7ffccf1c8