### PR TITLE
Integrate IdentityRegistry for agent authorization

### DIFF
--- a/contracts/v2/interfaces/IIdentityRegistry.sol
+++ b/contracts/v2/interfaces/IIdentityRegistry.sol
@@ -2,10 +2,28 @@
 pragma solidity ^0.8.25;
 
 interface IIdentityRegistry {
+    function isAuthorizedAgent(
+        address claimant,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external view returns (bool);
+
     function isAuthorizedValidator(
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
     ) external view returns (bool);
+
+    function verifyAgent(
+        address claimant,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external returns (bool);
+
+    function verifyValidator(
+        address claimant,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external returns (bool);
 }
 


### PR DESCRIPTION
## Summary
- Expand `IIdentityRegistry` interface to cover agent checks and verification helpers
- Wire `JobRegistry` to an optional `IdentityRegistry` for agent ENS verification
- Document IdentityRegistry deployment and configuration in README

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a65d680dac83339035dbef5adb7068