### PR TITLE
feat: reject ether in reputation engine

### DIFF
--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -6,6 +6,8 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 /// @title ReputationEngine
 /// @notice Tracks reputation scores with blacklist enforcement.
 /// Only authorised callers may update scores.
+/// @dev Holds no funds and rejects ether so neither the contract nor the
+///      owner ever custodies assets or incurs tax liabilities.
 contract ReputationEngine is Ownable {
     mapping(address => uint256) private _scores;
     mapping(address => bool) private _blacklisted;
@@ -76,6 +78,20 @@ contract ReputationEngine is Ownable {
     /// @notice Check blacklist status for a user.
     function isBlacklisted(address user) external view returns (bool) {
         return _blacklisted[user];
+    }
+
+    // ---------------------------------------------------------------
+    // Ether rejection
+    // ---------------------------------------------------------------
+
+    /// @dev Reject direct ETH transfers to keep the contract tax neutral.
+    receive() external payable {
+        revert("ReputationEngine: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("ReputationEngine: no ether");
     }
 }
 

--- a/contracts/v2/modules/ReputationEngine.sol
+++ b/contracts/v2/modules/ReputationEngine.sol
@@ -5,6 +5,8 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title ReputationEngine (module)
 /// @notice Tracks reputation per role and enforces thresholds with blacklist support.
+/// @dev Holds no funds and rejects ether so neither the contract nor its owner
+///      ever custodies assets or incurs tax liabilities.
 contract ReputationEngine is Ownable {
     enum Role {
         Agent,
@@ -97,6 +99,20 @@ contract ReputationEngine is Ownable {
 
     function _isAuthorized(Role role) internal pure returns (bool) {
         return role == Role.Agent || role == Role.Validator;
+    }
+
+    // ---------------------------------------------------------------
+    // Ether rejection
+    // ---------------------------------------------------------------
+
+    /// @dev Reject direct ETH transfers to keep the contract tax neutral.
+    receive() external payable {
+        revert("ReputationEngine: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("ReputationEngine: no ether");
     }
 }
 

--- a/test/v2/ReputationEngineModuleNoEther.test.js
+++ b/test/v2/ReputationEngineModuleNoEther.test.js
@@ -1,0 +1,31 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ReputationEngine module ether rejection", function () {
+  let owner, engine;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const Engine = await ethers.getContractFactory(
+      "contracts/v2/modules/ReputationEngine.sol:ReputationEngine"
+    );
+    engine = await Engine.deploy(owner.address);
+    await engine.waitForDeployment();
+  });
+
+  it("reverts on direct ether transfer", async () => {
+    await expect(
+      owner.sendTransaction({ to: await engine.getAddress(), value: 1 })
+    ).to.be.revertedWith("ReputationEngine: no ether");
+  });
+
+  it("reverts on unknown calldata with value", async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await engine.getAddress(),
+        data: "0x12345678",
+        value: 1,
+      })
+    ).to.be.revertedWith("ReputationEngine: no ether");
+  });
+});

--- a/test/v2/ReputationEngineNoEther.test.js
+++ b/test/v2/ReputationEngineNoEther.test.js
@@ -1,0 +1,31 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ReputationEngine ether rejection", function () {
+  let owner, engine;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const Engine = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    engine = await Engine.deploy(owner.address);
+    await engine.waitForDeployment();
+  });
+
+  it("reverts on direct ether transfer", async () => {
+    await expect(
+      owner.sendTransaction({ to: await engine.getAddress(), value: 1 })
+    ).to.be.revertedWith("ReputationEngine: no ether");
+  });
+
+  it("reverts on unknown calldata with value", async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await engine.getAddress(),
+        data: "0x12345678",
+        value: 1,
+      })
+    ).to.be.revertedWith("ReputationEngine: no ether");
+  });
+});


### PR DESCRIPTION
## Summary
- prevent ReputationEngine contracts from receiving ETH with reverting receive and fallback handlers
- document that the contracts and owners never hold funds or incur taxes
- test main and module ReputationEngine contracts reject direct ETH transfers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896b967df7483338d43be41b26e2e1d