### PR TITLE
docs: clarify token defaults and ENS usage

### DIFF
--- a/docs/v1-v2-function-map.md
+++ b/docs/v1-v2-function-map.md
@@ -1,0 +1,49 @@
+# v1 to v2 Function Map
+
+The table below maps common public functions from the monolithic `AGIJobManagerV1` contract to their equivalents in the modular v2 suite. Functions that were removed or split across modules are noted.
+
+| v1 function | v2 module | v2 function / note |
+| --- | --- | --- |
+| `createJob` | `JobRegistry` | `createJob` |
+| `applyForJob` | `JobRegistry` | `applyForJob` |
+| `requestJobCompletion` | `JobRegistry` | `submit` |
+| `commitValidation` | `ValidationModule` | `commitValidation` |
+| `revealValidation` | `ValidationModule` | `revealValidation` |
+| `validateJob` | `ValidationModule` | `revealValidation(approve=true)` |
+| `disapproveJob` | `ValidationModule` | `revealValidation(approve=false)` |
+| `disputeJob` | `JobRegistry` | `raiseDispute` |
+| `resolveDispute` | `DisputeModule` | `resolveDispute` |
+| `resolveStalledJob` | `JobRegistry` | `finalize` |
+| `cancelJob` / `cancelExpiredJob` | `JobRegistry` | `cancelJob` |
+| `stake` | `StakeManager` | `depositStake(role)` |
+| `withdrawStake` | `StakeManager` | `withdrawStake(role)` |
+| `stakeAgent` | `StakeManager` | `depositStake(Role.Agent)` |
+| `withdrawAgentStake` | `StakeManager` | `withdrawStake(Role.Agent)` |
+| `contributeToRewardPool` | `FeePool` | `contribute` |
+| `listNFT` | `CertificateNFT` | `list` |
+| `purchaseNFT` | `CertificateNFT` | `purchase` |
+| `delistNFT` | `CertificateNFT` | `delist` |
+| `updateAGITokenAddress` | `StakeManager` / `FeePool` | `setToken` on each module |
+| `blacklistAgent` / `clearAgentBlacklist` | `ReputationEngine` | `blacklist(user, status)` |
+| `blacklistValidator` / `clearValidatorBlacklist` | `ReputationEngine` | `blacklist(user, status)` |
+| `addModerator` / `removeModerator` | `DisputeModule` | `setModerator(address)` |
+| `setPremiumReputationThreshold` | `ReputationEngine` | `setThreshold` |
+| `setMaxJobPayout` | `JobRegistry` | `setMaxJobReward` |
+| `setJobDurationLimit` | `JobRegistry` | `setJobDurationLimit` |
+| `setClubRootNode` | `ENSOwnershipVerifier` | `setClubRootNode` |
+| `setAgentRootNode` | `JobRegistry` | `setAgentRootNode` |
+| `setValidatorMerkleRoot` | `ENSOwnershipVerifier` | `setValidatorMerkleRoot` |
+| `setAgentMerkleRoot` | `JobRegistry` | `setAgentMerkleRoot` |
+| `setENS` | `ENSOwnershipVerifier` | `setENS` |
+| `setNameWrapper` | `ENSOwnershipVerifier` | `setNameWrapper` |
+| `setStakeRequirement` | `StakeManager` | `setMinStake` |
+| `setAgentStakeRequirement` | `JobRegistry` | `setJobStake` |
+| `pause` / `unpause` | – | removed in v2 |
+| `acceptTerms` | `JobRegistry` | `acknowledgeTaxPolicy` |
+| `setBaseURI` | `CertificateNFT` | `setBaseURI` |
+| `setValidationRewardPercentage` | `JobRegistry` | `setValidatorRewardPct` |
+| `setBurnPercentage` / `setBurnAddress` | `FeePool` | `setBurnPct` / `setTreasury` |
+| `setValidatorsPerJob` | `ValidationModule` | `setValidatorBounds` |
+| `setCommitDuration` / `setRevealDuration` | `ValidationModule` | `setCommitWindow` / `setRevealWindow` |
+
+This list focuses on externally callable functions. Internal helpers and purely informational getters in v1 are omitted or replaced by public state variables in v2.


### PR DESCRIPTION
## Summary
- highlight $AGIALPHA as the default token and document token swap via StakeManager/FeePool
- expand ENS guidance with verifyOwnership example and troubleshooting tips
- add v1 to v2 function mapping table and Etherscan checklists for all roles

## Testing
- `npm test`
- `npm run lint`
- `forge test` *(fails: Source "forge-std/Script.sol" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08d91ff1c8333ac5f45779cca0e9a