### PR TITLE
feat: add single address agent and validator controls

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -131,6 +131,10 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     /// @param acknowledger Address being granted or revoked the role.
     /// @param allowed True if the address can acknowledge for others.
     event AcknowledgerUpdated(address indexed acknowledger, bool allowed);
+    /// @notice Emitted when an additional agent is added or removed.
+    /// @param agent Address being updated.
+    /// @param allowed True if the agent is whitelisted, false if removed.
+    event AdditionalAgentUpdated(address indexed agent, bool allowed);
 
     // job parameter template event
     event JobParametersUpdated(uint256 reward, uint256 stake);
@@ -272,7 +276,23 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         require(agents.length == allowed.length, "length");
         for (uint256 i; i < agents.length; ++i) {
             additionalAgents[agents[i]] = allowed[i];
+            emit AdditionalAgentUpdated(agents[i], allowed[i]);
         }
+    }
+
+    /// @notice Manually allow an agent to bypass ENS checks.
+    /// @param agent Address to whitelist.
+    function addAdditionalAgent(address agent) external onlyOwner {
+        require(agent != address(0), "agent");
+        additionalAgents[agent] = true;
+        emit AdditionalAgentUpdated(agent, true);
+    }
+
+    /// @notice Remove an agent from the manual allowlist.
+    /// @param agent Address to remove.
+    function removeAdditionalAgent(address agent) external onlyOwner {
+        additionalAgents[agent] = false;
+        emit AdditionalAgentUpdated(agent, false);
     }
 
     /// @notice update the FeePool contract used for revenue sharing

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -83,6 +83,10 @@ contract ValidationModule is IValidationModule, Ownable {
         address nameWrapper
     );
     event AgentMerkleRootUpdated(bytes32 agentMerkleRoot);
+    /// @notice Emitted when an additional validator is added or removed.
+    /// @param validator Address being updated.
+    /// @param allowed True if the validator is whitelisted, false if removed.
+    event AdditionalValidatorUpdated(address indexed validator, bool allowed);
 
     /// @notice Require caller to acknowledge current tax policy via JobRegistry.
     modifier requiresTaxAcknowledgement() {
@@ -193,7 +197,23 @@ contract ValidationModule is IValidationModule, Ownable {
         require(validators.length == allowed.length, "length");
         for (uint256 i; i < validators.length; ++i) {
             additionalValidators[validators[i]] = allowed[i];
+            emit AdditionalValidatorUpdated(validators[i], allowed[i]);
         }
+    }
+
+    /// @notice Manually allow a validator to bypass ENS checks.
+    /// @param validator Address to whitelist.
+    function addAdditionalValidator(address validator) external onlyOwner {
+        require(validator != address(0), "validator");
+        additionalValidators[validator] = true;
+        emit AdditionalValidatorUpdated(validator, true);
+    }
+
+    /// @notice Remove a validator from the manual allowlist.
+    /// @param validator Address to remove.
+    function removeAdditionalValidator(address validator) external onlyOwner {
+        additionalValidators[validator] = false;
+        emit AdditionalValidatorUpdated(validator, false);
     }
 
     /// @notice Set validator Merkle root for identity checks.

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -28,6 +28,7 @@ interface IJobRegistry {
         uint256 stake,
         uint256 fee
     );
+    event AdditionalAgentUpdated(address indexed agent, bool allowed);
     function createJob(string calldata details, uint256 reward) external;
     function setModules(
         address validation,
@@ -36,6 +37,8 @@ interface IJobRegistry {
         address dispute,
         address certificate
     ) external;
+    function addAdditionalAgent(address agent) external;
+    function removeAdditionalAgent(address agent) external;
 }
 
 interface IStakeManager {
@@ -48,10 +51,13 @@ interface IStakeManager {
 }
 
 interface IValidationModule {
+    event AdditionalValidatorUpdated(address indexed validator, bool allowed);
     function commit(uint256 jobId, bytes32 hash) external;
     function reveal(uint256 jobId, bool verdict, bytes32 salt) external;
     function finalize(uint256 jobId) external;
     function setParameters(uint256 commitWindow, uint256 revealWindow, uint256 minValidators) external;
+    function addAdditionalValidator(address validator) external;
+    function removeAdditionalValidator(address validator) external;
 }
 
 interface IReputationEngine {

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -277,5 +277,21 @@ describe("JobRegistry integration", function () {
 
     expect(await registry.acknowledgers(treasury.address)).to.equal(true);
   });
+
+  it("updates additional agents individually", async () => {
+    await expect(
+      registry.connect(owner).addAdditionalAgent(treasury.address)
+    )
+      .to.emit(registry, "AdditionalAgentUpdated")
+      .withArgs(treasury.address, true);
+    expect(await registry.additionalAgents(treasury.address)).to.equal(true);
+
+    await expect(
+      registry.connect(owner).removeAdditionalAgent(treasury.address)
+    )
+      .to.emit(registry, "AdditionalAgentUpdated")
+      .withArgs(treasury.address, false);
+    expect(await registry.additionalAgents(treasury.address)).to.equal(false);
+  });
 });
 

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -349,4 +349,21 @@ describe("ValidationModule V2", function () {
       validation.connect(val).revealValidation(1, true, salt)
     ).to.emit(validation, "VoteRevealed");
   });
+
+  it("updates additional validators individually", async () => {
+    const [, , , , , extra] = await ethers.getSigners();
+    await expect(
+      validation.connect(owner).addAdditionalValidator(extra.address)
+    )
+      .to.emit(validation, "AdditionalValidatorUpdated")
+      .withArgs(extra.address, true);
+    expect(await validation.additionalValidators(extra.address)).to.equal(true);
+
+    await expect(
+      validation.connect(owner).removeAdditionalValidator(extra.address)
+    )
+      .to.emit(validation, "AdditionalValidatorUpdated")
+      .withArgs(extra.address, false);
+    expect(await validation.additionalValidators(extra.address)).to.equal(false);
+  });
 });


### PR DESCRIPTION
## Summary
- allow job registry owner to add or remove individual agents with `AdditionalAgentUpdated` event
- allow validation module owner to add or remove individual validators with `AdditionalValidatorUpdated` event
- document new events and add tests for single-address updates

## Testing
- `npx hardhat test test/v2/JobRegistry.test.js test/v2/ValidationModule.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689f289b20d08333a61098ad22ba4d69