### PR TITLE
Clarify tax liability via TaxPolicy acknowledgment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,13 +1370,13 @@ npx eslint .
 How jobs, reputation, and value circulate within the AGI ecosystem. Read the expanded discussion in [docs/economy-of-agi.md](docs/economy-of-agi.md).
 
 ## Tax Obligations
-All taxes arising from job transactions are borne solely by the participants exchanging value:
+All taxes arising from job transactions fall exclusively on the parties exchanging value:
 
-- **Employers** calculate gains or losses on tokens that are burned or paid out.
-- **Agents and validators** treat received tokens as income and later report any capital gains when those tokens are sold.
+- **AGI Employers** calculate gains or losses on tokens that are burned or paid out.
+- **AGI Agents and validators** treat received tokens as income and later report any capital gains when those tokens are sold.
 - **Passive holders** have no tax impact until they dispose of their own tokens.
 
-The protocol’s contracts and the corporation that deployed them are always tax‑exempt. They never collect fees, hold tokens, or take custody of funds, so no direct, indirect, or implied tax liability attaches to the infrastructure. The `TaxPolicy` contract stores an owner‑editable URI pointing to the current off‑chain policy and exposes an `acknowledge()` helper for explorers like Etherscan.
+The protocol’s smart contracts and the corporation that deployed them are always tax‑exempt in every jurisdiction. They never collect fees, hold tokens, or take custody of funds, so no direct, indirect, or implied tax liability attaches to the infrastructure. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract stores a canonical policy URI and offers an `acknowledge()` helper that non‑technical users can call through Etherscan to view the on‑chain disclaimer.
 
 See [docs/tax-obligations.md](docs/tax-obligations.md) for a detailed breakdown of responsibilities.
 

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -7,8 +7,9 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 /// @notice Stores a canonical tax policy URI and acknowledgement helper.
 /// @dev Contract owner alone may update the policy URI. The contract never holds
 /// funds and exists solely to provide an on-chain reference for off-chain tax
-/// responsibilities. Participants remain fully responsible for their own tax
-/// obligations; the contract and its owner are tax-exempt.
+/// responsibilities. AGI Employers, AGI Agents, and Validators remain fully
+/// responsible for their own tax obligations; the contract and its owner are
+/// always tax‑exempt.
 contract TaxPolicy is Ownable {
     /// @notice Off-chain document describing tax responsibilities.
     string public policyURI;
@@ -29,9 +30,10 @@ contract TaxPolicy is Ownable {
     }
 
     /// @notice Returns a human-readable disclaimer for explorers like Etherscan.
-    /// @return disclaimer Text confirming participants bear all tax duties.
+    /// @return disclaimer Confirms all taxes fall on employers, agents, and validators.
     function acknowledge() external pure returns (string memory disclaimer) {
-        return "Participants are solely responsible for taxes; contract owner is exempt.";
+        return
+            "AGI Employers, Agents, and Validators handle all taxes; the contract and owner are tax-exempt.";
     }
 }
 

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -1,6 +1,6 @@
 # Tax Obligations in the AGI Job Platform Ecosystem
 
-The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction. The dedicated [`TaxPolicy`](../contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain by storing a canonical policy URI and returning a plain‑text acknowledgement so non‑technical users can confirm the disclaimer through explorers like Etherscan.
+The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction. The dedicated [`TaxPolicy`](../contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain by storing a canonical policy URI and returning a plain‑text acknowledgement—"AGI Employers, Agents, and Validators handle all taxes; the contract and owner are tax-exempt"—so non‑technical users can confirm the disclaimer through explorers like Etherscan.
 
 ## Employers
 - Provide the token escrow that funds jobs.

--- a/test/TaxPolicy.test.js
+++ b/test/TaxPolicy.test.js
@@ -29,7 +29,7 @@ describe("TaxPolicy", function () {
   it("returns acknowledgement string", async () => {
     const msg = await tax.acknowledge();
     expect(msg).to.equal(
-      "Participants are solely responsible for taxes; contract owner is exempt."
+      "AGI Employers, Agents, and Validators handle all taxes; the contract and owner are tax-exempt."
     );
   });
 });


### PR DESCRIPTION
## Summary
- specify in `TaxPolicy` that AGI Employers, Agents, and Validators shoulder all tax duties while the contract and owner remain exempt
- document tax responsibilities in README and tax-obligations guide, highlighting the on-chain `acknowledge()` helper for Etherscan users
- test coverage for new disclaimer string

## Testing
- `npm run compile`
- `npm run lint` *(warnings: 1958)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689692488ad48333a9e70b368f16e317