### PR TITLE
docs: outline ENS identity sprint and link deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ All modules expect amounts in 6‑decimal base units (`1 token = 1_000000`). Sho
 
 For a quick reference on migrating code, see [docs/v1-v2-function-map.md](docs/v1-v2-function-map.md) which maps every v1 function to its v2 counterpart.
 
+For step‑by‑step instructions on deploying the legacy manager with `$AGIALPHA`, see [docs/deployment-v0-agialpha.md](docs/deployment-v0-agialpha.md). The guide uses block‑explorer write tabs so non‑technical owners can configure the contract without additional tooling.
+
 ## v2 Modular Contract Overview
 
 The v2 release splits the monolithic manager into single‑purpose modules. Each contract owns its state and can be replaced without touching the rest of the system:

--- a/docs/coding-sprint-v2-ens-identity.md
+++ b/docs/coding-sprint-v2-ens-identity.md
@@ -1,0 +1,59 @@
+# Coding Sprint: ENS Identity & v1 Feature Parity
+
+This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 architecture while enforcing ENS subdomain identity.
+
+## Objectives
+- Require `*.agent.agi.eth` for agents and `*.club.agi.eth` for validators.
+- Preserve every feature from the legacy contract across the new modules.
+- Keep the system owner‑configurable and friendly for block‑explorer users.
+
+## Tasks
+
+### 1. Identity Verification Library
+- Build `ENSOwnershipVerifier` with Merkle proof, NameWrapper and resolver fallback.
+- Emit `OwnershipVerified` and `RecoveryInitiated` events.
+- Add owner setters for ENS registry, NameWrapper, root nodes and Merkle roots.
+- Maintain `additionalAgents`/`additionalValidators` allow‑lists.
+
+### 2. JobRegistry
+- Port `createJob`, `applyForJob`, `submit`, `finalize`, `cancelJob`, `dispute` and `forceCancel`.
+- On `applyForJob` call the verifier and check blacklists via `ReputationEngine`.
+- Require tax policy acknowledgement before any state‑changing action.
+- Enforce owner‑set `maxJobReward` and `maxJobDuration` limits.
+
+### 3. ValidationModule
+- Select validator committees and record commits & reveals.
+- Accept votes only from identities passing the verifier or in the allow‑list.
+- Finalise results once quorum or the reveal window ends.
+- Report outcomes back to `JobRegistry`.
+
+### 4. StakeManager
+- Custody all funds in $AGIALPHA (6 decimals) with owner‑settable token address.
+- Handle deposits, withdrawals, escrow locking, releases and slashing.
+- Apply protocol fees and validator rewards; support AGIType payout bonuses.
+
+### 5. ReputationEngine
+- Implement logarithmic reputation growth with diminishing returns.
+- Provide `onApply` and `onFinalize` hooks plus `rewardValidator`.
+- Owner‑managed blacklist and premium threshold.
+
+### 6. DisputeModule
+- Allow `JobRegistry.dispute` to escrow dispute fees and trigger resolution.
+- Moderator‑based `resolve(jobId, employerWins)` that directs `StakeManager` to refund or release.
+- Owner setter to manage moderator addresses and dispute fee size.
+
+### 7. CertificateNFT & Marketplace
+- Mint one certificate per completed job to the worker.
+- Add `list`, `purchase`, and `delist` functions using $AGIALPHA.
+- Owner can set base URI and `JobRegistry` address.
+
+### 8. Documentation & Tests
+- Update `README.md` with an AGIALPHA deployment guide and Etherscan walkthrough.
+- Add Hardhat tests covering identity checks, job lifecycle, validation, disputes and NFT marketplace.
+- Run `npx solhint 'contracts/**/*.sol'`, `npx eslint .` and `npx hardhat test` until green.
+
+## Definition of Done
+- All v1 capabilities available through modular contracts.
+- Agents and validators must own the correct ENS subdomain or be allow‑listed.
+- Owner can retune parameters and swap the staking token without redeploying.
+- Documentation enables non‑technical users to interact via a block explorer.


### PR DESCRIPTION
## Summary
- add ENS identity & v1 parity coding sprint doc
- link detailed $AGIALPHA deployment guide in README for non-technical owners

## Testing
- `npx solhint 'contracts/**/*.sol'`
- `npx eslint .`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68a1cee6bdc483338e24105467a6c8a9