### PR TITLE
Align marketplace token with StakeManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1531,6 +1531,19 @@ For detailed walkthroughs see [docs/etherscan-guide.md](docs/etherscan-guide.md)
 
 See [docs/architecture-v2.md](docs/architecture-v2.md) for expanded diagrams and interface definitions; the development plan appears in [docs/coding-sprint-v2.md](docs/coding-sprint-v2.md).
 
+### Marketplace Flow via Etherscan
+
+1. **List a certificate**
+   - Open the deployed `CertificateNFT` on Etherscan and switch to the **Write** tab.
+   - Call `list(tokenId, price)` with the token ID and sale price (6‑decimals).
+2. **Purchase a certificate**
+   - Buyer approves the `CertificateNFT` contract to spend the required amount of the staking token.
+   - Call `purchase(tokenId)` to transfer tokens and the NFT in a single transaction.
+3. **Delist a certificate**
+   - If the seller changes their mind, call `delist(tokenId)` to remove the listing.
+
+Each call emits `NFTListed`, `NFTPurchased`, or `NFTDelisted`, allowing marketplace activity to be tracked directly from event logs.
+
 ## Incentive Design
 
 - Validators finalise jobs by majority after a review window; minorities may escalate to the `DisputeModule` for an appeal.

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -9,7 +9,7 @@ import {JobRegistry} from "contracts/v2/JobRegistry.sol";
 import {ValidationModule} from "contracts/v2/ValidationModule.sol";
 import {ReputationEngine} from "contracts/v2/ReputationEngine.sol";
 import {DisputeModule} from "contracts/v2/modules/DisputeModule.sol";
-import {CertificateNFT} from "contracts/v2/modules/CertificateNFT.sol";
+import {CertificateNFT} from "contracts/v2/CertificateNFT.sol";
 import {ICertificateNFT} from "contracts/v2/interfaces/ICertificateNFT.sol";
 import {FeePool} from "contracts/v2/FeePool.sol";
 import {PlatformRegistry} from "contracts/v2/PlatformRegistry.sol";
@@ -61,7 +61,7 @@ contract DeployAll is Script {
         ReputationEngine reputation = new ReputationEngine(
             IStakeManager(address(stake))
         );
-        CertificateNFT nft = new CertificateNFT("Cert", "CERT", vm.addr(deployer));
+        CertificateNFT nft = new CertificateNFT("Cert", "CERT");
         DisputeModule dispute = new DisputeModule(registry, 0, 0, address(0));
 
         FeePool feePool = new FeePool(
@@ -83,6 +83,8 @@ contract DeployAll is Script {
             vm.addr(deployer)
         );
 
+        nft.setJobRegistry(address(registry));
+        nft.setStakeManager(address(stake));
         stake.setJobRegistry(address(registry));
         registry.setModules(
             validation,

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -45,9 +45,9 @@ async function main() {
   const reputation = await Reputation.deploy(deployer.address);
 
   const NFT = await ethers.getContractFactory(
-    "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
+    "contracts/v2/CertificateNFT.sol:CertificateNFT"
   );
-  const nft = await NFT.deploy("Cert", "CERT", deployer.address);
+  const nft = await NFT.deploy("Cert", "CERT");
 
   const Dispute = await ethers.getContractFactory(
     "contracts/v2/modules/DisputeModule.sol:DisputeModule"
@@ -72,6 +72,7 @@ async function main() {
   await reputation.setCaller(await registry.getAddress(), true);
   await reputation.setThreshold(1);
   await nft.setJobRegistry(await registry.getAddress());
+  await nft.setStakeManager(await stake.getAddress());
   await stake.setJobRegistry(await registry.getAddress());
   await nft.transferOwnership(await registry.getAddress());
   await dispute.setAppealFee(10);

--- a/scripts/deployAll.ts
+++ b/scripts/deployAll.ts
@@ -66,9 +66,9 @@ async function main() {
   await reputation.waitForDeployment();
 
   const NFT = await ethers.getContractFactory(
-    "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
+    "contracts/v2/CertificateNFT.sol:CertificateNFT"
   );
-  const nft = await NFT.deploy("Cert", "CERT", deployer.address);
+  const nft = await NFT.deploy("Cert", "CERT");
   await nft.waitForDeployment();
 
   const Dispute = await ethers.getContractFactory(
@@ -118,6 +118,8 @@ async function main() {
   await platformRegistry.waitForDeployment();
 
   // Wire up modules after deployment.
+  await nft.setJobRegistry(await registry.getAddress());
+  await nft.setStakeManager(await stake.getAddress());
   await stake.setJobRegistry(await registry.getAddress());
   await registry.setModules(
     await validation.getAddress(),

--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -1,0 +1,66 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CertificateNFT marketplace", function () {
+  const price = ethers.parseUnits("1", 6);
+  let owner, seller, buyer, token, stake, nft;
+
+  beforeEach(async () => {
+    [owner, seller, buyer] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory(
+      "contracts/mocks/MockERC206Decimals.sol:MockERC206Decimals"
+    );
+    token = await Token.deploy();
+    await token.mint(buyer.address, price);
+    await token.mint(seller.address, price);
+
+    const Stake = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stake = await Stake.deploy(
+      await token.getAddress(),
+      0,
+      0,
+      0,
+      owner.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
+    );
+
+    const NFT = await ethers.getContractFactory(
+      "contracts/v2/CertificateNFT.sol:CertificateNFT"
+    );
+    nft = await NFT.deploy("Cert", "CERT");
+    await nft.setJobRegistry(owner.address);
+    await nft.setStakeManager(await stake.getAddress());
+
+    await nft.mint(seller.address, 1, "ipfs://1");
+  });
+
+  it("lists, purchases, and delists with events", async () => {
+    await expect(nft.connect(seller).list(1, price))
+      .to.emit(nft, "NFTListed")
+      .withArgs(1, seller.address, price);
+
+    await expect(nft.connect(seller).list(1, price)).to.be.revertedWith(
+      "listed"
+    );
+
+    await expect(nft.connect(buyer).purchase(1)).to.be.revertedWith(
+      "allowance"
+    );
+
+    await token.connect(buyer).approve(await nft.getAddress(), price);
+    await expect(nft.connect(buyer).purchase(1))
+      .to.emit(nft, "NFTPurchased")
+      .withArgs(1, buyer.address, price);
+    expect(await nft.ownerOf(1)).to.equal(buyer.address);
+
+    await nft.mint(seller.address, 2, "ipfs://2");
+    await nft.connect(seller).list(2, price);
+    await expect(nft.connect(seller).delist(2))
+      .to.emit(nft, "NFTDelisted")
+      .withArgs(2);
+  });
+});


### PR DESCRIPTION
## Summary
- wire CertificateNFT to StakeManager during deployment so the marketplace and staking share the same ERC20 token
- enforce allowance checks and prevent duplicate listings in CertificateNFT
- document listing, purchase and delisting flow for Etherscan
- add tests covering marketplace events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f6e843d948333a2a78de7fda32c60