### PR TITLE
Add JobEscrow contract with routing-based job escrow

### DIFF
--- a/contracts/mocks/MockRoutingModule.sol
+++ b/contracts/mocks/MockRoutingModule.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+contract MockRoutingModule {
+    address public operator;
+
+    constructor(address _operator) {
+        operator = _operator;
+    }
+
+    function selectOperator(bytes32) external returns (address) {
+        return operator;
+    }
+}
+

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface IRoutingModule {
+    function selectOperator(bytes32 jobId) external returns (address);
+}
+
+/// @title JobEscrow
+/// @notice Minimal job management with escrowed payments in AGIALPHA.
+/// Jobs are routed to operators via the RoutingModule. Rewards are released
+/// to the operator once the employer accepts the submitted result or after a
+/// timeout.
+contract JobEscrow {
+    using SafeERC20 for IERC20;
+
+    enum State { None, Posted, Submitted, Accepted, Cancelled }
+
+    struct Job {
+        address employer;
+        address operator;
+        uint256 reward;
+        State state;
+        uint256 submittedAt;
+        string data;
+        string result;
+    }
+
+    uint256 public constant TIMEOUT = 3 days;
+
+    IERC20 public immutable token;
+    IRoutingModule public routingModule;
+    uint256 public nextJobId;
+    mapping(uint256 => Job) public jobs;
+
+    event JobPosted(uint256 indexed jobId, address indexed employer, address indexed operator, uint256 reward, string data);
+    event JobCancelled(uint256 indexed jobId);
+    event ResultSubmitted(uint256 indexed jobId, string result);
+    event ResultAccepted(uint256 indexed jobId, address caller);
+
+    constructor(IERC20 _token, IRoutingModule _routing) {
+        token = _token;
+        routingModule = _routing;
+    }
+
+    /// @notice Post a new job and escrow the reward.
+    /// @param reward Amount of AGIALPHA tokens to escrow.
+    /// @param data Metadata describing the job.
+    /// @return jobId Identifier of the created job.
+    function postJob(uint256 reward, string calldata data) external returns (uint256 jobId) {
+        require(reward > 0, "reward");
+        address operator = routingModule.selectOperator(bytes32(nextJobId));
+        require(operator != address(0), "operator");
+        jobId = nextJobId++;
+        token.safeTransferFrom(msg.sender, address(this), reward);
+        jobs[jobId] = Job({
+            employer: msg.sender,
+            operator: operator,
+            reward: reward,
+            state: State.Posted,
+            submittedAt: 0,
+            data: data,
+            result: ""
+        });
+        emit JobPosted(jobId, msg.sender, operator, reward, data);
+    }
+
+    /// @notice Operator submits the result for a job.
+    /// @param jobId Identifier of the job.
+    /// @param result Result data or URI.
+    function submitResult(uint256 jobId, string calldata result) external {
+        Job storage job = jobs[jobId];
+        require(job.state == State.Posted, "state");
+        require(msg.sender == job.operator, "operator");
+        job.state = State.Submitted;
+        job.submittedAt = block.timestamp;
+        job.result = result;
+        emit ResultSubmitted(jobId, result);
+    }
+
+    /// @notice Cancel a job before completion.
+    /// @param jobId Identifier of the job.
+    function cancelJob(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        require(job.state == State.Posted, "state");
+        require(msg.sender == job.employer, "employer");
+        job.state = State.Cancelled;
+        token.safeTransfer(job.employer, job.reward);
+        emit JobCancelled(jobId);
+    }
+
+    /// @notice Accept the job result and release payment.
+    /// Employer may call any time after submission. Operator may call after timeout.
+    /// @param jobId Identifier of the job.
+    function acceptResult(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        require(job.state == State.Submitted, "state");
+        if (msg.sender == job.employer) {
+            // employer approval
+        } else if (msg.sender == job.operator) {
+            require(block.timestamp >= job.submittedAt + TIMEOUT, "timeout");
+        } else {
+            revert("caller");
+        }
+        job.state = State.Accepted;
+        token.safeTransfer(job.operator, job.reward);
+        emit ResultAccepted(jobId, msg.sender);
+    }
+}
+

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -1,0 +1,71 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("JobEscrow", function () {
+  let token, routing, escrow, owner, employer, operator;
+
+  beforeEach(async () => {
+    [owner, employer, operator] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory(
+      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    token = await Token.deploy(owner.address);
+    await token.connect(owner).mint(employer.address, 1000000);
+
+    // Mock RoutingModule that always returns operator
+    const Routing = await ethers.getContractFactory("MockRoutingModule");
+    routing = await Routing.deploy(operator.address);
+
+    const Escrow = await ethers.getContractFactory(
+      "contracts/v2/modules/JobEscrow.sol:JobEscrow"
+    );
+    escrow = await Escrow.deploy(await token.getAddress(), await routing.getAddress());
+  });
+
+  it("runs normal job flow", async () => {
+    const reward = 1000;
+    await token.connect(employer).approve(await escrow.getAddress(), reward);
+    const tx = await escrow.connect(employer).postJob(reward, "ipfs://job");
+    const rcpt = await tx.wait();
+    const jobId = rcpt.logs.find((l) => l.fragment && l.fragment.name === "JobPosted").args.jobId;
+
+    await escrow.connect(operator).submitResult(jobId, "ipfs://result");
+    await escrow.connect(employer).acceptResult(jobId);
+
+    expect(await token.balanceOf(operator.address)).to.equal(reward);
+  });
+
+  it("allows cancellation before submission", async () => {
+    const reward = 500;
+    await token.connect(employer).approve(await escrow.getAddress(), reward);
+    const tx = await escrow.connect(employer).postJob(reward, "job");
+    const jobId = (await tx.wait()).logs.find((l) => l.fragment && l.fragment.name === "JobPosted").args.jobId;
+    await escrow.connect(employer).cancelJob(jobId);
+    expect(await token.balanceOf(employer.address)).to.equal(1000000);
+  });
+
+  it("operator can claim after timeout", async () => {
+    const reward = 700;
+    await token.connect(employer).approve(await escrow.getAddress(), reward);
+    const tx = await escrow.connect(employer).postJob(reward, "job");
+    const jobId = (await tx.wait()).logs.find((l) => l.fragment && l.fragment.name === "JobPosted").args.jobId;
+    await escrow.connect(operator).submitResult(jobId, "res");
+    await time.increase(3 * 24 * 60 * 60 + 1);
+    await escrow.connect(operator).acceptResult(jobId);
+    expect(await token.balanceOf(operator.address)).to.equal(reward);
+  });
+
+  it("prevents operator claiming before timeout", async () => {
+    const reward = 300;
+    await token.connect(employer).approve(await escrow.getAddress(), reward);
+    const tx = await escrow.connect(employer).postJob(reward, "job");
+    const jobId = (await tx.wait()).logs.find((l) => l.fragment && l.fragment.name === "JobPosted").args.jobId;
+    await escrow.connect(operator).submitResult(jobId, "res");
+    await expect(escrow.connect(operator).acceptResult(jobId)).to.be.revertedWith(
+      "timeout"
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- introduce JobEscrow contract that routes jobs via RoutingModule and escrows AGIALPHA rewards
- allow operators to submit results, employers to cancel or accept, and auto-claim after timeout
- add comprehensive unit tests covering normal execution, cancellation, and timeout edge cases

## Testing
- `npm run lint`
- `npm test test/v2/JobEscrow.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689a0cc13fa483338435c47e48343355