### PR TITLE
Add v2 deployment scripts with module wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 
 > **Warning**: Links above are provided for reference only. Always validate contract addresses and metadata on multiple block explorers before interacting.
 
+## Local v2 Deployment Addresses
+
+| Contract | Address |
+| --- | --- |
+| JobRegistry | 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0 |
+| ValidationModule | 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9 |
+| StakeManager | 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 |
+| ReputationEngine | 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9 |
+| DisputeModule | 0x0165878A594ca255338adfa4d48449f69242Eb8F |
+| CertificateNFT | 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707 |
+
 ## Quick Start (Etherscan)
 
 The flow below shows how each role interacts with the v2 modules using a block explorer. All functions are available in the **Write** tab and accept human‑readable `uint256` values (wei for tokens, seconds for timing).

--- a/scripts/v2/deploy.js
+++ b/scripts/v2/deploy.js
@@ -1,0 +1,94 @@
+const { ethers, run } = require("hardhat");
+
+async function verify(address, args = []) {
+  try {
+    await run("verify:verify", {
+      address,
+      constructorArguments: args,
+    });
+  } catch (err) {
+    console.error(`verification failed for ${address}`, err);
+  }
+}
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory("contracts/mocks/MockERC20.sol:MockERC20");
+  const token = await Token.deploy();
+  await token.waitForDeployment();
+
+  const Stake = await ethers.getContractFactory(
+    "contracts/v2/StakeManager.sol:StakeManager"
+  );
+  const stake = await Stake.deploy(
+    await token.getAddress(),
+    deployer.address,
+    deployer.address
+  );
+  await stake.waitForDeployment();
+
+  const Registry = await ethers.getContractFactory(
+    "contracts/v2/JobRegistry.sol:JobRegistry"
+  );
+  const registry = await Registry.deploy(deployer.address);
+  await registry.waitForDeployment();
+
+  const Validation = await ethers.getContractFactory(
+    "contracts/v2/ValidationModule.sol:ValidationModule"
+  );
+  const validation = await Validation.deploy(
+    await registry.getAddress(),
+    await stake.getAddress(),
+    deployer.address
+  );
+  await validation.waitForDeployment();
+
+  const Reputation = await ethers.getContractFactory(
+    "contracts/v2/ReputationEngine.sol:ReputationEngine"
+  );
+  const reputation = await Reputation.deploy(deployer.address);
+  await reputation.waitForDeployment();
+
+  const NFT = await ethers.getContractFactory(
+    "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
+  );
+  const nft = await NFT.deploy("Cert", "CERT", deployer.address);
+  await nft.waitForDeployment();
+
+  const Dispute = await ethers.getContractFactory(
+    "contracts/v2/DisputeModule.sol:DisputeModule"
+  );
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    deployer.address
+  );
+  await dispute.waitForDeployment();
+
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await dispute.getAddress(),
+    await nft.getAddress()
+  );
+
+  console.log("JobRegistry deployed to:", await registry.getAddress());
+  console.log("ValidationModule:", await validation.getAddress());
+  console.log("StakeManager:", await stake.getAddress());
+  console.log("ReputationEngine:", await reputation.getAddress());
+  console.log("DisputeModule:", await dispute.getAddress());
+  console.log("CertificateNFT:", await nft.getAddress());
+
+  await verify(await stake.getAddress(), [await token.getAddress(), deployer.address, deployer.address]);
+  await verify(await registry.getAddress(), [deployer.address]);
+  await verify(await validation.getAddress(), [await registry.getAddress(), await stake.getAddress(), deployer.address]);
+  await verify(await reputation.getAddress(), [deployer.address]);
+  await verify(await dispute.getAddress(), [await registry.getAddress(), deployer.address]);
+  await verify(await nft.getAddress(), ["Cert", "CERT", deployer.address]);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -1,0 +1,94 @@
+import { ethers, run } from "hardhat";
+
+async function verify(address: string, args: any[] = []) {
+  try {
+    await run("verify:verify", {
+      address,
+      constructorArguments: args,
+    });
+  } catch (err) {
+    console.error(`verification failed for ${address}`, err);
+  }
+}
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory("contracts/mocks/MockERC20.sol:MockERC20");
+  const token = await Token.deploy();
+  await token.waitForDeployment();
+
+  const Stake = await ethers.getContractFactory(
+    "contracts/v2/StakeManager.sol:StakeManager"
+  );
+  const stake = await Stake.deploy(
+    await token.getAddress(),
+    deployer.address,
+    deployer.address
+  );
+  await stake.waitForDeployment();
+
+  const Registry = await ethers.getContractFactory(
+    "contracts/v2/JobRegistry.sol:JobRegistry"
+  );
+  const registry = await Registry.deploy(deployer.address);
+  await registry.waitForDeployment();
+
+  const Validation = await ethers.getContractFactory(
+    "contracts/v2/ValidationModule.sol:ValidationModule"
+  );
+  const validation = await Validation.deploy(
+    await registry.getAddress(),
+    await stake.getAddress(),
+    deployer.address
+  );
+  await validation.waitForDeployment();
+
+  const Reputation = await ethers.getContractFactory(
+    "contracts/v2/ReputationEngine.sol:ReputationEngine"
+  );
+  const reputation = await Reputation.deploy(deployer.address);
+  await reputation.waitForDeployment();
+
+  const NFT = await ethers.getContractFactory(
+    "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
+  );
+  const nft = await NFT.deploy("Cert", "CERT", deployer.address);
+  await nft.waitForDeployment();
+
+  const Dispute = await ethers.getContractFactory(
+    "contracts/v2/DisputeModule.sol:DisputeModule"
+  );
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    deployer.address
+  );
+  await dispute.waitForDeployment();
+
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await dispute.getAddress(),
+    await nft.getAddress()
+  );
+
+  console.log("JobRegistry deployed to:", await registry.getAddress());
+  console.log("ValidationModule:", await validation.getAddress());
+  console.log("StakeManager:", await stake.getAddress());
+  console.log("ReputationEngine:", await reputation.getAddress());
+  console.log("DisputeModule:", await dispute.getAddress());
+  console.log("CertificateNFT:", await nft.getAddress());
+
+  await verify(await stake.getAddress(), [await token.getAddress(), deployer.address, deployer.address]);
+  await verify(await registry.getAddress(), [deployer.address]);
+  await verify(await validation.getAddress(), [await registry.getAddress(), await stake.getAddress(), deployer.address]);
+  await verify(await reputation.getAddress(), [deployer.address]);
+  await verify(await dispute.getAddress(), [await registry.getAddress(), deployer.address]);
+  await verify(await nft.getAddress(), ["Cert", "CERT", deployer.address]);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add v2 deployment script that sequentially deploys core modules and wires them to JobRegistry
- record sample v2 deployment addresses in README

## Testing
- `npm test`
- `npm run lint`
- `npx hardhat run scripts/v2/deploy.js` *(fails: HardhatNetworkNotSupportedError: The selected network is "hardhat", which is not supported for contract verification)*

------
https://chatgpt.com/codex/tasks/task_e_689618d8e0408333b6fb71eb04f785dd