### PR TITLE
Enforce job caps and policy acknowledgement in JobRegistry

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -172,6 +172,12 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         disputeModule = IDisputeModule(module);
     }
 
+    function setIdentityRegistry(address) external override {}
+
+    function setAgentRootNode(bytes32) external override {}
+
+    function setAgentMerkleRoot(bytes32) external override {}
+
     function setJobParameters(uint256, uint256 stake) external override {
         jobStake = stake;
     }

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -48,6 +48,9 @@ interface IJobRegistry {
     event StakeManagerUpdated(address manager);
     event CertificateNFTUpdated(address nft);
     event DisputeModuleUpdated(address module);
+    event IdentityRegistryUpdated(address identityRegistry);
+    event AgentRootNodeUpdated(bytes32 node);
+    event AgentMerkleRootUpdated(bytes32 root);
     event JobParametersUpdated(
         uint256 reward,
         uint256 stake,
@@ -96,6 +99,16 @@ interface IJobRegistry {
     /// @notice Set the dispute module contract handling appeals
     /// @param module Address of the dispute module contract
     function setDisputeModule(address module) external;
+
+    /// @notice Set the identity registry used for agent verification
+    /// @param registry Address of the identity registry contract
+    function setIdentityRegistry(address registry) external;
+
+    /// @notice Update the ENS root node used for agent verification
+    function setAgentRootNode(bytes32 node) external;
+
+    /// @notice Update the agent allowlist Merkle root
+    function setAgentMerkleRoot(bytes32 root) external;
 
     /// @notice Retrieve the StakeManager contract handling collateral
     /// @return Address of the StakeManager


### PR DESCRIPTION
## Summary
- add owner-settable agent root and merkle root hooks
- require tax policy acknowledgement in stakeAndApply
- allow owner or employer to cancel unassigned jobs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7730ece54833392b28e0a81aa781a