### PR TITLE
Document validator incentive mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
 - **Enum-based dispute resolution** – moderators settle conflicts with a typed `DisputeOutcome` enum instead of fragile string comparisons.
 - **Stake-based validator incentives**
   - Validators must stake $AGI and maintain a minimum reputation.
-  - Only validators voting with the final outcome earn rewards.
-  - Misaligned votes incur stake slashing and reputation penalties.
+  - Rewards accrue only to validators whose votes match the final outcome; others are excluded.
+  - Misaligned votes are slashed and lose reputation; correct validators share the slashed stake.
+  - If no validator votes correctly, slashed stakes go to `slashedStakeRecipient` and the reserved reward portion refunds to the agent or employer.
   - All validator parameters (reward %, slashing %, stake requirement,
-    approval thresholds, slashed-stake recipient, etc.) are owner-configurable.
+    approval thresholds, slashed-stake recipient, etc.) are owner-configurable via `onlyOwner` functions.
   - Setting the stake requirement or slashing percentage to `0` disables those mechanisms.
 - **Basis-point standardization** – percentage parameters like burns, slashing, and rewards are expressed in basis points for deterministic math.
 - **Configurable slashed stake recipient** – if no validator votes correctly, all slashed stake is sent to `slashedStakeRecipient` (initially the owner but adjustable, e.g. to the burn address) while the validator reward portion reverts to the agent or employer.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -376,6 +376,10 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         emit JobCompletionRequested(_jobId, msg.sender);
     }
 
+    /// @notice Approve a job's completion.
+    /// @dev Only validators with sufficient stake and reputation may vote.
+    ///      Rewards are paid only to validators whose approvals match the final
+    ///      outcome; incorrect approvals are slashed and lose reputation.
     function validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenNotPaused nonReentrant {
         require(_verifyOwnership(msg.sender, subdomain, proof, clubRootNode) || additionalValidators[msg.sender], "Not authorized validator");
         require(!blacklistedValidators[msg.sender], "Blacklisted validator");
@@ -400,6 +404,9 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         }
     }
 
+    /// @notice Reject a job's completion.
+    /// @dev Misaligned disapprovals are slashed and penalized. Validators voting
+    ///      with the ultimate outcome share the reward pool and any slashed stake.
     function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenNotPaused nonReentrant {
         require(_verifyOwnership(msg.sender, subdomain, proof, clubRootNode) || additionalValidators[msg.sender], "Not authorized validator");
         require(!blacklistedValidators[msg.sender], "Blacklisted validator");


### PR DESCRIPTION
## Summary
- clarify validator approval/disapproval functions with Natspec comments
- expand README validator incentive section with slashing distribution and owner configurability

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68913154e6bc83338f00fe37b0590701