### PR TITLE
docs: clarify tax responsibilities and owner control

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The $AGI ERC‑20 token is deployed at `0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f1
 
 ## Tax Obligations & Disclaimer
 
-All taxes in the AGI Jobs ecosystem fall solely on the parties exchanging value while the infrastructure and its owner remain perpetually tax‑exempt:
+All taxes in the AGI Jobs ecosystem fall solely on AGI Employers, AGI Agents, and Validators who exchange value. The smart contract suite and the deploying corporation are perpetually exempt from any direct, indirect, or theoretical tax liability in every jurisdiction:
 
 - **Employers** fund jobs and supply the tokens that may be burned. Burning is a disposal of property, so employers calculate any capital gain or loss on the burned amount. Tokens paid to agents may be deductible business expenses.
 - **Agents** receive tokens as compensation. The fair‑market value at receipt is ordinary income and becomes the cost basis for later capital gain or loss calculations. Burned tokens never belong to the agent and carry no tax impact.

--- a/docs/coding-sprint-v2.md
+++ b/docs/coding-sprint-v2.md
@@ -34,10 +34,12 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
    - Freeze compiler versions and verify bytecode locally.
    - Generate deployment scripts that record module addresses for `JobRegistry` wiring.
 7. **Tax Responsibility & Owner Neutrality**
-   - Ensure no module ever routes tokens or fees to the owner; the contracts and deploying corporation must remain revenue‑free and tax‑exempt worldwide.
-   - Wire the owner‑controlled `TaxPolicy` into `JobRegistry` and surface `taxPolicyDetails()` so explorers can display the canonical acknowledgement and policy URI.
+   - Ensure no module ever routes tokens or fees to the owner; the contracts and deploying corporation must remain revenue-free and tax-exempt worldwide.
+   - Require participants to call `acknowledgeTaxPolicy` before interacting with `JobRegistry`, tracking acknowledgements per address.
+   - Wire the owner-controlled `TaxPolicy` into `JobRegistry` and surface `taxPolicyDetails()` so explorers can display the canonical acknowledgement and policy URI.
+   - Guarantee only the owner can update the policy via `setPolicyURI`, `setAcknowledgement`, `setPolicy`, or `bumpTaxPolicyVersion`; unauthorized calls revert.
    - Describe in NatSpec and README that all tax obligations rest solely with AGI Employers, Agents, and Validators; the infrastructure bears no direct, indirect, or theoretical liability.
-   - Provide step‑by‑step Etherscan instructions so non‑technical users can view the disclaimer via `acknowledgement`/`acknowledge` and so the owner can update it with `setPolicyURI`/`setAcknowledgement`.
+   - Provide step-by-step Etherscan instructions so non-technical users can view the disclaimer via `acknowledgement`/`acknowledge` and so the owner can update it with `setPolicyURI`/`setAcknowledgement`.
 
 ## Deliverables
 - Verified Solidity contracts under `contracts/v2`.


### PR DESCRIPTION
## Summary
- Clarify in README that tax liability rests solely on AGI Employers, Agents, and Validators while the contracts and deploying corporation remain universally tax-exempt
- Expand v2 coding sprint with tasks for tax-policy acknowledgements and owner-only updates, ensuring explorer-friendly steps

## Testing
- `npm run compile`
- `npm run lint` (warnings only)
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68974ed70cec83338633c91f69d8ab3c