### PR TITLE
refactor dispute fee locking to revert on failure

### DIFF
--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -110,12 +110,10 @@ contract DisputeModule is Ownable {
 
         // Lock the dispute fee in the StakeManager if configured.
         if (appealFee > 0) {
-            try
-                IStakeManager(jobRegistry.stakeManager()).lockDisputeFee(
-                    claimant,
-                    appealFee
-                )
-            {} catch {}
+            IStakeManager(jobRegistry.stakeManager()).lockDisputeFee(
+                claimant,
+                appealFee
+            );
         }
 
         disputes[jobId] = Dispute({


### PR DESCRIPTION
## Summary
- refactor DisputeModule to lock appeal fees without try-catch

## Testing
- `npx hardhat test test/v2/ProtocolFeatures.test.js`
- `npx hardhat test test/v2/endToEnd.integration.test.js`
- `forge test --match-test Dispute` *(fails: Source "forge-std/Script.sol" not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc7c5a6c483338e9694252dc31989