### PR TITLE
feat: add ENS-based agent authorization

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -91,9 +91,9 @@ contract MockJobRegistry is IJobRegistry, IJobRegistryTax {
     }
     function setJobParameters(uint256, uint256) external override {}
     function createJob(uint256, string calldata) external override returns (uint256) {return 0;}
-      function applyForJob(uint256) external override {}
-      function stakeAndApply(uint256, uint256) external override {}
-      function acknowledgeAndApply(uint256) external override {}
+      function applyForJob(uint256, string calldata, bytes32[] calldata) external override {}
+      function stakeAndApply(uint256, uint256, string calldata, bytes32[] calldata) external override {}
+      function acknowledgeAndApply(uint256, string calldata, bytes32[] calldata) external override {}
       function completeJob(uint256) external override {}
       function acknowledgeAndCompleteJob(uint256) external override {}
     function dispute(uint256) external payable override {}

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -104,17 +104,36 @@ interface IJobRegistry {
 
     /// @notice Agent expresses interest in a job
     /// @param jobId Identifier of the job to apply for
+    /// @param subdomain ENS subdomain label
+    /// @param proof Merkle proof for ENS ownership verification
     /// @dev Reverts with {InvalidStatus} if job is not open for applications
-    function applyForJob(uint256 jobId) external;
+    function applyForJob(
+        uint256 jobId,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external;
 
     /// @notice Deposit stake and apply for a job in one call
     /// @param jobId Identifier of the job
     /// @param amount Stake amount in $AGIALPHA with 6 decimals
-    function stakeAndApply(uint256 jobId, uint256 amount) external;
+    /// @param subdomain ENS subdomain label
+    /// @param proof Merkle proof for ENS ownership verification
+    function stakeAndApply(
+        uint256 jobId,
+        uint256 amount,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external;
 
     /// @notice Acknowledge the tax policy and apply for a job in one call
     /// @param jobId Identifier of the job to apply for
-    function acknowledgeAndApply(uint256 jobId) external;
+    /// @param subdomain ENS subdomain label
+    /// @param proof Merkle proof for ENS ownership verification
+    function acknowledgeAndApply(
+        uint256 jobId,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external;
 
     /// @notice Agent completes the job and triggers validation
     /// @param jobId Identifier of the job being completed

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -105,6 +105,12 @@ describe("Full system integration", function () {
     await registry.connect(v1).acknowledgeTaxPolicy();
     await registry.connect(v2).acknowledgeTaxPolicy();
 
+    const Verifier = await ethers.getContractFactory(
+      "contracts/v2/mocks/ENSOwnershipVerifierMock.sol:ENSOwnershipVerifierMock"
+    );
+    const verifier = await Verifier.deploy();
+    await registry.setENSOwnershipVerifier(await verifier.getAddress());
+
     await token.mint(employer.address, 1000);
     await token.mint(agent.address, 1000);
     await token.mint(v1.address, 1000);
@@ -133,7 +139,7 @@ describe("Full system integration", function () {
   async function startJob() {
     await registry.connect(employer).createJob(reward, "uri");
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId);
+    await registry.connect(agent).applyForJob(jobId, "", []);
     return jobId;
   }
 

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -121,6 +121,12 @@ describe("end-to-end job lifecycle", function () {
     await registry.connect(employer).acknowledgeTaxPolicy();
     await registry.connect(agent).acknowledgeTaxPolicy();
     await registry.connect(platform).acknowledgeTaxPolicy();
+
+    const Verifier = await ethers.getContractFactory(
+      "contracts/v2/mocks/ENSOwnershipVerifierMock.sol:ENSOwnershipVerifierMock"
+    );
+    const verifier = await Verifier.deploy();
+    await registry.setENSOwnershipVerifier(await verifier.getAddress());
   });
 
   it("distributes fees to staked operators", async () => {
@@ -137,7 +143,7 @@ describe("end-to-end job lifecycle", function () {
       .approve(await stakeManager.getAddress(), reward + fee);
     await registry.connect(employer).createJob(reward, "uri");
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId);
+    await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);
     await registry.connect(agent).completeJob(jobId);
     await registry.finalize(jobId);

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -137,6 +137,12 @@ describe("multi-operator job lifecycle", function () {
     await registry.connect(agent).acknowledgeTaxPolicy();
     await registry.connect(platform1).acknowledgeTaxPolicy();
     await registry.connect(platform2).acknowledgeTaxPolicy();
+
+    const Verifier = await ethers.getContractFactory(
+      "contracts/v2/mocks/ENSOwnershipVerifierMock.sol:ENSOwnershipVerifierMock"
+    );
+    const verifier = await Verifier.deploy();
+    await registry.setENSOwnershipVerifier(await verifier.getAddress());
   });
 
   it("runs job lifecycle and handles multiple staked operators", async () => {
@@ -166,7 +172,7 @@ describe("multi-operator job lifecycle", function () {
       .approve(await stakeManager.getAddress(), reward + fee);
     await registry.connect(employer).createJob(reward, "uri");
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId);
+    await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);
     await registry.connect(agent).completeJob(jobId);
     await registry.finalize(jobId);


### PR DESCRIPTION
## Summary
- verify agent ENS ownership or allowlisted status before job application
- expose ENS verifier, agent root node and agent override configuration
- propagate subdomain and proof params through job application helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ea60df7b083338a3d371f16cdfc8e