### PR TITLE
feat: add module installer wiring helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ For screenshots and step-by-step instructions, see [docs/etherscan-guide.md](doc
 
 The modular v2 suite is deployed module by module and then wired together on‑chain. A typical flow is:
 
-1. Deploy `StakeManager`, `JobRegistry`, `ValidationModule(commitWindow, revealWindow, minValidators, maxValidators[, validatorPool])`, `ReputationEngine`, `DisputeModule`, `CertificateNFT`, `FeePool`, and `TaxPolicy`.
-2. Connect them with owner‑only setters such as `JobRegistry.setModules`, `StakeManager.setModules(jobRegistry, disputeModule)`, `JobRegistry.setFeePool`, and `JobRegistry.setTaxPolicy`.
+1. Deploy `StakeManager`, `JobRegistry`, `ValidationModule`, `ReputationEngine`, `DisputeModule`, `CertificateNFT`, `PlatformRegistry`, `JobRouter`, `PlatformIncentives`, `FeePool`, `TaxPolicy`, and finally `ModuleInstaller`.
+2. Call `ModuleInstaller.initialize(jobRegistry, stakeManager, validationModule, reputationEngine, disputeModule, certificateNFT, platformIncentives, platformRegistry, jobRouter)` once to wire cross‑links between modules.
 3. Tune economics via `StakeManager.setMinStake`, `StakeManager.setSlashingPercentages`, `ValidationModule.setCommitRevealWindows` (24h defaults) and `ValidationModule.setValidatorBounds`, `DisputeModule.setAppealFee`, and `FeePool.setBurnPct`.
 4. Authorize a helper such as `PlatformIncentives` with `PlatformRegistry.setRegistrar` and `JobRouter.setRegistrar` so operators can opt in using one transaction.
 5. For disputes, participants `approve` the `StakeManager` for the configured `appealFee` and invoke `JobRegistry.dispute(jobId)`; the `DisputeModule` locks the bond and later pays the winner in $AGIALPHA.

--- a/contracts/v2/ModuleInstaller.sol
+++ b/contracts/v2/ModuleInstaller.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {
+    JobRegistry,
+    IReputationEngine,
+    IDisputeModule,
+    ICertificateNFT
+} from "./JobRegistry.sol";
+import {StakeManager} from "./StakeManager.sol";
+import {PlatformIncentives} from "./PlatformIncentives.sol";
+import {IValidationModule} from "./interfaces/IValidationModule.sol";
+import {IStakeManager} from "./interfaces/IStakeManager.sol";
+import {IPlatformRegistryFull} from "./interfaces/IPlatformRegistryFull.sol";
+import {IJobRouter} from "./interfaces/IJobRouter.sol";
+
+/// @title ModuleInstaller
+/// @notice Wires deployed modules together in a single transaction.
+/// @dev Each module must transfer ownership to this installer prior to calling
+///      {initialize}. After wiring, ownership can be reclaimed via the modules'
+///      own `transferOwnership` functions.
+contract ModuleInstaller {
+    bool public initialized;
+
+    /// @notice Emitted after all modules are wired together.
+    event ModulesInstalled(
+        address jobRegistry,
+        address stakeManager,
+        address validationModule,
+        address reputationEngine,
+        address disputeModule,
+        address certificateNFT,
+        address platformIncentives,
+        address platformRegistry,
+        address jobRouter
+    );
+
+    /// @notice Connect core modules after deployment.
+    /// @param jobRegistry Address of the JobRegistry contract
+    /// @param stakeManager Address of the StakeManager contract
+    /// @param validationModule Address of the ValidationModule
+    /// @param reputationEngine Address of the ReputationEngine
+    /// @param disputeModule Address of the DisputeModule
+    /// @param certificateNFT Address of the CertificateNFT
+    /// @param platformIncentives Address of the PlatformIncentives helper
+    /// @param platformRegistry Address of the PlatformRegistry
+    /// @param jobRouter Address of the JobRouter
+    function initialize(
+        JobRegistry jobRegistry,
+        StakeManager stakeManager,
+        IValidationModule validationModule,
+        IReputationEngine reputationEngine,
+        IDisputeModule disputeModule,
+        ICertificateNFT certificateNFT,
+        PlatformIncentives platformIncentives,
+        IPlatformRegistryFull platformRegistry,
+        IJobRouter jobRouter
+    ) external {
+        require(!initialized, "init");
+        initialized = true;
+
+        jobRegistry.setModules(
+            validationModule,
+            IStakeManager(address(stakeManager)),
+            reputationEngine,
+            disputeModule,
+            certificateNFT
+        );
+        stakeManager.setModules(address(jobRegistry), address(disputeModule));
+        platformIncentives.setModules(
+            IStakeManager(address(stakeManager)),
+            platformRegistry,
+            jobRouter
+        );
+
+        emit ModulesInstalled(
+            address(jobRegistry),
+            address(stakeManager),
+            address(validationModule),
+            address(reputationEngine),
+            address(disputeModule),
+            address(certificateNFT),
+            address(platformIncentives),
+            address(platformRegistry),
+            address(jobRouter)
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ModuleInstaller contract to wire core v2 modules in one transaction
- document deployment order and single initialize call in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ba662374c833395a521cc9499f2e5