### PR TITLE
Fix reward split handling and expose stake manager config

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -42,6 +42,7 @@ contract MockStakeManager is IStakeManager {
     function setSlashingPercentages(uint256, uint256) external override {}
     function setTreasury(address) external override {}
     function setMaxStakePerAddress(uint256) external override {}
+    function setMaxAGITypes(uint256) external override {}
 
     function slash(address user, Role role, uint256 amount, address)
         external

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -21,8 +21,10 @@ interface IStakeManager {
     event StakeSlashed(
         address indexed user,
         Role indexed role,
-        uint256 amount,
-        address indexed employer
+        address indexed employer,
+        address treasury,
+        uint256 employerShare,
+        uint256 treasuryShare
     );
     event DisputeFeeLocked(address indexed payer, uint256 amount);
     event DisputeFeePaid(address indexed to, uint256 amount);
@@ -32,6 +34,7 @@ interface IStakeManager {
     event SlashingPercentagesUpdated(uint256 employerSlashPct, uint256 treasurySlashPct);
     event TreasuryUpdated(address indexed treasury);
     event MaxStakePerAddressUpdated(uint256 maxStake);
+    event MaxAGITypesUpdated(uint256 oldMax, uint256 newMax);
     event SlashPercentSumEnforcementUpdated(bool enforced);
 
     /// @notice deposit stake for caller for a specific role
@@ -91,6 +94,7 @@ interface IStakeManager {
     function setSlashingPercentages(uint256 _employerSlashPct, uint256 _treasurySlashPct) external;
     function setTreasury(address _treasury) external;
     function setMaxStakePerAddress(uint256 maxStake) external;
+    function setMaxAGITypes(uint256 newMax) external;
 
     /// @notice return total stake deposited by a user for a role
     function stakeOf(address user, Role role) external view returns (uint256);


### PR DESCRIPTION
## Summary
- compute validator and agent rewards correctly, releasing payouts from job escrow
- expand StakeManager interface with detailed slashing event and AGI type limit setter
- update mocks for new interface hook

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe5b612308333934bfb4284e90907