### PR TITLE
Use StakeManager for dispute bonds

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ These principles are encoded on‑chain via the owner‑controlled [`TaxPolicy`]
 
 The sample [deployment script](scripts/v2/deploy.ts) wires the modules, sets the `TaxPolicy`, and points the `StakeManager` at the `JobRegistry`, providing a turnkey, tax‑neutral configuration that non‑technical users can verify on explorers.
 
-For easy verification on block explorers, [`TaxPolicy`](contracts/v2/TaxPolicy.sol), [`JobRegistry`](contracts/v2/JobRegistry.sol), [`StakeManager`](contracts/v2/StakeManager.sol), [`ValidationModule`](contracts/v2/ValidationModule.sol), [`ReputationEngine`](contracts/v2/ReputationEngine.sol), [`DisputeModule`](contracts/v2/DisputeModule.sol), and [`CertificateNFT`](contracts/v2/CertificateNFT.sol) each expose `isTaxExempt()` which always returns `true`, signalling that neither these contracts nor the owner can ever accrue tax liability.
+For easy verification on block explorers, [`TaxPolicy`](contracts/v2/TaxPolicy.sol), [`JobRegistry`](contracts/v2/JobRegistry.sol), [`StakeManager`](contracts/v2/StakeManager.sol), [`ValidationModule`](contracts/v2/ValidationModule.sol), [`ReputationEngine`](contracts/v2/ReputationEngine.sol), [`DisputeModule`](contracts/v2/modules/DisputeModule.sol), and [`CertificateNFT`](contracts/v2/CertificateNFT.sol) each expose `isTaxExempt()` which always returns `true`, signalling that neither these contracts nor the owner can ever accrue tax liability.
 
 ### Checking the tax disclaimer on Etherscan
 

--- a/docs/Guidev0.md
+++ b/docs/Guidev0.md
@@ -587,7 +587,7 @@ Steps for an Agent:
 
 9. **Handling Disputes (if you think you were unfairly failed):** If validators mark your job as failed but you believe you did it correctly, and if the platform has disputes enabled, you (as agent) can appeal:
 
-   * Call `raiseDispute(uint256 jobId)` on JobRegistry during the dispute window (immediately after a failure outcome, before finalize). You might need to pay an **appeal fee** (in ETH or tokens) – check if `DisputeModule.appeal` requires a fee. The JobRegistry’s `raiseDispute` function will forward the call to DisputeModule along with your fee if needed. Only do this if you’re confident; it might cost you and if you lose the appeal, you could lose the fee.
+   * Call `raiseDispute(uint256 jobId)` on JobRegistry during the dispute window (immediately after a failure outcome, before finalize). You might need to pay an **appeal fee** in **$AGIALPHA** – check if the dispute module requires a fee. The JobRegistry’s `raiseDispute` function will forward the call along with your tokens if needed. Only do this if you’re confident; it might cost you and if you lose the appeal, you could lose the fee.
    * After raising a dispute, the job state becomes Disputed. The dispute may be resolved by a moderator or a larger jury (depending on system). Eventually, a resolution will come:
 
      * If the dispute decides in your favor (employer was wrong), the DisputeModule will call `JobRegistry.resolveDispute(jobId, employerWins=false)`, which flips `job.success` back to true. Then finalize would pay you as normal.

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -2,87 +2,114 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("DisputeModule", function () {
-  let dispute, jobRegistry, owner, employer, agent, moderator, jury;
+  let token, stakeManager, dispute, jobRegistry, owner, employer, agent;
   const appealFee = 10n;
 
   beforeEach(async () => {
-    [owner, employer, agent, moderator, jury] = await ethers.getSigners();
-    const RegistryStub = await ethers.getContractFactory(
-      "contracts/mocks/DisputeRegistryStub.sol:DisputeRegistryStub"
+    [owner, employer, agent] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    token = await Token.deploy();
+    await token.mint(agent.address, 1000);
+    await token.mint(employer.address, 1000);
+
+    const JobMock = await ethers.getContractFactory("MockJobRegistry");
+    jobRegistry = await JobMock.deploy();
+    await jobRegistry.waitForDeployment();
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
     );
-    jobRegistry = await RegistryStub.deploy();
-    const Dispute = await ethers.getContractFactory(
-      "contracts/v2/DisputeModule.sol:DisputeModule"
-    );
-    dispute = await Dispute.deploy(
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      0,
+      0,
+      0,
+      owner.address,
       await jobRegistry.getAddress(),
-      appealFee,
-      moderator.address,
-      jury.address
+      ethers.ZeroAddress
     );
+    await jobRegistry.setStakeManager(await stakeManager.getAddress());
+
+    const Dispute = await ethers.getContractFactory(
+      "contracts/v2/modules/DisputeModule.sol:DisputeModule"
+    );
+    dispute = await Dispute.deploy(await jobRegistry.getAddress());
+    await dispute.setAppealFee(appealFee);
+    await stakeManager.setDisputeModule(await dispute.getAddress());
   });
 
-  async function raise(jobId, agentSigner) {
-    await jobRegistry.acknowledge(agentSigner.address);
+  async function raise(jobId) {
     await jobRegistry.setJob(jobId, {
-      agent: agentSigner.address,
       employer: employer.address,
+      agent: agent.address,
       reward: 0,
       stake: 0,
-      state: 0,
+      success: false,
+      status: 0,
+      uri: ""
     });
-    await jobRegistry
-      .connect(agentSigner)
-      .appeal(await dispute.getAddress(), jobId, { value: appealFee });
+    await jobRegistry.connect(agent).acknowledgeTaxPolicy();
+    await token.connect(agent).approve(
+      await stakeManager.getAddress(),
+      appealFee
+    );
+    await dispute.connect(agent).raiseDispute(jobId, "evidence");
+  }
+
+  async function ensureOutcome(jobId, employerWinsDesired) {
+    while (true) {
+      const block = await ethers.provider.getBlock(
+        await ethers.provider.getBlockNumber()
+      );
+      const employerWins =
+        (BigInt(block.hash) ^ BigInt(jobId)) % 2n === 0n;
+      if (employerWins === employerWinsDesired) break;
+      await ethers.provider.send("evm_mine", []);
+    }
   }
 
   it("pays bond to employer when moderator rules for them", async () => {
-    await raise(1, agent);
-    expect(await dispute.bonds(1)).to.equal(appealFee);
-    const before = await ethers.provider.getBalance(employer.address);
-    await dispute.connect(moderator).resolve(1, true);
-    const after = await ethers.provider.getBalance(employer.address);
+    const jobId = 1;
+    await raise(jobId);
+    await ensureOutcome(jobId, true);
+    expect(await dispute.bonds(jobId)).to.equal(appealFee);
+    const before = await token.balanceOf(employer.address);
+    await dispute.connect(owner).resolveDispute(jobId);
+    const after = await token.balanceOf(employer.address);
     expect(after - before).to.equal(appealFee);
   });
 
   it("returns bond to agent when jury rejects employer claim", async () => {
-    await raise(2, agent);
-    expect(await dispute.bonds(2)).to.equal(appealFee);
-    const before = await ethers.provider.getBalance(agent.address);
-    await dispute.connect(jury).resolve(2, false);
-    const after = await ethers.provider.getBalance(agent.address);
+    const jobId = 2;
+    await raise(jobId);
+    await ensureOutcome(jobId, false);
+    expect(await dispute.bonds(jobId)).to.equal(appealFee);
+    const before = await token.balanceOf(agent.address);
+    await dispute.connect(owner).resolveDispute(jobId);
+    const after = await token.balanceOf(agent.address);
     expect(after - before).to.equal(appealFee);
   });
 
   it("reverts when appellant has not acknowledged", async () => {
     const jobId = 3;
+    await jobRegistry.setTaxPolicyVersion(1);
     await jobRegistry.setJob(jobId, {
-      agent: agent.address,
       employer: employer.address,
+      agent: agent.address,
       reward: 0,
       stake: 0,
-      state: 0,
+      success: false,
+      status: 0,
+      uri: "",
     });
+    await token.connect(agent).approve(
+      await stakeManager.getAddress(),
+      appealFee
+    );
     await expect(
-      dispute.connect(agent).appeal(jobId, { value: appealFee })
+      dispute.connect(agent).raiseDispute(jobId, "evidence")
     ).to.be.revertedWith("acknowledge tax policy");
-  });
-
-  it("only allows owner to update registry", async () => {
-    const RegistryStub = await ethers.getContractFactory(
-      "contracts/mocks/DisputeRegistryStub.sol:DisputeRegistryStub"
-    );
-    const newReg = await RegistryStub.deploy();
-    await expect(
-      dispute.connect(owner).setJobRegistry(await newReg.getAddress())
-    )
-      .to.emit(dispute, "JobRegistryUpdated")
-      .withArgs(await newReg.getAddress());
-    await expect(
-      dispute.connect(agent).setJobRegistry(await newReg.getAddress())
-    ).to.be.revertedWithCustomError(dispute, "OwnableUnauthorizedAccount").withArgs(
-      agent.address
-    );
   });
 
   it("restricts parameter updates to the owner", async () => {
@@ -92,9 +119,6 @@ describe("DisputeModule", function () {
     await expect(dispute.connect(owner).setModerator(employer.address))
       .to.emit(dispute, "ModeratorUpdated")
       .withArgs(employer.address);
-    await expect(dispute.connect(owner).setAppealJury(agent.address))
-      .to.emit(dispute, "AppealJuryUpdated")
-      .withArgs(agent.address);
     await expect(dispute.connect(employer).setAppealFee(30n))
       .to.be.revertedWithCustomError(dispute, "OwnableUnauthorizedAccount")
       .withArgs(employer.address);


### PR DESCRIPTION
## Summary
- switch dispute tests to token-based bonds via StakeManager
- document AGIALPHA appeal fees
- point README to token-based DisputeModule

## Testing
- `npx hardhat test test/v2/DisputeModule.test.js test/v2/LifecycleDispute.integration.test.js test/v2/endToEnd.integration.test.js` *(fails: Transaction reverted without a reason string)*

------
https://chatgpt.com/codex/tasks/task_e_689bfd91c3c883339fce0dc5ab7883b3