### PR TITLE
Use prevrandao-based validator selection and add VRF placeholder

### DIFF
--- a/contracts/v2/interfaces/IVRF.sol
+++ b/contracts/v2/interfaces/IVRF.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title IVRF
+/// @notice Placeholder interface for future VRF integrations without subscription.
+interface IVRF {
+    /// @notice Request random words from a VRF provider.
+    /// @return requestId Identifier for the randomness request.
+    function requestRandomWords() external returns (uint256 requestId);
+}

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -35,9 +35,6 @@ interface IValidationModule {
     /// @notice Owner configuration for validator counts
     function setValidatorBounds(uint256 minValidators, uint256 maxValidators) external;
 
-    /// @notice Owner configuration for randomness seed
-    function setRandomnessSeed(bytes32 seed) external;
-
     /// @notice Reset the validation nonce for a job after it is finalized or disputed
     /// @param jobId Identifier of the job
     function resetJobNonce(uint256 jobId) external;

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -27,8 +27,6 @@ contract ValidationStub is IValidationModule {
 
     function setValidatorBounds(uint256, uint256) external {}
 
-    function setRandomnessSeed(bytes32) external {}
-
     function resetJobNonce(uint256) external {}
 }
 


### PR DESCRIPTION
## Summary
- Seed validator selection with `keccak256(abi.encodePacked(block.prevrandao, jobId, block.timestamp))`
- Add optional VRF provider interface and setter for future randomness upgrades
- Update tests to reflect new stake-weighted selection logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898bb90bfbc8333aaaf66eb3e1750e6