### PR TITLE
Add acknowledge-and-cancel helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 | Participant | One-call helper | Notes |
 | --- | --- | --- |
 | Employer | `acknowledgeAndCreateJob(reward, uri)` | Approve `StakeManager` for `reward + fee` |
+| Employer (cancel) | `acknowledgeAndCancel(jobId)` | Cancels a job after acknowledging the tax policy |
 | Agent | `stakeAndApply(jobId, amount)` or `acknowledgeAndApply(jobId)` | Approve stake if required; combines acknowledgement and apply |
 | Platform operator | `acknowledgeStakeAndActivate(amount)` | Registers in `PlatformRegistry` and `JobRouter`; owner may pass `0` |
 | Platform (no stake) | `acknowledgeAndRegister()` | Registers in `PlatformRegistry` without staking |
@@ -36,6 +37,7 @@ All v2 constructors omit the `owner` argument—the deploying address automatica
 Helper functions expose common flows in single calls so Etherscan users do not have to chain multiple transactions:
 
 - `JobRegistry.acknowledgeAndCreateJob` posts work after acknowledging the tax policy.
+- `JobRegistry.acknowledgeAndCancel` cancels a job after acknowledging the tax policy.
 - `JobRegistry.stakeAndApply` deposits stake and applies to a job.
 - `JobRegistry.acknowledgeAndApply` acknowledges the tax policy and applies when no stake is needed.
 - `PlatformIncentives.stakeAndActivate` (and `acknowledgeStakeAndActivate`) stakes and registers a platform for routing and fees.

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -555,9 +555,16 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         finalize(jobId);
     }
 
+    /// @notice Acknowledge the tax policy and cancel a job in one call.
+    /// @param jobId Identifier of the job to cancel
+    function acknowledgeAndCancel(uint256 jobId) external {
+        _acknowledge(msg.sender);
+        cancelJob(jobId);
+    }
+
     /// @notice Cancel a job before completion and refund the employer.
     function cancelJob(uint256 jobId)
-        external
+        public
         requiresTaxAcknowledgement
     {
         Job storage job = jobs[jobId];


### PR DESCRIPTION
## Summary
- add `acknowledgeAndCancel` helper that acknowledges tax policy then cancels a job
- document helper in README deployment table and helper list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d09dd20d48333842e7357f335ce01