### PR TITLE
feat: add owner controls and module wiring

### DIFF
--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -116,6 +116,11 @@ contract StakeManager is Ownable, ReentrancyGuard, Pausable {
         emit BlacklistUpdated(user, status);
     }
 
+    /// @notice Recover ERC20 tokens sent to this contract by mistake.
+    function withdrawEmergency(address token, uint256 amount) external onlyOwner {
+        IERC20(token).safeTransfer(owner(), amount);
+    }
+
     // ------------------------------------------------------------------
     // Staking logic
     // ------------------------------------------------------------------

--- a/test/jobRegistryOwnership.test.js
+++ b/test/jobRegistryOwnership.test.js
@@ -22,7 +22,6 @@ describe("JobRegistry ownership", function () {
           user.address,
           user.address,
           user.address,
-          user.address,
           user.address
         )
     )


### PR DESCRIPTION
## Summary
- add pausable support and emergency token recovery to key modules
- expose v1-style parameter setters and Commit/Reveal window helper
- wire core modules in JobRegistry.setModules and cap job rewards

## Testing
- `npx hardhat test test/jobRegistryOwnership.test.js` *(fails: process did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68a6954475848333b322904b8dc75352