### PR TITLE
Skip owner payouts in RevenueDistributor

### DIFF
--- a/contracts/v2/modules/RevenueDistributor.sol
+++ b/contracts/v2/modules/RevenueDistributor.sol
@@ -63,7 +63,7 @@ contract RevenueDistributor is Ownable {
         uint256 totalStake;
         for (uint256 i; i < len; i++) {
             address op = operators[i];
-            if (!isOperator[op]) continue;
+            if (op == owner() || !isOperator[op]) continue;
             uint256 stake = stakeManager.stakeOf(op, IStakeManager.Role.Platform);
             if (stake == 0) continue;
             stakes[i] = stake;
@@ -74,6 +74,7 @@ contract RevenueDistributor is Ownable {
         uint256 distributed;
         for (uint256 i; i < len; i++) {
             address op = operators[i];
+            if (op == owner()) continue;
             uint256 stake = stakes[i];
             if (stake == 0) continue;
             uint256 share = (amount * stake) / totalStake;

--- a/test/v2/RevenueDistributor.test.js
+++ b/test/v2/RevenueDistributor.test.js
@@ -42,5 +42,28 @@ describe("RevenueDistributor", function () {
     expect(a2 - b2).to.equal(ethers.parseEther("2"));
     expect(a3 - b3).to.equal(ethers.parseEther("3"));
   });
+
+  it("skips owner even if registered and staked", async () => {
+    await stakeManager.setStake(owner.address, 2, 400);
+    await distributor.connect(owner).register();
+
+    const amount = ethers.parseEther("6");
+    const bOwner = await ethers.provider.getBalance(owner.address);
+    const b1 = await ethers.provider.getBalance(op1.address);
+    const b2 = await ethers.provider.getBalance(op2.address);
+    const b3 = await ethers.provider.getBalance(op3.address);
+
+    await distributor.connect(payer).distribute({ value: amount });
+
+    const aOwner = await ethers.provider.getBalance(owner.address);
+    const a1 = await ethers.provider.getBalance(op1.address);
+    const a2 = await ethers.provider.getBalance(op2.address);
+    const a3 = await ethers.provider.getBalance(op3.address);
+
+    expect(aOwner - bOwner).to.equal(0n);
+    expect(a1 - b1).to.equal(ethers.parseEther("1"));
+    expect(a2 - b2).to.equal(ethers.parseEther("2"));
+    expect(a3 - b3).to.equal(ethers.parseEther("3"));
+  });
 });
 


### PR DESCRIPTION
## Summary
- prevent RevenueDistributor from counting or paying the contract owner
- test owner registration and payout exclusion

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a15a03ea8833391ce7f6a323f3998