### PR TITLE
Emit NFTMinted event from JobNFT

### DIFF
--- a/contracts/JobNFT.sol
+++ b/contracts/JobNFT.sol
@@ -40,7 +40,8 @@ contract JobNFT is ERC721, Ownable {
 
     event BaseURIUpdated(string newURI);
     event JobRegistryUpdated(address registry);
-    event NFTIssued(address indexed to, uint256 indexed jobId);
+    /// @notice Emitted when a new NFT is minted.
+    event NFTMinted(address indexed to, uint256 indexed jobId);
     event NFTListed(uint256 indexed tokenId, address indexed seller, uint256 price);
     event NFTPurchased(uint256 indexed tokenId, address indexed buyer, uint256 price);
     event NFTDelisted(uint256 indexed tokenId);
@@ -90,7 +91,7 @@ contract JobNFT is ERC721, Ownable {
         tokenId = jobId;
         require(_ownerOf(tokenId) == address(0), "exists");
         _safeMint(to, tokenId);
-        emit NFTIssued(to, tokenId);
+        emit NFTMinted(to, tokenId);
     }
 
     /// @notice Burn a token, invalidating the associated job.

--- a/test/JobNFT.test.js
+++ b/test/JobNFT.test.js
@@ -50,7 +50,7 @@ describe("JobNFT", function () {
       "only JobRegistry"
     );
     await expect(nft.connect(jobRegistry).mint(seller.address, 1))
-      .to.emit(nft, "NFTIssued")
+      .to.emit(nft, "NFTMinted")
       .withArgs(seller.address, 1);
     expect(await nft.ownerOf(1)).to.equal(seller.address);
   });


### PR DESCRIPTION
## Summary
- rename NFTIssued to NFTMinted in JobNFT and tests
- still supports owner-only base URI and JobRegistry configuration

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a47e9533f48333a6ac07590ba0d70c