### PR TITLE
docs: refine v2 modular architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Each module inherits `Ownable` so only the contract owner can update parameters.
 - Adjust stakes, reward rates, timing windows, and reputation thresholds via owner‑only setters; every change emits a dedicated event.
 - Swap the payment token at any time using `StakeManager.setToken(newToken)`.
 - Transfer ownership to a multisig or timelock for added security.
+- Public functions accept primitive types and include NatSpec comments so owners can administer modules directly through Etherscan's **Write Contract** tab without scripts.
 
 ### Using $AGIALPHA (6 decimals)
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -13,7 +13,7 @@ Each component is immutable once deployed yet configurable by the owner through 
 
 ### Token Configuration
 
-`StakeManager` holds the address of the ERC‑20 used for all payments, staking and appeal fees.  The owner may replace this token at any time via `setToken` without redeploying the rest of the system.  The default deployment references the $AGIALPHA token at `0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe`, which operates with **6 decimals**.  All economic parameters (stakes, rewards, fees) must therefore be provided in base units of this token (e.g., `100_000000` for 100 AGIALPHA).  Modules do not assume a specific decimal count, preserving compatibility with future currencies.
+`StakeManager` holds the address of the ERC‑20 used for all payments, staking and appeal fees. The owner may replace this token at any time via `setToken` without redeploying the rest of the system. The default deployment references the $AGIALPHA token at `0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe`, which operates with **6 decimals**. All economic parameters (stakes, rewards, fees) must therefore be provided in base units of this token (e.g., `100_000000` for 100 AGIALPHA). Modules do not assume a specific decimal count, preserving compatibility with future currencies. The `DisputeModule` pulls its `appealFee` from `StakeManager`, so dispute resolution also uses the selected ERC‑20.
 
 | Module | Core responsibility | Owner‑controllable parameters |
 | --- | --- | --- |
@@ -27,6 +27,13 @@ Each component is immutable once deployed yet configurable by the owner through 
 Every module inherits `Ownable`, so only the contract owner (or future governance authority) may adjust these parameters.
 
 All public methods accept plain `uint256` values (wei and seconds) so they can be invoked directly from a block explorer without custom tooling. Owners configure modules by calling the published setter functions in Etherscan's **Write** tab, while agents and validators use the corresponding read/write interfaces for routine actions.
+
+### Owner Controls & Explorer Usability
+
+- Every setter is gated by `onlyOwner`, ensuring a single governance address (or multisig) tunes parameters.
+- `JobRegistry` can re‑point to replacement modules via `setModules`, enabling upgrades without migrating state.
+- Functions use primitive types and include NatSpec comments so Etherscan displays human‑readable names and prompts.
+- `StakeManager.setToken` lets the owner swap the payment currency—including dispute fees—without redeploying other contracts.
 
 ## Module Interactions
 ```mermaid

--- a/docs/coding-sprint-v2.md
+++ b/docs/coding-sprint-v2.md
@@ -6,6 +6,7 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
 - Implement immutable, ownable modules for job coordination, validation, staking, reputation, disputes and certificate NFTs.
 - Optimise for gas efficiency and composability while keeping explorer interactions simple for non‑technical users.
 - Align incentives so honest behaviour is the dominant strategy for agents, validators and employers.
+- Default to the $AGIALPHA token (6 decimals) for all payments, stakes and appeal fees while allowing the owner to swap tokens via `StakeManager.setToken`.
 - Publish an on-chain tax disclaimer that leaves all liabilities with employers, agents and validators while the owner remains exempt.
 
 ## Tasks
@@ -17,8 +18,9 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
    - `ValidationModule`: pseudo‑random selection, commit‑reveal voting, outcome reporting.
    - `StakeManager`: token custody, slashing, reward release.
    - `ReputationEngine`: reputation tracking, threshold enforcement, owner-managed blacklist.
-   - `DisputeModule`: optional appeal flow and final ruling.
+   - `DisputeModule`: optional appeal flow and final ruling with appeal fees paid in the configured ERC‑20.
    - `CertificateNFT`: ERC‑721 minting with owner‑settable base URI.
+   - Wire `StakeManager` into all modules and expose `setToken` so the owner can replace $AGIALPHA without redeploying.
 3. **Incentive Calibration**
    - Implement owner setters for stake ratios, rewards, slashing, timing windows and reputation thresholds.
    - Ensure slashing percentages exceed potential dishonest gains.
@@ -33,6 +35,7 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
 6. **Deployment Prep**
    - Freeze compiler versions and verify bytecode locally.
    - Generate deployment scripts that record module addresses for `JobRegistry` wiring.
+   - Document Etherscan-based deployment and configuration for non‑technical owners.
 7. **Tax Responsibility & Owner Neutrality**
    - Ensure no module ever routes tokens or fees to the owner; the contracts and deploying corporation must remain revenue-free and tax-exempt worldwide.
    - Require participants to call `acknowledgeTaxPolicy` before interacting with `JobRegistry`, tracking acknowledgements per address.


### PR DESCRIPTION
## Summary
- document owner-only controls and token-swapping flow for the modular v2 suite
- emphasize $AGIALPHA (6 decimals) as default payment token across modules
- expand sprint plan with token integration and explorer deployment tasks

## Testing
- `npm test`
- `npm run lint` *(warnings: Missing @return tag, use-natspec, GC: Use Custom Errors instead of revert statements, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6897d3de4f588333aedf22601e6236ff