### PR TITLE
docs: highlight owner controls for AGIALPHA incentives

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ graph TD
 - Governance uses token-weighted voting; active voters earn bonus shares from future `FeePool` epochs.
 - Minimum stake gates, configurable burns and reputation thresholds deter sybil attacks while keeping supply deflationary.
 - All value flows occur directly between pseudonymous wallets in $AGIALPHA, keeping operators tax-neutral and the owner revenue-free.
+- Every incentive parameter is adjustable only by the contract owner through on-chain setters, so a non-technical operator can tune fees, burns, and stake thresholds via Etherscan without redeploying.
 
 ### Economic Model
 

--- a/docs/incentive-mechanisms-agialpha.md
+++ b/docs/incentive-mechanisms-agialpha.md
@@ -24,5 +24,6 @@ This note details how $AGIALPHA (6 decimals) powers a tax‑neutral, reporting�
 ## 5. Owner Controls & User Experience
 - The contract owner may update fees, burn rates, stake thresholds, and even swap the token address via `StakeManager.setToken`.
 - All interactions rely on simple data types, enabling non‑technical users to operate entirely through Etherscan.
+- Reward flows never touch off‑chain accounts, keeping operators pseudonymous and outside traditional reporting regimes.
 
 These incentives encourage honest participation, amplify $AGIALPHA demand, and keep all flows pseudonymous and globally tax‑neutral.


### PR DESCRIPTION
## Summary
- Document owner-only controls for adjusting incentive parameters
- Clarify on-chain reward flows that preserve pseudonymity and avoid reporting

## Testing
- `npm run lint`
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_6899036896008333934d88f651956727