### PR TITLE
feat: restrict blacklist to authorized modules

### DIFF
--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -32,8 +32,9 @@ contract ReputationEngine is Ownable {
         threshold = newThreshold;
     }
 
-    /// @notice Manually set blacklist status for a user.
-    function setBlacklist(address user, bool status) external onlyOwner {
+    /// @notice Update blacklist status for a user.
+    /// @dev Only authorised modules may call this function.
+    function blacklist(address user, bool status) external onlyCaller {
         _blacklisted[user] = status;
         emit Blacklisted(user, status);
     }

--- a/test/v2/ReputationEngine.test.js
+++ b/test/v2/ReputationEngine.test.js
@@ -33,10 +33,10 @@ describe("ReputationEngine", function () {
     );
   });
 
-  it("allows owner to manually set blacklist status", async () => {
-    await engine.connect(owner).setBlacklist(user.address, true);
+  it("allows authorized caller to manually set blacklist status", async () => {
+    await engine.connect(caller).blacklist(user.address, true);
     expect(await engine.isBlacklisted(user.address)).to.equal(true);
-    await engine.connect(owner).setBlacklist(user.address, false);
+    await engine.connect(caller).blacklist(user.address, false);
     expect(await engine.isBlacklisted(user.address)).to.equal(false);
   });
 });


### PR DESCRIPTION
## Summary
- limit blacklist updates to authorized modules
- adjust tests for caller-based blacklist control

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896334af73c833391fae9c7ae20ddc5