### PR TITLE
feat: streamline module wiring

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -97,6 +97,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
     event MaxStakePerAddressUpdated(uint256 maxStake);
     event StakeLocked(address indexed user, uint256 amount, uint64 unlockTime);
     event StakeUnlocked(address indexed user, uint256 amount);
+    event ModulesUpdated(address indexed jobRegistry, address indexed disputeModule);
 
     constructor(
         IERC20 _token,
@@ -181,6 +182,21 @@ contract StakeManager is Ownable, ReentrancyGuard {
     function setDisputeModule(address module) external onlyOwner {
         disputeModule = module;
         emit DisputeModuleUpdated(module);
+    }
+
+    /// @notice update job registry and dispute module in one call
+    /// @param _jobRegistry registry contract enforcing tax acknowledgements
+    /// @param _disputeModule module contract allowed to move dispute fees
+    function setModules(address _jobRegistry, address _disputeModule)
+        external
+        onlyOwner
+    {
+        require(_jobRegistry != address(0) && _disputeModule != address(0), "module");
+        jobRegistry = _jobRegistry;
+        disputeModule = _disputeModule;
+        emit JobRegistryUpdated(_jobRegistry);
+        emit DisputeModuleUpdated(_disputeModule);
+        emit ModulesUpdated(_jobRegistry, _disputeModule);
     }
 
     /// @notice set maximum total stake allowed per address (0 disables limit)

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -16,12 +16,12 @@ This walkthrough shows a non‑technical owner how to deploy and wire the modula
 
 Deploy each contract from the **Write Contract** tabs (the deployer automatically becomes the owner). Parameters may be left as `0` to accept the defaults shown below:
 
-1. `AGIALPHAToken()` – mint the initial supply to the owner or treasury.
+1. `AGIALPHAToken()` – after deployment, call `mint(to, amount)` to create the initial supply.
 2. `StakeManager(token, minStake, employerPct, treasuryPct, treasury)` – pass `address(0)` for `token` to use the default $AGIALPHA and `0,0` for the slashing percentages to send 100% of any slash to the treasury.
 3. `JobRegistry(validation, stakeMgr, reputation, dispute, certNFT, feePool, feePct, jobStake)` – leaving `feePct = 0` applies a 5% protocol fee.
 4. `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators, validatorPool)` – zero values default to 1‑day windows and a 1–3 validator set.
 5. `ReputationEngine()` – optional reputation weighting.
-6. `DisputeModule(jobRegistry, stakeManager)` – manages appeals and dispute fees.
+6. `DisputeModule(jobRegistry, appealFee, moderator, jury)` – manages appeals and dispute fees.
 7. `CertificateNFT(name, symbol)` – certifies completed work.
 8. `FeePool(token, stakeManager, role, burnPct, treasury)` – use `address(0)` for `token` to fall back to $AGIALPHA; `burnPct` defaults to `0`.
 9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – `minStake` may be `0`.
@@ -34,7 +34,7 @@ After each deployment, copy the address for later wiring.
 
 Use each contract's **Write** tab to connect modules:
 
-- `StakeManager.setJobRegistry(jobRegistry)` and `StakeManager.setDisputeModule(disputeModule)`
+- `StakeManager.setModules(jobRegistry, disputeModule)`
 - `JobRegistry.setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT)`
 - `JobRegistry.setFeePool(feePool)` and `JobRegistry.setTaxPolicy(taxPolicy)` if used
 - `PlatformRegistry.setRegistrar(platformIncentives, true)` and `JobRouter.setRegistrar(platformIncentives, true)`

--- a/test/v2/PlatformIncentives.t.sol
+++ b/test/v2/PlatformIncentives.t.sol
@@ -28,8 +28,8 @@ contract PlatformIncentivesTest is Test {
     address operator = address(0xBEEF);
 
     function setUp() public {
-        token = new AGIALPHAToken(address(this));
-        stakeManager = new StakeManager(token, address(this), address(0));
+        token = new AGIALPHAToken();
+        stakeManager = new StakeManager(token, 0, 0, 0, address(this));
         jobRegistry = new MockJobRegistry();
         jobRegistry.setTaxPolicyVersion(1);
         stakeManager.setJobRegistry(address(jobRegistry));


### PR DESCRIPTION
## Summary
- add one-call `setModules` to StakeManager for registry and dispute module wiring
- document AGIALPHA deployment flow with consolidated wiring and mint instructions
- fix platform incentive test to match token and StakeManager constructors

## Testing
- `npm run lint`
- `npx hardhat test`
- `forge test` *(fails: Source "forge-std/Script.sol" not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8bf293a4833399bb753ae1dbbd26