### PR TITLE
feat: add revenue distribution and routing modules

### DIFF
--- a/contracts/v2/modules/RevenueDistributor.sol
+++ b/contracts/v2/modules/RevenueDistributor.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IStakeManager} from "../interfaces/IStakeManager.sol";
+
+/// @title RevenueDistributor
+/// @notice Splits incoming job fees among active operators based on stake.
+contract RevenueDistributor is Ownable {
+    IStakeManager public stakeManager;
+    address public treasury;
+
+    address[] public operators;
+    mapping(address => bool) public isOperator;
+
+    event OperatorRegistered(address indexed operator);
+    event OperatorDeregistered(address indexed operator);
+    event TreasuryUpdated(address indexed treasury);
+    event RevenueDistributed(address indexed from, uint256 amount);
+
+    constructor(IStakeManager _stakeManager, address owner) Ownable(owner) {
+        stakeManager = _stakeManager;
+    }
+
+    /// @notice Register the caller as an operator.
+    function register() external {
+        require(!isOperator[msg.sender], "registered");
+        uint256 stake = stakeManager.stakeOf(msg.sender, IStakeManager.Role.Platform);
+        require(stake > 0, "stake");
+        isOperator[msg.sender] = true;
+        operators.push(msg.sender);
+        emit OperatorRegistered(msg.sender);
+    }
+
+    /// @notice Deregister an operator. Only owner may remove.
+    function deregister(address operator) external onlyOwner {
+        if (!isOperator[operator]) return;
+        isOperator[operator] = false;
+        uint256 len = operators.length;
+        for (uint256 i; i < len; i++) {
+            if (operators[i] == operator) {
+                operators[i] = operators[len - 1];
+                operators.pop();
+                break;
+            }
+        }
+        emit OperatorDeregistered(operator);
+    }
+
+    /// @notice Update treasury address for rounding dust.
+    function setTreasury(address _treasury) external onlyOwner {
+        treasury = _treasury;
+        emit TreasuryUpdated(_treasury);
+    }
+
+    /// @notice Distribute received ETH to active operators by stake.
+    function distribute() external payable {
+        uint256 amount = msg.value;
+        require(amount > 0, "amount");
+
+        uint256 len = operators.length;
+        uint256[] memory stakes = new uint256[](len);
+        uint256 totalStake;
+        for (uint256 i; i < len; i++) {
+            address op = operators[i];
+            if (!isOperator[op]) continue;
+            uint256 stake = stakeManager.stakeOf(op, IStakeManager.Role.Platform);
+            if (stake == 0) continue;
+            stakes[i] = stake;
+            totalStake += stake;
+        }
+        require(totalStake > 0, "total stake");
+
+        uint256 distributed;
+        for (uint256 i; i < len; i++) {
+            address op = operators[i];
+            uint256 stake = stakes[i];
+            if (stake == 0) continue;
+            uint256 share = (amount * stake) / totalStake;
+            distributed += share;
+            (bool ok, ) = op.call{value: share}("");
+            require(ok, "transfer");
+        }
+        uint256 dust = amount - distributed;
+        if (dust > 0 && treasury != address(0)) {
+            (bool ok, ) = treasury.call{value: dust}("");
+            require(ok, "treasury");
+        }
+        emit RevenueDistributed(msg.sender, amount);
+    }
+
+    /// @notice Confirms the contract and its owner can never incur tax liability.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
+    /// @dev Reject direct ETH transfers to keep the contract tax neutral.
+    receive() external payable {
+        revert("RevenueDistributor: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("RevenueDistributor: no ether");
+    }
+}
+

--- a/contracts/v2/modules/RoutingModule.sol
+++ b/contracts/v2/modules/RoutingModule.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IStakeManager} from "../interfaces/IStakeManager.sol";
+import {IReputationEngine} from "../interfaces/IReputationEngine.sol";
+
+/// @title RoutingModule
+/// @notice Selects platform operators for jobs weighted by stake and optional reputation.
+contract RoutingModule is Ownable {
+    IStakeManager public stakeManager;
+    IReputationEngine public reputationEngine;
+    bool public reputationEnabled;
+
+    address[] public operators;
+    mapping(address => bool) public isOperator;
+
+    event OperatorRegistered(address indexed operator);
+    event OperatorDeregistered(address indexed operator);
+    event OperatorSelected(bytes32 indexed jobId, address indexed operator);
+    event ReputationEngineUpdated(address indexed engine);
+    event ReputationEnabled(bool enabled);
+
+    constructor(
+        IStakeManager _stakeManager,
+        IReputationEngine _reputationEngine,
+        address owner
+    ) Ownable(owner) {
+        stakeManager = _stakeManager;
+        reputationEngine = _reputationEngine;
+    }
+
+    /// @notice Register the caller as an operator.
+    function register() external {
+        require(!isOperator[msg.sender], "registered");
+        uint256 stake = stakeManager.stakeOf(msg.sender, IStakeManager.Role.Platform);
+        require(stake > 0, "stake");
+        isOperator[msg.sender] = true;
+        operators.push(msg.sender);
+        emit OperatorRegistered(msg.sender);
+    }
+
+    /// @notice Deregister an operator. Only owner may remove.
+    function deregister(address operator) external onlyOwner {
+        if (!isOperator[operator]) return;
+        isOperator[operator] = false;
+        uint256 len = operators.length;
+        for (uint256 i; i < len; i++) {
+            if (operators[i] == operator) {
+                operators[i] = operators[len - 1];
+                operators.pop();
+                break;
+            }
+        }
+        emit OperatorDeregistered(operator);
+    }
+
+    /// @notice Update the reputation engine.
+    function setReputationEngine(IReputationEngine engine) external onlyOwner {
+        reputationEngine = engine;
+        emit ReputationEngineUpdated(address(engine));
+    }
+
+    /// @notice Enable or disable reputation weighting.
+    function setReputationEnabled(bool enabled) external onlyOwner {
+        reputationEnabled = enabled;
+        emit ReputationEnabled(enabled);
+    }
+
+    /// @notice Select an operator using deterministic pseudo-randomness.
+    /// @param jobId identifier of the job to route
+    /// @return selected address of the chosen operator or address(0) if none
+    function selectOperator(bytes32 jobId) external returns (address selected) {
+        uint256 totalWeight;
+        uint256 len = operators.length;
+        for (uint256 i; i < len; i++) {
+            address op = operators[i];
+            if (!isOperator[op]) continue;
+            uint256 stake = stakeManager.stakeOf(op, IStakeManager.Role.Platform);
+            if (stake == 0) continue;
+            uint256 rep = 1;
+            if (reputationEnabled && address(reputationEngine) != address(0)) {
+                rep = reputationEngine.getReputation(op);
+                if (rep == 0) continue;
+            }
+            totalWeight += stake * rep;
+        }
+
+        if (totalWeight == 0) {
+            emit OperatorSelected(jobId, address(0));
+            return address(0);
+        }
+
+        uint256 rand =
+            uint256(keccak256(abi.encode(block.timestamp, jobId))) % totalWeight;
+        uint256 cumulative;
+        for (uint256 i; i < len; i++) {
+            address op = operators[i];
+            if (!isOperator[op]) continue;
+            uint256 stake = stakeManager.stakeOf(op, IStakeManager.Role.Platform);
+            if (stake == 0) continue;
+            uint256 rep = 1;
+            if (reputationEnabled && address(reputationEngine) != address(0)) {
+                rep = reputationEngine.getReputation(op);
+                if (rep == 0) continue;
+            }
+            uint256 weight = stake * rep;
+            cumulative += weight;
+            if (rand < cumulative) {
+                selected = op;
+                break;
+            }
+        }
+
+        emit OperatorSelected(jobId, selected);
+    }
+
+    /// @notice Confirms the contract and its owner can never incur tax liability.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
+    /// @dev Reject direct ETH transfers to keep the contract tax neutral.
+    receive() external payable {
+        revert("RoutingModule: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("RoutingModule: no ether");
+    }
+}
+

--- a/test/v2/RevenueDistributor.test.js
+++ b/test/v2/RevenueDistributor.test.js
@@ -1,0 +1,46 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("RevenueDistributor", function () {
+  let stakeManager, distributor, owner, op1, op2, op3, payer;
+
+  beforeEach(async () => {
+    [owner, op1, op2, op3, payer] = await ethers.getSigners();
+    const Stake = await ethers.getContractFactory("MockStakeManager");
+    stakeManager = await Stake.deploy();
+
+    const Distributor = await ethers.getContractFactory(
+      "contracts/v2/modules/RevenueDistributor.sol:RevenueDistributor"
+    );
+    distributor = await Distributor.deploy(
+      await stakeManager.getAddress(),
+      owner.address
+    );
+
+    await stakeManager.setStake(op1.address, 2, 100);
+    await stakeManager.setStake(op2.address, 2, 200);
+    await stakeManager.setStake(op3.address, 2, 300);
+
+    await distributor.connect(op1).register();
+    await distributor.connect(op2).register();
+    await distributor.connect(op3).register();
+  });
+
+  it("splits fees proportionally to stake", async () => {
+    const amount = ethers.parseEther("6");
+    const b1 = await ethers.provider.getBalance(op1.address);
+    const b2 = await ethers.provider.getBalance(op2.address);
+    const b3 = await ethers.provider.getBalance(op3.address);
+
+    await distributor.connect(payer).distribute({ value: amount });
+
+    const a1 = await ethers.provider.getBalance(op1.address);
+    const a2 = await ethers.provider.getBalance(op2.address);
+    const a3 = await ethers.provider.getBalance(op3.address);
+
+    expect(a1 - b1).to.equal(ethers.parseEther("1"));
+    expect(a2 - b2).to.equal(ethers.parseEther("2"));
+    expect(a3 - b3).to.equal(ethers.parseEther("3"));
+  });
+});
+

--- a/test/v2/RoutingModule.test.js
+++ b/test/v2/RoutingModule.test.js
@@ -1,0 +1,54 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("RoutingModule", function () {
+  let stakeManager, engine, router, owner, op1, op2;
+
+  beforeEach(async () => {
+    [owner, op1, op2] = await ethers.getSigners();
+    const Stake = await ethers.getContractFactory("MockStakeManager");
+    stakeManager = await Stake.deploy();
+    const Engine = await ethers.getContractFactory("MockReputationEngine");
+    engine = await Engine.deploy();
+    const Router = await ethers.getContractFactory(
+      "contracts/v2/modules/RoutingModule.sol:RoutingModule"
+    );
+    router = await Router.deploy(
+      await stakeManager.getAddress(),
+      await engine.getAddress(),
+      owner.address
+    );
+    await router.connect(owner).setReputationEnabled(true);
+
+    await stakeManager.setStake(op1.address, 2, 100);
+    await stakeManager.setStake(op2.address, 2, 300);
+    await engine.add(op1.address, 1);
+    await engine.add(op2.address, 3);
+
+    await router.connect(op1).register();
+    await router.connect(op2).register();
+  });
+
+  it("routes based on stake and reputation", async () => {
+    const jobId = ethers.encodeBytes32String("job");
+    const trials = 500;
+    const routerAddr = await router.getAddress();
+    let c1 = 0;
+    let c2 = 0;
+    for (let i = 0; i < trials; i++) {
+      const tx = await router.connect(owner).selectOperator(jobId);
+      const rcpt = await tx.wait();
+      const log = rcpt.logs.find((l) => l.address === routerAddr);
+      const parsed = router.interface.parseLog(log);
+      const selected = parsed.args.operator;
+      if (selected === op1.address) c1++;
+      if (selected === op2.address) c2++;
+    }
+    const r1 = c1 / trials;
+    const r2 = c2 / trials;
+    expect(r2).to.be.greaterThan(r1);
+    expect(r1).to.be.closeTo(0.1, 0.05);
+    expect(r2).to.be.closeTo(0.9, 0.05);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `RevenueDistributor` contract to split job fees among registered operators
- introduce `RoutingModule` that selects operators using stake and optional reputation weighting with deterministic randomness
- test revenue splits and routing probabilities across multiple operators

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a087fac4883338edb93a02bfce64a