### PR TITLE
feat: enforce tax acknowledgement and ether rejection

### DIFF
--- a/contracts/CertificateNFT.sol
+++ b/contracts/CertificateNFT.sol
@@ -66,5 +66,18 @@ contract CertificateNFT is ERC721, Ownable {
         }
         return super.tokenURI(tokenId);
     }
+
+    /// @notice Confirms the contract and owner are tax-exempt.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
+    receive() external payable {
+        revert("CertificateNFT: no ether");
+    }
+
+    fallback() external payable {
+        revert("CertificateNFT: no ether");
+    }
 }
 

--- a/contracts/ReputationEngine.sol
+++ b/contracts/ReputationEngine.sol
@@ -110,5 +110,18 @@ contract ReputationEngine is Ownable {
         }
         return false;
     }
+
+    /// @notice Confirms the contract and owner remain tax-exempt.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
+    receive() external payable {
+        revert("ReputationEngine: no ether");
+    }
+
+    fallback() external payable {
+        revert("ReputationEngine: no ether");
+    }
 }
 

--- a/contracts/ValidationModule.sol
+++ b/contracts/ValidationModule.sol
@@ -22,5 +22,18 @@ contract ValidationModule is Ownable {
     function validate(uint256 jobId) external view returns (bool) {
         return outcomes[jobId];
     }
+
+    /// @notice Confirms the contract and owner are tax-exempt.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
+    receive() external payable {
+        revert("ValidationModule: no ether");
+    }
+
+    fallback() external payable {
+        revert("ValidationModule: no ether");
+    }
 }
 

--- a/test/v2/DisputeModuleModuleNoEther.test.js
+++ b/test/v2/DisputeModuleModuleNoEther.test.js
@@ -19,7 +19,7 @@ describe("DisputeModule module ether rejection", function () {
   it("reverts on direct ether transfer", async () => {
     await expect(
       owner.sendTransaction({ to: await dispute.getAddress(), value: 1 })
-    ).to.be.revertedWith("DisputeModule: no direct ether");
+    ).to.be.revertedWith("DisputeModule: no ether");
   });
 
   it("reverts on unknown calldata with value", async () => {
@@ -29,7 +29,7 @@ describe("DisputeModule module ether rejection", function () {
         data: "0x12345678",
         value: 1,
       })
-    ).to.be.revertedWith("DisputeModule: no direct ether");
+    ).to.be.revertedWith("DisputeModule: no ether");
   });
 
   it("reports tax exemption", async () => {

--- a/test/v2/DisputeModuleNoEther.test.js
+++ b/test/v2/DisputeModuleNoEther.test.js
@@ -19,7 +19,7 @@ describe("DisputeModule ether rejection", function () {
   it("reverts on direct ether transfer", async () => {
     await expect(
       owner.sendTransaction({ to: await dispute.getAddress(), value: 1 })
-    ).to.be.revertedWith("DisputeModule: no direct ether");
+    ).to.be.revertedWith("DisputeModule: no ether");
   });
 
   it("reverts on unknown calldata with value", async () => {
@@ -29,7 +29,7 @@ describe("DisputeModule ether rejection", function () {
         data: "0x12345678",
         value: 1,
       })
-    ).to.be.revertedWith("DisputeModule: no direct ether");
+    ).to.be.revertedWith("DisputeModule: no ether");
   });
 
   it("reports tax exemption", async () => {

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -58,6 +58,9 @@ describe("JobRegistry integration", function () {
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
     await rep.connect(owner).setCaller(await registry.getAddress(), true);
     await rep.connect(owner).setThreshold(1);
+    await stakeManager
+      .connect(owner)
+      .setJobRegistry(await registry.getAddress());
     await stakeManager.connect(owner).transferOwnership(await registry.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
     await registry

--- a/test/v2/LifecycleDispute.integration.test.js
+++ b/test/v2/LifecycleDispute.integration.test.js
@@ -64,6 +64,9 @@ describe("Job lifecycle with disputes", function () {
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
     await rep.connect(owner).setCaller(await registry.getAddress(), true);
     await rep.connect(owner).setThreshold(1);
+    await stakeManager
+      .connect(owner)
+      .setJobRegistry(await registry.getAddress());
     await stakeManager.connect(owner).transferOwnership(await registry.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
     await registry


### PR DESCRIPTION
## Summary
- add JobRegistry tax acknowledgement gating to StakeManager stake actions
- expose `isTaxExempt()` and reject direct ETH in ValidationModule, ReputationEngine, CertificateNFT
- unify DisputeModule ether rejection message and require tax acknowledgement on disputes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68978c383564833395a4526a6c5e5c2d