### PR TITLE
Add explicit tax exemption helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The smart contracts and the corporation that deployed them:
 
 These principles are encoded on‑chain via the owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract. The owner alone may revise the canonical policy URI or acknowledgement text using `setPolicyURI`, `setAcknowledgement`, or `setPolicy`; unauthorized calls revert. Each update or explicit version bump triggers an incrementing `taxPolicyVersion` in [`JobRegistry`](contracts/v2/JobRegistry.sol) and forces all non‑owner participants to re‑acknowledge the disclaimer. Acknowledgements are tracked per user through `taxAcknowledgedVersion`. The owner can require a fresh acknowledgement without changing the policy address by calling `bumpTaxPolicyVersion`. `JobRegistry` mirrors the current disclaimer via `taxAcknowledgement`, `taxPolicyURI`, and `taxPolicyDetails` so any participant can confirm the message in a single read. See [tax-obligations.md](docs/tax-obligations.md) for a broader discussion and [TaxPolicyv0.md](docs/TaxPolicyv0.md) for the jurisdictional rationale.
 
+For easy verification on block explorers, `TaxPolicy` exposes `isTaxExempt()` which always returns `true`, signalling that neither the contract nor its owner can ever accrue tax liability.
+
 ### Checking the tax disclaimer on Etherscan
 
 Non‑technical participants can verify the policy directly in a browser:

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -76,6 +76,12 @@ contract TaxPolicy is Ownable, ITaxPolicy {
         uri = policyURI;
     }
 
+    /// @notice Confirms the contract and its owner are perpetually tax‑exempt.
+    /// @return True, signalling that no tax liability can ever accrue here.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
     /// @dev Rejects any incoming ether.
     receive() external payable {
         revert("TaxPolicy: no ether");

--- a/contracts/v2/interfaces/ITaxPolicy.sol
+++ b/contracts/v2/interfaces/ITaxPolicy.sol
@@ -19,4 +19,8 @@ interface ITaxPolicy {
         external
         view
         returns (string memory ack, string memory uri);
+
+    /// @notice Indicates that the contract and its owner hold no tax liability.
+    /// @return Always true; the infrastructure is perpetually tax‑exempt.
+    function isTaxExempt() external pure returns (bool);
 }

--- a/test/taxPolicy.ts
+++ b/test/taxPolicy.ts
@@ -70,6 +70,10 @@ describe("TaxPolicy", function () {
       .withArgs(user.address);
   });
 
+  it("confirms the contract and owner are tax-exempt", async () => {
+    expect(await tax.isTaxExempt()).to.equal(true);
+  });
+
   it("reverts on direct ether transfers", async () => {
     await expect(
       owner.sendTransaction({ to: await tax.getAddress(), value: 1 })

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -32,6 +32,7 @@ describe("JobRegistry tax policy integration", function () {
     await policy.connect(owner).setAcknowledgement("new ack");
     details = await registry.taxPolicyDetails();
     expect(details[0]).to.equal("new ack");
+    expect(await policy.isTaxExempt()).to.equal(true);
   });
 
   it("tracks user acknowledgement", async () => {


### PR DESCRIPTION
## Summary
- add `isTaxExempt()` helper to TaxPolicy and interface
- document Etherscan-friendly tax policy verification in README
- test tax exemption helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689755294f78833385a059d0f8992653