### PR TITLE
docs: clarify ModuleInstaller ownership in Etherscan guide

### DIFF
--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -27,11 +27,18 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 9. Deploy `PlatformRegistry(stakeManager, reputationEngine, 0)`.
 10. Deploy `JobRouter(platformRegistry)`.
 11. Deploy `PlatformIncentives(stakeManager, platformRegistry, jobRouter)`.
-12. Deploy `ModuleInstaller()`.
-13. Transfer ownership of each module to the installer and call `ModuleInstaller.initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` from the deploying account. The installer wires modules, assigns the fee pool and optional tax policy, then transfers ownership back automatically. Finally authorize registrars:
+12. Deploy `ModuleInstaller(owner)` with the address that will finalize wiring.
+13. Transfer ownership of each module to the installer. From that owner address, call `ModuleInstaller.initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` **once**. Only the nominated owner may invoke `initialize`, and the installer blocks subsequent calls. The transaction wires modules, assigns the fee pool and optional tax policy, then transfers ownership back automatically. Finally authorize registrars:
     - `PlatformRegistry.setRegistrar(platformIncentives, true)`
     - `JobRouter.setRegistrar(platformIncentives, true)`
 14. Verify each contract via **Contract → Verify and Publish** on Etherscan.
+
+### Minimal ownership transfer example
+
+1. Deploy `ModuleInstaller` with your address as `owner`.
+2. On each module contract, call `transferOwnership(installer)`.
+3. From that owner address, open **ModuleInstaller → Write Contract** and execute `initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)`.
+4. After the transaction, every module reports your address as `owner` again.
 
 ### Job posting, staking, and activation via Etherscan
 


### PR DESCRIPTION
## Summary
- document owner parameter when deploying ModuleInstaller
- note single-use initialize and add minimal ownership transfer example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc9c22c208333b25b9f08041c112e