### PR TITLE
feat: add agent staking with slashing safeguards

### DIFF
--- a/test/burn.test.js
+++ b/test/burn.test.js
@@ -41,6 +41,11 @@ async function deployFixture(burnPct = 1000) {
   await manager.addAdditionalValidator(validator.address);
   await manager.setValidatorsPerJob(1);
 
+  const stakeAmount = ethers.parseEther("100");
+  await token.mint(agent.address, stakeAmount);
+  await token.connect(agent).approve(await manager.getAddress(), stakeAmount);
+  await manager.connect(agent).stakeAgent(stakeAmount);
+
   return { token, manager, owner, employer, agent, validator };
 }
 

--- a/test/burn.test.ts
+++ b/test/burn.test.ts
@@ -39,6 +39,10 @@ async function deployFixture() {
   await manager.addAdditionalAgent(agent.address);
   await manager.addAdditionalValidator(validator.address);
   await manager.setValidatorsPerJob(1);
+  const stakeAmount = ethers.parseEther("100");
+  await token.mint(agent.address, stakeAmount);
+  await token.connect(agent).approve(await manager.getAddress(), stakeAmount);
+  await manager.connect(agent).stakeAgent(stakeAmount);
 
   return { owner, employer, agent, validator, token, manager };
 }

--- a/test/finalizationReentrancy.test.js
+++ b/test/finalizationReentrancy.test.js
@@ -42,6 +42,11 @@ async function deployFixture() {
   await manager.addModerator(moderator.address);
   await manager.addModerator(await token.getAddress());
 
+  const stakeAmount = ethers.parseEther("100");
+  await token.mint(agent.address, stakeAmount);
+  await token.connect(agent).approve(await manager.getAddress(), stakeAmount);
+  await manager.connect(agent).stakeAgent(stakeAmount);
+
   return { token, manager, owner, employer, agent, validator, moderator };
 }
 

--- a/test/validatorSelection.test.js
+++ b/test/validatorSelection.test.js
@@ -26,6 +26,10 @@ async function deployManager() {
   );
   await manager.waitForDeployment();
   await manager.addAdditionalAgent(agent.address);
+  const stakeAmount = ethers.parseEther("100");
+  await token.mint(agent.address, stakeAmount);
+  await token.connect(agent).approve(await manager.getAddress(), stakeAmount);
+  await manager.connect(agent).stakeAgent(stakeAmount);
   return { token, manager, employer, agent };
 }
 


### PR DESCRIPTION
## Summary
- add agent stake deposit & withdrawal with events
- require agent stake before applying and during employer win slashing
- expand tests for agent staking, withdrawal, and slashing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892cd3b2c108333a0bf43f6ce155a45