### PR TITLE
Add coverage for zero-stake owner registration

### DIFF
--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -148,7 +148,7 @@ describe("FeePool", function () {
     expect((await token2.balanceOf(user2.address)) - before2).to.equal(75n);
   });
 
-  it("prevents deployer from claiming rewards without stake", async () => {
+  it("emits zero payout for owner without stake", async () => {
     const feeAmount = 50;
     const jobId = ethers.encodeBytes32String("job4");
     await token.connect(employer).approve(await stakeManager.getAddress(), feeAmount);

--- a/test/v2/JobRouter.t.sol
+++ b/test/v2/JobRouter.t.sol
@@ -72,6 +72,13 @@ contract JobRouterTest {
         require(selected == address(this), "none");
     }
 
+    function testOwnerZeroStakeHasNoWeight() public {
+        setUp();
+        registry.register(address(this), 0);
+        router.register();
+        require(router.routingWeight(address(this)) == 0, "weight");
+    }
+
     function testRegisterRequiresRegistration() public {
         setUp();
         bool reverted;

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -77,7 +77,7 @@ describe("PlatformRegistry", function () {
     await registry.connect(platform).register();
   });
 
-  it("allows owner to register without stake and yields zero score", async () => {
+  it("returns zero score when owner registers without stake", async () => {
     await expect(registry.connect(owner).register())
       .to.emit(registry, "Registered")
       .withArgs(owner.address);


### PR DESCRIPTION
## Summary
- check owner registration without stake yields zero score in PlatformRegistry
- ensure JobRouter gives zero routing weight to unstaked owner
- verify FeePool claimRewards emits zero payout for owner without stake

## Testing
- `npm test`
- `forge test` *(fails: invalid type conversion in script/DeployAll.s.sol)*

------
https://chatgpt.com/codex/tasks/task_e_689a4f36e8548333a65a9e84683af47d