### PR TITLE
refactor: rename job submission to completion

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -73,7 +73,7 @@ contract MockJobRegistry is IJobRegistry {
     function setJobParameters(uint256, uint256) external override {}
     function createJob() external override returns (uint256) {return 0;}
     function applyForJob(uint256) external override {}
-    function submit(uint256) external override {}
+    function completeJob(uint256) external override {}
     function dispute(uint256) external payable override {}
     function resolveDispute(uint256, bool) external override {}
     function finalize(uint256) external override {}

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -82,7 +82,7 @@ contract JobRegistry is Ownable {
         uint256 stake
     );
     event AgentApplied(uint256 indexed jobId, address indexed agent);
-    event JobSubmitted(uint256 indexed jobId, bool success);
+    event JobCompleted(uint256 indexed jobId, bool success);
     event JobFinalized(uint256 indexed jobId, bool success);
     event JobCancelled(uint256 indexed jobId);
     event DisputeRaised(uint256 indexed jobId, address indexed caller);
@@ -164,19 +164,15 @@ contract JobRegistry is Ownable {
         emit AgentApplied(jobId, msg.sender);
     }
 
-    /// @notice Agent submits job result; validation outcome stored.
-    function submit(uint256 jobId) public {
+    /// @notice Agent completes the job; validation outcome stored.
+    function completeJob(uint256 jobId) public {
         Job storage job = jobs[jobId];
         require(job.state == State.Applied, "invalid state");
         require(msg.sender == job.agent, "only agent");
         bool outcome = validationModule.validate(jobId);
         job.success = outcome;
         job.state = State.Completed;
-        emit JobSubmitted(jobId, outcome);
-    }
-
-    function completeJob(uint256 jobId) external {
-        submit(jobId);
+        emit JobCompleted(jobId, outcome);
     }
 
     /// @notice Agent disputes a failed job outcome.

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -54,7 +54,7 @@ interface IJobRegistry {
         uint256 stake
     );
     event AgentApplied(uint256 indexed jobId, address indexed agent);
-    event JobSubmitted(uint256 indexed jobId, bool success);
+    event JobCompleted(uint256 indexed jobId, bool success);
     event JobFinalized(uint256 indexed jobId, bool success);
 
     // owner wiring of modules
@@ -96,10 +96,10 @@ interface IJobRegistry {
     /// @dev Reverts with {InvalidStatus} if job is not open for applications
     function applyForJob(uint256 jobId) external;
 
-    /// @notice Agent submits the result of a job for validation
-    /// @param jobId Identifier of the job being submitted
+    /// @notice Agent completes the job and triggers validation
+    /// @param jobId Identifier of the job being completed
     /// @dev Reverts with {InvalidStatus} or {OnlyAgent} accordingly
-    function submit(uint256 jobId) external;
+    function completeJob(uint256 jobId) external;
 
     /// @notice Raise a dispute for a completed job
     /// @param jobId Identifier of the disputed job

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -74,8 +74,8 @@ describe("JobRegistry integration", function () {
       .to.emit(registry, "AgentApplied")
       .withArgs(jobId, agent.address);
     await validation.connect(owner).setOutcome(jobId, true);
-    await expect(registry.connect(agent).submit(jobId))
-      .to.emit(registry, "JobSubmitted")
+    await expect(registry.connect(agent).completeJob(jobId))
+      .to.emit(registry, "JobCompleted")
       .withArgs(jobId, true);
     await expect(registry.finalize(jobId))
       .to.emit(registry, "JobFinalized")
@@ -93,7 +93,7 @@ describe("JobRegistry integration", function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId);
     await validation.connect(owner).setOutcome(jobId, false); // colluding validator
-    await registry.connect(agent).submit(jobId);
+    await registry.connect(agent).completeJob(jobId);
     await expect(
       registry.connect(agent).dispute(jobId, { value: appealFee })
     )
@@ -115,7 +115,7 @@ describe("JobRegistry integration", function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId);
     await validation.connect(owner).setOutcome(jobId, false);
-    await registry.connect(agent).submit(jobId);
+    await registry.connect(agent).completeJob(jobId);
     await expect(
       registry.connect(agent).dispute(jobId, { value: appealFee })
     )

--- a/test/v2/LifecycleDispute.integration.test.js
+++ b/test/v2/LifecycleDispute.integration.test.js
@@ -81,7 +81,7 @@ describe("Job lifecycle with disputes", function () {
   it("rewards agent when dispute resolves in their favor", async () => {
     const jobId = await startJob();
     await validation.connect(owner).setOutcome(jobId, false);
-    await registry.connect(agent).submit(jobId);
+    await registry.connect(agent).completeJob(jobId);
     await registry.connect(agent).dispute(jobId, { value: appealFee });
     await dispute.connect(owner).resolve(jobId, false);
 
@@ -94,7 +94,7 @@ describe("Job lifecycle with disputes", function () {
   it("slashes agent and reduces reputation when dispute is lost", async () => {
     const jobId = await startJob();
     await validation.connect(owner).setOutcome(jobId, false);
-    await registry.connect(agent).submit(jobId);
+    await registry.connect(agent).completeJob(jobId);
     await registry.connect(agent).dispute(jobId, { value: appealFee });
     await dispute.connect(owner).resolve(jobId, true);
 


### PR DESCRIPTION
## Summary
- rename JobSubmitted event to JobCompleted in v2 registry
- replace submit function with completeJob and update interface/tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689686a0ea188333929ca867c70c67fb