### PR TITLE
docs: expand v2 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,18 @@ All addresses should be independently verified before use.
 
 ### Modular v2 Architecture
 
-The upcoming v2 release splits the system into immutable modules—`JobRegistry`, `ValidationModule`, `DisputeModule`, `StakeManager`, `ReputationEngine` and `CertificateNFT`. Each contract has a single responsibility, is controlled by the owner through minimal setter functions, and can be interacted with directly via block explorers. Diagrammatic overviews and interface definitions live in [docs/architecture-v2.md](docs/architecture-v2.md).
+The upcoming v2 release decomposes the marketplace into a suite of immutable modules, each exposed through concise interfaces so non‑technical users can trigger calls from explorers like Etherscan. Every contract inherits `Ownable`, letting the owner (or future governance) tune parameters without redeploying the whole system.
+
+| Module | Responsibility |
+| --- | --- |
+| `JobRegistry` | Post jobs, escrow payouts, manage lifecycle. |
+| `ValidationModule` | Select validators, run commit‑reveal voting, return provisional outcomes. |
+| `DisputeModule` | Coordinate appeals and moderator or jury decisions. |
+| `StakeManager` | Hold validator/agent collateral, release rewards, execute slashing. |
+| `ReputationEngine` | Track reputation, apply penalties, maintain blacklists. |
+| `CertificateNFT` | Mint ERC‑721 certificates for completed jobs. |
+
+See [docs/architecture-v2.md](docs/architecture-v2.md) for diagrams, interface definitions, and incentive analysis grounded in game theory and statistical physics.
 
 ## Versions
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -11,6 +11,17 @@ AGIJobManager v2 decomposes the monolithic v1 contract into immutable modules wi
 - **CertificateNFT** – mints ERC‑721 proof of completion to employers.
 Each component is immutable once deployed yet configurable by the owner through minimal setter functions, enabling governance upgrades without redeploying the entire suite.
 
+| Module | Core responsibility | Owner‑controllable parameters |
+| --- | --- | --- |
+| JobRegistry | job postings, escrow, lifecycle management | maximum payout, job duration limits, expiration rewards |
+| ValidationModule | validator selection, commit‑reveal voting, tallying | stake ratios, reward/penalty rates, timing windows, validators per job |
+| DisputeModule | optional appeal and moderator decisions | appeal fee, jury size, moderator address |
+| StakeManager | custody of validator/agent collateral and slashing | minimum stakes, slashing percentages, reward recipients |
+| ReputationEngine | reputation tracking and blacklist enforcement | reputation thresholds, authorised caller list |
+| CertificateNFT | ERC‑721 proof of completion | base URI |
+
+Every module inherits `Ownable`, so only the contract owner (or future governance authority) may adjust these parameters.
+
 ## Module Interactions
 ```mermaid
 graph TD
@@ -123,7 +134,11 @@ If a result is contested, employers or agents invoke the DisputeModule's `raiseD
 - Parameters (burn rates, stake ratios, validator counts) are tunable by the owner to keep the Nash equilibrium at honest participation.
 
 ## Statistical‑Physics View
-The protocol behaves like a system seeking minimum Gibbs free energy. Honest completion is the ground state in this Hamiltonian system: any actor attempting to cheat must input additional "energy"—manifested as higher expected stake loss—which drives the system back toward the stable equilibrium.
+The protocol behaves like a system seeking minimum Gibbs free energy. Honest completion is the ground state in this Hamiltonian system: any actor attempting to cheat must input additional "energy"—manifested as higher expected stake loss—which drives the system back toward the stable equilibrium. Using the thermodynamic analogue
+
+\[ G = H - T S \]
+
+slashing raises the system's enthalpy \(H\) while the commit‑reveal process injects entropy \(S\). Owner‑tuned parameters act as the temperature \(T\), weighting how much randomness counterbalances potential gains from deviation. When parameters are calibrated so that \(G\) is minimised at honest behaviour, rational participants naturally settle into that state.
 
 ### Hamiltonian and Game Theory
 We can sketch a simplified Hamiltonian


### PR DESCRIPTION
## Summary
- detail modular v2 architecture with explicit module responsibilities and owner controls
- tie incentive design to statistical physics and game theory
- highlight modular layout in README for easy Etherscan interaction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68940ee24af08333a68868616e8f7206