### PR TITLE
Remove owner parameter from StakingRouter constructor

### DIFF
--- a/contracts/StakingRouter.sol
+++ b/contracts/StakingRouter.sol
@@ -26,8 +26,8 @@ contract StakingRouter is Ownable {
     event UnstakeInitiated(address indexed operator, uint256 amount, uint256 availableAt);
     event Withdrawal(address indexed operator, uint256 amount);
 
-    constructor(IERC20 _token, OperatorRegistry _registry, uint256 _cooldown, address owner)
-        Ownable(owner)
+    constructor(IERC20 _token, OperatorRegistry _registry, uint256 _cooldown)
+        Ownable(msg.sender)
     {
         token = _token;
         registry = _registry;

--- a/test/StakingRouter.test.js
+++ b/test/StakingRouter.test.js
@@ -19,7 +19,7 @@ describe("StakingRouter", function () {
     await registry.waitForDeployment();
 
     const Router = await ethers.getContractFactory("StakingRouter");
-    router = await Router.deploy(token.target, registry.target, cooldown, owner.address);
+    router = await Router.deploy(token.target, registry.target, cooldown);
     await router.waitForDeployment();
     await registry.setStakingRouter(router.target);
 

--- a/test/v2/ProtocolFeatures.test.js
+++ b/test/v2/ProtocolFeatures.test.js
@@ -59,8 +59,7 @@ describe("Protocol core features", function () {
     const router = await Router.deploy(
       token.target,
       registry.target,
-      0,
-      owner.address
+      0
     );
     await registry.setStakingRouter(router.target);
     await token.transfer(operator1.address, ethers.parseUnits("100", 6));


### PR DESCRIPTION
## Summary
- remove owner argument from StakingRouter constructor
- update tests for new deployment signature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d5cdd14a0833399cb6476fd3903f7