### PR TITLE
Clarify owner operations and enforce access controls

### DIFF
--- a/contracts/v2/AGIALPHAToken.sol
+++ b/contracts/v2/AGIALPHAToken.sol
@@ -20,6 +20,10 @@ contract AGIALPHAToken is ERC20, Ownable {
         return DECIMALS;
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice Mint new tokens to an address.
     /// @param to recipient of minted tokens
     /// @param amount token amount with 6 decimals

--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -45,6 +45,10 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
         _;
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     function setJobRegistry(address registry) external onlyOwner {
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);

--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -93,6 +93,10 @@ contract Deployer is Ownable {
     /// @return platformIncentives Address of the PlatformIncentives helper
     /// @return feePool Address of the FeePool
     /// @return taxPolicy Address of the TaxPolicy
+    // ---------------------------------------------------------------------
+    // Deployment entrypoints (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     function deploy(EconParams calldata econ, IdentityParams calldata ids)
         external
         onlyOwner

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -184,8 +184,13 @@ contract FeePool is Ownable {
         emit RewardsClaimed(msg.sender, owed);
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice owner-only emergency escape hatch to withdraw tokens
-    /// @dev Amount uses 6 decimal units.
+    /// @dev Intended for stuck-token recovery via Etherscan. Routine fees flow
+    ///      to this pool or the burn address. Amount uses 6 decimal units.
     /// @param to recipient address
     /// @param amount token amount with 6 decimals
     function ownerWithdraw(address to, uint256 amount) external onlyOwner {

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -255,6 +255,8 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     // ---------------------------------------------------------------------
     // Owner configuration
     // ---------------------------------------------------------------------
+    // Setters below are executed manually via Etherscan's "Write Contract"
+    // tab using the authorized owner account.
     function setModules(
         IValidationModule _validation,
         IStakeManager _stakeMgr,

--- a/contracts/v2/PlatformIncentives.sol
+++ b/contracts/v2/PlatformIncentives.sol
@@ -50,6 +50,10 @@ contract PlatformIncentives is Ownable {
         }
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice Update module addresses.
     function setModules(
         IStakeManager _stakeManager,

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -243,6 +243,7 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
     // ---------------------------------------------------------------
     // Owner functions
     // ---------------------------------------------------------------
+    // Use Etherscan's "Write Contract" tab to invoke these setters.
 
     function setStakeManager(IStakeManager manager) external onlyOwner {
         stakeManager = manager;

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -39,6 +39,10 @@ contract ReputationEngine is Ownable {
         _;
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice Authorize or revoke a caller.
     function setAuthorizedCaller(address caller, bool allowed) external onlyOwner {
         callers[caller] = allowed;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -195,8 +195,10 @@ contract StakeManager is Ownable, ReentrancyGuard {
     }
 
     // ---------------------------------------------------------------
-    // owner functions
+    // Owner setters
     // ---------------------------------------------------------------
+    // These helpers are intended for manual use via Etherscan's
+    // "Write Contract" tab by the authorized owner.
 
     /// @notice update the staking/payout token
     /// @param newToken ERC20 token address using 6 decimals

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -45,6 +45,10 @@ contract TaxPolicy is Ownable, ITaxPolicy {
         emit AcknowledgementUpdated(ack);
         emit PolicyVersionUpdated(1);
     }
+    
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
 
     /// @notice Updates the off-chain policy URI.
     /// @param uri New URI pointing to policy text (e.g., IPFS hash).

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -167,6 +167,10 @@ contract ValidationModule is IValidationModule, Ownable {
         }
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice Update the list of eligible validators.
     /// @param newPool Addresses of validators.
     function setValidatorPool(address[] calldata newPool)

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -23,6 +23,10 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
         _;
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     function setJobRegistry(address registry) external onlyOwner {
         jobRegistry = registry;
     }

--- a/contracts/v2/modules/DiscoveryModule.sol
+++ b/contracts/v2/modules/DiscoveryModule.sol
@@ -52,6 +52,10 @@ contract DiscoveryModule is Ownable {
         emit PlatformRegistered(operator);
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice Deregister a platform
     function deregisterPlatform(address operator) external onlyOwner {
         if (!isPlatform[operator]) return;

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -91,6 +91,10 @@ contract DisputeModule is Ownable {
         _;
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice Update the JobRegistry reference.
     /// @param newRegistry New JobRegistry contract implementing IJobRegistry.
     function setJobRegistry(IJobRegistry newRegistry) external onlyOwner {

--- a/contracts/v2/modules/ENSOwnershipVerifier.sol
+++ b/contracts/v2/modules/ENSOwnershipVerifier.sol
@@ -54,6 +54,10 @@ contract ENSOwnershipVerifier is Ownable {
         }
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice Update ENS registry address
     /// @param ensAddr New ENS registry contract address
     function setENS(address ensAddr) external onlyOwner {

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -57,6 +57,10 @@ contract JobEscrow is Ownable {
                 : _token;
         routingModule = _routing;
     }
+    
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
 
     function setToken(IERC20 newToken) external onlyOwner {
         IERC20Metadata meta = IERC20Metadata(address(newToken));

--- a/contracts/v2/modules/JobRouter.sol
+++ b/contracts/v2/modules/JobRouter.sol
@@ -74,6 +74,10 @@ contract JobRouter is Ownable {
         cooldown[msg.sender] = uint64(block.number + COOLDOWN_BLOCKS);
         emit Deregistered(msg.sender);
     }
+    
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
 
     /// @notice Authorize or revoke a registrar address.
     function setRegistrar(address registrar, bool allowed) external onlyOwner {

--- a/contracts/v2/modules/ReputationEngine.sol
+++ b/contracts/v2/modules/ReputationEngine.sol
@@ -35,6 +35,10 @@ contract ReputationEngine is Ownable {
         _;
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice Authorize or revoke a caller module
     function setCaller(address caller, bool allowed) external onlyOwner {
         callers[caller] = allowed;

--- a/contracts/v2/modules/RevenueDistributor.sol
+++ b/contracts/v2/modules/RevenueDistributor.sol
@@ -34,6 +34,10 @@ contract RevenueDistributor is Ownable {
         emit OperatorRegistered(msg.sender);
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice Deregister an operator. Only owner may remove.
     function deregister(address operator) external onlyOwner {
         if (!isOperator[operator]) return;

--- a/contracts/v2/modules/RoutingModule.sol
+++ b/contracts/v2/modules/RoutingModule.sol
@@ -50,6 +50,10 @@ contract RoutingModule is Ownable {
         emit OperatorRegistered(msg.sender);
     }
 
+    // ---------------------------------------------------------------------
+    // Owner setters (use Etherscan's "Write Contract" tab)
+    // ---------------------------------------------------------------------
+
     /// @notice Deregister an operator. Only owner may remove.
     function deregister(address operator) external onlyOwner {
         if (!isOperator[operator]) return;

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -41,6 +41,17 @@ For a narrated deployment walkthrough, see [deployment-agialpha.md](deployment-a
    ![claim-rewards](https://via.placeholder.com/650x150?text=claimRewards)
 6. **acknowledgeAndDispute** – if contesting a job, approve the `StakeManager` for the `appealFee` and call `JobRegistry.acknowledgeAndDispute(jobId, evidence)`.
 
+### Sample Owner Parameters
+
+When using the **Write Contract** tab as the owner, populate fields with explicit values:
+
+| Contract | Function | Example parameters |
+| --- | --- | --- |
+| `StakeManager` | `setFeePct(pct)` | `20` |
+| `JobRegistry` | `setFeePct(pct)` | `5` |
+| `TaxPolicy` | `setPolicyURI("ipfs://Qm...")` | `ipfs://QmPolicyHash` |
+| `FeePool` | `ownerWithdraw(to, amount)` | `0x1111111111111111111111111111111111111111`, `1000000` |
+
 ## Module Addresses & Roles
 | Module | Address | Role |
 | --- | --- | --- |

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -1,0 +1,108 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Ownable modules", function () {
+  it("enforces ownership and transfer across modules", async function () {
+    const [owner, other] = await ethers.getSigners();
+    const Deployer = await ethers.getContractFactory(
+      "contracts/v2/Deployer.sol:Deployer"
+    );
+    const deployer = await Deployer.deploy();
+    const econ = {
+      token: ethers.ZeroAddress,
+      feePct: 0,
+      burnPct: 0,
+      employerSlashPct: 0,
+      treasurySlashPct: 0,
+      commitWindow: 0,
+      revealWindow: 0,
+      minStake: 0,
+      jobStake: 0,
+    };
+    const ids = {
+      ens: ethers.ZeroAddress,
+      nameWrapper: ethers.ZeroAddress,
+      clubRootNode: ethers.ZeroHash,
+      agentRootNode: ethers.ZeroHash,
+      validatorMerkleRoot: ethers.ZeroHash,
+      agentMerkleRoot: ethers.ZeroHash,
+    };
+    const addresses = await deployer.deploy.staticCall(econ, ids);
+    await deployer.deploy(econ, ids);
+
+    const [
+      stake,
+      registry,
+      validation,
+      reputation,
+      dispute,
+      certificate,
+      platformRegistry,
+      router,
+      incentives,
+      feePool,
+      taxPolicy,
+      ensVerifier,
+    ] = addresses;
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const ValidationModule = await ethers.getContractFactory(
+      "contracts/v2/ValidationModule.sol:ValidationModule"
+    );
+    const ReputationEngine = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    const DisputeModule = await ethers.getContractFactory(
+      "contracts/v2/modules/DisputeModule.sol:DisputeModule"
+    );
+    const CertificateNFT = await ethers.getContractFactory(
+      "contracts/v2/CertificateNFT.sol:CertificateNFT"
+    );
+    const PlatformRegistry = await ethers.getContractFactory(
+      "contracts/v2/PlatformRegistry.sol:PlatformRegistry"
+    );
+    const JobRouter = await ethers.getContractFactory(
+      "contracts/v2/modules/JobRouter.sol:JobRouter"
+    );
+    const PlatformIncentives = await ethers.getContractFactory(
+      "contracts/v2/PlatformIncentives.sol:PlatformIncentives"
+    );
+    const FeePool = await ethers.getContractFactory(
+      "contracts/v2/FeePool.sol:FeePool"
+    );
+    const TaxPolicy = await ethers.getContractFactory(
+      "contracts/v2/TaxPolicy.sol:TaxPolicy"
+    );
+    const ENSVerifier = await ethers.getContractFactory(
+      "contracts/v2/modules/ENSOwnershipVerifier.sol:ENSOwnershipVerifier"
+    );
+
+    const modules = [
+      [StakeManager.attach(stake), (inst, signer) => inst.connect(signer).setFeePct(1)],
+      [JobRegistry.attach(registry), (inst, signer) => inst.connect(signer).setFeePct(1)],
+      [ValidationModule.attach(validation), (inst, signer) => inst.connect(signer).setCommitWindow(1)],
+      [ReputationEngine.attach(reputation), (inst, signer) => inst.connect(signer).setWeights(0, 0)],
+      [DisputeModule.attach(dispute), (inst, signer) => inst.connect(signer).setDisputeFee(0)],
+      [CertificateNFT.attach(certificate), (inst, signer) => inst.connect(signer).setBaseURI("ipfs://new")],
+      [PlatformRegistry.attach(platformRegistry), (inst, signer) => inst.connect(signer).setMinPlatformStake(0)],
+      [JobRouter.attach(router), (inst, signer) => inst.connect(signer).setRegistrar(ethers.ZeroAddress, false)],
+      [PlatformIncentives.attach(incentives), (inst, signer) => inst.connect(signer).setModules(ethers.ZeroAddress, ethers.ZeroAddress, ethers.ZeroAddress)],
+      [FeePool.attach(feePool), (inst, signer) => inst.connect(signer).setBurnPct(0)],
+      [TaxPolicy.attach(taxPolicy), (inst, signer) => inst.connect(signer).setPolicyURI("ipfs://new")],
+      [ENSVerifier.attach(ensVerifier), (inst, signer) => inst.connect(signer).setENS(ethers.ZeroAddress)],
+    ];
+
+    for (const [inst, call] of modules) {
+      await expect(call(inst, other)).to.be.reverted;
+      await inst.transferOwnership(other.address);
+      await expect(call(inst, owner)).to.be.reverted;
+      await call(inst, other);
+      await inst.connect(other).transferOwnership(owner.address);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- document Etherscan usage for owner-only setters across core contracts
- add example "Write Contract" parameters in Etherscan guide
- test ownership transfer and owner-only permissions across v2 modules

## Testing
- `npm test test/v2/Ownership.test.js test/v2/StakeManagerRelease.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a3c41fa5708333b9a15c074b139c0a