### PR TITLE
docs: add incentive analysis for v2 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ See [docs/architecture-v2.md](docs/architecture-v2.md) for expanded diagrams and
 - Slashing percentages exceed potential rewards so dishonest behaviour has negative expected value.
 - Employers receive a share of slashed agent stake on failures, aligning incentives across roles.
 - Commit–reveal randomness combined with owner‑tuned parameters keeps the Gibbs free energy lowest at honest participation, mirroring a Hamiltonian system where slashing raises enthalpy and randomness adds entropy so the stable state is honest behaviour.
-- For the economic rationale behind these settings, see [docs/incentive-analysis-v1.md](docs/incentive-analysis-v1.md).
+- For an expanded rationale, see [docs/incentive-analysis-v2.md](docs/incentive-analysis-v2.md).
 
 ```mermaid
 graph LR

--- a/docs/incentive-analysis-v2.md
+++ b/docs/incentive-analysis-v2.md
@@ -1,0 +1,42 @@
+# Incentive Analysis – AGIJobManager v2
+
+AGIJobManager v2 restructures the marketplace around standalone modules and calibrates their incentives so honest behaviour is the dominant strategy for every actor.
+
+## Roles and Stakes
+- **Agents** lock collateral via `StakeManager` equal to a percentage of job reward.
+- **Validators** stake separately and are randomly selected by `ValidationModule`.
+- **Employers** escrow payouts in `JobRegistry` and may claim a share of slashed collateral on failure.
+
+## Voting and Settlement
+Validators follow a commit–reveal scheme and outcomes finalise by majority:
+```mermaid
+sequenceDiagram
+    participant V as Validator
+    participant VM as ValidationModule
+    V->>VM: commit(hash)
+    V->>VM: reveal(vote, salt)
+    VM->>JR: result
+```
+
+Majority approval releases rewards; any minority can escalate to the `DisputeModule` by paying an appeal fee.
+
+## Slashing & Redistribution
+Slashing percentages exceed potential rewards. When misbehaviour occurs:
+- A portion of the agent’s slashed stake reimburses the employer.
+- The remainder routes to a treasury address, raising the system’s enthalpy and discouraging deviations.
+
+## Reputation Dynamics
+`ReputationEngine` adds or subtracts points per job outcome. Falling below owner‑set thresholds auto‑blacklists addresses, removing future earning opportunities.
+
+## Statistical Physics Analogy
+The protocol behaves like a thermodynamic system seeking minimum Gibbs free energy,
+\[ G = H - T S \]
+where:
+- **H** (Hamiltonian) is stake at risk; high slashing raises the energy cost of cheating.
+- **S** (entropy) stems from random validator selection and commit–reveal timing.
+- **T** (temperature) is tuned via owner‑set parameters, weighting the impact of randomness.
+
+Honest execution minimises \(G\); any attempt to cheat requires additional “energy” and is disincentivised.
+
+## Nash Equilibrium
+For Agents and Validators, expected loss from slashing outweighs any potential gain from collusion. Employers receive compensation when jobs fail, aligning incentives across roles. This configuration drives the system toward an equilibrium where cooperation is rational for all participants.


### PR DESCRIPTION
## Summary
- Document v2 incentive mechanics with commit–reveal voting, slashing redistribution and statistical-physics analogy
- Link README to the new v2 incentive analysis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68967d9dc53883338cbbee47963f031c