### PR TITLE
feat: add modular job system

### DIFF
--- a/contracts/CertificateNFT.sol
+++ b/contracts/CertificateNFT.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title CertificateNFT
+/// @notice ERC721 certificate minted upon successful job completion.
+contract CertificateNFT is ERC721, Ownable {
+    uint256 public nextId;
+    string private baseTokenURI;
+
+    event BaseURIUpdated(string newURI);
+
+    constructor(string memory name_, string memory symbol_, address owner)
+        ERC721(name_, symbol_)
+        Ownable(owner)
+    {}
+
+    /// @notice Update the base token URI.
+    function setBaseURI(string memory uri) external onlyOwner {
+        baseTokenURI = uri;
+        emit BaseURIUpdated(uri);
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return baseTokenURI;
+    }
+
+    /// @notice Mint a new certificate to `to`.
+    function mint(address to) external onlyOwner returns (uint256 tokenId) {
+        tokenId = ++nextId;
+        _safeMint(to, tokenId);
+    }
+}
+

--- a/contracts/JobRegistry.sol
+++ b/contracts/JobRegistry.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+interface IValidationModule {
+    function validate(uint256 jobId) external view returns (bool);
+}
+
+interface IReputationEngine {
+    function increaseReputation(address user, uint256 amount) external;
+    function decreaseReputation(address user, uint256 amount) external;
+}
+
+interface IStakeManager {
+    function lockReward(address from, uint256 amount) external;
+    function payReward(address to, uint256 amount) external;
+    function slash(address user, address recipient, uint256 amount) external;
+    function releaseStake(address user, uint256 amount) external;
+    function stakes(address user) external view returns (uint256);
+}
+
+interface ICertificateNFT {
+    function mint(address to) external returns (uint256);
+}
+
+/// @title JobRegistry
+/// @notice Orchestrates job lifecycle and coordinates with external modules.
+contract JobRegistry is Ownable {
+    enum Status { None, Created, Completed, Disputed, Finalized }
+
+    struct Job {
+        address employer;
+        address agent;
+        uint256 reward;
+        uint256 stake;
+        bool success;
+        Status status;
+    }
+
+    uint256 public nextJobId;
+    mapping(uint256 => Job) public jobs;
+
+    IValidationModule public validationModule;
+    IReputationEngine public reputationEngine;
+    IStakeManager public stakeManager;
+    ICertificateNFT public certificateNFT;
+
+    event ValidationModuleUpdated(address module);
+    event ReputationEngineUpdated(address engine);
+    event StakeManagerUpdated(address manager);
+    event CertificateNFTUpdated(address nft);
+
+    event JobCreated(
+        uint256 indexed jobId,
+        address indexed employer,
+        address indexed agent,
+        uint256 reward,
+        uint256 stake
+    );
+    event JobCompleted(uint256 indexed jobId, bool success);
+    event JobDisputed(uint256 indexed jobId);
+    event JobFinalized(uint256 indexed jobId, bool success);
+
+    constructor(address owner) Ownable(owner) {}
+
+    function setValidationModule(IValidationModule module) external onlyOwner {
+        validationModule = module;
+        emit ValidationModuleUpdated(address(module));
+    }
+
+    function setReputationEngine(IReputationEngine engine) external onlyOwner {
+        reputationEngine = engine;
+        emit ReputationEngineUpdated(address(engine));
+    }
+
+    function setStakeManager(IStakeManager manager) external onlyOwner {
+        stakeManager = manager;
+        emit StakeManagerUpdated(address(manager));
+    }
+
+    function setCertificateNFT(ICertificateNFT nft) external onlyOwner {
+        certificateNFT = nft;
+        emit CertificateNFTUpdated(address(nft));
+    }
+
+    /// @notice Create a new job.
+    function createJob(address agent, uint256 reward, uint256 stake)
+        external
+        returns (uint256 jobId)
+    {
+        require(stakeManager.stakes(agent) >= stake, "stake missing");
+        jobId = ++nextJobId;
+        jobs[jobId] = Job({
+            employer: msg.sender,
+            agent: agent,
+            reward: reward,
+            stake: stake,
+            success: false,
+            status: Status.Created
+        });
+        stakeManager.lockReward(msg.sender, reward);
+        emit JobCreated(jobId, msg.sender, agent, reward, stake);
+    }
+
+    /// @notice Agent submits job result; validation outcome stored.
+    function completeJob(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        require(job.status == Status.Created, "invalid status");
+        require(msg.sender == job.agent, "only agent");
+        bool outcome = validationModule.validate(jobId);
+        job.success = outcome;
+        job.status = Status.Completed;
+        emit JobCompleted(jobId, outcome);
+    }
+
+    /// @notice Agent disputes a failed job outcome.
+    function dispute(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        require(job.status == Status.Completed && !job.success, "cannot dispute");
+        require(msg.sender == job.agent, "only agent");
+        job.status = Status.Disputed;
+        emit JobDisputed(jobId);
+    }
+
+    /// @notice Owner resolves a dispute, setting the final outcome.
+    function resolveDispute(uint256 jobId, bool success) external onlyOwner {
+        Job storage job = jobs[jobId];
+        require(job.status == Status.Disputed, "no dispute");
+        job.success = success;
+        job.status = Status.Completed;
+    }
+
+    /// @notice Finalize a job and trigger payouts and reputation changes.
+    function finalize(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        require(job.status == Status.Completed, "not ready");
+        job.status = Status.Finalized;
+        if (job.success) {
+            stakeManager.payReward(job.agent, job.reward);
+            stakeManager.releaseStake(job.agent, job.stake);
+            reputationEngine.increaseReputation(job.agent, 1);
+            certificateNFT.mint(job.agent);
+        } else {
+            stakeManager.payReward(job.employer, job.reward);
+            stakeManager.slash(job.agent, job.employer, job.stake);
+            reputationEngine.decreaseReputation(job.agent, 1);
+        }
+        emit JobFinalized(jobId, job.success);
+    }
+}
+

--- a/contracts/ReputationEngine.sol
+++ b/contracts/ReputationEngine.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title ReputationEngine
+/// @notice Tracks reputation scores for participants.
+contract ReputationEngine is Ownable {
+    mapping(address => int256) public reputation;
+    mapping(address => bool) public callers;
+
+    event ReputationUpdated(address indexed user, int256 newScore);
+    event CallerAuthorized(address indexed caller, bool allowed);
+
+    constructor(address owner) Ownable(owner) {}
+
+    modifier onlyCaller() {
+        require(callers[msg.sender], "not authorized");
+        _;
+    }
+
+    /// @notice Authorize or revoke a caller that can update reputation.
+    function setCaller(address caller, bool allowed) external onlyOwner {
+        callers[caller] = allowed;
+        emit CallerAuthorized(caller, allowed);
+    }
+
+    /// @notice Increase reputation for a user.
+    function increaseReputation(address user, uint256 amount) external onlyCaller {
+        reputation[user] += int256(amount);
+        emit ReputationUpdated(user, reputation[user]);
+    }
+
+    /// @notice Decrease reputation for a user.
+    function decreaseReputation(address user, uint256 amount) external onlyCaller {
+        reputation[user] -= int256(amount);
+        emit ReputationUpdated(user, reputation[user]);
+    }
+}
+

--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title StakeManager
+/// @notice Handles staking and reward transfers for the job system.
+contract StakeManager is Ownable {
+    using SafeERC20 for IERC20;
+
+    IERC20 public token;
+
+    mapping(address => uint256) public stakes;
+
+    event TokenUpdated(address token);
+    event StakeDeposited(address indexed user, uint256 amount);
+    event StakeWithdrawn(address indexed user, uint256 amount);
+    event RewardLocked(address indexed from, uint256 amount);
+    event RewardPaid(address indexed to, uint256 amount);
+    event StakeSlashed(address indexed user, address indexed recipient, uint256 amount);
+
+    constructor(IERC20 _token, address owner) Ownable(owner) {
+        token = _token;
+        emit TokenUpdated(address(_token));
+    }
+
+    /// @notice Update the ERC20 token used for staking and rewards.
+    function setToken(IERC20 newToken) external onlyOwner {
+        token = newToken;
+        emit TokenUpdated(address(newToken));
+    }
+
+    /// @notice Deposit stake for the caller.
+    function depositStake(uint256 amount) external {
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        stakes[msg.sender] += amount;
+        emit StakeDeposited(msg.sender, amount);
+    }
+
+    /// @notice Withdraw stake for the caller.
+    function withdrawStake(uint256 amount) external {
+        uint256 staked = stakes[msg.sender];
+        require(staked >= amount, "insufficient stake");
+        stakes[msg.sender] = staked - amount;
+        token.safeTransfer(msg.sender, amount);
+        emit StakeWithdrawn(msg.sender, amount);
+    }
+
+    /// @notice Lock reward funds from an employer for a job.
+    function lockReward(address from, uint256 amount) external onlyOwner {
+        token.safeTransferFrom(from, address(this), amount);
+        emit RewardLocked(from, amount);
+    }
+
+    /// @notice Pay job reward to the recipient.
+    function payReward(address to, uint256 amount) external onlyOwner {
+        token.safeTransfer(to, amount);
+        emit RewardPaid(to, amount);
+    }
+
+    /// @notice Slash stake from a user and send to a recipient.
+    function slash(address user, address recipient, uint256 amount) external onlyOwner {
+        uint256 staked = stakes[user];
+        require(staked >= amount, "insufficient stake");
+        stakes[user] = staked - amount;
+        token.safeTransfer(recipient, amount);
+        emit StakeSlashed(user, recipient, amount);
+    }
+
+    /// @notice Release stake back to a user (used on job completion).
+    function releaseStake(address user, uint256 amount) external onlyOwner {
+        uint256 staked = stakes[user];
+        require(staked >= amount, "insufficient stake");
+        stakes[user] = staked - amount;
+        token.safeTransfer(user, amount);
+        emit StakeWithdrawn(user, amount);
+    }
+}
+

--- a/contracts/ValidationModule.sol
+++ b/contracts/ValidationModule.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title ValidationModule
+/// @notice Returns predetermined validation outcomes for jobs.
+contract ValidationModule is Ownable {
+    mapping(uint256 => bool) public outcomes;
+
+    event OutcomeSet(uint256 indexed jobId, bool success);
+
+    constructor(address owner) Ownable(owner) {}
+
+    /// @notice Set the validation outcome for a job.
+    function setOutcome(uint256 jobId, bool success) external onlyOwner {
+        outcomes[jobId] = success;
+        emit OutcomeSet(jobId, success);
+    }
+
+    /// @notice Validate a job and return the preset outcome.
+    function validate(uint256 jobId) external view returns (bool) {
+        return outcomes[jobId];
+    }
+}
+

--- a/test/CertificateNFT.test.js
+++ b/test/CertificateNFT.test.js
@@ -1,0 +1,21 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CertificateNFT", function () {
+  let nft, owner, user;
+
+  beforeEach(async () => {
+    [owner, user] = await ethers.getSigners();
+    const NFT = await ethers.getContractFactory("CertificateNFT");
+    nft = await NFT.deploy("Cert", "CERT", owner.address);
+  });
+
+  it("mints certificates", async () => {
+    await nft.connect(owner).setBaseURI("ipfs://base/");
+    await nft.connect(owner).mint(user.address);
+    const tokenId = await nft.nextId();
+    expect(await nft.ownerOf(tokenId)).to.equal(user.address);
+    expect(await nft.tokenURI(tokenId)).to.equal("ipfs://base/" + tokenId.toString());
+  });
+});
+

--- a/test/JobRegistry.integration.test.js
+++ b/test/JobRegistry.integration.test.js
@@ -1,0 +1,82 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobRegistry integration", function () {
+  let token, stakeManager, rep, validation, nft, registry;
+  let owner, employer, agent;
+
+  const reward = 100;
+  const stake = 200;
+
+  beforeEach(async () => {
+    [owner, employer, agent] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockERC20");
+    token = await Token.deploy();
+    const StakeManager = await ethers.getContractFactory("StakeManager");
+    stakeManager = await StakeManager.deploy(await token.getAddress(), owner.address);
+    const Validation = await ethers.getContractFactory("ValidationModule");
+    validation = await Validation.deploy(owner.address);
+    const Rep = await ethers.getContractFactory("ReputationEngine");
+    rep = await Rep.deploy(owner.address);
+    const NFT = await ethers.getContractFactory("CertificateNFT");
+    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    const Registry = await ethers.getContractFactory("JobRegistry");
+    registry = await Registry.deploy(owner.address);
+
+    await registry.connect(owner).setValidationModule(await validation.getAddress());
+    await registry.connect(owner).setStakeManager(await stakeManager.getAddress());
+    await registry.connect(owner).setReputationEngine(await rep.getAddress());
+    await registry.connect(owner).setCertificateNFT(await nft.getAddress());
+    await rep.connect(owner).setCaller(await registry.getAddress(), true);
+    await stakeManager.connect(owner).transferOwnership(await registry.getAddress());
+    await nft.connect(owner).transferOwnership(await registry.getAddress());
+
+    await token.mint(employer.address, 1000);
+    await token.mint(agent.address, 1000);
+
+    await token.connect(agent).approve(await stakeManager.getAddress(), stake);
+    await stakeManager.connect(agent).depositStake(stake);
+  });
+
+  it("runs successful job lifecycle", async () => {
+    await token.connect(employer).approve(await stakeManager.getAddress(), reward);
+    await validation.connect(owner).setOutcome(1, true);
+    await registry.connect(employer).createJob(agent.address, reward, stake);
+    await registry.connect(agent).completeJob(1);
+    await registry.finalize(1);
+
+    expect(await token.balanceOf(agent.address)).to.equal(1100);
+    expect(await rep.reputation(agent.address)).to.equal(1);
+    expect(await nft.balanceOf(agent.address)).to.equal(1);
+  });
+
+  it("handles collusion resolved by dispute", async () => {
+    await token.connect(employer).approve(await stakeManager.getAddress(), reward);
+    await validation.connect(owner).setOutcome(1, false); // colluding validator
+    await registry.connect(employer).createJob(agent.address, reward, stake);
+    await registry.connect(agent).completeJob(1);
+    await registry.connect(agent).dispute(1);
+    await registry.connect(owner).resolveDispute(1, true);
+    await registry.finalize(1);
+
+    expect(await token.balanceOf(agent.address)).to.equal(1100);
+    expect(await rep.reputation(agent.address)).to.equal(1);
+    expect(await nft.balanceOf(agent.address)).to.equal(1);
+  });
+
+  it("slashes stake when dispute fails", async () => {
+    await token.connect(employer).approve(await stakeManager.getAddress(), reward);
+    await validation.connect(owner).setOutcome(1, false);
+    await registry.connect(employer).createJob(agent.address, reward, stake);
+    await registry.connect(agent).completeJob(1);
+    await registry.connect(agent).dispute(1);
+    await registry.connect(owner).resolveDispute(1, false);
+    await registry.finalize(1);
+
+    expect(await token.balanceOf(agent.address)).to.equal(800);
+    expect(await token.balanceOf(employer.address)).to.equal(1200);
+    expect(await rep.reputation(agent.address)).to.equal(-1);
+    expect(await nft.balanceOf(agent.address)).to.equal(0);
+  });
+});
+

--- a/test/ReputationEngine.test.js
+++ b/test/ReputationEngine.test.js
@@ -1,0 +1,25 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ReputationEngine", function () {
+  let engine, owner, caller, user;
+
+  beforeEach(async () => {
+    [owner, caller, user] = await ethers.getSigners();
+    const Engine = await ethers.getContractFactory("ReputationEngine");
+    engine = await Engine.deploy(owner.address);
+  });
+
+  it("updates reputation by authorized caller", async () => {
+    await engine.connect(owner).setCaller(caller.address, true);
+    await engine.connect(caller).increaseReputation(user.address, 5);
+    expect(await engine.reputation(user.address)).to.equal(5);
+    await engine.connect(caller).decreaseReputation(user.address, 2);
+    expect(await engine.reputation(user.address)).to.equal(3);
+  });
+
+  it("reverts for unauthorized callers", async () => {
+    await expect(engine.connect(caller).increaseReputation(user.address, 1)).to.be.revertedWith("not authorized");
+  });
+});
+

--- a/test/StakeManager.test.js
+++ b/test/StakeManager.test.js
@@ -1,0 +1,41 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("StakeManager", function () {
+  let token, stakeManager, owner, employer, agent;
+
+  beforeEach(async () => {
+    [owner, employer, agent] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockERC20");
+    token = await Token.deploy();
+    await token.mint(agent.address, 1000);
+    await token.mint(employer.address, 1000);
+    const StakeManager = await ethers.getContractFactory("StakeManager");
+    stakeManager = await StakeManager.deploy(await token.getAddress(), owner.address);
+  });
+
+  it("handles stake deposits and withdrawals", async () => {
+    await token.connect(agent).approve(await stakeManager.getAddress(), 1000);
+    await stakeManager.connect(agent).depositStake(500);
+    expect(await stakeManager.stakes(agent.address)).to.equal(500);
+    await stakeManager.connect(agent).withdrawStake(200);
+    expect(await stakeManager.stakes(agent.address)).to.equal(300);
+  });
+
+  it("locks and pays rewards", async () => {
+    await token.connect(employer).approve(await stakeManager.getAddress(), 400);
+    await stakeManager.connect(owner).lockReward(employer.address, 400);
+    expect(await token.balanceOf(await stakeManager.getAddress())).to.equal(400);
+    await stakeManager.connect(owner).payReward(agent.address, 400);
+    expect(await token.balanceOf(agent.address)).to.equal(1400);
+  });
+
+  it("slashes stakes", async () => {
+    await token.connect(agent).approve(await stakeManager.getAddress(), 500);
+    await stakeManager.connect(agent).depositStake(500);
+    await stakeManager.connect(owner).slash(agent.address, employer.address, 200);
+    expect(await stakeManager.stakes(agent.address)).to.equal(300);
+    expect(await token.balanceOf(employer.address)).to.equal(1200);
+  });
+});
+

--- a/test/ValidationModule.test.js
+++ b/test/ValidationModule.test.js
@@ -1,0 +1,20 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ValidationModule", function () {
+  let validation, owner;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const ValidationModule = await ethers.getContractFactory("ValidationModule");
+    validation = await ValidationModule.deploy(owner.address);
+  });
+
+  it("returns preset outcomes", async () => {
+    await validation.connect(owner).setOutcome(1, true);
+    expect(await validation.validate(1)).to.equal(true);
+    await validation.connect(owner).setOutcome(2, false);
+    expect(await validation.validate(2)).to.equal(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add modular job registry integrating staking, validation, reputation, and certification
- wire inter-contract calls and owner controls
- cover modules and job lifecycle with unit and integration tests

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6893ff4d4cdc8333befd5b521b8aa7f3