### PR TITLE
docs: expand v2 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ All addresses should be independently verified before use.
 
 ### Modular v2 Architecture
 
-The upcoming v2 release decomposes the marketplace into a suite of immutable modules, each exposed through concise interfaces so non‑technical users can trigger calls from explorers like Etherscan. Every contract inherits `Ownable`, letting the owner (or future governance) tune parameters without redeploying the whole system.
+The upcoming v2 release decomposes the marketplace into a suite of immutable modules, each exposed through concise interfaces so non‑technical users can trigger calls from explorers like Etherscan. Modules interact only via interface addresses recorded in the JobRegistry, keeping storage separate and contracts upgrade‑free. Every contract inherits `Ownable`, letting the owner (or future governance) tune parameters without redeploying the whole system.
 
 | Module | Responsibility |
 | --- | --- |
@@ -471,7 +471,7 @@ The upcoming v2 release decomposes the marketplace into a suite of immutable mod
 | `ReputationEngine` | Track reputation, apply penalties, maintain blacklists. |
 | `CertificateNFT` | Mint ERC‑721 certificates for completed jobs. |
 
-See [docs/architecture-v2.md](docs/architecture-v2.md) for diagrams, interface definitions, and incentive analysis grounded in game theory and statistical physics.
+See [docs/architecture-v2.md](docs/architecture-v2.md) for diagrams, interface definitions, and incentive analysis grounded in game theory and statistical physics; the interfaces live in [`contracts/v2/interfaces`](contracts/v2/interfaces) for integration.
 
 ## Versions
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -1,6 +1,6 @@
 # AGIJobManager v2 Architecture
 
-AGIJobManager v2 decomposes the monolithic v1 contract into immutable modules with single responsibilities. Every module inherits `Ownable`, ensuring only the contract owner can tune parameters or perform privileged actions. The design emphasises gas efficiency, governance composability and game-theoretic soundness while remaining simple enough for non‑technical users to invoke through block explorers such as Etherscan.
+AGIJobManager v2 decomposes the monolithic v1 contract into immutable modules with single responsibilities. Each module is deployed once and interacts with others only through minimal interfaces so storage layouts remain isolated. Every module inherits `Ownable`, ensuring only the contract owner can tune parameters or perform privileged actions. The design emphasises gas efficiency, governance composability and game-theoretic soundness while remaining simple enough for non‑technical users to invoke through block explorers such as Etherscan.
 
 ## Modules
 - **JobRegistry** – posts jobs, escrows payouts and tracks lifecycle state.


### PR DESCRIPTION
## Summary
- clarify that v2 modules interact only via interface addresses and remain immutable
- document Etherscan-friendly modular design and note where interfaces live

## Testing
- `npm run compile`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68943257cc948333a8b3118cce931df8