### PR TITLE
feat: support multiple moderators in dispute module

### DIFF
--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -11,7 +11,7 @@ interface IDisputeModule {
     );
     event DisputeResolved(uint256 indexed jobId, bool employerWins);
     event DisputeFeeUpdated(uint256 fee);
-    event ModeratorUpdated(address moderator);
+    event ModeratorUpdated(address moderator, bool enabled);
     event DisputeWindowUpdated(uint256 window);
 
     function raiseDispute(
@@ -22,5 +22,5 @@ interface IDisputeModule {
     function resolveDispute(uint256 jobId, bool employerWins) external;
     function setDisputeFee(uint256 fee) external;
     function setDisputeWindow(uint256 window) external;
-    function setModerator(address moderator) external;
+    function setModerator(address moderator, bool enabled) external;
 }


### PR DESCRIPTION
## Summary
- support owner-appointed moderator mapping in DisputeModule
- expose setModerator(address,bool) and update interface
- arbiters now call resolveDispute which relays to JobRegistry and StakeManager

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a350e19e5883338bcb81f61c205fbb