### PR TITLE
Clarify tax responsibilities and add policy integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,17 @@ All tax duties in the AGI Jobs ecosystem fall solely on the participants who exc
 - **Employers** treat burned tokens as an asset disposal and report any resulting gains or losses.
 - **Agents** report tokens received for completed work as income and later capital gains or losses when they dispose of them.
 - **Validators** report any reward tokens as income.
+- **Passive token holders** have no tax impact until they dispose of their own tokens.
 
-The smart contracts and the corporation that deployed them never collect fees, hold funds, or realise gains. Consequently the infrastructure and its owner remain tax‑exempt in every jurisdiction. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain; non‑technical users can call `acknowledge()` on Etherscan to read the latest disclaimer. Only the owner may update the policy URI or message via `setPolicyURI`, `setAcknowledgement`, or the atomic `setPolicy` function.
+The smart contracts and the corporation that deployed them never collect fees, hold funds, or realise gains. Consequently the infrastructure and its owner remain tax‑exempt in every jurisdiction with zero direct, indirect, or theoretical liability. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain and is the sole place the disclaimer may be updated.
 
 ### Checking the tax disclaimer on Etherscan
 
 Non‑technical participants can verify the policy directly in a browser:
 
 1. Open the `TaxPolicy` contract address on a block explorer such as Etherscan.
-2. Under **Read Contract**, call `acknowledge()` to display the disclaimer or `policyURI()` for the canonical off‑chain document.
-3. Alternatively, read `taxPolicyDetails()` on the `JobRegistry` to fetch both values in a single call.
+2. Under **Read Contract**, call `acknowledgement` (or `acknowledge`) to display the disclaimer and `policyURI` for the canonical document.
+3. Alternatively, read `taxPolicyDetails` on the `JobRegistry` to fetch both values in a single call.
 4. Only the contract owner can change these fields via the **Write Contract** functions `setPolicyURI`, `setAcknowledgement`, or `setPolicy`.
 
 The contracts and their owner remain perpetually tax‑exempt.
@@ -665,8 +666,11 @@ graph TD
 - Verify each module address above on at least two explorers.
 - In Etherscan's **Write Contract** tab, connect your wallet and invoke the desired function.
 - Confirm emitted events to ensure configuration changes took effect.
-- `TaxPolicy` exposes `policyURI()`, `acknowledgement()`, and `acknowledge()` under the **Read** tab so participants can view the disclaimer; only the owner may update the URI via `setPolicyURI()`, the message via `setAcknowledgement()`, or both at once via `setPolicy()` in **Write**. `JobRegistry` mirrors both fields through `taxPolicyDetails()` for one-call discovery on explorers.
-- `JobRegistry` mirrors the disclaimer with `taxAcknowledgement()` and `taxPolicyURI()` for easy discovery on explorers.
+- To review the tax disclaimer:
+  1. Open the `TaxPolicy` contract address.
+  2. In **Read Contract**, call `acknowledgement` (or `acknowledge`) and `policyURI`.
+  3. `JobRegistry` surfaces the same values via `taxPolicyDetails`, `taxAcknowledgement`, and `taxPolicyURI`.
+- Only the owner may update the policy via `setPolicyURI`, `setAcknowledgement`, or `setPolicy` in **Write Contract**.
  
 Role-based quick steps:
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -31,7 +31,10 @@ interface ICertificateNFT {
 }
 
 /// @title JobRegistry
-/// @notice Minimal registry coordinating job lifecycle and external modules.
+/// @notice Coordinates job lifecycle and external modules.
+/// @dev Tax obligations never accrue to this registry or its owner. All
+/// liabilities remain with employers, agents, and validators as expressed by
+/// the owner‑controlled `TaxPolicy` reference.
 contract JobRegistry is Ownable {
     enum State {
         None,
@@ -121,17 +124,22 @@ contract JobRegistry is Ownable {
         emit CertificateNFTUpdated(address(_certNFT));
     }
 
+    /// @notice Sets the TaxPolicy contract holding the canonical disclaimer.
+    /// @dev Only callable by the owner; the policy address cannot be zero.
     function setTaxPolicy(ITaxPolicy _policy) external onlyOwner {
         require(address(_policy) != address(0), "policy");
         taxPolicy = _policy;
         emit TaxPolicyUpdated(address(_policy));
     }
 
+    /// @notice Returns the on-chain acknowledgement string stating that all
+    /// taxes are the responsibility of employers, agents, and validators.
     function taxAcknowledgement() external view returns (string memory) {
         if (address(taxPolicy) == address(0)) return "";
         return taxPolicy.acknowledge();
     }
 
+    /// @notice Returns the URI pointing to the full off-chain tax policy.
     function taxPolicyURI() external view returns (string memory) {
         if (address(taxPolicy) == address(0)) return "";
         return taxPolicy.policyURI();

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -6,11 +6,12 @@ import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 
 /// @title TaxPolicy
 /// @notice Stores canonical tax policy metadata and acknowledgement text.
-/// @dev Contract owner alone may update the policy URI or acknowledgement.
-/// The contract never accepts ether and exists solely to provide an on-chain
-/// reference for off-chain tax responsibilities. AGI Employers, AGI Agents, and
-/// Validators remain fully responsible for their own tax obligations; the
-/// contract and its owner are always tax-exempt.
+/// @dev The owner may update the policy URI or acknowledgement, but neither the
+/// contract nor the deploying corporation ever accrues direct, indirect, or
+/// theoretical tax liability in any jurisdiction. It accepts no ether and
+/// provides only an on-chain pointer for off-chain responsibilities. AGI
+/// Employers, AGI Agents, and Validators bear all tax obligations while the
+/// infrastructure and its owner remain perpetually exempt.
 contract TaxPolicy is Ownable, ITaxPolicy {
     /// @notice Off-chain document describing tax responsibilities.
     string public policyURI;

--- a/test/jobTaxPolicy.test.js
+++ b/test/jobTaxPolicy.test.js
@@ -1,0 +1,44 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobRegistry tax policy integration", function () {
+  let owner, other, registry, policy;
+
+  beforeEach(async () => {
+    [owner, other] = await ethers.getSigners();
+    const TaxPolicyFactory = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    policy = await TaxPolicyFactory.deploy(
+      owner.address,
+      "ipfs://policy",
+      "ack"
+    );
+    await policy.waitForDeployment();
+
+    const RegistryFactory = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    registry = await RegistryFactory.deploy(owner.address);
+    await registry.waitForDeployment();
+  });
+
+  it("owner can set policy and expose details", async () => {
+    await registry
+      .connect(owner)
+      .setTaxPolicy(await policy.getAddress());
+    expect(await registry.taxAcknowledgement()).to.equal("ack");
+    expect(await registry.taxPolicyURI()).to.equal("ipfs://policy");
+    const [ack, uri] = await registry.taxPolicyDetails();
+    expect(ack).to.equal("ack");
+    expect(uri).to.equal("ipfs://policy");
+  });
+
+  it("non-owner cannot set policy", async () => {
+    await expect(
+      registry.connect(other).setTaxPolicy(await policy.getAddress())
+    )
+      .to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+  });
+});


### PR DESCRIPTION
## Summary
- document perpetual tax exemption in TaxPolicy and JobRegistry
- surface TaxPolicy getters on JobRegistry and guide users in README
- cover JobRegistry–TaxPolicy wiring with a dedicated test

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896a96e142c8333812c195d42096d24