### PR TITLE
docs: add AGIALPHA interaction workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Key incentive features in the v2 suite:
 - [$AGIALPHA token contract on Etherscan](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe#code) – verify this 6‑decimal token on-chain before using it for staking or payments.
 - [AGIALPHAToken source](contracts/v2/AGIALPHAToken.sol) – default 6‑decimal ERC‑20 with owner‑controlled mint and burn.
 - [Etherscan Interaction Guide](docs/etherscan-guide.md) – module diagram, deployed addresses, role-based instructions, and verification checklist.
+- [AGIALPHA operational workflows](docs/agialpha-workflows.md) – approval/staking, platform registration, fee claiming, and dispute steps with 6‑decimal examples.
 - [Project Overview](docs/overview.md) – architecture diagram, module summaries, governance table, incentive mechanics, deployment addresses, and quick start.
 - [AGIJobManager v0 Source](legacy/AGIJobManagerv0.sol)
 - [AGIJobManager v1 Source](contracts/AGIJobManagerv1.sol) – experimental upgrade using Solidity 0.8.21; includes an automatic token burn on final validation via the `JobFinalizedAndBurned` event and configurable burn parameters. Not deployed; treat any address claiming to be v1 as unverified until announced through official channels.

--- a/docs/agialpha-workflows.md
+++ b/docs/agialpha-workflows.md
@@ -1,0 +1,44 @@
+# $AGIALPHA Operational Workflows
+
+This guide summarises common on-chain interactions for the $AGIALPHA-based AGIJobs v2 suite. All token amounts use 6‑decimal base units (`1 AGIALPHA = 1_000000`). Replace bracketed addresses with your deployment values before transacting.
+
+## 1. Approve & Stake $AGIALPHA
+
+1. **Approve tokens** – Open the [$AGIALPHA token Write tab](https://etherscan.io/address/0x2e8fb54C3EC41F55F06C1F082C081A609eAA4EbE#writeContract) and call `approve(spender, amount)`.
+   - `spender`: `StakeManager` address.
+   - `amount`: staking total in base units.
+   - *Example*: approving 50 tokens → `50_000000`.
+2. **Stake for a role** – On [StakeManager Write](https://etherscan.io/address/<StakeManagerAddress>#writeContract) call `depositStake(role, amount)`.
+   - `role`: `0` Agent, `1` Validator, `2` Platform.
+   - `amount`: must be approved above. Example agent stake of 10 tokens → `10_000000`.
+
+## 2. Register a Platform
+
+1. Stake as a platform operator with `depositStake(2, amount)` on StakeManager.
+   - Example minimum stake of 25 tokens → `25_000000`.
+2. Open [PlatformRegistry Write](https://etherscan.io/address/<PlatformRegistryAddress>#writeContract) and call `register()` (or `registerPlatform(operator)` if applicable) to list your platform for routing and fee shares.
+
+## 3. Claim Protocol Fees
+
+1. Check [FeePool Read](https://etherscan.io/address/<FeePoolAddress>#readContract) for `pendingFees()`.
+2. If `pendingFees > 0`, anyone may call `distributeFees()` on [FeePool Write](https://etherscan.io/address/<FeePoolAddress>#writeContract) to allocate rewards.
+3. Platform stakers withdraw earnings via `claimRewards()` on the same Write tab. Rewards stream in $AGIALPHA based on staked weight.
+
+## 4. Dispute a Job
+
+1. Ensure you have approved the `StakeManager` for at least the appeal fee. Example fee of 10 tokens → approve `10_000000`.
+2. On [DisputeModule Read](https://etherscan.io/address/<DisputeModuleAddress>#readContract) check `appealFee()` and `disputeWindow()`.
+3. Call `raiseDispute(jobId, evidence)` on [DisputeModule Write](https://etherscan.io/address/<DisputeModuleAddress>#writeContract) before the dispute window ends. The StakeManager will lock the `appealFee` from your wallet.
+4. After the window elapses, an authorised arbiter resolves the case with `resolveDispute(jobId)`. Depending on the outcome, the appeal fee is returned or paid out via `StakeManager.payDisputeFee`.
+
+---
+
+### Base‑Unit Examples
+
+```
+1.0 AGIALPHA  = 1_000000
+0.5 AGIALPHA  =   500000
+25  AGIALPHA  = 25_000000
+```
+
+Verify all addresses on multiple explorers and keep owner keys in secure wallets. All modules reject direct ETH and rely solely on $AGIALPHA for value transfer.


### PR DESCRIPTION
## Summary
- add AGIALPHA operational workflows covering approvals, staking, platform registration, fee claims, and dispute steps with 6-decimal examples
- link new workflow guide from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a30d5cac88333888711fbf9d89fa5