### PR TITLE
docs: expand v2 governance details

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ All addresses should be independently verified before use.
 
 ### Modular v2 Architecture
 
-The upcoming v2 release decomposes the marketplace into a suite of immutable modules, each exposed through concise interfaces so non‑technical users can trigger calls from explorers like Etherscan. Modules are deployed as **stand‑alone contracts** and wired together only through the addresses stored in `JobRegistry`, preserving storage isolation and making the system upgrade‑free. Every module inherits `Ownable`, ensuring that only the owner (or future governance) can adjust parameters. These owner‑only setters—such as stake ratios, timing windows or reputation thresholds—are callable through the explorer **Write** tabs, keeping administration approachable for non‑technical operators while remaining fully transparent on‑chain.
+The upcoming v2 release decomposes the marketplace into a suite of immutable modules, each exposed through concise interfaces so non‑technical users can trigger calls from explorers like Etherscan. Modules are deployed as **stand‑alone contracts** and wired together only through the addresses stored in `JobRegistry`, preserving storage isolation and making the system upgrade‑free. `JobRegistry` lets the owner swap module addresses, enabling governance to upgrade components individually without redeploying the entire suite. Every module inherits `Ownable`, ensuring that only the owner (or future governance) can adjust parameters. These owner‑only setters—such as stake ratios, timing windows or reputation thresholds—are callable through the explorer **Write** tabs, keeping administration approachable for non‑technical operators while remaining fully transparent on‑chain.
 
 | Module | Responsibility |
 | --- | --- |

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -126,18 +126,18 @@ interface ICertificateNFT {
 ```
 
 ## Governance and Owner Controls
-Each module exposes minimal `onlyOwner` setters so governance can tune economics without redeploying code. Typical controls include:
+Each module exposes minimal `onlyOwner` setters so governance can tune economics without redeploying code. Because `JobRegistry` can update the addresses of its companion modules, new implementations may be introduced piecemeal while existing state remains untouched, enabling governance composability.
 
-- **JobRegistry** – `setModules` wiring validation, reputation, stake manager, dispute and certificate NFT contracts.
-- **ValidationModule** – `setParameters` for stake ratios, rewards, slashing and timing.
-- **DisputeModule** – `setAppealParameters` and moderator address.
-- **StakeManager** – `setStakeParameters` and `setToken`.
-- **ReputationEngine** – `setCaller` and `setThresholds` for agent/validator reputation.
-- **CertificateNFT** – `setBaseURI` for metadata.
+| Module | Key owner functions | Purpose |
+| --- | --- | --- |
+| JobRegistry | `setValidationModule`, `setReputationEngine`, `setStakeManager`, `setCertificateNFT`, `setDisputeModule`, `setJobParameters` | Wire module addresses and set per‑job rewards/stake |
+| ValidationModule | `setParameters` | Adjust stake ratios, rewards, slashing and timing windows |
+| DisputeModule | `setAppealParameters` | Configure appeal fees, jury size and moderator address |
+| StakeManager | `setStakeParameters`, `setToken` | Tune minimum stakes/slashing and switch staking token |
+| ReputationEngine | `setCaller`, `setThresholds` | Authorise callers and set agent/validator reputation floors |
+| CertificateNFT | `setBaseURI` | Update metadata base URI |
 
-All setters are accessible through block‑explorer interfaces, keeping administration intuitive for non‑technical owners while preserving contract immutability.
-
-These interfaces favour explicit, single-purpose methods, keeping gas costs predictable and allowing front‑end or Etherscan interactions to remain intuitive.
+All setters are accessible through block‑explorer interfaces, keeping administration intuitive for non‑technical owners while preserving contract immutability. These interfaces favour explicit, single‑purpose methods, keeping gas costs predictable and allowing front‑end or Etherscan interactions to remain intuitive.
 
 ## User Experience
 Non‑technical employers, agents and validators can call these methods directly through Etherscan's read and write tabs. Every parameter uses human‑readable units (wei for token amounts and seconds for timing) so that wallets and explorers can display values without custom tooling. No external subscription or Chainlink VRF is required; validator selection relies on commit‑reveal randomness seeded by the owner.


### PR DESCRIPTION
## Summary
- document that JobRegistry can swap module addresses for piecemeal upgrades
- table owner-only controls for each v2 module and note explorer-friendly configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f7b7e2208333b18d0f3afcc6eb97