### PR TITLE
docs: document validator scaling and incentives

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Legacy sequence diagrams appear in [docs/architecture.md](docs/architecture.md);
 Key incentive refinements include:
 
 - Majority validator approval finalises jobs while minorities can appeal via the DisputeModule.
+- Validator committee size scales with job payout (e.g. 3 for <1k AGI, 5 for 1k–10k, 7 for >10k), raising collusion costs and configurable via owner parameters.
 - Slashing percentages exceed potential gains and a share of slashed agent stake returns to the employer.
 - Lone validators who misvote or fail to reveal suffer amplified penalties, deterring extortion attempts.
 - Commit–reveal randomness and owner‑set seeds inject entropy, making validator selection hard to game.

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -153,6 +153,17 @@ For detailed explorer walk-throughs see [docs/etherscan-guide.md](etherscan-guid
 - A dedicated DisputeModule coordinates appeals and moderator input, ensuring collusion requires prohibitive stake.
 - Parameters (burn rates, stake ratios, validator counts) are tunable by the owner to keep the Nash equilibrium at honest participation.
 
+### Dynamic Validator Committees
+Validator count expands with job value to raise collusion costs. An owner‑set schedule maps payout tiers to committee sizes:
+
+| Job payout (AGI) | Validators |
+| --- | --- |
+| < 1,000 | 3 |
+| 1,000–10,000 | 5 |
+| > 10,000 | 7 |
+
+Jobs default to majority rule; ties resolve to success unless appealed. Adjusting the tiers is an owner‑only action via `ValidationModule.setParameters`, keeping validator entropy proportional to value at risk.
+
 ## Statistical‑Physics View
 The protocol behaves like a system seeking minimum Gibbs free energy. Honest completion is the ground state in this Hamiltonian system: any actor attempting to cheat must input additional "energy"—manifested as higher expected stake loss—which drives the system back toward the stable equilibrium. Using the thermodynamic analogue
 


### PR DESCRIPTION
## Summary
- document dynamic validator committees based on job payouts
- highlight committee scaling in README incentive refinements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d8fe802083339c18acca0cd0beef