### PR TITLE
Restrict certificate minting to JobRegistry and add metadata base URI controls

### DIFF
--- a/contracts/CertificateNFT.sol
+++ b/contracts/CertificateNFT.sol
@@ -7,30 +7,64 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 /// @title CertificateNFT
 /// @notice ERC721 certificate minted upon successful job completion.
 contract CertificateNFT is ERC721, Ownable {
-    uint256 public nextId;
     string private baseTokenURI;
+    address public jobRegistry;
+    mapping(uint256 => string) private _tokenURIs;
 
     event BaseURIUpdated(string newURI);
+    event JobRegistryUpdated(address registry);
 
     constructor(string memory name_, string memory symbol_, address owner)
         ERC721(name_, symbol_)
         Ownable(owner)
     {}
 
+    modifier onlyJobRegistry() {
+        require(msg.sender == jobRegistry, "only JobRegistry");
+        _;
+    }
+
     /// @notice Update the base token URI.
-    function setBaseURI(string memory uri) external onlyOwner {
+    function setBaseURI(string calldata uri) external onlyOwner {
         baseTokenURI = uri;
         emit BaseURIUpdated(uri);
+    }
+
+    /// @notice Set the authorized JobRegistry contract.
+    function setJobRegistry(address registry) external onlyOwner {
+        jobRegistry = registry;
+        emit JobRegistryUpdated(registry);
+    }
+
+    /// @notice Mint a new certificate to `to` for `jobId`.
+    /// @dev Only callable by the configured JobRegistry.
+    function mintCertificate(
+        address to,
+        uint256 jobId,
+        string calldata uri
+    ) external onlyJobRegistry returns (uint256 tokenId) {
+        tokenId = jobId;
+        _safeMint(to, tokenId);
+        if (bytes(uri).length != 0) {
+            _tokenURIs[tokenId] = uri;
+        }
     }
 
     function _baseURI() internal view override returns (string memory) {
         return baseTokenURI;
     }
 
-    /// @notice Mint a new certificate to `to`.
-    function mint(address to) external onlyOwner returns (uint256 tokenId) {
-        tokenId = ++nextId;
-        _safeMint(to, tokenId);
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override
+        returns (string memory)
+    {
+        string memory custom = _tokenURIs[tokenId];
+        if (bytes(custom).length != 0) {
+            return custom;
+        }
+        return super.tokenURI(tokenId);
     }
 }
 

--- a/contracts/JobRegistry.sol
+++ b/contracts/JobRegistry.sol
@@ -21,7 +21,11 @@ interface IStakeManager {
 }
 
 interface ICertificateNFT {
-    function mint(address to) external returns (uint256);
+    function mintCertificate(
+        address to,
+        uint256 jobId,
+        string calldata uri
+    ) external returns (uint256);
 }
 
 interface IDisputeModule {
@@ -158,7 +162,7 @@ contract JobRegistry is Ownable {
             stakeManager.payReward(job.agent, job.reward);
             stakeManager.releaseStake(job.agent, job.stake);
             reputationEngine.addReputation(job.agent, 1);
-            certificateNFT.mint(job.agent);
+            certificateNFT.mintCertificate(job.agent, jobId, "");
         } else {
             stakeManager.payReward(job.employer, job.reward);
             stakeManager.slash(job.agent, job.employer, job.stake);


### PR DESCRIPTION
## Summary
- expand CertificateNFT into an ERC-721 gated to a configurable JobRegistry with owner-only base URI and registry setters
- update JobRegistry to use `mintCertificate` with jobId-based token IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c5778d9083338e8610d7fd8cc4da