### PR TITLE
feat: add tiered validator selection

### DIFF
--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -14,10 +14,11 @@ interface IValidationModule {
     function revealVote(uint256 jobId, bool approve, bytes32 salt) external;
     function tally(uint256 jobId) external returns (bool success);
 
-    /// @notice Owner configuration for timing and committee size
+    /// @notice Owner configuration for timing and validator tiers
     function setParameters(
         uint256 commitWindow,
         uint256 revealWindow,
-        uint256 validatorsPerJob
+        uint256[] calldata rewardTiers,
+        uint256[] calldata validatorsPerTier
     ) external;
 }

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -34,10 +34,10 @@ describe("ValidationModule V2", function () {
       .connect(owner)
       .setReputationEngine(await reputation.getAddress());
 
-    // set parameters: commit 60s, reveal 60s, validators per job 2
+    // set parameters: commit 60s, reveal 60s, one tier giving 2 validators
     await validation
       .connect(owner)
-      .setParameters(60, 60, 2);
+      .setParameters(60, 60, [1], [2]);
 
     // validator stakes and pool
     await stakeManager.setStake(v1.address, 1, ethers.parseEther("100"));


### PR DESCRIPTION
## Summary
- add reward-based validator tiers and selection helper
- expose owner `setParameters` for timing and tier config
- update tests for new tiered `ValidationModule`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896004362fc833390ed5aad509b8581