### PR TITLE
Add ETH rejection and owner-only tests

### DIFF
--- a/test/JobNFT.test.js
+++ b/test/JobNFT.test.js
@@ -21,6 +21,18 @@ describe("JobNFT", function () {
       .withArgs("ipfs://");
   });
 
+  it("allows only owner to set job registry", async function () {
+    const { nft, jobRegistry, user } = await deployFixture();
+    await expect(
+      nft.connect(jobRegistry).setJobRegistry(user.address)
+    )
+      .to.be.revertedWithCustomError(nft, "OwnableUnauthorizedAccount")
+      .withArgs(jobRegistry.address);
+    await expect(nft.setJobRegistry(user.address))
+      .to.emit(nft, "JobRegistryUpdated")
+      .withArgs(user.address);
+  });
+
   it("mints and burns only via JobRegistry", async function () {
     const { nft, jobRegistry, user } = await deployFixture();
     await expect(nft.connect(user).mint(user.address, "job1.json"))

--- a/test/ReputationEngine.test.js
+++ b/test/ReputationEngine.test.js
@@ -4,8 +4,8 @@ const { ethers } = require("hardhat");
 describe("ReputationEngine", function () {
   let engine, owner, agentCaller, validatorCaller, user;
 
-    beforeEach(async () => {
-      [owner, agentCaller, validatorCaller, user] = await ethers.getSigners();
+  beforeEach(async () => {
+    [owner, agentCaller, validatorCaller, user] = await ethers.getSigners();
       const Engine = await ethers.getContractFactory(
         "contracts/ReputationEngine.sol:ReputationEngine"
       );
@@ -41,6 +41,25 @@ describe("ReputationEngine", function () {
     await expect(
       engine.connect(user).addReputation(user.address, 1)
     ).to.be.revertedWith("not authorized");
+  });
+
+  it("allows only owner to configure", async () => {
+    await expect(
+      engine.connect(agentCaller).setCaller(user.address, 1)
+    )
+      .to.be.revertedWithCustomError(
+        engine,
+        "OwnableUnauthorizedAccount"
+      )
+      .withArgs(agentCaller.address);
+
+    await expect(engine.connect(agentCaller).setAgentThreshold(1))
+      .to.be.revertedWithCustomError(engine, "OwnableUnauthorizedAccount")
+      .withArgs(agentCaller.address);
+
+    await expect(engine.connect(agentCaller).setValidatorThreshold(1))
+      .to.be.revertedWithCustomError(engine, "OwnableUnauthorizedAccount")
+      .withArgs(agentCaller.address);
   });
 });
 

--- a/test/jobRegistryOwnership.test.js
+++ b/test/jobRegistryOwnership.test.js
@@ -1,0 +1,37 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobRegistry ownership", function () {
+  let owner, user, registry;
+
+  beforeEach(async () => {
+    [owner, user] = await ethers.getSigners();
+    const Factory = await ethers.getContractFactory(
+      "contracts/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Factory.deploy(owner.address);
+    await registry.waitForDeployment();
+  });
+
+  it("restricts configuration to owner", async () => {
+    await expect(
+      registry
+        .connect(user)
+        .setModules(
+          user.address,
+          user.address,
+          user.address,
+          user.address,
+          user.address
+        )
+    )
+      .to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount")
+      .withArgs(user.address);
+
+    await expect(
+      registry.connect(user).setJobParameters(1, 1)
+    )
+      .to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount")
+      .withArgs(user.address);
+  });
+});

--- a/test/legacyNoEther.test.js
+++ b/test/legacyNoEther.test.js
@@ -1,0 +1,105 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Legacy contract ether rejection", function () {
+  let owner;
+
+  before(async () => {
+    [owner] = await ethers.getSigners();
+  });
+
+  async function expectReject(contract) {
+    await expect(
+      owner.sendTransaction({ to: await contract.getAddress(), value: 1 })
+    ).to.be.reverted;
+  }
+
+  it("JobRegistry", async () => {
+    const Factory = await ethers.getContractFactory(
+      "contracts/JobRegistry.sol:JobRegistry"
+    );
+    const registry = await Factory.deploy(owner.address);
+    await registry.waitForDeployment();
+    await expectReject(registry);
+  });
+
+  it("JobNFT", async () => {
+    const Factory = await ethers.getContractFactory("JobNFT");
+    const nft = await Factory.deploy("Job", "JOB", owner.address);
+    await nft.waitForDeployment();
+    await expectReject(nft);
+  });
+
+  it("ReputationEngine", async () => {
+    const Factory = await ethers.getContractFactory(
+      "contracts/ReputationEngine.sol:ReputationEngine"
+    );
+    const engine = await Factory.deploy(owner.address);
+    await engine.waitForDeployment();
+    await expectReject(engine);
+  });
+
+  it("ValidationModule", async () => {
+    const Factory = await ethers.getContractFactory(
+      "contracts/ValidationModule.sol:ValidationModule"
+    );
+    const module = await Factory.deploy(owner.address);
+    await module.waitForDeployment();
+    await expectReject(module);
+  });
+
+  it("StakeManager", async () => {
+    const Token = await ethers.getContractFactory(
+      "contracts/mocks/MockERC20.sol:MockERC20"
+    );
+    const token = await Token.deploy();
+    await token.waitForDeployment();
+    const Factory = await ethers.getContractFactory(
+      "contracts/StakeManager.sol:StakeManager"
+    );
+    const stake = await Factory.deploy(await token.getAddress(), owner.address);
+    await stake.waitForDeployment();
+    await expectReject(stake);
+  });
+
+  it("CertificateNFT", async () => {
+    const Factory = await ethers.getContractFactory(
+      "contracts/CertificateNFT.sol:CertificateNFT"
+    );
+    const cert = await Factory.deploy("Cert", "CERT", owner.address);
+    await cert.waitForDeployment();
+    await expectReject(cert);
+  });
+
+  it("AGIJobManagerV1", async () => {
+    const Token = await ethers.getContractFactory(
+      "contracts/mocks/MockERC20.sol:MockERC20"
+    );
+    const token = await Token.deploy();
+    await token.waitForDeployment();
+    const ENS = await ethers.getContractFactory(
+      "contracts/mocks/MockENS.sol:MockENS"
+    );
+    const ens = await ENS.deploy();
+    await ens.waitForDeployment();
+    const Wrapper = await ethers.getContractFactory(
+      "contracts/mocks/MockNameWrapper.sol:MockNameWrapper"
+    );
+    const wrapper = await Wrapper.deploy();
+    await wrapper.waitForDeployment();
+    const Manager = await ethers.getContractFactory("AGIJobManagerV1");
+    const manager = await Manager.deploy(
+      await token.getAddress(),
+      "ipfs://",
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+    await manager.waitForDeployment();
+    await expectReject(manager);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure all contracts revert on direct ETH transfers
- restrict configuration functions to the owner in JobNFT, JobRegistry, and ReputationEngine

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896c1bf06888333b8107fb0ad624e84