### PR TITLE
feat: expose payout and AGI type configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ functions control validation incentives, burn behavior, and system limits.
 | `removeAdditionalValidator(address validator)` | Remove a validator from the manual allowlist; emits `ValidatorRemoved`. | previously added address |
 | `addAdditionalAgent(address agent)` | Manually whitelist an agent; emits `AdditionalAgentAdded`. | non-zero address |
 | `removeAdditionalAgent(address agent)` | Remove an agent from the manual allowlist; emits `AdditionalAgentRemoved`. | previously added address |
+| `updateAGITokenAddress(address addr)` | Switch to a new $AGI token contract if ever required. | non-zero address |
 
 The current implementation relies on on-chain entropy for validator selection. For stronger guarantees against manipulation, integrate a verifiable randomness oracle such as Chainlink VRF in a future deployment.
 
@@ -200,6 +201,8 @@ Convenience functions:
 - `setBurnConfig(address addr, uint256 bps)` atomically updates burn address and percentage and reverts if burn plus validator reward exceed 100%.
 - `setValidatorConfig(...)` adjusts reward, reputation, staking, slashing, and timing in one call.
 - `getTimingConfig()` and `getValidatorConfig()` let anyone inspect current timing and incentive parameters in a single read call.
+- `getPayoutConfig()` reports burn, validator reward, and expiration caller reward settings along with the burn address.
+- `getAGITypes()` lists all NFT collections currently eligible for payout bonuses.
 
 ### Example: Updating Burn and Validator Settings with a Block Explorer
 
@@ -904,6 +907,7 @@ npx eslint .
 - **NFT marketplace** – completed jobs can mint NFTs that are listed, purchased, or delisted using $AGI tokens, and include protections against duplicate listings and self-purchases.
 - **Reward pool contributions** – participants can contribute $AGI to a communal pool; custom AGI types and payout percentages enable flexible reward schemes.
 - **AGI type limit** – the list of NFT collections granting payout bonuses is capped at 50 entries to keep per-job checks efficient.
+- Use `getAGITypes()` to view the currently registered bonus NFT collections on-chain.
 
 ## The Economy of AGI
 How jobs, reputation, and value circulate within the AGI ecosystem. Read the expanded discussion in [docs/economy-of-agi.md](docs/economy-of-agi.md).

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -1460,6 +1460,30 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         );
     }
 
+    /// @notice Retrieve payout parameters in a single call.
+    /// @dev Exposes burn and reward settings for non-technical users.
+    /// @return burnPct Portion of a job payout destroyed on completion.
+    /// @return validationRewardPct Portion of a job payout allocated to correct validators.
+    /// @return cancelRewardPct Share of escrow granted to the caller of `cancelExpiredJob`.
+    /// @return burnAddr Destination address for burned tokens.
+    function getPayoutConfig()
+        external
+        view
+        returns (
+            uint256 burnPct,
+            uint256 validationRewardPct,
+            uint256 cancelRewardPct,
+            address burnAddr
+        )
+    {
+        return (
+            burnPercentage,
+            validationRewardPercentage,
+            cancelRewardPercentage,
+            burnAddress
+        );
+    }
+
     function _validatePayoutSplits(
         uint256 _burnPercentage,
         uint256 _validationRewardPercentage
@@ -2366,6 +2390,12 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
             }
         }
         revert AGITypeNotFound();
+    }
+
+    /// @notice Retrieve all AGI NFT types that grant payout bonuses.
+    /// @return types Array of AGIType structs with `nftAddress` and `payoutPercentage`.
+    function getAGITypes() external view returns (AGIType[] memory types) {
+        types = agiTypes;
     }
 
     /// @notice Determine the highest AGI payout bonus available to an agent.

--- a/test/agiType.test.js
+++ b/test/agiType.test.js
@@ -36,6 +36,10 @@ describe("AGIJobManagerV1 AGI types", function () {
     const nftAddress = await manager.getAddress();
 
     await manager.addAGIType(nftAddress, 500);
+    const types = await manager.getAGITypes();
+    expect(types.length).to.equal(1);
+    expect(types[0].nftAddress).to.equal(nftAddress);
+    expect(types[0].payoutPercentage).to.equal(500n);
 
     await expect(manager.removeAGIType(nftAddress))
       .to.emit(manager, "AGITypeRemoved")

--- a/test/payoutSplits.test.js
+++ b/test/payoutSplits.test.js
@@ -97,4 +97,24 @@ describe("payout split validation", function () {
       )
     ).to.emit(manager, "ValidatorConfigUpdated");
   });
+
+  it("returns current payout configuration", async function () {
+    const { manager } = await deployFixture();
+    const initial = await manager.getPayoutConfig();
+    expect(initial.burnPct).to.equal(500n);
+    expect(initial.validationRewardPct).to.equal(800n);
+    expect(initial.cancelRewardPct).to.equal(100n);
+    expect(initial.burnAddr).to.equal(await manager.BURN_ADDRESS());
+
+    const newBurnAddr = ethers.Wallet.createRandom().address;
+    await manager.setBurnConfig(newBurnAddr, 1000);
+    await manager.setValidationRewardPercentage(700);
+    await manager.setCancelRewardPercentage(200);
+
+    const updated = await manager.getPayoutConfig();
+    expect(updated.burnPct).to.equal(1000n);
+    expect(updated.validationRewardPct).to.equal(700n);
+    expect(updated.cancelRewardPct).to.equal(200n);
+    expect(updated.burnAddr).to.equal(newBurnAddr);
+  });
 });


### PR DESCRIPTION
## Summary
- add `getPayoutConfig` for one-call access to burn, validator reward, and cancel reward settings
- expose `getAGITypes` to list all NFT collections with payout bonuses
- document new owner controls and helper getters in README
- cover new view helpers with tests

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893698d803083338db8b077f7a416e4