### PR TITLE
feat: enforce ens verification

### DIFF
--- a/contracts/mocks/RevertingNameWrapper.sol
+++ b/contracts/mocks/RevertingNameWrapper.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title RevertingNameWrapper
+/// @notice Mock NameWrapper that always reverts.
+contract RevertingNameWrapper {
+    function ownerOf(uint256) external pure returns (address) {
+        revert("revert");
+    }
+}

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -301,12 +301,18 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     /// @notice Set the ENS root node used for agent verification.
     function setAgentRootNode(bytes32 node) external onlyOwner {
         agentRootNode = node;
+        if (address(ensOwnershipVerifier) != address(0)) {
+            ensOwnershipVerifier.setAgentRootNode(node);
+        }
         emit RootNodeUpdated("agent", node);
     }
 
     /// @notice Set the agent Merkle root used for identity proofs.
     function setAgentMerkleRoot(bytes32 root) external onlyOwner {
         agentMerkleRoot = root;
+        if (address(ensOwnershipVerifier) != address(0)) {
+            ensOwnershipVerifier.setAgentMerkleRoot(root);
+        }
         emit MerkleRootUpdated("agent", root);
     }
 

--- a/test/v2/ENSOwnershipVerifier.t.sol
+++ b/test/v2/ENSOwnershipVerifier.t.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "contracts/v2/modules/ENSOwnershipVerifier.sol";
+
+contract MockENS {
+    mapping(bytes32 => address) public resolvers;
+    function resolver(bytes32 node) external view returns (address) { return resolvers[node]; }
+    function setResolver(bytes32 node, address res) external { resolvers[node] = res; }
+}
+
+contract MockResolver {
+    mapping(bytes32 => address) public addrs;
+    function addr(bytes32 node) external view returns (address payable) { return payable(addrs[node]); }
+    function setAddr(bytes32 node, address a) external { addrs[node] = a; }
+}
+
+contract MockNameWrapper {
+    mapping(uint256 => address) public owners;
+    function ownerOf(uint256 node) external view returns (address) { return owners[node]; }
+    function setOwner(uint256 node, address owner) external { owners[node] = owner; }
+}
+
+contract ENSOwnershipVerifierTest {
+    ENSOwnershipVerifier verifier;
+    MockENS ens;
+    MockResolver resolver;
+    MockNameWrapper wrapper;
+    address agent = address(0xA1);
+    bytes32 root = keccak256(abi.encodePacked("agi"));
+
+    function setUp() public {
+        ens = new MockENS();
+        resolver = new MockResolver();
+        wrapper = new MockNameWrapper();
+        verifier = new ENSOwnershipVerifier(IENS(address(ens)), INameWrapper(address(wrapper)), bytes32(0));
+        verifier.setAgentRootNode(root);
+    }
+
+    function namehash(bytes32 parent, string memory label) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(parent, keccak256(bytes(label))));
+    }
+
+    function testRejectsUnverifiedSubdomain() public {
+        bool ok = verifier.verifyAgent(agent, "a", new bytes32[](0));
+        require(!ok, "should fail");
+    }
+
+    function testVerifiesWithNameWrapper() public {
+        bytes32 node = namehash(root, "a");
+        wrapper.setOwner(uint256(node), agent);
+        bool ok = verifier.verifyAgent(agent, "a", new bytes32[](0));
+        require(ok, "should verify");
+    }
+}

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -68,6 +68,23 @@ describe("JobRegistry agent gating", function () {
     return 1;
   }
 
+  it("syncs ENS roots and merkle updates to verifier", async () => {
+    const newRoot = ethers.id("root");
+    await expect(
+      registry.connect(agent).setAgentRootNode(newRoot)
+    ).to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount");
+    await expect(registry.setAgentRootNode(newRoot))
+      .to.emit(registry, "RootNodeUpdated")
+      .withArgs("agent", newRoot);
+    expect(await verifier.agentRootNode()).to.equal(newRoot);
+
+    const merkle = ethers.id("merkle");
+    await expect(registry.setAgentMerkleRoot(merkle))
+      .to.emit(registry, "MerkleRootUpdated")
+      .withArgs("agent", merkle);
+    expect(await verifier.agentMerkleRoot()).to.equal(merkle);
+  });
+
   it("rejects unverified agents", async () => {
     const jobId = await createJob();
     await expect(


### PR DESCRIPTION
## Summary
- ensure JobRegistry forwards ENS root/merkle updates to verifier
- expose public blacklist mapping in ReputationEngine
- add ENS edge-case tests and foundry verifier tests

## Testing
- `npm test`
- `forge test --match-contract ENSOwnershipVerifierTest` *(fails: Source "forge-std/Script.sol" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3867835bc8333b85b7d1060465e45