### PR TITLE
feat: tighten job completion checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
 - **Pausable and owner‑controlled** – emergency stop, moderator management, and tunable parameters.
 - **Transparent moderation** – emits `AgentBlacklisted`, `ValidatorBlacklisted`, `ModeratorAdded`, and `ModeratorRemoved` events for on-chain auditability.
 - **Gas-efficient validations** – v1 replaces string `require` messages with custom errors and unchecked prefix increments.
+- **Explicit completion checks** – `requestJobCompletion` now reverts with dedicated errors (`JobExpired`, `JobNotOpen`) and validator selection fails fast with `NotEnoughValidators` when the pool lacks participants.
 - **Enum-based dispute resolution** – moderators settle conflicts with a typed `DisputeOutcome` enum instead of fragile string comparisons.
 - **Unified job status** – a `JobStatus` enum (`Open`, `CompletionRequested`, `Disputed`, `Completed`) replaces multiple booleans and is emitted with state-change events like `JobCreated`, `JobCompletionRequested`, `JobDisputed`, and `JobCompleted`.
 - **Stake-based validator incentives**


### PR DESCRIPTION
## Summary
- add explicit custom errors for job duration, state, and validator pool size
- enforce job completion request timing with clear errors
- document new safeguards in README

## Testing
- `npm run lint`
- `npm test`
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_6891eb6481cc8333921741d5b343418b