### PR TITLE
feat: enforce validator stake percentage

### DIFF
--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -1392,7 +1392,38 @@ describe("AGIJobManagerV1 payouts", function () {
       ).to.be.revertedWithCustomError(manager, "PendingCommitments");
     });
 
-    it("exposes address and info helpers", async function () {
+  it("reverts commit when validator stake percentage increases", async function () {
+    const { token, manager, employer, agent, validator, validator2, validator3 } = await deployFixture();
+    await manager.setValidatorsPerJob(1);
+    await manager.removeAdditionalValidator(validator2.address);
+    await manager.removeAdditionalValidator(validator3.address);
+
+    const stakeAmount = ethers.parseEther("20");
+    await token.mint(validator.address, stakeAmount);
+    await token.connect(validator).approve(await manager.getAddress(), stakeAmount);
+    await manager.connect(validator).stake(stakeAmount);
+
+    const payout = ethers.parseEther("100");
+    await token.connect(employer).approve(await manager.getAddress(), payout);
+    await manager.connect(employer).createJob("jobhash", payout, 1000, "details");
+    const jobId = 0;
+    await manager.connect(agent).applyForJob(jobId, "", []);
+    await manager.connect(agent).requestJobCompletion(jobId, "result");
+
+    await manager.setValidatorStakePercentage(5000);
+    const salt = ethers.id("vstake");
+    const commitment = ethers.solidityPackedKeccak256([
+      "address",
+      "uint256",
+      "bool",
+      "bytes32",
+    ], [validator.address, jobId, true, salt]);
+    await expect(
+      manager.connect(validator).commitValidation(jobId, commitment, "", [])
+    ).to.be.revertedWithCustomError(manager, "InsufficientStake");
+  });
+
+  it("exposes address and info helpers", async function () {
       const { manager, owner } = await deployFixture();
       const [tokenAddr, , , ensAddr, wrapperAddr, ownerAddr] = await manager.getAddresses();
       expect(ownerAddr).to.equal(owner.address);

--- a/test/payoutSplits.test.js
+++ b/test/payoutSplits.test.js
@@ -120,6 +120,14 @@ describe("payout split validation", function () {
     expect(updated.burnAddr).to.equal(newBurnAddr);
   });
 
+  it("computes required validator stake", async function () {
+    const { manager } = await deployFixture();
+    await manager.setStakeRequirement(100);
+    await manager.setValidatorStakePercentage(2000);
+    const stakeNeeded = await manager.computeRequiredValidatorStake(2000);
+    expect(stakeNeeded).to.equal(400n); // max(100, 20% of payout)
+  });
+
   it("allows owner to atomically update payout settings", async function () {
     const { manager } = await deployFixture();
     const newBurnAddr = ethers.Wallet.createRandom().address;


### PR DESCRIPTION
## Summary
- ensure validators meet a payout-based minimum stake
- allow owner to tune validator stake percentage
- document and test validator stake calculations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893e62feea483339638d1095d5c6bf5