### PR TITLE
docs: add agialpha deployment and incentive architecture guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labor markets among autonomous agents. The legacy v0 deployment transacts in $AGI, while the modular v2 suite defaults to [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) – a 6‑decimal ERC‑20 used for payments, staking, rewards and dispute deposits. The contract owner can swap this token at any time via `StakeManager.setToken` without redeploying other modules. This repository hosts the immutable mainnet deployment (v0) and an unaudited v1 prototype under active development. Treat every address as unverified until you confirm it on-chain and through official AGI.eth channels.
 
+All participants opt in by staking `$AGIALPHA`. Staked operators gain routing priority and revenue share, while the main deploying entity is a special case that registers with **stake = 0**, earning no boosts so it remains tax neutral. Because every incentive flows on-chain, operators can participate pseudonymously without creating off‑chain reporting obligations.
+
 For a step‑by‑step deployment walkthrough using $AGIALPHA and Etherscan, see [docs/deployment-agialpha.md](docs/deployment-agialpha.md).
 For a detailed description of the platform-wide incentive architecture, see [docs/universal-platform-incentive-architecture.md](docs/universal-platform-incentive-architecture.md).
 

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -1,140 +1,72 @@
-# AGIJobs v2 Deployment with $AGIALPHA
+# Deployment Guide: AGIJobs v2 with $AGIALPHA
 
-This guide walks a non-technical owner through deploying and configuring the modular AGIJobs suite using the $AGIALPHA token (6 decimals) for payments, staking, rewards and disputes. All steps can be performed through [Etherscan](https://etherscan.io) once the bytecode for each module is verified.
+This walkthrough shows a non‑technical owner how to deploy and wire the modular v2 contracts using the 6‑decimal **$AGIALPHA** token. All steps can be executed from a browser via [Etherscan](https://etherscan.io) or any compatible block explorer.
 
-### Quick Role & Staking Summary
+## 1. Prerequisites
 
-- **Employer** – posts jobs and provides escrow.
-- **Agent** – stakes with `StakeManager.depositStake(0, amount)` and delivers results.
-- **Validator** – stakes with `StakeManager.depositStake(1, amount)` and votes on jobs.
-- **Platform operator** – stakes with `StakeManager.depositStake(2, amount)` then calls `PlatformRegistry.register()` for routing priority and fee share.
+- A wallet with sufficient ETH for gas.
+- The verified `$AGIALPHA` token contract address.
+- The compiled bytecode for each module (already provided in this repository).
+- Awareness that all contracts are **Ownable**; keep the deploying wallet secure.
 
-**Fee Claiming**
-1. After jobs settle, anyone may call `FeePool.distributeFees()`.
-2. Stakers withdraw rewards via `FeePool.claimRewards()`.
+> **Regulatory notice:** On‑chain rewards minimise reporting requirements but do **not** remove your duty to obey local laws. Consult professionals before proceeding.
 
-*Zero‑stake deployer* – the owner can call `PlatformRegistry.register()` with amount `0`, appearing in listings without routing weight or rewards.
+## 2. Deploy core modules
 
-Amounts use 6‑decimal base units (`1` token = `1_000000`; `0.5` token = `500000`).
+Deploy each contract from the **Write Contract** tabs:
 
-## Prerequisites
-- Ethereum wallet controlling the owner address (hardware wallet recommended).
-- $AGIALPHA token contract: `0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe`.
-- Sufficient ETH for gas fees and $AGIALPHA for testing job flows.
+1. `AGIALPHAToken(owner)` – mint the initial supply to the owner or treasury.
+2. `StakeManager(token, owner, treasury)` – records stake balances and holds job escrows.
+3. `JobRegistry(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, owner)` – tracks jobs and tax acknowledgements.
+4. `ValidationModule(jobRegistry, stakeManager, owner)` – handles validation and slashing.
+5. `ReputationEngine(owner)` – optional reputation weighting.
+6. `DisputeModule(jobRegistry, stakeManager, owner)` – manages appeals and dispute fees.
+7. `CertificateNFT(jobRegistry)` – certifies completed work.
+8. `FeePool(token, stakeManager, role, owner)` – redistributes protocol fees to stakers.
+9. `PlatformRegistry(stakeManager, reputationEngine, minStake, owner)` – lists platform operators.
+10. `JobRouter(platformRegistry, owner)` – stake‑weighted job routing.
+11. `PlatformIncentives(stakeManager, platformRegistry, jobRouter, owner)` – helper that lets operators stake and register in one call.
 
-## 1. Deploy the Modules
-Deploy each contract in the order below. On Etherscan, open **Contract → Deploy**, connect your wallet, paste the verified bytecode, and enter constructor arguments exactly as shown.
+After each deployment, copy the address for later wiring.
 
-| # | Module | Constructor arguments (example) |
-| --- | --- | --- |
-| 1 | StakeManager | `(tokenAddress, owner, treasury)` → `(0x2e8f...eabe, YOUR_ADDRESS, TREASURY_ADDRESS)` |
-| 2 | JobRegistry | `(owner)` → `(YOUR_ADDRESS)` |
-| 3 | ValidationModule | `(jobRegistry, stakeManager, owner)` → `(<JobRegistry>, <StakeManager>, YOUR_ADDRESS)` |
-| 4 | ReputationEngine | `(owner)` → `(YOUR_ADDRESS)` |
-| 5 | DisputeModule | `(jobRegistry, stakeManager, reputationEngine, owner)` → `(<JobRegistry>, <StakeManager>, <ReputationEngine>, YOUR_ADDRESS)` |
-| 6 | CertificateNFT | `(name, symbol, owner)` → `("AGI Jobs", "AGIJOB", YOUR_ADDRESS)` |
-| 7 | FeePool | `(token, stakeManager, rewardRole, owner)` → `(0x2e8f...eabe, <StakeManager>, 2, YOUR_ADDRESS)` |
-| 8 | TaxPolicy | `(owner)` → `(YOUR_ADDRESS)` |
-| 9 | *(Optional)* JobRouter/DiscoveryModule | per module docs |
+## 3. Wire the modules
 
-After each deployment, note the contract address for later wiring.
+Use each contract's **Write** tab to connect modules:
 
-**Example Etherscan deployment**
-1. Search for the compiled contract on Etherscan and open the **Contract → Verify and Publish** page. Upload the flattened source to verify bytecode.
-   ![verify bytecode](https://via.placeholder.com/650x300?text=Verify+and+Publish)
-2. Once verified, switch to **Contract → Deploy**, paste the constructor arguments in the order shown above, and press **Write**.
-   ![deploy contract](https://via.placeholder.com/650x300?text=Contract+Deploy)
-3. Confirm the transaction in your wallet and record the resulting contract address.
+- `StakeManager.setJobRegistry(jobRegistry)` and `StakeManager.setDisputeModule(disputeModule)`
+- `JobRegistry.setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT)`
+- `JobRegistry.setFeePool(feePool)` and `JobRegistry.setTaxPolicy(taxPolicy)` if used
+- `PlatformRegistry.setRegistrar(platformIncentives, true)` and `JobRouter.setRegistrar(platformIncentives, true)`
 
-## 2. Wire the Modules
-Using Etherscan's **Write Contract** tab, submit the following transactions in order:
-1. In **JobRegistry**, call `setModules(validation, stakeManager, reputation, dispute, certificate)`.
-2. In **StakeManager**, call `setJobRegistry(jobRegistry)`.
-3. Back in **JobRegistry**, call `setFeePool(feePool)` then `setFeePct(pct)` to choose the percentage of each job reward routed to the pool.
-4. Finally, on **JobRegistry** call `setTaxPolicy(taxPolicy)` and optionally `bumpTaxPolicyVersion`.
+Owners can retune parameters any time: `StakeManager.setToken`, `setMinStake`, `FeePool.setBurnPct`, `PlatformRegistry.setBlacklist`, etc. No redeployments are required when swapping tokens or adjusting fees.
 
-## 3. Configure Token Parameters
-The StakeManager already points to $AGIALPHA (6 decimals). To change tokens later, call `setToken(newToken)` on `StakeManager` and `FeePool` (and on `GovernanceReward` if used).
+## 4. Stake and register a platform
 
-For stakes, rewards and fees enter values in base units (all amounts are scaled by `10**6`):
-- `1` token = `1_000_000`
-- `100` tokens = `100_000000`
-- `0.5` token = `500000`
+1. In `$AGIALPHA`, approve the `StakeManager` for the desired amount (`1 token = 1_000000`).
+2. Call `PlatformIncentives.stakeAndActivate(amount)` from the operator's address. The helper stakes tokens, registers the platform in `PlatformRegistry`, and enrolls it with `JobRouter` for routing priority.
+3. The owner may register with `amount = 0` to appear in registries without fee or routing boosts.
 
-If interacting with an 18‑decimal token, divide values by `1e12` to convert to this 6‑decimal format; the division may truncate precision beyond six decimals.
+## 5. Claim fees and rewards
 
-Update parameters as needed:
-- `StakeManager.setMinStake(minStake)`
-- `StakeManager.setSlashingPercentages(employerPct, treasuryPct)`
-- `ValidationModule.setParameters(...)`
-- `DisputeModule.setAppealFee(fee)` (denominated in $AGIALPHA)
-- `FeePool.setBurnPct(pct)` to automatically destroy a portion of each fee
+- Employers send job fees directly to the `StakeManager`, which forwards them to `FeePool`.
+- Anyone may trigger `FeePool.distributeFees()`; rewards accrue to stakers according to `stake / totalStake`.
+- Operators withdraw with `FeePool.claimRewards()`.
 
-## 4. Post a Job
-1. Employer approves $AGIALPHA to the StakeManager via the token's `approve` function. The approval must cover the reward plus the protocol fee (`reward * feePct / 100`).
-2. Employer calls `JobRegistry.acknowledgeTaxPolicy()` once per address.
-3. Employer calls `JobRegistry.createJob(uri, reward)` where `reward` is in base units.
+## 6. Dispute resolution
 
-## 5. Agent and Validator Actions
-- **Agents** stake using `StakeManager.depositStake(amount)` and apply with `JobRegistry.applyForJob(jobId)`.
-- **Validators** stake similarly, then use `ValidationModule.commit(jobId, hash)` and later `reveal(jobId, approve, salt)`.
+- Participants approve the `StakeManager` for the configured `appealFee` and call `JobRegistry.dispute(jobId)`.
+- The `DisputeModule` holds the fee in `$AGIALPHA` and releases it to the winner or back to the payer after resolution.
 
-## 6. Finalisation and Disputes
-- After validation, anyone may call `JobRegistry.finalize(jobId)` to release escrowed $AGIALPHA.
-- If contested, raise an appeal with `DisputeModule.raiseDispute(jobId)`. Fees are charged in $AGIALPHA.
+## 7. Final checks
 
-## 7. Platform Operator Rewards
-Platform owners stake under `Role.Platform` via `StakeManager.depositStake(2, amount)`. As jobs finalize, `FeePool` receives the protocol fee and streams rewards. Operators claim with `FeePool.claimRewards()` directly through Etherscan.
-![distribute fees](https://via.placeholder.com/650x300?text=distributeFees)
-![claim rewards](https://via.placeholder.com/650x300?text=claimRewards)
+- Before staking or claiming rewards, each address must call `JobRegistry.acknowledgeTaxPolicy()`.
+- Verify that `isTaxExempt()` on every module returns `true` to confirm contracts remain tax neutral.
 
-## 8. Changing the Token
-Only the owner may switch currencies: invoke `setToken(newToken)` on `StakeManager`, `FeePool`, and any reward modules. Existing stakes and escrows remain untouched; new deposits and payouts use the updated token.
+## 8. Safety reminders
 
-## Troubleshooting & Security Tips
-- **Mismatched constructor inputs** – double‑check the argument order if deployment reverts.
-- **Missing module links** – if a call fails with "job registry" or similar, ensure `setModules` and `setJobRegistry` have been executed.
-- **Stuck transactions** – increase gas price or use your wallet’s speed‑up feature.
-- **Verify addresses** on at least two explorers before wiring modules.
-- **Protect the owner key** – use a hardware wallet or multisig and avoid untrusted networks.
-- **Keep records** of constructor parameters and ABIs for later verification.
+- Verify all addresses on multiple explorers before transacting.
+- Record every parameter change after calling owner setters.
+- Keep backups of deployment scripts and verify source code to improve transparency.
 
-By following these steps the owner can deploy the AGIJobs suite with $AGIALPHA as the unit of account, while retaining the ability to replace the token without redeploying other modules.
+Deployers and operators remain solely responsible for legal compliance. The protocol never issues tax forms or collects personal data.
 
-## Etherscan Walkthrough
-
-1. **Open contract pages** – for each deployed module, navigate to its Etherscan address and select **Contract → Write Contract**. Click **Connect to Web3** with the owner wallet.
-2. **Wire modules**
-   - In `JobRegistry` call `setModules(validation, stakeManager, reputation, dispute, certificate)`.
-   - In `StakeManager` call `setJobRegistry(jobRegistry)`.
-   - Back in `JobRegistry` call `setFeePool(feePool)` then `setFeePct(pct)` and `setTaxPolicy(taxPolicy)`.
-3. **Configure economics**
-   - On `StakeManager` call `setMinStake(amount)` and `setSlashingPercentages(empPct, treasuryPct)`.
-   - On `ValidationModule` call `setParameters(...)` with 6‑decimal base units.
-   - On `DisputeModule` call `setAppealFee(fee)` and link any reward pools via `setFeePool(feePool)`.
-   - On `FeePool` call `setBurnPct(pct)` to destroy a portion of each fee.
-4. **Verify state** – after each transaction switch to **Read Contract** to confirm the new values and emitted events.
-5. **Stay safe** – double‑check addresses, keep keys on hardware or multisig wallets, and never interact from untrusted networks.
-
-This sequence covers the critical owner‑only setters needed to bootstrap the system. For background on module responsibilities and token math, refer back to the sections above.
-
-## Platform Registry, Router & Incentives Example
-
-The following sequence mirrors the automated deployment script and shows each transaction with 6‑decimal arguments.
-
-1. **Deploy StakeManager** – `StakeManager(token, owner, treasury)` → `(0x2e8f…eabe, YOUR_ADDRESS, TREASURY_ADDRESS)`.
-2. **Deploy PlatformRegistry** – `PlatformRegistry(stakeManager, reputation, minStake, owner)` → `(<StakeManager>, <ReputationEngine>, 1000_000000, YOUR_ADDRESS)` sets a 1,000 token minimum.
-3. **Deploy JobRouter** – `JobRouter(platformRegistry, owner)` → `(<PlatformRegistry>, YOUR_ADDRESS)`.
-4. **Deploy FeePool** – `FeePool(token, stakeManager, 2, owner)` where `2` represents the `Platform` role.
-5. **Deploy PlatformIncentives** – `PlatformIncentives(stakeManager, platformRegistry, jobRouter, owner)`.
-6. **Wire modules**
-   - In `JobRegistry` call `setFeePool(<FeePool>)` then `setFeePct(5)` for a 5% protocol fee.
-   - In `PlatformRegistry` call `setRegistrar(<PlatformIncentives>, true)`.
-   - In `JobRouter` call `setRegistrar(<PlatformIncentives>, true)`.
-7. **Stake and activate** – a platform operator approves the StakeManager and calls `PlatformIncentives.stakeAndActivate(25_000000)` to lock 25 tokens and register for routing and fee sharing. The owner may pass `0` to register without staking.
-
-All amounts use 6‑decimal base units; e.g. `25_000000` represents 25 tokens. Adjust the example values to match your deployment.
-
----
-
-*Regulatory note: this guide is not legal or tax advice. Review [tax-obligations.md](tax-obligations.md) for jurisdiction‑specific obligations before deploying.*

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -1,57 +1,59 @@
 # Universal Platform Incentive Architecture
 
-This document details a stake-based framework that aligns every AGI Jobs v2 role within a single on-chain economy.  The design operates entirely in the six‑decimal **$AGIALPHA** token and allows the contract owner to reconfigure parameters without redeploying modules.
+The AGI Jobs v2 suite implements a single, stake‑based framework that treats the main deployer and third‑party operators under the same rules. Every value transfer occurs on‑chain in the 6‑decimal **$AGIALPHA** token.
 
-> Regulatory shifts continue to evolve. On-chain fee routing minimises reporting, but operators and owners must still comply with local laws and monitor policy updates.
+## Roles
+
+| Role | StakeManager enum | Purpose |
+|------|-------------------|---------|
+| Employer | n/a | Posts jobs and escrows rewards. |
+| Agent | `0` | Completes jobs. |
+| Validator | `1` | Audits and finalises jobs. |
+| Platform Operator | `2` | Hosts an AGI Jobs portal and receives protocol fees. |
 
 ## Core Modules
-- **StakeManager** – tracks deposits for agents, validators and platform operators; owner may update token, minimums and slashing percentages.
-- **PlatformRegistry** – records platform operators and exposes routing scores derived from stake and reputation.
-- **JobRouter** – selects platforms for new jobs according to `PlatformRegistry` scores.
-- **FeePool** – accumulates protocol fees and distributes them to staked platforms; burn and treasury percentages are owner‑settable.
-- **PlatformIncentives** – convenience wrapper letting an operator stake and activate routing in one transaction.
-- **JobRegistry**, **ValidationModule**, **ReputationEngine**, **DisputeModule**, and **CertificateNFT** – handle job lifecycle, validation, reputation, appeals and credentials.
 
-## Roles and Incentives
-| Role | Stake | Incentives |
-|------|------:|------------|
-| Platform operator | `minPlatformStake` | Routing priority and proportional share of `FeePool` distributions |
-| Agent | job‑level stake | Eligibility to complete work and earn rewards |
-| Validator | owner‑set minimum | Commit–reveal voting rights and validation rewards |
-| Main deployer | 0 | May register for demonstration but receives **no** routing or revenue boosts |
-| Owner | 0 | Adjusts parameters via `Ownable` setters; does not receive fees unless staking like any operator |
+- **AGIALPHAToken** – 6‑decimal ERC‑20 used for staking, rewards and dispute bonds. Owner can mint/burn and swap tokens across the system.
+- **StakeManager** – records stakes for all roles, escrows job funds and routes protocol fees to the `FeePool`. Owner setters allow changing the token, minimum stake, slashing percentages and treasury.
+- **PlatformRegistry** – lists operators and computes a routing score derived from stake and reputation. The owner can blacklist addresses or replace the reputation engine.
+- **JobRouter** – selects an operator for new jobs using `PlatformRegistry` scores. Deterministic randomness mixes caller‑supplied seeds with blockhashes; no external oracle is required.
+- **FeePool** – receives fees from `StakeManager` and distributes them to staked operators in proportion to their stake. The owner can adjust burn percentage, treasury, reward role or token without redeploying.
+- **PlatformIncentives** – helper that stakes `$AGIALPHA` on behalf of an operator and registers them with both `PlatformRegistry` and `JobRouter`. The owner (main deployer) may register with `amount = 0` to remain tax neutral and earn no routing or fee share.
 
-Platform rewards follow simple formulas:
+Every contract rejects direct ETH and exposes `isTaxExempt()` so neither the contracts nor the owner ever hold taxable revenue. Participants interact only through token transfers.
 
-- **Routing score** = `(stake * stakeWeight + reputation * reputationWeight) / 1e18` from `PlatformRegistry.getScore`.
-- **Fee share** for an operator = `fee * operatorStake / totalStake` in `FeePool`.
-  - If `operatorStake = 0` (the main deployer), both routing score and fee share evaluate to zero.
+## Incentive Flow
 
-All interactions flow through block‑explorer “Write” tabs so non‑technical users can participate without custom tooling.  Each contract exposes `isTaxExempt()` and rejects direct ETH to keep value transfers pseudonymous and on‑chain.
+1. **Stake** – operators lock `$AGIALPHA` in `StakeManager` under role `2`.
+2. **Register** – `PlatformIncentives.stakeAndActivate` registers the operator in `PlatformRegistry` and `JobRouter`.
+3. **Routing** – `JobRouter` forwards jobs using scores from `PlatformRegistry`, giving higher probability to addresses with greater stake or reputation.
+4. **Revenue Sharing** – job fees are sent to `StakeManager`, forwarded to `FeePool`, and distributed to operators according to `stake / totalStake` when `distributeFees()` is called.
+5. **Withdraw** – operators call `FeePool.claimRewards()` to receive their share in `$AGIALPHA`.
 
-## Zero‑Stake Special Case
-The primary deploying entity registers its reference platform with `stake = 0`.  The platform is listed but has a routing score of zero and cannot claim `FeePool` rewards.  This ensures the deployer remains tax neutral while still signalling expected behaviour to other operators.
+The main deployer follows the same process but typically stakes `0`. With zero stake, the deployer:
 
-## Owner Flexibility
-The owner can retune the system at any time:
-- `StakeManager.setToken` swaps the staking and payout token.
-- `setMinStake`, `setBurnPct`, `setTreasury`, and similar setters adjust economics.
-- Module addresses can be replaced through `setModules` functions to upgrade periphery contracts while preserving stakes and reputations.
+- Appears in registries for demonstration but receives no routing preference.
+- Claims rewards from `FeePool` and receives `0` tokens.
+- Remains tax neutral because no fees accrue to its address.
 
-## Coding Sprint – Implementation Tasks
-1. **Deploy core modules** in this order: `StakeManager`, `PlatformRegistry`, `JobRouter`, `FeePool`, `JobRegistry`, `ValidationModule`, `ReputationEngine`, `DisputeModule`, `CertificateNFT`, `PlatformIncentives`.
-2. **Implement staking flows**
-   - Expose `stakeAndActivate` for operators; allow owner to call with `amount = 0`.
-   - Emit events for stake deposits, registrations and fee claims.
-3. **Route and reward**
-   - Compute routing scores from `PlatformRegistry.getScore(addr)`.
-   - Distribute fees in `FeePool` proportional to registered stake; provide `claimRewards()`.
-4. **Testing & docs**
-   - Unit tests: staking, zero‑stake registration, routing weight, fee distribution, token swap.
-   - Integration tests: job creation through completion with multiple platforms.
-   - Update README and deployment guides with Etherscan walkthroughs and regulatory disclaimers.
-5. **Security**
-   - Reject unexpected ETH in every module.
-   - Verify `isTaxExempt()` returns `true` for helpers and owner addresses.
+## Pseudonymity & Governance
 
-Participants must still follow local laws despite the on-chain design; see `docs/tax-obligations.md` for guidance.
+- No personal data is stored; addresses act independently and can rotate keys.
+- Minimum stakes and optional blacklist controls mitigate sybil attacks while preserving pseudonymity.
+- Optional governance modules such as `GovernanceReward` can grant voting bonuses to staked participants, further aligning incentives.
+
+## Owner Upgradability
+
+All modules are `Ownable`. The owner can:
+
+- Swap out the staking token (`StakeManager.setToken` and related setters).
+- Adjust minimum stakes, slashing percentages and burn rates.
+- Replace auxiliary modules like the reputation engine or dispute handler.
+- Authorise helpers (`PlatformRegistry.setRegistrar`, `JobRouter.setRegistrar`).
+
+These setters enable economic and architectural adjustments without redeploying core contracts.
+
+## Compliance Notes
+
+The incentive system is designed to minimise off‑chain reporting by distributing rewards on‑chain, but local laws still apply. Operators should monitor regulatory changes and self‑report earnings as required. The protocol provides no tax forms or KYC facilities and accepts no responsibility for individual compliance.
+


### PR DESCRIPTION
## Summary
- document stake-based platform incentives and zero-stake deployer
- add non-technical AGIALPHA deployment guide
- clarify on-chain pseudonymous participation in README

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_689b49fdf7c883338c6574f954e0f6d0