### PR TITLE
Deterministic validator committees with configurable parameters

### DIFF
--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -15,6 +15,13 @@ interface IValidationModule {
     );
     event ValidationResult(uint256 indexed jobId, bool success);
     event ValidatorSubdomainUpdated(address indexed validator, string subdomain);
+    event ParametersUpdated(
+        uint256 committeeSize,
+        uint256 commitWindow,
+        uint256 revealWindow,
+        uint256 approvalThreshold,
+        uint256 slashingPct
+    );
 
     /// @notice Select validators for a given job
     /// @param jobId Identifier of the job
@@ -68,6 +75,20 @@ interface IValidationModule {
 
     /// @notice Alias for finalize using legacy naming.
     function finalizeValidation(uint256 jobId) external returns (bool success);
+
+    /// @notice Batch update core validation parameters
+    /// @param committeeSize Number of validators selected per job
+    /// @param commitWindow Duration of commit phase in seconds
+    /// @param revealWindow Duration of reveal phase in seconds
+    /// @param approvalThreshold Percentage of stake required for approval
+    /// @param slashingPct Percentage of stake slashed for incorrect votes
+    function setParameters(
+        uint256 committeeSize,
+        uint256 commitWindow,
+        uint256 revealWindow,
+        uint256 approvalThreshold,
+        uint256 slashingPct
+    ) external;
 
     /// @notice Owner configuration for timing windows
     function setCommitRevealWindows(uint256 commitWindow, uint256 revealWindow) external;

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -56,7 +56,7 @@ contract ValidationStub is IValidationModule {
     function finalize(uint256 jobId) external override returns (bool success) {
         success = result;
         if (jobRegistry != address(0)) {
-            IJobRegistry(jobRegistry).finalizeAfterValidation(jobId, success);
+            IJobRegistry(jobRegistry).validationComplete(jobId, success);
         }
     }
 
@@ -90,6 +90,14 @@ contract ValidationStub is IValidationModule {
     function setValidatorSubdomains(
         address[] calldata,
         string[] calldata
+    ) external override {}
+
+    function setParameters(
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256
     ) external override {}
 
     function resetJobNonce(uint256) external override {}


### PR DESCRIPTION
## Summary
- deterministically select validators from staked addresses and store stake weights
- add owner-only `setParameters` for committee size, timing windows and slashing/approval thresholds
- auto-fail jobs when validators miss reveals and notify JobRegistry via `validationComplete`

## Testing
- `npx hardhat test test/v2/ValidationModule.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a77631456c8333afa41ffb19226d3a