### PR TITLE
Align job duration setter naming in JobRegistry v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,7 +1282,7 @@ Use a block explorer like Etherscan—no coding required. Always verify addresse
 | `premiumReputationThreshold` | `setPremiumReputationThreshold(uint256)` | Reputation needed for premium tier |
 | `maxReputation` | `setMaxReputation(uint256)` | Upper bound on reputation |
 | `maxJobPayout` | `setMaxJobPayout(uint256)` | Maximum allowed job payout |
-| `maxJobDuration` | `setMaxJobDuration(uint256)` | Maximum job duration |
+| `maxJobDuration` | `setJobDurationLimit(uint256)` | Maximum job duration |
 | `agentBlacklistThreshold` | `setAgentBlacklistThreshold(uint256)` | Penalties before automatic agent blacklist |
 | `validatorBlacklistThreshold` | `setValidatorBlacklistThreshold(uint256)` | Penalties before automatic validator blacklist |
 | `maxValidatorPoolSize` | `setMaxValidatorPoolSize(uint256)` | Cap on validator pool size |
@@ -2030,7 +2030,7 @@ Several operational parameters are adjustable by the owner. Every update emits a
 - `setRequiredValidatorDisapprovals(uint256 count)` → `RequiredValidatorDisapprovalsUpdated`
 - `setPremiumReputationThreshold(uint256 newThreshold)` → `PremiumReputationThresholdUpdated`
 - `setMaxJobPayout(uint256 newMax)` → `MaxJobPayoutUpdated`
-- `setMaxJobDuration(uint256 newLimit)` → `JobDurationLimitUpdated`
+- `setJobDurationLimit(uint256 newLimit)` → `JobParametersUpdated`
 - `setCommitRevealWindows(uint256 commitWindow, uint256 revealWindow)` → `CommitRevealWindowsUpdated` – controls how long validators have to commit and reveal votes; the existing `reviewWindow` must be at least `commitWindow + revealWindow`. Zero values are rejected.
 - `setCommitDuration(uint256 newCommit)` or `setRevealDuration(uint256 newReveal)` → `CommitRevealWindowsUpdated` – tweak individual phase lengths; `reviewWindow` must remain ≥ `commitDuration + revealDuration`.
 - `setReviewWindow(uint256 newWindow)` → `ReviewWindowUpdated` – defines the mandatory wait after completion requests and must be greater than or equal to `commitDuration + revealDuration`.

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -191,7 +191,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         maxJobReward = maxReward;
     }
 
-    function setMaxJobDuration(uint256 limit) external override {
+    function setJobDurationLimit(uint256 limit) external override {
         maxJobDuration = limit;
     }
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -353,7 +353,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     }
 
     /// @notice set the maximum allowed job duration in seconds
-    function setMaxJobDuration(uint256 limit) external onlyOwner {
+    function setJobDurationLimit(uint256 limit) external onlyOwner {
         maxJobDuration = limit;
         emit JobParametersUpdated(0, jobStake, maxJobReward, limit);
     }

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -126,7 +126,7 @@ interface IJobRegistry {
     function setMaxJobReward(uint256 maxReward) external;
 
     /// @notice set the maximum allowed job duration in seconds
-    function setMaxJobDuration(uint256 limit) external;
+    function setJobDurationLimit(uint256 limit) external;
 
     /// @notice update the percentage of each job reward taken as a protocol fee
     function setFeePct(uint256 feePct) external;

--- a/test/jobRegistry.ts
+++ b/test/jobRegistry.ts
@@ -38,7 +38,7 @@ describe("JobRegistry tax policy gating", function () {
 
     await registry.connect(owner).setJobParameters(0, 0);
     await registry.connect(owner).setMaxJobReward(1000);
-    await registry.connect(owner).setMaxJobDuration(86400);
+    await registry.connect(owner).setJobDurationLimit(86400);
 
     const Identity = await ethers.getContractFactory(
       "contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock"

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -69,7 +69,7 @@ describe("Identity verification enforcement", function () {
       await registry.connect(employer).acknowledgeTaxPolicy();
       await registry.connect(agent).acknowledgeTaxPolicy();
       await registry.connect(owner).setMaxJobReward(1000);
-      await registry.connect(owner).setMaxJobDuration(1000);
+      await registry.connect(owner).setJobDurationLimit(1000);
       await registry.connect(owner).setFeePct(0);
       await registry.connect(owner).setJobParameters(0, 0);
     });

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -86,7 +86,7 @@ describe("JobRegistry integration", function () {
       .connect(owner)
       .setJobParameters(reward, stake);
     await registry.connect(owner).setMaxJobReward(1000000);
-    await registry.connect(owner).setMaxJobDuration(86400);
+    await registry.connect(owner).setJobDurationLimit(86400);
     await registry.connect(owner).setFeePct(0);
     await registry.connect(owner).setValidatorRewardPct(0);
     await nft.connect(owner).setJobRegistry(await registry.getAddress());

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -55,7 +55,7 @@ describe("JobRegistry agent gating", function () {
     await registry.connect(agent).acknowledgeTaxPolicy();
 
     await registry.connect(owner).setMaxJobReward(1000);
-    await registry.connect(owner).setMaxJobDuration(1000);
+    await registry.connect(owner).setJobDurationLimit(1000);
     await registry.connect(owner).setFeePct(0);
     await registry.connect(owner).setJobParameters(0, 0);
     await verifier.setAgentRootNode(ethers.id("agi"));

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -61,7 +61,7 @@ describe("JobRegistry tax policy integration", function () {
   it("requires re-acknowledgement after version bump", async () => {
     await registry.connect(owner).setJobParameters(0, 0);
     await registry.connect(owner).setMaxJobReward(10);
-    await registry.connect(owner).setMaxJobDuration(86400);
+    await registry.connect(owner).setJobDurationLimit(86400);
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
     await registry.connect(user).acknowledgeTaxPolicy();
     await registry.connect(owner).bumpTaxPolicyVersion();

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -119,7 +119,7 @@ describe("comprehensive job flows", function () {
     await registry.setTaxPolicy(await policy.getAddress());
     await registry.setJobParameters(0, stakeRequired);
     await registry.setMaxJobReward(reward);
-    await registry.setMaxJobDuration(86400);
+    await registry.setJobDurationLimit(86400);
     await stakeManager.setJobRegistry(await registry.getAddress());
     await stakeManager.setValidationModule(await validation.getAddress());
     await stakeManager.setDisputeModule(await dispute.getAddress());

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -113,7 +113,7 @@ describe("end-to-end job lifecycle", function () {
     await registry.setTaxPolicy(await policy.getAddress());
     await registry.setJobParameters(0, stakeRequired);
     await registry.setMaxJobReward(reward);
-    await registry.setMaxJobDuration(86400);
+    await registry.setJobDurationLimit(86400);
     await stakeManager.setJobRegistry(await registry.getAddress());
     await stakeManager.setValidationModule(await validation.getAddress());
     await stakeManager.setDisputeModule(await dispute.getAddress());

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -112,7 +112,7 @@ describe("job finalization integration", function () {
     await registry.setTaxPolicy(await policy.getAddress());
     await registry.setJobParameters(0, stakeRequired);
     await registry.setMaxJobReward(reward);
-    await registry.setMaxJobDuration(86400);
+    await registry.setJobDurationLimit(86400);
     await stakeManager.setJobRegistry(await registry.getAddress());
     await stakeManager.setValidationModule(await validation.getAddress());
     await stakeManager.setDisputeModule(await dispute.getAddress());

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -129,7 +129,7 @@ describe("multi-operator job lifecycle", function () {
     await registry.setTaxPolicy(await policy.getAddress());
     await registry.setJobParameters(0, stakeRequired);
     await registry.setMaxJobReward(reward);
-    await registry.setMaxJobDuration(86400);
+    await registry.setJobDurationLimit(86400);
     await stakeManager.setJobRegistry(await registry.getAddress());
     await stakeManager.setValidationModule(await validation.getAddress());
     await stakeManager.setDisputeModule(await dispute.getAddress());


### PR DESCRIPTION
## Summary
- rename `setMaxJobDuration` to `setJobDurationLimit` in JobRegistry
- update interface, docs, and tests to use new setter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7c22a61488333b53693c5d64be1df