### PR TITLE
chore: validate nonzero commitments

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Interact with the contracts using a wallet or block explorer. Always verify cont
 - Verify the contract address and ensure you meet the current stake requirement.
 - Stake AGI with `stake` to join the validator pool (≈1 transaction).
 - When selected, submit `commitValidation` during the commit phase (≈1 transaction) and later `revealValidation` in the reveal phase (≈1 transaction).
+- The commitment must be a non-zero hash; empty commitments are rejected.
 - Finalize the job with `validateJob` or `disapproveJob` once the review window ends (≈1 transaction).
 - Expect roughly 4–5 transactions per job, not counting the initial stake.
 

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -424,6 +424,9 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     /// @dev Thrown when a validator submits more than one commitment.
     error AlreadyCommitted();
 
+    /// @dev Thrown when an empty commitment is supplied.
+    error InvalidCommitment();
+
     /// @dev Thrown when a validator tries to reveal twice.
     error AlreadyRevealed();
 
@@ -745,6 +748,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (job.status != JobStatus.CompletionRequested) revert InvalidJobState();
         if (block.timestamp > job.validationStart + commitDuration)
             revert CommitPhaseOver();
+        if (commitment == bytes32(0)) revert InvalidCommitment();
         if (job.commitments[msg.sender] != bytes32(0)) revert AlreadyCommitted();
         job.commitments[msg.sender] = commitment;
         job.validators.push(msg.sender);


### PR DESCRIPTION
## Summary
- reject zero-value validator commitments using a dedicated error
- document that commit hashes must be non-zero

## Testing
- `npm test`
- `npm run lint` *(warnings: missing natspec comments in mock contracts)*

------
https://chatgpt.com/codex/tasks/task_e_6892a24fe58c8333a394ebc5cbc0c88d