### PR TITLE
feat: validate token decimals in v2 constructors

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -76,10 +76,13 @@ contract FeePool is Ownable {
     ) Ownable(msg.sender) {
         uint256 pct = _burnPct == 0 ? DEFAULT_BURN_PCT : _burnPct;
         require(pct <= 100, "pct");
-        token =
-            address(_token) == address(0)
-                ? IERC20(DEFAULT_TOKEN)
-                : _token;
+        if (address(_token) == address(0)) {
+            token = IERC20(DEFAULT_TOKEN);
+        } else {
+            IERC20Metadata meta = IERC20Metadata(address(_token));
+            require(meta.decimals() == 6, "decimals");
+            token = _token;
+        }
         emit TokenUpdated(address(token));
 
         stakeManager = _stakeManager;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -126,10 +126,13 @@ contract StakeManager is Ownable, ReentrancyGuard {
         address _jobRegistry,
         address _disputeModule
     ) Ownable(msg.sender) {
-        token =
-            address(_token) == address(0)
-                ? IERC20(DEFAULT_TOKEN)
-                : _token;
+        if (address(_token) == address(0)) {
+            token = IERC20(DEFAULT_TOKEN);
+        } else {
+            IERC20Metadata meta = IERC20Metadata(address(_token));
+            require(meta.decimals() == 6, "decimals");
+            token = _token;
+        }
         emit TokenUpdated(address(token));
 
         minStake = _minStake == 0 ? DEFAULT_MIN_STAKE : _minStake;

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -11,7 +11,7 @@ describe("JobRegistry integration", function () {
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
+    const Token = await ethers.getContractFactory("MockERC206Decimals");
     token = await Token.deploy();
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -7,7 +7,7 @@ describe("StakeManager", function () {
 
   beforeEach(async () => {
     [owner, user, employer, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
+    const Token = await ethers.getContractFactory("MockERC206Decimals");
     token = await Token.deploy();
     await token.mint(user.address, 1000);
     await token.mint(employer.address, 1000);

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -8,7 +8,7 @@ describe("StakeManager extras", function () {
 
   beforeEach(async () => {
     [owner, user, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
+    const Token = await ethers.getContractFactory("MockERC206Decimals");
     token = await Token.deploy();
     await token.mint(user.address, 1000);
     const StakeManager = await ethers.getContractFactory(

--- a/test/v2/StakeManagerNoEther.test.js
+++ b/test/v2/StakeManagerNoEther.test.js
@@ -6,7 +6,7 @@ describe("StakeManager ether rejection", function () {
 
   beforeEach(async () => {
     [owner] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
+    const Token = await ethers.getContractFactory("MockERC206Decimals");
     token = await Token.deploy();
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"


### PR DESCRIPTION
## Summary
- enforce 6‑decimal tokens in StakeManager and FeePool constructors
- emit TokenUpdated after validation

## Testing
- `npx hardhat test test/v2/StakeManager.test.js test/v2/FeePool.test.js`
- `forge test --match-path test/v2/FeePool.t.sol` *(fails: Compiler run failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e192a68248333aa2686ae54cba42d