### PR TITLE
feat: enforce validator accountability

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For detailed examples and code snippets, see the [Quick Start](#quick-start).
 3. Stake AGI with `stake` and wait to be selected.
 4. **Commit:** Off‑chain, compute `commitHash = keccak256(abi.encode(jobId, approve, salt))` using any Keccak‑256 tool (e.g., Node, ethers.js). Example: `node -e "console.log(require('ethers').solidityPackedKeccak256(['uint256','bool','bytes32'], [JOB_ID,true,'0xSALT']))"`. Call `commitValidation(jobId, commitHash)` during the commit window.
 5. **Reveal:** After the commit window ends, call `revealValidation(jobId, approve, salt)` using the same `approve` flag and secret `salt`.
-6. Finalize with `validateJob` or `disapproveJob` after the review window; correct validators split the reserved reward and any slashed stakes up to the `maxSlashedRewardPercentage` cap (excess goes to `slashedStakeRecipient`). Monitor `ValidationCommitted`, `ValidationRevealed`, and `JobFinalizedAndBurned` events.
+6. Finalize with `validateJob` or `disapproveJob` after the review window; correct validators split the reserved reward and any slashed stakes up to the `maxSlashedRewardPercentage` cap (excess goes to `slashedStakeRecipient`). Repeated incorrect or missed votes increase `validatorPenaltyCount`; reaching the owner‑set `validatorBlacklistThreshold` automatically blacklists the validator. Owners may restore participation with `clearValidatorBlacklist`. Monitor `ValidationCommitted`, `ValidationRevealed`, and `JobFinalizedAndBurned` events.
 
 ### Owner Configuration Summary
 
@@ -116,6 +116,7 @@ For detailed examples and code snippets, see the [Quick Start](#quick-start).
 | `maxJobPayout` | `setMaxJobPayout(uint256)` | Maximum allowed job payout |
 | `jobDurationLimit` | `setJobDurationLimit(uint256)` | Maximum job duration |
 | `agentBlacklistThreshold` | `setAgentBlacklistThreshold(uint256)` | Penalties before automatic agent blacklist |
+| `validatorBlacklistThreshold` | `setValidatorBlacklistThreshold(uint256)` | Penalties before automatic validator blacklist |
 | `maxValidatorPoolSize` | `setMaxValidatorPoolSize(uint256)` | Cap on validator pool size |
 | `maxAGITypes` | `setMaxAGITypes(uint256)` | Maximum allowed AGI types |
 | `AGI token address` | `updateAGITokenAddress(address)` | Replace the $AGI token used for payments |

--- a/test/AGIJobManagerV1.js
+++ b/test/AGIJobManagerV1.js
@@ -62,6 +62,7 @@ describe("AGIJobManagerV1 payouts", function () {
     await manager.connect(validator3).acceptTerms("ipfs://terms");
     await manager.connect(employer).acceptTerms("ipfs://terms");
     await manager.setValidatorsPerJob(3);
+    await manager.setValidatorBlacklistThreshold(1000);
 
     if (stakeAgent) {
       const stakeAmount = ethers.parseEther("100");

--- a/test/validatorBlacklist.test.js
+++ b/test/validatorBlacklist.test.js
@@ -1,0 +1,89 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+async function deployFixture() {
+  const [owner, employer, agent, validator] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory("MockERC20");
+  const token = await Token.deploy();
+  await token.waitForDeployment();
+
+  await token.mint(employer.address, ethers.parseEther("1000"));
+  await token.mint(validator.address, ethers.parseEther("100"));
+
+  const ENSMock = await ethers.getContractFactory("MockENS");
+  const ens = await ENSMock.deploy();
+  await ens.waitForDeployment();
+
+  const WrapperMock = await ethers.getContractFactory("MockNameWrapper");
+  const wrapper = await WrapperMock.deploy();
+  await wrapper.waitForDeployment();
+
+  const Manager = await ethers.getContractFactory("AGIJobManagerV1");
+  const manager = await Manager.deploy(
+    await token.getAddress(),
+    "ipfs://",
+    await ens.getAddress(),
+    await wrapper.getAddress(),
+    ethers.ZeroHash,
+    ethers.ZeroHash,
+    ethers.ZeroHash,
+    ethers.ZeroHash
+  );
+  await manager.waitForDeployment();
+
+  await manager.addAdditionalAgent(agent.address);
+  await manager.addAdditionalValidator(validator.address);
+  await manager.addModerator(owner.address);
+
+  await manager.setAgentStakeRequirement(0);
+  await manager.setStakeRequirement(0);
+  await manager.setValidatorSlashingPercentage(1000); // 10%
+  await manager.setRequiredValidatorApprovals(1);
+  await manager.setRequiredValidatorDisapprovals(1);
+  await manager.setValidatorsPerJob(1);
+  await manager.setValidatorBlacklistThreshold(1);
+  await manager.setTimingConfig(1, 10, 12, 1);
+
+  await manager.connect(agent).acceptTerms("ipfs://terms");
+  await manager.connect(validator).acceptTerms("ipfs://terms");
+
+  const stake = ethers.parseEther("10");
+  await token.connect(validator).approve(await manager.getAddress(), stake);
+  await manager.connect(validator).stake(stake);
+
+  return { token, manager, employer, agent, validator };
+}
+
+describe("Validator blacklist threshold", function () {
+  it("blacklists a validator after one penalty", async function () {
+    const { token, manager, employer, agent, validator } = await deployFixture();
+    const payout = ethers.parseEther("10");
+
+    await token.connect(employer).approve(await manager.getAddress(), payout);
+    await manager.connect(employer).createJob("jobhash", payout, 1, "details");
+    await manager.connect(agent).applyForJob(0, "", []);
+    await manager.connect(agent).requestJobCompletion(0, "resultHash");
+
+    const salt = ethers.encodeBytes32String("salt");
+    const commit = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "bool", "bytes32"],
+      [validator.address, 0, false, salt]
+    );
+      await manager
+        .connect(validator)
+        .commitValidation(0, commit, "", []);
+      await time.increase(2);
+      await manager.connect(validator).revealValidation(0, false, salt);
+      await time.increase(11);
+      await manager.connect(validator).disapproveJob(0, "", []);
+
+      await expect(manager.resolveDispute(0, 0))
+        .to.emit(manager, "ValidatorBlacklisted")
+        .withArgs(validator.address, true);
+
+    expect(await manager.validatorPenaltyCount(validator.address)).to.equal(1n);
+    expect(await manager.blacklistedValidators(validator.address)).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add per-validator penalty tracking and automatic blacklisting
- expose validator blacklist threshold in config getters and README
- document validator penalties and add test for blacklist threshold

## Testing
- `npx hardhat test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893f796bc008333945cd5596991bced