### PR TITLE
Allow zero addresses in module constructors

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -261,7 +261,9 @@ contract Deployer {
             new address[](0)
         );
 
-        ReputationEngine reputation = new ReputationEngine();
+        ReputationEngine reputation = new ReputationEngine(
+            IStakeManager(address(stake))
+        );
 
         DisputeModule dispute = new DisputeModule(
             IJobRegistry(address(registry)),

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -53,6 +53,7 @@ contract FeePool is Ownable {
     event RewardsClaimed(address indexed user, uint256 amount);
     event TokenUpdated(address indexed token);
     event StakeManagerUpdated(address indexed stakeManager);
+    event ModulesUpdated(address indexed stakeManager);
     event RewardRoleUpdated(IStakeManager.Role role);
     event BurnPctUpdated(uint256 pct);
     event TreasuryUpdated(address indexed treasury);
@@ -85,8 +86,11 @@ contract FeePool is Ownable {
         }
         emit TokenUpdated(address(token));
 
-        stakeManager = _stakeManager;
-        emit StakeManagerUpdated(address(_stakeManager));
+        if (address(_stakeManager) != address(0)) {
+            stakeManager = _stakeManager;
+            emit StakeManagerUpdated(address(_stakeManager));
+            emit ModulesUpdated(address(_stakeManager));
+        }
 
         rewardRole = _role;
         emit RewardRoleUpdated(_role);
@@ -214,6 +218,7 @@ contract FeePool is Ownable {
     function setStakeManager(IStakeManager manager) external onlyOwner {
         stakeManager = manager;
         emit StakeManagerUpdated(address(manager));
+        emit ModulesUpdated(address(manager));
     }
 
     /// @notice update reward role used for distribution

--- a/contracts/v2/ModuleInstaller.sol
+++ b/contracts/v2/ModuleInstaller.sol
@@ -22,10 +22,12 @@ interface IOwnable {
 }
 
 /// @title ModuleInstaller
-/// @notice Wires deployed modules together in a single transaction.
-/// @dev Each module must transfer ownership to this installer prior to calling
-///      {initialize}. After wiring, ownership can be reclaimed via the modules'
-///      own `transferOwnership` functions.
+/// @notice Optional helper wiring deployed modules in a single transaction.
+/// @dev Core contracts now accept zero addresses in their constructors so
+///      owners may either supply dependencies at deployment or call
+///      {initialize} later. Modules must transfer ownership to this installer
+///      prior to calling {initialize}. After wiring, ownership can be reclaimed
+///      via the modules' own `transferOwnership` functions.
 contract ModuleInstaller is Ownable {
     bool public initialized;
 

--- a/contracts/v2/PlatformIncentives.sol
+++ b/contracts/v2/PlatformIncentives.sol
@@ -28,9 +28,26 @@ contract PlatformIncentives is Ownable {
         IPlatformRegistryFull _platformRegistry,
         IJobRouter _jobRouter
     ) Ownable(msg.sender) {
-        stakeManager = _stakeManager;
-        platformRegistry = _platformRegistry;
-        jobRouter = _jobRouter;
+        if (address(_stakeManager) != address(0)) {
+            stakeManager = _stakeManager;
+        }
+        if (address(_platformRegistry) != address(0)) {
+            platformRegistry = _platformRegistry;
+        }
+        if (address(_jobRouter) != address(0)) {
+            jobRouter = _jobRouter;
+        }
+        if (
+            address(_stakeManager) != address(0) ||
+            address(_platformRegistry) != address(0) ||
+            address(_jobRouter) != address(0)
+        ) {
+            emit ModulesUpdated(
+                address(_stakeManager),
+                address(_platformRegistry),
+                address(_jobRouter)
+            );
+        }
     }
 
     /// @notice Update module addresses.

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -32,6 +32,7 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
     event Deregistered(address indexed operator);
     event StakeManagerUpdated(address indexed stakeManager);
     event ReputationEngineUpdated(address indexed engine);
+    event ModulesUpdated(address indexed stakeManager, address indexed reputationEngine);
     event MinPlatformStakeUpdated(uint256 stake);
     event Blacklisted(address indexed operator, bool status);
     event RegistrarUpdated(address indexed registrar, bool allowed);
@@ -55,6 +56,16 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
         reputationEngine = _reputationEngine;
         if (address(_reputationEngine) != address(0)) {
             emit ReputationEngineUpdated(address(_reputationEngine));
+        }
+
+        if (
+            address(_stakeManager) != address(0) ||
+            address(_reputationEngine) != address(0)
+        ) {
+            emit ModulesUpdated(
+                address(_stakeManager),
+                address(_reputationEngine)
+            );
         }
 
         minPlatformStake =

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -24,8 +24,14 @@ contract ReputationEngine is Ownable {
     event ThresholdUpdated(uint256 newThreshold);
     event StakeManagerUpdated(address stakeManager);
     event ScoringWeightsUpdated(uint256 stakeWeight, uint256 reputationWeight);
-
-    constructor() Ownable(msg.sender) {}
+    event ModulesUpdated(address indexed stakeManager);
+    constructor(IStakeManager _stakeManager) Ownable(msg.sender) {
+        if (address(_stakeManager) != address(0)) {
+            stakeManager = _stakeManager;
+            emit StakeManagerUpdated(address(_stakeManager));
+            emit ModulesUpdated(address(_stakeManager));
+        }
+    }
 
     modifier onlyCaller() {
         require(callers[msg.sender], "not authorized");
@@ -42,6 +48,7 @@ contract ReputationEngine is Ownable {
     function setStakeManager(IStakeManager manager) external onlyOwner {
         stakeManager = manager;
         emit StakeManagerUpdated(address(manager));
+        emit ModulesUpdated(address(manager));
     }
 
     /// @notice Configure weighting factors for stake and reputation.

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -43,6 +43,7 @@ contract DisputeModule is Ownable {
     event AppealFeeUpdated(uint256 fee);
     event DisputeWindowUpdated(uint256 window);
     event JobRegistryUpdated(IJobRegistry newRegistry);
+    event ModulesUpdated(address indexed jobRegistry);
 
     /// @param _jobRegistry Address of the JobRegistry contract.
     /// @param _appealFee Initial appeal fee in token units (6 decimals); defaults to 1e6.
@@ -54,7 +55,11 @@ contract DisputeModule is Ownable {
         uint256 _disputeWindow,
         address _moderator
     ) Ownable(msg.sender) {
-        jobRegistry = _jobRegistry;
+        if (address(_jobRegistry) != address(0)) {
+            jobRegistry = _jobRegistry;
+            emit JobRegistryUpdated(_jobRegistry);
+            emit ModulesUpdated(address(_jobRegistry));
+        }
 
         appealFee = _appealFee > 0 ? _appealFee : 1e6;
         emit AppealFeeUpdated(appealFee);
@@ -82,6 +87,7 @@ contract DisputeModule is Ownable {
     function setJobRegistry(IJobRegistry newRegistry) external onlyOwner {
         jobRegistry = newRegistry;
         emit JobRegistryUpdated(newRegistry);
+        emit ModulesUpdated(address(newRegistry));
     }
 
     /// @notice Set the moderator address.

--- a/contracts/v2/modules/JobRouter.sol
+++ b/contracts/v2/modules/JobRouter.sol
@@ -27,9 +27,13 @@ contract JobRouter is Ownable {
     event Deregistered(address indexed operator);
     event PlatformSelected(bytes32 indexed seed, address indexed operator);
     event RegistrarUpdated(address indexed registrar, bool allowed);
+    event ModulesUpdated(address indexed platformRegistry);
 
     constructor(IPlatformRegistry _platformRegistry) Ownable(msg.sender) {
-        platformRegistry = _platformRegistry;
+        if (address(_platformRegistry) != address(0)) {
+            platformRegistry = _platformRegistry;
+            emit ModulesUpdated(address(_platformRegistry));
+        }
     }
 
     /// @notice Register the caller for job routing.
@@ -142,6 +146,7 @@ contract JobRouter is Ownable {
     /// @notice Update the PlatformRegistry address.
     function setPlatformRegistry(IPlatformRegistry registry) external onlyOwner {
         platformRegistry = registry;
+        emit ModulesUpdated(address(registry));
     }
 
     /// @notice Confirms the contract and its owner can never incur tax liability.

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -14,26 +14,26 @@ This walkthrough shows a non‑technical owner how to deploy and wire the modula
 
 ## 2. Deploy core modules
 
-Deploy each contract **in the order listed below** from the **Write Contract** tabs (the deployer automatically becomes the owner). Parameters may be left as `0` to accept the defaults shown below:
+Deploy each contract **in the order listed below** from the **Write Contract** tabs (the deployer automatically becomes the owner). Addresses for dependent modules may be passed at deployment or left as `0` and wired later. Parameters may be left as `0` to accept the defaults shown below:
 
 1. `AGIALPHAToken()` – after deployment, call `mint(to, amount)` to create the initial supply.
 2. `StakeManager(token, minStake, employerPct, treasuryPct, treasury)` – pass `address(0)` for `token` to use the default $AGIALPHA and `0,0` for the slashing percentages to send 100% of any slash to the treasury. The owner can later swap to a different ERC‑20 with `StakeManager.setToken`.
 3. `JobRegistry(validation, stakeMgr, reputation, dispute, certNFT, feePool, taxPolicy, feePct, jobStake)` – leaving `feePct = 0` applies a 5% protocol fee. Supplying a nonzero `taxPolicy` sets the disclaimer at deployment; otherwise the owner may call `setTaxPolicy` later.
 4. `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators, validatorPool)` – zero values default to 1‑day windows and a 1–3 validator set.
-5. `ReputationEngine()` – optional reputation weighting.
+5. `ReputationEngine(stakeManager)` – optional reputation weighting (pass `0` to wire later).
 6. `DisputeModule(jobRegistry, appealFee, moderator, jury)` – manages appeals and dispute fees.
 7. `CertificateNFT(name, symbol)` – certifies completed work.
 8. `FeePool(token, stakeManager, role, burnPct, treasury)` – use `address(0)` for `token` to fall back to $AGIALPHA; `burnPct` defaults to `0`.
 9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – `minStake` may be `0`.
 10. `JobRouter(platformRegistry)` – stake‑weighted job routing.
 11. `PlatformIncentives(stakeManager, platformRegistry, jobRouter)` – helper that lets operators stake and register with routing in one call. For simple flows without `JobRouter`, call `PlatformRegistry.stakeAndRegister(amount)` or `acknowledgeStakeAndRegister(amount)` directly.
-12. `ModuleInstaller()` – temporary `Ownable` helper for wiring modules.
+12. `ModuleInstaller()` – optional `Ownable` helper for wiring modules after deployment.
 
 After each deployment, copy the address for later wiring.
 
 ## 3. Wire the modules
 
-Transfer ownership of each module to the `ModuleInstaller` and, from the owner's account, call:
+If addresses were not supplied during deployment, transfer ownership of each module to the `ModuleInstaller` and, from the owner's account, call:
 
 ```
 ModuleInstaller.initialize(jobRegistry, stakeManager, validationModule, reputationEngine, disputeModule, certificateNFT, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)

--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -20,15 +20,15 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 2. Deploy `JobRegistry()`.
 3. Deploy `TaxPolicy(uri, acknowledgement)` and call `JobRegistry.setTaxPolicy(taxPolicy)`.
 4. Deploy `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, 1, 3, [])`.
-5. Deploy `ReputationEngine()`.
+5. Deploy `ReputationEngine(stakeManager)` or `ReputationEngine(address(0))` if wiring later.
 6. Deploy `CertificateNFT("AGI Jobs", "AGIJOB")`.
 7. Deploy `DisputeModule(jobRegistry, 0, owner, owner)`.
 8. Deploy `FeePool(token, stakeManager, 2, burnPct, treasury)`.
 9. Deploy `PlatformRegistry(stakeManager, reputationEngine, 0)`.
 10. Deploy `JobRouter(platformRegistry)`.
 11. Deploy `PlatformIncentives(stakeManager, platformRegistry, jobRouter)`.
-12. Deploy `ModuleInstaller()`; the deployer becomes the temporary owner via `Ownable`.
-13. Transfer ownership of each module to the installer. From that owner address, call `ModuleInstaller.initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` **once**. Only the owner may invoke `initialize`, and the installer blocks subsequent calls. The transaction wires modules, assigns the fee pool and optional tax policy, then transfers ownership back automatically. Finally authorize registrars:
+12. Deploy `ModuleInstaller()` if you prefer to wire modules after deployment; the deployer becomes the temporary owner via `Ownable`.
+13. If using the installer, transfer ownership of each module to it and from that owner address call `ModuleInstaller.initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` **once**. Only the owner may invoke `initialize`, and the installer blocks subsequent calls. The transaction wires modules, assigns the fee pool and optional tax policy, then transfers ownership back automatically. Finally authorize registrars:
     - `PlatformRegistry.setRegistrar(platformIncentives, true)`
     - `JobRouter.setRegistrar(platformIncentives, true)`
 14. Verify each contract via **Contract → Verify and Publish** on Etherscan.
@@ -37,7 +37,7 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 
 1. Deploy `ModuleInstaller()`; the deploying address is the owner.
 2. On each module contract, call `transferOwnership(installer)`.
-3. From that owner address, open **ModuleInstaller → Write Contract** and execute `initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` (gated by `onlyOwner`).
+3. From that owner address, open **ModuleInstaller → Write Contract** and execute `initialize(jobRegistry, stakeManager, validation, reputation, dispute, nft, platformIncentives, platformRegistry, jobRouter, feePool, taxPolicy)` (gated by `onlyOwner`) to wire any remaining zero addresses.
 4. After the transaction, every module reports your address as `owner` again.
 
 ### Job posting, staking, and activation via Etherscan

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -58,7 +58,9 @@ contract DeployAll is Script {
             new address[](0)
         );
 
-        ReputationEngine reputation = new ReputationEngine(vm.addr(deployer));
+        ReputationEngine reputation = new ReputationEngine(
+            IStakeManager(address(stake))
+        );
         CertificateNFT nft = new CertificateNFT("Cert", "CERT", vm.addr(deployer));
         DisputeModule dispute = new DisputeModule(registry, 0, 0, address(0));
 

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -36,7 +36,7 @@ describe("Full system integration", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    rep = await Rep.deploy();
+    rep = await Rep.deploy(await stakeManager.getAddress());
 
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"

--- a/test/taxExempt.test.ts
+++ b/test/taxExempt.test.ts
@@ -51,7 +51,7 @@ describe("Tax exemption flags", function () {
     const ReputationEngine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const rep = await ReputationEngine.deploy();
+    const rep = await ReputationEngine.deploy(await stake.getAddress());
     await rep.waitForDeployment();
 
     const CertificateNFT = await ethers.getContractFactory(

--- a/test/v2/DiscoveryModule.test.js
+++ b/test/v2/DiscoveryModule.test.js
@@ -12,7 +12,7 @@ describe("DiscoveryModule", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy();
+    engine = await Engine.deploy(ethers.ZeroAddress);
     await engine.connect(owner).setCaller(owner.address, true);
     await engine.connect(owner).setStakeManager(await stakeManager.getAddress());
 

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -201,7 +201,7 @@ describe("FeePool", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const rep = await Rep.connect(owner).deploy();
+    const rep = await Rep.connect(owner).deploy(ethers.ZeroAddress);
     await rep.setStakeManager(await stakeManager.getAddress());
     await rep.setCaller(owner.address, true);
 

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -34,7 +34,7 @@ describe("JobRegistry integration", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    rep = await Rep.deploy();
+    rep = await Rep.deploy(await stakeManager.getAddress());
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );

--- a/test/v2/PlatformIncentivesAck.test.js
+++ b/test/v2/PlatformIncentivesAck.test.js
@@ -27,7 +27,7 @@ describe("PlatformIncentives acknowledge", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const reputation = await Rep.deploy();
+    const reputation = await Rep.deploy(await stakeManager.getAddress());
     await reputation.setStakeManager(await stakeManager.getAddress());
 
     const Registry = await ethers.getContractFactory(

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -35,7 +35,9 @@ describe("PlatformRegistry", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    reputationEngine = await Rep.connect(owner).deploy();
+    reputationEngine = await Rep.connect(owner).deploy(
+      await stakeManager.getAddress()
+    );
     await reputationEngine.setStakeManager(await stakeManager.getAddress());
     await reputationEngine.setCaller(owner.address, true);
 

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -68,7 +68,9 @@ describe("Platform reward flow", function () {
     const Reputation = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const reputation = await Reputation.deploy();
+    const reputation = await Reputation.deploy(
+      await stakeManager.getAddress()
+    );
 
     const PlatformRegistry = await ethers.getContractFactory(
       "contracts/v2/PlatformRegistry.sol:PlatformRegistry"

--- a/test/v2/ReputationEngine.test.js
+++ b/test/v2/ReputationEngine.test.js
@@ -9,7 +9,7 @@ describe("ReputationEngine", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy();
+    engine = await Engine.deploy(ethers.ZeroAddress);
     await engine.connect(owner).setCaller(caller.address, true);
     await engine.connect(owner).setThreshold(2);
   });

--- a/test/v2/ReputationEngineNoEther.test.js
+++ b/test/v2/ReputationEngineNoEther.test.js
@@ -9,7 +9,7 @@ describe("ReputationEngine ether rejection", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy();
+    engine = await Engine.deploy(ethers.ZeroAddress);
     await engine.waitForDeployment();
   });
 

--- a/test/v2/RoutingModule.test.js
+++ b/test/v2/RoutingModule.test.js
@@ -14,7 +14,7 @@ describe("JobRouter", function () {
     const Reputation = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    reputation = await Reputation.deploy();
+    reputation = await Reputation.deploy(ethers.ZeroAddress);
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/PlatformRegistry.sol:PlatformRegistry"

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -44,7 +44,7 @@ describe("end-to-end job lifecycle", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    rep = await Rep.deploy();
+    rep = await Rep.deploy(await stakeManager.getAddress());
 
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -45,7 +45,7 @@ describe("multi-operator job lifecycle", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    rep = await Rep.deploy();
+    rep = await Rep.deploy(await stakeManager.getAddress());
 
     const NFT = await ethers.getContractFactory(
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"


### PR DESCRIPTION
## Summary
- Permit zero addresses in core module constructors and emit `ModulesUpdated` when supplied
- Make ModuleInstaller optional and update deployment docs for flexible wiring
- Adjust tests and scripts for new constructor signatures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e6974eed883339a9d4adbde79b64b