### PR TITLE
feat: enforce nonzero validation windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
   - Misaligned votes are slashed and lose reputation; correct validators share the slashed stake.
   - `validatorsPerJob` defaults to three and can never fall below the approval or disapproval thresholds, preventing owner misconfiguration.
   - If no validator votes correctly, slashed stakes go to `slashedStakeRecipient` and the reserved reward portion refunds to the agent or employer.
-  - Default timing uses a one-hour commit phase and one-hour reveal phase with a two-hour review window, all adjustable by the owner.
+  - Default timing uses a one-hour commit phase and one-hour reveal phase with a two-hour review window, all adjustable by the owner. Attempts to set either window to zero revert with the `InvalidDuration` custom error.
   - Validator reputation gains use a separate `validatorReputationPercentage` so reputation rewards can differ from token rewards.
   - All validator parameters (reward %, reputation %, slashing %, stake requirement,
     approval thresholds, commit/reveal/review windows, validator count, slashed-stake recipient, etc.) are owner-configurable via `onlyOwner` functions.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -470,6 +470,9 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     /// @dev Thrown when a numeric count is out of range or zero.
     error InvalidCount();
 
+    /// @dev Thrown when a duration parameter is zero.
+    error InvalidDuration();
+
     /// @dev Thrown when approval thresholds are misconfigured.
     error InvalidApprovals();
 
@@ -1301,7 +1304,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         uint256 commitWindow,
         uint256 revealWindow
     ) external onlyOwner {
-        require(commitWindow > 0 && revealWindow > 0);
+        if (commitWindow == 0 || revealWindow == 0) revert InvalidDuration();
         if (reviewWindow < commitWindow + revealWindow)
             revert ReviewWindowTooShort();
         commitDuration = commitWindow;
@@ -1356,7 +1359,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (disapprovals == 0 || disapprovals > validatorsCount)
             revert InvalidDisapprovals();
         if (slashRecipient == address(0)) revert InvalidAddress();
-        require(commitWindow > 0 && revealWindow > 0);
+        if (commitWindow == 0 || revealWindow == 0) revert InvalidDuration();
         if (reviewWin < commitWindow + revealWindow)
             revert WindowBelowCommitReveal();
         validationRewardPercentage = rewardPercentage;

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -68,6 +68,16 @@ describe("AGIJobManagerV1 payouts", function () {
     ).to.be.revertedWithCustomError(manager, "InvalidAddress");
   });
 
+  it("reverts when commit or reveal window is zero", async function () {
+    const { manager } = await deployFixture();
+    await expect(
+      manager.setCommitRevealWindows(0, 1)
+    ).to.be.revertedWithCustomError(manager, "InvalidDuration");
+    await expect(
+      manager.setCommitRevealWindows(1, 0)
+    ).to.be.revertedWithCustomError(manager, "InvalidDuration");
+  });
+
   it("allows agent to apply for a job using a Merkle proof", async function () {
     const { token, manager, employer, agent, proof } = await deployFixture(1000, true);
     const payout = ethers.parseEther("1");


### PR DESCRIPTION
## Summary
- add `InvalidDuration` custom error for zero-length commit or reveal windows
- guard owner configuration functions with `InvalidDuration`
- document nonzero commit/reveal window requirement

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892603842b0833398535ef98d84df0a