### PR TITLE
Clarify tax responsibility and reject stray ETH in v2 modules

### DIFF
--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -7,8 +7,8 @@ import {ICertificateNFT} from "../interfaces/ICertificateNFT.sol";
 
 /// @title CertificateNFT (module)
 /// @notice ERC721 certificate minted upon successful job completion.
-/// @dev Holds no ether so neither the contract nor its owner ever custodies
-///      assets or incurs taxable obligations.
+/// @dev Only participants bear any tax obligations; the contract holds no
+///      ether and rejects unsolicited transfers.
 contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     address public jobRegistry;
     mapping(uint256 => string) private _tokenURIs;

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -6,6 +6,8 @@ import {IJobRegistry} from "../interfaces/IJobRegistry.sol";
 
 /// @title DisputeModule
 /// @notice Allows job participants to raise disputes with evidence and resolves them after a dispute window.
+/// @dev Only participants bear any tax obligations; the module temporarily
+/// holds dispute bonds and rejects unsolicited ETH transfers.
 contract DisputeModule is Ownable {
     IJobRegistry public jobRegistry;
 
@@ -119,6 +121,19 @@ contract DisputeModule is Ownable {
     /// @dev Determine dispute outcome. Uses blockhash for a pseudorandom coin flip.
     function _decideOutcome(uint256 jobId) internal view returns (bool) {
         return uint256(blockhash(block.number - 1) ^ bytes32(jobId)) % 2 == 0;
+    }
+    // ---------------------------------------------------------------
+    // Ether rejection
+    // ---------------------------------------------------------------
+
+    /// @dev Reject direct ETH transfers that are not dispute bonds.
+    receive() external payable {
+        revert("DisputeModule: no direct ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("DisputeModule: no direct ether");
     }
 }
 

--- a/contracts/v2/modules/ReputationEngine.sol
+++ b/contracts/v2/modules/ReputationEngine.sol
@@ -5,8 +5,8 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title ReputationEngine (module)
 /// @notice Tracks reputation per role and enforces thresholds with blacklist support.
-/// @dev Holds no funds and rejects ether so neither the contract nor its owner
-///      ever custodies assets or incurs tax liabilities.
+/// @dev Only participants bear any tax obligations; the contract holds no funds
+///      and rejects ether.
 contract ReputationEngine is Ownable {
     enum Role {
         Agent,

--- a/contracts/v2/modules/StakeManager.sol
+++ b/contracts/v2/modules/StakeManager.sol
@@ -10,6 +10,8 @@ import {IStakeManager} from "../interfaces/IStakeManager.sol";
 
 /// @title StakeManager (module)
 /// @notice Minimal stake escrow with role based accounting and slashing.
+/// @dev Only participants bear any tax obligations; this contract remains
+/// tax neutral and rejects any direct ETH transfers.
 contract StakeManager is Ownable, ReentrancyGuard, IStakeManager {
     using SafeERC20 for IERC20;
 
@@ -161,6 +163,19 @@ contract StakeManager is Ownable, ReentrancyGuard, IStakeManager {
         returns (uint256)
     {
         return _locked[user][role];
+    }
+    // ---------------------------------------------------------------
+    // Ether rejection
+    // ---------------------------------------------------------------
+
+    /// @dev Reject direct ETH transfers to keep the contract tax neutral.
+    receive() external payable {
+        revert("StakeManager: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("StakeManager: no ether");
     }
 }
 

--- a/test/v2/DisputeModuleModuleNoEther.test.js
+++ b/test/v2/DisputeModuleModuleNoEther.test.js
@@ -1,0 +1,35 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("DisputeModule module ether rejection", function () {
+  let owner, registry, dispute;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const JobMock = await ethers.getContractFactory("MockJobRegistry");
+    registry = await JobMock.deploy();
+    await registry.waitForDeployment();
+    const Dispute = await ethers.getContractFactory(
+      "contracts/v2/modules/DisputeModule.sol:DisputeModule"
+    );
+    dispute = await Dispute.deploy(await registry.getAddress(), owner.address);
+    await dispute.waitForDeployment();
+  });
+
+  it("reverts on direct ether transfer", async () => {
+    await expect(
+      owner.sendTransaction({ to: await dispute.getAddress(), value: 1 })
+    ).to.be.revertedWith("DisputeModule: no direct ether");
+  });
+
+  it("reverts on unknown calldata with value", async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await dispute.getAddress(),
+        data: "0x12345678",
+        value: 1,
+      })
+    ).to.be.revertedWith("DisputeModule: no direct ether");
+  });
+});
+

--- a/test/v2/StakeManagerModuleNoEther.test.js
+++ b/test/v2/StakeManagerModuleNoEther.test.js
@@ -1,0 +1,37 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("StakeManager module ether rejection", function () {
+  let owner, token, stakeManager;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockERC20");
+    token = await Token.deploy();
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/modules/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      owner.address
+    );
+    await stakeManager.waitForDeployment();
+  });
+
+  it("reverts on direct ether transfer", async () => {
+    await expect(
+      owner.sendTransaction({ to: await stakeManager.getAddress(), value: 1 })
+    ).to.be.revertedWith("StakeManager: no ether");
+  });
+
+  it("reverts on unknown calldata with value", async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await stakeManager.getAddress(),
+        data: "0x12345678",
+        value: 1,
+      })
+    ).to.be.revertedWith("StakeManager: no ether");
+  });
+});
+


### PR DESCRIPTION
## Summary
- clarify tax obligations are solely on participants across v2 modules
- add receive/fallback handlers rejecting direct ETH in StakeManager and DisputeModule
- test ETH rejection for StakeManager and DisputeModule modules

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6896be6dc66c83339162ca4d30d7ac1d