### PR TITLE
docs: add module architecture and walkthroughs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,22 @@
-# Architecture Diagram
+# Architecture
 
+## Modules
+- [JobRegistry](../contracts/JobRegistry.sol) – orchestrates job lifecycle and coordinates with external modules.
+- [StakeManager](../contracts/StakeManager.sol) – holds deposits, pays rewards, and slashes stake.
+- [ReputationEngine](../contracts/ReputationEngine.sol) – tracks reputation scores for participants.
+- [ValidationModule](../contracts/ValidationModule.sol) – returns preset validation outcomes for jobs.
+- [CertificateNFT](../contracts/CertificateNFT.sol) – mints ERC721 certificates for successful jobs.
+
+## Module Interactions
+```mermaid
+graph TD
+    JobRegistry --> ValidationModule
+    JobRegistry --> StakeManager
+    JobRegistry --> ReputationEngine
+    JobRegistry --> CertificateNFT
+```
+
+## Job Flow
 ```mermaid
 sequenceDiagram
     participant Employer
@@ -16,7 +33,6 @@ sequenceDiagram
 ```
 
 ## Employer-Win Dispute Flow
-
 ```mermaid
 sequenceDiagram
     participant Employer
@@ -30,4 +46,3 @@ sequenceDiagram
     AGI-->>Validator: Split reward & slashed stake
     AGI-->>Employer: Return remaining escrow
 ```
-


### PR DESCRIPTION
## Summary
- add architecture section with mermaid diagram and module links
- document owner settings per module and Etherscan walkthroughs for employers, agents, validators
- note future v2 contract addresses in references

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894026665c08333828e270711b9b1bf