### PR TITLE
feat: pass acknowledgers in deployment

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -170,7 +170,8 @@ contract Deployer {
             address(0),
             address(0)
         );
-
+        address[] memory ackInit = new address[](1);
+        ackInit[0] = address(stake);
         JobRegistry registry = new JobRegistry(
             IValidationModule(address(0)),
             IStakeManager(address(0)),
@@ -180,7 +181,8 @@ contract Deployer {
             IFeePool(address(0)),
             ITaxPolicy(address(0)),
             feePct,
-            jobStake
+            jobStake,
+            ackInit
         );
 
         ValidationModule validation = new ValidationModule(
@@ -237,22 +239,21 @@ contract Deployer {
         }
 
         // Wire modules
+        address[] memory acks = new address[](2);
+        acks[0] = address(pRegistry);
+        acks[1] = address(incentives);
         registry.setModules(
             validation,
             IStakeManager(address(stake)),
             JIReputationEngine(address(reputation)),
             JIDisputeModule(address(dispute)),
             JICertificateNFT(address(certificate)),
-            new address[](0)
+            acks
         );
         registry.setFeePool(IFeePool(address(pool)));
         if (address(policy) != address(0)) {
             registry.setTaxPolicy(ITaxPolicy(address(policy)));
         }
-
-        registry.setAcknowledger(address(stake), true);
-        registry.setAcknowledger(address(pRegistry), true);
-        registry.setAcknowledger(address(incentives), true);
 
         validation.setReputationEngine(repInterface);
         stake.setModules(address(registry), address(dispute));

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -156,7 +156,8 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         IFeePool _feePool,
         ITaxPolicy _policy,
         uint256 _feePct,
-        uint96 _jobStake
+        uint96 _jobStake,
+        address[] memory _ackModules
     ) Ownable(msg.sender) {
         validationModule = _validation;
         stakeManager = _stakeMgr;
@@ -198,6 +199,10 @@ contract JobRegistry is Ownable, ReentrancyGuard {
             taxPolicy = _policy;
             taxPolicyVersion++;
             emit TaxPolicyUpdated(address(_policy), taxPolicyVersion);
+        }
+        for (uint256 i; i < _ackModules.length; i++) {
+            acknowledgers[_ackModules[i]] = true;
+            emit AcknowledgerUpdated(_ackModules[i], true);
         }
     }
 

--- a/contracts/v2/ModuleInstaller.sol
+++ b/contracts/v2/ModuleInstaller.sol
@@ -70,7 +70,8 @@ contract ModuleInstaller is Ownable {
         IPlatformRegistryFull platformRegistry,
         IJobRouter jobRouter,
         IFeePool feePool,
-        ITaxPolicy taxPolicy
+        ITaxPolicy taxPolicy,
+        address[] calldata _ackModules
     ) external onlyOwner {
         require(!initialized, "init");
         initialized = true;
@@ -81,15 +82,12 @@ contract ModuleInstaller is Ownable {
             reputationEngine,
             disputeModule,
             certificateNFT,
-            new address[](0)
+            _ackModules
         );
         jobRegistry.setFeePool(feePool);
         if (address(taxPolicy) != address(0)) {
             jobRegistry.setTaxPolicy(taxPolicy);
         }
-        jobRegistry.setAcknowledger(address(stakeManager), true);
-        jobRegistry.setAcknowledger(address(platformRegistry), true);
-        jobRegistry.setAcknowledger(address(platformIncentives), true);
         stakeManager.setModules(address(jobRegistry), address(disputeModule));
         platformIncentives.setModules(
             IStakeManager(address(stakeManager)),

--- a/test/jobRegistry.ts
+++ b/test/jobRegistry.ts
@@ -22,7 +22,8 @@ describe("JobRegistry tax policy gating", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
 
     const Policy = await ethers.getContractFactory(

--- a/test/jobTaxPolicy.test.js
+++ b/test/jobTaxPolicy.test.js
@@ -27,7 +27,8 @@ describe("JobRegistry tax policy integration", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     await registry.waitForDeployment();
   });

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -55,7 +55,8 @@ describe("Full system integration", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
 
     const Dispute = await ethers.getContractFactory(

--- a/test/taxExempt.test.ts
+++ b/test/taxExempt.test.ts
@@ -29,7 +29,8 @@ describe("Tax exemption flags", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     await registry.waitForDeployment();
 

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -36,7 +36,8 @@ describe("FeePool", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -37,7 +37,8 @@ describe("Governance reward lifecycle", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -37,7 +37,8 @@ describe("GovernanceReward", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -51,7 +51,8 @@ describe("JobRegistry integration", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     const Dispute = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"

--- a/test/v2/JobRegistryNoEther.test.js
+++ b/test/v2/JobRegistryNoEther.test.js
@@ -18,7 +18,8 @@ describe("JobRegistry ether rejection", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     await registry.waitForDeployment();
   });

--- a/test/v2/ModuleInstaller.test.js
+++ b/test/v2/ModuleInstaller.test.js
@@ -23,7 +23,8 @@ describe("ModuleInstaller", function () {
           ethers.ZeroAddress,
           ethers.ZeroAddress,
           ethers.ZeroAddress,
-          ethers.ZeroAddress
+          ethers.ZeroAddress,
+          []
         )
     ).to.be.revertedWithCustomError(
       installer,

--- a/test/v2/PlatformIncentivesAck.test.js
+++ b/test/v2/PlatformIncentivesAck.test.js
@@ -67,7 +67,8 @@ describe("PlatformIncentives acknowledge", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -100,7 +100,8 @@ describe("PlatformRegistry", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -50,7 +50,8 @@ describe("Platform reward flow", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
 
     const TaxPolicy = await ethers.getContractFactory(

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -39,7 +39,8 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -39,7 +39,8 @@ describe("StakeManager extras", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     const TaxPolicy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -18,7 +18,8 @@ describe("JobRegistry tax policy integration", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -63,7 +63,8 @@ describe("end-to-end job lifecycle", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
 
     const Dispute = await ethers.getContractFactory(

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -64,7 +64,8 @@ describe("multi-operator job lifecycle", function () {
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       0,
-      0
+      0,
+      []
     );
 
     const Dispute = await ethers.getContractFactory(


### PR DESCRIPTION
## Summary
- allow JobRegistry constructor to take an array of initial acknowledgers
- update Deployer and ModuleInstaller to supply acknowledger lists instead of separate calls
- adjust tests for new constructor and wiring APIs

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e23d407a88333906ca592a231b78a