### PR TITLE
docs: expand agialpha incentive guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AGIJob Manager
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
-AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labor markets among autonomous agents.  The legacy v0 deployment transacts in $AGI, while the modular v2 suite defaults to [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) – a 6‑decimal ERC‑20 that the contract owner can replace at any time through `StakeManager.setToken`. This repository hosts the immutable mainnet deployment (v0) and an unaudited v1 prototype under active development. Treat every address as unverified until you confirm it on-chain and through official AGI.eth channels.
+AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labor markets among autonomous agents. The legacy v0 deployment transacts in $AGI, while the modular v2 suite defaults to [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) – a 6‑decimal ERC‑20 used for payments, staking, rewards and dispute deposits. The contract owner can swap this token at any time via `StakeManager.setToken` without redeploying other modules. This repository hosts the immutable mainnet deployment (v0) and an unaudited v1 prototype under active development. Treat every address as unverified until you confirm it on-chain and through official AGI.eth channels.
 
 > **Critical Security Notice:** `AGIJobManagerv0.sol` in `legacy/` is the exact source for the mainnet contract at [`0x0178…ba477`](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477). It is immutable and must never be altered. Any future releases will appear as new files (for example, `contracts/AGIJobManagerv1.sol`) and will be announced only through official AGI.eth channels. Always cross‑check contract addresses and bytecode on multiple explorers before sending funds or interacting with a deployment.
 
@@ -179,7 +179,7 @@ graph TD
 - **On-chain revenue sharing** – the `FeePool` redistributes protocol fees to platform operators in proportion to their staked $AGIALPHA so rewards require no off-chain reporting.
 - **Algorithmic & reputational perks** – `JobRouter`, `DiscoveryModule` and the `ReputationEngine` grant stake‑weighted job routing priority, validator throughput and search visibility.
 - **Governance-aligned rewards** – staked operators vote on parameters and participating voters earn small bonus shares in the next `FeePool` epoch.
-- **Sybil & regulatory mitigation** – minimum stakes, slashing, configurable burns and on-chain tax acknowledgements keep operations pseudonymous while deterring sybil attacks.
+- **Sybil & regulatory mitigation** – minimum stakes, slashing, appeal deposits, and owner‑tuned burns and blacklist thresholds keep operations pseudonymous while deterring sybil attacks.
 - **Pseudonymous value flows** – all transfers occur directly between wallets in $AGIALPHA, leaving operators tax-neutral and the owner revenue-free.
 - **Owner-controlled & Etherscan-friendly** – only the contract owner can adjust fees, burns, stake thresholds or even swap the token, and every action uses simple function calls suitable for Etherscan.
 

--- a/docs/coding-sprint-agialpha-incentives.md
+++ b/docs/coding-sprint-agialpha-incentives.md
@@ -21,9 +21,10 @@ This sprint adds revenue sharing and routing incentives to the v2 suite while pr
 4. **DiscoveryModule**
    - Index platforms and expose a paginated list sorted by stake and reputation.
    - Include a stake badge for UI clients.
-5. **Governance Hooks**
+5. **Dispute & Governance Hooks**
    - Add token‑weighted voting using staked balances for configuration changes (e.g., fee rates).
    - Implement bonus distribution to participating voters in the next `FeePool` epoch.
+   - Denominate appeal deposits in $AGIALPHA via `DisputeModule.setAppealFee` and route slashed fees to the `FeePool` or burner.
 6. **Sybil Mitigations**
    - Enforce minimum stake for platform registration.
    - Add optional identity commitments or human‑check modules that can be toggled by the owner.

--- a/docs/incentive-mechanisms-agialpha.md
+++ b/docs/incentive-mechanisms-agialpha.md
@@ -19,6 +19,7 @@ This note details how $AGIALPHA (6 decimals) powers a tax‑neutral, reporting�
 ## 4. Sybil & Regulatory Mitigation
 - Minimum stake gates every platform deployment; failure or misconduct can slash this collateral.
 - A configurable burn percentage on each payout permanently removes tokens, countering sybil farms and increasing scarcity.
+- Appeal deposits in `DisputeModule` are denominated in $AGIALPHA and may be burned or paid to honest parties, discouraging frivolous challenges.
 - On-chain tax acknowledgements and blacklist thresholds are owner‑tuned, letting deployments adapt to local compliance signals while keeping addresses pseudonymous.
 - Because the protocol never takes custody or issues off‑chain payouts, there is no centralized revenue that would trigger reporting duties.
 


### PR DESCRIPTION
## Summary
- clarify $AGIALPHA usage for payments, staking, rewards and dispute deposits
- detail appeal deposit incentives and owner-tuned sybil mitigations
- extend sprint plan with dispute fee tasks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689925f2b7d483338ae9411cef9564aa