### PR TITLE
Add ENS ownership mocks and validator tests

### DIFF
--- a/contracts/mocks/MockENS.sol
+++ b/contracts/mocks/MockENS.sol
@@ -1,8 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+/// @title MockENS
+/// @notice Basic ENS registry mock returning configurable resolver addresses.
 contract MockENS {
-    function resolver(bytes32) external pure returns (address) {
-        return address(0);
+    mapping(bytes32 => address) public resolvers;
+
+    function resolver(bytes32 node) external view returns (address) {
+        return resolvers[node];
+    }
+
+    function setResolver(bytes32 node, address resolver_) external {
+        resolvers[node] = resolver_;
     }
 }

--- a/contracts/mocks/MockNameWrapper.sol
+++ b/contracts/mocks/MockNameWrapper.sol
@@ -1,8 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+/// @title MockNameWrapper
+/// @notice Simplified ENS NameWrapper mock returning configurable owners.
 contract MockNameWrapper {
-    function ownerOf(uint256) external pure returns (address) {
-        return address(0);
+    mapping(uint256 => address) public owners;
+
+    function ownerOf(uint256 node) external view returns (address) {
+        return owners[node];
+    }
+
+    function setOwner(uint256 node, address owner) external {
+        owners[node] = owner;
     }
 }

--- a/contracts/mocks/MockResolver.sol
+++ b/contracts/mocks/MockResolver.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+/// @title MockResolver
+/// @notice Minimal ENS resolver mock allowing adjustable addr records.
+contract MockResolver {
+    mapping(bytes32 => address payable) public addresses;
+
+    function addr(bytes32 node) external view returns (address payable) {
+        return addresses[node];
+    }
+
+    function setAddr(bytes32 node, address payable addr_) external {
+        addresses[node] = addr_;
+    }
+}

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -113,6 +113,7 @@ contract MockJobRegistry is IJobRegistry, IJobRegistryTax {
 
 contract MockReputationEngine is IReputationEngine {
     mapping(address => uint256) private _rep;
+    mapping(address => bool) private _blacklist;
 
     function add(address user, uint256 amount) external override {
         _rep[user] += amount;
@@ -131,15 +132,17 @@ contract MockReputationEngine is IReputationEngine {
         return _rep[user];
     }
 
-    function isBlacklisted(address) external pure override returns (bool) {
-        return false;
+    function isBlacklisted(address user) external view override returns (bool) {
+        return _blacklist[user];
     }
 
     function setCaller(address, bool) external override {}
 
     function setThreshold(uint256) external override {}
 
-    function setBlacklist(address, bool) external override {}
+    function setBlacklist(address user, bool val) external override {
+        _blacklist[user] = val;
+    }
 
     function getOperatorScore(address user) external view override returns (uint256) {
         return _rep[user];

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -1,0 +1,191 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+function namehash(root, label) {
+  return ethers.keccak256(
+    ethers.solidityPacked(
+      ["bytes32", "bytes32"],
+      [root, ethers.keccak256(ethers.toUtf8Bytes(label))]
+    )
+  );
+}
+
+describe("Validator ENS integration", function () {
+  let owner, validator, other;
+  let ens, resolver, wrapper, verifier;
+  let stakeManager, jobRegistry, reputation, validation;
+  const root = ethers.id("agi");
+
+  beforeEach(async () => {
+    [owner, validator, other] = await ethers.getSigners();
+
+    const ENS = await ethers.getContractFactory("MockENS");
+    ens = await ENS.deploy();
+    await ens.waitForDeployment();
+
+    const Resolver = await ethers.getContractFactory("MockResolver");
+    resolver = await Resolver.deploy();
+    await resolver.waitForDeployment();
+
+    const Wrapper = await ethers.getContractFactory("MockNameWrapper");
+    wrapper = await Wrapper.deploy();
+    await wrapper.waitForDeployment();
+
+    await ens.setResolver(root, await resolver.getAddress());
+
+    const Verifier = await ethers.getContractFactory(
+      "contracts/v2/modules/ENSOwnershipVerifier.sol:ENSOwnershipVerifier"
+    );
+    verifier = await Verifier.deploy(
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      root
+    );
+    await verifier.waitForDeployment();
+
+    const StakeMock = await ethers.getContractFactory("MockStakeManager");
+    stakeManager = await StakeMock.deploy();
+    await stakeManager.waitForDeployment();
+
+    const JobMock = await ethers.getContractFactory("MockJobRegistry");
+    jobRegistry = await JobMock.deploy();
+    await jobRegistry.waitForDeployment();
+
+    const RepMock = await ethers.getContractFactory("MockReputationEngine");
+    reputation = await RepMock.deploy();
+    await reputation.waitForDeployment();
+
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/ValidationModule.sol:ValidationModule"
+    );
+    validation = await Validation.deploy(
+      await jobRegistry.getAddress(),
+      await stakeManager.getAddress(),
+      60,
+      60,
+      1,
+      1,
+      []
+    );
+    await validation.waitForDeployment();
+    await validation.setReputationEngine(await reputation.getAddress());
+    await validation.setENSOwnershipVerifier(await verifier.getAddress());
+    await validation.setClubRootNode(root);
+  });
+
+  it("rejects validators without subdomains and emits events on success", async () => {
+    await expect(
+      validation
+        .connect(owner)
+        .setValidatorPool([validator.address], ["v"])
+    ).to.be.revertedWith("ens verify");
+
+    await wrapper.setOwner(
+      ethers.toBigInt(namehash(root, "v")),
+      validator.address
+    );
+    await resolver.setAddr(namehash(root, "v"), validator.address);
+    await expect(
+      validation
+        .connect(owner)
+        .setValidatorPool([validator.address], ["v"])
+    )
+      .to.emit(verifier, "OwnershipVerified")
+      .withArgs(validator.address, "v")
+      .and.to.emit(validation, "ValidatorsUpdated");
+  });
+
+  it("rejects invalid Merkle proofs", async () => {
+    const leaf = ethers.solidityPackedKeccak256(
+      ["address"],
+      [validator.address]
+    );
+    await verifier.setValidatorMerkleRoot(leaf);
+    const badProof = [ethers.id("bad")];
+    await expect(
+      verifier.verifyOwnership(validator.address, "v", badProof, root)
+    ).to.not.emit(verifier, "OwnershipVerified");
+    expect(
+      await verifier.verifyOwnership.staticCall(
+        validator.address,
+        "v",
+        badProof,
+        root
+      )
+    ).to.equal(false);
+  });
+
+  it("removes validator privileges after subdomain transfer and allows override", async () => {
+    const node = namehash(root, "v");
+    await wrapper.setOwner(ethers.toBigInt(node), validator.address);
+    await resolver.setAddr(node, validator.address);
+    await validation.setValidatorPool([validator.address], ["v"]);
+
+    await stakeManager.setStake(
+      validator.address,
+      1,
+      ethers.parseEther("1")
+    );
+
+    const job = {
+      employer: owner.address,
+      agent: ethers.ZeroAddress,
+      reward: 0,
+      stake: 0,
+      success: false,
+      status: 0,
+      uri: "",
+    };
+    await jobRegistry.setJob(1, job);
+    await validation.selectValidators(1);
+
+    // transfer ENS ownership
+    await wrapper.setOwner(ethers.toBigInt(node), other.address);
+    await expect(
+      validation
+        .connect(validator)
+        .commitValidation(1, ethers.id("h"))
+    ).to.be.revertedWith("ens owner");
+
+    // non-owner cannot override
+    await expect(
+      validation
+        .connect(other)
+        .setAdditionalValidators([validator.address], [true])
+    ).to.be.revertedWithCustomError(validation, "OwnableUnauthorizedAccount");
+
+    // owner override and commit succeeds
+    await validation
+      .connect(owner)
+      .setAdditionalValidators([validator.address], [true]);
+    await expect(
+      validation.connect(validator).commitValidation(1, ethers.id("h"))
+    ).to.emit(validation, "VoteCommitted");
+  });
+
+  it("skips blacklisted validators", async () => {
+    const node = namehash(root, "v");
+    await wrapper.setOwner(ethers.toBigInt(node), validator.address);
+    await resolver.setAddr(node, validator.address);
+    await validation.setValidatorPool([validator.address], ["v"]);
+    await stakeManager.setStake(
+      validator.address,
+      1,
+      ethers.parseEther("1")
+    );
+    await reputation.setBlacklist(validator.address, true);
+    const job = {
+      employer: owner.address,
+      agent: ethers.ZeroAddress,
+      reward: 0,
+      stake: 0,
+      success: false,
+      status: 0,
+      uri: "",
+    };
+    await jobRegistry.setJob(1, job);
+    await expect(validation.selectValidators(1)).to.be.revertedWith(
+      "insufficient validators"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- make NameWrapper, ENS, and resolver mocks configurable for testing
- allow reputation engine mock to blacklist validators
- add ENS validator tests for pool setup, privilege loss, overrides, and blacklisting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ea3cce28483339d5ce5c21935eb59