### PR TITLE
docs: add owner control reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,20 @@ Role-based quick steps:
 3. Cast a commit with ValidationModule `commitValidation(jobId, hash)` and later reveal via `revealValidation(jobId, approve, salt)`.
 4. If a vote period lapses without resolution, anyone may call `finalize(jobId)` on the ValidationModule.
 
+#### Owner Control Quick Reference
+
+The contract owner can retune economics or swap tokens at any time without redeploying modules. Common setters accessible from a block explorer include:
+
+- **StakeManager** – `setToken`, `setMinStake`, `setSlashingPercentages`, `setTreasury`, `setMaxStakePerAddress`.
+- **FeePool** – `setToken`, `setStakeManager`, `setRewardRole`, `setBurnPct`.
+- **PlatformRegistry** – `setStakeManager`, `setReputationEngine`, `setMinPlatformStake`.
+- **ReputationEngine** – `setCaller`, `setWeights`, `blacklist`, `unblacklist`.
+- **GovernanceReward** – `setToken`, `recordVoters`, `finalizeEpoch`.
+- **DisputeModule** – `setAppealFee`, `setTaxPolicy`, `setFeePool`.
+- **JobRegistry** – `setModules`, `setFeePool`, `setTaxPolicy`.
+
+All amounts are entered using the 6‑decimal base units of $AGIALPHA, preserving on‑chain accounting while keeping the owner tax neutral.
+
 ### Step-by-Step Job Flow via Etherscan
 
 Verified contract addresses:

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -27,7 +27,7 @@ Use the *Deploy* tab on each contract's Etherscan page. Confirm transactions thr
 4. In **JobRegistry**, call `setTaxPolicy(taxPolicy)` and optionally `bumpTaxPolicyVersion`.
 
 ## 3. Configure Token Parameters
-The StakeManager already points to $AGIALPHA (6 decimals). To change tokens later, use `setToken(newToken)`.
+The StakeManager already points to $AGIALPHA (6 decimals). To change tokens later, call `setToken(newToken)` on `StakeManager` and `FeePool` (and on `GovernanceReward` if used).
 
 For stakes, rewards and fees enter values in base units (all amounts are scaled by `10**6`):
 - `1` token = `1_000_000`
@@ -60,7 +60,7 @@ Update parameters as needed:
 Platform owners stake under `Role.Platform` via `StakeManager.depositStake(2, amount)`. As jobs finalize, `FeePool` receives the protocol fee and streams rewards. Operators claim with `FeePool.claimRewards()` directly through Etherscan.
 
 ## 8. Changing the Token
-Only the owner may switch currencies: `StakeManager.setToken(newToken)`. Existing stakes and escrows remain untouched; new deposits and payouts use the updated token.
+Only the owner may switch currencies: invoke `setToken(newToken)` on `StakeManager`, `FeePool`, and any reward modules. Existing stakes and escrows remain untouched; new deposits and payouts use the updated token.
 
 ## Security Notes
 - Verify each deployed address on at least two explorers.


### PR DESCRIPTION
## Summary
- document owner setters for economic tuning and token swaps
- note multi-module `setToken` calls in AGIALPHA deployment guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68993f35c8c883338bbc21540bbc0632