### PR TITLE
feat: add dispute module moderator controls

### DIFF
--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -7,6 +7,7 @@ interface IDisputeModule {
     event DisputeRaised(uint256 indexed jobId, address indexed caller);
     event DisputeResolved(uint256 indexed jobId, bool employerWins);
     event AppealParametersUpdated();
+    event ModeratorUpdated(address moderator);
 
     function raiseDispute(uint256 jobId) external payable;
     function resolve(uint256 jobId, bool employerWins) external;
@@ -14,4 +15,8 @@ interface IDisputeModule {
     /// @notice Owner configuration for appeal economics
     /// @dev Only callable by contract owner
     function setAppealParameters(uint256 appealFee, uint256 jurySize) external;
+
+    /// @notice Owner configuration for dispute moderator
+    /// @dev Only callable by contract owner
+    function setModerator(address moderator) external;
 }


### PR DESCRIPTION
## Summary
- expand DisputeModule with appeal fee escrow, jury size tracking and moderator controls
- expose moderator setter in interface and allow moderator/owner to resolve disputes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e6e9ba788333bd812bbb9dfaa665