### PR TITLE
Use Ownable in ModuleInstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 ### Deployment Quickstart
 
 1. **Deploy modules with defaults** – Deploy `StakeManager`, `JobRegistry`, `ValidationModule`, `ReputationEngine`, `DisputeModule`, `CertificateNFT`, `FeePool`, `PlatformRegistry`, `JobRouter`, `PlatformIncentives`, then `ModuleInstaller` (deployer auto‑assigned as owner), supplying `0` or `address(0)` to accept defaults such as the 6‑decimal `$AGIALPHA` token and owner treasury.
-2. **Initialize once** – Transfer ownership of each module to the installer and call `ModuleInstaller.initialize(jobRegistry, stakeManager, validationModule, reputationEngine, disputeModule, certificateNFT, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)`. This single call wires cross‑links, assigns the fee pool and optional tax policy, and automatically registers `PlatformIncentives` with both the `PlatformRegistry` and `JobRouter`.
+2. **Initialize once** – Transfer ownership of each module to the installer and call `ModuleInstaller.initialize(jobRegistry, stakeManager, validationModule, reputationEngine, disputeModule, certificateNFT, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` from the installer's owner account. This `onlyOwner` call wires cross‑links, assigns the fee pool and optional tax policy, and automatically registers `PlatformIncentives` with both the `PlatformRegistry` and `JobRouter`.
 3. **Token‑only disputes** – Agents approve the `StakeManager` for the `appealFee` and raise disputes with `JobRegistry.acknowledgeAndDispute(jobId, evidence)`; the bond stays entirely in tokens, never ETH.
 
 | Participant | One-call helper | Notes |
@@ -268,7 +268,7 @@ The modular v2 suite is deployed module by module and then wired together on‑c
 11. `TaxPolicy` (optional)
 12. `ModuleInstaller`
 
-Transfer ownership of each module to the installer and call `ModuleInstaller.initialize(jobRegistry, stakeManager, validationModule, reputationEngine, disputeModule, certificateNFT, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` once to wire cross‑links, set the protocol fee pool and optional tax policy, and automatically return ownership. Every parameter remains owner‑configurable post‑deployment via module `onlyOwner` setters.
+Transfer ownership of each module to the installer and call `ModuleInstaller.initialize(jobRegistry, stakeManager, validationModule, reputationEngine, disputeModule, certificateNFT, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` once from the installer's owner. This `onlyOwner` call wires cross‑links, sets the protocol fee pool and optional tax policy, and automatically returns ownership. Every parameter remains owner‑configurable post‑deployment via module `onlyOwner` setters.
 
 Authorize a helper such as `PlatformIncentives` with `PlatformRegistry.setRegistrar` and `JobRouter.setRegistrar` so operators can opt in using one transaction. Dispute appeals require approving the `StakeManager` for the `appealFee` in $AGIALPHA and calling `JobRegistry.raiseDispute(jobId, evidence)`; no ETH is ever sent, the bond stays entirely in `$AGIALPHA`.
 

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -27,19 +27,19 @@ Deploy each contract **in the order listed below** from the **Write Contract** t
 9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – `minStake` may be `0`.
 10. `JobRouter(platformRegistry)` – stake‑weighted job routing.
 11. `PlatformIncentives(stakeManager, platformRegistry, jobRouter)` – helper that lets operators stake and register with routing in one call. For simple flows without `JobRouter`, call `PlatformRegistry.stakeAndRegister(amount)` or `acknowledgeStakeAndRegister(amount)` directly.
-12. `ModuleInstaller()` – temporary helper for wiring modules.
+12. `ModuleInstaller()` – temporary `Ownable` helper for wiring modules.
 
 After each deployment, copy the address for later wiring.
 
 ## 3. Wire the modules
 
-Transfer ownership of each module to the `ModuleInstaller` and, from the deploying account, call:
+Transfer ownership of each module to the `ModuleInstaller` and, from the owner's account, call:
 
 ```
 ModuleInstaller.initialize(jobRegistry, stakeManager, validationModule, reputationEngine, disputeModule, certificateNFT, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)
 ```
 
-The installer sets cross‑links, assigns the fee pool and optional tax policy, registers `PlatformIncentives` with both the `PlatformRegistry` and `JobRouter`, then automatically transfers ownership of all modules back to you.
+This `onlyOwner` call sets cross‑links, assigns the fee pool and optional tax policy, registers `PlatformIncentives` with both the `PlatformRegistry` and `JobRouter`, then automatically transfers ownership of all modules back to you.
 
 Owners can retune parameters any time: `StakeManager.setToken`, `setMinStake`, `FeePool.setBurnPct`, `PlatformRegistry.setBlacklist`, etc. No redeployments are required when swapping tokens or adjusting fees.
 

--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -27,8 +27,8 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 9. Deploy `PlatformRegistry(stakeManager, reputationEngine, 0)`.
 10. Deploy `JobRouter(platformRegistry)`.
 11. Deploy `PlatformIncentives(stakeManager, platformRegistry, jobRouter)`.
-12. Deploy `ModuleInstaller()`; the deployer becomes the temporary owner.
-13. Transfer ownership of each module to the installer. From that owner address, call `ModuleInstaller.initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` **once**. Only the deployer may invoke `initialize`, and the installer blocks subsequent calls. The transaction wires modules, assigns the fee pool and optional tax policy, then transfers ownership back automatically. Finally authorize registrars:
+12. Deploy `ModuleInstaller()`; the deployer becomes the temporary owner via `Ownable`.
+13. Transfer ownership of each module to the installer. From that owner address, call `ModuleInstaller.initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` **once**. Only the owner may invoke `initialize`, and the installer blocks subsequent calls. The transaction wires modules, assigns the fee pool and optional tax policy, then transfers ownership back automatically. Finally authorize registrars:
     - `PlatformRegistry.setRegistrar(platformIncentives, true)`
     - `JobRouter.setRegistrar(platformIncentives, true)`
 14. Verify each contract via **Contract → Verify and Publish** on Etherscan.
@@ -37,7 +37,7 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 
 1. Deploy `ModuleInstaller()`; the deploying address is the owner.
 2. On each module contract, call `transferOwnership(installer)`.
-3. From that owner address, open **ModuleInstaller → Write Contract** and execute `initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)`.
+3. From that owner address, open **ModuleInstaller → Write Contract** and execute `initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` (gated by `onlyOwner`).
 4. After the transaction, every module reports your address as `owner` again.
 
 ### Job posting, staking, and activation via Etherscan

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -271,7 +271,7 @@ async function main() {
   await verify(await platformRegistry.getAddress(), [await stake.getAddress(), await reputation.getAddress(), minPlatformStake, owner]);
   await verify(await jobRouter.getAddress(), [await platformRegistry.getAddress(), owner]);
   await verify(await incentives.getAddress(), [await stake.getAddress(), await platformRegistry.getAddress(), await jobRouter.getAddress(), owner]);
-  await verify(await installer.getAddress(), [owner]);
+  await verify(await installer.getAddress(), []);
 
   await incentives.connect(ownerSigner).stakeAndActivate(0);
 }

--- a/test/v2/ModuleInstaller.test.js
+++ b/test/v2/ModuleInstaller.test.js
@@ -1,0 +1,35 @@
+const { expect } = require("chai");
+
+describe("ModuleInstaller", function () {
+  it("restricts initialize to owner and reports tax exemption", async function () {
+    const [, other] = await ethers.getSigners();
+    const Installer = await ethers.getContractFactory(
+      "contracts/v2/ModuleInstaller.sol:ModuleInstaller"
+    );
+    const installer = await Installer.deploy();
+    await installer.waitForDeployment();
+
+    await expect(
+      installer
+        .connect(other)
+        .initialize(
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress
+        )
+    ).to.be.revertedWithCustomError(
+      installer,
+      "OwnableUnauthorizedAccount"
+    );
+
+    expect(await installer.isTaxExempt()).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- inherit `Ownable` in `ModuleInstaller` and gate `initialize` with `onlyOwner`
- surface `isTaxExempt()` helper and return ownership using `owner()`
- document updated installer flow and remove obsolete owner argument from deploy script

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dfc1f62a483338de6c83d1d8ca6ca