### PR TITLE
feat: add reputation lifecycle hooks

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -354,6 +354,10 @@ contract MockReputationEngine is IReputationEngine {
         return _rep[user];
     }
 
+    function reputationOf(address user) external view override returns (uint256) {
+        return _rep[user];
+    }
+
     function isBlacklisted(address user) external view override returns (bool) {
         return _blacklist[user];
     }
@@ -368,8 +372,25 @@ contract MockReputationEngine is IReputationEngine {
         threshold = t;
     }
 
+    function setPremiumThreshold(uint256 t) external override {
+        threshold = t;
+    }
+
     function setBlacklist(address user, bool val) external override {
         _blacklist[user] = val;
+    }
+
+    function onApply(address user) external override {
+        require(!_blacklist[user], "blacklisted");
+        require(_rep[user] >= threshold, "insufficient reputation");
+    }
+
+    function onFinalize(address user, bool success, uint256, uint256) external override {
+        if (success) {
+            _rep[user] += 1;
+        } else if (_rep[user] < threshold) {
+            _blacklist[user] = true;
+        }
     }
 
     function getOperatorScore(address user) external view override returns (uint256) {

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -18,7 +18,7 @@ contract ReputationEngine is Ownable {
     uint256 public stakeWeight = 1e18;
     uint256 public reputationWeight = 1e18;
 
-    event ReputationChanged(address indexed user, int256 delta, uint256 newScore);
+    event ReputationUpdated(address indexed user, int256 delta, uint256 newScore);
     event Blacklisted(address indexed user, bool status);
     event CallerUpdated(address indexed caller, bool allowed);
     event ThresholdUpdated(uint256 newThreshold);
@@ -60,24 +60,34 @@ contract ReputationEngine is Ownable {
         emit ScoringWeightsUpdated(stakeW, repW);
     }
 
-    /// @notice Set reputation threshold for automatic blacklisting.
-    function setThreshold(uint256 newThreshold) external onlyOwner {
+    /// @notice Set reputation threshold for premium access.
+    function setPremiumThreshold(uint256 newThreshold) public onlyOwner {
         threshold = newThreshold;
         emit ThresholdUpdated(newThreshold);
     }
 
+    /// @notice Backwards compatible threshold setter.
+    function setThreshold(uint256 newThreshold) external onlyOwner {
+        setPremiumThreshold(newThreshold);
+    }
+
     /// @notice Update blacklist status for a user.
     /// @dev Only authorised modules may call this function.
-    function blacklist(address user, bool status) external onlyCaller {
+    function setBlacklist(address user, bool status) public onlyCaller {
         _blacklisted[user] = status;
         emit Blacklisted(user, status);
+    }
+
+    /// @notice Backwards compatible blacklist setter.
+    function blacklist(address user, bool status) external onlyCaller {
+        setBlacklist(user, status);
     }
 
     /// @notice Increase reputation for a user.
     function add(address user, uint256 amount) external onlyCaller {
         uint256 newScore = _scores[user] + amount;
         _scores[user] = newScore;
-        emit ReputationChanged(user, int256(amount), newScore);
+        emit ReputationUpdated(user, int256(amount), newScore);
 
         if (_blacklisted[user] && newScore >= threshold) {
             _blacklisted[user] = false;
@@ -90,7 +100,7 @@ contract ReputationEngine is Ownable {
         uint256 current = _scores[user];
         uint256 newScore = current > amount ? current - amount : 0;
         _scores[user] = newScore;
-        emit ReputationChanged(user, -int256(amount), newScore);
+        emit ReputationUpdated(user, -int256(amount), newScore);
 
         if (!_blacklisted[user] && newScore < threshold) {
             _blacklisted[user] = true;
@@ -107,6 +117,11 @@ contract ReputationEngine is Ownable {
         return reputation(user);
     }
 
+    /// @notice Alias for {reputation}.
+    function reputationOf(address user) external view returns (uint256) {
+        return _scores[user];
+    }
+
     /// @notice Check blacklist status for a user.
     function isBlacklisted(address user) external view returns (bool) {
         return _blacklisted[user];
@@ -115,6 +130,83 @@ contract ReputationEngine is Ownable {
     /// @notice Determine whether a user meets the premium access threshold.
     function canAccessPremium(address user) external view returns (bool) {
         return _scores[user] >= threshold;
+    }
+
+    // ---------------------------------------------------------------------
+    // Job lifecycle hooks
+    // ---------------------------------------------------------------------
+
+    /// @notice Ensure an applicant meets premium requirements and is not blacklisted.
+    function onApply(address user) external onlyCaller {
+        require(!_blacklisted[user], "blacklisted");
+        require(_scores[user] >= threshold, "insufficient reputation");
+    }
+
+    /// @notice Finalise a job and update reputation using v1 formulas.
+    function onFinalize(
+        address user,
+        bool success,
+        uint256 payout,
+        uint256 duration
+    ) external onlyCaller {
+        if (success) {
+            uint256 gain = calculateReputationPoints(payout, duration);
+            uint256 newScore = _enforceReputationGrowth(_scores[user], gain);
+            _scores[user] = newScore;
+            emit ReputationUpdated(user, int256(gain), newScore);
+            if (_blacklisted[user] && newScore >= threshold) {
+                _blacklisted[user] = false;
+                emit Blacklisted(user, false);
+            }
+        } else if (_scores[user] < threshold) {
+            _blacklisted[user] = true;
+            emit Blacklisted(user, true);
+        }
+    }
+
+    /// @notice Compute reputation gain based on payout and duration.
+    function calculateReputationPoints(uint256 payout, uint256 duration) public pure returns (uint256) {
+        uint256 scaledPayout = payout / 1e18;
+        uint256 payoutPoints = (scaledPayout ** 3) / 1e5;
+        return log2(1 + payoutPoints * 1e6) + duration / 10000;
+    }
+
+    /// @notice Log base 2 implementation from v1.
+    function log2(uint256 x) public pure returns (uint256 y) {
+        assembly {
+            let arg := x
+            x := sub(x, 1)
+            x := or(x, div(x, 0x02))
+            x := or(x, div(x, 0x04))
+            x := or(x, div(x, 0x10))
+            x := or(x, div(x, 0x100))
+            x := or(x, div(x, 0x10000))
+            x := or(x, div(x, 0x100000000))
+            x := or(x, div(x, 0x10000000000000000))
+            x := or(x, div(x, 0x100000000000000000000000000000000))
+            x := add(x, 1)
+            y := 0
+            for { let shift := 128 } gt(shift, 0) { shift := div(shift, 2) } {
+                let temp := shr(shift, x)
+                if gt(temp, 0) {
+                    x := temp
+                    y := add(y, shift)
+                }
+            }
+        }
+    }
+
+    uint256 public constant maxReputation = 88_888;
+
+    /// @notice Apply diminishing returns and cap to reputation growth.
+    function _enforceReputationGrowth(uint256 current, uint256 points) internal pure returns (uint256) {
+        uint256 newReputation = current + points;
+        uint256 diminishingFactor = 1 + ((newReputation * newReputation) / (maxReputation * maxReputation));
+        uint256 diminishedReputation = newReputation / diminishingFactor;
+        if (diminishedReputation > maxReputation) {
+            return maxReputation;
+        }
+        return diminishedReputation;
     }
 
     /// @notice Return the combined operator score based on stake and reputation.

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -10,7 +10,7 @@ interface IReputationEngine {
     /// @dev Reverts when attempting to act on a blacklisted user
     error BlacklistedUser(address user);
 
-    event ReputationChanged(address indexed user, int256 delta, uint256 newScore);
+    event ReputationUpdated(address indexed user, int256 delta, uint256 newScore);
     event Blacklisted(address indexed user, bool status);
     event StakeManagerUpdated(address stakeManager);
     event ScoringWeightsUpdated(uint256 stakeWeight, uint256 reputationWeight);
@@ -35,9 +35,10 @@ interface IReputationEngine {
     function reputation(address user) external view returns (uint256);
 
     /// @notice Alias for {reputation} for backwards compatibility
-    /// @param user Address to query
-    /// @return The current reputation score of the user
     function getReputation(address user) external view returns (uint256);
+
+    /// @notice Alternate view to mirror v1 naming
+    function reputationOf(address user) external view returns (uint256);
 
     /// @notice Check if a user is blacklisted
     /// @param user Address to query
@@ -57,13 +58,20 @@ interface IReputationEngine {
     function setCaller(address caller, bool allowed) external;
 
     /// @notice Set the minimum score threshold for certain actions
-    /// @param newThreshold New reputation threshold value
     function setThreshold(uint256 newThreshold) external;
+
+    /// @notice Set premium reputation threshold
+    function setPremiumThreshold(uint256 newThreshold) external;
 
     /// @notice Add or remove a user from the blacklist
     /// @param user Address to update
     /// @param status True to blacklist the user, false to remove
     function setBlacklist(address user, bool status) external;
+
+    /// @notice Job lifecycle hooks
+    function onApply(address user) external;
+
+    function onFinalize(address user, bool success, uint256 payout, uint256 duration) external;
 
     /// @notice Retrieve combined operator score using stake and reputation
     /// @param operator Address to query


### PR DESCRIPTION
## Summary
- add onApply/onFinalize hooks with v1 reputation math
- expose premium threshold, blacklist controls, and reputation views
- cover hooks and access controls in tests

## Testing
- `npx -y solhint 'contracts/**/*.sol'`
- `npx -y eslint .`
- `npx hardhat test test/v2/ReputationEngine.test.js test/v2/ReputationEngineNoEther.test.js`
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ed55f23483339fe345b1fde83ef5