### PR TITLE
Use future block for validator selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ For detailed examples and code snippets, see the [Quick Start](#quick-start).
 
 Review `*Updated` events after any call to confirm changes on-chain.
 
+To lessen predictability in validator selection, the contract owner should
+periodically call `setValidatorSelectionSeed` with a fresh random value.
+
 ## Disclaimer
 
 - Verify every address independently before sending transactions. Cross-check on multiple block explorers (e.g., Etherscan, Blockscout) and official channels.


### PR DESCRIPTION
## Summary
- select validators using blockhash of future `selectionBlock`
- emit `SelectionBlockSet` and reseed when blockhash unavailable
- document refreshing `validatorSelectionSeed` in README

## Testing
- `npm test`
- `npm run lint` *(warnings: 762)*

------
https://chatgpt.com/codex/tasks/task_e_6893bcf7ea2c8333a67f8594bf2dc266