### PR TITLE
Allow zero-stake deployer registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,6 +1088,7 @@ $AGIALPHA is a 6‑decimal ERC‑20 token used across the platform for payments,
 2. **Configure staking and rewards**
    - On `StakeManager`, call `setMinStake`, `setSlashingPercentages`, and `setTreasury` as needed.
    - On `FeePool`, call `setRewardRole(2)` to direct revenue to platform stakers and adjust `setBurnPct` if desired.
+   - The deploying entity may register its reference platform without staking; it will appear in `PlatformRegistry` but receive no routing priority or fee share.
 3. **Wire modules together**
    - In `JobRegistry`, call `setModules` with addresses of `ValidationModule`, `StakeManager`, `ReputationEngine`, `DisputeModule`, and `CertificateNFT`.
    - In `ValidationModule`, set validator windows, pool, and connect the `ReputationEngine`.

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -49,8 +49,9 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
         require(!registered[msg.sender], "registered");
         require(!blacklist[msg.sender], "blacklisted");
         uint256 stake = stakeManager.stakeOf(msg.sender, IStakeManager.Role.Platform);
-        if (msg.sender == owner()) require(stake > 0, "owner stake");
-        require(stake >= minPlatformStake, "stake");
+        if (msg.sender != owner()) {
+            require(stake >= minPlatformStake, "stake");
+        }
         registered[msg.sender] = true;
         emit Registered(msg.sender);
     }
@@ -66,6 +67,7 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
     function getScore(address operator) public view returns (uint256) {
         if (blacklist[operator] || reputationEngine.isBlacklisted(operator)) return 0;
         uint256 stake = stakeManager.stakeOf(operator, IStakeManager.Role.Platform);
+        if (operator == owner() && stake == 0) return 0;
         uint256 rep = reputationEngine.reputation(operator);
         uint256 stakeW = reputationEngine.stakeWeight();
         uint256 repW = reputationEngine.reputationWeight();

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -77,19 +77,14 @@ describe("PlatformRegistry", function () {
     await registry.connect(platform).register();
   });
 
-  it("requires deployer to stake before registering", async () => {
-    const Registry = await ethers.getContractFactory(
-      "contracts/v2/PlatformRegistry.sol:PlatformRegistry"
-    );
-    const reg2 = await Registry.connect(owner).deploy(
-      await stakeManager.getAddress(),
-      await reputationEngine.getAddress(),
-      0,
-      owner.address
-    );
-    await expect(reg2.connect(owner).register()).to.be.revertedWith(
-      "owner stake"
-    );
+  it("allows owner to register without stake and yields zero score", async () => {
+    await expect(registry.connect(owner).register())
+      .to.emit(registry, "Registered")
+      .withArgs(owner.address);
+    expect(await registry.getScore(owner.address)).to.equal(0);
+    await reputationEngine.add(owner.address, 10);
+    // reputation alone should not give score without stake for owner
+    expect(await registry.getScore(owner.address)).to.equal(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- let PlatformRegistry owner register without staking while keeping zero routing score
- document zero-stake deployer behavior in AGIALPHA deployment guide

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a390dd0788333b59735b0161e7988