### PR TITLE
Initialize defaults for staking and fees

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -60,17 +60,15 @@ contract FeePool is Ownable {
         IERC20 _token,
         IStakeManager _stakeManager,
         IStakeManager.Role _role,
-        uint256 _burnPct,
         address _treasury
     ) Ownable(msg.sender) {
-        require(_burnPct <= 100, "pct");
         token =
             address(_token) == address(0)
                 ? IERC20(DEFAULT_TOKEN)
                 : _token;
         stakeManager = _stakeManager;
         rewardRole = _role;
-        burnPct = _burnPct;
+        burnPct = 5;
         treasury = _treasury == address(0) ? msg.sender : _treasury;
     }
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -144,9 +144,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         IReputationEngine _reputation,
         IDisputeModule _dispute,
         ICertificateNFT _certNFT,
-        IFeePool _feePool,
-        uint256 _feePct,
-        uint96 _jobStake
+        IFeePool _feePool
     ) Ownable(msg.sender) {
         validationModule = _validation;
         stakeManager = _stakeMgr;
@@ -154,12 +152,8 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         disputeModule = _dispute;
         certificateNFT = _certNFT;
         feePool = _feePool;
-        uint256 pct = _feePct == 0 ? DEFAULT_FEE_PCT : _feePct;
-        require(pct <= 100, "pct");
-        feePct = pct;
-        if (_jobStake > 0) {
-            jobStake = _jobStake;
-        }
+        feePct = DEFAULT_FEE_PCT;
+        jobStake = 0;
     }
 
     // ---------------------------------------------------------------------

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -99,29 +99,15 @@ contract StakeManager is Ownable, ReentrancyGuard {
     event StakeUnlocked(address indexed user, uint256 amount);
     event ModulesUpdated(address indexed jobRegistry, address indexed disputeModule);
 
-    constructor(
-        IERC20 _token,
-        uint256 _minStake,
-        uint256 _employerSlashPct,
-        uint256 _treasurySlashPct,
-        address _treasury
-    ) Ownable(msg.sender) {
+    constructor(IERC20 _token, address _treasury) Ownable(msg.sender) {
         token =
             address(_token) == address(0)
                 ? IERC20(DEFAULT_TOKEN)
                 : _token;
-        minStake = _minStake;
-        if (_employerSlashPct + _treasurySlashPct == 0) {
-            employerSlashPct = 0;
-            treasurySlashPct = 100;
-        } else {
-            require(
-                _employerSlashPct + _treasurySlashPct <= 100,
-                "pct"
-            );
-            employerSlashPct = _employerSlashPct;
-            treasurySlashPct = _treasurySlashPct;
-        }
+        minStake = 1_000000;
+        employerSlashPct = 80;
+        treasurySlashPct = 20;
+        maxStakePerAddress = 10_000_000;
         treasury = _treasury == address(0) ? msg.sender : _treasury;
     }
 

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -79,24 +79,14 @@ contract ValidationModule is IValidationModule, Ownable {
     constructor(
         IJobRegistry _jobRegistry,
         IStakeManager _stakeManager,
-        uint256 _commitWindow,
-        uint256 _revealWindow,
-        uint256 _minValidators,
-        uint256 _maxValidators,
         address[] memory _validatorPool
     ) Ownable(msg.sender) {
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
-        commitWindow =
-            _commitWindow == 0 ? DEFAULT_COMMIT_WINDOW : _commitWindow;
-        revealWindow =
-            _revealWindow == 0 ? DEFAULT_REVEAL_WINDOW : _revealWindow;
-        minValidators =
-            _minValidators == 0 ? DEFAULT_MIN_VALIDATORS : _minValidators;
-        maxValidators =
-            _maxValidators == 0 ? DEFAULT_MAX_VALIDATORS : _maxValidators;
-        require(commitWindow > 0 && revealWindow > 0, "windows");
-        require(maxValidators >= minValidators, "bounds");
+        commitWindow = DEFAULT_COMMIT_WINDOW;
+        revealWindow = DEFAULT_REVEAL_WINDOW;
+        minValidators = DEFAULT_MIN_VALIDATORS;
+        maxValidators = DEFAULT_MAX_VALIDATORS;
         if (_validatorPool.length != 0) {
             validatorPool = _validatorPool;
             emit ValidatorsUpdated(_validatorPool);

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -13,14 +13,20 @@ async function main() {
   );
   const stake = await Stake.deploy(
     await token.getAddress(),
-    deployer.address,
     deployer.address
   );
 
   const Registry = await ethers.getContractFactory(
     "contracts/v2/JobRegistry.sol:JobRegistry"
   );
-  const registry = await Registry.deploy(deployer.address);
+  const registry = await Registry.deploy(
+    ethers.ZeroAddress,
+    await stake.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress
+  );
 
   const Validation = await ethers.getContractFactory(
     "contracts/v2/ValidationModule.sol:ValidationModule"
@@ -28,12 +34,10 @@ async function main() {
   const validation = await Validation.deploy(
     await registry.getAddress(),
     await stake.getAddress(),
-    60,
-    60,
-    1,
-    3,
     []
   );
+  await validation.setCommitRevealWindows(60, 60);
+  await validation.setValidatorBounds(1, 3);
 
   const Reputation = await ethers.getContractFactory(
     "contracts/v2/ReputationEngine.sol:ReputationEngine"

--- a/scripts/deployAll.ts
+++ b/scripts/deployAll.ts
@@ -21,7 +21,6 @@ async function main() {
   );
   const stake = await Stake.deploy(
     await token.getAddress(),
-    deployer.address,
     deployer.address
   );
   await stake.waitForDeployment();
@@ -30,7 +29,14 @@ async function main() {
   const Registry = await ethers.getContractFactory(
     "contracts/v2/JobRegistry.sol:JobRegistry"
   );
-  const registry = await Registry.deploy(deployer.address);
+  const registry = await Registry.deploy(
+    ethers.ZeroAddress,
+    await stake.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress
+  );
   await registry.waitForDeployment();
 
   // Simple tax policy used for sample deployments.
@@ -51,13 +57,11 @@ async function main() {
   const validation = await Validation.deploy(
     await registry.getAddress(),
     await stake.getAddress(),
-    60,
-    60,
-    1,
-    3,
     []
   );
   await validation.waitForDeployment();
+  await validation.setCommitRevealWindows(60, 60);
+  await validation.setValidatorBounds(1, 3);
 
   const Reputation = await ethers.getContractFactory(
     "contracts/v2/ReputationEngine.sol:ReputationEngine"

--- a/scripts/v2/deploy.js
+++ b/scripts/v2/deploy.js
@@ -30,7 +30,14 @@ async function main() {
   const Registry = await ethers.getContractFactory(
     "contracts/v2/JobRegistry.sol:JobRegistry"
   );
-  const registry = await Registry.deploy();
+  const registry = await Registry.deploy(
+    ethers.ZeroAddress,
+    await stake.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress
+  );
   await registry.waitForDeployment();
 
   const TaxPolicy = await ethers.getContractFactory(
@@ -49,13 +56,11 @@ async function main() {
   const validation = await Validation.deploy(
     await registry.getAddress(),
     await stake.getAddress(),
-    60,
-    60,
-    1,
-    3,
     []
   );
   await validation.waitForDeployment();
+  await validation.setCommitRevealWindows(60, 60);
+  await validation.setValidatorBounds(1, 3);
 
   const Reputation = await ethers.getContractFactory(
     "contracts/v2/ReputationEngine.sol:ReputationEngine"
@@ -96,8 +101,19 @@ async function main() {
   console.log("TaxPolicy:", await tax.getAddress());
 
   await verify(await stake.getAddress(), [await token.getAddress(), deployer.address]);
-  await verify(await registry.getAddress(), []);
-  await verify(await validation.getAddress(), [await registry.getAddress(), await stake.getAddress()]);
+  await verify(await registry.getAddress(), [
+    ethers.ZeroAddress,
+    await stake.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+  ]);
+  await verify(await validation.getAddress(), [
+    await registry.getAddress(),
+    await stake.getAddress(),
+    [],
+  ]);
   await verify(await reputation.getAddress(), []);
   await verify(await dispute.getAddress(), [await registry.getAddress()]);
   await verify(await nft.getAddress(), ["Cert", "CERT"]);

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -15,9 +15,6 @@ describe("FeePool", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      0,
-      100,
-      0,
       treasury.address
     );
 
@@ -30,9 +27,7 @@ describe("FeePool", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -57,9 +52,9 @@ describe("FeePool", function () {
       await token.getAddress(),
       await stakeManager.getAddress(),
       2,
-      0,
       treasury.address
     );
+    await feePool.connect(owner).setBurnPct(0);
 
     const registryAddr = await jobRegistry.getAddress();
     await ethers.provider.send("hardhat_setBalance", [

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -17,9 +17,6 @@ describe("Governance reward lifecycle", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      0,
-      100,
-      0,
       treasury.address
     );
 
@@ -32,9 +29,7 @@ describe("Governance reward lifecycle", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -56,9 +51,9 @@ describe("Governance reward lifecycle", function () {
       await token.getAddress(),
       await stakeManager.getAddress(),
       2,
-      0,
       treasury.address
     );
+    await feePool.connect(owner).setBurnPct(0);
 
     const Reward = await ethers.getContractFactory(
       "contracts/v2/GovernanceReward.sol:GovernanceReward"

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -17,9 +17,6 @@ describe("GovernanceReward", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      0,
-      100,
-      0,
       treasury.address
     );
 
@@ -32,9 +29,7 @@ describe("GovernanceReward", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -55,9 +50,9 @@ describe("GovernanceReward", function () {
       await token.getAddress(),
       await stakeManager.getAddress(),
       2,
-      0,
       treasury.address
     );
+    await feePool.connect(owner).setBurnPct(0);
 
     const Reward = await ethers.getContractFactory(
       "contracts/v2/GovernanceReward.sol:GovernanceReward"

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -18,9 +18,6 @@ describe("JobRegistry integration", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      0,
-      100,
-      0,
       treasury.address
     );
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
@@ -45,9 +42,7 @@ describe("JobRegistry integration", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/DisputeModule.sol:DisputeModule"
@@ -129,9 +124,9 @@ describe("JobRegistry integration", function () {
       await token.getAddress(),
       await stakeManager.getAddress(),
       2,
-      0,
       treasury.address
     );
+    await feePool.connect(owner).setBurnPct(0);
     await registry.connect(owner).setFeePool(await feePool.getAddress());
     await registry.connect(owner).setFeePct(10); // 10%
     await token.mint(owner.address, reward);

--- a/test/v2/LifecycleDispute.integration.test.js
+++ b/test/v2/LifecycleDispute.integration.test.js
@@ -20,9 +20,6 @@ describe("Job lifecycle with disputes", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      0,
-      100,
-      0,
       treasury.address
     );
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
@@ -51,9 +48,7 @@ describe("Job lifecycle with disputes", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
 
     const Dispute = await ethers.getContractFactory(

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -29,9 +29,6 @@ describe("Platform reward flow", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      0,
-      100,
-      0,
       treasury.address
     );
     await stakeManager.connect(owner).setMinStake(0);
@@ -45,9 +42,7 @@ describe("Platform reward flow", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
 
     const TaxPolicy = await ethers.getContractFactory(
@@ -89,9 +84,9 @@ describe("Platform reward flow", function () {
       await token.getAddress(),
       await stakeManager.getAddress(),
       2,
-      0,
       treasury.address
     );
+    await feePool.connect(owner).setBurnPct(0);
   });
 
   it("handles zero-stake owner, proportional fees, and token swap", async () => {

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -16,9 +16,6 @@ describe("StakeManager", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      0,
-      50,
-      50,
       treasury.address
     );
     await stakeManager.connect(owner).setMinStake(0);
@@ -34,9 +31,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -89,13 +84,13 @@ describe("StakeManager", function () {
       0,
       employer.address,
       treasury.address,
-      50,
-      50
+      80,
+      20
     );
     expect(await stakeManager.stakes(user.address, 0)).to.equal(50n);
     expect(await stakeManager.totalStake(0)).to.equal(50n);
-    expect(await token.balanceOf(employer.address)).to.equal(750n);
-    expect(await token.balanceOf(treasury.address)).to.equal(50n);
+    expect(await token.balanceOf(employer.address)).to.equal(780n);
+    expect(await token.balanceOf(treasury.address)).to.equal(20n);
   });
 
   it("rejects unauthorized slashing and excessive amounts", async () => {
@@ -108,9 +103,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -154,9 +147,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -199,9 +190,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -246,9 +235,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -313,9 +300,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -495,9 +480,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -554,9 +537,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -604,9 +585,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -635,9 +614,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -677,9 +654,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -714,9 +689,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -16,9 +16,6 @@ describe("StakeManager extras", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      0,
-      100,
-      0,
       treasury.address
     );
     await stakeManager.connect(owner).setMinStake(0);
@@ -34,9 +31,7 @@ describe("StakeManager extras", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/StakeManagerNoEther.test.js
+++ b/test/v2/StakeManagerNoEther.test.js
@@ -13,9 +13,6 @@ describe("StakeManager ether rejection", function () {
     );
     stakeManager = await StakeManager.deploy(
       await token.getAddress(),
-      0,
-      100,
-      0,
       owner.address
     );
     await stakeManager.waitForDeployment();

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -26,16 +26,14 @@ describe("ValidationModule V2", function () {
     validation = await Validation.deploy(
       await jobRegistry.getAddress(),
       await stakeManager.getAddress(),
-      60,
-      60,
-      2,
-      2,
       []
     );
     await validation.waitForDeployment();
     await validation
       .connect(owner)
       .setReputationEngine(await reputation.getAddress());
+    await validation.connect(owner).setCommitRevealWindows(60, 60);
+    await validation.connect(owner).setValidatorBounds(2, 2);
 
     // validator stakes and pool
     await stakeManager.setStake(v1.address, 1, ethers.parseEther("100"));

--- a/test/v2/ValidationModuleNoEther.test.js
+++ b/test/v2/ValidationModuleNoEther.test.js
@@ -18,10 +18,6 @@ describe("ValidationModule ether rejection", function () {
     validation = await Validation.deploy(
       await jobRegistry.getAddress(),
       await stakeManager.getAddress(),
-      1,
-      1,
-      1,
-      1,
       []
     );
     await validation.waitForDeployment();

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -28,9 +28,6 @@ describe("end-to-end job lifecycle", function () {
     );
     stakeManager = await Stake.deploy(
       await token.getAddress(),
-      0,
-      100,
-      0,
       owner.address
     );
 
@@ -58,9 +55,7 @@ describe("end-to-end job lifecycle", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0
+      ethers.ZeroAddress
     );
 
     const Dispute = await ethers.getContractFactory(
@@ -80,9 +75,9 @@ describe("end-to-end job lifecycle", function () {
       await token.getAddress(),
       await stakeManager.getAddress(),
       2,
-      0,
       owner.address
     );
+    await feePool.connect(owner).setBurnPct(0);
 
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"


### PR DESCRIPTION
## Summary
- Set StakeManager defaults for min stake, slashing splits, and max address stake
- Default FeePool burn percent to 5%
- Simplify ValidationModule and JobRegistry constructors with sensible defaults

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b9e1ffe848333bc0180588df24846