### PR TITLE
docs: add ens parity sprint details

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Owners retain `onlyOwner` control over parameters, letting them reconfigure live
 - ENS registry and NameWrapper contract addresses.
 
 **Steps**
-1. Deploy or reuse the [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) token.
+1. Deploy or reuse the [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) token; it powers job payouts, agent/validator stakes, validation rewards and dispute fees by default.
 2. On a block explorer, open `legacy/AGIJobManagerv0.sol` and use the **Deploy** or **Write Contract** interface to provide the constructor fields: token address, base IPFS URI, ENS registry, NameWrapper, agent/club root nodes, and the corresponding Merkle roots.
 3. Submit the transaction; the sender becomes the owner.
-4. After deployment the owner can switch payout tokens with `updateAGITokenAddress(newToken)` and rotate ENS roots or allowlists without redeploying.
+4. After deployment the owner can switch payout, staking and reward tokens with `updateAGITokenAddress(newToken)` and rotate ENS roots or allowlists without redeploying.
 5. All job posting, application, validation, dispute, and NFT marketplace calls happen through the contract's **Write** tab. Enter token amounts using 6‑decimal units (`1 token = 1_000000`).
 
 #### Etherscan deployment steps

--- a/docs/coding-sprint-v2-ens-identity.md
+++ b/docs/coding-sprint-v2-ens-identity.md
@@ -12,7 +12,7 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 ### 1. Identity Verification Library
 - Build `ENSOwnershipVerifier` with Merkle proof, NameWrapper and resolver fallback.
 - Emit `OwnershipVerified` and `RecoveryInitiated` events.
-- Add owner setters for ENS registry, NameWrapper, root nodes and Merkle roots.
+- Add owner setters for ENS registry, NameWrapper, root nodes and Merkle roots, emitting update events for audit trails.
 - Maintain `additionalAgents`/`additionalValidators` allow‑lists.
 
 ### 2. JobRegistry
@@ -20,17 +20,20 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 - On `applyForJob` call the verifier and check blacklists via `ReputationEngine`.
 - Require tax policy acknowledgement before any state‑changing action.
 - Enforce owner‑set `maxJobReward` and `maxJobDuration` limits.
+- Mirror v1 event names and cross‑check `docs/v1-v2-function-map.md` to ensure feature parity.
 
 ### 3. ValidationModule
 - Select validator committees and record commits & reveals.
 - Accept votes only from identities passing the verifier or in the allow‑list.
 - Finalise results once quorum or the reveal window ends.
 - Report outcomes back to `JobRegistry`.
+- Use deterministic on‑chain randomness; avoid Chainlink VRF or subscription services.
 
 ### 4. StakeManager
 - Custody all funds in $AGIALPHA (6 decimals) with owner‑settable token address.
 - Handle deposits, withdrawals, escrow locking, releases and slashing.
 - Apply protocol fees and validator rewards; support AGIType payout bonuses.
+- Provide a `contribute` function for reward‑pool top‑ups to match v1's `contributeToRewardPool`.
 
 ### 5. ReputationEngine
 - Implement logarithmic reputation growth with diminishing returns.
@@ -51,6 +54,7 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 - Update `README.md` with an AGIALPHA deployment guide and Etherscan walkthrough.
 - Add Hardhat tests covering identity checks, job lifecycle, validation, disputes and NFT marketplace.
 - Run `npx solhint 'contracts/**/*.sol'`, `npx eslint .` and `npx hardhat test` until green.
+- Verify coverage against `docs/v1-v2-function-map.md` so every v1 function has a v2 counterpart.
 
 ## Definition of Done
 - All v1 capabilities available through modular contracts.


### PR DESCRIPTION
## Summary
- expand v2 ENS parity sprint with deterministic validator selection, reward-pool contributions, and cross-module parity checks
- document AGIJobManager v0 deployment with $AGIALPHA token and ability to retune token without redeploying

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d5dfef548333abac921862ee4e37