### PR TITLE
Add comprehensive v2 test coverage

### DIFF
--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -225,4 +225,10 @@ describe("FeePool", function () {
       incentives.connect(user1).stakeAndActivate(0)
     ).to.be.revertedWith("amount");
   });
+
+  it("reverts when distributing with zero fees", async () => {
+    await expect(feePool.connect(owner).distributeFees()).to.be.revertedWith(
+      "amount"
+    );
+  });
 });

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -133,5 +133,20 @@ describe("PlatformRegistry", function () {
       incentives.connect(platform).stakeAndActivate(0)
     ).to.be.revertedWith("amount");
   });
+
+  it("allows zero-stake registration when min stake is zero", async () => {
+    await registry.setMinPlatformStake(0);
+    await expect(registry.connect(sybil).register())
+      .to.emit(registry, "Registered")
+      .withArgs(sybil.address);
+    expect(await registry.getScore(sybil.address)).to.equal(0);
+  });
+
+  it("allows operator to deregister", async () => {
+    await registry.connect(platform).register();
+    expect(await registry.registered(platform.address)).to.equal(true);
+    await registry.connect(platform).deregister();
+    expect(await registry.registered(platform.address)).to.equal(false);
+  });
 });
 

--- a/test/v2/RoutingModule.test.js
+++ b/test/v2/RoutingModule.test.js
@@ -63,4 +63,13 @@ describe("JobRouter", function () {
     expect(r1).to.be.closeTo(0.25, 0.05);
     expect(r2).to.be.closeTo(0.75, 0.05);
   });
+
+  it("computes routing weight based on stake", async () => {
+    const w1 = await router.routingWeight(op1.address);
+    const w2 = await router.routingWeight(op2.address);
+    const quarter = ethers.parseUnits("0.25", 18);
+    const threeQuarter = ethers.parseUnits("0.75", 18);
+    expect(w1).to.be.closeTo(quarter, ethers.parseUnits("0.05", 18));
+    expect(w2).to.be.closeTo(threeQuarter, ethers.parseUnits("0.05", 18));
+  });
 });

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -1,0 +1,93 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+// Additional StakeManager unit tests focusing on staking flows and limits
+
+describe("StakeManager extras", function () {
+  let token, stakeManager, owner, user, treasury;
+
+  beforeEach(async () => {
+    [owner, user, treasury] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockERC20");
+    token = await Token.deploy();
+    await token.mint(user.address, 1000);
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      owner.address,
+      treasury.address
+    );
+    await stakeManager.connect(owner).setMinStake(0);
+  });
+
+  async function setupRegistryAck(signer) {
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const TaxPolicy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    const taxPolicy = await TaxPolicy.deploy(
+      owner.address,
+      "ipfs://policy",
+      "ack"
+    );
+    await jobRegistry
+      .connect(owner)
+      .setTaxPolicy(await taxPolicy.getAddress());
+    await stakeManager
+      .connect(owner)
+      .setJobRegistry(await jobRegistry.getAddress());
+    if (signer) {
+      await jobRegistry.connect(signer).acknowledgeTaxPolicy();
+    }
+    return { jobRegistry };
+  }
+
+  it("allows deposit and withdrawal of stake", async () => {
+    await setupRegistryAck(user);
+    await token.connect(user).approve(await stakeManager.getAddress(), 200);
+    await stakeManager.connect(user).depositStake(0, 200);
+    await stakeManager.connect(user).withdrawStake(0, 50);
+    expect(await stakeManager.stakeOf(user.address, 0)).to.equal(150n);
+  });
+
+  it("requires tax policy acknowledgement before staking", async () => {
+    await setupRegistryAck();
+    await token.connect(user).approve(await stakeManager.getAddress(), 100);
+    await expect(
+      stakeManager.connect(user).depositStake(0, 100)
+    ).to.be.revertedWith("acknowledge tax policy");
+  });
+
+  it("enforces max stake per address", async () => {
+    await setupRegistryAck(user);
+    await stakeManager.connect(owner).setMaxStakePerAddress(150);
+    await token.connect(user).approve(await stakeManager.getAddress(), 200);
+    await stakeManager.connect(user).depositStake(0, 100);
+    await expect(
+      stakeManager.connect(user).depositStake(0, 100)
+    ).to.be.revertedWith("max stake");
+  });
+
+  it("emits event and accepts new token after token swap", async () => {
+    await setupRegistryAck(user);
+    const Token = await ethers.getContractFactory("MockERC20");
+    const token2 = await Token.deploy();
+    await token2.mint(user.address, 200);
+    await expect(
+      stakeManager.connect(owner).setToken(await token2.getAddress())
+    )
+      .to.emit(stakeManager, "TokenUpdated")
+      .withArgs(await token2.getAddress());
+    await token2
+      .connect(user)
+      .approve(await stakeManager.getAddress(), 200);
+    await stakeManager.connect(user).depositStake(0, 200);
+    expect(await stakeManager.stakeOf(user.address, 0)).to.equal(200n);
+  });
+});
+

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -1,0 +1,172 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("multi-operator job lifecycle", function () {
+  let token, stakeManager, rep, validation, nft, registry, dispute, feePool, policy;
+  let platformRegistry, jobRouter;
+  let owner, employer, agent, platform1, platform2;
+  const reward = ethers.parseUnits("1000", 6);
+  const stakeRequired = ethers.parseUnits("200", 6);
+  const platformStake1 = ethers.parseUnits("100", 6);
+  const platformStake2 = ethers.parseUnits("300", 6);
+  const feePct = 10;
+
+  beforeEach(async () => {
+    [owner, employer, agent, platform1, platform2] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory(
+      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    token = await Token.deploy(owner.address);
+    const mintAmount = ethers.parseUnits("10000", 6);
+    await token.mint(employer.address, mintAmount);
+    await token.mint(agent.address, mintAmount);
+    await token.mint(platform1.address, mintAmount);
+    await token.mint(platform2.address, mintAmount);
+
+    const Stake = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await Stake.deploy(
+      await token.getAddress(),
+      owner.address,
+      owner.address
+    );
+
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/mocks/ValidationStub.sol:ValidationStub"
+    );
+    validation = await Validation.deploy();
+
+    const Rep = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    rep = await Rep.deploy(owner.address);
+
+    const NFT = await ethers.getContractFactory(
+      "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
+    );
+    nft = await NFT.deploy("Cert", "CERT", owner.address);
+
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Registry.deploy(owner.address);
+
+    const Dispute = await ethers.getContractFactory(
+      "contracts/v2/DisputeModule.sol:DisputeModule"
+    );
+    dispute = await Dispute.deploy(await registry.getAddress(), owner.address);
+
+    const FeePoolF = await ethers.getContractFactory(
+      "contracts/v2/FeePool.sol:FeePool"
+    );
+    feePool = await FeePoolF.deploy(
+      await token.getAddress(),
+      await stakeManager.getAddress(),
+      2,
+      owner.address
+    );
+
+    const Policy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    policy = await Policy.deploy(
+      owner.address,
+      "ipfs://policy",
+      "ack"
+    );
+
+    const PlatformRegistryF = await ethers.getContractFactory(
+      "contracts/v2/PlatformRegistry.sol:PlatformRegistry"
+    );
+    platformRegistry = await PlatformRegistryF.deploy(
+      await stakeManager.getAddress(),
+      await rep.getAddress(),
+      0,
+      owner.address
+    );
+
+    const JobRouterF = await ethers.getContractFactory(
+      "contracts/v2/modules/JobRouter.sol:JobRouter"
+    );
+    jobRouter = await JobRouterF.deploy(
+      await platformRegistry.getAddress(),
+      owner.address
+    );
+
+    await registry.setModules(
+      await validation.getAddress(),
+      await stakeManager.getAddress(),
+      await rep.getAddress(),
+      await dispute.getAddress(),
+      await nft.getAddress()
+    );
+    await registry.setFeePool(await feePool.getAddress());
+    await registry.setFeePct(feePct);
+    await registry.setTaxPolicy(await policy.getAddress());
+    await registry.setJobParameters(0, stakeRequired);
+    await stakeManager.setJobRegistry(await registry.getAddress());
+    await nft.setJobRegistry(await registry.getAddress());
+    await rep.setCaller(await registry.getAddress(), true);
+    await rep.setThreshold(1);
+    await nft.transferOwnership(await registry.getAddress());
+
+    await registry.acknowledgeTaxPolicy();
+    await registry.connect(employer).acknowledgeTaxPolicy();
+    await registry.connect(agent).acknowledgeTaxPolicy();
+    await registry.connect(platform1).acknowledgeTaxPolicy();
+    await registry.connect(platform2).acknowledgeTaxPolicy();
+  });
+
+  it("runs job lifecycle and handles multiple staked operators", async () => {
+    const fee = (reward * BigInt(feePct)) / 100n;
+
+    await token
+      .connect(platform1)
+      .approve(await stakeManager.getAddress(), platformStake1);
+    await stakeManager.connect(platform1).depositStake(2, platformStake1);
+    await platformRegistry.connect(platform1).register();
+    await jobRouter.connect(platform1).register();
+
+    await token
+      .connect(platform2)
+      .approve(await stakeManager.getAddress(), platformStake2);
+    await stakeManager.connect(platform2).depositStake(2, platformStake2);
+    await platformRegistry.connect(platform2).register();
+    await jobRouter.connect(platform2).register();
+
+    await token
+      .connect(agent)
+      .approve(await stakeManager.getAddress(), stakeRequired);
+    await stakeManager.connect(agent).depositStake(0, stakeRequired);
+
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), reward + fee);
+    await registry.connect(employer).createJob(reward, "uri");
+    const jobId = 1;
+    await registry.connect(agent).applyForJob(jobId);
+    await validation.connect(owner).setResult(true);
+    await registry.connect(agent).completeJob(jobId);
+    await registry.finalize(jobId);
+
+    expect(await feePool.pendingFees()).to.equal(fee);
+    await feePool.distributeFees();
+    const before1 = await token.balanceOf(platform1.address);
+    const before2 = await token.balanceOf(platform2.address);
+    await feePool.connect(platform1).claimRewards();
+    await feePool.connect(platform2).claimRewards();
+    const after1 = await token.balanceOf(platform1.address);
+    const after2 = await token.balanceOf(platform2.address);
+    const total = platformStake1 + platformStake2;
+    expect(after1 - before1).to.equal((fee * platformStake1) / total);
+    expect(after2 - before2).to.equal((fee * platformStake2) / total);
+
+    await jobRouter.connect(platform1).deregister();
+    expect(await jobRouter.registered(platform1.address)).to.equal(false);
+
+    await expect(feePool.distributeFees()).to.be.revertedWith("amount");
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend StakeManager tests for staking flows, tax policy gating, max stake, and token swap handling
- cover zero-stake platform registration and deregistration, plus routing weight calculations
- add integration test for multi-operator job lifecycle and zero-fee distribution handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689abb6210a88333b57d7829ef9246e3