### PR TITLE
feat: add owner controls contract

### DIFF
--- a/contracts/OwnerControls.sol
+++ b/contracts/OwnerControls.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title OwnerControls
+/// @notice Stores system level configuration parameters controllable by the owner
+contract OwnerControls is Ownable {
+    uint256 public minStake;
+    uint256 public feePercent;
+    string public routingAlgo;
+    uint256 public disputeBond;
+
+    address public jobRegistry;
+    address public stakeManager;
+    address public validationModule;
+    address public reputationEngine;
+    address public certificateNFT;
+    address public disputeModule;
+
+    event MinStakeUpdated(uint256 newMinStake);
+    event FeePercentUpdated(uint256 newFeePercent);
+    event RoutingAlgoUpdated(string newRoutingAlgo);
+    event DisputeBondUpdated(uint256 newDisputeBond);
+    event JobRegistryUpdated(address newAddress);
+    event StakeManagerUpdated(address newAddress);
+    event ValidationModuleUpdated(address newAddress);
+    event ReputationEngineUpdated(address newAddress);
+    event CertificateNFTUpdated(address newAddress);
+    event DisputeModuleUpdated(address newAddress);
+
+    constructor(address owner) Ownable(owner) {}
+
+    function setMinStake(uint256 newMinStake) external onlyOwner {
+        minStake = newMinStake;
+        emit MinStakeUpdated(newMinStake);
+    }
+
+    function setFeePercent(uint256 newFeePercent) external onlyOwner {
+        feePercent = newFeePercent;
+        emit FeePercentUpdated(newFeePercent);
+    }
+
+    function setRoutingAlgo(string calldata newRoutingAlgo) external onlyOwner {
+        routingAlgo = newRoutingAlgo;
+        emit RoutingAlgoUpdated(newRoutingAlgo);
+    }
+
+    function setDisputeBond(uint256 newDisputeBond) external onlyOwner {
+        disputeBond = newDisputeBond;
+        emit DisputeBondUpdated(newDisputeBond);
+    }
+
+    function setJobRegistry(address newAddress) external onlyOwner {
+        jobRegistry = newAddress;
+        emit JobRegistryUpdated(newAddress);
+    }
+
+    function setStakeManager(address newAddress) external onlyOwner {
+        stakeManager = newAddress;
+        emit StakeManagerUpdated(newAddress);
+    }
+
+    function setValidationModule(address newAddress) external onlyOwner {
+        validationModule = newAddress;
+        emit ValidationModuleUpdated(newAddress);
+    }
+
+    function setReputationEngine(address newAddress) external onlyOwner {
+        reputationEngine = newAddress;
+        emit ReputationEngineUpdated(newAddress);
+    }
+
+    function setCertificateNFT(address newAddress) external onlyOwner {
+        certificateNFT = newAddress;
+        emit CertificateNFTUpdated(newAddress);
+    }
+
+    function setDisputeModule(address newAddress) external onlyOwner {
+        disputeModule = newAddress;
+        emit DisputeModuleUpdated(newAddress);
+    }
+}
+

--- a/test/OwnerControls.test.js
+++ b/test/OwnerControls.test.js
@@ -1,0 +1,99 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("OwnerControls", function () {
+  let controls, owner, other, addr1;
+
+  beforeEach(async () => {
+    [owner, other, addr1] = await ethers.getSigners();
+    const Factory = await ethers.getContractFactory("OwnerControls");
+    controls = await Factory.deploy(owner.address);
+    await controls.waitForDeployment();
+  });
+
+  it("allows owner to update parameters", async () => {
+    await expect(controls.setMinStake(100))
+      .to.emit(controls, "MinStakeUpdated")
+      .withArgs(100);
+    expect(await controls.minStake()).to.equal(100);
+
+    await expect(controls.setFeePercent(5))
+      .to.emit(controls, "FeePercentUpdated")
+      .withArgs(5);
+    expect(await controls.feePercent()).to.equal(5);
+
+    await expect(controls.setRoutingAlgo("algo1"))
+      .to.emit(controls, "RoutingAlgoUpdated")
+      .withArgs("algo1");
+    expect(await controls.routingAlgo()).to.equal("algo1");
+
+    await expect(controls.setDisputeBond(50))
+      .to.emit(controls, "DisputeBondUpdated")
+      .withArgs(50);
+    expect(await controls.disputeBond()).to.equal(50);
+
+    await expect(controls.setStakeManager(addr1.address))
+      .to.emit(controls, "StakeManagerUpdated")
+      .withArgs(addr1.address);
+    expect(await controls.stakeManager()).to.equal(addr1.address);
+
+    await expect(controls.setValidationModule(addr1.address))
+      .to.emit(controls, "ValidationModuleUpdated")
+      .withArgs(addr1.address);
+    expect(await controls.validationModule()).to.equal(addr1.address);
+
+    await expect(controls.setReputationEngine(addr1.address))
+      .to.emit(controls, "ReputationEngineUpdated")
+      .withArgs(addr1.address);
+    expect(await controls.reputationEngine()).to.equal(addr1.address);
+
+    await expect(controls.setJobRegistry(addr1.address))
+      .to.emit(controls, "JobRegistryUpdated")
+      .withArgs(addr1.address);
+    expect(await controls.jobRegistry()).to.equal(addr1.address);
+
+    await expect(controls.setCertificateNFT(addr1.address))
+      .to.emit(controls, "CertificateNFTUpdated")
+      .withArgs(addr1.address);
+    expect(await controls.certificateNFT()).to.equal(addr1.address);
+
+    await expect(controls.setDisputeModule(addr1.address))
+      .to.emit(controls, "DisputeModuleUpdated")
+      .withArgs(addr1.address);
+    expect(await controls.disputeModule()).to.equal(addr1.address);
+  });
+
+  it("restricts setters to owner", async () => {
+    await expect(controls.connect(other).setMinStake(1))
+      .to.be.revertedWithCustomError(controls, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(controls.connect(other).setFeePercent(1))
+      .to.be.revertedWithCustomError(controls, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(controls.connect(other).setRoutingAlgo("a"))
+      .to.be.revertedWithCustomError(controls, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(controls.connect(other).setDisputeBond(1))
+      .to.be.revertedWithCustomError(controls, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(controls.connect(other).setStakeManager(other.address))
+      .to.be.revertedWithCustomError(controls, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(controls.connect(other).setValidationModule(other.address))
+      .to.be.revertedWithCustomError(controls, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(controls.connect(other).setReputationEngine(other.address))
+      .to.be.revertedWithCustomError(controls, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(controls.connect(other).setJobRegistry(other.address))
+      .to.be.revertedWithCustomError(controls, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(controls.connect(other).setCertificateNFT(other.address))
+      .to.be.revertedWithCustomError(controls, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(controls.connect(other).setDisputeModule(other.address))
+      .to.be.revertedWithCustomError(controls, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add OwnerControls contract for centralized config management
- emit events on parameter changes and restrict updates to owner
- test all setters and access control

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a00a13e6883338fb9aab76bebb02c