### PR TITLE
feat: add JobNFT contract

### DIFF
--- a/contracts/JobNFT.sol
+++ b/contracts/JobNFT.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title JobNFT
+/// @notice Minimal ERC721 token for representing jobs.
+/// @dev Minting and burning are restricted to the JobRegistry contract.
+contract JobNFT is ERC721, Ownable {
+    string private baseTokenURI;
+    address public jobRegistry;
+    uint256 public nextTokenId;
+    mapping(uint256 => string) private _tokenURIs;
+
+    event BaseURIUpdated(string newURI);
+    event JobRegistryUpdated(address registry);
+
+    constructor(string memory name_, string memory symbol_, address owner)
+        ERC721(name_, symbol_)
+        Ownable(owner)
+    {}
+
+    modifier onlyJobRegistry() {
+        require(msg.sender == jobRegistry, "only JobRegistry");
+        _;
+    }
+
+    /// @notice Set the base URI for all tokens.
+    function setBaseURI(string calldata uri) external onlyOwner {
+        baseTokenURI = uri;
+        emit BaseURIUpdated(uri);
+    }
+
+    /// @notice Configure the authorized JobRegistry.
+    function setJobRegistry(address registry) external onlyOwner {
+        jobRegistry = registry;
+        emit JobRegistryUpdated(registry);
+    }
+
+    /// @notice Mint a new token to `to` with optional `uri`.
+    /// @dev Only callable by the JobRegistry.
+    function mint(address to, string calldata uri)
+        external
+        onlyJobRegistry
+        returns (uint256 tokenId)
+    {
+        tokenId = ++nextTokenId;
+        _safeMint(to, tokenId);
+        if (bytes(uri).length != 0) {
+            _tokenURIs[tokenId] = uri;
+        }
+    }
+
+    /// @notice Burn a token, invalidating the associated job.
+    /// @dev Only callable by the JobRegistry.
+    function burn(uint256 tokenId) external onlyJobRegistry {
+        _burn(tokenId);
+        if (bytes(_tokenURIs[tokenId]).length != 0) {
+            delete _tokenURIs[tokenId];
+        }
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return baseTokenURI;
+    }
+
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override
+        returns (string memory)
+    {
+        string memory custom = _tokenURIs[tokenId];
+        if (bytes(custom).length != 0) {
+            string memory base = _baseURI();
+            if (bytes(base).length != 0) {
+                return string(abi.encodePacked(base, custom));
+            }
+            return custom;
+        }
+        return super.tokenURI(tokenId);
+    }
+}
+

--- a/test/JobNFT.test.js
+++ b/test/JobNFT.test.js
@@ -1,0 +1,47 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+async function deployFixture() {
+  const [owner, jobRegistry, user] = await ethers.getSigners();
+  const JobNFT = await ethers.getContractFactory("JobNFT");
+  const nft = await JobNFT.deploy("Job", "JOB", owner.address);
+  await nft.waitForDeployment();
+  await nft.setJobRegistry(jobRegistry.address);
+  return { nft, owner, jobRegistry, user };
+}
+
+describe("JobNFT", function () {
+  it("allows only owner to set base URI", async function () {
+    const { nft, jobRegistry } = await deployFixture();
+    await expect(nft.connect(jobRegistry).setBaseURI("ipfs://"))
+      .to.be.revertedWithCustomError(nft, "OwnableUnauthorizedAccount")
+      .withArgs(jobRegistry.address);
+    await expect(nft.setBaseURI("ipfs://"))
+      .to.emit(nft, "BaseURIUpdated")
+      .withArgs("ipfs://");
+  });
+
+  it("mints and burns only via JobRegistry", async function () {
+    const { nft, jobRegistry, user } = await deployFixture();
+    await expect(nft.connect(user).mint(user.address, "job1.json"))
+      .to.be.revertedWith("only JobRegistry");
+    await nft.connect(jobRegistry).mint(user.address, "job1.json");
+    const tokenId = await nft.nextTokenId();
+
+    expect(await nft.ownerOf(tokenId)).to.equal(user.address);
+    await nft.connect(jobRegistry).burn(tokenId);
+    await expect(nft.ownerOf(tokenId)).to.be.revertedWithCustomError(
+      nft,
+      "ERC721NonexistentToken"
+    ).withArgs(tokenId);
+  });
+
+  it("prefixes tokenURI with base URI", async function () {
+    const { nft, jobRegistry, user } = await deployFixture();
+    await nft.setBaseURI("ipfs://");
+    await nft.connect(jobRegistry).mint(user.address, "job1.json");
+    const tokenId = await nft.nextTokenId();
+
+    expect(await nft.tokenURI(tokenId)).to.equal("ipfs://job1.json");
+  });
+});


### PR DESCRIPTION
## Summary
- implement minimal JobNFT ERC-721 with owner-settable base URI
- allow JobRegistry-only minting and burning for job tokens
- add tests covering base URI control and token lifecycle

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951d4a94548333a145cc1ae5ee2f0d