### PR TITLE
Make AGI type cap configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ For detailed examples and code snippets, see the [Quick Start](#quick-start).
 | `jobDurationLimit` | `setJobDurationLimit(uint256)` | Maximum job duration |
 | `agentBlacklistThreshold` | `setAgentBlacklistThreshold(uint256)` | Penalties before automatic agent blacklist |
 | `maxValidatorPoolSize` | `setMaxValidatorPoolSize(uint256)` | Cap on validator pool size |
+| `maxAGITypes` | `setMaxAGITypes(uint256)` | Maximum allowed AGI types |
 | `AGI token address` | `updateAGITokenAddress(address)` | Replace the $AGI token used for payments |
 | `baseURI` | `setBaseURI(string)` | Prefix for NFT metadata |
 

--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -289,7 +289,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     uint256 public totalJobEscrow;
     uint256 public totalValidatorStake;
     uint256 public totalAgentStake;
-    uint256 public constant MAX_AGI_TYPES = 50; // limits AGI type iterations
+    uint256 public maxAGITypes = 50; // limits AGI type iterations
     AGIType[] public agiTypes;
 
     event JobCreated(
@@ -378,6 +378,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     event RecoveryInitiated(string reason);
     event AGITypeUpdated(address indexed nftAddress, uint256 payoutPercentage);
     event AGITypeRemoved(address indexed nftAddress);
+    event MaxAGITypesUpdated(uint256 oldMax, uint256 newMax);
     event NFTIssued(uint256 indexed tokenId, address indexed employer, string tokenURI);
     event NFTListed(uint256 indexed tokenId, address indexed seller, uint256 price);
     event NFTPurchased(uint256 indexed tokenId, address indexed buyer, uint256 price);
@@ -2738,6 +2739,15 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit RewardPoolContribution(msg.sender, amount);
     }
 
+    /// @notice Update the maximum number of AGI NFT types tracked.
+    /// @param newMax New maximum number of AGI types.
+    function setMaxAGITypes(uint256 newMax) external onlyOwner {
+        if (newMax == 0 || newMax < agiTypes.length) revert InvalidParameters();
+        uint256 oldMax = maxAGITypes;
+        maxAGITypes = newMax;
+        emit MaxAGITypesUpdated(oldMax, newMax);
+    }
+
     /// @notice Register or update an AGI NFT type that grants bonus payouts.
     /// @param nftAddress Address of the qualifying NFT collection.
     /// @param payoutPercentage Bonus percentage in basis points applied to job payouts for holders of the NFT.
@@ -2759,7 +2769,7 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
             }
         }
         if (!exists) {
-            if (length >= MAX_AGI_TYPES) {
+            if (length >= maxAGITypes) {
                 revert MaxAGITypesReached();
             }
             agiTypes.push(AGIType({ nftAddress: nftAddress, payoutPercentage: payoutPercentage }));

--- a/test/agiType.test.js
+++ b/test/agiType.test.js
@@ -70,9 +70,17 @@ describe("AGIJobManagerV1 AGI types", function () {
     expect(await manager.getHighestPayoutPercentage(agent.address)).to.equal(500);
   });
 
+  it("updates max AGI types", async function () {
+    const { manager } = await deploy();
+    await expect(manager.setMaxAGITypes(100))
+      .to.emit(manager, "MaxAGITypesUpdated")
+      .withArgs(50n, 100n);
+    expect(await manager.maxAGITypes()).to.equal(100n);
+  });
+
   it("enforces AGI type cap", async function () {
     const { manager } = await deploy();
-    const max = Number(await manager.MAX_AGI_TYPES());
+    const max = Number(await manager.maxAGITypes());
 
     for (let i = 0; i < max; i++) {
       await manager.addAGIType(ethers.Wallet.createRandom().address, 100);


### PR DESCRIPTION
## Summary
- replace MAX_AGI_TYPES constant with mutable `maxAGITypes`
- add `setMaxAGITypes` with `MaxAGITypesUpdated` event
- document AGI type cap in owner configuration table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893de1339808333983994a815a744d8