### PR TITLE
docs: clarify randomness and expand v2 interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Key incentive refinements include:
 - Slashing percentages exceed potential gains and a share of slashed agent stake returns to the employer.
 - Lone validators who misvote or fail to reveal suffer amplified penalties, deterring extortion attempts.
 - Commit–reveal randomness and owner‑set seeds inject entropy, making validator selection hard to game.
+- Validator selection relies solely on on‑chain entropy; no Chainlink VRF or subscription services are required.
 
 #### Module interface paths
 
@@ -500,7 +501,7 @@ functions control validation incentives, burn behavior, and system limits.
 | `removeAdditionalAgent(address agent)` | Remove an agent from the manual allowlist; emits `AdditionalAgentRemoved`. | previously added address |
 | `updateAGITokenAddress(address addr)` | Switch to a new $AGI token contract if ever required. | non-zero address |
 
-The current implementation relies on on-chain entropy for validator selection. For stronger guarantees against manipulation, integrate a verifiable randomness oracle such as Chainlink VRF in a future deployment.
+Validator selection mixes owner‑supplied seeds with on‑chain entropy and purposely avoids any subscription‑based randomness services. No Chainlink VRF is required.
 
 Convenience functions:
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -70,8 +70,17 @@ Key Solidity interfaces live in [`contracts/v2/interfaces`](../contracts/v2/inte
 
 ```solidity
 interface IJobRegistry {
-    function createJob(address agent) external returns (uint256 jobId);
+    function createJob(uint256 reward, string calldata uri) external returns (uint256 jobId);
+    function applyForJob(uint256 jobId) external;
+    function completeJob(uint256 jobId, bytes calldata result) external;
     function finalize(uint256 jobId) external;
+    function setModules(
+        address validation,
+        address reputation,
+        address stake,
+        address dispute,
+        address cert
+    ) external;
     function setJobParameters(uint256 reward, uint256 stake) external;
 }
 


### PR DESCRIPTION
## Summary
- clarify randomness design: validator selection uses owner-provided seeds and on-chain entropy, no Chainlink VRF
- highlight in incentives that no subscription-based randomness is required
- expand JobRegistry interface in architecture docs to show apply/complete and module wiring

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895f0065ad0833389bb34f3fe23abd7