### PR TITLE
docs: expand etherscan instructions and architecture

### DIFF
--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -37,6 +37,12 @@ graph TD
 3. During validation, send hashed votes with **commitVote**.
 4. Reveal decisions using **revealVote** before the window closes.
 
+### Moderators
+1. Watch for **DisputeRaised** events on the `DisputeModule`.
+2. In **Write Contract**, connect the moderator wallet.
+3. Call **resolve(jobId, employerWins)** to finalize the dispute.
+4. Verify the transaction emits **DisputeResolved** and the corresponding `JobRegistry` event.
+
 ## Parameter Glossary
 
 | Parameter | Description |


### PR DESCRIPTION
## Summary
- document AGI token address and safety checklist
- refresh module architecture diagram and incentive overview
- add step-by-step Etherscan guidance for employers, agents, validators, and moderators

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894ed9393908333b89bd96af93714a3