### PR TITLE
feat: add routing score and discovery pagination

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -112,6 +112,10 @@ contract MockReputationEngine is IReputationEngine {
         return _rep[user];
     }
 
+    function getReputation(address user) external view override returns (uint256) {
+        return _rep[user];
+    }
+
     function isBlacklisted(address) external pure override returns (bool) {
         return false;
     }

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -92,8 +92,12 @@ contract ReputationEngine is Ownable {
     }
 
     /// @notice Get reputation score for a user.
-    function reputation(address user) external view returns (uint256) {
+    function reputation(address user) public view returns (uint256) {
         return _scores[user];
+    }
+
+    function getReputation(address user) external view returns (uint256) {
+        return reputation(user);
     }
 
     /// @notice Check blacklist status for a user.

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -34,6 +34,11 @@ interface IReputationEngine {
     /// @return The current reputation score of the user
     function reputation(address user) external view returns (uint256);
 
+    /// @notice Alias for {reputation} for backwards compatibility
+    /// @param user Address to query
+    /// @return The current reputation score of the user
+    function getReputation(address user) external view returns (uint256);
+
     /// @notice Check if a user is blacklisted
     /// @param user Address to query
     /// @return True if the user is blacklisted

--- a/test/v2/DiscoveryModule.test.js
+++ b/test/v2/DiscoveryModule.test.js
@@ -27,9 +27,9 @@ describe("DiscoveryModule", function () {
     await discovery.connect(owner).setMinStake(0);
   });
 
-  it("updates rankings when stake or reputation changes", async () => {
-    await stakeManager.setStake(p1.address, 2, 100); // platform stake
-    await stakeManager.setStake(p2.address, 2, 100); // platform stake
+  it("orders and paginates platforms by score", async () => {
+    await stakeManager.setStake(p1.address, 2, 100);
+    await stakeManager.setStake(p2.address, 2, 100);
 
     await discovery.registerPlatform(p1.address);
     await discovery.registerPlatform(p2.address);
@@ -37,23 +37,30 @@ describe("DiscoveryModule", function () {
     await engine.connect(owner).add(p1.address, 1);
     await engine.connect(owner).add(p2.address, 2);
 
-    let top = await discovery.getTopPlatforms(2);
-    expect(top).to.include.members([p1.address, p2.address]);
+    let list = await discovery.getPlatforms(0, 2);
+    expect(list[0]).to.equal(p2.address);
+    expect(list[1]).to.equal(p1.address);
 
-    await stakeManager.setStake(p1.address, 0, 500); // agent stake boosts score
-    top = await discovery.getTopPlatforms(2);
-    expect(top[0]).to.equal(p1.address);
+    await stakeManager.setStake(p1.address, 2, 500);
+    list = await discovery.getPlatforms(0, 2);
+    expect(list[0]).to.equal(p1.address);
 
     await engine.connect(owner).add(p2.address, 1000);
-    top = await discovery.getTopPlatforms(2);
-    expect(top[0]).to.equal(p2.address);
+    list = await discovery.getPlatforms(0, 2);
+    expect(list[0]).to.equal(p2.address);
+
+    // pagination
+    let first = await discovery.getPlatforms(0, 1);
+    let second = await discovery.getPlatforms(1, 1);
+    expect(first[0]).to.equal(p2.address);
+    expect(second[0]).to.equal(p1.address);
   });
 
   it("excludes blacklisted platforms", async () => {
     await stakeManager.setStake(p1.address, 2, 100);
     await discovery.registerPlatform(p1.address);
     await engine.connect(owner).blacklist(p1.address, true);
-    const top = await discovery.getTopPlatforms(1);
+    const top = await discovery.getPlatforms(0, 1);
     expect(top.length).to.equal(0);
   });
 });

--- a/test/v2/Integration.t.sol
+++ b/test/v2/Integration.t.sol
@@ -74,6 +74,7 @@ contract MockReputationEngine is IReputationEngine {
     function isBlacklisted(address user) external view override returns (bool) { return blacklist[user]; }
     function setReputation(address user, uint256 amount) external { reps[user] = amount; }
     function reputation(address user) external view override returns (uint256) { return reps[user]; }
+    function getReputation(address user) external view override returns (uint256) { return reps[user]; }
     function getOperatorScore(address user) external view override returns (uint256) { return reps[user]; }
     function setStakeManager(address) external override {}
     function setScoringWeights(uint256, uint256) external override {}

--- a/test/v2/JobRouter.t.sol
+++ b/test/v2/JobRouter.t.sol
@@ -66,6 +66,9 @@ contract MockReputationEngine is IReputationEngine {
     function reputation(address user) external view override returns (uint256) {
         return reps[user];
     }
+    function getReputation(address user) external view override returns (uint256) {
+        return reps[user];
+    }
     function getOperatorScore(address user) external view override returns (uint256) {
         return reps[user];
     }
@@ -93,6 +96,12 @@ contract JobRouterTest {
         repEngine.setReputation(platform2, 3);
         router.registerPlatform(platform1);
         router.registerPlatform(platform2);
+    }
+
+    function testRoutingScore() public {
+        setUp();
+        require(router.getRoutingScore(platform1) == 100, "score1");
+        require(router.getRoutingScore(platform2) == 300, "score2");
     }
 
     function testDeterministicSelection() public {


### PR DESCRIPTION
## Summary
- add `getRoutingScore` to JobRouter and use it for platform selection
- paginate and score operator discovery using stake and reputation
- adjust tests for routing score and discovery ordering

## Testing
- `npm test`
- `forge test` *(fails: Contract "MockStakeManager" should be marked as abstract)*


------
https://chatgpt.com/codex/tasks/task_e_6899493230988333b5563308520454d3