### PR TITLE
Add root node setters and blacklist checks

### DIFF
--- a/contracts/DisputeResolution.sol
+++ b/contracts/DisputeResolution.sol
@@ -10,6 +10,7 @@ interface IStakeManager {
 interface IReputationEngine {
     function addReputation(address user, uint256 amount) external;
     function subtractReputation(address user, uint256 amount) external;
+    function isBlacklisted(address user) external view returns (bool);
 }
 
 interface IValidationModule {
@@ -41,6 +42,16 @@ contract DisputeResolution is Ownable {
         require(challengerAddr != address(0), "no challenge");
         address validator = validationModule.owner();
         uint256 bond = validationModule.disputeBond();
+        if (address(reputationEngine) != address(0)) {
+            require(
+                !reputationEngine.isBlacklisted(challengerAddr),
+                "challenger blacklisted"
+            );
+            require(
+                !reputationEngine.isBlacklisted(validator),
+                "validator blacklisted"
+            );
+        }
 
         if (validatorWins) {
             stakeManager.slash(challengerAddr, validator, bond);

--- a/contracts/mocks/StubReputationEngine.sol
+++ b/contracts/mocks/StubReputationEngine.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.21;
 
 contract StubReputationEngine {
     mapping(address => uint256) public reputation;
+    mapping(address => bool) public blacklist;
 
     function addReputation(address user, uint256 amount) external {
         reputation[user] += amount;
@@ -11,5 +12,13 @@ contract StubReputationEngine {
     function subtractReputation(address user, uint256 amount) external {
         uint256 rep = reputation[user];
         reputation[user] = rep > amount ? rep - amount : 0;
+    }
+
+    function isBlacklisted(address user) external view returns (bool) {
+        return blacklist[user];
+    }
+
+    function setBlacklist(address user, bool val) external {
+        blacklist[user] = val;
     }
 }


### PR DESCRIPTION
## Summary
- expose `setAgentRootNode`/`setAgentMerkleRoot` in `JobRegistry`
- mirror root & Merkle setters in `ValidationModule`
- guard user flows with `reputationEngine.isBlacklisted`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fda4ebf348333b901c793dfee1e3b