### PR TITLE
Clarify 6-decimal scaling in StakeManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,15 @@ interface ICertificateNFT { function mintCertificate(address employer, uint256 j
 
 ### Using $AGIALPHA (6 decimals)
 
-The v2 contracts treat the payment token as an owner‑configurable parameter. By default the `StakeManager` points to the $AGIALPHA ERC‑20 at `0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe` (6 decimals).
+The v2 contracts treat the payment token as an owner‑configurable parameter. By default the `StakeManager` points to the $AGIALPHA ERC‑20 at `0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe` (6 decimals). All token operations are scaled by `10**6`, so callers must convert whole values to base units before submitting transactions. For example:
+
+```
+1   token = 1_000_000
+0.1 token =   100_000
+5   tokens = 5_000_000
+```
+
+When integrating with standard 18‑decimal ERC‑20s, divide amounts by `1e12` to obtain 6‑decimal values; this downscaling can truncate precision beyond six decimals.
 
 **Deployment steps**
 

--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -8,6 +8,10 @@ import {IJobRegistryTax} from "./v2/interfaces/IJobRegistryTax.sol";
 
 /// @title StakeManager
 /// @notice Handles staking and reward transfers for the job system.
+/// @dev All token operations use 6 decimal scaling (1 token = 1e6 units).
+///      Example: to stake 5 tokens pass `5_000_000`. Integrations with
+///      standard 18-decimal ERC-20s must downscale amounts by 1e12, which
+///      can introduce precision loss.
 contract StakeManager is Ownable {
     using SafeERC20 for IERC20;
 

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -11,7 +11,10 @@ import {IJobRegistryTax} from "./interfaces/IJobRegistryTax.sol";
 /// @dev Holds only the staking token and rejects direct ether so neither the
 ///      contract nor the owner ever custodies funds that could create tax
 ///      liabilities. All taxes remain the responsibility of employers, agents
-///      and validators.
+///      and validators. All token amounts are scaled by 1e6 (6 decimals); for
+///      instance `2` tokens should be provided as `2_000_000`. Contracts that
+///      operate on 18‑decimal tokens must downscale by `1e12`, which may cause
+///      precision loss.
 contract StakeManager is Ownable {
     using SafeERC20 for IERC20;
 

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -3,6 +3,10 @@ pragma solidity ^0.8.25;
 
 /// @title IStakeManager
 /// @notice Interface for handling token collateral for agents and validators
+/// @dev Amounts are expressed using 6‑decimal scaling (1 token = 1e6 units).
+///      For example `3` tokens should be provided as `3_000_000`. Contracts
+///      working with 18‑decimal tokens need to divide by `1e12` and may lose
+///      precision.
 interface IStakeManager {
     enum Role {
         Agent,

--- a/contracts/v2/modules/StakeManager.sol
+++ b/contracts/v2/modules/StakeManager.sol
@@ -11,7 +11,10 @@ import {IStakeManager} from "../interfaces/IStakeManager.sol";
 /// @title StakeManager (module)
 /// @notice Minimal stake escrow with role based accounting and slashing.
 /// @dev Only participants bear any tax obligations; this contract remains
-/// tax neutral and rejects any direct ETH transfers.
+///      tax neutral and rejects any direct ETH transfers. Token amounts use
+///      6‑decimal scaling (1 token = 1e6). For example `0.1` token should be
+///      passed as `100_000`. Integrations with 18‑decimal tokens must
+///      downscale by 1e12, potentially losing precision.
 contract StakeManager is Ownable, ReentrancyGuard, IStakeManager {
     using SafeERC20 for IERC20;
 

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -26,9 +26,12 @@ Use the *Deploy* tab on each contract's Etherscan page. Confirm transactions thr
 ## 3. Configure Token Parameters
 The StakeManager already points to $AGIALPHA (6 decimals). To change tokens later, use `setToken(newToken)`.
 
-For stakes, rewards and fees enter values in base units:
+For stakes, rewards and fees enter values in base units (all amounts are scaled by `10**6`):
+- `1` token = `1_000_000`
 - `100` tokens = `100_000000`
 - `0.5` token = `500000`
+
+If interacting with an 18‑decimal token, divide values by `1e12` to convert to this 6‑decimal format; the division may truncate precision beyond six decimals.
 
 Update parameters as needed:
 - `StakeManager.setMinStake(minStake)`

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -77,7 +77,7 @@ interface ICertificateNFT {
 Stakes form potential energy \(H\); commit–reveal voting injects entropy \(S\). Owner‑tuned parameters act as temperature \(T\). The network evolves toward minimum Gibbs free energy \(G = H - TS\), making honest behaviour the dominant, low‑energy strategy. Slashing raises \(H\) for cheaters, while random validator selection increases \(S\), keeping collusion energetically unfavourable.
 
 ## Owner Control & Token Flexibility
-All setters are `onlyOwner`. `StakeManager.setToken` lets the owner swap the payment/staking token (default [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe), 6 decimals) without redeploying other modules. All amounts are supplied in base units (1 token = 1e6).
+All setters are `onlyOwner`. `StakeManager.setToken` lets the owner swap the payment/staking token (default [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe), 6 decimals) without redeploying other modules. All amounts are supplied in base units (1 token = 1e6). For example `0.1` token is `100_000` and `12` tokens are `12_000_000`. When interacting with 18‑decimal tokens, divide values by `1e12` to fit this format; any remainder beyond six decimals will be truncated.
 
 ## Governance Composability
 - Modules are immutable once deployed; to upgrade a component the owner deploys a new module and calls `JobRegistry.setModules` with the replacement address.


### PR DESCRIPTION
## Summary
- document that StakeManager token math uses 6-decimal (1e6) units
- add conversion examples and warn about precision when downscaling 18-dec tokens
- note scaling in README and deployment guide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689807d946f48333b87a8d435882e69c