### PR TITLE
Support bonus basis points and redistribute burn

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -1337,18 +1337,28 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
         uint256 agentPayout = job.payout - burnAmount - validatorPayoutTotal;
         uint256 bonusPercentage = getHighestPayoutPercentage(job.assignedAgent);
+        uint256 bonusAmount;
         if (bonusPercentage > 0) {
-            uint256 bonusAmount = (agentPayout * bonusPercentage) / 100;
-            uint256 maxBonus = job.payout - (agentPayout + validatorPayoutTotal + burnAmount);
-            if (bonusAmount > maxBonus) {
-                bonusAmount = maxBonus;
+            bonusAmount =
+                (agentPayout * bonusPercentage) /
+                PERCENTAGE_DENOMINATOR;
+            uint256 available = burnAmount + validatorPayoutTotal;
+            if (bonusAmount > available) {
+                bonusAmount = available;
+            }
+            if (bonusAmount <= burnAmount) {
+                burnAmount -= bonusAmount;
+            } else {
+                uint256 remaining = bonusAmount - burnAmount;
+                burnAmount = 0;
+                validatorPayoutTotal -= remaining;
             }
             agentPayout += bonusAmount;
         }
 
         require(
-            agentPayout + validatorPayoutTotal + burnAmount <= job.payout,
-            "Payout exceeds escrow"
+            agentPayout + validatorPayoutTotal + burnAmount == job.payout,
+            "Payout mismatch"
         );
 
         agiToken.safeTransfer(job.assignedAgent, agentPayout);
@@ -1540,9 +1550,13 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     /// @notice Register or update an AGI NFT type that grants bonus payouts.
     /// @param nftAddress Address of the qualifying NFT collection.
-    /// @param payoutPercentage Bonus percentage applied to job payouts for holders of the NFT.
+    /// @param payoutPercentage Bonus percentage in basis points for holders of the NFT.
     function addAGIType(address nftAddress, uint256 payoutPercentage) external onlyOwner {
-        if (nftAddress == address(0) || payoutPercentage == 0 || payoutPercentage > 100) {
+        if (
+            nftAddress == address(0) ||
+            payoutPercentage == 0 ||
+            payoutPercentage > PERCENTAGE_DENOMINATOR
+        ) {
             revert InvalidAGITypeParameters();
         }
 
@@ -1563,7 +1577,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     /// @notice Determine the highest AGI payout bonus available to an agent.
     /// @param agent Address being queried.
-    /// @return highestPercentage Maximum bonus percentage among held AGI types.
+    /// @return highestPercentage Maximum bonus in basis points among held AGI types.
     function getHighestPayoutPercentage(address agent) public view returns (uint256 highestPercentage) {
         uint256 len = agiTypes.length;
         for (uint256 i; i < len; ++i) {

--- a/contracts/mocks/MockERC721.sol
+++ b/contracts/mocks/MockERC721.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract MockERC721 is ERC721 {
+    uint256 public nextTokenId;
+
+    constructor() ERC721("MockNFT", "MNFT") {}
+
+    function mint(address to) external returns (uint256) {
+        uint256 tokenId = nextTokenId++;
+        _mint(to, tokenId);
+        return tokenId;
+    }
+}
+

--- a/test/bonus.test.js
+++ b/test/bonus.test.js
@@ -1,0 +1,121 @@
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("Agent bonus distribution", function () {
+  async function deployFixture() {
+    const [owner, employer, agent, validator] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    const token = await Token.deploy();
+    await token.waitForDeployment();
+    await token.mint(employer.address, ethers.parseEther("1000"));
+
+    const ENSMock = await ethers.getContractFactory("MockENS");
+    const ens = await ENSMock.deploy();
+    await ens.waitForDeployment();
+
+    const WrapperMock = await ethers.getContractFactory("MockNameWrapper");
+    const wrapper = await WrapperMock.deploy();
+    await wrapper.waitForDeployment();
+
+    const Manager = await ethers.getContractFactory("AGIJobManagerV1");
+    const manager = await Manager.deploy(
+      await token.getAddress(),
+      "ipfs://",
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+    await manager.waitForDeployment();
+
+    await manager.setRequiredValidatorApprovals(1);
+    await manager.setBurnPercentage(1000);
+    await manager.setValidationRewardPercentage(800);
+    await manager.setReviewWindow(7200);
+    await manager.setCommitRevealWindows(1000, 1000);
+    await manager.addAdditionalAgent(agent.address);
+    await manager.addAdditionalValidator(validator.address);
+
+    const NFT = await ethers.getContractFactory("MockERC721");
+    const nft = await NFT.deploy();
+    await nft.waitForDeployment();
+
+    return { token, manager, nft, owner, employer, agent, validator };
+  }
+
+  it("redistributes burn to pay bonus when agent holds NFT", async function () {
+    const { token, manager, nft, employer, agent, validator } = await deployFixture();
+
+    await manager.addAGIType(await nft.getAddress(), 500);
+    await nft.mint(agent.address);
+
+    const payout = ethers.parseEther("1000");
+    await token.connect(employer).approve(await manager.getAddress(), payout);
+    await manager.connect(employer).createJob("jobhash", payout, 1000, "details");
+
+    const jobId = 0;
+    await manager.connect(agent).applyForJob(jobId, "", []);
+    await manager.connect(agent).requestJobCompletion(jobId, "result");
+    const salt = ethers.id("bonus");
+    const commitment = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "bool", "bytes32"],
+      [validator.address, jobId, true, salt]
+    );
+    await manager
+      .connect(validator)
+      .commitValidation(jobId, commitment, "", []);
+    await time.increase(1001);
+    await manager.connect(validator).revealValidation(jobId, true, salt);
+    await time.increase(1000);
+    await manager.connect(validator).validateJob(jobId, "", []);
+
+    const burnOrig = (payout * 1000n) / 10000n;
+    const validatorPayout = (payout * 800n) / 10000n;
+    const baseAgent = payout - burnOrig - validatorPayout;
+    const bonusAmount = (baseAgent * 500n) / 10000n;
+    const burnExpected = burnOrig - bonusAmount;
+    const agentExpected = baseAgent + bonusAmount;
+
+    expect(await token.balanceOf(await manager.burnAddress())).to.equal(burnExpected);
+    expect(await token.balanceOf(validator.address)).to.equal(validatorPayout);
+    expect(await token.balanceOf(agent.address)).to.equal(agentExpected);
+    expect(agentExpected + validatorPayout + burnExpected).to.equal(payout);
+  });
+
+  it("keeps burn and validator shares when agent lacks bonus NFT", async function () {
+    const { token, manager, employer, agent, validator } = await deployFixture();
+
+    const payout = ethers.parseEther("1000");
+    await token.connect(employer).approve(await manager.getAddress(), payout);
+    await manager.connect(employer).createJob("jobhash", payout, 1000, "details");
+
+    const jobId = 0;
+    await manager.connect(agent).applyForJob(jobId, "", []);
+    await manager.connect(agent).requestJobCompletion(jobId, "result");
+    const salt = ethers.id("nobonus");
+    const commitment = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "bool", "bytes32"],
+      [validator.address, jobId, true, salt]
+    );
+    await manager
+      .connect(validator)
+      .commitValidation(jobId, commitment, "", []);
+    await time.increase(1001);
+    await manager.connect(validator).revealValidation(jobId, true, salt);
+    await time.increase(1000);
+    await manager.connect(validator).validateJob(jobId, "", []);
+
+    const burnAmount = (payout * 1000n) / 10000n;
+    const validatorPayoutTotal = (payout * 800n) / 10000n;
+    const agentExpected = payout - burnAmount - validatorPayoutTotal;
+
+    expect(await token.balanceOf(await manager.burnAddress())).to.equal(burnAmount);
+    expect(await token.balanceOf(validator.address)).to.equal(validatorPayoutTotal);
+    expect(await token.balanceOf(agent.address)).to.equal(agentExpected);
+    expect(agentExpected + validatorPayoutTotal + burnAmount).to.equal(payout);
+  });
+});
+


### PR DESCRIPTION
## Summary
- compute agent bonuses in `_finalizeJobAndBurn` before distributing burn/validator shares, ensuring escrow balances
- switch bonus NFT percentages to basis points via `addAGIType` and `getHighestPayoutPercentage`
- add `MockERC721` and tests covering bonus and non-bonus agents

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6891829c22cc833399845ccdb3fba873