### PR TITLE
feat: enforce acknowledgment for appeals

### DIFF
--- a/contracts/mocks/DisputeRegistryStub.sol
+++ b/contracts/mocks/DisputeRegistryStub.sol
@@ -14,9 +14,15 @@ contract DisputeRegistryStub {
     }
 
     mapping(uint256 => Job) public jobs;
+    uint256 public taxPolicyVersion = 1;
+    mapping(address => uint256) public taxAcknowledgedVersion;
 
     function setJob(uint256 id, Job calldata job) external {
         jobs[id] = job;
+    }
+
+    function acknowledge(address user) external {
+        taxAcknowledgedVersion[user] = taxPolicyVersion;
     }
 
     function resolveDispute(uint256, bool) external {}


### PR DESCRIPTION
## Summary
- require tax policy acknowledgment before posting an appeal
- add owner-only setter for job registry
- test unacknowledged appeals revert and registry ownership

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689783c403148333974c02114ee281b0