### PR TITLE
docs: add v0 deployment and ENS-parity sprint plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 
 ## Deployment & Configuration
 
+### Deploying legacy v0 with $AGIALPHA
+1. **Token** – deploy the 6‑decimal [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) token or reuse an existing deployment.
+2. **AGIJobManagerv0** – from a block explorer's **Write Contract** tab, deploy `legacy/AGIJobManagerv0.sol` passing the `$AGIALPHA` address, base IPFS URI, ENS registry, NameWrapper, and the agent/club root nodes and Merkle roots.
+3. **Owner configuration** – the deployer becomes owner and may later swap the payout token with `updateAGITokenAddress(newToken)` or rotate ENS roots and allowlists without redeploying.
+4. **Usage** – all job posting, application, validation, dispute, and NFT marketplace calls can be executed through the contract's **Write** tab; amounts use 6‑decimal base units.
+
 ### Module sequence
 1. **Deploy** – use [`Deployer.sol`](contracts/v2/Deployer.sol) and call `deployDefaults()` or deploy each module manually.
 2. **Wire modules** – if deploying individually, call `setModules(...)` on `JobRegistry` to provide the addresses of `StakeManager`, `ValidationModule`, `DisputeModule`, and `FeePool`.

--- a/docs/coding-sprint-v2.md
+++ b/docs/coding-sprint-v2.md
@@ -43,6 +43,17 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
    - Guarantee only the owner can update the policy via `setPolicyURI`, `setAcknowledgement`, `setPolicy`, or `bumpTaxPolicyVersion`; unauthorized calls revert.
    - Describe in NatSpec and README that all tax obligations rest solely with AGI Employers, Agents, and Validators; the infrastructure bears no direct, indirect, or theoretical liability.
    - Provide step-by-step Etherscan instructions so non-technical users can view the disclaimer via `acknowledgement`/`acknowledge` and so the owner can update it with `setPolicyURI`/`setAcknowledgement`.
+8. **v1 Feature Parity & ENS Identity**
+   - Port every capability from `legacy/AGIJobManagerv0.sol` into dedicated v2 modules.
+       - `JobRegistry`: `createJob`, `applyForJob`, `submit`, `cancelJob`, `delistJob`, `disputeJob`, and finalization hooks.
+       - `ValidationModule`: validator selection, `commitValidation`, `revealValidation`, approval/disapproval tallies, and threshold checks.
+       - `DisputeModule`: `raiseDispute`, moderator managed `resolve`, and appeal-fee escrow.
+       - `StakeManager`: escrow and release of rewards, slashing, AGIType payout bonuses, and reward/fee percentages.
+       - `ReputationEngine`: logarithmic reputation growth, premium thresholds, and owner‑managed blacklists.
+       - `CertificateNFT`: minting of completion certificates plus the simple marketplace (`list`, `purchase`, `delist`).
+   - Enforce ENS subdomain ownership for agents (`*.agent.agi.eth`) and validators (`*.club.agi.eth`) using the Merkle proof + NameWrapper + resolver fallback sequence. Emit `OwnershipVerified` and `RecoveryInitiated` where appropriate.
+   - Maintain owner‑controlled allowlists (`additionalAgents`, `additionalValidators`), blacklists, and configurable root nodes and Merkle roots with corresponding events.
+   - Mirror v0 administrative setters: validator thresholds, validation reward percentage, job payout and duration caps, AGI type management, terms text, and NFT marketplace controls.
 
 ## Deliverables
 - Verified Solidity contracts under `contracts/v2`.


### PR DESCRIPTION
## Summary
- document how to deploy legacy AGIJobManager v0 with $AGIALPHA and adjustable token/ENS settings
- expand v2 coding sprint with ENS subdomain checks and full v1 feature parity tasks

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_689f8e30d4488333871a88ff8df51d14