### PR TITLE
Restrict certificate minting and integrate StakeManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The contract owner can reconfigure live deployments without redeployment. Use a 
 
 #### CertificateNFT
 - `setBaseURI(string)`
-- `setMinter(address, bool)`
+- `setJobRegistry(address)`
 
 #### FeePool
 - `ownerWithdraw(address to, uint256 amount)`

--- a/test/JobNFT.test.js
+++ b/test/JobNFT.test.js
@@ -9,11 +9,16 @@ async function deployFixture() {
   );
   const initialSupply = ethers.parseUnits("1000", 6);
   const token = await AGI.deploy("AGI ALPHA", "AGIA", initialSupply);
+  const StakeManager = await ethers.getContractFactory("StakeManager");
+  const stakeManager = await StakeManager.deploy();
+  await stakeManager.waitForDeployment();
+  await stakeManager.setToken(await token.getAddress());
 
   const JobNFT = await ethers.getContractFactory("JobNFT");
-  const nft = await JobNFT.deploy(await token.getAddress());
+  const nft = await JobNFT.deploy();
   await nft.waitForDeployment();
   await nft.setJobRegistry(jobRegistry.address);
+  await nft.setStakeManager(await stakeManager.getAddress());
 
   // distribute tokens
   const price = ethers.parseUnits("1", 6);

--- a/test/JobNFT.test.js
+++ b/test/JobNFT.test.js
@@ -9,7 +9,9 @@ async function deployFixture() {
   );
   const initialSupply = ethers.parseUnits("1000", 6);
   const token = await AGI.deploy("AGI ALPHA", "AGIA", initialSupply);
-  const StakeManager = await ethers.getContractFactory("StakeManager");
+  const StakeManager = await ethers.getContractFactory(
+    "contracts/StakeManager.sol:StakeManager"
+  );
   const stakeManager = await StakeManager.deploy();
   await stakeManager.waitForDeployment();
   await stakeManager.setToken(await token.getAddress());

--- a/test/JobRegistryCertificate.test.js
+++ b/test/JobRegistryCertificate.test.js
@@ -41,7 +41,7 @@ async function deployFixture() {
   await registry.setCertificateNFT(await cert.getAddress());
   await registry.setJobParameters(1, 1);
 
-  await cert.setMinter(await registry.getAddress(), true);
+  await cert.setJobRegistry(await registry.getAddress());
   await cert.setBaseURI("ipfs://");
 
   return { owner, employer, agent, other, validation, reputation, stake, cert, registry };
@@ -76,6 +76,6 @@ describe("JobRegistry and CertificateNFT", function () {
     const { cert, agent } = await deployFixture();
     await expect(
       cert.connect(agent).mintCertificate(agent.address, 1, "foo")
-    ).to.be.revertedWith("not minter");
+    ).to.be.revertedWith("only JobRegistry");
   });
 });

--- a/test/jobFlow.test.js
+++ b/test/jobFlow.test.js
@@ -174,13 +174,26 @@ describe("AGI job flow", function () {
     await time.increase(6);
     await manager.connect(v1).validateJob(0, "", []);
 
+    const AGI = await ethers.getContractFactory(
+      "contracts/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    const initialSupply = ethers.parseUnits("1000", 6);
+    const saleToken = await AGI.deploy("AGI ALPHA", "AGIA", initialSupply);
+    const StakeManager = await ethers.getContractFactory("StakeManager");
+    const stakeManager = await StakeManager.deploy();
+    await stakeManager.setToken(await saleToken.getAddress());
     const JobNFT = await ethers.getContractFactory("JobNFT");
-    const nft = await JobNFT.deploy(await token.getAddress());
+    const nft = await JobNFT.deploy();
     await nft.setJobRegistry(owner.address);
+    await nft.setStakeManager(await stakeManager.getAddress());
     await nft.connect(owner).mint(agent.address, 1);
-    const price = ethers.parseEther("1");
+    const price = ethers.parseUnits("1", 6);
+    await saleToken.transfer(agent.address, price);
+    await saleToken.transfer(employer.address, price);
     await nft.connect(agent).list(1, price);
-    await token.connect(employer).approve(await nft.getAddress(), price);
+    await saleToken
+      .connect(employer)
+      .approve(await nft.getAddress(), price);
     await expect(nft.connect(employer).purchase(1))
       .to.emit(nft, "NFTPurchased")
       .withArgs(1, employer.address, price);

--- a/test/jobFlow.test.js
+++ b/test/jobFlow.test.js
@@ -179,7 +179,9 @@ describe("AGI job flow", function () {
     );
     const initialSupply = ethers.parseUnits("1000", 6);
     const saleToken = await AGI.deploy("AGI ALPHA", "AGIA", initialSupply);
-    const StakeManager = await ethers.getContractFactory("StakeManager");
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/StakeManager.sol:StakeManager"
+    );
     const stakeManager = await StakeManager.deploy();
     await stakeManager.setToken(await saleToken.getAddress());
     const JobNFT = await ethers.getContractFactory("JobNFT");

--- a/test/legacyNoEther.test.js
+++ b/test/legacyNoEther.test.js
@@ -24,12 +24,8 @@ describe("Legacy contract ether rejection", function () {
   });
 
   it("JobNFT", async () => {
-    const Token = await ethers.getContractFactory(
-      "contracts/AGIALPHAToken.sol:AGIALPHAToken"
-    );
-    const token = await Token.deploy("AGI ALPHA", "AGIA", 0);
     const Factory = await ethers.getContractFactory("JobNFT");
-    const nft = await Factory.deploy(await token.getAddress());
+    const nft = await Factory.deploy();
     await nft.waitForDeployment();
     await expectReject(nft);
   });


### PR DESCRIPTION
## Summary
- Restrict CertificateNFT minting to the JobRegistry and emit `CertificateMinted`
- Use StakeManager to handle $AGIALPHA transfers and add seller/price guardrails in JobNFT marketplace functions
- Update documentation and tests for new JobRegistry and StakeManager flows

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a75f7f3df48333a3ef50f2cc84e303