### PR TITLE
refactor: update validator commit auth

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -47,8 +47,6 @@ contract ValidationModule is IValidationModule, Ownable {
     INameWrapper public nameWrapper;
     ENSOwnershipVerifier public ensOwnershipVerifier;
 
-    // mapping of validator address to subdomain namehash
-    mapping(address => bytes32) public validatorNamehash;
     // optional override for validators without ENS identity
     mapping(address => bool) public additionalValidators;
 
@@ -144,39 +142,13 @@ contract ValidationModule is IValidationModule, Ownable {
         }
     }
 
-    /// @notice Update the list of eligible validators with ENS verification.
+    /// @notice Update the list of eligible validators.
     /// @param validators Addresses of validators.
-    /// @param labels Corresponding ENS subdomain labels for each validator.
-    function setValidatorPool(
-        address[] calldata validators,
-        string[] calldata labels
-    ) external onlyOwner {
-        require(validators.length == labels.length, "length");
-        ENSOwnershipVerifier verifier = ensOwnershipVerifier;
-        require(address(verifier) != address(0), "verifier");
-
-        uint256 len = validatorPool.length;
-        for (uint256 i; i < len; ++i) {
-            delete validatorNamehash[validatorPool[i]];
-        }
-        delete validatorPool;
-
-        bytes32[] memory proof = new bytes32[](0);
-        for (uint256 i; i < validators.length; ++i) {
-            require(
-                verifier.verifyOwnership(
-                    validators[i],
-                    labels[i],
-                    proof,
-                    clubRootNode
-                ),
-                "ens verify"
-            );
-            validatorPool.push(validators[i]);
-            validatorNamehash[validators[i]] = keccak256(
-                abi.encodePacked(clubRootNode, keccak256(bytes(labels[i])))
-            );
-        }
+    function setValidatorPool(address[] calldata validators)
+        external
+        onlyOwner
+    {
+        validatorPool = validators;
         emit ValidatorsUpdated(validators);
     }
 
@@ -331,26 +303,31 @@ contract ValidationModule is IValidationModule, Ownable {
     }
 
     /// @notice Commit a validation hash for a job.
-    function commitValidation(uint256 jobId, bytes32 commitHash)
-        public
-        override
-        requiresTaxAcknowledgement
-    {
+    function commitValidation(
+        uint256 jobId,
+        bytes32 commitHash,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) public override requiresTaxAcknowledgement {
         Round storage r = rounds[jobId];
         require(
             r.commitDeadline != 0 && block.timestamp <= r.commitDeadline,
             "commit closed"
         );
         require(_isValidator(jobId, msg.sender), "not validator");
-        if (!additionalValidators[msg.sender]) {
-            bytes32 node = validatorNamehash[msg.sender];
-            require(node != bytes32(0), "ens");
-            require(
-                address(nameWrapper) != address(0) &&
-                    nameWrapper.ownerOf(uint256(node)) == msg.sender,
-                "ens owner"
-            );
-        }
+        require(
+            ensOwnershipVerifier.verifyOwnership(
+                msg.sender,
+                subdomain,
+                proof,
+                clubRootNode
+            ) || additionalValidators[msg.sender],
+            "Not authorized validator"
+        );
+        require(
+            !reputationEngine.isBlacklisted(msg.sender),
+            "Blacklisted validator"
+        );
         require(validatorStakes[jobId][msg.sender] > 0, "stake");
         uint256 nonce = jobNonce[jobId];
         require(
@@ -371,15 +348,10 @@ contract ValidationModule is IValidationModule, Ownable {
         Round storage r = rounds[jobId];
         require(block.timestamp > r.commitDeadline, "commit phase");
         require(block.timestamp <= r.revealDeadline, "reveal closed");
-        if (!additionalValidators[msg.sender]) {
-            bytes32 node = validatorNamehash[msg.sender];
-            require(node != bytes32(0), "ens");
-            require(
-                address(nameWrapper) != address(0) &&
-                    nameWrapper.ownerOf(uint256(node)) == msg.sender,
-                "ens owner"
-            );
-        }
+        require(
+            !reputationEngine.isBlacklisted(msg.sender),
+            "Blacklisted validator"
+        );
         uint256 nonce = jobNonce[jobId];
         bytes32 commitHash = commitments[jobId][msg.sender][nonce];
         require(commitHash != bytes32(0), "no commit");
@@ -399,11 +371,13 @@ contract ValidationModule is IValidationModule, Ownable {
     }
 
     /// @notice Backwards-compatible wrapper for commitValidation.
-    function commitVote(uint256 jobId, bytes32 commitHash)
-        external
-        requiresTaxAcknowledgement
-    {
-        commitValidation(jobId, commitHash);
+    function commitVote(
+        uint256 jobId,
+        bytes32 commitHash,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external requiresTaxAcknowledgement {
+        commitValidation(jobId, commitHash, subdomain, proof);
     }
 
     /// @notice Backwards-compatible wrapper for revealValidation.

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -16,7 +16,14 @@ interface IValidationModule {
     /// @notice Commit a validation hash for a job
     /// @param jobId Identifier of the job being voted on
     /// @param commitHash Hash of the vote and salt
-    function commitValidation(uint256 jobId, bytes32 commitHash) external;
+    /// @param subdomain ENS subdomain label used for ownership verification
+    /// @param proof Merkle proof validating the subdomain
+    function commitValidation(
+        uint256 jobId,
+        bytes32 commitHash,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external;
 
     /// @notice Reveal a previously committed validation vote
     /// @param jobId Identifier of the job

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -15,7 +15,12 @@ contract ValidationStub is IValidationModule {
         return new address[](0);
     }
 
-    function commitValidation(uint256, bytes32) external {}
+    function commitValidation(
+        uint256,
+        bytes32,
+        string calldata,
+        bytes32[] calldata
+    ) external {}
 
     function revealValidation(uint256, bool, bytes32) external {}
 

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -60,10 +60,7 @@ describe("ValidationModule V2", function () {
 
     await validation
       .connect(owner)
-      .setValidatorPool(
-        [v1.address, v2.address, v3.address],
-        ["v1", "v2", "v3"]
-      );
+      .setValidatorPool([v1.address, v2.address, v3.address]);
 
     // setup job
     const jobStruct = {
@@ -124,12 +121,12 @@ describe("ValidationModule V2", function () {
     await (
       await validation
         .connect(signerMap[selected[0].toLowerCase()])
-        .commitValidation(1, commit1)
+        .commitValidation(1, commit1, "", [])
     ).wait();
     await (
       await validation
         .connect(signerMap[selected[1].toLowerCase()])
-        .commitValidation(1, commit2)
+        .commitValidation(1, commit2, "", [])
     ).wait();
     await advance(61);
     await validation
@@ -179,12 +176,12 @@ describe("ValidationModule V2", function () {
     await (
       await validation
         .connect(signerMap[selected[0].toLowerCase()])
-        .commitValidation(1, commit1)
+        .commitValidation(1, commit1, "", [])
     ).wait();
     await (
       await validation
         .connect(signerMap[selected[1].toLowerCase()])
-        .commitValidation(1, commit2)
+        .commitValidation(1, commit2, "", [])
     ).wait();
     await advance(61);
     const stake0 = await stakeManager.stakeOf(selected[0], 1);
@@ -227,7 +224,7 @@ describe("ValidationModule V2", function () {
     await (
       await validation
         .connect(signerMap[selected[0].toLowerCase()])
-        .commitValidation(1, commit)
+        .commitValidation(1, commit, "", [])
     ).wait();
     await advance(61);
     await expect(
@@ -241,7 +238,7 @@ describe("ValidationModule V2", function () {
     await validation.connect(owner).setValidatorBounds(1, 1);
     await validation
       .connect(owner)
-      .setValidatorPool([v1.address], ["v1"]);
+      .setValidatorPool([v1.address]);
 
     await validation.selectValidators(1);
     const nonce1 = await validation.jobNonce(1);
@@ -250,10 +247,10 @@ describe("ValidationModule V2", function () {
       ["uint256", "uint256", "bool", "bytes32"],
       [1n, nonce1, true, salt]
     );
-    await (await validation.connect(v1).commitValidation(1, commit1)).wait();
+    await (await validation.connect(v1).commitValidation(1, commit1, "", [])).wait();
 
     await expect(
-      validation.connect(v1).commitValidation(1, commit1)
+      validation.connect(v1).commitValidation(1, commit1, "", [])
     ).to.be.revertedWith("already committed");
 
     await validation.connect(owner).resetJobNonce(1);
@@ -268,7 +265,7 @@ describe("ValidationModule V2", function () {
       [1n, nonce2, true, salt]
     );
     await expect(
-      validation.connect(v1).commitValidation(1, commit2)
+      validation.connect(v1).commitValidation(1, commit2, "", [])
     ).to.not.be.reverted;
   });
 
@@ -333,12 +330,12 @@ describe("ValidationModule V2", function () {
     );
 
     await expect(
-      validation.connect(val).commitValidation(1, commit)
+      validation.connect(val).commitValidation(1, commit, "", [])
     ).to.be.revertedWith("acknowledge tax policy");
 
     await jobRegistry.connect(val).acknowledgeTaxPolicy();
     await expect(
-      validation.connect(val).commitValidation(1, commit)
+      validation.connect(val).commitValidation(1, commit, "", [])
     ).to.emit(validation, "VoteCommitted");
 
     await advance(61);


### PR DESCRIPTION
## Summary
- require ENSOwnershipVerifier ownership proof & blacklist check when committing
- simplify validator pool management and remove stored namehashes
- update ValidationModule interface and tests

## Testing
- `npx hardhat test test/v2/ValidationModule.test.js`
- `npx hardhat test test/v2/ENSValidatorBehavior.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ea8b9a7708333bfdee57cafcb56b0