### PR TITLE
docs: add v2 deployment and operations guide

### DIFF
--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -1,0 +1,114 @@
+# AGIJobs v2 Deployment & Operations Guide
+
+## Architecture Overview
+AGIJobs v2 decomposes the platform into small, immutable modules wired
+through a central `JobRegistry`. Each module owns a single
+responsibility and exposes `onlyOwner` setters so governance can retune
+parameters without redeploying the whole system.
+
+Identity for agents and validators is enforced with the
+`ENSOwnershipVerifier` library. Participants must control an ENS
+subdomain—`*.agent.agi.eth` for agents and `*.club.agi.eth` for
+validators—and supply the subdomain label plus Merkle proof when
+interacting. The verifier checks ownership via NameWrapper and the ENS
+resolver, emitting `OwnershipVerified` on success.
+
+## Step-by-Step Deployment
+1. **Deploy `StakeManager`** with constructor parameters:
+   - `_token` – ERC‑20 used for staking. Pass `0` to default to
+     $AGIALPHA (`0x2e8fb54C3eC41F55F06c1F082c081A609eAa4eBE`).
+   - `_minStake` – minimum stake for validators and platforms (6 decimals).
+   - `_employerSlashPct` / `_treasurySlashPct` – split of slashed stake.
+   - `_treasury` – address receiving treasury share.
+   - `_jobRegistry` and `_disputeModule` – optional module addresses.
+2. **Deploy `JobRegistry`** (no constructor params) then call
+   `setModules(validation, stake, reputation, dispute, certificate)` to
+   wire the ecosystem.
+3. **Deploy `ValidationModule`** with constructor parameters:
+   - `_jobRegistry`, `_stakeManager`, `_reputationEngine` addresses.
+   - `_commitWindow` and `_revealWindow` – phase durations in seconds.
+4. **Deploy `ReputationEngine`, `DisputeModule` and `CertificateNFT`**
+   supplying their respective constructor arguments.
+5. **Configure ownership** – the deployer becomes `owner` for every
+   module; transfer to a multisig if desired using `transferOwnership`.
+6. **Set ENS roots** – on `ENSOwnershipVerifier` call
+   `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot`, and
+   `setValidatorMerkleRoot` with the namehashes and allowlist roots for
+   your subdomains.
+7. **Verify events** – confirm `ModulesUpdated`, `TokenUpdated` and
+   `RootNodeUpdated` are emitted before allowing user funds.
+
+## Interacting via Etherscan
+### Job Creation
+1. Approve the job reward on the staking token.
+2. In `JobRegistry` → **Write**, call `createJob(reward, uri)`.
+3. Watch for `JobCreated(jobId, employer, reward)` in the log.
+
+### Staking
+1. Approve tokens on `$AGIALPHA`.
+2. In `StakeManager` call `depositStake(role, amount)` (0 = agent,
+   1 = validator, 2 = platform).
+3. `Staked(role, user, amount)` confirms the bond.
+
+### Applying for a Job
+1. Ensure your ENS subdomain is set up and whitelisted.
+2. Call `JobRegistry.applyForJob(jobId, subdomain, proof)` or
+   `stakeAndApply(jobId, amount, subdomain, proof)`.
+3. `JobApplied(jobId, agent)` will be emitted.
+
+### Validation
+1. During commit phase, validators call
+   `ValidationModule.commitValidation(jobId, commitHash, subdomain, proof)`.
+2. During reveal phase, call `revealValidation(jobId, approve, salt)`.
+3. After reveal, anyone may call `finalize(jobId)`.
+
+### Dispute
+1. Approve the dispute fee on `$AGIALPHA`.
+2. Call `JobRegistry.raiseDispute(jobId, evidence)`.
+3. Owner resolves via `DisputeModule.resolveDispute(jobId, uphold)`.
+4. Monitor `DisputeRaised` and `DisputeResolved` events.
+
+### NFT Marketplace
+1. `CertificateNFT` holders list tokens by approving the marketplace and
+   calling `list(tokenId, price)`.
+2. Buyers call `purchase(tokenId)` after approving the token amount.
+3. `TokenPurchased(buyer, tokenId, price)` confirms the sale.
+
+## Token Configuration
+- Default staking/reward token: `$AGIALPHA` at
+  `0x2e8fb54C3eC41F55F06c1F082c081A609eAa4eBE` (6 decimals).
+- To swap the token, the owner calls
+  `StakeManager.setToken(newToken)`; emit `TokenUpdated(newToken)` to
+  verify.
+
+## Troubleshooting
+- **Missing subdomain proof** – ensure your ENS label and Merkle proof
+  match the configured roots.
+- **Token approvals** – most functions require prior `approve` calls on
+  the staking token.
+- **Tax policy** – users must call `acknowledgeTaxPolicy()` on
+  `JobRegistry` before staking or disputing.
+- **Wrong decimals** – `setToken` only accepts ERC‑20 tokens with
+  exactly 6 decimals.
+
+## Event & Function Glossary
+| Event | Emitted by | Meaning |
+| --- | --- | --- |
+| `JobCreated(uint256 jobId, address employer, uint256 reward)` | `JobRegistry` | Employer posted a job and escrowed funds. |
+| `JobApplied(uint256 jobId, address agent)` | `JobRegistry` | Agent applied for a job. |
+| `ValidationCommitted(uint256 jobId, address validator)` | `ValidationModule` | Validator submitted hashed vote. |
+| `ValidationRevealed(uint256 jobId, address validator, bool approve)` | `ValidationModule` | Validator revealed vote. |
+| `DisputeRaised(uint256 jobId)` | `DisputeModule` | A job result was contested. |
+| `DisputeResolved(uint256 jobId, bool employerWins)` | `DisputeModule` | Moderator issued final ruling. |
+| `CertificateMinted(address to, uint256 jobId)` | `CertificateNFT` | NFT minted for a completed job. |
+
+| Function | Module | Purpose |
+| --- | --- | --- |
+| `createJob(uint256 reward, string uri)` | `JobRegistry` | Post a job and lock payout. |
+| `depositStake(uint8 role, uint256 amount)` | `StakeManager` | Bond tokens for a role. |
+| `applyForJob(uint256 jobId, string subdomain, bytes32[] proof)` | `JobRegistry` | Enter candidate pool for a job. |
+| `commitValidation(uint256 jobId, bytes32 hash, string subdomain, bytes32[] proof)` | `ValidationModule` | Submit a hidden vote. |
+| `revealValidation(uint256 jobId, bool approve, bytes32 salt)` | `ValidationModule` | Reveal vote. |
+| `raiseDispute(uint256 jobId, string reason)` | `JobRegistry` | Start appeal process. |
+| `list(uint256 tokenId, uint256 price)` | `CertificateNFT` | List job certificate for sale. |
+| `purchase(uint256 tokenId)` | `CertificateNFT` | Buy listed certificate. |


### PR DESCRIPTION
## Summary
- document modular architecture and ENS-based identity
- add step-by-step v2 deployment and Etherscan operation instructions
- include token configuration, troubleshooting, and event/function glossary

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a206114da883339d87cb8886af648a