### PR TITLE
feat: add dispute module wiring

### DIFF
--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -20,6 +20,7 @@ interface IJobRegistry {
     event ReputationEngineUpdated(address engine);
     event StakeManagerUpdated(address manager);
     event CertificateNFTUpdated(address nft);
+    event DisputeModuleUpdated(address module);
 
     // job lifecycle
     event JobCreated(
@@ -39,6 +40,7 @@ interface IJobRegistry {
     function setReputationEngine(address engine) external;
     function setStakeManager(address manager) external;
     function setCertificateNFT(address nft) external;
+    function setDisputeModule(address module) external;
 
     /// @notice Owner configuration of job limits
     function setJobParameters(uint256 maxJobPayout, uint256 jobDurationLimit) external;


### PR DESCRIPTION
## Summary
- wire JobRegistry to optional DisputeModule with new setter and events
- expand v2 interface to include DisputeModule support
- document modular dispute flow and owner controls in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894130841a48333bdf192596cd747be