### PR TITLE
feat: enforce identity verification

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -178,6 +178,12 @@ contract IdentityRegistry is Ownable {
         string calldata subdomain,
         bytes32[] calldata proof
     ) external returns (bool) {
+        if (
+            address(reputationEngine) != address(0) &&
+            reputationEngine.isBlacklisted(claimant)
+        ) {
+            return false;
+        }
         if (additionalAgents[claimant]) {
             emit OwnershipVerified(claimant, subdomain);
             return true;
@@ -190,6 +196,12 @@ contract IdentityRegistry is Ownable {
         string calldata subdomain,
         bytes32[] calldata proof
     ) external returns (bool) {
+        if (
+            address(reputationEngine) != address(0) &&
+            reputationEngine.isBlacklisted(claimant)
+        ) {
+            return false;
+        }
         if (additionalValidators[claimant]) {
             emit OwnershipVerified(claimant, subdomain);
             return true;

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -538,13 +538,6 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         string calldata subdomain,
         bytes32[] calldata proof
     ) internal requiresTaxAcknowledgement {
-        require(address(identityRegistry) != address(0), "identity reg");
-        bool authorized = identityRegistry.verifyAgent(
-            msg.sender,
-            subdomain,
-            proof
-        );
-        require(authorized, "Not authorized agent");
         Job storage job = jobs[jobId];
         require(job.state == State.Created, "not open");
         if (address(reputationEngine) != address(0)) {
@@ -552,6 +545,15 @@ contract JobRegistry is Ownable, ReentrancyGuard {
                 !reputationEngine.isBlacklisted(msg.sender),
                 "Blacklisted agent"
             );
+        }
+        require(address(identityRegistry) != address(0), "identity reg");
+        bool authorized = identityRegistry.verifyAgent(
+            msg.sender,
+            subdomain,
+            proof
+        );
+        require(authorized, "Not authorized agent");
+        if (address(reputationEngine) != address(0)) {
             reputationEngine.onApply(msg.sender);
         }
         if (job.stake > 0 && address(stakeManager) != address(0)) {
@@ -630,13 +632,6 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         require(job.state == State.Applied, "invalid state");
         require(msg.sender == job.agent, "only agent");
         require(block.timestamp <= job.deadline, "deadline");
-        require(address(identityRegistry) != address(0), "identity reg");
-        bool authorized = identityRegistry.verifyAgent(
-            msg.sender,
-            subdomain,
-            proof
-        );
-        require(authorized, "Not authorized agent");
         if (address(reputationEngine) != address(0)) {
             require(
                 !reputationEngine.isBlacklisted(msg.sender),
@@ -647,6 +642,13 @@ contract JobRegistry is Ownable, ReentrancyGuard {
                 "Blacklisted employer"
             );
         }
+        require(address(identityRegistry) != address(0), "identity reg");
+        bool authorized = identityRegistry.verifyAgent(
+            msg.sender,
+            subdomain,
+            proof
+        );
+        require(authorized, "Not authorized agent");
         job.result = result;
         job.state = State.Submitted;
         emit JobSubmitted(jobId, msg.sender, result);


### PR DESCRIPTION
## Summary
- add reputation blacklist checks in IdentityRegistry verification functions
- call identityRegistry.verifyAgent and verifyValidator with blacklist guards in JobRegistry and ValidationModule
- test agent and validator rejection without ENS or Merkle proof

## Testing
- `npx hardhat test test/v2/IdentityVerification.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7bc958bfc8333ad8df3415a926f00