### PR TITLE
docs: add overview with architecture and governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 - [AGIJobs NFT contract on Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code) / [Blockscout](https://blockscout.com/eth/mainnet/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477/contracts) – cross-check the address on multiple explorers before trading.
 - [$AGI token contract on Etherscan](https://etherscan.io/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D#code) / [Blockscout](https://eth.blockscout.com/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D?tab=contract) – cross-verify the token address before transacting.
 - [Etherscan Interaction Guide](docs/etherscan-guide.md) – module diagram, deployed addresses, role-based instructions, and verification checklist.
+- [Project Overview](docs/overview.md) – architecture diagram, module summaries, governance table, incentive mechanics, deployment addresses, and quick start.
 - [AGIJobManager v0 Source](legacy/AGIJobManagerv0.sol)
 - [AGIJobManager v1 Source](contracts/AGIJobManagerv1.sol) – experimental upgrade using Solidity 0.8.21; includes an automatic token burn on final validation via the `JobFinalizedAndBurned` event and configurable burn parameters. Not deployed; treat any address claiming to be v1 as unverified until announced through official channels.
 - [AGIJobManager v2 Architecture](docs/architecture-v2.md) – modular design with incentive analysis and interface definitions.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,68 @@
+# AGIJobs Overview
+
+## Architecture
+
+```mermaid
+graph TD
+    Employer -->|createJob| JobRegistry
+    Agent -->|apply/submit| JobRegistry
+    JobRegistry -->|selectValidators| ValidationModule
+    ValidationModule -->|stake| StakeManager
+    ValidationModule -->|reputation| ReputationEngine
+    ValidationModule -->|dispute?| DisputeModule
+    DisputeModule -->|final ruling| JobRegistry
+    JobRegistry -->|mint| CertificateNFT
+```
+
+### Module Summaries
+| Module | Responsibility |
+| --- | --- |
+| JobRegistry | Posts jobs, escrows payouts, tracks lifecycle. |
+| ValidationModule | Selects validators and runs commit‑reveal voting. |
+| DisputeModule | Coordinates appeals and final rulings. |
+| StakeManager | Custodies collateral, releases rewards, executes slashing. |
+| ReputationEngine | Updates reputation, enforces blacklists. |
+| CertificateNFT | Mints ERC‑721 certificates for completed jobs. |
+
+## Etherscan Interactions
+1. Open the relevant contract address on Etherscan.
+2. In **Write Contract**, connect your wallet.
+3. Call the desired function and submit the transaction.
+4. Verify emitted events and new state in **Read Contract** or on a second explorer.
+
+### Governance Table
+| Module | Owner Functions | Purpose |
+| --- | --- | --- |
+| JobRegistry | `setModules`, `setJobParameters` | Wire module addresses and set job rewards/stake. |
+| ValidationModule | `setParameters` | Tune validator counts, stake ratios, rewards and slashing. |
+| DisputeModule | `setAppealParameters` | Configure appeal fees and moderator/jury settings. |
+| StakeManager | `setStakeParameters`, `setToken` | Adjust stakes, slashing and staking token. |
+| ReputationEngine | `setCaller`, `setThresholds` | Authorise callers and set reputation floors. |
+| CertificateNFT | `setJobRegistry` | Authorise the registry allowed to mint. |
+
+## Incentive Mechanics
+Honest participation minimises a system-wide free energy similar to the thermodynamic relation `G = H - T S`.
+Slashing raises the enthalpy `H` of dishonest paths, while commit–reveal randomness injects entropy `S`.
+Governance tunes the effective temperature `T` via parameters such as stake ratios and reward percentages.
+When calibrated so that honest behaviour yields the lowest `G`, deviations carry higher expected energy cost than cooperation.
+
+## Deployment Addresses
+| Contract | Network | Address |
+| --- | --- | --- |
+| AGIJobManager v0 | Ethereum mainnet | [0x0178b6bad606aaf908f72135b8ec32fc1d5ba477](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477) |
+| $AGI Token | Ethereum mainnet | [0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D](https://etherscan.io/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D) |
+
+## Quick Start
+1. Clone the repository and install dependencies:
+   ```bash
+   git clone https://github.com/MontrealAI/AGIJobsv0.git
+   cd AGIJobsv0
+   npm install
+   ```
+2. Compile contracts and run the tests:
+   ```bash
+   npm run compile
+   npm test
+   ```
+3. Interact with deployed contracts through a wallet or block explorer.
+


### PR DESCRIPTION
## Summary
- add overview doc with architecture diagram, module summaries, governance table and quick start
- link overview from README quick links

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689573cb0ef483338263ac019192061d