### PR TITLE
feat: add moderator management to dispute module

### DIFF
--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -22,5 +22,6 @@ interface IDisputeModule {
     function resolveDispute(uint256 jobId, bool employerWins) external;
     function setDisputeFee(uint256 fee) external;
     function setDisputeWindow(uint256 window) external;
-    function setModerator(address moderator, bool enabled) external;
+    function addModerator(address moderator) external;
+    function removeModerator(address moderator) external;
 }

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -103,15 +103,18 @@ contract DisputeModule is Ownable {
         emit ModulesUpdated(address(newRegistry));
     }
 
-    /// @notice Add or remove a moderator address.
-    /// @param _moderator Address of the moderator.
-    /// @param enabled True to grant, false to revoke.
-    function setModerator(address _moderator, bool enabled)
-        external
-        onlyOwner
-    {
-        moderators[_moderator] = enabled;
-        emit ModeratorUpdated(_moderator, enabled);
+    /// @notice Add a moderator address.
+    /// @param _moderator Address to grant moderator rights.
+    function addModerator(address _moderator) external onlyOwner {
+        moderators[_moderator] = true;
+        emit ModeratorUpdated(_moderator, true);
+    }
+
+    /// @notice Remove a moderator address.
+    /// @param _moderator Address to revoke moderator rights from.
+    function removeModerator(address _moderator) external onlyOwner {
+        moderators[_moderator] = false;
+        emit ModeratorUpdated(_moderator, false);
     }
 
     /// @notice Configure the dispute fee in token units (6 decimals).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -70,7 +70,7 @@ For a step-by-step deployment walkthrough with owner-only setters, see [deployme
 | --- | --- | --- |
 | JobRegistry | `setModules` (none set), `setJobParameters` (`reward=0`, `stake=0`), `setFeePool` (0 address), `setFeePct` (`0`), `setTaxPolicy` (0 address) | Wire modules, set template stake/reward, and configure fees/tax policy. |
 | ValidationModule | `setValidatorPool` (empty), `setReputationEngine` (0 address), `setCommitRevealWindows` (`0`, `0`), `setValidatorBounds` (`0`, `0`), `setVRF` (0 address) | Choose validators and tune commit/reveal timing and committee sizes. |
-| DisputeModule | `setModerator` (owner), `setAppealJury` (owner), `setDisputeFee` (`0`), `setJobRegistry` (constructor address) | Configure dispute bond and arbiters. |
+| DisputeModule | `addModerator` / `removeModerator` (owner), `setAppealJury` (owner), `setDisputeFee` (`0`), `setJobRegistry` (constructor address) | Configure dispute bond and arbiters. |
 | StakeManager | `setToken` (constructor token), `setMinStake` (`0`), `setSlashingPercentages` (`0`, `0`), `setTreasury` (constructor treasury), `setJobRegistry` (0 address), `setDisputeModule` (0 address), `setSlashPercentSumEnforcement` (`false`), `setMaxStakePerAddress` (`0`) | Adjust staking token, minimums, slashing rules, and authorised modules. |
 | ReputationEngine | `setCaller` (`false`), `setStakeManager` (0 address), `setScoringWeights` (`1e18`, `1e18`), `setThreshold` (`0`), `blacklist` (`false`) | Manage scoring weights, authorised callers, and blacklist threshold. |
 | CertificateNFT | `setJobRegistry` (0 address), `setBaseURI` (empty) | Authorise minting registry and metadata base URI. |

--- a/docs/v1-v2-function-map.md
+++ b/docs/v1-v2-function-map.md
@@ -26,7 +26,7 @@ The table below maps common public functions from the monolithic `AGIJobManagerV
 | `updateAGITokenAddress` | `StakeManager` / `FeePool` | `setToken` on each module |
 | `blacklistAgent` / `clearAgentBlacklist` | `ReputationEngine` | `blacklist(user, status)` |
 | `blacklistValidator` / `clearValidatorBlacklist` | `ReputationEngine` | `blacklist(user, status)` |
-| `addModerator` / `removeModerator` | `DisputeModule` | `setModerator(address)` |
+| `addModerator` / `removeModerator` | `DisputeModule` | `addModerator` / `removeModerator` |
 | `setPremiumReputationThreshold` | `ReputationEngine` | `setThreshold` |
 | `setMaxJobPayout` | `JobRegistry` | `setMaxJobReward` |
 | `setJobDurationLimit` | `JobRegistry` | `setJobDurationLimit` |

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -43,6 +43,17 @@ describe("DisputeModule", function () {
         .to.be.revertedWithCustomError(dispute, "OwnableUnauthorizedAccount")
         .withArgs(other.address);
     });
+
+    it("allows owner to add and remove moderators", async () => {
+      await expect(dispute.connect(owner).addModerator(other.address))
+        .to.emit(dispute, "ModeratorUpdated")
+        .withArgs(other.address, true);
+      expect(await dispute.moderators(other.address)).to.equal(true);
+      await expect(dispute.connect(owner).removeModerator(other.address))
+        .to.emit(dispute, "ModeratorUpdated")
+        .withArgs(other.address, false);
+      expect(await dispute.moderators(other.address)).to.equal(false);
+    });
   });
 
   describe("dispute resolution", function () {

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -82,6 +82,8 @@ describe("ValidationModule access controls", function () {
       (l) => l.fragment && l.fragment.name === "ValidatorsSelected"
     ).args[1];
     const val = selected[0];
+    const signer =
+      val.toLowerCase() === v1.address.toLowerCase() ? v1 : v2;
 
     const Toggle = await ethers.getContractFactory(
       "ENSOwnershipVerifierToggle"
@@ -103,7 +105,7 @@ describe("ValidationModule access controls", function () {
       [1n, nonce, true, salt]
     );
     await expect(
-      validation.connect(v1).commitValidation(1, commit, "", [])
+      validation.connect(signer).commitValidation(1, commit, "", [])
     ).to.be.revertedWith("Not authorized validator");
 
     // allow commit then block reveal
@@ -112,7 +114,7 @@ describe("ValidationModule access controls", function () {
       .setAdditionalValidators([val], [true]);
     await toggle.setResult(true);
     await (
-      await validation.connect(v1).commitValidation(1, commit, "", [])
+      await validation.connect(signer).commitValidation(1, commit, "", [])
     ).wait();
     await advance(61);
     await validation
@@ -120,7 +122,7 @@ describe("ValidationModule access controls", function () {
       .setAdditionalValidators([val], [false]);
     await toggle.setResult(false);
     await expect(
-      validation.connect(v1).revealValidation(1, true, salt, "", [])
+      validation.connect(signer).revealValidation(1, true, salt, "", [])
     ).to.be.revertedWith("Not authorized validator");
   });
 
@@ -131,6 +133,8 @@ describe("ValidationModule access controls", function () {
       (l) => l.fragment && l.fragment.name === "ValidatorsSelected"
     ).args[1];
     const val = selected[0];
+    const signer =
+      val.toLowerCase() === v1.address.toLowerCase() ? v1 : v2;
 
     const salt = ethers.keccak256(ethers.toUtf8Bytes("salt"));
     const nonce = await validation.jobNonce(1);
@@ -140,17 +144,17 @@ describe("ValidationModule access controls", function () {
     );
     await reputation.setBlacklist(val, true);
     await expect(
-      validation.connect(v1).commitValidation(1, commit, "", [])
+      validation.connect(signer).commitValidation(1, commit, "", [])
     ).to.be.revertedWith("Blacklisted validator");
 
     await reputation.setBlacklist(val, false);
     await (
-      await validation.connect(v1).commitValidation(1, commit, "", [])
+      await validation.connect(signer).commitValidation(1, commit, "", [])
     ).wait();
     await advance(61);
     await reputation.setBlacklist(val, true);
     await expect(
-      validation.connect(v1).revealValidation(1, true, salt, "", [])
+      validation.connect(signer).revealValidation(1, true, salt, "", [])
     ).to.be.revertedWith("Blacklisted validator");
   });
 


### PR DESCRIPTION
## Summary
- expose addModerator/removeModerator controls in dispute module
- document moderator management in interface and docs
- test moderator lifecycle via new unit test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68a4da122fd0833385ccbb478b488e08