### PR TITLE
feat: add module-based reputation engine

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -83,24 +83,24 @@ contract MockJobRegistry is IJobRegistry {
 contract MockReputationEngine is IReputationEngine {
     mapping(address => uint256) private _rep;
 
-    function addReputation(address user, uint256 amount) external override {
+    function add(address user, uint256 amount) external override {
         _rep[user] += amount;
     }
 
-    function subtractReputation(address user, uint256 amount) external override {
+    function subtract(address user, uint256 amount) external override {
         uint256 rep = _rep[user];
         _rep[user] = rep > amount ? rep - amount : 0;
     }
 
-    function reputationOf(address user) external view override returns (uint256) {
+    function reputation(address user) external view override returns (uint256) {
         return _rep[user];
     }
 
-    function isBlacklisted(address) external pure override returns (bool) {
+    function blacklist(address) external pure override returns (bool) {
         return false;
     }
 
-    function setCaller(address, bool) external override {}
+    function setModule(address, bool) external override {}
 
     function setRole(address, uint8) external override {}
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -16,8 +16,8 @@ interface IStakeManager {
 }
 
 interface IReputationEngine {
-    function addReputation(address user, uint256 amount) external;
-    function subtractReputation(address user, uint256 amount) external;
+    function add(address user, uint256 amount) external;
+    function subtract(address user, uint256 amount) external;
 }
 
 interface IDisputeModule {
@@ -235,7 +235,7 @@ contract JobRegistry is Ownable {
                 }
             }
             if (address(reputationEngine) != address(0)) {
-                reputationEngine.addReputation(job.agent, 1);
+                reputationEngine.add(job.agent, 1);
             }
             if (address(certificateNFT) != address(0)) {
                 certificateNFT.mintCertificate(job.agent, jobId, "");
@@ -250,7 +250,7 @@ contract JobRegistry is Ownable {
                 }
             }
             if (address(reputationEngine) != address(0)) {
-                reputationEngine.subtractReputation(job.agent, 1);
+                reputationEngine.subtract(job.agent, 1);
             }
         }
         emit JobFinalized(jobId, job.success);

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -92,7 +92,7 @@ contract ValidationModule is IValidationModule, Ownable {
         for (uint256 i; i < n; ++i) {
             uint256 stake = stakeManager.stakeOf(pool[i], IStakeManager.Role.Validator);
             if (address(reputationEngine) != address(0)) {
-                if (reputationEngine.isBlacklisted(pool[i])) continue;
+                if (reputationEngine.blacklist(pool[i])) continue;
             }
             if (stake > 0) {
                 stakes[m] = stake;
@@ -195,10 +195,10 @@ contract ValidationModule is IValidationModule, Ownable {
                     );
                 }
                 if (address(reputationEngine) != address(0)) {
-                    reputationEngine.subtractReputation(val, 1);
+                    reputationEngine.subtract(val, 1);
                 }
             } else if (address(reputationEngine) != address(0)) {
-                reputationEngine.addReputation(val, 1);
+                reputationEngine.add(val, 1);
             }
         }
 

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -7,13 +7,13 @@ interface IReputationEngine {
     event ReputationChanged(address indexed user, int256 delta, uint256 newScore);
     event BlacklistUpdated(address indexed user, bool status);
 
-    function addReputation(address user, uint256 amount) external;
-    function subtractReputation(address user, uint256 amount) external;
-    function reputationOf(address user) external view returns (uint256);
-    function isBlacklisted(address user) external view returns (bool);
+    function add(address user, uint256 amount) external;
+    function subtract(address user, uint256 amount) external;
+    function reputation(address user) external view returns (uint256);
+    function blacklist(address user) external view returns (bool);
 
     /// @notice Owner functions
-    function setCaller(address caller, bool allowed) external;
+    function setModule(address module, bool allowed) external;
     function setRole(address user, uint8 role) external;
     function setThresholds(uint256 agentThreshold, uint256 validatorThreshold) external;
 }

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -22,7 +22,7 @@ describe("JobRegistry integration", function () {
     );
     validation = await Validation.deploy(owner.address);
     const Rep = await ethers.getContractFactory(
-      "contracts/ReputationEngine.sol:ReputationEngine"
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
     rep = await Rep.deploy(owner.address);
       const NFT = await ethers.getContractFactory(
@@ -52,8 +52,8 @@ describe("JobRegistry integration", function () {
       .setJobParameters(reward, stake);
     await dispute.connect(owner).setAppealParameters(appealFee, 0);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
-    await rep.connect(owner).setCaller(await registry.getAddress(), 1);
-    await rep.connect(owner).setAgentThreshold(1);
+    await rep.connect(owner).setModule(await registry.getAddress(), true);
+    await rep.connect(owner).setThresholds(1, 0);
     await stakeManager.connect(owner).transferOwnership(await registry.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
 
@@ -74,8 +74,8 @@ describe("JobRegistry integration", function () {
     await registry.finalize(jobId);
 
     expect(await token.balanceOf(agent.address)).to.equal(1100);
-    expect(await rep.reputationOf(agent.address, 1)).to.equal(1);
-    expect(await rep.isBlacklisted(agent.address, 1)).to.equal(false);
+    expect(await rep.reputation(agent.address)).to.equal(1);
+    expect(await rep.blacklist(agent.address)).to.equal(false);
     expect(await nft.balanceOf(agent.address)).to.equal(1);
   });
 
@@ -91,8 +91,8 @@ describe("JobRegistry integration", function () {
     await registry.finalize(jobId);
 
     expect(await token.balanceOf(agent.address)).to.equal(1100);
-    expect(await rep.reputationOf(agent.address, 1)).to.equal(1);
-    expect(await rep.isBlacklisted(agent.address, 1)).to.equal(false);
+    expect(await rep.reputation(agent.address)).to.equal(1);
+    expect(await rep.blacklist(agent.address)).to.equal(false);
     expect(await nft.balanceOf(agent.address)).to.equal(1);
   });
 
@@ -109,8 +109,8 @@ describe("JobRegistry integration", function () {
 
     expect(await token.balanceOf(agent.address)).to.equal(800);
     expect(await token.balanceOf(employer.address)).to.equal(1200);
-    expect(await rep.reputationOf(agent.address, 1)).to.equal(0);
-    expect(await rep.isBlacklisted(agent.address, 1)).to.equal(true);
+    expect(await rep.reputation(agent.address)).to.equal(0);
+    expect(await rep.blacklist(agent.address)).to.equal(true);
     expect(await nft.balanceOf(agent.address)).to.equal(0);
   });
 

--- a/test/v2/ReputationEngine.test.js
+++ b/test/v2/ReputationEngine.test.js
@@ -1,36 +1,36 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-describe("ReputationEngineV2", function () {
+describe("ReputationEngine", function () {
   let engine, owner, caller, user;
 
   beforeEach(async () => {
     [owner, caller, user] = await ethers.getSigners();
     const Engine = await ethers.getContractFactory(
-      "contracts/v2/ReputationEngine.sol:ReputationEngineV2"
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
     engine = await Engine.deploy(owner.address);
-    await engine.connect(owner).setCaller(caller.address, true);
+    await engine.connect(owner).setModule(caller.address, true);
     await engine.connect(owner).setThresholds(2, 1);
     await engine.connect(owner).setRole(user.address, 0); // agent role
   });
 
   it("applies reputation gains and decay with blacklisting", async () => {
-    await engine.connect(caller).addReputation(user.address, 3);
-    expect(await engine.reputationOf(user.address)).to.equal(3);
+    await engine.connect(caller).add(user.address, 3);
+    expect(await engine.reputation(user.address)).to.equal(3);
 
-    await engine.connect(caller).subtractReputation(user.address, 2);
-    expect(await engine.reputationOf(user.address)).to.equal(1);
-    expect(await engine.isBlacklisted(user.address)).to.equal(true);
+    await engine.connect(caller).subtract(user.address, 2);
+    expect(await engine.reputation(user.address)).to.equal(1);
+    expect(await engine.blacklist(user.address)).to.equal(true);
 
-    await engine.connect(caller).addReputation(user.address, 2);
-    expect(await engine.reputationOf(user.address)).to.equal(3);
-    expect(await engine.isBlacklisted(user.address)).to.equal(false);
+    await engine.connect(caller).add(user.address, 2);
+    expect(await engine.reputation(user.address)).to.equal(3);
+    expect(await engine.blacklist(user.address)).to.equal(false);
   });
 
   it("rejects unauthorized callers", async () => {
-    await expect(
-      engine.connect(user).addReputation(user.address, 1)
-    ).to.be.revertedWith("not authorized");
+    await expect(engine.connect(user).add(user.address, 1)).to.be.revertedWith(
+      "not authorized"
+    );
   });
 });

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -165,7 +165,7 @@ describe("ValidationModule V2", function () {
           ? ethers.parseEther("50")
           : ethers.parseEther("10");
       expect(stake).to.equal(expectedStake);
-      expect(await reputation.reputationOf(addr)).to.equal(1n);
+      expect(await reputation.reputation(addr)).to.equal(1n);
     }
   });
 
@@ -215,7 +215,7 @@ describe("ValidationModule V2", function () {
     expect(await stakeManager.stakeOf(slashed, 1)).to.equal(
       slashedStakeBefore / 2n
     );
-    expect(await reputation.reputationOf(winner)).to.equal(1n);
-    expect(await reputation.reputationOf(slashed)).to.equal(0n);
+    expect(await reputation.reputation(winner)).to.equal(1n);
+    expect(await reputation.reputation(slashed)).to.equal(0n);
   });
 });


### PR DESCRIPTION
## Summary
- implement module-gated ReputationEngine with add/subtract API and automatic blacklisting
- update interface and modules to new reputation methods
- adjust tests and mocks for new contract functions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689562d5a70483338d3e0cd20bdc3c96