### PR TITLE
Refine job finalization payouts and events

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -88,6 +88,10 @@ contract MockStakeManager is IStakeManager {
         return 100;
     }
 
+    function burnPct() external pure override returns (uint256) {
+        return 0;
+    }
+
     // legacy helper for tests
     function setTokenLegacy(address) external {}
 }
@@ -350,7 +354,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
             }
         }
         emit DisputeResolved(jobId, employerWins);
-        emit JobFinalized(jobId, job.success);
+        emit JobFinalized(jobId, job.agent);
     }
 
     function finalize(uint256 jobId) public override {
@@ -366,7 +370,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         if (address(certificateNFT) != address(0)) {
             certificateNFT.mint(job.agent, jobId, job.uri);
         }
-        emit JobFinalized(jobId, true);
+        emit JobFinalized(jobId, job.agent);
     }
 
     function acknowledgeAndFinalize(uint256 jobId) external override {

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -67,7 +67,10 @@ interface IJobRegistry {
     event JobApplied(uint256 indexed jobId, address indexed agent);
     event JobSubmitted(uint256 indexed jobId, address indexed worker, string result);
     event JobCompleted(uint256 indexed jobId, bool success);
-    event JobFinalized(uint256 indexed jobId, bool success);
+    /// @notice Emitted when a job is finalized
+    /// @param jobId Identifier of the job
+    /// @param worker Agent who performed the job
+    event JobFinalized(uint256 indexed jobId, address worker);
     event JobDisputed(uint256 indexed jobId, address indexed caller);
     event JobCancelled(uint256 indexed jobId);
     event DisputeResolved(uint256 indexed jobId, bool employerWins);

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -87,6 +87,9 @@ interface IStakeManager {
     /// @notice distribute validator rewards equally among selected validators
     function distributeValidatorRewards(bytes32 jobId, uint256 amount) external;
 
+    /// @notice Current burn percentage applied to rewards
+    function burnPct() external view returns (uint256);
+
     /// @notice set the dispute module authorized to manage dispute fees
     function setDisputeModule(address module) external;
 

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -110,5 +110,14 @@ interface IValidationModule {
     /// @param jobId Identifier of the job
     /// @return validators Array of validator addresses
     function validators(uint256 jobId) external view returns (address[] memory validators);
+
+    /// @notice Retrieve a validator's vote outcome for a job
+    /// @param jobId Identifier of the job
+    /// @param validator Address of the validator
+    /// @return approved True if the validator approved the job
+    function votes(
+        uint256 jobId,
+        address validator
+    ) external view returns (bool approved);
 }
 

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -63,6 +63,15 @@ contract ValidationStub is IValidationModule {
         vals = new address[](0);
     }
 
+    function votes(uint256, address)
+        external
+        view
+        override
+        returns (bool approved)
+    {
+        approved = result;
+    }
+
     function setCommitRevealWindows(uint256, uint256) external override {}
 
     function setTiming(uint256, uint256) external override {}

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -144,7 +144,7 @@ describe("JobRegistry integration", function () {
       .to.emit(registry, "JobCompleted")
       .withArgs(jobId, true)
       .and.to.emit(registry, "JobFinalized")
-      .withArgs(jobId, true);
+      .withArgs(jobId, agent.address);
 
     expect(await token.balanceOf(agent.address)).to.equal(900);
     expect(await rep.reputation(agent.address)).to.equal(0);

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -154,7 +154,7 @@ describe("job finalization integration", function () {
       .to.emit(registry, "JobCompleted")
       .withArgs(jobId, true)
       .and.to.emit(registry, "JobFinalized")
-      .withArgs(jobId, true);
+      .withArgs(jobId, agent.address);
     const agentAfter = await token.balanceOf(agent.address);
     const employerAfter = await token.balanceOf(employer.address);
     expect(agentAfter - agentBefore).to.equal(reward);
@@ -187,7 +187,7 @@ describe("job finalization integration", function () {
       registry.connect(disputeSigner).resolveDispute(jobId, true)
     )
       .to.emit(registry, "JobFinalized")
-      .withArgs(jobId, false);
+      .withArgs(jobId, agent.address);
     await network.provider.request({
       method: "hardhat_stopImpersonatingAccount",
       params: [dispute.target],
@@ -220,7 +220,7 @@ describe("job finalization integration", function () {
       registry.connect(disputeSigner).resolveDispute(jobId, false)
     )
       .to.emit(registry, "JobFinalized")
-      .withArgs(jobId, true);
+      .withArgs(jobId, agent.address);
     await network.provider.request({
       method: "hardhat_stopImpersonatingAccount",
       params: [dispute.target],


### PR DESCRIPTION
## Summary
- emit JobFinalized with worker address rather than boolean
- finalize successful jobs by rewarding honest validators and computing agent reputation with completion time
- expose validator vote lookup and burn percentage in interfaces and mocks

## Testing
- `npm test test/v2/JobRegistry.test.js test/v2/jobFinalization.integration.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a68343eb2483338ef2fb096aac73b4