### PR TITLE
Add CertificateNFT module

### DIFF
--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ICertificateNFT} from "../interfaces/ICertificateNFT.sol";
+
+/// @title CertificateNFT (module)
+/// @notice ERC721 certificate minted upon successful job completion.
+contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
+    string private baseTokenURI;
+    address public jobRegistry;
+    mapping(uint256 => string) private _tokenURIs;
+
+    event JobRegistryUpdated(address registry);
+    event TokenURIUpdated(uint256 indexed tokenId, string uri);
+
+    constructor(string memory name_, string memory symbol_, address owner_)
+        ERC721(name_, symbol_)
+        Ownable(owner_)
+    {}
+
+    modifier onlyJobRegistry() {
+        require(msg.sender == jobRegistry, "only JobRegistry");
+        _;
+    }
+
+    /// @notice Owner function to update metadata base URI.
+    function setBaseURI(string calldata uri) external onlyOwner {
+        baseTokenURI = uri;
+        emit BaseURIUpdated(uri);
+    }
+
+    /// @notice Owner function to set JobRegistry address permitted to mint certificates.
+    function setJobRegistry(address registry) external onlyOwner {
+        jobRegistry = registry;
+        emit JobRegistryUpdated(registry);
+    }
+
+    /// @notice Mint a certificate NFT for a completed job.
+    /// @param to Recipient of the certificate.
+    /// @param jobId Identifier tying certificate to job.
+    /// @param uri Optional metadata URI overriding base.
+    function mintCertificate(
+        address to,
+        uint256 jobId,
+        string calldata uri
+    ) external onlyJobRegistry returns (uint256 tokenId) {
+        tokenId = jobId;
+        _safeMint(to, tokenId);
+        if (bytes(uri).length != 0) {
+            _tokenURIs[tokenId] = uri;
+            emit TokenURIUpdated(tokenId, uri);
+        }
+        emit CertificateMinted(to, jobId);
+    }
+
+    /// @notice Owner function to update an existing token's metadata URI.
+    /// @param tokenId The token to update.
+    /// @param uri New metadata URI.
+    function updateTokenURI(uint256 tokenId, string calldata uri) external onlyOwner {
+        _requireOwned(tokenId);
+        _tokenURIs[tokenId] = uri;
+        emit TokenURIUpdated(tokenId, uri);
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return baseTokenURI;
+    }
+
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        string memory custom = _tokenURIs[tokenId];
+        if (bytes(custom).length != 0) {
+            return custom;
+        }
+        return super.tokenURI(tokenId);
+    }
+}
+

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -30,7 +30,7 @@ async function main() {
   const reputation = await Reputation.deploy(deployer.address);
 
   const NFT = await ethers.getContractFactory(
-    "contracts/v2/CertificateNFT.sol:CertificateNFT"
+    "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
   );
   const nft = await NFT.deploy("Cert", "CERT", deployer.address);
 

--- a/test/v2/CertificateNFT.test.js
+++ b/test/v2/CertificateNFT.test.js
@@ -7,7 +7,7 @@ describe("CertificateNFT", function () {
   beforeEach(async () => {
     [owner, user] = await ethers.getSigners();
     const NFT = await ethers.getContractFactory(
-      "contracts/v2/CertificateNFT.sol:CertificateNFT"
+      "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );
     nft = await NFT.deploy("Cert", "CERT", owner.address);
   });
@@ -22,6 +22,13 @@ describe("CertificateNFT", function () {
       .withArgs(user.address, 1);
     expect(await nft.ownerOf(1)).to.equal(user.address);
     expect(await nft.tokenURI(1)).to.equal("ipfs://base/1");
+  });
+
+  it("allows owner to update token URI", async () => {
+    await nft.connect(owner).setJobRegistry(owner.address);
+    await nft.connect(owner).mintCertificate(user.address, 1, "ipfs://old");
+    await nft.connect(owner).updateTokenURI(1, "ipfs://new");
+    expect(await nft.tokenURI(1)).to.equal("ipfs://new");
   });
 });
 

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -25,9 +25,9 @@ describe("JobRegistry integration", function () {
       "contracts/ReputationEngine.sol:ReputationEngine"
     );
     rep = await Rep.deploy(owner.address);
-    const NFT = await ethers.getContractFactory(
-      "contracts/v2/CertificateNFT.sol:CertificateNFT"
-    );
+      const NFT = await ethers.getContractFactory(
+        "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
+      );
     nft = await NFT.deploy("Cert", "CERT", owner.address);
     const Registry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"


### PR DESCRIPTION
## Summary
- implement CertificateNFT module with JobRegistry-restricted minting
- allow owner to set base URI and update per-token metadata
- adjust tests and deploy script to reference new module

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689553dcdba88333b8d7e44a601a973e