### PR TITLE
feat: add max validator pool size

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
   - All validator parameters (reward %, reputation %, slashing %, stake requirement,
     approval thresholds, commit/reveal/review windows, validator count, slashed-stake recipient, etc.) are owner-configurable via `onlyOwner` functions.
   - The contract owner may add or remove validators from the selection pool with `addAdditionalValidator` and `removeAdditionalValidator`; removed validators emit `ValidatorRemoved` and become ineligible for future jobs.
+  - The validator pool is limited by `maxValidatorPoolSize` (default 100). Exceeding the cap in `addAdditionalValidator` or `setValidatorPool` reverts. Owners can adjust the limit via `setMaxValidatorPoolSize`, which emits `MaxValidatorPoolSizeUpdated`.
   - Setting the stake requirement or slashing percentage to `0` disables those mechanisms.
 - **Basis-point standardization** – percentage parameters like burns, slashing, and rewards are expressed in basis points for deterministic math.
 - **Configurable slashed stake recipient** – if no validator votes correctly, all slashed stake is sent to `slashedStakeRecipient` (initially the owner but adjustable, e.g. to the burn address) while the validator reward portion reverts to the agent or employer.
@@ -185,9 +186,9 @@ The v1 prototype destroys a slice of each finalized job's escrow, permanently re
 
 1. `setBurnConfig(newAddress, newBps)` – set burn destination and rate in one call, or use `setBurnAddress`/`setBurnPercentage` individually.
 2. Ensure each validator has staked at least `stakeRequirement` before validating.
-3. Curate the validator set with `addAdditionalValidator` and `removeAdditionalValidator`; listen for `ValidatorRemoved` when pruning the pool.
+3. Curate the validator set with `addAdditionalValidator` and `removeAdditionalValidator`; listen for `ValidatorRemoved` when pruning the pool and adjust `maxValidatorPoolSize` with `setMaxValidatorPoolSize` if the pool approaches the cap.
 4. Validators may call `withdrawStake` only after all of their jobs finalize without disputes.
-5. Monitor `StakeRequirementUpdated`, `SlashingPercentageUpdated`, `ValidationRewardPercentageUpdated`, `MinValidatorReputationUpdated`, `ValidatorsPerJobUpdated` (always ≥ the approval/disapproval thresholds), `CommitRevealWindowsUpdated`, `ReviewWindowUpdated` (must remain ≥ `commitDuration + revealDuration`), and `SlashedStakeRecipientUpdated` for configuration changes.
+5. Monitor `StakeRequirementUpdated`, `SlashingPercentageUpdated`, `ValidationRewardPercentageUpdated`, `MinValidatorReputationUpdated`, `ValidatorsPerJobUpdated` (always ≥ the approval/disapproval thresholds), `MaxValidatorPoolSizeUpdated`, `CommitRevealWindowsUpdated`, `ReviewWindowUpdated` (must remain ≥ `commitDuration + revealDuration`), and `SlashedStakeRecipientUpdated` for configuration changes.
 6. On final validator approval, watch for `JobFinalizedAndBurned` to confirm payout and burn amounts.
 
 **Example finalization**

--- a/test/validatorPoolSize.test.js
+++ b/test/validatorPoolSize.test.js
@@ -1,0 +1,53 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("maxValidatorPoolSize", function () {
+  async function deployFixture() {
+    const [owner, v1, v2, v3] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    const token = await Token.deploy();
+    await token.waitForDeployment();
+
+    const ENSMock = await ethers.getContractFactory("MockENS");
+    const ens = await ENSMock.deploy();
+    await ens.waitForDeployment();
+
+    const WrapperMock = await ethers.getContractFactory("MockNameWrapper");
+    const wrapper = await WrapperMock.deploy();
+    await wrapper.waitForDeployment();
+
+    const Manager = await ethers.getContractFactory("AGIJobManagerV1");
+    const manager = await Manager.deploy(
+      await token.getAddress(),
+      "ipfs://",
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+    await manager.waitForDeployment();
+
+    return { manager, owner, v1, v2, v3 };
+  }
+
+  it("reverts when adding a validator beyond the max", async function () {
+    const { manager, v1, v2, v3 } = await deployFixture();
+    await manager.setMaxValidatorPoolSize(2);
+    await manager.addAdditionalValidator(v1.address);
+    await manager.addAdditionalValidator(v2.address);
+    await expect(
+      manager.addAdditionalValidator(v3.address)
+    ).to.be.revertedWithCustomError(manager, "ValidatorPoolFull");
+  });
+
+  it("reverts when setting a pool larger than the max", async function () {
+    const { manager, v1, v2, v3 } = await deployFixture();
+    await manager.setMaxValidatorPoolSize(2);
+    await expect(
+      manager.setValidatorPool([v1.address, v2.address, v3.address])
+    ).to.be.revertedWithCustomError(manager, "ValidatorPoolFull");
+  });
+});


### PR DESCRIPTION
## Summary
- limit validator pool using `maxValidatorPoolSize` and `ValidatorPoolFull` error
- allow owner to adjust cap via `setMaxValidatorPoolSize`
- document validator pool cap and add tests for enforcement

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892525841588333801cbf523c337ef6