### PR TITLE
feat: enforce AGIALPHA decimals in FeePool

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
@@ -58,6 +59,7 @@ contract FeePool is Ownable {
         IStakeManager.Role _role,
         address owner
     ) Ownable(owner) {
+        require(IERC20Metadata(address(_token)).decimals() == 6, "decimals");
         token = _token;
         stakeManager = _stakeManager;
         rewardRole = _role;
@@ -128,6 +130,7 @@ contract FeePool is Ownable {
 
     /// @notice update ERC20 token used for payouts
     function setToken(IERC20 newToken) external onlyOwner {
+        require(IERC20Metadata(address(newToken)).decimals() == 6, "decimals");
         token = newToken;
         emit TokenUpdated(address(newToken));
     }

--- a/contracts/v2/interfaces/IFeePool.sol
+++ b/contracts/v2/interfaces/IFeePool.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 /// @title IFeePool
-/// @notice Minimal interface for depositing job fees
+/// @notice Minimal interface for depositing job fees and owner controls
 interface IFeePool {
     /// @notice notify the pool about newly received fees
     /// @param amount amount of tokens transferred to the pool scaled to 6 decimals
@@ -18,4 +20,13 @@ interface IFeePool {
     /// @param to address receiving the tokens
     /// @param amount token amount with 6 decimals
     function transferReward(address to, uint256 amount) external;
+
+    /// @notice update percentage of fees to burn (only owner)
+    function setBurnPct(uint256 pct) external;
+
+    /// @notice update treasury address receiving dust (only owner)
+    function setTreasury(address treasury) external;
+
+    /// @notice update ERC20 token used for payouts (only owner)
+    function setToken(IERC20 newToken) external;
 }


### PR DESCRIPTION
## Summary
- enforce AGIALPHA's 6-decimal precision when setting fee token
- expose burn percent, treasury, and token setters in IFeePool
- update FeePool tests to use 6-decimal AGIALPHAToken

## Testing
- `npx hardhat test test/v2/FeePool.test.js`
- `npm run lint`
- `forge test --match-path test/v2/FeePool.t.sol` *(fails: Invalid type for argument in function call in script/DeployAll.s.sol)*

------
https://chatgpt.com/codex/tasks/task_e_689aafb1a0508333b4a5decb5f39858f