### PR TITLE
docs: add v2 ens parity sprint and deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 ## Deployment & Configuration
 
 ### Deploying legacy v0 with $AGIALPHA
-1. **Token** – deploy the 6‑decimal [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) token or reuse an existing deployment.
-2. **AGIJobManagerv0** – from a block explorer's **Write Contract** tab, deploy `legacy/AGIJobManagerv0.sol` passing the `$AGIALPHA` address, base IPFS URI, ENS registry, NameWrapper, and the agent/club root nodes and Merkle roots.
-3. **Owner configuration** – the deployer becomes owner and may later swap the payout token with `updateAGITokenAddress(newToken)` or rotate ENS roots and allowlists without redeploying.
-4. **Usage** – all job posting, application, validation, dispute, and NFT marketplace calls can be executed through the contract's **Write** tab; amounts use 6‑decimal base units.
+
+**Prerequisites**
+- `$AGIALPHA` token address (6‑decimal).
+- ENS registry and NameWrapper contract addresses.
+
+**Steps**
+1. Deploy or reuse the [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) token.
+2. On a block explorer, open `legacy/AGIJobManagerv0.sol` and use the **Deploy** or **Write Contract** interface to provide the constructor fields: token address, base IPFS URI, ENS registry, NameWrapper, agent/club root nodes, and the corresponding Merkle roots.
+3. Submit the transaction; the sender becomes the owner.
+4. After deployment the owner can switch payout tokens with `updateAGITokenAddress(newToken)` and rotate ENS roots or allowlists without redeploying.
+5. All job posting, application, validation, dispute, and NFT marketplace calls happen through the contract's **Write** tab. Enter token amounts using 6‑decimal units (`1 token = 1_000000`).
 
 #### Etherscan deployment steps
 1. Navigate to the verified `AGIJobManagerv0` contract page on a block explorer and open the **Contract → Write Contract** tab.

--- a/docs/ens-v1-parity-sprint.md
+++ b/docs/ens-v1-parity-sprint.md
@@ -1,0 +1,52 @@
+# Coding Sprint: ENS Identity & v1 Feature Parity
+
+This sprint migrates every capability from the legacy `AGIJobManager` into the modular v2 suite while enforcing ENS-based identity for agents and validators. It serves as a checklist for developers implementing the upgrade.
+
+## 1. Identity Enforcement
+- **Goal**: Every agent must control a subdomain of `agent.agi.eth`; every validator must control a subdomain of `club.agi.eth`.
+- **Mechanism**:
+  1. Accept a Merkle proof of pre-approved addresses. If the proof verifies, accept without further calls.
+  2. Otherwise, compute the subnode hash and query ENS NameWrapper `ownerOf`. If the caller owns the NFT, accept.
+  3. Fallback to the ENS resolver's `addr` record when NameWrapper doesn't resolve.
+  4. Emit `OwnershipVerified(claimant, subdomain)` when any check passes and `RecoveryInitiated(reason)` on failures.
+- **Integration**:
+  - `JobRegistry.applyForJob` must require a valid agent subdomain and reject blacklisted or unapproved addresses.
+  - `ValidationModule.commitValidation` and `revealValidation` must require a valid validator subdomain.
+  - Maintain owner-managed allowlists (`additionalAgents`, `additionalValidators`) and blacklists in `ReputationEngine`.
+  - Provide owner setters for root nodes, Merkle roots, ENS registry and NameWrapper addresses with update events.
+
+## 2. Module Parity with v0
+- **JobRegistry**
+  - `createJob`, `applyForJob`, `submit`, `cancelJob`, `dispute`, `finalize`.
+  - Enforce `maxJobReward` and `maxJobDuration` caps; require tax policy acknowledgement before participation.
+- **ValidationModule**
+  - Commit–reveal voting with owner-settable validator count and time windows.
+  - Select eligible validators and tally approvals versus disapprovals.
+- **StakeManager**
+  - Handle stake deposits/withdrawals, job reward escrow, fee deductions, validator rewards and AGIType payout bonuses.
+  - Owner setters: payout token, minimum stake, slashing percentages.
+- **ReputationEngine**
+  - Logarithmic reputation growth (`onApply`, `onFinalize`), premium threshold gating and owner-maintained blacklist.
+- **DisputeModule**
+  - `raiseDispute`, moderator or jury based `resolve`, optional appeal fees.
+- **CertificateNFT**
+  - Mint completion certificates and support `list`, `purchase`, `delist` marketplace actions.
+
+## 3. Administrative Controls
+- Each module inherits `Ownable`; only the owner can update parameters or swap tokens.
+- No module routes funds to the owner; fees go to `FeePool` or are burned to preserve tax neutrality.
+- Events mirror v0 naming where possible (`JobCreated`, `JobApplied`, `JobSubmitted`, `JobFinalized`, etc.).
+
+## 4. Testing and Verification
+- Write Hardhat and Foundry tests for:
+  - Successful job flow from creation to NFT minting.
+  - Identity rejection paths for both agents and validators.
+  - Dispute resolution and slashing.
+  - NFT marketplace listing and purchase.
+- Run `npx hardhat test`, `forge test`, `npx solhint 'contracts/**/*.sol'` and `npx eslint .` until all pass.
+
+## 5. Deployment Notes
+- Default token is `$AGIALPHA` (6 decimals). The owner may swap to any ERC‑20 via `StakeManager.setToken`.
+- Document Etherscan-based deployment: deploy modules, call `setModules` on `JobRegistry`, then update Merkle roots and root nodes.
+
+Completion of this sprint yields a v2 system with full feature parity, ENS identity enforcement and owner-controlled configurability without contract redeployment.


### PR DESCRIPTION
## Summary
- add dedicated sprint plan for ENS identity and v1 feature parity
- expand README with step-by-step AGIJobManagerv0 deployment using $AGIALPHA

## Testing
- `npm test`
- `npx solhint 'contracts/**/*.sol'`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_689fb4b111c08333a54c72faebacc0d6