### PR TITLE
feat: configurable dispute module defaults

### DIFF
--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -60,7 +60,7 @@ contract DeployAll is Script {
 
         ReputationEngine reputation = new ReputationEngine(vm.addr(deployer));
         CertificateNFT nft = new CertificateNFT("Cert", "CERT", vm.addr(deployer));
-        DisputeModule dispute = new DisputeModule(registry);
+        DisputeModule dispute = new DisputeModule(registry, 0, 0, address(0));
 
         FeePool feePool = new FeePool(
             IERC20(address(token)),

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -52,7 +52,12 @@ async function main() {
   const Dispute = await ethers.getContractFactory(
     "contracts/v2/modules/DisputeModule.sol:DisputeModule"
   );
-  const dispute = await Dispute.deploy(await registry.getAddress());
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    0,
+    0,
+    ethers.ZeroAddress
+  );
 
   await registry.setModules(
     await validation.getAddress(),

--- a/scripts/deployAll.ts
+++ b/scripts/deployAll.ts
@@ -74,7 +74,12 @@ async function main() {
   const Dispute = await ethers.getContractFactory(
     "contracts/v2/modules/DisputeModule.sol:DisputeModule"
   );
-  const dispute = await Dispute.deploy(await registry.getAddress());
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    0,
+    0,
+    ethers.ZeroAddress
+  );
   await dispute.waitForDeployment();
 
   // FeePool receives protocol fees and streams them to staked operators.

--- a/scripts/v2/deploy.js
+++ b/scripts/v2/deploy.js
@@ -78,7 +78,10 @@ async function main() {
     "contracts/v2/modules/DisputeModule.sol:DisputeModule"
   );
   const dispute = await Dispute.deploy(
-    await registry.getAddress()
+    await registry.getAddress(),
+    0,
+    0,
+    ethers.ZeroAddress
   );
   await dispute.waitForDeployment();
 
@@ -104,7 +107,12 @@ async function main() {
   await verify(await registry.getAddress(), []);
   await verify(await validation.getAddress(), [await registry.getAddress(), await stake.getAddress()]);
   await verify(await reputation.getAddress(), []);
-  await verify(await dispute.getAddress(), [await registry.getAddress()]);
+  await verify(await dispute.getAddress(), [
+    await registry.getAddress(),
+    0,
+    0,
+    ethers.ZeroAddress,
+  ]);
   await verify(await nft.getAddress(), ["Cert", "CERT"]);
   await verify(await tax.getAddress(), ["ipfs://policy", "All taxes on participants; contract and owner exempt"]);
 }

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -117,8 +117,19 @@ async function main() {
   const Dispute = await ethers.getContractFactory(
     "contracts/v2/modules/DisputeModule.sol:DisputeModule"
   );
+  const appealFee = ethers.parseUnits(
+    typeof args.appealFee === "string" ? args.appealFee : "0",
+    6
+  );
+  const disputeWindow =
+    typeof args.disputeWindow === "string" ? Number(args.disputeWindow) : 0;
+  const moderator =
+    typeof args.moderator === "string" ? args.moderator : ethers.ZeroAddress;
   const dispute = await Dispute.deploy(
-    await registry.getAddress()
+    await registry.getAddress(),
+    appealFee,
+    disputeWindow,
+    moderator
   );
   await dispute.waitForDeployment();
 
@@ -235,7 +246,13 @@ async function main() {
   await verify(await registry.getAddress(), [owner]);
   await verify(await validation.getAddress(), [await registry.getAddress(), await stake.getAddress(), owner]);
   await verify(await reputation.getAddress(), [owner]);
-  await verify(await dispute.getAddress(), [await registry.getAddress(), owner]);
+  await verify(await dispute.getAddress(), [
+    await registry.getAddress(),
+    appealFee,
+    disputeWindow,
+    moderator,
+    owner,
+  ]);
   await verify(await nft.getAddress(), ["Cert", "CERT", owner]);
   await verify(await tax.getAddress(), [owner, "ipfs://policy", "All taxes on participants; contract and owner exempt"]);
   await verify(await feePool.getAddress(), [tokenAddress, await stake.getAddress(), 2, owner]);

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -61,7 +61,12 @@ describe("Full system integration", function () {
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress());
+    dispute = await Dispute.deploy(
+      await registry.getAddress(),
+      0,
+      0,
+      ethers.ZeroAddress
+    );
     await dispute.connect(owner).setAppealFee(appealFee);
 
     const Policy = await ethers.getContractFactory(

--- a/test/taxExempt.test.ts
+++ b/test/taxExempt.test.ts
@@ -75,7 +75,12 @@ describe("Tax exemption flags", function () {
     const DisputeModule = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"
     );
-    const disp = await DisputeModule.deploy(await registry.getAddress());
+    const disp = await DisputeModule.deploy(
+      await registry.getAddress(),
+      0,
+      0,
+      ethers.ZeroAddress
+    );
     await disp.waitForDeployment();
 
     expect(await tax.isTaxExempt()).to.equal(true);

--- a/test/v2/DisputeModuleModuleNoEther.test.js
+++ b/test/v2/DisputeModuleModuleNoEther.test.js
@@ -12,7 +12,12 @@ describe("DisputeModule module ether rejection", function () {
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress());
+    dispute = await Dispute.deploy(
+      await registry.getAddress(),
+      0,
+      0,
+      ethers.ZeroAddress
+    );
     await dispute.waitForDeployment();
   });
 

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -56,7 +56,12 @@ describe("JobRegistry integration", function () {
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress());
+    dispute = await Dispute.deploy(
+      await registry.getAddress(),
+      0,
+      0,
+      ethers.ZeroAddress
+    );
     await dispute.connect(owner).setAppealFee(appealFee);
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/ProtocolFeatures.test.js
+++ b/test/v2/ProtocolFeatures.test.js
@@ -123,7 +123,12 @@ describe("Protocol core features", function () {
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"
     );
-    const dispute = await Dispute.deploy(registry.target);
+    const dispute = await Dispute.deploy(
+      registry.target,
+      0,
+      0,
+      ethers.ZeroAddress
+    );
     await dispute.connect(owner).setAppealFee(5);
     await dispute.connect(owner).setDisputeWindow(0);
     await registry.setDisputeModule(dispute.target);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -69,7 +69,12 @@ describe("end-to-end job lifecycle", function () {
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress());
+    dispute = await Dispute.deploy(
+      await registry.getAddress(),
+      0,
+      0,
+      ethers.ZeroAddress
+    );
     await dispute.connect(owner).setAppealFee(appealFee);
 
     const FeePool = await ethers.getContractFactory(

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -70,7 +70,12 @@ describe("multi-operator job lifecycle", function () {
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"
     );
-    dispute = await Dispute.deploy(await registry.getAddress());
+    dispute = await Dispute.deploy(
+      await registry.getAddress(),
+      0,
+      0,
+      ethers.ZeroAddress
+    );
 
     const FeePoolF = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"


### PR DESCRIPTION
## Summary
- allow configuring appeal fees, dispute windows and moderators at deployment with sensible defaults
- surface constructor changes through deploy scripts and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc01836588333b5f12ab21be94b3f