### PR TITLE
Expose validator slashing control and test validation outcomes

### DIFF
--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -76,6 +76,9 @@ interface IValidationModule {
     /// @notice Update approval threshold percentage
     function setApprovalThreshold(uint256 pct) external;
 
+    /// @notice Update percentage of stake slashed for incorrect validator votes
+    function setValidatorSlashingPct(uint256 pct) external;
+
     /// @notice Manually allow a validator to bypass ENS checks.
     function addAdditionalValidator(address validator) external;
 

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -63,6 +63,8 @@ contract ValidationStub is IValidationModule {
 
     function setApprovalThreshold(uint256) external override {}
 
+    function setValidatorSlashingPct(uint256) external override {}
+
     function addAdditionalValidator(address) external override {}
 
     function removeAdditionalValidator(address) external override {}

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -1,0 +1,132 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+async function setup() {
+  const [owner, employer, v1, v2] = await ethers.getSigners();
+
+  const StakeMock = await ethers.getContractFactory("MockStakeManager");
+  const stakeManager = await StakeMock.deploy();
+  await stakeManager.waitForDeployment();
+
+  const JobMock = await ethers.getContractFactory("MockJobRegistry");
+  const jobRegistry = await JobMock.deploy();
+  await jobRegistry.waitForDeployment();
+
+  const RepMock = await ethers.getContractFactory("MockReputationEngine");
+  const reputation = await RepMock.deploy();
+  await reputation.waitForDeployment();
+
+  const Validation = await ethers.getContractFactory(
+    "contracts/v2/ValidationModule.sol:ValidationModule"
+  );
+  const validation = await Validation.deploy(
+    await jobRegistry.getAddress(),
+    await stakeManager.getAddress(),
+    60,
+    60,
+    2,
+    2,
+    []
+  );
+  await validation.waitForDeployment();
+  await validation.connect(owner).setReputationEngine(await reputation.getAddress());
+
+  const Verifier = await ethers.getContractFactory("ENSOwnershipVerifierMock");
+  const verifier = await Verifier.deploy();
+  await verifier.waitForDeployment();
+  await validation
+    .connect(owner)
+    .setENSOwnershipVerifier(await verifier.getAddress());
+  await validation.connect(owner).setClubRootNode(ethers.ZeroHash);
+  await validation
+    .connect(owner)
+    .setAdditionalValidators([v1.address, v2.address], [true, true]);
+
+  await stakeManager.setStake(v1.address, 1, ethers.parseEther("100"));
+  await stakeManager.setStake(v2.address, 1, ethers.parseEther("50"));
+  await validation
+    .connect(owner)
+    .setValidatorPool([v1.address, v2.address]);
+
+  const jobStruct = {
+    employer: employer.address,
+    agent: ethers.ZeroAddress,
+    reward: 0,
+    stake: 0,
+    success: false,
+    status: 3,
+    uri: "",
+    result: "",
+  };
+  await jobRegistry.setJob(1, jobStruct);
+  return { owner, employer, v1, v2, validation, stakeManager, jobRegistry };
+}
+
+async function advance(seconds) {
+  await ethers.provider.send("evm_increaseTime", [seconds]);
+  await ethers.provider.send("evm_mine", []);
+}
+
+describe("ValidationModule finalize flows", function () {
+  it("records majority approval as success", async () => {
+    const { v1, v2, validation, jobRegistry } = await setup();
+    await validation.selectValidators(1);
+    const salt1 = ethers.keccak256(ethers.toUtf8Bytes("s1"));
+    const salt2 = ethers.keccak256(ethers.toUtf8Bytes("s2"));
+    const nonce = await validation.jobNonce(1);
+    const commit1 = ethers.solidityPackedKeccak256(
+      ["uint256", "uint256", "bool", "bytes32"],
+      [1n, nonce, true, salt1]
+    );
+    const commit2 = ethers.solidityPackedKeccak256(
+      ["uint256", "uint256", "bool", "bytes32"],
+      [1n, nonce, false, salt2]
+    );
+    await validation.connect(v1).commitValidation(1, commit1, "", []);
+    await validation.connect(v2).commitValidation(1, commit2, "", []);
+    await advance(61);
+    await validation.connect(v1).revealValidation(1, true, salt1, "", []);
+    await validation.connect(v2).revealValidation(1, false, salt2, "", []);
+    await advance(61);
+    await validation.finalize(1);
+    const job = await jobRegistry.jobs(1);
+    expect(job.status).to.equal(6); // Finalized
+    expect(job.success).to.equal(true);
+  });
+
+  it("records majority rejection as dispute", async () => {
+    const { v1, v2, validation, jobRegistry } = await setup();
+    await validation.selectValidators(1);
+    const salt1 = ethers.keccak256(ethers.toUtf8Bytes("s1"));
+    const salt2 = ethers.keccak256(ethers.toUtf8Bytes("s2"));
+    const nonce = await validation.jobNonce(1);
+    const commit1 = ethers.solidityPackedKeccak256(
+      ["uint256", "uint256", "bool", "bytes32"],
+      [1n, nonce, false, salt1]
+    );
+    const commit2 = ethers.solidityPackedKeccak256(
+      ["uint256", "uint256", "bool", "bytes32"],
+      [1n, nonce, false, salt2]
+    );
+    await validation.connect(v1).commitValidation(1, commit1, "", []);
+    await validation.connect(v2).commitValidation(1, commit2, "", []);
+    await advance(61);
+    await validation.connect(v1).revealValidation(1, false, salt1, "", []);
+    await validation.connect(v2).revealValidation(1, false, salt2, "", []);
+    await advance(61);
+    await validation.finalize(1);
+    const job = await jobRegistry.jobs(1);
+    expect(job.status).to.equal(5); // Disputed
+  });
+
+  it("disputes when validators fail to reveal", async () => {
+    const { validation, jobRegistry } = await setup();
+    await validation.selectValidators(1);
+    await advance(61); // end commit
+    await advance(61); // end reveal
+    await validation.finalize(1);
+    const job = await jobRegistry.jobs(1);
+    expect(job.status).to.equal(5); // Disputed
+  });
+});
+


### PR DESCRIPTION
## Summary
- expose `setValidatorSlashingPct` in the validation module interface
- update validation stub to implement new interface function
- add tests covering validator approval/dispute flows and no-reveal quorum edge case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a39bb2f7c883339fd855ade433d06d