### PR TITLE
feat: add tax-policy aware platform registration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 | --- | --- | --- |
 | Employer | `acknowledgeAndCreateJob(reward, uri)` | Approve `StakeManager` for `reward + fee` |
 | Agent | `stakeAndApply(jobId, amount)` | Approve stake amount; combines deposit and apply |
-| Platform operator | `stakeAndActivate(amount)` | Registers in `PlatformRegistry` and `JobRouter`; owner may pass `0` |
+| Platform operator | `acknowledgeStakeAndActivate(amount)` | Registers in `PlatformRegistry` and `JobRouter`; owner may pass `0` |
+| Platform (no stake) | `acknowledgeAndRegister()` | Registers in `PlatformRegistry` without staking |
 
 See [docs/deployment-agialpha.md](docs/deployment-agialpha.md) for a narrated walkthrough and [docs/etherscan-guide.md](docs/etherscan-guide.md) for block‑explorer screenshots.
 
@@ -36,6 +37,7 @@ Helper functions expose common flows in single calls so Etherscan users do not h
 - `JobRegistry.acknowledgeAndCreateJob` posts work after acknowledging the tax policy.
 - `JobRegistry.stakeAndApply` deposits stake and applies to a job.
 - `PlatformIncentives.stakeAndActivate` (and `acknowledgeStakeAndActivate`) stakes and registers a platform for routing and fees.
+- `PlatformRegistry.acknowledgeAndRegister` lists an operator without staking.
 - `FeePool.claimRewards` auto-distributes any pending fees before paying the caller.
 - `StakeManager.acknowledgeAndDeposit` and `acknowledgeAndDepositFor` stake tokens after acknowledging the tax policy, reducing transactions for users and helpers.
 

--- a/contracts/v2/interfaces/IPlatformRegistryFull.sol
+++ b/contracts/v2/interfaces/IPlatformRegistryFull.sol
@@ -9,6 +9,12 @@ interface IPlatformRegistryFull is IPlatformRegistry {
     /// @notice Register an operator on their behalf
     function registerFor(address operator) external;
 
+    /// @notice Register caller after acknowledging the tax policy
+    function acknowledgeAndRegister() external;
+
+    /// @notice Register an operator on their behalf after acknowledgement
+    function acknowledgeAndRegisterFor(address operator) external;
+
     /// @notice Authorize or revoke a registrar
     function setRegistrar(address registrar, bool allowed) external;
 }

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -59,6 +59,21 @@ describe("PlatformRegistry", function () {
     );
   });
 
+  it("acknowledgeAndRegister registers caller", async () => {
+    await expect(registry.connect(platform).acknowledgeAndRegister())
+      .to.emit(registry, "Registered")
+      .withArgs(platform.address);
+  });
+
+  it("acknowledgeAndRegisterFor works for registrars", async () => {
+    await registry.setRegistrar(owner.address, true);
+    await expect(
+      registry.connect(owner).acknowledgeAndRegisterFor(platform.address)
+    )
+      .to.emit(registry, "Registered")
+      .withArgs(platform.address);
+  });
+
   it("registrar enforces operator stake", async () => {
     await registry.setRegistrar(owner.address, true);
     await expect(


### PR DESCRIPTION
## Summary
- add acknowledgeAndRegister helpers to PlatformRegistry for one-call registration
- expand IPlatformRegistryFull interface and tests
- document platform registration helpers in README

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689cd28d72a483339e7f387a5adc026a