### PR TITLE
feat: add acknowledgeAndWithdrawFor

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -457,6 +457,27 @@ contract StakeManager is Ownable, ReentrancyGuard {
         _withdraw(msg.sender, role, amount);
     }
 
+    /**
+     * @notice Acknowledge the tax policy and withdraw $AGIALPHA stake on behalf of a user.
+     * @dev Uses 6-decimal base units. Caller must be authorized and the `user` must
+     *      have previously staked tokens. Invoking this helper acknowledges the
+     *      current tax policy for the `user` via the associated `JobRegistry`.
+     * @param user Address whose stake is being withdrawn.
+     * @param role Participant role of the stake being withdrawn.
+     * @param amount Withdraw amount in $AGIALPHA with 6 decimals.
+     */
+    function acknowledgeAndWithdrawFor(
+        address user,
+        Role role,
+        uint256 amount
+    ) external onlyOwner nonReentrant {
+        require(user != address(0), "user");
+        address registry = jobRegistry;
+        require(registry != address(0), "registry");
+        IJobRegistryAck(registry).acknowledgeFor(user);
+        _withdraw(user, role, amount);
+    }
+
     // ---------------------------------------------------------------
     // job escrow logic
     // ---------------------------------------------------------------

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -876,5 +876,59 @@ describe("StakeManager", function () {
       version
     );
   });
+
+  it("acknowledgeAndWithdrawFor requires authorization and re-acknowledges", async () => {
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const jobRegistry = await JobRegistry.deploy(
+      ethers.ZeroAddress,
+      await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0
+    );
+    const TaxPolicy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    const policy1 = await TaxPolicy.deploy("ipfs://policy1", "ack");
+    await jobRegistry.connect(owner).setTaxPolicy(await policy1.getAddress());
+    await jobRegistry
+      .connect(owner)
+      .setAcknowledger(await stakeManager.getAddress(), true);
+    await stakeManager
+      .connect(owner)
+      .setJobRegistry(await jobRegistry.getAddress());
+
+    await token.connect(user).approve(await stakeManager.getAddress(), 100);
+    await stakeManager.connect(user).acknowledgeAndDeposit(0, 100);
+
+    const policy2 = await TaxPolicy.deploy("ipfs://policy2", "ack");
+    await jobRegistry.connect(owner).setTaxPolicy(await policy2.getAddress());
+
+    await expect(
+      stakeManager
+        .connect(user)
+        .acknowledgeAndWithdrawFor(user.address, 0, 50)
+    )
+      .to.be.revertedWithCustomError(
+        stakeManager,
+        "OwnableUnauthorizedAccount"
+      )
+      .withArgs(user.address);
+
+    await stakeManager
+      .connect(owner)
+      .acknowledgeAndWithdrawFor(user.address, 0, 50);
+    const version = await jobRegistry.taxPolicyVersion();
+    expect(await stakeManager.stakes(user.address, 0)).to.equal(50n);
+    expect(await jobRegistry.taxAcknowledgedVersion(user.address)).to.equal(
+      version
+    );
+  });
 });
 


### PR DESCRIPTION
## Summary
- allow owner to acknowledge tax policy and withdraw stake for a user
- test acknowledgeAndWithdrawFor authorization and tax acknowledgement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df864d8708333810043bcd91de5ae