### PR TITLE
feat: secure Deployer and allow custom token

### DIFF
--- a/test/v2/Deployer.test.js
+++ b/test/v2/Deployer.test.js
@@ -10,6 +10,7 @@ describe("Deployer", function () {
     const deployer = await Deployer.deploy();
 
     const econ = {
+      token: ethers.ZeroAddress,
       feePct: 0,
       burnPct: 0,
       employerSlashPct: 0,
@@ -127,6 +128,7 @@ describe("Deployer", function () {
     );
     const deployer = await Deployer.deploy();
     const econ = {
+      token: ethers.ZeroAddress,
       feePct: 0,
       burnPct: 0,
       employerSlashPct: 0,


### PR DESCRIPTION
## Summary
- make Deployer Ownable and gate public deployment functions with onlyOwner
- allow specifying a custom ERC20 token via EconParams and forward to StakeManager and FeePool
- update tests for new token field

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e97b26afc8333a999cc9cb185bbc1