### PR TITLE
docs: add etherscan deployment walkthrough

### DIFF
--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -1,6 +1,21 @@
 # Etherscan Deployment Quickstart
 
+For screenshots and a deeper explanation see [etherscan-guide.md](etherscan-guide.md). All owner interactions occur through the explorer's **Write Contract** tabs.
+
 All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPHA = 1_000_000 units**). Convert values before entering them on Etherscan.
+
+## Quick Walkthrough
+
+### v0
+1. Open the [AGIJobManager v0](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code) contract and choose **Contract → Deploy**.
+2. Enter constructor args in 6‑decimal units: token address, base IPFS URL, ENS registry and NameWrapper, plus the namehashes and Merkle roots for `club.agi.eth` and `agent.agi.eth` (`0x00` for open access).
+3. Deploy; the sender becomes owner. Agents need subdomains under `agent.agi.eth` and validators under `club.agi.eth` or matching Merkle proofs.
+
+### v2
+1. Open the `Deployer` contract and under **Write Contract** call `deployDefaults(ids)` (or `deployDefaultsWithoutTaxPolicy`).
+2. Supply namehashes and optional Merkle roots for the required ENS subdomains. Token amounts still use 6‑decimal `$AGIALPHA` units.
+3. After modules deploy, wire them via `JobRegistry.setModules(...)` and register the identity registry with `JobRegistry.setIdentityRegistry` and `ValidationModule.setIdentityRegistry`.
+4. As with v0, agents require `.agent.agi.eth` subdomains and validators need `.club.agi.eth`.
 
 ## Deploying AGIJobsv0 with $AGIALPHA
 
@@ -85,6 +100,22 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 - `ValidationModule.setCommitRevealWindows(commitWindow, revealWindow)`
 - `FeePool.setBurnPct(pct)`
 - `DisputeModule.setDisputeFee(fee)`
+
+## Owner Action Checklist
+
+### v0
+- [ ] `updateAGITokenAddress(newToken)`
+- [ ] `setRootNodes(clubRootNode, agentRootNode)`
+- [ ] `setMerkleRoots(validatorRoot, agentRoot)`
+
+### v2
+- [ ] `StakeManager.setToken(newToken)` and `FeePool.setToken(newToken)`
+- [ ] `ENSOwnershipVerifier.setRootNodes(clubRootNode, agentRootNode)`
+- [ ] `IdentityRegistry.setMerkleRoots(validatorRoot, agentRoot)`
+- [ ] `JobRegistry.setModules(...)`
+- [ ] `JobRegistry.setIdentityRegistry(identityRegistry)` and `ValidationModule.setIdentityRegistry(identityRegistry)`
+
+All of the above owner calls are executed from the explorer's **Write Contract** tabs.
 
 ## Distribute Fees
 


### PR DESCRIPTION
## Summary
- add quick Etherscan walkthroughs for v0 and v2 deployments
- highlight owner-only actions in a checklist and link to etherscan-guide

## Testing
- `npm run lint`
- `npm test` *(fails: downloading compiler 0.8.21)*

------
https://chatgpt.com/codex/tasks/task_e_68a764c154e88333a6c8372962038720