### PR TITLE
Enhance agent blacklisting guard in JobRegistry

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -551,7 +551,12 @@ contract JobRegistry is Ownable, ReentrancyGuard {
             ) || additionalAgents[msg.sender];
         require(authorized, "Not authorized agent");
         emit OwnershipVerified(msg.sender, subdomain);
-        require(!reputationEngine.isBlacklisted(msg.sender), "Blacklisted agent");
+        if (address(reputationEngine) != address(0)) {
+            require(
+                !reputationEngine.isBlacklisted(msg.sender),
+                "Blacklisted agent"
+            );
+        }
         Job storage job = jobs[jobId];
         require(job.state == State.Created, "not open");
         if (job.stake > 0 && address(stakeManager) != address(0)) {


### PR DESCRIPTION
## Summary
- Guard ReputationEngine blacklist checks in `_applyForJob` so registry can operate even if module not configured

## Testing
- `npx hardhat test test/v2/JobRegistry.test.js --no-compile` *(fails: Artifact for contract "contracts/v2/StakeManager.sol:StakeManager" not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a0e9f4244c8333b53247f7ba27165c