### PR TITLE
refactor: centralize AGIALPHA token constant

### DIFF
--- a/contracts/v2/Constants.sol
+++ b/contracts/v2/Constants.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+// Shared AGI Jobs v2 constants.
+address constant AGIALPHA = 0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe;

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {AGIALPHA} from "./Constants.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 /// @title FeePool
@@ -19,8 +20,7 @@ contract FeePool is Ownable {
     uint256 public constant DEFAULT_BURN_PCT = 5;
 
     /// @notice default $AGIALPHA token used when no token is specified
-    address public constant DEFAULT_TOKEN =
-        0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe;
+    address public constant DEFAULT_TOKEN = AGIALPHA;
 
     /// @notice ERC20 token used for fees and rewards
     IERC20 public token;

--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {AGIALPHA} from "./Constants.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
@@ -17,8 +18,7 @@ contract GovernanceReward is Ownable {
     uint256 public constant ACCUMULATOR_SCALE = 1e12;
 
     /// @notice default $AGIALPHA token used when no token is specified
-    address public constant DEFAULT_TOKEN =
-        0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe;
+    address public constant DEFAULT_TOKEN = AGIALPHA;
 
     /// @notice default epoch length when constructor param is zero
     uint256 public constant DEFAULT_EPOCH_LENGTH = 1 weeks;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -5,6 +5,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {AGIALPHA} from "./Constants.sol";
 import {IJobRegistryTax} from "./interfaces/IJobRegistryTax.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
 
@@ -32,8 +33,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
     }
 
     /// @notice default $AGIALPHA token used when no token is specified
-    address public constant DEFAULT_TOKEN =
-        0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe;
+    address public constant DEFAULT_TOKEN = AGIALPHA;
 
     /// @notice default minimum stake when constructor param is zero
     uint256 public constant DEFAULT_MIN_STAKE = 1e6;

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {AGIALPHA} from "../Constants.sol";
 
 interface IRoutingModule {
     function selectOperator(bytes32 jobId) external returns (address);
@@ -30,6 +31,8 @@ contract JobEscrow is Ownable {
     }
 
     uint256 public constant TIMEOUT = 3 days;
+    /// @notice default $AGIALPHA token used when no token is specified
+    address public constant DEFAULT_TOKEN = AGIALPHA;
 
     IERC20 public token;
     IRoutingModule public routingModule;
@@ -44,9 +47,10 @@ contract JobEscrow is Ownable {
     event ResultAccepted(uint256 indexed jobId, address caller);
 
     constructor(IERC20 _token, IRoutingModule _routing) Ownable(msg.sender) {
-        token = address(_token) == address(0)
-            ? IERC20(0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe)
-            : _token;
+        token =
+            address(_token) == address(0)
+                ? IERC20(DEFAULT_TOKEN)
+                : _token;
         routingModule = _routing;
     }
 


### PR DESCRIPTION
## Summary
- add `contracts/v2/Constants.sol` exporting the `AGIALPHA` address
- use shared constant in `StakeManager`, `FeePool`, `GovernanceReward`, and `modules/JobEscrow`
- compile contracts to ensure modules reference the constant

## Testing
- `npx hardhat compile`


------
https://chatgpt.com/codex/tasks/task_e_689ceb4444cc8333a3034feb9da4fefb