### PR TITLE
feat: enforce tax policy acknowledgment

### DIFF
--- a/test/JobRegistryCertificate.test.js
+++ b/test/JobRegistryCertificate.test.js
@@ -50,6 +50,7 @@ async function deployFixture() {
 describe("JobRegistry and CertificateNFT", function () {
   it("prevents self-hiring", async function () {
     const { registry, employer } = await deployFixture();
+    await registry.connect(employer).acknowledgeTaxPolicy();
     await expect(
       registry.connect(employer).createJob(employer.address)
     ).to.be.revertedWith("self");
@@ -58,6 +59,8 @@ describe("JobRegistry and CertificateNFT", function () {
   it("mints certificate with output URI on completion", async function () {
     const { registry, employer, agent, validation, cert } = await deployFixture();
 
+    await registry.connect(employer).acknowledgeTaxPolicy();
+    await registry.connect(agent).acknowledgeTaxPolicy();
     await registry.connect(employer).createJob(agent.address);
     const jobId = 1;
     await validation.setOutcome(jobId, true);


### PR DESCRIPTION
## Summary
- track tax policy acknowledgments per address
- gate StakeManager staking actions on tax acknowledgments
- require tax policy acknowledgment for JobRegistry lifecycle actions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899e9c180bc83338c82e738cf1b10f6