### PR TITLE
Add JobEscrow ETH rejection and helper tax exemption test

### DIFF
--- a/contracts/mocks/TaxExemptHelper.sol
+++ b/contracts/mocks/TaxExemptHelper.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface ITaxExempt {
+    function isTaxExempt() external view returns (bool);
+}
+
+contract TaxExemptHelper {
+    function check(address target) external view returns (bool) {
+        return ITaxExempt(target).isTaxExempt();
+    }
+}

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -108,5 +108,20 @@ contract JobEscrow {
         token.safeTransfer(job.operator, job.reward);
         emit ResultAccepted(jobId, msg.sender);
     }
+
+    /// @notice Confirms this contract and its owner remain tax neutral.
+    function isTaxExempt() external pure returns (bool) {
+        return true;
+    }
+
+    /// @dev Reject direct ETH transfers to keep the escrow token-only.
+    receive() external payable {
+        revert("JobEscrow: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("JobEscrow: no ether");
+    }
 }
 

--- a/test/v2/JobEscrowNoEther.test.js
+++ b/test/v2/JobEscrowNoEther.test.js
@@ -1,0 +1,52 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobEscrow ether rejection", function () {
+  let owner, employer, operator, token, routing, escrow;
+
+  beforeEach(async () => {
+    [owner, employer, operator] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory(
+      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    token = await Token.deploy(owner.address);
+    await token.connect(owner).mint(employer.address, 1000);
+
+    const Routing = await ethers.getContractFactory(
+      "contracts/mocks/MockRoutingModule.sol:MockRoutingModule"
+    );
+    routing = await Routing.deploy(operator.address);
+
+    const Escrow = await ethers.getContractFactory(
+      "contracts/v2/modules/JobEscrow.sol:JobEscrow"
+    );
+    escrow = await Escrow.deploy(await token.getAddress(), await routing.getAddress());
+  });
+
+  it("reverts on direct ether transfer", async () => {
+    await expect(
+      owner.sendTransaction({ to: await escrow.getAddress(), value: 1 })
+    ).to.be.revertedWith("JobEscrow: no ether");
+  });
+
+  it("reverts on unknown calldata with value", async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await escrow.getAddress(),
+        data: "0x12345678",
+        value: 1,
+      })
+    ).to.be.revertedWith("JobEscrow: no ether");
+  });
+
+  it("reports tax exemption for owner and helper", async () => {
+    expect(await escrow.isTaxExempt()).to.equal(true);
+
+    const Helper = await ethers.getContractFactory(
+      "contracts/mocks/TaxExemptHelper.sol:TaxExemptHelper"
+    );
+    const helper = await Helper.deploy();
+    expect(await helper.check(await escrow.getAddress())).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure JobEscrow rejects unexpected ETH and reports perpetual tax neutrality
- add mock TaxExemptHelper contract and tests that check JobEscrow from both owner and helper

## Testing
- `npx hardhat test test/v2/JobEscrowNoEther.test.js`
- `npx hardhat test test/v2/JobEscrow.test.js`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b401d26dc83339181804848570813