### PR TITLE
feat: add commit reveal validation

### DIFF
--- a/contracts/ValidationModule.sol
+++ b/contracts/ValidationModule.sol
@@ -5,6 +5,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 interface IStakeManager {
     function lockReward(address from, uint256 amount) external;
+    function stakes(address user) external view returns (uint256);
 }
 
 interface IReputationEngine {
@@ -16,7 +17,7 @@ interface IReputationEngine {
 contract ValidationModule is Ownable {
     mapping(uint256 => bool) public outcomes;
 
-    /// @notice stake manager used to lock dispute bonds
+    /// @notice stake manager used to lock dispute bonds and verify stake
     IStakeManager public stakeManager;
     IReputationEngine public reputationEngine;
     bytes32 public clubRootNode;
@@ -33,6 +34,37 @@ contract ValidationModule is Ownable {
     /// @dev challenger per job
     mapping(uint256 => address) public challenger;
 
+    // ------------------------------------------------------------------
+    // commit–reveal validation storage
+    // ------------------------------------------------------------------
+
+    /// @notice number of validators selected per job
+    uint256 public validatorsPerJob = 1;
+    /// @notice duration of the commit phase in seconds
+    uint256 public commitWindow = 1 days;
+    /// @notice duration of the reveal phase in seconds
+    uint256 public revealWindow = 1 days;
+
+    /// @notice global pool of potential validators
+    address[] public validatorPool;
+
+    /// @dev selected validators for a job
+    mapping(uint256 => address[]) public jobValidators;
+    /// @dev quick lookup of whether an address is selected for a job
+    mapping(uint256 => mapping(address => bool)) public isValidator;
+    /// @dev commit deadline per job
+    mapping(uint256 => uint256) public commitDeadline;
+    /// @dev reveal deadline per job
+    mapping(uint256 => uint256) public revealDeadline;
+    /// @dev stored commitments per job and validator
+    mapping(uint256 => mapping(address => bytes32)) public commitments;
+    /// @dev whether a validator revealed their vote
+    mapping(uint256 => mapping(address => bool)) public revealed;
+    /// @dev approvals count per job
+    mapping(uint256 => uint256) public approvals;
+    /// @dev total revealed votes per job
+    mapping(uint256 => uint256) public totalReveals;
+
     event OutcomeSet(uint256 indexed jobId, bool success);
     event OutcomeChallenged(uint256 indexed jobId, address indexed challenger);
     event StakeManagerUpdated(address manager);
@@ -42,6 +74,28 @@ contract ValidationModule is Ownable {
     event ReputationEngineUpdated(address engine);
     event ClubRootNodeUpdated(bytes32 node);
     event ValidatorMerkleRootUpdated(bytes32 root);
+
+    // events for commit–reveal validation
+    event ValidatorsPerJobUpdated(uint256 count);
+    event CommitWindowUpdated(uint256 window);
+    event RevealWindowUpdated(uint256 window);
+    event ValidatorPoolUpdated(address[] pool);
+    event ValidatorsSelected(uint256 indexed jobId, address[] validators);
+    event ValidationCommitted(
+        uint256 indexed jobId,
+        address indexed validator,
+        bytes32 commitHash
+    );
+    event ValidationRevealed(
+        uint256 indexed jobId,
+        address indexed validator,
+        bool approve
+    );
+    event ValidationResult(
+        uint256 indexed jobId,
+        bool success,
+        address[] validators
+    );
 
     constructor() Ownable(msg.sender) {}
 
@@ -80,6 +134,30 @@ contract ValidationModule is Ownable {
         emit ValidatorMerkleRootUpdated(root);
     }
 
+    /// @notice Set number of validators selected per job.
+    function setValidatorsPerJob(uint256 count) external onlyOwner {
+        validatorsPerJob = count;
+        emit ValidatorsPerJobUpdated(count);
+    }
+
+    /// @notice Set the commit phase duration.
+    function setCommitWindow(uint256 window) external onlyOwner {
+        commitWindow = window;
+        emit CommitWindowUpdated(window);
+    }
+
+    /// @notice Set the reveal phase duration.
+    function setRevealWindow(uint256 window) external onlyOwner {
+        revealWindow = window;
+        emit RevealWindowUpdated(window);
+    }
+
+    /// @notice Update the pool of potential validators.
+    function setValidatorPool(address[] calldata pool) external onlyOwner {
+        validatorPool = pool;
+        emit ValidatorPoolUpdated(pool);
+    }
+
     /// @notice Set the validation outcome for a job.
     function setOutcome(uint256 jobId, bool success) external onlyOwner {
         outcomes[jobId] = success;
@@ -113,6 +191,125 @@ contract ValidationModule is Ownable {
         );
         delete challenger[jobId];
         delete challengeDeadline[jobId];
+    }
+
+    // ------------------------------------------------------------------
+    // Commit–reveal validation logic
+    // ------------------------------------------------------------------
+
+    /// @notice Select validators for a job filtering by stake and identity.
+    /// @dev Uses pseudo-random sampling from the validator pool.
+    function selectValidators(uint256 jobId)
+        external
+        onlyOwner
+        returns (address[] memory selected)
+    {
+        uint256 poolLength = validatorPool.length;
+        address[] memory pool = new address[](poolLength);
+        uint256 eligible;
+        for (uint256 i; i < poolLength; ) {
+            address v = validatorPool[i];
+            bool ok = stakeManager.stakes(v) > 0;
+            if (ok && address(reputationEngine) != address(0)) {
+                ok = !reputationEngine.isBlacklisted(v);
+            }
+            if (ok) {
+                pool[eligible] = v;
+                unchecked {
+                    ++eligible;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        require(eligible >= validatorsPerJob, "not enough validators");
+        assembly {
+            mstore(pool, eligible)
+        }
+        selected = new address[](validatorsPerJob);
+        bytes32 seed = keccak256(
+            abi.encodePacked(block.timestamp, block.prevrandao, jobId)
+        );
+        uint256 remaining = eligible;
+        for (uint256 i; i < validatorsPerJob; ) {
+            seed = keccak256(abi.encodePacked(seed, i));
+            uint256 index = uint256(seed) % remaining;
+            address val = pool[index];
+            selected[i] = val;
+            jobValidators[jobId].push(val);
+            isValidator[jobId][val] = true;
+            pool[index] = pool[--remaining];
+            unchecked {
+                ++i;
+            }
+        }
+
+        commitDeadline[jobId] = block.timestamp + commitWindow;
+        revealDeadline[jobId] = commitDeadline[jobId] + revealWindow;
+        emit ValidatorsSelected(jobId, selected);
+    }
+
+    /// @notice Commit to a validation vote.
+    function commitValidation(uint256 jobId, bytes32 commitHash) external {
+        require(isValidator[jobId][msg.sender], "not validator");
+        require(block.timestamp <= commitDeadline[jobId], "commit over");
+        require(commitments[jobId][msg.sender] == bytes32(0), "committed");
+        commitments[jobId][msg.sender] = commitHash;
+        emit ValidationCommitted(jobId, msg.sender, commitHash);
+    }
+
+    /// @notice Reveal a previously committed vote.
+    function revealValidation(
+        uint256 jobId,
+        bool approve,
+        bytes32 salt
+    ) external {
+        require(isValidator[jobId][msg.sender], "not validator");
+        require(block.timestamp > commitDeadline[jobId], "commit phase");
+        require(block.timestamp <= revealDeadline[jobId], "reveal over");
+        bytes32 commitment = commitments[jobId][msg.sender];
+        require(commitment != bytes32(0), "no commit");
+        require(!revealed[jobId][msg.sender], "revealed");
+        bytes32 expected = keccak256(
+            abi.encodePacked(msg.sender, jobId, approve, salt)
+        );
+        require(expected == commitment, "hash mismatch");
+        revealed[jobId][msg.sender] = true;
+        if (approve) {
+            approvals[jobId] += 1;
+        }
+        totalReveals[jobId] += 1;
+        emit ValidationRevealed(jobId, msg.sender, approve);
+    }
+
+    /// @notice Finalize validation and compute the result.
+    /// @return success True if approvals exceed rejections
+    /// @return participants Validators that revealed their votes
+    function finalizeValidation(uint256 jobId)
+        external
+        returns (bool success, address[] memory participants)
+    {
+        require(block.timestamp > revealDeadline[jobId], "reveal pending");
+        uint256 reveals = totalReveals[jobId];
+        participants = new address[](reveals);
+        address[] storage vals = jobValidators[jobId];
+        uint256 idx;
+        for (uint256 i; i < vals.length; ++i) {
+            address v = vals[i];
+            if (revealed[jobId][v]) {
+                participants[idx++] = v;
+            }
+            delete isValidator[jobId][v];
+            delete commitments[jobId][v];
+            delete revealed[jobId][v];
+        }
+        success = approvals[jobId] * 2 >= reveals && reveals > 0;
+        outcomes[jobId] = success;
+        delete approvals[jobId];
+        delete totalReveals[jobId];
+        delete jobValidators[jobId];
+        emit ValidationResult(jobId, success, participants);
     }
 
     /// @notice Confirms the contract and owner are tax-exempt.

--- a/test/ValidationModule.test.js
+++ b/test/ValidationModule.test.js
@@ -1,11 +1,12 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("ValidationModule", function () {
-  let validation, owner, challenger, stakeManager;
+  let validation, owner, challenger, stakeManager, validator;
 
   beforeEach(async () => {
-    [owner, challenger] = await ethers.getSigners();
+    [owner, challenger, validator] = await ethers.getSigners();
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/mocks/StubStakeManager.sol:StubStakeManager"
@@ -20,6 +21,7 @@ describe("ValidationModule", function () {
     await validation.connect(owner).setStakeManager(stakeAddr);
     await validation.connect(owner).setChallengeWindow(1000);
     await validation.connect(owner).setDisputeBond(50);
+    await stakeManager.setStake(validator.address, 1);
   });
 
   it("returns preset outcomes", async () => {
@@ -42,6 +44,43 @@ describe("ValidationModule", function () {
     await expect(
       validation.connect(challenger).challenge(1)
     ).to.be.revertedWith("expired");
+  });
+
+  it("supports commit-reveal flow", async () => {
+    await validation.connect(owner).setValidatorsPerJob(1);
+    await validation.connect(owner).setCommitWindow(5);
+    await validation.connect(owner).setRevealWindow(5);
+    await validation
+      .connect(owner)
+      .setValidatorPool([validator.address]);
+    await validation.connect(owner).selectValidators(1);
+
+    const salt = ethers.encodeBytes32String("salt");
+    const commit = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "bool", "bytes32"],
+      [validator.address, 1, true, salt]
+    );
+    await expect(
+      validation.connect(validator).commitValidation(1, commit)
+    )
+      .to.emit(validation, "ValidationCommitted")
+      .withArgs(1, validator.address, commit);
+
+    await time.increase(6);
+
+    await expect(
+      validation.connect(validator).revealValidation(1, true, salt)
+    )
+      .to.emit(validation, "ValidationRevealed")
+      .withArgs(1, validator.address, true);
+
+    await time.increase(6);
+
+    await expect(validation.finalizeValidation(1)).to.emit(
+      validation,
+      "ValidationResult"
+    );
+    expect(await validation.outcomes(1)).to.equal(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add commit-reveal validation flow with configurable validator parameters
- expose commit and reveal vote functions with validation finalization
- test commit-reveal workflow in ValidationModule

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a13913ff748333abcad8b93ffede9e