### PR TITLE
Rename jury configuration function in DisputeModule

### DIFF
--- a/contracts/v2/DisputeModule.sol
+++ b/contracts/v2/DisputeModule.sol
@@ -66,9 +66,9 @@ contract DisputeModule is IDisputeModule, Ownable {
     }
 
     /// @notice Set the jury allowed to resolve disputes alongside the owner
-    function setJury(address _jury) external override onlyOwner {
+    function setAppealJury(address _jury) external override onlyOwner {
         jury = _jury;
-        emit JuryUpdated(_jury);
+        emit AppealJuryUpdated(_jury);
     }
 
     /// @notice Configure the appeal bond required to escalate a job

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -23,7 +23,7 @@ interface IDisputeModule {
     event AppealResolved(uint256 indexed jobId, bool employerWins);
     event AppealFeeUpdated(uint256 fee);
     event ModeratorUpdated(address moderator);
-    event JuryUpdated(address jury);
+    event AppealJuryUpdated(address jury);
 
     /// @notice Escalate a job dispute by posting the appeal fee
     /// @param jobId Identifier of the disputed job
@@ -51,5 +51,5 @@ interface IDisputeModule {
     /// @notice Owner configuration for dispute jury
     /// @param jury Address allowed to resolve disputes alongside owner
     /// @dev Only callable by contract owner
-    function setJury(address jury) external;
+    function setAppealJury(address jury) external;
 }

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -17,7 +17,7 @@ describe("DisputeModule", function () {
     dispute = await Dispute.deploy(await jobRegistry.getAddress(), owner.address);
     await dispute.connect(owner).setAppealFee(appealFee);
     await dispute.connect(owner).setModerator(moderator.address);
-    await dispute.connect(owner).setJury(jury.address);
+    await dispute.connect(owner).setAppealJury(jury.address);
   });
 
   async function raise(jobId, agentSigner) {


### PR DESCRIPTION
## Summary
- rename `setJury` to `setAppealJury` in DisputeModule and interface
- emit `AppealJuryUpdated` when jury address changes
- update tests for new API

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6896b3e0fda0833381e50f413ff8c18c