### PR TITLE
docs: clarify v2 module overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,16 @@ Legacy sequence diagrams appear in [docs/architecture.md](docs/architecture.md);
 
 ### AGIJobManager v2
 
- The forthcoming v2 release splits responsibilities across immutable modules—JobRegistry, ValidationModule, StakeManager, ReputationEngine, DisputeModule and CertificateNFT. Validator committees reach majority decisions with dissenters able to escalate through the DisputeModule, and slashing percentages exceed potential rewards so cheating is irrational. Each module is `Ownable` so only the contract owner may adjust parameters, and interfaces remain minimal to keep Etherscan usage straightforward. Incentive settings such as burn rate, stake ratios and slashing percentages are all updated through owner‑only functions, preserving governance control while keeping the surface area small for non‑technical users. Interface definitions live in [contracts/v2/interfaces](contracts/v2/interfaces) and architectural diagrams, including a Hamiltonian view of incentives, in [docs/architecture-v2.md](docs/architecture-v2.md).
+The forthcoming v2 release splits responsibilities across immutable modules. Each contract is `Ownable`, allowing the owner to tune economics directly from Etherscan while the code itself remains fixed. The suite comprises:
+
+- **JobRegistry** – posts jobs, escrows payouts and routes calls to other modules.
+- **ValidationModule** – pseudo‑random validator selection plus commit–reveal majority voting.
+- **StakeManager** – custodial contract for agent/validator stakes, reward release and slashing.
+- **ReputationEngine** – tracks scores and blacklists low‑reputation actors.
+- **DisputeModule** – optional appeal layer for contested outcomes.
+- **CertificateNFT** – mints ERC‑721 certificates proving completion.
+
+Validator committees reach majority decisions with dissenters able to escalate through the DisputeModule, and slashing percentages exceed potential rewards so cheating is irrational. Interfaces remain minimal to keep Etherscan usage straightforward, and incentive settings such as burn rate, stake ratios and slashing percentages are updated through owner‑only functions. Interface definitions live in [contracts/v2/interfaces](contracts/v2/interfaces) and architectural diagrams—including a Hamiltonian view of incentives—in [docs/architecture-v2.md](docs/architecture-v2.md).
 
 Key incentive refinements include:
 


### PR DESCRIPTION
## Summary
- document v2 module responsibilities and owner controls in README
- point to interface definitions and architecture diagrams for AGIJobManager v2

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68965c0636788333aedf626b9281dcb8