### PR TITLE
docs: note regulatory shifts and owner controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a detailed description of the platform-wide incentive architecture, see [doc
 
 ### Regulatory disclaimer
 
-On-chain fee sharing reduces but does not eliminate tax or reporting duties. Regulations continue to evolve, so participants must monitor policy changes, comply with local laws, and seek professional advice before using the contracts.
+Regulatory shifts may change compliance obligations even when rewards flow entirely on-chain. While the design minimises reporting by routing fees directly in $AGIALPHA, participants must still monitor policy updates, obey local laws, and obtain professional advice before interacting with the contracts.
 
 Key incentive features in the v2 suite:
 
@@ -36,6 +36,10 @@ Staking $AGIALPHA through `PlatformIncentives.stakeAndActivate` registers a plat
   3. `PlatformRegistry.getScore(owner)` returns `0` and `FeePool.claimRewards()` emits a zero payout.
 
 On-chain rewards do not remove your obligation to follow local tax laws; consult professionals.
+
+### Owner Controls
+
+The contract owner may retune any economic parameter without redeploying modules. `StakeManager.setToken`, `FeePool.setToken`, and related setters swap the payment token (default $AGIALPHA, 6 decimals), while `setMinStake`, `setFeePct`, `setBurnPct`, and module `setModules` calls update fees, stake thresholds, burn rates, and wiring. All changes are performed through block‑explorer "Write" tabs, keeping administration accessible to non‑technical owners.
 
 ### Universal Stake-Based Incentive Architecture
 

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -2,6 +2,8 @@
 
 This document details a stake-based framework that aligns every AGI Jobs v2 role within a single on-chain economy.  The design operates entirely in the six‑decimal **$AGIALPHA** token and allows the contract owner to reconfigure parameters without redeploying modules.
 
+> Regulatory shifts continue to evolve. On-chain fee routing minimises reporting, but operators and owners must still comply with local laws and monitor policy updates.
+
 ## Core Modules
 - **StakeManager** – tracks deposits for agents, validators and platform operators; owner may update token, minimums and slashing percentages.
 - **PlatformRegistry** – records platform operators and exposes routing scores derived from stake and reputation.


### PR DESCRIPTION
## Summary
- warn that regulatory shifts may alter obligations even with on-chain rewards
- document owner controls for retuning tokens, fees, and stake parameters via explorer write tabs
- mention regulatory shifts in universal incentive architecture overview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a929a0ae88333b2db7a36ed4efd9d