### PR TITLE
docs: add v2 owner control quick reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,15 @@ The upcoming v2 release decomposes the marketplace into a suite of immutable mod
 | `ReputationEngine` | Track reputation, apply penalties, maintain blacklists. |
 | `CertificateNFT` | Mint ERC‑721 certificates for completed jobs. |
 
+| Module | Key owner controls |
+| --- | --- |
+| `JobRegistry` | `setModules`, `setJobParameters` |
+| `ValidationModule` | `setParameters` |
+| `StakeManager` | `setStakeParameters`, `setToken` |
+| `ReputationEngine` | `setCaller`, `setThresholds` |
+| `DisputeModule` | `setAppealParameters` |
+| `CertificateNFT` | `setBaseURI` |
+
 ```mermaid
 graph TD
     Employer -->|createJob| JobRegistry


### PR DESCRIPTION
## Summary
- document v2 module responsibilities and owner-only controls in README
- retain references to architecture and coding sprint docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894ff0987f08333957284a959cbf2c0