### PR TITLE
Document tax policy and reject stray ether

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All tax duties in the AGI Jobs ecosystem fall solely on the participants who exc
 - **Validators** report any reward tokens as income.
 - **Passive token holders** have no tax impact until they dispose of their own tokens.
 
-The smart contracts and the corporation that deployed them never collect fees, hold funds, or realise gains. Consequently the infrastructure and its owner remain tax‑exempt in every jurisdiction with zero direct, indirect, or theoretical liability. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain and is the sole place the disclaimer may be updated.
+The smart contracts and the corporation that deployed them never collect fees, accept ether, hold funds, or realise gains. Stray transfers are rejected on‑chain, so the infrastructure and its owner remain tax‑exempt in every jurisdiction with zero direct, indirect, or theoretical liability. The owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain and is the only location where the disclaimer can be updated.
 
 ### Checking the tax disclaimer on Etherscan
 
@@ -69,7 +69,7 @@ Non‑technical participants can verify the policy directly in a browser:
 3. Alternatively, read `taxPolicyDetails` on the `JobRegistry` to fetch both values in a single call.
 4. Only the contract owner can change these fields via the **Write Contract** functions `setPolicyURI`, `setAcknowledgement`, or `setPolicy`.
 
-The contracts and their owner remain perpetually tax‑exempt.
+Both `JobRegistry` and `TaxPolicy` revert on direct ETH transfers, ensuring the contracts never take custody of funds. The contracts and their owner therefore remain perpetually tax‑exempt.
 
 ## Architecture
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -297,6 +297,21 @@ contract JobRegistry is Ownable {
         }
         emit JobCancelled(jobId);
     }
+
+    // ---------------------------------------------------------------------
+    // Ether rejection
+    // ---------------------------------------------------------------------
+    /// @dev Prevent accidental ETH transfers; this registry never holds funds
+    /// and cannot accrue tax liabilities. All value flows through the
+    /// StakeManager or DisputeModule according to participant actions.
+    receive() external payable {
+        revert("JobRegistry: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("JobRegistry: no ether");
+    }
 }
 
 

--- a/test/v2/JobRegistryNoEther.test.js
+++ b/test/v2/JobRegistryNoEther.test.js
@@ -1,0 +1,31 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobRegistry ether rejection", function () {
+  let owner, registry;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const Factory = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Factory.deploy(owner.address);
+    await registry.waitForDeployment();
+  });
+
+  it("reverts on direct ether transfer", async () => {
+    await expect(
+      owner.sendTransaction({ to: await registry.getAddress(), value: 1 })
+    ).to.be.revertedWith("JobRegistry: no ether");
+  });
+
+  it("reverts on unknown calldata with value", async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await registry.getAddress(),
+        data: "0x12345678",
+        value: 1,
+      })
+    ).to.be.revertedWith("JobRegistry: no ether");
+  });
+});


### PR DESCRIPTION
## Summary
- Reassert tax-exempt architecture by hardening JobRegistry against stray ETH and anchoring responsibilities in TaxPolicy
- Clarify README with jurisdiction-independent disclaimer and explorer instructions for verifying on-chain tax policy
- Add unit test covering JobRegistry ether rejection

## Testing
- `npm run compile`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896abf3f2148333928e5dfe6cdbf1b9