### PR TITLE
Use custom error for missing jobs

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -446,6 +446,9 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     /// @dev Thrown when a job fails validation checks prior to finalization.
     error JobNotValidated();
 
+    /// @dev Thrown when a referenced job cannot be found.
+    error JobDoesNotExist();
+
     constructor(
         address _agiTokenAddress,
         string memory _baseIpfsUrl,
@@ -478,7 +481,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     }
 
     modifier jobExists(uint256 jobId) {
-        require(jobs[jobId].employer != address(0), "Job does not exist");
+        if (jobs[jobId].employer == address(0)) revert JobDoesNotExist();
         _;
     }
 


### PR DESCRIPTION
## Summary
- add JobDoesNotExist custom error
- use JobDoesNotExist in jobExists modifier

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892090edb008333a32f7329f309df6e