### PR TITLE
docs: expand v2 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [docs/architecture.md](docs/architecture.md) for sequence diagrams of job an
 
 ### AGIJobManager v2
 
-The forthcoming v2 release formalises these contracts into standalone modules such as JobRegistry, ValidationModule, StakeManager, ReputationEngine and CertificateNFT. It adds dynamic validator counts, stronger slashing and optional appeal rounds to harden incentives. Interface stubs live in [contracts/v2/interfaces](contracts/v2/interfaces), and design diagrams are in [docs/architecture-v2.md](docs/architecture-v2.md).
+The forthcoming v2 release splits responsibilities across immutable modules—JobRegistry, ValidationModule, StakeManager, ReputationEngine and CertificateNFT. Each module is `Ownable` so only the contract owner may adjust parameters, and interfaces remain minimal to keep Etherscan usage straightforward. Interface definitions live in [contracts/v2/interfaces](contracts/v2/interfaces) and architectural diagrams in [docs/architecture-v2.md](docs/architecture-v2.md).
 
 
 ## Etherscan Walk-throughs

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -2,27 +2,50 @@
 pragma solidity ^0.8.21;
 
 /// @title IJobRegistry
-/// @notice Interface for the JobRegistry module responsible for job lifecycle management
+/// @notice Interface for orchestrating job lifecycles and module coordination
 interface IJobRegistry {
-    enum JobState { Open, Assigned, InReview, Finalized, Disputed }
+    enum Status { None, Created, Completed, Disputed, Finalized }
 
     struct Job {
         address employer;
         address agent;
-        uint256 payout;
-        uint256 deadline;
-        JobState state;
+        uint256 reward;
+        uint256 stake;
+        bool success;
+        Status status;
     }
 
-    event JobCreated(uint256 indexed jobId, address indexed employer, uint256 payout, uint256 deadline);
-    event JobAssigned(uint256 indexed jobId, address indexed agent);
-    event JobCompletionRequested(uint256 indexed jobId, string resultURI);
+    // module configuration
+    event ValidationModuleUpdated(address module);
+    event ReputationEngineUpdated(address engine);
+    event StakeManagerUpdated(address manager);
+    event CertificateNFTUpdated(address nft);
+
+    // job lifecycle
+    event JobCreated(
+        uint256 indexed jobId,
+        address indexed employer,
+        address indexed agent,
+        uint256 reward,
+        uint256 stake
+    );
+    event JobCompleted(uint256 indexed jobId, bool success);
+    event JobDisputed(uint256 indexed jobId);
     event JobFinalized(uint256 indexed jobId, bool success);
 
-    function createJob(uint256 payout, uint256 duration, string calldata metadata) external returns (uint256 jobId);
-    function applyForJob(uint256 jobId) external;
-    function requestJobCompletion(uint256 jobId, string calldata resultURI) external;
-    function finalizeJob(uint256 jobId) external;
-    function disputeJob(uint256 jobId) external;
-}
+    // owner wiring of modules
+    function setValidationModule(address module) external;
+    function setReputationEngine(address engine) external;
+    function setStakeManager(address manager) external;
+    function setCertificateNFT(address nft) external;
 
+    // core job flow
+    function createJob(address agent, uint256 reward, uint256 stake) external returns (uint256 jobId);
+    function completeJob(uint256 jobId) external;
+    function dispute(uint256 jobId) external;
+    function resolveDispute(uint256 jobId, bool success) external;
+    function finalize(uint256 jobId) external;
+
+    // view helper
+    function jobs(uint256 jobId) external view returns (Job memory);
+}


### PR DESCRIPTION
## Summary
- document modular v2 architecture and interfaces
- clarify owner wiring and Etherscan-friendly flows
- add IJobRegistry interface detailing module coordination

## Testing
- `npx hardhat test test/StakeManager.test.js`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689406fbbdc083338c9132d0110ce4bc