### PR TITLE
feat: enforce tax acknowledgement before staking

### DIFF
--- a/contracts/v2/interfaces/IJobRegistryTax.sol
+++ b/contracts/v2/interfaces/IJobRegistryTax.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title IJobRegistryTax
+/// @notice Interface exposing tax acknowledgement tracking from the JobRegistry
+interface IJobRegistryTax {
+    /// @notice Current tax policy version participants must acknowledge
+    function taxPolicyVersion() external view returns (uint256);
+
+    /// @notice Mapping of participant to acknowledged tax policy version
+    /// @param user Address of the participant
+    function taxAcknowledgedVersion(address user) external view returns (uint256);
+}


### PR DESCRIPTION
## Summary
- add IJobRegistryTax interface for tax policy version tracking
- guard StakeManager staking functions with tax acknowledgement checks
- test that staking reverts until users acknowledge the latest tax policy

## Testing
- `npm test test/v2/StakeManager.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897802beae48333b11057be23a98efc