### PR TITLE
Add governance reward distribution with epoch snapshots

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -50,6 +50,7 @@ contract FeePool is Ownable {
     event RewardRoleUpdated(IStakeManager.Role role);
     event BurnPctUpdated(uint256 pct);
     event TreasuryUpdated(address indexed treasury);
+    event RewardTransferred(address indexed to, uint256 amount);
 
     constructor(
         IERC20 _token,
@@ -111,6 +112,14 @@ contract FeePool is Ownable {
         userCheckpoint[msg.sender] = cumulative;
         token.safeTransfer(msg.sender, owed);
         emit RewardsClaimed(msg.sender, owed);
+    }
+
+    /// @notice transfer tokens to an external reward contract
+    /// @param to recipient address
+    /// @param amount token amount with 6 decimals
+    function transferReward(address to, uint256 amount) external {
+        token.safeTransfer(to, amount);
+        emit RewardTransferred(to, amount);
     }
 
     /// @notice update ERC20 token used for payouts

--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -4,89 +4,124 @@ pragma solidity ^0.8.25;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IFeePool} from "./interfaces/IFeePool.sol";
+import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 /// @title GovernanceReward
-/// @notice Distributes owner‑funded bonuses to voters that participate in governance.
-/// @dev Uses 6‑decimal token amounts. The owner deposits rewards which voters
-///      claim proportionally (equal share per recorded voter). No ether is ever
-///      accepted, keeping the contract and owner tax neutral.
+/// @notice Distributes a portion of the FeePool to voters based on staked balance snapshots.
+/// @dev Uses 6‑decimal token amounts. Rewards are funded from the FeePool and
+///      allocated proportionally to each recorded voter's stake for the epoch.
 contract GovernanceReward is Ownable {
     using SafeERC20 for IERC20;
 
-    IERC20 public token;
-    uint256 public currentEpoch;
+    uint256 public constant ACCUMULATOR_SCALE = 1e12;
 
-    /// @notice reward amount each voter can claim for an epoch
-    mapping(uint256 => uint256) public rewardPerVoter;
-    /// @notice number of voters recorded for an epoch
-    mapping(uint256 => uint256) public voterCount;
-    /// @notice tracks whether an address participated in an epoch
+    IERC20 public token;
+    IFeePool public feePool;
+    IStakeManager public stakeManager;
+    IStakeManager.Role public rewardRole;
+
+    uint256 public epochLength;
+    uint256 public rewardPct;
+    uint256 public currentEpoch;
+    uint256 public lastEpochTime;
+
+    /// @notice stake snapshot per voter for an epoch
+    mapping(uint256 => mapping(address => uint256)) public stakeSnapshot;
+    /// @notice total recorded stake for an epoch
+    mapping(uint256 => uint256) public totalStake;
+    /// @notice reward per staked token for an epoch scaled by ACCUMULATOR_SCALE
+    mapping(uint256 => uint256) public rewardPerStake;
+    /// @notice tracks whether a voter was recorded in an epoch
     mapping(uint256 => mapping(address => bool)) public recorded;
-    /// @notice tracks whether an address has claimed its reward for an epoch
+    /// @notice tracks whether a voter has claimed for an epoch
     mapping(uint256 => mapping(address => bool)) public claimed;
 
-    event VoterRecorded(uint256 indexed epoch, address indexed voter);
-    event EpochFinalized(uint256 indexed epoch, uint256 rewardPerVoter);
+    event VoterRecorded(uint256 indexed epoch, address indexed voter, uint256 stake);
+    event EpochLengthUpdated(uint256 length);
+    event RewardPctUpdated(uint256 pct);
+    event EpochFinalized(uint256 indexed epoch, uint256 rewardAmount);
     event RewardClaimed(uint256 indexed epoch, address indexed voter, uint256 amount);
     event TokenUpdated(address indexed token);
 
-    constructor(IERC20 _token, address owner) Ownable(owner) {
+    constructor(
+        IERC20 _token,
+        IFeePool _feePool,
+        IStakeManager _stakeManager,
+        IStakeManager.Role _role,
+        address owner
+    ) Ownable(owner) {
         token = _token;
+        feePool = _feePool;
+        stakeManager = _stakeManager;
+        rewardRole = _role;
+        lastEpochTime = block.timestamp;
     }
 
-    /// @notice record voters for the current epoch
-    /// @param voters addresses that participated in governance
+    /// @notice set the length of each epoch in seconds
+    function setEpochLength(uint256 length) external onlyOwner {
+        epochLength = length;
+        emit EpochLengthUpdated(length);
+    }
+
+    /// @notice set the percentage of FeePool balance rewarded each epoch
+    function setRewardPct(uint256 pct) external onlyOwner {
+        require(pct <= 100, "pct");
+        rewardPct = pct;
+        emit RewardPctUpdated(pct);
+    }
+
+    /// @notice update the token address
+    function setToken(IERC20 newToken) external onlyOwner {
+        token = newToken;
+        emit TokenUpdated(address(newToken));
+    }
+
+    /// @notice record voters for the current epoch and snapshot their stake
     function recordVoters(address[] calldata voters) external onlyOwner {
         uint256 epoch = currentEpoch;
-        uint256 count = voterCount[epoch];
         for (uint256 i; i < voters.length; i++) {
             address v = voters[i];
             if (!recorded[epoch][v]) {
                 recorded[epoch][v] = true;
-                count++;
-                emit VoterRecorded(epoch, v);
+                uint256 stake = stakeManager.stakeOf(v, rewardRole);
+                stakeSnapshot[epoch][v] = stake;
+                totalStake[epoch] += stake;
+                emit VoterRecorded(epoch, v, stake);
             }
         }
-        voterCount[epoch] = count;
     }
 
-    /// @notice finalize the current epoch and deposit rewards
-    /// @param totalReward total reward amount to split among recorded voters (6 decimals)
-    function finalizeEpoch(uint256 totalReward) external onlyOwner {
+    /// @notice finalize the current epoch and pull rewards from the FeePool
+    function finalizeEpoch() external onlyOwner {
+        require(block.timestamp >= lastEpochTime + epochLength, "early");
         uint256 epoch = currentEpoch;
-        uint256 count = voterCount[epoch];
-        require(count > 0, "no voters");
-        token.safeTransferFrom(msg.sender, address(this), totalReward);
-        rewardPerVoter[epoch] = totalReward / count;
-        emit EpochFinalized(epoch, rewardPerVoter[epoch]);
+        uint256 total = totalStake[epoch];
+        require(total > 0, "no voters");
+        uint256 poolBal = token.balanceOf(address(feePool));
+        uint256 rewardAmount = (poolBal * rewardPct) / 100;
+        feePool.transferReward(address(this), rewardAmount);
+        rewardPerStake[epoch] = (rewardAmount * ACCUMULATOR_SCALE) / total;
+        emit EpochFinalized(epoch, rewardAmount);
         currentEpoch = epoch + 1;
+        lastEpochTime = block.timestamp;
     }
 
-    /// @notice claim reward for a given epoch
-    /// @param epoch epoch index to claim
+    /// @notice claim rewards for a given epoch
     function claim(uint256 epoch) external {
         require(recorded[epoch][msg.sender], "not voter");
         require(!claimed[epoch][msg.sender], "claimed");
         claimed[epoch][msg.sender] = true;
-        uint256 amount = rewardPerVoter[epoch];
+        uint256 stake = stakeSnapshot[epoch][msg.sender];
+        uint256 amount = (stake * rewardPerStake[epoch]) / ACCUMULATOR_SCALE;
         token.safeTransfer(msg.sender, amount);
         emit RewardClaimed(epoch, msg.sender, amount);
-    }
-
-    /// @notice update the ERC20 token used for rewards
-    function setToken(IERC20 newToken) external onlyOwner {
-        token = newToken;
-        emit TokenUpdated(address(newToken));
     }
 
     /// @notice Confirms the contract and owner are perpetually tax neutral.
     function isTaxExempt() external pure returns (bool) {
         return true;
     }
-
-    // ---------------------------------------------------------------
-    // Ether rejection
-    // ---------------------------------------------------------------
 
     receive() external payable {
         revert("GovernanceReward: no ether");

--- a/contracts/v2/interfaces/IFeePool.sol
+++ b/contracts/v2/interfaces/IFeePool.sol
@@ -13,4 +13,9 @@ interface IFeePool {
 
     /// @notice claim accumulated rewards for caller
     function claimRewards() external;
+
+    /// @notice transfer tokens from the pool to a recipient
+    /// @param to address receiving the tokens
+    /// @param amount token amount with 6 decimals
+    function transferReward(address to, uint256 amount) external;
 }

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -2,43 +2,103 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("Governance reward lifecycle", function () {
-  let owner, voter1, voter2, voter3, token, reward;
+  let owner, voter1, voter2, voter3, token, stakeManager, feePool, reward, treasury;
 
   beforeEach(async () => {
-    [owner, voter1, voter2, voter3] = await ethers.getSigners();
+    [owner, voter1, voter2, voter3, treasury] = await ethers.getSigners();
 
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
     token = await Token.deploy(owner.address);
-    await token.mint(owner.address, 1000 * 1e6);
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      owner.address,
+      treasury.address
+    );
+
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const TaxPolicy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    const taxPolicy = await TaxPolicy.deploy(
+      owner.address,
+      "ipfs://policy",
+      "ack"
+    );
+    await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await stakeManager.connect(owner).setJobRegistry(await jobRegistry.getAddress());
+    await jobRegistry.connect(voter1).acknowledgeTaxPolicy();
+    await jobRegistry.connect(voter2).acknowledgeTaxPolicy();
+    await jobRegistry.connect(voter3).acknowledgeTaxPolicy();
+
+    const FeePool = await ethers.getContractFactory(
+      "contracts/v2/FeePool.sol:FeePool"
+    );
+    feePool = await FeePool.deploy(
+      await token.getAddress(),
+      await stakeManager.getAddress(),
+      2,
+      owner.address
+    );
 
     const Reward = await ethers.getContractFactory(
       "contracts/v2/GovernanceReward.sol:GovernanceReward"
     );
-    reward = await Reward.deploy(await token.getAddress(), owner.address);
+    reward = await Reward.deploy(
+      await token.getAddress(),
+      await feePool.getAddress(),
+      await stakeManager.getAddress(),
+      2,
+      owner.address
+    );
+
+    await reward.setEpochLength(1);
+    await reward.setRewardPct(50);
+
+    // stake setup
+    await token.mint(voter1.address, 100 * 1e6);
+    await token.mint(voter2.address, 100 * 1e6);
+    await token.mint(voter3.address, 100 * 1e6);
+
+    await token.connect(voter1).approve(await stakeManager.getAddress(), 100 * 1e6);
+    await token.connect(voter2).approve(await stakeManager.getAddress(), 100 * 1e6);
+    await token.connect(voter3).approve(await stakeManager.getAddress(), 100 * 1e6);
+    await stakeManager.connect(voter1).depositStake(2, 100 * 1e6);
+    await stakeManager.connect(voter2).depositStake(2, 100 * 1e6);
+    await stakeManager.connect(voter3).depositStake(2, 100 * 1e6);
+
+    // fund pool with 200 tokens
+    await token.mint(await feePool.getAddress(), 200 * 1e6);
   });
 
   it("distributes rewards across epochs and allows claims", async () => {
     // epoch 0 with two voters
     await reward.recordVoters([voter1.address, voter2.address]);
-    const total0 = 200 * 1e6;
-    await token.approve(await reward.getAddress(), total0);
-    await reward.finalizeEpoch(total0);
+    await ethers.provider.send("evm_increaseTime", [1]);
+    await ethers.provider.send("evm_mine", []);
+    await reward.finalizeEpoch();
 
     await reward.connect(voter1).claim(0);
     await reward.connect(voter2).claim(0);
 
-    expect(await token.balanceOf(voter1.address)).to.equal(100 * 1e6);
-    expect(await token.balanceOf(voter2.address)).to.equal(100 * 1e6);
+    expect(await token.balanceOf(voter1.address)).to.equal(50 * 1e6);
+    expect(await token.balanceOf(voter2.address)).to.equal(50 * 1e6);
     await expect(reward.connect(voter1).claim(0)).to.be.revertedWith("claimed");
     await expect(reward.connect(voter3).claim(0)).to.be.revertedWith("not voter");
 
-    // epoch 1 with a single voter
+    // fund pool with remaining 100 tokens for next epoch already there
     await reward.recordVoters([voter3.address]);
-    const total1 = 50 * 1e6;
-    await token.approve(await reward.getAddress(), total1);
-    await reward.finalizeEpoch(total1);
+    await ethers.provider.send("evm_increaseTime", [1]);
+    await ethers.provider.send("evm_mine", []);
+    await reward.finalizeEpoch();
 
     await reward.connect(voter3).claim(1);
     expect(await token.balanceOf(voter3.address)).to.equal(50 * 1e6);

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -2,36 +2,99 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("GovernanceReward", function () {
-  let owner, voter1, voter2, token, reward;
+  let owner, voter1, voter2, token, stakeManager, feePool, reward, treasury;
 
   beforeEach(async () => {
-    [owner, voter1, voter2] = await ethers.getSigners();
+    [owner, voter1, voter2, treasury] = await ethers.getSigners();
+
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
     token = await Token.deploy(owner.address);
-    await token.mint(owner.address, 1000 * 1e6); // 1000 tokens
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      owner.address,
+      treasury.address
+    );
+
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const TaxPolicy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    const taxPolicy = await TaxPolicy.deploy(
+      owner.address,
+      "ipfs://policy",
+      "ack"
+    );
+    await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await stakeManager.connect(owner).setJobRegistry(await jobRegistry.getAddress());
+    await jobRegistry.connect(voter1).acknowledgeTaxPolicy();
+    await jobRegistry.connect(voter2).acknowledgeTaxPolicy();
+
+    const FeePool = await ethers.getContractFactory(
+      "contracts/v2/FeePool.sol:FeePool"
+    );
+    feePool = await FeePool.deploy(
+      await token.getAddress(),
+      await stakeManager.getAddress(),
+      2,
+      owner.address
+    );
 
     const Reward = await ethers.getContractFactory(
       "contracts/v2/GovernanceReward.sol:GovernanceReward"
     );
-    reward = await Reward.deploy(await token.getAddress(), owner.address);
+    reward = await Reward.deploy(
+      await token.getAddress(),
+      await feePool.getAddress(),
+      await stakeManager.getAddress(),
+      2,
+      owner.address
+    );
+
+    await reward.setEpochLength(1);
+    await reward.setRewardPct(50);
+
+    await token.mint(voter1.address, 100 * 1e6);
+    await token.mint(voter2.address, 300 * 1e6);
+
+    await token.connect(voter1).approve(await stakeManager.getAddress(), 100 * 1e6);
+    await token.connect(voter2).approve(await stakeManager.getAddress(), 300 * 1e6);
+    await stakeManager.connect(voter1).depositStake(2, 100 * 1e6);
+    await stakeManager.connect(voter2).depositStake(2, 300 * 1e6);
+
+    // fund fee pool
+    await token.mint(await feePool.getAddress(), 100 * 1e6);
   });
 
-  it("distributes rewards equally to recorded voters", async () => {
+  it("rewards voters proportional to staked balance", async () => {
     await reward.recordVoters([voter1.address, voter2.address]);
-    const total = 200 * 1e6; // 200 tokens
-    await token.approve(await reward.getAddress(), total);
-    await reward.finalizeEpoch(total);
 
-    await reward.connect(voter1).claim(0);
-    await reward.connect(voter2).claim(0);
+    await ethers.provider.send("evm_increaseTime", [1]);
+    await ethers.provider.send("evm_mine", []);
 
-    expect(await token.balanceOf(voter1.address)).to.equal(100 * 1e6);
-    expect(await token.balanceOf(voter2.address)).to.equal(100 * 1e6);
+    await expect(reward.finalizeEpoch())
+      .to.emit(reward, "EpochFinalized")
+      .withArgs(0, 50 * 1e6);
+
+    await expect(reward.connect(voter1).claim(0))
+      .to.emit(reward, "RewardClaimed")
+      .withArgs(0, voter1.address, 12_500_000);
+    await expect(reward.connect(voter2).claim(0))
+      .to.emit(reward, "RewardClaimed")
+      .withArgs(0, voter2.address, 37_500_000);
+
+    expect(await token.balanceOf(voter1.address)).to.equal(12_500_000);
+    expect(await token.balanceOf(voter2.address)).to.equal(37_500_000);
 
     await expect(reward.connect(voter1).claim(0)).to.be.revertedWith("claimed");
-    await expect(reward.connect(owner).claim(0)).to.be.revertedWith("not voter");
   });
 });
 


### PR DESCRIPTION
## Summary
- snapshot voter stakes and finalize epochs with FeePool-funded rewards
- let owner configure epoch length and reward percentage
- allow FeePool to transfer reward tokens externally

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e30aa7488333a793377c8adc02cf