### PR TITLE
Add CertificateNFT mint and marketplace tests

### DIFF
--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -91,6 +91,14 @@ describe("CertificateNFT marketplace", function () {
       );
     });
 
+  it("prevents self purchase", async () => {
+      await nft.connect(seller).list(1, price);
+      await token.connect(seller).approve(await nft.getAddress(), price);
+      await expect(nft.connect(seller).purchase(1)).to.be.revertedWith(
+        "self"
+      );
+    });
+
   it("guards purchase against reentrancy", async () => {
       await nft.connect(seller).list(1, price);
 

--- a/test/v2/CertificateNFTMint.test.js
+++ b/test/v2/CertificateNFTMint.test.js
@@ -1,0 +1,43 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CertificateNFT minting", function () {
+  let owner, jobRegistry, user, nft;
+
+  beforeEach(async () => {
+    [owner, jobRegistry, user] = await ethers.getSigners();
+    const NFT = await ethers.getContractFactory(
+      "contracts/v2/CertificateNFT.sol:CertificateNFT"
+    );
+    nft = await NFT.deploy("Cert", "CERT");
+    await nft.setJobRegistry(jobRegistry.address);
+  });
+
+  it("mints with jobId tokenId and enforces registry and URI", async () => {
+    await expect(
+      nft.connect(jobRegistry).mint(user.address, 1, "ipfs://1")
+    )
+      .to.emit(nft, "CertificateMinted")
+      .withArgs(user.address, 1);
+    expect(await nft.ownerOf(1)).to.equal(user.address);
+    expect(await nft.tokenURI(1)).to.equal("ipfs://1");
+
+    await expect(
+      nft.connect(jobRegistry).mint(user.address, 2, "")
+    ).to.be.revertedWithCustomError(nft, "EmptyURI");
+
+    await expect(
+      nft.connect(owner).mint(user.address, 3, "ipfs://3")
+    ).to.be.revertedWithCustomError(nft, "NotJobRegistry").withArgs(
+      owner.address
+    );
+  });
+
+  it("updates base URI and emits event", async () => {
+    await nft.connect(jobRegistry).mint(user.address, 1, "1");
+    await expect(nft.setBaseURI("https://base/"))
+      .to.emit(nft, "BaseURIUpdated")
+      .withArgs("https://base/");
+    expect(await nft.tokenURI(1)).to.equal("https://base/1");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering CertificateNFT minting restrictions and base URI updates
- test marketplace self-purchase prevention alongside existing listing edge cases

## Testing
- `npx hardhat test test/v2/CertificateNFTMint.test.js test/v2/CertificateNFTMarketplace.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7d07b5bc883339cd94a0abf7e9fb8