### PR TITLE
enforce minimum stake for platform registration

### DIFF
--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -44,11 +44,13 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
     }
 
     /// @notice Register caller as a platform operator.
-    /// @dev No minimum stake is required; routing weight derives from stake and
-    ///      reputation via `getScore`.
     function register() external nonReentrant {
         require(!registered[msg.sender], "registered");
         require(!blacklist[msg.sender], "blacklisted");
+        uint256 stake = stakeManager.stakeOf(msg.sender, IStakeManager.Role.Platform);
+        if (msg.sender != owner()) {
+            require(stake >= minPlatformStake, "stake");
+        }
         registered[msg.sender] = true;
         emit Registered(msg.sender);
     }
@@ -110,6 +112,10 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
         }
         require(!registered[operator], "registered");
         require(!blacklist[operator], "blacklisted");
+        uint256 stake = stakeManager.stakeOf(operator, IStakeManager.Role.Platform);
+        if (operator != owner()) {
+            require(stake >= minPlatformStake, "stake");
+        }
         registered[operator] = true;
         emit Registered(operator);
     }


### PR DESCRIPTION
## Summary
- require non-owner platform operators to meet minimum stake when registering
- enforce same stake check for registrar-based registration
- test stake enforcement for direct and registrar registration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6abf6c108333a23ac750959ad144