### PR TITLE
fix: avoid unsafe NFT purchase order

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -1379,9 +1379,9 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     function purchaseNFT(uint256 tokenId) external nonReentrant {
         Listing storage listing = listings[tokenId];
         require(listing.isActive, "Listing not active");
-        agiToken.safeTransferFrom(msg.sender, listing.seller, listing.price);
-        _transfer(listing.seller, msg.sender, tokenId);
         listing.isActive = false;
+        agiToken.safeTransferFrom(msg.sender, listing.seller, listing.price);
+        _safeTransfer(listing.seller, msg.sender, tokenId, "");
         emit NFTPurchased(tokenId, msg.sender, listing.price);
     }
 


### PR DESCRIPTION
## Summary
- prevent external interactions from re-using active listings
- use `_safeTransfer` when handing ERC-721 tokens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68917b110ea883338e49483823d0fcee