### PR TITLE
feat: add dispute resolution and challenge flow

### DIFF
--- a/contracts/DisputeResolution.sol
+++ b/contracts/DisputeResolution.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+interface IStakeManager {
+    function slash(address user, address recipient, uint256 amount) external;
+}
+
+interface IReputationEngine {
+    function addReputation(address user, uint256 amount) external;
+    function subtractReputation(address user, uint256 amount) external;
+}
+
+interface IValidationModule {
+    function challenger(uint256 jobId) external view returns (address);
+    function disputeBond() external view returns (uint256);
+    function clearChallenge(uint256 jobId) external;
+    function owner() external view returns (address);
+}
+
+/// @title DisputeResolution
+/// @notice Resolves validation challenges, distributes bonds and updates reputation
+contract DisputeResolution is Ownable {
+    IStakeManager public stakeManager;
+    IReputationEngine public reputationEngine;
+    IValidationModule public validationModule;
+
+    event DisputeResolved(uint256 indexed jobId, bool validatorWins);
+    event StakeManagerUpdated(address manager);
+    event ReputationEngineUpdated(address engine);
+    event ValidationModuleUpdated(address module);
+
+    constructor(
+        IStakeManager _stakeManager,
+        IReputationEngine _reputationEngine,
+        IValidationModule _validationModule,
+        address owner
+    ) Ownable(owner) {
+        stakeManager = _stakeManager;
+        reputationEngine = _reputationEngine;
+        validationModule = _validationModule;
+    }
+
+    /// @notice Resolve a challenged result and distribute bonds accordingly
+    /// @param jobId Identifier of the disputed job
+    /// @param validatorWins True if the original validator outcome is upheld
+    function resolve(uint256 jobId, bool validatorWins) external onlyOwner {
+        address challengerAddr = validationModule.challenger(jobId);
+        require(challengerAddr != address(0), "no challenge");
+        address validator = validationModule.owner();
+        uint256 bond = validationModule.disputeBond();
+
+        if (validatorWins) {
+            stakeManager.slash(challengerAddr, validator, bond);
+            reputationEngine.subtractReputation(challengerAddr, 1);
+            reputationEngine.addReputation(validator, 1);
+        } else {
+            stakeManager.slash(validator, challengerAddr, bond);
+            reputationEngine.subtractReputation(validator, 1);
+            reputationEngine.addReputation(challengerAddr, 1);
+        }
+
+        validationModule.clearChallenge(jobId);
+        emit DisputeResolved(jobId, validatorWins);
+    }
+
+    function setStakeManager(IStakeManager manager) external onlyOwner {
+        stakeManager = manager;
+        emit StakeManagerUpdated(address(manager));
+    }
+
+    function setReputationEngine(IReputationEngine engine) external onlyOwner {
+        reputationEngine = engine;
+        emit ReputationEngineUpdated(address(engine));
+    }
+
+    function setValidationModule(IValidationModule module) external onlyOwner {
+        validationModule = module;
+        emit ValidationModuleUpdated(address(module));
+    }
+
+    /// @notice Confirms the contract and owner are tax-exempt.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
+    receive() external payable {
+        revert("DisputeResolution: no ether");
+    }
+
+    fallback() external payable {
+        revert("DisputeResolution: no ether");
+    }
+}

--- a/contracts/ValidationModule.sol
+++ b/contracts/ValidationModule.sol
@@ -3,24 +3,88 @@ pragma solidity ^0.8.21;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
+interface IStakeManager {
+    function lockReward(address from, uint256 amount) external;
+}
+
 /// @title ValidationModule
-/// @notice Returns predetermined validation outcomes for jobs.
+/// @notice Returns predetermined validation outcomes and supports result challenges.
 contract ValidationModule is Ownable {
     mapping(uint256 => bool) public outcomes;
 
+    /// @notice stake manager used to lock dispute bonds
+    IStakeManager public stakeManager;
+    /// @notice bond required to challenge a result
+    uint256 public disputeBond;
+    /// @notice period during which challenges are accepted
+    uint256 public challengeWindow;
+    /// @notice address allowed to clear challenges
+    address public disputeResolution;
+
+    /// @dev challenge deadline per job
+    mapping(uint256 => uint256) public challengeDeadline;
+    /// @dev challenger per job
+    mapping(uint256 => address) public challenger;
+
     event OutcomeSet(uint256 indexed jobId, bool success);
+    event OutcomeChallenged(uint256 indexed jobId, address indexed challenger);
+    event StakeManagerUpdated(address manager);
+    event DisputeBondUpdated(uint256 bond);
+    event ChallengeWindowUpdated(uint256 window);
+    event DisputeResolutionUpdated(address resolver);
 
     constructor(address owner) Ownable(owner) {}
+
+    function setStakeManager(IStakeManager manager) external onlyOwner {
+        stakeManager = manager;
+        emit StakeManagerUpdated(address(manager));
+    }
+
+    function setDisputeBond(uint256 bond) external onlyOwner {
+        disputeBond = bond;
+        emit DisputeBondUpdated(bond);
+    }
+
+    function setChallengeWindow(uint256 window) external onlyOwner {
+        challengeWindow = window;
+        emit ChallengeWindowUpdated(window);
+    }
+
+    function setDisputeResolution(address resolver) external onlyOwner {
+        disputeResolution = resolver;
+        emit DisputeResolutionUpdated(resolver);
+    }
 
     /// @notice Set the validation outcome for a job.
     function setOutcome(uint256 jobId, bool success) external onlyOwner {
         outcomes[jobId] = success;
+        challengeDeadline[jobId] = block.timestamp + challengeWindow;
+        delete challenger[jobId];
         emit OutcomeSet(jobId, success);
     }
 
     /// @notice Validate a job and return the preset outcome.
     function validate(uint256 jobId) external view returns (bool) {
         return outcomes[jobId];
+    }
+
+    /// @notice Challenge a validation result by locking a dispute bond.
+    function challenge(uint256 jobId) external {
+        require(block.timestamp <= challengeDeadline[jobId], "expired");
+        require(challenger[jobId] == address(0), "challenged");
+        stakeManager.lockReward(msg.sender, disputeBond);
+        challenger[jobId] = msg.sender;
+        emit OutcomeChallenged(jobId, msg.sender);
+    }
+
+    /// @notice Clear challenge data after resolution.
+    function clearChallenge(uint256 jobId) external {
+        require(
+            msg.sender == disputeResolution || msg.sender == owner(),
+            "not authorized"
+        );
+        delete challenger[jobId];
+        delete challengeDeadline[jobId];
     }
 
     /// @notice Confirms the contract and owner are tax-exempt.

--- a/contracts/mocks/StubStakeManager.sol
+++ b/contracts/mocks/StubStakeManager.sol
@@ -4,15 +4,25 @@ pragma solidity ^0.8.21;
 contract StubStakeManager {
     mapping(address => uint256) public stakes;
 
+    /// @notice tracks locked amounts for testing bond logic
+    mapping(address => uint256) public locked;
+
+    /// @notice records slashed amounts from users to recipients
+    mapping(address => mapping(address => uint256)) public slashed;
+
     function setStake(address user, uint256 amount) external {
         stakes[user] = amount;
     }
 
-    function lockReward(address, uint256) external {}
+    function lockReward(address from, uint256 amount) external {
+        locked[from] += amount;
+    }
 
     function payReward(address, uint256) external {}
 
-    function slash(address, address, uint256) external {}
+    function slash(address user, address recipient, uint256 amount) external {
+        slashed[user][recipient] += amount;
+    }
 
     function releaseStake(address, uint256) external {}
 }

--- a/test/DisputeResolution.test.js
+++ b/test/DisputeResolution.test.js
@@ -1,0 +1,70 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("DisputeResolution", function () {
+  let owner, challenger, stakeManager, reputation, validation, dispute;
+
+  beforeEach(async () => {
+    [owner, challenger] = await ethers.getSigners();
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/mocks/StubStakeManager.sol:StubStakeManager"
+    );
+    stakeManager = await StakeManager.deploy();
+    const stakeAddr = await stakeManager.getAddress();
+
+    const Reputation = await ethers.getContractFactory(
+      "contracts/mocks/StubReputationEngine.sol:StubReputationEngine"
+    );
+    reputation = await Reputation.deploy();
+    const repAddr = await reputation.getAddress();
+
+    const Validation = await ethers.getContractFactory(
+      "contracts/ValidationModule.sol:ValidationModule"
+    );
+    validation = await Validation.deploy(owner.address);
+    const valAddr = await validation.getAddress();
+    await validation.connect(owner).setStakeManager(stakeAddr);
+    await validation.connect(owner).setChallengeWindow(1000);
+    await validation.connect(owner).setDisputeBond(50);
+
+    const Dispute = await ethers.getContractFactory(
+      "contracts/DisputeResolution.sol:DisputeResolution"
+    );
+    dispute = await Dispute.deploy(
+      stakeAddr,
+      repAddr,
+      valAddr,
+      owner.address
+    );
+    const disputeAddr = await dispute.getAddress();
+    await validation.connect(owner).setDisputeResolution(disputeAddr);
+  });
+
+  it("slashes challenger and rewards validator when validator wins", async () => {
+    await validation.connect(owner).setOutcome(1, true);
+    await validation.connect(challenger).challenge(1);
+
+    await dispute.connect(owner).resolve(1, true);
+
+    expect(
+      await stakeManager.slashed(challenger.address, owner.address)
+    ).to.equal(50n);
+    expect(await reputation.reputation(owner.address)).to.equal(1n);
+    expect(await reputation.reputation(challenger.address)).to.equal(0n);
+    expect(await validation.challenger(1)).to.equal(ethers.ZeroAddress);
+  });
+
+  it("slashes validator and rewards challenger when challenger wins", async () => {
+    await validation.connect(owner).setOutcome(1, true);
+    await validation.connect(challenger).challenge(1);
+
+    await dispute.connect(owner).resolve(1, false);
+
+    expect(
+      await stakeManager.slashed(owner.address, challenger.address)
+    ).to.equal(50n);
+    expect(await reputation.reputation(challenger.address)).to.equal(1n);
+    expect(await reputation.reputation(owner.address)).to.equal(0n);
+  });
+});

--- a/test/ValidationModule.test.js
+++ b/test/ValidationModule.test.js
@@ -2,14 +2,24 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("ValidationModule", function () {
-  let validation, owner;
+  let validation, owner, challenger, stakeManager;
 
   beforeEach(async () => {
-    [owner] = await ethers.getSigners();
+    [owner, challenger] = await ethers.getSigners();
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/mocks/StubStakeManager.sol:StubStakeManager"
+    );
+    stakeManager = await StakeManager.deploy();
+    const stakeAddr = await stakeManager.getAddress();
+
     const ValidationModule = await ethers.getContractFactory(
       "contracts/ValidationModule.sol:ValidationModule"
     );
     validation = await ValidationModule.deploy(owner.address);
+    await validation.connect(owner).setStakeManager(stakeAddr);
+    await validation.connect(owner).setChallengeWindow(1000);
+    await validation.connect(owner).setDisputeBond(50);
   });
 
   it("returns preset outcomes", async () => {
@@ -17,6 +27,21 @@ describe("ValidationModule", function () {
     expect(await validation.validate(1)).to.equal(true);
     await validation.connect(owner).setOutcome(2, false);
     expect(await validation.validate(2)).to.equal(false);
+  });
+
+  it("allows challenges within deadline and locks bond", async () => {
+    await validation.connect(owner).setOutcome(1, true);
+    await validation.connect(challenger).challenge(1);
+    expect(await validation.challenger(1)).to.equal(challenger.address);
+    expect(await stakeManager.locked(challenger.address)).to.equal(50n);
+  });
+
+  it("rejects challenges after deadline", async () => {
+    await validation.connect(owner).setOutcome(1, true);
+    await ethers.provider.send("evm_increaseTime", [1001]);
+    await expect(
+      validation.connect(challenger).challenge(1)
+    ).to.be.revertedWith("expired");
   });
 });
 


### PR DESCRIPTION
## Summary
- add challenge window and bond locking to ValidationModule
- introduce DisputeResolution for bond slashing, rewards and reputation
- track locked and slashed amounts in stub stake manager

## Testing
- `npm test --silent test/ValidationModule.test.js test/DisputeResolution.test.js`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_689a0f08d18c8333a4499e67ebbac9ec