### PR TITLE
feat: add default deploy helpers

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -37,7 +37,7 @@ contract Deployer {
 
     /// @notice Economic configuration applied during deployment.
     /// @dev Zero values use each module's baked-in default such as a 5% fee,
-    ///      5% burn, 1-day commit/reveal windows and a 1 token minimum stake.
+    ///      5% burn, 1-day commit/reveal windows and a 1e6 minimum stake.
     struct EconParams {
         uint256 feePct; // protocol fee percentage for JobRegistry
         uint256 burnPct; // portion of fees burned by FeePool
@@ -124,6 +124,72 @@ contract Deployer {
             address taxPolicy
         )
     {
+        return _deploy(false, econ);
+    }
+
+    /// @notice Deploy and wire all modules using module defaults.
+    /// @dev Mirrors module constants: 5% fee, 5% burn and a 1e6 minimum stake.
+    /// @return stakeManager Address of the StakeManager
+    /// @return jobRegistry Address of the JobRegistry
+    /// @return validationModule Address of the ValidationModule
+    /// @return reputationEngine Address of the ReputationEngine
+    /// @return disputeModule Address of the DisputeModule
+    /// @return certificateNFT Address of the CertificateNFT
+    /// @return platformRegistry Address of the PlatformRegistry
+    /// @return jobRouter Address of the JobRouter
+    /// @return platformIncentives Address of the PlatformIncentives helper
+    /// @return feePool Address of the FeePool
+    /// @return taxPolicy Address of the TaxPolicy
+    function deployDefaults()
+        external
+        returns (
+            address stakeManager,
+            address jobRegistry,
+            address validationModule,
+            address reputationEngine,
+            address disputeModule,
+            address certificateNFT,
+            address platformRegistry,
+            address jobRouter,
+            address platformIncentives,
+            address feePool,
+            address taxPolicy
+        )
+    {
+        EconParams memory econ;
+        return _deploy(true, econ);
+    }
+
+    /// @notice Deploy and wire modules with defaults and no TaxPolicy.
+    /// @dev Mirrors module constants: 5% fee, 5% burn and a 1e6 minimum stake.
+    /// @return stakeManager Address of the StakeManager
+    /// @return jobRegistry Address of the JobRegistry
+    /// @return validationModule Address of the ValidationModule
+    /// @return reputationEngine Address of the ReputationEngine
+    /// @return disputeModule Address of the DisputeModule
+    /// @return certificateNFT Address of the CertificateNFT
+    /// @return platformRegistry Address of the PlatformRegistry
+    /// @return jobRouter Address of the JobRouter
+    /// @return platformIncentives Address of the PlatformIncentives helper
+    /// @return feePool Address of the FeePool
+    /// @return taxPolicy Address of the TaxPolicy (always zero)
+    function deployDefaultsWithoutTaxPolicy()
+        external
+        returns (
+            address stakeManager,
+            address jobRegistry,
+            address validationModule,
+            address reputationEngine,
+            address disputeModule,
+            address certificateNFT,
+            address platformRegistry,
+            address jobRouter,
+            address platformIncentives,
+            address feePool,
+            address taxPolicy
+        )
+    {
+        EconParams memory econ;
         return _deploy(false, econ);
     }
 

--- a/scripts/v2/deployDefaults.ts
+++ b/scripts/v2/deployDefaults.ts
@@ -1,0 +1,112 @@
+import { ethers, run } from "hardhat";
+
+async function verify(address: string, args: any[] = []) {
+  try {
+    await run("verify:verify", {
+      address,
+      constructorArguments: args,
+    });
+  } catch (err) {
+    console.error(`verification failed for ${address}`, err);
+  }
+}
+
+async function main() {
+  const [owner] = await ethers.getSigners();
+  const withTax = !process.argv.includes("--no-tax");
+
+  const Deployer = await ethers.getContractFactory(
+    "contracts/v2/Deployer.sol:Deployer"
+  );
+  const deployer = await Deployer.deploy();
+  await deployer.waitForDeployment();
+  const deployerAddress = await deployer.getAddress();
+  console.log("Deployer", deployerAddress);
+
+  const tx = withTax
+    ? await deployer.deployDefaults()
+    : await deployer.deployDefaultsWithoutTaxPolicy();
+  const receipt = await tx.wait();
+  const log = receipt.logs.find((l) => l.address === deployerAddress)!;
+  const decoded = deployer.interface.decodeEventLog(
+    "Deployed",
+    log.data,
+    log.topics
+  );
+
+  const [
+    stakeManager,
+    jobRegistry,
+    validationModule,
+    reputationEngine,
+    disputeModule,
+    certificateNFT,
+    platformRegistry,
+    jobRouter,
+    platformIncentives,
+    feePool,
+    taxPolicy,
+  ] = decoded as string[];
+
+  await verify(deployerAddress);
+  await verify(stakeManager, [
+    ethers.ZeroAddress,
+    1_000_000,
+    0,
+    100,
+    owner.address,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+  ]);
+  await verify(jobRegistry, [
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    5,
+    0,
+    [stakeManager],
+  ]);
+  await verify(validationModule, [
+    jobRegistry,
+    stakeManager,
+    86400,
+    86400,
+    0,
+    0,
+    [],
+  ]);
+  await verify(reputationEngine);
+  await verify(disputeModule, [jobRegistry, 0, 0, owner.address]);
+  await verify(certificateNFT, ["Cert", "CERT"]);
+  await verify(platformRegistry, [stakeManager, reputationEngine, 0]);
+  await verify(jobRouter, [platformRegistry]);
+  await verify(platformIncentives, [
+    stakeManager,
+    platformRegistry,
+    jobRouter,
+  ]);
+  await verify(feePool, [
+    ethers.ZeroAddress,
+    stakeManager,
+    2,
+    5,
+    owner.address,
+  ]);
+  if (withTax) {
+    await verify(taxPolicy, [
+      "ipfs://policy",
+      "All taxes on participants; contract and owner exempt",
+    ]);
+  }
+
+  console.log("Deployment complete");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `deployDefaults` and `deployDefaultsWithoutTaxPolicy` helpers mirroring module constants
- document module default values and update min stake to 1e6
- add Hardhat script for Etherscan deployment using default helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e468aac4083338cafe07c0c344b5e