### PR TITLE
Integrate IdentityLib agent verification and stake locking

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -29,6 +29,7 @@ contract MockStakeManager is IStakeManager {
     function depositStakeFor(address, Role, uint256) external override {}
     function acknowledgeAndWithdraw(Role, uint256) external override {}
     function withdrawStake(Role, uint256) external override {}
+    function lockStake(address, uint256, uint64) external override {}
     function lockJobFunds(bytes32, address, uint256) external override {}
     function lock(address, uint256) external override {}
     function releaseJobFunds(bytes32, address, uint256) external override {}

--- a/contracts/v2/interfaces/IIdentityLib.sol
+++ b/contracts/v2/interfaces/IIdentityLib.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IIdentityLib {
+    function verifyAgent(
+        address claimant,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external returns (bool);
+}
+

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -57,6 +57,12 @@ interface IStakeManager {
     /// @notice acknowledge the tax policy and withdraw stake in one call
     function acknowledgeAndWithdraw(Role role, uint256 amount) external;
 
+    /// @notice lock a portion of a user's stake for a period of time
+    /// @param user address whose stake is being locked
+    /// @param amount token amount with 6 decimals
+    /// @param lockTime seconds until the stake unlocks
+    function lockStake(address user, uint256 amount, uint64 lockTime) external;
+
     /// @notice lock job funds from an employer
     function lockJobFunds(bytes32 jobId, address from, uint256 amount) external;
 


### PR DESCRIPTION
## Summary
- use IdentityLib for agent verification when applying for a job
- lock agent stake and record assignment time on job application
- expose lockStake in IStakeManager interface

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6780c838c8333987a534803fe091b