### PR TITLE
feat: enhance reputation engine

### DIFF
--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -106,8 +106,8 @@ contract ReputationEngine is Ownable {
     }
 
     /// @notice Increase reputation for a user.
+    /// @dev Blacklisted users may gain reputation to clear their status.
     function add(address user, uint256 amount) external onlyCaller {
-        require(!isBlacklisted[user], "Blacklisted agent");
         uint256 current = _scores[user];
         uint256 newScore = _enforceReputationGrowth(current, amount);
         uint256 delta = newScore - current;
@@ -175,7 +175,6 @@ contract ReputationEngine is Ownable {
         uint256 payout,
         uint256 duration
     ) external onlyCaller {
-        require(!isBlacklisted[user], "Blacklisted agent");
         if (success) {
             uint256 gain = calculateReputationPoints(payout, duration);
             uint256 current = _scores[user];
@@ -200,7 +199,6 @@ contract ReputationEngine is Ownable {
     /// @param validator The validator address
     /// @param agentGain Reputation points awarded to the agent
     function rewardValidator(address validator, uint256 agentGain) external onlyCaller {
-        require(!isBlacklisted[validator], "Blacklisted validator");
         uint256 gain = calculateValidatorReputationPoints(agentGain);
         uint256 current = _scores[validator];
         uint256 newScore = _enforceReputationGrowth(current, gain);


### PR DESCRIPTION
## Summary
- allow blacklisted agents and validators to regain standing through reputation gains
- reward validators with a percentage of agent gains
- add tests for reputation scaling, validator rewards, and blacklist clearing

## Testing
- `npx solhint contracts/v2/ReputationEngine.sol && npx eslint test/v2/ReputationEngine.test.js`
- `npx hardhat test test/v2/ReputationEngine.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7cd8f97dc8333b989b86847370fbb