### PR TITLE
feat: add configurable staking and slashing

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -49,6 +49,7 @@ contract MockStakeManager is IStakeManager {
     function setStakeParameters(
         uint256,
         uint256,
+        uint256,
         uint256
     ) external override {}
 }

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -35,6 +35,7 @@ interface IStakeManager {
     function setStakeParameters(
         uint256 agentStakePercentage,
         uint256 validatorStakePercentage,
+        uint256 agentSlashingPercentage,
         uint256 validatorSlashingPercentage
     ) external;
 }

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -110,11 +110,12 @@ interface IStakeManager {
     enum Role { Agent, Validator }
     function depositStake(Role role, uint256 amount) external;
     function withdrawStake(Role role, uint256 amount) external;
-    function lockStake(address user, Role role, uint256 amount) external;
-    function slash(address user, uint256 amount, address recipient) external;
+    function lockStake(address user, Role role, uint256 payout) external;
+    function slash(address user, Role role, uint256 payout, address employer) external;
     function setStakeParameters(
         uint256 agentStakePercentage,
         uint256 validatorStakePercentage,
+        uint256 agentSlashingPercentage,
         uint256 validatorSlashingPercentage
     ) external;
 }

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -29,53 +29,54 @@ describe("StakeManager", function () {
     await token.connect(validator).approve(await stakeManager.getAddress(), 400);
     await stakeManager.connect(validator).depositStake(Role.Validator, 400);
 
-    expect(await stakeManager.stakeOf(agent.address, Role.Agent)).to.equal(500);
+    expect(await stakeManager.stakeOf(agent.address, Role.Agent)).to.equal(500n);
     expect(await stakeManager.stakeOf(validator.address, Role.Validator)).to.equal(
-      400
+      400n
     );
 
     await stakeManager
       .connect(owner)
-      .lockStake(agent.address, Role.Agent, 200);
+      .lockStake(agent.address, Role.Agent, 1000);
     await stakeManager
       .connect(owner)
-      .lockStake(validator.address, Role.Validator, 100);
+      .lockStake(validator.address, Role.Validator, 1000);
 
     expect(await stakeManager.lockedStakeOf(agent.address, Role.Agent)).to.equal(
-      200
+      200n
     );
     expect(
       await stakeManager.lockedStakeOf(validator.address, Role.Validator)
-    ).to.equal(100);
+    ).to.equal(100n);
 
     await expect(
       stakeManager.connect(agent).withdrawStake(Role.Agent, 400)
     ).to.be.revertedWith("insufficient stake");
     await stakeManager.connect(agent).withdrawStake(Role.Agent, 300);
-    expect(await stakeManager.stakeOf(agent.address, Role.Agent)).to.equal(200);
+    expect(await stakeManager.stakeOf(agent.address, Role.Agent)).to.equal(200n);
 
     await stakeManager
       .connect(owner)
-      .slash(agent.address, Role.Agent, 100, employer.address);
-    expect(await stakeManager.stakeOf(agent.address, Role.Agent)).to.equal(100);
+      .slash(agent.address, Role.Agent, 1000, employer.address);
+    expect(await stakeManager.stakeOf(agent.address, Role.Agent)).to.equal(100n);
     expect(await stakeManager.lockedStakeOf(agent.address, Role.Agent)).to.equal(
-      100
+      0n
     );
-    expect(await token.balanceOf(employer.address)).to.equal(1050);
-    expect(await token.balanceOf(treasury.address)).to.equal(50);
+    expect(await token.balanceOf(employer.address)).to.equal(1050n);
+    expect(await token.balanceOf(treasury.address)).to.equal(50n);
   });
 
   it("restricts parameter updates to owner", async () => {
     await expect(
-      stakeManager.connect(agent).setStakeParameters(30, 20, 60)
+      stakeManager.connect(agent).setStakeParameters(30, 20, 60, 40)
     ).to.be.revertedWithCustomError(
       stakeManager,
       "OwnableUnauthorizedAccount"
     );
-    await stakeManager.connect(owner).setStakeParameters(30, 20, 60);
-    expect(await stakeManager.agentStakePercentage()).to.equal(30);
-    expect(await stakeManager.validatorStakePercentage()).to.equal(20);
-    expect(await stakeManager.validatorSlashingPercentage()).to.equal(60);
+    await stakeManager.connect(owner).setStakeParameters(30, 20, 60, 40);
+    expect(await stakeManager.agentStakePercentage()).to.equal(30n);
+    expect(await stakeManager.validatorStakePercentage()).to.equal(20n);
+    expect(await stakeManager.agentSlashingPercentage()).to.equal(60n);
+    expect(await stakeManager.validatorSlashingPercentage()).to.equal(40n);
 
     const Token2 = await ethers.getContractFactory("MockERC20");
     const token2 = await Token2.deploy();


### PR DESCRIPTION
## Summary
- enforce role-based stake locking and percentage slashing
- split penalties between employer and treasury
- allow owner to configure staking/slashing percentages and token

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895141e747483339cc68b6b12faf49d