### PR TITLE
chore: harden validator flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
 - **Pausable and owner‑controlled** – emergency stop, moderator management, and tunable parameters.
 - **Transparent moderation** – emits `AgentBlacklisted`, `ValidatorBlacklisted`, `ModeratorAdded`, and `ModeratorRemoved` events for on-chain auditability.
 - **Gas-efficient validations** – v1 replaces string `require` messages with custom errors and unchecked prefix increments.
+- **Enhanced state enforcement** – agents can only apply to jobs in the `Open` state, and validator actions revert with dedicated
+  custom errors (e.g., `InsufficientStake`, `ReviewWindowActive`) for clearer failure modes and lower gas use.
 - **Explicit completion checks** – `requestJobCompletion` now reverts with dedicated errors (`JobExpired`, `JobNotOpen`) and validator selection fails fast with `NotEnoughValidators` when the pool lacks participants.
 - **Enum-based dispute resolution** – moderators settle conflicts with a typed `DisputeOutcome` enum instead of fragile string comparisons.
 - **Unified job status** – a `JobStatus` enum (`Open`, `CompletionRequested`, `Disputed`, `Completed`) replaces multiple booleans and is emitted with state-change events like `JobCreated`, `JobCompletionRequested`, `JobDisputed`, and `JobCompleted`.

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -187,7 +187,7 @@ describe("AGIJobManagerV1 payouts", function () {
 
     await expect(
       manager.connect(validator).validateJob(jobId, "", [])
-    ).to.be.revertedWith("Completion not requested");
+    ).to.be.revertedWithCustomError(manager, "InvalidJobState");
   });
 
   it("enforces review window before validation", async function () {
@@ -212,7 +212,7 @@ describe("AGIJobManagerV1 payouts", function () {
     await manager.connect(validator).revealValidation(jobId, true, salt);
     await expect(
       manager.connect(validator).validateJob(jobId, "", [])
-    ).to.be.revertedWith("Review window active");
+    ).to.be.revertedWithCustomError(manager, "ReviewWindowActive");
 
     await time.increase(5000);
     await manager.connect(validator).validateJob(jobId, "", []);
@@ -240,7 +240,7 @@ describe("AGIJobManagerV1 payouts", function () {
     await manager.connect(validator).revealValidation(jobId, false, salt);
     await expect(
       manager.connect(validator).disapproveJob(jobId, "", [])
-    ).to.be.revertedWith("Review window active");
+    ).to.be.revertedWithCustomError(manager, "ReviewWindowActive");
 
     await time.increase(5000);
     await manager.connect(validator).disapproveJob(jobId, "", []);
@@ -280,14 +280,14 @@ describe("AGIJobManagerV1 payouts", function () {
       manager
         .connect(validator2)
         .commitValidation(jobId, otherCommitment, "", [])
-    ).to.be.revertedWith("Validator not selected");
+    ).to.be.revertedWithCustomError(manager, "ValidatorNotSelected");
     await time.increase(1001);
     await manager.connect(validator).revealValidation(jobId, true, salt);
     await expect(
       manager
         .connect(validator2)
         .revealValidation(jobId, true, otherSalt)
-    ).to.be.revertedWith("Validator not selected");
+    ).to.be.revertedWithCustomError(manager, "ValidatorNotSelected");
   });
 
   it("restricts burn address updates to owner and emits event", async function () {
@@ -801,9 +801,9 @@ describe("AGIJobManagerV1 payouts", function () {
 
       await time.increase(201);
 
-      await expect(
-        manager.connect(validator).revealValidation(jobId, true, salt)
-      ).to.be.revertedWith("Reveal phase over");
+    await expect(
+      manager.connect(validator).revealValidation(jobId, true, salt)
+    ).to.be.revertedWithCustomError(manager, "RevealPhaseOver");
     });
 
     it("blocks stake withdrawal with pending commits", async function () {


### PR DESCRIPTION
## Summary
- add comprehensive custom errors and state guards
- tighten validator commit/reveal/validation checks
- optimize marketplace purchase logic and expand docs

## Testing
- `npx solhint 'contracts/**/*.sol'`
- `npx eslint .`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6891fa0cf2b48333b58d287567b31a3b