### PR TITLE
feat: add job router with weighted platform selection

### DIFF
--- a/contracts/v2/modules/JobRouter.sol
+++ b/contracts/v2/modules/JobRouter.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IStakeManager} from "../interfaces/IStakeManager.sol";
+import {IReputationEngine} from "../interfaces/IReputationEngine.sol";
+
+/// @title JobRouter
+/// @notice Routes jobs to registered platforms based on stake and reputation weighting
+contract JobRouter is Ownable {
+    IStakeManager public immutable stakeManager;
+    IReputationEngine public immutable reputationEngine;
+
+    /// @notice minimum stake required for a platform to register and remain eligible
+    uint256 public minStake;
+
+    /// @notice weighting factor applied to stake when computing selection weight
+    /// @dev scaled by 1e18 for precision
+    uint256 public stakeWeighting = 1e18;
+
+    /// @dev list of registered platforms
+    address[] public platforms;
+    mapping(address => bool) public isPlatform;
+
+    /// @dev records selected platform for a jobId
+    mapping(bytes32 => address) public routingHistory;
+
+    event PlatformRegistered(address indexed operator);
+    event PlatformSelected(bytes32 indexed jobId, address indexed platform);
+    event MinStakeUpdated(uint256 minStake);
+    event StakeWeightingUpdated(uint256 stakeWeighting);
+
+    constructor(IStakeManager _stakeManager, IReputationEngine _reputationEngine, address owner)
+        Ownable(owner)
+    {
+        stakeManager = _stakeManager;
+        reputationEngine = _reputationEngine;
+    }
+
+    /// @notice Register a platform if it meets the minimum stake requirement
+    /// @param operator Address of the platform operator
+    function registerPlatform(address operator) external {
+        require(!isPlatform[operator], "registered");
+        uint256 stake = stakeManager.stakeOf(operator, IStakeManager.Role.Agent);
+        require(stake >= minStake, "stake too low");
+        isPlatform[operator] = true;
+        platforms.push(operator);
+        emit PlatformRegistered(operator);
+    }
+
+    /// @notice Select a platform for a given jobId based on weighted randomness
+    /// @param jobId Identifier of the job
+    /// @return selected address of chosen platform or address(0) if none eligible
+    function selectPlatform(bytes32 jobId) external returns (address selected) {
+        uint256 len = platforms.length;
+        uint256 totalWeight;
+        uint256[] memory weights = new uint256[](len);
+
+        for (uint256 i = 0; i < len; i++) {
+            address platform = platforms[i];
+            uint256 stake = stakeManager.stakeOf(platform, IStakeManager.Role.Agent);
+            uint256 rep = reputationEngine.reputation(platform);
+            if (stake >= minStake && rep > 0) {
+                uint256 weight = (stake * stakeWeighting / 1e18) * rep;
+                weights[i] = weight;
+                totalWeight += weight;
+            }
+        }
+
+        if (totalWeight == 0) {
+            emit PlatformSelected(jobId, address(0));
+            routingHistory[jobId] = address(0);
+            return address(0);
+        }
+
+        uint256 rand = uint256(keccak256(abi.encodePacked(jobId, block.prevrandao))) % totalWeight;
+        uint256 cumulative;
+        for (uint256 i = 0; i < len; i++) {
+            uint256 weight = weights[i];
+            if (weight == 0) continue;
+            cumulative += weight;
+            if (rand < cumulative) {
+                selected = platforms[i];
+                break;
+            }
+        }
+        routingHistory[jobId] = selected;
+        emit PlatformSelected(jobId, selected);
+    }
+
+    /// @notice Update minimum stake requirement
+    function setMinStake(uint256 _minStake) external onlyOwner {
+        minStake = _minStake;
+        emit MinStakeUpdated(_minStake);
+    }
+
+    /// @notice Update stake weighting factor
+    function setStakeWeighting(uint256 _stakeWeighting) external onlyOwner {
+        stakeWeighting = _stakeWeighting;
+        emit StakeWeightingUpdated(_stakeWeighting);
+    }
+}
+

--- a/test/v2/JobRouter.t.sol
+++ b/test/v2/JobRouter.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "contracts/v2/modules/JobRouter.sol";
+import "contracts/v2/interfaces/IStakeManager.sol";
+import "contracts/v2/interfaces/IReputationEngine.sol";
+
+// minimal cheatcode interface
+interface Vm {
+    function prank(address) external;
+    function startPrank(address) external;
+    function stopPrank() external;
+    function prevrandao(bytes32) external;
+}
+
+contract MockStakeManager is IStakeManager {
+    function depositStake(Role, uint256) external override {}
+    function withdrawStake(Role, uint256) external override {}
+    function lockJobFunds(bytes32, address, uint256) external override {}
+    function releaseJobFunds(bytes32, address, uint256) external override {}
+    function setDisputeModule(address) external override {}
+    function lockDisputeFee(address, uint256) external override {}
+    function payDisputeFee(address, uint256) external override {}
+    function slash(address, Role, uint256, address) external override {}
+    function setSlashPercentSumEnforcement(bool) external override {}
+
+    mapping(address => uint256) public stakes;
+    function setStake(address user, uint256 amount) external {
+        stakes[user] = amount;
+    }
+    function stakeOf(address user, Role) external view override returns (uint256) {
+        return stakes[user];
+    }
+}
+
+contract MockReputationEngine is IReputationEngine {
+    function add(address, uint256) external override {}
+    function subtract(address, uint256) external override {}
+    function isBlacklisted(address) external view override returns (bool) { return false; }
+    function setCaller(address, bool) external override {}
+    function setThreshold(uint256) external override {}
+    function setBlacklist(address, bool) external override {}
+
+    mapping(address => uint256) public reps;
+    function setReputation(address user, uint256 amount) external {
+        reps[user] = amount;
+    }
+    function reputation(address user) external view override returns (uint256) {
+        return reps[user];
+    }
+}
+
+contract JobRouterTest {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
+
+    JobRouter router;
+    MockStakeManager stakeManager;
+    MockReputationEngine repEngine;
+    address platform1 = address(0x1);
+    address platform2 = address(0x2);
+
+    function setUp() public {
+        stakeManager = new MockStakeManager();
+        repEngine = new MockReputationEngine();
+        router = new JobRouter(stakeManager, repEngine, address(this));
+        router.setMinStake(50);
+        stakeManager.setStake(platform1, 100);
+        stakeManager.setStake(platform2, 100);
+        repEngine.setReputation(platform1, 1);
+        repEngine.setReputation(platform2, 3);
+        router.registerPlatform(platform1);
+        router.registerPlatform(platform2);
+    }
+
+    function testDeterministicSelection() public {
+        setUp();
+        bytes32 jobId = bytes32(uint256(123));
+        vm.prevrandao(bytes32(uint256(1)));
+        address selected = router.selectPlatform(jobId);
+        uint256 totalWeight = 100 + 300; // weights based on stake and reputation
+        uint256 rand = uint256(keccak256(abi.encodePacked(jobId, bytes32(uint256(1))))) % totalWeight;
+        address expected = rand < 100 ? platform1 : platform2;
+        require(selected == expected, "selection mismatch");
+        require(router.routingHistory(jobId) == expected, "history");
+    }
+
+    function testNoEligiblePlatforms() public {
+        stakeManager.setStake(platform1, 0);
+        stakeManager.setStake(platform2, 0);
+        vm.prevrandao(bytes32(uint256(1)));
+        address selected = router.selectPlatform(bytes32(uint256(1)));
+        require(selected == address(0), "should return zero");
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement JobRouter module that selects platforms proportionally to stake * reputation with pseudo-random seed from job and block prevrandao
- allow owner to configure minimum stake and stake weighting
- add JobRouter tests covering deterministic selection and zero-eligibility fallback

## Testing
- `forge test --match-path test/v2/JobRouter.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_6898e7e1dae883339760779125d62ce3