### PR TITLE
feat: add AGIALPHAToken with 6 decimals

### DIFF
--- a/contracts/AGIALPHAToken.sol
+++ b/contracts/AGIALPHAToken.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title AGIALPHAToken
+/// @notice Basic ERC20 token with fixed 6 decimals and initial supply minted to deployer.
+contract AGIALPHAToken is ERC20 {
+    uint8 private constant DECIMALS = 6;
+
+    /// @notice Deploy the token contract.
+    /// @param name_   Token name
+    /// @param symbol_ Token symbol
+    /// @param initialSupply Initial supply minted to the deployer
+    constructor(string memory name_, string memory symbol_, uint256 initialSupply) ERC20(name_, symbol_) {
+        _mint(msg.sender, initialSupply);
+    }
+
+    /// @notice Returns token decimals (6).
+    function decimals() public pure override returns (uint8) {
+        return DECIMALS;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `AGIALPHAToken` ERC20 with fixed 6 decimals and initial supply minted to deployer
- test transfer functionality and decimal precision

## Testing
- `npm test`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_6899fe37a1a483338777a4196f6f83e1