### PR TITLE
Enforce 6-decimal tokens across core contracts

### DIFF
--- a/contracts/mocks/MockERC206Decimals.sol
+++ b/contracts/mocks/MockERC206Decimals.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC206Decimals is ERC20 {
+    constructor() ERC20("Mock6D", "M6D") {
+        _mint(msg.sender, 1e24);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {AGIALPHA} from "./Constants.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
@@ -171,6 +172,8 @@ contract FeePool is Ownable {
     /// @notice update ERC20 token used for payouts
     /// @param newToken fee/reward token address which must use 6 decimals
     function setToken(IERC20 newToken) external onlyOwner {
+        IERC20Metadata meta = IERC20Metadata(address(newToken));
+        require(meta.decimals() == 6, "decimals");
         token = newToken;
         emit TokenUpdated(address(newToken));
     }

--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {AGIALPHA} from "./Constants.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
@@ -101,11 +102,16 @@ contract GovernanceReward is Ownable {
     /// @param newToken ERC20 token using 6 decimals. Set to zero address to
     /// revert to DEFAULT_TOKEN.
     function setToken(IERC20 newToken) external onlyOwner {
-        token =
+        IERC20 candidate =
             address(newToken) == address(0)
                 ? IERC20(DEFAULT_TOKEN)
                 : newToken;
-        emit TokenUpdated(address(token));
+        require(
+            IERC20Metadata(address(candidate)).decimals() == 6,
+            "decimals"
+        );
+        token = candidate;
+        emit TokenUpdated(address(candidate));
     }
 
     /// @notice record voters for the current epoch and snapshot their stake

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {AGIALPHA} from "./Constants.sol";
@@ -169,6 +170,8 @@ contract StakeManager is Ownable, ReentrancyGuard {
     /// @notice update the staking/payout token
     /// @param newToken ERC20 token address using 6 decimals
     function setToken(IERC20 newToken) external onlyOwner {
+        IERC20Metadata meta = IERC20Metadata(address(newToken));
+        require(meta.decimals() == 6, "decimals");
         token = newToken;
         emit TokenUpdated(address(newToken));
     }

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {AGIALPHA} from "../Constants.sol";
@@ -55,6 +56,8 @@ contract JobEscrow is Ownable {
     }
 
     function setToken(IERC20 newToken) external onlyOwner {
+        IERC20Metadata meta = IERC20Metadata(address(newToken));
+        require(meta.decimals() == 6, "decimals");
         token = newToken;
         emit TokenUpdated(address(newToken));
     }

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -6,7 +6,7 @@ describe("FeePool", function () {
 
   beforeEach(async () => {
     [owner, user1, user2, employer, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
+    const Token = await ethers.getContractFactory("MockERC206Decimals");
     token = await Token.deploy();
     token2 = await Token.deploy();
 
@@ -77,6 +77,14 @@ describe("FeePool", function () {
     await token.connect(user2).approve(await stakeManager.getAddress(), 1000);
     await stakeManager.connect(user1).depositStake(2, 100);
     await stakeManager.connect(user2).depositStake(2, 300);
+  });
+
+  it("requires 6-decimal tokens", async () => {
+    const Bad = await ethers.getContractFactory("MockERC20");
+    const bad = await Bad.deploy();
+    await expect(
+      feePool.connect(owner).setToken(await bad.getAddress())
+    ).to.be.revertedWith("decimals");
   });
 
   it("distributes rewards proportionally", async () => {

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -89,6 +89,22 @@ describe("GovernanceReward", function () {
     await token.mint(await feePool.getAddress(), 100 * 1e6);
   });
 
+  it("enforces 6-decimal tokens", async () => {
+    const Bad = await ethers.getContractFactory("MockERC20");
+    const bad = await Bad.deploy();
+    await expect(
+      reward.connect(owner).setToken(await bad.getAddress())
+    ).to.be.revertedWith("decimals");
+
+    const Good = await ethers.getContractFactory("MockERC206Decimals");
+    const good = await Good.deploy();
+    await expect(
+      reward.connect(owner).setToken(await good.getAddress())
+    )
+      .to.emit(reward, "TokenUpdated")
+      .withArgs(await good.getAddress());
+  });
+
   it("rewards voters proportional to staked balance", async () => {
     await reward.recordVoters([voter1.address, voter2.address]);
 

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -24,6 +24,22 @@ describe("JobEscrow", function () {
     escrow = await Escrow.deploy(await token.getAddress(), await routing.getAddress());
   });
 
+  it("enforces 6-decimal tokens", async () => {
+    const Bad = await ethers.getContractFactory("MockERC20");
+    const bad = await Bad.deploy();
+    await expect(
+      escrow.connect(owner).setToken(await bad.getAddress())
+    ).to.be.revertedWith("decimals");
+
+    const Good = await ethers.getContractFactory("MockERC206Decimals");
+    const good = await Good.deploy();
+    await expect(
+      escrow.connect(owner).setToken(await good.getAddress())
+    )
+      .to.emit(escrow, "TokenUpdated")
+      .withArgs(await good.getAddress());
+  });
+
   it("runs normal job flow", async () => {
     const reward = 1000;
     await token.connect(employer).approve(await escrow.getAddress(), reward);

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -88,7 +88,7 @@ describe("StakeManager extras", function () {
 
   it("emits event and accepts new token after token swap", async () => {
     await setupRegistryAck(user);
-    const Token = await ethers.getContractFactory("MockERC20");
+    const Token = await ethers.getContractFactory("MockERC206Decimals");
     const token2 = await Token.deploy();
     await token2.mint(user.address, 200);
     await expect(


### PR DESCRIPTION
## Summary
- ensure StakeManager, FeePool, GovernanceReward, and JobEscrow accept only 6-decimal ERC20 tokens
- add mock 6-decimal token and comprehensive tests for token validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d05000c548333bbea634126f0eb94