### PR TITLE
feat: add fee distribution controls

### DIFF
--- a/contracts/v2/interfaces/IFeePool.sol
+++ b/contracts/v2/interfaces/IFeePool.sol
@@ -8,6 +8,9 @@ interface IFeePool {
     /// @param amount amount of tokens transferred to the pool scaled to 6 decimals
     function depositFee(uint256 amount) external;
 
+    /// @notice distribute pending fees to stakers
+    function distributeFees() external;
+
     /// @notice claim accumulated rewards for caller
     function claimRewards() external;
 }

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -82,6 +82,7 @@ describe("FeePool", function () {
 
     const before1 = await token.balanceOf(user1.address);
     const before2 = await token.balanceOf(user2.address);
+    await feePool.connect(owner).distributeFees();
     await feePool.connect(user1).claimRewards();
     await feePool.connect(user2).claimRewards();
     expect((await token.balanceOf(user1.address)) - before1).to.equal(25n);
@@ -108,6 +109,7 @@ describe("FeePool", function () {
 
     const before1 = await token.balanceOf(user1.address);
     const before2 = await token.balanceOf(user2.address);
+    await feePool.connect(owner).distributeFees();
     await feePool.connect(user1).claimRewards();
     await feePool.connect(user2).claimRewards();
     expect((await token.balanceOf(user1.address)) - before1).to.equal(15n);
@@ -139,6 +141,7 @@ describe("FeePool", function () {
 
     const before1 = await token2.balanceOf(user1.address);
     const before2 = await token2.balanceOf(user2.address);
+    await feePool.connect(owner).distributeFees();
     await feePool.connect(user1).claimRewards();
     await feePool.connect(user2).claimRewards();
     expect((await token2.balanceOf(user1.address)) - before1).to.equal(25n);

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -138,6 +138,7 @@ describe("JobRegistry integration", function () {
 
     // platform operator should be able to claim fee
     const before = await token.balanceOf(owner.address);
+    await feePool.connect(owner).distributeFees();
     await feePool.connect(owner).claimRewards();
     const after = await token.balanceOf(owner.address);
     expect(after - before).to.equal(BigInt(reward / 10));

--- a/test/v2/JobRouter.t.sol
+++ b/test/v2/JobRouter.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import "contracts/v2/modules/JobRouter.sol";
 import "contracts/v2/interfaces/IStakeManager.sol";
 import "contracts/v2/interfaces/IReputationEngine.sol";
+import "contracts/v2/interfaces/IFeePool.sol";
 
 // minimal cheatcode interface
 interface Vm {
@@ -18,6 +19,7 @@ contract MockStakeManager is IStakeManager {
     function withdrawStake(Role, uint256) external override {}
     function lockJobFunds(bytes32, address, uint256) external override {}
     function releaseJobFunds(bytes32, address, uint256) external override {}
+    function finalizeJobFunds(bytes32, address, uint256, uint256, IFeePool) external override {}
     function setDisputeModule(address) external override {}
     function lockDisputeFee(address, uint256) external override {}
     function payDisputeFee(address, uint256) external override {}


### PR DESCRIPTION
## Summary
- track pending fees and distribute with `distributeFees`
- allow owner to set burn percentage and treasury address
- expose `distributeFees` via interface and update tests

## Testing
- `npm run lint`
- `npm test`
- `forge test`


------
https://chatgpt.com/codex/tasks/task_e_6899640e45a88333a96bcfe1dd851f88