### PR TITLE
doc: restrict root updates to owner

### DIFF
--- a/contracts/JobRegistry.sol
+++ b/contracts/JobRegistry.sol
@@ -85,7 +85,11 @@ contract JobRegistry is Ownable {
     event DisputeModuleUpdated(address module);
     event FeePoolUpdated(address pool);
     event FeePctUpdated(uint256 feePct);
+    /// @notice Emitted when the ENS root node for agents changes.
+    /// @param node The new ENS root node.
     event AgentRootNodeUpdated(bytes32 node);
+    /// @notice Emitted when the agent allowlist Merkle root changes.
+    /// @param root The new Merkle root.
     event AgentMerkleRootUpdated(bytes32 root);
 
     event JobCreated(
@@ -164,11 +168,15 @@ contract JobRegistry is Ownable {
         emit FeePctUpdated(_feePct);
     }
 
+    /// @notice Update the ENS root node for agent identities.
+    /// @param node Namehash of the agent parent node (e.g. `agent.agi.eth`).
     function setAgentRootNode(bytes32 node) external onlyOwner {
         agentRootNode = node;
         emit AgentRootNodeUpdated(node);
     }
 
+    /// @notice Update the Merkle root for the agent allowlist.
+    /// @param root Merkle root of approved agent addresses.
     function setAgentMerkleRoot(bytes32 root) external onlyOwner {
         agentMerkleRoot = root;
         emit AgentMerkleRootUpdated(root);

--- a/contracts/ValidationModule.sol
+++ b/contracts/ValidationModule.sol
@@ -72,7 +72,11 @@ contract ValidationModule is Ownable {
     event ChallengeWindowUpdated(uint256 window);
     event DisputeResolutionUpdated(address resolver);
     event ReputationEngineUpdated(address engine);
+    /// @notice Emitted when the ENS root node for validators changes.
+    /// @param node The new ENS root node.
     event ClubRootNodeUpdated(bytes32 node);
+    /// @notice Emitted when the validator allowlist Merkle root changes.
+    /// @param root The new Merkle root.
     event ValidatorMerkleRootUpdated(bytes32 root);
 
     // events for commit–reveal validation
@@ -124,11 +128,15 @@ contract ValidationModule is Ownable {
         emit ReputationEngineUpdated(address(engine));
     }
 
+    /// @notice Update the ENS root node for validator clubs.
+    /// @param node Namehash of the validator parent node (e.g. `club.agi.eth`).
     function setClubRootNode(bytes32 node) external onlyOwner {
         clubRootNode = node;
         emit ClubRootNodeUpdated(node);
     }
 
+    /// @notice Update the Merkle root for the validator allowlist.
+    /// @param root Merkle root of approved validator addresses.
     function setValidatorMerkleRoot(bytes32 root) external onlyOwner {
         validatorMerkleRoot = root;
         emit ValidatorMerkleRootUpdated(root);

--- a/test/rootNodes.test.js
+++ b/test/rootNodes.test.js
@@ -1,0 +1,64 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ENS root node and Merkle root setters", function () {
+  let owner, other, registry, validation;
+
+  beforeEach(async () => {
+    [owner, other] = await ethers.getSigners();
+
+    const Registry = await ethers.getContractFactory(
+      "contracts/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Registry.deploy();
+    await registry.waitForDeployment();
+
+    const Validation = await ethers.getContractFactory(
+      "contracts/ValidationModule.sol:ValidationModule"
+    );
+    validation = await Validation.deploy();
+    await validation.waitForDeployment();
+  });
+
+  it("restricts agent root updates to owner", async () => {
+    const node = ethers.id("node");
+    const root = ethers.id("root");
+
+    await expect(registry.connect(other).setAgentRootNode(node))
+      .to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+
+    await expect(registry.setAgentRootNode(node))
+      .to.emit(registry, "AgentRootNodeUpdated")
+      .withArgs(node);
+
+    await expect(registry.connect(other).setAgentMerkleRoot(root))
+      .to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+
+    await expect(registry.setAgentMerkleRoot(root))
+      .to.emit(registry, "AgentMerkleRootUpdated")
+      .withArgs(root);
+  });
+
+  it("restricts validator root updates to owner", async () => {
+    const node = ethers.id("node");
+    const root = ethers.id("root");
+
+    await expect(validation.connect(other).setClubRootNode(node))
+      .to.be.revertedWithCustomError(validation, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+
+    await expect(validation.setClubRootNode(node))
+      .to.emit(validation, "ClubRootNodeUpdated")
+      .withArgs(node);
+
+    await expect(validation.connect(other).setValidatorMerkleRoot(root))
+      .to.be.revertedWithCustomError(validation, "OwnableUnauthorizedAccount")
+      .withArgs(other.address);
+
+    await expect(validation.setValidatorMerkleRoot(root))
+      .to.emit(validation, "ValidatorMerkleRootUpdated")
+      .withArgs(root);
+  });
+});


### PR DESCRIPTION
## Summary
- document ENS and Merkle root setters in JobRegistry and ValidationModule
- add tests ensuring only the owner can update root nodes and allowlists

## Testing
- `npm test -- test/rootNodes.test.js` *(fails: compiler download stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68a22c80d0848333a4e1a423e2cf86ac