### PR TITLE
feat: enforce stake and randomness in validation

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -104,6 +104,7 @@ contract ValidationModule is IValidationModule, Ownable {
         override
         onlyOwner
     {
+        require(commitDur > 0 && revealDur > 0, "windows");
         commitWindow = commitDur;
         revealWindow = revealDur;
         emit TimingUpdated(commitDur, revealDur);
@@ -146,7 +147,7 @@ contract ValidationModule is IValidationModule, Ownable {
         uint256 count = m < maxValidators ? m : maxValidators;
 
         bytes32 seed = keccak256(
-            abi.encodePacked(block.prevrandao, jobId, block.timestamp)
+            abi.encodePacked(blockhash(block.number - 1), jobId, block.timestamp)
         );
 
         selected = new address[](count);
@@ -193,6 +194,7 @@ contract ValidationModule is IValidationModule, Ownable {
             "commit closed"
         );
         require(_isValidator(jobId, msg.sender), "not validator");
+        require(validatorStakes[jobId][msg.sender] > 0, "stake");
         uint256 nonce = jobNonce[jobId];
         require(
             commitments[jobId][msg.sender][nonce] == bytes32(0),


### PR DESCRIPTION
## Summary
- ensure commit and reveal windows are non-zero
- require validators to maintain a stake when committing votes
- derive validator selection randomness from blockhash

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899ccddfaf48333ac4039f5e252d659