### PR TITLE
docs: outline v2 module interfaces and incentive flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,37 @@ Legacy sequence diagrams appear in [docs/architecture.md](docs/architecture.md);
 
  The forthcoming v2 release splits responsibilities across immutable modules—JobRegistry, ValidationModule, StakeManager, ReputationEngine, DisputeModule and CertificateNFT. Validator committees reach majority decisions with dissenters able to escalate through the DisputeModule, and slashing percentages exceed potential rewards so cheating is irrational. Each module is `Ownable` so only the contract owner may adjust parameters, and interfaces remain minimal to keep Etherscan usage straightforward. Incentive settings such as burn rate, stake ratios and slashing percentages are all updated through owner‑only functions, preserving governance control while keeping the surface area small for non‑technical users. Interface definitions live in [contracts/v2/interfaces](contracts/v2/interfaces) and architectural diagrams, including a Hamiltonian view of incentives, in [docs/architecture-v2.md](docs/architecture-v2.md).
 
-An end‑to‑end incentive flow chart mapping stakes, rewards and slashing destinations appears in [docs/architecture-v2.md#incentive-flow-diagram](docs/architecture-v2.md#incentive-flow-diagram).
+Key incentive refinements include:
+
+- Majority validator approval finalises jobs while minorities can appeal via the DisputeModule.
+- Slashing percentages exceed potential gains and a share of slashed agent stake returns to the employer.
+- Lone validators who misvote or fail to reveal suffer amplified penalties, deterring extortion attempts.
+- Commit–reveal randomness and owner‑set seeds inject entropy, making validator selection hard to game.
+
+#### Module interface paths
+
+| Module | Interface |
+| --- | --- |
+| JobRegistry | [`contracts/v2/interfaces/IJobRegistry.sol`](contracts/v2/interfaces/IJobRegistry.sol) |
+| ValidationModule | [`contracts/v2/interfaces/IValidationModule.sol`](contracts/v2/interfaces/IValidationModule.sol) |
+| StakeManager | [`contracts/v2/interfaces/IStakeManager.sol`](contracts/v2/interfaces/IStakeManager.sol) |
+| ReputationEngine | [`contracts/v2/interfaces/IReputationEngine.sol`](contracts/v2/interfaces/IReputationEngine.sol) |
+| DisputeModule | [`contracts/v2/interfaces/IDisputeModule.sol`](contracts/v2/interfaces/IDisputeModule.sol) |
+| CertificateNFT | [`contracts/v2/interfaces/ICertificateNFT.sol`](contracts/v2/interfaces/ICertificateNFT.sol) |
+
+#### Incentive flow
+
+```mermaid
+graph LR
+    Agent -->|stake| StakeManager
+    Validator -->|stake| StakeManager
+    StakeManager -->|reward| Agent
+    StakeManager -->|reward| Validator
+    StakeManager -->|slash| Employer
+    StakeManager -->|slash| Treasury
+```
+
+A more detailed incentive flow chart appears in [docs/architecture-v2.md#incentive-flow-diagram](docs/architecture-v2.md#incentive-flow-diagram).
 
 Key owner-configurable entry points include:
 


### PR DESCRIPTION
## Summary
- document key incentive refinements for modular v2 contracts
- link module interface paths and show incentive flow diagram in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689536ba274c8333aaac826b379b2501