### PR TITLE
Emit tax policy acknowledgement text and update docs

### DIFF
--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -34,23 +34,23 @@ graph TD
 
 ## Role-based Instructions
 
-Before performing any on-chain action, employers, agents, and validators must call `JobRegistry.acknowledgeTaxPolicy` and verify `isTaxExempt()`—all taxes fall on participants while the contracts and owner remain globally exempt.
+Before performing any on-chain action, employers, agents, and validators must call `JobRegistry.acknowledgeTaxPolicy` and verify `isTaxExempt()`—all taxes fall on participants while the contracts and owner remain globally exempt. The `acknowledgeTaxPolicy` transaction emits `TaxAcknowledged(user, version, acknowledgement)` so the accepted disclaimer text is permanently recorded on-chain.
 
 ### Employers
 1. Open the `JobRegistry` address on Etherscan.
-2. In **Write Contract**, connect an employer wallet and execute **acknowledgeTaxPolicy**.
+2. In **Write Contract**, connect an employer wallet and execute **acknowledgeTaxPolicy**, then review the `TaxAcknowledged` event log for the disclaimer text.
 3. In **Read Contract**, confirm **isTaxExempt()** returns `true`.
 4. Call **createJob** with job parameters and escrowed token amount.
 5. Monitor **JobCreated** events to confirm posting.
 
 ### Agents
-1. On `JobRegistry`, execute **acknowledgeTaxPolicy** and verify **isTaxExempt()**.
+1. On `JobRegistry`, execute **acknowledgeTaxPolicy** and verify **isTaxExempt()**. Check the emitted `TaxAcknowledged` event for the recorded disclaimer.
 2. Open `StakeManager`; in **Read Contract** confirm **isTaxExempt()**, then stake with **depositStake(0, amount)** (role `0` = Agent).
 3. Use **applyForJob** and **completeJob** as needed.
 4. Call **requestJobCompletion** when work is ready for validation.
 
 ### Validators
-1. On `JobRegistry`, execute **acknowledgeTaxPolicy** and verify **isTaxExempt()**.
+1. On `JobRegistry`, execute **acknowledgeTaxPolicy** and verify **isTaxExempt()**. Inspect the `TaxAcknowledged` event log for the acknowledgement text.
 2. Stake required AGI via **StakeManager.depositStake(1, amount)** after confirming **StakeManager.isTaxExempt()**.
 3. During validation, open `ValidationModule`, confirm **isTaxExempt()**, and send hashed votes with **commitValidation(jobId, commitHash)**.
 4. Reveal decisions using **revealValidation(jobId, approve, salt)** before the window closes.
@@ -62,7 +62,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 1. Open [`JobRegistry` on Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#readContract).
 2. In **Read Contract**, call **taxPolicyDetails** to view the canonical policy URI and acknowledgement text. *(Example screenshot: [taxPolicyDetails](https://via.placeholder.com/650x150?text=taxPolicyDetails))*
 3. Still under **Read Contract**, call **isTaxExempt** and confirm it returns `true`.
-4. Switch to **Write Contract**, connect your wallet, and execute **acknowledgeTaxPolicy**.
+4. Switch to **Write Contract**, connect your wallet, and execute **acknowledgeTaxPolicy**. The transaction log will show `TaxAcknowledged(user, version, acknowledgement)` with the disclaimer you accepted.
 5. Back in **Read Contract**, call **taxAcknowledgedVersion(address)** to ensure it matches **taxPolicyVersion**.
 
 #### Owner: update the policy

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -4,7 +4,7 @@
 
 - Employers, agents, and validators shoulder all tax liability.
 - The smart contracts and deploying corporation remain tax‑exempt everywhere, confirmed by `isTaxExempt()`.
-- Verify the policy on Etherscan: read `taxPolicyDetails`, acknowledge via `acknowledgeTaxPolicy`, and check `isTaxExempt`.
+- Verify the policy on Etherscan: read `taxPolicyDetails`, acknowledge via `acknowledgeTaxPolicy` (which emits `TaxAcknowledged(user, version, acknowledgement)`), and check `isTaxExempt`.
 - The owner edits the policy text or URI with `setPolicyURI`/`setAcknowledgement`, tracks changes via `policyVersion`, and bumps `taxPolicyVersion` using `bumpTaxPolicyVersion`.
 
 The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction and remain exempt from direct, indirect, or theoretical taxes. This neutrality holds globally—United States, Canada, the European Union, and beyond—because the infrastructure never realises income or disposes of assets. The dedicated [`TaxPolicy`](../contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain by storing both a canonical policy URI **and** a human‑readable acknowledgement string—each controlled solely by the owner—so non‑technical users can confirm the disclaimer through explorers like Etherscan. Call `policyDetails` to fetch both fields at once, `acknowledgement` (or `acknowledge`) and `policyURI` individually on the `TaxPolicy` contract, or `taxPolicyDetails` on `JobRegistry`. `policyVersion` reveals the current version and `bumpPolicyVersion` increments it without altering text. `isTaxExempt()` on both contracts returns `true` for additional assurance. Only the owner can update these values via `setPolicyURI`, `setAcknowledgement`, `setPolicy`, or `bumpPolicyVersion`; unauthorized calls revert.
@@ -16,7 +16,7 @@ All other core modules—`StakeManager`, `ValidationModule`, `ReputationEngine`,
 
 1. Open the `JobRegistry` address on Etherscan.
 2. Under **Read Contract**, call `taxPolicyDetails` to view the current policy text and URI and check `taxPolicyVersion` against `TaxPolicy.policyVersion`.
-3. Switch to **Write Contract** and call `acknowledgeTaxPolicy` to accept the active version.
+3. Switch to **Write Contract** and call `acknowledgeTaxPolicy` to accept the active version. The transaction emits `TaxAcknowledged(user, version, acknowledgement)` containing the disclaimer text.
 4. Back under **Read Contract**, verify `isTaxExempt` returns `true` and that `taxAcknowledgedVersion(address)` matches `taxPolicyVersion`.
 5. Owners can update the text or URI via `setPolicyURI`, `setAcknowledgement`, `setPolicy`, or `bumpPolicyVersion` on `TaxPolicy`, then enforce a new acknowledgement by calling `bumpTaxPolicyVersion` on `JobRegistry`.
 

--- a/test/jobRegistry.ts
+++ b/test/jobRegistry.ts
@@ -44,7 +44,7 @@ describe("JobRegistry tax policy gating", function () {
       registry.connect(employer).acknowledgeTaxPolicy()
     )
       .to.emit(registry, "TaxAcknowledged")
-      .withArgs(employer.address, 1);
+      .withArgs(employer.address, 1, "ack");
 
     await expect(
       registry.connect(employer).createJob()
@@ -58,7 +58,7 @@ describe("JobRegistry tax policy gating", function () {
       registry.connect(agent).acknowledgeTaxPolicy()
     )
       .to.emit(registry, "TaxAcknowledged")
-      .withArgs(agent.address, 1);
+      .withArgs(agent.address, 1, "ack");
 
     await expect(
       registry.connect(agent).applyForJob(1)

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -39,7 +39,7 @@ describe("JobRegistry tax policy integration", function () {
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
     await expect(registry.connect(user).acknowledgeTaxPolicy())
       .to.emit(registry, "TaxAcknowledged")
-      .withArgs(user.address, 1);
+      .withArgs(user.address, 1, "ack");
     expect(await registry.taxAcknowledgedVersion(user.address)).to.equal(1);
   });
 
@@ -53,7 +53,7 @@ describe("JobRegistry tax policy integration", function () {
     ).to.be.revertedWith("acknowledge tax policy");
     await expect(registry.connect(user).acknowledgeTaxPolicy())
       .to.emit(registry, "TaxAcknowledged")
-      .withArgs(user.address, 2);
+      .withArgs(user.address, 2, "ack");
     await expect(registry.connect(user).createJob())
       .to.emit(registry, "JobCreated")
       .withArgs(1, user.address, ethers.ZeroAddress, 1, 0);


### PR DESCRIPTION
## Summary
- include acknowledgement text in `TaxAcknowledged` event and return value
- document Etherscan workflow to review the `TaxAcknowledged` log and confirm tax neutrality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a1327ea48333ad6181888bed6c7a