### PR TITLE
feat: add job NFT marketplace and staking links

### DIFF
--- a/contracts/JobNFT.sol
+++ b/contracts/JobNFT.sol
@@ -1,20 +1,40 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface IStakeManager {
+    function token() external view returns (IERC20);
+}
 
 /// @title JobNFT
-/// @notice Minimal ERC721 token for representing jobs.
+/// @notice Minimal ERC721 token for representing jobs with a simple marketplace.
 /// @dev Minting and burning are restricted to the JobRegistry contract.
 contract JobNFT is ERC721, Ownable {
+    using SafeERC20 for IERC20;
+
     string private baseTokenURI;
     address public jobRegistry;
-    uint256 public nextTokenId;
+    IStakeManager public stakeManager;
     mapping(uint256 => string) private _tokenURIs;
+
+    struct Listing {
+        address seller;
+        uint256 price;
+        bool active;
+    }
+
+    mapping(uint256 => Listing) public listings;
 
     event BaseURIUpdated(string newURI);
     event JobRegistryUpdated(address registry);
+    event StakeManagerUpdated(address manager);
+    event NFTListed(uint256 indexed tokenId, address indexed seller, uint256 price);
+    event NFTPurchased(uint256 indexed tokenId, address indexed buyer, uint256 price);
+    event NFTDelisted(uint256 indexed tokenId);
 
     constructor() ERC721("Job", "JOB") Ownable(msg.sender) {}
 
@@ -35,14 +55,21 @@ contract JobNFT is ERC721, Ownable {
         emit JobRegistryUpdated(registry);
     }
 
-    /// @notice Mint a new token to `to` with optional `uri`.
-    /// @dev Only callable by the JobRegistry.
-    function mint(address to, string calldata uri)
-        external
-        onlyJobRegistry
-        returns (uint256 tokenId)
-    {
-        tokenId = ++nextTokenId;
+    /// @notice Configure the StakeManager used for marketplace payments.
+    function setStakeManager(address manager) external onlyOwner {
+        stakeManager = IStakeManager(manager);
+        emit StakeManagerUpdated(manager);
+    }
+
+    /// @notice Mint a new token to `to` for the provided `jobId` with optional `uri`.
+    /// @dev Only callable by the JobRegistry. The tokenId matches the jobId.
+    function mint(
+        address to,
+        uint256 jobId,
+        string calldata uri
+    ) external onlyJobRegistry returns (uint256 tokenId) {
+        tokenId = jobId;
+        require(_ownerOf(tokenId) == address(0), "existing");
         _safeMint(to, tokenId);
         if (bytes(uri).length != 0) {
             _tokenURIs[tokenId] = uri;
@@ -77,6 +104,45 @@ contract JobNFT is ERC721, Ownable {
             return custom;
         }
         return super.tokenURI(tokenId);
+    }
+
+    /// @notice List an NFT for sale at `price` using the StakeManager token.
+    function list(uint256 tokenId, uint256 price) external {
+        require(ownerOf(tokenId) == msg.sender, "owner");
+        require(price > 0, "price");
+        Listing storage listing = listings[tokenId];
+        require(!listing.active, "listed");
+        listing.seller = msg.sender;
+        listing.price = price;
+        listing.active = true;
+        emit NFTListed(tokenId, msg.sender, price);
+    }
+
+    /// @notice Purchase a listed NFT using the StakeManager's staking token.
+    function purchase(uint256 tokenId) external {
+        Listing storage listing = listings[tokenId];
+        require(listing.active, "not listed");
+        address seller = listing.seller;
+        require(seller != msg.sender, "self");
+        IERC20 token = stakeManager.token();
+        require(
+            token.allowance(msg.sender, address(this)) >= listing.price,
+            "allowance"
+        );
+        uint256 price = listing.price;
+        delete listings[tokenId];
+        token.safeTransferFrom(msg.sender, seller, price);
+        _safeTransfer(seller, msg.sender, tokenId, "");
+        emit NFTPurchased(tokenId, msg.sender, price);
+    }
+
+    /// @notice Remove a listed NFT from the marketplace.
+    function delist(uint256 tokenId) external {
+        Listing storage listing = listings[tokenId];
+        require(listing.active, "not listed");
+        require(listing.seller == msg.sender, "owner");
+        delete listings[tokenId];
+        emit NFTDelisted(tokenId);
     }
 }
 

--- a/test/JobNFT.test.js
+++ b/test/JobNFT.test.js
@@ -33,12 +33,22 @@ describe("JobNFT", function () {
       .withArgs(user.address);
   });
 
+  it("allows only owner to set stake manager", async function () {
+    const { nft, jobRegistry, user } = await deployFixture();
+    await expect(nft.connect(jobRegistry).setStakeManager(user.address))
+      .to.be.revertedWithCustomError(nft, "OwnableUnauthorizedAccount")
+      .withArgs(jobRegistry.address);
+    await expect(nft.setStakeManager(user.address))
+      .to.emit(nft, "StakeManagerUpdated")
+      .withArgs(user.address);
+  });
+
   it("mints and burns only via JobRegistry", async function () {
     const { nft, jobRegistry, user } = await deployFixture();
-    await expect(nft.connect(user).mint(user.address, "job1.json"))
+    await expect(nft.connect(user).mint(user.address, 1, "job1.json"))
       .to.be.revertedWith("only JobRegistry");
-    await nft.connect(jobRegistry).mint(user.address, "job1.json");
-    const tokenId = await nft.nextTokenId();
+    await nft.connect(jobRegistry).mint(user.address, 1, "job1.json");
+    const tokenId = 1;
 
     expect(await nft.ownerOf(tokenId)).to.equal(user.address);
     await nft.connect(jobRegistry).burn(tokenId);
@@ -51,9 +61,10 @@ describe("JobNFT", function () {
   it("prefixes tokenURI with base URI", async function () {
     const { nft, jobRegistry, user } = await deployFixture();
     await nft.setBaseURI("ipfs://");
-    await nft.connect(jobRegistry).mint(user.address, "job1.json");
-    const tokenId = await nft.nextTokenId();
+    await nft.connect(jobRegistry).mint(user.address, 1, "job1.json");
+    const tokenId = 1;
 
     expect(await nft.tokenURI(tokenId)).to.equal("ipfs://job1.json");
   });
 });
+

--- a/test/JobNFTMarketplace.test.js
+++ b/test/JobNFTMarketplace.test.js
@@ -1,0 +1,54 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobNFT marketplace", function () {
+  const price = ethers.parseUnits("1", 6);
+  let owner, seller, buyer, token, stake, nft;
+
+  beforeEach(async () => {
+    [owner, seller, buyer] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("AGIALPHAToken");
+    token = await Token.deploy("AGI ALPHA", "AGIA", ethers.parseUnits("1000", 6));
+    await token.transfer(buyer.address, price);
+    await token.transfer(seller.address, price);
+
+    const Stake = await ethers.getContractFactory("contracts/StakeManager.sol:StakeManager");
+    stake = await Stake.deploy();
+    await stake.setToken(await token.getAddress());
+
+    const NFT = await ethers.getContractFactory("JobNFT");
+    nft = await NFT.deploy();
+    await nft.setJobRegistry(owner.address);
+    await nft.setStakeManager(await stake.getAddress());
+
+    await nft.connect(owner).mint(seller.address, 1, "ipfs://1");
+  });
+
+  it("lists, purchases, and delists with events", async () => {
+    await expect(nft.connect(seller).list(1, price))
+      .to.emit(nft, "NFTListed")
+      .withArgs(1, seller.address, price);
+
+    await expect(nft.connect(seller).list(1, price)).to.be.revertedWith(
+      "listed"
+    );
+
+    await expect(nft.connect(buyer).purchase(1)).to.be.revertedWith(
+      "allowance"
+    );
+
+    await token.connect(buyer).approve(await nft.getAddress(), price);
+    await expect(nft.connect(buyer).purchase(1))
+      .to.emit(nft, "NFTPurchased")
+      .withArgs(1, buyer.address, price);
+    expect(await nft.ownerOf(1)).to.equal(buyer.address);
+
+    await nft.connect(owner).mint(seller.address, 2, "ipfs://2");
+    await nft.connect(seller).list(2, price);
+    await expect(nft.connect(seller).delist(2))
+      .to.emit(nft, "NFTDelisted")
+      .withArgs(2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- lock JobNFT minting to JobRegistry and align tokenId with jobId
- expose owner setters for base URI, JobRegistry and StakeManager
- add AGIALPHA-powered marketplace with list, purchase and delist flows

## Testing
- `HARDHAT_DISABLE_TELEMETRY=1 npm test` *(fails: process exceeded time/limit)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bdc16d7c8333bff13ddc8f0411e5