### PR TITLE
feat: expose agent payout pct

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -84,7 +84,7 @@ contract MockStakeManager is IStakeManager {
         return totalStakes[role];
     }
 
-    function getHighestPayoutPercentage(address) external pure override returns (uint256) {
+    function getAgentPayoutPct(address) external pure override returns (uint256) {
         return 100;
     }
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -989,9 +989,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
             if (address(reputationEngine) != address(0)) {
                 uint256 agentPct = 100;
                 if (address(stakeManager) != address(0)) {
-                    agentPct = stakeManager.getHighestPayoutPercentage(
-                        job.agent
-                    );
+                    agentPct = stakeManager.getAgentPayoutPct(job.agent);
                 }
                 uint256 agentModified =
                     (rewardAfterValidator * agentPct) / 100;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -380,11 +380,11 @@ contract StakeManager is Ownable, ReentrancyGuard {
         types = agiTypes;
     }
 
-    /// @notice Determine the highest payout percentage for an agent
+    /// @notice Determine the payout percentage for an agent based on AGI type NFTs
     /// @dev Iterates through registered AGI types and selects the highest payout
     ///      percentage from NFTs held by the agent. Reverts from malicious NFT
     ///      contracts are ignored.
-    function getHighestPayoutPercentage(address agent) public view returns (uint256) {
+    function getAgentPayoutPct(address agent) public view returns (uint256) {
         uint256 highest = 100;
         uint256 length = agiTypes.length;
         for (uint256 i; i < length; ++i) {
@@ -672,7 +672,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
         external
         onlyJobRegistry
     {
-        uint256 pct = getHighestPayoutPercentage(to);
+        uint256 pct = getAgentPayoutPct(to);
         uint256 payout = (amount * pct) / 100;
         uint256 escrow = jobEscrows[jobId];
         require(escrow >= payout, "escrow");
@@ -688,7 +688,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
     /// @param amount Base token amount with 6 decimals before AGI bonus.
     function release(address to, uint256 amount) external onlyJobRegistry {
         // apply AGI type payout modifier
-        uint256 pct = getHighestPayoutPercentage(to);
+        uint256 pct = getAgentPayoutPct(to);
         uint256 modified = (amount * pct) / 100;
 
         // apply protocol fees and burn on the modified amount
@@ -725,7 +725,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
         uint256 fee,
         IFeePool _feePool
     ) external onlyJobRegistry {
-        uint256 pct = getHighestPayoutPercentage(agent);
+        uint256 pct = getAgentPayoutPct(agent);
         uint256 modified = (reward * pct) / 100;
         uint256 burnAmount = (modified * burnPct) / 100;
         uint256 payout = modified - burnAmount;

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -135,7 +135,7 @@ interface IStakeManager {
     /// @notice address of the JobRegistry authorized to deposit fees
     function jobRegistry() external view returns (address);
 
-    /// @notice Highest payout percentage for an agent based on AGI type NFTs
-    function getHighestPayoutPercentage(address agent) external view returns (uint256);
+    /// @notice Payout percentage for an agent based on AGI type NFTs
+    function getAgentPayoutPct(address agent) external view returns (uint256);
 }
 


### PR DESCRIPTION
## Summary
- provide `getAgentPayoutPct` in StakeManager for AGI type bonus lookup
- call new payout helper from JobRegistry
- expose new function through interfaces and mocks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a68c3b5bb883338cb9e42d6d9f2385