### PR TITLE
refine validator incentives and docs

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -446,11 +446,6 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         bool committed,
         bool revealed
     );
-    event ValidatorRewardReduced(
-        uint256 indexed jobId,
-        uint256 availableSlashed,
-        uint256 expectedReward
-    );
     event ValidatorConfigUpdated(
         uint256 rewardPercentage,
         uint256 reputationPercentage,
@@ -1071,9 +1066,6 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         Job storage job = jobs[_jobId];
         job.status = JobStatus.Completed;
         totalJobEscrow -= job.payout;
-        uint256 validatorPayoutTotal =
-            (job.payout * validationRewardPercentage) /
-            PERCENTAGE_DENOMINATOR;
         uint256 completionTime = block.timestamp - job.assignedAt;
         uint256 reputationPoints =
             calculateReputationPoints(job.payout, completionTime);
@@ -1122,16 +1114,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         );
 
         if (correctValidatorCount > 0) {
-            uint256 rewardCap = validatorPayoutTotal;
-            if (totalSlashed < rewardCap) {
-                rewardCap = totalSlashed;
-                emit ValidatorRewardReduced(
-                    _jobId,
-                    totalSlashed,
-                    validatorPayoutTotal
-                );
-            }
-            uint256 rewardPerValidator = rewardCap / correctValidatorCount;
+            uint256 rewardPerValidator = totalSlashed / correctValidatorCount;
             uint256 distributed = rewardPerValidator * correctValidatorCount;
             uint256 leftover = totalSlashed - distributed;
             for (uint256 i; i < correctValidatorCount; ) {

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -887,12 +887,8 @@ describe("AGIJobManagerV1 payouts", function () {
     await manager.connect(validator2).disapproveJob(jobId, "", []);
 
     await manager.addModerator(owner.address);
-    const validatorPayoutTotal = (payout * 800n) / 10000n;
     const slashAmount = (stakeAmount * 5000n) / 10000n;
-    await expect(manager.resolveDispute(jobId, 1))
-      .to.emit(manager, "ValidatorRewardReduced")
-      .withArgs(jobId, slashAmount, validatorPayoutTotal);
-
+    await manager.resolveDispute(jobId, 1);
     expect(await token.balanceOf(validator2.address)).to.equal(slashAmount);
     expect(await token.balanceOf(employer.address)).to.equal(payout);
     await expect(


### PR DESCRIPTION
## Summary
- redistribute all slashed validator stake among honest validators with leftover sent to `slashedStakeRecipient`
- document updated slashing/reward flow and remainder handling in README
- adjust unit tests for new slashed stake distribution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893a9cbd3588333a26ba71e6c66dea0