### PR TITLE
Add platform blacklist controls and adversarial slashing tests

### DIFF
--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -66,5 +66,15 @@ describe("PlatformRegistry", function () {
       .to.emit(registry, "MinPlatformStakeUpdated")
       .withArgs(STAKE * 2);
   });
+
+  it("enforces owner-managed blacklist", async () => {
+    await registry.setBlacklist(platform.address, true);
+    await expect(registry.connect(platform).register()).to.be.revertedWith(
+      "blacklisted"
+    );
+    expect(await registry.getScore(platform.address)).to.equal(0);
+    await registry.setBlacklist(platform.address, false);
+    await registry.connect(platform).register();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add owner-managed blacklist and minimum stake enforcement to PlatformRegistry
- extend PlatformRegistry tests to cover blacklist behavior
- add StakeManager tests for unauthorized and excessive slashing

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68994fc337ac8333ac85165d29516c40