### PR TITLE
feat: add score-based job router

### DIFF
--- a/contracts/v2/interfaces/IPlatformRegistry.sol
+++ b/contracts/v2/interfaces/IPlatformRegistry.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title IPlatformRegistry
+/// @notice Minimal interface for querying platform registration and scores
+interface IPlatformRegistry {
+    /// @notice whether an operator is currently registered
+    function registered(address operator) external view returns (bool);
+
+    /// @notice routing score for an operator combining stake and reputation
+    function getScore(address operator) external view returns (uint256);
+}


### PR DESCRIPTION
## Summary
- add JobRouter v2 querying PlatformRegistry scores for operator selection
- implement fallback to deployer when no eligible operators exist
- update tests and introduce IPlatformRegistry interface

## Testing
- `npm test`
- `forge test --match-path test/v2/JobRouter.t.sol`
- `forge test --match-path test/v2/Integration.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_689a285443f4833398ac899196840a50