### PR TITLE
feat: add role based reputation engine

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -99,5 +99,7 @@ contract MockReputationEngine is IReputationEngine {
 
     function setCaller(address, bool) external override {}
 
+    function setRole(address, uint8) external override {}
+
     function setThresholds(uint256, uint256) external override {}
 }

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -4,9 +4,8 @@ pragma solidity ^0.8.21;
 /// @title IReputationEngine
 /// @notice Interface for tracking and updating participant reputation scores
 interface IReputationEngine {
-    event ReputationUpdated(address indexed user, int256 delta, uint256 newScore);
-    event CallerSet(address caller, bool allowed);
-    event ThresholdsUpdated(uint256 agentBlacklistThreshold, uint256 validatorBlacklistThreshold);
+    event ReputationChanged(address indexed user, int256 delta, uint256 newScore);
+    event BlacklistUpdated(address indexed user, bool status);
 
     function addReputation(address user, uint256 amount) external;
     function subtractReputation(address user, uint256 amount) external;
@@ -15,6 +14,7 @@ interface IReputationEngine {
 
     /// @notice Owner functions
     function setCaller(address caller, bool allowed) external;
+    function setRole(address user, uint8 role) external;
     function setThresholds(uint256 agentThreshold, uint256 validatorThreshold) external;
 }
 


### PR DESCRIPTION
## Summary
- add role-aware ReputationEngineV2 contract with caller controls and automatic blacklisting
- update interface and mocks for new events and role configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894e47568b483338e50b00d088ed182