### PR TITLE
feat: add platform stake-and-register helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 | Employer | `acknowledgeAndCreateJob(reward, uri)` | Approve `StakeManager` for `reward + fee` |
 | Agent | `stakeAndApply(jobId, amount)` or `acknowledgeAndApply(jobId)` | Approve stake if required; combines acknowledgement and apply |
 | Platform operator | `acknowledgeStakeAndActivate(amount)` | Registers in `PlatformRegistry` and `JobRouter`; owner may pass `0` |
+| Platform operator (registry only) | `acknowledgeStakeAndRegister(amount)` or `stakeAndRegister(amount)` | Registers in `PlatformRegistry` without JobRouter |
 | Platform (no stake) | `acknowledgeAndRegister()` | Registers in `PlatformRegistry` without staking |
 
 See [docs/deployment-agialpha.md](docs/deployment-agialpha.md) for a narrated walkthrough and [docs/etherscan-guide.md](docs/etherscan-guide.md) for block‑explorer screenshots.


### PR DESCRIPTION
## Summary
- add `stakeAndRegister` and `acknowledgeStakeAndRegister` helpers in PlatformRegistry for one-step onboarding
- document new helper in README quickstart table
- test platform staking registration flow

## Testing
- `npm test`
- `forge test` *(fails: Source "forge-std/Script.sol" not found / wrong argument count)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cdb0d34148333af81713cdb64075b