### PR TITLE
Start validation on job submission

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -272,11 +272,12 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         Job storage job = _jobs[jobId];
         require(job.status == Status.Applied, "state");
         require(msg.sender == job.agent, "agent");
+        require(block.timestamp <= deadlines[jobId], "deadline");
         job.result = result;
         job.status = Status.Submitted;
-        emit JobSubmitted(jobId, result);
+        emit JobSubmitted(jobId, msg.sender, result);
         if (address(validationModule) != address(0)) {
-            validationModule.selectValidators(jobId);
+            validationModule.startValidation(jobId, result);
         }
     }
 

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -430,7 +430,7 @@ contract ValidationModule is IValidationModule, Ownable {
     }
 
     /// @inheritdoc IValidationModule
-    function selectValidators(uint256 jobId) external override returns (address[] memory selected) {
+    function selectValidators(uint256 jobId) public override returns (address[] memory selected) {
         Round storage r = rounds[jobId];
         require(r.validators.length == 0, "already selected");
         jobNonce[jobId] += 1;
@@ -503,6 +503,15 @@ contract ValidationModule is IValidationModule, Ownable {
 
         emit ValidatorsSelected(jobId, selected);
         return selected;
+    }
+
+    /// @inheritdoc IValidationModule
+    function startValidation(uint256 jobId, string calldata /*result*/)
+        external
+        override
+        returns (address[] memory validators)
+    {
+        validators = selectValidators(jobId);
     }
 
     /// @notice Commit a validation hash for a job.

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -65,7 +65,7 @@ interface IJobRegistry {
         uint256 fee
     );
     event JobApplied(uint256 indexed jobId, address indexed agent);
-    event JobSubmitted(uint256 indexed jobId, string result);
+    event JobSubmitted(uint256 indexed jobId, address indexed worker, string result);
     event JobCompleted(uint256 indexed jobId, bool success);
     event JobFinalized(uint256 indexed jobId, bool success);
     event JobDisputed(uint256 indexed jobId, address indexed caller);

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -21,6 +21,14 @@ interface IValidationModule {
     /// @return Array of selected validator addresses
     function selectValidators(uint256 jobId) external returns (address[] memory);
 
+    /// @notice Start validation by selecting validators for a job
+    /// @param jobId Identifier of the job
+    /// @param result Submitted job result to be validated
+    /// @return validators Array of selected validator addresses
+    function startValidation(uint256 jobId, string calldata result)
+        external
+        returns (address[] memory validators);
+
     /// @notice Commit a validation hash for a job
     /// @param jobId Identifier of the job being voted on
     /// @param commitHash Hash of the vote and salt

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -17,8 +17,16 @@ contract ValidationStub is IValidationModule {
         result = _result;
     }
 
-    function selectValidators(uint256) external pure override returns (address[] memory) {
+    function selectValidators(uint256) public pure override returns (address[] memory) {
         return new address[](0);
+    }
+
+    function startValidation(uint256 jobId, string calldata)
+        external
+        override
+        returns (address[] memory validators)
+    {
+        validators = selectValidators(jobId);
     }
 
     function commitValidation(

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -139,7 +139,7 @@ describe("JobRegistry integration", function () {
     await validation.connect(owner).setResult(true);
     await expect(registry.connect(agent).submit(jobId, "result", "", []))
       .to.emit(registry, "JobSubmitted")
-      .withArgs(jobId, "result");
+      .withArgs(jobId, agent.address, "result");
     await expect(validation.finalize(jobId))
       .to.emit(registry, "JobCompleted")
       .withArgs(jobId, true)


### PR DESCRIPTION
## Summary
- track submitting worker in `JobSubmitted`
- start validation committee selection on job result submission
- enforce submission deadline

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68a67bf59bbc8333871c4b6c5397c3d4