### PR TITLE
Add configurable commit-reveal validation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Interact with the deployment directly from a block explorer using the **Write** 
 2. **Agents and validators** stake $AGI through `StakeManager.depositStake`.
 3. **Employer** posts work with `JobRegistry.createJob`, escrowing the reward.
 4. **Agent** applies using `JobRegistry.applyForJob` and submits results via `JobRegistry.completeJob`.
-5. **Validators** commit and reveal votes through `ValidationModule.commitVote` and `revealVote`.
+5. **Validators** commit and reveal votes through `ValidationModule.commitValidation` and `revealValidation`.
 6. After reveal, anyone may call `ValidationModule.tally`; `JobRegistry.finalize` releases rewards or `raiseDispute` escalates to `DisputeModule`.
 
 No custom tooling is required—everything happens in the browser.

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -7,60 +7,35 @@ interface IValidationModule {
     event ValidatorsSelected(uint256 indexed jobId, address[] validators);
     event VoteCommitted(uint256 indexed jobId, address indexed validator, bytes32 commitHash);
     event VoteRevealed(uint256 indexed jobId, address indexed validator, bool approve);
-    event ParametersUpdated();
-
-    /// @dev Reverts when validator selection fails
-    error ValidatorSelectionFailed(uint256 jobId);
-
-    /// @dev Reverts when a validator commits more than once
-    error AlreadyCommitted(uint256 jobId, address validator);
-
-    /// @dev Reverts when the commit phase is not active
-    error CommitPhaseClosed(uint256 jobId);
-
-    /// @dev Reverts when the reveal phase is invalid for the caller
-    error RevealPhaseInvalid(uint256 jobId, address validator);
 
     /// @notice Select validators for a given job
     /// @param jobId Identifier of the job
     /// @return Array of selected validator addresses
-    /// @dev Reverts with {ValidatorSelectionFailed} if selection cannot be made
-    function selectValidators(uint256 jobId)
-        external
-        returns (address[] memory);
+    function selectValidators(uint256 jobId) external returns (address[] memory);
 
-    /// @notice Commit a vote hash for a job
+    /// @notice Commit a validation hash for a job
     /// @param jobId Identifier of the job being voted on
     /// @param commitHash Hash of the vote and salt
-    /// @dev Reverts with {AlreadyCommitted} if validator has already committed or
-    ///      {CommitPhaseClosed} if committing outside the allowed window
-    function commitVote(uint256 jobId, bytes32 commitHash) external;
+    function commitValidation(uint256 jobId, bytes32 commitHash) external;
 
-    /// @notice Reveal a previously committed vote
+    /// @notice Reveal a previously committed validation vote
     /// @param jobId Identifier of the job
     /// @param approve True to approve, false to reject
     /// @param salt Salt used in the original commitment
-    /// @dev Reverts with {RevealPhaseInvalid} if reveal is not permitted
-    function revealVote(
-        uint256 jobId,
-        bool approve,
-        bytes32 salt
-    ) external;
+    function revealValidation(uint256 jobId, bool approve, bytes32 salt) external;
 
     /// @notice Tally revealed votes and determine job outcome
     /// @param jobId Identifier of the job
     /// @return success True if validators approved the job
     function tally(uint256 jobId) external returns (bool success);
 
-    /// @notice Owner configuration for timing and validator tiers
-    /// @param commitWindow Duration of the commit phase in seconds
-    /// @param revealWindow Duration of the reveal phase in seconds
-    /// @param rewardTiers Reward tiers paid to validators based on ranking
-    /// @param validatorsPerTier Number of validators selected per tier
-    function setParameters(
-        uint256 commitWindow,
-        uint256 revealWindow,
-        uint256[] calldata rewardTiers,
-        uint256[] calldata validatorsPerTier
-    ) external;
+    /// @notice Owner configuration for timing windows
+    function setCommitRevealWindows(uint256 commitWindow, uint256 revealWindow) external;
+
+    /// @notice Owner configuration for validator counts
+    function setValidatorBounds(uint256 minValidators, uint256 maxValidators) external;
+
+    /// @notice Owner configuration for randomness seed
+    function setRandomnessSeed(bytes32 seed) external;
 }
+

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -46,8 +46,8 @@ graph TD
 ### Validators
 1. Navigate to the contract and connect a validator wallet.
 2. Stake required AGI via **stake**.
-3. During validation, send hashed votes with **commitVote**.
-4. Reveal decisions using **revealVote** before the window closes.
+3. During validation, send hashed votes with **commitValidation**.
+4. Reveal decisions using **revealValidation** before the window closes.
 
 ### Disputers
 1. Open the `DisputeModule` address on Etherscan.

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -34,10 +34,9 @@ describe("ValidationModule V2", function () {
       .connect(owner)
       .setReputationEngine(await reputation.getAddress());
 
-    // set parameters: commit 60s, reveal 60s, one tier giving 2 validators
-    await validation
-      .connect(owner)
-      .setParameters(60, 60, [1], [2]);
+    // set timing and validator bounds
+    await validation.connect(owner).setCommitRevealWindows(60, 60);
+    await validation.connect(owner).setValidatorBounds(2, 2);
 
     // validator stakes and pool
     await stakeManager.setStake(v1.address, 1, ethers.parseEther("100"));
@@ -139,20 +138,20 @@ describe("ValidationModule V2", function () {
     await (
       await validation
         .connect(signerMap[selected[0].toLowerCase()])
-        .commitVote(1, commit1)
+        .commitValidation(1, commit1)
     ).wait();
     await (
       await validation
         .connect(signerMap[selected[1].toLowerCase()])
-        .commitVote(1, commit2)
+        .commitValidation(1, commit2)
     ).wait();
     await advance(61);
     await validation
       .connect(signerMap[selected[0].toLowerCase()])
-      .revealVote(1, true, salt1);
+      .revealValidation(1, true, salt1);
     await validation
       .connect(signerMap[selected[1].toLowerCase()])
-      .revealVote(1, true, salt2);
+      .revealValidation(1, true, salt2);
     await advance(61);
     expect(await validation.tally.staticCall(1)).to.equal(true);
     await validation.tally(1);
@@ -191,22 +190,22 @@ describe("ValidationModule V2", function () {
     await (
       await validation
         .connect(signerMap[selected[0].toLowerCase()])
-        .commitVote(1, commit1)
+        .commitValidation(1, commit1)
     ).wait();
     await (
       await validation
         .connect(signerMap[selected[1].toLowerCase()])
-        .commitVote(1, commit2)
+        .commitValidation(1, commit2)
     ).wait();
     await advance(61);
     const stake0 = await stakeManager.stakeOf(selected[0], 1);
     const stake1 = await stakeManager.stakeOf(selected[1], 1);
     await validation
       .connect(signerMap[selected[0].toLowerCase()])
-      .revealVote(1, true, salt1);
+      .revealValidation(1, true, salt1);
     await validation
       .connect(signerMap[selected[1].toLowerCase()])
-      .revealVote(1, false, salt2);
+      .revealValidation(1, false, salt2);
     await advance(61);
     await validation.tally(1);
     const slashed = stake0 >= stake1 ? selected[1] : selected[0];


### PR DESCRIPTION
## Summary
- add commitValidation/revealValidation flows with tallying and slashing
- allow owner to configure commit/reveal windows, validator count bounds, and randomness seed
- document new commit/reveal calls in README and Etherscan guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689689a30b2c83338a40d4fddf770fe5