### PR TITLE
Require nonzero commit and reveal windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Several operational parameters are adjustable by the owner. Every update emits a
 - `setPremiumReputationThreshold(uint256 newThreshold)` → `PremiumReputationThresholdUpdated`
 - `setMaxJobPayout(uint256 newMax)` → `MaxJobPayoutUpdated`
 - `setJobDurationLimit(uint256 newLimit)` → `JobDurationLimitUpdated`
-- `setCommitRevealWindows(uint256 commitWindow, uint256 revealWindow)` → `CommitRevealWindowsUpdated` – controls how long validators have to commit and reveal votes; the existing `reviewWindow` must be at least `commitWindow + revealWindow`.
+- `setCommitRevealWindows(uint256 commitWindow, uint256 revealWindow)` → `CommitRevealWindowsUpdated` – controls how long validators have to commit and reveal votes; the existing `reviewWindow` must be at least `commitWindow + revealWindow`. Zero values are rejected.
 - `setReviewWindow(uint256 newWindow)` → `ReviewWindowUpdated` – defines the mandatory wait after completion requests and must be greater than or equal to `commitDuration + revealDuration`.
 - `updateTermsAndConditionsIpfsHash(string newHash)` → `TermsAndConditionsIpfsHashUpdated`
 - `updateContactEmail(string newEmail)` → `ContactEmailUpdated`
@@ -713,7 +713,7 @@ cast send $AGI_JOB_MANAGER "validateJob(uint256)" $JOB_ID --from $V2 # finalizes
 
 The contract owner can tune validator requirements and incentives. Each update emits an event so indexers can track new values:
 
-- `setValidatorConfig(uint256 rewardPct, uint256 repPct, uint256 stakeReq, uint256 slashPct, uint256 minRep, uint256 approvals, uint256 disapprovals, address slashRecipient, uint256 commitWindow, uint256 revealWindow, uint256 reviewWin, uint256 validatorsCount)` – update all validator parameters in one transaction; emits `ValidatorConfigUpdated`.
+- `setValidatorConfig(uint256 rewardPct, uint256 repPct, uint256 stakeReq, uint256 slashPct, uint256 minRep, uint256 approvals, uint256 disapprovals, address slashRecipient, uint256 commitWindow, uint256 revealWindow, uint256 reviewWin, uint256 validatorsCount)` – update all validator parameters in one transaction; emits `ValidatorConfigUpdated`. Zero `commitWindow` or `revealWindow` values are rejected.
 - `setValidationRewardPercentage(uint256 percentage)` – define the token reward share for validators in basis points (set to `0` to disable); emits `ValidationRewardPercentageUpdated`.
 - `setValidatorReputationPercentage(uint256 percentage)` – set the fraction of agent reputation awarded to correct validators; emits `ValidatorReputationPercentageUpdated`.
 - `setSlashingPercentage(uint256 percentage)` – adjust how much stake is slashed for incorrect votes (basis points); emits `SlashingPercentageUpdated`.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -1294,13 +1294,14 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     }
 
     /// @notice Update commit and reveal window durations.
-    /// @param commitWindow Length of the commit phase in seconds.
-    /// @param revealWindow Length of the reveal phase in seconds.
-    /// @dev Setting either value to zero results in an instant phase with no time for participation.
+    /// @param commitWindow Length of the commit phase in seconds; must be greater than zero.
+    /// @param revealWindow Length of the reveal phase in seconds; must be greater than zero.
+    /// @dev Both `commitWindow` and `revealWindow` must be greater than zero.
     function setCommitRevealWindows(
         uint256 commitWindow,
         uint256 revealWindow
     ) external onlyOwner {
+        require(commitWindow > 0 && revealWindow > 0);
         if (reviewWindow < commitWindow + revealWindow)
             revert ReviewWindowTooShort();
         commitDuration = commitWindow;
@@ -1326,8 +1327,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     /// @param approvals Validator approvals needed to finalize a job.
     /// @param disapprovals Validator disapprovals needed to dispute a job.
     /// @param slashRecipient Address receiving slashed stake when no validator votes correctly.
-    /// @param commitWindow Length of commit phase in seconds.
-    /// @param revealWindow Length of reveal phase in seconds.
+    /// @param commitWindow Length of commit phase in seconds; must be greater than zero.
+    /// @param revealWindow Length of reveal phase in seconds; must be greater than zero.
     /// @param reviewWin Mandatory waiting period before validators may vote.
     /// @param validatorsCount Number of validators randomly selected per job.
     function setValidatorConfig(
@@ -1355,6 +1356,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (disapprovals == 0 || disapprovals > validatorsCount)
             revert InvalidDisapprovals();
         if (slashRecipient == address(0)) revert InvalidAddress();
+        require(commitWindow > 0 && revealWindow > 0);
         if (reviewWin < commitWindow + revealWindow)
             revert WindowBelowCommitReveal();
         validationRewardPercentage = rewardPercentage;


### PR DESCRIPTION
## Summary
- enforce nonzero commit & reveal windows in setCommitRevealWindows
- validate commit & reveal windows in setValidatorConfig
- document that zero durations are rejected

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68925a30841483339e4b8fab4d3a7c68