### PR TITLE
feat: make agent blacklist threshold configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ Interact with the contracts using a wallet or block explorer. Always verify cont
 - Monitor the job status until validators approve and funds release.
 - Request completion before the deadline or anyone can cancel via `cancelExpiredJob` to refund the employer's escrow and claim the caller reward, so keep a close eye on the timer.
 - Losing a dispute reduces your reputation and can slash any staked AGI. The `AgentPenalized` event records the penalty.
-- Accumulating three penalties (missed deadlines or employer wins) automatically blacklists your address until the owner calls `clearAgentBlacklist`.
+- Accumulating three penalties (missed deadlines or employer wins) automatically blacklists your address until the owner calls `clearAgentBlacklist`. The owner may adjust this threshold via `setAgentBlacklistThreshold`.
  - Disputes still resolve even if your stake drops below the required threshold; jobs finalize but no additional slashing occurs when funds are insufficient.
 
 **Penalties**
 - Missing a deadline or having a moderator side with the employer via `resolveDispute` can lower your reputation and slash staked AGI if the job is cancelled with `cancelExpiredJob`.
-- After three such penalties, `blacklistedAgents[agent]` becomes `true` and you must appeal to the owner to run `clearAgentBlacklist` before applying again.
+- After the configured number of penalties, `blacklistedAgents[agent]` becomes `true` and you must appeal to the owner to run `clearAgentBlacklist` before applying again. By default, the threshold is three.
 
 **Validators**
 - Verify the contract address and ensure you meet the current stake requirement.

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -193,7 +193,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     /// @notice Denominator used for percentage calculations (100% = 10_000).
     uint256 public constant PERCENTAGE_DENOMINATOR = 10_000;
     /// @notice Number of penalties before an agent is automatically blacklisted.
-    uint256 public constant AGENT_BLACKLIST_THRESHOLD = 3;
+    uint256 public agentBlacklistThreshold = 3;
     /// @notice Duration of the commit phase for validator votes.
     /// @dev Defaults to 1 hour and may be updated by the owner.
     uint256 public commitDuration;
@@ -431,6 +431,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     event AgentSlashingPercentageUpdated(uint256 newPercentage);
     event MinValidatorReputationUpdated(uint256 newMinimum);
     event MinAgentReputationUpdated(uint256 newMinimum);
+    event AgentBlacklistThresholdUpdated(uint256 newThreshold);
     event StakeSlashed(address indexed validator, uint256 amount);
     event AgentPenalized(
         address indexed agent,
@@ -1103,7 +1104,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         );
         agentPenaltyCount[job.assignedAgent] += 1;
         if (
-            agentPenaltyCount[job.assignedAgent] >= AGENT_BLACKLIST_THRESHOLD &&
+            agentPenaltyCount[job.assignedAgent] >= agentBlacklistThreshold &&
             !blacklistedAgents[job.assignedAgent]
         ) {
             blacklistedAgents[job.assignedAgent] = true;
@@ -1664,6 +1665,11 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit MinAgentReputationUpdated(minimum);
     }
 
+    function setAgentBlacklistThreshold(uint256 newThreshold) external onlyOwner {
+        agentBlacklistThreshold = newThreshold;
+        emit AgentBlacklistThresholdUpdated(newThreshold);
+    }
+
     function setValidatorsPerJob(uint256 count) external onlyOwner {
         if (
             count == 0 ||
@@ -2009,7 +2015,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit AgentPenalized(agent, reputationPenalty, agentSlashAmount);
         agentPenaltyCount[agent] += 1;
         if (
-            agentPenaltyCount[agent] >= AGENT_BLACKLIST_THRESHOLD &&
+            agentPenaltyCount[agent] >= agentBlacklistThreshold &&
             !blacklistedAgents[agent]
         ) {
             blacklistedAgents[agent] = true;


### PR DESCRIPTION
## Summary
- replace agent blacklist threshold constant with state variable
- add onlyOwner setter and event for blacklist threshold
- document configurable blacklist threshold

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68939fcd23948333ab081543bf53e77c