### PR TITLE
docs: clarify token units and approvals

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -137,9 +137,11 @@ contract FeePool is Ownable {
         emit FeesDistributed(accounted);
     }
 
-    /// @notice claim accumulated rewards for caller
-    /// @dev Rewards are denominated using 6 decimal units. Triggers
-    ///      `distributeFees` if there are unaccounted fees.
+    /**
+     * @notice Claim accumulated $AGIALPHA rewards for the caller.
+     * @dev Rewards use 6-decimal units. Automatically calls `distributeFees`
+     *      if there are pending fees awaiting distribution.
+     */
     function claimRewards() external {
         if (pendingFees > 0) {
             distributeFees();

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -367,6 +367,14 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         jobId = _createJob(reward, uri);
     }
 
+    /**
+     * @notice Acknowledge the tax policy and create a job in one transaction.
+     * @dev `reward` uses 6-decimal base units. Caller must `approve` the
+     *      StakeManager for `reward + fee` $AGIALPHA before calling.
+     * @param reward Job reward in $AGIALPHA with 6 decimals.
+     * @param uri Metadata URI describing the job.
+     * @return jobId Identifier of the newly created job.
+     */
     function acknowledgeAndCreateJob(uint256 reward, string calldata uri)
         external
         returns (uint256 jobId)
@@ -394,6 +402,13 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         _applyForJob(jobId);
     }
 
+    /**
+     * @notice Deposit stake and apply for a job in a single call.
+     * @dev `amount` uses 6-decimal base units. Caller must `approve` the
+     *      StakeManager to pull `amount` $AGIALPHA beforehand.
+     * @param jobId Identifier of the job to apply for.
+     * @param amount Stake amount in $AGIALPHA with 6 decimals.
+     */
     function stakeAndApply(uint256 jobId, uint256 amount) external {
         if (taxAcknowledgedVersion[msg.sender] != taxPolicyVersion) {
             _acknowledge(msg.sender);
@@ -453,9 +468,14 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         raiseDispute(jobId);
     }
 
-    /// @notice Acknowledge tax policy if needed and raise a dispute with evidence.
-    /// @param jobId Identifier of the disputed job
-    /// @param evidence Supporting evidence for the dispute
+    /**
+     * @notice Acknowledge the tax policy if needed and raise a dispute with
+     *         supporting evidence.
+     * @dev No tokens are transferred; any stake requirements elsewhere use
+     *      6-decimal $AGIALPHA units that must have been approved previously.
+     * @param jobId Identifier of the disputed job.
+     * @param evidence Supporting evidence for the dispute.
+     */
     function acknowledgeAndDispute(uint256 jobId, string calldata evidence) external {
         if (taxAcknowledgedVersion[msg.sender] != taxPolicyVersion) {
             _acknowledge(msg.sender);

--- a/contracts/v2/PlatformIncentives.sol
+++ b/contracts/v2/PlatformIncentives.sol
@@ -49,9 +49,13 @@ contract PlatformIncentives is Ownable {
         emit ModulesUpdated(address(_stakeManager), address(_platformRegistry), address(_jobRouter));
     }
 
-    /// @notice Stake tokens and activate routing for the caller.
-    /// @dev Caller must `approve` the StakeManager for `amount` tokens beforehand.
-    ///      The main deployer may pass `amount = 0` to register without incentives.
+    /**
+     * @notice Stake $AGIALPHA and activate routing for the caller.
+     * @dev `amount` uses 6-decimal base units. Caller must `approve` the
+     *      StakeManager for at least `amount` tokens beforehand. The owner may
+     *      pass `0` to register without incentives.
+     * @param amount Stake amount in $AGIALPHA with 6 decimals.
+     */
     function stakeAndActivate(uint256 amount) external {
         if (amount > 0) {
             stakeManager.depositStakeFor(
@@ -67,8 +71,13 @@ contract PlatformIncentives is Ownable {
         emit Activated(msg.sender, amount);
     }
 
-    /// @notice Acknowledge tax policy if needed, stake tokens and activate routing.
-    /// @param amount token amount with 6 decimals; caller must approve first
+    /**
+     * @notice Acknowledge the tax policy, stake $AGIALPHA, and activate routing.
+     * @dev `amount` uses 6-decimal base units. Caller must `approve` the
+     *      StakeManager before calling. Owner may pass `0` to register without
+     *      incentives.
+     * @param amount Stake amount in $AGIALPHA with 6 decimals.
+     */
     function acknowledgeStakeAndActivate(uint256 amount) external {
         address registry = stakeManager.jobRegistry();
         if (registry != address(0)) {

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -353,9 +353,13 @@ contract StakeManager is Ownable, ReentrancyGuard {
         _deposit(msg.sender, role, amount);
     }
 
-    /// @notice acknowledge the tax policy and deposit stake in one transaction
-    /// @param role participant role for the stake
-    /// @param amount token amount with 6 decimals; caller must approve first
+    /**
+     * @notice Acknowledge the tax policy and deposit $AGIALPHA stake in one call.
+     * @dev Uses 6-decimal base units (1 token = 1_000000). Caller must `approve`
+     *      this contract to transfer at least `amount` $AGIALPHA beforehand.
+     * @param role Participant role receiving credit for the stake.
+     * @param amount Stake amount in $AGIALPHA with 6 decimals.
+     */
     function acknowledgeAndDeposit(Role role, uint256 amount) external nonReentrant {
         address registry = jobRegistry;
         require(registry != address(0), "job registry");
@@ -368,10 +372,15 @@ contract StakeManager is Ownable, ReentrancyGuard {
         _deposit(msg.sender, role, amount);
     }
 
-    /// @notice acknowledge the tax policy and deposit stake on behalf of a user
-    /// @param user address receiving credit for the stake
-    /// @param role participant role for the stake
-    /// @param amount token amount with 6 decimals; user must approve first
+    /**
+     * @notice Acknowledge the tax policy and deposit $AGIALPHA stake on behalf of
+     *         a user.
+     * @dev Uses 6-decimal base units. The `user` must `approve` this contract to
+     *      transfer at least `amount` tokens beforehand.
+     * @param user Address receiving credit for the stake.
+     * @param role Participant role receiving credit for the stake.
+     * @param amount Stake amount in $AGIALPHA with 6 decimals.
+     */
     function acknowledgeAndDepositFor(
         address user,
         Role role,


### PR DESCRIPTION
## Summary
- document 6-decimal $AGIALPHA units and pre-approval requirements across job creation, staking, and claims
- expand staking helpers with clearer NatSpec notices and parameter descriptions

## Testing
- `npm run lint`
- `npm test`
- `forge test` *(fails: Wrong argument count for function call)*

------
https://chatgpt.com/codex/tasks/task_e_689cab915c4c8333baf2cc4d89a463f5