### PR TITLE
feat: add job nonce to validation commits

### DIFF
--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -37,5 +37,9 @@ interface IValidationModule {
 
     /// @notice Owner configuration for randomness seed
     function setRandomnessSeed(bytes32 seed) external;
+
+    /// @notice Reset the validation nonce for a job after it is finalized or disputed
+    /// @param jobId Identifier of the job
+    function resetJobNonce(uint256 jobId) external;
 }
 

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -28,5 +28,7 @@ contract ValidationStub is IValidationModule {
     function setValidatorBounds(uint256, uint256) external {}
 
     function setRandomnessSeed(bytes32) external {}
+
+    function resetJobNonce(uint256) external {}
 }
 


### PR DESCRIPTION
## Summary
- track per-job nonce for validation rounds
- include job nonce in commit-reveal hash
- allow registry or owner to reset nonce after job resolution

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898968b41a08333a4f5aa2b9ce6903e