### PR TITLE
feat: add platform registry module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,6 +1008,7 @@ interface IStakeManager {
 | `ValidationModule` | `0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9` | Selects validators and runs commit‑reveal voting |
 | `StakeManager` | `0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512` | Custodies collateral and executes slashing |
 | `ReputationEngine` | `0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9` | Updates reputation scores and applies penalties |
+| `PlatformRegistry` | `0x0000000000000000000000000000000000000000` | Registers staked operators and exposes routing scores |
 | `DisputeModule` | `0x0165878A594ca255338adfa4d48449f69242Eb8F` | Handles appeals and renders final rulings |
 | `CertificateNFT` | `0x5FC8d32690cc91D4c39d9d3abcBD16989F875707` | Mints ERC‑721 certificates for completed jobs |
 | `TaxPolicy` | `0x0000000000000000000000000000000000000000` | Stores tax disclaimer URI and acknowledgement helper |
@@ -1031,14 +1032,14 @@ $AGIALPHA is a 6‑decimal ERC‑20 token used across the platform for payments,
 1. **Deploy core modules** in the following order using any wallet or Etherscan `Write` tab:
    - `StakeManager` – constructor takes the $AGIALPHA token and treasury address.
    - `ReputationEngine` – pass your address as owner and later call `setCaller` for authorized modules.
-   - `FeePool`, `JobRegistry`, `ValidationModule`, `DisputeModule`, `CertificateNFT`, `JobRouter`, and `DiscoveryModule` – use the previously deployed module addresses in their constructors.
+   - `FeePool`, `JobRegistry`, `ValidationModule`, `DisputeModule`, `CertificateNFT`, and `PlatformRegistry` – use the previously deployed module addresses in their constructors.
 2. **Configure staking and rewards**
    - On `StakeManager`, call `setMinStake`, `setSlashingPercentages`, and `setTreasury` as needed.
    - On `FeePool`, call `setRewardRole(2)` to direct revenue to platform stakers and adjust `setBurnPct` if desired.
 3. **Wire modules together**
    - In `JobRegistry`, call `setModules` with addresses of `ValidationModule`, `StakeManager`, `ReputationEngine`, `DisputeModule`, and `CertificateNFT`.
    - In `ValidationModule`, set validator windows, pool, and connect the `ReputationEngine`.
-   - For discovery and routing benefits, register platform operators in `JobRouter` and `DiscoveryModule` once they have staked tokens (`Role 2 = Platform`).
+   - Once operators have staked tokens (role `2 = Platform`), have them call `register()` on `PlatformRegistry` to gain routing priority and fee shares.
 4. **Token flexibility**
    - If a new payout token is needed, the owner may call `setToken` on `StakeManager`, `FeePool`, and any other module holding tokens. No redeployment is required.
 
@@ -1056,6 +1057,9 @@ Once configured, all interaction—job creation, staking, validation, dispute re
 **depositStake**
 1. Open `StakeManager` **Read Contract** and confirm `isTaxExempt()`.
 2. In **Write Contract**, call `depositStake(role, amount)` (role `0` = Agent, `1` = Validator, `2` = Platform).
+
+**registerPlatform**
+1. After staking under role `2`, open `PlatformRegistry` **Write Contract** and call `register()` to receive routing priority and fee shares.
 
 **commitValidation / revealValidation**
 1. On `ValidationModule` **Read Contract**, check `isTaxExempt()`.

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IStakeManager} from "./interfaces/IStakeManager.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+interface IReputationEngine {
+    function reputation(address user) external view returns (uint256);
+    function isBlacklisted(address user) external view returns (bool);
+    function stakeWeight() external view returns (uint256);
+    function reputationWeight() external view returns (uint256);
+}
+
+/// @title PlatformRegistry
+/// @notice Registers platform operators that stake $AGIALPHA and exposes
+///         reputation-weighted scores for job routing and discovery.
+/// @dev Holds no tokens and rejects ether to remain tax neutral. All values
+///      use 6 decimals via the `StakeManager`.
+contract PlatformRegistry is Ownable, ReentrancyGuard {
+    IStakeManager public stakeManager;
+    IReputationEngine public reputationEngine;
+    uint256 public minPlatformStake;
+
+    mapping(address => bool) public registered;
+
+    event Registered(address indexed operator);
+    event Deregistered(address indexed operator);
+    event StakeManagerUpdated(address indexed stakeManager);
+    event ReputationEngineUpdated(address indexed engine);
+    event MinPlatformStakeUpdated(uint256 stake);
+
+    constructor(
+        IStakeManager _stakeManager,
+        IReputationEngine _reputationEngine,
+        uint256 _minStake,
+        address owner
+    ) Ownable(owner) {
+        stakeManager = _stakeManager;
+        reputationEngine = _reputationEngine;
+        minPlatformStake = _minStake;
+    }
+
+    /// @notice Register caller as a platform operator.
+    /// @dev Requires caller to maintain at least `minPlatformStake` of
+    ///      `Role.Platform` stake within the `StakeManager`.
+    function register() external nonReentrant {
+        require(!registered[msg.sender], "registered");
+        uint256 stake = stakeManager.stakeOf(msg.sender, IStakeManager.Role.Platform);
+        require(stake >= minPlatformStake, "stake");
+        registered[msg.sender] = true;
+        emit Registered(msg.sender);
+    }
+
+    /// @notice Remove caller from the registry.
+    function deregister() external nonReentrant {
+        require(registered[msg.sender], "not registered");
+        registered[msg.sender] = false;
+        emit Deregistered(msg.sender);
+    }
+
+    /// @notice Retrieve routing score for a platform based on stake and reputation.
+    function getScore(address operator) public view returns (uint256) {
+        if (reputationEngine.isBlacklisted(operator)) return 0;
+        uint256 stake = stakeManager.stakeOf(operator, IStakeManager.Role.Platform);
+        uint256 rep = reputationEngine.reputation(operator);
+        uint256 stakeW = reputationEngine.stakeWeight();
+        uint256 repW = reputationEngine.reputationWeight();
+        return ((stake * stakeW) + (rep * repW)) / 1e18;
+    }
+
+    // ---------------------------------------------------------------
+    // Owner functions
+    // ---------------------------------------------------------------
+
+    function setStakeManager(IStakeManager manager) external onlyOwner {
+        stakeManager = manager;
+        emit StakeManagerUpdated(address(manager));
+    }
+
+    function setReputationEngine(IReputationEngine engine) external onlyOwner {
+        reputationEngine = engine;
+        emit ReputationEngineUpdated(address(engine));
+    }
+
+    function setMinPlatformStake(uint256 stake) external onlyOwner {
+        minPlatformStake = stake;
+        emit MinPlatformStakeUpdated(stake);
+    }
+
+    /// @notice Confirms the contract and owner are perpetually tax neutral.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
+    // ---------------------------------------------------------------
+    // Ether rejection
+    // ---------------------------------------------------------------
+
+    receive() external payable {
+        revert("PlatformRegistry: no ether");
+    }
+
+    fallback() external payable {
+        revert("PlatformRegistry: no ether");
+    }
+}
+

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -1,0 +1,70 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("PlatformRegistry", function () {
+  let owner, platform, sybil, treasury;
+  let token, stakeManager, reputationEngine, registry;
+
+  const STAKE = 1e6; // 1 token with 6 decimals
+
+  beforeEach(async () => {
+    [owner, platform, sybil, treasury] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory(
+      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    token = await Token.connect(owner).deploy(owner.address);
+    await token.mint(platform.address, STAKE);
+
+    const Stake = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await Stake.connect(platform).deploy(
+      await token.getAddress(),
+      platform.address,
+      treasury.address
+    );
+    await stakeManager.connect(platform).setMinStake(STAKE);
+    await token.connect(platform).approve(await stakeManager.getAddress(), STAKE);
+    await stakeManager.connect(platform).depositStake(2, STAKE); // Role.Platform = 2
+
+    const Rep = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    reputationEngine = await Rep.connect(owner).deploy(owner.address);
+    await reputationEngine.setStakeManager(await stakeManager.getAddress());
+    await reputationEngine.setCaller(owner.address, true);
+
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/PlatformRegistry.sol:PlatformRegistry"
+    );
+    registry = await Registry.connect(owner).deploy(
+      await stakeManager.getAddress(),
+      await reputationEngine.getAddress(),
+      STAKE,
+      owner.address
+    );
+  });
+
+  it("registers staked operator and rejects unstaked", async () => {
+    await expect(registry.connect(platform).register())
+      .to.emit(registry, "Registered")
+      .withArgs(platform.address);
+    expect(await registry.registered(platform.address)).to.equal(true);
+    await expect(registry.connect(sybil).register()).to.be.revertedWith("stake");
+  });
+
+  it("computes score based on stake and reputation", async () => {
+    await registry.connect(platform).register();
+    expect(await registry.getScore(platform.address)).to.equal(STAKE);
+    await reputationEngine.add(platform.address, 5);
+    expect(await registry.getScore(platform.address)).to.equal(STAKE + 5);
+  });
+
+  it("owner can update settings", async () => {
+    await expect(registry.setMinPlatformStake(STAKE * 2))
+      .to.emit(registry, "MinPlatformStakeUpdated")
+      .withArgs(STAKE * 2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add PlatformRegistry contract for registering staked operators and computing routing scores
- document PlatformRegistry in deployment guide and quick start steps
- add tests for PlatformRegistry integration with StakeManager and ReputationEngine

## Testing
- `npm run lint`
- `npx hardhat test test/v2/PlatformRegistry.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68992f82f7e483338a321614dc13bafb