### PR TITLE
docs: detail modular v2 governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 - [$AGI token contract on Etherscan](https://etherscan.io/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D#code) / [Blockscout](https://eth.blockscout.com/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D?tab=contract) – cross-verify the token address before transacting.
 - [AGIJobManager v0 Source](legacy/AGIJobManagerv0.sol)
 - [AGIJobManager v1 Source](contracts/AGIJobManagerv1.sol) – experimental upgrade using Solidity 0.8.21; includes an automatic token burn on final validation via the `JobFinalizedAndBurned` event and configurable burn parameters. Not deployed; treat any address claiming to be v1 as unverified until announced through official channels.
+- [AGIJobManager v2 Architecture](docs/architecture-v2.md) – modular design with incentive analysis and interface definitions.
 
 > **Warning**: Links above are provided for reference only. Always validate contract addresses and metadata on multiple block explorers before interacting.
  
@@ -35,7 +36,7 @@ graph TD
     JobRegistry --> CertificateNFT
 ```
 
-See [docs/architecture.md](docs/architecture.md) for sequence diagrams of job and dispute flows.
+Legacy sequence diagrams appear in [docs/architecture.md](docs/architecture.md); the modular v2 design, interfaces and incentive model are detailed in [docs/architecture-v2.md](docs/architecture-v2.md).
 
 ### AGIJobManager v2
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -119,6 +119,18 @@ interface IStakeManager {
 }
 ```
 
+## Governance and Owner Controls
+Each module exposes minimal `onlyOwner` setters so governance can tune economics without redeploying code. Typical controls include:
+
+- **JobRegistry** – `setValidationModule`, `setReputationEngine`, `setStakeManager`, `setCertificateNFT`, `setJobParameters`.
+- **ValidationModule** – `setParameters` for stake ratios, rewards, slashing and timing.
+- **DisputeModule** – `setAppealParameters` and moderator address.
+- **StakeManager** – `setStakeParameters` and `setToken`.
+- **ReputationEngine** – `setCaller` and `setThresholds` for agent/validator reputation.
+- **CertificateNFT** – `setBaseURI` for metadata.
+
+All setters are accessible through block‑explorer interfaces, keeping administration intuitive for non‑technical owners while preserving contract immutability.
+
 These interfaces favour explicit, single-purpose methods, keeping gas costs predictable and allowing front‑end or Etherscan interactions to remain intuitive.
 
 ## User Experience


### PR DESCRIPTION
## Summary
- link v2 architecture doc from README and reference modular design within architecture section
- document owner-only governance controls for JobRegistry, ValidationModule, DisputeModule, StakeManager, ReputationEngine and CertificateNFT

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689410f61fd88333a577523a319bbc2c