### PR TITLE
feat: add role-based staking and job fund controls

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -10,6 +10,12 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 contract StakeManager is Ownable {
     using SafeERC20 for IERC20;
 
+    /// @notice participant roles
+    enum Role {
+        Agent,
+        Validator
+    }
+
     /// @notice ERC20 token used for staking and payouts
     IERC20 public token;
 
@@ -25,23 +31,24 @@ contract StakeManager is Ownable {
     /// @notice percentage of slashed amount sent to treasury (out of 100)
     uint256 public treasurySlashPct;
 
-    /// @notice staked balance per user
-    mapping(address => uint256) public stakes;
+    /// @notice staked balance per user and role
+    mapping(address => mapping(Role => uint256)) public stakes;
 
-    /// @notice escrowed job rewards
-    mapping(bytes32 => uint256) public rewardEscrows;
+    /// @notice escrowed job funds
+    mapping(bytes32 => uint256) public jobEscrows;
 
-    event StakeDeposited(address indexed user, uint256 amount);
-    event StakeWithdrawn(address indexed user, uint256 amount);
+    event StakeDeposited(address indexed user, Role indexed role, uint256 amount);
+    event StakeWithdrawn(address indexed user, Role indexed role, uint256 amount);
     event StakeSlashed(
         address indexed user,
+        Role indexed role,
         address indexed employer,
-        address indexed treasury,
+        address treasury,
         uint256 employerShare,
         uint256 treasuryShare
     );
-    event RewardLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
-    event RewardReleased(bytes32 indexed jobId, address indexed to, uint256 amount);
+    event JobFundsLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
+    event JobFundsReleased(bytes32 indexed jobId, address indexed to, uint256 amount);
 
     constructor(IERC20 _token, address owner, address _treasury) Ownable(owner) {
         token = _token;
@@ -81,67 +88,70 @@ contract StakeManager is Ownable {
     // staking logic
     // ---------------------------------------------------------------
 
-    /// @notice deposit stake for caller
-    function depositStake(uint256 amount) external {
+    /// @notice deposit stake for caller for a specific role
+    function depositStake(Role role, uint256 amount) external {
         require(amount > 0, "amount");
-        uint256 newStake = stakes[msg.sender] + amount;
+        uint256 newStake = stakes[msg.sender][role] + amount;
         require(newStake >= minStake, "min stake");
-        stakes[msg.sender] = newStake;
+        stakes[msg.sender][role] = newStake;
         token.safeTransferFrom(msg.sender, address(this), amount);
-        emit StakeDeposited(msg.sender, amount);
+        emit StakeDeposited(msg.sender, role, amount);
     }
 
-    /// @notice withdraw available stake
-    function withdrawStake(uint256 amount) external {
-        uint256 staked = stakes[msg.sender];
+    /// @notice withdraw available stake for a specific role
+    function withdrawStake(Role role, uint256 amount) external {
+        uint256 staked = stakes[msg.sender][role];
         require(staked >= amount, "stake");
         uint256 newStake = staked - amount;
         require(newStake == 0 || newStake >= minStake, "min stake");
-        stakes[msg.sender] = newStake;
+        stakes[msg.sender][role] = newStake;
         token.safeTransfer(msg.sender, amount);
-        emit StakeWithdrawn(msg.sender, amount);
+        emit StakeWithdrawn(msg.sender, role, amount);
     }
 
     // ---------------------------------------------------------------
     // job escrow logic
     // ---------------------------------------------------------------
 
-    /// @notice lock reward for a job from an employer
-    function lockReward(bytes32 jobId, address from, uint256 amount)
+    /// @notice lock job funds from an employer
+    function lockJobFunds(bytes32 jobId, address from, uint256 amount)
         external
         onlyOwner
     {
         token.safeTransferFrom(from, address(this), amount);
-        rewardEscrows[jobId] += amount;
-        emit RewardLocked(jobId, from, amount);
+        jobEscrows[jobId] += amount;
+        emit JobFundsLocked(jobId, from, amount);
     }
 
-    /// @notice release locked reward to recipient
-    function releaseReward(bytes32 jobId, address to, uint256 amount)
+    /// @notice release locked job funds to recipient
+    function releaseJobFunds(bytes32 jobId, address to, uint256 amount)
         external
         onlyOwner
     {
-        uint256 escrow = rewardEscrows[jobId];
+        uint256 escrow = jobEscrows[jobId];
         require(escrow >= amount, "escrow");
-        rewardEscrows[jobId] = escrow - amount;
+        jobEscrows[jobId] = escrow - amount;
         token.safeTransfer(to, amount);
-        emit RewardReleased(jobId, to, amount);
+        emit JobFundsReleased(jobId, to, amount);
     }
 
     // ---------------------------------------------------------------
     // slashing logic
     // ---------------------------------------------------------------
 
-    /// @notice slash stake from a user and distribute shares
-    function slash(address user, uint256 amount, address employer) external onlyOwner {
-        uint256 staked = stakes[user];
+    /// @notice slash stake from a user for a specific role and distribute shares
+    function slash(address user, Role role, uint256 amount, address employer)
+        external
+        onlyOwner
+    {
+        uint256 staked = stakes[user][role];
         require(staked >= amount, "stake");
 
         uint256 employerShare = (amount * employerSlashPct) / 100;
         uint256 treasuryShare = (amount * treasurySlashPct) / 100;
         uint256 total = employerShare + treasuryShare;
 
-        stakes[user] = staked - total;
+        stakes[user][role] = staked - total;
 
         if (employerShare > 0) {
             token.safeTransfer(employer, employerShare);
@@ -150,7 +160,7 @@ contract StakeManager is Ownable {
             token.safeTransfer(treasury, treasuryShare);
         }
 
-        emit StakeSlashed(user, employer, treasury, employerShare, treasuryShare);
+        emit StakeSlashed(user, role, employer, treasury, employerShare, treasuryShare);
     }
 }
 

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -26,35 +26,36 @@ describe("StakeManager", function () {
   it("handles staking, job escrow and slashing", async () => {
     await token.connect(user).approve(await stakeManager.getAddress(), 200);
     await expect(
-      stakeManager.connect(user).depositStake(200)
-    ).to.emit(stakeManager, "StakeDeposited").withArgs(user.address, 200);
+      stakeManager.connect(user).depositStake(0, 200)
+    ).to.emit(stakeManager, "StakeDeposited").withArgs(user.address, 0, 200);
 
-    expect(await stakeManager.stakes(user.address)).to.equal(200n);
+    expect(await stakeManager.stakes(user.address, 0)).to.equal(200n);
 
-    await stakeManager.connect(user).withdrawStake(50);
-    expect(await stakeManager.stakes(user.address)).to.equal(150n);
+    await stakeManager.connect(user).withdrawStake(0, 50);
+    expect(await stakeManager.stakes(user.address, 0)).to.equal(150n);
 
     const jobId = ethers.encodeBytes32String("job1");
     await token.connect(employer).approve(await stakeManager.getAddress(), 300);
     await stakeManager
       .connect(owner)
-      .lockReward(jobId, employer.address, 300);
+      .lockJobFunds(jobId, employer.address, 300);
 
     await expect(
-      stakeManager.connect(owner).releaseReward(jobId, user.address, 200)
-    ).to.emit(stakeManager, "RewardReleased").withArgs(jobId, user.address, 200);
+      stakeManager.connect(owner).releaseJobFunds(jobId, user.address, 200)
+    ).to.emit(stakeManager, "JobFundsReleased").withArgs(jobId, user.address, 200);
     expect(await token.balanceOf(user.address)).to.equal(1050n);
 
     await expect(
-      stakeManager.connect(owner).slash(user.address, 100, employer.address)
+      stakeManager.connect(owner).slash(user.address, 0, 100, employer.address)
     ).to.emit(stakeManager, "StakeSlashed").withArgs(
       user.address,
+      0,
       employer.address,
       treasury.address,
       50,
       50
     );
-    expect(await stakeManager.stakes(user.address)).to.equal(50n);
+    expect(await stakeManager.stakes(user.address, 0)).to.equal(50n);
     expect(await token.balanceOf(employer.address)).to.equal(750n);
     expect(await token.balanceOf(treasury.address)).to.equal(50n);
   });


### PR DESCRIPTION
## Summary
- track stakes per participant role
- lock and release job funds via StakeManager
- enable role-specific slashing with employer and treasury shares

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68968bfdab988333b446231909e154ee