### PR TITLE
Remove owner constructor args from v2 modules

### DIFF
--- a/contracts/v2/AGIALPHAToken.sol
+++ b/contracts/v2/AGIALPHAToken.sol
@@ -13,7 +13,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 contract AGIALPHAToken is ERC20, Ownable {
     uint8 private constant DECIMALS = 6;
 
-    constructor(address owner) ERC20("AGI ALPHA", "AGIALPHA") Ownable(owner) {}
+    constructor() ERC20("AGI ALPHA", "AGIALPHA") Ownable(msg.sender) {}
 
     /// @notice Returns token decimals (6).
     function decimals() public pure override returns (uint8) {

--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -17,9 +17,9 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     event BaseURIUpdated(string newURI);
     event JobRegistryUpdated(address registry);
 
-    constructor(string memory name_, string memory symbol_, address owner_)
+    constructor(string memory name_, string memory symbol_)
         ERC721(name_, symbol_)
-        Ownable(owner_)
+        Ownable(msg.sender)
     {}
 
     modifier onlyJobRegistry() {

--- a/contracts/v2/DisputeModule.sol
+++ b/contracts/v2/DisputeModule.sol
@@ -53,10 +53,10 @@ contract DisputeModule is IDisputeModule, Ownable {
     /// @dev Amount of bond posted for each job appeal.
     mapping(uint256 => uint256) public bonds;
 
-    constructor(IJobRegistry _jobRegistry, address owner) Ownable(owner) {
+    constructor(IJobRegistry _jobRegistry) Ownable(msg.sender) {
         jobRegistry = _jobRegistry;
-        moderator = owner;
-        jury = owner;
+        moderator = msg.sender;
+        jury = msg.sender;
     }
 
     /// @notice Ensure participant has acknowledged current tax policy.

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -55,9 +55,8 @@ contract FeePool is Ownable {
     constructor(
         IERC20 _token,
         IStakeManager _stakeManager,
-        IStakeManager.Role _role,
-        address owner
-    ) Ownable(owner) {
+        IStakeManager.Role _role
+    ) Ownable(msg.sender) {
         token = _token;
         stakeManager = _stakeManager;
         rewardRole = _role;

--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -48,9 +48,8 @@ contract GovernanceReward is Ownable {
         IERC20 _token,
         IFeePool _feePool,
         IStakeManager _stakeManager,
-        IStakeManager.Role _role,
-        address owner
-    ) Ownable(owner) {
+        IStakeManager.Role _role
+    ) Ownable(msg.sender) {
         token = _token;
         feePool = _feePool;
         stakeManager = _stakeManager;

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -136,7 +136,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     event FeePoolUpdated(address pool);
     event FeePctUpdated(uint256 feePct);
 
-    constructor(address owner) Ownable(owner) {}
+    constructor() Ownable(msg.sender) {}
 
     // ---------------------------------------------------------------------
     // Owner configuration

--- a/contracts/v2/PlatformIncentives.sol
+++ b/contracts/v2/PlatformIncentives.sol
@@ -25,9 +25,8 @@ contract PlatformIncentives is Ownable {
     constructor(
         IStakeManager _stakeManager,
         IPlatformRegistryFull _platformRegistry,
-        IJobRouter _jobRouter,
-        address owner
-    ) Ownable(owner) {
+        IJobRouter _jobRouter
+    ) Ownable(msg.sender) {
         stakeManager = _stakeManager;
         platformRegistry = _platformRegistry;
         jobRouter = _jobRouter;

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -36,9 +36,8 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
     constructor(
         IStakeManager _stakeManager,
         IReputationEngine _reputationEngine,
-        uint256 _minStake,
-        address owner
-    ) Ownable(owner) {
+        uint256 _minStake
+    ) Ownable(msg.sender) {
         stakeManager = _stakeManager;
         reputationEngine = _reputationEngine;
         minPlatformStake = _minStake;

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -25,7 +25,7 @@ contract ReputationEngine is Ownable {
     event StakeManagerUpdated(address stakeManager);
     event ScoringWeightsUpdated(uint256 stakeWeight, uint256 reputationWeight);
 
-    constructor(address owner) Ownable(owner) {}
+    constructor() Ownable(msg.sender) {}
 
     modifier onlyCaller() {
         require(callers[msg.sender], "not authorized");

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -94,7 +94,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
     event StakeLocked(address indexed user, uint256 amount, uint64 unlockTime);
     event StakeUnlocked(address indexed user, uint256 amount);
 
-    constructor(IERC20 _token, address owner, address _treasury) Ownable(owner) {
+    constructor(IERC20 _token, address _treasury) Ownable(msg.sender) {
         token = _token;
         treasury = _treasury;
     }

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -37,9 +37,7 @@ contract TaxPolicy is Ownable, ITaxPolicy {
     /// @notice Emitted when a user acknowledges the tax policy.
     event PolicyAcknowledged(address indexed user);
 
-    constructor(address owner_, string memory uri, string memory ack)
-        Ownable(owner_)
-    {
+    constructor(string memory uri, string memory ack) Ownable(msg.sender) {
         _policyURI = uri;
         _acknowledgement = ack;
         _version = 1;

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -73,9 +73,8 @@ contract ValidationModule is IValidationModule, Ownable {
 
     constructor(
         IJobRegistry _jobRegistry,
-        IStakeManager _stakeManager,
-        address owner
-    ) Ownable(owner) {
+        IStakeManager _stakeManager
+    ) Ownable(msg.sender) {
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
     }

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -13,9 +13,9 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     address public jobRegistry;
     mapping(uint256 => string) private _tokenURIs;
 
-    constructor(string memory name_, string memory symbol_, address owner_)
+    constructor(string memory name_, string memory symbol_)
         ERC721(name_, symbol_)
-        Ownable(owner_)
+        Ownable(msg.sender)
     {}
 
     modifier onlyJobRegistry() {

--- a/contracts/v2/modules/DiscoveryModule.sol
+++ b/contracts/v2/modules/DiscoveryModule.sol
@@ -24,9 +24,8 @@ contract DiscoveryModule is Ownable {
 
     constructor(
         IStakeManager _stakeManager,
-        IReputationEngine _reputationEngine,
-        address owner
-    ) Ownable(owner) {
+        IReputationEngine _reputationEngine
+    ) Ownable(msg.sender) {
         stakeManager = _stakeManager;
         reputationEngine = _reputationEngine;
     }

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -40,9 +40,9 @@ contract DisputeModule is Ownable {
     event AppealFeeUpdated(uint256 fee);
     event DisputeWindowUpdated(uint256 window);
 
-    constructor(IJobRegistry _jobRegistry, address owner) Ownable(owner) {
+    constructor(IJobRegistry _jobRegistry) Ownable(msg.sender) {
         jobRegistry = _jobRegistry;
-        moderator = owner;
+        moderator = msg.sender;
     }
 
     modifier requiresTaxAcknowledgement() {

--- a/contracts/v2/modules/JobRouter.sol
+++ b/contracts/v2/modules/JobRouter.sol
@@ -28,7 +28,7 @@ contract JobRouter is Ownable {
     event PlatformSelected(bytes32 indexed seed, address indexed operator);
     event RegistrarUpdated(address indexed registrar, bool allowed);
 
-    constructor(IPlatformRegistry _platformRegistry, address owner) Ownable(owner) {
+    constructor(IPlatformRegistry _platformRegistry) Ownable(msg.sender) {
         platformRegistry = _platformRegistry;
     }
 

--- a/contracts/v2/modules/ReputationEngine.sol
+++ b/contracts/v2/modules/ReputationEngine.sol
@@ -28,7 +28,7 @@ contract ReputationEngine is Ownable {
     event CallerAuthorized(address indexed caller, bool allowed);
     event WeightsUpdated(uint256 performanceWeight, uint256 slashingWeight);
 
-    constructor(address owner) Ownable(owner) {}
+    constructor() Ownable(msg.sender) {}
 
     modifier onlyCaller() {
         require(callers[msg.sender], "not authorized");

--- a/contracts/v2/modules/RevenueDistributor.sol
+++ b/contracts/v2/modules/RevenueDistributor.sol
@@ -18,7 +18,7 @@ contract RevenueDistributor is Ownable {
     event TreasuryUpdated(address indexed treasury);
     event RevenueDistributed(address indexed from, uint256 amount);
 
-    constructor(IStakeManager _stakeManager, address owner) Ownable(owner) {
+    constructor(IStakeManager _stakeManager) Ownable(msg.sender) {
         stakeManager = _stakeManager;
     }
 

--- a/contracts/v2/modules/RoutingModule.sol
+++ b/contracts/v2/modules/RoutingModule.sol
@@ -33,9 +33,8 @@ contract RoutingModule is Ownable {
 
     constructor(
         IStakeManager _stakeManager,
-        IReputationEngine _reputationEngine,
-        address owner
-    ) Ownable(owner) {
+        IReputationEngine _reputationEngine
+    ) Ownable(msg.sender) {
         stakeManager = _stakeManager;
         reputationEngine = _reputationEngine;
     }

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -8,24 +8,25 @@ This walkthrough shows a non‑technical owner how to deploy and wire the modula
 - The verified `$AGIALPHA` token contract address.
 - The compiled bytecode for each module (already provided in this repository).
 - Awareness that all contracts are **Ownable**; keep the deploying wallet secure.
+- The deploying address automatically becomes the owner; constructors no longer take an `owner` parameter.
 
 > **Regulatory notice:** On‑chain rewards minimise reporting requirements but do **not** remove your duty to obey local laws. Consult professionals before proceeding.
 
 ## 2. Deploy core modules
 
-Deploy each contract from the **Write Contract** tabs:
+Deploy each contract from the **Write Contract** tabs (the deployer automatically becomes the owner):
 
-1. `AGIALPHAToken(owner)` – mint the initial supply to the owner or treasury.
-2. `StakeManager(token, owner, treasury)` – records stake balances and holds job escrows.
-3. `JobRegistry(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, owner)` – tracks jobs and tax acknowledgements.
-4. `ValidationModule(jobRegistry, stakeManager, owner)` – handles validation and slashing.
-5. `ReputationEngine(owner)` – optional reputation weighting.
-6. `DisputeModule(jobRegistry, stakeManager, owner)` – manages appeals and dispute fees.
-7. `CertificateNFT(jobRegistry)` – certifies completed work.
-8. `FeePool(token, stakeManager, role, owner)` – redistributes protocol fees to stakers.
-9. `PlatformRegistry(stakeManager, reputationEngine, minStake, owner)` – lists platform operators.
-10. `JobRouter(platformRegistry, owner)` – stake‑weighted job routing.
-11. `PlatformIncentives(stakeManager, platformRegistry, jobRouter, owner)` – helper that lets operators stake and register in one call.
+1. `AGIALPHAToken()` – mint the initial supply to the owner or treasury.
+2. `StakeManager(token, treasury)` – records stake balances and holds job escrows.
+3. `JobRegistry()` – tracks jobs and tax acknowledgements.
+4. `ValidationModule(jobRegistry, stakeManager)` – handles validation and slashing.
+5. `ReputationEngine()` – optional reputation weighting.
+6. `DisputeModule(jobRegistry, stakeManager)` – manages appeals and dispute fees.
+7. `CertificateNFT(name, symbol)` – certifies completed work.
+8. `FeePool(token, stakeManager, role)` – redistributes protocol fees to stakers.
+9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – lists platform operators.
+10. `JobRouter(platformRegistry)` – stake‑weighted job routing.
+11. `PlatformIncentives(stakeManager, platformRegistry, jobRouter)` – helper that lets operators stake and register in one call.
 
 After each deployment, copy the address for later wiring.
 

--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -4,19 +4,19 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 
 ## 1. Deploy Each Module
 
-Deploy contracts in the following order from Etherscan's **Contract → Deploy** tab. Use your owner address for every `owner` field.
+Deploy contracts in the following order from Etherscan's **Contract → Deploy** tab. The deploying address automatically becomes the owner.
 
 | # | Module | Constructor arguments (example) |
 | --- | --- | --- |
-| 1 | StakeManager | `(token, owner, treasury)` → `(0x2e8f…eabe, YOU, TREASURY)` |
-| 2 | JobRegistry | `(owner)` → `(YOU)` |
-| 3 | ValidationModule | `(jobRegistry, stakeManager, owner)` → `(<JobRegistry>, <StakeManager>, YOU)` |
-| 4 | ReputationEngine | `(owner)` → `(YOU)` |
-| 5 | DisputeModule | `(jobRegistry, stakeManager, reputationEngine, owner)` → `(<JobRegistry>, <StakeManager>, <ReputationEngine>, YOU)` |
-| 6 | CertificateNFT | `(name, symbol, owner)` → `("AGI Jobs", "AGIJOB", YOU)` |
-| 7 | FeePool | `(token, stakeManager, rewardRole, owner)` → `(0x2e8f…eabe, <StakeManager>, 2, YOU)` |
-| 8 | TaxPolicy | `(owner)` → `(YOU)` |
-| 9 | PlatformIncentives | `(stakeManager, platformRegistry, feePool, owner)` or as required |
+| 1 | StakeManager | `(token, treasury)` → `(0x2e8f…eabe, TREASURY)` |
+| 2 | JobRegistry | `()` |
+| 3 | ValidationModule | `(jobRegistry, stakeManager)` → `(<JobRegistry>, <StakeManager>)` |
+| 4 | ReputationEngine | `()` |
+| 5 | DisputeModule | `(jobRegistry, stakeManager, reputationEngine)` → `(<JobRegistry>, <StakeManager>, <ReputationEngine>)` |
+| 6 | CertificateNFT | `(name, symbol)` → `("AGI Jobs", "AGIJOB")` |
+| 7 | FeePool | `(token, stakeManager, rewardRole)` → `(0x2e8f…eabe, <StakeManager>, 2)` |
+| 8 | TaxPolicy | `(uri, acknowledgement)` → `("ipfs://policy", "All taxes on participants; contract and owner exempt")` |
+| 9 | PlatformIncentives | `(stakeManager, platformRegistry, feePool)` or as required |
 
 Record each address for later configuration.
 

--- a/scripts/v2/deploy.js
+++ b/scripts/v2/deploy.js
@@ -23,7 +23,6 @@ async function main() {
   );
   const stake = await Stake.deploy(
     await token.getAddress(),
-    deployer.address,
     deployer.address
   );
   await stake.waitForDeployment();
@@ -31,14 +30,13 @@ async function main() {
   const Registry = await ethers.getContractFactory(
     "contracts/v2/JobRegistry.sol:JobRegistry"
   );
-  const registry = await Registry.deploy(deployer.address);
+  const registry = await Registry.deploy();
   await registry.waitForDeployment();
 
   const TaxPolicy = await ethers.getContractFactory(
     "contracts/v2/TaxPolicy.sol:TaxPolicy"
   );
   const tax = await TaxPolicy.deploy(
-    deployer.address,
     "ipfs://policy",
     "All taxes on participants; contract and owner exempt"
   );
@@ -50,29 +48,27 @@ async function main() {
   );
   const validation = await Validation.deploy(
     await registry.getAddress(),
-    await stake.getAddress(),
-    deployer.address
+    await stake.getAddress()
   );
   await validation.waitForDeployment();
 
   const Reputation = await ethers.getContractFactory(
     "contracts/v2/ReputationEngine.sol:ReputationEngine"
   );
-  const reputation = await Reputation.deploy(deployer.address);
+  const reputation = await Reputation.deploy();
   await reputation.waitForDeployment();
 
   const NFT = await ethers.getContractFactory(
     "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
   );
-  const nft = await NFT.deploy("Cert", "CERT", deployer.address);
+  const nft = await NFT.deploy("Cert", "CERT");
   await nft.waitForDeployment();
 
   const Dispute = await ethers.getContractFactory(
     "contracts/v2/DisputeModule.sol:DisputeModule"
   );
   const dispute = await Dispute.deploy(
-    await registry.getAddress(),
-    deployer.address
+    await registry.getAddress()
   );
   await dispute.waitForDeployment();
 
@@ -94,13 +90,13 @@ async function main() {
   console.log("CertificateNFT:", await nft.getAddress());
   console.log("TaxPolicy:", await tax.getAddress());
 
-  await verify(await stake.getAddress(), [await token.getAddress(), deployer.address, deployer.address]);
-  await verify(await registry.getAddress(), [deployer.address]);
-  await verify(await validation.getAddress(), [await registry.getAddress(), await stake.getAddress(), deployer.address]);
-  await verify(await reputation.getAddress(), [deployer.address]);
-  await verify(await dispute.getAddress(), [await registry.getAddress(), deployer.address]);
-  await verify(await nft.getAddress(), ["Cert", "CERT", deployer.address]);
-  await verify(await tax.getAddress(), [deployer.address, "ipfs://policy", "All taxes on participants; contract and owner exempt"]);
+  await verify(await stake.getAddress(), [await token.getAddress(), deployer.address]);
+  await verify(await registry.getAddress(), []);
+  await verify(await validation.getAddress(), [await registry.getAddress(), await stake.getAddress()]);
+  await verify(await reputation.getAddress(), []);
+  await verify(await dispute.getAddress(), [await registry.getAddress()]);
+  await verify(await nft.getAddress(), ["Cert", "CERT"]);
+  await verify(await tax.getAddress(), ["ipfs://policy", "All taxes on participants; contract and owner exempt"]);
 }
 
 main().catch((error) => {

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -61,20 +61,19 @@ async function main() {
   );
   const treasury =
     typeof args.treasury === "string" ? args.treasury : owner;
-  const stake = await Stake.deploy(tokenAddress, owner, treasury);
+  const stake = await Stake.deploy(tokenAddress, treasury);
   await stake.waitForDeployment();
 
   const Registry = await ethers.getContractFactory(
     "contracts/v2/JobRegistry.sol:JobRegistry"
   );
-  const registry = await Registry.deploy(owner);
+  const registry = await Registry.deploy();
   await registry.waitForDeployment();
 
   const TaxPolicy = await ethers.getContractFactory(
     "contracts/v2/TaxPolicy.sol:TaxPolicy"
   );
   const tax = await TaxPolicy.deploy(
-    owner,
     "ipfs://policy",
     "All taxes on participants; contract and owner exempt"
   );
@@ -86,29 +85,27 @@ async function main() {
   );
   const validation = await Validation.deploy(
     await registry.getAddress(),
-    await stake.getAddress(),
-    owner
+    await stake.getAddress()
   );
   await validation.waitForDeployment();
 
   const Reputation = await ethers.getContractFactory(
     "contracts/v2/ReputationEngine.sol:ReputationEngine"
   );
-  const reputation = await Reputation.deploy(owner);
+  const reputation = await Reputation.deploy();
   await reputation.waitForDeployment();
 
   const NFT = await ethers.getContractFactory(
     "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
   );
-  const nft = await NFT.deploy("Cert", "CERT", owner);
+  const nft = await NFT.deploy("Cert", "CERT");
   await nft.waitForDeployment();
 
   const Dispute = await ethers.getContractFactory(
     "contracts/v2/DisputeModule.sol:DisputeModule"
   );
   const dispute = await Dispute.deploy(
-    await registry.getAddress(),
-    owner
+    await registry.getAddress()
   );
   await dispute.waitForDeployment();
 
@@ -118,8 +115,7 @@ async function main() {
   const feePool = await FeePool.deploy(
     tokenAddress,
     await stake.getAddress(),
-    2, // IStakeManager.Role.Platform
-    owner
+    2 // IStakeManager.Role.Platform
   );
   await feePool.waitForDeployment();
 
@@ -133,8 +129,7 @@ async function main() {
   const platformRegistry = await PlatformRegistry.deploy(
     await stake.getAddress(),
     await reputation.getAddress(),
-    minPlatformStake,
-    owner
+    minPlatformStake
   );
   await platformRegistry.waitForDeployment();
 
@@ -142,8 +137,7 @@ async function main() {
     "contracts/v2/modules/JobRouter.sol:JobRouter"
   );
   const jobRouter = await JobRouter.deploy(
-    await platformRegistry.getAddress(),
-    owner
+    await platformRegistry.getAddress()
   );
   await jobRouter.waitForDeployment();
 
@@ -153,8 +147,7 @@ async function main() {
   const incentives = await PlatformIncentives.deploy(
     await stake.getAddress(),
     await platformRegistry.getAddress(),
-    await jobRouter.getAddress(),
-    owner
+    await jobRouter.getAddress()
   );
   await incentives.waitForDeployment();
 

--- a/test/jobRegistry.ts
+++ b/test/jobRegistry.ts
@@ -13,12 +13,12 @@ describe("JobRegistry tax policy gating", function () {
     const Registry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    registry = await Registry.deploy(owner.address);
+    registry = await Registry.deploy();
 
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    policy = await Policy.deploy(owner.address, "ipfs://policy", "ack");
+    policy = await Policy.deploy("ipfs://policy", "ack");
 
     await registry.connect(owner).setJobParameters(0, 0);
   });

--- a/test/jobTaxPolicy.test.js
+++ b/test/jobTaxPolicy.test.js
@@ -10,7 +10,6 @@ describe("JobRegistry tax policy integration", function () {
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
     policy = await TaxPolicyFactory.deploy(
-      owner.address,
       "ipfs://policy",
       "ack"
     );
@@ -19,7 +18,7 @@ describe("JobRegistry tax policy integration", function () {
     const RegistryFactory = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    registry = await RegistryFactory.deploy(owner.address);
+    registry = await RegistryFactory.deploy();
     await registry.waitForDeployment();
   });
 

--- a/test/legacyNoEther.test.js
+++ b/test/legacyNoEther.test.js
@@ -52,7 +52,7 @@ describe("Legacy contract ether rejection", function () {
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
-    const token = await Token.deploy(owner.address);
+    const token = await Token.deploy();
     await token.waitForDeployment();
     const Factory = await ethers.getContractFactory(
       "contracts/StakeManager.sol:StakeManager"

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -19,7 +19,6 @@ describe("Full system integration", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       owner.address
     );
 
@@ -31,27 +30,27 @@ describe("Full system integration", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    rep = await Rep.deploy(owner.address);
+    rep = await Rep.deploy();
 
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );
-    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    nft = await NFT.deploy("Cert", "CERT");
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    registry = await Registry.deploy(owner.address);
+    registry = await Registry.deploy();
 
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress(), owner.address);
+    dispute = await Dispute.deploy(await registry.getAddress());
 
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    policy = await Policy.deploy(owner.address, "ipfs://policy", "ack");
+    policy = await Policy.deploy("ipfs://policy", "ack");
 
     await registry
       .connect(owner)

--- a/test/taxExempt.test.ts
+++ b/test/taxExempt.test.ts
@@ -14,13 +14,13 @@ describe("Tax exemption flags", function () {
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const tax = await TaxPolicy.deploy(owner.address, "ipfs://policy", "ack");
+    const tax = await TaxPolicy.deploy("ipfs://policy", "ack");
     await tax.waitForDeployment();
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const registry = await JobRegistry.deploy(owner.address);
+    const registry = await JobRegistry.deploy();
     await registry.waitForDeployment();
 
     const StakeManager = await ethers.getContractFactory(
@@ -28,7 +28,6 @@ describe("Tax exemption flags", function () {
     );
     const stake = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       owner.address
     );
     await stake.waitForDeployment();
@@ -36,13 +35,13 @@ describe("Tax exemption flags", function () {
     const ReputationEngine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const rep = await ReputationEngine.deploy(owner.address);
+    const rep = await ReputationEngine.deploy();
     await rep.waitForDeployment();
 
     const CertificateNFT = await ethers.getContractFactory(
       "contracts/v2/CertificateNFT.sol:CertificateNFT"
     );
-    const cert = await CertificateNFT.deploy("Cert", "CERT", owner.address);
+    const cert = await CertificateNFT.deploy("Cert", "CERT");
     await cert.waitForDeployment();
 
     const ValidationModule = await ethers.getContractFactory(
@@ -50,8 +49,7 @@ describe("Tax exemption flags", function () {
     );
     const val = await ValidationModule.deploy(
       await registry.getAddress(),
-      await stake.getAddress(),
-      owner.address
+      await stake.getAddress()
     );
     await val.waitForDeployment();
 
@@ -59,8 +57,7 @@ describe("Tax exemption flags", function () {
       "contracts/v2/DisputeModule.sol:DisputeModule"
     );
     const disp = await DisputeModule.deploy(
-      await registry.getAddress(),
-      owner.address
+      await registry.getAddress()
     );
     await disp.waitForDeployment();
 

--- a/test/v2/CertificateNFT.test.js
+++ b/test/v2/CertificateNFT.test.js
@@ -9,7 +9,7 @@ describe("CertificateNFT", function () {
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );
-    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    nft = await NFT.deploy("Cert", "CERT");
     await nft.connect(owner).setJobRegistry(jobRegistry.address);
   });
 

--- a/test/v2/CertificateNFTModuleNoEther.test.js
+++ b/test/v2/CertificateNFTModuleNoEther.test.js
@@ -9,7 +9,7 @@ describe("CertificateNFT module ether rejection", function () {
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );
-    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    nft = await NFT.deploy("Cert", "CERT");
     await nft.waitForDeployment();
   });
 

--- a/test/v2/CertificateNFTNoEther.test.js
+++ b/test/v2/CertificateNFTNoEther.test.js
@@ -9,7 +9,7 @@ describe("CertificateNFT ether rejection", function () {
     const NFT = await ethers.getContractFactory(
       "contracts/v2/CertificateNFT.sol:CertificateNFT"
     );
-    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    nft = await NFT.deploy("Cert", "CERT");
     await nft.waitForDeployment();
   });
 

--- a/test/v2/DiscoveryModule.test.js
+++ b/test/v2/DiscoveryModule.test.js
@@ -12,7 +12,7 @@ describe("DiscoveryModule", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy(owner.address);
+    engine = await Engine.deploy();
     await engine.connect(owner).setCaller(owner.address, true);
     await engine.connect(owner).setStakeManager(await stakeManager.getAddress());
 
@@ -21,8 +21,7 @@ describe("DiscoveryModule", function () {
     );
     discovery = await Discovery.deploy(
       await stakeManager.getAddress(),
-      await engine.getAddress(),
-      owner.address
+      await engine.getAddress()
     );
     await discovery.connect(owner).setMinStake(0);
   });

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -14,7 +14,7 @@ describe("DisputeModule", function () {
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await jobRegistry.getAddress(), owner.address);
+    dispute = await Dispute.deploy(await jobRegistry.getAddress());
     await dispute.connect(owner).setAppealFee(appealFee);
     await dispute.connect(owner).setModerator(moderator.address);
     await dispute.connect(owner).setAppealJury(jury.address);

--- a/test/v2/DisputeModuleModuleNoEther.test.js
+++ b/test/v2/DisputeModuleModuleNoEther.test.js
@@ -12,7 +12,7 @@ describe("DisputeModule module ether rejection", function () {
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress(), owner.address);
+    dispute = await Dispute.deploy(await registry.getAddress());
     await dispute.waitForDeployment();
   });
 

--- a/test/v2/DisputeModuleNoEther.test.js
+++ b/test/v2/DisputeModuleNoEther.test.js
@@ -12,7 +12,7 @@ describe("DisputeModule ether rejection", function () {
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress(), owner.address);
+    dispute = await Dispute.deploy(await registry.getAddress());
     await dispute.waitForDeployment();
   });
 

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -15,19 +15,17 @@ describe("FeePool", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       treasury.address
     );
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    jobRegistry = await JobRegistry.deploy(owner.address);
+    jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
     const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
       "ipfs://policy",
       "ack"
     );
@@ -46,8 +44,7 @@ describe("FeePool", function () {
     feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
-      owner.address
+      2
     );
 
     const registryAddr = await jobRegistry.getAddress();
@@ -176,7 +173,7 @@ describe("FeePool", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const rep = await Rep.connect(owner).deploy(owner.address);
+    const rep = await Rep.connect(owner).deploy();
     await rep.setStakeManager(await stakeManager.getAddress());
     await rep.setCaller(owner.address, true);
 
@@ -186,16 +183,14 @@ describe("FeePool", function () {
     const registry = await Registry.connect(owner).deploy(
       await stakeManager.getAddress(),
       await rep.getAddress(),
-      1,
-      owner.address
+      1
     );
 
     const JobRouter = await ethers.getContractFactory(
       "contracts/v2/modules/JobRouter.sol:JobRouter"
     );
     const jobRouter = await JobRouter.connect(owner).deploy(
-      await registry.getAddress(),
-      owner.address
+      await registry.getAddress()
     );
 
     const Incentives = await ethers.getContractFactory(
@@ -204,8 +199,7 @@ describe("FeePool", function () {
     const incentives = await Incentives.connect(owner).deploy(
       await stakeManager.getAddress(),
       await registry.getAddress(),
-      await jobRouter.getAddress(),
-      owner.address
+      await jobRouter.getAddress()
     );
 
     await registry.setRegistrar(await incentives.getAddress(), true);

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -10,26 +10,24 @@ describe("Governance reward lifecycle", function () {
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
-    token = await Token.deploy(owner.address);
+    token = await Token.deploy();
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       treasury.address
     );
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
     const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
       "ipfs://policy",
       "ack"
     );
@@ -45,8 +43,7 @@ describe("Governance reward lifecycle", function () {
     feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
-      owner.address
+      2
     );
 
     const Reward = await ethers.getContractFactory(
@@ -56,8 +53,7 @@ describe("Governance reward lifecycle", function () {
       await token.getAddress(),
       await feePool.getAddress(),
       await stakeManager.getAddress(),
-      2,
-      owner.address
+      2
     );
 
     await reward.setEpochLength(1);

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -10,26 +10,24 @@ describe("GovernanceReward", function () {
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
-    token = await Token.deploy(owner.address);
+    token = await Token.deploy();
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       treasury.address
     );
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
     const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
       "ipfs://policy",
       "ack"
     );
@@ -44,8 +42,7 @@ describe("GovernanceReward", function () {
     feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
-      owner.address
+      2
     );
 
     const Reward = await ethers.getContractFactory(
@@ -55,8 +52,7 @@ describe("GovernanceReward", function () {
       await token.getAddress(),
       await feePool.getAddress(),
       await stakeManager.getAddress(),
-      2,
-      owner.address
+      2
     );
 
     await reward.setEpochLength(1);

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -11,7 +11,7 @@ describe("JobEscrow", function () {
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
-    token = await Token.deploy(owner.address);
+    token = await Token.deploy();
     await token.connect(owner).mint(employer.address, 1000000);
 
     // Mock RoutingModule that always returns operator

--- a/test/v2/JobEscrowNoEther.test.js
+++ b/test/v2/JobEscrowNoEther.test.js
@@ -10,7 +10,7 @@ describe("JobEscrow ether rejection", function () {
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
-    token = await Token.deploy(owner.address);
+    token = await Token.deploy();
     await token.connect(owner).mint(employer.address, 1000);
 
     const Routing = await ethers.getContractFactory(

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -18,7 +18,6 @@ describe("JobRegistry integration", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       treasury.address
     );
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
@@ -29,23 +28,23 @@ describe("JobRegistry integration", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    rep = await Rep.deploy(owner.address);
+    rep = await Rep.deploy();
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );
-    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    nft = await NFT.deploy("Cert", "CERT");
     const Registry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    registry = await Registry.deploy(owner.address);
+    registry = await Registry.deploy();
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress(), owner.address);
+    dispute = await Dispute.deploy(await registry.getAddress());
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    policy = await Policy.deploy(owner.address, "ipfs://policy", "ack");
+    policy = await Policy.deploy("ipfs://policy", "ack");
 
     await registry
       .connect(owner)
@@ -112,8 +111,7 @@ describe("JobRegistry integration", function () {
     const feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
-      owner.address
+      2
     );
     await registry.connect(owner).setFeePool(await feePool.getAddress());
     await registry.connect(owner).setFeePct(10); // 10%

--- a/test/v2/JobRegistryNoEther.test.js
+++ b/test/v2/JobRegistryNoEther.test.js
@@ -9,7 +9,7 @@ describe("JobRegistry ether rejection", function () {
     const Factory = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    registry = await Factory.deploy(owner.address);
+    registry = await Factory.deploy();
     await registry.waitForDeployment();
   });
 

--- a/test/v2/LifecycleDispute.integration.test.js
+++ b/test/v2/LifecycleDispute.integration.test.js
@@ -20,7 +20,6 @@ describe("Job lifecycle with disputes", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       treasury.address
     );
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
@@ -33,26 +32,26 @@ describe("Job lifecycle with disputes", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    rep = await Rep.deploy(owner.address);
+    rep = await Rep.deploy();
 
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );
-    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    nft = await NFT.deploy("Cert", "CERT");
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    registry = await Registry.deploy(owner.address);
+    registry = await Registry.deploy();
 
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress(), owner.address);
+    dispute = await Dispute.deploy(await registry.getAddress());
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    policy = await Policy.deploy(owner.address, "ipfs://policy", "ack");
+    policy = await Policy.deploy("ipfs://policy", "ack");
 
     await registry.connect(owner).setModules(
       await validation.getAddress(),

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -13,7 +13,7 @@ describe("PlatformRegistry", function () {
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
-    token = await Token.connect(owner).deploy(owner.address);
+    token = await Token.connect(owner).deploy();
     await token.mint(platform.address, STAKE);
 
     const Stake = await ethers.getContractFactory(
@@ -21,7 +21,6 @@ describe("PlatformRegistry", function () {
     );
     stakeManager = await Stake.connect(platform).deploy(
       await token.getAddress(),
-      platform.address,
       treasury.address
     );
     await stakeManager.connect(platform).setMinStake(STAKE);
@@ -31,7 +30,7 @@ describe("PlatformRegistry", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    reputationEngine = await Rep.connect(owner).deploy(owner.address);
+    reputationEngine = await Rep.connect(owner).deploy();
     await reputationEngine.setStakeManager(await stakeManager.getAddress());
     await reputationEngine.setCaller(owner.address, true);
 
@@ -41,8 +40,7 @@ describe("PlatformRegistry", function () {
     registry = await Registry.connect(owner).deploy(
       await stakeManager.getAddress(),
       await reputationEngine.getAddress(),
-      STAKE,
-      owner.address
+      STAKE
     );
   });
 
@@ -96,8 +94,7 @@ describe("PlatformRegistry", function () {
       "contracts/v2/modules/JobRouter.sol:JobRouter"
     );
     const jobRouter = await JobRouter.connect(owner).deploy(
-      await registry.getAddress(),
-      owner.address
+      await registry.getAddress()
     );
 
     const FeePool = await ethers.getContractFactory(
@@ -106,8 +103,7 @@ describe("PlatformRegistry", function () {
     const feePool = await FeePool.connect(owner).deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
-      owner.address
+      2
     );
 
     const Incentives = await ethers.getContractFactory(
@@ -116,8 +112,7 @@ describe("PlatformRegistry", function () {
     const incentives = await Incentives.connect(owner).deploy(
       await stakeManager.getAddress(),
       await registry.getAddress(),
-      await jobRouter.getAddress(),
-      owner.address
+      await jobRouter.getAddress()
     );
 
     await registry.setRegistrar(await incentives.getAddress(), true);

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -19,7 +19,7 @@ describe("Platform reward flow", function () {
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
-    token = await Token.deploy(owner.address);
+    token = await Token.deploy();
     await token.mint(alice.address, 1000n * TOKEN);
     await token.mint(bob.address, 1000n * TOKEN);
     await token.mint(employer.address, 1000n * TOKEN);
@@ -29,7 +29,6 @@ describe("Platform reward flow", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       treasury.address
     );
     await stakeManager.connect(owner).setMinStake(0);
@@ -37,13 +36,12 @@ describe("Platform reward flow", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    jobRegistry = await JobRegistry.deploy(owner.address);
+    jobRegistry = await JobRegistry.deploy();
 
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
     const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
       "ipfs://policy",
       "ack"
     );
@@ -54,7 +52,7 @@ describe("Platform reward flow", function () {
     const Reputation = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const reputation = await Reputation.deploy(owner.address);
+    const reputation = await Reputation.deploy();
 
     const PlatformRegistry = await ethers.getContractFactory(
       "contracts/v2/PlatformRegistry.sol:PlatformRegistry"
@@ -62,16 +60,14 @@ describe("Platform reward flow", function () {
     platformRegistry = await PlatformRegistry.deploy(
       await stakeManager.getAddress(),
       await reputation.getAddress(),
-      0,
-      owner.address
+      0
     );
 
     const JobRouter = await ethers.getContractFactory(
       "contracts/v2/modules/JobRouter.sol:JobRouter"
     );
     jobRouter = await JobRouter.deploy(
-      await platformRegistry.getAddress(),
-      owner.address
+      await platformRegistry.getAddress()
     );
 
     const FeePool = await ethers.getContractFactory(
@@ -80,8 +76,7 @@ describe("Platform reward flow", function () {
     feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
-      owner.address
+      2
     );
   });
 
@@ -147,7 +142,7 @@ describe("Platform reward flow", function () {
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
-    token2 = await Token.deploy(owner.address);
+    token2 = await Token.deploy();
     await token2.mint(employer.address, 1000n * TOKEN);
 
     await stakeManager.connect(owner).setToken(await token2.getAddress());

--- a/test/v2/ProtocolFeatures.test.js
+++ b/test/v2/ProtocolFeatures.test.js
@@ -90,8 +90,7 @@ describe("Protocol core features", function () {
       "contracts/v2/modules/RevenueDistributor.sol:RevenueDistributor"
     );
     const distributor = await Distributor.deploy(
-      stakeManager.target,
-      owner.address
+      stakeManager.target
     );
     await stakeManager.setStake(operator1.address, 2, 100);
     await stakeManager.setStake(operator2.address, 2, 300);
@@ -123,7 +122,7 @@ describe("Protocol core features", function () {
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"
     );
-    const dispute = await Dispute.deploy(registry.target, owner.address);
+    const dispute = await Dispute.deploy(registry.target);
     await dispute.connect(owner).setAppealFee(5);
     await dispute.connect(owner).setDisputeWindow(0);
     const jobId = 1;

--- a/test/v2/ReputationEngine.test.js
+++ b/test/v2/ReputationEngine.test.js
@@ -9,7 +9,7 @@ describe("ReputationEngine", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy(owner.address);
+    engine = await Engine.deploy();
     await engine.connect(owner).setCaller(caller.address, true);
     await engine.connect(owner).setThreshold(2);
   });

--- a/test/v2/ReputationEngineModule.test.js
+++ b/test/v2/ReputationEngineModule.test.js
@@ -9,7 +9,7 @@ describe("ReputationEngine module", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/modules/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy(owner.address);
+    engine = await Engine.deploy();
     await engine.waitForDeployment();
   });
 

--- a/test/v2/ReputationEngineModuleNoEther.test.js
+++ b/test/v2/ReputationEngineModuleNoEther.test.js
@@ -9,7 +9,7 @@ describe("ReputationEngine module ether rejection", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/modules/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy(owner.address);
+    engine = await Engine.deploy();
     await engine.waitForDeployment();
   });
 

--- a/test/v2/ReputationEngineNoEther.test.js
+++ b/test/v2/ReputationEngineNoEther.test.js
@@ -9,7 +9,7 @@ describe("ReputationEngine ether rejection", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy(owner.address);
+    engine = await Engine.deploy();
     await engine.waitForDeployment();
   });
 

--- a/test/v2/RevenueDistributor.test.js
+++ b/test/v2/RevenueDistributor.test.js
@@ -13,8 +13,7 @@ describe("RevenueDistributor", function () {
       "contracts/v2/modules/RevenueDistributor.sol:RevenueDistributor"
     );
     distributor = await Distributor.deploy(
-      await stakeManager.getAddress(),
-      owner.address
+      await stakeManager.getAddress()
     );
 
     await stakeManager.setStake(op1.address, 2, 100);

--- a/test/v2/RoutingModule.test.js
+++ b/test/v2/RoutingModule.test.js
@@ -14,7 +14,7 @@ describe("JobRouter", function () {
     const Reputation = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    reputation = await Reputation.deploy(owner.address);
+    reputation = await Reputation.deploy();
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/PlatformRegistry.sol:PlatformRegistry"
@@ -22,8 +22,7 @@ describe("JobRouter", function () {
     registry = await Registry.deploy(
       await stakeManager.getAddress(),
       await reputation.getAddress(),
-      0,
-      owner.address
+      0
     );
 
     // set platform stakes
@@ -37,7 +36,7 @@ describe("JobRouter", function () {
     const Router = await ethers.getContractFactory(
       "contracts/v2/modules/JobRouter.sol:JobRouter"
     );
-    router = await Router.deploy(await registry.getAddress(), owner.address);
+    router = await Router.deploy(await registry.getAddress());
     await router.connect(op1).register();
     await router.connect(op2).register();
   });

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -16,7 +16,6 @@ describe("StakeManager", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       treasury.address
     );
     await stakeManager.connect(owner).setMinStake(0);
@@ -28,12 +27,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
     const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
       "ipfs://policy",
       "ack"
     );
@@ -94,15 +92,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
@@ -135,15 +129,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
@@ -175,15 +165,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
@@ -217,15 +203,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
@@ -279,15 +261,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
@@ -456,15 +434,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
@@ -510,15 +484,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
@@ -555,15 +525,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
@@ -581,15 +547,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
@@ -618,15 +580,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
@@ -650,15 +608,11 @@ describe("StakeManager", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
-      "ipfs://policy",
-      "ack"
-    );
+    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -16,7 +16,6 @@ describe("StakeManager extras", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       treasury.address
     );
     await stakeManager.connect(owner).setMinStake(0);
@@ -26,12 +25,11 @@ describe("StakeManager extras", function () {
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const jobRegistry = await JobRegistry.deploy(owner.address);
+    const jobRegistry = await JobRegistry.deploy();
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
     const taxPolicy = await TaxPolicy.deploy(
-      owner.address,
       "ipfs://policy",
       "ack"
     );

--- a/test/v2/StakeManagerNoEther.test.js
+++ b/test/v2/StakeManagerNoEther.test.js
@@ -13,7 +13,6 @@ describe("StakeManager ether rejection", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      owner.address,
       owner.address
     );
     await stakeManager.waitForDeployment();

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -9,11 +9,11 @@ describe("JobRegistry tax policy integration", function () {
     const Registry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    registry = await Registry.deploy(owner.address);
+    registry = await Registry.deploy();
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    policy = await Policy.deploy(owner.address, "ipfs://policy", "ack");
+    policy = await Policy.deploy("ipfs://policy", "ack");
   });
 
   it("allows owner to set policy and expose acknowledgement", async () => {

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -25,8 +25,7 @@ describe("ValidationModule V2", function () {
     );
     validation = await Validation.deploy(
       await jobRegistry.getAddress(),
-      await stakeManager.getAddress(),
-      owner.address
+      await stakeManager.getAddress()
     );
     await validation.waitForDeployment();
     await validation

--- a/test/v2/ValidationModuleNoEther.test.js
+++ b/test/v2/ValidationModuleNoEther.test.js
@@ -17,8 +17,7 @@ describe("ValidationModule ether rejection", function () {
     );
     validation = await Validation.deploy(
       await jobRegistry.getAddress(),
-      await stakeManager.getAddress(),
-      owner.address
+      await stakeManager.getAddress()
     );
     await validation.waitForDeployment();
   });

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -16,7 +16,7 @@ describe("end-to-end job lifecycle", function () {
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
-    token = await Token.deploy(owner.address);
+    token = await Token.deploy();
     await token.mint(owner.address, 0);
     const mintAmount = ethers.parseUnits("10000", 6);
     await token.mint(employer.address, mintAmount);
@@ -28,7 +28,6 @@ describe("end-to-end job lifecycle", function () {
     );
     stakeManager = await Stake.deploy(
       await token.getAddress(),
-      owner.address,
       owner.address
     );
 
@@ -40,22 +39,22 @@ describe("end-to-end job lifecycle", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    rep = await Rep.deploy(owner.address);
+    rep = await Rep.deploy();
 
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );
-    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    nft = await NFT.deploy("Cert", "CERT");
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    registry = await Registry.deploy(owner.address);
+    registry = await Registry.deploy();
 
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress(), owner.address);
+    dispute = await Dispute.deploy(await registry.getAddress());
 
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
@@ -63,15 +62,13 @@ describe("end-to-end job lifecycle", function () {
     feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
-      owner.address
+      2
     );
 
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
     policy = await Policy.deploy(
-      owner.address,
       "ipfs://policy",
       "All taxes on participants; contract and owner exempt"
     );

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -17,7 +17,7 @@ describe("multi-operator job lifecycle", function () {
     const Token = await ethers.getContractFactory(
       "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
     );
-    token = await Token.deploy(owner.address);
+    token = await Token.deploy();
     const mintAmount = ethers.parseUnits("10000", 6);
     await token.mint(employer.address, mintAmount);
     await token.mint(agent.address, mintAmount);
@@ -29,7 +29,6 @@ describe("multi-operator job lifecycle", function () {
     );
     stakeManager = await Stake.deploy(
       await token.getAddress(),
-      owner.address,
       owner.address
     );
 
@@ -41,22 +40,22 @@ describe("multi-operator job lifecycle", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    rep = await Rep.deploy(owner.address);
+    rep = await Rep.deploy();
 
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );
-    nft = await NFT.deploy("Cert", "CERT", owner.address);
+    nft = await NFT.deploy("Cert", "CERT");
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    registry = await Registry.deploy(owner.address);
+    registry = await Registry.deploy();
 
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress(), owner.address);
+    dispute = await Dispute.deploy(await registry.getAddress());
 
     const FeePoolF = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
@@ -64,15 +63,13 @@ describe("multi-operator job lifecycle", function () {
     feePool = await FeePoolF.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
-      owner.address
+      2
     );
 
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
     policy = await Policy.deploy(
-      owner.address,
       "ipfs://policy",
       "ack"
     );
@@ -83,16 +80,14 @@ describe("multi-operator job lifecycle", function () {
     platformRegistry = await PlatformRegistryF.deploy(
       await stakeManager.getAddress(),
       await rep.getAddress(),
-      0,
-      owner.address
+      0
     );
 
     const JobRouterF = await ethers.getContractFactory(
       "contracts/v2/modules/JobRouter.sol:JobRouter"
     );
     jobRouter = await JobRouterF.deploy(
-      await platformRegistry.getAddress(),
-      owner.address
+      await platformRegistry.getAddress()
     );
 
     await registry.setModules(


### PR DESCRIPTION
## Summary
- Default all v2 contract ownership to the deployer
- Document deployer-as-owner behavior in README and deployment guides

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5049eed883338545cb18b8881ecd