### PR TITLE
Add ENS configuration setters with owner guards

### DIFF
--- a/contracts/v2/modules/ENSOwnershipVerifier.sol
+++ b/contracts/v2/modules/ENSOwnershipVerifier.sol
@@ -49,24 +49,28 @@ contract ENSOwnershipVerifier is Ownable {
     }
 
     /// @notice Update ENS registry address
-    function setENS(IENS _ens) external onlyOwner {
-        ens = _ens;
-        emit ENSUpdated(address(_ens));
+    /// @param ensAddr New ENS registry contract address
+    function setENS(address ensAddr) external onlyOwner {
+        ens = IENS(ensAddr);
+        emit ENSUpdated(ensAddr);
     }
 
     /// @notice Update ENS NameWrapper address
-    function setNameWrapper(INameWrapper _nameWrapper) external onlyOwner {
-        nameWrapper = _nameWrapper;
-        emit NameWrapperUpdated(address(_nameWrapper));
+    /// @param wrapper New ENS NameWrapper contract address
+    function setNameWrapper(address wrapper) external onlyOwner {
+        nameWrapper = INameWrapper(wrapper);
+        emit NameWrapperUpdated(wrapper);
     }
 
     /// @notice Update club root node
-    function setClubRootNode(bytes32 _clubRootNode) external onlyOwner {
-        clubRootNode = _clubRootNode;
-        emit ClubRootNodeUpdated(_clubRootNode);
+    /// @param root New club root node hash
+    function setClubRootNode(bytes32 root) external onlyOwner {
+        clubRootNode = root;
+        emit ClubRootNodeUpdated(root);
     }
 
     /// @notice Update validator Merkle root
+    /// @param root New validator allowlist Merkle root
     function setValidatorMerkleRoot(bytes32 root) external onlyOwner {
         validatorMerkleRoot = root;
         emit ValidatorMerkleRootUpdated(root);

--- a/test/v2/ENSOwnershipVerifier.test.js
+++ b/test/v2/ENSOwnershipVerifier.test.js
@@ -1,0 +1,64 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ENSOwnershipVerifier setters", function () {
+  let owner, other, verifier;
+
+  beforeEach(async () => {
+    [owner, other] = await ethers.getSigners();
+    const Verifier = await ethers.getContractFactory(
+      "contracts/v2/modules/ENSOwnershipVerifier.sol:ENSOwnershipVerifier"
+    );
+    verifier = await Verifier.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroHash
+    );
+    await verifier.waitForDeployment();
+  });
+
+  it("allows only owner to update ENS address", async function () {
+    const addr = ethers.getAddress(
+      "0x000000000000000000000000000000000000dEaD"
+    );
+    await expect(verifier.connect(other).setENS(addr))
+      .to.be.revertedWithCustomError(verifier, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(verifier.setENS(addr))
+      .to.emit(verifier, "ENSUpdated")
+      .withArgs(addr);
+  });
+
+  it("allows only owner to update NameWrapper", async function () {
+    const wrapper = ethers.getAddress(
+      "0x000000000000000000000000000000000000bEEF"
+    );
+    await expect(verifier.connect(other).setNameWrapper(wrapper))
+      .to.be.revertedWithCustomError(verifier, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(verifier.setNameWrapper(wrapper))
+      .to.emit(verifier, "NameWrapperUpdated")
+      .withArgs(wrapper);
+  });
+
+  it("allows only owner to update club root node", async function () {
+    const root = ethers.id("club");
+    await expect(verifier.connect(other).setClubRootNode(root))
+      .to.be.revertedWithCustomError(verifier, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(verifier.setClubRootNode(root))
+      .to.emit(verifier, "ClubRootNodeUpdated")
+      .withArgs(root);
+  });
+
+  it("allows only owner to update validator Merkle root", async function () {
+    const root = ethers.id("validator");
+    await expect(verifier.connect(other).setValidatorMerkleRoot(root))
+      .to.be.revertedWithCustomError(verifier, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+    await expect(verifier.setValidatorMerkleRoot(root))
+      .to.emit(verifier, "ValidatorMerkleRootUpdated")
+      .withArgs(root);
+  });
+});
+


### PR DESCRIPTION
## Summary
- expose setters for ENS registry, NameWrapper, club root node, and validator Merkle root
- restrict setters to the contract owner and emit update events
- add tests ensuring non-owners cannot update these parameters

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ea14848588333adbaeb6e96c8d54e