### PR TITLE
Add ModuleUpdated events to JobRegistry

### DIFF
--- a/contracts/JobRegistry.sol
+++ b/contracts/JobRegistry.sol
@@ -59,6 +59,7 @@ contract JobRegistry is Ownable {
     uint256 public jobReward;
     uint256 public jobStake;
 
+    event ModuleUpdated(string module, address newAddress);
     event ValidationModuleUpdated(address module);
     event ReputationEngineUpdated(address engine);
     event StakeManagerUpdated(address manager);
@@ -82,26 +83,31 @@ contract JobRegistry is Ownable {
     function setValidationModule(IValidationModule module) external onlyOwner {
         validationModule = module;
         emit ValidationModuleUpdated(address(module));
+        emit ModuleUpdated("ValidationModule", address(module));
     }
 
     function setReputationEngine(IReputationEngine engine) external onlyOwner {
         reputationEngine = engine;
         emit ReputationEngineUpdated(address(engine));
+        emit ModuleUpdated("ReputationEngine", address(engine));
     }
 
     function setStakeManager(IStakeManager manager) external onlyOwner {
         stakeManager = manager;
         emit StakeManagerUpdated(address(manager));
+        emit ModuleUpdated("StakeManager", address(manager));
     }
 
     function setCertificateNFT(ICertificateNFT nft) external onlyOwner {
         certificateNFT = nft;
         emit CertificateNFTUpdated(address(nft));
+        emit ModuleUpdated("CertificateNFT", address(nft));
     }
 
     function setDisputeModule(IDisputeModule module) external onlyOwner {
         disputeModule = module;
         emit DisputeModuleUpdated(address(module));
+        emit ModuleUpdated("DisputeModule", address(module));
     }
 
     function setModules(
@@ -117,10 +123,15 @@ contract JobRegistry is Ownable {
         certificateNFT = _certificateNFT;
         disputeModule = _disputeModule;
         emit ValidationModuleUpdated(address(_validationModule));
+        emit ModuleUpdated("ValidationModule", address(_validationModule));
         emit ReputationEngineUpdated(address(_reputationEngine));
+        emit ModuleUpdated("ReputationEngine", address(_reputationEngine));
         emit StakeManagerUpdated(address(_stakeManager));
+        emit ModuleUpdated("StakeManager", address(_stakeManager));
         emit CertificateNFTUpdated(address(_certificateNFT));
+        emit ModuleUpdated("CertificateNFT", address(_certificateNFT));
         emit DisputeModuleUpdated(address(_disputeModule));
+        emit ModuleUpdated("DisputeModule", address(_disputeModule));
     }
 
     function setJobParameters(uint256 reward, uint256 stake) external onlyOwner {

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -86,6 +86,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     uint96 public jobStake;
 
     // module configuration events
+    event ModuleUpdated(string module, address newAddress);
     event ValidationModuleUpdated(address module);
     event StakeManagerUpdated(address manager);
     event ReputationEngineUpdated(address engine);
@@ -152,10 +153,15 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         disputeModule = _dispute;
         certificateNFT = _certNFT;
         emit ValidationModuleUpdated(address(_validation));
+        emit ModuleUpdated("ValidationModule", address(_validation));
         emit StakeManagerUpdated(address(_stakeMgr));
+        emit ModuleUpdated("StakeManager", address(_stakeMgr));
         emit ReputationEngineUpdated(address(_reputation));
+        emit ModuleUpdated("ReputationEngine", address(_reputation));
         emit DisputeModuleUpdated(address(_dispute));
+        emit ModuleUpdated("DisputeModule", address(_dispute));
         emit CertificateNFTUpdated(address(_certNFT));
+        emit ModuleUpdated("CertificateNFT", address(_certNFT));
     }
 
     /// @notice Sets the TaxPolicy contract holding the canonical disclaimer and
@@ -168,6 +174,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         taxPolicy = _policy;
         taxPolicyVersion++;
         emit TaxPolicyUpdated(address(_policy), taxPolicyVersion);
+        emit ModuleUpdated("TaxPolicy", address(_policy));
     }
 
     /// @notice Increments the tax policy version without changing the contract

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -39,6 +39,7 @@ interface IJobRegistry {
     error InvalidStatus(Status expected, Status actual);
 
     // module configuration
+    event ModuleUpdated(string module, address newAddress);
     event ValidationModuleUpdated(address module);
     event ReputationEngineUpdated(address engine);
     event StakeManagerUpdated(address manager);


### PR DESCRIPTION
## Summary
- add generic `ModuleUpdated` event
- emit event when JobRegistry modules or tax policy change

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6898c66ecd388333b9f783ed84f27029