### PR TITLE
docs: clarify AGIALPHA workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labor markets among autonomous agents. The legacy v0 deployment transacts in $AGI, while the modular v2 suite defaults to [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) – a 6‑decimal ERC‑20 used for payments, staking, rewards and dispute deposits. The contract owner can swap this token at any time via `StakeManager.setToken` and `FeePool.setToken` without redeploying other modules. This repository hosts the immutable mainnet deployment (v0) and an unaudited v1 prototype under active development. Treat every address as unverified until you confirm it on-chain and through official AGI.eth channels.
 
-All modules expect amounts in 6‑decimal base units (`1 token = 1_000000`). Should the owner choose to migrate to a different ERC‑20, calling `setToken` on `StakeManager` and `FeePool` updates the system without redeployment or data loss.
+All modules expect amounts in 6‑decimal base units (`1 token = 1_000000`). Agents must control an ENS subdomain ending in `.agent.agi.eth`, while validators require one ending in `.club.agi.eth`. Should the owner choose to migrate to a different ERC‑20, calling `setToken` on `StakeManager` and `FeePool` updates the system without redeployment or data loss.
 
 For a quick reference on migrating code, see [docs/v1-v2-function-map.md](docs/v1-v2-function-map.md) which maps every v1 function to its v2 counterpart.
 
@@ -60,6 +60,17 @@ Owners retain `onlyOwner` control over parameters, letting them reconfigure live
 2. Execute **deployDefaults(ids)** – leaving struct fields empty uses `$AGIALPHA` and sensible defaults; the caller becomes owner and all modules wire themselves.
 3. To change the payout token later, call [`StakeManager.setToken(newToken)`](contracts/v2/StakeManager.sol) and [`FeePool.setToken(newToken)`](contracts/v2/FeePool.sol); emit `TokenUpdated` to confirm the swap.
 4. Other modules remain untouched, so token rotation never requires redeployment.
+
+```ts
+// deploy everything with sensible defaults
+const Deployer = await ethers.getContractFactory("Deployer");
+const deployer = await Deployer.deploy();
+await deployer.deployDefaults({});
+
+// swap the ERC-20 used for fees, stakes, and rewards
+await stakeManager.setToken("0xNewToken");
+await feePool.setToken("0xNewToken");
+```
 
 ### Token setup
 - All modules default to `$AGIALPHA` (6 decimals) for fees, staking, and rewards.

--- a/docs/agialpha-workflows.md
+++ b/docs/agialpha-workflows.md
@@ -1,40 +1,35 @@
 # $AGIALPHA Operational Workflows
 
-This guide summarises common on-chain interactions for the $AGIALPHA-based AGIJobs v2 suite. All token amounts use 6‑decimal base units (`1 AGIALPHA = 1_000000`). Replace bracketed addresses with your deployment values before transacting.
+This guide summarises Etherscan-based interactions for the $AGIALPHA-powered AGIJobs v2 suite. All token amounts use 6‑decimal base units (`1 AGIALPHA = 1_000000`). Agents must control a subdomain ending in `.agent.agi.eth`; validators require `.club.agi.eth`. Replace bracketed addresses with deployment values before transacting.
 
-## 1. Approve & Stake $AGIALPHA
+## 1. Post a Job (Employer)
+1. **Approve reward** – open the [$AGIALPHA token Write tab](https://etherscan.io/address/0x2e8fb54C3EC41F55F06C1F082C081A609eAA4EbE#writeContract) and call `approve(spender, amount)` where `spender` is the `StakeManager` and `amount` is `reward + fee` in base units.
+2. **Create job** – on [`JobRegistry` Write](https://etherscan.io/address/<JobRegistryAddress>#writeContract) call `acknowledgeAndCreateJob(reward, uri)`.
 
-1. **Approve tokens** – Open the [$AGIALPHA token Write tab](https://etherscan.io/address/0x2e8fb54C3EC41F55F06C1F082C081A609eAA4EbE#writeContract) and call `approve(spender, amount)`.
-   - `spender`: `StakeManager` address.
-   - `amount`: staking total in base units.
-   - *Example*: approving 50 tokens → `50_000000`.
-2. **Stake for a role** – On [StakeManager Write](https://etherscan.io/address/<StakeManagerAddress>#writeContract) call `depositStake(role, amount)`.
-   - `role`: `0` Agent, `1` Validator, `2` Platform.
-   - `amount`: must be approved above. Example agent stake of 10 tokens → `10_000000`.
+## 2. Apply for a Job (Agent)
+1. **Stake (if required)** – approve the stake amount and call `StakeManager.depositStake(0, amount)` or use `JobRegistry.stakeAndApply(jobId, amount)`.
+2. **Apply** – in `JobRegistry` call `applyForJob(jobId, subdomain, proof)` using your `.agent.agi.eth` label and Merkle proof.
 
-## 2. Register a Platform
+## 3. Validate Work (Validator)
+1. **Stake** – approve tokens and call `StakeManager.depositStake(1, amount)`.
+2. **Commit** – during the commit window call `ValidationModule.commitValidation(jobId, hash, subdomain, proof)` with your `.club.agi.eth` label.
+3. **Reveal** – when the reveal window opens call `ValidationModule.revealValidation(jobId, approve, salt)`.
 
-1. Stake as a platform operator with `depositStake(2, amount)` on StakeManager.
-   - Example minimum stake of 25 tokens → `25_000000`.
-2. Open [PlatformRegistry Write](https://etherscan.io/address/<PlatformRegistryAddress>#writeContract) and call `register()` (or `registerPlatform(operator)` if applicable) to list your platform for routing and fee shares.
+## 4. Raise a Dispute (Anyone)
+1. **Approve fee** – approve the dispute fee for `StakeManager` (e.g., `10_000000` for 10 tokens).
+2. **Raise** – on [`DisputeModule` Write](https://etherscan.io/address/<DisputeModuleAddress>#writeContract) call `raiseDispute(jobId, evidence)` before the window ends.
+3. **Resolve** – after the window an authorised arbiter calls `resolveDispute(jobId)`.
 
-## 3. Claim Protocol Fees
+## 5. Trade a Certificate (Peer to Peer)
+1. **List** – certificate owner calls `list(tokenId, price)` on [`CertificateNFT` Write](https://etherscan.io/address/<CertificateNFTAddress>#writeContract)` using 6‑decimal pricing.
+2. **Purchase** – buyer approves the NFT contract for `price` tokens and calls `purchase(tokenId)`.
+3. **Delist** – seller may remove a listing with `delist(tokenId)`.
 
-1. Check [FeePool Read](https://etherscan.io/address/<FeePoolAddress>#readContract) for `pendingFees()`.
-2. If `pendingFees > 0`, anyone may call `distributeFees()` on [FeePool Write](https://etherscan.io/address/<FeePoolAddress>#writeContract) to allocate rewards.
-3. Platform stakers withdraw earnings via `claimRewards()` on the same Write tab. Rewards stream in $AGIALPHA based on staked weight.
-
-## 4. Dispute a Job
-
-1. Ensure you have approved the `StakeManager` for at least the dispute fee. Example fee of 10 tokens → approve `10_000000`.
-2. On [DisputeModule Read](https://etherscan.io/address/<DisputeModuleAddress>#readContract) check `disputeFee()` and `disputeWindow()`.
-3. Call `raiseDispute(jobId, evidence)` on [DisputeModule Write](https://etherscan.io/address/<DisputeModuleAddress>#writeContract) before the dispute window ends. The StakeManager will lock the `disputeFee` from your wallet.
-4. After the window elapses, an authorised arbiter resolves the case with `resolveDispute(jobId)`. Depending on the outcome, the dispute fee is returned or paid out via `StakeManager.payDisputeFee`.
-
----
+### Additional Flows
+- **Register a Platform** – stake with `depositStake(2, amount)` then call `PlatformRegistry.register()`.
+- **Claim Protocol Fees** – anyone calls `FeePool.distributeFees()`; stakers withdraw via `FeePool.claimRewards()`.
 
 ### Base‑Unit Examples
-
 ```
 1.0 AGIALPHA  = 1_000000
 0.5 AGIALPHA  =   500000


### PR DESCRIPTION
## Summary
- document 6-decimal $AGIALPHA units and ENS subdomain requirements
- add quick-start snippets for `Deployer.deployDefaults` and token swaps
- extend operational workflows with job, dispute, and certificate trading steps

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a28fcceaf88333a1b85a0267a7cf8e