### PR TITLE
feat: route dispute fees through StakeManager

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -8,6 +8,7 @@ import "../v2/interfaces/IReputationEngine.sol";
 
 contract MockStakeManager is IStakeManager {
     mapping(address => mapping(Role => uint256)) private _stakes;
+    address public disputeModule;
 
     function setStake(address user, Role role, uint256 amount) external {
         _stakes[user][role] = amount;
@@ -17,6 +18,11 @@ contract MockStakeManager is IStakeManager {
     function withdrawStake(Role, uint256) external override {}
     function lockJobFunds(bytes32, address, uint256) external override {}
     function releaseJobFunds(bytes32, address, uint256) external override {}
+    function setDisputeModule(address module) external override {
+        disputeModule = module;
+    }
+    function lockDisputeFee(address, uint256) external override {}
+    function payDisputeFee(address, uint256) external override {}
 
     function slash(address user, Role role, uint256 amount, address)
         external
@@ -38,6 +44,7 @@ contract MockJobRegistry is IJobRegistry, IJobRegistryTax {
     mapping(uint256 => Job) private _jobs;
     uint256 public taxPolicyVersion;
     mapping(address => uint256) public taxAcknowledgedVersion;
+    address private _stakeManager;
 
     function setJob(uint256 jobId, Job calldata job) external {
         _jobs[jobId] = job;
@@ -57,7 +64,9 @@ contract MockJobRegistry is IJobRegistry, IJobRegistryTax {
 
     function setValidationModule(address) external override {}
     function setReputationEngine(address) external override {}
-    function setStakeManager(address) external override {}
+    function setStakeManager(address manager) external override {
+        _stakeManager = manager;
+    }
     function setCertificateNFT(address) external override {}
     function setDisputeModule(address) external override {}
     function setJobParameters(uint256, uint256) external override {}
@@ -68,6 +77,10 @@ contract MockJobRegistry is IJobRegistry, IJobRegistryTax {
     function resolveDispute(uint256, bool) external override {}
     function finalize(uint256) external override {}
     function cancelJob(uint256) external override {}
+
+    function stakeManager() external view override returns (address) {
+        return _stakeManager;
+    }
 }
 
 contract MockReputationEngine is IReputationEngine {

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -79,6 +79,10 @@ interface IJobRegistry {
     /// @param module Address of the dispute module contract
     function setDisputeModule(address module) external;
 
+    /// @notice Retrieve the StakeManager contract handling collateral
+    /// @return Address of the StakeManager
+    function stakeManager() external view returns (address);
+
     /// @notice Owner configuration of job limits
     /// @param reward Reward paid upon successful job completion
     /// @param stake Stake required from the agent to accept a job

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -20,6 +20,9 @@ interface IStakeManager {
         uint256 amount,
         address indexed employer
     );
+    event DisputeFeeLocked(address indexed payer, uint256 amount);
+    event DisputeFeePaid(address indexed to, uint256 amount);
+    event DisputeModuleUpdated(address module);
     event TokenUpdated(address token);
     event ParametersUpdated();
 
@@ -34,6 +37,15 @@ interface IStakeManager {
 
     /// @notice release locked job funds to recipient
     function releaseJobFunds(bytes32 jobId, address to, uint256 amount) external;
+
+    /// @notice set the dispute module authorized to manage dispute fees
+    function setDisputeModule(address module) external;
+
+    /// @notice lock a dispute fee from the payer
+    function lockDisputeFee(address payer, uint256 amount) external;
+
+    /// @notice pay out a locked dispute fee to the recipient
+    function payDisputeFee(address to, uint256 amount) external;
 
     /// @notice slash stake from a user for a specific role
     function slash(address user, Role role, uint256 amount, address employer) external;


### PR DESCRIPTION
## Summary
- add dispute fee management to StakeManager and interface
- route DisputeModule disputes through StakeManager using token units
- document appeal fee as 6-decimal token value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68989c10c214833399d449166c4f0d2d