### PR TITLE
feat: restrict job escrow to registry

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -61,7 +61,7 @@ async function main() {
   await reputation.setCaller(await registry.getAddress(), true);
   await reputation.setThreshold(1);
   await nft.setJobRegistry(await registry.getAddress());
-  await stake.transferOwnership(await registry.getAddress());
+  await stake.setJobRegistry(await registry.getAddress());
   await nft.transferOwnership(await registry.getAddress());
   await dispute.setAppealFee(10);
 

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -71,9 +71,6 @@ describe("Full system integration", function () {
       .connect(owner)
       .setJobRegistry(await registry.getAddress());
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
-    await stakeManager
-      .connect(owner)
-      .transferOwnership(await registry.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
     await registry.connect(owner).acknowledgeTaxPolicy();

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -66,7 +66,6 @@ describe("JobRegistry integration", function () {
     await stakeManager
       .connect(owner)
       .setJobRegistry(await registry.getAddress());
-    await stakeManager.connect(owner).transferOwnership(await registry.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
     await registry
       .connect(owner)

--- a/test/v2/LifecycleDispute.integration.test.js
+++ b/test/v2/LifecycleDispute.integration.test.js
@@ -69,7 +69,6 @@ describe("Job lifecycle with disputes", function () {
     await stakeManager
       .connect(owner)
       .setJobRegistry(await registry.getAddress());
-    await stakeManager.connect(owner).transferOwnership(await registry.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
     await registry
       .connect(owner)


### PR DESCRIPTION
## Summary
- gate job fund escrow and slashing functions behind a JobRegistry-only modifier
- allow owner to configure JobRegistry while keeping other settings owner-only
- update deployment scripts and tests for new StakeManager access pattern

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6898cc8c1da483338d660c2f53caa783