### PR TITLE
docs: outline role steps for Etherscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,21 @@ graph TD
 - In Etherscan's **Write Contract** tab, connect your wallet and invoke the desired function.
 - Confirm emitted events to ensure configuration changes took effect.
  
+Role-based quick steps:
+
+**Employers**
+1. Post work through JobRegistry `createJob(reward, uri)` after approving AGI.
+2. Once validation succeeds, call `finalize(jobId)` to pay the agent.
+
+**Agents**
+1. Stake tokens in StakeManager via `depositStake(amount)`.
+2. Join a task with JobRegistry `applyForJob(jobId)` and submit results using `completeJob(jobId, data)`.
+
+**Validators**
+1. Stake via StakeManager, then watch for selection.
+2. Cast a commit with ValidationModule `commitValidation(jobId, hash)` and later reveal via `revealValidation(jobId, approve, salt)`.
+3. If a vote period lapses without resolution, anyone may call `finalize(jobId)` on the ValidationModule.
+
 For detailed walkthroughs see [docs/etherscan-guide.md](docs/etherscan-guide.md).
 
 See [docs/architecture-v2.md](docs/architecture-v2.md) for expanded diagrams and interface definitions; the development plan appears in [docs/coding-sprint-v2.md](docs/coding-sprint-v2.md).


### PR DESCRIPTION
## Summary
- add role-based walkthrough for using JobRegistry, StakeManager, and ValidationModule via Etherscan

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689661c257508333bd3f16f9ae792a16