### PR TITLE
docs: expand v2 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,18 @@ The upcoming v2 release decomposes the marketplace into a suite of immutable mod
 | `ReputationEngine` | Track reputation, apply penalties, maintain blacklists. |
 | `CertificateNFT` | Mint ERC‑721 certificates for completed jobs. |
 
+```mermaid
+graph TD
+    Employer -->|createJob| JobRegistry
+    Agent -->|apply/submit| JobRegistry
+    JobRegistry -->|selectValidators| ValidationModule
+    ValidationModule -->|stake| StakeManager
+    ValidationModule -->|reputation| ReputationEngine
+    ValidationModule -->|dispute?| DisputeModule
+    DisputeModule -->|final ruling| JobRegistry
+    JobRegistry -->|mint| CertificateNFT
+```
+
 See [docs/architecture-v2.md](docs/architecture-v2.md) for diagrams, interface definitions, and incentive analysis grounded in game theory and statistical physics; the interfaces live in [`contracts/v2/interfaces`](contracts/v2/interfaces) for integration.
 
 ## Versions

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -117,6 +117,11 @@ interface IStakeManager {
         uint256 validatorSlashingPercentage
     ) external;
 }
+
+interface ICertificateNFT {
+    function mint(address to, string memory uri) external returns (uint256 tokenId);
+    function setBaseURI(string memory newBaseURI) external;
+}
 ```
 
 ## Governance and Owner Controls
@@ -168,3 +173,5 @@ Reference Solidity interfaces are provided in `contracts/v2/interfaces` for inte
 - Isolate permissioned setters with `onlyOwner` modifiers and emit update events for every configuration change.
 - Avoid external libraries requiring subscriptions; commit‑reveal randomness keeps the system trust-minimised.
 - Separate state-changing logic from read-only helpers to simplify audits and Etherscan interactions.
+- Use custom errors instead of revert strings to save deployment and runtime gas.
+- Where arithmetic is already bounds-checked, wrap operations in `unchecked` blocks for marginal savings.


### PR DESCRIPTION
## Summary
- document `ICertificateNFT` interface and additional gas-oriented structure tips
- show v2 module interaction diagram directly in README

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894b37159e483339b1e390c8ebce407