### PR TITLE
feat: allow employers to reclaim expired jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ Interact with the contracts using a wallet or block explorer. Always verify cont
 - Confirm the AGIJobManager contract address on Etherscan, Blockscout, or official channels.
 - From the explorer's **Write** tab or your wallet's contract interface, call `createJob` to post the task and escrow funds (≈1 transaction).
 - Wait for an agent to apply and for validators to finalize; the NFT and remaining payout arrive automatically.
+- If the agent fails to request completion before the duration expires, reclaim your escrow with `cancelExpiredJob`.
 
 **Agents**
 - Double-check the contract address before interacting.
 - Use `applyForJob` to claim the task (≈1 transaction).
 - After completing the work, call `requestJobCompletion` with a non-empty result reference such as an IPFS hash (≈1 transaction).
 - Monitor the job status until validators approve and funds release.
+- Request completion before the deadline or the employer can cancel via `cancelExpiredJob` and recover the escrow.
 - Losing a dispute reduces your reputation and can slash any staked AGI. The `AgentPenalized` event records the penalty.
 
 **Validators**
@@ -75,12 +77,14 @@ See the [Glossary](docs/glossary.md) for key terminology.
 **Employers**
 - Post a job and deposit the payout.
 - Wait for an agent to finish and validators to approve.
+- If no completion request arrives before the deadline, use `cancelExpiredJob` to reclaim escrow and close the job.
 - Receive the NFT and any remaining funds.
 - Example: [createJob transaction](https://etherscan.io/tx/0xccd6d21a8148a06e233063f57b286832f3c2ca015ab4d8387a529e3508e8f32e).
 
 **Agents**
 - Claim an open job.
 - Submit your work with a link or hash.
+- Be sure to request completion before the job duration expires; otherwise the employer can call `cancelExpiredJob` and recover the escrow.
 - Get paid after validators sign off.
 - Examples: [applyForJob](https://etherscan.io/tx/0x55f8ee0370c9c08a6e871a4184650419b520d4e9666536cbdcf47f4f03917ce2) · [requestJobCompletion](https://etherscan.io/tx/0xd4f85a33a73319c04df3497ebe8f43095bfae6ed8e5acdd6a80d295869e6f809).
 
@@ -95,10 +99,12 @@ See the [Glossary](docs/glossary.md) for key terminology.
 **Employers**
 - Call [`createJob`](contracts/AGIJobManagerv1.sol#L602) to post a task and escrow the payout.
 - Confirm the contract address and wait for the `JobCreated` event to learn the job ID.
+- If the agent misses the deadline without requesting completion, reclaim escrow with [`cancelExpiredJob`](contracts/AGIJobManagerv1.sol#L1635).
 
 **Agents**
 - Use [`applyForJob`](contracts/AGIJobManagerv1.sol#L624) to claim an open job.
 - After finishing work, [`requestJobCompletion`](contracts/AGIJobManagerv1.sol#L650) with a non-empty IPFS hash.
+- Submit before the deadline to avoid employer cancelling with [`cancelExpiredJob`](contracts/AGIJobManagerv1.sol#L1635).
 - Verify addresses and watch for `JobApplied` and `JobCompletionRequested` events.
 
 **Validators**


### PR DESCRIPTION
## Summary
- add `Cancelled` job status and `JobExpired` event
- enable employers to call `cancelExpiredJob` to reclaim escrow when agents miss deadlines
- document the new cancellation flow for employers and agents

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892bf7416f883339b2728d7d745e274