### PR TITLE
feat: add v2 deployer

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {
+    JobRegistry,
+    IReputationEngine as JIReputationEngine,
+    IDisputeModule as JIDisputeModule,
+    ICertificateNFT as JICertificateNFT
+} from "./JobRegistry.sol";
+import {StakeManager} from "./StakeManager.sol";
+import {ValidationModule} from "./ValidationModule.sol";
+import {ReputationEngine} from "./ReputationEngine.sol";
+import {DisputeModule} from "./modules/DisputeModule.sol";
+import {CertificateNFT} from "./CertificateNFT.sol";
+import {PlatformRegistry, IReputationEngine as PRReputationEngine} from "./PlatformRegistry.sol";
+import {JobRouter} from "./modules/JobRouter.sol";
+import {PlatformIncentives} from "./PlatformIncentives.sol";
+import {FeePool} from "./FeePool.sol";
+import {TaxPolicy} from "./TaxPolicy.sol";
+import {IPlatformRegistryFull} from "./interfaces/IPlatformRegistryFull.sol";
+import {IPlatformRegistry} from "./interfaces/IPlatformRegistry.sol";
+import {IJobRouter} from "./interfaces/IJobRouter.sol";
+import {IFeePool} from "./interfaces/IFeePool.sol";
+import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
+import {IStakeManager} from "./interfaces/IStakeManager.sol";
+import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IValidationModule} from "./interfaces/IValidationModule.sol";
+import {IReputationEngine as IRInterface} from "./interfaces/IReputationEngine.sol";
+
+/// @title Deployer
+/// @notice One shot helper that deploys and wires the core module set.
+/// @dev Each module is deployed with default parameters (zero values) and
+///      ownership is transferred to the caller once wiring is complete.
+contract Deployer {
+    bool public deployed;
+
+    /// @notice Deploy and wire all modules.
+    /// @param withTaxPolicy Whether to deploy the optional TaxPolicy module.
+    /// @return stakeManager Address of the StakeManager
+    /// @return jobRegistry Address of the JobRegistry
+    /// @return validationModule Address of the ValidationModule
+    /// @return reputationEngine Address of the ReputationEngine
+    /// @return disputeModule Address of the DisputeModule
+    /// @return certificateNFT Address of the CertificateNFT
+    /// @return platformRegistry Address of the PlatformRegistry
+    /// @return jobRouter Address of the JobRouter
+    /// @return platformIncentives Address of the PlatformIncentives helper
+    /// @return feePool Address of the FeePool
+    /// @return taxPolicy Address of the TaxPolicy (zero if not deployed)
+    function deploy(bool withTaxPolicy)
+        external
+        returns (
+            address stakeManager,
+            address jobRegistry,
+            address validationModule,
+            address reputationEngine,
+            address disputeModule,
+            address certificateNFT,
+            address platformRegistry,
+            address jobRouter,
+            address platformIncentives,
+            address feePool,
+            address taxPolicy
+        )
+    {
+        require(!deployed, "deployed");
+        deployed = true;
+        address owner = msg.sender;
+
+        StakeManager stake = new StakeManager(
+            IERC20(address(0)),
+            0,
+            0,
+            0,
+            owner,
+            address(0),
+            address(0)
+        );
+
+        JobRegistry registry = new JobRegistry(
+            IValidationModule(address(0)),
+            IStakeManager(address(0)),
+            JIReputationEngine(address(0)),
+            JIDisputeModule(address(0)),
+            JICertificateNFT(address(0)),
+            IFeePool(address(0)),
+            ITaxPolicy(address(0)),
+            0,
+            0
+        );
+
+        ValidationModule validation = new ValidationModule(
+            IJobRegistry(address(registry)),
+            IStakeManager(address(stake)),
+            0,
+            0,
+            0,
+            0,
+            new address[](0)
+        );
+
+        ReputationEngine reputation = new ReputationEngine();
+
+        DisputeModule dispute = new DisputeModule(
+            IJobRegistry(address(registry)),
+            0,
+            0,
+            owner
+        );
+
+        CertificateNFT certificate = new CertificateNFT("Cert", "CERT");
+        certificate.setJobRegistry(address(registry));
+
+        FeePool pool = new FeePool(
+            IERC20(address(0)),
+            IStakeManager(address(stake)),
+            IStakeManager.Role.Platform,
+            0,
+            owner
+        );
+
+        IRInterface repInterface = IRInterface(address(reputation));
+        PlatformRegistry pRegistry = new PlatformRegistry(
+            IStakeManager(address(stake)),
+            PRReputationEngine(address(reputation)),
+            0
+        );
+
+        JobRouter router = new JobRouter(IPlatformRegistry(address(pRegistry)));
+
+        PlatformIncentives incentives = new PlatformIncentives(
+            IStakeManager(address(stake)),
+            IPlatformRegistryFull(address(pRegistry)),
+            IJobRouter(address(router))
+        );
+
+        TaxPolicy policy;
+        if (withTaxPolicy) {
+            policy = new TaxPolicy(
+                "ipfs://policy",
+                "All taxes on participants; contract and owner exempt"
+            );
+        }
+
+        // Wire modules
+        registry.setModules(
+            validation,
+            IStakeManager(address(stake)),
+            JIReputationEngine(address(reputation)),
+            JIDisputeModule(address(dispute)),
+            JICertificateNFT(address(certificate))
+        );
+        registry.setFeePool(IFeePool(address(pool)));
+        if (address(policy) != address(0)) {
+            registry.setTaxPolicy(ITaxPolicy(address(policy)));
+        }
+
+        validation.setReputationEngine(repInterface);
+        stake.setModules(address(registry), address(dispute));
+        incentives.setModules(
+            IStakeManager(address(stake)),
+            IPlatformRegistryFull(address(pRegistry)),
+            IJobRouter(address(router))
+        );
+        pRegistry.setRegistrar(address(incentives), true);
+        router.setRegistrar(address(incentives), true);
+        reputation.setCaller(address(registry), true);
+        reputation.setCaller(address(validation), true);
+
+        // Transfer ownership
+        registry.transferOwnership(owner);
+        stake.transferOwnership(owner);
+        validation.transferOwnership(owner);
+        reputation.transferOwnership(owner);
+        dispute.transferOwnership(owner);
+        certificate.transferOwnership(owner);
+        pRegistry.transferOwnership(owner);
+        router.transferOwnership(owner);
+        incentives.transferOwnership(owner);
+        pool.transferOwnership(owner);
+        if (address(policy) != address(0)) {
+            policy.transferOwnership(owner);
+        }
+
+        return (
+            address(stake),
+            address(registry),
+            address(validation),
+            address(reputation),
+            address(dispute),
+            address(certificate),
+            address(pRegistry),
+            address(router),
+            address(incentives),
+            address(pool),
+            address(policy)
+        );
+    }
+}

--- a/test/v2/Deployer.test.js
+++ b/test/v2/Deployer.test.js
@@ -1,0 +1,127 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Deployer", function () {
+  it("deploys and wires modules, transferring ownership", async function () {
+    const [owner] = await ethers.getSigners();
+    const Deployer = await ethers.getContractFactory(
+      "contracts/v2/Deployer.sol:Deployer"
+    );
+    const deployer = await Deployer.deploy();
+
+    const addresses = await deployer.deploy.staticCall(true);
+    await deployer.deploy(true);
+
+    const [
+      stake,
+      registry,
+      validation,
+      reputation,
+      dispute,
+      certificate,
+      platformRegistry,
+      router,
+      incentives,
+      feePool,
+      taxPolicy,
+    ] = addresses;
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const ValidationModule = await ethers.getContractFactory(
+      "contracts/v2/ValidationModule.sol:ValidationModule"
+    );
+    const ReputationEngine = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    const DisputeModule = await ethers.getContractFactory(
+      "contracts/v2/modules/DisputeModule.sol:DisputeModule"
+    );
+    const CertificateNFT = await ethers.getContractFactory(
+      "contracts/v2/CertificateNFT.sol:CertificateNFT"
+    );
+    const PlatformRegistry = await ethers.getContractFactory(
+      "contracts/v2/PlatformRegistry.sol:PlatformRegistry"
+    );
+    const JobRouter = await ethers.getContractFactory(
+      "contracts/v2/modules/JobRouter.sol:JobRouter"
+    );
+    const PlatformIncentives = await ethers.getContractFactory(
+      "contracts/v2/PlatformIncentives.sol:PlatformIncentives"
+    );
+    const FeePool = await ethers.getContractFactory(
+      "contracts/v2/FeePool.sol:FeePool"
+    );
+    const TaxPolicy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+
+    const stakeC = StakeManager.attach(stake);
+    const registryC = JobRegistry.attach(registry);
+    const validationC = ValidationModule.attach(validation);
+    const reputationC = ReputationEngine.attach(reputation);
+    const disputeC = DisputeModule.attach(dispute);
+    const certificateC = CertificateNFT.attach(certificate);
+    const platformRegistryC = PlatformRegistry.attach(platformRegistry);
+    const routerC = JobRouter.attach(router);
+    const incentivesC = PlatformIncentives.attach(incentives);
+    const feePoolC = FeePool.attach(feePool);
+    const taxPolicyC = TaxPolicy.attach(taxPolicy);
+
+    // ownership
+    expect(await stakeC.owner()).to.equal(owner.address);
+    expect(await registryC.owner()).to.equal(owner.address);
+    expect(await validationC.owner()).to.equal(owner.address);
+    expect(await reputationC.owner()).to.equal(owner.address);
+    expect(await disputeC.owner()).to.equal(owner.address);
+    expect(await certificateC.owner()).to.equal(owner.address);
+    expect(await platformRegistryC.owner()).to.equal(owner.address);
+    expect(await routerC.owner()).to.equal(owner.address);
+    expect(await incentivesC.owner()).to.equal(owner.address);
+    expect(await feePoolC.owner()).to.equal(owner.address);
+    expect(await taxPolicyC.owner()).to.equal(owner.address);
+
+    // wiring
+    expect(await stakeC.jobRegistry()).to.equal(registry);
+    expect(await stakeC.disputeModule()).to.equal(dispute);
+    expect(await registryC.stakeManager()).to.equal(stake);
+    expect(await registryC.validationModule()).to.equal(validation);
+    expect(await registryC.reputationEngine()).to.equal(reputation);
+    expect(await registryC.disputeModule()).to.equal(dispute);
+    expect(await registryC.certificateNFT()).to.equal(certificate);
+    expect(await registryC.feePool()).to.equal(feePool);
+    expect(await registryC.taxPolicy()).to.equal(taxPolicy);
+    expect(await validationC.jobRegistry()).to.equal(registry);
+    expect(await validationC.stakeManager()).to.equal(stake);
+    expect(await validationC.reputationEngine()).to.equal(reputation);
+    expect(await reputationC.callers(registry)).to.equal(true);
+    expect(await reputationC.callers(validation)).to.equal(true);
+    expect(await certificateC.jobRegistry()).to.equal(registry);
+    expect(await incentivesC.stakeManager()).to.equal(stake);
+    expect(await incentivesC.platformRegistry()).to.equal(platformRegistry);
+    expect(await incentivesC.jobRouter()).to.equal(router);
+    expect(await platformRegistryC.registrars(incentives)).to.equal(true);
+    expect(await routerC.registrars(incentives)).to.equal(true);
+  });
+
+  it("can skip tax policy", async function () {
+    const Deployer = await ethers.getContractFactory(
+      "contracts/v2/Deployer.sol:Deployer"
+    );
+    const deployer = await Deployer.deploy();
+    const addresses = await deployer.deploy.staticCall(false);
+    await deployer.deploy(false);
+    const [, registry,,,,,,,,, taxPolicy] = addresses;
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const registryC = JobRegistry.attach(addresses[1]);
+    expect(taxPolicy).to.equal(ethers.ZeroAddress);
+    expect(await registryC.taxPolicy()).to.equal(ethers.ZeroAddress);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Deployer contract to spin up and wire core v2 modules with optional tax policy
- cover deployment wiring and ownership transfers in tests

## Testing
- `npx hardhat test test/v2/Deployer.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689d158f4ba88333b220eb5021dfad23