### PR TITLE
docs: document tax obligations and owner neutrality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1364,6 +1364,9 @@ npx eslint .
 ## The Economy of AGI
 How jobs, reputation, and value circulate within the AGI ecosystem. Read the expanded discussion in [docs/economy-of-agi.md](docs/economy-of-agi.md).
 
+## Tax Obligations
+All taxes arising from job transactions are the responsibility of the parties exchanging value. Employers account for capital gains or losses on burned tokens, agents and validators treat tokens received as income, and passive holders incur no tax until they dispose of their own tokens. The smart contract and its deploying corporation never collect fees or hold user funds and therefore remain tax‑exempt in every jurisdiction. See [docs/tax-obligations.md](docs/tax-obligations.md) for a detailed breakdown.
+
 ## Legal & Regulatory
 Explains the utility-token nature of $AGI and related considerations. See [docs/legal-regulatory.md](docs/legal-regulatory.md) for full details.
 

--- a/docs/coding-sprint-v2.md
+++ b/docs/coding-sprint-v2.md
@@ -32,6 +32,10 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
 6. **Deployment Prep**
    - Freeze compiler versions and verify bytecode locally.
    - Generate deployment scripts that record module addresses for `JobRegistry` wiring.
+7. **Tax Responsibility & Owner Neutrality**
+   - Confirm modules never route funds or fees to the owner account.
+   - Document in NatSpec that employers, agents and validators handle all tax reporting.
+   - Provide explorer instructions so non‑technical users can review owner‑only parameters on Etherscan.
 
 ## Deliverables
 - Verified Solidity contracts under `contracts/v2`.

--- a/docs/legal-regulatory.md
+++ b/docs/legal-regulatory.md
@@ -1,3 +1,5 @@
 # Legal & Regulatory
 
 $AGI is strictly a utility token. It is minted only when AGI Nodes contribute computational resources and is used to acquire products and services within the network. Holding $AGI tokens does not constitute an investment, and they confer no ownership, voting rights, or entitlement to profits. For full disclosures, see [AGIJobManagerv0.sol](../legacy/AGIJobManagerv0.sol).
+
+For tax treatment of jobs executed through the protocol, see [tax-obligations.md](tax-obligations.md). The platform and its owner never collect fees or handle user funds and therefore remain tax‑neutral across jurisdictions.

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -1,0 +1,31 @@
+# Tax Obligations in the AGI Job Platform Ecosystem
+
+The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction.
+
+## Employers
+- Provide the token escrow that funds jobs.
+- When a job finalizes, a portion of the employer's deposit is burned.
+- Burning is a disposal of property, so employers record any capital gain or loss on the burned amount based on cost basis versus fair market value at burn.
+- Token payments to agents may be deductible business expenses where applicable.
+
+## Agents
+- Receive tokens as compensation for completed work.
+- Token value at receipt is ordinary income; later sales trigger capital gains or losses relative to this basis.
+- Burned tokens never belong to agents and have no tax impact on them.
+
+## Validators
+- If rewarded for validation, tokens received are income; later sales realise capital gains or losses.
+- Validators with no rewards have no tax consequences.
+
+## Platform Owner and Contract
+- Collect no fees and never take custody of tokens.
+- Do not mint, burn, or transfer tokens for themselves.
+- Provide infrastructure without consideration, so no sales/VAT/GST applies.
+- Therefore incur zero direct, indirect, or theoretical tax liability worldwide.
+
+## Passive Token Holders
+- Passive holders unaffected by burns or job flows until they dispose of their own tokens.
+
+## Responsibilities
+Participants must track their own transactions and consult professional advisers for jurisdiction‑specific reporting. The platform and its owner do not provide tax services or reporting.
+


### PR DESCRIPTION
## Summary
- Document that tax duties rest with employers, agents, and validators while the platform and owner remain tax-neutral
- Add sprint task ensuring modules never route funds to the owner and explain tax handling in NatSpec
- Link legal documentation to new tax responsibilities outline

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_68968d80e7108333a881d361aaa025df