### PR TITLE
Emit CertificateMinted event for v2 certificates

### DIFF
--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -41,6 +41,7 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
         if (bytes(uri).length != 0) {
             _tokenURIs[tokenId] = uri;
         }
+        emit CertificateMinted(to, jobId);
     }
 
     function _baseURI() internal view override returns (string memory) {

--- a/contracts/v2/interfaces/ICertificateNFT.sol
+++ b/contracts/v2/interfaces/ICertificateNFT.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.21;
 /// @notice Interface for minting non-fungible job completion certificates
 interface ICertificateNFT {
     event BaseURIUpdated(string uri);
+    event CertificateMinted(address indexed to, uint256 indexed jobId);
 
     function mintCertificate(
         address to,

--- a/test/CertificateNFT.test.js
+++ b/test/CertificateNFT.test.js
@@ -15,9 +15,11 @@ describe("CertificateNFT", function () {
   it("mints certificates", async () => {
     await nft.connect(owner).setBaseURI("ipfs://base/");
     await nft.connect(owner).setJobRegistry(owner.address);
-    await nft
-      .connect(owner)
-      .mintCertificate(user.address, 1, "");
+    await expect(
+      nft.connect(owner).mintCertificate(user.address, 1, "")
+    )
+      .to.emit(nft, "CertificateMinted")
+      .withArgs(user.address, 1);
     expect(await nft.ownerOf(1)).to.equal(user.address);
     expect(await nft.tokenURI(1)).to.equal("ipfs://base/1");
   });


### PR DESCRIPTION
## Summary
- emit `CertificateMinted` when new certificates are minted
- expose `CertificateMinted` in `ICertificateNFT`
- test emission while keeping JobRegistry-only minting and base URI update

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894e8b075648333a26d2f465dfbc9e3