### PR TITLE
test: ensure owner zero stake activation has no rewards

### DIFF
--- a/test/v2/PlatformIncentives.t.sol
+++ b/test/v2/PlatformIncentives.t.sol
@@ -68,6 +68,8 @@ contract PlatformIncentivesTest is Test {
         incentives.stakeAndActivate(0);
         assertTrue(platformRegistry.registered(address(this)));
         assertTrue(jobRouter.registered(address(this)));
+        assertEq(platformRegistry.getScore(address(this)), 0);
+        assertEq(jobRouter.routingWeight(address(this)), 0);
 
         token.mint(address(this), 5e6);
         token.transfer(address(feePool), 5e6);
@@ -81,7 +83,15 @@ contract PlatformIncentivesTest is Test {
         assertEq(token.balanceOf(operator) - before, 5e6);
 
         uint256 ownerBefore = token.balanceOf(address(this));
+        vm.expectEmit(true, false, false, true, address(feePool));
+        emit FeePool.RewardsClaimed(address(this), 0);
         feePool.claimRewards();
         assertEq(token.balanceOf(address(this)) - ownerBefore, 0);
+    }
+
+    function testStakeZeroRevertsForNonOwner() public {
+        vm.prank(operator);
+        vm.expectRevert(bytes("amount"));
+        incentives.stakeAndActivate(0);
     }
 }


### PR DESCRIPTION
## Summary
- extend PlatformIncentives tests to ensure owner activation with zero stake leaves score and routing weight at 0 and emits zero rewards; non-owners reverting
- add JS tests for PlatformRegistry and FeePool verifying `stakeAndActivate(0)` produces no score, routing weight, or rewards
- cover non-owner zero-stake calls reverting

## Testing
- `forge test --match-path test/v2/PlatformIncentives.t.sol -v` *(fails: Contract "MockStakeManager" should be marked as abstract)*
- `npx hardhat test test/v2/PlatformRegistry.test.js`
- `npx hardhat test test/v2/FeePool.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a736e27a4833391ee3e5368a087a0