### PR TITLE
Rename FeePool.transferReward to ownerWithdraw

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -56,7 +56,7 @@ contract FeePool is Ownable {
     event RewardRoleUpdated(IStakeManager.Role role);
     event BurnPctUpdated(uint256 pct);
     event TreasuryUpdated(address indexed treasury);
-    event RewardTransferred(address indexed to, uint256 amount);
+    event OwnerWithdrawal(address indexed to, uint256 amount);
 
     /// @notice Deploys the FeePool.
     /// @param _token ERC20 token used for fees and rewards. Defaults to
@@ -161,13 +161,13 @@ contract FeePool is Ownable {
         emit RewardsClaimed(msg.sender, owed);
     }
 
-    /// @notice transfer tokens to an external reward contract
+    /// @notice owner-only emergency escape hatch to withdraw tokens
     /// @dev Amount uses 6 decimal units.
     /// @param to recipient address
     /// @param amount token amount with 6 decimals
-    function transferReward(address to, uint256 amount) external onlyOwner {
+    function ownerWithdraw(address to, uint256 amount) external onlyOwner {
         token.safeTransfer(to, amount);
-        emit RewardTransferred(to, amount);
+        emit OwnerWithdrawal(to, amount);
     }
 
     /// @notice update ERC20 token used for payouts

--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -137,7 +137,7 @@ contract GovernanceReward is Ownable {
         require(total > 0, "no voters");
         uint256 poolBal = token.balanceOf(address(feePool));
         uint256 rewardAmount = (poolBal * rewardPct) / 100;
-        feePool.transferReward(address(this), rewardAmount);
+        feePool.ownerWithdraw(address(this), rewardAmount);
         rewardPerStake[epoch] = (rewardAmount * ACCUMULATOR_SCALE) / total;
         emit EpochFinalized(epoch, rewardAmount);
         currentEpoch = epoch + 1;

--- a/contracts/v2/interfaces/IFeePool.sol
+++ b/contracts/v2/interfaces/IFeePool.sol
@@ -16,9 +16,9 @@ interface IFeePool {
     /// @dev Rewards use 6 decimal units.
     function claimRewards() external;
 
-    /// @notice transfer tokens from the pool to a recipient
+    /// @notice owner-only emergency withdrawal of tokens from the pool
     /// @dev Amount uses 6 decimal units.
     /// @param to address receiving the tokens
     /// @param amount token amount with 6 decimals
-    function transferReward(address to, uint256 amount) external;
+    function ownerWithdraw(address to, uint256 amount) external;
 }


### PR DESCRIPTION
## Summary
- rename FeePool's `transferReward` to `ownerWithdraw`
- emit `OwnerWithdrawal` event
- update interface and GovernanceReward usage

## Testing
- `npm test`
- `npm run lint`
- `forge test` *(fails: Source "forge-std/Script.sol" not found & other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_689dde0e7dd48333be3e523d8d0e24b2