### PR TITLE
Auto-distribute rewards and secure fee pool

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -85,7 +85,8 @@ contract FeePool is Ownable {
     }
 
     /// @notice distribute accumulated fees to stakers
-    function distributeFees() external {
+    /// @dev All fee amounts use 6 decimal units.
+    function distributeFees() public {
         uint256 amount = pendingFees;
         require(amount > 0, "amount");
         pendingFees = 0;
@@ -109,7 +110,11 @@ contract FeePool is Ownable {
     }
 
     /// @notice claim accumulated rewards for caller
+    /// @dev Rewards are denominated using 6 decimal units.
     function claimRewards() external {
+        if (pendingFees > 0) {
+            distributeFees();
+        }
         uint256 stake = stakeManager.stakeOf(msg.sender, rewardRole);
         // Deployer may claim but receives no rewards without stake.
         if (msg.sender == owner() && stake == 0) {
@@ -124,9 +129,10 @@ contract FeePool is Ownable {
     }
 
     /// @notice transfer tokens to an external reward contract
+    /// @dev Amount uses 6 decimal units.
     /// @param to recipient address
     /// @param amount token amount with 6 decimals
-    function transferReward(address to, uint256 amount) external {
+    function transferReward(address to, uint256 amount) external onlyOwner {
         token.safeTransfer(to, amount);
         emit RewardTransferred(to, amount);
     }

--- a/contracts/v2/interfaces/IFeePool.sol
+++ b/contracts/v2/interfaces/IFeePool.sol
@@ -9,12 +9,15 @@ interface IFeePool {
     function depositFee(uint256 amount) external;
 
     /// @notice distribute pending fees to stakers
+    /// @dev All fee amounts use 6 decimal units.
     function distributeFees() external;
 
     /// @notice claim accumulated rewards for caller
+    /// @dev Rewards use 6 decimal units.
     function claimRewards() external;
 
     /// @notice transfer tokens from the pool to a recipient
+    /// @dev Amount uses 6 decimal units.
     /// @param to address receiving the tokens
     /// @param amount token amount with 6 decimals
     function transferReward(address to, uint256 amount) external;

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -63,15 +63,17 @@ describe("Governance reward lifecycle", function () {
     const Reward = await ethers.getContractFactory(
       "contracts/v2/GovernanceReward.sol:GovernanceReward"
     );
-    reward = await Reward.deploy(
-      await token.getAddress(),
-      await feePool.getAddress(),
-      await stakeManager.getAddress(),
-      2
-    );
+      reward = await Reward.deploy(
+        await token.getAddress(),
+        await feePool.getAddress(),
+        await stakeManager.getAddress(),
+        2
+      );
 
-    await reward.setEpochLength(1);
-    await reward.setRewardPct(50);
+      await feePool.connect(owner).transferOwnership(await reward.getAddress());
+
+      await reward.setEpochLength(1);
+      await reward.setRewardPct(50);
 
     // stake setup
     await token.mint(voter1.address, 100 * 1e6);

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -62,15 +62,17 @@ describe("GovernanceReward", function () {
     const Reward = await ethers.getContractFactory(
       "contracts/v2/GovernanceReward.sol:GovernanceReward"
     );
-    reward = await Reward.deploy(
-      await token.getAddress(),
-      await feePool.getAddress(),
-      await stakeManager.getAddress(),
-      2
-    );
+      reward = await Reward.deploy(
+        await token.getAddress(),
+        await feePool.getAddress(),
+        await stakeManager.getAddress(),
+        2
+      );
 
-    await reward.setEpochLength(1);
-    await reward.setRewardPct(50);
+      await feePool.connect(owner).transferOwnership(await reward.getAddress());
+
+      await reward.setEpochLength(1);
+      await reward.setRewardPct(50);
 
     await token.mint(voter1.address, 100 * 1e6);
     await token.mint(voter2.address, 300 * 1e6);


### PR DESCRIPTION
## Summary
- Auto-distribute pending fees inside `claimRewards`
- Restrict `transferReward` to contract owner only
- Document 6-decimal token units in FeePool and interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b68aaac6c833396e96c66ab043846