### PR TITLE
Add incentive analysis for AGIJobManager v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ graph TD
     JobRegistry -->|mint| CertificateNFT
 ```
 
-See [docs/architecture-v2.md](docs/architecture-v2.md) for diagrams, interface definitions, and incentive analysis grounded in game theory and statistical physics; the interfaces live in [`contracts/v2/interfaces`](contracts/v2/interfaces) for integration. Step‑by‑step explorer instructions are in [docs/etherscan-guide.md](docs/etherscan-guide.md), and the development plan appears in [docs/coding-sprint-v2.md](docs/coding-sprint-v2.md).
+See [docs/architecture-v2.md](docs/architecture-v2.md) for diagrams and interface definitions. Incentive rationale for v1 lives in [docs/incentive-analysis-v1.md](docs/incentive-analysis-v1.md). Interfaces reside in [`contracts/v2/interfaces`](contracts/v2/interfaces); step‑by‑step explorer instructions are in [docs/etherscan-guide.md](docs/etherscan-guide.md) and the development plan appears in [docs/coding-sprint-v2.md](docs/coding-sprint-v2.md).
 
 #### Incentive Design
 
@@ -581,6 +581,7 @@ See [docs/architecture-v2.md](docs/architecture-v2.md) for diagrams, interface d
 - Slashing percentages exceed potential rewards so dishonest behaviour has negative expected value.
 - Employers receive a share of slashed agent stake on failures, aligning incentives across roles.
 - Commit–reveal randomness combined with owner‑tuned parameters keeps the Gibbs free energy lowest at honest participation, mirroring a Hamiltonian system where slashing raises enthalpy and randomness adds entropy so the stable state is honest behaviour.
+- For the economic rationale behind these settings, see [docs/incentive-analysis-v1.md](docs/incentive-analysis-v1.md).
 
 ## Versions
 

--- a/docs/incentive-analysis-v1.md
+++ b/docs/incentive-analysis-v1.md
@@ -1,0 +1,27 @@
+# Incentive Analysis of AGIJobManagerV1
+
+AGIJobManagerV1 introduced staking, commit–reveal voting and reputation tracking to align agents, validators and employers. The analysis below summarises how the incentives operate and motivates the modular improvements in v2.
+
+## Role Incentives
+- **Agents** stake $AGI before taking jobs. Successful delivery returns the escrowed reward while failure triggers reputation loss and stake slashing.
+- **Validators** stake tokens to review work. Honest votes earn a share of the job payout; incorrect or missing votes lose stake and reputation.
+- **Employers** escrow job rewards. If work is poor or late, employers receive a portion of the slashed agent stake as compensation.
+- **Tokenomics** burn and validator reward percentages deduct from each payout to discourage spam and fund validation.
+
+## Observed Issues in v1
+- **Unanimous voting** allowed a single validator to stall job finalisation.
+- **Low stake requirements** reduced the deterrent against cheating or collusion.
+- **Small validator sets** made high‑value jobs susceptible to bribery.
+- **Monolithic contract** complicated audits and upgrades.
+
+## Incentive Improvements for v2
+- **Majority voting** with an optional appeal layer prevents validator hold‑up.
+- **Higher slashing than reward** makes dishonest behaviour irrational.
+- **Stake redistribution** compensates harmed employers directly.
+- **Dynamic validator committees** scale security with job value.
+- **Reputation enforcement** blacklists actors falling below thresholds.
+
+## Physics and Game Theory Perspective
+Stake acts as the system's enthalpy while commit–reveal randomness adds entropy. By tuning parameters so that slashing loss exceeds potential gains, the protocol keeps the Gibbs free energy of honest behaviour lower than any cheating strategy, forming a Nash equilibrium.
+
+These insights underpin the modular v2 architecture detailed in [docs/architecture-v2.md](architecture-v2.md).


### PR DESCRIPTION
## Summary
- document incentive structure and weaknesses in AGIJobManager v1
- link new incentive analysis doc from README and reference architecture/UX docs

## Testing
- `npm test`
- `tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6895770122088333bd40ba685e557890