### PR TITLE
Add tax policy management and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ No custom tooling is required—everything happens in the browser.
 
 The $AGI ERC‑20 token is deployed at `0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D`. Cross‑verify this address on Etherscan and Blockscout before transferring or staking tokens. Consult the [Safety Checklist](#safety-checklist) for operational best practices.
 
+## Tax Obligations & Disclaimer
+
+All tax duties in the AGI Jobs ecosystem fall solely on the participants who exchange value:
+
+- **Employers** treat burned tokens as an asset disposal and report any resulting gains or losses.
+- **Agents** report tokens received for completed work as income and later capital gains or losses when they dispose of them.
+- **Validators** report any reward tokens as income.
+
+The smart contracts and the corporation that deployed them never collect fees, hold funds, or realise gains. Consequently the infrastructure and its owner remain tax‑exempt in every jurisdiction. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain; non‑technical users can call `acknowledge()` on Etherscan to read the latest disclaimer. Only the owner may update the policy URI or message via `setPolicyURI`, `setAcknowledgement`, or the atomic `setPolicy` function.
+
 ## Architecture
 
 The modular design separates concerns across dedicated contracts:
@@ -603,7 +613,7 @@ Validator committees expand with job value and settle outcomes by majority after
 | `ReputationEngine` | `setCaller`, `setThreshold`, `setBlacklist` |
 | `DisputeModule` | `setAppealParameters` |
 | `CertificateNFT` | `setJobRegistry` |
-| `TaxPolicy` | `setPolicyURI`, `setAcknowledgement` |
+| `TaxPolicy` | `setPolicyURI`, `setAcknowledgement`, `setPolicy` |
 
 | Module | Interface / Key functions |
 | --- | --- |
@@ -613,7 +623,7 @@ Validator committees expand with job value and settle outcomes by majority after
 | `ReputationEngine` | [`IReputationEngine`](contracts/v2/interfaces/IReputationEngine.sol) – `addReputation`, `subtractReputation`, `setBlacklist`, `isBlacklisted` |
 | `DisputeModule` | [`IDisputeModule`](contracts/v2/interfaces/IDisputeModule.sol) – `raiseDispute`, `resolve` |
 | `CertificateNFT` | [`ICertificateNFT`](contracts/v2/interfaces/ICertificateNFT.sol) – `mint` |
-| `TaxPolicy` | – `policyURI`, `acknowledgement`, `setPolicyURI`, `setAcknowledgement`, `acknowledge` |
+| `TaxPolicy` | – `policyURI`, `acknowledgement`, `setPolicyURI`, `setAcknowledgement`, `setPolicy`, `acknowledge` |
 
 #### Module Addresses & Roles
 
@@ -644,7 +654,7 @@ graph TD
 - Verify each module address above on at least two explorers.
 - In Etherscan's **Write Contract** tab, connect your wallet and invoke the desired function.
 - Confirm emitted events to ensure configuration changes took effect.
-- `TaxPolicy` exposes `policyURI()`, `acknowledgement()`, and `acknowledge()` under the **Read** tab so participants can view the disclaimer; only the owner may update the URI via `setPolicyURI()` or the message via `setAcknowledgement()` in **Write**. `JobRegistry` mirrors both fields through `taxPolicyDetails()` for one-call discovery on explorers.
+- `TaxPolicy` exposes `policyURI()`, `acknowledgement()`, and `acknowledge()` under the **Read** tab so participants can view the disclaimer; only the owner may update the URI via `setPolicyURI()`, the message via `setAcknowledgement()`, or both at once via `setPolicy()` in **Write**. `JobRegistry` mirrors both fields through `taxPolicyDetails()` for one-call discovery on explorers.
 - `JobRegistry` mirrors the disclaimer with `taxAcknowledgement()` and `taxPolicyURI()` for easy discovery on explorers.
  
 Role-based quick steps:
@@ -1377,7 +1387,7 @@ All taxes arising from job transactions fall exclusively on the parties exchangi
 - **AGI Agents and validators** treat received tokens as income and later report any capital gains when those tokens are sold.
 - **Passive holders** have no tax impact until they dispose of their own tokens.
 
-The protocol’s smart contracts and the corporation that deployed them are perpetually tax‑exempt across all jurisdictions. They never collect fees, hold tokens, or take custody of funds, leaving no direct, indirect, or even theoretical tax liability for the infrastructure. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract stores a canonical policy URI and an owner‑editable acknowledgement string. Non‑technical users can confirm the disclaimer directly on Etherscan by calling `acknowledgement()`/`acknowledge()` on the `TaxPolicy` contract or `taxPolicyDetails()` on `JobRegistry`. Only the owner may update the URI with `setPolicyURI()` or the message with `setAcknowledgement()`.
+The protocol’s smart contracts and the corporation that deployed them are perpetually tax‑exempt across all jurisdictions. They never collect fees, hold tokens, or take custody of funds, leaving no direct, indirect, or even theoretical tax liability for the infrastructure. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract stores a canonical policy URI and an owner‑editable acknowledgement string. Non‑technical users can confirm the disclaimer directly on Etherscan by calling `acknowledgement()`/`acknowledge()` on the `TaxPolicy` contract or `taxPolicyDetails()` on `JobRegistry`. Only the owner may update the URI with `setPolicyURI()`, the message with `setAcknowledgement()`, or both with `setPolicy()`.
 
 See [docs/tax-obligations.md](docs/tax-obligations.md) for a detailed breakdown of responsibilities.
 

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -6,7 +6,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 /// @title TaxPolicy
 /// @notice Stores canonical tax policy metadata and acknowledgement text.
 /// @dev Contract owner alone may update the policy URI or acknowledgement.
-/// The contract never holds funds and exists solely to provide an on-chain
+/// The contract never accepts ether and exists solely to provide an on-chain
 /// reference for off-chain tax responsibilities. AGI Employers, AGI Agents, and
 /// Validators remain fully responsible for their own tax obligations; the
 /// contract and its owner are always tax-exempt.
@@ -46,10 +46,30 @@ contract TaxPolicy is Ownable {
         emit AcknowledgementUpdated(text);
     }
 
+    /// @notice Atomically updates both the policy URI and acknowledgement text.
+    /// @param uri New URI pointing to the policy text.
+    /// @param text Human-readable disclaimer for participants.
+    function setPolicy(string calldata uri, string calldata text) external onlyOwner {
+        policyURI = uri;
+        acknowledgement = text;
+        emit TaxPolicyURIUpdated(uri);
+        emit AcknowledgementUpdated(text);
+    }
+
     /// @notice Returns a human-readable disclaimer confirming tax obligations.
     /// @return disclaimer Confirms all taxes fall on employers, agents, and validators.
     function acknowledge() external view returns (string memory disclaimer) {
         return acknowledgement;
+    }
+
+    /// @dev Rejects any incoming ether.
+    receive() external payable {
+        revert("TaxPolicy: no ether");
+    }
+
+    /// @dev Rejects calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("TaxPolicy: no ether");
     }
 }
 

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -56,7 +56,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 1. Open the `TaxPolicy` address in Etherscan.
 2. Under **Read Contract**, call **acknowledgement** or **acknowledge** to view the disclaimer stating that the contracts and deploying corporation are tax‑exempt worldwide, or **policyURI** for the canonical document.
 3. `JobRegistry` exposes the same text and URI via **taxPolicyDetails** for one-call access.
-4. Only the owner may update the URI with **setPolicyURI** or the message with **setAcknowledgement** in **Write Contract**.
+4. Only the owner may update the URI with **setPolicyURI**, the message with **setAcknowledgement**, or both simultaneously with **setPolicy** in **Write Contract**.
 
 ### Disputers
 1. Open the `DisputeModule` address on Etherscan.

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -22,7 +22,7 @@ The AGI Jobs protocol routes all tax duties to the participants who exchange val
 - Do not mint, burn, or transfer tokens for themselves.
 - Provide infrastructure without consideration, so no sales/VAT/GST applies.
 - Therefore incur zero direct, indirect, or theoretical tax liability worldwide.
-- May update the `TaxPolicy` URI but remain tax‑exempt regardless of jurisdiction.
+ - May update the `TaxPolicy` URI and acknowledgement (individually or atomically) but remain tax‑exempt regardless of jurisdiction.
 
 ## Passive Token Holders
 - Passive holders unaffected by burns or job flows until they dispose of their own tokens.

--- a/test/TaxPolicy.test.js
+++ b/test/TaxPolicy.test.js
@@ -47,5 +47,25 @@ describe("TaxPolicy", function () {
     const msg = await tax.acknowledge();
     expect(msg).to.equal("initial ack");
   });
+
+  it("allows owner to update URI and acknowledgement atomically", async () => {
+    await tax.connect(owner).setPolicy("ipfs://u", "msg");
+    expect(await tax.policyURI()).to.equal("ipfs://u");
+    expect(await tax.acknowledge()).to.equal("msg");
+  });
+
+  it("rejects non-owner setPolicy calls", async () => {
+    await expect(
+      tax.connect(user).setPolicy("x", "y")
+    )
+      .to.be.revertedWithCustomError(tax, "OwnableUnauthorizedAccount")
+      .withArgs(user.address);
+  });
+
+  it("reverts on direct ether transfers", async () => {
+    await expect(
+      owner.sendTransaction({ to: await tax.getAddress(), value: 1 })
+    ).to.be.revertedWith("TaxPolicy: no ether");
+  });
 });
 


### PR DESCRIPTION
## Summary
- allow contract owner to atomically update tax policy URI and acknowledgement
- reject accidental ether transfers so TaxPolicy never holds funds
- document tax responsibilities and update Etherscan guide/README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896a17208888333aa30188dd9f7c773