### PR TITLE
feat: configurable economics via deployer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,16 @@ See [docs/deployment-agialpha.md](docs/deployment-agialpha.md) for a narrated wa
 
 ### Beginner Deployment via Etherscan
 
-Before interacting, verify the [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) token (**decimals = 6**) and each module address emitted by `Deployer.deploy()` (see [docs/etherscan-guide.md](docs/etherscan-guide.md) for screenshots). A single call to `deploy()` on the verified **Deployer** contract wires defaults and sets the caller as owner.
+Before interacting, verify the [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) token (**decimals = 6**) and each module address emitted by `Deployer.deploy()` (see [docs/etherscan-guide.md](docs/etherscan-guide.md) for screenshots). A single call to `deploy(econ)` on the verified **Deployer** contract wires modules, sets the caller as owner, and optionally customises economics:
+
+- `feePct` – protocol fee percentage for `JobRegistry` (default `5`)
+- `burnPct` – portion of each fee burned by `FeePool` (default `5`)
+- `employerSlashPct`/`treasurySlashPct` – slashed stake split (defaults `0/100`)
+- `commitWindow`/`revealWindow` – validator timing windows in seconds (defaults `1 day` each)
+- `minStake` – global minimum stake in `StakeManager` (default `1_000_000`, i.e. 1 token)
+- `jobStake` – minimum agent stake per job in `JobRegistry` (default `0`)
+
+Supplying `0` for any field keeps the module’s baked‑in default.
 
 Use role‑specific helpers from the **Write** tabs to minimise transactions:
 

--- a/test/v2/Deployer.test.js
+++ b/test/v2/Deployer.test.js
@@ -9,8 +9,19 @@ describe("Deployer", function () {
     );
     const deployer = await Deployer.deploy();
 
-    const addresses = await deployer.deploy.staticCall();
-    await expect(deployer.deploy())
+    const econ = {
+      feePct: 0,
+      burnPct: 0,
+      employerSlashPct: 0,
+      treasurySlashPct: 0,
+      commitWindow: 0,
+      revealWindow: 0,
+      minStake: 0,
+      jobStake: 0,
+    };
+
+    const addresses = await deployer.deploy.staticCall(econ);
+    await expect(deployer.deploy(econ))
       .to.emit(deployer, "Deployed")
       .withArgs(...addresses);
 
@@ -115,8 +126,18 @@ describe("Deployer", function () {
       "contracts/v2/Deployer.sol:Deployer"
     );
     const deployer = await Deployer.deploy();
-    const addresses = await deployer.deployWithoutTaxPolicy.staticCall();
-    await expect(deployer.deployWithoutTaxPolicy())
+    const econ = {
+      feePct: 0,
+      burnPct: 0,
+      employerSlashPct: 0,
+      treasurySlashPct: 0,
+      commitWindow: 0,
+      revealWindow: 0,
+      minStake: 0,
+      jobStake: 0,
+    };
+    const addresses = await deployer.deployWithoutTaxPolicy.staticCall(econ);
+    await expect(deployer.deployWithoutTaxPolicy(econ))
       .to.emit(deployer, "Deployed")
       .withArgs(...addresses);
     const [, registry,,,,,,,,, taxPolicy] = addresses;


### PR DESCRIPTION
## Summary
- allow specifying fee %, burn %, slashing splits, validator windows and stake limits via new EconParams struct on Deployer
- pass provided economics to module constructors with sensible defaults when set to zero
- document deployment economics in README and adjust tests for new parameters

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689de5aa5be08333ab323b5150e280d7