### PR TITLE
feat: block ether in CertificateNFT

### DIFF
--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -7,6 +7,8 @@ import {ICertificateNFT} from "./interfaces/ICertificateNFT.sol";
 
 /// @title CertificateNFT
 /// @notice ERC721 certificate minted upon successful job completion.
+/// @dev Holds no ether so neither the contract nor its owner ever custodies
+///      assets or accrues taxable exposure in any jurisdiction.
 contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     address public jobRegistry;
     string private baseTokenURI;
@@ -60,6 +62,21 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
             return string.concat(base, custom);
         }
         return custom;
+    }
+
+    // ---------------------------------------------------------------------
+    // Ether rejection
+    // ---------------------------------------------------------------------
+
+    /// @dev Reject direct ETH transfers to keep the contract and its owner
+    /// tax neutral.
+    receive() external payable {
+        revert("CertificateNFT: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("CertificateNFT: no ether");
     }
 }
 

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -7,6 +7,8 @@ import {ICertificateNFT} from "../interfaces/ICertificateNFT.sol";
 
 /// @title CertificateNFT (module)
 /// @notice ERC721 certificate minted upon successful job completion.
+/// @dev Holds no ether so neither the contract nor its owner ever custodies
+///      assets or incurs taxable obligations.
 contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     address public jobRegistry;
     mapping(uint256 => string) private _tokenURIs;
@@ -41,6 +43,21 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         _requireOwned(tokenId);
         return _tokenURIs[tokenId];
+    }
+
+    // ---------------------------------------------------------------
+    // Ether rejection
+    // ---------------------------------------------------------------
+
+    /// @dev Reject direct ETH transfers to keep the contract and its owner
+    /// free of taxable assets.
+    receive() external payable {
+        revert("CertificateNFT: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("CertificateNFT: no ether");
     }
 }
 

--- a/test/v2/CertificateNFTModuleNoEther.test.js
+++ b/test/v2/CertificateNFTModuleNoEther.test.js
@@ -1,0 +1,31 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CertificateNFT module ether rejection", function () {
+  let owner, nft;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const NFT = await ethers.getContractFactory(
+      "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
+    );
+    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    await nft.waitForDeployment();
+  });
+
+  it("reverts on direct ether transfer", async () => {
+    await expect(
+      owner.sendTransaction({ to: await nft.getAddress(), value: 1 })
+    ).to.be.revertedWith("CertificateNFT: no ether");
+  });
+
+  it("reverts on unknown calldata with value", async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await nft.getAddress(),
+        data: "0x12345678",
+        value: 1,
+      })
+    ).to.be.revertedWith("CertificateNFT: no ether");
+  });
+});

--- a/test/v2/CertificateNFTNoEther.test.js
+++ b/test/v2/CertificateNFTNoEther.test.js
@@ -1,0 +1,31 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CertificateNFT ether rejection", function () {
+  let owner, nft;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const NFT = await ethers.getContractFactory(
+      "contracts/v2/CertificateNFT.sol:CertificateNFT"
+    );
+    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    await nft.waitForDeployment();
+  });
+
+  it("reverts on direct ether transfer", async () => {
+    await expect(
+      owner.sendTransaction({ to: await nft.getAddress(), value: 1 })
+    ).to.be.revertedWith("CertificateNFT: no ether");
+  });
+
+  it("reverts on unknown calldata with value", async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await nft.getAddress(),
+        data: "0x12345678",
+        value: 1,
+      })
+    ).to.be.revertedWith("CertificateNFT: no ether");
+  });
+});


### PR DESCRIPTION
## Summary
- add receive and fallback handlers to CertificateNFT contracts that reject ETH so contract and owner remain tax neutral
- document that CertificateNFT contracts hold no taxable assets
- test both CertificateNFT variants revert on unexpected ETH

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896bb4a5e34833398a3d463f536cfbb