### PR TITLE
Add AGIALPHA token and document incentive mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 - [AGIJobs NFT contract on Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code) / [Blockscout](https://blockscout.com/eth/mainnet/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477/contracts) – cross-check the address on multiple explorers before trading.
 - [$AGI token contract on Etherscan](https://etherscan.io/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D#code) / [Blockscout](https://eth.blockscout.com/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D?tab=contract) – cross-verify the token address before transacting.
 - [$AGIALPHA token contract on Etherscan](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe#code) – verify this 6‑decimal token on-chain before using it for staking or payments.
+- [AGIALPHAToken source](contracts/v2/AGIALPHAToken.sol) – default 6‑decimal ERC‑20 with owner‑controlled mint and burn.
 - [Etherscan Interaction Guide](docs/etherscan-guide.md) – module diagram, deployed addresses, role-based instructions, and verification checklist.
 - [Project Overview](docs/overview.md) – architecture diagram, module summaries, governance table, incentive mechanics, deployment addresses, and quick start.
 - [AGIJobManager v0 Source](legacy/AGIJobManagerv0.sol)
@@ -144,6 +145,10 @@ graph TD
 - Agents and validators must stake $AGIALPHA; dishonest behaviour is slashed.
 - Correct validators share rewards while employers receive a portion of slashed stakes.
 - Burn and stake parameters make cheating unprofitable, keeping honest participation in equilibrium.
+- Platform operators that stake $AGIALPHA receive on-chain fee dividends from `FeePool` with no off-chain accounting.
+- Higher stake and reputation improve job-routing priority and validator access, granting discovery advantages.
+- Minimum stake requirements, reputation thresholds and tax-policy acknowledgements make Sybil attacks costly.
+- All rewards flow directly to wallets in $AGIALPHA, keeping the protocol pseudonymous and tax-neutral.
 
 ### Economic Model
 

--- a/contracts/v2/AGIALPHAToken.sol
+++ b/contracts/v2/AGIALPHAToken.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title AGIALPHAToken
+/// @notice ERC20 token with 6 decimals used across AGI Jobs v2.
+/// @dev Owner can mint or burn to maintain full control. Decimals set to 6
+///      so all staking and payout amounts match on-chain accounting. The
+///      contract holds no special tax logic and never accepts ether to
+///      preserve tax neutrality for the owner.
+contract AGIALPHAToken is ERC20, Ownable {
+    uint8 private constant DECIMALS = 6;
+
+    constructor(address owner) ERC20("AGI ALPHA", "AGIALPHA") Ownable(owner) {}
+
+    /// @notice Returns token decimals (6).
+    function decimals() public pure override returns (uint8) {
+        return DECIMALS;
+    }
+
+    /// @notice Mint new tokens to an address.
+    /// @param to recipient of minted tokens
+    /// @param amount token amount with 6 decimals
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+
+    /// @notice Burn tokens from an address.
+    /// @param from address holding the tokens
+    /// @param amount token amount with 6 decimals
+    function burn(address from, uint256 amount) external onlyOwner {
+        _burn(from, amount);
+    }
+
+    /// @dev Reject direct ETH transfers to preserve tax neutrality.
+    receive() external payable {
+        revert("AGIALPHA: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("AGIALPHA: no ether");
+    }
+}
+

--- a/test/AGIALPHAToken.test.ts
+++ b/test/AGIALPHAToken.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("AGIALPHAToken", function () {
+  it("uses 6 decimals and allows owner mint/burn", async function () {
+    const [owner, user] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory(
+      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    const token = await Token.deploy(owner.address);
+
+    await token.mint(user.address, 1_000_000); // 1 token
+    expect(await token.decimals()).to.equal(6);
+    expect(await token.balanceOf(user.address)).to.equal(1_000_000);
+
+    await token.burn(user.address, 400_000);
+    expect(await token.balanceOf(user.address)).to.equal(600_000);
+  });
+
+  it("prevents non-owner minting", async function () {
+    const [owner, user] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory(
+      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    const token = await Token.deploy(owner.address);
+    await expect(
+      token.connect(user).mint(user.address, 1)
+    ).to.be.reverted;
+  });
+});


### PR DESCRIPTION
## Summary
- add 6-decimal `AGIALPHAToken` with owner-controlled mint/burn and ether rejection
- document on-chain fee sharing, routing priority and sybil resistance in README, linking to token source
- test `AGIALPHAToken` decimals and mint/burn rights

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_6898efc5bef48333ac318d2efe1c95dc