### PR TITLE
Use basis points for AGI NFT bonuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
 - **Configurable slashed stake recipient** – if no validator votes correctly, all slashed stake is sent to `slashedStakeRecipient` (initially the owner but adjustable, e.g. to the burn address) while the validator reward portion reverts to the agent or employer.
 - **Automatic finalization & configurable token burn** – the last validator approval triggers `_finalizeJobAndBurn`, minting the completion NFT, releasing the payout, and burning the configured portion of escrow. The `JobFinalizedAndBurned` event records agent payouts and burn amounts.
 
+### NFT Bonus
+
+Agents holding qualifying AGI NFTs receive a payout boost. Each bonus is specified in basis points (1 bp = 0.01%) when calling `addAGIType`, and the highest applicable bonus is applied to the agent's payout.
+
 ### Burn Mechanism
 
 The v1 prototype destroys a slice of each finalized job's escrow, permanently reducing total supply. Burning occurs automatically when the last validator approval triggers `_finalizeJobAndBurn` to mint the NFT, release payment and burn tokens—no separate call is required.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -219,7 +219,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     struct AGIType {
         address nftAddress;
-        uint256 payoutPercentage;
+        uint256 payoutPercentage; // bonus in basis points
     }
 
     struct Listing {
@@ -1338,7 +1338,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         uint256 agentPayout = job.payout - burnAmount - validatorPayoutTotal;
         uint256 bonusPercentage = getHighestPayoutPercentage(job.assignedAgent);
         if (bonusPercentage > 0) {
-            uint256 bonusAmount = (agentPayout * bonusPercentage) / 100;
+            uint256 bonusAmount = (agentPayout * bonusPercentage) / PERCENTAGE_DENOMINATOR;
             uint256 maxBonus = job.payout - (agentPayout + validatorPayoutTotal + burnAmount);
             if (bonusAmount > maxBonus) {
                 bonusAmount = maxBonus;
@@ -1540,9 +1540,9 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     /// @notice Register or update an AGI NFT type that grants bonus payouts.
     /// @param nftAddress Address of the qualifying NFT collection.
-    /// @param payoutPercentage Bonus percentage applied to job payouts for holders of the NFT.
+    /// @param payoutPercentage Bonus percentage in basis points applied to job payouts for holders of the NFT.
     function addAGIType(address nftAddress, uint256 payoutPercentage) external onlyOwner {
-        if (nftAddress == address(0) || payoutPercentage == 0 || payoutPercentage > 100) {
+        if (nftAddress == address(0) || payoutPercentage == 0 || payoutPercentage > PERCENTAGE_DENOMINATOR) {
             revert InvalidAGITypeParameters();
         }
 
@@ -1563,7 +1563,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     /// @notice Determine the highest AGI payout bonus available to an agent.
     /// @param agent Address being queried.
-    /// @return highestPercentage Maximum bonus percentage among held AGI types.
+    /// @return highestPercentage Maximum bonus percentage in basis points among held AGI types.
     function getHighestPayoutPercentage(address agent) public view returns (uint256 highestPercentage) {
         uint256 len = agiTypes.length;
         for (uint256 i; i < len; ++i) {


### PR DESCRIPTION
## Summary
- interpret AGI NFT payout bonuses in basis points
- apply bonus calculations using `PERCENTAGE_DENOMINATOR`
- document NFT bonus basis-point scale in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891857231988333a6f90cbd1a34f0c1