### PR TITLE
feat: enforce versioned tax policy acknowledgements

### DIFF
--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -55,8 +55,8 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 
 1. Open the `TaxPolicy` address in Etherscan.
 2. Under **Read Contract**, call **policyDetails** to return both the disclaimer and canonical document URI, or call **acknowledgement**/ **acknowledge** and **policyURI** individually.
-3. `JobRegistry` exposes the same text and URI via **taxPolicyDetails** for one-call access.
-4. Only the owner may update the URI with **setPolicyURI**, the message with **setAcknowledgement**, or both simultaneously with **setPolicy** in **Write Contract**.
+3. `JobRegistry` exposes the same text and URI via **taxPolicyDetails** and reveals the active **taxPolicyVersion**; participants can confirm their latest acknowledgement through **taxAcknowledgedVersion(address)**.
+4. Only the owner may update the URI with **setPolicyURI**, the message with **setAcknowledgement**, or both simultaneously with **setPolicy** in **Write Contract**. The owner can force a fresh acknowledgement without changing addresses by calling **bumpTaxPolicyVersion** on `JobRegistry`.
 
 ### Disputers
 1. Open the `DisputeModule` address on Etherscan.

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -2,6 +2,8 @@
 
 The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction and remain exempt from direct, indirect, or theoretical taxes. The dedicated [`TaxPolicy`](../contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain by storing both a canonical policy URI **and** a human‑readable acknowledgement string—each controlled solely by the owner—so non‑technical users can confirm the disclaimer through explorers like Etherscan. Call `policyDetails` to fetch both fields at once, `acknowledgement` (or `acknowledge`) and `policyURI` individually on the `TaxPolicy` contract, or `taxPolicyDetails` on `JobRegistry`. Only the owner can update these values via `setPolicyURI`, `setAcknowledgement`, or `setPolicy`; unauthorized calls revert.
 
+`JobRegistry` maintains an incrementing `taxPolicyVersion` and records the last acknowledged version per address in `taxAcknowledgedVersion`. Any update or explicit version bump by the owner requires employers, agents, and validators to call `acknowledgeTaxPolicy` again before interacting, keeping the tax disclaimer evergreen while the platform itself remains tax‑exempt.
+
 ## Employers
 - Provide the token escrow that funds jobs.
 - When a job finalizes, a portion of the employer's deposit is burned.

--- a/test/jobRegistry.ts
+++ b/test/jobRegistry.ts
@@ -34,7 +34,7 @@ describe("JobRegistry tax policy gating", function () {
       registry.connect(owner).setTaxPolicy(await policy.getAddress())
     )
       .to.emit(registry, "TaxPolicyUpdated")
-      .withArgs(await policy.getAddress());
+      .withArgs(await policy.getAddress(), 1);
 
     await expect(
       registry.connect(employer).createJob()
@@ -44,7 +44,7 @@ describe("JobRegistry tax policy gating", function () {
       registry.connect(employer).acknowledgeTaxPolicy()
     )
       .to.emit(registry, "TaxAcknowledged")
-      .withArgs(employer.address);
+      .withArgs(employer.address, 1);
 
     await expect(
       registry.connect(employer).createJob()
@@ -58,7 +58,7 @@ describe("JobRegistry tax policy gating", function () {
       registry.connect(agent).acknowledgeTaxPolicy()
     )
       .to.emit(registry, "TaxAcknowledged")
-      .withArgs(agent.address);
+      .withArgs(agent.address, 1);
 
     await expect(
       registry.connect(agent).applyForJob(1)
@@ -70,7 +70,7 @@ describe("JobRegistry tax policy gating", function () {
       registry.connect(owner).setTaxPolicy(await policy.getAddress())
     )
       .to.emit(registry, "TaxPolicyUpdated")
-      .withArgs(await policy.getAddress());
+      .withArgs(await policy.getAddress(), 1);
 
     await expect(
       registry.connect(employer).setTaxPolicy(await policy.getAddress())


### PR DESCRIPTION
## Summary
- require participants to acknowledge a versioned tax disclaimer before interacting
- allow owner to bump tax policy versions and keep participants in sync
- document tax policy versioning and Etherscan usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897436d0cd0833394cf4d2483ad38c6