### PR TITLE
Integrate tax policy reference into job registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ Validator committees expand with job value and settle outcomes by majority after
 
 | Module | Key owner controls |
 | --- | --- |
-| `JobRegistry` | `setModules`, `setJobParameters` |
+| `JobRegistry` | `setModules`, `setJobParameters`, `setTaxPolicy` |
 | `ValidationModule` | `setParameters` |
 | `StakeManager` | `setToken`, `setMinStake`, `setSlashingPercentages`, `setTreasury` |
 | `ReputationEngine` | `setCaller`, `setThreshold`, `setBlacklist` |
@@ -607,7 +607,7 @@ Validator committees expand with job value and settle outcomes by majority after
 
 | Module | Interface / Key functions |
 | --- | --- |
-| `JobRegistry` | [`IJobRegistry`](contracts/v2/interfaces/IJobRegistry.sol) – `createJob`, `applyForJob`, `completeJob`, `dispute`, `finalize` |
+| `JobRegistry` | [`IJobRegistry`](contracts/v2/interfaces/IJobRegistry.sol) – `createJob`, `applyForJob`, `completeJob`, `dispute`, `finalize`, `taxAcknowledgement`, `taxPolicyURI` |
 | `ValidationModule` | [`IValidationModule`](contracts/v2/interfaces/IValidationModule.sol) – `selectValidators`, `commitValidation`, `revealValidation`, `finalize`, `appeal` |
 | `StakeManager` | [`IStakeManager`](contracts/v2/interfaces/IStakeManager.sol) – `depositStake`, `withdrawStake`, `lockStake`, `slash`, `stakeOf` |
 | `ReputationEngine` | [`IReputationEngine`](contracts/v2/interfaces/IReputationEngine.sol) – `addReputation`, `subtractReputation`, `setBlacklist`, `isBlacklisted` |
@@ -645,6 +645,7 @@ graph TD
 - In Etherscan's **Write Contract** tab, connect your wallet and invoke the desired function.
 - Confirm emitted events to ensure configuration changes took effect.
 - `TaxPolicy` exposes `policyURI()` and `acknowledge()` under the **Read** tab so participants can view the disclaimer; only the owner may update the URI via `setPolicyURI()` in **Write**.
+- `JobRegistry` mirrors the disclaimer with `taxAcknowledgement()` and `taxPolicyURI()` for easy discovery on explorers.
  
 Role-based quick steps:
 
@@ -1376,7 +1377,7 @@ All taxes arising from job transactions fall exclusively on the parties exchangi
 - **AGI Agents and validators** treat received tokens as income and later report any capital gains when those tokens are sold.
 - **Passive holders** have no tax impact until they dispose of their own tokens.
 
-The protocol’s smart contracts and the corporation that deployed them are always tax‑exempt in every jurisdiction. They never collect fees, hold tokens, or take custody of funds, so no direct, indirect, or implied tax liability attaches to the infrastructure. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract stores a canonical policy URI and offers an `acknowledge()` helper that non‑technical users can call through Etherscan to view the on‑chain disclaimer.
+The protocol’s smart contracts and the corporation that deployed them are always tax‑exempt in every jurisdiction. They never collect fees, hold tokens, or take custody of funds, so no direct, indirect, or implied tax liability attaches to the infrastructure. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract stores a canonical policy URI and offers an `acknowledge()` helper that non‑technical users can call through Etherscan to view the on‑chain disclaimer. `JobRegistry` surfaces the same text and URI through `taxAcknowledgement()` and `taxPolicyURI()` so explorers can display it without manual lookups.
 
 See [docs/tax-obligations.md](docs/tax-obligations.md) for a detailed breakdown of responsibilities.
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -29,6 +29,11 @@ interface ICertificateNFT {
     function mint(address to, uint256 jobId, string calldata uri) external returns (uint256);
 }
 
+interface ITaxPolicy {
+    function acknowledge() external view returns (string memory);
+    function policyURI() external view returns (string memory);
+}
+
 /// @title JobRegistry
 /// @notice Minimal registry coordinating job lifecycle and external modules.
 contract JobRegistry is Ownable {
@@ -59,6 +64,7 @@ contract JobRegistry is Ownable {
     IReputationEngine public reputationEngine;
     IDisputeModule public disputeModule;
     ICertificateNFT public certificateNFT;
+    ITaxPolicy public taxPolicy;
 
     uint128 public jobReward;
     uint96 public jobStake;
@@ -69,6 +75,7 @@ contract JobRegistry is Ownable {
     event ReputationEngineUpdated(address engine);
     event DisputeModuleUpdated(address module);
     event CertificateNFTUpdated(address nft);
+    event TaxPolicyUpdated(address policy);
 
     // job parameter template event
     event JobParametersUpdated(uint256 reward, uint256 stake);
@@ -116,6 +123,22 @@ contract JobRegistry is Ownable {
         emit ReputationEngineUpdated(address(_reputation));
         emit DisputeModuleUpdated(address(_dispute));
         emit CertificateNFTUpdated(address(_certNFT));
+    }
+
+    function setTaxPolicy(ITaxPolicy _policy) external onlyOwner {
+        require(address(_policy) != address(0), "policy");
+        taxPolicy = _policy;
+        emit TaxPolicyUpdated(address(_policy));
+    }
+
+    function taxAcknowledgement() external view returns (string memory) {
+        if (address(taxPolicy) == address(0)) return "";
+        return taxPolicy.acknowledge();
+    }
+
+    function taxPolicyURI() external view returns (string memory) {
+        if (address(taxPolicy) == address(0)) return "";
+        return taxPolicy.policyURI();
     }
 
     function setJobParameters(uint256 reward, uint256 stake) external onlyOwner {

--- a/docs/coding-sprint-v2.md
+++ b/docs/coding-sprint-v2.md
@@ -6,6 +6,7 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
 - Implement immutable, ownable modules for job coordination, validation, staking, reputation, disputes and certificate NFTs.
 - Optimise for gas efficiency and composability while keeping explorer interactions simple for non‑technical users.
 - Align incentives so honest behaviour is the dominant strategy for agents, validators and employers.
+- Publish an on-chain tax disclaimer that leaves all liabilities with employers, agents and validators while the owner remains exempt.
 
 ## Tasks
 1. **Interface Stabilisation**
@@ -34,6 +35,7 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
    - Generate deployment scripts that record module addresses for `JobRegistry` wiring.
 7. **Tax Responsibility & Owner Neutrality**
    - Confirm modules never route funds or fees to the owner account.
+   - Wire `TaxPolicy` into `JobRegistry` so the owner can update a canonical policy URI and expose `taxAcknowledgement()`/`taxPolicyURI()`.
    - Document in NatSpec that employers, agents and validators handle all tax reporting.
    - Provide explorer instructions so non‑technical users can review owner‑only parameters on Etherscan.
 

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -1,0 +1,38 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobRegistry tax policy integration", function () {
+  let owner, user, registry, policy;
+
+  beforeEach(async () => {
+    [owner, user] = await ethers.getSigners();
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Registry.deploy(owner.address);
+    const Policy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    policy = await Policy.deploy(owner.address, "ipfs://policy");
+  });
+
+  it("allows owner to set policy and expose acknowledgement", async () => {
+    await expect(
+      registry.connect(owner).setTaxPolicy(await policy.getAddress())
+    )
+      .to.emit(registry, "TaxPolicyUpdated")
+      .withArgs(await policy.getAddress());
+    expect(await registry.taxAcknowledgement()).to.equal(
+      await policy.acknowledge()
+    );
+    expect(await registry.taxPolicyURI()).to.equal("ipfs://policy");
+  });
+
+  it("blocks non-owner from setting policy", async () => {
+    await expect(
+      registry.connect(user).setTaxPolicy(await policy.getAddress())
+    )
+      .to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount")
+      .withArgs(user.address);
+  });
+});


### PR DESCRIPTION
## Summary
- expose on-chain tax policy via owner-settable reference in `JobRegistry`
- document tax policy wiring in README and coding sprint docs
- add tests verifying only owner can update the policy

## Testing
- `npm test`
- `npx eslint .`
- `npx solhint 'contracts/**/*.sol'`


------
https://chatgpt.com/codex/tasks/task_e_689696304ae08333ab0cdabfa0e35cea