### PR TITLE
Remove obsolete validators array

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ The v1 prototype destroys a slice of each finalized job's escrow, permanently re
  - **Custom error finalization** – [`_finalizeJobAndBurn`](contracts/AGIJobManagerv1.sol#L1577-L1765) reverts with dedicated custom errors, lowering gas costs versus string-based `require`s.
 - **Verifiable randomness roadmap** – Validators are presently chosen with blockhash entropy via [`_selectValidators`](contracts/AGIJobManagerv1.sol#L674-L720); future versions will integrate verifiable randomness (e.g., VRF) for stronger guarantees.
 - **Owner-controlled parameters** – Only the contract owner may tune validator counts, reward and slashing percentages, burn settings, timing windows, and recipient addresses via `onlyOwner` functions such as [`setValidatorConfig`](contracts/AGIJobManagerv1.sol#L1385-L1440) and [`setBurnConfig`](contracts/AGIJobManagerv1.sol#L1289-L1299); each change emits a corresponding `*Updated` event.
-- **User-friendly getters** – [`getJobInfo`](contracts/AGIJobManagerv1.sol#L1188-L1222), [`getJobValidators`](contracts/AGIJobManagerv1.sol#L1225-L1232), and [`getSelectedValidators`](contracts/AGIJobManagerv1.sol#L1235-L1242) expose job and validator details for front‑end integrations without traversing storage mappings.
+- **User-friendly getters** – [`getJobInfo`](contracts/AGIJobManagerv1.sol#L1246-L1278) and [`getSelectedValidators`](contracts/AGIJobManagerv1.sol#L1283-L1290) expose job and validator details for front‑end integrations without traversing storage mappings.
 
 **Setup checklist**
 

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -217,7 +217,6 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         string details;
         mapping(address => bool) approvals;
         mapping(address => bool) disapprovals;
-        address[] validators;
         address[] selectedValidators;
         mapping(address => bool) isSelectedValidator;
         mapping(address => bool) committed;
@@ -776,7 +775,6 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
             revert CommitPhaseOver();
         if (job.commitments[msg.sender] != bytes32(0)) revert AlreadyCommitted();
         job.commitments[msg.sender] = commitment;
-        job.validators.push(msg.sender);
         job.committed[msg.sender] = true;
         emit ValidationCommitted(_jobId, msg.sender, commitment);
     }
@@ -1042,7 +1040,6 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
             }
         }
 
-        delete job.validators;
         for (uint256 i; i < svLen; ) {
             delete job.isSelectedValidator[job.selectedValidators[i]];
             unchecked {
@@ -1280,16 +1277,6 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
             job.validatorDisapprovals,
             job.details
         );
-    }
-
-    /// @notice Retrieve validators that committed to a job.
-    function getJobValidators(uint256 _jobId)
-        external
-        view
-        jobExists(_jobId)
-        returns (address[] memory)
-    {
-        return jobs[_jobId].validators;
     }
 
     /// @notice Retrieve validators selected for a job.
@@ -1777,7 +1764,6 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
             }
         }
 
-        delete job.validators;
         for (uint256 i; i < svLen; ) {
             delete job.isSelectedValidator[job.selectedValidators[i]];
             unchecked {


### PR DESCRIPTION
## Summary
- drop the unused `job.validators` array and related operations
- rely exclusively on `selectedValidators` for slashing and rewards
- remove old `getJobValidators` helper and update documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892c1eea6c4833380bb5b79a80e8793