### PR TITLE
Allow zero-stake platform registration and expose fee distribution

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -81,7 +81,7 @@ contract FeePool is Ownable {
     }
 
     /// @notice distribute accumulated fees to stakers
-    function distributeFees() public {
+    function distributeFees() external {
         uint256 amount = pendingFees;
         require(amount > 0, "amount");
         pendingFees = 0;

--- a/contracts/v2/PlatformIncentives.sol
+++ b/contracts/v2/PlatformIncentives.sol
@@ -20,6 +20,7 @@ contract PlatformIncentives is Ownable {
         address indexed platformRegistry,
         address indexed jobRouter
     );
+    event Activated(address indexed operator, uint256 amount);
 
     constructor(
         IStakeManager _stakeManager,
@@ -59,6 +60,7 @@ contract PlatformIncentives is Ownable {
         }
         platformRegistry.registerFor(msg.sender);
         jobRouter.registerFor(msg.sender);
+        emit Activated(msg.sender, amount);
     }
 
     /// @notice Confirms this contract and its owner remain tax neutral.

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -45,15 +45,11 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
     }
 
     /// @notice Register caller as a platform operator.
-    /// @dev Requires caller to maintain at least `minPlatformStake` of
-    ///      `Role.Platform` stake within the `StakeManager`.
+    /// @dev No minimum stake is required; routing weight derives from stake and
+    ///      reputation via `getScore`.
     function register() external nonReentrant {
         require(!registered[msg.sender], "registered");
         require(!blacklist[msg.sender], "blacklisted");
-        uint256 stake = stakeManager.stakeOf(msg.sender, IStakeManager.Role.Platform);
-        if (msg.sender != owner()) {
-            require(stake >= minPlatformStake, "stake");
-        }
         registered[msg.sender] = true;
         emit Registered(msg.sender);
     }
@@ -115,10 +111,6 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
         }
         require(!registered[operator], "registered");
         require(!blacklist[operator], "blacklisted");
-        uint256 stake = stakeManager.stakeOf(operator, IStakeManager.Role.Platform);
-        if (operator != owner()) {
-            require(stake >= minPlatformStake, "stake");
-        }
         registered[operator] = true;
         emit Registered(operator);
     }

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -215,7 +215,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
         nonReentrant
     {
         require(user != address(0), "user");
-        require(uint256(role) <= uint256(Role.Platform), "role");
+        require(role <= Role.Platform, "role");
         require(amount > 0, "amount");
 
         if (user != owner()) {
@@ -252,7 +252,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
         requiresTaxAcknowledgement
         nonReentrant
     {
-        require(uint256(role) <= uint256(Role.Platform), "role");
+        require(role <= Role.Platform, "role");
         require(amount > 0, "amount");
         uint256 newStake = stakes[msg.sender][role] + amount;
         require(newStake >= minStake, "min stake");
@@ -278,7 +278,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
         requiresTaxAcknowledgement
         nonReentrant
     {
-        require(uint256(role) <= uint256(Role.Platform), "role");
+        require(role <= Role.Platform, "role");
         uint256 staked = stakes[msg.sender][role];
         require(staked >= amount, "stake");
         uint256 newStake = staked - amount;
@@ -394,7 +394,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
         external
         onlyJobRegistry
     {
-        require(uint256(role) <= uint256(Role.Platform), "role");
+        require(role <= Role.Platform, "role");
         uint256 staked = stakes[user][role];
         require(staked >= amount, "stake");
 

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -46,12 +46,16 @@ describe("PlatformRegistry", function () {
     );
   });
 
-  it("registers staked operator and rejects unstaked", async () => {
+  it("registers operators regardless of stake", async () => {
     await expect(registry.connect(platform).register())
       .to.emit(registry, "Registered")
       .withArgs(platform.address);
     expect(await registry.registered(platform.address)).to.equal(true);
-    await expect(registry.connect(sybil).register()).to.be.revertedWith("stake");
+    await expect(registry.connect(sybil).register())
+      .to.emit(registry, "Registered")
+      .withArgs(sybil.address);
+    expect(await registry.registered(sybil.address)).to.equal(true);
+    expect(await registry.getScore(sybil.address)).to.equal(0);
   });
 
   it("computes score based on stake and reputation", async () => {
@@ -132,14 +136,6 @@ describe("PlatformRegistry", function () {
     await expect(
       incentives.connect(platform).stakeAndActivate(0)
     ).to.be.revertedWith("amount");
-  });
-
-  it("allows zero-stake registration when min stake is zero", async () => {
-    await registry.setMinPlatformStake(0);
-    await expect(registry.connect(sybil).register())
-      .to.emit(registry, "Registered")
-      .withArgs(sybil.address);
-    expect(await registry.getScore(sybil.address)).to.equal(0);
   });
 
   it("allows operator to deregister", async () => {


### PR DESCRIPTION
## Summary
- permit platforms to register without staking while scoring still depends on stake and reputation
- tighten stake role checks and surface fee distribution helpers
- emit activation event when staking through incentives helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b2b50be6c8333a1720e18f464a67c