### PR TITLE
Set DiscoveryModule default min stake and optional dependencies

### DIFF
--- a/contracts/v2/modules/DiscoveryModule.sol
+++ b/contracts/v2/modules/DiscoveryModule.sol
@@ -11,6 +11,8 @@ contract DiscoveryModule is Ownable {
     IStakeManager public stakeManager;
     IReputationEngine public reputationEngine;
 
+    uint256 public constant DEFAULT_MIN_STAKE = 1e6;
+
     uint256 public minStake;
 
     address[] public platforms;
@@ -24,10 +26,19 @@ contract DiscoveryModule is Ownable {
 
     constructor(
         IStakeManager _stakeManager,
-        IReputationEngine _reputationEngine
+        IReputationEngine _reputationEngine,
+        uint256 _minStake
     ) Ownable(msg.sender) {
         stakeManager = _stakeManager;
+        if (address(_stakeManager) != address(0)) {
+            emit StakeManagerUpdated(address(_stakeManager));
+        }
         reputationEngine = _reputationEngine;
+        if (address(_reputationEngine) != address(0)) {
+            emit ReputationEngineUpdated(address(_reputationEngine));
+        }
+        minStake = _minStake == 0 ? DEFAULT_MIN_STAKE : _minStake;
+        emit MinStakeUpdated(minStake);
     }
 
     /// @notice Register a platform if it meets the minimum stake requirement

--- a/test/v2/DiscoveryModule.test.js
+++ b/test/v2/DiscoveryModule.test.js
@@ -21,7 +21,8 @@ describe("DiscoveryModule", function () {
     );
     discovery = await Discovery.deploy(
       await stakeManager.getAddress(),
-      await engine.getAddress()
+      await engine.getAddress(),
+      0
     );
     await discovery.connect(owner).setMinStake(0);
   });


### PR DESCRIPTION
## Summary
- add DEFAULT_MIN_STAKE constant
- allow zero addresses for StakeManager and ReputationEngine in constructor
- set minStake with default and emit MinStakeUpdated

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d22fa05c083338b10b81da74d289f