### PR TITLE
feat: add default job stake

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 | `commitWindow` | 1 day | Validator commit window |
 | `revealWindow` | 1 day | Validator reveal window |
 | `minStake` | 1_000_000 (1 token) | Global minimum stake in `StakeManager` |
-| `jobStake` | 0 | Minimum agent stake per job |
+| `jobStake` | 1_000_000 (1 token) | Minimum agent stake per job |
 
 All defaults assume the `$AGIALPHA` token (`decimals = 6`); owners can swap tokens later via `StakeManager.setToken` and `FeePool.setToken`.
 
@@ -49,7 +49,7 @@ A single call to `deploy(econ)` on the verified **Deployer** contract wires modu
 - `employerSlashPct`/`treasurySlashPct` – slashed stake split (defaults `0/100`)
 - `commitWindow`/`revealWindow` – validator timing windows in seconds (defaults `1 day` each)
 - `minStake` – global minimum stake in `StakeManager` (default `1_000_000`, i.e. 1 token)
-- `jobStake` – minimum agent stake per job in `JobRegistry` (default `0`)
+- `jobStake` – minimum agent stake per job in `JobRegistry` (default `1_000_000`, i.e. 1 token)
 
 Supplying `0` for any field keeps the module’s baked‑in default.
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -91,6 +91,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
 
     // default agent stake requirement configured by owner
     uint96 public jobStake;
+    uint96 public constant DEFAULT_JOB_STAKE = 1e6;
     uint256 public feePct;
     uint256 public constant DEFAULT_FEE_PCT = 5;
 
@@ -166,9 +167,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         uint256 pct = _feePct == 0 ? DEFAULT_FEE_PCT : _feePct;
         require(pct <= 100, "pct");
         feePct = pct;
-        if (_jobStake > 0) {
-            jobStake = _jobStake;
-        }
+        jobStake = _jobStake == 0 ? DEFAULT_JOB_STAKE : _jobStake;
         if (address(_validation) != address(0)) {
             emit ValidationModuleUpdated(address(_validation));
             emit ModuleUpdated("ValidationModule", address(_validation));


### PR DESCRIPTION
## Summary
- default to 1 token stake per job via `DEFAULT_JOB_STAKE`
- document new default job stake in README

## Testing
- `npm run compile`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689e01d9099883339a9127072380e3e9