### PR TITLE
docs: expand v2 architecture guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 - [AGIJobManager v0 Source](legacy/AGIJobManagerv0.sol)
 - [AGIJobManager v1 Source](contracts/AGIJobManagerv1.sol) – experimental upgrade using Solidity 0.8.21; includes an automatic token burn on final validation via the `JobFinalizedAndBurned` event and configurable burn parameters. Not deployed; treat any address claiming to be v1 as unverified until announced through official channels.
 - [AGIJobManager v2 Architecture](docs/architecture-v2.md) – modular design with incentive analysis and interface definitions.
+- [Coding Sprint for v2](docs/coding-sprint-v2.md) – step-by-step plan for implementing the modular suite.
 
 > **Warning**: Links above are provided for reference only. Always validate contract addresses and metadata on multiple block explorers before interacting.
 
@@ -59,7 +60,7 @@ Legacy sequence diagrams appear in [docs/architecture.md](docs/architecture.md);
 
 ### AGIJobManager v2
 
-The forthcoming v2 release splits responsibilities across immutable modules—JobRegistry, ValidationModule, StakeManager, ReputationEngine, DisputeModule and CertificateNFT. Each module is `Ownable` so only the contract owner may adjust parameters, and interfaces remain minimal to keep Etherscan usage straightforward. Incentive settings such as burn rate, stake ratios and slashing percentages are all updated through owner‑only functions, preserving governance control while keeping the surface area small for non‑technical users. Interface definitions live in [contracts/v2/interfaces](contracts/v2/interfaces) and architectural diagrams, including a Hamiltonian view of incentives, in [docs/architecture-v2.md](docs/architecture-v2.md).
+ The forthcoming v2 release splits responsibilities across immutable modules—JobRegistry, ValidationModule, StakeManager, ReputationEngine, DisputeModule and CertificateNFT. Validator committees reach majority decisions with dissenters able to escalate through the DisputeModule, and slashing percentages exceed potential rewards so cheating is irrational. Each module is `Ownable` so only the contract owner may adjust parameters, and interfaces remain minimal to keep Etherscan usage straightforward. Incentive settings such as burn rate, stake ratios and slashing percentages are all updated through owner‑only functions, preserving governance control while keeping the surface area small for non‑technical users. Interface definitions live in [contracts/v2/interfaces](contracts/v2/interfaces) and architectural diagrams, including a Hamiltonian view of incentives, in [docs/architecture-v2.md](docs/architecture-v2.md).
 
 Key owner-configurable entry points include:
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -176,3 +176,11 @@ Reference Solidity interfaces are provided in `contracts/v2/interfaces` for inte
 - Separate state-changing logic from read-only helpers to simplify audits and Etherscan interactions.
 - Use custom errors instead of revert strings to save deployment and runtime gas.
 - Where arithmetic is already bounds-checked, wrap operations in `unchecked` blocks for marginal savings.
+
+### Additional Gas Optimization Tips
+
+- Mark functions `external` when they are not called internally.
+- Prefer `calldata` for array parameters to avoid unnecessary copies.
+- Enable the Solidity optimizer with high `runs` to reduce bytecode size.
+- Group related storage writes to minimise `SSTORE` operations.
+- Declare configuration constants as `immutable` or `constant` to cut storage reads.


### PR DESCRIPTION
## Summary
- reference v2 coding sprint in README quick links
- clarify majority validation & slashing incentives in v2 overview
- document extra gas-optimization tips for module implementations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950466702c8333b7d9a4926c85ffb7