### PR TITLE
feat: add platform stake-and-register helpers

### DIFF
--- a/contracts/v2/interfaces/IPlatformRegistryFull.sol
+++ b/contracts/v2/interfaces/IPlatformRegistryFull.sol
@@ -12,8 +12,14 @@ interface IPlatformRegistryFull is IPlatformRegistry {
     /// @notice Register caller after acknowledging the tax policy
     function acknowledgeAndRegister() external;
 
+    /// @notice Deposit stake and register caller in one call
+    function stakeAndRegister(uint256 amount) external;
+
     /// @notice Register an operator on their behalf after acknowledgement
     function acknowledgeAndRegisterFor(address operator) external;
+
+    /// @notice Acknowledge the tax policy, stake and register caller
+    function acknowledgeStakeAndRegister(uint256 amount) external;
 
     /// @notice Authorize or revoke a registrar
     function setRegistrar(address registrar, bool allowed) external;

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -26,7 +26,7 @@ Deploy each contract **in the order listed below** from the **Write Contract** t
 8. `FeePool(token, stakeManager, role, burnPct, treasury)` – use `address(0)` for `token` to fall back to $AGIALPHA; `burnPct` defaults to `0`.
 9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – `minStake` may be `0`.
 10. `JobRouter(platformRegistry)` – stake‑weighted job routing.
-11. `PlatformIncentives(stakeManager, platformRegistry, jobRouter)` – helper that lets operators stake and register in one call.
+11. `PlatformIncentives(stakeManager, platformRegistry, jobRouter)` – helper that lets operators stake and register with routing in one call. For simple flows without `JobRouter`, call `PlatformRegistry.stakeAndRegister(amount)` or `acknowledgeStakeAndRegister(amount)` directly.
 12. `ModuleInstaller()` – temporary helper for wiring modules.
 
 After each deployment, copy the address for later wiring.
@@ -49,13 +49,15 @@ Owners can retune parameters any time: `StakeManager.setToken`, `setMinStake`, `
 | --- | --- | --- |
 | Employer | `JobRegistry.acknowledgeAndCreateJob(reward, uri)` | Accept tax policy and post a job |
 | Agent | `JobRegistry.stakeAndApply(jobId, amount)` | Deposit stake and apply in one call |
-| Platform operator | `PlatformIncentives.stakeAndActivate(amount)` | Stake and register for routing and rewards |
+| Platform operator (no routing) | `PlatformRegistry.stakeAndRegister(amount)` or `acknowledgeStakeAndRegister(amount)` | Stake and register without routing |
+| Platform operator (with routing) | `PlatformIncentives.stakeAndActivate(amount)` | Stake and register for routing and rewards |
 
 ## 5. Stake and register a platform
 
 1. In `$AGIALPHA`, approve the `StakeManager` for the desired amount (`1 token = 1_000000`, `0.1 token = 100000`).
-2. Call `PlatformIncentives.stakeAndActivate(amount)` from the operator's address. The helper stakes tokens, registers the platform in `PlatformRegistry`, and enrolls it with `JobRouter` for routing priority.
-3. The owner may register with `amount = 0` to appear in registries without fee or routing boosts.
+2. Call `PlatformIncentives.stakeAndActivate(amount)` from the operator's address to register and enable routing. The helper stakes tokens, registers the platform in `PlatformRegistry`, and enrolls it with `JobRouter` for routing priority.
+3. If routing is unnecessary, call `PlatformRegistry.stakeAndRegister(amount)` or `acknowledgeStakeAndRegister(amount)` instead.
+4. The owner may register with `amount = 0` to appear in registries without fee or routing boosts.
 
 ## 6. Claim fees and rewards
 

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -18,14 +18,14 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 - **PlatformRegistry** – lists operators and computes a routing score derived from stake and reputation. The owner can blacklist addresses or replace the reputation engine.
 - **JobRouter** – selects an operator for new jobs using `PlatformRegistry` scores. Deterministic randomness mixes caller‑supplied seeds with blockhashes; no external oracle is required.
 - **FeePool** – receives fees from `StakeManager` and distributes them to staked operators in proportion to their stake. The owner can adjust burn percentage, treasury, reward role or token without redeploying.
-- **PlatformIncentives** – helper that stakes `$AGIALPHA` on behalf of an operator and registers them with both `PlatformRegistry` and `JobRouter`. The owner (main deployer) may register with `amount = 0` to remain tax neutral and earn no routing or fee share.
+- **PlatformIncentives** – helper that stakes `$AGIALPHA` on behalf of an operator and registers them with both `PlatformRegistry` and `JobRouter`. The owner (main deployer) may register with `amount = 0` to remain tax neutral and earn no routing or fee share. When routing or fee sharing isn't required, operators can instead call `PlatformRegistry.stakeAndRegister` or `acknowledgeStakeAndRegister` directly.
 
 Every contract rejects direct ETH and exposes `isTaxExempt()` so neither the contracts nor the owner ever hold taxable revenue. Participants interact only through token transfers.
 
 ## Incentive Flow
 
 1. **Stake** – operators lock `$AGIALPHA` in `StakeManager` under role `2`.
-2. **Register** – `PlatformIncentives.stakeAndActivate` registers the operator in `PlatformRegistry` and `JobRouter`.
+2. **Register** – `PlatformIncentives.stakeAndActivate` registers the operator in `PlatformRegistry` and `JobRouter`. When only registry membership is needed, `PlatformRegistry.stakeAndRegister` or `acknowledgeStakeAndRegister` handle staking and registration without touching `JobRouter`.
 3. **Routing** – `JobRouter` forwards jobs using scores from `PlatformRegistry`, giving higher probability to addresses with greater stake or reputation.
 4. **Revenue Sharing** – job fees are sent to `StakeManager`, forwarded to `FeePool`, and distributed to operators according to `stake / totalStake` when `distributeFees()` is called.
 5. **Withdraw** – operators call `FeePool.claimRewards()` to receive their share in `$AGIALPHA`.

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -65,6 +65,18 @@ describe("PlatformRegistry", function () {
       .withArgs(platform.address);
   });
 
+  it("stakeAndRegister stakes and registers caller", async () => {
+    await stakeManager.connect(platform).withdrawStake(2, STAKE);
+    await token
+      .connect(platform)
+      .approve(await stakeManager.getAddress(), STAKE);
+    await expect(registry.connect(platform).stakeAndRegister(STAKE))
+      .to.emit(registry, "Activated")
+      .withArgs(platform.address, STAKE);
+    expect(await registry.registered(platform.address)).to.equal(true);
+    expect(await stakeManager.stakeOf(platform.address, 2)).to.equal(STAKE);
+  });
+
   it("acknowledgeAndRegisterFor works for registrars", async () => {
     await registry.setRegistrar(owner.address, true);
     await expect(
@@ -72,6 +84,47 @@ describe("PlatformRegistry", function () {
     )
       .to.emit(registry, "Registered")
       .withArgs(platform.address);
+  });
+
+  it("acknowledgeStakeAndRegister stakes, acknowledges, and registers", async () => {
+    await stakeManager.connect(platform).withdrawStake(2, STAKE);
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const jobRegistry = await JobRegistry.deploy(
+      ethers.ZeroAddress,
+      await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0
+    );
+    const TaxPolicy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
+    await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await jobRegistry
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
+    await stakeManager
+      .connect(platform)
+      .setJobRegistry(await jobRegistry.getAddress());
+    await token
+      .connect(platform)
+      .approve(await stakeManager.getAddress(), STAKE);
+    await expect(
+      registry.connect(platform).acknowledgeStakeAndRegister(STAKE)
+    )
+      .to.emit(registry, "Activated")
+      .withArgs(platform.address, STAKE);
+    const version = await jobRegistry.taxPolicyVersion();
+    expect(await jobRegistry.taxAcknowledgedVersion(platform.address)).to.equal(
+      version
+    );
   });
 
   it("acknowledgeAndRegister records acknowledgement", async () => {


### PR DESCRIPTION
## Summary
- add `stakeAndRegister` and `acknowledgeStakeAndRegister` helpers to PlatformRegistry
- emit `Activated` event for combined staking/registration
- document when PlatformRegistry's built-in helpers can replace PlatformIncentives

## Testing
- `npm test`
- `npm run lint`
- `forge test` *(fails: Source "forge-std/Script.sol" not found / Wrong argument count)*

------
https://chatgpt.com/codex/tasks/task_e_689df28572ac83339a20119eeabe768c