### PR TITLE
feat: add decaying reputation metrics

### DIFF
--- a/contracts/v2/modules/RoutingModule.sol
+++ b/contracts/v2/modules/RoutingModule.sol
@@ -76,14 +76,14 @@ contract RoutingModule is Ownable {
         for (uint256 i; i < len; i++) {
             address op = operators[i];
             if (!isOperator[op]) continue;
-            uint256 stake = stakeManager.stakeOf(op, IStakeManager.Role.Platform);
-            if (stake == 0) continue;
-            uint256 rep = 1;
+            uint256 weight;
             if (reputationEnabled && address(reputationEngine) != address(0)) {
-                rep = reputationEngine.getReputation(op);
-                if (rep == 0) continue;
+                weight = reputationEngine.getOperatorScore(op);
+            } else {
+                weight = stakeManager.stakeOf(op, IStakeManager.Role.Platform);
             }
-            totalWeight += stake * rep;
+            if (weight == 0) continue;
+            totalWeight += weight;
         }
 
         if (totalWeight == 0) {
@@ -97,14 +97,13 @@ contract RoutingModule is Ownable {
         for (uint256 i; i < len; i++) {
             address op = operators[i];
             if (!isOperator[op]) continue;
-            uint256 stake = stakeManager.stakeOf(op, IStakeManager.Role.Platform);
-            if (stake == 0) continue;
-            uint256 rep = 1;
+            uint256 weight;
             if (reputationEnabled && address(reputationEngine) != address(0)) {
-                rep = reputationEngine.getReputation(op);
-                if (rep == 0) continue;
+                weight = reputationEngine.getOperatorScore(op);
+            } else {
+                weight = stakeManager.stakeOf(op, IStakeManager.Role.Platform);
             }
-            uint256 weight = stake * rep;
+            if (weight == 0) continue;
             cumulative += weight;
             if (rand < cumulative) {
                 selected = op;

--- a/test/v2/RoutingModule.test.js
+++ b/test/v2/RoutingModule.test.js
@@ -8,8 +8,12 @@ describe("RoutingModule", function () {
     [owner, op1, op2] = await ethers.getSigners();
     const Stake = await ethers.getContractFactory("MockStakeManager");
     stakeManager = await Stake.deploy();
-    const Engine = await ethers.getContractFactory("MockReputationEngine");
-    engine = await Engine.deploy();
+    const Engine = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    engine = await Engine.deploy(owner.address);
+    await engine.connect(owner).setStakeManager(await stakeManager.getAddress());
+    await engine.connect(owner).setCaller(owner.address, true);
     const Router = await ethers.getContractFactory(
       "contracts/v2/modules/RoutingModule.sol:RoutingModule"
     );
@@ -22,8 +26,10 @@ describe("RoutingModule", function () {
 
     await stakeManager.setStake(op1.address, 2, 100);
     await stakeManager.setStake(op2.address, 2, 300);
-    await engine.add(op1.address, 1);
-    await engine.add(op2.address, 3);
+    await engine.connect(owner).recordCompletion(op1.address);
+    await engine.connect(owner).recordCompletion(op2.address);
+    await engine.connect(owner).recordCompletion(op2.address);
+    await engine.connect(owner).recordCompletion(op2.address);
 
     await router.connect(op1).register();
     await router.connect(op2).register();


### PR DESCRIPTION
## Summary
- track operator performance metrics with decay in `ReputationEngine`
- expose combined stake/reputation score for job routing
- add tests covering reputation updates and routing weighting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a12c39e9083339d0a71f09e96f544