### PR TITLE
Add marketplace transfer tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Owners retain `onlyOwner` control over parameters, letting them reconfigure live
 3. **Validate** – selected validators call `commitValidation(jobId, hash, subdomain, proof)` and later `revealValidation(jobId, approve, salt)`.
 4. **Finalize** – after the reveal window the employer calls `finalize(jobId)` (or any validator can finalize once the window closes); rewards and stakes settle automatically.
 
+### NFT marketplace
+`JobNFT` and `CertificateNFT` include minimal listing helpers for peer-to-peer sales. All prices use 6-decimal `$AGIALPHA` units (e.g., `ethers.parseUnits("1", 6)` for `1.000000`).
+
+1. **List** – token owner calls `list(tokenId, price)`.
+2. **Purchase** – buyer approves the NFT contract for `price` and calls `purchase(tokenId)`; the contract transfers `price` tokens to the seller and moves the NFT to the buyer.
+3. **Delist** – seller removes an active listing via `delist(tokenId)`.
+
 ### Owner controls
 The contract owner can reconfigure live deployments without redeployment:
 - **ENS roots & Merkle proofs** – rotate subdomains with [`JobRegistry.setAgentRootNode`](contracts/v2/JobRegistry.sol) and [`ValidationModule.setClubRootNode`](contracts/v2/ValidationModule.sol), and update allowlists via [`JobRegistry.setAgentMerkleRoot`](contracts/v2/JobRegistry.sol) and [`ValidationModule.setValidatorMerkleRoot`](contracts/v2/ValidationModule.sol). Watch for `RootNodeUpdated` or `MerkleRootUpdated` events. Update ENS contract references through [`ENSOwnershipVerifier.setENS`](contracts/v2/modules/ENSOwnershipVerifier.sol) and [`setNameWrapper`](contracts/v2/modules/ENSOwnershipVerifier.sol).

--- a/contracts/mocks/ReentrantBuyer.sol
+++ b/contracts/mocks/ReentrantBuyer.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IMarketplaceNFT {
+    function purchase(uint256 tokenId) external;
+}
+
+/// @dev Buyer contract that attempts to reenter the marketplace during a purchase.
+contract ReentrantBuyer is IERC721Receiver {
+    IMarketplaceNFT public immutable nft;
+
+    constructor(address nft_) {
+        nft = IMarketplaceNFT(nft_);
+    }
+
+    /// @notice Approve the NFT contract to pull `amount` of the ERC-20 `token`.
+    function approveToken(address token, uint256 amount) external {
+        IERC20(token).approve(address(nft), amount);
+    }
+
+    /// @notice Initiate a purchase which triggers the reentrancy attempt.
+    function buy(uint256 tokenId) external {
+        nft.purchase(tokenId);
+    }
+
+    /// @dev During receipt of the NFT, attempt to purchase again.
+    function onERC721Received(
+        address,
+        address,
+        uint256 tokenId,
+        bytes calldata
+    ) external returns (bytes4) {
+        // Swallow any failure – the second call should revert because the
+        // listing was cleared before transfer.
+        try nft.purchase(tokenId) {} catch {}
+        return this.onERC721Received.selector;
+    }
+}
+

--- a/test/JobNFT.test.js
+++ b/test/JobNFT.test.js
@@ -67,6 +67,9 @@ describe("JobNFT", function () {
 
     await nft.connect(jobRegistry).mint(seller.address, 1);
 
+    const sellerStart = await token.balanceOf(seller.address);
+    const buyerStart = await token.balanceOf(buyer.address);
+
     await expect(nft.connect(seller).list(1, price))
       .to.emit(nft, "NFTListed")
       .withArgs(1, seller.address, price);
@@ -82,6 +85,11 @@ describe("JobNFT", function () {
       .withArgs(1, buyer.address, price);
     expect(await nft.ownerOf(1)).to.equal(buyer.address);
 
+    expect(await token.balanceOf(seller.address)).to.equal(
+      sellerStart + price
+    );
+    expect(await token.balanceOf(buyer.address)).to.equal(buyerStart - price);
+
     await nft.connect(jobRegistry).mint(seller.address, 2);
     await expect(nft.connect(seller).list(2, price))
       .to.emit(nft, "NFTListed")
@@ -89,6 +97,47 @@ describe("JobNFT", function () {
     await expect(nft.connect(seller).delist(2))
       .to.emit(nft, "NFTDelisted")
       .withArgs(2);
+    await expect(nft.connect(seller).delist(2)).to.be.revertedWith("not listed");
+  });
+
+  it("rejects invalid listings", async function () {
+    const { nft, token, jobRegistry, seller, buyer, price } = await deployFixture();
+
+    await nft.connect(jobRegistry).mint(seller.address, 1);
+
+    await expect(nft.connect(buyer).list(1, price)).to.be.revertedWith("owner");
+    await expect(nft.connect(seller).list(1, 0)).to.be.revertedWith("price");
+
+    await expect(nft.connect(buyer).purchase(1)).to.be.revertedWith("not listed");
+
+    await nft.connect(seller).list(1, price);
+    await expect(nft.connect(buyer).delist(1)).to.be.revertedWith("owner");
+    await expect(nft.connect(seller).list(1, price)).to.be.revertedWith("listed");
+
+    await token.connect(buyer).approve(await nft.getAddress(), price);
+    await expect(nft.connect(buyer).purchase(1))
+      .to.emit(nft, "NFTPurchased")
+      .withArgs(1, buyer.address, price);
+  });
+
+  it("guards purchase against reentrancy", async function () {
+    const { nft, token, jobRegistry, seller, price } = await deployFixture();
+
+    await nft.connect(jobRegistry).mint(seller.address, 1);
+    await nft.connect(seller).list(1, price);
+
+    const Reenter = await ethers.getContractFactory(
+      "contracts/mocks/ReentrantBuyer.sol:ReentrantBuyer"
+    );
+    const attacker = await Reenter.deploy(await nft.getAddress());
+
+    await token.transfer(await attacker.getAddress(), price);
+    await attacker.approveToken(await token.getAddress(), price);
+
+    await expect(attacker.buy(1))
+      .to.emit(nft, "NFTPurchased")
+      .withArgs(1, await attacker.getAddress(), price);
+    expect(await nft.ownerOf(1)).to.equal(await attacker.getAddress());
   });
 });
 


### PR DESCRIPTION
## Summary
- document NFT marketplace workflow using 6-decimal `$AGIALPHA`
- verify marketplace ERC-20 and NFT transfers plus failure cases
- guard against reentrancy with a mock buyer contract

## Testing
- `npx hardhat test test/JobNFT.test.js test/v2/CertificateNFTMarketplace.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a2267a973c8333957a463870942050