### PR TITLE
docs: clarify AGIALPHA deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [docs/deployment-agialpha.md](docs/deployment-agialpha.md) for a narrated wa
 
 `$AGIALPHA` (6 decimals) is the default payment token for all modules. The owner can swap it later via `StakeManager.setToken`.
 
-1. **Deploy with defaults** – Deploy the verified `Deployer` contract and call `deploy()`; the `TaxPolicy` module is wired in automatically.
+1. **Deploy with defaults** – On Etherscan, deploy the verified `Deployer` contract and call `deploy()` from its **Write Contract** tab. The single transaction emits a `Deployed` event listing every module address and sets the caller as owner, wiring `TaxPolicy` automatically.
 2. **Verify token decimals** – In the token or `StakeManager` **Read Contract** tab call `decimals()` and ensure it returns `6` before sending amounts.
 3. **Use helper flows** – Post jobs, stake, and register in single calls through `JobRegistry.acknowledgeAndCreateJob`, `JobRegistry.stakeAndApply`, and `PlatformIncentives.stakeAndActivate`.
 4. **Retune as owner** – `onlyOwner` setters like `setToken`, `setFeePct`, and `setBurnPct` can adjust tokens, fees, and other parameters after deployment.

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -141,7 +141,8 @@ contract FeePool is Ownable {
     /**
      * @notice Claim accumulated $AGIALPHA rewards for the caller.
      * @dev Rewards use 6-decimal units. Automatically calls `distributeFees`
-     *      if there are pending fees awaiting distribution.
+     *      if there are pending fees awaiting distribution, letting non‑technical
+     *      stakers claim in a single Etherscan transaction.
      */
     function claimRewards() external {
         if (pendingFees > 0) {


### PR DESCRIPTION
## Summary
- document one-click Deployer flow and $AGIALPHA usage in README
- clarify `claimRewards` Etherscan workflow for non‑technical stakers

## Testing
- `npm test`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_689d2be764b883338edd781511f1b2b6