### PR TITLE
feat: add manual whitelist events

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ functions control validation incentives, burn behavior, and system limits.
 | `setValidatorsPerJob(uint256 count)` | Number of validators randomly selected per job. | `1`–`10` (default `3`) |
 | `setCommitRevealWindows(uint256 commit, uint256 reveal)` | Length of commit/reveal phases in seconds. | `300`–`3600` seconds each |
 | `setReviewWindow(uint256 secs)` | Waiting period before validators vote. | ≥ commit + reveal, typically `3600`–`86400` |
+| `addAdditionalValidator(address validator)` | Manually whitelist a validator outside the Merkle allowlist; emits `AdditionalValidatorAdded`. | non-zero address |
+| `removeAdditionalValidator(address validator)` | Remove a validator from the manual allowlist; emits `ValidatorRemoved`. | previously added address |
+| `addAdditionalAgent(address agent)` | Manually whitelist an agent; emits `AdditionalAgentAdded`. | non-zero address |
+| `removeAdditionalAgent(address agent)` | Remove an agent from the manual allowlist; emits `AdditionalAgentRemoved`. | previously added address |
 
 Convenience functions:
 


### PR DESCRIPTION
## Summary
- add events for manual agent/validator allowlists and enforce non-zero addresses
- document new owner functions for manual allowlists

## Testing
- `npm test`
- `npx solhint 'contracts/**/*.sol'`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_6892a005b9b4833385fc2fc715a57c7e