### PR TITLE
docs: add event name mapping

### DIFF
--- a/docs/v1-v2-function-map.md
+++ b/docs/v1-v2-function-map.md
@@ -47,3 +47,16 @@ The table below maps common public functions from the monolithic `AGIJobManagerV
 | `setCommitDuration` / `setRevealDuration` | `ValidationModule` | `setCommitWindow` / `setRevealWindow` |
 
 This list focuses on externally callable functions. Internal helpers and purely informational getters in v1 are omitted or replaced by public state variables in v2.
+
+## Event name mapping
+
+To aid log filtering during migration, v2 preserves the familiar event names from v1.
+
+| v1 event | v2 event |
+| --- | --- |
+| `JobCreated` | `JobCreated` |
+| `JobApplied` | `JobApplied` |
+| `JobSubmitted` | `JobSubmitted` |
+| `JobCompleted` | `JobCompleted` |
+| `JobFinalized` | `JobFinalized` |
+


### PR DESCRIPTION
## Summary
- document mapping of core JobRegistry events from v1 to v2

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4c459d7c48333a51c9576623b8df5