### PR TITLE
feat: add v2 stake manager

### DIFF
--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -1,87 +1,63 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-const Role = { Agent: 0, Validator: 1 };
-
 describe("StakeManager", function () {
-  let token, stakeManager, owner, treasury, employer, agent, validator;
+  let token, stakeManager, owner, user, employer, recipient;
 
   beforeEach(async () => {
-    [owner, treasury, employer, agent, validator] = await ethers.getSigners();
+    [owner, user, employer, recipient] = await ethers.getSigners();
     const Token = await ethers.getContractFactory("MockERC20");
     token = await Token.deploy();
-    await token.mint(agent.address, 1000);
-    await token.mint(validator.address, 1000);
+    await token.mint(user.address, 1000);
     await token.mint(employer.address, 1000);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      treasury.address,
       owner.address
     );
   });
 
-  it("tracks stakes per role and supports locking and slashing", async () => {
-    await token.connect(agent).approve(await stakeManager.getAddress(), 500);
-    await stakeManager.connect(agent).depositStake(Role.Agent, 500);
-    await token.connect(validator).approve(await stakeManager.getAddress(), 400);
-    await stakeManager.connect(validator).depositStake(Role.Validator, 400);
+  it("handles staking, job funds and slashing", async () => {
+    await token.connect(user).approve(await stakeManager.getAddress(), 200);
+    await expect(
+      stakeManager.connect(user).depositStake(200)
+    ).to.emit(stakeManager, "StakeDeposited").withArgs(user.address, 200);
 
-    expect(await stakeManager.stakeOf(agent.address, Role.Agent)).to.equal(500n);
-    expect(await stakeManager.stakeOf(validator.address, Role.Validator)).to.equal(
-      400n
-    );
+    expect(await stakeManager.stakes(user.address)).to.equal(200n);
 
+    await stakeManager.connect(user).withdrawStake(50);
+    expect(await stakeManager.stakes(user.address)).to.equal(150n);
+
+    await token.connect(employer).approve(await stakeManager.getAddress(), 300);
     await stakeManager
       .connect(owner)
-      .lockStake(agent.address, Role.Agent, 1000);
-    await stakeManager
-      .connect(owner)
-      .lockStake(validator.address, Role.Validator, 1000);
-
-    expect(await stakeManager.lockedStakeOf(agent.address, Role.Agent)).to.equal(
-      200n
-    );
-    expect(
-      await stakeManager.lockedStakeOf(validator.address, Role.Validator)
-    ).to.equal(100n);
+      .lockJobFunds(employer.address, 300);
 
     await expect(
-      stakeManager.connect(agent).withdrawStake(Role.Agent, 400)
-    ).to.be.revertedWith("insufficient stake");
-    await stakeManager.connect(agent).withdrawStake(Role.Agent, 300);
-    expect(await stakeManager.stakeOf(agent.address, Role.Agent)).to.equal(200n);
+      stakeManager.connect(owner).releaseJobFunds(user.address, 200)
+    ).to.emit(stakeManager, "FundsReleased").withArgs(user.address, 200);
+    expect(await token.balanceOf(user.address)).to.equal(1050n);
 
-    await stakeManager
-      .connect(owner)
-      .slash(agent.address, Role.Agent, 1000, employer.address);
-    expect(await stakeManager.stakeOf(agent.address, Role.Agent)).to.equal(100n);
-    expect(await stakeManager.lockedStakeOf(agent.address, Role.Agent)).to.equal(
-      0n
+    await expect(
+      stakeManager
+        .connect(owner)
+        .slash(user.address, recipient.address, 100)
+    ).to.emit(stakeManager, "StakeSlashed").withArgs(
+      user.address,
+      recipient.address,
+      100
     );
-    expect(await token.balanceOf(employer.address)).to.equal(1050n);
-    expect(await token.balanceOf(treasury.address)).to.equal(50n);
+    expect(await stakeManager.stakes(user.address)).to.equal(50n);
+    expect(await token.balanceOf(recipient.address)).to.equal(100n);
   });
 
-  it("restricts parameter updates to owner", async () => {
-    await expect(
-      stakeManager.connect(agent).setStakeParameters(30, 20, 60, 40)
-    ).to.be.revertedWithCustomError(
-      stakeManager,
-      "OwnableUnauthorizedAccount"
-    );
-    await stakeManager.connect(owner).setStakeParameters(30, 20, 60, 40);
-    expect(await stakeManager.agentStakePercentage()).to.equal(30n);
-    expect(await stakeManager.validatorStakePercentage()).to.equal(20n);
-    expect(await stakeManager.agentSlashingPercentage()).to.equal(60n);
-    expect(await stakeManager.validatorSlashingPercentage()).to.equal(40n);
-
+  it("restricts token updates to owner", async () => {
     const Token2 = await ethers.getContractFactory("MockERC20");
     const token2 = await Token2.deploy();
     await expect(
-      stakeManager.connect(agent).setToken(await token2.getAddress())
+      stakeManager.connect(user).setToken(await token2.getAddress())
     ).to.be.revertedWithCustomError(
       stakeManager,
       "OwnableUnauthorizedAccount"
@@ -90,5 +66,4 @@ describe("StakeManager", function () {
     expect(await stakeManager.token()).to.equal(await token2.getAddress());
   });
 });
-
 


### PR DESCRIPTION
## Summary
- add minimal ERC20 stake manager with job escrow, slashing and token updates
- test staking, fund release and slashing flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689560e3c9e0833393ab86dd97065f19