### PR TITLE
Finalize validator rewards and enforce fee caps

### DIFF
--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -8,6 +8,7 @@ import {IJobRegistry} from "../interfaces/IJobRegistry.sol";
 contract ValidationStub is IValidationModule {
     bool public result;
     address public jobRegistry;
+    address[] public validatorList;
 
     function setJobRegistry(address registry) external {
         jobRegistry = registry;
@@ -17,8 +18,12 @@ contract ValidationStub is IValidationModule {
         result = _result;
     }
 
-    function selectValidators(uint256) public pure override returns (address[] memory) {
-        return new address[](0);
+    function setValidators(address[] calldata vals) external {
+        validatorList = vals;
+    }
+
+    function selectValidators(uint256) public view override returns (address[] memory) {
+        return validatorList;
     }
 
     function startValidation(uint256 jobId, string calldata)
@@ -59,8 +64,8 @@ contract ValidationStub is IValidationModule {
         return this.finalize(jobId);
     }
 
-    function validators(uint256) external pure override returns (address[] memory vals) {
-        vals = new address[](0);
+    function validators(uint256) external view override returns (address[] memory vals) {
+        vals = validatorList;
     }
 
     function votes(uint256, address)

--- a/docs/job-lifecycle-audit.md
+++ b/docs/job-lifecycle-audit.md
@@ -1,0 +1,15 @@
+# Job Lifecycle Audit
+
+This document cross-checks key `JobRegistry` entry points with the v1 `AGIJobManager` function map to ensure parity in parameters, state transitions, and emitted events.
+
+| v1 function | v2 function | Parameters match | Status change | Event emitted |
+|-------------|-------------|------------------|---------------|---------------|
+| `createJob` | `createJob` | `reward`, `deadline`, `uri` retained. | `None -> Created` | `JobCreated` |
+| `applyForJob` | `applyForJob` | `jobId`, ENS `subdomain`, `proof`. | `Created -> Applied` | `JobApplied` |
+| `requestJobCompletion` | `submit` | `jobId`, `result`, ENS proof. | `Applied -> Submitted` | `JobSubmitted` |
+| `resolveStalledJob` / `finalizeJob` | `finalize` | `jobId`. | `Completed -> Finalized` or refunds on failure. | `JobFinalized` |
+| `cancelJob` | `cancelJob` | `jobId`. | `Created -> Cancelled` | `JobCancelled` |
+| `disputeJob` | `raiseDispute`/`dispute` | `jobId`, `evidence`. | `Completed -> Disputed` | `JobDisputed` |
+| `resolveDispute` | `resolveDispute` | `jobId`, `employerWins`. | `Disputed -> Completed` before finalisation. | `DisputeResolved` |
+
+Each function preserves the semantics and logging behaviour of its v1 counterpart while integrating tax-policy acknowledgement and modular hooks in v2.

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -257,6 +257,17 @@ describe("JobRegistry integration", function () {
     ).to.be.revertedWithCustomError(dispute, "OwnableUnauthorizedAccount");
   });
 
+  it("validates fee percentage caps", async () => {
+    await registry.connect(owner).setValidatorRewardPct(60);
+    await expect(
+      registry.connect(owner).setFeePct(50)
+    ).to.be.revertedWith("pct");
+    await registry.connect(owner).setFeePct(40);
+    await expect(
+      registry.connect(owner).setValidatorRewardPct(70)
+    ).to.be.revertedWith("pct");
+  });
+
   it("emits events when setting modules", async () => {
     await expect(
       registry


### PR DESCRIPTION
## Summary
- enforce combined fee and validator reward percentages in JobRegistry
- streamline finalization by delegating validator rewards to StakeManager
- add audit summary of v1-v2 job lifecycle parity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a737e1662c833390e32077f3d50161