### PR TITLE
feat: add stake-weighted validation module

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import "../v2/interfaces/IStakeManager.sol";
+import "../v2/interfaces/IJobRegistry.sol";
+
+contract MockStakeManager is IStakeManager {
+    mapping(address => uint256) private _validatorStakes;
+    mapping(address => uint256) private _agentStakes;
+
+    function setValidatorStake(address v, uint256 amount) external {
+        _validatorStakes[v] = amount;
+    }
+
+    function setAgentStake(address a, uint256 amount) external {
+        _agentStakes[a] = amount;
+    }
+
+    function depositAgentStake(address, uint256) external override {}
+    function depositValidatorStake(address, uint256) external override {}
+    function withdrawStake(uint256) external override {}
+
+    function slash(address user, uint256 amount, address) external override {
+        if (_validatorStakes[user] >= amount) {
+            _validatorStakes[user] -= amount;
+        } else if (_agentStakes[user] >= amount) {
+            _agentStakes[user] -= amount;
+        }
+    }
+
+    function agentStake(address agent) external view override returns (uint256) {
+        return _agentStakes[agent];
+    }
+
+    function validatorStake(address validator) external view override returns (uint256) {
+        return _validatorStakes[validator];
+    }
+
+    function setToken(address) external override {}
+
+    function setStakeParameters(
+        uint256,
+        uint256,
+        uint256,
+        uint256
+    ) external override {}
+}
+
+contract MockJobRegistry is IJobRegistry {
+    mapping(uint256 => Job) private _jobs;
+
+    function setJob(uint256 jobId, Job calldata job) external {
+        _jobs[jobId] = job;
+    }
+
+    function jobs(uint256 jobId) external view override returns (Job memory) {
+        return _jobs[jobId];
+    }
+
+    function setValidationModule(address) external override {}
+    function setReputationEngine(address) external override {}
+    function setStakeManager(address) external override {}
+    function setCertificateNFT(address) external override {}
+    function setDisputeModule(address) external override {}
+    function setJobParameters(uint256, uint256) external override {}
+    function createJob(address, uint256, uint256) external override returns (uint256) {return 0;}
+    function completeJob(uint256) external override {}
+    function dispute(uint256) external override {}
+    function resolveDispute(uint256, bool) external override {}
+    function finalize(uint256) external override {}
+}

--- a/test/v2ValidationModule.test.js
+++ b/test/v2ValidationModule.test.js
@@ -1,0 +1,115 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ValidationModule V2", function () {
+  let owner, employer, v1, v2, v3;
+  let validation, stakeManager, jobRegistry;
+  const coder = ethers.AbiCoder.defaultAbiCoder();
+
+  beforeEach(async () => {
+    [owner, employer, v1, v2, v3] = await ethers.getSigners();
+
+    const StakeMock = await ethers.getContractFactory("MockStakeManager");
+    stakeManager = await StakeMock.deploy();
+    await stakeManager.waitForDeployment();
+
+    const JobMock = await ethers.getContractFactory("MockJobRegistry");
+    jobRegistry = await JobMock.deploy();
+    await jobRegistry.waitForDeployment();
+
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/ValidationModule.sol:ValidationModule"
+    );
+    validation = await Validation.deploy(
+      await jobRegistry.getAddress(),
+      await stakeManager.getAddress(),
+      owner.address
+    );
+    await validation.waitForDeployment();
+
+    // set parameters: commit 60s, reveal 60s, validators per job 2
+    await validation
+      .connect(owner)
+      .setParameters(0, 0, 0, 50, 60, 60, 0, 0, 2);
+
+    // validator stakes and pool
+    await stakeManager.setValidatorStake(v1.address, ethers.parseEther("100"));
+    await stakeManager.setValidatorStake(v2.address, ethers.parseEther("50"));
+    await stakeManager.setValidatorStake(v3.address, ethers.parseEther("10"));
+
+    await validation
+      .connect(owner)
+      .setValidatorPool([v1.address, v2.address, v3.address]);
+
+    // setup job
+    const jobStruct = {
+      employer: employer.address,
+      agent: ethers.ZeroAddress,
+      reward: 0,
+      stake: 0,
+      success: false,
+      status: 0,
+    };
+    await jobRegistry.setJob(1, jobStruct);
+  });
+
+  async function advance(seconds) {
+    await ethers.provider.send("evm_increaseTime", [seconds]);
+    await ethers.provider.send("evm_mine", []);
+  }
+
+  it("selects validators by highest stake", async () => {
+    const selected = await validation.selectValidators.staticCall(1);
+    await validation.selectValidators(1);
+    expect(selected).to.deep.equal([v1.address, v2.address]);
+  });
+
+  it("does not slash honest validators", async () => {
+    await validation.selectValidators(1);
+    const salt1 = ethers.keccak256(ethers.toUtf8Bytes("salt1"));
+    const salt2 = ethers.keccak256(ethers.toUtf8Bytes("salt2"));
+    const coder = ethers.AbiCoder.defaultAbiCoder();
+    const commit1 = ethers.keccak256(
+      coder.encode(["bool", "bytes32"], [true, salt1])
+    );
+    const commit2 = ethers.keccak256(
+      coder.encode(["bool", "bytes32"], [true, salt2])
+    );
+    await (await validation.connect(v1).commitValidation(1, commit1)).wait();
+    await (await validation.connect(v2).commitValidation(1, commit2)).wait();
+    await advance(61);
+    await validation.connect(v1).revealValidation(1, true, salt1);
+    await validation.connect(v2).revealValidation(1, true, salt2);
+    await advance(61);
+    expect(await validation.finalize.staticCall(1)).to.equal(true);
+    await validation.finalize(1);
+    expect(await stakeManager.validatorStake(v1.address)).to.equal(
+      ethers.parseEther("100")
+    );
+    expect(await stakeManager.validatorStake(v2.address)).to.equal(
+      ethers.parseEther("50")
+    );
+  });
+
+  it("slashes validator voting against majority", async () => {
+    await validation.selectValidators(1);
+    const salt1 = ethers.keccak256(ethers.toUtf8Bytes("salt1"));
+    const salt2 = ethers.keccak256(ethers.toUtf8Bytes("salt2"));
+    const commit1 = ethers.keccak256(
+      coder.encode(["bool", "bytes32"], [true, salt1])
+    );
+    const commit2 = ethers.keccak256(
+      coder.encode(["bool", "bytes32"], [false, salt2])
+    );
+    await (await validation.connect(v1).commitValidation(1, commit1)).wait();
+    await (await validation.connect(v2).commitValidation(1, commit2)).wait();
+    await advance(61);
+    await validation.connect(v1).revealValidation(1, true, salt1);
+    await validation.connect(v2).revealValidation(1, false, salt2);
+    await advance(61);
+    await validation.finalize(1);
+    expect(await stakeManager.validatorStake(v2.address)).to.equal(
+      ethers.parseEther("25")
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- implement stake-weighted validator selection and slashing in ValidationModule
- add mocks and tests for commit-reveal voting scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894998c9aa88333aefcbfc5aac6aaf7