### PR TITLE
Refactor deployer API to split TaxPolicy deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [docs/deployment-agialpha.md](docs/deployment-agialpha.md) for a narrated wa
 
 ### Etherscan Quick Deploy
 
-1. **Call `Deployer.deploy`** – On Etherscan, open the verified `Deployer` contract and execute `deploy()` to launch all modules with `$AGIALPHA` defaults.
+1. **Call `Deployer.deploy`** – On Etherscan, open the verified `Deployer` contract and execute `deploy()` to launch all modules with `$AGIALPHA` defaults. For setups that omit the `TaxPolicy` module, call `deployWithoutTaxPolicy()` instead.
 2. **Check token decimals** – In the token or `StakeManager` **Read Contract** tab call `decimals()`; it must return `6` before sending amounts.
 3. **Practice with helpers** – Post a small job and then reclaim funds via `JobRegistry.acknowledgeAndCancel(jobId)` to confirm flows and acknowledgements.
 4. **Owner-only tuning** – Configuration setters such as `setToken`, `setFeePct`, and `setBurnPct` remain `onlyOwner` and can be adjusted later through explorer "Write" tabs.

--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -35,8 +35,21 @@ import {IReputationEngine as IRInterface} from "./interfaces/IReputationEngine.s
 contract Deployer {
     bool public deployed;
 
-    /// @notice Deploy and wire all modules.
-    /// @param withTaxPolicy Whether to deploy the optional TaxPolicy module.
+    event Deployed(
+        address stakeManager,
+        address jobRegistry,
+        address validationModule,
+        address reputationEngine,
+        address disputeModule,
+        address certificateNFT,
+        address platformRegistry,
+        address jobRouter,
+        address platformIncentives,
+        address feePool,
+        address taxPolicy
+    );
+
+    /// @notice Deploy and wire all modules including TaxPolicy.
     /// @return stakeManager Address of the StakeManager
     /// @return jobRegistry Address of the JobRegistry
     /// @return validationModule Address of the ValidationModule
@@ -47,9 +60,59 @@ contract Deployer {
     /// @return jobRouter Address of the JobRouter
     /// @return platformIncentives Address of the PlatformIncentives helper
     /// @return feePool Address of the FeePool
-    /// @return taxPolicy Address of the TaxPolicy (zero if not deployed)
-    function deploy(bool withTaxPolicy)
+    /// @return taxPolicy Address of the TaxPolicy
+    function deploy()
         external
+        returns (
+            address stakeManager,
+            address jobRegistry,
+            address validationModule,
+            address reputationEngine,
+            address disputeModule,
+            address certificateNFT,
+            address platformRegistry,
+            address jobRouter,
+            address platformIncentives,
+            address feePool,
+            address taxPolicy
+        )
+    {
+        return _deploy(true);
+    }
+
+    /// @notice Deploy and wire all modules without the TaxPolicy.
+    /// @return stakeManager Address of the StakeManager
+    /// @return jobRegistry Address of the JobRegistry
+    /// @return validationModule Address of the ValidationModule
+    /// @return reputationEngine Address of the ReputationEngine
+    /// @return disputeModule Address of the DisputeModule
+    /// @return certificateNFT Address of the CertificateNFT
+    /// @return platformRegistry Address of the PlatformRegistry
+    /// @return jobRouter Address of the JobRouter
+    /// @return platformIncentives Address of the PlatformIncentives helper
+    /// @return feePool Address of the FeePool
+    /// @return taxPolicy Address of the TaxPolicy (always zero)
+    function deployWithoutTaxPolicy()
+        external
+        returns (
+            address stakeManager,
+            address jobRegistry,
+            address validationModule,
+            address reputationEngine,
+            address disputeModule,
+            address certificateNFT,
+            address platformRegistry,
+            address jobRouter,
+            address platformIncentives,
+            address feePool,
+            address taxPolicy
+        )
+    {
+        return _deploy(false);
+    }
+
+    function _deploy(bool withTaxPolicy)
+        internal
         returns (
             address stakeManager,
             address jobRegistry,
@@ -182,6 +245,20 @@ contract Deployer {
         if (address(policy) != address(0)) {
             policy.transferOwnership(owner);
         }
+
+        emit Deployed(
+            address(stake),
+            address(registry),
+            address(validation),
+            address(reputation),
+            address(dispute),
+            address(certificate),
+            address(pRegistry),
+            address(router),
+            address(incentives),
+            address(pool),
+            address(policy)
+        );
 
         return (
             address(stake),

--- a/test/v2/Deployer.test.js
+++ b/test/v2/Deployer.test.js
@@ -9,8 +9,10 @@ describe("Deployer", function () {
     );
     const deployer = await Deployer.deploy();
 
-    const addresses = await deployer.deploy.staticCall(true);
-    await deployer.deploy(true);
+    const addresses = await deployer.deploy.staticCall();
+    await expect(deployer.deploy())
+      .to.emit(deployer, "Deployed")
+      .withArgs(...addresses);
 
     const [
       stake,
@@ -113,13 +115,15 @@ describe("Deployer", function () {
       "contracts/v2/Deployer.sol:Deployer"
     );
     const deployer = await Deployer.deploy();
-    const addresses = await deployer.deploy.staticCall(false);
-    await deployer.deploy(false);
+    const addresses = await deployer.deployWithoutTaxPolicy.staticCall();
+    await expect(deployer.deployWithoutTaxPolicy())
+      .to.emit(deployer, "Deployed")
+      .withArgs(...addresses);
     const [, registry,,,,,,,,, taxPolicy] = addresses;
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
-    const registryC = JobRegistry.attach(addresses[1]);
+    const registryC = JobRegistry.attach(registry);
     expect(taxPolicy).to.equal(ethers.ZeroAddress);
     expect(await registryC.taxPolicy()).to.equal(ethers.ZeroAddress);
   });


### PR DESCRIPTION
## Summary
- add `deploy` and `deployWithoutTaxPolicy` entrypoints with new `Deployed` event
- update README and tests for the new deployer functions

## Testing
- `npm test`
- `npm run lint` *(fails: 3 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_689d24ffc23c8333991f54961bb82305