### PR TITLE
feat: add fee pool for validator rewards

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title FeePool
+/// @notice Accumulates job fees and distributes them to stakers proportionally.
+/// @dev All token amounts use 6 decimals. Uses an accumulator scaled by 1e12
+///      to avoid precision loss when dividing fees by total stake.
+interface IStakeManager {
+    enum Role { Agent, Validator }
+
+    function stakeOf(address user, Role role) external view returns (uint256);
+    function totalStake(Role role) external view returns (uint256);
+    function jobRegistry() external view returns (address);
+}
+
+contract FeePool is Ownable {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant ACCUMULATOR_SCALE = 1e12;
+
+    /// @notice ERC20 token used for fees and rewards
+    IERC20 public token;
+
+    /// @notice StakeManager tracking validator stakes
+    IStakeManager public stakeManager;
+
+    /// @notice cumulative fee per staked token scaled by ACCUMULATOR_SCALE
+    uint256 public cumulativePerToken;
+
+    /// @notice checkpoint of claimed rewards per user
+    mapping(address => uint256) public userCheckpoint;
+
+    event FeeDeposited(address indexed from, uint256 amount);
+    event RewardsClaimed(address indexed user, uint256 amount);
+    event TokenUpdated(address indexed token);
+    event StakeManagerUpdated(address indexed stakeManager);
+
+    constructor(IERC20 _token, IStakeManager _stakeManager, address owner)
+        Ownable(owner)
+    {
+        token = _token;
+        stakeManager = _stakeManager;
+    }
+
+    modifier onlyJobRegistry() {
+        require(msg.sender == stakeManager.jobRegistry(), "only job registry");
+        _;
+    }
+
+    /// @notice deposit job fee for distribution to stakers
+    /// @param amount fee amount scaled to 6 decimals
+    function depositFee(uint256 amount) external onlyJobRegistry {
+        uint256 total = stakeManager.totalStake(IStakeManager.Role.Validator);
+        require(total > 0, "total stake");
+        cumulativePerToken += (amount * ACCUMULATOR_SCALE) / total;
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        emit FeeDeposited(msg.sender, amount);
+    }
+
+    /// @notice claim accumulated rewards for caller
+    function claimRewards() external {
+        uint256 stake = stakeManager.stakeOf(msg.sender, IStakeManager.Role.Validator);
+        uint256 cumulative = (stake * cumulativePerToken) / ACCUMULATOR_SCALE;
+        uint256 owed = cumulative - userCheckpoint[msg.sender];
+        userCheckpoint[msg.sender] = cumulative;
+        token.safeTransfer(msg.sender, owed);
+        emit RewardsClaimed(msg.sender, owed);
+    }
+
+    /// @notice update ERC20 token used for payouts
+    function setToken(IERC20 newToken) external onlyOwner {
+        token = newToken;
+        emit TokenUpdated(address(newToken));
+    }
+
+    /// @notice update StakeManager contract
+    function setStakeManager(IStakeManager manager) external onlyOwner {
+        stakeManager = manager;
+        emit StakeManagerUpdated(address(manager));
+    }
+
+    /// @notice Confirms the contract and its owner can never incur tax liability.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
+    /// @dev Reject direct ETH transfers to keep the contract tax neutral.
+    receive() external payable {
+        revert("FeePool: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("FeePool: no ether");
+    }
+}
+

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = 'contracts/v2'
+test = 'test/v2'
+libs = ['lib', 'node_modules']
+remappings = ['@openzeppelin/contracts=node_modules/@openzeppelin/contracts']
+via_ir = true

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "contracts/v2/FeePool.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+// minimal cheatcode interface
+interface Vm {
+    function prank(address) external;
+    function startPrank(address) external;
+    function stopPrank() external;
+}
+
+contract TestToken is ERC20 {
+    constructor() ERC20("Test", "TST") {}
+    function decimals() public pure override returns (uint8) { return 6; }
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+contract MockStakeManager is IStakeManager {
+    mapping(address => uint256) public stakes;
+    uint256 public totalStakeAmount;
+    address public override jobRegistry;
+
+    function setJobRegistry(address j) external { jobRegistry = j; }
+
+    function setStake(address user, uint256 amount) external {
+        totalStakeAmount = totalStakeAmount - stakes[user] + amount;
+        stakes[user] = amount;
+    }
+
+    function totalStake(Role) external view override returns (uint256) {
+        return totalStakeAmount;
+    }
+
+    function stakeOf(address user, Role) external view override returns (uint256) {
+        return stakes[user];
+    }
+}
+
+contract FeePoolTest {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
+
+    FeePool feePool;
+    TestToken token;
+    MockStakeManager stakeManager;
+    address jobRegistry = address(0x123);
+    address alice = address(0xA1);
+    address bob = address(0xB2);
+
+    function setUp() public {
+        token = new TestToken();
+        stakeManager = new MockStakeManager();
+        stakeManager.setJobRegistry(jobRegistry);
+        feePool = new FeePool(token, stakeManager, address(this));
+        stakeManager.setStake(alice, 1_000_000);
+        stakeManager.setStake(bob, 2_000_000);
+    }
+
+    function testDepositFee() public {
+        setUp();
+        token.mint(jobRegistry, 1_000_000);
+        vm.startPrank(jobRegistry);
+        token.approve(address(feePool), 1_000_000);
+        feePool.depositFee(1_000_000);
+        vm.stopPrank();
+        uint256 expected = 1_000_000 * feePool.ACCUMULATOR_SCALE() / 3_000_000;
+        require(feePool.cumulativePerToken() == expected, "acc");
+        require(token.balanceOf(address(feePool)) == 1_000_000, "bal");
+    }
+
+    function testClaimRewards() public {
+        setUp();
+        token.mint(jobRegistry, 1_500_000);
+        vm.startPrank(jobRegistry);
+        token.approve(address(feePool), 1_500_000);
+        feePool.depositFee(1_500_000);
+        vm.stopPrank();
+        vm.prank(alice);
+        feePool.claimRewards();
+        uint256 expected = 1_500_000 * 1_000_000 / 3_000_000;
+        require(token.balanceOf(alice) == expected, "claim");
+    }
+
+    function testTokenSwitch() public {
+        setUp();
+        TestToken token2 = new TestToken();
+        vm.prank(address(this));
+        feePool.setToken(token2);
+        token2.mint(jobRegistry, 1_000_000);
+        vm.startPrank(jobRegistry);
+        token2.approve(address(feePool), 1_000_000);
+        feePool.depositFee(1_000_000);
+        vm.stopPrank();
+        vm.prank(alice);
+        feePool.claimRewards();
+        require(token2.balanceOf(alice) == 333_333, "switch");
+    }
+
+    function testPrecisionSixDecimals() public {
+        setUp();
+        token.mint(jobRegistry, 1_000_000);
+        vm.startPrank(jobRegistry);
+        token.approve(address(feePool), 1_000_000);
+        feePool.depositFee(1_000_000);
+        vm.stopPrank();
+        vm.prank(alice);
+        feePool.claimRewards();
+        vm.prank(bob);
+        feePool.claimRewards();
+        require(token.balanceOf(alice) == 333_333, "alice");
+        require(token.balanceOf(bob) == 666_666, "bob");
+        require(token.balanceOf(alice) + token.balanceOf(bob) == 999_999, "sum");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add FeePool contract for distributing job fees to stakers
- allow owner to update fee token and stake manager
- cover deposit, reward claims, token switching, and decimal precision in tests

## Testing
- `forge test -vv`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e00f8c3483339ea2f85e1d6ef747