### PR TITLE
Enforce non-empty completion hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Interact with the contracts using a wallet or block explorer. Always verify cont
 **Agents**
 - Double-check the contract address before interacting.
 - Use `applyForJob` to claim the task (≈1 transaction).
-- After completing the work, call `requestJobCompletion` with the result reference such as an IPFS hash (≈1 transaction).
+- After completing the work, call `requestJobCompletion` with a non-empty result reference such as an IPFS hash (≈1 transaction).
 - Monitor the job status until validators approve and funds release.
 
 **Validators**
@@ -73,7 +73,7 @@ Interact with the contracts using a wallet or block explorer. Always verify cont
 
 **Agents**
 - Use [`applyForJob`](contracts/AGIJobManagerv1.sol#L568) to claim an open job.
-- After finishing work, [`requestJobCompletion`](contracts/AGIJobManagerv1.sol#L594) with the result's IPFS hash.
+- After finishing work, [`requestJobCompletion`](contracts/AGIJobManagerv1.sol#L594) with a non-empty IPFS hash.
 - Verify addresses and watch for `JobApplied` and `JobCompletionRequested` events.
 
 **Validators**

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -613,6 +613,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (msg.sender != job.assignedAgent) revert Unauthorized();
         if (block.timestamp > job.assignedAt + job.duration) revert JobExpired();
         if (job.status != JobStatus.Open) revert JobNotOpen();
+        if (bytes(_ipfsHash).length == 0) revert InvalidParameters();
         job.ipfsHash = _ipfsHash;
         job.status = JobStatus.CompletionRequested;
         job.validationStart = block.timestamp;

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -81,6 +81,18 @@ describe("AGIJobManagerV1 payouts", function () {
       .withArgs(agent.address, "alice");
   });
 
+  it("reverts when requesting completion with an empty IPFS hash", async function () {
+    const { token, manager, employer, agent } = await deployFixture();
+    const payout = ethers.parseEther("1");
+    await token.connect(employer).approve(await manager.getAddress(), payout);
+    await manager.connect(employer).createJob("jobhash", payout, 1000, "details");
+    const jobId = 0;
+    await manager.connect(agent).applyForJob(jobId, "", []);
+    await expect(
+      manager.connect(agent).requestJobCompletion(jobId, "")
+    ).to.be.revertedWithCustomError(manager, "InvalidParameters");
+  });
+
   it("distributes burn, validator, and agent payouts equal to job.payout", async function () {
     const { token, manager, employer, agent, validator } = await deployFixture();
     const payout = ethers.parseEther("1000");


### PR DESCRIPTION
## Summary
- validate that `requestJobCompletion` receives a non-empty IPFS hash
- clarify in README that agents must supply a non-empty hash when calling `requestJobCompletion`
- add unit test for empty hash rejection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892581913688333a8d9954b0cfd3eb8