### PR TITLE
Ensure slashing deducts full amount and covers percentage edge cases

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -24,6 +24,8 @@ contract MockStakeManager is IStakeManager {
     function lockDisputeFee(address, uint256) external override {}
     function payDisputeFee(address, uint256) external override {}
 
+    function setSlashPercentSumEnforcement(bool) external override {}
+
     function slash(address user, Role role, uint256 amount, address)
         external
         override

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -25,6 +25,7 @@ interface IStakeManager {
     event DisputeModuleUpdated(address module);
     event TokenUpdated(address token);
     event ParametersUpdated();
+    event SlashPercentSumEnforcementUpdated(bool enforced);
 
     /// @notice deposit stake for caller for a specific role
     function depositStake(Role role, uint256 amount) external;
@@ -49,6 +50,9 @@ interface IStakeManager {
 
     /// @notice slash stake from a user for a specific role
     function slash(address user, Role role, uint256 amount, address employer) external;
+
+    /// @notice toggle enforcement requiring slashing percentages to sum to 100
+    function setSlashPercentSumEnforcement(bool enforced) external;
 
     /// @notice return total stake deposited by a user for a role
     function stakeOf(address user, Role role) external view returns (uint256);


### PR DESCRIPTION
## Summary
- Deduct entire `amount` from stake during slashing and distribute employer/treasury shares
- Add optional enforcement requiring slash percentages to sum to 100
- Test slashing outcomes for percentage sums under, equal to, and over 100

## Testing
- `npm test`
- `npm run lint` *(warn: 2267 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898cf51df188333807e04a06f57b1d1