### PR TITLE
Use safe mint for job token issuance

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -1355,7 +1355,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
         uint256 tokenId = nextTokenId++;
         string memory tokenURI = string(abi.encodePacked(baseIpfsUrl, "/", job.ipfsHash));
-        _mint(job.employer, tokenId);
+        _safeMint(job.employer, tokenId);
         _setTokenURI(tokenId, tokenURI);
         emit NFTIssued(tokenId, job.employer, tokenURI);
         emit JobFinalizedAndBurned(


### PR DESCRIPTION
## Summary
- use `_safeMint` when issuing NFTs to job employers to ensure proper ERC721 receipt handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68917c41db9083338440a34830ea18cc