### PR TITLE
Refactor stake withdrawal and add tax-aware helper

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -23,6 +23,7 @@ contract MockStakeManager is IStakeManager {
     function depositStake(Role, uint256) external override {}
     function acknowledgeAndDeposit(Role, uint256) external override {}
     function depositStakeFor(address, Role, uint256) external override {}
+    function acknowledgeAndWithdraw(Role, uint256) external override {}
     function withdrawStake(Role, uint256) external override {}
     function lockJobFunds(bytes32, address, uint256) external override {}
     function releaseJobFunds(bytes32, address, uint256) external override {}

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -42,6 +42,9 @@ interface IStakeManager {
     /// @notice withdraw available stake for a specific role
     function withdrawStake(Role role, uint256 amount) external;
 
+    /// @notice acknowledge the tax policy and withdraw stake in one call
+    function acknowledgeAndWithdraw(Role role, uint256 amount) external;
+
     /// @notice lock job funds from an employer
     function lockJobFunds(bytes32 jobId, address from, uint256 amount) external;
 

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -31,7 +31,9 @@ contract MockStakeManager is IStakeManager {
     }
 
     function depositStake(Role, uint256) external override {}
+    function acknowledgeAndDeposit(Role, uint256) external override {}
     function depositStakeFor(address, Role, uint256) external override {}
+    function acknowledgeAndWithdraw(Role, uint256) external override {}
     function withdrawStake(Role, uint256) external override {}
     function lockJobFunds(bytes32, address, uint256) external override {}
     function releaseJobFunds(bytes32, address, uint256) external override {}

--- a/test/v2/Integration.t.sol
+++ b/test/v2/Integration.t.sol
@@ -63,7 +63,9 @@ contract MockStakeManager is IStakeManager {
         stakes[user][role] = amount;
     }
     function depositStake(Role, uint256) external override {}
+    function acknowledgeAndDeposit(Role, uint256) external override {}
     function depositStakeFor(address, Role, uint256) external override {}
+    function acknowledgeAndWithdraw(Role, uint256) external override {}
     function withdrawStake(Role, uint256) external override {}
     function lockJobFunds(bytes32, address, uint256) external override {}
     function releaseJobFunds(bytes32, address, uint256) external override {}


### PR DESCRIPTION
## Summary
- factor out stake withdrawal logic into `_withdraw`
- add tax-aware `acknowledgeAndWithdraw` helper and update interface
- cover tax acknowledgement withdrawal in tests

## Testing
- `npm test test/v2/StakeManager.test.js`
- `npm test test/v2/StakeManagerExtras.test.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d628135348333b9236cb88a04e313