### PR TITLE
feat: track validator participation

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -237,7 +237,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         submit(jobId, result);
     }
 
-    function finalizeAfterValidation(uint256 jobId, bool success) external override {
+    function finalizeAfterValidation(uint256 jobId, bool success) public override {
         Job storage job = _jobs[jobId];
         require(job.status == Status.Submitted, "state");
         job.success = success;
@@ -247,6 +247,10 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         } else {
             emit JobDisputed(jobId, msg.sender);
         }
+    }
+
+    function validationComplete(uint256 jobId, bool success) external override {
+        finalizeAfterValidation(jobId, success);
     }
 
     function dispute(uint256 jobId, string calldata evidence) public override {

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -667,7 +667,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     ///      computed result of the commit-reveal process.
     /// @param jobId Identifier of the job being finalised.
     /// @param success True if validators approved the job.
-    function finalizeAfterValidation(uint256 jobId, bool success) external {
+    function finalizeAfterValidation(uint256 jobId, bool success) public {
         require(msg.sender == address(validationModule), "only validation");
         Job storage job = jobs[jobId];
         require(job.state == State.Submitted, "not submitted");
@@ -677,6 +677,10 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         if (success) {
             finalize(jobId);
         }
+    }
+
+    function validationComplete(uint256 jobId, bool success) external {
+        finalizeAfterValidation(jobId, success);
     }
 
     /// @notice Agent or employer disputes a job outcome with supporting evidence.

--- a/contracts/v2/interfaces/IIdentityRegistry.sol
+++ b/contracts/v2/interfaces/IIdentityRegistry.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IIdentityRegistry {
+    function isAuthorizedValidator(
+        address claimant,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external view returns (bool);
+}
+

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -170,6 +170,9 @@ interface IJobRegistry {
     /// @param success True if validators approved the job
     function finalizeAfterValidation(uint256 jobId, bool success) external;
 
+    /// @notice Alias for {finalizeAfterValidation} for backwards compatibility
+    function validationComplete(uint256 jobId, bool success) external;
+
     /// @notice Raise a dispute for a completed job
     /// @param jobId Identifier of the disputed job
     /// @param evidence Supporting evidence for the dispute

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -13,6 +13,7 @@ interface IValidationModule {
         uint256 approvals,
         uint256 rejections
     );
+    event ValidationResult(uint256 indexed jobId, bool success);
     event ValidatorSubdomainUpdated(address indexed validator, string subdomain);
 
     /// @notice Select validators for a given job

--- a/contracts/v2/mocks/IdentityRegistryMock.sol
+++ b/contracts/v2/mocks/IdentityRegistryMock.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+contract IdentityRegistryMock {
+    function isAuthorizedValidator(
+        address,
+        string calldata,
+        bytes32[] calldata
+    ) external pure returns (bool) {
+        return true;
+    }
+}
+


### PR DESCRIPTION
## Summary
- integrate optional IdentityRegistry for validator authorization
- track revealed validators for later payouts
- expose validation results to JobRegistry via new validationComplete hook

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f5ff98208333a43602f99b47cab4