### PR TITLE
feat: enforce ENS-verified validator selection

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -52,6 +52,7 @@ contract ValidationModule is IValidationModule, Ownable {
 
     // optional override for validators without ENS identity
     mapping(address => bool) public additionalValidators;
+    mapping(address => string) public validatorSubdomains;
 
     struct Round {
         address[] validators;
@@ -161,13 +162,13 @@ contract ValidationModule is IValidationModule, Ownable {
     }
 
     /// @notice Update the list of eligible validators.
-    /// @param validators Addresses of validators.
-    function setValidatorPool(address[] calldata validators)
+    /// @param newPool Addresses of validators.
+    function setValidatorPool(address[] calldata newPool)
         external
         onlyOwner
     {
-        validatorPool = validators;
-        emit ValidatorsUpdated(validators);
+        validatorPool = newPool;
+        emit ValidatorsUpdated(newPool);
     }
 
     /// @notice Update the reputation engine used for validator feedback.
@@ -210,13 +211,27 @@ contract ValidationModule is IValidationModule, Ownable {
 
     /// @notice Configure additional validators that bypass ENS checks.
     function setAdditionalValidators(
-        address[] calldata validators,
+        address[] calldata accounts,
         bool[] calldata allowed
     ) external onlyOwner {
-        require(validators.length == allowed.length, "length");
-        for (uint256 i; i < validators.length; ++i) {
-            additionalValidators[validators[i]] = allowed[i];
-            emit AdditionalValidatorUpdated(validators[i], allowed[i]);
+        require(accounts.length == allowed.length, "length");
+        for (uint256 i; i < accounts.length; ++i) {
+            additionalValidators[accounts[i]] = allowed[i];
+            emit AdditionalValidatorUpdated(accounts[i], allowed[i]);
+        }
+    }
+
+    /// @notice Map validators to their ENS subdomains for selection-time checks.
+    /// @param accounts Validator addresses to configure.
+    /// @param subdomains ENS labels owned by each validator.
+    function setValidatorSubdomains(
+        address[] calldata accounts,
+        string[] calldata subdomains
+    ) external onlyOwner {
+        require(accounts.length == subdomains.length, "length");
+        for (uint256 i; i < accounts.length; ++i) {
+            validatorSubdomains[accounts[i]] = subdomains[i];
+            emit ValidatorSubdomainUpdated(accounts[i], subdomains[i]);
         }
     }
 
@@ -347,12 +362,15 @@ contract ValidationModule is IValidationModule, Ownable {
                 bool authorized = additionalValidators[candidate];
                 if (!authorized && address(ensOwnershipVerifier) != address(0)) {
                     bytes32[] memory proof;
-                    authorized = ensOwnershipVerifier.verifyOwnership(
-                        candidate,
-                        "",
-                        proof,
-                        clubRootNode
-                    );
+                    string memory subdomain = validatorSubdomains[candidate];
+                    if (bytes(subdomain).length != 0) {
+                        authorized = ensOwnershipVerifier.verifyOwnership(
+                            candidate,
+                            subdomain,
+                            proof,
+                            clubRootNode
+                        );
+                    }
                 }
                 if (!authorized) continue;
                 stakes[m] = stake;

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -13,6 +13,7 @@ interface IValidationModule {
         uint256 approvals,
         uint256 rejections
     );
+    event ValidatorSubdomainUpdated(address indexed validator, string subdomain);
 
     /// @notice Select validators for a given job
     /// @param jobId Identifier of the job
@@ -62,6 +63,12 @@ interface IValidationModule {
 
     /// @notice Update approval threshold percentage
     function setApprovalThreshold(uint256 pct) external;
+
+    /// @notice Map validators to ENS subdomains for selection
+    function setValidatorSubdomains(
+        address[] calldata accounts,
+        string[] calldata subdomains
+    ) external;
 
     /// @notice Return validators selected for a job
     /// @param jobId Identifier of the job

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.8.25;
 /// @notice Interface for validator selection and commit-reveal voting
 interface IValidationModule {
     event ValidatorsSelected(uint256 indexed jobId, address[] validators);
-    event VoteCommitted(uint256 indexed jobId, address indexed validator, bytes32 commitHash);
-    event VoteRevealed(uint256 indexed jobId, address indexed validator, bool approve);
+    event ValidationCommitted(uint256 indexed jobId, address indexed validator, bytes32 commitHash);
+    event ValidationRevealed(uint256 indexed jobId, address indexed validator, bool approve);
     event ValidationFinalized(
         uint256 indexed jobId,
         bool success,

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -53,6 +53,11 @@ contract ValidationStub is IValidationModule {
 
     function setApprovalThreshold(uint256) external {}
 
+    function setValidatorSubdomains(
+        address[] calldata,
+        string[] calldata
+    ) external {}
+
     function resetJobNonce(uint256) external {}
 }
 

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -92,20 +92,18 @@ describe("Validator ENS integration", function () {
       uri: "",
     };
     await jobRegistry.setJob(1, job);
-    await validation.selectValidators(1);
+    await expect(validation.selectValidators(1)).to.be.revertedWith(
+      "insufficient validators"
+    );
 
-    await expect(
-      validation
-        .connect(validator)
-        .commitValidation(1, ethers.id("h"), "v", [])
-    ).to.be.revertedWith("Not authorized validator");
-
+    await validation.setValidatorSubdomains([validator.address], ["v"]);
     await wrapper.setOwner(
       ethers.toBigInt(namehash(root, "v")),
       validator.address
     );
     await resolver.setAddr(namehash(root, "v"), validator.address);
 
+    await validation.selectValidators(1);
     await expect(
       validation
         .connect(validator)
@@ -141,6 +139,7 @@ describe("Validator ENS integration", function () {
     await wrapper.setOwner(ethers.toBigInt(node), validator.address);
     await resolver.setAddr(node, validator.address);
     await validation.setValidatorPool([validator.address]);
+    await validation.setValidatorSubdomains([validator.address], ["v"]);
 
     await stakeManager.setStake(
       validator.address,
@@ -191,6 +190,7 @@ describe("Validator ENS integration", function () {
     await wrapper.setOwner(ethers.toBigInt(node), validator.address);
     await resolver.setAddr(node, validator.address);
     await validation.setValidatorPool([validator.address]);
+    await validation.setValidatorSubdomains([validator.address], ["v"]);
     await stakeManager.setStake(
       validator.address,
       1,

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -113,7 +113,7 @@ describe("Validator ENS integration", function () {
     )
       .to.emit(verifier, "OwnershipVerified")
       .withArgs(validator.address, "v")
-      .and.to.emit(validation, "VoteCommitted");
+      .and.to.emit(validation, "ValidationCommitted");
   });
 
   it("rejects invalid Merkle proofs", async () => {
@@ -183,7 +183,7 @@ describe("Validator ENS integration", function () {
       validation
         .connect(validator)
         .commitValidation(1, ethers.id("h"), "v", [])
-    ).to.emit(validation, "VoteCommitted");
+    ).to.emit(validation, "ValidationCommitted");
   });
 
   it("skips blacklisted validators", async () => {

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -336,7 +336,7 @@ describe("ValidationModule V2", function () {
     await jobRegistry.connect(val).acknowledgeTaxPolicy();
     await expect(
       validation.connect(val).commitValidation(1, commit, "", [])
-    ).to.emit(validation, "VoteCommitted");
+    ).to.emit(validation, "ValidationCommitted");
 
     await advance(61);
     await jobRegistry.setTaxPolicyVersion(2);
@@ -347,7 +347,7 @@ describe("ValidationModule V2", function () {
     await jobRegistry.connect(val).acknowledgeTaxPolicy();
     await expect(
       validation.connect(val).revealValidation(1, true, salt, "", [])
-    ).to.emit(validation, "VoteRevealed");
+    ).to.emit(validation, "ValidationRevealed");
   });
 
   it("updates additional validators individually", async () => {


### PR DESCRIPTION
## Summary
- filter selected validators by ENS ownership or manual allowlist
- rename commit and reveal events to `ValidationCommitted`/`ValidationRevealed`
- update tests for new events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0a4ac68648333b2a829391aa48ba9