### PR TITLE
feat: default governance reward config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Other constructors now ship with sensible defaults so a deployer can leave param
 - `JobRegistry` emits `ModuleUpdated` events for any modules supplied at deployment, making on-chain verification easier.
 - `ValidationModule` defaults to 1‑day commit/reveal windows with 1–3 validators if zero values are provided.
 - Constructors emit configuration events (`TokenUpdated`, `MinStakeUpdated`, etc.) at deployment so non‑technical users can confirm settings directly on Etherscan.
+- `GovernanceReward` falls back to `$AGIALPHA`, a 1‑week epoch and 5% reward share when its constructor arguments are left blank.
 
 All v2 constructors omit the `owner` argument—the deploying address automatically becomes the owner via `Ownable(msg.sender)`.
 

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -67,17 +67,16 @@ describe("Governance reward lifecycle", function () {
     const Reward = await ethers.getContractFactory(
       "contracts/v2/GovernanceReward.sol:GovernanceReward"
     );
-      reward = await Reward.deploy(
-        await token.getAddress(),
-        await feePool.getAddress(),
-        await stakeManager.getAddress(),
-        2
-      );
+    reward = await Reward.deploy(
+      await token.getAddress(),
+      await feePool.getAddress(),
+      await stakeManager.getAddress(),
+      2,
+      1,
+      50
+    );
 
-      await feePool.connect(owner).transferOwnership(await reward.getAddress());
-
-      await reward.setEpochLength(1);
-      await reward.setRewardPct(50);
+    await feePool.connect(owner).transferOwnership(await reward.getAddress());
 
     // stake setup
     await token.mint(voter1.address, 100 * 1e6);

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -66,17 +66,16 @@ describe("GovernanceReward", function () {
     const Reward = await ethers.getContractFactory(
       "contracts/v2/GovernanceReward.sol:GovernanceReward"
     );
-      reward = await Reward.deploy(
-        await token.getAddress(),
-        await feePool.getAddress(),
-        await stakeManager.getAddress(),
-        2
-      );
+    reward = await Reward.deploy(
+      await token.getAddress(),
+      await feePool.getAddress(),
+      await stakeManager.getAddress(),
+      2,
+      1,
+      50
+    );
 
-      await feePool.connect(owner).transferOwnership(await reward.getAddress());
-
-      await reward.setEpochLength(1);
-      await reward.setRewardPct(50);
+    await feePool.connect(owner).transferOwnership(await reward.getAddress());
 
     await token.mint(voter1.address, 100 * 1e6);
     await token.mint(voter2.address, 300 * 1e6);


### PR DESCRIPTION
## Summary
- default GovernanceReward to AGIALPHA token when no token is provided
- add constructor defaults for epoch length and reward percent
- mention GovernanceReward defaults in README for easier deployment

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689cdef033448333b41cd352d4fa4812