### PR TITLE
Add acknowledgement helpers for deregistration and escrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ Call `Deployer.deployDefaults()` to spin up and wire all core modules in one tra
 - `JobRegistry.stakeAndApply(jobId, amount)`
 - `JobRegistry.acknowledgeAndApply(jobId)`
 - `PlatformRegistry.acknowledgeStakeAndRegister(amount)`
+- `PlatformRegistry.acknowledgeAndDeregister()`
 - `PlatformIncentives.acknowledgeStakeAndActivate(amount)`
 - `PlatformIncentives.stakeAndActivate(amount)`
+- `JobEscrow.acknowledgeAndAcceptResult(jobId)`
 
 **Base units:** `$AGIALPHA` uses 6 decimals (`1 token = 1_000000`). Approve these amounts before using helpers.
 
@@ -38,6 +40,8 @@ Call `Deployer.deployDefaults()` to spin up and wire all core modules in one tra
 | `acknowledgeStakeAndRegister` | `amount` to `StakeManager` | Stake and register a platform |
 | `acknowledgeStakeAndActivate` | `amount` to `StakeManager` | Stake, register, and enable routing |
 | `stakeAndActivate` | `amount` to `StakeManager` | Register and route without acknowledgement |
+| `acknowledgeAndDeregister` | `0` | Deregister a platform after acknowledging policy |
+| `acknowledgeAndAcceptResult` | `0` | Employer acknowledges policy and accepts result |
 
 For screenshot walkthroughs, see [docs/deployment-agialpha.md](docs/deployment-agialpha.md) and [docs/etherscan-guide.md](docs/etherscan-guide.md).
 
@@ -74,8 +78,10 @@ All helper calls below accept `$AGIALPHA` amounts in 6‑decimal base units and 
 - `StakeManager.acknowledgeAndDeposit`
 - `PlatformRegistry.acknowledgeAndRegister`
 - `PlatformRegistry.acknowledgeStakeAndRegister`
+- `PlatformRegistry.acknowledgeAndDeregister`
 - `PlatformIncentives.acknowledgeStakeAndActivate`
 - `JobRegistry.acknowledgeAndCreateJob` / `JobRegistry.stakeAndApply`
+- `JobEscrow.acknowledgeAndAcceptResult`
 
 ### Deployment simplifications & defaults
 
@@ -100,6 +106,8 @@ Helper functions expose common flows in single calls so Etherscan users do not h
 - `JobRegistry.acknowledgeAndApply` acknowledges the tax policy and applies when no stake is needed.
 - `PlatformIncentives.stakeAndActivate` (and `acknowledgeStakeAndActivate`) stakes and registers a platform for routing and fees.
 - `PlatformRegistry.acknowledgeAndRegister` lists an operator without staking.
+- `PlatformRegistry.acknowledgeAndDeregister` removes an operator after acknowledging the tax policy.
+- `JobEscrow.acknowledgeAndAcceptResult` lets employers acknowledge the policy and release escrow.
 - `FeePool.claimRewards` auto-distributes any pending fees before paying the caller.
 - `FeePool.distributeFees` never reverts; if no stake exists, fees are sent to the treasury after burning.
 - `StakeManager.acknowledgeAndDeposit` and `acknowledgeAndDepositFor` stake tokens after acknowledging the tax policy, reducing transactions for users and helpers.

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -154,6 +154,21 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
         emit Activated(msg.sender, amount);
     }
 
+    /**
+     * @notice Deregister the caller after acknowledging the tax policy.
+     * @dev Invoking this helper implicitly accepts the current tax policy via
+     *      the associated `JobRegistry` when set.
+     */
+    function acknowledgeAndDeregister() external nonReentrant {
+        require(registered[msg.sender], "not registered");
+        address registry = stakeManager.jobRegistry();
+        if (registry != address(0)) {
+            IJobRegistryAck(registry).acknowledgeFor(msg.sender);
+        }
+        registered[msg.sender] = false;
+        emit Deregistered(msg.sender);
+    }
+
     /// @notice Register an operator on their behalf.
     function registerFor(address operator) external nonReentrant {
         if (msg.sender != operator) {

--- a/contracts/v2/interfaces/IJobEscrow.sol
+++ b/contracts/v2/interfaces/IJobEscrow.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title IJobEscrow
+/// @notice Minimal interface for job escrow helpers
+interface IJobEscrow {
+    /// @notice Post a new job and escrow the reward
+    function postJob(uint256 reward, string calldata data) external returns (uint256);
+
+    /// @notice Operator submits the result for a job
+    function submitResult(uint256 jobId, string calldata result) external;
+
+    /// @notice Cancel a job before completion
+    function cancelJob(uint256 jobId) external;
+
+    /// @notice Accept the job result and release payment
+    function acceptResult(uint256 jobId) external;
+
+    /// @notice Acknowledge the tax policy and accept the job result
+    function acknowledgeAndAcceptResult(uint256 jobId) external;
+}

--- a/contracts/v2/interfaces/IPlatformRegistryFull.sol
+++ b/contracts/v2/interfaces/IPlatformRegistryFull.sol
@@ -21,6 +21,9 @@ interface IPlatformRegistryFull is IPlatformRegistry {
     /// @notice Acknowledge the tax policy, stake and register caller
     function acknowledgeStakeAndRegister(uint256 amount) external;
 
+    /// @notice Deregister caller after acknowledging the tax policy
+    function acknowledgeAndDeregister() external;
+
     /// @notice Authorize or revoke a registrar
     function setRegistrar(address registrar, bool allowed) external;
 }


### PR DESCRIPTION
## Summary
- allow platforms to acknowledge tax policy and deregister in one call
- add JobEscrow helper to acknowledge policy and accept results
- document new helpers and expose interfaces

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689e729c6b988333b6164d05b81225b9