### PR TITLE
feat: add moderator dispute resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ await feePool.setToken("0xNewToken");
 **Moderators**
 1. Watch for `JobDisputed` events on `JobRegistry`.
 2. Review evidence off-chain.
-3. In `DisputeModule` → **Write**, call `resolveDispute(jobId, employerWins)`.
+3. In `DisputeModule` → **Write**, call `resolve(jobId, employerWins)`.
 4. Confirm `DisputeResolved` in the transaction log.
 
 #### End-to-End Etherscan Flow
@@ -940,7 +940,7 @@ Interact with the deployment directly from a block explorer using the **Write** 
 
 ### Dispute
 1. If the outcome is contested, call `DisputeModule.raiseDispute(jobId, reason)`.
-2. Moderators resolve via `DisputeModule.resolveDispute(jobId, upheld)`; results flow back to `JobRegistry` for payout.
+2. Moderators resolve via `DisputeModule.resolve(jobId, upheld)`; results flow back to `JobRegistry` for payout.
 
 No custom tooling is required—everything happens in the browser.
 
@@ -1399,7 +1399,7 @@ Interact with the contracts using a wallet or block explorer. Always verify cont
  - Disputes still resolve even if your stake drops below the required threshold; jobs finalize but no additional slashing occurs when funds are insufficient.
 
 **Penalties**
-- Missing a deadline or having a moderator side with the employer via `resolveDispute` can lower your reputation and slash staked AGI if the job is cancelled with `cancelExpiredJob`.
+- Missing a deadline or having a moderator side with the employer via `resolve` can lower your reputation and slash staked AGI if the job is cancelled with `cancelExpiredJob`.
 - After the configured number of penalties, `blacklistedAgents[agent]` becomes `true` and you must appeal to the owner to run `clearAgentBlacklist` before applying again. By default, the threshold is three.
 
 **Validators**

--- a/contracts/mocks/DisputeRegistryStub.sol
+++ b/contracts/mocks/DisputeRegistryStub.sol
@@ -2,11 +2,7 @@
 pragma solidity ^0.8.23;
 
 interface IDisputeModule {
-    function raiseDispute(
-        uint256 jobId,
-        address claimant,
-        string calldata evidence
-    ) external;
+    function raiseDispute(uint256 jobId, address claimant) external;
 }
 
 /// @notice Simple job registry stub to interact with DisputeModule in tests
@@ -36,6 +32,6 @@ contract DisputeRegistryStub {
     function finalize(uint256) external {}
 
     function appeal(address module, uint256 jobId) external payable {
-        IDisputeModule(module).raiseDispute(jobId, msg.sender, "");
+        IDisputeModule(module).raiseDispute(jobId, msg.sender);
     }
 }

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -314,7 +314,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         Job storage job = _jobs[jobId];
         job.status = Status.Disputed;
         if (address(disputeModule) != address(0)) {
-            disputeModule.raiseDispute(jobId, msg.sender, evidence);
+            disputeModule.raiseDispute(jobId, msg.sender);
         }
         emit JobDisputed(jobId, msg.sender);
     }

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -28,12 +28,8 @@ interface IReputationEngine {
 }
 
 interface IDisputeModule {
-    function raiseDispute(
-        uint256 jobId,
-        address claimant,
-        string calldata evidence
-    ) external;
-    function resolveDispute(uint256 jobId, bool employerWins) external;
+    function raiseDispute(uint256 jobId, address claimant) external;
+    function resolve(uint256 jobId, bool employerWins) external;
 }
 
 interface ICertificateNFT {
@@ -858,7 +854,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
             );
         }
         if (address(disputeModule) != address(0)) {
-            disputeModule.raiseDispute(jobId, msg.sender, evidence);
+            disputeModule.raiseDispute(jobId, msg.sender);
         }
         emit JobDisputed(jobId, msg.sender);
     }

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -2,24 +2,20 @@
 pragma solidity ^0.8.25;
 
 /// @title IDisputeModule
-/// @notice Interface for raising and resolving disputes with evidence
+/// @notice Interface for raising and resolving disputes
 interface IDisputeModule {
-    event DisputeRaised(
+    event DisputeRaised(uint256 indexed jobId, address indexed claimant);
+    event DisputeResolved(
         uint256 indexed jobId,
-        address indexed claimant,
-        string evidence
+        address indexed resolver,
+        bool employerWins
     );
-    event DisputeResolved(uint256 indexed jobId, bool employerWins);
     event DisputeFeeUpdated(uint256 fee);
     event ModeratorUpdated(address moderator, bool enabled);
     event DisputeWindowUpdated(uint256 window);
 
-    function raiseDispute(
-        uint256 jobId,
-        address claimant,
-        string calldata evidence
-    ) external;
-    function resolveDispute(uint256 jobId, bool employerWins) external;
+    function raiseDispute(uint256 jobId, address claimant) external;
+    function resolve(uint256 jobId, bool employerWins) external;
     function setDisputeFee(uint256 fee) external;
     function setDisputeWindow(uint256 window) external;
     function addModerator(address moderator) external;

--- a/docs/agialpha-workflows.md
+++ b/docs/agialpha-workflows.md
@@ -18,7 +18,7 @@ This guide summarises Etherscan-based interactions for the $AGIALPHA-powered AGI
 ## 4. Raise a Dispute (Anyone)
 1. **Approve fee** – approve the dispute fee for `StakeManager` (e.g., `10_000000` for 10 tokens).
 2. **Raise** – on [`DisputeModule` Write](https://etherscan.io/address/<DisputeModuleAddress>#writeContract) call `raiseDispute(jobId, evidence)` before the window ends.
-3. **Resolve** – after the window an authorised arbiter calls `resolveDispute(jobId)`.
+3. **Resolve** – after the window an authorised arbiter calls `resolve(jobId)`.
 
 ## 5. Trade a Certificate (Peer to Peer)
 1. **List** – certificate owner calls `list(tokenId, price)` on [`CertificateNFT` Write](https://etherscan.io/address/<CertificateNFTAddress>#writeContract)` using 6‑decimal pricing.

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -21,7 +21,7 @@ For a narrated deployment walkthrough, see [deployment-agialpha.md](deployment-a
 | Employer | `$AGIALPHA.approve(StakeManager, 1_050000)` → `JobRegistry.acknowledgeTaxPolicy()` → `JobRegistry.createJob(1_000000, uri)` | approve `1_050000` for a 1‑token reward + 5% fee |
 | Agent | `$AGIALPHA.approve(StakeManager, 1_000000)` → `JobRegistry.stakeAndApply(jobId, 1_000000)` | stake `1_000000` |
 | Validator | `$AGIALPHA.approve(StakeManager, 1_000000)` → `StakeManager.depositStake(1, 1_000000)` → `ValidationModule.commitValidation(jobId, hash, sub, proof)` → `ValidationModule.revealValidation(jobId, approve, salt)` | stake `1_000000` |
-| Disputer | `$AGIALPHA.approve(StakeManager, 1_000000)` → `JobRegistry.acknowledgeAndDispute(jobId, evidence)` → owner `DisputeModule.resolveDispute(jobId, uphold)` | dispute fee `1_000000` |
+| Disputer | `$AGIALPHA.approve(StakeManager, 1_000000)` → `JobRegistry.acknowledgeAndDispute(jobId, evidence)` → owner `DisputeModule.resolve(jobId, uphold)` | dispute fee `1_000000` |
 
 ## ENS prerequisites
 - Agents need an ENS subdomain ending in `.agent.agi.eth`; validators require `.club.agi.eth`.
@@ -169,7 +169,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 ### Raise & resolve disputes
 1. Approve the dispute fee on `$AGIALPHA`.
 2. On `JobRegistry` → **Write**, call **acknowledgeAndDispute(jobId, evidence)**.
-3. The owner finalizes by calling **resolveDispute(jobId, uphold)** on `DisputeModule`.
+3. The owner finalizes by calling **resolve(jobId, uphold)** on `DisputeModule`.
 
 ### List & purchase NFTs
 1. To list a certificate, open `CertificateNFT` → **Write** and call **approve(marketplace, tokenId)** or **setApprovalForAll(operator, true)**.
@@ -202,7 +202,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 | Function | Parameters | Typical Use Case |
 | --- | --- | --- |
 | `raiseDispute(uint256 jobId, string reason)` | jobId, reason URI | Participant appeals a validation outcome. |
-| `resolveDispute(uint256 jobId, bool uphold)` | jobId, `uphold` – sustain original result? | Moderator issues a final ruling. |
+| `resolve(uint256 jobId, bool uphold)` | jobId, `uphold` – sustain original result? | Moderator issues a final ruling. |
 | `setDisputeFee(uint256 fee)` | fee amount | Owner adjusts the dispute bond charged on disputes. |
 
 ## Parameter Glossary

--- a/docs/modular-architecture-v2.md
+++ b/docs/modular-architecture-v2.md
@@ -84,7 +84,7 @@ interface IReputationEngine {
 
 interface IDisputeModule {
     function raiseDispute(uint256 jobId, string calldata reason) external;
-    function resolveDispute(uint256 jobId, bool uphold) external;
+    function resolve(uint256 jobId, bool uphold) external;
     function setDisputeFee(uint256 fee) external;
 }
 

--- a/docs/v1-v2-function-map.md
+++ b/docs/v1-v2-function-map.md
@@ -12,7 +12,7 @@ The table below maps common public functions from the monolithic `AGIJobManagerV
 | `validateJob` | `ValidationModule` | `revealValidation(approve=true)` |
 | `disapproveJob` | `ValidationModule` | `revealValidation(approve=false)` |
 | `disputeJob` | `JobRegistry` | `raiseDispute` |
-| `resolveDispute` | `DisputeModule` | `resolveDispute` |
+| `resolveDispute` | `DisputeModule` | `resolve` |
 | `resolveStalledJob` | `JobRegistry` | `finalize` |
 | `cancelJob` / `cancelExpiredJob` | `JobRegistry` | `cancelJob` |
 | `stake` | `StakeManager` | `depositStake(role)` |

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -70,7 +70,7 @@ resolver, emitting `OwnershipVerified` on success.
 ### Dispute
 1. Approve the dispute fee on `$AGIALPHA`.
 2. Call `JobRegistry.raiseDispute(jobId, evidence)`.
-3. Owner resolves via `DisputeModule.resolveDispute(jobId, uphold)`.
+3. Owner resolves via `DisputeModule.resolve(jobId, uphold)`.
 4. Monitor `DisputeRaised` and `DisputeResolved` events.
 
 ### NFT Marketplace

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -69,7 +69,7 @@ interface IReputationEngine {
 
 interface IDisputeModule {
     function raiseDispute(uint256 jobId, string calldata reason) external;
-    function resolveDispute(uint256 jobId, bool uphold) external;
+    function resolve(uint256 jobId, bool uphold) external;
     function setDisputeFee(uint256 fee) external;
 }
 

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -162,7 +162,7 @@ describe("Full system integration", function () {
     await validation.setResult(false);
     await registry.connect(agent).completeJob(jobId);
     await registry.connect(agent).raiseDispute(jobId, "evidence");
-    await dispute.connect(owner).resolveDispute(jobId, false);
+    await dispute.connect(owner).resolve(jobId, false);
     await registry.connect(owner).finalize(jobId);
 
     expect(await token.balanceOf(agent.address)).to.equal(900n);
@@ -175,7 +175,7 @@ describe("Full system integration", function () {
     await validation.setResult(false);
     await registry.connect(agent).completeJob(jobId);
     await registry.connect(agent).raiseDispute(jobId, "evidence");
-    await dispute.connect(owner).resolveDispute(jobId, true);
+    await dispute.connect(owner).resolve(jobId, true);
     await registry.connect(owner).finalize(jobId);
 
     expect(await token.balanceOf(agent.address)).to.equal(800n);

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -137,9 +137,9 @@ describe("DisputeModule", function () {
         await token.balanceOf(await stakeManager.getAddress())
       ).to.equal(fee);
       await time.increase(1);
-      await expect(dispute.connect(owner).resolveDispute(1, true))
+      await expect(dispute.connect(owner).resolve(1, true))
         .to.emit(dispute, "DisputeResolved")
-        .withArgs(1, true);
+        .withArgs(1, owner.address, true);
       expect(await token.balanceOf(employer.address)).to.equal(
         employerStart + fee
       );
@@ -152,9 +152,9 @@ describe("DisputeModule", function () {
       const agentStart = await token.balanceOf(agent.address);
       await registry.connect(agent).dispute(1, "evidence");
       await time.increase(1);
-      await expect(dispute.connect(owner).resolveDispute(1, false))
+      await expect(dispute.connect(owner).resolve(1, false))
         .to.emit(dispute, "DisputeResolved")
-        .withArgs(1, false);
+        .withArgs(1, owner.address, false);
       expect(await token.balanceOf(agent.address)).to.equal(agentStart);
       expect(
         await token.balanceOf(await stakeManager.getAddress())
@@ -165,7 +165,7 @@ describe("DisputeModule", function () {
       await registry.connect(agent).dispute(1, "evidence");
       await time.increase(1);
       await expect(
-        dispute.connect(outsider).resolveDispute(1, true)
+        dispute.connect(outsider).resolve(1, true)
       ).to.be.revertedWith("not authorized");
     });
   });

--- a/test/v2/ProtocolFeatures.test.js
+++ b/test/v2/ProtocolFeatures.test.js
@@ -150,9 +150,9 @@ describe("Protocol core features", function () {
     expect(disputeInfo.fee).to.equal(5);
     const block = await ethers.provider.getBlock(rcpt.blockNumber);
     const expected = (BigInt(block.hash) ^ BigInt(jobId)) % 2n === 0n;
-    await expect(dispute.connect(owner).resolveDispute(jobId, expected))
+    await expect(dispute.connect(owner).resolve(jobId, expected))
       .to.emit(dispute, "DisputeResolved")
-      .withArgs(jobId, expected);
+      .withArgs(jobId, owner.address, expected);
     const cleared = await dispute.disputes(jobId);
     expect(cleared.raisedAt).to.equal(0);
   });


### PR DESCRIPTION
## Summary
- allow moderators to manage DisputeModule
- support resolving disputes with resolver address and job slashing
- update docs and tests for new resolve/raiseDispute flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6886fd2708333a08d4e3739bd3498