### PR TITLE
feat: add price unit enforcement and allowance check in JobNFT

### DIFF
--- a/contracts/JobNFT.sol
+++ b/contracts/JobNFT.sol
@@ -34,6 +34,9 @@ contract JobNFT is ERC721, Ownable {
 
     mapping(uint256 => Listing) public listings;
 
+    /// @notice Price granularity enforcing 6-decimal units for $AGIALPHA.
+    uint256 private constant PRICE_UNIT = 1e6;
+
     // ---------------------------------------------------------------------
     // Events
     // ---------------------------------------------------------------------
@@ -116,6 +119,7 @@ contract JobNFT is ERC721, Ownable {
     function list(uint256 tokenId, uint256 price) external {
         require(ownerOf(tokenId) == msg.sender, "owner");
         require(price > 0, "price");
+        require(price % PRICE_UNIT == 0, "decimals");
         Listing storage listing = listings[tokenId];
         require(!listing.active, "listed");
 
@@ -133,6 +137,8 @@ contract JobNFT is ERC721, Ownable {
         address seller = listing.seller;
         require(seller != msg.sender, "self");
         uint256 price = listing.price;
+
+        require(agiAlpha.allowance(msg.sender, address(this)) >= price, "allowance");
 
         delete listings[tokenId];
 

--- a/test/JobNFT.test.js
+++ b/test/JobNFT.test.js
@@ -74,9 +74,8 @@ describe("JobNFT", function () {
       .to.emit(nft, "NFTListed")
       .withArgs(1, seller.address, price);
 
-    await expect(nft.connect(buyer).purchase(1)).to.be.revertedWithCustomError(
-      token,
-      "ERC20InsufficientAllowance"
+    await expect(nft.connect(buyer).purchase(1)).to.be.revertedWith(
+      "allowance"
     );
 
     await token.connect(buyer).approve(await nft.getAddress(), price);
@@ -107,6 +106,9 @@ describe("JobNFT", function () {
 
     await expect(nft.connect(buyer).list(1, price)).to.be.revertedWith("owner");
     await expect(nft.connect(seller).list(1, 0)).to.be.revertedWith("price");
+    await expect(nft.connect(seller).list(1, price - 1n)).to.be.revertedWith(
+      "decimals"
+    );
 
     await expect(nft.connect(buyer).purchase(1)).to.be.revertedWith("not listed");
 


### PR DESCRIPTION
## Summary
- enforce 6-decimal price units for JobNFT listings
- require prior AGIALPHA approval before purchasing
- test coverage for listing decimals and approval requirement

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a529dee3848333bd602ba611e6d398