### PR TITLE
Add penalty tracking and auto-blacklist to reputation system

### DIFF
--- a/contracts/JobRegistry.sol
+++ b/contracts/JobRegistry.sol
@@ -8,8 +8,8 @@ interface IValidationModule {
 }
 
 interface IReputationEngine {
-    function increaseReputation(address user, uint256 amount) external;
-    function decreaseReputation(address user, uint256 amount) external;
+    function addReputation(address user, uint256 amount) external;
+    function subtractReputation(address user, uint256 amount) external;
 }
 
 interface IStakeManager {
@@ -157,12 +157,12 @@ contract JobRegistry is Ownable {
         if (job.success) {
             stakeManager.payReward(job.agent, job.reward);
             stakeManager.releaseStake(job.agent, job.stake);
-            reputationEngine.increaseReputation(job.agent, 1);
+            reputationEngine.addReputation(job.agent, 1);
             certificateNFT.mint(job.agent);
         } else {
             stakeManager.payReward(job.employer, job.reward);
             stakeManager.slash(job.agent, job.employer, job.stake);
-            reputationEngine.decreaseReputation(job.agent, 1);
+            reputationEngine.subtractReputation(job.agent, 1);
         }
         emit JobFinalized(jobId, job.success);
     }

--- a/contracts/ReputationEngine.sol
+++ b/contracts/ReputationEngine.sol
@@ -4,13 +4,27 @@ pragma solidity ^0.8.21;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title ReputationEngine
-/// @notice Tracks reputation scores for participants.
+/// @notice Tracks participant reputation, penalties and blacklist status.
 contract ReputationEngine is Ownable {
-    mapping(address => int256) public reputation;
+    /// @dev mapping of user => reputation score
+    mapping(address => uint256) private _reputation;
+
+    /// @dev number of penalties applied to a user
+    mapping(address => uint256) public penaltyCount;
+
+    /// @dev mapping of user => blacklist status
+    mapping(address => bool) public blacklisted;
+
+    /// @dev authorised callers that may update reputation
     mapping(address => bool) public callers;
 
-    event ReputationUpdated(address indexed user, int256 newScore);
+    /// @notice penalty threshold after which a user is blacklisted
+    uint256 public penaltyThreshold;
+
+    event ReputationUpdated(address indexed user, int256 delta, uint256 newScore);
     event CallerAuthorized(address indexed caller, bool allowed);
+    event PenaltyThresholdUpdated(uint256 newThreshold);
+    event BlacklistUpdated(address indexed user, bool status);
 
     constructor(address owner) Ownable(owner) {}
 
@@ -25,16 +39,42 @@ contract ReputationEngine is Ownable {
         emit CallerAuthorized(caller, allowed);
     }
 
-    /// @notice Increase reputation for a user.
-    function increaseReputation(address user, uint256 amount) external onlyCaller {
-        reputation[user] += int256(amount);
-        emit ReputationUpdated(user, reputation[user]);
+    /// @notice Set the penalty threshold that triggers blacklisting.
+    function setPenaltyThreshold(uint256 threshold) external onlyOwner {
+        penaltyThreshold = threshold;
+        emit PenaltyThresholdUpdated(threshold);
     }
 
-    /// @notice Decrease reputation for a user.
-    function decreaseReputation(address user, uint256 amount) external onlyCaller {
-        reputation[user] -= int256(amount);
-        emit ReputationUpdated(user, reputation[user]);
+    /// @notice Increase reputation for a user.
+    function addReputation(address user, uint256 amount) external onlyCaller {
+        uint256 newScore = _reputation[user] + amount;
+        _reputation[user] = newScore;
+        emit ReputationUpdated(user, int256(amount), newScore);
+    }
+
+    /// @notice Decrease reputation for a user and track penalties.
+    function subtractReputation(address user, uint256 amount) external onlyCaller {
+        uint256 current = _reputation[user];
+        uint256 newScore = current > amount ? current - amount : 0;
+        _reputation[user] = newScore;
+
+        penaltyCount[user] += 1;
+        emit ReputationUpdated(user, -int256(amount), newScore);
+
+        if (!blacklisted[user] && penaltyThreshold > 0 && penaltyCount[user] >= penaltyThreshold) {
+            blacklisted[user] = true;
+            emit BlacklistUpdated(user, true);
+        }
+    }
+
+    /// @notice Retrieve a user's reputation score.
+    function reputationOf(address user) external view returns (uint256) {
+        return _reputation[user];
+    }
+
+    /// @notice Check if a user is blacklisted.
+    function isBlacklisted(address user) external view returns (bool) {
+        return blacklisted[user];
     }
 }
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -8,8 +8,8 @@ interface IValidationModule {
 }
 
 interface IReputationEngine {
-    function increaseReputation(address user, uint256 amount) external;
-    function decreaseReputation(address user, uint256 amount) external;
+    function addReputation(address user, uint256 amount) external;
+    function subtractReputation(address user, uint256 amount) external;
 }
 
 interface IStakeManager {
@@ -169,12 +169,12 @@ contract JobRegistry is Ownable {
         if (job.success) {
             stakeManager.payReward(job.agent, job.reward);
             stakeManager.releaseStake(job.agent, job.stake);
-            reputationEngine.increaseReputation(job.agent, 1);
+            reputationEngine.addReputation(job.agent, 1);
             certificateNFT.mintCertificate(job.agent, jobId, "");
         } else {
             stakeManager.payReward(job.employer, job.reward);
             stakeManager.slash(job.agent, job.employer, job.stake);
-            reputationEngine.decreaseReputation(job.agent, 1);
+            reputationEngine.subtractReputation(job.agent, 1);
         }
         emit JobFinalized(jobId, job.success);
     }

--- a/test/JobRegistry.integration.test.js
+++ b/test/JobRegistry.integration.test.js
@@ -38,6 +38,7 @@ describe("JobRegistry integration", function () {
     await registry.connect(owner).setJobParameters(reward, stake);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
     await rep.connect(owner).setCaller(await registry.getAddress(), true);
+    await rep.connect(owner).setPenaltyThreshold(1);
     await stakeManager.connect(owner).transferOwnership(await registry.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
 
@@ -56,7 +57,9 @@ describe("JobRegistry integration", function () {
     await registry.finalize(1);
 
     expect(await token.balanceOf(agent.address)).to.equal(1100);
-    expect(await rep.reputation(agent.address)).to.equal(1);
+    expect(await rep.reputationOf(agent.address)).to.equal(1);
+    expect(await rep.penaltyCount(agent.address)).to.equal(0);
+    expect(await rep.isBlacklisted(agent.address)).to.equal(false);
     expect(await nft.balanceOf(agent.address)).to.equal(1);
   });
 
@@ -70,7 +73,9 @@ describe("JobRegistry integration", function () {
     await registry.finalize(1);
 
     expect(await token.balanceOf(agent.address)).to.equal(1100);
-    expect(await rep.reputation(agent.address)).to.equal(1);
+    expect(await rep.reputationOf(agent.address)).to.equal(1);
+    expect(await rep.penaltyCount(agent.address)).to.equal(0);
+    expect(await rep.isBlacklisted(agent.address)).to.equal(false);
     expect(await nft.balanceOf(agent.address)).to.equal(1);
   });
 
@@ -85,7 +90,9 @@ describe("JobRegistry integration", function () {
 
     expect(await token.balanceOf(agent.address)).to.equal(800);
     expect(await token.balanceOf(employer.address)).to.equal(1200);
-    expect(await rep.reputation(agent.address)).to.equal(-1);
+    expect(await rep.reputationOf(agent.address)).to.equal(0);
+    expect(await rep.penaltyCount(agent.address)).to.equal(1);
+    expect(await rep.isBlacklisted(agent.address)).to.equal(true);
     expect(await nft.balanceOf(agent.address)).to.equal(0);
   });
 });


### PR DESCRIPTION
## Summary
- track participant reputation, penalties and blacklist status
- expose add/subtract reputation helpers and auto-blacklist once penalties exceed threshold
- update JobRegistry modules and tests to use new reputation API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894bfcee3a483339bb98faacae5f4d2