### PR TITLE
feat: add AGI type removal

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -305,6 +305,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
     event OwnershipVerified(address claimant, string subdomain);
     event RecoveryInitiated(string reason);
     event AGITypeUpdated(address indexed nftAddress, uint256 payoutPercentage);
+    event AGITypeRemoved(address indexed nftAddress);
     event NFTIssued(uint256 indexed tokenId, address indexed employer, string tokenURI);
     event NFTListed(uint256 indexed tokenId, address indexed seller, uint256 price);
     event NFTPurchased(uint256 indexed tokenId, address indexed buyer, uint256 price);
@@ -371,6 +372,9 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
 
     /// @dev Thrown when an AGI type is added with invalid parameters.
     error InvalidAGITypeParameters();
+
+    /// @dev Thrown when the specified AGI type does not exist.
+    error AGITypeNotFound();
 
     /// @dev Thrown when the supplied amount is zero or exceeds the contract balance.
     error InvalidAmount();
@@ -1757,6 +1761,24 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage
         }
 
         emit AGITypeUpdated(nftAddress, payoutPercentage);
+    }
+
+    /// @notice Remove an AGI NFT type.
+    /// @param nftAddress Address of the NFT collection to remove.
+    function removeAGIType(address nftAddress) external onlyOwner {
+        uint256 length = agiTypes.length;
+        for (uint256 i; i < length; ) {
+            if (agiTypes[i].nftAddress == nftAddress) {
+                agiTypes[i] = agiTypes[length - 1];
+                agiTypes.pop();
+                emit AGITypeRemoved(nftAddress);
+                return;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        revert AGITypeNotFound();
     }
 
     /// @notice Determine the highest AGI payout bonus available to an agent.

--- a/test/agiType.test.js
+++ b/test/agiType.test.js
@@ -1,0 +1,49 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AGIJobManagerV1 AGI types", function () {
+  async function deploy() {
+    const Token = await ethers.getContractFactory("MockERC20");
+    const token = await Token.deploy();
+    await token.waitForDeployment();
+
+    const ENSMock = await ethers.getContractFactory("MockENS");
+    const ens = await ENSMock.deploy();
+    await ens.waitForDeployment();
+
+    const WrapperMock = await ethers.getContractFactory("MockNameWrapper");
+    const wrapper = await WrapperMock.deploy();
+    await wrapper.waitForDeployment();
+
+    const Manager = await ethers.getContractFactory("AGIJobManagerV1");
+    const manager = await Manager.deploy(
+      await token.getAddress(),
+      "ipfs://",
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+    await manager.waitForDeployment();
+
+    return { manager };
+  }
+
+  it("adds and removes AGI types", async function () {
+    const { manager } = await deploy();
+    const nftAddress = await manager.getAddress();
+
+    await manager.addAGIType(nftAddress, 500);
+
+    await expect(manager.removeAGIType(nftAddress))
+      .to.emit(manager, "AGITypeRemoved")
+      .withArgs(nftAddress);
+
+    await expect(manager.removeAGIType(nftAddress)).to.be.revertedWithCustomError(
+      manager,
+      "AGITypeNotFound"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- allow owner to remove AGI types with `removeAGIType`
- add custom error and event for AGI type removal
- test adding and removing AGI types

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689215baf92c833391ceb12c84618a21