### PR TITLE
Add zero-address guard for AGI token updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Control these owner functions with a multisig or timelock, and watch the event l
 
 Several operational parameters are adjustable by the owner. Every update emits a dedicated event so off‑chain services can react to new values:
 
-- `updateAGITokenAddress(address newToken)` → `AGITokenAddressUpdated`
+- `updateAGITokenAddress(address newToken)` → `AGITokenAddressUpdated` (reverts if `newToken` is the zero address)
 - `setBaseIpfsUrl(string newUrl)` → `BaseIpfsUrlUpdated`
 - `setRequiredValidatorApprovals(uint256 count)` → `RequiredValidatorApprovalsUpdated`
 - `setRequiredValidatorDisapprovals(uint256 count)` → `RequiredValidatorDisapprovalsUpdated`

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -795,6 +795,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     }
 
     function updateAGITokenAddress(address _newTokenAddress) external onlyOwner {
+        require(_newTokenAddress != address(0), "invalid address");
         agiToken = IERC20(_newTokenAddress);
         emit AGITokenAddressUpdated(_newTokenAddress);
     }

--- a/legacy/AGIJobManagerv0.sol
+++ b/legacy/AGIJobManagerv0.sol
@@ -352,6 +352,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
     }
 
     function updateAGITokenAddress(address _newTokenAddress) external onlyOwner {
+        require(_newTokenAddress != address(0), "invalid address");
         agiToken = IERC20(_newTokenAddress);
     }
 

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -48,6 +48,13 @@ describe("AGIJobManagerV1 payouts", function () {
     return { token, manager, owner, employer, agent, validator, validator2, validator3 };
   }
 
+  it("reverts when updating AGI token address to zero", async function () {
+    const { manager } = await deployFixture();
+    await expect(
+      manager.updateAGITokenAddress(ethers.ZeroAddress)
+    ).to.be.revertedWith("invalid address");
+  });
+
   it("distributes burn, validator, and agent payouts equal to job.payout", async function () {
     const { token, manager, employer, agent, validator } = await deployFixture();
     const payout = ethers.parseEther("1000");


### PR DESCRIPTION
## Summary
- prevent zero address in `updateAGITokenAddress`
- document token address restrictions
- test reverting on zero address updates

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68918bd16f688333be6598ec4af57697