### PR TITLE
Add tax policy and job registry acknowledgement tests

### DIFF
--- a/test/jobRegistry.ts
+++ b/test/jobRegistry.ts
@@ -1,0 +1,81 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobRegistry tax policy gating", function () {
+  let owner;
+  let employer;
+  let agent;
+  let registry;
+  let policy;
+
+  beforeEach(async () => {
+    [owner, employer, agent] = await ethers.getSigners();
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Registry.deploy(owner.address);
+
+    const Policy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    policy = await Policy.deploy(owner.address, "ipfs://policy", "ack");
+
+    await registry
+      .connect(owner)
+      .setJobParameters(1, 0);
+  });
+
+  it("requires acknowledgement before job actions", async () => {
+    await expect(
+      registry.connect(employer).createJob()
+    ).to.be.revertedWith("acknowledge tax policy");
+
+    await expect(
+      registry.connect(owner).setTaxPolicy(await policy.getAddress())
+    )
+      .to.emit(registry, "TaxPolicyUpdated")
+      .withArgs(await policy.getAddress());
+
+    await expect(
+      registry.connect(employer).createJob()
+    ).to.be.revertedWith("acknowledge tax policy");
+
+    await expect(
+      registry.connect(employer).acknowledgeTaxPolicy()
+    )
+      .to.emit(registry, "TaxAcknowledged")
+      .withArgs(employer.address);
+
+    await expect(
+      registry.connect(employer).createJob()
+    ).to.emit(registry, "JobCreated").withArgs(1, employer.address, ethers.ZeroAddress, 1, 0);
+
+    await expect(
+      registry.connect(agent).applyForJob(1)
+    ).to.be.revertedWith("acknowledge tax policy");
+
+    await expect(
+      registry.connect(agent).acknowledgeTaxPolicy()
+    )
+      .to.emit(registry, "TaxAcknowledged")
+      .withArgs(agent.address);
+
+    await expect(
+      registry.connect(agent).applyForJob(1)
+    ).to.emit(registry, "AgentApplied").withArgs(1, agent.address);
+  });
+
+  it("only owner can set tax policy", async () => {
+    await expect(
+      registry.connect(owner).setTaxPolicy(await policy.getAddress())
+    )
+      .to.emit(registry, "TaxPolicyUpdated")
+      .withArgs(await policy.getAddress());
+
+    await expect(
+      registry.connect(employer).setTaxPolicy(await policy.getAddress())
+    )
+      .to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount")
+      .withArgs(employer.address);
+  });
+});

--- a/test/taxPolicy.ts
+++ b/test/taxPolicy.ts
@@ -2,7 +2,9 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("TaxPolicy", function () {
-  let owner, user, tax;
+  let owner;
+  let user;
+  let tax;
 
   beforeEach(async () => {
     [owner, user] = await ethers.getSigners();
@@ -71,6 +73,16 @@ describe("TaxPolicy", function () {
   it("reverts on direct ether transfers", async () => {
     await expect(
       owner.sendTransaction({ to: await tax.getAddress(), value: 1 })
+    ).to.be.revertedWith("TaxPolicy: no ether");
+  });
+
+  it("rejects ether via fallback", async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await tax.getAddress(),
+        value: 1,
+        data: "0x1234",
+      })
     ).to.be.revertedWith("TaxPolicy: no ether");
   });
 });


### PR DESCRIPTION
## Summary
- add TypeScript coverage for TaxPolicy owner controls, details helpers, and ETH rejection
- ensure JobRegistry actions require tax policy acknowledgement and emit events

## Testing
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_68974092c9848333aebbde5e3e7b0626