### PR TITLE
docs: document agialpha incentives

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,12 @@ graph TD
 
 ### Incentive Summary
 
-- Agents and validators post $AGIALPHA collateral and are slashed for dishonest behaviour.
-- Protocol fees stream to staking operators through an on-chain `FeePool`, requiring no off-chain reporting.
-- Job routing and discovery modules prioritise platforms with higher stake and reputation, granting visibility and validator throughput advantages.
-- Governance uses token-weighted voting; active voters earn bonus shares from future `FeePool` epochs.
-- Minimum stake gates, configurable burns and reputation thresholds deter sybil attacks while keeping supply deflationary.
-- All value flows occur directly between pseudonymous wallets in $AGIALPHA, keeping operators tax-neutral and the owner revenue-free.
-- Every incentive parameter is adjustable only by the contract owner through on-chain setters, so a non-technical operator can tune fees, burns, and stake thresholds via Etherscan without redeploying.
+- **On-chain revenue sharing** – the `FeePool` redistributes protocol fees to platform operators in proportion to their staked $AGIALPHA so rewards require no off-chain reporting.
+- **Algorithmic & reputational perks** – `JobRouter`, `DiscoveryModule` and the `ReputationEngine` grant stake‑weighted job routing priority, validator throughput and search visibility.
+- **Governance-aligned rewards** – staked operators vote on parameters and participating voters earn small bonus shares in the next `FeePool` epoch.
+- **Sybil & regulatory mitigation** – minimum stakes, slashing, configurable burns and on-chain tax acknowledgements keep operations pseudonymous while deterring sybil attacks.
+- **Pseudonymous value flows** – all transfers occur directly between wallets in $AGIALPHA, leaving operators tax-neutral and the owner revenue-free.
+- **Owner-controlled & Etherscan-friendly** – only the contract owner can adjust fees, burns, stake thresholds or even swap the token, and every action uses simple function calls suitable for Etherscan.
 
 ### Economic Model
 

--- a/docs/incentive-mechanisms-agialpha.md
+++ b/docs/incentive-mechanisms-agialpha.md
@@ -19,6 +19,7 @@ This note details how $AGIALPHA (6 decimals) powers a tax‑neutral, reporting�
 ## 4. Sybil & Regulatory Mitigation
 - Minimum stake gates every platform deployment; failure or misconduct can slash this collateral.
 - A configurable burn percentage on each payout permanently removes tokens, countering sybil farms and increasing scarcity.
+- On-chain tax acknowledgements and blacklist thresholds are owner‑tuned, letting deployments adapt to local compliance signals while keeping addresses pseudonymous.
 - Because the protocol never takes custody or issues off‑chain payouts, there is no centralized revenue that would trigger reporting duties.
 
 ## 5. Owner Controls & User Experience


### PR DESCRIPTION
## Summary
- detail on-chain revenue sharing and routing perks for AGIALPHA stakers
- expand sybil and regulatory mitigation notes in incentive docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689914664f0c8333bbae38f58c32bea4