### PR TITLE
feat: add role-based reputation tracking

### DIFF
--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -50,8 +50,8 @@ describe("JobRegistry integration", function () {
       .setJobParameters(reward, stake);
     await dispute.connect(owner).setAppealParameters(appealFee, 0);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
-    await rep.connect(owner).setCaller(await registry.getAddress(), true);
-    await rep.connect(owner).setPenaltyThreshold(1);
+    await rep.connect(owner).setCaller(await registry.getAddress(), 1);
+    await rep.connect(owner).setAgentThreshold(1);
     await stakeManager.connect(owner).transferOwnership(await registry.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
 
@@ -72,9 +72,8 @@ describe("JobRegistry integration", function () {
     await registry.finalize(jobId);
 
     expect(await token.balanceOf(agent.address)).to.equal(1100);
-    expect(await rep.reputationOf(agent.address)).to.equal(1);
-    expect(await rep.penaltyCount(agent.address)).to.equal(0);
-    expect(await rep.isBlacklisted(agent.address)).to.equal(false);
+    expect(await rep.reputationOf(agent.address, 1)).to.equal(1);
+    expect(await rep.isBlacklisted(agent.address, 1)).to.equal(false);
     expect(await nft.balanceOf(agent.address)).to.equal(1);
   });
 
@@ -90,9 +89,8 @@ describe("JobRegistry integration", function () {
     await registry.finalize(jobId);
 
     expect(await token.balanceOf(agent.address)).to.equal(1100);
-    expect(await rep.reputationOf(agent.address)).to.equal(1);
-    expect(await rep.penaltyCount(agent.address)).to.equal(0);
-    expect(await rep.isBlacklisted(agent.address)).to.equal(false);
+    expect(await rep.reputationOf(agent.address, 1)).to.equal(1);
+    expect(await rep.isBlacklisted(agent.address, 1)).to.equal(false);
     expect(await nft.balanceOf(agent.address)).to.equal(1);
   });
 
@@ -109,9 +107,8 @@ describe("JobRegistry integration", function () {
 
     expect(await token.balanceOf(agent.address)).to.equal(800);
     expect(await token.balanceOf(employer.address)).to.equal(1200);
-    expect(await rep.reputationOf(agent.address)).to.equal(0);
-    expect(await rep.penaltyCount(agent.address)).to.equal(1);
-    expect(await rep.isBlacklisted(agent.address)).to.equal(true);
+    expect(await rep.reputationOf(agent.address, 1)).to.equal(0);
+    expect(await rep.isBlacklisted(agent.address, 1)).to.equal(true);
     expect(await nft.balanceOf(agent.address)).to.equal(0);
   });
 


### PR DESCRIPTION
## Summary
- track agent and validator reputation separately with role-specific thresholds
- automatically blacklist addresses when reputation drops under their threshold
- authorize JobRegistry and ValidationModule via role-based caller whitelist

## Testing
- `npm test test/ReputationEngine.test.js test/v2/JobRegistry.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68951932281483338f2ca2f13d72a441