### PR TITLE
docs: expand v2 architecture and governance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [docs/architecture.md](docs/architecture.md) for sequence diagrams of job an
 
 ### AGIJobManager v2
 
-The forthcoming v2 release splits responsibilities across immutable modules—JobRegistry, ValidationModule, StakeManager, ReputationEngine and CertificateNFT. Each module is `Ownable` so only the contract owner may adjust parameters, and interfaces remain minimal to keep Etherscan usage straightforward. Interface definitions live in [contracts/v2/interfaces](contracts/v2/interfaces) and architectural diagrams in [docs/architecture-v2.md](docs/architecture-v2.md).
+The forthcoming v2 release splits responsibilities across immutable modules—JobRegistry, ValidationModule, StakeManager, ReputationEngine and CertificateNFT. Each module is `Ownable` so only the contract owner may adjust parameters, and interfaces remain minimal to keep Etherscan usage straightforward. Incentive settings such as burn rate, stake ratios and slashing percentages are all updated through owner‑only functions, preserving governance control while keeping the surface area small for non‑technical users. Interface definitions live in [contracts/v2/interfaces](contracts/v2/interfaces) and architectural diagrams, including a Hamiltonian view of incentives, in [docs/architecture-v2.md](docs/architecture-v2.md).
 
 
 ## Etherscan Walk-throughs

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -91,5 +91,12 @@ Non‑technical employers, agents and validators can call these methods directly
 ## Statistical‑Physics View
 The protocol behaves like a system seeking minimum Gibbs free energy. Honest completion is the ground state in this Hamiltonian system: any actor attempting to cheat must input additional "energy"—manifested as higher expected stake loss—which drives the system back toward the stable equilibrium.
 
+### Hamiltonian and Game Theory
+We can sketch a simplified Hamiltonian
+
+\[ H = \sum_i s_i - \sum_j r_j \]
+
+where \(s_i\) represents stake lost by misbehaving participants and \(r_j\) denotes rewards for correct actions. The owner adjusts coefficients through setter functions, shaping the potential landscape so that the minimal free energy occurs when agents, validators and employers follow the protocol. Deviations raise \(H\), matching game‑theoretic expectations that dishonest strategies carry higher expected cost than cooperative ones.
+
 ## Interfaces
 Reference Solidity interfaces are provided in `contracts/v2/interfaces` for integration and future implementation.


### PR DESCRIPTION
## Summary
- document modular v2 architecture with per-module responsibilities and governance controls
- outline Hamiltonian-style incentive model for job market
- mention owner-only parameter adjustments and link to diagrams in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894094c5ac48333bf6ed32ed975f069