### PR TITLE
docs: detail ENS parity sprint and deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Owners retain `onlyOwner` control over parameters, letting them reconfigure live
 3. Submit the transaction; the sender becomes the owner.
 4. After deployment the owner can switch payout, staking and reward tokens with `updateAGITokenAddress(newToken)` and rotate ENS roots or allowlists without redeploying.
 5. All job posting, application, validation, dispute, and NFT marketplace calls happen through the contract's **Write** tab. Enter token amounts using 6‑decimal units (`1 token = 1_000000`).
+6. For a screenshot walkthrough tailored to non‑technical users, consult [docs/etherscan-guide.md](docs/etherscan-guide.md).
 
 #### Etherscan deployment steps
 1. Navigate to the verified `AGIJobManagerv0` contract page on a block explorer and open the **Contract → Write Contract** tab.

--- a/docs/coding-sprint-v2-ens-identity.md
+++ b/docs/coding-sprint-v2-ens-identity.md
@@ -12,19 +12,20 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 ### 1. Identity Verification Library
 - Build `ENSOwnershipVerifier` with Merkle proof, NameWrapper and resolver fallback.
 - Emit `OwnershipVerified` and `RecoveryInitiated` events.
-- Add owner setters for ENS registry, NameWrapper, root nodes and Merkle roots, emitting update events for audit trails.
-- Maintain `additionalAgents`/`additionalValidators` allow‑lists.
+- Store `agentRootNode`, `clubRootNode`, `agentMerkleRoot` and `validatorMerkleRoot`; owner setters (`setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot`, `setValidatorMerkleRoot`) fire `RootNodeUpdated`/`MerkleRootUpdated` events.
+- Provide `addAdditionalAgent`/`addAdditionalValidator` and removal counterparts so the owner can override identity checks.
+- Expose helper `isAuthorizedAgent`/`isAuthorizedValidator` that consults allow‑lists and `ReputationEngine.isBlacklisted`.
 
 ### 2. JobRegistry
 - Port `createJob`, `applyForJob`, `submit`, `finalize`, `cancelJob`, `dispute` and `forceCancel`.
-- On `applyForJob` call the verifier and check blacklists via `ReputationEngine`.
+- On `applyForJob` use `isAuthorizedAgent` and reject blacklisted addresses via `ReputationEngine`.
 - Require tax policy acknowledgement before any state‑changing action.
 - Enforce owner‑set `maxJobReward` and `maxJobDuration` limits.
 - Mirror v1 event names and cross‑check `docs/v1-v2-function-map.md` to ensure feature parity.
 
 ### 3. ValidationModule
 - Select validator committees and record commits & reveals.
-- Accept votes only from identities passing the verifier or in the allow‑list.
+- Accept votes only from identities passing `isAuthorizedValidator`.
 - Finalise results once quorum or the reveal window ends.
 - Report outcomes back to `JobRegistry`.
 - Use deterministic on‑chain randomness; avoid Chainlink VRF or subscription services.


### PR DESCRIPTION
## Summary
- expand ENS identity sprint with root node updates, allowlists, and blacklist helper hooks
- link non-technical users to the Etherscan walkthrough in the legacy deployment steps

## Testing
- `npx solhint 'contracts/**/*.sol'`
- `npx eslint .`
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_68a2353506a08333bd3fa4bc36c10fac