### PR TITLE
docs: clarify agialpha incentive objectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ graph TD
 - **Algorithmic & reputational perks** – `JobRouter`, `DiscoveryModule` and the `ReputationEngine` grant stake‑weighted job routing priority, validator throughput and search visibility.
 - **Governance-aligned rewards** – staked operators vote on parameters and participating voters earn small bonus shares in the next `FeePool` epoch.
 - **Sybil & regulatory mitigation** – minimum stakes, slashing, appeal deposits, and owner‑tuned burns and blacklist thresholds keep operations pseudonymous while deterring sybil attacks.
-- **Pseudonymous value flows** – all transfers occur directly between wallets in $AGIALPHA, leaving operators tax-neutral and the owner revenue-free.
+- **Tax‑neutral pseudonymous value flows** – all transfers occur directly between wallets in $AGIALPHA with no off‑chain reporting, leaving operators tax‑neutral and the owner revenue‑free.
 - **Owner-controlled & Etherscan-friendly** – only the contract owner can adjust fees, burns, stake thresholds or even swap the token, and every action uses simple function calls suitable for Etherscan.
 
 ### Economic Model

--- a/docs/coding-sprint-agialpha-incentives.md
+++ b/docs/coding-sprint-agialpha-incentives.md
@@ -6,6 +6,8 @@ This sprint adds revenue sharing and routing incentives to the v2 suite while pr
 - Implement smart‑contract revenue sharing for platform operators.
 - Introduce stake‑weighted job routing and discovery modules.
 - Align governance with rewards and embed sybil resistance.
+- Keep all value flows on‑chain in $AGIALPHA (6 decimals) and let the owner swap
+  the token or adjust parameters without redeploying contracts.
 
 ## Tasks
 1. **FeePool Contract**


### PR DESCRIPTION
## Summary
- Document tax-neutral pseudonymous fee flows for AGIALPHA rewards
- Note that incentives must keep value on-chain in 6-decimal AGIALPHA with owner-controlled token swaps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689929352d2483338ec093620cd5a292