### PR TITLE
Check TaxPolicy acknowledgements

### DIFF
--- a/contracts/mocks/BadTaxPolicy.sol
+++ b/contracts/mocks/BadTaxPolicy.sol
@@ -6,12 +6,22 @@ import "../v2/interfaces/ITaxPolicy.sol";
 /// @dev Mock implementation that reports non-exempt status.
 contract BadTaxPolicy is ITaxPolicy {
     uint256 private _version;
+    mapping(address => bool) public acknowledgedUsers;
 
     constructor() {
         _version = 1;
     }
 
-    function acknowledge() external pure returns (string memory) {
+    function acknowledge(address user) external returns (string memory) {
+        acknowledgedUsers[user] = true;
+        return "bad";
+    }
+
+    function acknowledged(address user) external view returns (bool) {
+        return acknowledgedUsers[user];
+    }
+
+    function acknowledgement() external pure returns (string memory) {
         return "bad";
     }
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -72,6 +72,12 @@ contract JobRegistry is Ownable, ReentrancyGuard {
                 taxAcknowledgedVersion[msg.sender] == taxPolicyVersion,
                 "acknowledge tax policy"
             );
+            if (address(taxPolicy) != address(0)) {
+                require(
+                    taxPolicy.acknowledged(msg.sender),
+                    "acknowledge tax policy"
+                );
+            }
         }
         _;
     }
@@ -182,7 +188,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     /// taxes are the responsibility of employers, agents, and validators.
     function taxAcknowledgement() external view returns (string memory) {
         if (address(taxPolicy) == address(0)) return "";
-        return taxPolicy.acknowledge();
+        return taxPolicy.acknowledgement();
     }
 
     /// @notice Returns the URI pointing to the full off-chain tax policy.
@@ -211,7 +217,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     /// tax responsibility.
     function acknowledgeTaxPolicy() external returns (string memory ack) {
         require(address(taxPolicy) != address(0), "policy");
-        ack = taxPolicy.acknowledge();
+        ack = taxPolicy.acknowledge(msg.sender);
         taxAcknowledgedVersion[msg.sender] = taxPolicyVersion;
         emit TaxAcknowledged(msg.sender, taxPolicyVersion, ack);
     }

--- a/contracts/v2/interfaces/ITaxPolicy.sol
+++ b/contracts/v2/interfaces/ITaxPolicy.sol
@@ -4,9 +4,18 @@ pragma solidity ^0.8.25;
 /// @title ITaxPolicy
 /// @notice Interface for retrieving tax policy details.
 interface ITaxPolicy {
-    /// @notice Returns a human-readable disclaimer confirming tax responsibilities.
+    /// @notice Record that `user` has acknowledged the current policy.
+    /// @param user Address of the participant acknowledging.
+    /// @return disclaimer Confirmation text stating the caller bears all tax liability.
+    function acknowledge(address user) external returns (string memory disclaimer);
+
+    /// @notice Check if a user has acknowledged the policy.
+    /// @param user Address of the participant.
+    function acknowledged(address user) external view returns (bool);
+
+    /// @notice Returns the acknowledgement text without recording acceptance.
     /// @return disclaimer Confirms all taxes fall on employers, agents, and validators.
-    function acknowledge() external view returns (string memory disclaimer);
+    function acknowledgement() external view returns (string memory disclaimer);
 
     /// @notice Returns the URI pointing to the canonical policy document.
     /// @return uri Off-chain document location (e.g., IPFS hash).

--- a/test/taxPolicy.ts
+++ b/test/taxPolicy.ts
@@ -34,7 +34,7 @@ describe("TaxPolicy", function () {
 
   it("allows owner to update acknowledgement", async () => {
     await tax.connect(owner).setAcknowledgement("updated ack");
-    expect(await tax.acknowledge()).to.equal("updated ack");
+    expect(await tax.acknowledgement()).to.equal("updated ack");
   });
 
   it("blocks non-owner acknowledgement updates", async () => {
@@ -46,7 +46,7 @@ describe("TaxPolicy", function () {
   });
 
   it("returns acknowledgement string", async () => {
-    const msg = await tax.acknowledge();
+    const msg = await tax.acknowledgement();
     expect(msg).to.equal("initial ack");
   });
 
@@ -59,7 +59,7 @@ describe("TaxPolicy", function () {
   it("allows owner to update URI and acknowledgement atomically", async () => {
     await tax.connect(owner).setPolicy("ipfs://u", "msg");
     expect(await tax.policyURI()).to.equal("ipfs://u");
-    expect(await tax.acknowledge()).to.equal("msg");
+    expect(await tax.acknowledgement()).to.equal("msg");
   });
 
   it("rejects non-owner setPolicy calls", async () => {
@@ -72,6 +72,13 @@ describe("TaxPolicy", function () {
 
   it("confirms the contract and owner are tax-exempt", async () => {
     expect(await tax.isTaxExempt()).to.equal(true);
+  });
+
+  it("records acknowledgement and emits event", async () => {
+    await expect(tax.connect(user).acknowledge(user.address))
+      .to.emit(tax, "PolicyAcknowledged")
+      .withArgs(user.address);
+    expect(await tax.acknowledged(user.address)).to.equal(true);
   });
 
   it("tracks policy version bumps", async () => {

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -23,7 +23,7 @@ describe("JobRegistry tax policy integration", function () {
       .to.emit(registry, "TaxPolicyUpdated")
       .withArgs(await policy.getAddress(), 1);
     expect(await registry.taxAcknowledgement()).to.equal(
-      await policy.acknowledge()
+      await policy.acknowledgement()
     );
     expect(await registry.taxPolicyURI()).to.equal("ipfs://policy");
     let details = await registry.taxPolicyDetails();
@@ -38,9 +38,12 @@ describe("JobRegistry tax policy integration", function () {
   it("tracks user acknowledgement", async () => {
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
     await expect(registry.connect(user).acknowledgeTaxPolicy())
-      .to.emit(registry, "TaxAcknowledged")
+      .to.emit(policy, "PolicyAcknowledged")
+      .withArgs(user.address)
+      .and.to.emit(registry, "TaxAcknowledged")
       .withArgs(user.address, 1, "ack");
     expect(await registry.taxAcknowledgedVersion(user.address)).to.equal(1);
+    expect(await policy.acknowledged(user.address)).to.equal(true);
   });
 
   it("requires re-acknowledgement after version bump", async () => {


### PR DESCRIPTION
## Summary
- enforce TaxPolicy acknowledgement for createJob and applyForJob
- track acknowledgements and emit PolicyAcknowledged event in TaxPolicy
- update tests for new acknowledgement flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b4fdc8b083338641d4058f9f4314