### PR TITLE
feat: enforce ENS ownership for validators

### DIFF
--- a/contracts/v2/mocks/ENSOwnershipVerifierMock.sol
+++ b/contracts/v2/mocks/ENSOwnershipVerifierMock.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+contract ENSOwnershipVerifierMock {
+    function verifyOwnership(
+        address,
+        string calldata,
+        bytes32[] calldata,
+        bytes32
+    ) external pure returns (bool) {
+        return true;
+    }
+}
+

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -37,6 +37,22 @@ describe("ValidationModule V2", function () {
       .connect(owner)
       .setReputationEngine(await reputation.getAddress());
 
+    const Verifier = await ethers.getContractFactory(
+      "ENSOwnershipVerifierMock"
+    );
+    const verifier = await Verifier.deploy();
+    await verifier.waitForDeployment();
+    await validation
+      .connect(owner)
+      .setENSOwnershipVerifier(await verifier.getAddress());
+    await validation.connect(owner).setClubRootNode(ethers.ZeroHash);
+    await validation
+      .connect(owner)
+      .setAdditionalValidators(
+        [v1.address, v2.address, v3.address],
+        [true, true, true]
+      );
+
     // validator stakes and pool
     await stakeManager.setStake(v1.address, 1, ethers.parseEther("100"));
     await stakeManager.setStake(v2.address, 1, ethers.parseEther("50"));
@@ -44,7 +60,10 @@ describe("ValidationModule V2", function () {
 
     await validation
       .connect(owner)
-      .setValidatorPool([v1.address, v2.address, v3.address]);
+      .setValidatorPool(
+        [v1.address, v2.address, v3.address],
+        ["v1", "v2", "v3"]
+      );
 
     // setup job
     const jobStruct = {
@@ -220,7 +239,9 @@ describe("ValidationModule V2", function () {
 
   it("clears commitments when job nonce is reset", async () => {
     await validation.connect(owner).setValidatorBounds(1, 1);
-    await validation.connect(owner).setValidatorPool([v1.address]);
+    await validation
+      .connect(owner)
+      .setValidatorPool([v1.address], ["v1"]);
 
     await validation.selectValidators(1);
     const nonce1 = await validation.jobNonce(1);


### PR DESCRIPTION
## Summary
- require ENS ownership for validators during commit/reveal
- verify subdomains when updating validator pool
- add configurable ENS identity settings and additional validator overrides

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e9db825e08333a8230c49167103e8