### PR TITLE
docs: clarify pseudonymity and owner controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ Key incentive features in the v2 suite:
 - [Tax Obligations & Disclaimer](docs/tax-obligations.md) – participants bear all taxes; contracts and owner remain exempt.
 - [TaxPolicy contract](contracts/v2/TaxPolicy.sol) – owner‑updatable disclaimer with `policyDetails`, `policyVersion`, and `isTaxExempt()` helpers; `JobRegistry.acknowledgeTaxPolicy` emits `TaxAcknowledged(user, version, acknowledgement)` for on‑chain proof.
 - [v2 deployment script](scripts/v2/deploy.ts) – deploys core modules, wires `StakeManager`, and installs the tax‑neutral `TaxPolicy`.
- 
+
+## Pseudonymity & Legal Minimisation
+
+- Every module rejects direct ether and exposes an `isTaxExempt()` view so neither the contracts nor the owner ever take custody or earn revenue.
+- All value flows occur directly between participant wallets in $AGIALPHA, allowing operators to remain pseudonymous with no off‑chain reporting.
+- Staking gates, slashing and optional blacklist hooks deter sybil attacks while preserving address‑level privacy.
+- Owners configure fees, burns, stakes and even swap the payment token entirely through `Ownable` setters accessible in Etherscan's **Write Contract** tab.
+
 ## Quick Start: FeePool, JobRouter & GovernanceReward
 
 1. **Deploy & verify** – deploy `FeePool(token, stakeManager, rewardRole, owner)` and `JobRouter(stakeManager, reputationEngine, owner)`. On Etherscan, open each address, select the **Contract** tab, and use **Verify and Publish** to upload the source code.

--- a/docs/coding-sprint-agialpha-incentives.md
+++ b/docs/coding-sprint-agialpha-incentives.md
@@ -55,12 +55,13 @@ v2 suite while keeping all flows tax‑neutral, reporting‑free and pseudonymou
    - Optional identity commitment module (stub) plug‑in for `PlatformRegistry`.
    - Document tax‑policy acknowledgement flows; wire `TaxPolicy` and
      `JobRegistry.acknowledgeTaxPolicy`.
+   - Surface `isTaxExempt()` on every module and reject direct ETH so owners and contracts remain revenue‑free and off‑ledger.
 9. **Testing & Documentation**
    - Extend Hardhat tests for revenue distribution, routing priority,
      governance rewards, slashing and blacklist enforcement.
    - Update `README.md`, `docs/incentive-mechanisms-agialpha.md` and
-     `docs/deployment-agialpha.md` to cover Etherscan flows and base‑unit
-     conversions.
+     `docs/deployment-agialpha.md` to cover Etherscan flows, owner‑only setters
+     and base‑unit conversions.
 
 ## Definition of Done
 - All modules deployed immutably and wired through `JobRegistry`.

--- a/docs/incentive-mechanisms-agialpha.md
+++ b/docs/incentive-mechanisms-agialpha.md
@@ -7,6 +7,8 @@ This note details how $AGIALPHA (6 decimals) powers a tax‑neutral, reporting�
 - A `FeePool` contract receives a protocol fee from each finalized job and periodically streams rewards to operators proportional to stake weight.
 - Rewards are paid directly on‑chain; no custody of user funds or off‑chain accounting is required.
 
+Token burns may be configured on every fee so a portion of payouts is destroyed, creating a deflationary sink that increases scarcity without routing revenue to the owner.
+
 ## 2. Algorithmic & Reputational Incentives
 - `JobRouter` favors platforms with higher stakes when routing unspecific jobs, giving committed operators more volume.
 - `DiscoveryModule` surfaces staked platforms earlier in search results and displays a stake badge as reputation.
@@ -22,6 +24,8 @@ This note details how $AGIALPHA (6 decimals) powers a tax‑neutral, reporting�
 - Appeal deposits in `DisputeModule` are denominated in $AGIALPHA and may be burned or paid to honest parties, discouraging frivolous challenges.
 - On-chain tax acknowledgements and blacklist thresholds are owner‑tuned, letting deployments adapt to local compliance signals while keeping addresses pseudonymous.
 - Because the protocol never takes custody or issues off‑chain payouts, there is no centralized revenue that would trigger reporting duties.
+
+All modules expose simple `Ownable` setters so the contract owner can retune fees, stakes, burn rates or even swap the token address through Etherscan without redeploying contracts.
 
 ## 5. Owner Controls & User Experience
 - The contract owner may update fees, burn rates, stake thresholds, and even swap the token address via `StakeManager.setToken`.


### PR DESCRIPTION
## Summary
- document pseudonymity and legal minimization features, including `isTaxExempt()` helpers and owner-only setters
- expand incentive design docs with deflationary fee burns and owner configurability
- note `isTaxExempt()` and Etherscan-focused deployment steps in coding sprint guide

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899398047548333ac38c9a048fba1d9