### PR TITLE
Add submission and post-validation finalization flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,8 +542,8 @@ graph TD
 
 1. Employers, agents, and validators must call `JobRegistry.acknowledgeTaxPolicy` before staking, voting, or appealing. The transaction emits `TaxAcknowledged(user, version, acknowledgement)` so the accepted disclaimer is permanently logged on‑chain.
 2. Employer escrows a reward and posts a job via `JobRegistry.createJob`.
-3. Agents stake and apply; one agent submits work with `completeJob`.
-4. `ValidationModule` picks validators who commit and reveal votes.
+3. Agents stake and apply; the assigned agent submits work with `submit`, triggering validator selection.
+4. Validators commit and reveal votes. After tally, anyone calls `finalizeAfterValidation` to record the outcome.
 5. `JobRegistry.finalize` pays the agent and validators or allows `DisputeModule` appeal.
 6. On success, `CertificateNFT` mints proof of completion.
 
@@ -1318,7 +1318,7 @@ The suite defaults to [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f5
 
 | Module | Interface / Key functions |
 | --- | --- |
-| `JobRegistry` | [`IJobRegistry`](contracts/v2/interfaces/IJobRegistry.sol) – `createJob`, `applyForJob`, `completeJob`, `dispute`, `finalize`, `acknowledgeTaxPolicy`, `taxPolicyDetails`, `taxPolicyVersion` |
+| `JobRegistry` | [`IJobRegistry`](contracts/v2/interfaces/IJobRegistry.sol) – `createJob`, `applyForJob`, `submit`, `finalizeAfterValidation`, `dispute`, `finalize`, `acknowledgeTaxPolicy`, `taxPolicyDetails`, `taxPolicyVersion` |
 | `ValidationModule` | [`IValidationModule`](contracts/v2/interfaces/IValidationModule.sol) – `selectValidators`, `commitValidation`, `revealValidation`, `finalize`, `appeal` |
 | `StakeManager` | [`IStakeManager`](contracts/v2/interfaces/IStakeManager.sol) – `depositStake`, `withdrawStake`, `lockStake`, `slash`, `stakeOf` |
 | `ReputationEngine` | [`IReputationEngine`](contracts/v2/interfaces/IReputationEngine.sol) – `addReputation`, `subtractReputation`, `setBlacklist`, `isBlacklisted` |
@@ -1429,7 +1429,7 @@ Role-based quick steps:
 **Agents**
 1. Acknowledge the tax policy and confirm exemptions.
 2. Stake tokens in StakeManager via `depositStake(0, amount)`.
-3. Join a task with JobRegistry `applyForJob(jobId)` and submit results using `completeJob(jobId, data)`.
+3. Join a task with JobRegistry `applyForJob(jobId)` and submit results using `submit(jobId, uri)`. After validators vote, anyone may call `finalizeAfterValidation(jobId)`.
 
 **Validators**
 1. Acknowledge the tax policy and confirm exemptions.

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -94,8 +94,9 @@ contract MockJobRegistry is IJobRegistry, IJobRegistryTax {
       function applyForJob(uint256, string calldata, bytes32[] calldata) external override {}
       function stakeAndApply(uint256, uint256, string calldata, bytes32[] calldata) external override {}
       function acknowledgeAndApply(uint256, string calldata, bytes32[] calldata) external override {}
-      function completeJob(uint256) external override {}
-      function acknowledgeAndCompleteJob(uint256) external override {}
+      function submit(uint256, string calldata) external override {}
+      function acknowledgeAndSubmit(uint256, string calldata) external override {}
+      function finalizeAfterValidation(uint256) external override {}
     function dispute(uint256) external payable override {}
     function acknowledgeAndDispute(uint256, string calldata) external override {}
     function resolveDispute(uint256, bool) external override {}

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -321,6 +321,10 @@ contract ValidationModule is IValidationModule, Ownable {
     ) public override requiresTaxAcknowledgement {
         Round storage r = rounds[jobId];
         require(
+            jobRegistry.jobs(jobId).status == IJobRegistry.Status.Submitted,
+            "not submitted"
+        );
+        require(
             r.commitDeadline != 0 && block.timestamp <= r.commitDeadline,
             "commit closed"
         );

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -8,6 +8,7 @@ interface IJobRegistry {
         None,
         Created,
         Applied,
+        Submitted,
         Completed,
         Disputed,
         Finalized,
@@ -135,14 +136,19 @@ interface IJobRegistry {
         bytes32[] calldata proof
     ) external;
 
-    /// @notice Agent completes the job and triggers validation
-    /// @param jobId Identifier of the job being completed
-    /// @dev Reverts with {InvalidStatus} or {OnlyAgent} accordingly
-    function completeJob(uint256 jobId) external;
+    /// @notice Agent submits completed work for validation.
+    /// @param jobId Identifier of the job being submitted
+    /// @param uri Metadata URI of the submission
+    function submit(uint256 jobId, string calldata uri) external;
 
-    /// @notice Acknowledge tax policy and complete the job in one call
-    /// @param jobId Identifier of the job being completed
-    function acknowledgeAndCompleteJob(uint256 jobId) external;
+    /// @notice Acknowledge tax policy and submit work in one call
+    /// @param jobId Identifier of the job being submitted
+    /// @param uri Metadata URI of the submission
+    function acknowledgeAndSubmit(uint256 jobId, string calldata uri) external;
+
+    /// @notice Finalise a job after validator voting
+    /// @param jobId Identifier of the job being finalised
+    function finalizeAfterValidation(uint256 jobId) external;
 
     /// @notice Raise a dispute for a completed job
     /// @param jobId Identifier of the disputed job

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -88,8 +88,8 @@ Before performing any on-chain action, employers, agents, and validators must ca
 1. On `JobRegistry`, execute **acknowledgeTaxPolicy** and verify **isTaxExempt()**. Check the emitted `TaxAcknowledged` event for the recorded disclaimer.
 2. Open `StakeManager`; in **Read Contract** confirm **isTaxExempt()**, then stake with **depositStake(0, amount)** (role `0` = Agent).
    ![agent stake](https://via.placeholder.com/650x150?text=depositStake)
-3. Use **applyForJob** and **completeJob** as needed.
-4. Call **requestJobCompletion** when work is ready for validation.
+3. Use **applyForJob** then **submit(jobId, uri)** when work is ready.
+4. After validators reveal votes, call **finalizeAfterValidation(jobId)** to record the outcome.
 
 ### Validators
 1. On `JobRegistry`, execute **acknowledgeTaxPolicy** and verify **isTaxExempt()**. Inspect the `TaxAcknowledged` event log for the acknowledgement text.

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -87,7 +87,7 @@ describe("Validator ENS integration", function () {
       reward: 0,
       stake: 0,
       success: false,
-      status: 0,
+      status: 3,
       uri: "",
     };
     await jobRegistry.setJob(1, job);
@@ -153,7 +153,7 @@ describe("Validator ENS integration", function () {
       reward: 0,
       stake: 0,
       success: false,
-      status: 0,
+      status: 3,
       uri: "",
     };
     await jobRegistry.setJob(1, job);
@@ -202,7 +202,7 @@ describe("Validator ENS integration", function () {
       reward: 0,
       stake: 0,
       success: false,
-      status: 0,
+      status: 3,
       uri: "",
     };
     await jobRegistry.setJob(1, job);

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -125,7 +125,8 @@ describe("JobRegistry integration", function () {
       .to.emit(registry, "AgentApplied")
       .withArgs(jobId, agent.address);
     await validation.connect(owner).setResult(true);
-    await expect(registry.connect(agent).completeJob(jobId))
+    await registry.connect(agent).submit(jobId, "result");
+    await expect(registry.finalizeAfterValidation(jobId))
       .to.emit(registry, "JobCompleted")
       .withArgs(jobId, true);
     await expect(registry.connect(employer).finalize(jobId))
@@ -182,7 +183,8 @@ describe("JobRegistry integration", function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);
-    await registry.connect(agent).completeJob(jobId);
+    await registry.connect(agent).submit(jobId, "result");
+    await registry.finalizeAfterValidation(jobId);
     await registry.connect(employer).finalize(jobId);
 
     // platform operator should be able to claim fee
@@ -202,7 +204,7 @@ describe("JobRegistry integration", function () {
       .to.emit(registry, "JobCancelled")
       .withArgs(jobId);
     const job = await registry.jobs(jobId);
-    expect(job.state).to.equal(6); // Cancelled enum value
+    expect(job.state).to.equal(7); // Cancelled enum value
     expect(await token.balanceOf(employer.address)).to.equal(1000);
   });
 

--- a/test/v2/ProtocolFeatures.test.js
+++ b/test/v2/ProtocolFeatures.test.js
@@ -138,7 +138,7 @@ describe("Protocol core features", function () {
       reward: 0,
       stake: 0,
       success: false,
-      status: 0,
+      status: 5,
       uri: ""
     });
     const tx = await registry

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -69,7 +69,7 @@ describe("ValidationModule V2", function () {
       reward: 0,
       stake: 0,
       success: false,
-      status: 0,
+       status: 3,
       uri: "",
     };
     await jobRegistry.setJob(1, jobStruct);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -145,7 +145,8 @@ describe("end-to-end job lifecycle", function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);
-    await registry.connect(agent).completeJob(jobId);
+    await registry.connect(agent).submit(jobId, "result");
+    await registry.finalizeAfterValidation(jobId);
     await registry.finalize(jobId);
 
     // fee moved to FeePool

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -174,7 +174,8 @@ describe("multi-operator job lifecycle", function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);
-    await registry.connect(agent).completeJob(jobId);
+    await registry.connect(agent).submit(jobId, "result");
+    await registry.finalizeAfterValidation(jobId);
     await registry.finalize(jobId);
 
     expect(await feePool.pendingFees()).to.equal(fee);


### PR DESCRIPTION
## Summary
- add `Submitted` state and `submit` workflow that records a URI and picks validators
- require jobs be `Submitted` before validators can commit
- finalize results after tally with `finalizeAfterValidation` and document new flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eb5568f14833392aa0801b701dab8