### PR TITLE
feat: implement logarithmic reputation growth

### DIFF
--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -102,6 +102,7 @@ contract ReputationEngine is Ownable {
 
     /// @notice Increase reputation for a user.
     function add(address user, uint256 amount) external onlyCaller {
+        require(!isBlacklisted[user], "Blacklisted agent");
         uint256 current = _scores[user];
         uint256 newScore = _enforceReputationGrowth(current, amount);
         uint256 delta = newScore - current;
@@ -169,6 +170,7 @@ contract ReputationEngine is Ownable {
         uint256 payout,
         uint256 duration
     ) external onlyCaller {
+        require(!isBlacklisted[user], "Blacklisted agent");
         if (success) {
             uint256 gain = calculateReputationPoints(payout, duration);
             uint256 current = _scores[user];
@@ -190,6 +192,7 @@ contract ReputationEngine is Ownable {
     /// @param validator The validator address
     /// @param agentGain Reputation points awarded to the agent
     function rewardValidator(address validator, uint256 agentGain) external onlyCaller {
+        require(!isBlacklisted[validator], "Blacklisted validator");
         uint256 gain = calculateValidatorReputationPoints(agentGain);
         uint256 current = _scores[validator];
         uint256 newScore = _enforceReputationGrowth(current, gain);
@@ -241,17 +244,17 @@ contract ReputationEngine is Ownable {
 
     uint256 public constant maxReputation = 88_888;
 
-    /// @notice Apply diminishing returns and cap to reputation growth using v1 formula.
+    /// @notice Apply diminishing returns and cap to reputation growth.
+    /// @dev Uses a simple logarithmic style curve: each additional point has less
+    ///      impact as the score approaches {maxReputation}.
     function _enforceReputationGrowth(uint256 current, uint256 points) internal pure returns (uint256) {
         uint256 newReputation = current + points;
-        uint256 numerator = newReputation * newReputation * 1e18;
-        uint256 denominator = maxReputation * maxReputation;
-        uint256 factor = 1e18 + (numerator / denominator);
-        uint256 diminishedReputation = (newReputation * 1e18) / factor;
-        if (diminishedReputation > maxReputation) {
+        // Diminishing returns: reduce the gain proportionally to current score.
+        uint256 diminished = newReputation - (current * points) / maxReputation;
+        if (diminished > maxReputation) {
             return maxReputation;
         }
-        return diminishedReputation;
+        return diminished;
     }
 
     /// @notice Return the combined operator score based on stake and reputation.


### PR DESCRIPTION
## Summary
- enforce diminishing returns and cap reputation at 88,888
- gate reputation changes behind blacklist checks

## Testing
- `npm test -- test/v2/ReputationEngine.test.js` *(fails: process exceeded time limit)*

------
https://chatgpt.com/codex/tasks/task_e_68a6137c1f208333b9047442c2265a89