### PR TITLE
Rename appeal events for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ interface IReputationEngine {
 }
 
 interface IDisputeModule {
-    event AppealRaised(uint256 indexed jobId, address indexed caller);
+    event DisputeRaised(uint256 indexed jobId, address indexed caller);
     function appeal(uint256 jobId) external payable;
     function resolve(uint256 jobId, bool employerWins) external;
     function setAppealFee(uint256 fee) external;

--- a/contracts/v2/DisputeModule.sol
+++ b/contracts/v2/DisputeModule.sol
@@ -132,7 +132,7 @@ contract DisputeModule is IDisputeModule, Ownable {
         appellants[jobId] = payable(caller);
         bonds[jobId] = msg.value;
 
-        emit AppealRaised(jobId, caller);
+        emit DisputeRaised(jobId, caller);
     }
 
     // ---------------------------------------------------------------------
@@ -181,7 +181,7 @@ contract DisputeModule is IDisputeModule, Ownable {
         (bool ok, ) = recipient.call{value: bond}("");
         require(ok, "transfer failed");
 
-        emit AppealResolved(jobId, employerWins);
+        emit DisputeResolved(jobId, employerWins);
     }
 
     /// @notice Confirms the module and its owner are perpetually tax-exempt.

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -19,8 +19,8 @@ interface IDisputeModule {
     /// @dev Reverts when no appeal bond exists for a job
     error NoAppealBond(uint256 jobId);
 
-    event AppealRaised(uint256 indexed jobId, address indexed caller);
-    event AppealResolved(uint256 indexed jobId, bool employerWins);
+    event DisputeRaised(uint256 indexed jobId, address indexed caller);
+    event DisputeResolved(uint256 indexed jobId, bool employerWins);
     event AppealFeeUpdated(uint256 fee);
     event ModeratorUpdated(address moderator);
     event AppealJuryUpdated(address jury);


### PR DESCRIPTION
## Summary
- rename IDisputeModule events to DisputeRaised/DisputeResolved
- update DisputeModule to emit the new event names
- adjust README interface snippet accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899ddddd17c83338e0aac0246725761