### PR TITLE
feat: add governance reward module

### DIFF
--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title GovernanceReward
+/// @notice Distributes owner‑funded bonuses to voters that participate in governance.
+/// @dev Uses 6‑decimal token amounts. The owner deposits rewards which voters
+///      claim proportionally (equal share per recorded voter). No ether is ever
+///      accepted, keeping the contract and owner tax neutral.
+contract GovernanceReward is Ownable {
+    using SafeERC20 for IERC20;
+
+    IERC20 public token;
+    uint256 public currentEpoch;
+
+    /// @notice reward amount each voter can claim for an epoch
+    mapping(uint256 => uint256) public rewardPerVoter;
+    /// @notice number of voters recorded for an epoch
+    mapping(uint256 => uint256) public voterCount;
+    /// @notice tracks whether an address participated in an epoch
+    mapping(uint256 => mapping(address => bool)) public recorded;
+    /// @notice tracks whether an address has claimed its reward for an epoch
+    mapping(uint256 => mapping(address => bool)) public claimed;
+
+    event VoterRecorded(uint256 indexed epoch, address indexed voter);
+    event EpochFinalized(uint256 indexed epoch, uint256 rewardPerVoter);
+    event RewardClaimed(uint256 indexed epoch, address indexed voter, uint256 amount);
+    event TokenUpdated(address indexed token);
+
+    constructor(IERC20 _token, address owner) Ownable(owner) {
+        token = _token;
+    }
+
+    /// @notice record voters for the current epoch
+    /// @param voters addresses that participated in governance
+    function recordVoters(address[] calldata voters) external onlyOwner {
+        uint256 epoch = currentEpoch;
+        uint256 count = voterCount[epoch];
+        for (uint256 i; i < voters.length; i++) {
+            address v = voters[i];
+            if (!recorded[epoch][v]) {
+                recorded[epoch][v] = true;
+                count++;
+                emit VoterRecorded(epoch, v);
+            }
+        }
+        voterCount[epoch] = count;
+    }
+
+    /// @notice finalize the current epoch and deposit rewards
+    /// @param totalReward total reward amount to split among recorded voters (6 decimals)
+    function finalizeEpoch(uint256 totalReward) external onlyOwner {
+        uint256 epoch = currentEpoch;
+        uint256 count = voterCount[epoch];
+        require(count > 0, "no voters");
+        token.safeTransferFrom(msg.sender, address(this), totalReward);
+        rewardPerVoter[epoch] = totalReward / count;
+        emit EpochFinalized(epoch, rewardPerVoter[epoch]);
+        currentEpoch = epoch + 1;
+    }
+
+    /// @notice claim reward for a given epoch
+    /// @param epoch epoch index to claim
+    function claim(uint256 epoch) external {
+        require(recorded[epoch][msg.sender], "not voter");
+        require(!claimed[epoch][msg.sender], "claimed");
+        claimed[epoch][msg.sender] = true;
+        uint256 amount = rewardPerVoter[epoch];
+        token.safeTransfer(msg.sender, amount);
+        emit RewardClaimed(epoch, msg.sender, amount);
+    }
+
+    /// @notice update the ERC20 token used for rewards
+    function setToken(IERC20 newToken) external onlyOwner {
+        token = newToken;
+        emit TokenUpdated(address(newToken));
+    }
+
+    /// @notice Confirms the contract and owner are perpetually tax neutral.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
+    // ---------------------------------------------------------------
+    // Ether rejection
+    // ---------------------------------------------------------------
+
+    receive() external payable {
+        revert("GovernanceReward: no ether");
+    }
+
+    fallback() external payable {
+        revert("GovernanceReward: no ether");
+    }
+}
+

--- a/docs/coding-sprint-agialpha-incentives.md
+++ b/docs/coding-sprint-agialpha-incentives.md
@@ -23,14 +23,17 @@ This sprint adds revenue sharing and routing incentives to the v2 suite while pr
 4. **DiscoveryModule**
    - Index platforms and expose a paginated list sorted by stake and reputation.
    - Include a stake badge for UI clients.
-5. **Dispute & Governance Hooks**
+5. **GovernanceReward Contract**
+   - Record voters during parameter polls and hold owner‑funded bonuses on‑chain.
+   - After each vote the owner finalises the epoch so recorded voters claim equal rewards.
+6. **Dispute & Governance Hooks**
    - Add token‑weighted voting using staked balances for configuration changes (e.g., fee rates).
-   - Implement bonus distribution to participating voters in the next `FeePool` epoch.
+   - Connect the `GovernanceReward` to parameter changes so participants receive bonuses.
    - Denominate appeal deposits in $AGIALPHA via `DisputeModule.setAppealFee` and route slashed fees to the `FeePool` or burner.
-6. **Sybil Mitigations**
+7. **Sybil Mitigations**
    - Enforce minimum stake for platform registration.
    - Add optional identity commitments or human‑check modules that can be toggled by the owner.
-7. **Testing & Docs**
+8. **Testing & Docs**
    - Extend Hardhat tests to cover revenue distribution, routing, governance, and slashing scenarios.
    - Update `README.md` and `docs/incentive-mechanisms-agialpha.md` once modules are complete.
 

--- a/docs/incentive-mechanisms-agialpha.md
+++ b/docs/incentive-mechanisms-agialpha.md
@@ -14,7 +14,7 @@ This note details how $AGIALPHA (6 decimals) powers a tax‑neutral, reporting�
 
 ## 3. Governance‑Aligned Rewards
 - Staked operators participate in token‑weighted votes that adjust module parameters and fee splits.
-- Winning voters gain small bonus shares from the next reward epoch, linking governance diligence to revenue.
+- A dedicated `GovernanceReward` contract records voters and distributes owner‑funded bonuses after each poll, linking governance diligence to revenue.
 
 ## 4. Sybil & Regulatory Mitigation
 - Minimum stake gates every platform deployment; failure or misconduct can slash this collateral.

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -1,0 +1,37 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("GovernanceReward", function () {
+  let owner, voter1, voter2, token, reward;
+
+  beforeEach(async () => {
+    [owner, voter1, voter2] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory(
+      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    token = await Token.deploy(owner.address);
+    await token.mint(owner.address, 1000 * 1e6); // 1000 tokens
+
+    const Reward = await ethers.getContractFactory(
+      "contracts/v2/GovernanceReward.sol:GovernanceReward"
+    );
+    reward = await Reward.deploy(await token.getAddress(), owner.address);
+  });
+
+  it("distributes rewards equally to recorded voters", async () => {
+    await reward.recordVoters([voter1.address, voter2.address]);
+    const total = 200 * 1e6; // 200 tokens
+    await token.approve(await reward.getAddress(), total);
+    await reward.finalizeEpoch(total);
+
+    await reward.connect(voter1).claim(0);
+    await reward.connect(voter2).claim(0);
+
+    expect(await token.balanceOf(voter1.address)).to.equal(100 * 1e6);
+    expect(await token.balanceOf(voter2.address)).to.equal(100 * 1e6);
+
+    await expect(reward.connect(voter1).claim(0)).to.be.revertedWith("claimed");
+    await expect(reward.connect(owner).claim(0)).to.be.revertedWith("not voter");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add GovernanceReward contract for on-chain voter bonuses
- document governance incentives and AGIALPHA deployment updates
- include tests for GovernanceReward and update sprint plan

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689933c3ddf883338893bfdb93d3d030