### PR TITLE
chore: default ModuleInstaller owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 
 ### Deployment Quickstart
 
-1. **Deploy modules with defaults** – Deploy `StakeManager`, `JobRegistry`, `ValidationModule`, `ReputationEngine`, `DisputeModule`, `CertificateNFT`, `FeePool`, `PlatformRegistry`, `JobRouter`, `PlatformIncentives`, then `ModuleInstaller`, supplying `0` or `address(0)` to accept defaults such as the 6‑decimal `$AGIALPHA` token and owner treasury.
+1. **Deploy modules with defaults** – Deploy `StakeManager`, `JobRegistry`, `ValidationModule`, `ReputationEngine`, `DisputeModule`, `CertificateNFT`, `FeePool`, `PlatformRegistry`, `JobRouter`, `PlatformIncentives`, then `ModuleInstaller` (deployer auto‑assigned as owner), supplying `0` or `address(0)` to accept defaults such as the 6‑decimal `$AGIALPHA` token and owner treasury.
 2. **Initialize once** – Transfer ownership of each module to the installer and call `ModuleInstaller.initialize(jobRegistry, stakeManager, validationModule, reputationEngine, disputeModule, certificateNFT, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)`. This single call wires cross‑links, assigns the fee pool and optional tax policy, and automatically registers `PlatformIncentives` with both the `PlatformRegistry` and `JobRouter`.
 3. **Token‑only disputes** – Agents approve the `StakeManager` for the `appealFee` and raise disputes with `JobRegistry.acknowledgeAndDispute(jobId, evidence)`; the bond stays entirely in tokens, never ETH.
 

--- a/contracts/v2/ModuleInstaller.sol
+++ b/contracts/v2/ModuleInstaller.sol
@@ -44,8 +44,9 @@ contract ModuleInstaller {
         address taxPolicy
     );
 
-    constructor(address _owner) {
-        owner = _owner;
+    /// @notice Sets the deployer as the temporary owner.
+    constructor() {
+        owner = msg.sender;
     }
 
     /// @notice Connect core modules after deployment.

--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -27,15 +27,15 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 9. Deploy `PlatformRegistry(stakeManager, reputationEngine, 0)`.
 10. Deploy `JobRouter(platformRegistry)`.
 11. Deploy `PlatformIncentives(stakeManager, platformRegistry, jobRouter)`.
-12. Deploy `ModuleInstaller(owner)` with the address that will finalize wiring.
-13. Transfer ownership of each module to the installer. From that owner address, call `ModuleInstaller.initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` **once**. Only the nominated owner may invoke `initialize`, and the installer blocks subsequent calls. The transaction wires modules, assigns the fee pool and optional tax policy, then transfers ownership back automatically. Finally authorize registrars:
+12. Deploy `ModuleInstaller()`; the deployer becomes the temporary owner.
+13. Transfer ownership of each module to the installer. From that owner address, call `ModuleInstaller.initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` **once**. Only the deployer may invoke `initialize`, and the installer blocks subsequent calls. The transaction wires modules, assigns the fee pool and optional tax policy, then transfers ownership back automatically. Finally authorize registrars:
     - `PlatformRegistry.setRegistrar(platformIncentives, true)`
     - `JobRouter.setRegistrar(platformIncentives, true)`
 14. Verify each contract via **Contract → Verify and Publish** on Etherscan.
 
 ### Minimal ownership transfer example
 
-1. Deploy `ModuleInstaller` with your address as `owner`.
+1. Deploy `ModuleInstaller()`; the deploying address is the owner.
 2. On each module contract, call `transferOwnership(installer)`.
 3. From that owner address, open **ModuleInstaller → Write Contract** and execute `initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)`.
 4. After the transaction, every module reports your address as `owner` again.

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -177,7 +177,7 @@ async function main() {
   const Installer = await ethers.getContractFactory(
     "contracts/v2/ModuleInstaller.sol:ModuleInstaller"
   );
-  const installer = await Installer.deploy(owner);
+  const installer = await Installer.deploy();
   await installer.waitForDeployment();
 
   await registry.transferOwnership(await installer.getAddress());


### PR DESCRIPTION
## Summary
- default ModuleInstaller owner to deployer
- document new no-arg ModuleInstaller deploy flow
- adjust deployment script for new signature

## Testing
- `npm test`
- `forge test` *(fails: Source "forge-std/Script.sol" not found: File not found. Searched the following locations: "/workspace/AGIJobsv0". Wrong argument count etc)*

------
https://chatgpt.com/codex/tasks/task_e_689ccef432788333b623848095e6448e