### PR TITLE
feat: add convenience tax acknowledgement flows

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -20,6 +20,7 @@ contract MockStakeManager is IStakeManager {
     }
 
     function depositStake(Role, uint256) external override {}
+    function acknowledgeAndDeposit(Role, uint256) external override {}
     function depositStakeFor(address, Role, uint256) external override {}
     function withdrawStake(Role, uint256) external override {}
     function lockJobFunds(bytes32, address, uint256) external override {}
@@ -88,6 +89,7 @@ contract MockJobRegistry is IJobRegistry, IJobRegistryTax {
     function applyForJob(uint256) external override {}
     function completeJob(uint256) external override {}
     function dispute(uint256) external payable override {}
+    function acknowledgeAndDispute(uint256, string calldata) external override {}
     function resolveDispute(uint256, bool) external override {}
     function finalize(uint256) external override {}
     function cancelJob(uint256) external override {}

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -117,6 +117,11 @@ interface IJobRegistry {
     /// @dev Reverts with {InvalidStatus} or {OnlyAgent}
     function dispute(uint256 jobId) external payable;
 
+    /// @notice Acknowledge tax policy if needed and raise a dispute with evidence
+    /// @param jobId Identifier of the disputed job
+    /// @param evidence Supporting evidence for the dispute
+    function acknowledgeAndDispute(uint256 jobId, string calldata evidence) external;
+
     /// @notice Resolve a dispute and record the final outcome
     /// @param jobId Identifier of the disputed job
     /// @param employerWins True if the employer wins the dispute

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -33,6 +33,9 @@ interface IStakeManager {
     /// @notice deposit stake for caller for a specific role
     function depositStake(Role role, uint256 amount) external;
 
+    /// @notice acknowledge the tax policy and deposit stake in one call
+    function acknowledgeAndDeposit(Role role, uint256 amount) external;
+
     /// @notice deposit stake on behalf of a user for a specific role
     function depositStakeFor(address user, Role role, uint256 amount) external;
 


### PR DESCRIPTION
## Summary
- add StakeManager.acknowledgeAndDeposit to combine tax acknowledgement and staking
- add PlatformIncentives.acknowledgeStakeAndActivate for one-step platform registration
- expose JobRegistry.acknowledgeAndDispute for token-based dispute bonds

## Testing
- `npm test`
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bad578d088333880929047da868bf