### PR TITLE
feat: wire modules via constructors

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -143,6 +143,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         IDisputeModule _dispute,
         ICertificateNFT _certNFT,
         IFeePool _feePool,
+        ITaxPolicy _taxPolicy,
         uint256 _feePct,
         uint96 _jobStake
     ) Ownable(msg.sender) {
@@ -152,6 +153,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         disputeModule = _dispute;
         certificateNFT = _certNFT;
         feePool = _feePool;
+        taxPolicy = _taxPolicy;
         if (_feePct > 0) {
             require(_feePct <= 100, "pct");
             feePct = _feePct;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -99,7 +99,9 @@ contract StakeManager is Ownable, ReentrancyGuard {
         uint256 _minStake,
         uint256 _employerSlashPct,
         uint256 _treasurySlashPct,
-        address _treasury
+        address _treasury,
+        address _jobRegistry,
+        address _disputeModule
     ) Ownable(msg.sender) {
         require(_employerSlashPct + _treasurySlashPct <= 100, "pct");
         token = _token;
@@ -107,6 +109,8 @@ contract StakeManager is Ownable, ReentrancyGuard {
         employerSlashPct = _employerSlashPct;
         treasurySlashPct = _treasurySlashPct;
         treasury = _treasury == address(0) ? msg.sender : _treasury;
+        jobRegistry = _jobRegistry;
+        disputeModule = _disputeModule;
     }
 
     // ---------------------------------------------------------------

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -17,26 +17,25 @@ This walkthrough shows a non‑technical owner how to deploy and wire the modula
 Deploy each contract from the **Write Contract** tabs (the deployer automatically becomes the owner):
 
 1. `AGIALPHAToken()` – mint the initial supply to the owner or treasury.
-2. `StakeManager(token, treasury)` – records stake balances and holds job escrows.
-3. `JobRegistry()` – tracks jobs and tax acknowledgements.
-4. `ValidationModule(jobRegistry, stakeManager)` – handles validation and slashing.
-5. `ReputationEngine()` – optional reputation weighting.
-6. `DisputeModule(jobRegistry, stakeManager)` – manages appeals and dispute fees.
-7. `CertificateNFT(name, symbol)` – certifies completed work.
-8. `FeePool(token, stakeManager, role)` – redistributes protocol fees to stakers.
-9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – lists platform operators.
-10. `JobRouter(platformRegistry)` – stake‑weighted job routing.
-11. `PlatformIncentives(stakeManager, platformRegistry, jobRouter)` – helper that lets operators stake and register in one call.
+2. `StakeManager(token, minStake, employerPct, treasuryPct, treasury, jobRegistry, disputeModule)` – records stake balances and holds job escrows.
+3. `ValidationModule(jobRegistry, stakeManager)` – handles validation and slashing.
+4. `ReputationEngine()` – optional reputation weighting.
+5. `DisputeModule(jobRegistry, stakeManager)` – manages appeals and dispute fees.
+6. `CertificateNFT(name, symbol)` – certifies completed work.
+7. `FeePool(token, stakeManager, role)` – redistributes protocol fees to stakers.
+8. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – lists platform operators.
+9. `JobRouter(platformRegistry)` – stake‑weighted job routing.
+10. `PlatformIncentives(stakeManager, platformRegistry, jobRouter)` – helper that lets operators stake and register in one call.
 
-After each deployment, copy the address for later wiring.
+After deploying these modules and recording their addresses, deploy the registry last:
+
+11. `JobRegistry(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, taxPolicy, feePct, jobStake)` – tracks jobs and tax acknowledgements.
 
 ## 3. Wire the modules
 
-Use each contract's **Write** tab to connect modules:
+Use each contract's **Write** tab to connect remaining references:
 
-- `StakeManager.setJobRegistry(jobRegistry)` and `StakeManager.setDisputeModule(disputeModule)`
-- `JobRegistry.setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT)`
-- `JobRegistry.setFeePool(feePool)` and `JobRegistry.setTaxPolicy(taxPolicy)` if used
+- `StakeManager.setJobRegistry(jobRegistry)` and `StakeManager.setDisputeModule(disputeModule)` if not provided at deploy time.
 - `PlatformRegistry.setRegistrar(platformIncentives, true)` and `JobRouter.setRegistrar(platformIncentives, true)`
 
 Owners can retune parameters any time: `StakeManager.setToken`, `setMinStake`, `FeePool.setBurnPct`, `PlatformRegistry.setBlacklist`, etc. No redeployments are required when swapping tokens or adjusting fees.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -68,10 +68,10 @@ For a step-by-step deployment walkthrough with owner-only setters, see [deployme
 ### Owner Controls and Defaults
 | Module | Owner-only setters (default) | Purpose |
 | --- | --- | --- |
-| JobRegistry | `setModules` (none set), `setJobParameters` (`reward=0`, `stake=0`), `setFeePool` (0 address), `setFeePct` (`0`), `setTaxPolicy` (0 address) | Wire modules, set template stake/reward, and configure fees/tax policy. |
+| JobRegistry | modules wired in constructor, `setModules` (for upgrades), `setJobParameters` (`reward=0`, `stake=0`), `setFeePool` (0 address), `setFeePct` (`0`), `setTaxPolicy` (0 address) | Wire modules, set template stake/reward, and configure fees/tax policy. |
 | ValidationModule | `setValidatorPool` (empty), `setReputationEngine` (0 address), `setCommitRevealWindows` (`0`, `0`), `setValidatorBounds` (`0`, `0`), `setVRF` (0 address) | Choose validators and tune commit/reveal timing and committee sizes. |
 | DisputeModule | `setModerator` (owner), `setAppealJury` (owner), `setAppealFee` (`0`), `setJobRegistry` (constructor address) | Configure appeal bond and arbiters. |
-| StakeManager | `setToken` (constructor token), `setMinStake` (`0`), `setSlashingPercentages` (`0`, `0`), `setTreasury` (constructor treasury), `setJobRegistry` (0 address), `setDisputeModule` (0 address), `setSlashPercentSumEnforcement` (`false`), `setMaxStakePerAddress` (`0`) | Adjust staking token, minimums, slashing rules, and authorised modules. |
+| StakeManager | `setToken` (constructor token), `setMinStake` (`0`), `setSlashingPercentages` (`0`, `0`), `setTreasury` (constructor treasury), `setJobRegistry` (constructor address), `setDisputeModule` (constructor address), `setSlashPercentSumEnforcement` (`false`), `setMaxStakePerAddress` (`0`) | Adjust staking token, minimums, slashing rules, and authorised modules. |
 | ReputationEngine | `setCaller` (`false`), `setStakeManager` (0 address), `setScoringWeights` (`1e18`, `1e18`), `setThreshold` (`0`), `blacklist` (`false`) | Manage scoring weights, authorised callers, and blacklist threshold. |
 | CertificateNFT | `setJobRegistry` (0 address), `setBaseURI` (empty) | Authorise minting registry and metadata base URI. |
 

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -18,7 +18,9 @@ describe("FeePool", function () {
       0,
       100,
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
 
     const JobRegistry = await ethers.getContractFactory(
@@ -27,6 +29,8 @@ describe("FeePool", function () {
     jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -20,7 +20,9 @@ describe("Governance reward lifecycle", function () {
       0,
       100,
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
 
     const JobRegistry = await ethers.getContractFactory(
@@ -29,6 +31,8 @@ describe("Governance reward lifecycle", function () {
     const jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -20,7 +20,9 @@ describe("GovernanceReward", function () {
       0,
       100,
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
 
     const JobRegistry = await ethers.getContractFactory(
@@ -29,6 +31,8 @@ describe("GovernanceReward", function () {
     const jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -21,7 +21,9 @@ describe("JobRegistry integration", function () {
       0,
       100,
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
     const Validation = await ethers.getContractFactory(
@@ -42,6 +44,8 @@ describe("JobRegistry integration", function () {
     registry = await Registry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -81,6 +85,9 @@ describe("JobRegistry integration", function () {
     await stakeManager
       .connect(owner)
       .setJobRegistry(await registry.getAddress());
+    await stakeManager
+      .connect(owner)
+      .setDisputeModule(await dispute.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
     await registry
       .connect(owner)
@@ -129,7 +136,9 @@ describe("JobRegistry integration", function () {
       await stakeManager.getAddress(),
       2,
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
     await registry.connect(owner).setFeePool(await feePool.getAddress());
     await registry.connect(owner).setFeePct(10); // 10%

--- a/test/v2/JobRegistryNoEther.test.js
+++ b/test/v2/JobRegistryNoEther.test.js
@@ -16,6 +16,7 @@ describe("JobRegistry ether rejection", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
+      ethers.ZeroAddress,
       0,
       0
     );

--- a/test/v2/LifecycleDispute.integration.test.js
+++ b/test/v2/LifecycleDispute.integration.test.js
@@ -23,7 +23,9 @@ describe("Job lifecycle with disputes", function () {
       0,
       100,
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
 
@@ -48,6 +50,7 @@ describe("Job lifecycle with disputes", function () {
     registry = await Registry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -84,6 +87,9 @@ describe("Job lifecycle with disputes", function () {
     await stakeManager
       .connect(owner)
       .setJobRegistry(await registry.getAddress());
+    await stakeManager
+      .connect(owner)
+      .setDisputeModule(await dispute.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
     await registry
       .connect(owner)

--- a/test/v2/PlatformIncentives.t.sol
+++ b/test/v2/PlatformIncentives.t.sol
@@ -29,7 +29,15 @@ contract PlatformIncentivesTest is Test {
 
     function setUp() public {
         token = new AGIALPHAToken(address(this));
-        stakeManager = new StakeManager(token, address(this), address(0));
+        stakeManager = new StakeManager(
+            token,
+            0,
+            100,
+            0,
+            address(this),
+            address(0),
+            address(0)
+        );
         jobRegistry = new MockJobRegistry();
         jobRegistry.setTaxPolicyVersion(1);
         stakeManager.setJobRegistry(address(jobRegistry));

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -24,7 +24,9 @@ describe("PlatformRegistry", function () {
       0,
       100,
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
     await stakeManager.connect(platform).setMinStake(STAKE);
     await token.connect(platform).approve(await stakeManager.getAddress(), STAKE);

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -32,7 +32,9 @@ describe("Platform reward flow", function () {
       0,
       100,
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
     await stakeManager.connect(owner).setMinStake(0);
 
@@ -42,6 +44,8 @@ describe("Platform reward flow", function () {
     jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -19,7 +19,9 @@ describe("StakeManager", function () {
       0,
       50,
       50,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
     await stakeManager.connect(owner).setMinStake(0);
   });
@@ -31,6 +33,9 @@ describe("StakeManager", function () {
     const jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -109,6 +114,9 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       0,
       0
     );
@@ -151,6 +159,9 @@ describe("StakeManager", function () {
     const jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -200,6 +211,9 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       0,
       0
     );
@@ -243,6 +257,9 @@ describe("StakeManager", function () {
     const jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -310,6 +327,9 @@ describe("StakeManager", function () {
     const jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -496,6 +516,9 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       0,
       0
     );
@@ -555,6 +578,9 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       0,
       0
     );
@@ -605,6 +631,9 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       0,
       0
     );
@@ -632,6 +661,9 @@ describe("StakeManager", function () {
     const jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -678,6 +710,9 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       0,
       0
     );
@@ -711,6 +746,9 @@ describe("StakeManager", function () {
     const jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -19,7 +19,9 @@ describe("StakeManager extras", function () {
       0,
       100,
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
     await stakeManager.connect(owner).setMinStake(0);
   });
@@ -31,6 +33,8 @@ describe("StakeManager extras", function () {
     const jobRegistry = await JobRegistry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/test/v2/StakeManagerNoEther.test.js
+++ b/test/v2/StakeManagerNoEther.test.js
@@ -16,7 +16,9 @@ describe("StakeManager ether rejection", function () {
       0,
       100,
       0,
-      owner.address
+      owner.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
     await stakeManager.waitForDeployment();
   });

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -16,6 +16,7 @@ describe("JobRegistry tax policy integration", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
+      ethers.ZeroAddress,
       0,
       0
     );

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -31,7 +31,9 @@ describe("end-to-end job lifecycle", function () {
       0,
       100,
       0,
-      owner.address
+      owner.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
 
     const Validation = await ethers.getContractFactory(
@@ -55,6 +57,7 @@ describe("end-to-end job lifecycle", function () {
     registry = await Registry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -105,6 +108,8 @@ describe("end-to-end job lifecycle", function () {
     await registry.setJobParameters(0, stakeRequired);
     await stakeManager.setJobRegistry(await registry.getAddress());
     await stakeManager.setSlashingPercentages(100, 0);
+    await stakeManager.setJobRegistry(await registry.getAddress());
+    await stakeManager.setDisputeModule(await dispute.getAddress());
     await nft.setJobRegistry(await registry.getAddress());
     await rep.setCaller(await registry.getAddress(), true);
     await rep.setThreshold(1);

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -32,7 +32,9 @@ describe("multi-operator job lifecycle", function () {
       0,
       100,
       0,
-      owner.address
+      owner.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
     );
 
     const Validation = await ethers.getContractFactory(
@@ -56,6 +58,7 @@ describe("multi-operator job lifecycle", function () {
     registry = await Registry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),
+      ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -121,6 +124,7 @@ describe("multi-operator job lifecycle", function () {
     await registry.setTaxPolicy(await policy.getAddress());
     await registry.setJobParameters(0, stakeRequired);
     await stakeManager.setJobRegistry(await registry.getAddress());
+    await stakeManager.setDisputeModule(await dispute.getAddress());
     await nft.setJobRegistry(await registry.getAddress());
     await rep.setCaller(await registry.getAddress(), true);
     await rep.setThreshold(1);


### PR DESCRIPTION
## Summary
- accept and store module addresses in `JobRegistry` constructor
- allow `StakeManager` to be configured with registry and dispute modules at deploy time
- document module-first deployment flow and constructor wiring

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b5ecb86f483339fb4a28ae195b3db