### PR TITLE
Require terms acceptance for validator and agent actions

### DIFF
--- a/contracts/AGIJobManagerv1.sol
+++ b/contracts/AGIJobManagerv1.sol
@@ -792,6 +792,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         whenNotPaused
         jobExists(_jobId)
     {
+        if (acceptedTermsVersion[msg.sender] != termsVersion)
+            revert TermsNotAccepted();
         Job storage job = jobs[_jobId];
         if (msg.sender != job.assignedAgent) revert Unauthorized();
         if (block.timestamp > job.assignedAt + job.duration)
@@ -890,6 +892,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         nonReentrant
         jobExists(_jobId)
     {
+        if (acceptedTermsVersion[msg.sender] != termsVersion)
+            revert TermsNotAccepted();
         if (
             !(
                 _verifyOwnership(msg.sender, subdomain, proof, clubRootNode) ||
@@ -926,6 +930,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         nonReentrant
         jobExists(_jobId)
     {
+        if (acceptedTermsVersion[msg.sender] != termsVersion)
+            revert TermsNotAccepted();
         Job storage job = jobs[_jobId];
         if (!job.isSelectedValidator[msg.sender]) revert ValidatorNotSelected();
         if (job.status != JobStatus.CompletionRequested) revert InvalidJobState();
@@ -957,6 +963,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         nonReentrant
         jobExists(_jobId)
     {
+        if (acceptedTermsVersion[msg.sender] != termsVersion)
+            revert TermsNotAccepted();
         if (
             !(
                 _verifyOwnership(msg.sender, subdomain, proof, clubRootNode) ||
@@ -1001,6 +1009,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         nonReentrant
         jobExists(_jobId)
     {
+        if (acceptedTermsVersion[msg.sender] != termsVersion)
+            revert TermsNotAccepted();
         if (
             !(
                 _verifyOwnership(msg.sender, subdomain, proof, clubRootNode) ||
@@ -1041,6 +1051,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
         nonReentrant
         jobExists(_jobId)
     {
+        if (acceptedTermsVersion[msg.sender] != termsVersion)
+            revert TermsNotAccepted();
         Job storage job = jobs[_jobId];
         if (
             (msg.sender != job.assignedAgent && msg.sender != job.employer) ||
@@ -2713,6 +2725,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     }
 
     function withdrawStake(uint256 amount) external nonReentrant {
+        if (acceptedTermsVersion[msg.sender] != termsVersion)
+            revert TermsNotAccepted();
         if (amount == 0 || amount > validatorStake[msg.sender]) revert InvalidAmount();
         if (
             validatorApprovedJobs[msg.sender].length != 0 ||
@@ -2744,6 +2758,8 @@ contract AGIJobManagerV1 is Ownable, ReentrancyGuard, Pausable, ERC721 {
     /// @notice Withdraw staked $AGI for agents.
     /// @param amount Quantity of tokens to withdraw.
     function withdrawAgentStake(uint256 amount) external nonReentrant {
+        if (acceptedTermsVersion[msg.sender] != termsVersion)
+            revert TermsNotAccepted();
         if (amount == 0 || amount > agentStake[msg.sender]) revert InvalidAmount();
         if (agentActiveJobs[msg.sender] != 0) revert PendingOrDisputedJob();
         agentStake[msg.sender] -= amount;

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -60,6 +60,7 @@ describe("AGIJobManagerV1 payouts", function () {
     await manager.connect(validator).acceptTerms("ipfs://terms");
     await manager.connect(validator2).acceptTerms("ipfs://terms");
     await manager.connect(validator3).acceptTerms("ipfs://terms");
+    await manager.connect(employer).acceptTerms("ipfs://terms");
     await manager.setValidatorsPerJob(3);
 
     if (stakeAgent) {

--- a/test/finalizationReentrancy.test.js
+++ b/test/finalizationReentrancy.test.js
@@ -44,6 +44,7 @@ async function deployFixture() {
 
   await manager.connect(agent).acceptTerms("ipfs://terms");
   await manager.connect(validator).acceptTerms("ipfs://terms");
+  await manager.connect(employer).acceptTerms("ipfs://terms");
 
   const stakeAmount = ethers.parseEther("100");
   await token.mint(agent.address, stakeAmount);


### PR DESCRIPTION
## Summary
- require latest terms acceptance for validator commits, reveals, job approvals/disapprovals, and disputes
- enforce terms check for agent job completion requests and stake withdrawals
- update tests to ensure employers accept terms

## Testing
- `npm test`
- `npm run lint` (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_6893eeec772c83339b37be097e20e285