### PR TITLE
Add cancel wrapper for unassigned jobs

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -916,6 +916,15 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         cancelJob(jobId);
     }
 
+    /// @notice Cancel an unassigned job and refund the employer.
+    /// @dev Convenience wrapper matching earlier interface expectations.
+    /// Calls {cancelJob} which handles tax acknowledgement checks and
+    /// refunds any locked reward back to the employer.
+    /// @param jobId Identifier of the job to cancel.
+    function cancel(uint256 jobId) external {
+        cancelJob(jobId);
+    }
+
     /// @notice Cancel a job before completion and refund the employer.
     function cancelJob(uint256 jobId)
         public


### PR DESCRIPTION
## Summary
- expose a `cancel` wrapper in `JobRegistry` so employers can reclaim escrow on unassigned jobs

## Testing
- `npm test --silent test/v2/JobRegistry.test.js`
- `npm test --silent test/v2/endToEnd.integration.test.js`
- `npm test --silent test/v2/jobFinalization.integration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8627fa5f48333899efd6bfb66285d