### PR TITLE
Restrict dispute resolution to moderators

### DIFF
--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -76,12 +76,11 @@ contract DisputeModule is Ownable {
         emit ModeratorUpdated(initialModerator, true);
     }
 
-    /// @notice Modifier restricting calls to the owner or moderator.
-    modifier onlyArbiter() {
-        require(
-            msg.sender == owner() || moderators[msg.sender],
-            "not authorized"
-        );
+    /// @notice Restrict calls to approved moderators.
+    /// @dev The owner can grant or revoke moderator status via
+    ///      {addModerator} and {removeModerator}.
+    modifier onlyModerator() {
+        require(moderators[msg.sender], "not authorized");
         _;
     }
 
@@ -173,7 +172,7 @@ contract DisputeModule is Ownable {
     /// @param employerWins True if the employer prevails.
     function resolveDispute(uint256 jobId, bool employerWins)
         external
-        onlyArbiter
+        onlyModerator
     {
         Dispute storage d = disputes[jobId];
         require(d.raisedAt != 0 && !d.resolved, "no dispute");


### PR DESCRIPTION
## Summary
- limit dispute resolution to addresses explicitly marked as moderators
- allow owner to manage moderator list and set dispute fee/window
- route dispute fees and outcomes through JobRegistry and StakeManager

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5e849cd8c8333b9fc7e7dd0cff572