### PR TITLE
Add timeout finalization fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
 - **Basis-point standardization** – percentage parameters like burns, slashing, and rewards are expressed in basis points for deterministic math.
 - **Configurable slashed stake recipient** – if no validator votes correctly, all slashed stake is sent to `slashedStakeRecipient` (initially the owner but adjustable, e.g. to the burn address) while the validator reward portion reverts to the agent or employer.
 - **Automatic finalization & configurable token burn** – the last validator approval triggers `_finalizeJobAndBurn`, minting the completion NFT, releasing the payout, and burning the configured portion of escrow. The `JobFinalizedAndBurned` event records agent payouts and burn amounts.
+- **Timeout recovery** – if validators never reach the approval or disapproval thresholds by `reviewWindow + commitDuration + revealDuration + gracePeriod`, the employer, agent, or a moderator may invoke `finalizeAfterTimeout` to either pay the agent or refund the employer. The `JobTimedOut(jobId, caller, agentPaid)` event logs this fallback.
 
 ### NFT Bonus
 
@@ -146,6 +147,11 @@ The v1 prototype destroys a slice of each finalized job's escrow, permanently re
 5. The contract computes `burnAmount = payout * burnPercentage / 10_000` and sends it to `burnAddress`.
 6. Validator rewards and the remaining payout are transferred to participants.
 7. The completion NFT is minted and sent to the employer.
+8. If neither approval nor disapproval thresholds are met once `reviewWindow + commitDuration + revealDuration + gracePeriod` elapses, any party (employer, agent, or moderator) may call `finalizeAfterTimeout` to pay the agent or refund the employer.
+
+### Timeout & Recovery
+
+If validators fail to reach consensus before the combined `reviewWindow`, `commitDuration`, `revealDuration`, and `gracePeriod` expire, the job can be closed manually. Calling `finalizeAfterTimeout(jobId, payAgent)` releases escrow either to the agent (`payAgent = true`) or back to the employer (`payAgent = false`). `JobTimedOut(jobId, caller, agentPaid)` records which path was taken, and owners may tune the extra buffer with `setGracePeriod`.
 
 ### Security & Marketplace Updates
 
@@ -164,7 +170,7 @@ The v1 prototype destroys a slice of each finalized job's escrow, permanently re
 2. Ensure each validator has staked at least `stakeRequirement` before validating.
 3. Curate the validator set with `addAdditionalValidator` and `removeAdditionalValidator`; listen for `ValidatorRemoved` when pruning the pool.
 4. Validators may call `withdrawStake` only after all of their jobs finalize without disputes.
-5. Monitor `StakeRequirementUpdated`, `SlashingPercentageUpdated`, `ValidationRewardPercentageUpdated`, `MinValidatorReputationUpdated`, `ValidatorsPerJobUpdated` (always ≥ the approval/disapproval thresholds), `CommitRevealWindowsUpdated`, `ReviewWindowUpdated` (must remain ≥ `commitDuration + revealDuration`), and `SlashedStakeRecipientUpdated` for configuration changes.
+5. Monitor `StakeRequirementUpdated`, `SlashingPercentageUpdated`, `ValidationRewardPercentageUpdated`, `MinValidatorReputationUpdated`, `ValidatorsPerJobUpdated` (always ≥ the approval/disapproval thresholds), `CommitRevealWindowsUpdated`, `ReviewWindowUpdated` (must remain ≥ `commitDuration + revealDuration`), `GracePeriodUpdated`, and `SlashedStakeRecipientUpdated` for configuration changes.
 6. On final validator approval, watch for `JobFinalizedAndBurned` to confirm payout and burn amounts.
 
 **Example finalization**

--- a/test/timeout.test.js
+++ b/test/timeout.test.js
@@ -1,0 +1,92 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("finalizeAfterTimeout", function () {
+  async function deployFixture() {
+    const [employer, agent, validator1, validator2, validator3] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    const token = await Token.deploy();
+    await token.waitForDeployment();
+    await token.mint(employer.address, ethers.parseEther("1000"));
+
+    const ENSMock = await ethers.getContractFactory("MockENS");
+    const ens = await ENSMock.deploy();
+    await ens.waitForDeployment();
+
+    const WrapperMock = await ethers.getContractFactory("MockNameWrapper");
+    const wrapper = await WrapperMock.deploy();
+    await wrapper.waitForDeployment();
+
+    const Manager = await ethers.getContractFactory("AGIJobManagerV1");
+    const manager = await Manager.deploy(
+      await token.getAddress(),
+      "ipfs://",
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+    await manager.waitForDeployment();
+
+    await manager.setRequiredValidatorApprovals(1);
+    await manager.setRequiredValidatorDisapprovals(1);
+    await manager.setBurnPercentage(1000);
+    await manager.setCommitRevealWindows(1000, 1000);
+    await manager.setReviewWindow(2000);
+    await manager.setGracePeriod(1000);
+    await manager.addAdditionalAgent(agent.address);
+    await manager.addAdditionalValidator(validator1.address);
+    await manager.addAdditionalValidator(validator2.address);
+    await manager.addAdditionalValidator(validator3.address);
+    await manager.setValidatorsPerJob(3);
+
+    return { token, manager, employer, agent };
+  }
+
+  it("allows employer to reclaim funds after timeout", async function () {
+    const { token, manager, employer, agent } = await deployFixture();
+    const payout = ethers.parseEther("1000");
+    await token.connect(employer).approve(await manager.getAddress(), payout);
+    await manager.connect(employer).createJob("jobhash", payout, 1000, "details");
+    const jobId = 0;
+    await manager.connect(agent).applyForJob(jobId, "", []);
+    await manager.connect(agent).requestJobCompletion(jobId, "result");
+    await time.increase(5001);
+    await manager.connect(employer).finalizeAfterTimeout(jobId, false);
+    expect(await token.balanceOf(employer.address)).to.equal(payout);
+  });
+
+  it("pays agent after timeout and burns portion", async function () {
+    const { token, manager, employer, agent } = await deployFixture();
+    const payout = ethers.parseEther("1000");
+    await token.connect(employer).approve(await manager.getAddress(), payout);
+    await manager.connect(employer).createJob("hash", payout, 1000, "details");
+    const jobId = 0;
+    await manager.connect(agent).applyForJob(jobId, "", []);
+    await manager.connect(agent).requestJobCompletion(jobId, "res");
+    await time.increase(5001);
+    await manager.connect(agent).finalizeAfterTimeout(jobId, true);
+    const burnAmount = (payout * 1000n) / 10000n;
+    const burnAddr = await manager.burnAddress();
+    expect(await token.balanceOf(agent.address)).to.equal(payout - burnAmount);
+    expect(await token.balanceOf(burnAddr)).to.equal(burnAmount);
+  });
+
+  it("reverts if called before timeout", async function () {
+    const { token, manager, employer, agent } = await deployFixture();
+    const payout = ethers.parseEther("1000");
+    await token.connect(employer).approve(await manager.getAddress(), payout);
+    await manager.connect(employer).createJob("early", payout, 1000, "details");
+    const jobId = 0;
+    await manager.connect(agent).applyForJob(jobId, "", []);
+    await manager.connect(agent).requestJobCompletion(jobId, "res");
+    await time.increase(1000);
+    await expect(
+      manager.connect(employer).finalizeAfterTimeout(jobId, false)
+    ).to.be.revertedWithCustomError(manager, "TimeoutNotReached");
+  });
+});


### PR DESCRIPTION
## Summary
- allow jobs to finalize after a timeout if validator thresholds are unmet
- add grace period configuration and emit JobTimedOut on fallback
- document timeout recovery and add coverage tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923be2127c8333bf2988385b8d43c9