### PR TITLE
docs: add AGIALPHA deployment walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,30 @@ Key incentive features in the v2 suite:
 - [TaxPolicy contract](contracts/v2/TaxPolicy.sol) – owner‑updatable disclaimer with `policyDetails`, `policyVersion`, and `isTaxExempt()` helpers; `JobRegistry.acknowledgeTaxPolicy` emits `TaxAcknowledged(user, version, acknowledgement)` for on‑chain proof.
 - [v2 deployment script](scripts/v2/deploy.ts) – deploys core modules, wires `StakeManager`, and installs the tax‑neutral `TaxPolicy`.
 
+## Deploying with $AGIALPHA
+
+The modular v2 suite is deployed module by module and then wired together on‑chain. A typical flow is:
+
+1. Deploy `StakeManager`, `JobRegistry`, `ValidationModule`, `ReputationEngine`, `DisputeModule`, `CertificateNFT`, `FeePool`, and `TaxPolicy`.
+2. Connect them with owner‑only setters such as `JobRegistry.setModules`, `StakeManager.setJobRegistry`, `JobRegistry.setFeePool`, and `JobRegistry.setTaxPolicy`.
+3. Tune economics via `StakeManager.setMinStake`, `StakeManager.setSlashingPercentages`, `ValidationModule.setParameters`, `DisputeModule.setAppealFee`, and `FeePool.setBurnPct`.
+
+Amounts use 6‑decimal base units:
+
+```
+1 token   = 1_000_000
+0.5 token =   500_000
+25 tokens = 25_000000
+```
+
+Safety tips:
+
+- Verify addresses and constructor parameters on multiple explorers before sending transactions.
+- Prefer hardware wallets or multisigs for owner actions.
+- After each setter call, confirm new values in the **Read Contract** tab.
+
+For a detailed walkthrough of these steps in Etherscan, see [docs/deployment-agialpha.md](docs/deployment-agialpha.md).
+
 ## Pseudonymity & Legal Minimisation
 
 - Every module rejects direct ether and exposes an `isTaxExempt()` view so neither the contracts nor the owner ever take custody or earn revenue.

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -68,3 +68,20 @@ Only the owner may switch currencies: invoke `setToken(newToken)` on `StakeManag
 - Keep constructor parameters and ABI files for later verification.
 
 By following these steps the owner can deploy the AGIJobs suite with $AGIALPHA as the unit of account, while retaining the ability to replace the token without redeploying other modules.
+
+## Etherscan Walkthrough
+
+1. **Open contract pages** – for each deployed module, navigate to its Etherscan address and select **Contract → Write Contract**. Click **Connect to Web3** with the owner wallet.
+2. **Wire modules**
+   - In `JobRegistry` call `setModules(validation, stakeManager, reputation, dispute, certificate)`.
+   - In `StakeManager` call `setJobRegistry(jobRegistry)`.
+   - Back in `JobRegistry` call `setFeePool(feePool)` then `setFeePct(pct)` and `setTaxPolicy(taxPolicy)`.
+3. **Configure economics**
+   - On `StakeManager` call `setMinStake(amount)` and `setSlashingPercentages(empPct, treasuryPct)`.
+   - On `ValidationModule` call `setParameters(...)` with 6‑decimal base units.
+   - On `DisputeModule` call `setAppealFee(fee)` and link any reward pools via `setFeePool(feePool)`.
+   - On `FeePool` call `setBurnPct(pct)` to destroy a portion of each fee.
+4. **Verify state** – after each transaction switch to **Read Contract** to confirm the new values and emitted events.
+5. **Stay safe** – double‑check addresses, keep keys on hardware or multisig wallets, and never interact from untrusted networks.
+
+This sequence covers the critical owner‑only setters needed to bootstrap the system. For background on module responsibilities and token math, refer back to the sections above.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,6 +30,8 @@ graph TD
 3. Call the desired function and submit the transaction.
 4. Verify emitted events and new state in **Read Contract** or on a second explorer.
 
+For a step-by-step deployment walkthrough with owner-only setters, see [deployment-agialpha.md](deployment-agialpha.md).
+
 ### Governance Table
 | Module | Owner Functions | Purpose |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary
- add "Deploying with $AGIALPHA" section to README with module flow, base-unit examples, and safety tips
- append step-by-step Etherscan walkthrough with owner-only setters to `docs/deployment-agialpha.md`
- link deployment doc from project overview and README

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68995202bcc083338b6a8a13d86c8699