### PR TITLE
feat: allow modules to acknowledge tax policy for users

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -219,6 +219,10 @@ contract Deployer {
             registry.setTaxPolicy(ITaxPolicy(address(policy)));
         }
 
+        registry.setAcknowledger(address(stake), true);
+        registry.setAcknowledger(address(pRegistry), true);
+        registry.setAcknowledger(address(incentives), true);
+
         validation.setReputationEngine(repInterface);
         stake.setModules(address(registry), address(dispute));
         incentives.setModules(

--- a/contracts/v2/ModuleInstaller.sol
+++ b/contracts/v2/ModuleInstaller.sol
@@ -89,6 +89,9 @@ contract ModuleInstaller {
         if (address(taxPolicy) != address(0)) {
             jobRegistry.setTaxPolicy(taxPolicy);
         }
+        jobRegistry.setAcknowledger(address(stakeManager), true);
+        jobRegistry.setAcknowledger(address(platformRegistry), true);
+        jobRegistry.setAcknowledger(address(platformIncentives), true);
         stakeManager.setModules(address(jobRegistry), address(disputeModule));
         platformIncentives.setModules(
             IStakeManager(address(stakeManager)),

--- a/contracts/v2/PlatformIncentives.sol
+++ b/contracts/v2/PlatformIncentives.sol
@@ -5,11 +5,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 import {IPlatformRegistryFull} from "./interfaces/IPlatformRegistryFull.sol";
 import {IJobRouter} from "./interfaces/IJobRouter.sol";
-import {IJobRegistryTax} from "./interfaces/IJobRegistryTax.sol";
-
-interface IJobRegistryAck {
-    function acknowledgeTaxPolicy() external returns (string memory);
-}
+import {IJobRegistryAck} from "./interfaces/IJobRegistryAck.sol";
 
 /// @title PlatformIncentives
 /// @notice Helper that stakes $AGIALPHA for platform operators and registers them
@@ -84,10 +80,7 @@ contract PlatformIncentives is Ownable {
     function acknowledgeStakeAndActivate(uint256 amount) external {
         address registry = stakeManager.jobRegistry();
         if (registry != address(0)) {
-            IJobRegistryTax reg = IJobRegistryTax(registry);
-            if (reg.taxAcknowledgedVersion(msg.sender) != reg.taxPolicyVersion()) {
-                IJobRegistryAck(registry).acknowledgeTaxPolicy();
-            }
+            IJobRegistryAck(registry).acknowledgeFor(msg.sender);
         }
 
         if (amount > 0) {

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -4,11 +4,7 @@ pragma solidity ^0.8.25;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
-import {IJobRegistryTax} from "./interfaces/IJobRegistryTax.sol";
-
-interface IJobRegistryAck {
-    function acknowledgeTaxPolicy() external returns (string memory);
-}
+import {IJobRegistryAck} from "./interfaces/IJobRegistryAck.sol";
 
 interface IReputationEngine {
     function reputation(address user) external view returns (uint256);
@@ -99,10 +95,7 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
     function acknowledgeAndRegister() external nonReentrant {
         address registry = stakeManager.jobRegistry();
         if (registry != address(0)) {
-            IJobRegistryTax reg = IJobRegistryTax(registry);
-            if (reg.taxAcknowledgedVersion(msg.sender) != reg.taxPolicyVersion()) {
-                IJobRegistryAck(registry).acknowledgeTaxPolicy();
-            }
+            IJobRegistryAck(registry).acknowledgeFor(msg.sender);
         }
         _register(msg.sender);
     }
@@ -130,10 +123,7 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
         }
         address registry = stakeManager.jobRegistry();
         if (registry != address(0)) {
-            IJobRegistryTax reg = IJobRegistryTax(registry);
-            if (reg.taxAcknowledgedVersion(operator) != reg.taxPolicyVersion()) {
-                IJobRegistryAck(registry).acknowledgeTaxPolicy();
-            }
+            IJobRegistryAck(registry).acknowledgeFor(operator);
         }
         _register(operator);
     }

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -9,10 +9,7 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 import {AGIALPHA} from "./Constants.sol";
 import {IJobRegistryTax} from "./interfaces/IJobRegistryTax.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
-
-interface IJobRegistryAck {
-    function acknowledgeTaxPolicy() external returns (string memory);
-}
+import {IJobRegistryAck} from "./interfaces/IJobRegistryAck.sol";
 
 /// @title StakeManager
 /// @notice Handles staking balances, job escrows and slashing logic.
@@ -367,11 +364,8 @@ contract StakeManager is Ownable, ReentrancyGuard {
      */
     function acknowledgeAndDeposit(Role role, uint256 amount) external nonReentrant {
         address registry = jobRegistry;
-        require(registry != address(0), "job registry");
-        IJobRegistryTax reg = IJobRegistryTax(registry);
-        if (reg.taxAcknowledgedVersion(msg.sender) != reg.taxPolicyVersion()) {
-            IJobRegistryAck(registry).acknowledgeTaxPolicy();
-        }
+        require(registry != address(0), "registry");
+        IJobRegistryAck(registry).acknowledgeFor(msg.sender);
         require(role <= Role.Platform, "role");
         require(amount > 0, "amount");
         _deposit(msg.sender, role, amount);
@@ -394,11 +388,8 @@ contract StakeManager is Ownable, ReentrancyGuard {
     ) external nonReentrant {
         require(user != address(0), "user");
         address registry = jobRegistry;
-        require(registry != address(0), "job registry");
-        IJobRegistryTax reg = IJobRegistryTax(registry);
-        if (reg.taxAcknowledgedVersion(user) != reg.taxPolicyVersion()) {
-            IJobRegistryAck(registry).acknowledgeTaxPolicy();
-        }
+        require(registry != address(0), "registry");
+        IJobRegistryAck(registry).acknowledgeFor(user);
         require(role <= Role.Platform, "role");
         require(amount > 0, "amount");
         _deposit(user, role, amount);

--- a/contracts/v2/interfaces/IJobRegistryAck.sol
+++ b/contracts/v2/interfaces/IJobRegistryAck.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IJobRegistryAck {
+    function acknowledgeTaxPolicy() external returns (string memory);
+    function acknowledgeFor(address user) external returns (string memory);
+}
+

--- a/test/v2/PlatformIncentivesAck.test.js
+++ b/test/v2/PlatformIncentivesAck.test.js
@@ -1,0 +1,97 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("PlatformIncentives acknowledge", function () {
+  it("acknowledgeStakeAndActivate records acknowledgement", async () => {
+    const [owner, operator, treasury] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory(
+      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    const token = await Token.deploy();
+
+    const Stake = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    const stakeManager = await Stake.deploy(
+      await token.getAddress(),
+      0,
+      100,
+      0,
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
+    );
+    await stakeManager.connect(owner).setMinStake(0);
+
+    const Rep = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    const reputation = await Rep.deploy();
+    await reputation.setStakeManager(await stakeManager.getAddress());
+
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/PlatformRegistry.sol:PlatformRegistry"
+    );
+    const platformRegistry = await Registry.deploy(
+      await stakeManager.getAddress(),
+      await reputation.getAddress(),
+      0
+    );
+
+    const Router = await ethers.getContractFactory(
+      "contracts/v2/modules/JobRouter.sol:JobRouter"
+    );
+    const jobRouter = await Router.deploy(await platformRegistry.getAddress());
+
+    const Incentives = await ethers.getContractFactory(
+      "contracts/v2/PlatformIncentives.sol:PlatformIncentives"
+    );
+    const incentives = await Incentives.deploy(
+      await stakeManager.getAddress(),
+      await platformRegistry.getAddress(),
+      await jobRouter.getAddress()
+    );
+    await platformRegistry.setRegistrar(await incentives.getAddress(), true);
+    await jobRouter.setRegistrar(await incentives.getAddress(), true);
+
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const jobRegistry = await JobRegistry.deploy(
+      ethers.ZeroAddress,
+      await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0
+    );
+    const TaxPolicy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
+    await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await jobRegistry
+      .connect(owner)
+      .setAcknowledger(await incentives.getAddress(), true);
+    await stakeManager
+      .connect(owner)
+      .setJobRegistry(await jobRegistry.getAddress());
+
+    const STAKE = 1e6;
+    await token.mint(operator.address, STAKE);
+    await token
+      .connect(operator)
+      .approve(await stakeManager.getAddress(), STAKE);
+
+    await incentives.connect(operator).acknowledgeStakeAndActivate(STAKE);
+    const version = await jobRegistry.taxPolicyVersion();
+    expect(await jobRegistry.taxAcknowledgedVersion(operator.address)).to.equal(
+      version
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add acknowledger role and helpers in JobRegistry
- ensure StakeManager, PlatformRegistry and PlatformIncentives acknowledge for users
- wire acknowledger roles in Deployer and ModuleInstaller and add tests

## Testing
- `npm test test/v2/StakeManager.test.js test/v2/PlatformRegistry.test.js test/v2/PlatformIncentivesAck.test.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d33ce57748333b8d4e1466b5c926c