### PR TITLE
docs: add NatSpec and custom errors to interfaces

### DIFF
--- a/contracts/v2/interfaces/ICertificateNFT.sol
+++ b/contracts/v2/interfaces/ICertificateNFT.sol
@@ -4,8 +4,23 @@ pragma solidity ^0.8.25;
 /// @title ICertificateNFT
 /// @notice Interface for minting non-fungible job completion certificates
 interface ICertificateNFT {
+    /// @dev Reverts when caller is not the authorised JobRegistry
+    error NotJobRegistry(address caller);
+
+    /// @dev Reverts when attempting to mint more than once for the same job
+    error CertificateAlreadyMinted(uint256 jobId);
+
+    /// @dev Reverts when an empty metadata URI is supplied
+    error EmptyURI();
+
     event CertificateMinted(address indexed to, uint256 indexed jobId);
 
+    /// @notice Mint a completion certificate NFT for a job
+    /// @param to Recipient of the certificate
+    /// @param jobId Identifier of the job; doubles as the NFT tokenId
+    /// @param uri Metadata URI for the certificate
+    /// @return tokenId The identifier of the minted certificate
+    /// @dev Reverts with {NotJobRegistry} if called by an unauthorised address
     function mint(
         address to,
         uint256 jobId,

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -4,24 +4,52 @@ pragma solidity ^0.8.25;
 /// @title IDisputeModule
 /// @notice Interface for raising and resolving disputes or appeals
 interface IDisputeModule {
+    /// @dev Reverts when appeal fee sent does not match required value
+    error IncorrectAppealFee(uint256 expected, uint256 provided);
+
+    /// @dev Reverts when a job has already been appealed
+    error AlreadyAppealed(uint256 jobId);
+
+    /// @dev Reverts when caller is neither the employer nor the agent
+    error NotParticipant(address caller);
+
+    /// @dev Reverts when dispute resolution is attempted by an unauthorised account
+    error NotArbiter(address caller);
+
+    /// @dev Reverts when no appeal bond exists for a job
+    error NoAppealBond(uint256 jobId);
+
     event AppealRaised(uint256 indexed jobId, address indexed caller);
     event AppealResolved(uint256 indexed jobId, bool employerWins);
     event AppealFeeUpdated(uint256 fee);
     event ModeratorUpdated(address moderator);
     event JuryUpdated(address jury);
 
+    /// @notice Escalate a job dispute by posting the appeal fee
+    /// @param jobId Identifier of the disputed job
+    /// @dev Reverts with {IncorrectAppealFee} if the supplied value is wrong
+    ///      or {AlreadyAppealed} if a bond already exists
     function appeal(uint256 jobId) external payable;
+
+    /// @notice Resolve an appealed job and distribute the bond to the winner
+    /// @param jobId Identifier of the job being appealed
+    /// @param employerWins True if the employer prevails in the dispute
+    /// @dev Reverts with {NotArbiter} if caller is unauthorised or
+    ///      {NoAppealBond} if no bond was posted
     function resolve(uint256 jobId, bool employerWins) external;
 
     /// @notice Owner configuration for appeal economics
+    /// @param fee New fee required to raise an appeal
     /// @dev Only callable by contract owner
     function setAppealFee(uint256 fee) external;
 
     /// @notice Owner configuration for dispute moderator
+    /// @param moderator Address allowed to resolve disputes in addition to owner
     /// @dev Only callable by contract owner
     function setModerator(address moderator) external;
 
     /// @notice Owner configuration for dispute jury
+    /// @param jury Address allowed to resolve disputes alongside owner
     /// @dev Only callable by contract owner
     function setJury(address jury) external;
 }

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -4,17 +4,53 @@ pragma solidity ^0.8.25;
 /// @title IReputationEngine
 /// @notice Interface for tracking and updating participant reputation scores
 interface IReputationEngine {
+    /// @dev Reverts when a caller is not authorised to update reputation
+    error UnauthorizedCaller(address caller);
+
+    /// @dev Reverts when attempting to act on a blacklisted user
+    error BlacklistedUser(address user);
+
     event ReputationChanged(address indexed user, int256 delta, uint256 newScore);
     event Blacklisted(address indexed user, bool status);
 
+    /// @notice Increase a user's reputation score
+    /// @param user Address whose reputation is increased
+    /// @param amount Amount to add to the user's score
+    /// @dev Reverts with {UnauthorizedCaller} if caller is not permitted
+    ///      or {BlacklistedUser} if the user is blacklisted
     function add(address user, uint256 amount) external;
+
+    /// @notice Decrease a user's reputation score
+    /// @param user Address whose reputation is decreased
+    /// @param amount Amount to subtract from the user's score
+    /// @dev Reverts with {UnauthorizedCaller} if caller is not permitted
+    ///      or {BlacklistedUser} if the user is blacklisted
     function subtract(address user, uint256 amount) external;
+
+    /// @notice Retrieve a user's reputation score
+    /// @param user Address to query
+    /// @return The current reputation score of the user
     function reputation(address user) external view returns (uint256);
+
+    /// @notice Check if a user is blacklisted
+    /// @param user Address to query
+    /// @return True if the user is blacklisted
     function isBlacklisted(address user) external view returns (bool);
 
     /// @notice Owner functions
+
+    /// @notice Allow or disallow a caller to update reputation
+    /// @param caller Address of the caller to configure
+    /// @param allowed True to authorise the caller, false to revoke
     function setCaller(address caller, bool allowed) external;
+
+    /// @notice Set the minimum score threshold for certain actions
+    /// @param newThreshold New reputation threshold value
     function setThreshold(uint256 newThreshold) external;
+
+    /// @notice Add or remove a user from the blacklist
+    /// @param user Address to update
+    /// @param status True to blacklist the user, false to remove
     function setBlacklist(address user, bool status) external;
 }
 

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -22,16 +22,75 @@ interface IStakeManager {
     event TokenUpdated(address token);
     event ParametersUpdated();
 
-    function depositStake(Role role, uint256 amount) external;
-    function withdrawStake(Role role, uint256 amount) external;
-    function lockStake(address user, Role role, uint256 amount) external;
-    function slash(address user, Role role, uint256 amount, address employer) external;
+    /// @dev Reverts when user does not have enough available stake
+    error InsufficientStake(
+        address user,
+        Role role,
+        uint256 available,
+        uint256 required
+    );
 
+    /// @dev Reverts when attempting to withdraw stake that is locked
+    error StakeCurrentlyLocked(address user, Role role, uint256 lockedAmount);
+
+    /// @dev Reverts when caller is not authorised for privileged operations
+    error NotAuthorised(address caller);
+
+    /// @notice Deposit tokens as stake for a specific role
+    /// @param role Role of the participant depositing stake
+    /// @param amount Amount of tokens to deposit
+    function depositStake(Role role, uint256 amount) external;
+
+    /// @notice Withdraw available stake for a specific role
+    /// @param role Role of the participant withdrawing stake
+    /// @param amount Amount of tokens to withdraw
+    /// @dev Reverts with {StakeCurrentlyLocked} if attempting to withdraw locked funds
+    function withdrawStake(Role role, uint256 amount) external;
+
+    /// @notice Lock a user's stake for job execution or validation
+    /// @param user Address whose stake will be locked
+    /// @param role Role of the participant whose stake is locked
+    /// @param amount Amount of tokens to lock
+    /// @dev Reverts with {InsufficientStake} if available stake is too low
+    ///      or {NotAuthorised} if caller lacks permission
+    function lockStake(address user, Role role, uint256 amount) external;
+
+    /// @notice Slash a user's stake and transfer it to an employer and treasury
+    /// @param user Address whose stake is slashed
+    /// @param role Role associated with the stake
+    /// @param amount Amount of tokens to slash
+    /// @param employer Employer receiving a portion of the slashed stake
+    /// @dev Reverts with {InsufficientStake} or {NotAuthorised} as appropriate
+    function slash(
+        address user,
+        Role role,
+        uint256 amount,
+        address employer
+    ) external;
+
+    /// @notice Return the total stake deposited by a user for a role
+    /// @param user Address to query
+    /// @param role Role for which stake is queried
+    /// @return Amount of stake deposited
     function stakeOf(address user, Role role) external view returns (uint256);
+
+    /// @notice Return the locked portion of a user's stake
+    /// @param user Address to query
+    /// @param role Role for which locked stake is queried
+    /// @return Amount of stake currently locked
     function lockedStakeOf(address user, Role role) external view returns (uint256);
 
     /// @notice Owner functions
+
+    /// @notice Set the ERC20 token used for staking
+    /// @param token Address of the staking token
     function setToken(address token) external;
+
+    /// @notice Configure stake and slashing parameters
+    /// @param agentStakePercentage Percentage of reward required as agent stake
+    /// @param validatorStakePercentage Percentage required for validators
+    /// @param agentSlashingPercentage Percentage of agent stake to slash
+    /// @param validatorSlashingPercentage Percentage of validator stake to slash
     function setStakeParameters(
         uint256 agentStakePercentage,
         uint256 validatorStakePercentage,

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -9,12 +9,54 @@ interface IValidationModule {
     event VoteRevealed(uint256 indexed jobId, address indexed validator, bool approve);
     event ParametersUpdated();
 
-    function selectValidators(uint256 jobId) external returns (address[] memory);
+    /// @dev Reverts when validator selection fails
+    error ValidatorSelectionFailed(uint256 jobId);
+
+    /// @dev Reverts when a validator commits more than once
+    error AlreadyCommitted(uint256 jobId, address validator);
+
+    /// @dev Reverts when the commit phase is not active
+    error CommitPhaseClosed(uint256 jobId);
+
+    /// @dev Reverts when the reveal phase is invalid for the caller
+    error RevealPhaseInvalid(uint256 jobId, address validator);
+
+    /// @notice Select validators for a given job
+    /// @param jobId Identifier of the job
+    /// @return Array of selected validator addresses
+    /// @dev Reverts with {ValidatorSelectionFailed} if selection cannot be made
+    function selectValidators(uint256 jobId)
+        external
+        returns (address[] memory);
+
+    /// @notice Commit a vote hash for a job
+    /// @param jobId Identifier of the job being voted on
+    /// @param commitHash Hash of the vote and salt
+    /// @dev Reverts with {AlreadyCommitted} if validator has already committed or
+    ///      {CommitPhaseClosed} if committing outside the allowed window
     function commitVote(uint256 jobId, bytes32 commitHash) external;
-    function revealVote(uint256 jobId, bool approve, bytes32 salt) external;
+
+    /// @notice Reveal a previously committed vote
+    /// @param jobId Identifier of the job
+    /// @param approve True to approve, false to reject
+    /// @param salt Salt used in the original commitment
+    /// @dev Reverts with {RevealPhaseInvalid} if reveal is not permitted
+    function revealVote(
+        uint256 jobId,
+        bool approve,
+        bytes32 salt
+    ) external;
+
+    /// @notice Tally revealed votes and determine job outcome
+    /// @param jobId Identifier of the job
+    /// @return success True if validators approved the job
     function tally(uint256 jobId) external returns (bool success);
 
     /// @notice Owner configuration for timing and validator tiers
+    /// @param commitWindow Duration of the commit phase in seconds
+    /// @param revealWindow Duration of the reveal phase in seconds
+    /// @param rewardTiers Reward tiers paid to validators based on ranking
+    /// @param validatorsPerTier Number of validators selected per tier
     function setParameters(
         uint256 commitWindow,
         uint256 revealWindow,


### PR DESCRIPTION
## Summary
- document every v2 interface with NatSpec
- add domain-specific custom errors to interfaces
- verify interfaces map 1:1 to implementation modules

## Testing
- `npx hardhat compile`
- `npx hardhat test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68962a2fe8ec8333848438c5a2490a1a