### PR TITLE
feat: add job limits and delisting

### DIFF
--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("end-to-end job lifecycle", function () {
   let token, stakeManager, rep, validation, nft, registry, dispute, feePool, policy;
@@ -109,6 +110,8 @@ describe("end-to-end job lifecycle", function () {
     await registry.setFeePct(feePct);
     await registry.setTaxPolicy(await policy.getAddress());
     await registry.setJobParameters(0, stakeRequired);
+    await registry.setMaxJobReward(reward);
+    await registry.setJobDurationLimit(86400);
     await stakeManager.setJobRegistry(await registry.getAddress());
     await stakeManager.setDisputeModule(await dispute.getAddress());
     await stakeManager.setSlashingPercentages(100, 0);
@@ -141,7 +144,8 @@ describe("end-to-end job lifecycle", function () {
     await token
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + fee);
-    await registry.connect(employer).createJob(reward, "uri");
+    const deadline = (await time.latest()) + 1000;
+    await registry.connect(employer).createJob(reward, deadline, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("multi-operator job lifecycle", function () {
   let token, stakeManager, rep, validation, nft, registry, dispute, feePool, policy;
@@ -125,6 +126,8 @@ describe("multi-operator job lifecycle", function () {
     await registry.setFeePct(feePct);
     await registry.setTaxPolicy(await policy.getAddress());
     await registry.setJobParameters(0, stakeRequired);
+    await registry.setMaxJobReward(reward);
+    await registry.setJobDurationLimit(86400);
     await stakeManager.setJobRegistry(await registry.getAddress());
     await stakeManager.setDisputeModule(await dispute.getAddress());
     await nft.setJobRegistry(await registry.getAddress());
@@ -170,7 +173,8 @@ describe("multi-operator job lifecycle", function () {
     await token
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + fee);
-    await registry.connect(employer).createJob(reward, "uri");
+    const deadline = (await time.latest()) + 1000;
+    await registry.connect(employer).createJob(reward, deadline, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);


### PR DESCRIPTION
## Summary
- add max job reward and job duration limit with owner setters and events
- enforce reward and deadline limits when creating jobs
- allow owner to delist unassigned jobs and refund escrow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3902fa98833399541a5a577b0092