### PR TITLE
docs: add incentive flow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Legacy sequence diagrams appear in [docs/architecture.md](docs/architecture.md);
 
  The forthcoming v2 release splits responsibilities across immutable modules—JobRegistry, ValidationModule, StakeManager, ReputationEngine, DisputeModule and CertificateNFT. Validator committees reach majority decisions with dissenters able to escalate through the DisputeModule, and slashing percentages exceed potential rewards so cheating is irrational. Each module is `Ownable` so only the contract owner may adjust parameters, and interfaces remain minimal to keep Etherscan usage straightforward. Incentive settings such as burn rate, stake ratios and slashing percentages are all updated through owner‑only functions, preserving governance control while keeping the surface area small for non‑technical users. Interface definitions live in [contracts/v2/interfaces](contracts/v2/interfaces) and architectural diagrams, including a Hamiltonian view of incentives, in [docs/architecture-v2.md](docs/architecture-v2.md).
 
+An end‑to‑end incentive flow chart mapping stakes, rewards and slashing destinations appears in [docs/architecture-v2.md#incentive-flow-diagram](docs/architecture-v2.md#incentive-flow-diagram).
+
 Key owner-configurable entry points include:
 
 - `JobRegistry.setJobParameters(reward, stake)`

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -166,6 +166,18 @@ We can sketch a simplified Hamiltonian
 
 where \(s_i\) represents stake lost by misbehaving participants and \(r_j\) denotes rewards for correct actions. The owner adjusts coefficients through setter functions, shaping the potential landscape so that the minimal free energy occurs when agents, validators and employers follow the protocol. Deviations raise \(H\), matching game‑theoretic expectations that dishonest strategies carry higher expected cost than cooperative ones.
 
+### Incentive Flow Diagram
+```mermaid
+graph LR
+    Agent -- stake --> StakeManager
+    Validator -- stake --> StakeManager
+    StakeManager -- reward --> Agent
+    StakeManager -- reward --> Validator
+    StakeManager -- slash --> Employer
+    StakeManager -- slash --> Treasury
+```
+The flow highlights how collateral enters the system and where it is routed on success or failure. Rewards are paid out of escrow while slashed stakes are split between the employer and treasury, ensuring misbehaviour carries an immediate, quantifiable cost.
+
 ## Interfaces
 Reference Solidity interfaces are provided in `contracts/v2/interfaces` for integration and future implementation.
 


### PR DESCRIPTION
## Summary
- document incentive flow for v2 architecture and link from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68952d09b16c833383dde0a53a116956