### PR TITLE
feat: add v2 reputation engine with caller gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Key owner-configurable entry points include:
 - `JobRegistry.setJobParameters(reward, stake)`
 - `ValidationModule.setParameters(...)` for stake, reward and timing settings
 - `StakeManager.setStakeParameters(...)` and `setToken(token)`
-- `ReputationEngine.setCaller(module, allowed)`, `setThresholds(agent, validator)` and `setBlacklist(user, status)`
+- `ReputationEngine.setCaller(caller, allowed)`, `setThreshold(threshold)` and `setBlacklist(user, status)`
 - `CertificateNFT.setBaseURI(uri)`
 - `DisputeModule.setAppealParameters(appealFee, jurySize)`
 
@@ -552,7 +552,7 @@ The upcoming v2 release decomposes the marketplace into a suite of immutable mod
 | `JobRegistry` | `setModules`, `setJobParameters` |
 | `ValidationModule` | `setParameters` |
 | `StakeManager` | `setStakeParameters`, `setToken` |
-| `ReputationEngine` | `setCaller`, `setThresholds`, `setBlacklist` |
+| `ReputationEngine` | `setCaller`, `setThreshold`, `setBlacklist` |
 | `DisputeModule` | `setAppealParameters` |
 | `CertificateNFT` | `setJobRegistry` |
 

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -100,11 +100,9 @@ contract MockReputationEngine is IReputationEngine {
         return false;
     }
 
-    function setModule(address, bool) external override {}
+    function setCaller(address, bool) external override {}
 
-    function setRole(address, uint8) external override {}
-
-    function setThresholds(uint256, uint256) external override {}
+    function setThreshold(uint256) external override {}
 
     function setBlacklist(address, bool) external override {}
 }

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.25;
 /// @notice Interface for tracking and updating participant reputation scores
 interface IReputationEngine {
     event ReputationChanged(address indexed user, int256 delta, uint256 newScore);
-    event BlacklistUpdated(address indexed user, bool status);
+    event Blacklisted(address indexed user, bool status);
 
     function add(address user, uint256 amount) external;
     function subtract(address user, uint256 amount) external;
@@ -13,9 +13,8 @@ interface IReputationEngine {
     function isBlacklisted(address user) external view returns (bool);
 
     /// @notice Owner functions
-    function setModule(address module, bool allowed) external;
-    function setRole(address user, uint8 role) external;
-    function setThresholds(uint256 agentThreshold, uint256 validatorThreshold) external;
+    function setCaller(address caller, bool allowed) external;
+    function setThreshold(uint256 newThreshold) external;
     function setBlacklist(address user, bool status) external;
 }
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -109,11 +109,11 @@ interface IDisputeModule {
 }
 
 interface IReputationEngine {
-    function addReputation(address user, uint256 amount) external;
-    function subtractReputation(address user, uint256 amount) external;
+    function add(address user, uint256 amount) external;
+    function subtract(address user, uint256 amount) external;
     function isBlacklisted(address user) external view returns (bool);
     function setCaller(address caller, bool allowed) external;
-    function setThresholds(uint256 agentThreshold, uint256 validatorThreshold) external;
+    function setThreshold(uint256 threshold) external;
     function setBlacklist(address user, bool status) external;
 }
 
@@ -145,7 +145,7 @@ Each module exposes minimal `onlyOwner` setters so governance can tune economics
 | ValidationModule | `setParameters` | Adjust stake ratios, rewards, slashing and timing windows |
 | DisputeModule | `setAppealParameters` | Configure appeal fees, jury size and moderator address |
 | StakeManager | `setStakeParameters`, `setToken` | Tune minimum stakes/slashing and switch staking token |
-| ReputationEngine | `setCaller`, `setThresholds`, `setBlacklist` | Authorise callers, set reputation floors, manage blacklist |
+| ReputationEngine | `setCaller`, `setThreshold`, `setBlacklist` | Authorise callers, set reputation floors, manage blacklist |
 | CertificateNFT | `setJobRegistry` | Configure authorized JobRegistry |
 
 All setters are accessible through block‑explorer interfaces, keeping administration intuitive for non‑technical owners while preserving contract immutability. These interfaces favour explicit, single‑purpose methods, keeping gas costs predictable and allowing front‑end or Etherscan interactions to remain intuitive.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,7 +37,7 @@ graph TD
 | ValidationModule | `setParameters` | Tune validator counts, stake ratios, rewards and slashing. |
 | DisputeModule | `setAppealParameters` | Configure appeal fees and moderator/jury settings. |
 | StakeManager | `setStakeParameters`, `setToken` | Adjust stakes, slashing and staking token. |
-| ReputationEngine | `setCaller`, `setThresholds`, `setBlacklist` | Authorise callers, set reputation floors, manage blacklist. |
+| ReputationEngine | `setCaller`, `setThreshold`, `setBlacklist` | Authorise callers, set reputation floors, manage blacklist. |
 | CertificateNFT | `setJobRegistry` | Authorise the registry allowed to mint. |
 
 ## Incentive Mechanics

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -56,7 +56,8 @@ async function main() {
   );
 
   await validation.setReputationEngine(await reputation.getAddress());
-  await reputation.setModule(await registry.getAddress(), true);
+  await reputation.setCaller(await registry.getAddress(), true);
+  await reputation.setThreshold(1);
   await nft.setJobRegistry(await registry.getAddress());
   await stake.transferOwnership(await registry.getAddress());
   await nft.transferOwnership(await registry.getAddress());

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -52,8 +52,8 @@ describe("JobRegistry integration", function () {
       .setJobParameters(reward, stake);
     await dispute.connect(owner).setAppealFee(appealFee);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
-    await rep.connect(owner).setModule(await registry.getAddress(), true);
-    await rep.connect(owner).setThresholds(1, 0);
+    await rep.connect(owner).setCaller(await registry.getAddress(), true);
+    await rep.connect(owner).setThreshold(1);
     await stakeManager.connect(owner).transferOwnership(await registry.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
 

--- a/test/v2/ReputationEngine.test.js
+++ b/test/v2/ReputationEngine.test.js
@@ -10,9 +10,8 @@ describe("ReputationEngine", function () {
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
     engine = await Engine.deploy(owner.address);
-    await engine.connect(owner).setModule(caller.address, true);
-    await engine.connect(owner).setThresholds(2, 1);
-    await engine.connect(owner).setRole(user.address, 0); // agent role
+    await engine.connect(owner).setCaller(caller.address, true);
+    await engine.connect(owner).setThreshold(2);
   });
 
   it("applies reputation gains and decay with blacklisting", async () => {


### PR DESCRIPTION
## Summary
- implement v2 `ReputationEngine` with score tracking, caller authorization and automatic blacklisting
- update interface, mocks, scripts, docs and tests for new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689609b6415483338009751cd628da08