### PR TITLE
feat: add job constraints and auto finalization

### DIFF
--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -47,8 +47,12 @@ interface IJobRegistry {
     event StakeManagerUpdated(address manager);
     event CertificateNFTUpdated(address nft);
     event DisputeModuleUpdated(address module);
-    event MaxJobRewardUpdated(uint256 maxJobReward);
-    event JobDurationLimitUpdated(uint256 limit);
+    event JobParametersUpdated(
+        uint256 reward,
+        uint256 stake,
+        uint256 maxJobReward,
+        uint256 jobDurationLimit
+    );
 
     // job lifecycle
     event JobCreated(

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -132,9 +132,8 @@ describe("JobRegistry integration", function () {
     await registry.connect(agent).submit(jobId, "result");
     await expect(registry.finalizeAfterValidation(jobId))
       .to.emit(registry, "JobCompleted")
-      .withArgs(jobId, true);
-    await expect(registry.connect(employer).finalize(jobId))
-      .to.emit(registry, "JobFinalized")
+      .withArgs(jobId, true)
+      .and.to.emit(registry, "JobFinalized")
       .withArgs(jobId, true);
 
     expect(await token.balanceOf(agent.address)).to.equal(900);
@@ -191,7 +190,6 @@ describe("JobRegistry integration", function () {
     await validation.connect(owner).setResult(true);
     await registry.connect(agent).submit(jobId, "result");
     await registry.finalizeAfterValidation(jobId);
-    await registry.connect(employer).finalize(jobId);
 
     // platform operator should be able to claim fee
     const before = await token.balanceOf(owner.address);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -151,7 +151,6 @@ describe("end-to-end job lifecycle", function () {
     await validation.connect(owner).setResult(true);
     await registry.connect(agent).submit(jobId, "result");
     await registry.finalizeAfterValidation(jobId);
-    await registry.finalize(jobId);
 
     // fee moved to FeePool
     expect(await feePool.pendingFees()).to.equal(fee);

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -180,7 +180,6 @@ describe("multi-operator job lifecycle", function () {
     await validation.connect(owner).setResult(true);
     await registry.connect(agent).submit(jobId, "result");
     await registry.finalizeAfterValidation(jobId);
-    await registry.finalize(jobId);
 
     expect(await feePool.pendingFees()).to.equal(fee);
     await feePool.distributeFees();


### PR DESCRIPTION
## Summary
- unify job parameter limits with a single `JobParametersUpdated` event
- allow owner to cap rewards and job duration via `setMaxJobReward` and `setJobDurationLimit`
- automatically finalize successful jobs in `finalizeAfterValidation`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fdc4973c88333896fcbef97dbb22c