### PR TITLE
feat: expand validator config controls

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -328,7 +328,11 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         uint256 minValidatorReputation,
         uint256 requiredApprovals,
         uint256 requiredDisapprovals,
-        address slashedStakeRecipient
+        address slashedStakeRecipient,
+        uint256 commitWindow,
+        uint256 revealWindow,
+        uint256 reviewWindow,
+        uint256 validatorsPerJob
     );
 
     /// @dev Thrown when an AGI type is added with invalid parameters.
@@ -899,6 +903,10 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     /// @param approvals Validator approvals needed to finalize a job.
     /// @param disapprovals Validator disapprovals needed to dispute a job.
     /// @param slashRecipient Address receiving slashed stake when no validator votes correctly.
+    /// @param commitWindow Length of commit phase in seconds.
+    /// @param revealWindow Length of reveal phase in seconds.
+    /// @param reviewWin Mandatory waiting period before validators may vote.
+    /// @param validatorsCount Number of validators randomly selected per job.
     function setValidatorConfig(
         uint256 rewardPercentage,
         uint256 stakeReq,
@@ -906,12 +914,17 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         uint256 minRep,
         uint256 approvals,
         uint256 disapprovals,
-        address slashRecipient
+        address slashRecipient,
+        uint256 commitWindow,
+        uint256 revealWindow,
+        uint256 reviewWin,
+        uint256 validatorsCount
     ) external onlyOwner {
         require(rewardPercentage <= PERCENTAGE_DENOMINATOR, "Invalid percentage");
         require(slashPercentage <= PERCENTAGE_DENOMINATOR, "Invalid percentage");
         require(approvals > 0, "Invalid approvals");
         require(disapprovals > 0, "Invalid disapprovals");
+        require(validatorsCount > 0, "Invalid validators");
         require(slashRecipient != address(0), "invalid address");
         validationRewardPercentage = rewardPercentage;
         stakeRequirement = stakeReq;
@@ -920,6 +933,10 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         requiredValidatorApprovals = approvals;
         requiredValidatorDisapprovals = disapprovals;
         slashedStakeRecipient = slashRecipient;
+        commitDuration = commitWindow;
+        revealDuration = revealWindow;
+        reviewWindow = reviewWin;
+        validatorsPerJob = validatorsCount;
         emit ValidatorConfigUpdated(
             rewardPercentage,
             stakeReq,
@@ -927,7 +944,11 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
             minRep,
             approvals,
             disapprovals,
-            slashRecipient
+            slashRecipient,
+            commitWindow,
+            revealWindow,
+            reviewWin,
+            validatorsCount
         );
     }
 

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -609,6 +609,10 @@ describe("AGIJobManagerV1 payouts", function () {
       approvals: 2,
       disapprovals: 3,
       recipient: validator.address,
+      commitWindow: 60,
+      revealWindow: 60,
+      reviewWin: 30,
+      validatorsCount: 1,
     };
 
     await expect(
@@ -621,7 +625,11 @@ describe("AGIJobManagerV1 payouts", function () {
           cfg.minRep,
           cfg.approvals,
           cfg.disapprovals,
-          cfg.recipient
+          cfg.recipient,
+          cfg.commitWindow,
+          cfg.revealWindow,
+          cfg.reviewWin,
+          cfg.validatorsCount
         )
     )
       .to.be.revertedWithCustomError(manager, "OwnableUnauthorizedAccount")
@@ -635,7 +643,11 @@ describe("AGIJobManagerV1 payouts", function () {
         cfg.minRep,
         cfg.approvals,
         cfg.disapprovals,
-        cfg.recipient
+        cfg.recipient,
+        cfg.commitWindow,
+        cfg.revealWindow,
+        cfg.reviewWin,
+        cfg.validatorsCount
       )
     )
       .to.emit(manager, "ValidatorConfigUpdated")
@@ -646,7 +658,11 @@ describe("AGIJobManagerV1 payouts", function () {
         cfg.minRep,
         cfg.approvals,
         cfg.disapprovals,
-        cfg.recipient
+        cfg.recipient,
+        cfg.commitWindow,
+        cfg.revealWindow,
+        cfg.reviewWin,
+        cfg.validatorsCount
       );
 
     expect(await manager.validationRewardPercentage()).to.equal(cfg.rewardPct);
@@ -658,6 +674,10 @@ describe("AGIJobManagerV1 payouts", function () {
       cfg.disapprovals
     );
     expect(await manager.slashedStakeRecipient()).to.equal(cfg.recipient);
+    expect(await manager.commitDuration()).to.equal(cfg.commitWindow);
+    expect(await manager.revealDuration()).to.equal(cfg.revealWindow);
+    expect(await manager.reviewWindow()).to.equal(cfg.reviewWin);
+    expect(await manager.validatorsPerJob()).to.equal(cfg.validatorsCount);
   });
 
   it("cleans up validator history enabling stake withdrawal after many jobs", async function () {


### PR DESCRIPTION
## Summary
- extend validator configuration to control commit/reveal/review windows and validator pool size
- document new validator incentive controls and update line references
- adjust tests for expanded `setValidatorConfig`

## Testing
- `npm run lint`
- `npm test`
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_68915527401c83339be3619639b97bdb