### PR TITLE
Add tax policy module and clarify participant tax duties

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ Validator committees expand with job value and settle outcomes by majority after
 | `StakeManager` | Hold validator/agent collateral, release rewards, execute slashing. |
 | `ReputationEngine` | Track reputation, apply penalties, maintain blacklists. |
 | `CertificateNFT` | Mint ERC‑721 certificates for completed jobs. |
+| `TaxPolicy` | Publish tax disclaimer and canonical policy URI. |
 
 | Module | Key owner controls |
 | --- | --- |
@@ -602,6 +603,7 @@ Validator committees expand with job value and settle outcomes by majority after
 | `ReputationEngine` | `setCaller`, `setThreshold`, `setBlacklist` |
 | `DisputeModule` | `setAppealParameters` |
 | `CertificateNFT` | `setJobRegistry` |
+| `TaxPolicy` | `setPolicyURI` |
 
 | Module | Interface / Key functions |
 | --- | --- |
@@ -611,6 +613,7 @@ Validator committees expand with job value and settle outcomes by majority after
 | `ReputationEngine` | [`IReputationEngine`](contracts/v2/interfaces/IReputationEngine.sol) – `addReputation`, `subtractReputation`, `setBlacklist`, `isBlacklisted` |
 | `DisputeModule` | [`IDisputeModule`](contracts/v2/interfaces/IDisputeModule.sol) – `raiseDispute`, `resolve` |
 | `CertificateNFT` | [`ICertificateNFT`](contracts/v2/interfaces/ICertificateNFT.sol) – `mint` |
+| `TaxPolicy` | – `policyURI`, `setPolicyURI`, `acknowledge` |
 
 #### Module Addresses & Roles
 
@@ -622,6 +625,7 @@ Validator committees expand with job value and settle outcomes by majority after
 | `ReputationEngine` | `0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9` | Updates reputation scores and applies penalties |
 | `DisputeModule` | `0x0165878A594ca255338adfa4d48449f69242Eb8F` | Handles appeals and renders final rulings |
 | `CertificateNFT` | `0x5FC8d32690cc91D4c39d9d3abcBD16989F875707` | Mints ERC‑721 certificates for completed jobs |
+| `TaxPolicy` | `0x0000000000000000000000000000000000000000` | Stores tax disclaimer URI and acknowledgement helper |
 
 ```mermaid
 graph TD
@@ -640,6 +644,7 @@ graph TD
 - Verify each module address above on at least two explorers.
 - In Etherscan's **Write Contract** tab, connect your wallet and invoke the desired function.
 - Confirm emitted events to ensure configuration changes took effect.
+- `TaxPolicy` exposes `policyURI()` and `acknowledge()` under the **Read** tab so participants can view the disclaimer; only the owner may update the URI via `setPolicyURI()` in **Write**.
  
 Role-based quick steps:
 
@@ -1365,7 +1370,15 @@ npx eslint .
 How jobs, reputation, and value circulate within the AGI ecosystem. Read the expanded discussion in [docs/economy-of-agi.md](docs/economy-of-agi.md).
 
 ## Tax Obligations
-All taxes arising from job transactions are the responsibility of the parties exchanging value. Employers account for capital gains or losses on burned tokens, agents and validators treat tokens received as income, and passive holders incur no tax until they dispose of their own tokens. The smart contract and its deploying corporation never collect fees or hold user funds and therefore remain tax‑exempt in every jurisdiction. See [docs/tax-obligations.md](docs/tax-obligations.md) for a detailed breakdown.
+All taxes arising from job transactions are borne solely by the participants exchanging value:
+
+- **Employers** calculate gains or losses on tokens that are burned or paid out.
+- **Agents and validators** treat received tokens as income and later report any capital gains when those tokens are sold.
+- **Passive holders** have no tax impact until they dispose of their own tokens.
+
+The protocol’s contracts and the corporation that deployed them are always tax‑exempt. They never collect fees, hold tokens, or take custody of funds, so no direct, indirect, or implied tax liability attaches to the infrastructure. The `TaxPolicy` contract stores an owner‑editable URI pointing to the current off‑chain policy and exposes an `acknowledge()` helper for explorers like Etherscan.
+
+See [docs/tax-obligations.md](docs/tax-obligations.md) for a detailed breakdown of responsibilities.
 
 ## Legal & Regulatory
 Explains the utility-token nature of $AGI and related considerations. See [docs/legal-regulatory.md](docs/legal-regulatory.md) for full details.

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title TaxPolicy
+/// @notice Stores a canonical tax policy URI and acknowledgement helper.
+/// @dev Contract owner alone may update the policy URI. The contract never holds
+/// funds and exists solely to provide an on-chain reference for off-chain tax
+/// responsibilities. Participants remain fully responsible for their own tax
+/// obligations; the contract and its owner are tax-exempt.
+contract TaxPolicy is Ownable {
+    /// @notice Off-chain document describing tax responsibilities.
+    string public policyURI;
+
+    /// @notice Emitted when the tax policy URI is updated.
+    event TaxPolicyURIUpdated(string uri);
+
+    constructor(address owner_, string memory uri) Ownable(owner_) {
+        policyURI = uri;
+        emit TaxPolicyURIUpdated(uri);
+    }
+
+    /// @notice Updates the off-chain policy URI.
+    /// @param uri New URI pointing to policy text (e.g., IPFS hash).
+    function setPolicyURI(string calldata uri) external onlyOwner {
+        policyURI = uri;
+        emit TaxPolicyURIUpdated(uri);
+    }
+
+    /// @notice Returns a human-readable disclaimer for explorers like Etherscan.
+    /// @return disclaimer Text confirming participants bear all tax duties.
+    function acknowledge() external pure returns (string memory disclaimer) {
+        return "Participants are solely responsible for taxes; contract owner is exempt.";
+    }
+}
+

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -13,6 +13,7 @@
 | ReputationEngine | *TBD* | Updates reputation scores and applies penalties |
 | DisputeModule | *TBD* | Handles appeals and renders final rulings |
 | CertificateNFT | *TBD* | Mints ERC‑721 certificates for completed jobs |
+| TaxPolicy | *TBD* | Stores tax disclaimer URI and acknowledgement helper |
 
 > Addresses will be published after deployment. Always verify each on multiple explorers before interacting.
 
@@ -48,6 +49,11 @@ graph TD
 2. Stake required AGI via **stake**.
 3. During validation, send hashed votes with **commitValidation**.
 4. Reveal decisions using **revealValidation** before the window closes.
+
+### Tax Policy
+1. Open the `TaxPolicy` address in Etherscan.
+2. Under **Read Contract**, call **acknowledge** to view the disclaimer or **policyURI** for the canonical document.
+3. Only the owner may update the URI via **setPolicyURI** in **Write Contract**.
 
 ### Disputers
 1. Open the `DisputeModule` address on Etherscan.

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -1,6 +1,6 @@
 # Tax Obligations in the AGI Job Platform Ecosystem
 
-The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction.
+The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction. The dedicated [`TaxPolicy`](../contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain by storing a canonical policy URI and returning a plain‑text acknowledgement so non‑technical users can confirm the disclaimer through explorers like Etherscan.
 
 ## Employers
 - Provide the token escrow that funds jobs.
@@ -22,6 +22,7 @@ The AGI Jobs protocol routes all tax duties to the participants who exchange val
 - Do not mint, burn, or transfer tokens for themselves.
 - Provide infrastructure without consideration, so no sales/VAT/GST applies.
 - Therefore incur zero direct, indirect, or theoretical tax liability worldwide.
+- May update the `TaxPolicy` URI but remain tax‑exempt regardless of jurisdiction.
 
 ## Passive Token Holders
 - Passive holders unaffected by burns or job flows until they dispose of their own tokens.

--- a/test/TaxPolicy.test.js
+++ b/test/TaxPolicy.test.js
@@ -1,0 +1,36 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("TaxPolicy", function () {
+  let owner, user, tax;
+
+  beforeEach(async () => {
+    [owner, user] = await ethers.getSigners();
+    const Factory = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    tax = await Factory.deploy(owner.address, "ipfs://initial");
+    await tax.waitForDeployment();
+  });
+
+  it("allows owner to update URI", async () => {
+    await tax.connect(owner).setPolicyURI("ipfs://new");
+    expect(await tax.policyURI()).to.equal("ipfs://new");
+  });
+
+  it("prevents non-owner updates", async () => {
+    await expect(
+      tax.connect(user).setPolicyURI("x")
+    )
+      .to.be.revertedWithCustomError(tax, "OwnableUnauthorizedAccount")
+      .withArgs(user.address);
+  });
+
+  it("returns acknowledgement string", async () => {
+    const msg = await tax.acknowledge();
+    expect(msg).to.equal(
+      "Participants are solely responsible for taxes; contract owner is exempt."
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `TaxPolicy` contract with owner-managed policy URI and acknowledgement helper
- document tax responsibilities exclusively for employers, agents, and validators
- guide non-technical users to read and update the policy via Etherscan

## Testing
- `npm run compile`
- `npm run lint` (warnings only)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68968f38a6f48333bffa97e303830392