### PR TITLE
Pay validator rewards from slashed stake

### DIFF
--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -588,16 +588,14 @@ describe("AGIJobManagerV1 payouts", function () {
     await manager.connect(validator2).disapproveJob(jobId, "", []);
 
     await manager.addModerator(owner.address);
-    await manager.resolveDispute(jobId, 1); // 1 = DisputeOutcome.EmployerWin
-
     const validatorPayoutTotal = (payout * 800n) / 10000n;
     const slashAmount = (stakeAmount * 5000n) / 10000n;
-    const employerRefund = payout - validatorPayoutTotal;
+    await expect(manager.resolveDispute(jobId, 1))
+      .to.emit(manager, "ValidatorRewardReduced")
+      .withArgs(jobId, slashAmount, validatorPayoutTotal);
 
-    expect(await token.balanceOf(validator2.address)).to.equal(
-      validatorPayoutTotal + slashAmount
-    );
-    expect(await token.balanceOf(employer.address)).to.equal(employerRefund);
+    expect(await token.balanceOf(validator2.address)).to.equal(slashAmount);
+    expect(await token.balanceOf(employer.address)).to.equal(payout);
     await expect(
       manager
         .connect(validator)


### PR DESCRIPTION
## Summary
- Prioritize slashed validator stake for employer-win dispute rewards and refund employer escrow
- Cap validator payouts when slashed stake is insufficient and emit `ValidatorRewardReduced`
- Update dispute test to expect capped reward and full escrow refund

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689174be42688333baa61d6f2936ee0c