### PR TITLE
Implement v2 reputation lifecycle hooks and controls

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -366,7 +366,7 @@ contract MockReputationEngine is IReputationEngine {
         return _rep[user] >= threshold;
     }
 
-    function setCaller(address, bool) external override {}
+    function setAuthorizedCaller(address, bool) external override {}
 
     function setThreshold(uint256 t) external override {
         threshold = t;
@@ -376,7 +376,7 @@ contract MockReputationEngine is IReputationEngine {
         threshold = t;
     }
 
-    function setBlacklist(address user, bool val) external override {
+    function blacklist(address user, bool val) external override {
         _blacklist[user] = val;
     }
 
@@ -391,6 +391,10 @@ contract MockReputationEngine is IReputationEngine {
         } else if (_rep[user] < threshold) {
             _blacklist[user] = true;
         }
+    }
+
+    function rewardValidator(address user, uint256) external override {
+        _rep[user] += 1;
     }
 
     function getOperatorScore(address user) external view override returns (uint256) {

--- a/contracts/mocks/StubReputationEngine.sol
+++ b/contracts/mocks/StubReputationEngine.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.21;
 
 contract StubReputationEngine {
     mapping(address => uint256) public reputation;
-    mapping(address => bool) public blacklist;
+    mapping(address => bool) public _blacklist;
 
     function add(address user, uint256 amount) external {
         reputation[user] += amount;
@@ -15,10 +15,10 @@ contract StubReputationEngine {
     }
 
     function isBlacklisted(address user) external view returns (bool) {
-        return blacklist[user];
+        return _blacklist[user];
     }
 
-    function setBlacklist(address user, bool val) external {
-        blacklist[user] = val;
+    function blacklist(address user, bool val) external {
+        _blacklist[user] = val;
     }
 }

--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -382,8 +382,8 @@ contract Deployer is Ownable {
         );
         pRegistry.setRegistrar(address(incentives), true);
         router.setRegistrar(address(incentives), true);
-        reputation.setCaller(address(registry), true);
-        reputation.setCaller(address(validation), true);
+        reputation.setAuthorizedCaller(address(registry), true);
+        reputation.setAuthorizedCaller(address(validation), true);
 
         // Transfer ownership
         registry.transferOwnership(owner_);

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -11,7 +11,7 @@ interface IReputationEngine {
     error BlacklistedUser(address user);
 
     event ReputationUpdated(address indexed user, int256 delta, uint256 newScore);
-    event Blacklisted(address indexed user, bool status);
+    event BlacklistUpdated(address indexed user, bool status);
     event StakeManagerUpdated(address stakeManager);
     event ScoringWeightsUpdated(uint256 stakeWeight, uint256 reputationWeight);
 
@@ -55,7 +55,7 @@ interface IReputationEngine {
     /// @notice Allow or disallow a caller to update reputation
     /// @param caller Address of the caller to configure
     /// @param allowed True to authorise the caller, false to revoke
-    function setCaller(address caller, bool allowed) external;
+    function setAuthorizedCaller(address caller, bool allowed) external;
 
     /// @notice Set the minimum score threshold for certain actions
     function setThreshold(uint256 newThreshold) external;
@@ -66,12 +66,14 @@ interface IReputationEngine {
     /// @notice Add or remove a user from the blacklist
     /// @param user Address to update
     /// @param status True to blacklist the user, false to remove
-    function setBlacklist(address user, bool status) external;
+    function blacklist(address user, bool status) external;
 
     /// @notice Job lifecycle hooks
     function onApply(address user) external;
 
     function onFinalize(address user, bool success, uint256 payout, uint256 duration) external;
+
+    function rewardValidator(address validator, uint256 agentGain) external;
 
     /// @notice Retrieve combined operator score using stake and reputation
     /// @param operator Address to query

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -69,7 +69,7 @@ async function main() {
   );
 
   await validation.setReputationEngine(await reputation.getAddress());
-  await reputation.setCaller(await registry.getAddress(), true);
+  await reputation.setAuthorizedCaller(await registry.getAddress(), true);
   await reputation.setThreshold(1);
   await nft.setJobRegistry(await registry.getAddress());
   await nft.setStakeManager(await stake.getAddress());

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -88,7 +88,9 @@ describe("Full system integration", function () {
     await registry.connect(owner).setJobParameters(reward, stake);
     await registry.connect(owner).setFeePct(0);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
-    await rep.connect(owner).setCaller(await registry.getAddress(), true);
+    await rep
+      .connect(owner)
+      .setAuthorizedCaller(await registry.getAddress(), true);
     await rep.connect(owner).setThreshold(1);
     await stakeManager
       .connect(owner)

--- a/test/v2/DiscoveryModule.test.js
+++ b/test/v2/DiscoveryModule.test.js
@@ -13,7 +13,9 @@ describe("DiscoveryModule", function () {
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
     engine = await Engine.deploy(ethers.ZeroAddress);
-    await engine.connect(owner).setCaller(owner.address, true);
+    await engine
+      .connect(owner)
+      .setAuthorizedCaller(owner.address, true);
     await engine.connect(owner).setStakeManager(await stakeManager.getAddress());
 
     const Discovery = await ethers.getContractFactory(

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -197,7 +197,7 @@ describe("Validator ENS integration", function () {
       1,
       ethers.parseEther("1")
     );
-    await reputation.setBlacklist(validator.address, true);
+    await reputation.blacklist(validator.address, true);
     const job = {
       employer: owner.address,
       agent: ethers.ZeroAddress,

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -252,7 +252,7 @@ describe("FeePool", function () {
     );
     const rep = await Rep.connect(owner).deploy(ethers.ZeroAddress);
     await rep.setStakeManager(await stakeManager.getAddress());
-    await rep.setCaller(owner.address, true);
+    await rep.setAuthorizedCaller(owner.address, true);
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/PlatformRegistry.sol:PlatformRegistry"

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -88,7 +88,9 @@ describe("JobRegistry integration", function () {
     await registry.connect(owner).setMaxJobDuration(86400);
     await registry.connect(owner).setFeePct(0);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());
-    await rep.connect(owner).setCaller(await registry.getAddress(), true);
+    await rep
+      .connect(owner)
+      .setAuthorizedCaller(await registry.getAddress(), true);
     await rep.connect(owner).setThreshold(1);
     await stakeManager
       .connect(owner)

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -41,8 +41,10 @@ describe("JobRegistry agent gating", function () {
     );
     await registry.connect(owner).setENSOwnershipVerifier(await verifier.getAddress());
 
-    await rep.connect(owner).setCaller(await registry.getAddress(), true);
-    await rep.connect(owner).setCaller(owner.address, true);
+    await rep
+      .connect(owner)
+      .setAuthorizedCaller(await registry.getAddress(), true);
+    await rep.connect(owner).setAuthorizedCaller(owner.address, true);
 
     const Policy = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
@@ -85,7 +87,7 @@ describe("JobRegistry agent gating", function () {
 
   it("rejects blacklisted agents", async () => {
     await verifier.setResult(true);
-    await rep.connect(owner).setBlacklist(agent.address, true);
+    await rep.connect(owner).blacklist(agent.address, true);
     const jobId = await createJob();
     await expect(
       registry.connect(agent).applyForJob(jobId, "a", [])

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -39,7 +39,7 @@ describe("PlatformRegistry", function () {
       await stakeManager.getAddress()
     );
     await reputationEngine.setStakeManager(await stakeManager.getAddress());
-    await reputationEngine.setCaller(owner.address, true);
+    await reputationEngine.setAuthorizedCaller(owner.address, true);
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/PlatformRegistry.sol:PlatformRegistry"

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -138,17 +138,17 @@ describe("ValidationModule access controls", function () {
       ["uint256", "uint256", "bool", "bytes32"],
       [1n, nonce, true, salt]
     );
-    await reputation.setBlacklist(val, true);
+    await reputation.blacklist(val, true);
     await expect(
       validation.connect(v1).commitValidation(1, commit, "", [])
     ).to.be.revertedWith("Blacklisted validator");
 
-    await reputation.setBlacklist(val, false);
+    await reputation.blacklist(val, false);
     await (
       await validation.connect(v1).commitValidation(1, commit, "", [])
     ).wait();
     await advance(61);
-    await reputation.setBlacklist(val, true);
+    await reputation.blacklist(val, true);
     await expect(
       validation.connect(v1).revealValidation(1, true, salt, "", [])
     ).to.be.revertedWith("Blacklisted validator");

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -117,7 +117,7 @@ describe("end-to-end job lifecycle", function () {
     await stakeManager.setDisputeModule(await dispute.getAddress());
     await stakeManager.setSlashingPercentages(100, 0);
     await nft.setJobRegistry(await registry.getAddress());
-    await rep.setCaller(await registry.getAddress(), true);
+    await rep.setAuthorizedCaller(await registry.getAddress(), true);
     await rep.setThreshold(1);
     await nft.transferOwnership(await registry.getAddress());
 

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -115,7 +115,7 @@ describe("job finalization integration", function () {
     await stakeManager.setDisputeModule(await dispute.getAddress());
     await stakeManager.setSlashingPercentages(100, 0);
     await nft.setJobRegistry(await registry.getAddress());
-    await rep.setCaller(await registry.getAddress(), true);
+    await rep.setAuthorizedCaller(await registry.getAddress(), true);
     await rep.setThreshold(1);
     await nft.transferOwnership(await registry.getAddress());
 
@@ -163,7 +163,7 @@ describe("job finalization integration", function () {
 
   it("finalizes failed job after employer dispute", async () => {
     // seed reputation to observe subtraction
-    await rep.connect(owner).setCaller(owner.address, true);
+    await rep.connect(owner).setAuthorizedCaller(owner.address, true);
     await rep.connect(owner).add(agent.address, 5);
 
     const { jobId, fee } = await setupJob(false);

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -132,7 +132,7 @@ describe("multi-operator job lifecycle", function () {
     await stakeManager.setJobRegistry(await registry.getAddress());
     await stakeManager.setDisputeModule(await dispute.getAddress());
     await nft.setJobRegistry(await registry.getAddress());
-    await rep.setCaller(await registry.getAddress(), true);
+    await rep.setAuthorizedCaller(await registry.getAddress(), true);
     await rep.setThreshold(1);
     await nft.transferOwnership(await registry.getAddress());
 


### PR DESCRIPTION
## Summary
- add onApply, onFinalize, and rewardValidator reputation hooks with diminishing returns
- add owner-only controls for premium threshold, caller authorization, and manual blacklisting
- expose reputationOf and isBlacklisted views with events for state changes

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a36b201f808333a5e6633eacba0ff2