### PR TITLE
Emit deployment configuration events

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Other constructors now ship with sensible defaults so a deployer can leave param
 - `JobRegistry` applies a 5% protocol fee if `_feePct` is `0`.
 - `JobRegistry` emits `ModuleUpdated` events for any modules supplied at deployment, making on-chain verification easier.
 - `ValidationModule` defaults to 1‑day commit/reveal windows with 1–3 validators if zero values are provided.
+- Constructors emit configuration events (`TokenUpdated`, `MinStakeUpdated`, etc.) at deployment so non‑technical users can confirm settings directly on Etherscan.
 
 All v2 constructors omit the `owner` argument—the deploying address automatically becomes the owner via `Ownable(msg.sender)`.
 

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -68,10 +68,19 @@ contract FeePool is Ownable {
             address(_token) == address(0)
                 ? IERC20(DEFAULT_TOKEN)
                 : _token;
+        emit TokenUpdated(address(token));
+
         stakeManager = _stakeManager;
+        emit StakeManagerUpdated(address(_stakeManager));
+
         rewardRole = _role;
+        emit RewardRoleUpdated(_role);
+
         burnPct = _burnPct;
+        emit BurnPctUpdated(_burnPct);
+
         treasury = _treasury == address(0) ? msg.sender : _treasury;
+        emit TreasuryUpdated(treasury);
     }
 
     modifier onlyStakeManager() {

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -39,8 +39,19 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
         uint256 _minStake
     ) Ownable(msg.sender) {
         stakeManager = _stakeManager;
+        if (address(_stakeManager) != address(0)) {
+            emit StakeManagerUpdated(address(_stakeManager));
+        }
+
         reputationEngine = _reputationEngine;
+        if (address(_reputationEngine) != address(0)) {
+            emit ReputationEngineUpdated(address(_reputationEngine));
+        }
+
         minPlatformStake = _minStake;
+        if (_minStake > 0) {
+            emit MinPlatformStakeUpdated(_minStake);
+        }
     }
 
     /// @notice Register caller as a platform operator.

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -116,7 +116,12 @@ contract StakeManager is Ownable, ReentrancyGuard {
             address(_token) == address(0)
                 ? IERC20(DEFAULT_TOKEN)
                 : _token;
+        emit TokenUpdated(address(token));
+
         minStake = _minStake;
+        if (_minStake > 0) {
+            emit MinStakeUpdated(_minStake);
+        }
         if (_employerSlashPct + _treasurySlashPct == 0) {
             employerSlashPct = 0;
             treasurySlashPct = 100;
@@ -128,7 +133,10 @@ contract StakeManager is Ownable, ReentrancyGuard {
             employerSlashPct = _employerSlashPct;
             treasurySlashPct = _treasurySlashPct;
         }
+        emit SlashingPercentagesUpdated(employerSlashPct, treasurySlashPct);
+
         treasury = _treasury == address(0) ? msg.sender : _treasury;
+        emit TreasuryUpdated(treasury);
         if (_jobRegistry != address(0)) {
             jobRegistry = _jobRegistry;
         }

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -91,10 +91,14 @@ contract ValidationModule is IValidationModule, Ownable {
             _commitWindow == 0 ? DEFAULT_COMMIT_WINDOW : _commitWindow;
         revealWindow =
             _revealWindow == 0 ? DEFAULT_REVEAL_WINDOW : _revealWindow;
+        emit TimingUpdated(commitWindow, revealWindow);
+
         minValidators =
             _minValidators == 0 ? DEFAULT_MIN_VALIDATORS : _minValidators;
         maxValidators =
             _maxValidators == 0 ? DEFAULT_MAX_VALIDATORS : _maxValidators;
+        emit ValidatorBoundsUpdated(minValidators, maxValidators);
+
         require(commitWindow > 0 && revealWindow > 0, "windows");
         require(maxValidators >= minValidators, "bounds");
         if (_validatorPool.length != 0) {

--- a/test/v2/JobRouter.t.sol
+++ b/test/v2/JobRouter.t.sol
@@ -38,7 +38,7 @@ contract JobRouterTest {
 
     function setUp() public {
         registry = new MockPlatformRegistry();
-        router = new JobRouter(registry, address(this));
+        router = new JobRouter(registry);
     }
 
     function registerPlatforms() internal {

--- a/test/v2/PlatformIncentives.t.sol
+++ b/test/v2/PlatformIncentives.t.sol
@@ -36,17 +36,21 @@ contract PlatformIncentivesTest is Test {
         rep = new MockReputationEngine();
         platformRegistry = new PlatformRegistry(
             IStakeManager(address(stakeManager)),
-            rep,
-            1e6,
+            IReputationEngine(address(rep)),
+            1e6
+        );
+        jobRouter = new JobRouter(IPlatformRegistry(address(platformRegistry)));
+        feePool = new FeePool(
+            token,
+            IStakeManager(address(stakeManager)),
+            IStakeManager.Role.Platform,
+            0,
             address(this)
         );
-        jobRouter = new JobRouter(IPlatformRegistry(address(platformRegistry)), address(this));
-        feePool = new FeePool(token, IStakeManager(address(stakeManager)), IStakeManager.Role.Platform, address(this));
         incentives = new PlatformIncentives(
             IStakeManager(address(stakeManager)),
             IPlatformRegistryFull(address(platformRegistry)),
-            IJobRouter(address(jobRouter)),
-            address(this)
+            IJobRouter(address(jobRouter))
         );
         platformRegistry.setRegistrar(address(incentives), true);
         jobRouter.setRegistrar(address(incentives), true);


### PR DESCRIPTION
## Summary
- emit deployment-time events in StakeManager, FeePool, PlatformRegistry, and ValidationModule constructors
- document constructor events and defaults in README for easier Etherscan setup
- update v2 tests for new module constructors

## Testing
- `npm test`
- `forge test` *(fails: Source "forge-std/Script.sol" not found / wrong argument counts in legacy tests)*

------
https://chatgpt.com/codex/tasks/task_e_689beccecfec83338fcd21ae1e87d393