### PR TITLE
docs: add zero-stake registration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,10 @@ $AGIALPHA is a 6‑decimal ERC‑20 token used across the platform for payments,
    - On `StakeManager`, call `setMinStake`, `setSlashingPercentages`, and `setTreasury` as needed.
    - On `FeePool`, call `setRewardRole(2)` to direct revenue to platform stakers and adjust `setBurnPct` if desired.
    - The deploying entity may register its reference platform without staking; it will appear in `PlatformRegistry` but receive no routing priority or fee share.
+      - **Worked example**
+        1. The owner skips `depositStake` (amount = `0`) and calls `PlatformRegistry.register()`.
+        2. Querying `PlatformRegistry.getScore(owner)` returns `0`, so the platform has no routing weight.
+        3. Calling `FeePool.claimRewards()` emits `RewardsClaimed(owner, 0)`, confirming no payout.
 3. **Wire modules together**
    - In `JobRegistry`, call `setModules` with addresses of `ValidationModule`, `StakeManager`, `ReputationEngine`, `DisputeModule`, and `CertificateNFT`.
    - In `ValidationModule`, set validator windows, pool, and connect the `ReputationEngine`.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -31,6 +31,10 @@ The v2 contracts share a unified incentive model:
 - **Routing** – `JobRegistry` locks each job's reward and protocol fee, then routes the fee portion to `FeePool` on finalisation.
 - **Revenue share** – `FeePool` streams accumulated fees to platform operators pro‑rata to their staked amount.
 - **Zero‑stake main deployer** – The primary deployment address holds no stake and receives no rewards; all revenue accrues to platform stakers.
+  - **Worked example**
+    1. The owner skips `depositStake` (amount = `0`) and calls `PlatformRegistry.register()`.
+    2. `PlatformRegistry.getScore(owner)` returns `0`, so the platform has no routing weight.
+    3. Calling `FeePool.claimRewards()` emits `RewardsClaimed(owner, 0)`, confirming no payout.
 
 ## Etherscan Interactions
 1. Open the relevant contract address on Etherscan.


### PR DESCRIPTION
## Summary
- document zero-stake platform registration showing owner gets no routing score or rewards

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4b90731483338380f252752508ed