### PR TITLE
Expose TaxPolicy interface and improve tax-policy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ All tax duties in the AGI Jobs ecosystem fall solely on the participants who exc
 
 The smart contracts and the corporation that deployed them never collect fees, hold funds, or realise gains. Consequently the infrastructure and its owner remain tax‑exempt in every jurisdiction. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain; non‑technical users can call `acknowledge()` on Etherscan to read the latest disclaimer. Only the owner may update the policy URI or message via `setPolicyURI`, `setAcknowledgement`, or the atomic `setPolicy` function.
 
+### Checking the tax disclaimer on Etherscan
+
+Non‑technical participants can verify the policy directly in a browser:
+
+1. Open the `TaxPolicy` contract address on a block explorer such as Etherscan.
+2. Under **Read Contract**, call `acknowledge()` to display the disclaimer or `policyURI()` for the canonical off‑chain document.
+3. Alternatively, read `taxPolicyDetails()` on the `JobRegistry` to fetch both values in a single call.
+4. Only the contract owner can change these fields via the **Write Contract** functions `setPolicyURI`, `setAcknowledgement`, or `setPolicy`.
+
+The contracts and their owner remain perpetually tax‑exempt.
+
 ## Architecture
 
 The modular design separates concerns across dedicated contracts:

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 
 interface IValidationModule {
     function validate(uint256 jobId) external view returns (bool);
@@ -27,11 +28,6 @@ interface IDisputeModule {
 
 interface ICertificateNFT {
     function mint(address to, uint256 jobId, string calldata uri) external returns (uint256);
-}
-
-interface ITaxPolicy {
-    function acknowledge() external view returns (string memory);
-    function policyURI() external view returns (string memory);
 }
 
 /// @title JobRegistry

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 
 /// @title TaxPolicy
 /// @notice Stores canonical tax policy metadata and acknowledgement text.
@@ -10,7 +11,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 /// reference for off-chain tax responsibilities. AGI Employers, AGI Agents, and
 /// Validators remain fully responsible for their own tax obligations; the
 /// contract and its owner are always tax-exempt.
-contract TaxPolicy is Ownable {
+contract TaxPolicy is Ownable, ITaxPolicy {
     /// @notice Off-chain document describing tax responsibilities.
     string public policyURI;
 

--- a/contracts/v2/interfaces/ITaxPolicy.sol
+++ b/contracts/v2/interfaces/ITaxPolicy.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title ITaxPolicy
+/// @notice Interface for retrieving tax policy details.
+interface ITaxPolicy {
+    /// @notice Returns a human-readable disclaimer confirming tax responsibilities.
+    /// @return disclaimer Confirms all taxes fall on employers, agents, and validators.
+    function acknowledge() external view returns (string memory disclaimer);
+
+    /// @notice Returns the URI pointing to the canonical policy document.
+    /// @return uri Off-chain document location (e.g., IPFS hash).
+    function policyURI() external view returns (string memory uri);
+}


### PR DESCRIPTION
## Summary
- add `ITaxPolicy` interface and implement it in `TaxPolicy`
- import `ITaxPolicy` in `JobRegistry` and expose helper to read policy/acknowledgement
- document how to verify tax disclaimer on Etherscan

## Testing
- `npm run lint` (warnings only)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896a598d7fc8333b9745f71927b1513