### PR TITLE
docs: outline v2 modular architecture sprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ All addresses should be independently verified before use.
 
 ### Modular v2 Architecture
 
-The upcoming v2 release decomposes the marketplace into a suite of immutable modules, each exposed through concise interfaces so non‑technical users can trigger calls from explorers like Etherscan. Modules interact only via interface addresses recorded in the JobRegistry, keeping storage separate and contracts upgrade‑free. Every contract inherits `Ownable`, letting the owner (or future governance) tune parameters without redeploying the whole system.
+The upcoming v2 release decomposes the marketplace into a suite of immutable modules, each exposed through concise interfaces so non‑technical users can trigger calls from explorers like Etherscan. Modules are deployed as **stand‑alone contracts** and wired together only through the addresses stored in `JobRegistry`, preserving storage isolation and making the system upgrade‑free. Every module inherits `Ownable`, ensuring that only the owner (or future governance) can adjust parameters. These owner‑only setters—such as stake ratios, timing windows or reputation thresholds—are callable through the explorer **Write** tabs, keeping administration approachable for non‑technical operators while remaining fully transparent on‑chain.
 
 | Module | Responsibility |
 | --- | --- |
@@ -510,7 +510,7 @@ graph TD
     JobRegistry -->|mint| CertificateNFT
 ```
 
-See [docs/architecture-v2.md](docs/architecture-v2.md) for diagrams, interface definitions, and incentive analysis grounded in game theory and statistical physics; the interfaces live in [`contracts/v2/interfaces`](contracts/v2/interfaces) for integration.
+See [docs/architecture-v2.md](docs/architecture-v2.md) for diagrams, interface definitions, and incentive analysis grounded in game theory and statistical physics; the interfaces live in [`contracts/v2/interfaces`](contracts/v2/interfaces) for integration. A step‑by‑step development outline is available in [docs/coding-sprint-v2.md](docs/coding-sprint-v2.md).
 
 ## Versions
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -22,6 +22,8 @@ Each component is immutable once deployed yet configurable by the owner through 
 
 Every module inherits `Ownable`, so only the contract owner (or future governance authority) may adjust these parameters.
 
+All public methods accept plain `uint256` values (wei and seconds) so they can be invoked directly from a block explorer without custom tooling. Owners configure modules by calling the published setter functions in Etherscan's **Write** tab, while agents and validators use the corresponding read/write interfaces for routine actions.
+
 ## Module Interactions
 ```mermaid
 graph TD

--- a/docs/coding-sprint-v2.md
+++ b/docs/coding-sprint-v2.md
@@ -1,0 +1,45 @@
+# Coding Sprint: AGIJobManager v2 Modular Suite
+
+This sprint turns the v2 architecture into production-ready code. Each task references the modules and interfaces defined in `contracts/v2` and described in `docs/architecture-v2.md`.
+
+## Sprint Goals
+- Implement immutable, ownable modules for job coordination, validation, staking, reputation, disputes and certificate NFTs.
+- Optimise for gas efficiency and composability while keeping explorer interactions simple for non‑technical users.
+- Align incentives so honest behaviour is the dominant strategy for agents, validators and employers.
+
+## Tasks
+1. **Interface Stabilisation**
+   - Finalise interfaces in `contracts/v2/interfaces`.
+   - Add NatSpec comments and custom errors for clarity.
+2. **Module Implementation**
+   - `JobRegistry`: job lifecycle, wiring module addresses, owner configuration.
+   - `ValidationModule`: pseudo‑random selection, commit‑reveal voting, outcome reporting.
+   - `StakeManager`: token custody, slashing, reward release.
+   - `ReputationEngine`: reputation tracking and threshold enforcement.
+   - `DisputeModule`: optional appeal flow and final ruling.
+   - `CertificateNFT`: ERC‑721 minting with owner‑settable base URI.
+3. **Incentive Calibration**
+   - Implement owner setters for stake ratios, rewards, slashing, timing windows and reputation thresholds.
+   - Ensure slashing percentages exceed potential dishonest gains.
+   - Route a share of slashed agent stake to the employer on failures.
+4. **Testing & Simulation**
+   - Write Hardhat tests covering happy paths and failure scenarios.
+   - Simulate validator collusion, missed reveals and disputes to verify game‑theoretic soundness.
+   - Run `npx hardhat test` and `forge test` until green.
+5. **Gas & Lint Pass**
+   - Profile gas with Hardhat's `--gas` flag; apply `unchecked` blocks where safe.
+   - Run `npx solhint 'contracts/**/*.sol'` and `npx eslint .`.
+6. **Deployment Prep**
+   - Freeze compiler versions and verify bytecode locally.
+   - Generate deployment scripts that record module addresses for `JobRegistry` wiring.
+
+## Deliverables
+- Verified Solidity contracts under `contracts/v2`.
+- Comprehensive test suite and lint-clean codebase.
+- Updated documentation: `README.md`, `docs/architecture-v2.md` and this sprint plan.
+
+## Definition of Done
+- All tests pass.
+- No linter or compile warnings.
+- Module addresses and configuration steps are documented for explorer-based usage.
+- Governance can adjust parameters solely through owner-restricted functions.


### PR DESCRIPTION
## Summary
- clarify README's modular v2 overview and explorer-friendly owner controls
- document owner-based interaction flow in architecture spec
- add coding sprint plan for implementing v2 module suite

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f3ae3cf8833394f734e5b6597dc3