### PR TITLE
feat: rank platforms via reputation and stake

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -110,4 +110,12 @@ contract MockReputationEngine is IReputationEngine {
     function setThreshold(uint256) external override {}
 
     function setBlacklist(address, bool) external override {}
+
+    function getOperatorScore(address user) external view override returns (uint256) {
+        return _rep[user];
+    }
+
+    function setStakeManager(address) external override {}
+
+    function setScoringWeights(uint256, uint256) external override {}
 }

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -12,6 +12,8 @@ interface IReputationEngine {
 
     event ReputationChanged(address indexed user, int256 delta, uint256 newScore);
     event Blacklisted(address indexed user, bool status);
+    event StakeManagerUpdated(address stakeManager);
+    event ScoringWeightsUpdated(uint256 stakeWeight, uint256 reputationWeight);
 
     /// @notice Increase a user's reputation score
     /// @param user Address whose reputation is increased
@@ -52,5 +54,19 @@ interface IReputationEngine {
     /// @param user Address to update
     /// @param status True to blacklist the user, false to remove
     function setBlacklist(address user, bool status) external;
+
+    /// @notice Retrieve combined operator score using stake and reputation
+    /// @param operator Address to query
+    /// @return Weighted score used for ranking
+    function getOperatorScore(address operator) external view returns (uint256);
+
+    /// @notice Set the StakeManager used for stake lookups
+    /// @param manager Address of the StakeManager contract
+    function setStakeManager(address manager) external;
+
+    /// @notice Update weighting factors for stake and reputation contributions
+    /// @param stakeWeight Weight applied to stake (scaled by 1e18)
+    /// @param reputationWeight Weight applied to reputation (scaled by 1e18)
+    function setScoringWeights(uint256 stakeWeight, uint256 reputationWeight) external;
 }
 

--- a/contracts/v2/modules/DiscoveryModule.sol
+++ b/contracts/v2/modules/DiscoveryModule.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IStakeManager} from "../interfaces/IStakeManager.sol";
+import {IReputationEngine} from "../interfaces/IReputationEngine.sol";
+
+/// @title DiscoveryModule
+/// @notice Ranks registered platforms based on operator scores combining stake and reputation
+contract DiscoveryModule is Ownable {
+    IStakeManager public immutable stakeManager;
+    IReputationEngine public immutable reputationEngine;
+
+    uint256 public minStake;
+
+    address[] public platforms;
+    mapping(address => bool) public isPlatform;
+
+    event PlatformRegistered(address indexed operator);
+    event MinStakeUpdated(uint256 minStake);
+
+    constructor(
+        IStakeManager _stakeManager,
+        IReputationEngine _reputationEngine,
+        address owner
+    ) Ownable(owner) {
+        stakeManager = _stakeManager;
+        reputationEngine = _reputationEngine;
+    }
+
+    /// @notice Register a platform if it meets the minimum stake requirement
+    function registerPlatform(address operator) external {
+        require(!isPlatform[operator], "registered");
+        uint256 stake = stakeManager.stakeOf(operator, IStakeManager.Role.Agent);
+        require(stake >= minStake, "stake too low");
+        isPlatform[operator] = true;
+        platforms.push(operator);
+        emit PlatformRegistered(operator);
+    }
+
+    /// @notice Get top platforms ranked by operator score
+    /// @param limit Maximum number of platforms to return
+    function getTopPlatforms(uint256 limit)
+        external
+        view
+        returns (address[] memory)
+    {
+        uint256 len = platforms.length;
+        if (limit > len) limit = len;
+
+        address[] memory addrs = new address[](len);
+        uint256[] memory scores = new uint256[](len);
+        uint256 count;
+
+        for (uint256 i = 0; i < len; i++) {
+            address p = platforms[i];
+            uint256 stake = stakeManager.stakeOf(p, IStakeManager.Role.Agent);
+            if (stake < minStake) continue;
+            uint256 score = reputationEngine.getOperatorScore(p);
+            if (score == 0) continue;
+            addrs[count] = p;
+            scores[count] = score;
+            count++;
+        }
+
+        // selection sort descending by score
+        for (uint256 i = 0; i < count; i++) {
+            uint256 maxIndex = i;
+            for (uint256 j = i + 1; j < count; j++) {
+                if (scores[j] > scores[maxIndex]) {
+                    maxIndex = j;
+                }
+            }
+            if (maxIndex != i) {
+                (scores[i], scores[maxIndex]) = (scores[maxIndex], scores[i]);
+                (addrs[i], addrs[maxIndex]) = (addrs[maxIndex], addrs[i]);
+            }
+        }
+
+        if (limit < count) {
+            address[] memory result = new address[](limit);
+            for (uint256 i = 0; i < limit; i++) {
+                result[i] = addrs[i];
+            }
+            return result;
+        }
+        address[] memory all = new address[](count);
+        for (uint256 i = 0; i < count; i++) {
+            all[i] = addrs[i];
+        }
+        return all;
+    }
+
+    /// @notice Update minimum stake requirement for registration and ranking
+    function setMinStake(uint256 _minStake) external onlyOwner {
+        minStake = _minStake;
+        emit MinStakeUpdated(_minStake);
+    }
+}
+

--- a/test/v2/DiscoveryModule.test.js
+++ b/test/v2/DiscoveryModule.test.js
@@ -1,0 +1,53 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("DiscoveryModule", function () {
+  let stakeManager, engine, discovery, owner, p1, p2;
+
+  beforeEach(async () => {
+    [owner, p1, p2] = await ethers.getSigners();
+    const Stake = await ethers.getContractFactory("MockStakeManager");
+    stakeManager = await Stake.deploy();
+
+    const Engine = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    engine = await Engine.deploy(owner.address);
+    await engine.connect(owner).setCaller(owner.address, true);
+    await engine.connect(owner).setStakeManager(await stakeManager.getAddress());
+
+    const Discovery = await ethers.getContractFactory(
+      "contracts/v2/modules/DiscoveryModule.sol:DiscoveryModule"
+    );
+    discovery = await Discovery.deploy(
+      await stakeManager.getAddress(),
+      await engine.getAddress(),
+      owner.address
+    );
+    await discovery.connect(owner).setMinStake(0);
+  });
+
+  it("updates rankings when stake or reputation changes", async () => {
+    await stakeManager.setStake(p1.address, 0, 100);
+    await stakeManager.setStake(p2.address, 0, 100);
+
+    await discovery.registerPlatform(p1.address);
+    await discovery.registerPlatform(p2.address);
+
+    await engine.add(p1.address, 1);
+    await engine.add(p2.address, 2);
+
+    let top = await discovery.getTopPlatforms(2);
+    expect(top[0]).to.equal(p2.address);
+    expect(top[1]).to.equal(p1.address);
+
+    await stakeManager.setStake(p1.address, 0, 500);
+    top = await discovery.getTopPlatforms(2);
+    expect(top[0]).to.equal(p1.address);
+
+    await engine.add(p2.address, 1000);
+    top = await discovery.getTopPlatforms(2);
+    expect(top[0]).to.equal(p2.address);
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend ReputationEngine with operator scoring that combines stake and reputation
- add DiscoveryModule to rank platforms and expose `getTopPlatforms`
- cover ranking changes when stake or reputation updates

## Testing
- `npx hardhat test`
- `npx hardhat test test/v2/DiscoveryModule.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6898e9e562948333b0415f8077d982c3