### PR TITLE
feat: add default staking and burn parameters

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -16,6 +16,7 @@ contract FeePool is Ownable {
 
     uint256 public constant ACCUMULATOR_SCALE = 1e12;
     address public constant BURN_ADDRESS = 0x000000000000000000000000000000000000dEaD;
+    uint256 public constant DEFAULT_BURN_PCT = 5;
 
     /// @notice default $AGIALPHA token used when no token is specified
     address public constant DEFAULT_TOKEN =
@@ -56,6 +57,15 @@ contract FeePool is Ownable {
     event TreasuryUpdated(address indexed treasury);
     event RewardTransferred(address indexed to, uint256 amount);
 
+    /// @notice Deploys the FeePool.
+    /// @param _token ERC20 token used for fees and rewards. Defaults to
+    /// DEFAULT_TOKEN when zero address.
+    /// @param _stakeManager StakeManager tracking staker balances.
+    /// @param _role Staker role whose participants receive rewards.
+    /// @param _burnPct Percentage of each fee to burn (0-100). Defaults to
+    /// DEFAULT_BURN_PCT when set to zero.
+    /// @param _treasury Address receiving rounding dust. Defaults to deployer
+    /// when zero address.
     constructor(
         IERC20 _token,
         IStakeManager _stakeManager,
@@ -63,7 +73,8 @@ contract FeePool is Ownable {
         uint256 _burnPct,
         address _treasury
     ) Ownable(msg.sender) {
-        require(_burnPct <= 100, "pct");
+        uint256 pct = _burnPct == 0 ? DEFAULT_BURN_PCT : _burnPct;
+        require(pct <= 100, "pct");
         token =
             address(_token) == address(0)
                 ? IERC20(DEFAULT_TOKEN)
@@ -76,8 +87,8 @@ contract FeePool is Ownable {
         rewardRole = _role;
         emit RewardRoleUpdated(_role);
 
-        burnPct = _burnPct;
-        emit BurnPctUpdated(_burnPct);
+        burnPct = pct;
+        emit BurnPctUpdated(pct);
 
         treasury = _treasury == address(0) ? msg.sender : _treasury;
         emit TreasuryUpdated(treasury);

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -18,6 +18,8 @@ interface IReputationEngine {
 /// @dev Holds no tokens and rejects ether to remain tax neutral. All values
 ///      use 6 decimals via the `StakeManager`.
 contract PlatformRegistry is Ownable, ReentrancyGuard {
+    uint256 public constant DEFAULT_MIN_PLATFORM_STAKE = 1e6;
+
     IStakeManager public stakeManager;
     IReputationEngine public reputationEngine;
     uint256 public minPlatformStake;
@@ -33,6 +35,11 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
     event Blacklisted(address indexed operator, bool status);
     event RegistrarUpdated(address indexed registrar, bool allowed);
 
+    /// @notice Deploys the PlatformRegistry.
+    /// @param _stakeManager StakeManager contract.
+    /// @param _reputationEngine Reputation engine used for scoring.
+    /// @param _minStake Minimum stake required for platforms to register.
+    /// Defaults to DEFAULT_MIN_PLATFORM_STAKE when set to zero.
     constructor(
         IStakeManager _stakeManager,
         IReputationEngine _reputationEngine,
@@ -48,10 +55,9 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
             emit ReputationEngineUpdated(address(_reputationEngine));
         }
 
-        minPlatformStake = _minStake;
-        if (_minStake > 0) {
-            emit MinPlatformStakeUpdated(_minStake);
-        }
+        minPlatformStake =
+            _minStake == 0 ? DEFAULT_MIN_PLATFORM_STAKE : _minStake;
+        emit MinPlatformStakeUpdated(minPlatformStake);
     }
 
     /// @notice Register caller as a platform operator.

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -35,6 +35,9 @@ contract StakeManager is Ownable, ReentrancyGuard {
     address public constant DEFAULT_TOKEN =
         0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe;
 
+    /// @notice default minimum stake when constructor param is zero
+    uint256 public constant DEFAULT_MIN_STAKE = 1e6;
+
     /// @notice ERC20 token used for staking and payouts
     IERC20 public token;
 
@@ -103,6 +106,19 @@ contract StakeManager is Ownable, ReentrancyGuard {
     event StakeUnlocked(address indexed user, uint256 amount);
     event ModulesUpdated(address indexed jobRegistry, address indexed disputeModule);
 
+    /// @notice Deploys the StakeManager.
+    /// @param _token ERC20 token used for staking and payouts. Defaults to
+    /// DEFAULT_TOKEN when zero address.
+    /// @param _minStake Minimum stake required to participate. Defaults to
+    /// DEFAULT_MIN_STAKE when set to zero.
+    /// @param _employerSlashPct Percentage of slashed amount sent to employer
+    /// (0-100).
+    /// @param _treasurySlashPct Percentage of slashed amount sent to treasury
+    /// (0-100).
+    /// @param _treasury Address receiving treasury share of slashed stake.
+    /// Defaults to deployer when zero address.
+    /// @param _jobRegistry JobRegistry enforcing tax acknowledgements.
+    /// @param _disputeModule Dispute module authorized to manage dispute fees.
     constructor(
         IERC20 _token,
         uint256 _minStake,
@@ -118,10 +134,8 @@ contract StakeManager is Ownable, ReentrancyGuard {
                 : _token;
         emit TokenUpdated(address(token));
 
-        minStake = _minStake;
-        if (_minStake > 0) {
-            emit MinStakeUpdated(_minStake);
-        }
+        minStake = _minStake == 0 ? DEFAULT_MIN_STAKE : _minStake;
+        emit MinStakeUpdated(minStake);
         if (_employerSlashPct + _treasurySlashPct == 0) {
             employerSlashPct = 0;
             treasurySlashPct = 100;

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -26,6 +26,7 @@ describe("Full system integration", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress
     );
+    await stakeManager.connect(owner).setMinStake(0);
 
     const Validation = await ethers.getContractFactory(
       "contracts/v2/mocks/ValidationStub.sol:ValidationStub"

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -22,6 +22,7 @@ describe("FeePool", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress
     );
+    await stakeManager.connect(owner).setMinStake(0);
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
@@ -62,6 +63,7 @@ describe("FeePool", function () {
       0,
       treasury.address
     );
+    await feePool.setBurnPct(0);
 
     const registryAddr = await jobRegistry.getAddress();
     await ethers.provider.send("hardhat_setBalance", [

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -61,6 +61,7 @@ describe("Governance reward lifecycle", function () {
       0,
       treasury.address
     );
+    await feePool.setBurnPct(0);
 
     const Reward = await ethers.getContractFactory(
       "contracts/v2/GovernanceReward.sol:GovernanceReward"

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -60,6 +60,7 @@ describe("GovernanceReward", function () {
       0,
       treasury.address
     );
+    await feePool.setBurnPct(0);
 
     const Reward = await ethers.getContractFactory(
       "contracts/v2/GovernanceReward.sol:GovernanceReward"

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -25,6 +25,7 @@ describe("JobRegistry integration", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress
     );
+    await stakeManager.connect(owner).setMinStake(0);
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
     const Validation = await ethers.getContractFactory(
       "contracts/v2/mocks/ValidationStub.sol:ValidationStub"
@@ -134,6 +135,7 @@ describe("JobRegistry integration", function () {
       0,
       treasury.address
     );
+    await feePool.setBurnPct(0);
     await registry.connect(owner).setFeePool(await feePool.getAddress());
     await registry.connect(owner).setFeePct(10); // 10%
     await token.mint(owner.address, reward);

--- a/test/v2/LifecycleDispute.integration.test.js
+++ b/test/v2/LifecycleDispute.integration.test.js
@@ -27,6 +27,7 @@ describe("Job lifecycle with disputes", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress
     );
+    await stakeManager.connect(owner).setMinStake(0);
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
 
     const Validation = await ethers.getContractFactory(

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -94,6 +94,7 @@ describe("Platform reward flow", function () {
       0,
       treasury.address
     );
+    await feePool.setBurnPct(0);
   });
 
   it("handles zero-stake owner, proportional fees, and token swap", async () => {

--- a/test/v2/RoutingModule.test.js
+++ b/test/v2/RoutingModule.test.js
@@ -24,6 +24,7 @@ describe("JobRouter", function () {
       await reputation.getAddress(),
       0
     );
+    await registry.setMinPlatformStake(0);
 
     // set platform stakes
     await stakeManager.setStake(op1.address, 2, 100);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -85,6 +85,7 @@ describe("end-to-end job lifecycle", function () {
       0,
       owner.address
     );
+    await feePool.setBurnPct(0);
 
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -86,6 +86,7 @@ describe("multi-operator job lifecycle", function () {
       0,
       owner.address
     );
+    await feePool.setBurnPct(0);
 
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"


### PR DESCRIPTION
## Summary
- add configurable default minimum stake in StakeManager
- set default platform stake and burn percentage in PlatformRegistry and FeePool
- document defaults in constructors and update tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf499e1208333b66ebe0c96c7a7b7