### PR TITLE
feat: job nft marketplace and registry integration

### DIFF
--- a/contracts/mocks/ReentrantBuyer.sol
+++ b/contracts/mocks/ReentrantBuyer.sol
@@ -5,7 +5,7 @@ import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Recei
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IMarketplaceNFT {
-    function purchase(uint256 tokenId) external;
+    function purchase(uint256 tokenId, bytes32 jobId) external;
 }
 
 /// @dev Buyer contract that attempts to reenter the marketplace during a purchase.
@@ -23,7 +23,7 @@ contract ReentrantBuyer is IERC721Receiver {
 
     /// @notice Initiate a purchase which triggers the reentrancy attempt.
     function buy(uint256 tokenId) external {
-        nft.purchase(tokenId);
+        nft.purchase(tokenId, bytes32(0));
     }
 
     /// @dev During receipt of the NFT, attempt to purchase again.
@@ -35,7 +35,7 @@ contract ReentrantBuyer is IERC721Receiver {
     ) external returns (bytes4) {
         // Swallow any failure – the second call should revert because the
         // listing was cleared before transfer.
-        try nft.purchase(tokenId) {} catch {}
+        try nft.purchase(tokenId, bytes32(0)) {} catch {}
         return this.onERC721Received.selector;
     }
 }

--- a/test/JobNFT.test.js
+++ b/test/JobNFT.test.js
@@ -74,13 +74,13 @@ describe("JobNFT", function () {
       .to.emit(nft, "NFTListed")
       .withArgs(1, seller.address, price);
 
-    await expect(nft.connect(buyer).purchase(1)).to.be.revertedWithCustomError(
+    await expect(nft.connect(buyer).purchase(1, ethers.ZeroHash)).to.be.revertedWithCustomError(
       token,
       "ERC20InsufficientAllowance"
     );
 
     await token.connect(buyer).approve(await nft.getAddress(), price);
-    await expect(nft.connect(buyer).purchase(1))
+    await expect(nft.connect(buyer).purchase(1, ethers.ZeroHash))
       .to.emit(nft, "NFTPurchased")
       .withArgs(1, buyer.address, price);
     expect(await nft.ownerOf(1)).to.equal(buyer.address);
@@ -108,14 +108,14 @@ describe("JobNFT", function () {
     await expect(nft.connect(buyer).list(1, price)).to.be.revertedWith("owner");
     await expect(nft.connect(seller).list(1, 0)).to.be.revertedWith("price");
 
-    await expect(nft.connect(buyer).purchase(1)).to.be.revertedWith("not listed");
+    await expect(nft.connect(buyer).purchase(1, ethers.ZeroHash)).to.be.revertedWith("not listed");
 
     await nft.connect(seller).list(1, price);
     await expect(nft.connect(buyer).delist(1)).to.be.revertedWith("owner");
     await expect(nft.connect(seller).list(1, price)).to.be.revertedWith("listed");
 
     await token.connect(buyer).approve(await nft.getAddress(), price);
-    await expect(nft.connect(buyer).purchase(1))
+    await expect(nft.connect(buyer).purchase(1, ethers.ZeroHash))
       .to.emit(nft, "NFTPurchased")
       .withArgs(1, buyer.address, price);
   });

--- a/test/JobRegistryNFT.test.js
+++ b/test/JobRegistryNFT.test.js
@@ -1,0 +1,80 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+async function deployFixture() {
+  const [owner, employer, agent] = await ethers.getSigners();
+
+  const Validation = await ethers.getContractFactory(
+    "contracts/ValidationModule.sol:ValidationModule"
+  );
+  const validation = await Validation.deploy();
+  await validation.waitForDeployment();
+
+  const Reputation = await ethers.getContractFactory(
+    "contracts/mocks/StubReputationEngine.sol:StubReputationEngine"
+  );
+  const reputation = await Reputation.deploy();
+  await reputation.waitForDeployment();
+
+  const Stake = await ethers.getContractFactory(
+    "contracts/mocks/StubStakeManager.sol:StubStakeManager"
+  );
+  const stake = await Stake.deploy();
+  await stake.waitForDeployment();
+  await stake.setStake(agent.address, 1);
+
+  const Cert = await ethers.getContractFactory(
+    "contracts/CertificateNFT.sol:CertificateNFT"
+  );
+  const cert = await Cert.deploy();
+  await cert.waitForDeployment();
+
+  const Token = await ethers.getContractFactory(
+    "contracts/AGIALPHAToken.sol:AGIALPHAToken"
+  );
+  const token = await Token.deploy("AGI ALPHA", "AGIA", 0);
+  await token.waitForDeployment();
+
+  const NFT = await ethers.getContractFactory("JobNFT");
+  const nft = await NFT.deploy(await token.getAddress());
+  await nft.waitForDeployment();
+
+  const Registry = await ethers.getContractFactory(
+    "contracts/JobRegistry.sol:JobRegistry"
+  );
+  const registry = await Registry.deploy();
+  await registry.waitForDeployment();
+
+  await registry.setValidationModule(await validation.getAddress());
+  await registry.setReputationEngine(await reputation.getAddress());
+  await registry.setStakeManager(await stake.getAddress());
+  await registry.setCertificateNFT(await cert.getAddress());
+  await registry.setJobNFT(await nft.getAddress());
+  await registry.setJobParameters(1, 1);
+
+  await cert.setMinter(await registry.getAddress(), true);
+  await nft.setJobRegistry(await registry.getAddress());
+
+  return { registry, validation, reputation, stake, cert, nft, employer, agent };
+}
+
+describe("JobRegistry integrates JobNFT", function () {
+  it("mints JobNFT to employer on finalization", async function () {
+    const { registry, validation, cert, nft, employer, agent } = await deployFixture();
+
+    await registry.connect(employer).acknowledgeTaxPolicy();
+    await registry.connect(agent).acknowledgeTaxPolicy();
+    await registry.connect(employer).createJob(agent.address);
+    const jobId = 1;
+    await validation.setOutcome(jobId, true);
+    await registry.connect(agent).completeJob(jobId, "output.json");
+    await expect(registry.finalize(jobId))
+      .to.emit(nft, "NFTIssued")
+      .withArgs(employer.address, jobId);
+
+    expect(await nft.ownerOf(jobId)).to.equal(employer.address);
+    // certificate also minted to agent
+    expect(await cert.ownerOf(jobId)).to.equal(agent.address);
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow JobNFT marketplace purchases via optional StakeManager escrow
- wire JobRegistry to mint JobNFT to employers on successful finalization
- test listing/purchase/delist flows and minting during finalization

## Testing
- `npx hardhat test test/JobNFT.test.js test/JobRegistryNFT.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a3bbdf2494833399f3768d39609dbe