### PR TITLE
feat: add role-based stake manager

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title StakeManager
+/// @notice Manages staking for agents and validators with role-based locking and slashing.
+contract StakeManager is Ownable {
+    using SafeERC20 for IERC20;
+
+    enum Role { Agent, Validator }
+
+    IERC20 public token;
+
+    mapping(address => uint256) public agentStakes;
+    mapping(address => uint256) public validatorStakes;
+    mapping(address => uint256) public lockedAgentStakes;
+    mapping(address => uint256) public lockedValidatorStakes;
+
+    mapping(address => bool) public callers;
+
+    event TokenUpdated(address token);
+    event CallerAuthorized(address indexed caller, bool allowed);
+    event StakeDeposited(address indexed user, Role indexed role, uint256 amount);
+    event StakeWithdrawn(address indexed user, Role indexed role, uint256 amount);
+    event StakeLocked(address indexed user, Role indexed role, uint256 amount);
+    event StakeSlashed(
+        address indexed user,
+        Role indexed role,
+        uint256 amount,
+        address indexed recipient
+    );
+
+    constructor(IERC20 _token, address owner) Ownable(owner) {
+        token = _token;
+        emit TokenUpdated(address(_token));
+    }
+
+    modifier onlyCaller() {
+        require(callers[msg.sender], "not authorized");
+        _;
+    }
+
+    function setCaller(address caller, bool allowed) external onlyOwner {
+        callers[caller] = allowed;
+        emit CallerAuthorized(caller, allowed);
+    }
+
+    function setToken(IERC20 newToken) external onlyOwner {
+        token = newToken;
+        emit TokenUpdated(address(newToken));
+    }
+
+    function depositStake(Role role, uint256 amount) external {
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        if (role == Role.Agent) {
+            agentStakes[msg.sender] += amount;
+        } else {
+            validatorStakes[msg.sender] += amount;
+        }
+        emit StakeDeposited(msg.sender, role, amount);
+    }
+
+    function withdrawStake(Role role, uint256 amount) external {
+        if (role == Role.Agent) {
+            uint256 available = agentStakes[msg.sender] - lockedAgentStakes[msg.sender];
+            require(available >= amount, "insufficient stake");
+            agentStakes[msg.sender] -= amount;
+        } else {
+            uint256 available = validatorStakes[msg.sender] - lockedValidatorStakes[msg.sender];
+            require(available >= amount, "insufficient stake");
+            validatorStakes[msg.sender] -= amount;
+        }
+        token.safeTransfer(msg.sender, amount);
+        emit StakeWithdrawn(msg.sender, role, amount);
+    }
+
+    function lockStake(address user, Role role, uint256 amount) external onlyCaller {
+        if (role == Role.Agent) {
+            uint256 available = agentStakes[user] - lockedAgentStakes[user];
+            require(available >= amount, "insufficient stake");
+            lockedAgentStakes[user] += amount;
+        } else {
+            uint256 available = validatorStakes[user] - lockedValidatorStakes[user];
+            require(available >= amount, "insufficient stake");
+            lockedValidatorStakes[user] += amount;
+        }
+        emit StakeLocked(user, role, amount);
+    }
+
+    function slashStake(address user, Role role, uint256 amount, address recipient)
+        external
+        onlyCaller
+    {
+        if (role == Role.Agent) {
+            require(lockedAgentStakes[user] >= amount, "insufficient locked");
+            lockedAgentStakes[user] -= amount;
+            agentStakes[user] -= amount;
+        } else {
+            require(lockedValidatorStakes[user] >= amount, "insufficient locked");
+            lockedValidatorStakes[user] -= amount;
+            validatorStakes[user] -= amount;
+        }
+        token.safeTransfer(recipient, amount);
+        emit StakeSlashed(user, role, amount, recipient);
+    }
+}
+

--- a/test/JobRegistry.integration.test.js
+++ b/test/JobRegistry.integration.test.js
@@ -12,7 +12,9 @@ describe("JobRegistry integration", function () {
     [owner, employer, agent] = await ethers.getSigners();
     const Token = await ethers.getContractFactory("MockERC20");
     token = await Token.deploy();
-    const StakeManager = await ethers.getContractFactory("StakeManager");
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/StakeManager.sol:StakeManager"
+    );
     stakeManager = await StakeManager.deploy(await token.getAddress(), owner.address);
     const Validation = await ethers.getContractFactory(
       "contracts/ValidationModule.sol:ValidationModule"

--- a/test/StakeManager.test.js
+++ b/test/StakeManager.test.js
@@ -1,41 +1,67 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
+const Role = { Agent: 0, Validator: 1 };
+
 describe("StakeManager", function () {
-  let token, stakeManager, owner, employer, agent;
+  let token, stakeManager, owner, employer, agent, validator;
 
   beforeEach(async () => {
-    [owner, employer, agent] = await ethers.getSigners();
+    [owner, employer, agent, validator] = await ethers.getSigners();
     const Token = await ethers.getContractFactory("MockERC20");
     token = await Token.deploy();
     await token.mint(agent.address, 1000);
+    await token.mint(validator.address, 1000);
     await token.mint(employer.address, 1000);
-    const StakeManager = await ethers.getContractFactory("StakeManager");
-    stakeManager = await StakeManager.deploy(await token.getAddress(), owner.address);
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      owner.address
+    );
+    await stakeManager.connect(owner).setCaller(owner.address, true);
   });
 
-  it("handles stake deposits and withdrawals", async () => {
-    await token.connect(agent).approve(await stakeManager.getAddress(), 1000);
-    await stakeManager.connect(agent).depositStake(500);
-    expect(await stakeManager.stakes(agent.address)).to.equal(500);
-    await stakeManager.connect(agent).withdrawStake(200);
-    expect(await stakeManager.stakes(agent.address)).to.equal(300);
-  });
-
-  it("locks and pays rewards", async () => {
-    await token.connect(employer).approve(await stakeManager.getAddress(), 400);
-    await stakeManager.connect(owner).lockReward(employer.address, 400);
-    expect(await token.balanceOf(await stakeManager.getAddress())).to.equal(400);
-    await stakeManager.connect(owner).payReward(agent.address, 400);
-    expect(await token.balanceOf(agent.address)).to.equal(1400);
-  });
-
-  it("slashes stakes", async () => {
+  it("tracks stakes per role and supports locking and slashing", async () => {
     await token.connect(agent).approve(await stakeManager.getAddress(), 500);
-    await stakeManager.connect(agent).depositStake(500);
-    await stakeManager.connect(owner).slash(agent.address, employer.address, 200);
-    expect(await stakeManager.stakes(agent.address)).to.equal(300);
-    expect(await token.balanceOf(employer.address)).to.equal(1200);
+    await stakeManager.connect(agent).depositStake(Role.Agent, 500);
+    await token.connect(validator).approve(await stakeManager.getAddress(), 400);
+    await stakeManager.connect(validator).depositStake(Role.Validator, 400);
+
+    expect(await stakeManager.agentStakes(agent.address)).to.equal(500);
+    expect(await stakeManager.validatorStakes(validator.address)).to.equal(400);
+
+    await stakeManager
+      .connect(owner)
+      .lockStake(agent.address, Role.Agent, 200);
+    await stakeManager
+      .connect(owner)
+      .lockStake(validator.address, Role.Validator, 100);
+
+    expect(await stakeManager.lockedAgentStakes(agent.address)).to.equal(200);
+    expect(await stakeManager.lockedValidatorStakes(validator.address)).to.equal(100);
+
+    await expect(
+      stakeManager.connect(agent).withdrawStake(Role.Agent, 400)
+    ).to.be.revertedWith("insufficient stake");
+    await stakeManager.connect(agent).withdrawStake(Role.Agent, 300);
+    expect(await stakeManager.agentStakes(agent.address)).to.equal(200);
+
+    await stakeManager
+      .connect(owner)
+      .slashStake(agent.address, Role.Agent, 100, employer.address);
+    expect(await stakeManager.agentStakes(agent.address)).to.equal(100);
+    expect(await stakeManager.lockedAgentStakes(agent.address)).to.equal(100);
+    expect(await token.balanceOf(employer.address)).to.equal(1100);
+  });
+
+  it("restricts stake operations to authorized callers", async () => {
+    await token.connect(agent).approve(await stakeManager.getAddress(), 100);
+    await stakeManager.connect(agent).depositStake(Role.Agent, 100);
+    await expect(
+      stakeManager.connect(agent).lockStake(agent.address, Role.Agent, 50)
+    ).to.be.revertedWith("not authorized");
   });
 });
 


### PR DESCRIPTION
## Summary
- add v2 StakeManager with distinct stake tracking for agents and validators
- allow authorized modules to lock and slash stakes per role

## Testing
- `npx hardhat compile`
- `npx hardhat test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894225795b88333b490b4253a4e6305