### PR TITLE
Add installer ownership and automate registrar setup

### DIFF
--- a/contracts/v2/ModuleInstaller.sol
+++ b/contracts/v2/ModuleInstaller.sol
@@ -27,6 +27,7 @@ interface IOwnable {
 ///      own `transferOwnership` functions.
 contract ModuleInstaller {
     bool public initialized;
+    address public owner;
 
     /// @notice Emitted after all modules are wired together.
     event ModulesInstalled(
@@ -42,6 +43,10 @@ contract ModuleInstaller {
         address feePool,
         address taxPolicy
     );
+
+    constructor(address _owner) {
+        owner = _owner;
+    }
 
     /// @notice Connect core modules after deployment.
     /// @param jobRegistry Address of the JobRegistry contract
@@ -69,6 +74,7 @@ contract ModuleInstaller {
         ITaxPolicy taxPolicy
     ) external {
         require(!initialized, "init");
+        require(msg.sender == owner, "owner");
         initialized = true;
 
         jobRegistry.setModules(
@@ -88,6 +94,8 @@ contract ModuleInstaller {
             platformRegistry,
             jobRouter
         );
+        platformRegistry.setRegistrar(address(platformIncentives), true);
+        jobRouter.setRegistrar(address(platformIncentives), true);
 
         jobRegistry.transferOwnership(msg.sender);
         stakeManager.transferOwnership(msg.sender);

--- a/contracts/v2/interfaces/IJobRouter.sol
+++ b/contracts/v2/interfaces/IJobRouter.sol
@@ -9,4 +9,7 @@ interface IJobRouter {
 
     /// @notice Whether an operator is registered
     function registered(address operator) external view returns (bool);
+
+    /// @notice Authorize or revoke a registrar
+    function setRegistrar(address registrar, bool allowed) external;
 }

--- a/contracts/v2/interfaces/IPlatformRegistryFull.sol
+++ b/contracts/v2/interfaces/IPlatformRegistryFull.sol
@@ -8,4 +8,7 @@ import {IPlatformRegistry} from "./IPlatformRegistry.sol";
 interface IPlatformRegistryFull is IPlatformRegistry {
     /// @notice Register an operator on their behalf
     function registerFor(address operator) external;
+
+    /// @notice Authorize or revoke a registrar
+    function setRegistrar(address registrar, bool allowed) external;
 }


### PR DESCRIPTION
## Summary
- Secure ModuleInstaller with explicit owner and add registrar authorization
- Expose registrar permissions in interfaces
- Use ModuleInstaller in deployment script and remove manual registrar calls

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689cc29b677883339aa36a398bd44c86