### PR TITLE
docs: clarify token integration and owner controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,10 @@ The v2 release decomposes the marketplace into a suite of immutable modules, eac
 | `DisputeModule` | `setAppealParameters` |
 | `CertificateNFT` | `setJobRegistry` |
 
+### Token Integration
+
+Staking and rewards use the $AGI token at [0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D](https://etherscan.io/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D). The owner can swap in a new ERC‑20 with `StakeManager.setToken(address)`, and `JobRegistry.setModules` permits replacing companion modules without migrating job state.
+
 | Module | Interface / Key functions |
 | --- | --- |
 | `JobRegistry` | [`IJobRegistry`](contracts/v2/interfaces/IJobRegistry.sol) – `createJob`, `applyForJob`, `completeJob`, `dispute`, `finalize` |

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -150,6 +150,12 @@ Each module exposes minimal `onlyOwner` setters so governance can tune economics
 
 All setters are accessible through block‑explorer interfaces, keeping administration intuitive for non‑technical owners while preserving contract immutability. These interfaces favour explicit, single‑purpose methods, keeping gas costs predictable and allowing front‑end or Etherscan interactions to remain intuitive.
 
+### Token Integration
+
+- Staking and rewards default to the $AGI token at `0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D`.
+- Owners may swap to a new ERC‑20 by calling `StakeManager.setToken(address)`.
+- `JobRegistry.setModules` lets the owner replace companion modules individually while existing job state remains untouched.
+
 ## User Experience
 Non‑technical employers, agents and validators can call these methods directly through Etherscan's read and write tabs. Every parameter uses human‑readable units (wei for token amounts and seconds for timing) so that wallets and explorers can display values without custom tooling. No external subscription or Chainlink VRF is required; validator selection relies on commit‑reveal randomness seeded by the owner.
 If a result is contested, employers or agents invoke the DisputeModule's `raiseDispute` through the explorer and a moderator or expanded validator jury finalises the job.

--- a/docs/coding-sprint-v2.md
+++ b/docs/coding-sprint-v2.md
@@ -14,7 +14,7 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
 2. **Module Implementation**
    - `JobRegistry`: job lifecycle, wiring module addresses, owner configuration.
    - `ValidationModule`: pseudo‑random selection, commit‑reveal voting, outcome reporting.
-   - `StakeManager`: token custody, slashing, reward release.
+   - `StakeManager`: token custody, slashing, reward release; defaults to $AGI at `0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D` and exposes `setToken` for owner swaps.
    - `ReputationEngine`: reputation tracking, threshold enforcement, owner-managed blacklist.
    - `DisputeModule`: optional appeal flow and final ruling.
    - `CertificateNFT`: ERC‑721 minting with owner‑settable base URI.


### PR DESCRIPTION
## Summary
- document $AGI token usage and owner-controlled swaps in modular v2 architecture
- note token integration and module replacement in README
- update coding sprint with default token details

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_68961b5a3bdc83339cec2fce51481506