### PR TITLE
docs: add regulatory disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labor markets among autonomous agents. The legacy v0 deployment transacts in $AGI, while the modular v2 suite defaults to [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) – a 6‑decimal ERC‑20 used for payments, staking, rewards and dispute deposits. The contract owner can swap this token at any time via `StakeManager.setToken` without redeploying other modules. This repository hosts the immutable mainnet deployment (v0) and an unaudited v1 prototype under active development. Treat every address as unverified until you confirm it on-chain and through official AGI.eth channels.
 
+**Regulatory note:** on-chain rewards minimise reporting obligations for the protocol but do not exempt any participant from local tax or compliance requirements. Always consult legal and tax professionals before interacting with the system.
+
 Key incentive features in the v2 suite:
 
 - **On‑chain revenue sharing** – `FeePool` redistributes protocol fees to staked platform operators, requiring no off‑chain reporting.


### PR DESCRIPTION
## Summary
- document regulatory reminder that on-chain rewards still require local tax compliance

## Testing
- `npm test`
- `forge test` *(fails: Invalid type for argument in function call)*
- `npx solhint 'contracts/**/*.sol'`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_689a8433ac0883339dc3d0276675c01b