### PR TITLE
Simplify deployment defaults for AGIJobs v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labor markets among autonomous agents. The legacy v0 deployment transacts in $AGI, while the modular v2 suite defaults to [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) – a 6‑decimal ERC‑20 used for payments, staking, rewards and dispute deposits. The contract owner can swap this token at any time via `StakeManager.setToken` without redeploying other modules. This repository hosts the immutable mainnet deployment (v0) and an unaudited v1 prototype under active development. Treat every address as unverified until you confirm it on-chain and through official AGI.eth channels.
 
-StakeManager and FeePool constructors each accept an `IERC20 token` address and an optional `_treasury`. Deployments here default to the $AGIALPHA token above, and passing `address(0)` uses the owner as treasury. Should economics change, the owner may later call `setToken` on these modules to point to a different ERC‑20 without redeploying.
+StakeManager and FeePool constructors each accept an `IERC20 token` address and an optional `_treasury`. Deployments here default to the $AGIALPHA token above, and passing `address(0)` uses the owner as treasury. Should economics change, the owner may later call `setToken` on these modules to point to a different ERC‑20 without redeploying. If a zero token address is supplied, both modules automatically fall back to the $AGIALPHA default.
+
+Other constructors now ship with sensible defaults so a deployer can leave parameters empty when using Etherscan:
+
+- `StakeManager` splits slashing 100% to the treasury when percentages are omitted.
+- `JobRegistry` applies a 5% protocol fee if `_feePct` is `0`.
+- `ValidationModule` defaults to 1‑day commit/reveal windows with 1–3 validators if zero values are provided.
 
 All v2 constructors omit the `owner` argument—the deploying address automatically becomes the owner via `Ownable(msg.sender)`.
 

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -17,6 +17,10 @@ contract FeePool is Ownable {
     uint256 public constant ACCUMULATOR_SCALE = 1e12;
     address public constant BURN_ADDRESS = 0x000000000000000000000000000000000000dEaD;
 
+    /// @notice default $AGIALPHA token used when no token is specified
+    address public constant DEFAULT_TOKEN =
+        0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe;
+
     /// @notice ERC20 token used for fees and rewards
     IERC20 public token;
 
@@ -60,7 +64,10 @@ contract FeePool is Ownable {
         address _treasury
     ) Ownable(msg.sender) {
         require(_burnPct <= 100, "pct");
-        token = _token;
+        token =
+            address(_token) == address(0)
+                ? IERC20(DEFAULT_TOKEN)
+                : _token;
         stakeManager = _stakeManager;
         rewardRole = _role;
         burnPct = _burnPct;

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -89,6 +89,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     // default agent stake requirement configured by owner
     uint96 public jobStake;
     uint256 public feePct;
+    uint256 public constant DEFAULT_FEE_PCT = 5;
 
     // module configuration events
     event ModuleUpdated(string module, address newAddress);
@@ -153,10 +154,9 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         disputeModule = _dispute;
         certificateNFT = _certNFT;
         feePool = _feePool;
-        if (_feePct > 0) {
-            require(_feePct <= 100, "pct");
-            feePct = _feePct;
-        }
+        uint256 pct = _feePct == 0 ? DEFAULT_FEE_PCT : _feePct;
+        require(pct <= 100, "pct");
+        feePct = pct;
         if (_jobStake > 0) {
             jobStake = _jobStake;
         }

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -27,6 +27,10 @@ contract StakeManager is Ownable, ReentrancyGuard {
         Platform
     }
 
+    /// @notice default $AGIALPHA token used when no token is specified
+    address public constant DEFAULT_TOKEN =
+        0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe;
+
     /// @notice ERC20 token used for staking and payouts
     IERC20 public token;
 
@@ -101,11 +105,22 @@ contract StakeManager is Ownable, ReentrancyGuard {
         uint256 _treasurySlashPct,
         address _treasury
     ) Ownable(msg.sender) {
-        require(_employerSlashPct + _treasurySlashPct <= 100, "pct");
-        token = _token;
+        token =
+            address(_token) == address(0)
+                ? IERC20(DEFAULT_TOKEN)
+                : _token;
         minStake = _minStake;
-        employerSlashPct = _employerSlashPct;
-        treasurySlashPct = _treasurySlashPct;
+        if (_employerSlashPct + _treasurySlashPct == 0) {
+            employerSlashPct = 0;
+            treasurySlashPct = 100;
+        } else {
+            require(
+                _employerSlashPct + _treasurySlashPct <= 100,
+                "pct"
+            );
+            employerSlashPct = _employerSlashPct;
+            treasurySlashPct = _treasurySlashPct;
+        }
         treasury = _treasury == address(0) ? msg.sender : _treasury;
     }
 

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -26,6 +26,11 @@ contract ValidationModule is IValidationModule, Ownable {
     uint256 public minValidators;
     uint256 public maxValidators;
 
+    uint256 public constant DEFAULT_COMMIT_WINDOW = 1 days;
+    uint256 public constant DEFAULT_REVEAL_WINDOW = 1 days;
+    uint256 public constant DEFAULT_MIN_VALIDATORS = 1;
+    uint256 public constant DEFAULT_MAX_VALIDATORS = 3;
+
     // slashing percentage applied to validator stake for incorrect votes
     uint256 public validatorSlashingPercentage = 50;
 
@@ -80,14 +85,18 @@ contract ValidationModule is IValidationModule, Ownable {
         uint256 _maxValidators,
         address[] memory _validatorPool
     ) Ownable(msg.sender) {
-        require(_commitWindow > 0 && _revealWindow > 0, "windows");
-        require(_minValidators > 0 && _maxValidators >= _minValidators, "bounds");
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
-        commitWindow = _commitWindow;
-        revealWindow = _revealWindow;
-        minValidators = _minValidators;
-        maxValidators = _maxValidators;
+        commitWindow =
+            _commitWindow == 0 ? DEFAULT_COMMIT_WINDOW : _commitWindow;
+        revealWindow =
+            _revealWindow == 0 ? DEFAULT_REVEAL_WINDOW : _revealWindow;
+        minValidators =
+            _minValidators == 0 ? DEFAULT_MIN_VALIDATORS : _minValidators;
+        maxValidators =
+            _maxValidators == 0 ? DEFAULT_MAX_VALIDATORS : _maxValidators;
+        require(commitWindow > 0 && revealWindow > 0, "windows");
+        require(maxValidators >= minValidators, "bounds");
         if (_validatorPool.length != 0) {
             validatorPool = _validatorPool;
             emit ValidatorsUpdated(_validatorPool);

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -14,17 +14,17 @@ This walkthrough shows a non‑technical owner how to deploy and wire the modula
 
 ## 2. Deploy core modules
 
-Deploy each contract from the **Write Contract** tabs (the deployer automatically becomes the owner):
+Deploy each contract from the **Write Contract** tabs (the deployer automatically becomes the owner). Parameters may be left as `0` to accept the defaults shown below:
 
 1. `AGIALPHAToken()` – mint the initial supply to the owner or treasury.
-2. `StakeManager(token, treasury)` – records stake balances and holds job escrows.
-3. `JobRegistry()` – tracks jobs and tax acknowledgements.
-4. `ValidationModule(jobRegistry, stakeManager)` – handles validation and slashing.
+2. `StakeManager(token, minStake, employerPct, treasuryPct, treasury)` – pass `address(0)` for `token` to use the default $AGIALPHA and `0,0` for the slashing percentages to send 100% of any slash to the treasury.
+3. `JobRegistry(validation, stakeMgr, reputation, dispute, certNFT, feePool, feePct, jobStake)` – leaving `feePct = 0` applies a 5% protocol fee.
+4. `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators, validatorPool)` – zero values default to 1‑day windows and a 1–3 validator set.
 5. `ReputationEngine()` – optional reputation weighting.
 6. `DisputeModule(jobRegistry, stakeManager)` – manages appeals and dispute fees.
 7. `CertificateNFT(name, symbol)` – certifies completed work.
-8. `FeePool(token, stakeManager, role)` – redistributes protocol fees to stakers.
-9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – lists platform operators.
+8. `FeePool(token, stakeManager, role, burnPct, treasury)` – use `address(0)` for `token` to fall back to $AGIALPHA; `burnPct` defaults to `0`.
+9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – `minStake` may be `0`.
 10. `JobRouter(platformRegistry)` – stake‑weighted job routing.
 11. `PlatformIncentives(stakeManager, platformRegistry, jobRouter)` – helper that lets operators stake and register in one call.
 

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -79,6 +79,7 @@ describe("Full system integration", function () {
         await nft.getAddress()
       );
     await registry.connect(owner).setJobParameters(reward, stake);
+    await registry.connect(owner).setFeePct(0);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
     await rep.connect(owner).setCaller(await registry.getAddress(), true);
     await rep.connect(owner).setThreshold(1);

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -75,6 +75,7 @@ describe("JobRegistry integration", function () {
     await registry
       .connect(owner)
       .setJobParameters(reward, stake);
+    await registry.connect(owner).setFeePct(0);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
     await rep.connect(owner).setCaller(await registry.getAddress(), true);
     await rep.connect(owner).setThreshold(1);

--- a/test/v2/LifecycleDispute.integration.test.js
+++ b/test/v2/LifecycleDispute.integration.test.js
@@ -78,6 +78,7 @@ describe("Job lifecycle with disputes", function () {
       await nft.getAddress()
     );
     await registry.connect(owner).setJobParameters(reward, stake);
+    await registry.connect(owner).setFeePct(0);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
     await rep.connect(owner).setCaller(await registry.getAddress(), true);
     await rep.connect(owner).setThreshold(1);


### PR DESCRIPTION
## Summary
- default to $AGIALPHA when no token is provided to StakeManager and FeePool
- apply 5% fee default and convenient validator timing defaults
- document zero-config deployment and update tests for new defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b87b8505c8333b827185f298bbc8b