### PR TITLE
Refactor StakeManager reward escrow and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Key owner-configurable entry points include:
 
 - `JobRegistry.setJobParameters(reward, stake)`
 - `ValidationModule.setParameters(...)` for stake, reward and timing settings
-- `StakeManager.setStakeParameters(...)` and `setToken(token)`
+- `StakeManager.setToken(token)`, `setMinStake(amount)`, `setSlashingPercentages(empPct, treasPct)`, `setTreasury(addr)`
 - `ReputationEngine.setCaller(caller, allowed)`, `setThreshold(threshold)` and `setBlacklist(user, status)`
 - `CertificateNFT.setBaseURI(uri)`
 - `DisputeModule.setAppealParameters(appealFee, jurySize)`
@@ -574,7 +574,7 @@ The v2 release decomposes the marketplace into a suite of immutable modules, eac
 | --- | --- |
 | `JobRegistry` | `setModules`, `setJobParameters` |
 | `ValidationModule` | `setParameters` |
-| `StakeManager` | `setStakeParameters`, `setToken` |
+| `StakeManager` | `setToken`, `setMinStake`, `setSlashingPercentages`, `setTreasury` |
 | `ReputationEngine` | `setCaller`, `setThreshold`, `setBlacklist` |
 | `DisputeModule` | `setAppealParameters` |
 | `CertificateNFT` | `setJobRegistry` |

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -28,8 +28,8 @@ contract StakeManager is Ownable {
     /// @notice staked balance per user
     mapping(address => uint256) public stakes;
 
-    /// @notice escrowed job payouts
-    mapping(bytes32 => uint256) public jobEscrows;
+    /// @notice escrowed job rewards
+    mapping(bytes32 => uint256) public rewardEscrows;
 
     event StakeDeposited(address indexed user, uint256 amount);
     event StakeWithdrawn(address indexed user, uint256 amount);
@@ -40,7 +40,8 @@ contract StakeManager is Ownable {
         uint256 employerShare,
         uint256 treasuryShare
     );
-    event PayoutReleased(bytes32 indexed jobId, address indexed to, uint256 amount);
+    event RewardLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
+    event RewardReleased(bytes32 indexed jobId, address indexed to, uint256 amount);
 
     constructor(IERC20 _token, address owner, address _treasury) Ownable(owner) {
         token = _token;
@@ -56,17 +57,23 @@ contract StakeManager is Ownable {
         token = newToken;
     }
 
-    /// @notice set staking parameters and slashing percentages
-    function setStakeParameters(
-        uint256 _minStake,
+    /// @notice update the minimum stake required
+    function setMinStake(uint256 _minStake) external onlyOwner {
+        minStake = _minStake;
+    }
+
+    /// @notice update slashing percentage splits
+    function setSlashingPercentages(
         uint256 _employerSlashPct,
-        uint256 _treasurySlashPct,
-        address _treasury
+        uint256 _treasurySlashPct
     ) external onlyOwner {
         require(_employerSlashPct + _treasurySlashPct <= 100, "pct");
-        minStake = _minStake;
         employerSlashPct = _employerSlashPct;
         treasurySlashPct = _treasurySlashPct;
+    }
+
+    /// @notice update treasury recipient address
+    function setTreasury(address _treasury) external onlyOwner {
         treasury = _treasury;
     }
 
@@ -78,6 +85,7 @@ contract StakeManager is Ownable {
     function depositStake(uint256 amount) external {
         require(amount > 0, "amount");
         uint256 newStake = stakes[msg.sender] + amount;
+        require(newStake >= minStake, "min stake");
         stakes[msg.sender] = newStake;
         token.safeTransferFrom(msg.sender, address(this), amount);
         emit StakeDeposited(msg.sender, amount);
@@ -87,7 +95,9 @@ contract StakeManager is Ownable {
     function withdrawStake(uint256 amount) external {
         uint256 staked = stakes[msg.sender];
         require(staked >= amount, "stake");
-        stakes[msg.sender] = staked - amount;
+        uint256 newStake = staked - amount;
+        require(newStake == 0 || newStake >= minStake, "min stake");
+        stakes[msg.sender] = newStake;
         token.safeTransfer(msg.sender, amount);
         emit StakeWithdrawn(msg.sender, amount);
     }
@@ -96,25 +106,26 @@ contract StakeManager is Ownable {
     // job escrow logic
     // ---------------------------------------------------------------
 
-    /// @notice lock payout for a job from an employer
-    function lockPayout(bytes32 jobId, address from, uint256 amount)
+    /// @notice lock reward for a job from an employer
+    function lockReward(bytes32 jobId, address from, uint256 amount)
         external
         onlyOwner
     {
         token.safeTransferFrom(from, address(this), amount);
-        jobEscrows[jobId] += amount;
+        rewardEscrows[jobId] += amount;
+        emit RewardLocked(jobId, from, amount);
     }
 
-    /// @notice release locked payout to recipient
-    function releasePayout(bytes32 jobId, address to, uint256 amount)
+    /// @notice release locked reward to recipient
+    function releaseReward(bytes32 jobId, address to, uint256 amount)
         external
         onlyOwner
     {
-        uint256 escrow = jobEscrows[jobId];
+        uint256 escrow = rewardEscrows[jobId];
         require(escrow >= amount, "escrow");
-        jobEscrows[jobId] = escrow - amount;
+        rewardEscrows[jobId] = escrow - amount;
         token.safeTransfer(to, amount);
-        emit PayoutReleased(jobId, to, amount);
+        emit RewardReleased(jobId, to, amount);
     }
 
     // ---------------------------------------------------------------

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -123,12 +123,13 @@ interface IStakeManager {
     function withdrawStake(Role role, uint256 amount) external;
     function lockStake(address user, Role role, uint256 payout) external;
     function slash(address user, Role role, uint256 payout, address employer) external;
-    function setStakeParameters(
-        uint256 agentStakePercentage,
-        uint256 validatorStakePercentage,
-        uint256 agentSlashingPercentage,
-        uint256 validatorSlashingPercentage
+    function setToken(address token) external;
+    function setMinStake(uint256 minStake) external;
+    function setSlashingPercentages(
+        uint256 employerSlashPct,
+        uint256 treasurySlashPct
     ) external;
+    function setTreasury(address treasury) external;
 }
 
 interface ICertificateNFT {
@@ -144,7 +145,7 @@ Each module exposes minimal `onlyOwner` setters so governance can tune economics
 | JobRegistry | `setValidationModule`, `setReputationEngine`, `setStakeManager`, `setCertificateNFT`, `setDisputeModule`, `setJobParameters` | Wire module addresses and set per‑job rewards/stake |
 | ValidationModule | `setParameters` | Adjust stake ratios, rewards, slashing and timing windows |
 | DisputeModule | `setAppealParameters` | Configure appeal fees, jury size and moderator address |
-| StakeManager | `setStakeParameters`, `setToken` | Tune minimum stakes/slashing and switch staking token |
+| StakeManager | `setToken`, `setMinStake`, `setSlashingPercentages`, `setTreasury` | Tune minimum stake, slashing shares and treasury |
 | ReputationEngine | `setCaller`, `setThreshold`, `setBlacklist` | Authorise callers, set reputation floors, manage blacklist |
 | CertificateNFT | `setJobRegistry` | Configure authorized JobRegistry |
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,7 +36,7 @@ graph TD
 | JobRegistry | `setModules`, `setJobParameters` | Wire module addresses and set job rewards/stake. |
 | ValidationModule | `setParameters` | Tune validator counts, stake ratios, rewards and slashing. |
 | DisputeModule | `setAppealParameters` | Configure appeal fees and moderator/jury settings. |
-| StakeManager | `setStakeParameters`, `setToken` | Adjust stakes, slashing and staking token. |
+| StakeManager | `setToken`, `setMinStake`, `setSlashingPercentages`, `setTreasury` | Adjust staking token, minimum stake, slashing splits and treasury. |
 | ReputationEngine | `setCaller`, `setThreshold`, `setBlacklist` | Authorise callers, set reputation floors, manage blacklist. |
 | CertificateNFT | `setJobRegistry` | Authorise the registry allowed to mint. |
 

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -18,9 +18,9 @@ describe("StakeManager", function () {
       owner.address,
       treasury.address
     );
-    await stakeManager
-      .connect(owner)
-      .setStakeParameters(0, 50, 50, treasury.address);
+    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setSlashingPercentages(50, 50);
+    await stakeManager.connect(owner).setTreasury(treasury.address);
   });
 
   it("handles staking, job escrow and slashing", async () => {
@@ -38,11 +38,11 @@ describe("StakeManager", function () {
     await token.connect(employer).approve(await stakeManager.getAddress(), 300);
     await stakeManager
       .connect(owner)
-      .lockPayout(jobId, employer.address, 300);
+      .lockReward(jobId, employer.address, 300);
 
     await expect(
-      stakeManager.connect(owner).releasePayout(jobId, user.address, 200)
-    ).to.emit(stakeManager, "PayoutReleased").withArgs(jobId, user.address, 200);
+      stakeManager.connect(owner).releaseReward(jobId, user.address, 200)
+    ).to.emit(stakeManager, "RewardReleased").withArgs(jobId, user.address, 200);
     expect(await token.balanceOf(user.address)).to.equal(1050n);
 
     await expect(


### PR DESCRIPTION
## Summary
- rename payout escrow functions to `lockReward` and `releaseReward`
- add owner setters for min stake, slashing percentages and treasury address
- document new StakeManager controls and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896311cdf308333b9df3dd0f36b8834