### PR TITLE
feat: integrate fee pool revenue sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ When integrating with standard 18‑decimal ERC‑20s, divide amounts by `1e12` 
 **Deployment steps**
 
 1. Deploy `StakeManager` with the $AGIALPHA address, or call `setToken` after deployment to switch tokens.
-2. Wire modules via `JobRegistry.setModules` and adjust stake or fee parameters to 6‑decimal units (e.g. `100_000000` for 100 tokens).
-3. Employers and agents `approve` the `StakeManager` to spend $AGIALPHA, then use `createJob` or `depositStake` normally.
+2. Wire modules via `JobRegistry.setModules`, then attach the fee pool through `JobRegistry.setFeePool(pool)` and choose a protocol fee with `setFeePct(pct)`. All stake and fee parameters use 6‑decimal units (e.g. `100_000000` for 100 tokens).
+3. Employers and agents `approve` the `StakeManager` to spend $AGIALPHA, then use `createJob` or `depositStake` normally. Employer approvals must cover the reward plus protocol fee.
 4. Platform operators stake under `Role.Platform` via `StakeManager.depositStake(2, amount)` and register their marketplace with `JobRouter.registerPlatform(operator)`. Staked operators share job fees through `FeePool` and can claim rewards with `claimRewards()`.
 5. Appeal fees in `DisputeModule` are denominated in $AGIALPHA and set with `setAppealFee`.
 6. All owner and user actions can be performed in a browser through Etherscan's **Write Contract** tab – connect a wallet, enter the primitive arguments, and submit the transaction.

--- a/contracts/v2/interfaces/IFeePool.sol
+++ b/contracts/v2/interfaces/IFeePool.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title IFeePool
+/// @notice Minimal interface for depositing job fees
+interface IFeePool {
+    /// @notice notify the pool about newly received fees
+    /// @param amount amount of tokens transferred to the pool scaled to 6 decimals
+    function depositFee(uint256 amount) external;
+}

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -59,11 +59,9 @@ contract FeePoolTest {
 
     function testDepositFee() public {
         setUp();
-        token.mint(jobRegistry, 1_000_000);
-        vm.startPrank(jobRegistry);
-        token.approve(address(feePool), 1_000_000);
+        token.mint(address(feePool), 1_000_000);
+        vm.prank(jobRegistry);
         feePool.depositFee(1_000_000);
-        vm.stopPrank();
         uint256 expected = 1_000_000 * feePool.ACCUMULATOR_SCALE() / 3_000_000;
         require(feePool.cumulativePerToken() == expected, "acc");
         require(token.balanceOf(address(feePool)) == 1_000_000, "bal");
@@ -71,11 +69,9 @@ contract FeePoolTest {
 
     function testClaimRewards() public {
         setUp();
-        token.mint(jobRegistry, 1_500_000);
-        vm.startPrank(jobRegistry);
-        token.approve(address(feePool), 1_500_000);
+        token.mint(address(feePool), 1_500_000);
+        vm.prank(jobRegistry);
         feePool.depositFee(1_500_000);
-        vm.stopPrank();
         vm.prank(alice);
         feePool.claimRewards();
         uint256 expected = 1_500_000 * 1_000_000 / 3_000_000;
@@ -87,11 +83,9 @@ contract FeePoolTest {
         TestToken token2 = new TestToken();
         vm.prank(address(this));
         feePool.setToken(token2);
-        token2.mint(jobRegistry, 1_000_000);
-        vm.startPrank(jobRegistry);
-        token2.approve(address(feePool), 1_000_000);
+        token2.mint(address(feePool), 1_000_000);
+        vm.prank(jobRegistry);
         feePool.depositFee(1_000_000);
-        vm.stopPrank();
         vm.prank(alice);
         feePool.claimRewards();
         require(token2.balanceOf(alice) == 333_333, "switch");
@@ -99,11 +93,9 @@ contract FeePoolTest {
 
     function testPrecisionSixDecimals() public {
         setUp();
-        token.mint(jobRegistry, 1_000_000);
-        vm.startPrank(jobRegistry);
-        token.approve(address(feePool), 1_000_000);
+        token.mint(address(feePool), 1_000_000);
+        vm.prank(jobRegistry);
         feePool.depositFee(1_000_000);
-        vm.stopPrank();
         vm.prank(alice);
         feePool.claimRewards();
         vm.prank(bob);

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -104,6 +104,43 @@ describe("JobRegistry integration", function () {
     expect(await nft.balanceOf(agent.address)).to.equal(1);
   });
 
+  it("distributes platform fee to stakers", async () => {
+    // set up fee pool rewarding platform stakers
+    const FeePool = await ethers.getContractFactory(
+      "contracts/v2/FeePool.sol:FeePool"
+    );
+    const feePool = await FeePool.deploy(
+      await token.getAddress(),
+      await stakeManager.getAddress(),
+      2,
+      owner.address
+    );
+    await registry.connect(owner).setFeePool(await feePool.getAddress());
+    await registry.connect(owner).setFeePct(10); // 10%
+    await token.mint(owner.address, reward);
+    await token
+      .connect(owner)
+      .approve(await stakeManager.getAddress(), reward);
+    await stakeManager
+      .connect(owner)
+      .depositStake(2, reward); // owner is platform operator
+
+    // employer locks reward + fee
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), reward + reward / 10);
+    await registry.connect(employer).createJob();
+    const jobId = 1;
+    await registry.connect(agent).applyForJob(jobId);
+    await validation.connect(owner).setResult(true);
+    await registry.connect(agent).completeJob(jobId);
+    await registry.connect(employer).finalize(jobId);
+
+    // platform operator should be able to claim fee
+    await feePool.connect(owner).claimRewards();
+    expect(await token.balanceOf(owner.address)).to.equal(reward / 10);
+  });
+
   it("handles collusion resolved by dispute", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     await registry.connect(employer).createJob();


### PR DESCRIPTION
## Summary
- route protocol fees to a modular FeePool and stream rewards to staked platforms
- allow JobRegistry owner to configure fee pool and protocol fee percentage
- document AGIALPHA deployment flow and fee pool setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898fd1044688333a1dfe0f945d91006