### PR TITLE
feat: add configurable job parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Use a block explorer like Etherscan—no coding required. Always verify contract
 
 ### Employers
 1. Open the **Write Contract** tab of `JobRegistry` and connect your wallet.
-2. Call `createJob(agent, reward, stake)` to post a task. `reward` and `stake` are specified in wei (typical range 1–1000 AGI).
+2. Ensure the owner has set `reward` and `stake` via `setJobParameters`. Call `createJob(agent)` to post a task using those values.
 3. Share the emitted `JobCreated` event with the agent to communicate the job ID.
 4. After completion, the owner finalizes the job via `finalize(jobId)` to trigger payouts.
 

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -63,8 +63,8 @@ contract MockJobRegistry is IJobRegistry {
     function setCertificateNFT(address) external override {}
     function setDisputeModule(address) external override {}
     function setJobParameters(uint256, uint256) external override {}
-    function createJob(address, uint256, uint256) external override returns (uint256) {return 0;}
-    function completeJob(uint256) external override {}
+    function createJob(address) external override returns (uint256) {return 0;}
+    function requestJobCompletion(uint256) external override {}
     function dispute(uint256) external override {}
     function resolveDispute(uint256, bool) external override {}
     function finalize(uint256) external override {}

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -30,10 +30,10 @@ interface IJobRegistry {
         uint256 reward,
         uint256 stake
     );
-    event JobCompleted(uint256 indexed jobId, bool success);
+    event CompletionRequested(uint256 indexed jobId, bool success);
     event JobDisputed(uint256 indexed jobId);
     event JobFinalized(uint256 indexed jobId, bool success);
-    event JobParametersUpdated();
+    event JobParametersUpdated(uint256 reward, uint256 stake);
 
     // owner wiring of modules
     function setValidationModule(address module) external;
@@ -43,11 +43,11 @@ interface IJobRegistry {
     function setDisputeModule(address module) external;
 
     /// @notice Owner configuration of job limits
-    function setJobParameters(uint256 maxJobPayout, uint256 jobDurationLimit) external;
+    function setJobParameters(uint256 reward, uint256 stake) external;
 
     // core job flow
-    function createJob(address agent, uint256 reward, uint256 stake) external returns (uint256 jobId);
-    function completeJob(uint256 jobId) external;
+    function createJob(address agent) external returns (uint256 jobId);
+    function requestJobCompletion(uint256 jobId) external;
     function dispute(uint256 jobId) external;
     function resolveDispute(uint256 jobId, bool success) external;
     function finalize(uint256 jobId) external;

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -13,7 +13,7 @@ Each component is immutable once deployed yet configurable by the owner through 
 
 | Module | Core responsibility | Owner‑controllable parameters |
 | --- | --- | --- |
-| JobRegistry | job postings, escrow, lifecycle management | maximum payout, job duration limits, expiration rewards |
+| JobRegistry | job postings, escrow, lifecycle management | job reward, required agent stake |
 | ValidationModule | validator selection, commit‑reveal voting, tallying | stake ratios, reward/penalty rates, timing windows, validators per job |
 | DisputeModule | optional appeal and moderator decisions | appeal fee, jury size, moderator address |
 | StakeManager | custody of validator/agent collateral and slashing | minimum stakes, slashing percentages, reward recipients |
@@ -68,11 +68,9 @@ Key Solidity interfaces live in [`contracts/v2/interfaces`](../contracts/v2/inte
 
 ```solidity
 interface IJobRegistry {
-    function createJob(address agent, uint256 reward, uint256 stake)
-        external
-        returns (uint256 jobId);
+    function createJob(address agent) external returns (uint256 jobId);
     function finalize(uint256 jobId) external;
-    function setJobParameters(uint256 maxJobPayout, uint256 jobDurationLimit) external;
+    function setJobParameters(uint256 reward, uint256 stake) external;
 }
 
 interface IValidationModule {

--- a/test/JobRegistry.integration.test.js
+++ b/test/JobRegistry.integration.test.js
@@ -35,6 +35,7 @@ describe("JobRegistry integration", function () {
     await registry.connect(owner).setStakeManager(await stakeManager.getAddress());
     await registry.connect(owner).setReputationEngine(await rep.getAddress());
     await registry.connect(owner).setCertificateNFT(await nft.getAddress());
+    await registry.connect(owner).setJobParameters(reward, stake);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
     await rep.connect(owner).setCaller(await registry.getAddress(), true);
     await stakeManager.connect(owner).transferOwnership(await registry.getAddress());
@@ -50,7 +51,7 @@ describe("JobRegistry integration", function () {
   it("runs successful job lifecycle", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     await validation.connect(owner).setOutcome(1, true);
-    await registry.connect(employer).createJob(agent.address, reward, stake);
+    await registry.connect(employer).createJob(agent.address);
     await registry.connect(agent).requestJobCompletion(1);
     await registry.finalize(1);
 
@@ -62,7 +63,7 @@ describe("JobRegistry integration", function () {
   it("handles collusion resolved by dispute", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     await validation.connect(owner).setOutcome(1, false); // colluding validator
-    await registry.connect(employer).createJob(agent.address, reward, stake);
+    await registry.connect(employer).createJob(agent.address);
     await registry.connect(agent).requestJobCompletion(1);
     await registry.connect(agent).dispute(1);
     await registry.connect(owner).resolveDispute(1, true);
@@ -76,7 +77,7 @@ describe("JobRegistry integration", function () {
   it("slashes stake when dispute fails", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     await validation.connect(owner).setOutcome(1, false);
-    await registry.connect(employer).createJob(agent.address, reward, stake);
+    await registry.connect(employer).createJob(agent.address);
     await registry.connect(agent).requestJobCompletion(1);
     await registry.connect(agent).dispute(1);
     await registry.connect(owner).resolveDispute(1, false);


### PR DESCRIPTION
## Summary
- allow owner to set default reward and stake for v2 JobRegistry
- create jobs using configured parameters and escrow funds via StakeManager
- update tests and docs for new job flow

## Testing
- `npx hardhat test test/JobRegistry.integration.test.js`
- `npx hardhat test test/v2ValidationModule.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6894b7e099a88333a2b0212d14d1583f