### PR TITLE
chore: clarify validator timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
   - Rewards accrue only to validators whose votes match the final outcome; others are excluded.
   - Misaligned votes are slashed and lose reputation; correct validators share the slashed stake.
   - If no validator votes correctly, slashed stakes go to `slashedStakeRecipient` and the reserved reward portion refunds to the agent or employer.
+  - Default timing uses a one-hour commit phase and one-hour reveal phase with a two-hour review window, all adjustable by the owner.
   - All validator parameters (reward %, slashing %, stake requirement,
     approval thresholds, commit/reveal/review windows, validator count, slashed-stake recipient, etc.) are owner-configurable via `onlyOwner` functions.
   - The contract owner may add or remove validators from the rotation with `addAdditionalValidator` and `removeAdditionalValidator`; removed validators emit `ValidatorRemoved` and cease being selected for jobs.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -368,6 +368,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         // Set sensible non-zero defaults to avoid inadvertent instant phases.
         commitDuration = 1 hours;
         revealDuration = 1 hours;
+        // Ensure the initial review window accommodates both phases.
+        reviewWindow = commitDuration + revealDuration;
     }
 
     modifier onlyModerator() {


### PR DESCRIPTION
## Summary
- set default review window to cover commit and reveal phases
- document default validator timing controls in README

## Testing
- `npm run compile`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68916436cd24833383f68d167b496d85