### PR TITLE
Add owner-managed blacklist to reputation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Key owner-configurable entry points include:
 - `JobRegistry.setJobParameters(reward, stake)`
 - `ValidationModule.setParameters(...)` for stake, reward and timing settings
 - `StakeManager.setStakeParameters(...)` and `setToken(token)`
-- `ReputationEngine.setCaller(module, allowed)` and `setThresholds(agent, validator)`
+- `ReputationEngine.setCaller(module, allowed)`, `setThresholds(agent, validator)` and `setBlacklist(user, status)`
 - `CertificateNFT.setBaseURI(uri)`
 - `DisputeModule.setAppealParameters(appealFee, jurySize)`
 
@@ -551,7 +551,7 @@ The upcoming v2 release decomposes the marketplace into a suite of immutable mod
 | `JobRegistry` | `setModules`, `setJobParameters` |
 | `ValidationModule` | `setParameters` |
 | `StakeManager` | `setStakeParameters`, `setToken` |
-| `ReputationEngine` | `setCaller`, `setThresholds` |
+| `ReputationEngine` | `setCaller`, `setThresholds`, `setBlacklist` |
 | `DisputeModule` | `setAppealParameters` |
 | `CertificateNFT` | `setJobRegistry` |
 
@@ -560,7 +560,7 @@ The upcoming v2 release decomposes the marketplace into a suite of immutable mod
 | `JobRegistry` | [`IJobRegistry`](contracts/v2/interfaces/IJobRegistry.sol) – `createJob`, `applyForJob`, `completeJob`, `dispute`, `finalize` |
 | `ValidationModule` | [`IValidationModule`](contracts/v2/interfaces/IValidationModule.sol) – `selectValidators`, `commitValidation`, `revealValidation`, `finalize`, `appeal` |
 | `StakeManager` | [`IStakeManager`](contracts/v2/interfaces/IStakeManager.sol) – `depositStake`, `withdrawStake`, `lockStake`, `slash`, `stakeOf` |
-| `ReputationEngine` | [`IReputationEngine`](contracts/v2/interfaces/IReputationEngine.sol) – `addReputation`, `subtractReputation`, `isBlacklisted` |
+| `ReputationEngine` | [`IReputationEngine`](contracts/v2/interfaces/IReputationEngine.sol) – `addReputation`, `subtractReputation`, `setBlacklist`, `isBlacklisted` |
 | `DisputeModule` | [`IDisputeModule`](contracts/v2/interfaces/IDisputeModule.sol) – `raiseDispute`, `resolve` |
 | `CertificateNFT` | [`ICertificateNFT`](contracts/v2/interfaces/ICertificateNFT.sol) – `mint` |
 

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -96,7 +96,7 @@ contract MockReputationEngine is IReputationEngine {
         return _rep[user];
     }
 
-    function blacklist(address) external pure override returns (bool) {
+    function isBlacklisted(address) external pure override returns (bool) {
         return false;
     }
 
@@ -105,4 +105,6 @@ contract MockReputationEngine is IReputationEngine {
     function setRole(address, uint8) external override {}
 
     function setThresholds(uint256, uint256) external override {}
+
+    function setBlacklist(address, bool) external override {}
 }

--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/v2/DisputeModule.sol
+++ b/contracts/v2/DisputeModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IDisputeModule} from "./interfaces/IDisputeModule.sol";

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IReputationEngine} from "./interfaces/IReputationEngine.sol";
@@ -77,13 +77,19 @@ contract ReputationEngine is IReputationEngine, Ownable {
         }
     }
 
+    /// @notice Manually set blacklist status for a user.
+    function setBlacklist(address user, bool status) external override onlyOwner {
+        _blacklisted[user] = status;
+        emit BlacklistUpdated(user, status);
+    }
+
     /// @notice Get reputation score for a user.
     function reputation(address user) external view override returns (uint256) {
         return _reputation[user];
     }
 
     /// @notice Check blacklist status for a user.
-    function blacklist(address user) external view override returns (bool) {
+    function isBlacklisted(address user) external view override returns (bool) {
         return _blacklisted[user];
     }
 

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IValidationModule} from "./interfaces/IValidationModule.sol";
@@ -92,7 +92,7 @@ contract ValidationModule is IValidationModule, Ownable {
         for (uint256 i; i < n; ++i) {
             uint256 stake = stakeManager.stakeOf(pool[i], IStakeManager.Role.Validator);
             if (address(reputationEngine) != address(0)) {
-                if (reputationEngine.blacklist(pool[i])) continue;
+                if (reputationEngine.isBlacklisted(pool[i])) continue;
             }
             if (stake > 0) {
                 stakes[m] = stake;

--- a/contracts/v2/interfaces/ICertificateNFT.sol
+++ b/contracts/v2/interfaces/ICertificateNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 /// @title ICertificateNFT
 /// @notice Interface for minting non-fungible job completion certificates

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.25;
 
 /// @title IDisputeModule
 /// @notice Interface for raising and resolving disputes or appeals

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.25;
 
 /// @title IJobRegistry
 /// @notice Interface for orchestrating job lifecycles and module coordination

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 /// @title IReputationEngine
 /// @notice Interface for tracking and updating participant reputation scores
@@ -10,11 +10,12 @@ interface IReputationEngine {
     function add(address user, uint256 amount) external;
     function subtract(address user, uint256 amount) external;
     function reputation(address user) external view returns (uint256);
-    function blacklist(address user) external view returns (bool);
+    function isBlacklisted(address user) external view returns (bool);
 
     /// @notice Owner functions
     function setModule(address module, bool allowed) external;
     function setRole(address user, uint8 role) external;
     function setThresholds(uint256 agentThreshold, uint256 validatorThreshold) external;
+    function setBlacklist(address user, bool status) external;
 }
 

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 /// @title IStakeManager
 /// @notice Interface for handling token collateral for agents and validators

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 /// @title IValidationModule
 /// @notice Interface for validator selection and commit-reveal voting

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IJobRegistry} from "../interfaces/IJobRegistry.sol";

--- a/contracts/v2/modules/ReputationEngine.sol
+++ b/contracts/v2/modules/ReputationEngine.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -40,6 +40,12 @@ contract ReputationEngine is Ownable {
         agentThreshold = agent;
         validatorThreshold = validator;
         emit ThresholdsUpdated(agent, validator);
+    }
+
+    /// @notice Owner can manually override blacklist status for a user and role.
+    function setBlacklist(address user, Role role, bool status) external onlyOwner {
+        _blacklisted[user][role] = status;
+        emit BlacklistUpdated(user, role, status);
     }
 
     /// @notice Increase reputation for the caller's role.

--- a/contracts/v2/modules/StakeManager.sol
+++ b/contracts/v2/modules/StakeManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -102,8 +102,10 @@ interface IDisputeModule {
 interface IReputationEngine {
     function addReputation(address user, uint256 amount) external;
     function subtractReputation(address user, uint256 amount) external;
+    function isBlacklisted(address user) external view returns (bool);
     function setCaller(address caller, bool allowed) external;
     function setThresholds(uint256 agentThreshold, uint256 validatorThreshold) external;
+    function setBlacklist(address user, bool status) external;
 }
 
 interface IStakeManager {
@@ -134,7 +136,7 @@ Each module exposes minimal `onlyOwner` setters so governance can tune economics
 | ValidationModule | `setParameters` | Adjust stake ratios, rewards, slashing and timing windows |
 | DisputeModule | `setAppealParameters` | Configure appeal fees, jury size and moderator address |
 | StakeManager | `setStakeParameters`, `setToken` | Tune minimum stakes/slashing and switch staking token |
-| ReputationEngine | `setCaller`, `setThresholds` | Authorise callers and set agent/validator reputation floors |
+| ReputationEngine | `setCaller`, `setThresholds`, `setBlacklist` | Authorise callers, set reputation floors, manage blacklist |
 | CertificateNFT | `setJobRegistry` | Configure authorized JobRegistry |
 
 All setters are accessible through block‑explorer interfaces, keeping administration intuitive for non‑technical owners while preserving contract immutability. These interfaces favour explicit, single‑purpose methods, keeping gas costs predictable and allowing front‑end or Etherscan interactions to remain intuitive.

--- a/docs/coding-sprint-v2.md
+++ b/docs/coding-sprint-v2.md
@@ -15,7 +15,7 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
    - `JobRegistry`: job lifecycle, wiring module addresses, owner configuration.
    - `ValidationModule`: pseudo‑random selection, commit‑reveal voting, outcome reporting.
    - `StakeManager`: token custody, slashing, reward release.
-   - `ReputationEngine`: reputation tracking and threshold enforcement.
+   - `ReputationEngine`: reputation tracking, threshold enforcement, owner-managed blacklist.
    - `DisputeModule`: optional appeal flow and final ruling.
    - `CertificateNFT`: ERC‑721 minting with owner‑settable base URI.
 3. **Incentive Calibration**

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,7 +37,7 @@ graph TD
 | ValidationModule | `setParameters` | Tune validator counts, stake ratios, rewards and slashing. |
 | DisputeModule | `setAppealParameters` | Configure appeal fees and moderator/jury settings. |
 | StakeManager | `setStakeParameters`, `setToken` | Adjust stakes, slashing and staking token. |
-| ReputationEngine | `setCaller`, `setThresholds` | Authorise callers and set reputation floors. |
+| ReputationEngine | `setCaller`, `setThresholds`, `setBlacklist` | Authorise callers, set reputation floors, manage blacklist. |
 | CertificateNFT | `setJobRegistry` | Authorise the registry allowed to mint. |
 
 ## Incentive Mechanics

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -83,7 +83,7 @@ describe("JobRegistry integration", function () {
 
     expect(await token.balanceOf(agent.address)).to.equal(1100);
     expect(await rep.reputation(agent.address)).to.equal(1);
-    expect(await rep.blacklist(agent.address)).to.equal(false);
+    expect(await rep.isBlacklisted(agent.address)).to.equal(false);
     expect(await nft.balanceOf(agent.address)).to.equal(1);
   });
 
@@ -105,7 +105,7 @@ describe("JobRegistry integration", function () {
 
     expect(await token.balanceOf(agent.address)).to.equal(1100);
     expect(await rep.reputation(agent.address)).to.equal(1);
-    expect(await rep.blacklist(agent.address)).to.equal(false);
+    expect(await rep.isBlacklisted(agent.address)).to.equal(false);
     expect(await nft.balanceOf(agent.address)).to.equal(1);
   });
 
@@ -128,7 +128,7 @@ describe("JobRegistry integration", function () {
     expect(await token.balanceOf(agent.address)).to.equal(800);
     expect(await token.balanceOf(employer.address)).to.equal(1200);
     expect(await rep.reputation(agent.address)).to.equal(0);
-    expect(await rep.blacklist(agent.address)).to.equal(true);
+    expect(await rep.isBlacklisted(agent.address)).to.equal(true);
     expect(await nft.balanceOf(agent.address)).to.equal(0);
   });
 

--- a/test/v2/ReputationEngine.test.js
+++ b/test/v2/ReputationEngine.test.js
@@ -21,16 +21,23 @@ describe("ReputationEngine", function () {
 
     await engine.connect(caller).subtract(user.address, 2);
     expect(await engine.reputation(user.address)).to.equal(1);
-    expect(await engine.blacklist(user.address)).to.equal(true);
+    expect(await engine.isBlacklisted(user.address)).to.equal(true);
 
     await engine.connect(caller).add(user.address, 2);
     expect(await engine.reputation(user.address)).to.equal(3);
-    expect(await engine.blacklist(user.address)).to.equal(false);
+    expect(await engine.isBlacklisted(user.address)).to.equal(false);
   });
 
   it("rejects unauthorized callers", async () => {
     await expect(engine.connect(user).add(user.address, 1)).to.be.revertedWith(
       "not authorized"
     );
+  });
+
+  it("allows owner to manually set blacklist status", async () => {
+    await engine.connect(owner).setBlacklist(user.address, true);
+    expect(await engine.isBlacklisted(user.address)).to.equal(true);
+    await engine.connect(owner).setBlacklist(user.address, false);
+    expect(await engine.isBlacklisted(user.address)).to.equal(false);
   });
 });


### PR DESCRIPTION
## Summary
- allow contract owner to manually set user blacklist status in v2 ReputationEngine
- align ValidationModule, tests, and docs with `isBlacklisted`/`setBlacklist`
- bump v2 modules and interfaces to Solidity ^0.8.25

## Testing
- `npx hardhat test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6895de124e788333804ee06d9bdfb2a2