### PR TITLE
docs: clarify modular governance and link sprint plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 - [Modular Architecture & Interfaces](docs/modular-architecture-v2.md) – contract separation with interface snippets and gas tips.
 - [v2 Module & Interface Reference](docs/v2-module-interface-reference.md) – condensed module graph, core interfaces, and gas/incentive notes.
 - [Coding Sprint for v2](docs/coding-sprint-v2.md) – step-by-step plan for implementing the modular suite.
+- [Production-Scale AGIJobs Platform Sprint Plan](docs/ProductionScaleAGIJobsPlatformSprintPlanv0.md) – background research and
+  architectural rationale behind the modular design.
 - [Deployment Guide for $AGIALPHA](docs/deployment-agialpha.md) – non-technical walkthrough for deploying and configuring the suite with the 6‑decimal token.
 - [Tax Obligations & Disclaimer](docs/tax-obligations.md) – participants bear all taxes; contracts and owner remain exempt.
 - [TaxPolicy contract](contracts/v2/TaxPolicy.sol) – owner‑updatable disclaimer with `policyDetails`, `policyVersion`, and `isTaxExempt()` helpers; `JobRegistry.acknowledgeTaxPolicy` emits `TaxAcknowledged(user, version, acknowledgement)` for on‑chain proof.

--- a/docs/modular-architecture-v2.md
+++ b/docs/modular-architecture-v2.md
@@ -96,3 +96,18 @@ currencies via `setToken(newToken)` without redeploying other modules.  All amou
 All public methods use simple data types so employers, agents and validators can interact through Etherscan's **Write** tab.
 Deployment and configuration steps for $AGIALPHA appear in [docs/deployment-agialpha.md](deployment-agialpha.md).
 
+## Governance & Composability
+- Every module inherits `Ownable`; only the contract owner or its designated multisig can adjust parameters.
+- `JobRegistry.setModules` lets the owner swap in new `ValidationModule`, `StakeManager`, `ReputationEngine`, `DisputeModule`,
+  or `CertificateNFT` addresses without migrating state.
+- Each setter emits a dedicated event (`ModuleUpdated`, `ParameterUpdated`, etc.), giving off‑chain governance a verifiable
+  audit trail.
+
+## Game‑Theoretic Incentives
+- Agent and validator stakes create an energy cost for deviation; expected slashing exceeds any short‑term gain.
+- The commit–reveal scheme, combined with random validator selection, raises the entropy term so collusion is statistically
+  disfavoured.
+- `ReputationEngine` reinforces cooperation by reducing future earnings for misbehaving addresses and blacklisting chronic
+  offenders.
+- Appeals require a token fee via `DisputeModule`, ensuring that only disputes with positive expected value are raised.
+


### PR DESCRIPTION
## Summary
- link production-scale sprint plan from README quick links
- expand modular architecture doc with governance and game-theory sections

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897d75400308333b7efd4448fddf0f6