### PR TITLE
docs: modular v2 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,10 @@ contains two smart‑contract generations:
 
 All addresses should be independently verified before use.
 
+### Modular v2 Architecture
+
+The upcoming v2 release splits the system into immutable modules—`JobRegistry`, `ValidationModule`, `DisputeModule`, `StakeManager`, `ReputationEngine` and `CertificateNFT`. Each contract has a single responsibility, is controlled by the owner through minimal setter functions, and can be interacted with directly via block explorers. Diagrammatic overviews and interface definitions live in [docs/architecture-v2.md](docs/architecture-v2.md).
+
 ## Versions
 
 - **v0 – Legacy:** Immutable code deployed at [0x0178b6bad606aaf908f72135b8ec32fc1d5ba477](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477).

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+/// @title IDisputeModule
+/// @notice Interface for raising and resolving disputes or appeals
+interface IDisputeModule {
+    event DisputeRaised(uint256 indexed jobId, address indexed caller);
+    event DisputeResolved(uint256 indexed jobId, bool employerWins);
+    event AppealParametersUpdated();
+
+    function raiseDispute(uint256 jobId) external payable;
+    function resolve(uint256 jobId, bool employerWins) external;
+
+    /// @notice Owner configuration for appeal economics
+    /// @dev Only callable by contract owner
+    function setAppealParameters(uint256 appealFee, uint256 jurySize) external;
+}


### PR DESCRIPTION
## Summary
- document modular v2 design with new DisputeModule and owner-governed components
- describe module interactions and add interface definitions, including IDisputeModule
- update README with v2 architecture overview

## Testing
- `npm run lint`
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68940d0a9ca483338225108d65eb1766