### PR TITLE
feat: add validator tiers and stake defaults

### DIFF
--- a/test/StakeManager.test.js
+++ b/test/StakeManager.test.js
@@ -53,7 +53,7 @@ describe("StakeManager", function () {
       .slashStake(agent.address, Role.Agent, 100, employer.address);
     expect(await stakeManager.agentStakes(agent.address)).to.equal(100);
     expect(await stakeManager.lockedAgentStakes(agent.address)).to.equal(100);
-    expect(await token.balanceOf(employer.address)).to.equal(1100);
+    expect(await token.balanceOf(employer.address)).to.equal(1050);
   });
 
   it("restricts stake operations to authorized callers", async () => {


### PR DESCRIPTION
## Summary
- add configurable stake percentages with employer-share slashing
- support payout-based validator tier counts
- adjust tests for updated slashing behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68942f9140f08333845f74035af91463