### PR TITLE
feat: add updatable tax policy acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ Validator committees expand with job value and settle outcomes by majority after
 | `StakeManager` | Hold validator/agent collateral, release rewards, execute slashing. |
 | `ReputationEngine` | Track reputation, apply penalties, maintain blacklists. |
 | `CertificateNFT` | Mint ERC‑721 certificates for completed jobs. |
-| `TaxPolicy` | Publish tax disclaimer and canonical policy URI. |
+| `TaxPolicy` | Publish tax disclaimer and canonical policy URI/acknowledgement. |
 
 | Module | Key owner controls |
 | --- | --- |
@@ -603,7 +603,7 @@ Validator committees expand with job value and settle outcomes by majority after
 | `ReputationEngine` | `setCaller`, `setThreshold`, `setBlacklist` |
 | `DisputeModule` | `setAppealParameters` |
 | `CertificateNFT` | `setJobRegistry` |
-| `TaxPolicy` | `setPolicyURI` |
+| `TaxPolicy` | `setPolicyURI`, `setAcknowledgement` |
 
 | Module | Interface / Key functions |
 | --- | --- |
@@ -613,7 +613,7 @@ Validator committees expand with job value and settle outcomes by majority after
 | `ReputationEngine` | [`IReputationEngine`](contracts/v2/interfaces/IReputationEngine.sol) – `addReputation`, `subtractReputation`, `setBlacklist`, `isBlacklisted` |
 | `DisputeModule` | [`IDisputeModule`](contracts/v2/interfaces/IDisputeModule.sol) – `raiseDispute`, `resolve` |
 | `CertificateNFT` | [`ICertificateNFT`](contracts/v2/interfaces/ICertificateNFT.sol) – `mint` |
-| `TaxPolicy` | – `policyURI`, `setPolicyURI`, `acknowledge` |
+| `TaxPolicy` | – `policyURI`, `acknowledgement`, `setPolicyURI`, `setAcknowledgement`, `acknowledge` |
 
 #### Module Addresses & Roles
 
@@ -644,7 +644,7 @@ graph TD
 - Verify each module address above on at least two explorers.
 - In Etherscan's **Write Contract** tab, connect your wallet and invoke the desired function.
 - Confirm emitted events to ensure configuration changes took effect.
-- `TaxPolicy` exposes `policyURI()` and `acknowledge()` under the **Read** tab so participants can view the disclaimer; only the owner may update the URI via `setPolicyURI()` in **Write**.
+- `TaxPolicy` exposes `policyURI()`, `acknowledgement()`, and `acknowledge()` under the **Read** tab so participants can view the disclaimer; only the owner may update the URI via `setPolicyURI()` or the message via `setAcknowledgement()` in **Write**. `JobRegistry` mirrors both fields through `taxPolicyDetails()` for one-call discovery on explorers.
 - `JobRegistry` mirrors the disclaimer with `taxAcknowledgement()` and `taxPolicyURI()` for easy discovery on explorers.
  
 Role-based quick steps:
@@ -1377,7 +1377,7 @@ All taxes arising from job transactions fall exclusively on the parties exchangi
 - **AGI Agents and validators** treat received tokens as income and later report any capital gains when those tokens are sold.
 - **Passive holders** have no tax impact until they dispose of their own tokens.
 
-The protocol’s smart contracts and the corporation that deployed them are always tax‑exempt in every jurisdiction. They never collect fees, hold tokens, or take custody of funds, so no direct, indirect, or implied tax liability attaches to the infrastructure. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract stores a canonical policy URI and offers an `acknowledge()` helper that non‑technical users can call through Etherscan to view the on‑chain disclaimer. `JobRegistry` surfaces the same text and URI through `taxAcknowledgement()` and `taxPolicyURI()` so explorers can display it without manual lookups.
+The protocol’s smart contracts and the corporation that deployed them are always tax‑exempt in every jurisdiction. They never collect fees, hold tokens, or take custody of funds, so no direct, indirect, or implied tax liability attaches to the infrastructure. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract stores a canonical policy URI and an owner‑editable acknowledgement string that non‑technical users can call through Etherscan via `acknowledgement()` or `acknowledge()`. `JobRegistry` surfaces the same text and URI through `taxAcknowledgement()`, `taxPolicyURI()`, and the combined `taxPolicyDetails()` helper so explorers can display it without manual lookups.
 
 See [docs/tax-obligations.md](docs/tax-obligations.md) for a detailed breakdown of responsibilities.
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -141,6 +141,19 @@ contract JobRegistry is Ownable {
         return taxPolicy.policyURI();
     }
 
+    /// @notice Convenience helper returning both acknowledgement and URI.
+    /// @return ack Plain-text disclaimer confirming tax responsibilities.
+    /// @return uri Off-chain document location (e.g., IPFS hash).
+    function taxPolicyDetails()
+        external
+        view
+        returns (string memory ack, string memory uri)
+    {
+        if (address(taxPolicy) == address(0)) return ("", "");
+        ack = taxPolicy.acknowledge();
+        uri = taxPolicy.policyURI();
+    }
+
     function setJobParameters(uint256 reward, uint256 stake) external onlyOwner {
         jobReward = uint128(reward);
         jobStake = uint96(stake);

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -4,22 +4,32 @@ pragma solidity ^0.8.25;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title TaxPolicy
-/// @notice Stores a canonical tax policy URI and acknowledgement helper.
-/// @dev Contract owner alone may update the policy URI. The contract never holds
-/// funds and exists solely to provide an on-chain reference for off-chain tax
-/// responsibilities. AGI Employers, AGI Agents, and Validators remain fully
-/// responsible for their own tax obligations; the contract and its owner are
-/// always tax‑exempt.
+/// @notice Stores canonical tax policy metadata and acknowledgement text.
+/// @dev Contract owner alone may update the policy URI or acknowledgement.
+/// The contract never holds funds and exists solely to provide an on-chain
+/// reference for off-chain tax responsibilities. AGI Employers, AGI Agents, and
+/// Validators remain fully responsible for their own tax obligations; the
+/// contract and its owner are always tax-exempt.
 contract TaxPolicy is Ownable {
     /// @notice Off-chain document describing tax responsibilities.
     string public policyURI;
 
+    /// @notice Plain-text disclaimer accessible from explorers like Etherscan.
+    string public acknowledgement;
+
     /// @notice Emitted when the tax policy URI is updated.
     event TaxPolicyURIUpdated(string uri);
 
-    constructor(address owner_, string memory uri) Ownable(owner_) {
+    /// @notice Emitted when the acknowledgement text is updated.
+    event AcknowledgementUpdated(string text);
+
+    constructor(address owner_, string memory uri, string memory ack)
+        Ownable(owner_)
+    {
         policyURI = uri;
+        acknowledgement = ack;
         emit TaxPolicyURIUpdated(uri);
+        emit AcknowledgementUpdated(ack);
     }
 
     /// @notice Updates the off-chain policy URI.
@@ -29,11 +39,17 @@ contract TaxPolicy is Ownable {
         emit TaxPolicyURIUpdated(uri);
     }
 
-    /// @notice Returns a human-readable disclaimer for explorers like Etherscan.
+    /// @notice Updates the acknowledgement text returned on-chain.
+    /// @param text Human-readable disclaimer for participants.
+    function setAcknowledgement(string calldata text) external onlyOwner {
+        acknowledgement = text;
+        emit AcknowledgementUpdated(text);
+    }
+
+    /// @notice Returns a human-readable disclaimer confirming tax obligations.
     /// @return disclaimer Confirms all taxes fall on employers, agents, and validators.
-    function acknowledge() external pure returns (string memory disclaimer) {
-        return
-            "AGI Employers, Agents, and Validators handle all taxes; the contract and owner are tax-exempt.";
+    function acknowledge() external view returns (string memory disclaimer) {
+        return acknowledgement;
     }
 }
 

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -52,8 +52,9 @@ graph TD
 
 ### Tax Policy
 1. Open the `TaxPolicy` address in Etherscan.
-2. Under **Read Contract**, call **acknowledge** to view the disclaimer or **policyURI** for the canonical document.
-3. Only the owner may update the URI via **setPolicyURI** in **Write Contract**.
+2. Under **Read Contract**, call **acknowledgement** or **acknowledge** to view the disclaimer, or **policyURI** for the canonical document.
+3. `JobRegistry` exposes both fields via **taxPolicyDetails** for one-call access.
+4. Only the owner may update the URI with **setPolicyURI** or the message with **setAcknowledgement** in **Write Contract**.
 
 ### Disputers
 1. Open the `DisputeModule` address on Etherscan.

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -1,6 +1,6 @@
 # Tax Obligations in the AGI Job Platform Ecosystem
 
-The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction. The dedicated [`TaxPolicy`](../contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain by storing a canonical policy URI and returning a plain‑text acknowledgement—"AGI Employers, Agents, and Validators handle all taxes; the contract and owner are tax-exempt"—so non‑technical users can confirm the disclaimer through explorers like Etherscan.
+The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction. The dedicated [`TaxPolicy`](../contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain by storing both a canonical policy URI **and** a human‑readable acknowledgement string—each controlled solely by the owner—so non‑technical users can confirm the disclaimer through explorers like Etherscan.
 
 ## Employers
 - Provide the token escrow that funds jobs.

--- a/test/TaxPolicy.test.js
+++ b/test/TaxPolicy.test.js
@@ -9,7 +9,11 @@ describe("TaxPolicy", function () {
     const Factory = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    tax = await Factory.deploy(owner.address, "ipfs://initial");
+    tax = await Factory.deploy(
+      owner.address,
+      "ipfs://initial",
+      "initial ack"
+    );
     await tax.waitForDeployment();
   });
 
@@ -26,11 +30,22 @@ describe("TaxPolicy", function () {
       .withArgs(user.address);
   });
 
+  it("allows owner to update acknowledgement", async () => {
+    await tax.connect(owner).setAcknowledgement("updated ack");
+    expect(await tax.acknowledge()).to.equal("updated ack");
+  });
+
+  it("blocks non-owner acknowledgement updates", async () => {
+    await expect(
+      tax.connect(user).setAcknowledgement("x")
+    )
+      .to.be.revertedWithCustomError(tax, "OwnableUnauthorizedAccount")
+      .withArgs(user.address);
+  });
+
   it("returns acknowledgement string", async () => {
     const msg = await tax.acknowledge();
-    expect(msg).to.equal(
-      "AGI Employers, Agents, and Validators handle all taxes; the contract and owner are tax-exempt."
-    );
+    expect(msg).to.equal("initial ack");
   });
 });
 

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -13,7 +13,7 @@ describe("JobRegistry tax policy integration", function () {
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    policy = await Policy.deploy(owner.address, "ipfs://policy");
+    policy = await Policy.deploy(owner.address, "ipfs://policy", "ack");
   });
 
   it("allows owner to set policy and expose acknowledgement", async () => {
@@ -26,6 +26,12 @@ describe("JobRegistry tax policy integration", function () {
       await policy.acknowledge()
     );
     expect(await registry.taxPolicyURI()).to.equal("ipfs://policy");
+    let details = await registry.taxPolicyDetails();
+    expect(details[0]).to.equal("ack");
+    expect(details[1]).to.equal("ipfs://policy");
+    await policy.connect(owner).setAcknowledgement("new ack");
+    details = await registry.taxPolicyDetails();
+    expect(details[0]).to.equal("new ack");
   });
 
   it("blocks non-owner from setting policy", async () => {


### PR DESCRIPTION
## Summary
- allow contract owner to update on-chain tax disclaimer text alongside policy URI
- expose `taxPolicyDetails` in `JobRegistry` so explorers can fetch both disclaimer and URI in one call
- document how employers, agents, and validators handle taxes while the contract remains exempt

## Testing
- `npm run compile`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68969be708e083339f152744fd26ca39