### PR TITLE
feat: add caller alias for reputation engine

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -427,6 +427,8 @@ contract MockReputationEngine is IReputationEngine {
         return _rep[user] >= threshold;
     }
 
+    function setCaller(address, bool) external override {}
+
     function setAuthorizedCaller(address, bool) external override {}
 
     function setThreshold(uint256 t) external override {

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -45,9 +45,14 @@ contract ReputationEngine is Ownable {
     // ---------------------------------------------------------------------
 
     /// @notice Authorize or revoke a caller.
-    function setAuthorizedCaller(address caller, bool allowed) external onlyOwner {
+    function setCaller(address caller, bool allowed) public onlyOwner {
         callers[caller] = allowed;
         emit CallerUpdated(caller, allowed);
+    }
+
+    /// @notice Backwards compatible alias for {setCaller}.
+    function setAuthorizedCaller(address caller, bool allowed) external onlyOwner {
+        setCaller(caller, allowed);
     }
 
     /// @notice Set the StakeManager used for stake lookups.

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -55,6 +55,9 @@ interface IReputationEngine {
     /// @notice Allow or disallow a caller to update reputation
     /// @param caller Address of the caller to configure
     /// @param allowed True to authorise the caller, false to revoke
+    function setCaller(address caller, bool allowed) external;
+
+    /// @notice Backwards compatible alias for {setCaller}
     function setAuthorizedCaller(address caller, bool allowed) external;
 
     /// @notice Set the minimum score threshold for certain actions

--- a/test/v2/ReputationEngine.test.js
+++ b/test/v2/ReputationEngine.test.js
@@ -10,9 +10,7 @@ describe("ReputationEngine", function () {
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
     engine = await Engine.deploy(ethers.ZeroAddress);
-    await engine
-      .connect(owner)
-      .setAuthorizedCaller(caller.address, true);
+    await engine.connect(owner).setCaller(caller.address, true);
     await engine
       .connect(owner)
       .setPremiumReputationThreshold(2);


### PR DESCRIPTION
## Summary
- expose `setCaller` in v2 ReputationEngine with backwards-compatible alias
- update IReputationEngine interface, mock, and tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a68f8ac1188333a87c06e03602a7b6