### PR TITLE
feat: add agent acknowledge-and-apply helper

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -90,9 +90,11 @@ contract MockJobRegistry is IJobRegistry, IJobRegistryTax {
     }
     function setJobParameters(uint256, uint256) external override {}
     function createJob(uint256, string calldata) external override returns (uint256) {return 0;}
-    function applyForJob(uint256) external override {}
-    function completeJob(uint256) external override {}
-    function acknowledgeAndCompleteJob(uint256) external override {}
+      function applyForJob(uint256) external override {}
+      function stakeAndApply(uint256, uint256) external override {}
+      function acknowledgeAndApply(uint256) external override {}
+      function completeJob(uint256) external override {}
+      function acknowledgeAndCompleteJob(uint256) external override {}
     function dispute(uint256) external payable override {}
     function acknowledgeAndDispute(uint256, string calldata) external override {}
     function resolveDispute(uint256, bool) external override {}

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -399,6 +399,15 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     }
 
     /**
+     * @notice Acknowledge the tax policy and apply for a job.
+     * @param jobId Identifier of the job to apply for.
+     */
+    function acknowledgeAndApply(uint256 jobId) external {
+        _acknowledge(msg.sender);
+        _applyForJob(jobId);
+    }
+
+    /**
      * @notice Deposit stake and apply for a job in a single call.
      * @dev `amount` uses 6-decimal base units. Caller must `approve` the
      *      StakeManager to pull `amount` $AGIALPHA beforehand.

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -107,6 +107,15 @@ interface IJobRegistry {
     /// @dev Reverts with {InvalidStatus} if job is not open for applications
     function applyForJob(uint256 jobId) external;
 
+    /// @notice Deposit stake and apply for a job in one call
+    /// @param jobId Identifier of the job
+    /// @param amount Stake amount in $AGIALPHA with 6 decimals
+    function stakeAndApply(uint256 jobId, uint256 amount) external;
+
+    /// @notice Acknowledge the tax policy and apply for a job in one call
+    /// @param jobId Identifier of the job to apply for
+    function acknowledgeAndApply(uint256 jobId) external;
+
     /// @notice Agent completes the job and triggers validation
     /// @param jobId Identifier of the job being completed
     /// @dev Reverts with {InvalidStatus} or {OnlyAgent} accordingly


### PR DESCRIPTION
## Summary
- allow agents to acknowledge the tax policy and apply for jobs in one call when no stake is needed
- expose new helper in JobRegistry interface and test coverage
- document the new zero-stake agent flow in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cd4f5215c833393b9e4582c1a8772