### PR TITLE
Enforce job deadlines and expand lifecycle tests

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -569,6 +569,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         }
         Job storage job = jobs[jobId];
         require(job.state == State.Created, "not open");
+        require(block.timestamp <= job.deadline, "deadline");
         if (job.stake > 0 && address(stakeManager) != address(0)) {
             require(
                 stakeManager.stakeOf(msg.sender, IStakeManager.Role.Agent) >=
@@ -646,6 +647,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         Job storage job = jobs[jobId];
         require(job.state == State.Applied, "invalid state");
         require(msg.sender == job.agent, "only agent");
+        require(block.timestamp <= job.deadline, "deadline");
         job.result = result;
         job.state = State.Submitted;
         emit JobSubmitted(jobId, result);

--- a/test/v2/JobRegistryDeadline.test.js
+++ b/test/v2/JobRegistryDeadline.test.js
@@ -1,0 +1,84 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("JobRegistry deadline enforcement", function () {
+  let owner, employer, agent;
+  let token, stakeManager, validation, registry;
+  const reward = 100;
+
+  beforeEach(async () => {
+    [owner, employer, agent] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC206Decimals");
+    token = await Token.deploy();
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      0,
+      100,
+      0,
+      owner.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
+    );
+    await stakeManager.connect(owner).setMinStake(0);
+
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/mocks/ValidationStub.sol:ValidationStub"
+    );
+    validation = await Validation.deploy();
+
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Registry.deploy(
+      await validation.getAddress(),
+      await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      []
+    );
+
+    await validation.setJobRegistry(await registry.getAddress());
+    await registry.connect(owner).setJobParameters(reward, 0);
+    await registry.connect(owner).setMaxJobReward(1000);
+    await registry.connect(owner).setMaxJobDuration(1000);
+    await registry.connect(owner).setFeePct(0);
+    await registry.connect(owner).acknowledgeTaxPolicy();
+    await registry.connect(employer).acknowledgeTaxPolicy();
+    await registry.connect(agent).acknowledgeTaxPolicy();
+
+    await token.mint(employer.address, 1000);
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), reward);
+  });
+
+  it("rejects applications after the deadline", async () => {
+    const deadline = (await time.latest()) + 1;
+    await registry.connect(employer).createJob(reward, deadline, "uri");
+    await time.increase(2);
+    await expect(
+      registry.connect(agent).applyForJob(1, "", [])
+    ).to.be.revertedWith("deadline");
+  });
+
+  it("rejects submissions after the deadline", async () => {
+    const deadline = (await time.latest()) + 100;
+    await registry.connect(employer).createJob(reward, deadline, "uri");
+    await registry.connect(agent).applyForJob(1, "", []);
+    await time.increaseTo(deadline + 1);
+    await expect(
+      registry.connect(agent).submit(1, "res")
+    ).to.be.revertedWith("deadline");
+  });
+});

--- a/test/v2/JobRegistryLifecycle.t.sol
+++ b/test/v2/JobRegistryLifecycle.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {JobRegistry} from "../../contracts/v2/JobRegistry.sol";
+import {ValidationStub} from "../../contracts/v2/mocks/ValidationStub.sol";
+import {MockStakeManager} from "../../contracts/mocks/MockV2.sol";
+import {DisputeModule} from "../../contracts/v2/modules/DisputeModule.sol";
+import {IJobRegistry} from "../../contracts/v2/interfaces/IJobRegistry.sol";
+import {IReputationEngine} from "../../contracts/v2/interfaces/IReputationEngine.sol";
+import {ICertificateNFT} from "../../contracts/v2/interfaces/ICertificateNFT.sol";
+import {IFeePool} from "../../contracts/v2/interfaces/IFeePool.sol";
+import {ITaxPolicy} from "../../contracts/v2/interfaces/ITaxPolicy.sol";
+import {IDisputeModule} from "../../contracts/v2/interfaces/IDisputeModule.sol";
+
+contract JobRegistryLifecycleTest is Test {
+    JobRegistry registry;
+    ValidationStub validation;
+    MockStakeManager stake;
+    DisputeModule dispute;
+
+    address employer = address(0xA1);
+    address agent = address(0xB2);
+
+    function setUp() public {
+        stake = new MockStakeManager();
+        validation = new ValidationStub();
+        registry = new JobRegistry(
+            validation,
+            stake,
+            IReputationEngine(address(0)),
+            IDisputeModule(address(0)),
+            ICertificateNFT(address(0)),
+            IFeePool(address(0)),
+            ITaxPolicy(address(0)),
+            0,
+            0,
+            new address[](0)
+        );
+        validation.setJobRegistry(address(registry));
+        stake.setJobRegistry(address(registry));
+        registry.setJobParameters(0, 0);
+        registry.setMaxJobReward(1000);
+        registry.setMaxJobDuration(1000);
+        registry.setFeePct(0);
+
+        vm.prank(employer);
+        registry.acknowledgeTaxPolicy();
+        vm.prank(agent);
+        registry.acknowledgeTaxPolicy();
+
+        dispute = new DisputeModule(IJobRegistry(address(registry)), 0, 0, address(0));
+        registry.setDisputeModule(address(dispute));
+        stake.setDisputeModule(address(dispute));
+    }
+
+    function testHappyPathFinalize() public {
+        uint64 deadline = uint64(block.timestamp + 100);
+        vm.prank(employer);
+        uint256 jobId = registry.createJob(10, deadline, "uri");
+
+        vm.prank(agent);
+        registry.applyForJob(jobId, "", new bytes32[](0));
+
+        vm.prank(agent);
+        registry.submit(jobId, "res");
+
+        validation.setResult(true);
+        validation.finalize(jobId);
+
+        JobRegistry.Job memory job = registry.jobs(jobId);
+        assertEq(uint(job.state), uint(JobRegistry.State.Finalized));
+        assertTrue(job.success);
+    }
+
+    function testCancelJob() public {
+        uint64 deadline = uint64(block.timestamp + 100);
+        vm.prank(employer);
+        uint256 jobId = registry.createJob(10, deadline, "uri");
+        vm.prank(employer);
+        registry.cancelJob(jobId);
+        JobRegistry.Job memory job = registry.jobs(jobId);
+        assertEq(uint(job.state), uint(JobRegistry.State.Cancelled));
+    }
+
+    function testDisputeFlow() public {
+        uint64 deadline = uint64(block.timestamp + 100);
+        vm.prank(employer);
+        uint256 jobId = registry.createJob(10, deadline, "uri");
+
+        vm.prank(agent);
+        registry.applyForJob(jobId, "", new bytes32[](0));
+
+        vm.prank(agent);
+        registry.submit(jobId, "res");
+
+        validation.setResult(false);
+        validation.finalize(jobId);
+
+        vm.prank(agent);
+        registry.dispute(jobId, "evidence");
+
+        dispute.resolveDispute(jobId, true);
+
+        JobRegistry.Job memory job = registry.jobs(jobId);
+        assertEq(uint(job.state), uint(JobRegistry.State.Finalized));
+        assertFalse(job.success);
+    }
+}


### PR DESCRIPTION
## Summary
- require job deadline to be respected when applying or submitting
- add hardhat tests for late applications and submissions
- add foundry lifecycle test covering finalize, cancel and dispute flows

## Testing
- `npx hardhat test test/v2/JobRegistryDeadline.test.js` *(fails: process exceeded time during compilation)*
- `forge test --match-path test/v2/JobRegistryLifecycle.t.sol` *(fails: compilation errors in unrelated test contracts)*

------
https://chatgpt.com/codex/tasks/task_e_68a389fcfb3c8333b493081058c5c5c8