### PR TITLE
feat: implement job-linked certificate nft

### DIFF
--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ICertificateNFT} from "./interfaces/ICertificateNFT.sol";
+
+/// @title CertificateNFT
+/// @notice ERC721 certificate minted upon successful job completion.
+contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
+    string private baseTokenURI;
+    address public jobRegistry;
+    mapping(uint256 => string) private _tokenURIs;
+
+    event JobRegistryUpdated(address registry);
+
+    constructor(string memory name_, string memory symbol_, address owner_) ERC721(name_, symbol_) Ownable(owner_) {}
+
+    modifier onlyJobRegistry() {
+        require(msg.sender == jobRegistry, "only JobRegistry");
+        _;
+    }
+
+    function setBaseURI(string calldata uri) external onlyOwner {
+        baseTokenURI = uri;
+        emit BaseURIUpdated(uri);
+    }
+
+    function setJobRegistry(address registry) external onlyOwner {
+        jobRegistry = registry;
+        emit JobRegistryUpdated(registry);
+    }
+
+    function mintCertificate(
+        address to,
+        uint256 jobId,
+        string calldata uri
+    ) external onlyJobRegistry returns (uint256 tokenId) {
+        tokenId = jobId;
+        _safeMint(to, tokenId);
+        if (bytes(uri).length != 0) {
+            _tokenURIs[tokenId] = uri;
+        }
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return baseTokenURI;
+    }
+
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        string memory custom = _tokenURIs[tokenId];
+        if (bytes(custom).length != 0) {
+            return custom;
+        }
+        return super.tokenURI(tokenId);
+    }
+}

--- a/contracts/v2/interfaces/ICertificateNFT.sol
+++ b/contracts/v2/interfaces/ICertificateNFT.sol
@@ -6,7 +6,11 @@ pragma solidity ^0.8.21;
 interface ICertificateNFT {
     event BaseURIUpdated(string uri);
 
-    function mint(address to, uint256 jobId, string calldata uri) external returns (uint256 tokenId);
+    function mintCertificate(
+        address to,
+        uint256 jobId,
+        string calldata uri
+    ) external returns (uint256 tokenId);
 
     /// @notice Owner function to set metadata base URI
     function setBaseURI(string calldata uri) external;


### PR DESCRIPTION
## Summary
- rename certificate NFT interface to use `mintCertificate`
- add v2 CertificateNFT contract with JobRegistry-restricted minting and base URI support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68942af284e48333a5601379ceaaf907