### PR TITLE
feat: harden job creation and streamline validator loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
 - **Indexed events** – key identifiers like `jobId` and participant addresses are indexed in events (`JobCreated`, `JobCompleted`, `JobValidated`, etc.) for easier off-chain filtering and monitoring.
 - **Escrow accounting** – tracks total job escrow and validator stakes so owner withdrawals never touch locked funds.
 - **Custom-error reverts** – v1 eliminates string `require` messages in favor of named custom errors across admin and validation paths, reducing gas and giving clearer failures.
+- **Checks–effects–interactions discipline** – `createJob` now transfers escrow before recording job details, and dispute-resolution loops cache lengths with unchecked increments, reducing reentrancy surface and gas usage.
 - **Enhanced state enforcement** – agents can only apply to jobs in the `Open` state, and validator actions revert with dedicated
   custom errors (e.g., `InsufficientStake`, `ReviewWindowActive`) for clearer failure modes and lower gas use.
 - **Explicit completion checks** – `requestJobCompletion` now reverts with dedicated errors (`JobExpired`, `JobNotOpen`) and validator selection fails fast with `NotEnoughValidators` when the pool lacks participants.


### PR DESCRIPTION
## Summary
- apply checks-effects-interactions to `createJob` escrow flow
- cache validator list lengths and use unchecked increments for gas
- document checks-effects-interactions discipline in README

## Testing
- `npm test`
- `npm run lint` *(warnings: 617)*

------
https://chatgpt.com/codex/tasks/task_e_6892842798c48333b24013eeea51d706