### PR TITLE
Expose tax exemption helper in JobRegistry and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ The smart contracts and the corporation that deployed them:
 
 These principles are encoded on‑chain via the owner‑controlled [`TaxPolicy`](contracts/v2/TaxPolicy.sol) contract. The owner alone may revise the canonical policy URI or acknowledgement text using `setPolicyURI`, `setAcknowledgement`, or `setPolicy`; unauthorized calls revert. Each update or explicit version bump triggers an incrementing `taxPolicyVersion` in [`JobRegistry`](contracts/v2/JobRegistry.sol) and forces all non‑owner participants to re‑acknowledge the disclaimer. Acknowledgements are tracked per user through `taxAcknowledgedVersion`. The owner can require a fresh acknowledgement without changing the policy address by calling `bumpTaxPolicyVersion`. `JobRegistry` mirrors the current disclaimer via `taxAcknowledgement`, `taxPolicyURI`, and `taxPolicyDetails` so any participant can confirm the message in a single read. See [tax-obligations.md](docs/tax-obligations.md) for a broader discussion and [TaxPolicyv0.md](docs/TaxPolicyv0.md) for the jurisdictional rationale.
 
-For easy verification on block explorers, `TaxPolicy` exposes `isTaxExempt()` which always returns `true`, signalling that neither the contract nor its owner can ever accrue tax liability.
+For easy verification on block explorers, both [`TaxPolicy`](contracts/v2/TaxPolicy.sol) and [`JobRegistry`](contracts/v2/JobRegistry.sol) expose `isTaxExempt()` which always returns `true`, signalling that neither contract nor the owner can ever accrue tax liability.
 
 ### Checking the tax disclaimer on Etherscan
 
 Non‑technical participants can verify the policy directly in a browser:
 
-1. Open the `TaxPolicy` contract address on a block explorer such as Etherscan.
-2. Under **Read Contract**, call `policyDetails` to retrieve both the disclaimer and canonical document URI, or call `acknowledgement`/`acknowledge` and `policyURI` individually.
+1. Open the `TaxPolicy` or `JobRegistry` address on a block explorer such as Etherscan.
+2. Under **Read Contract**, call `policyDetails` to retrieve both the disclaimer and canonical document URI, or call `acknowledgement`/`acknowledge` and `policyURI` individually. `isTaxExempt` confirms the infrastructure's perpetual tax immunity.
 3. `JobRegistry` exposes the same values via `taxPolicyDetails` and reveals the active `taxPolicyVersion` so users can confirm whether they have acknowledged the latest revision through `taxAcknowledgedVersion(address)`.
 4. Only the contract owner can change these fields via the **Write Contract** functions `setPolicyURI`, `setAcknowledgement`, or `setPolicy`; calls from any other address revert.
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -171,6 +171,12 @@ contract JobRegistry is Ownable {
         emit TaxPolicyUpdated(address(taxPolicy), taxPolicyVersion);
     }
 
+    /// @notice Confirms this registry and its owner are perpetually tax‑exempt.
+    /// @return Always true; no tax liability can accrue here.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
     /// @notice Returns the on-chain acknowledgement string stating that all
     /// taxes are the responsibility of employers, agents, and validators.
     function taxAcknowledgement() external view returns (string memory) {

--- a/test/jobTaxPolicy.test.js
+++ b/test/jobTaxPolicy.test.js
@@ -40,6 +40,10 @@ describe("JobRegistry tax policy integration", function () {
     expect(uri).to.equal("ipfs://policy");
   });
 
+  it("registry confirms tax exemption", async () => {
+    expect(await registry.isTaxExempt()).to.equal(true);
+  });
+
   it("non-owner cannot set policy", async () => {
     await expect(
       registry.connect(other).setTaxPolicy(await policy.getAddress())


### PR DESCRIPTION
## Summary
- expose `isTaxExempt()` on `JobRegistry` so explorers can confirm the registry and owner are tax-free
- document explorer flow for `isTaxExempt` in README
- test registry `isTaxExempt()` helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689760935d1883338cce3416c8f25355