### PR TITLE
feat: add platform staking and configurable fee pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ When integrating with standard 18‑decimal ERC‑20s, divide amounts by `1e12` 
 1. Deploy `StakeManager` with the $AGIALPHA address, or call `setToken` after deployment to switch tokens.
 2. Wire modules via `JobRegistry.setModules` and adjust stake or fee parameters to 6‑decimal units (e.g. `100_000000` for 100 tokens).
 3. Employers and agents `approve` the `StakeManager` to spend $AGIALPHA, then use `createJob` or `depositStake` normally.
-4. Appeal fees in `DisputeModule` are denominated in $AGIALPHA and set with `setAppealFee`.
-5. All owner and user actions can be performed in a browser through Etherscan's **Write Contract** tab – connect a wallet, enter the primitive arguments, and submit the transaction.
+4. Platform operators stake under `Role.Platform` via `StakeManager.depositStake(2, amount)` and register their marketplace with `JobRouter.registerPlatform(operator)`. Staked operators share job fees through `FeePool` and can claim rewards with `claimRewards()`.
+5. Appeal fees in `DisputeModule` are denominated in $AGIALPHA and set with `setAppealFee`.
+6. All owner and user actions can be performed in a browser through Etherscan's **Write Contract** tab – connect a wallet, enter the primitive arguments, and submit the transaction.
 
 Each module is deployed once and remains immutable; the owner upgrades components by deploying a replacement and repointing `JobRegistry.setModules` or other owner‑only setters. Token amounts are always passed in base units (1 AGIALPHA = 1e6 units). The owner may replace the token later without redeploying other modules via `StakeManager.setToken(newToken)`.
 

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -8,9 +8,11 @@ import "../v2/interfaces/IReputationEngine.sol";
 
 contract MockStakeManager is IStakeManager {
     mapping(address => mapping(Role => uint256)) private _stakes;
+    mapping(Role => uint256) public totalStakes;
     address public disputeModule;
 
     function setStake(address user, Role role, uint256 amount) external {
+        totalStakes[role] = totalStakes[role] - _stakes[user][role] + amount;
         _stakes[user][role] = amount;
     }
 
@@ -33,10 +35,15 @@ contract MockStakeManager is IStakeManager {
         uint256 st = _stakes[user][role];
         require(st >= amount, "stake");
         _stakes[user][role] = st - amount;
+        totalStakes[role] -= amount;
     }
 
     function stakeOf(address user, Role role) external view override returns (uint256) {
         return _stakes[user][role];
+    }
+
+    function totalStake(Role role) external view override returns (uint256) {
+        return totalStakes[role];
     }
 
     function setToken(address) external {}

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -7,7 +7,8 @@ interface IStakeManager {
     /// @notice participant roles
     enum Role {
         Agent,
-        Validator
+        Validator,
+        Platform
     }
 
     event StakeDeposited(address indexed user, Role indexed role, uint256 amount);
@@ -56,5 +57,8 @@ interface IStakeManager {
 
     /// @notice return total stake deposited by a user for a role
     function stakeOf(address user, Role role) external view returns (uint256);
+
+    /// @notice return aggregate stake for a role
+    function totalStake(Role role) external view returns (uint256);
 }
 

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -52,7 +52,7 @@ contract FeePoolTest {
         token = new TestToken();
         stakeManager = new MockStakeManager();
         stakeManager.setJobRegistry(jobRegistry);
-        feePool = new FeePool(token, stakeManager, address(this));
+        feePool = new FeePool(token, stakeManager, IStakeManager.Role.Validator, address(this));
         stakeManager.setStake(alice, 1_000_000);
         stakeManager.setStake(bob, 2_000_000);
     }

--- a/test/v2/JobRouter.t.sol
+++ b/test/v2/JobRouter.t.sol
@@ -25,11 +25,17 @@ contract MockStakeManager is IStakeManager {
     function setSlashPercentSumEnforcement(bool) external override {}
 
     mapping(address => uint256) public stakes;
+    uint256 public totalStakeAmount;
+
     function setStake(address user, uint256 amount) external {
+        totalStakeAmount = totalStakeAmount - stakes[user] + amount;
         stakes[user] = amount;
     }
     function stakeOf(address user, Role) external view override returns (uint256) {
         return stakes[user];
+    }
+    function totalStake(Role) external view override returns (uint256) {
+        return totalStakeAmount;
     }
 }
 
@@ -48,6 +54,11 @@ contract MockReputationEngine is IReputationEngine {
     function reputation(address user) external view override returns (uint256) {
         return reps[user];
     }
+    function getOperatorScore(address user) external view override returns (uint256) {
+        return reps[user];
+    }
+    function setStakeManager(address) external override {}
+    function setScoringWeights(uint256, uint256) external override {}
 }
 
 contract JobRouterTest {

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -50,9 +50,11 @@ describe("StakeManager", function () {
     ).to.emit(stakeManager, "StakeDeposited").withArgs(user.address, 0, 200);
 
     expect(await stakeManager.stakes(user.address, 0)).to.equal(200n);
+    expect(await stakeManager.totalStake(0)).to.equal(200n);
 
     await stakeManager.connect(user).withdrawStake(0, 50);
     expect(await stakeManager.stakes(user.address, 0)).to.equal(150n);
+    expect(await stakeManager.totalStake(0)).to.equal(150n);
 
     const registryAddr = await jobRegistry.getAddress();
     await ethers.provider.send("hardhat_setBalance", [registryAddr, "0x56BC75E2D63100000"]);
@@ -82,6 +84,7 @@ describe("StakeManager", function () {
       50
     );
     expect(await stakeManager.stakes(user.address, 0)).to.equal(50n);
+    expect(await stakeManager.totalStake(0)).to.equal(50n);
     expect(await token.balanceOf(employer.address)).to.equal(750n);
     expect(await token.balanceOf(treasury.address)).to.equal(50n);
   });


### PR DESCRIPTION
## Summary
- track total stakes per role and support platform operator staking
- add configurable FeePool with burn percentage and selectable reward role
- document platform deployment steps using AGIALPHA

## Testing
- `npm test`
- `forge test`
- `npm run lint` *(warnings, no errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898f37324bc833392e5c0ced114e94d