### PR TITLE
feat: harden AGIJobManager against accidental ETH transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Follow these steps before trusting any address or artifact:
 - Reproduce builds locally with pinned compiler and dependency versions to confirm bytecode.
 - Avoid links or addresses from untrusted third parties.
 - Marketplace functions prevent duplicate listings and block sellers from purchasing their own NFTs, reducing accidental misuse.
+- Direct ETH transfers revert, preventing accidental loss of Ether.
 - Verify repository integrity (`git tag --verify` / `git log --show-signature`) before relying on published code.
 - Understand that tokens are burned instantly upon the final validator approval, irreversibly sending `burnPercentage` of escrow to `burnAddress`. Both parameters remain `onlyOwner` configurable.
 - All percentage parameters use basis points (1 bp = 0.01%); double‑check values before submitting transactions.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -535,6 +535,9 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     /// @dev Thrown when payout accounting exceeds escrowed funds.
     error PayoutExceedsEscrow();
 
+    /// @dev Thrown when the contract is sent Ether directly.
+    error ETHNotAccepted();
+
     constructor(
         address _agiTokenAddress,
         string memory _initialBaseURI,
@@ -2033,6 +2036,17 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
                 ++i;
             }
         }
+    }
+
+    /// @notice Reject any direct ETH transfers to the contract.
+    /// @dev Prevents accidental ETH deposits which would otherwise be locked.
+    receive() external payable {
+        revert ETHNotAccepted();
+    }
+
+    /// @notice Fallback handler that reverts on unexpected calls or ETH transfers.
+    fallback() external payable {
+        revert ETHNotAccepted();
     }
 }
 

--- a/test/ethRejection.test.js
+++ b/test/ethRejection.test.js
@@ -1,0 +1,41 @@
+const { ethers } = require("hardhat");
+
+describe("Ether rejection", function () {
+  async function deployManager() {
+    const [owner] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    const token = await Token.deploy();
+    await token.waitForDeployment();
+
+    const ENSMock = await ethers.getContractFactory("MockENS");
+    const ens = await ENSMock.deploy();
+    await ens.waitForDeployment();
+
+    const WrapperMock = await ethers.getContractFactory("MockNameWrapper");
+    const wrapper = await WrapperMock.deploy();
+    await wrapper.waitForDeployment();
+
+    const Manager = await ethers.getContractFactory("AGIJobManagerV1");
+    const manager = await Manager.deploy(
+      await token.getAddress(),
+      "ipfs://",
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+    await manager.waitForDeployment();
+
+    return { manager, owner };
+  }
+
+  it("reverts when sending ETH directly", async function () {
+    const { manager, owner } = await deployManager();
+    await expect(
+      owner.sendTransaction({ to: await manager.getAddress(), value: 1n })
+    ).to.be.revertedWithCustomError(manager, "ETHNotAccepted");
+  });
+});


### PR DESCRIPTION
## Summary
- reject direct ETH transfers with custom error and receive/fallback handlers
- document ETH rejection in safety checklist
- test ETH rejection behaviour

## Testing
- `npm test`
- `npm run lint` *(warnings: Missing @notice tags, Missing @param tags, Mismatch in @param names, Missing @return tags, Mismatch in @return count)*

------
https://chatgpt.com/codex/tasks/task_e_68929680d87c8333976e8287502cacf8