### PR TITLE
docs: clarify zero-stake deployer effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Staking $AGIALPHA through `PlatformIncentives.stakeAndActivate` registers a plat
   2. Open `PlatformIncentives` on Etherscan and call `stakeAndActivate(amount)` from the **Write Contract** tab.
   3. Verify `PlatformRegistry.getScore(address)` is greater than zero and later claim fees via `FeePool.claimRewards()`.
 
-- **Owner zero-stake registration**
+- **Owner zero-stake registration** – The deployer may register to test the system but receives no routing or revenue boost.
   1. Skip staking and open `PlatformRegistry` on Etherscan.
   2. From the **Write Contract** tab, call `register()` to list the platform without routing weight or fee share.
   3. `PlatformRegistry.getScore(owner)` returns `0` and `FeePool.claimRewards()` emits a zero payout.

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -107,6 +107,7 @@ contract FeePool is Ownable {
     /// @notice claim accumulated rewards for caller
     function claimRewards() external {
         uint256 stake = stakeManager.stakeOf(msg.sender, rewardRole);
+        // Deployer may claim but receives no rewards without stake.
         if (msg.sender == owner() && stake == 0) {
             emit RewardsClaimed(msg.sender, 0);
             return;

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -69,6 +69,7 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
     function getScore(address operator) public view returns (uint256) {
         if (blacklist[operator] || reputationEngine.isBlacklisted(operator)) return 0;
         uint256 stake = stakeManager.stakeOf(operator, IStakeManager.Role.Platform);
+        // Deployer may register without staking but receives no routing boost.
         if (operator == owner() && stake == 0) return 0;
         uint256 rep = reputationEngine.reputation(operator);
         uint256 stakeW = reputationEngine.stakeWeight();

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -31,6 +31,7 @@ The v2 contracts share a unified incentive model:
 - **Routing** – `JobRegistry` locks each job's reward and protocol fee, then routes the fee portion to `FeePool` on finalisation.
 - **Revenue share** – `FeePool` streams accumulated fees to platform operators pro‑rata to their staked amount.
 - **Zero‑stake main deployer** – The primary deployment address holds no stake and receives no rewards; all revenue accrues to platform stakers.
+- The deployer may still register its platform but gains no routing priority or revenue share without staking.
   - **Worked example**
     1. The owner skips `depositStake` (amount = `0`) and calls `PlatformRegistry.register()`.
     2. `PlatformRegistry.getScore(owner)` returns `0`, so the platform has no routing weight.


### PR DESCRIPTION
## Summary
- clarify zero-stake deployer behavior in PlatformRegistry and FeePool
- document that the deployer can register but gains no routing or revenue boost

## Testing
- `npm test`
- `forge test` *(fails: Source "forge-std/Script.sol" not found / invalid type for argument in function call)*

------
https://chatgpt.com/codex/tasks/task_e_689ab6d48ac88333a9a545a7679ba21a