### PR TITLE
Guard finalization against reentrancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
 - **Escrow accounting** – tracks total job escrow and validator stakes so owner withdrawals never touch locked funds.
 - **Custom-error reverts** – v1 eliminates string `require` messages in favor of named custom errors across admin and validation paths, reducing gas and giving clearer failures.
 - **Checks–effects–interactions discipline** – `createJob` now transfers escrow before recording job details, and dispute-resolution loops cache lengths with unchecked increments, reducing reentrancy surface and gas usage.
+- **Reentrancy-guarded finalization** – `validateJob` and `resolveDispute` now use `nonReentrant`, preventing malicious re-entry during payout and dispute resolution.
 - **Enhanced state enforcement** – agents can only apply to jobs in the `Open` state, and validator actions revert with dedicated
   custom errors (e.g., `InsufficientStake`, `ReviewWindowActive`) for clearer failure modes and lower gas use.
 - **Explicit completion checks** – `requestJobCompletion` now reverts with dedicated errors (`JobExpired`, `JobNotOpen`) and validator selection fails fast with `NotEnoughValidators` when the pool lacks participants.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -788,6 +788,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     function validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)
         external
         whenNotPaused
+        nonReentrant
         jobExists(_jobId)
     {
         if (
@@ -892,6 +893,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     function resolveDispute(uint256 _jobId, DisputeOutcome outcome)
         external
         onlyModerator
+        nonReentrant
         jobExists(_jobId)
     {
         Job storage job = jobs[_jobId];
@@ -904,7 +906,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit DisputeResolved(_jobId, msg.sender, outcome);
     }
 
-    function _resolveEmployerWin(uint256 _jobId) internal nonReentrant {
+    function _resolveEmployerWin(uint256 _jobId) internal {
         Job storage job = jobs[_jobId];
         job.status = JobStatus.Completed;
         totalJobEscrow -= job.payout;
@@ -1562,7 +1564,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
     /// @notice Finalize a job, distribute payouts, burn tokens and mint the completion NFT.
     /// @dev Invoked when the last validator approval or dispute resolution finalizes a job.
-    function _finalizeJobAndBurn(uint256 _jobId) internal nonReentrant jobExists(_jobId) {
+    function _finalizeJobAndBurn(uint256 _jobId) internal jobExists(_jobId) {
         Job storage job = jobs[_jobId];
         if (job.status == JobStatus.Completed) revert JobAlreadyFinalized();
         // Disallow payout without an explicit completion request


### PR DESCRIPTION
## Summary
- protect `validateJob` and `resolveDispute` with `nonReentrant`
- centralize reentrancy guard in external paths and update docs

## Testing
- `npm run compile`
- `npx solhint 'contracts/**/*.sol'` (warnings only)
- `npx eslint .`
- `npx hardhat test`
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68929274926083338fd10b55faf61812