### PR TITLE
Default FeePool reward role to platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ For step‑by‑step screenshots of these flows, see [docs/deployment-agialpha.m
 
 ## Quick Start: FeePool, JobRouter & GovernanceReward
 
-1. **Deploy & verify** – deploy `FeePool(token, stakeManager, rewardRole)` and `JobRouter(stakeManager, reputationEngine)`. The deployer automatically becomes the owner. On Etherscan, open each address, select the **Contract** tab, and use **Verify and Publish** to upload the source code.
+1. **Deploy & verify** – deploy `FeePool(token, stakeManager, burnPct, treasury)` (rewards default to platform stakers) and `JobRouter(stakeManager, reputationEngine)`. The deployer automatically becomes the owner. On Etherscan, open each address, select the **Contract** tab, and use **Verify and Publish** to upload the source code.
 2. **Connect wallet** – from the **Write Contract** tab click **Connect to Web3**. Owners may initialize modules immediately after verification.
 3. **Initialize parameters**
    - On `StakeManager`, call `setToken(token)` if the staking token differs from the constructor value.
@@ -451,7 +451,7 @@ When integrating with standard 18‑decimal ERC‑20s, divide amounts by `1e12` 
 
 **Etherscan deployment steps**
 
-1. **Deploy modules** – From each contract's **Deploy** tab, deploy `StakeManager(token, minStake, employerPct, treasuryPct, treasury, jobRegistry, disputeModule)`, `JobRegistry(validation, stakeManager, reputation, dispute, certificate, feePool, taxPolicy, feePct, jobStake)`, `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators[, validatorPool])`, `ReputationEngine(stakeManager)` (or pass `0` to wire later), `DisputeModule(jobRegistry, appealFee, moderator, jury)`, `CertificateNFT(name, symbol)`, `FeePool(token, stakeManager, role, burnPct, treasury)` and `TaxPolicy(uri, acknowledgement)`. The deployer address becomes the owner for every module. Leaving numeric fields or addresses as `0` uses sensible defaults and allows wiring via `setModules` or `ModuleInstaller.initialize` later.
+1. **Deploy modules** – From each contract's **Deploy** tab, deploy `StakeManager(token, minStake, employerPct, treasuryPct, treasury, jobRegistry, disputeModule)`, `JobRegistry(validation, stakeManager, reputation, dispute, certificate, feePool, taxPolicy, feePct, jobStake)`, `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators[, validatorPool])`, `ReputationEngine(stakeManager)` (or pass `0` to wire later), `DisputeModule(jobRegistry, appealFee, moderator, jury)`, `CertificateNFT(name, symbol)`, `FeePool(token, stakeManager, burnPct, treasury)` (payouts default to platform stakers) and `TaxPolicy(uri, acknowledgement)`. The deployer address becomes the owner for every module. Leaving numeric fields or addresses as `0` uses sensible defaults and allows wiring via `setModules` or `ModuleInstaller.initialize` later.
 2. **Wire them together** – If any module addresses were left as `0` during deployment, call `JobRegistry.setModules(validation, stakeManager, reputation, dispute, certificate, [extraAcknowledgers])` then `setFeePool(feePool)` and `setFeePct(pct)`. This auto-registers the `StakeManager` and any optional addresses as tax-policy acknowledgers. Link the `StakeManager` to the registry and dispute module with `setModules(jobRegistry, disputeModule)`.
 3. **Approve and stake** – Employers and agents `approve` the `StakeManager` to spend `$AGIALPHA` and then:
    - Employers post work with `createJob(reward, uri)` or combine acknowledgement via `acknowledgeAndCreateJob(reward, uri)` after approving `reward + fee`.
@@ -1353,7 +1353,7 @@ $AGIALPHA is a 6‑decimal ERC‑20 token used across the platform for payments,
    - `FeePool`, `JobRegistry`, `ValidationModule`, `DisputeModule`, `CertificateNFT`, and `PlatformRegistry` – use the previously deployed module addresses in their constructors.
 2. **Configure staking and rewards**
    - On `StakeManager`, call `setMinStake`, `setSlashingPercentages`, and `setTreasury` as needed.
-   - On `FeePool`, call `setRewardRole(2)` to direct revenue to platform stakers, adjust `setBurnPct` if desired, and `setTreasury(treasury)` to collect any rounding dust from distributions.
+   - On `FeePool`, rewards already flow to platform stakers; owners may call `setRewardRole` to redirect payouts, adjust `setBurnPct` if desired, and `setTreasury(treasury)` to collect any rounding dust from distributions.
    - The deploying entity may register its reference platform without staking; it will appear in `PlatformRegistry` but receive no routing priority or fee share.
       - **Worked example**
         1. The owner skips `depositStake` (amount = `0`) and calls `PlatformRegistry.register()`.

--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -278,7 +278,6 @@ contract Deployer {
         FeePool pool = new FeePool(
             IERC20(address(0)),
             IStakeManager(address(stake)),
-            IStakeManager.Role.Platform,
             burnPct,
             owner
         );

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -29,7 +29,7 @@ contract FeePool is Ownable {
     /// @notice StakeManager tracking stakes
     IStakeManager public stakeManager;
 
-    /// @notice role whose stakers receive rewards
+    /// @notice role whose stakers receive rewards (defaults to Platform operators)
     IStakeManager.Role public rewardRole;
 
     /// @notice percentage of each fee burned (out of 100)
@@ -63,7 +63,6 @@ contract FeePool is Ownable {
     /// @param _token ERC20 token used for fees and rewards. Defaults to
     /// DEFAULT_TOKEN when zero address.
     /// @param _stakeManager StakeManager tracking staker balances.
-    /// @param _role Staker role whose participants receive rewards.
     /// @param _burnPct Percentage of each fee to burn (0-100). Defaults to
     /// DEFAULT_BURN_PCT when set to zero.
     /// @param _treasury Address receiving rounding dust. Defaults to deployer
@@ -71,7 +70,6 @@ contract FeePool is Ownable {
     constructor(
         IERC20 _token,
         IStakeManager _stakeManager,
-        IStakeManager.Role _role,
         uint256 _burnPct,
         address _treasury
     ) Ownable(msg.sender) {
@@ -92,8 +90,8 @@ contract FeePool is Ownable {
             emit ModulesUpdated(address(_stakeManager));
         }
 
-        rewardRole = _role;
-        emit RewardRoleUpdated(_role);
+        rewardRole = IStakeManager.Role.Platform;
+        emit RewardRoleUpdated(IStakeManager.Role.Platform);
 
         burnPct = pct;
         emit BurnPctUpdated(pct);

--- a/docs/Guidev0.md
+++ b/docs/Guidev0.md
@@ -82,7 +82,7 @@ D3["📦 ValidationModule(jobRegistry, stakeManager, owner=YOU)"]:::step
 D4["📦 ReputationEngine(owner=YOU)"]:::step
 D5["📦 DisputeModule(jobRegistry, stakeManager, reputationEngine, owner=YOU)  (optional)"]:::step
 D6["📦 CertificateNFT(name, symbol, owner=YOU)"]:::step
-D7["📦 FeePool(token=$AGIALPHA, stakeManager, rewardRole=2 (Platform), owner=YOU)"]:::step
+D7["📦 FeePool(token=$AGIALPHA, stakeManager, burnPct=0, owner=YOU)"]:::step
 D8["📦 TaxPolicy(owner=YOU)"]:::step
 D9["📦 JobRouter(stakeManager, reputationEngine, owner=YOU)  (optional, multi‑platform)"]:::step
 end
@@ -97,7 +97,7 @@ L3["JobRegistry.setTaxPolicy(taxPolicy)"]:::step
 L4["StakeManager.setJobRegistry(jobRegistry)"]:::step
 L5["StakeManager.setDisputeModule(dispute)  (if used)"]:::step
 L6["FeePool.setStakeManager(stakeManager)"]:::step
-L7["FeePool.setRewardRole(2)  (Platform)"]:::step
+L7["FeePool.setRewardRole(2)  (optional, defaults to Platform)"]:::step
 L8["DisputeModule.setFeePool(feePool), setTaxPolicy(taxPolicy)  (if used)"]:::step
 L9["JobRouter link StakeManager & ReputationEngine  (if used)"]:::step
 end
@@ -330,11 +330,11 @@ Now, deploy the modules in this recommended order:
 
 * **Contract:** `FeePool` (accumulates fees from jobs and distributes them to stakers). This is effectively the **treasury router** for protocol fees – it will route fees to those who stake as platform operators.
 
-* **Constructor inputs:** `(address token, address stakeManager, uint8 rewardRole, address owner)`.
+* **Constructor inputs:** `(address token, address stakeManager, uint256 burnPct, address owner)`.
 
   * **token:** \$AGIALPHA token address (same one used in StakeManager).
   * **stakeManager:** Address of the StakeManager you deployed.
-  * **rewardRole:** This defines which type of staker will receive the distributed fees. In the StakeManager, roles are defined as: `0 = Agent`, `1 = Validator`, `2 = Platform Operator`. We want platform operators (the third role) to earn the protocol fees, so enter **`2`** here for the reward role (Platform).
+  * **burnPct:** Percentage of each fee burned (0-100). Rewards default to platform operators.
   * **owner:** Your address (owner).
 
 * Deploy FeePool and save the address. (This contract will later be linked to JobRegistry so that a percentage of each job’s reward is diverted as a fee and stored here for distribution.)
@@ -398,7 +398,7 @@ First, connect all the modules so they know about each other’s addresses:
   On **FeePool**’s Write tab, call `setStakeManager(address manager)` with your StakeManager’s address. This ensures the FeePool knows which stake balances to use for reward calculations.
 
 * **FeePool – (Optional) Update Reward Role:**
-  If you did **not** set the correct `rewardRole` in the FeePool constructor, or if you want to change which role earns fees, call `setRewardRole(uint8 role)` on FeePool. For platform operators, use **2** as the role ID. (If you followed the deployment step with `rewardRole = 2`, this is already set. FeePool emits `RewardRoleUpdated` event when changed.)
+  Rewards are paid to platform operators by default. If you want a different role to earn fees, call `setRewardRole(uint8 role)` on FeePool. For platform operators, use **2** as the role ID. FeePool emits `RewardRoleUpdated` when changed.
 
 * **FeePool – Set Treasury (optional):**
   FeePool has an internal `treasury` address for any tiny rounding remainders (“dust”) when distributing fees. By default this is empty. As owner, you can call `setTreasury(address _treasury)` on FeePool to set an address (maybe your treasury or the burn address) to receive these small leftovers. This is not critical; you may set it to the same treasury address used in StakeManager or leave it as zero.

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -23,7 +23,7 @@ Deploy each contract **in the order listed below** from the **Write Contract** t
 5. `ReputationEngine(stakeManager)` – optional reputation weighting (pass `0` to wire later).
 6. `DisputeModule(jobRegistry, appealFee, moderator, jury)` – manages appeals and dispute fees.
 7. `CertificateNFT(name, symbol)` – certifies completed work.
-8. `FeePool(token, stakeManager, role, burnPct, treasury)` – use `address(0)` for `token` to fall back to $AGIALPHA; `burnPct` defaults to `0`.
+8. `FeePool(token, stakeManager, burnPct, treasury)` – rewards default to platform stakers; use `address(0)` for `token` to fall back to $AGIALPHA` and `burnPct` defaults to `0`.
 9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – `minStake` may be `0`.
 10. `JobRouter(platformRegistry)` – stake‑weighted job routing.
 11. `PlatformIncentives(stakeManager, platformRegistry, jobRouter)` – helper that lets operators stake and register with routing in one call. For simple flows without `JobRouter`, call `PlatformRegistry.stakeAndRegister(amount)` or `acknowledgeStakeAndRegister(amount)` directly.

--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -23,7 +23,7 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 5. Deploy `ReputationEngine(stakeManager)` or `ReputationEngine(address(0))` if wiring later.
 6. Deploy `CertificateNFT("AGI Jobs", "AGIJOB")`.
 7. Deploy `DisputeModule(jobRegistry, 0, owner, owner)`.
-8. Deploy `FeePool(token, stakeManager, 2, burnPct, treasury)`.
+8. Deploy `FeePool(token, stakeManager, burnPct, treasury)`; rewards default to platform stakers.
 9. Deploy `PlatformRegistry(stakeManager, reputationEngine, 0)`.
 10. Deploy `JobRouter(platformRegistry)`.
 11. Deploy `PlatformIncentives(stakeManager, platformRegistry, jobRouter)`.

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -67,7 +67,7 @@ contract DeployAll is Script {
         FeePool feePool = new FeePool(
             IERC20(address(token)),
             IStakeManager(address(stake)),
-            IStakeManager.Role.Platform,
+            0,
             vm.addr(deployer)
         );
 

--- a/scripts/deployAll.ts
+++ b/scripts/deployAll.ts
@@ -89,7 +89,7 @@ async function main() {
   const feePool = await FeePool.deploy(
     await token.getAddress(),
     await stake.getAddress(),
-    2, // IStakeManager.Role.Platform
+    0,
     deployer.address
   );
   await feePool.waitForDeployment();

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -146,10 +146,12 @@ async function main() {
   const FeePool = await ethers.getContractFactory(
     "contracts/v2/FeePool.sol:FeePool"
   );
+  const burnPct = typeof args.burnPct === "string" ? parseInt(args.burnPct) : 0;
   const feePool = await FeePool.deploy(
     tokenAddress,
     await stake.getAddress(),
-    2 // IStakeManager.Role.Platform
+    burnPct,
+    treasury
   );
   await feePool.waitForDeployment();
 

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -67,7 +67,8 @@ contract FeePoolTest {
         token = new TestToken();
         stakeManager = new MockStakeManager();
         stakeManager.setJobRegistry(jobRegistry);
-        feePool = new FeePool(token, stakeManager, IStakeManager.Role.Validator, address(this));
+        feePool = new FeePool(token, stakeManager, 0, address(this));
+        feePool.setRewardRole(IStakeManager.Role.Validator);
         stakeManager.setStake(alice, 1_000_000);
         stakeManager.setStake(bob, 2_000_000);
     }

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -61,7 +61,6 @@ describe("FeePool", function () {
     feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
       0,
       treasury.address
     );

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -59,7 +59,6 @@ describe("Governance reward lifecycle", function () {
     feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
       0,
       treasury.address
     );

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -58,7 +58,6 @@ describe("GovernanceReward", function () {
     feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
       0,
       treasury.address
     );

--- a/test/v2/Integration.t.sol
+++ b/test/v2/Integration.t.sol
@@ -101,7 +101,7 @@ contract IntegrationTest {
         stakeManager = new MockStakeManager();
         stakeManager.setJobRegistry(jobRegistryAddr);
         registry = new MockPlatformRegistry();
-        feePool = new FeePool(token, stakeManager, IStakeManager.Role.Platform, address(this));
+        feePool = new FeePool(token, stakeManager, 0, address(this));
         router = new JobRouter(registry, address(this));
     }
 

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -152,7 +152,6 @@ describe("JobRegistry integration", function () {
     const feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
       0,
       treasury.address
     );

--- a/test/v2/PlatformIncentives.t.sol
+++ b/test/v2/PlatformIncentives.t.sol
@@ -43,7 +43,6 @@ contract PlatformIncentivesTest is Test {
         feePool = new FeePool(
             token,
             IStakeManager(address(stakeManager)),
-            IStakeManager.Role.Platform,
             0,
             address(this)
         );

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -269,7 +269,6 @@ describe("PlatformRegistry", function () {
     const feePool = await FeePool.connect(owner).deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
       0,
       treasury.address
     );

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -94,7 +94,6 @@ describe("Platform reward flow", function () {
     feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
       0,
       treasury.address
     );

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -84,7 +84,6 @@ describe("end-to-end job lifecycle", function () {
     feePool = await FeePool.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
       0,
       owner.address
     );

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -84,7 +84,6 @@ describe("multi-operator job lifecycle", function () {
     feePool = await FeePoolF.deploy(
       await token.getAddress(),
       await stakeManager.getAddress(),
-      2,
       0,
       owner.address
     );


### PR DESCRIPTION
## Summary
- simplify `FeePool` constructor by removing reward role parameter and defaulting rewards to Platform stakers
- update deployment scripts, tests, and docs for the new FeePool signature and defaults
- clarify README deployment steps and owner controls around rewards

## Testing
- `npm test`
- `forge test` *(fails: Wrong argument count in script/DeployAll.s.sol and related compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e8f74844883338af155b3f9bedc61