### PR TITLE
feat: add module and job config setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The forthcoming v2 release splits responsibilities across immutable modules—Jo
 
 Key owner-configurable entry points include:
 
-- `JobRegistry.setJobParameters(maxJobPayout, jobDurationLimit)`
+- `JobRegistry.setJobParameters(reward, stake)`
 - `ValidationModule.setParameters(...)` for stake, reward and timing settings
 - `StakeManager.setStakeParameters(...)` and `setToken(token)`
 - `ReputationEngine.setCaller(module, allowed)` and `setThresholds(agent, validator)`
@@ -79,6 +79,12 @@ Honesty yields the best payoff for every role, making truthful behavior the domi
 ## Etherscan Walk-throughs
 
 Use a block explorer like Etherscan—no coding required. Always verify contract addresses on multiple explorers before interacting.
+
+### Owner
+1. Connect the owner wallet to `JobRegistry` in the **Write Contract** tab on Etherscan.
+2. Call `setModules(validation, stakeMgr, reputation, dispute, certNFT)` to wire external modules.
+3. Invoke `setJobParameters(reward, stake)` to define the default payout and required agent stake.
+4. Each module exposes its own `onlyOwner` setters—use their Write tabs (e.g., `StakeManager.setToken`, `ValidationModule.setOutcome`, `ReputationEngine.setPenaltyThreshold`) to tune economics.
 
 ### Employers
 1. Open the **Write Contract** tab of `JobRegistry` and connect your wallet.

--- a/contracts/JobRegistry.sol
+++ b/contracts/JobRegistry.sol
@@ -56,6 +56,9 @@ contract JobRegistry is Ownable {
     ICertificateNFT public certificateNFT;
     IDisputeModule public disputeModule;
 
+    uint256 public jobReward;
+    uint256 public jobStake;
+
     event ValidationModuleUpdated(address module);
     event ReputationEngineUpdated(address engine);
     event StakeManagerUpdated(address manager);
@@ -72,6 +75,7 @@ contract JobRegistry is Ownable {
     event JobCompleted(uint256 indexed jobId, bool success);
     event JobDisputed(uint256 indexed jobId);
     event JobFinalized(uint256 indexed jobId, bool success);
+    event JobParametersUpdated(uint256 reward, uint256 stake);
 
     constructor(address owner) Ownable(owner) {}
 
@@ -100,23 +104,46 @@ contract JobRegistry is Ownable {
         emit DisputeModuleUpdated(address(module));
     }
 
+    function setModules(
+        IValidationModule _validationModule,
+        IReputationEngine _reputationEngine,
+        IStakeManager _stakeManager,
+        ICertificateNFT _certificateNFT,
+        IDisputeModule _disputeModule
+    ) external onlyOwner {
+        validationModule = _validationModule;
+        reputationEngine = _reputationEngine;
+        stakeManager = _stakeManager;
+        certificateNFT = _certificateNFT;
+        disputeModule = _disputeModule;
+        emit ValidationModuleUpdated(address(_validationModule));
+        emit ReputationEngineUpdated(address(_reputationEngine));
+        emit StakeManagerUpdated(address(_stakeManager));
+        emit CertificateNFTUpdated(address(_certificateNFT));
+        emit DisputeModuleUpdated(address(_disputeModule));
+    }
+
+    function setJobParameters(uint256 reward, uint256 stake) external onlyOwner {
+        jobReward = reward;
+        jobStake = stake;
+        emit JobParametersUpdated(reward, stake);
+    }
+
     /// @notice Create a new job.
-    function createJob(address agent, uint256 reward, uint256 stake)
-        external
-        returns (uint256 jobId)
-    {
-        require(stakeManager.stakes(agent) >= stake, "stake missing");
+    function createJob(address agent) external returns (uint256 jobId) {
+        require(jobReward > 0 || jobStake > 0, "params not set");
+        require(stakeManager.stakes(agent) >= jobStake, "stake missing");
         jobId = ++nextJobId;
         jobs[jobId] = Job({
             employer: msg.sender,
             agent: agent,
-            reward: reward,
-            stake: stake,
+            reward: jobReward,
+            stake: jobStake,
             success: false,
             status: Status.Created
         });
-        stakeManager.lockReward(msg.sender, reward);
-        emit JobCreated(jobId, msg.sender, agent, reward, stake);
+        stakeManager.lockReward(msg.sender, jobReward);
+        emit JobCreated(jobId, msg.sender, agent, jobReward, jobStake);
     }
 
     /// @notice Agent submits job result; validation outcome stored.


### PR DESCRIPTION
## Summary
- wire validation, reputation, staking, dispute and certificate modules in one owner-only call
- add owner-only job reward and stake configuration
- document Etherscan steps for owners to configure modules and economics

## Testing
- `npm test`
- `npm run lint` *(fails: 1810 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6894eab90b94833392b2e84b74d91934