### PR TITLE
docs: ENS parity sprint plan and v0 deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,11 @@ All value transfers occur on-chain while `Ownable` setters let the owner retune 
 - [Incentive Mechanisms for $AGIALPHA](docs/incentive-mechanisms-agialpha.md) – revenue sharing, routing priority, governance rewards, and sybil mitigation.
 - [Coding Sprint: $AGIALPHA Incentive Modules](docs/coding-sprint-agialpha-incentives.md) – tasks for integrating fee pools and discovery incentives.
 - [Coding Sprint: Platform Incentives](docs/coding-sprint-platform-incentives.md) – consolidates operator staking, routing and fee share.
+- [Coding Sprint: ENS Identity & v1 Feature Parity](docs/coding-sprint-ens-parity.md) – tasks for ENS subdomain enforcement and v0 parity.
 - [Production-Scale AGIJobs Platform Sprint Plan](docs/ProductionScaleAGIJobsPlatformSprintPlanv0.md) – background research and
   architectural rationale behind the modular design.
 - [Deployment Guide for $AGIALPHA](docs/deployment-agialpha.md) – non-technical walkthrough for deploying and configuring the suite with the 6‑decimal token.
+- [Deployment Guide: AGIJobManager v0 with $AGIALPHA](docs/deployment-v0-agialpha.md) – step-by-step explorer walkthrough for the monolithic contract.
 - [Tax Obligations & Disclaimer](docs/tax-obligations.md) – participants bear all taxes; contracts and owner remain exempt.
 - [TaxPolicy contract](contracts/v2/TaxPolicy.sol) – owner‑updatable disclaimer with `policyDetails`, `policyVersion`, and `isTaxExempt()` helpers; `JobRegistry.acknowledgeTaxPolicy` emits `TaxAcknowledged(user, version, acknowledgement)` for on‑chain proof.
 - [v2 deployment script](scripts/v2/deploy.ts) – deploys core modules, wires `StakeManager`, and installs the tax‑neutral `TaxPolicy`.
@@ -1436,7 +1438,7 @@ graph TD
     JobRegistry -->|mint| CertificateNFT
 ```
 
-### Deployment Guide (AGIJobsv0 with $AGIALPHA)
+### Deployment Guide (AGIJobs v2 with $AGIALPHA)
 
 $AGIALPHA is a 6‑decimal ERC‑20 token used across the platform for payments, staking, rewards, and dispute fees. All modules allow the owner to update the token or parameters without redeploying contracts.
 

--- a/docs/coding-sprint-ens-parity.md
+++ b/docs/coding-sprint-ens-parity.md
@@ -1,0 +1,45 @@
+# Coding Sprint: ENS Identity & v1 Feature Parity
+
+This sprint ports every capability from `legacy/AGIJobManagerv0.sol` into the modular AGI Jobs v2 suite while enforcing Ethereum Name Service (ENS) subdomain identities for agents and validators. The plan maintains owner control over all parameters and keeps the default payout token as the 6‑decimal `$AGIALPHA`.
+
+## Goals
+- Mirror v0 behaviour across dedicated v2 modules.
+- Require each agent to own a subdomain of `agent.agi.eth` and each validator a subdomain of `club.agi.eth` (or be owner‑approved).
+- Preserve owner flexibility: token swaps, allowlists, and parameter tuning without redeployment.
+- Keep explorer interactions simple for non‑technical users.
+
+## Tasks
+### 1. Identity Verification
+- Implement an `ENSOwnershipVerifier` library replicating the `_verifyOwnership` logic from v0 (Merkle proof → NameWrapper → resolver fallback) and emitting `OwnershipVerified`/`RecoveryInitiated`.
+- Store `agentRootNode`, `clubRootNode`, `agentMerkleRoot`, and `validatorMerkleRoot` with owner setters and `RootNodeUpdated`/`MerkleRootUpdated` events.
+- Add `addAdditionalAgent/Validator` and blacklist controls in `ReputationEngine`.
+- Call the verifier from `JobRegistry.applyForJob` and validator commit/reveal functions in `ValidationModule`.
+
+### 2. Job Lifecycle
+- **JobRegistry**: implement `createJob`, `applyForJob`, `submit`, `finalize`, `cancelJob`, `delistJob`, and `dispute` mirroring v0 semantics. Enforce max payout/duration caps and tax‑policy acknowledgement.
+- **ValidationModule**: pseudo‑random validator selection, `commitValidation`, `revealValidation`, tallying approvals/disapprovals, and notifying `JobRegistry` of outcomes.
+- **DisputeModule**: `raiseDispute` and moderator `resolve` with appeal‑fee escrow.
+- **CertificateNFT**: `mint` on completion plus marketplace functions `list`, `purchase`, and `delist`.
+
+### 3. Reputation & Rewards
+- **ReputationEngine**: logarithmic growth formula, premium threshold view, and blacklist storage. Provide `onApply`, `onFinalize`, and `rewardValidator` hooks.
+- **StakeManager**: custody `$AGIALPHA`, owner‑settable token address, minimum stakes, slashing percentages, fee/burn ratios, and AGIType payout bonuses.
+- Pay agents and validators via `StakeManager.release` and update reputation on success; handle slashing and refunds on failure.
+
+### 4. Administration & Upgradability
+- Expose owner setters for validator committee size, commit/reveal windows, job caps, validation reward percentage, fee shares, and base NFT URI.
+- Keep modules ownable and pausable where necessary. Ensure `JobRegistry.setModules` wires module addresses and emits `ModulesUpdated`.
+
+### 5. Testing & Verification
+- Write Hardhat/Foundry tests covering:
+  - Agent/validator identity checks (Merkle, NameWrapper, resolver paths).
+  - Full job flow: post → apply → submit → commit/reveal → finalize.
+  - Dispute resolution and stake slashing.
+  - NFT marketplace operations.
+- Run `npx hardhat test`, `forge test`, `npx solhint 'contracts/**/*.sol'`, and `npx eslint .` until clean.
+
+## Definition of Done
+- All v0 features available through v2 modules with ENS identity enforcement.
+- Owner can retune or swap tokens via setters without redeployment.
+- Documentation updated (`README.md`, `docs/architecture-v2.md`, and this sprint plan).
+- All tests and linters pass.

--- a/docs/deployment-v0-agialpha.md
+++ b/docs/deployment-v0-agialpha.md
@@ -1,0 +1,31 @@
+# Deployment Guide: AGIJobManager v0 with $AGIALPHA
+
+This guide walks a non‑technical owner through deploying the monolithic **AGIJobManager v0** contract using the 6‑decimal `$AGIALPHA` token for all escrow, staking, validator rewards, and dispute fees. Every parameter can be updated later by the owner without redeploying the contract.
+
+## Prerequisites
+- `$AGIALPHA` token address.
+- ENS registry and NameWrapper addresses.
+- Namehashes for `agent.agi.eth` and `club.agi.eth` plus optional Merkle roots for allowlists.
+- Base IPFS URI for job result metadata.
+
+## Deployment Steps
+1. Open the compiled `AGIJobManagerv0` in a block explorer and supply constructor fields:
+   - `_agiTokenAddress` – `$AGIALPHA` address.
+   - `_baseIpfsUrl` – e.g. `ipfs://`.
+   - `_ensAddress` and `_nameWrapperAddress` – official ENS contracts.
+   - `_clubRootNode`, `_agentRootNode`, `_validatorMerkleRoot`, `_agentMerkleRoot` – `0x00` if unused.
+2. Confirm transaction; the sender becomes the contract owner.
+3. In the **Write Contract** tab the owner can:
+   - Switch payout tokens with `updateAGITokenAddress(newToken)`.
+   - Add allowlisted addresses via `addAdditionalAgent` or `addAdditionalValidator`.
+   - Update ENS roots and Merkle proofs as identity policies change.
+   - Tune parameters like `setRequiredValidatorApprovals`, `setValidationRewardPercentage`, `setMaxJobPayout`, and blacklist users.
+
+## Usage Notes
+- All token amounts use 6‑decimal units (`1 token = 1_000000`).
+- Employers post jobs with `createJob` after approving the token.
+- Agents call `applyForJob` with their subdomain and optional Merkle proof.
+- Validators vote through `validateJob` or `disapproveJob` and earn rewards once `_completeJob` runs.
+- The owner may refund or slash parties through dispute functions without ever redeploying the contract.
+
+By keeping `$AGIALPHA` configurable through `updateAGITokenAddress`, the deployment stays flexible while offering a simple explorer‑based workflow for non‑technical participants.


### PR DESCRIPTION
## Summary
- add ENS identity & v1 parity coding sprint plan
- provide user-friendly AGIJobManager v0 deployment guide
- link new docs from README and clarify v2 deployment heading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fb846cd388333b5b465e6517c2b22