### PR TITLE
feat: add premium access helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ The platform’s v2 release decomposes coordination into immutable, single‑pur
 - **JobRegistry** – posts jobs, escrows rewards, and routes calls to companion modules.
 - **ValidationModule** – runs commit–reveal voting and tallies preliminary outcomes.
 - **StakeManager** – holds stakes, escrows payouts, and executes slashing.
-- **ReputationEngine** – accrues or subtracts reputation and manages blacklists.
+- **ReputationEngine** – accrues or subtracts reputation, manages blacklists, and exposes `canAccessPremium(user)` for gating premium features.
 - **DisputeModule** – optional appeal layer for contested jobs.
 - **CertificateNFT** – mints ERC‑721 completion certificates to employers.
 
@@ -598,6 +598,7 @@ interface IReputationEngine {
     function add(address user, uint256 amount) external;
     function subtract(address user, uint256 amount) external;
     function reputation(address user) external view returns (uint256);
+    function canAccessPremium(address user) external view returns (bool);
     function setCaller(address caller, bool allowed) external;
 }
 

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -115,6 +115,7 @@ contract MockJobRegistry is IJobRegistry, IJobRegistryTax {
 contract MockReputationEngine is IReputationEngine {
     mapping(address => uint256) private _rep;
     mapping(address => bool) private _blacklist;
+    uint256 public threshold;
 
     function add(address user, uint256 amount) external override {
         _rep[user] += amount;
@@ -137,9 +138,15 @@ contract MockReputationEngine is IReputationEngine {
         return _blacklist[user];
     }
 
+    function canAccessPremium(address user) external view override returns (bool) {
+        return _rep[user] >= threshold;
+    }
+
     function setCaller(address, bool) external override {}
 
-    function setThreshold(uint256) external override {}
+    function setThreshold(uint256 t) external override {
+        threshold = t;
+    }
 
     function setBlacklist(address user, bool val) external override {
         _blacklist[user] = val;

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -112,6 +112,11 @@ contract ReputationEngine is Ownable {
         return _blacklisted[user];
     }
 
+    /// @notice Determine whether a user meets the premium access threshold.
+    function canAccessPremium(address user) external view returns (bool) {
+        return _scores[user] >= threshold;
+    }
+
     /// @notice Return the combined operator score based on stake and reputation.
     /// @dev Blacklisted users score 0.
     function getOperatorScore(address operator) external view returns (uint256) {

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -44,6 +44,11 @@ interface IReputationEngine {
     /// @return True if the user is blacklisted
     function isBlacklisted(address user) external view returns (bool);
 
+    /// @notice Determine whether a user meets the premium access threshold
+    /// @param user Address to query
+    /// @return True if the user's reputation meets or exceeds the threshold
+    function canAccessPremium(address user) external view returns (bool);
+
     /// @notice Owner functions
 
     /// @notice Allow or disallow a caller to update reputation


### PR DESCRIPTION
## Summary
- expose `canAccessPremium` helper in `ReputationEngine` to check reputation threshold
- document premium access helper for frontend integration
- update mocks and interface to compile with new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f33a23e6883338611e81f1dc39d89