### PR TITLE
feat: add job registry setter to DisputeModule

### DIFF
--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -6,10 +6,11 @@ import {IJobRegistry} from "../interfaces/IJobRegistry.sol";
 import {IStakeManager} from "../interfaces/IStakeManager.sol";
 
 /// @title DisputeModule
-/// @notice Allows job participants to raise disputes with evidence and resolves them after a dispute window.
-/// @dev Only participants bear any tax obligations; the module escrows token
-/// based dispute fees via the StakeManager and rejects unsolicited ETH
-/// transfers.
+/// @notice Allows job participants to raise disputes with evidence and resolves
+/// them after a dispute window.
+/// @dev Maintains tax neutrality by rejecting ether and escrowing only token
+///      based dispute fees via the StakeManager. Assumes all token amounts use
+///      6 decimals (`1 token == 1e6` units).
 contract DisputeModule is Ownable {
     IJobRegistry public jobRegistry;
 
@@ -41,6 +42,7 @@ contract DisputeModule is Ownable {
     event ModeratorUpdated(address moderator);
     event AppealFeeUpdated(uint256 fee);
     event DisputeWindowUpdated(uint256 window);
+    event JobRegistryUpdated(IJobRegistry newRegistry);
 
     /// @param _jobRegistry Address of the JobRegistry contract.
     /// @param _appealFee Initial appeal fee in token units (6 decimals); defaults to 1e6.
@@ -73,6 +75,13 @@ contract DisputeModule is Ownable {
     modifier onlyJobRegistry() {
         require(msg.sender == address(jobRegistry), "not registry");
         _;
+    }
+
+    /// @notice Update the JobRegistry reference.
+    /// @param newRegistry New JobRegistry contract implementing IJobRegistry.
+    function setJobRegistry(IJobRegistry newRegistry) external onlyOwner {
+        jobRegistry = newRegistry;
+        emit JobRegistryUpdated(newRegistry);
     }
 
     /// @notice Set the moderator address.

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -1,0 +1,45 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("DisputeModule", function () {
+  let owner, other, registry, dispute, newRegistry;
+
+  beforeEach(async () => {
+    [owner, other] = await ethers.getSigners();
+    const JobMock = await ethers.getContractFactory("MockJobRegistry");
+    registry = await JobMock.deploy();
+    await registry.waitForDeployment();
+    const Dispute = await ethers.getContractFactory(
+      "contracts/v2/modules/DisputeModule.sol:DisputeModule"
+    );
+    dispute = await Dispute.deploy(
+      await registry.getAddress(),
+      0,
+      0,
+      ethers.ZeroAddress
+    );
+    await dispute.waitForDeployment();
+    newRegistry = await JobMock.deploy();
+    await newRegistry.waitForDeployment();
+  });
+
+  it("allows owner to update job registry", async () => {
+    await expect(
+      dispute.connect(owner).setJobRegistry(await newRegistry.getAddress())
+    )
+      .to.emit(dispute, "JobRegistryUpdated")
+      .withArgs(await newRegistry.getAddress());
+    expect(await dispute.jobRegistry()).to.equal(
+      await newRegistry.getAddress()
+    );
+  });
+
+  it("restricts job registry update to owner", async () => {
+    await expect(
+      dispute.connect(other).setJobRegistry(await newRegistry.getAddress())
+    )
+      .to.be.revertedWithCustomError(dispute, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow owner to update DisputeModule's job registry
- document 6-decimal token assumption and tax neutrality
- add tests enforcing owner-only registry updates

## Testing
- `npx solhint 'contracts/v2/modules/DisputeModule.sol'`
- `npx eslint test/v2/DisputeModule.test.js`
- `npx hardhat test test/v2/DisputeModule.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689e41e5e2c88333b14cfc6f6cdb7080