### PR TITLE
Add dispute slashing API and alias setter

### DIFF
--- a/contracts/DisputeResolution.sol
+++ b/contracts/DisputeResolution.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.21;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 interface IStakeManager {
-    function slash(address user, address recipient, uint256 amount) external;
+    function slash(address user, uint256 amount, address recipient) external;
 }
 
 interface IReputationEngine {
@@ -54,11 +54,11 @@ contract DisputeResolution is Ownable {
         }
 
         if (validatorWins) {
-            stakeManager.slash(challengerAddr, validator, bond);
+            stakeManager.slash(challengerAddr, bond, validator);
             reputationEngine.subtractReputation(challengerAddr, 1);
             reputationEngine.addReputation(validator, 1);
         } else {
-            stakeManager.slash(validator, challengerAddr, bond);
+            stakeManager.slash(validator, bond, challengerAddr);
             reputationEngine.subtractReputation(validator, 1);
             reputationEngine.addReputation(challengerAddr, 1);
         }

--- a/contracts/JobRegistry.sol
+++ b/contracts/JobRegistry.sol
@@ -16,7 +16,7 @@ interface IReputationEngine {
 interface IStakeManager {
     function lockReward(address from, uint256 amount) external;
     function payReward(address to, uint256 amount) external;
-    function slash(address user, address recipient, uint256 amount) external;
+    function slash(address user, uint256 amount, address recipient) external;
     function releaseStake(address user, uint256 amount) external;
     function stakes(address user) external view returns (uint256);
 }
@@ -328,7 +328,7 @@ contract JobRegistry is Ownable {
             certificateNFT.mintCertificate(job.agent, jobId, job.outputURI);
         } else {
             stakeManager.payReward(job.employer, job.reward + job.fee);
-            stakeManager.slash(job.agent, job.employer, job.stake);
+            stakeManager.slash(job.agent, job.stake, job.employer);
             reputationEngine.subtractReputation(job.agent, 1);
         }
         emit JobFinalized(jobId, job.success);

--- a/contracts/JobRegistry.sol
+++ b/contracts/JobRegistry.sol
@@ -16,7 +16,8 @@ interface IReputationEngine {
 interface IStakeManager {
     function lockReward(address from, uint256 amount) external;
     function payReward(address to, uint256 amount) external;
-    function slash(address user, uint256 amount, address recipient) external;
+    enum Role { Agent, Validator, Platform }
+    function slash(address user, Role role, uint256 amount, address employer) external;
     function releaseStake(address user, uint256 amount) external;
     function stakes(address user) external view returns (uint256);
 }
@@ -328,7 +329,7 @@ contract JobRegistry is Ownable {
             certificateNFT.mintCertificate(job.agent, jobId, job.outputURI);
         } else {
             stakeManager.payReward(job.employer, job.reward + job.fee);
-            stakeManager.slash(job.agent, job.stake, job.employer);
+            stakeManager.slash(job.agent, IStakeManager.Role.Agent, job.stake, job.employer);
             reputationEngine.subtractReputation(job.agent, 1);
         }
         emit JobFinalized(jobId, job.success);

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -43,6 +43,7 @@ contract MockStakeManager is IStakeManager {
     function setToken(IERC20) external override {}
     function setMinStake(uint256) external override {}
     function setSlashingPercentages(uint256, uint256) external override {}
+    function setSlashingParameters(uint256, uint256) external override {}
     function setTreasury(address) external override {}
     function setMaxStakePerAddress(uint256) external override {}
     function setMaxAGITypes(uint256) external override {}
@@ -58,6 +59,16 @@ contract MockStakeManager is IStakeManager {
         require(st >= amount, "stake");
         _stakes[user][role] = st - amount;
         totalStakes[role] -= amount;
+    }
+
+    function slash(address user, uint256 amount, address)
+        external
+        override
+    {
+        uint256 st = _stakes[user][Role.Validator];
+        require(st >= amount, "stake");
+        _stakes[user][Role.Validator] = st - amount;
+        totalStakes[Role.Validator] -= amount;
     }
 
     function stakeOf(address user, Role role) external view override returns (uint256) {

--- a/contracts/mocks/StubStakeManager.sol
+++ b/contracts/mocks/StubStakeManager.sol
@@ -20,7 +20,7 @@ contract StubStakeManager {
 
     function payReward(address, uint256) external {}
 
-    function slash(address user, address recipient, uint256 amount) external {
+    function slash(address user, uint256 amount, address recipient) external {
         slashed[user][recipient] += amount;
     }
 

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -88,6 +88,9 @@ interface IStakeManager {
     /// @notice slash stake from a user for a specific role
     function slash(address user, Role role, uint256 amount, address employer) external;
 
+    /// @notice slash validator stake during dispute resolution
+    function slash(address user, uint256 amount, address recipient) external;
+
     /// @notice toggle enforcement requiring slashing percentages to sum to 100
     function setSlashPercentSumEnforcement(bool enforced) external;
 
@@ -95,6 +98,7 @@ interface IStakeManager {
     function setToken(IERC20 newToken) external;
     function setMinStake(uint256 _minStake) external;
     function setSlashingPercentages(uint256 _employerSlashPct, uint256 _treasurySlashPct) external;
+    function setSlashingParameters(uint256 _employerSlashPct, uint256 _treasurySlashPct) external;
     function setTreasury(address _treasury) external;
     function setMaxStakePerAddress(uint256 maxStake) external;
     function setMaxAGITypes(uint256 newMax) external;

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -87,7 +87,7 @@ describe("StakeManager", function () {
     await expect(
       stakeManager
         .connect(registrySigner)
-        .slash(user.address, 0, 100, employer.address)
+        ["slash(address,uint8,uint256,address)"](user.address, 0, 100, employer.address)
     ).to.emit(stakeManager, "StakeSlashed").withArgs(
       user.address,
       0,
@@ -136,7 +136,7 @@ describe("StakeManager", function () {
     await expect(
       stakeManager
         .connect(user)
-        .slash(user.address, 0, 10, employer.address)
+        ["slash(address,uint8,uint256,address)"](user.address, 0, 10, employer.address)
     ).to.be.revertedWith("only job registry");
 
     const registryAddr = await jobRegistry.getAddress();
@@ -146,7 +146,7 @@ describe("StakeManager", function () {
     await expect(
       stakeManager
         .connect(registrySigner)
-        .slash(user.address, 0, 200, employer.address)
+        ["slash(address,uint8,uint256,address)"](user.address, 0, 200, employer.address)
     ).to.be.revertedWith("stake");
   });
 
@@ -192,7 +192,7 @@ describe("StakeManager", function () {
       expect(await stakeManager.stakes(user.address, role)).to.equal(100n);
       await stakeManager
         .connect(registrySigner)
-        .slash(user.address, role, 50, employer.address);
+        ["slash(address,uint8,uint256,address)"](user.address, role, 50, employer.address);
       expect(await stakeManager.stakes(user.address, role)).to.equal(50n);
     }
   });
@@ -242,7 +242,7 @@ describe("StakeManager", function () {
     await expect(
       stakeManager
         .connect(registrySigner)
-        .slash(user.address, 3, 1, employer.address)
+        ["slash(address,uint8,uint256,address)"](user.address, 3, 1, employer.address)
     ).to.be.revertedWithoutReason();
   });
 
@@ -445,7 +445,7 @@ describe("StakeManager", function () {
     await stakeManager.connect(owner).depositStake(0, 100);
     await stakeManager
       .connect(owner)
-      .slash(owner.address, 0, 100, employer.address);
+      ["slash(address,uint8,uint256,address)"](owner.address, 0, 100, employer.address);
     expect(await stakeManager.stakes(owner.address, 0)).to.equal(0n);
     expect(await token.balanceOf(employer.address)).to.equal(1060n);
     expect(await token.balanceOf(treasury.address)).to.equal(20n);
@@ -461,7 +461,7 @@ describe("StakeManager", function () {
     await stakeManager.connect(owner).depositStake(0, 100);
     await stakeManager
       .connect(owner)
-      .slash(owner.address, 0, 100, employer.address);
+      ["slash(address,uint8,uint256,address)"](owner.address, 0, 100, employer.address);
     expect(await stakeManager.stakes(owner.address, 0)).to.equal(0n);
     expect(await token.balanceOf(employer.address)).to.equal(1070n);
     expect(await token.balanceOf(treasury.address)).to.equal(30n);
@@ -487,7 +487,7 @@ describe("StakeManager", function () {
     await expect(
       stakeManager
         .connect(owner)
-        .slash(owner.address, 0, 100, employer.address)
+        ["slash(address,uint8,uint256,address)"](owner.address, 0, 100, employer.address)
     ).to.be.revertedWith("pct");
   });
 
@@ -609,7 +609,7 @@ describe("StakeManager", function () {
     await expect(
       stakeManager
         .connect(registrySigner)
-        .slash(user.address, 0, 100, employer.address)
+        ["slash(address,uint8,uint256,address)"](user.address, 0, 100, employer.address)
     )
       .to.emit(stakeManager, "StakeSlashed")
       .withArgs(user.address, 0, employer.address, treasury.address, 50, 50)
@@ -689,7 +689,7 @@ describe("StakeManager", function () {
 
     await stakeManager
       .connect(registrySigner)
-      .slash(user.address, 0, 100, employer.address);
+      ["slash(address,uint8,uint256,address)"](user.address, 0, 100, employer.address);
     await stakeManager.connect(user).withdrawStake(0, 100);
 
     expect(await stakeManager.stakes(user.address, 0)).to.equal(0n);
@@ -778,7 +778,7 @@ describe("StakeManager", function () {
 
     await stakeManager
       .connect(registrySigner)
-      .slash(user.address, 0, amount, employer.address);
+      ["slash(address,uint8,uint256,address)"](user.address, 0, amount, employer.address);
 
     const employerAfter = await token.balanceOf(employer.address);
     const treasuryAfter = await token.balanceOf(treasury.address);


### PR DESCRIPTION
## Summary
- support dispute-driven slashing with recipient and validator role
- add `setSlashingParameters` alias for configuring slash splits
- update interfaces, mocks, registry and dispute module for new signature

## Testing
- `CI=1 npx hardhat test test/DisputeResolution.test.js` *(failed: no output from Hardhat in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a1da222ca08333be16a93789da7a94