### PR TITLE
feat: add stake locking and per-address limits

### DIFF
--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -358,14 +358,14 @@ describe("StakeManager", function () {
     const registrySigner = await ethers.getImpersonatedSigner(registryAddr);
 
     const lockDuration = 3600n;
-    const current = await time.latest();
+    const current = BigInt(await time.latest());
     await expect(
       stakeManager
         .connect(registrySigner)
         .lockStake(user.address, 200, Number(lockDuration))
     )
       .to.emit(stakeManager, "StakeLocked")
-      .withArgs(user.address, 200, current + lockDuration);
+      .withArgs(user.address, 200n, current + lockDuration);
 
     await expect(
       stakeManager.connect(user).withdrawStake(0, 1)
@@ -377,9 +377,9 @@ describe("StakeManager", function () {
       stakeManager.connect(user).withdrawStake(0, 50)
     )
       .to.emit(stakeManager, "StakeUnlocked")
-      .withArgs(user.address, 200)
+      .withArgs(user.address, 200n)
       .and.to.emit(stakeManager, "StakeWithdrawn")
-      .withArgs(user.address, 0, 50);
+      .withArgs(user.address, 0, 50n);
   });
 
   it("allows slashing during active lock", async () => {

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -359,13 +359,14 @@ describe("StakeManager", function () {
 
     const lockDuration = 3600n;
     const current = BigInt(await time.latest());
+    const expectedUnlock = current + 1n + lockDuration;
     await expect(
       stakeManager
         .connect(registrySigner)
         .lockStake(user.address, 200, Number(lockDuration))
     )
       .to.emit(stakeManager, "StakeLocked")
-      .withArgs(user.address, 200n, current + lockDuration);
+      .withArgs(user.address, 200n, expectedUnlock);
 
     await expect(
       stakeManager.connect(user).withdrawStake(0, 1)


### PR DESCRIPTION
## Summary
- add time-locked stake commitments and per-address stake cap
- emit lock/unlock events and prevent withdrawals before unlock
- test stake locking, unlocking, and slashing while locked

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68990633d6c88333bd444b743fe69924