### PR TITLE
docs: clarify tax policy responsibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ The $AGI ERC‑20 token is deployed at `0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f1
 
 ## Tax Obligations & Disclaimer
 
+**Summary**
+
+- Employers, agents, and validators bear every tax obligation.
+- Smart contracts and the deploying corporation are tax‑exempt worldwide; `isTaxExempt()` on each module proves it.
+- Verify the policy on Etherscan by reading `taxPolicyDetails`, then calling `acknowledgeTaxPolicy`, and confirming `isTaxExempt`.
+- The owner updates text or URI via `setPolicyURI`/`setAcknowledgement` and enforces a new `taxPolicyVersion` with `bumpTaxPolicyVersion`.
+
 All taxes in the AGI Jobs ecosystem fall solely on AGI Employers, AGI Agents, and Validators who exchange value. The smart contract suite and the deploying corporation are perpetually exempt from any direct, indirect, or theoretical tax liability in every jurisdiction—including the United States, Canada, and the European Union—because no revenue, fees, or asset disposals ever accrue to the infrastructure:
 
 - **Employers** fund jobs and supply the tokens that may be burned. Burning is a disposal of property, so employers calculate any capital gain or loss on the burned amount. Tokens paid to agents may be deductible business expenses.
@@ -120,10 +127,11 @@ For easy verification on block explorers, [`TaxPolicy`](contracts/v2/TaxPolicy.s
 
 Non‑technical participants can verify the policy directly in a browser:
 
-1. Open the `TaxPolicy`, `JobRegistry`, or any core module address on a block explorer such as Etherscan.
-2. Under **Read Contract**, call `policyDetails` to retrieve both the disclaimer and canonical document URI, or call `acknowledgement`/`acknowledge` and `policyURI` individually. `isTaxExempt` on each module confirms the infrastructure's perpetual tax immunity.
-3. `JobRegistry` exposes the same values via `taxPolicyDetails` and reveals the active `taxPolicyVersion` so users can confirm whether they have acknowledged the latest revision through `taxAcknowledgedVersion(address)`.
-4. Only the contract owner can change these fields via the **Write Contract** functions `setPolicyURI`, `setAcknowledgement`, or `setPolicy`; calls from any other address revert.
+1. Open the `JobRegistry` address on a block explorer such as Etherscan.
+2. Under **Read Contract**, call `taxPolicyDetails` to view the current disclaimer text and canonical URI.
+3. Switch to **Write Contract** and call `acknowledgeTaxPolicy` to record acceptance of the active `taxPolicyVersion`.
+4. Back in **Read Contract**, confirm `isTaxExempt` returns `true` and check `taxAcknowledgedVersion(address)` against `taxPolicyVersion`.
+5. Only the contract owner can change the policy via `setPolicyURI`, `setAcknowledgement`, or `setPolicy`; unauthorized calls revert.
 
 ### Owner checklist: updating the policy via Etherscan
 

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -51,12 +51,15 @@ graph TD
 4. Reveal decisions using **revealValidation** before the window closes.
 
 ### Tax Policy
-The `TaxPolicy` contract is informational only: it never holds funds and imposes no tax liability on the infrastructure or its owner. All taxes remain with employers, agents, and validators.
+The `TaxPolicy` contract is informational only: it never holds funds and imposes no tax liability on the infrastructure or its owner. Employers, agents, and validators bear every tax duty while the contracts and deploying corporation remain exempt in all jurisdictions.
 
-1. Open the `TaxPolicy` address in Etherscan.
-2. Under **Read Contract**, call **policyDetails** to return both the disclaimer and canonical document URI, or call **acknowledgement**/ **acknowledge** and **policyURI** individually.
-3. `JobRegistry` exposes the same text and URI via **taxPolicyDetails** and reveals the active **taxPolicyVersion**; participants can confirm their latest acknowledgement through **taxAcknowledgedVersion(address)**.
-4. Only the owner may update the URI with **setPolicyURI**, the message with **setAcknowledgement**, or both simultaneously with **setPolicy** in **Write Contract**. The owner can force a fresh acknowledgement without changing addresses by calling **bumpTaxPolicyVersion** on `JobRegistry`.
+**Etherscan steps**
+
+1. Open the `JobRegistry` address in Etherscan.
+2. Under **Read Contract**, call **taxPolicyDetails** to fetch the current disclaimer text and canonical URI.
+3. Switch to **Write Contract** and execute **acknowledgeTaxPolicy** to record acceptance of the active policy.
+4. Return to **Read Contract** and call **isTaxExempt** to confirm the contract's perpetual exemption and **taxAcknowledgedVersion(address)** to ensure you accepted the latest **taxPolicyVersion**.
+5. Owners update the text or URI via **setPolicyURI**, **setAcknowledgement**, or **setPolicy** on `TaxPolicy`, then call **bumpTaxPolicyVersion** on `JobRegistry` to require fresh acknowledgements.
 
 ### Disputers
 1. Open the `DisputeModule` address on Etherscan.

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -1,9 +1,24 @@
 # Tax Obligations in the AGI Job Platform Ecosystem
 
+**Summary**
+
+- Employers, agents, and validators shoulder all tax liability.
+- The smart contracts and deploying corporation remain tax‑exempt everywhere, confirmed by `isTaxExempt()`.
+- Verify the policy on Etherscan: read `taxPolicyDetails`, acknowledge via `acknowledgeTaxPolicy`, and check `isTaxExempt`.
+- The owner edits the policy text or URI with `setPolicyURI`/`setAcknowledgement` and bumps `taxPolicyVersion` using `bumpTaxPolicyVersion`.
+
 The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction and remain exempt from direct, indirect, or theoretical taxes. This neutrality holds globally—United States, Canada, the European Union, and beyond—because the infrastructure never realises income or disposes of assets. The dedicated [`TaxPolicy`](../contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain by storing both a canonical policy URI **and** a human‑readable acknowledgement string—each controlled solely by the owner—so non‑technical users can confirm the disclaimer through explorers like Etherscan. Call `policyDetails` to fetch both fields at once, `acknowledgement` (or `acknowledge`) and `policyURI` individually on the `TaxPolicy` contract, or `taxPolicyDetails` on `JobRegistry`. `isTaxExempt()` on both contracts returns `true` for additional assurance. Only the owner can update these values via `setPolicyURI`, `setAcknowledgement`, or `setPolicy`; unauthorized calls revert.
 All other core modules—`StakeManager`, `ValidationModule`, `ReputationEngine`, `DisputeModule`, and `CertificateNFT`—likewise expose `isTaxExempt()` helpers so explorers can verify that neither those contracts nor the owner can ever accrue tax liability.
 
 `JobRegistry` maintains an incrementing `taxPolicyVersion` and records the last acknowledged version per address in `taxAcknowledgedVersion`. Any update or explicit version bump by the owner requires employers, agents, and validators to call `acknowledgeTaxPolicy` again before interacting, keeping the tax disclaimer evergreen while the platform itself remains tax‑exempt.
+
+### Etherscan steps
+
+1. Open the `JobRegistry` address on Etherscan.
+2. Under **Read Contract**, call `taxPolicyDetails` to view the current policy text and URI.
+3. Switch to **Write Contract** and call `acknowledgeTaxPolicy` to accept the active version.
+4. Back under **Read Contract**, verify `isTaxExempt` returns `true` and that `taxAcknowledgedVersion(address)` matches `taxPolicyVersion`.
+5. Owners can update the text or URI via `setPolicyURI`, `setAcknowledgement`, or `setPolicy` on `TaxPolicy`, then enforce a new acknowledgement by calling `bumpTaxPolicyVersion` on `JobRegistry`.
 
 ## Employers
 - Provide the token escrow that funds jobs.


### PR DESCRIPTION
## Summary
- Summarize tax duties for employers, agents, and validators while noting contracts and the deploying company remain exempt
- Add Etherscan walkthrough for `taxPolicyDetails`, `acknowledgeTaxPolicy`, and `isTaxExempt`
- Document how owners update policy text/URI and bump `taxPolicyVersion`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68977d014818833399ad0dfb7ae3f3e7