### PR TITLE
docs: clarify helper token requirements

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -399,7 +399,10 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Acknowledge the tax policy and apply for a job.
+     * @notice Acknowledge the current tax policy and apply for a job.
+     * @dev No tokens are transferred. Job reward and stake amounts elsewhere
+     *      use 6-decimal $AGIALPHA units. Any stake deposits require prior
+     *      `approve` calls on the $AGIALPHA token via the `StakeManager`.
      * @param jobId Identifier of the job to apply for.
      */
     function acknowledgeAndApply(uint256 jobId) external {
@@ -408,9 +411,12 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Deposit stake and apply for a job in a single call.
+     * @notice Deposit stake, implicitly acknowledge the tax policy if needed,
+     *         and apply for a job in a single call.
      * @dev `amount` uses 6-decimal base units. Caller must `approve` the
-     *      StakeManager to pull `amount` $AGIALPHA beforehand.
+     *      `StakeManager` to pull `amount` $AGIALPHA beforehand. If the caller
+     *      has not yet acknowledged the tax policy, this helper will do so
+     *      automatically on their behalf.
      * @param jobId Identifier of the job to apply for.
      * @param amount Stake amount in $AGIALPHA with 6 decimals.
      */

--- a/contracts/v2/PlatformIncentives.sol
+++ b/contracts/v2/PlatformIncentives.sol
@@ -52,8 +52,10 @@ contract PlatformIncentives is Ownable {
     /**
      * @notice Stake $AGIALPHA and activate routing for the caller.
      * @dev `amount` uses 6-decimal base units. Caller must `approve` the
-     *      StakeManager for at least `amount` tokens beforehand. The owner may
-     *      pass `0` to register without incentives.
+     *      `StakeManager` for at least `amount` tokens beforehand. This helper
+     *      does **not** acknowledge the tax policy; use
+     *      `acknowledgeStakeAndActivate` if acknowledgement is required. The
+     *      owner may pass `0` to register without incentives.
      * @param amount Stake amount in $AGIALPHA with 6 decimals.
      */
     function stakeAndActivate(uint256 amount) external {
@@ -74,8 +76,9 @@ contract PlatformIncentives is Ownable {
     /**
      * @notice Acknowledge the tax policy, stake $AGIALPHA, and activate routing.
      * @dev `amount` uses 6-decimal base units. Caller must `approve` the
-     *      StakeManager before calling. Owner may pass `0` to register without
-     *      incentives.
+     *      `StakeManager` before calling. Owner may pass `0` to register without
+     *      incentives. Calling this helper implicitly accepts the current tax
+     *      policy via the linked JobRegistry.
      * @param amount Stake amount in $AGIALPHA with 6 decimals.
      */
     function acknowledgeStakeAndActivate(uint256 amount) external {

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -88,7 +88,14 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
         emit Deregistered(msg.sender);
     }
 
-    /// @notice Register caller after acknowledging the tax policy if needed.
+    /**
+     * @notice Register the caller after acknowledging the tax policy when
+     *         necessary.
+     * @dev Assumes the caller has already staked the required $AGIALPHA via the
+     *      `StakeManager`, which uses 6-decimal base units and requires prior
+     *      token `approve` calls. Invoking this helper implicitly accepts the
+     *      current tax policy if it has not been acknowledged yet.
+     */
     function acknowledgeAndRegister() external nonReentrant {
         address registry = stakeManager.jobRegistry();
         if (registry != address(0)) {
@@ -108,7 +115,15 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
         _register(operator);
     }
 
-    /// @notice Register an operator after acknowledgement on their behalf.
+    /**
+     * @notice Register an operator after acknowledging the tax policy on their
+     *         behalf.
+     * @dev The operator must already have the minimum stake recorded in
+     *      6-decimal $AGIALPHA units within the `StakeManager`, requiring a
+     *      prior token `approve`. Calling this helper implicitly acknowledges
+     *      the tax policy for the operator if needed.
+     * @param operator Address to be registered.
+     */
     function acknowledgeAndRegisterFor(address operator) external nonReentrant {
         if (msg.sender != operator) {
             require(registrars[msg.sender], "registrar");

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -360,6 +360,8 @@ contract StakeManager is Ownable, ReentrancyGuard {
      * @notice Acknowledge the tax policy and deposit $AGIALPHA stake in one call.
      * @dev Uses 6-decimal base units (1 token = 1_000000). Caller must `approve`
      *      this contract to transfer at least `amount` $AGIALPHA beforehand.
+     *      Invoking this helper implicitly accepts the current tax policy via the
+     *      associated `JobRegistry`.
      * @param role Participant role receiving credit for the stake.
      * @param amount Stake amount in $AGIALPHA with 6 decimals.
      */
@@ -379,7 +381,8 @@ contract StakeManager is Ownable, ReentrancyGuard {
      * @notice Acknowledge the tax policy and deposit $AGIALPHA stake on behalf of
      *         a user.
      * @dev Uses 6-decimal base units. The `user` must `approve` this contract to
-     *      transfer at least `amount` tokens beforehand.
+     *      transfer at least `amount` tokens beforehand. Calling this helper
+     *      implicitly acknowledges the current tax policy for the `user`.
      * @param user Address receiving credit for the stake.
      * @param role Participant role receiving credit for the stake.
      * @param amount Stake amount in $AGIALPHA with 6 decimals.


### PR DESCRIPTION
## Summary
- document that helper flows use 6‑decimals and require prior AGIALPHA approval
- note when helpers implicitly acknowledge the tax policy

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d279b6d048333bea7113b650bb76b