### PR TITLE
Use default token and deployer treasury in StakeManager and FeePool

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -16,6 +16,8 @@ contract FeePool is Ownable {
 
     uint256 public constant ACCUMULATOR_SCALE = 1e12;
     address public constant BURN_ADDRESS = 0x000000000000000000000000000000000000dEaD;
+    address public constant DEFAULT_TOKEN =
+        0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe;
 
     /// @notice ERC20 token used for fees and rewards
     IERC20 public token;
@@ -53,18 +55,16 @@ contract FeePool is Ownable {
     event RewardTransferred(address indexed to, uint256 amount);
 
     constructor(
-        IERC20 _token,
         IStakeManager _stakeManager,
         IStakeManager.Role _role,
-        uint256 _burnPct,
-        address _treasury
+        uint256 _burnPct
     ) Ownable(msg.sender) {
         require(_burnPct <= 100, "pct");
-        token = _token;
+        token = IERC20(DEFAULT_TOKEN);
         stakeManager = _stakeManager;
         rewardRole = _role;
         burnPct = _burnPct;
-        treasury = _treasury == address(0) ? msg.sender : _treasury;
+        treasury = msg.sender;
     }
 
     modifier onlyStakeManager() {

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -20,6 +20,10 @@ import {IFeePool} from "./interfaces/IFeePool.sol";
 contract StakeManager is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
+    /// @notice default staking token address
+    address public constant DEFAULT_TOKEN =
+        0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe;
+
     /// @notice participant roles
     enum Role {
         Agent,
@@ -95,18 +99,16 @@ contract StakeManager is Ownable, ReentrancyGuard {
     event StakeUnlocked(address indexed user, uint256 amount);
 
     constructor(
-        IERC20 _token,
         uint256 _minStake,
         uint256 _employerSlashPct,
-        uint256 _treasurySlashPct,
-        address _treasury
+        uint256 _treasurySlashPct
     ) Ownable(msg.sender) {
         require(_employerSlashPct + _treasurySlashPct <= 100, "pct");
-        token = _token;
+        token = IERC20(DEFAULT_TOKEN);
         minStake = _minStake;
         employerSlashPct = _employerSlashPct;
         treasurySlashPct = _treasurySlashPct;
-        treasury = _treasury == address(0) ? msg.sender : _treasury;
+        treasury = msg.sender;
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add DEFAULT_TOKEN constant to StakeManager and FeePool
- default constructors to use DEFAULT_TOKEN and msg.sender as treasury

## Testing
- `npx hardhat test test/v2/StakeManager.test.js --no-compile` *(fails: Artifact for contract "contracts/v2/StakeManager.sol:StakeManager" not found)*
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b824764cc8333a5b2257af50f1f40