### PR TITLE
Align validator rewards with outcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Follow these steps before trusting any address or artifact:
 - Confirm the current `stakeRequirement`, `agentStakeRequirement`, `agentStakePercentage`, and `minAgentReputation` with the contract's **Read** tab before staking or applying; `withdrawStake` only succeeds once all of your jobs are finalized without disputes. Agents can check their own stake via `agentStake(address)`.
 - Monitor `*Updated` events for changes to burn rates, slashing percentages, reward splits, minimum reputation, the slashed‑stake recipient, or validator pool resets via `ValidatorPoolSet`.
 - Validators that fall below `minValidatorReputation` are automatically blacklisted; the restriction lifts once their reputation rises back above the threshold.
-- If no validator votes correctly, only slashed stake goes to `slashedStakeRecipient` while the reserved validator reward portion returns to the job's agent or employer; when at least one validator is correct, they split the entire slashed stake and any rounding remainder goes to `slashedStakeRecipient`.
+- If no validator votes correctly, slashed stake goes to `slashedStakeRecipient` and the reserved validator reward portion returns to the job's agent or employer; if at least one validator is correct, they split the entire reward pool and all slashed stake, including any rounding remainder.
 
 ## Default Parameters
 
@@ -403,7 +403,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
   - Rewards accrue only to validators whose votes match the final outcome; others are excluded.
   - Misaligned votes are slashed and lose reputation; correct validators split the entire slashed stake.
   - `validatorsPerJob` defaults to three and can never fall below the approval or disapproval thresholds, preventing owner misconfiguration.
-  - If no validator votes correctly, all slashed stakes are sent to `slashedStakeRecipient` and the reserved reward portion refunds to the agent or employer.
+  - If no validator votes correctly, all slashed stakes are sent to `slashedStakeRecipient` and the reserved reward portion refunds to the agent or employer; otherwise, correct validators share the entire reward pool.
   - Default timing uses a one-hour commit phase and one-hour reveal phase with a two-hour review window, all adjustable by the owner. Attempts to set either window to zero revert with the `InvalidDuration` custom error.
   - Validator reputation gains use a separate `validatorReputationPercentage` so reputation rewards can differ from token rewards.
   - All validator parameters (reward %, reputation %, slashing %, stake requirement,
@@ -412,7 +412,7 @@ Aims to coordinate trustless labor markets for autonomous agents using the $AGI 
   - The validator pool is limited by `maxValidatorPoolSize` (default 100). Exceeding the cap in `addAdditionalValidator` or `setValidatorPool` reverts. Owners can adjust the limit via `setMaxValidatorPoolSize`, which emits `MaxValidatorPoolSizeUpdated`.
   - Setting the stake requirement or slashing percentage to `0` disables those mechanisms.
 - **Basis-point standardization** – percentage parameters like burns, slashing, and rewards are expressed in basis points for deterministic math.
-- **Configurable slashed stake recipient** – if no validator votes correctly, all slashed stake is sent to `slashedStakeRecipient` (initially the owner but adjustable, e.g. to the burn address). Any remainder from validator reward splitting is also directed here while the validator reward portion reverts to the agent or employer.
+- **Configurable slashed stake recipient** – if no validator votes correctly, all slashed stake is sent to `slashedStakeRecipient` (initially the owner but adjustable, e.g. to the burn address) and the reserved reward portion reverts to the agent or employer. When at least one validator is correct, the entire reward pool—including slashed stake and any rounding remainder—is shared among them.
 - **Automatic finalization & configurable token burn** – the last validator approval triggers `_finalizeJobAndBurn`, minting the completion NFT, releasing the payout, and burning the configured portion of escrow. The `JobFinalizedAndBurned` event records agent payouts and burn amounts.
 
 ### NFT Bonus
@@ -610,7 +610,7 @@ Validators follow a commit–reveal process and can finalize their vote only aft
 - **Staking & withdrawals** – validators deposit $AGI via `stake()` and may top up incrementally. Validation is only permitted once their total stake meets `stakeRequirement`. Stakes can be withdrawn with `withdrawStake` only after all participated jobs are finalized and undisputed.
 - **Aligned rewards** – when a job finalizes, only validators whose votes match the outcome split `validationRewardPercentage` basis points of the remaining escrow along with any slashed stake. If no votes are correct, slashed tokens go to `slashedStakeRecipient` and the reserved validator reward portion is returned to the job's agent or employer.
 - **Slashing & reputation penalties** – incorrect votes lose `validatorSlashingPercentage` basis points of staked tokens and incur a reputation deduction.
-- **Remainder handling** – integer division leftovers from reward or slashed-stake calculations are sent to `slashedStakeRecipient`. If no validator votes correctly, all slashed stake goes to `slashedStakeRecipient` and the validator reward pool returns to the agent or employer as appropriate.
+- **Remainder handling** – integer division leftovers from reward calculations are distributed across correct validators. If no validator votes correctly, all slashed stake goes to `slashedStakeRecipient` and the validator reward pool returns to the agent or employer as appropriate.
 - **Owner‑tunable parameters** – the contract owner can adjust `stakeRequirement` (must be greater than zero), `validatorSlashingPercentage` and `agentSlashingPercentage` (basis points), `validationRewardPercentage` (basis points), `minValidatorReputation`, `slashedStakeRecipient`, and approval/disapproval thresholds. All of these values can be updated atomically via `setValidatorConfig`, which also sets `slashedStakeRecipient`; each `onlyOwner` update emits a dedicated event.
 - **Dispute lock** – once a job is disputed, no additional validator votes are accepted until a moderator resolves the dispute.
 - **Dispute timing** – `disputeJob` is callable only after the review window and commit/reveal phases elapse (`block.timestamp >= job.validationStart + commitDuration + revealDuration`).
@@ -620,7 +620,7 @@ Validators follow a commit–reveal process and can finalize their vote only aft
 
 When validators disapprove a job and the employer prevails:
 
-- Disapproving validators split `validationRewardPercentage` basis points of the escrow along with any slashed stake. If none disapprove correctly, slashed tokens go to `slashedStakeRecipient` and the reward portion returns to the employer.
+- Disapproving validators split `validationRewardPercentage` basis points of the escrow along with any slashed stake and rounding remainder. If none disapprove correctly, slashed tokens go to `slashedStakeRecipient` and the reward portion returns to the employer.
 - Approving validators are slashed and receive no reward.
 - The remaining escrow returns to the employer.
 

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -183,7 +183,7 @@ describe("AGIJobManagerV1 payouts", function () {
     expect(agentExpected + validatorPayoutTotal + burnAmount).to.equal(payout);
   });
 
-  it("sends validator leftovers to slashedStakeRecipient", async function () {
+  it("distributes validator leftovers among correct validators", async function () {
     const { token, manager, owner, employer, agent, validator, validator2, validator3 } = await deployFixture();
     await manager.setRequiredValidatorApprovals(3);
     const payout = ethers.parseEther("1000");
@@ -216,25 +216,27 @@ describe("AGIJobManagerV1 payouts", function () {
     await time.increase(1000);
     await manager.connect(validator).validateJob(jobId, "", []);
     await manager.connect(validator2).validateJob(jobId, "", []);
-    await expect(
-      manager.connect(validator3).validateJob(jobId, "", [])
-    )
-      .to.emit(manager, "LeftoverTransferred")
-      .withArgs(owner.address, 2n);
+    await manager.connect(validator3).validateJob(jobId, "", []);
 
     const burnAddr = await manager.burnAddress();
     const burnAmount = (payout * 1000n) / 10000n;
     const validatorPayoutTotal = (payout * 800n) / 10000n;
     const baseReward = validatorPayoutTotal / 3n;
-    const leftover = validatorPayoutTotal - baseReward * 3n;
     const agentExpected = payout - burnAmount - validatorPayoutTotal;
 
-    expect(await token.balanceOf(validator.address)).to.equal(baseReward);
-    expect(await token.balanceOf(validator2.address)).to.equal(baseReward);
-    expect(await token.balanceOf(validator3.address)).to.equal(baseReward);
-    expect(await token.balanceOf(owner.address)).to.equal(
-      initialOwnerBalance + leftover
+    const vBalances = [
+      await token.balanceOf(validator.address),
+      await token.balanceOf(validator2.address),
+      await token.balanceOf(validator3.address),
+    ];
+    const totalDistributed = vBalances.reduce((a, b) => a + b, 0n);
+    expect(totalDistributed).to.equal(validatorPayoutTotal);
+    const higherCount = vBalances.filter((b) => b === baseReward + 1n).length;
+    expect(higherCount).to.equal(Number(validatorPayoutTotal % 3n));
+    vBalances.forEach((b) =>
+      expect([baseReward, baseReward + 1n]).to.include(b)
     );
+    expect(await token.balanceOf(owner.address)).to.equal(initialOwnerBalance);
     expect(await token.balanceOf(burnAddr)).to.equal(burnAmount);
     expect(await token.balanceOf(agent.address)).to.equal(agentExpected);
     expect(agentExpected + validatorPayoutTotal + burnAmount).to.equal(payout);


### PR DESCRIPTION
## Summary
- distribute validator reward pool and slashed stakes among correct validators with per-validator remainder handling
- document updated incentive model and slashed-stake flow in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893cfa1519883338987a9256a502ef4