### PR TITLE
chore: add overflow guard to job params

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -217,6 +217,10 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     }
 
     function setJobParameters(uint256 reward, uint256 stake) external onlyOwner {
+        require(
+            reward <= type(uint128).max && stake <= type(uint96).max,
+            "overflow"
+        );
         jobReward = uint128(reward);
         jobStake = uint96(stake);
         emit JobParametersUpdated(reward, stake);


### PR DESCRIPTION
## Summary
- require reward and stake fit in uint128/uint96 to prevent overflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987638b3dc8333929afe5370f1451d