### PR TITLE
Add staking router and operator registry

### DIFF
--- a/contracts/OperatorRegistry.sol
+++ b/contracts/OperatorRegistry.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title OperatorRegistry
+/// @notice Tracks operator status, stake and reputation.
+contract OperatorRegistry is Ownable {
+    struct Operator {
+        bool active;
+        uint256 stake;
+        uint256 reputation;
+    }
+
+    mapping(address => Operator) private _operators;
+    address public stakingRouter;
+
+    event OperatorStatusUpdated(address indexed operator, bool active);
+    event OperatorStakeUpdated(address indexed operator, uint256 stake);
+    event OperatorReputationUpdated(address indexed operator, uint256 reputation);
+    event StakingRouterUpdated(address indexed router);
+
+    constructor(address owner) Ownable(owner) {}
+
+    modifier onlyStakingRouter() {
+        require(msg.sender == stakingRouter, "router");
+        _;
+    }
+
+    /// @notice update address allowed to push stake changes
+    function setStakingRouter(address router) external onlyOwner {
+        stakingRouter = router;
+        emit StakingRouterUpdated(router);
+    }
+
+    /// @notice activate or deactivate an operator
+    function setOperatorStatus(address operator, bool active) external onlyOwner {
+        _operators[operator].active = active;
+        emit OperatorStatusUpdated(operator, active);
+    }
+
+    /// @notice set operator reputation score reference
+    function setOperatorReputation(address operator, uint256 reputation) external onlyOwner {
+        _operators[operator].reputation = reputation;
+        emit OperatorReputationUpdated(operator, reputation);
+    }
+
+    /// @notice update stake value; callable only by staking router
+    function updateStake(address operator, uint256 stake) external onlyStakingRouter {
+        _operators[operator].stake = stake;
+        emit OperatorStakeUpdated(operator, stake);
+    }
+
+    /// @notice return operator metadata
+    function getOperator(address operator) external view returns (Operator memory) {
+        return _operators[operator];
+    }
+}
+

--- a/contracts/StakingRouter.sol
+++ b/contracts/StakingRouter.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {OperatorRegistry} from "./OperatorRegistry.sol";
+
+/// @title StakingRouter
+/// @notice Manages operator stake balances with cooldown withdrawals and weight calculation.
+contract StakingRouter is Ownable {
+    using SafeERC20 for IERC20;
+
+    error OwnerCannotStake();
+    error CooldownActive();
+
+    IERC20 public immutable token;
+    OperatorRegistry public immutable registry;
+    uint256 public immutable cooldown;
+
+    mapping(address => uint256) public stakes;
+    mapping(address => uint256) public pendingWithdrawals;
+    mapping(address => uint256) public withdrawalTime;
+
+    event Staked(address indexed operator, uint256 amount);
+    event UnstakeInitiated(address indexed operator, uint256 amount, uint256 availableAt);
+    event Withdrawal(address indexed operator, uint256 amount);
+
+    constructor(IERC20 _token, OperatorRegistry _registry, uint256 _cooldown, address owner)
+        Ownable(owner)
+    {
+        token = _token;
+        registry = _registry;
+        cooldown = _cooldown;
+    }
+
+    /// @notice deposit stake for the sender
+    function stake(uint256 amount) external {
+        if (msg.sender == owner()) revert OwnerCannotStake();
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        stakes[msg.sender] += amount;
+        registry.updateStake(msg.sender, stakes[msg.sender]);
+        emit Staked(msg.sender, amount);
+    }
+
+    /// @notice begin unstaking process with cooldown
+    function initiateUnstake(uint256 amount) external {
+        uint256 staked = stakes[msg.sender];
+        require(staked >= amount, "amount");
+        stakes[msg.sender] = staked - amount;
+        pendingWithdrawals[msg.sender] += amount;
+        withdrawalTime[msg.sender] = block.timestamp + cooldown;
+        registry.updateStake(msg.sender, stakes[msg.sender]);
+        emit UnstakeInitiated(msg.sender, amount, withdrawalTime[msg.sender]);
+    }
+
+    /// @notice withdraw tokens after cooldown
+    function withdraw() external {
+        uint256 availableAt = withdrawalTime[msg.sender];
+        if (block.timestamp < availableAt) revert CooldownActive();
+        uint256 amount = pendingWithdrawals[msg.sender];
+        pendingWithdrawals[msg.sender] = 0;
+        withdrawalTime[msg.sender] = 0;
+        token.safeTransfer(msg.sender, amount);
+        emit Withdrawal(msg.sender, amount);
+    }
+
+    /// @notice compute stake weight using registry reputation
+    function weightOf(address operator) external view returns (uint256) {
+        OperatorRegistry.Operator memory op = registry.getOperator(operator);
+        return op.stake * op.reputation;
+    }
+}
+

--- a/test/StakingRouter.test.js
+++ b/test/StakingRouter.test.js
@@ -1,0 +1,56 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("StakingRouter", function () {
+  let token, registry, router, owner, operator, other;
+  const cooldown = 100; // seconds
+
+  beforeEach(async () => {
+    [owner, operator, other] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory(
+      "contracts/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    token = await Token.deploy("AGI", "AGI", ethers.parseUnits("1000", 6));
+    await token.waitForDeployment();
+
+    const Registry = await ethers.getContractFactory("OperatorRegistry");
+    registry = await Registry.deploy(owner.address);
+    await registry.waitForDeployment();
+
+    const Router = await ethers.getContractFactory("StakingRouter");
+    router = await Router.deploy(token.target, registry.target, cooldown, owner.address);
+    await router.waitForDeployment();
+    await registry.setStakingRouter(router.target);
+
+    await token.transfer(operator.address, ethers.parseUnits("100", 6));
+  });
+
+  it("allows staking and weight calculation", async () => {
+    const stakeAmount = ethers.parseUnits("10", 6);
+    await registry.setOperatorReputation(operator.address, 2);
+
+    await token.connect(operator).approve(router.target, stakeAmount);
+    await router.connect(operator).stake(stakeAmount);
+
+    expect(await router.stakes(operator.address)).to.equal(stakeAmount);
+    const weight = await router.weightOf(operator.address);
+    expect(weight).to.equal(stakeAmount * 2n);
+  });
+
+  it("allows owner to activate operator", async () => {
+    await registry.setOperatorStatus(operator.address, true);
+    const info = await registry.getOperator(operator.address);
+    expect(info.active).to.equal(true);
+  });
+
+  it("reverts when owner stakes", async () => {
+    const stakeAmount = ethers.parseUnits("1", 6);
+    await token.approve(router.target, stakeAmount);
+    await expect(router.stake(stakeAmount)).to.be.revertedWithCustomError(
+      router,
+      "OwnerCannotStake"
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- introduce `OperatorRegistry` for tracking operator status, stake and reputation
- add `StakingRouter` with stake management, cooldown withdrawals and weight calculation
- test staking, activation and owner staking restriction

## Testing
- `npx hardhat test test/StakingRouter.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a06ade5d48333a38c6cfc2e7f3ece