### PR TITLE
feat: add basic escrow helpers and expose stake manager setters

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -26,7 +26,9 @@ contract MockStakeManager is IStakeManager {
     function acknowledgeAndWithdraw(Role, uint256) external override {}
     function withdrawStake(Role, uint256) external override {}
     function lockJobFunds(bytes32, address, uint256) external override {}
+    function lock(address, uint256) external override {}
     function releaseJobFunds(bytes32, address, uint256) external override {}
+    function release(address, uint256) external override {}
     function finalizeJobFunds(bytes32, address, uint256, uint256, IFeePool) external override {}
     function setDisputeModule(address module) external override {
         disputeModule = module;
@@ -35,6 +37,11 @@ contract MockStakeManager is IStakeManager {
     function payDisputeFee(address, uint256) external override {}
 
     function setSlashPercentSumEnforcement(bool) external override {}
+    function setToken(IERC20) external override {}
+    function setMinStake(uint256) external override {}
+    function setSlashingPercentages(uint256, uint256) external override {}
+    function setTreasury(address) external override {}
+    function setMaxStakePerAddress(uint256) external override {}
 
     function slash(address user, Role role, uint256 amount, address)
         external
@@ -54,7 +61,8 @@ contract MockStakeManager is IStakeManager {
         return totalStakes[role];
     }
 
-    function setToken(address) external {}
+    // legacy helper for tests
+    function setTokenLegacy(address) external {}
 }
 
 contract MockJobRegistry is IJobRegistry, IJobRegistryTax {

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {IFeePool} from "./IFeePool.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @title IStakeManager
 /// @notice Interface for staking balances, job escrows and slashing logic
@@ -26,8 +27,11 @@ interface IStakeManager {
     event DisputeFeeLocked(address indexed payer, uint256 amount);
     event DisputeFeePaid(address indexed to, uint256 amount);
     event DisputeModuleUpdated(address module);
-    event TokenUpdated(address token);
-    event ParametersUpdated();
+    event TokenUpdated(address indexed token);
+    event MinStakeUpdated(uint256 minStake);
+    event SlashingPercentagesUpdated(uint256 employerSlashPct, uint256 treasurySlashPct);
+    event TreasuryUpdated(address indexed treasury);
+    event MaxStakePerAddressUpdated(uint256 maxStake);
     event SlashPercentSumEnforcementUpdated(bool enforced);
 
     /// @notice deposit stake for caller for a specific role
@@ -48,8 +52,14 @@ interface IStakeManager {
     /// @notice lock job funds from an employer
     function lockJobFunds(bytes32 jobId, address from, uint256 amount) external;
 
+    /// @notice generic escrow lock when job ID is managed externally
+    function lock(address from, uint256 amount) external;
+
     /// @notice release locked job funds to recipient
     function releaseJobFunds(bytes32 jobId, address to, uint256 amount) external;
+
+    /// @notice release funds locked via {lock}
+    function release(address to, uint256 amount) external;
 
     /// @notice finalize job funds by paying agent and forwarding fees
     function finalizeJobFunds(
@@ -74,6 +84,13 @@ interface IStakeManager {
 
     /// @notice toggle enforcement requiring slashing percentages to sum to 100
     function setSlashPercentSumEnforcement(bool enforced) external;
+
+    /// @notice owner configuration helpers
+    function setToken(IERC20 newToken) external;
+    function setMinStake(uint256 _minStake) external;
+    function setSlashingPercentages(uint256 _employerSlashPct, uint256 _treasurySlashPct) external;
+    function setTreasury(address _treasury) external;
+    function setMaxStakePerAddress(uint256 maxStake) external;
 
     /// @notice return total stake deposited by a user for a role
     function stakeOf(address user, Role role) external view returns (uint256);


### PR DESCRIPTION
## Summary
- add generic `lock` and `release` helpers to StakeManager for external job escrows
- expose owner configuration setters and events via `IStakeManager`
- update mocks for new interface

## Testing
- `npm test test/v2/StakeManager.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689f6593f7148333a5f57dfcec9da10a