### PR TITLE
Allow fee modules to be reconfigured

### DIFF
--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -54,6 +54,9 @@ contract GovernanceReward is Ownable {
     event EpochFinalized(uint256 indexed epoch, uint256 rewardAmount);
     event RewardClaimed(uint256 indexed epoch, address indexed voter, uint256 amount);
     event TokenUpdated(address indexed token);
+    event FeePoolUpdated(address indexed feePool);
+    event StakeManagerUpdated(address indexed stakeManager);
+    event RewardRoleUpdated(IStakeManager.Role role);
 
     constructor(
         IERC20 _token,
@@ -72,6 +75,9 @@ contract GovernanceReward is Ownable {
         feePool = _feePool;
         stakeManager = _stakeManager;
         rewardRole = _role;
+        emit FeePoolUpdated(address(_feePool));
+        emit StakeManagerUpdated(address(_stakeManager));
+        emit RewardRoleUpdated(_role);
 
         epochLength =
             _epochLength == 0 ? DEFAULT_EPOCH_LENGTH : _epochLength;
@@ -112,6 +118,24 @@ contract GovernanceReward is Ownable {
         );
         token = candidate;
         emit TokenUpdated(address(candidate));
+    }
+
+    /// @notice update the FeePool reference
+    function setFeePool(IFeePool newFeePool) external onlyOwner {
+        feePool = newFeePool;
+        emit FeePoolUpdated(address(newFeePool));
+    }
+
+    /// @notice update the StakeManager reference
+    function setStakeManager(IStakeManager newStakeManager) external onlyOwner {
+        stakeManager = newStakeManager;
+        emit StakeManagerUpdated(address(newStakeManager));
+    }
+
+    /// @notice update the staker role used for reward snapshots
+    function setRewardRole(IStakeManager.Role role) external onlyOwner {
+        rewardRole = role;
+        emit RewardRoleUpdated(role);
     }
 
     /// @notice record voters for the current epoch and snapshot their stake

--- a/contracts/v2/modules/RevenueDistributor.sol
+++ b/contracts/v2/modules/RevenueDistributor.sol
@@ -17,9 +17,11 @@ contract RevenueDistributor is Ownable {
     event OperatorDeregistered(address indexed operator);
     event TreasuryUpdated(address indexed treasury);
     event RevenueDistributed(address indexed from, uint256 amount);
+    event StakeManagerUpdated(address indexed stakeManager);
 
     constructor(IStakeManager _stakeManager) Ownable(msg.sender) {
         stakeManager = _stakeManager;
+        emit StakeManagerUpdated(address(_stakeManager));
     }
 
     /// @notice Register the caller as an operator.
@@ -51,6 +53,13 @@ contract RevenueDistributor is Ownable {
     function setTreasury(address _treasury) external onlyOwner {
         treasury = _treasury;
         emit TreasuryUpdated(_treasury);
+    }
+
+    /// @notice Update StakeManager contract used for stake lookups.
+    /// @param manager new StakeManager address
+    function setStakeManager(IStakeManager manager) external onlyOwner {
+        stakeManager = manager;
+        emit StakeManagerUpdated(address(manager));
     }
 
     /// @notice Distribute received ETH to active operators by stake.


### PR DESCRIPTION
## Summary
- emit configuration events and add owner setters for GovernanceReward dependencies
- allow RevenueDistributor to update StakeManager address

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e7018cde88333a7ccdcdc9d2f75cb