### PR TITLE
chore: remove unused owner variables in tests

### DIFF
--- a/test/OwnerControls.test.js
+++ b/test/OwnerControls.test.js
@@ -2,10 +2,10 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("OwnerControls", function () {
-  let controls, owner, other, addr1;
+  let controls, other, addr1;
 
   beforeEach(async () => {
-    [owner, other, addr1] = await ethers.getSigners();
+    [, other, addr1] = await ethers.getSigners();
     const Factory = await ethers.getContractFactory("OwnerControls");
     controls = await Factory.deploy();
     await controls.waitForDeployment();

--- a/test/StakingRouter.test.js
+++ b/test/StakingRouter.test.js
@@ -2,11 +2,11 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("StakingRouter", function () {
-  let token, registry, router, owner, operator;
+  let token, registry, router, operator;
   const cooldown = 100; // seconds
 
   beforeEach(async () => {
-    [owner, operator] = await ethers.getSigners();
+    [, operator] = await ethers.getSigners();
 
     const Token = await ethers.getContractFactory(
       "contracts/AGIALPHAToken.sol:AGIALPHAToken"

--- a/test/jobRegistryOwnership.test.js
+++ b/test/jobRegistryOwnership.test.js
@@ -2,10 +2,10 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("JobRegistry ownership", function () {
-  let owner, user, registry;
+  let user, registry;
 
   beforeEach(async () => {
-    [owner, user] = await ethers.getSigners();
+    [, user] = await ethers.getSigners();
     const Factory = await ethers.getContractFactory(
       "contracts/JobRegistry.sol:JobRegistry"
     );

--- a/test/v2/ReputationEngineModule.test.js
+++ b/test/v2/ReputationEngineModule.test.js
@@ -2,10 +2,10 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("ReputationEngine module", function () {
-  let owner, caller, user, engine;
+  let caller, user, engine;
 
   beforeEach(async () => {
-    [owner, caller, user] = await ethers.getSigners();
+    [, caller, user] = await ethers.getSigners();
     const Engine = await ethers.getContractFactory(
       "contracts/v2/modules/ReputationEngine.sol:ReputationEngine"
     );


### PR DESCRIPTION
## Summary
- remove unused owner declarations across test files

## Testing
- `npm run lint` *(fails: `✖ 3350 problems (0 errors, 3350 warnings)`)*
- `npx eslint test/OwnerControls.test.js test/StakingRouter.test.js test/jobRegistryOwnership.test.js test/v2/ReputationEngineModule.test.js -f json`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e6719adc48333ba02a701868ba4ed