### PR TITLE
Add tax-aware completion and finalization helpers

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -88,10 +88,12 @@ contract MockJobRegistry is IJobRegistry, IJobRegistryTax {
     function createJob(uint256, string calldata) external override returns (uint256) {return 0;}
     function applyForJob(uint256) external override {}
     function completeJob(uint256) external override {}
+    function acknowledgeAndCompleteJob(uint256) external override {}
     function dispute(uint256) external payable override {}
     function acknowledgeAndDispute(uint256, string calldata) external override {}
     function resolveDispute(uint256, bool) external override {}
     function finalize(uint256) external override {}
+    function acknowledgeAndFinalize(uint256) external override {}
     function cancelJob(uint256) external override {}
 
     function stakeManager() external view override returns (address) {

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -413,6 +413,13 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         emit JobCompleted(jobId, outcome);
     }
 
+    /// @notice Acknowledge the tax policy and complete the job in one call.
+    /// @param jobId Identifier of the job being completed
+    function acknowledgeAndCompleteJob(uint256 jobId) external {
+        _acknowledge(msg.sender);
+        completeJob(jobId);
+    }
+
     /// @notice Agent disputes a failed job outcome.
     function raiseDispute(uint256 jobId)
         public
@@ -474,7 +481,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     /// @dev The dispute module may call this without acknowledgement as it
     ///      merely relays the arbiter's ruling and holds no tax liability.
     function finalize(uint256 jobId)
-        external
+        public
         requiresTaxAcknowledgement
         nonReentrant
     {
@@ -527,6 +534,13 @@ contract JobRegistry is Ownable, ReentrancyGuard {
             }
         }
         emit JobFinalized(jobId, job.success);
+    }
+
+    /// @notice Acknowledge the tax policy and finalise the job in one call.
+    /// @param jobId Identifier of the job to finalise
+    function acknowledgeAndFinalize(uint256 jobId) external {
+        _acknowledge(msg.sender);
+        finalize(jobId);
     }
 
     /// @notice Cancel a job before completion and refund the employer.

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -112,6 +112,10 @@ interface IJobRegistry {
     /// @dev Reverts with {InvalidStatus} or {OnlyAgent} accordingly
     function completeJob(uint256 jobId) external;
 
+    /// @notice Acknowledge tax policy and complete the job in one call
+    /// @param jobId Identifier of the job being completed
+    function acknowledgeAndCompleteJob(uint256 jobId) external;
+
     /// @notice Raise a dispute for a completed job
     /// @param jobId Identifier of the disputed job
     /// @dev Reverts with {InvalidStatus} or {OnlyAgent}
@@ -132,6 +136,10 @@ interface IJobRegistry {
     /// @param jobId Identifier of the job to finalise
     /// @dev Reverts with {InvalidStatus} if job is not ready for finalisation
     function finalize(uint256 jobId) external;
+
+    /// @notice Acknowledge tax policy and finalise the job in one call
+    /// @param jobId Identifier of the job to finalise
+    function acknowledgeAndFinalize(uint256 jobId) external;
 
     /// @notice Employer cancels a job before an agent is selected
     /// @param jobId Identifier of the job to cancel


### PR DESCRIPTION
## Summary
- allow agents to acknowledge tax policy and complete jobs in a single call
- allow acknowledgment + finalization helper
- expose new helpers in interface and mocks

## Testing
- `npx hardhat compile`
- `npx hardhat test test/v2/JobRegistry.test.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c865428c8833384b1a47f24325edf