### PR TITLE
feat: allow reward pool contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Use the following quick checklists for common flows (see [docs/etherscan-guide.m
 2. **Helper call** – on `PlatformRegistry` → **Write**, call `acknowledgeStakeAndRegister(amount)`.
 3. **Verify events** – check for `Registered` and any `StakeDeposited` logs.
 
+#### Contribute to the Reward Pool
+1. **Approve** – approve the contribution amount on `$AGIALPHA`.
+2. **Call** – on `FeePool` → **Write**, call `contribute(amount)` using 6‑decimal units.
+3. **Verify events** – check for `RewardPoolContribution` on `FeePool`.
+
 #### Raise a Dispute
 1. **Approve** – approve the appeal fee on `$AGIALPHA`.
 2. **Helper call** – in `JobRegistry` → **Write**, call `acknowledgeAndDispute(jobId, evidence)`; the registry forwards to `DisputeModule.raiseDispute`.
@@ -174,6 +179,7 @@ Helper functions expose common flows in single calls so Etherscan users do not h
 - `JobEscrow.acknowledgeAndAcceptResult` lets employers acknowledge the policy and release escrow.
 - `FeePool.claimRewards` auto-distributes any pending fees before paying the caller.
 - `FeePool.distributeFees` never reverts; if no stake exists, fees are sent to the treasury after burning.
+- `FeePool.contribute` transfers tokens to the pool and credits `pendingFees`.
 - `StakeManager.acknowledgeAndDeposit` and `acknowledgeAndDepositFor` stake tokens after acknowledging the tax policy, reducing transactions for users and helpers.
 
 All participants opt in by staking `$AGIALPHA`. Staked operators gain routing priority and revenue share, while the main deploying entity is a special case that registers with **stake = 0**, earning no boosts so it remains tax neutral. Because every incentive flows on-chain, operators can participate pseudonymously without creating off‑chain reporting obligations.

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -58,6 +58,7 @@ contract FeePool is Ownable {
     event BurnPctUpdated(uint256 pct);
     event TreasuryUpdated(address indexed treasury);
     event OwnerWithdrawal(address indexed to, uint256 amount);
+    event RewardPoolContribution(address indexed contributor, uint256 amount);
 
     /// @notice Deploys the FeePool.
     /// @param _token ERC20 token used for fees and rewards. Defaults to
@@ -115,6 +116,15 @@ contract FeePool is Ownable {
         require(amount > 0, "amount");
         pendingFees += amount;
         emit FeeDeposited(msg.sender, amount);
+    }
+
+    /// @notice Contribute tokens directly to the reward pool.
+    /// @param amount fee amount scaled to 6 decimals.
+    function contribute(uint256 amount) external {
+        require(amount > 0, "amount");
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        pendingFees += amount;
+        emit RewardPoolContribution(msg.sender, amount);
     }
 
     /// @notice Distribute accumulated fees to stakers.

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -84,6 +84,17 @@ contract FeePoolTest {
         require(token.balanceOf(address(feePool)) == 1_000_000, "bal");
     }
 
+    function testContribute() public {
+        setUp();
+        token.mint(alice, 500_000);
+        vm.startPrank(alice);
+        token.approve(address(feePool), 500_000);
+        feePool.contribute(500_000);
+        vm.stopPrank();
+        require(token.balanceOf(address(feePool)) == 500_000, "pool bal");
+        require(feePool.pendingFees() == 500_000, "pending");
+    }
+
     function testClaimRewards() public {
         setUp();
         token.mint(address(feePool), 1_500_000);

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -87,6 +87,17 @@ describe("FeePool", function () {
     ).to.be.revertedWith("decimals");
   });
 
+  it("allows direct contributions", async () => {
+    await token
+      .connect(user1)
+      .approve(await feePool.getAddress(), 100);
+    await expect(feePool.connect(user1).contribute(100))
+      .to.emit(feePool, "RewardPoolContribution")
+      .withArgs(user1.address, 100);
+    expect(await token.balanceOf(await feePool.getAddress())).to.equal(100n);
+    expect(await feePool.pendingFees()).to.equal(100n);
+  });
+
   it("distributes rewards proportionally", async () => {
     const feeAmount = 100;
     const jobId = ethers.encodeBytes32String("job1");


### PR DESCRIPTION
## Summary
- allow direct token contributions into FeePool
- document `contribute` in the Etherscan guide
- cover contributions with Foundry and Hardhat tests

## Testing
- `npm run lint`
- `npm run test`
- `forge test` *(fails: Source "forge-std/Script.sol" not found: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f3e1256108333a9654c6b047df935