### PR TITLE
docs: add AGIALPHA deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The v2 contracts treat the payment token as an owner‑configurable parameter. B
 
 Token amounts are always passed in base units (1 AGIALPHA = 1e6 units). The owner may replace the token later without redeploying other modules via `StakeManager.setToken(newToken)`.
 
+For a full step‑by‑step deployment walkthrough using $AGIALPHA, see [docs/deployment-agialpha.md](docs/deployment-agialpha.md).
+
 > **Warning**: Links above are provided for reference only. Always validate contract addresses and metadata on multiple block explorers before interacting.
 
 > **Tax Neutral Infrastructure:** Every module rejects unsolicited ether and exposes an `isTaxExempt()` helper so users on explorers like Etherscan can confirm that only employers, agents, and validators carry tax duties while the contracts and deploying corporation remain perpetually exempt.

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -11,6 +11,10 @@ AGIJobManager v2 decomposes the monolithic v1 contract into immutable modules wi
 - **CertificateNFT** – mints ERC‑721 proof of completion to employers.
 Each component is immutable once deployed yet configurable by the owner through minimal setter functions, enabling governance upgrades without redeploying the entire suite.
 
+### Token Configuration
+
+`StakeManager` holds the address of the ERC‑20 used for all payments, staking and appeal fees.  The owner may replace this token at any time via `setToken` without redeploying the rest of the system.  The default deployment references the $AGIALPHA token at `0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe`, which operates with **6 decimals**.  All economic parameters (stakes, rewards, fees) must therefore be provided in base units of this token (e.g., `100_000000` for 100 AGIALPHA).  Modules do not assume a specific decimal count, preserving compatibility with future currencies.
+
 | Module | Core responsibility | Owner‑controllable parameters |
 | --- | --- | --- |
 | JobRegistry | job postings, escrow, lifecycle management | job reward, required agent stake |

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -1,0 +1,60 @@
+# AGIJobs v2 Deployment with $AGIALPHA
+
+This guide walks a non-technical owner through deploying and configuring the modular AGIJobs suite using the $AGIALPHA token (6 decimals) for payments, staking, rewards and disputes. All steps can be performed through [Etherscan](https://etherscan.io) once the bytecode for each module is verified.
+
+## Prerequisites
+- Ethereum wallet controlling the owner address (hardware wallet recommended).
+- $AGIALPHA token contract: `0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe`.
+- Sufficient ETH for gas fees and $AGIALPHA for testing job flows.
+
+## 1. Deploy the Modules
+1. **StakeManager** – constructor arguments `(tokenAddress, owner)`.
+2. **JobRegistry** – constructor argument `owner`.
+3. **ValidationModule** – constructor arguments `(jobRegistry, stakeManager, owner)`.
+4. **ReputationEngine** – constructor argument `owner`.
+5. **DisputeModule** – constructor arguments `(jobRegistry, stakeManager, reputationEngine, owner)`.
+6. **CertificateNFT** – constructor arguments `(name, symbol, owner)`.
+7. **TaxPolicy** – constructor argument `owner`.
+
+Use the *Deploy* tab on each contract's Etherscan page. Confirm transactions through your wallet.
+
+## 2. Wire the Modules
+1. In **JobRegistry**, call `setModules(validation, stakeManager, reputation, dispute, certificate)`.
+2. In **StakeManager**, call `setJobRegistry(jobRegistry)`.
+3. In **JobRegistry**, call `setTaxPolicy(taxPolicy)` and optionally `bumpTaxPolicyVersion`.
+
+## 3. Configure Token Parameters
+The StakeManager already points to $AGIALPHA (6 decimals). To change tokens later, use `setToken(newToken)`.
+
+For stakes, rewards and fees enter values in base units:
+- `100` tokens = `100_000000`
+- `0.5` token = `500000`
+
+Update parameters as needed:
+- `StakeManager.setMinStake(minStake)`
+- `StakeManager.setSlashingPercentages(employerPct, treasuryPct)`
+- `ValidationModule.setParameters(...)`
+- `DisputeModule.setAppealFee(fee)` (denominated in $AGIALPHA)
+
+## 4. Post a Job
+1. Employer approves $AGIALPHA to the StakeManager via the token's `approve` function.
+2. Employer calls `JobRegistry.acknowledgeTaxPolicy()` once per address.
+3. Employer calls `JobRegistry.createJob(uri, reward)` where `reward` is in base units.
+
+## 5. Agent and Validator Actions
+- **Agents** stake using `StakeManager.depositStake(amount)` and apply with `JobRegistry.applyForJob(jobId)`.
+- **Validators** stake similarly, then use `ValidationModule.commit(jobId, hash)` and later `reveal(jobId, approve, salt)`.
+
+## 6. Finalisation and Disputes
+- After validation, anyone may call `JobRegistry.finalize(jobId)` to release escrowed $AGIALPHA.
+- If contested, raise an appeal with `DisputeModule.raiseDispute(jobId)`. Fees are charged in $AGIALPHA.
+
+## 7. Changing the Token
+Only the owner may switch currencies: `StakeManager.setToken(newToken)`. Existing stakes and escrows remain untouched; new deposits and payouts use the updated token.
+
+## Security Notes
+- Verify each deployed address on at least two explorers.
+- Use multisig or timelock for the owner where possible.
+- Keep constructor parameters and ABI files for later verification.
+
+By following these steps the owner can deploy the AGIJobs suite with $AGIALPHA as the unit of account, while retaining the ability to replace the token without redeploying other modules.


### PR DESCRIPTION
## Summary
- document token configurability and default AGIALPHA usage in architecture overview
- add step-by-step AGIALPHA deployment guide and link from README

## Testing
- `HARDHAT_TELEMETRY_DISABLED=1 npx hardhat test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6897bd307e848333a1dc13a2a1daab1c