### PR TITLE
feat: streamline rewards claiming

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labor markets among autonomous agents. The legacy v0 deployment transacts in $AGI, while the modular v2 suite defaults to [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) – a 6‑decimal ERC‑20 used for payments, staking, rewards and dispute deposits. The contract owner can swap this token at any time via `StakeManager.setToken` and `FeePool.setToken` without redeploying other modules. This repository hosts the immutable mainnet deployment (v0) and an unaudited v1 prototype under active development. Treat every address as unverified until you confirm it on-chain and through official AGI.eth channels.
 
+## Non-technical deployment guide
+
+1. **Deploy modules** – on the [`Deployer`](contracts/v2/Deployer.sol) page of a block explorer choose `deployDefaults()`; the caller becomes owner and all modules wire themselves using `$AGIALPHA` with sensible defaults (5% fee, 5% burn, 1‑token minimum stake).
+2. **Confirm defaults** – after deployment check emitted `TokenUpdated`, `FeePctUpdated`, and similar events to verify parameters. Constructors fall back to the caller for owner/treasury addresses when inputs are left blank.
+3. **Post jobs** – employers approve `$AGIALPHA` for the `StakeManager` and call `JobRegistry.acknowledgeAndCreateJob(reward, uri)` from the Write tab.
+4. **Stake & apply** – agents approve the stake amount and call `JobRegistry.stakeAndApply(jobId, amount)` (or `acknowledgeAndApply(jobId)` when no stake is required).
+5. **Register platforms** – operators stake and register in one transaction through `PlatformRegistry.acknowledgeStakeAndRegister(amount)` or use `PlatformIncentives.acknowledgeStakeAndActivate(amount)` to enable routing.
+6. **Claim fees** – stakers withdraw revenue by calling `FeePool.claimRewards()`, which first runs the idempotent `distributeFees` so no extra transaction is needed.
+
 For narrated walkthroughs and block‑explorer screenshots, see [docs/deployment-agialpha.md](docs/deployment-agialpha.md) and [docs/etherscan-guide.md](docs/etherscan-guide.md).
 
 **$AGIALPHA units** – The token powers all fees, stakes, and rewards. It reports `decimals = 6`, so enter amounts in base units (`1` token = `1_000000`).

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -158,30 +158,11 @@ contract FeePool is Ownable {
 
     /**
      * @notice Claim accumulated $AGIALPHA rewards for the caller.
-     * @dev Rewards use 6-decimal units. Automatically calls `distributeFees`
-     *      if there are pending fees awaiting distribution, letting non‑technical
-     *      stakers claim in a single Etherscan transaction.
-    */
+     * @dev Invokes the idempotent `distributeFees` so stakers can settle and
+     *      claim in a single Etherscan transaction. Rewards use 6‑decimal units.
+     */
     function claimRewards() external {
-        if (pendingFees > 0) {
-            uint256 totalStake = stakeManager.totalStake(rewardRole);
-            if (totalStake == 0) {
-                uint256 amount = pendingFees;
-                pendingFees = 0;
-
-                uint256 burnAmount = (amount * burnPct) / 100;
-                if (burnAmount > 0) {
-                    token.safeTransfer(BURN_ADDRESS, burnAmount);
-                    emit Burned(burnAmount);
-                }
-                uint256 remainder = amount - burnAmount;
-                if (remainder > 0 && treasury != address(0)) {
-                    token.safeTransfer(treasury, remainder);
-                }
-            } else {
-                distributeFees();
-            }
-        }
+        distributeFees();
         uint256 stake = stakeManager.stakeOf(msg.sender, rewardRole);
         // Deployer may claim but receives no rewards without stake.
         if (msg.sender == owner() && stake == 0) {


### PR DESCRIPTION
## Summary
- make claiming rewards a single step by running `distributeFees()` inside `FeePool.claimRewards`
- document a non-technical deployment flow using `$AGIALPHA`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e8201fcf083338b838c1cb0c691bd