### PR TITLE
feat: add v2 stake manager with role-based slashing

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -2,164 +2,42 @@
 pragma solidity ^0.8.21;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+import {IStakeManager} from "./interfaces/IStakeManager.sol";
+
 /// @title StakeManager
-/// @notice Manages staking for agents and validators with role-based locking and slashing.
-contract StakeManager is Ownable {
+/// @notice Handles staking for agents and validators with role-based locking and slashing
+contract StakeManager is IStakeManager, Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
-    enum Role { Agent, Validator }
-
     IERC20 public token;
-
-    mapping(address => uint256) public agentStakes;
-    mapping(address => uint256) public validatorStakes;
-    mapping(address => uint256) public lockedAgentStakes;
-    mapping(address => uint256) public lockedValidatorStakes;
+    address public treasury;
 
     // percentage settings
     uint256 public agentStakePercentage = 20; // 20% of payout
     uint256 public validatorStakePercentage = 10; // 10% of payout
     uint256 public validatorSlashingPercentage = 50; // 50% of stake
 
-    mapping(address => bool) public callers;
+    // user => role => amount
+    mapping(address => mapping(Role => uint256)) private _stakes;
+    mapping(address => mapping(Role => uint256)) private _locked;
 
-    event TokenUpdated(address token);
-    event CallerAuthorized(address indexed caller, bool allowed);
-    event StakeDeposited(address indexed user, Role indexed role, uint256 amount);
-    event StakeWithdrawn(address indexed user, Role indexed role, uint256 amount);
-    event StakeLocked(address indexed user, Role indexed role, uint256 amount);
-    event StakeSlashed(
-        address indexed user,
-        Role indexed role,
-        uint256 amount,
-        address indexed recipient
-    );
-    event ParametersUpdated();
-
-    constructor(IERC20 _token, address owner) Ownable(owner) {
+    constructor(IERC20 _token, address _treasury, address owner) Ownable(owner) {
         token = _token;
+        treasury = _treasury;
         emit TokenUpdated(address(_token));
     }
 
-    modifier onlyCaller() {
-        require(callers[msg.sender], "not authorized");
-        _;
+    /// @notice Update the ERC20 token used for staking and rewards
+    function setToken(address newToken) external onlyOwner {
+        token = IERC20(newToken);
+        emit TokenUpdated(newToken);
     }
 
-    function setCaller(address caller, bool allowed) external onlyOwner {
-        callers[caller] = allowed;
-        emit CallerAuthorized(caller, allowed);
-    }
-
-    function setToken(IERC20 newToken) external onlyOwner {
-        token = newToken;
-        emit TokenUpdated(address(newToken));
-    }
-
-    function agentStake(address agent) external view returns (uint256) {
-        return agentStakes[agent];
-    }
-
-    function validatorStake(address validator) external view returns (uint256) {
-        return validatorStakes[validator];
-    }
-
-    function lockedAgentStake(address agent) external view returns (uint256) {
-        return lockedAgentStakes[agent];
-    }
-
-    function lockedValidatorStake(address validator) external view returns (uint256) {
-        return lockedValidatorStakes[validator];
-    }
-
-    function depositAgentStake(address agent, uint256 amount) external {
-        require(agent == msg.sender, "self");
-        token.safeTransferFrom(msg.sender, address(this), amount);
-        agentStakes[msg.sender] += amount;
-        emit StakeDeposited(msg.sender, Role.Agent, amount);
-    }
-
-    function depositValidatorStake(address validator, uint256 amount) external {
-        require(validator == msg.sender, "self");
-        token.safeTransferFrom(msg.sender, address(this), amount);
-        validatorStakes[msg.sender] += amount;
-        emit StakeDeposited(msg.sender, Role.Validator, amount);
-    }
-
-    function depositStake(Role role, uint256 amount) external {
-        token.safeTransferFrom(msg.sender, address(this), amount);
-        if (role == Role.Agent) {
-            agentStakes[msg.sender] += amount;
-            emit StakeDeposited(msg.sender, Role.Agent, amount);
-        } else {
-            validatorStakes[msg.sender] += amount;
-            emit StakeDeposited(msg.sender, Role.Validator, amount);
-        }
-    }
-
-    function withdrawStake(Role role, uint256 amount) external {
-        if (role == Role.Agent) {
-            uint256 available = agentStakes[msg.sender] - lockedAgentStakes[msg.sender];
-            require(available >= amount, "insufficient stake");
-            agentStakes[msg.sender] -= amount;
-            token.safeTransfer(msg.sender, amount);
-            emit StakeWithdrawn(msg.sender, Role.Agent, amount);
-        } else {
-            uint256 available =
-                validatorStakes[msg.sender] - lockedValidatorStakes[msg.sender];
-            require(available >= amount, "insufficient stake");
-            validatorStakes[msg.sender] -= amount;
-            token.safeTransfer(msg.sender, amount);
-            emit StakeWithdrawn(msg.sender, Role.Validator, amount);
-        }
-    }
-
-    function lockStake(address user, Role role, uint256 amount) external onlyCaller {
-        if (role == Role.Agent) {
-            uint256 available = agentStakes[user] - lockedAgentStakes[user];
-            require(available >= amount, "insufficient stake");
-            lockedAgentStakes[user] += amount;
-        } else {
-            uint256 available = validatorStakes[user] - lockedValidatorStakes[user];
-            require(available >= amount, "insufficient stake");
-            lockedValidatorStakes[user] += amount;
-        }
-        emit StakeLocked(user, role, amount);
-    }
-
-    function slashStake(
-        address user,
-        Role role,
-        uint256 amount,
-        address recipient
-    ) public onlyCaller {
-        if (role == Role.Agent) {
-            require(lockedAgentStakes[user] >= amount, "insufficient locked");
-            lockedAgentStakes[user] -= amount;
-            agentStakes[user] -= amount;
-            uint256 employerPortion = amount / 2;
-            token.safeTransfer(recipient, employerPortion);
-            emit StakeSlashed(user, Role.Agent, amount, recipient);
-        } else {
-            require(lockedValidatorStakes[user] >= amount, "insufficient locked");
-            lockedValidatorStakes[user] -= amount;
-            validatorStakes[user] -= amount;
-            token.safeTransfer(recipient, amount);
-            emit StakeSlashed(user, Role.Validator, amount, recipient);
-        }
-    }
-
-    function slash(address user, uint256 amount, address recipient) external onlyCaller {
-        if (lockedAgentStakes[user] >= amount) {
-            slashStake(user, Role.Agent, amount, recipient);
-        } else {
-            slashStake(user, Role.Validator, amount, recipient);
-        }
-    }
-
+    /// @notice Update stake and slashing parameters
     function setStakeParameters(
         uint256 _agentStakePct,
         uint256 _validatorStakePct,
@@ -171,5 +49,62 @@ contract StakeManager is Ownable {
         emit ParametersUpdated();
     }
 
+    /// @notice Deposit stake for the caller under a specific role
+    function depositStake(Role role, uint256 amount) external nonReentrant {
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        _stakes[msg.sender][role] += amount;
+        emit StakeDeposited(msg.sender, role, amount);
+    }
+
+    /// @notice Withdraw stake for the caller
+    function withdrawStake(Role role, uint256 amount) external nonReentrant {
+        uint256 available = _stakes[msg.sender][role] - _locked[msg.sender][role];
+        require(available >= amount, "insufficient stake");
+        _stakes[msg.sender][role] -= amount;
+        token.safeTransfer(msg.sender, amount);
+        emit StakeWithdrawn(msg.sender, role, amount);
+    }
+
+    /// @notice Lock stake for a user and role
+    function lockStake(address user, Role role, uint256 amount)
+        external
+        onlyOwner
+        nonReentrant
+    {
+        uint256 available = _stakes[user][role] - _locked[user][role];
+        require(available >= amount, "insufficient stake");
+        _locked[user][role] += amount;
+        emit StakeLocked(user, role, amount);
+    }
+
+    /// @notice Slash locked stake and distribute to employer and treasury
+    function slash(
+        address user,
+        Role role,
+        uint256 amount,
+        address employer
+    ) external onlyOwner nonReentrant {
+        require(_locked[user][role] >= amount, "insufficient locked");
+        _locked[user][role] -= amount;
+        _stakes[user][role] -= amount;
+        uint256 half = amount / 2;
+        token.safeTransfer(employer, half);
+        token.safeTransfer(treasury, amount - half);
+        emit StakeSlashed(user, role, amount, employer, treasury);
+    }
+
+    /// @notice Get total stake for a user and role
+    function stakeOf(address user, Role role) external view returns (uint256) {
+        return _stakes[user][role];
+    }
+
+    /// @notice Get locked stake for a user and role
+    function lockedStakeOf(address user, Role role)
+        external
+        view
+        returns (uint256)
+    {
+        return _locked[user][role];
+    }
 }
 

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -95,7 +95,7 @@ contract ValidationModule is IValidationModule, Ownable {
         uint256 m;
 
         for (uint256 i; i < n; ++i) {
-            uint256 stake = stakeManager.validatorStake(pool[i]);
+            uint256 stake = stakeManager.stakeOf(pool[i], IStakeManager.Role.Validator);
             if (stake >= validatorStakeRequirement) {
                 stakes[m] = stake;
                 pool[m] = pool[i];
@@ -189,7 +189,12 @@ contract ValidationModule is IValidationModule, Ownable {
             uint256 slashAmount = (stake * validatorSlashingPercentage) / 100;
             if (!revealed[jobId][val] || votes[jobId][val] != success) {
                 if (slashAmount > 0) {
-                    stakeManager.slash(val, slashAmount, job.employer);
+                    stakeManager.slash(
+                        val,
+                        IStakeManager.Role.Validator,
+                        slashAmount,
+                        job.employer
+                    );
                 }
                 if (address(reputationEngine) != address(0)) {
                     reputationEngine.subtractReputation(val, 1);

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -16,7 +16,8 @@ interface IStakeManager {
         address indexed user,
         Role indexed role,
         uint256 amount,
-        address indexed recipient
+        address indexed employer,
+        address treasury
     );
     event TokenUpdated(address token);
     event ParametersUpdated();
@@ -24,12 +25,10 @@ interface IStakeManager {
     function depositStake(Role role, uint256 amount) external;
     function withdrawStake(Role role, uint256 amount) external;
     function lockStake(address user, Role role, uint256 amount) external;
-    function slash(address user, uint256 amount, address recipient) external;
+    function slash(address user, Role role, uint256 amount, address employer) external;
 
-    function agentStake(address agent) external view returns (uint256);
-    function validatorStake(address validator) external view returns (uint256);
-    function lockedAgentStake(address agent) external view returns (uint256);
-    function lockedValidatorStake(address validator) external view returns (uint256);
+    function stakeOf(address user, Role role) external view returns (uint256);
+    function lockedStakeOf(address user, Role role) external view returns (uint256);
 
     /// @notice Owner functions
     function setToken(address token) external;

--- a/test/v2ValidationModule.test.js
+++ b/test/v2ValidationModule.test.js
@@ -40,9 +40,9 @@ describe("ValidationModule V2", function () {
       .setParameters(0, 0, 0, 50, 60, 60, 0, 0, 2);
 
     // validator stakes and pool
-    await stakeManager.setValidatorStake(v1.address, ethers.parseEther("100"));
-    await stakeManager.setValidatorStake(v2.address, ethers.parseEther("50"));
-    await stakeManager.setValidatorStake(v3.address, ethers.parseEther("10"));
+    await stakeManager.setStake(v1.address, 1, ethers.parseEther("100"));
+    await stakeManager.setStake(v2.address, 1, ethers.parseEther("50"));
+    await stakeManager.setStake(v3.address, 1, ethers.parseEther("10"));
 
     await validation
       .connect(owner)
@@ -157,7 +157,7 @@ describe("ValidationModule V2", function () {
     expect(await validation.finalize.staticCall(1)).to.equal(true);
     await validation.finalize(1);
     for (const addr of selected) {
-      const stake = await stakeManager.validatorStake(addr);
+      const stake = await stakeManager.stakeOf(addr, 1);
       const expectedStake =
         addr.toLowerCase() === v1.address.toLowerCase()
           ? ethers.parseEther("100")
@@ -199,8 +199,8 @@ describe("ValidationModule V2", function () {
         .commitValidation(1, commit2)
     ).wait();
     await advance(61);
-    const stake0 = await stakeManager.validatorStake(selected[0]);
-    const stake1 = await stakeManager.validatorStake(selected[1]);
+    const stake0 = await stakeManager.stakeOf(selected[0], 1);
+    const stake1 = await stakeManager.stakeOf(selected[1], 1);
     await validation
       .connect(signerMap[selected[0].toLowerCase()])
       .revealValidation(1, true, salt1);
@@ -212,7 +212,7 @@ describe("ValidationModule V2", function () {
     const slashed = stake0 >= stake1 ? selected[1] : selected[0];
     const winner = slashed === selected[0] ? selected[1] : selected[0];
     const slashedStakeBefore = stake0 >= stake1 ? stake1 : stake0;
-    expect(await stakeManager.validatorStake(slashed)).to.equal(
+    expect(await stakeManager.stakeOf(slashed, 1)).to.equal(
       slashedStakeBefore / 2n
     );
     expect(await reputation.reputationOf(winner)).to.equal(1n);


### PR DESCRIPTION
## Summary
- add ReentrancyGuarded v2 StakeManager that tracks stakes per role
- split slashed stake between employer and treasury
- update interfaces, validation module, mocks and tests

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894e0b26dec8333837a6eb0d71c5eda