### PR TITLE
Handle employer-won disputes immediately

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -662,14 +662,51 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         dispute(jobId, evidence);
     }
 
-    /// @notice Owner resolves a dispute, setting the final outcome.
+    /// @notice Resolve a dispute relayed by the dispute module.
+    /// @dev When the employer wins the dispute the job is immediately
+    ///      finalised – escrowed funds are returned to the employer and the
+    ///      agent's stake is slashed. If the agent wins, the job moves back to
+    ///      the completed state so it can be finalised normally via
+    ///      {finalize}.
+    /// @param jobId Identifier of the disputed job
+    /// @param employerWins True if the employer won the dispute
     function resolveDispute(uint256 jobId, bool employerWins) external {
         require(msg.sender == address(disputeModule), "only dispute");
         Job storage job = jobs[jobId];
         require(job.state == State.Disputed, "no dispute");
-        job.success = !employerWins;
-        job.state = State.Completed;
-        emit DisputeResolved(jobId, employerWins);
+
+        if (employerWins) {
+            job.success = false;
+            job.state = State.Finalized;
+            bytes32 jobKey = bytes32(jobId);
+            if (address(stakeManager) != address(0)) {
+                uint256 fee = (uint256(job.reward) * job.feePct) / 100;
+                if (job.reward > 0) {
+                    stakeManager.releaseJobFunds(
+                        jobKey,
+                        job.employer,
+                        uint256(job.reward) + fee
+                    );
+                }
+                if (job.stake > 0) {
+                    stakeManager.slash(
+                        job.agent,
+                        IStakeManager.Role.Agent,
+                        uint256(job.stake),
+                        job.employer
+                    );
+                }
+            }
+            if (address(reputationEngine) != address(0)) {
+                reputationEngine.subtract(job.agent, 1);
+            }
+            emit DisputeResolved(jobId, true);
+            emit JobFinalized(jobId, false);
+        } else {
+            job.success = true;
+            job.state = State.Completed;
+            emit DisputeResolved(jobId, false);
+        }
     }
 
     /// @notice Finalize a job and trigger payouts and reputation changes.


### PR DESCRIPTION
## Summary
- Finalize disputes in `JobRegistry` when the employer wins, refunding escrow and slashing agent stake
- Emit dispute and finalization events and keep agent-won disputes for normal finalization

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f626f85cc83339c14edf3971391fc