### PR TITLE
feat: make fee distribution idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ For a detailed description of the platform-wide incentive architecture, see [doc
 4. **Stake** – on `StakeManager` call `acknowledgeAndDeposit(role, amount)`.
 5. **Activate a platform** – if you are an operator, call `PlatformIncentives.stakeAndActivate(amount)` (use `0` for the owner’s zero‑stake case).
 6. **Verify registration** – check `PlatformRegistry.getScore(address)` and `JobRouter.registered(address)` in the **Read** tabs.
-7. **Claim fees later** – simply call `FeePool.claimRewards()`; the function distributes any pending fees before paying rewards.
+7. **Claim fees later** – simply call `FeePool.claimRewards()`; it first runs the idempotent `distributeFees` to settle any pending fees before paying rewards.
 
 This summary is for convenience only. Screenshots and extended explanations are provided in [docs/deployment-agialpha.md](docs/deployment-agialpha.md).
 

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -115,9 +115,12 @@ contract FeePool is Ownable {
     /// @notice distribute accumulated fees to stakers
     /// @dev All fee amounts use 6 decimal units.
     /// @dev Should be called after `depositFee` to settle pending fees.
+    /// @dev Safe to call even when no fees are pending; returns immediately.
     function distributeFees() public {
         uint256 amount = pendingFees;
-        require(amount > 0, "amount");
+        if (amount == 0) {
+            return;
+        }
         pendingFees = 0;
 
         uint256 burnAmount = (amount * burnPct) / 100;

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -247,9 +247,10 @@ describe("FeePool", function () {
     ).to.be.revertedWith("amount");
   });
 
-  it("reverts when distributing with zero fees", async () => {
-    await expect(feePool.connect(owner).distributeFees()).to.be.revertedWith(
-      "amount"
-    );
+  it("returns immediately when distributing with zero fees", async () => {
+    const cumulative = await feePool.cumulativePerToken();
+    await expect(feePool.connect(owner).distributeFees()).to.not.be.reverted;
+    expect(await feePool.pendingFees()).to.equal(0);
+    expect(await feePool.cumulativePerToken()).to.equal(cumulative);
   });
 });

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -186,7 +186,9 @@ describe("multi-operator job lifecycle", function () {
     await jobRouter.connect(platform1).deregister();
     expect(await jobRouter.registered(platform1.address)).to.equal(false);
 
-    await expect(feePool.distributeFees()).to.be.revertedWith("amount");
+    const cumulative = await feePool.cumulativePerToken();
+    await expect(feePool.distributeFees()).to.not.be.reverted;
+    expect(await feePool.cumulativePerToken()).to.equal(cumulative);
   });
 });
 


### PR DESCRIPTION
## Summary
- make `FeePool.distributeFees` return early when no fees are pending
- document the idempotent distribution in README

## Testing
- `npm test`
- `forge test` *(fails: Source "forge-std/Script.sol" not found; wrong argument count for function call)*

------
https://chatgpt.com/codex/tasks/task_e_689e0c248c388333a816cf875084d444