### PR TITLE
docs: expand v2 module graph and governance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,17 @@ The platform’s v2 release decomposes coordination into immutable, single‑pur
 - **DisputeModule** – optional appeal layer for contested jobs.
 - **CertificateNFT** – mints ERC‑721 completion certificates to employers.
 
-Each module inherits `Ownable` so only the contract owner can update parameters. Upgrades occur by deploying a replacement module and repointing `JobRegistry.setModules`, preserving governance composability while keeping every contract immutable.
+```mermaid
+graph LR
+  JobRegistry --> StakeManager
+  JobRegistry --> ValidationModule
+  JobRegistry --> ReputationEngine
+  JobRegistry --> DisputeModule
+  JobRegistry --> CertificateNFT
+  StakeManager --> Token[$AGIALPHA]
+```
+
+Each module inherits `Ownable` so only the contract owner can update parameters. Upgrades occur by deploying a replacement module and repointing `JobRegistry.setModules`, preserving governance composability while keeping every contract immutable. Full interface definitions and gas‑optimization tips live in [docs/v2-module-interface-reference.md](docs/v2-module-interface-reference.md).
 
 ### Owner Controls & Upgradeability
 

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -79,3 +79,8 @@ Stakes form potential energy \(H\); commit–reveal voting injects entropy \(S\)
 ## Owner Control & Token Flexibility
 All setters are `onlyOwner`. `StakeManager.setToken` lets the owner swap the payment/staking token (default [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe), 6 decimals) without redeploying other modules. All amounts are supplied in base units (1 token = 1e6).
 
+## Governance Composability
+- Modules are immutable once deployed; to upgrade a component the owner deploys a new module and calls `JobRegistry.setModules` with the replacement address.
+- Parameter tweaks emit dedicated events (`ParameterUpdated`, `ModuleUpdated`) so off-chain tooling and multisigs can monitor governance moves.
+- Minimal, single-purpose setters keep Etherscan interactions straightforward for non-technical owners while ensuring clear on-chain audit trails.
+


### PR DESCRIPTION
## Summary
- document v2 module graph with $AGIALPHA token in README
- add governance composability notes to module interface reference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897de464e0883338c86fd287c52085c