### PR TITLE
feat: allow updating commit and reveal durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ functions control validation incentives, burn behavior, and system limits.
 | `setValidatorsPerJob(uint256 count)` | Number of validators pseudo-randomly selected per job. | `1`–`10` (default `3`) |
 | `setValidatorSelectionSeed(bytes32 seed)` | Extra entropy mixed into validator selection. | any `bytes32` |
 | `setCommitRevealWindows(uint256 commit, uint256 reveal)` | Length of commit/reveal phases in seconds. | `300`–`3600` seconds each |
+| `setCommitDuration(uint256 secs)` | Adjust commit phase length without changing reveal. | `300`–`3600` seconds |
+| `setRevealDuration(uint256 secs)` | Adjust reveal phase length without changing commit. | `300`–`3600` seconds |
 | `setReviewWindow(uint256 secs)` | Waiting period before validators vote. | ≥ commit + reveal, typically `3600`–`86400` |
 | `addAdditionalValidator(address validator)` | Manually whitelist a validator outside the Merkle allowlist; emits `AdditionalValidatorAdded`. | non-zero address |
 | `removeAdditionalValidator(address validator)` | Remove a validator from the manual allowlist; emits `ValidatorRemoved`. | previously added address |
@@ -377,6 +379,7 @@ Several operational parameters are adjustable by the owner. Every update emits a
 - `setMaxJobPayout(uint256 newMax)` → `MaxJobPayoutUpdated`
 - `setJobDurationLimit(uint256 newLimit)` → `JobDurationLimitUpdated`
 - `setCommitRevealWindows(uint256 commitWindow, uint256 revealWindow)` → `CommitRevealWindowsUpdated` – controls how long validators have to commit and reveal votes; the existing `reviewWindow` must be at least `commitWindow + revealWindow`. Zero values are rejected.
+- `setCommitDuration(uint256 newCommit)` or `setRevealDuration(uint256 newReveal)` → `CommitRevealWindowsUpdated` – tweak individual phase lengths; `reviewWindow` must remain ≥ `commitDuration + revealDuration`.
 - `setReviewWindow(uint256 newWindow)` → `ReviewWindowUpdated` – defines the mandatory wait after completion requests and must be greater than or equal to `commitDuration + revealDuration`.
 - `updateTermsAndConditionsIpfsHash(string newHash)` → `TermsAndConditionsIpfsHashUpdated`
 - `updateContactEmail(string newEmail)` → `ContactEmailUpdated`

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -1473,6 +1473,26 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit ValidatorSelectionSeedUpdated(newSeed);
     }
 
+    /// @notice Update the commit phase duration.
+    /// @param newCommitDuration Length of the commit phase in seconds; must be greater than zero.
+    function setCommitDuration(uint256 newCommitDuration) external onlyOwner {
+        if (newCommitDuration == 0) revert InvalidDuration();
+        if (reviewWindow < newCommitDuration + revealDuration)
+            revert ReviewWindowTooShort();
+        commitDuration = newCommitDuration;
+        emit CommitRevealWindowsUpdated(newCommitDuration, revealDuration);
+    }
+
+    /// @notice Update the reveal phase duration.
+    /// @param newRevealDuration Length of the reveal phase in seconds; must be greater than zero.
+    function setRevealDuration(uint256 newRevealDuration) external onlyOwner {
+        if (newRevealDuration == 0) revert InvalidDuration();
+        if (reviewWindow < commitDuration + newRevealDuration)
+            revert ReviewWindowTooShort();
+        revealDuration = newRevealDuration;
+        emit CommitRevealWindowsUpdated(commitDuration, newRevealDuration);
+    }
+
     /// @notice Update commit and reveal window durations.
     /// @param commitWindow Length of the commit phase in seconds; must be greater than zero.
     /// @param revealWindow Length of the reveal phase in seconds; must be greater than zero.

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -85,6 +85,24 @@ describe("AGIJobManagerV1 payouts", function () {
     ).to.be.revertedWithCustomError(manager, "InvalidDuration");
   });
 
+  it("allows owner to update commit and reveal durations individually", async function () {
+    const { manager } = await deployFixture();
+    await manager.setCommitDuration(500);
+    expect(await manager.commitDuration()).to.equal(500);
+    await manager.setRevealDuration(600);
+    expect(await manager.revealDuration()).to.equal(600);
+  });
+
+  it("reverts when commit or reveal duration exceeds review window", async function () {
+    const { manager } = await deployFixture();
+    await expect(
+      manager.setCommitDuration(1900)
+    ).to.be.revertedWithCustomError(manager, "ReviewWindowTooShort");
+    await expect(
+      manager.setRevealDuration(1900)
+    ).to.be.revertedWithCustomError(manager, "ReviewWindowTooShort");
+  });
+
   it("allows agent to apply for a job using a Merkle proof", async function () {
     const { token, manager, employer, agent, proof } = await deployFixture(1000, true);
     const payout = ethers.parseEther("1");


### PR DESCRIPTION
## Summary
- allow owner to adjust commit or reveal windows independently
- document commit/reveal duration setters for finer validator control
- test commit/reveal window setters and review-window bounds

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689343bbdf5c8333acc6cf946f173869