### PR TITLE
refactor: finalize burn after state updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Follow these steps before trusting any address or artifact:
 - Avoid links or addresses from untrusted third parties.
 - Marketplace functions prevent duplicate listings and block sellers from purchasing their own NFTs, reducing accidental misuse.
 - Verify repository integrity (`git tag --verify` / `git log --show-signature`) before relying on published code.
-- Understand that tokens are burned instantly upon the final validator approval, irreversibly sending `burnPercentage` of escrow to `burnAddress`. Both parameters remain `onlyOwner` configurable.
+- Understand that tokens are burned instantly upon the final validator approval, irreversibly sending `burnPercentage` of escrow to `burnAddress`. The burn occurs only after all internal state updates are complete to follow the checks‑effects‑interactions pattern. Both parameters remain `onlyOwner` configurable.
 - All percentage parameters use basis points (1 bp = 0.01%); double‑check values before submitting transactions.
 - Jobs finalize only after the agent calls `requestJobCompletion`; even moderator resolutions in favor of the agent revert otherwise.
 - Escrowed payouts and validator stakes are tracked separately; `withdrawAGI` only permits withdrawing surplus funds not locked for jobs or staking.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -1618,11 +1618,6 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (agentPayout + validatorPayoutTotal + burnAmount > job.payout)
             revert PayoutExceedsEscrow();
 
-        if (burnAmount > 0) {
-            if (burnAddress == address(0)) revert BurnAddressNotSet();
-            agiToken.safeTransfer(burnAddress, burnAmount);
-        }
-
         uint256 validatorReputationChange =
             calculateValidatorReputationPoints(reputationPoints);
         uint256 correctValidatorCount = job.validatorApprovals;
@@ -1707,6 +1702,11 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         uint256 leftover =
             (validatorPayoutTotal - distributedValidator) +
             (totalSlashed - distributedSlashed);
+
+        if (burnAmount > 0) {
+            if (burnAddress == address(0)) revert BurnAddressNotSet();
+            agiToken.safeTransfer(burnAddress, burnAmount);
+        }
 
         if (correctValidatorCount == 0) {
             if (totalSlashed > 0) {


### PR DESCRIPTION
## Summary
- ensure job payouts verify escrow totals and burn tokens only after state updates
- document burn sequence following checks-effects-interactions best practice

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68929dcade688333a3c918f75f45d0f7