### PR TITLE
Enforce explicit completion requests before finalizing jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Follow these steps before trusting any address or artifact:
 - Verify repository integrity (`git tag --verify` / `git log --show-signature`) before relying on published code.
 - Understand that tokens are burned instantly upon the final validator approval, irreversibly sending `burnPercentage` of escrow to `burnAddress`. Both parameters remain `onlyOwner` configurable.
 - All percentage parameters use basis points (1 bp = 0.01%); double‑check values before submitting transactions.
+- Jobs finalize only after the agent calls `requestJobCompletion`; even moderator resolutions in favor of the agent revert otherwise.
 - Confirm the current `stakeRequirement` before staking and plan for withdrawals; `withdrawStake` only succeeds once all of your jobs are finalized without disputes.
 - Monitor `*Updated` events for changes to burn rates, slashing percentages, reward splits, minimum reputation, or the slashed‑stake recipient.
 - Validators that fall below `minValidatorReputation` are automatically blacklisted; the restriction lifts once their reputation rises back above the threshold.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -869,6 +869,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         // Explicit existence and completion checks per best practices
         require(job.employer != address(0), "Job does not exist");
         require(!job.completed, "Already finalized");
+        // Disallow payout without an explicit completion request
+        require(job.completionRequested, "Completion not requested");
         // Ensure burning and payouts occur only after the job meets validation requirements
         require(
             job.validatorApprovals >= requiredValidatorApprovals || job.disputed,


### PR DESCRIPTION
## Summary
- require `requestJobCompletion` to be called before a job can finalize
- document completion-request requirement in safety checklist

## Testing
- `npm test`
- `npm run lint` (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_68912f24eaf4833397983f395ff4cebc