### PR TITLE
feat(validation): add ENS-gated commit-reveal controls

### DIFF
--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -32,6 +32,9 @@ interface IValidationModule {
         bytes32[] calldata proof
     ) external;
 
+    /// @notice Commit a validation hash without ENS parameters (legacy wrapper)
+    function commitValidation(uint256 jobId, bytes32 commitHash) external;
+
     /// @notice Reveal a previously committed validation vote
     /// @param jobId Identifier of the job
     /// @param approve True to approve, false to reject
@@ -46,13 +49,22 @@ interface IValidationModule {
         bytes32[] calldata proof
     ) external;
 
+    /// @notice Reveal a previously committed validation vote (legacy wrapper)
+    function revealValidation(uint256 jobId, bool approve, bytes32 salt) external;
+
     /// @notice Finalize validation round and slash incorrect validators
     /// @param jobId Identifier of the job
     /// @return success True if validators approved the job
     function finalize(uint256 jobId) external returns (bool success);
 
+    /// @notice Alias for finalize using legacy naming.
+    function finalizeValidation(uint256 jobId) external returns (bool success);
+
     /// @notice Owner configuration for timing windows
     function setCommitRevealWindows(uint256 commitWindow, uint256 revealWindow) external;
+
+    /// @notice Convenience wrapper for timing configuration.
+    function setTiming(uint256 commitWindow, uint256 revealWindow) external;
 
     /// @notice Owner configuration for validator counts
     function setValidatorBounds(uint256 minValidators, uint256 maxValidators) external;
@@ -63,6 +75,18 @@ interface IValidationModule {
 
     /// @notice Update approval threshold percentage
     function setApprovalThreshold(uint256 pct) external;
+
+    /// @notice Manually allow a validator to bypass ENS checks.
+    function addAdditionalValidator(address validator) external;
+
+    /// @notice Remove a validator from the manual allowlist.
+    function removeAdditionalValidator(address validator) external;
+
+    /// @notice Update ENS root nodes for agents and validators.
+    function setENSRoots(bytes32 agentRoot, bytes32 clubRoot) external;
+
+    /// @notice Update Merkle roots for agents and validators.
+    function setMerkleRoots(bytes32 agentRoot, bytes32 validatorRoot) external;
 
     /// @notice Map validators to ENS subdomains for selection
     function setValidatorSubdomains(

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -17,7 +17,7 @@ contract ValidationStub is IValidationModule {
         result = _result;
     }
 
-    function selectValidators(uint256) external pure returns (address[] memory) {
+    function selectValidators(uint256) external pure override returns (address[] memory) {
         return new address[](0);
     }
 
@@ -26,7 +26,9 @@ contract ValidationStub is IValidationModule {
         bytes32,
         string calldata,
         bytes32[] calldata
-    ) external {}
+    ) external override {}
+
+    function commitValidation(uint256, bytes32) external override {}
 
     function revealValidation(
         uint256,
@@ -34,30 +36,46 @@ contract ValidationStub is IValidationModule {
         bytes32,
         string calldata,
         bytes32[] calldata
-    ) external {}
+    ) external override {}
 
-    function finalize(uint256 jobId) external returns (bool success) {
+    function revealValidation(uint256, bool, bytes32) external override {}
+
+    function finalize(uint256 jobId) external override returns (bool success) {
         success = result;
         if (jobRegistry != address(0)) {
             IJobRegistry(jobRegistry).finalizeAfterValidation(jobId, success);
         }
     }
 
-    function validators(uint256) external pure returns (address[] memory vals) {
+    function finalizeValidation(uint256 jobId) external override returns (bool success) {
+        return this.finalize(jobId);
+    }
+
+    function validators(uint256) external pure override returns (address[] memory vals) {
         vals = new address[](0);
     }
 
-    function setCommitRevealWindows(uint256, uint256) external {}
+    function setCommitRevealWindows(uint256, uint256) external override {}
 
-    function setValidatorBounds(uint256, uint256) external {}
+    function setTiming(uint256, uint256) external override {}
 
-    function setApprovalThreshold(uint256) external {}
+    function setValidatorBounds(uint256, uint256) external override {}
+
+    function setApprovalThreshold(uint256) external override {}
+
+    function addAdditionalValidator(address) external override {}
+
+    function removeAdditionalValidator(address) external override {}
+
+    function setENSRoots(bytes32, bytes32) external override {}
+
+    function setMerkleRoots(bytes32, bytes32) external override {}
 
     function setValidatorSubdomains(
         address[] calldata,
         string[] calldata
-    ) external {}
+    ) external override {}
 
-    function resetJobNonce(uint256) external {}
+    function resetJobNonce(uint256) external override {}
 }
 


### PR DESCRIPTION
## Summary
- expose timing, ENS, and Merkle root configuration helpers in ValidationModule
- add legacy commit/reveal/finalize wrappers and interface updates
- extend ValidationStub and interface for additional validator management

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68a3207e39c88333be74e9e71a001206