### PR TITLE
Allow owner resolution in DisputeModule

### DIFF
--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -75,11 +75,16 @@ contract DisputeModule is Ownable {
         emit ModeratorUpdated(initialModerator, true);
     }
 
-    /// @notice Restrict calls to approved moderators.
+    /// @notice Restrict calls to approved moderators or the contract owner.
     /// @dev The owner can grant or revoke moderator status via
-    ///      {addModerator} and {removeModerator}.
-    modifier onlyModerator() {
-        require(moderators[msg.sender], "not authorized");
+    ///      {addModerator} and {removeModerator}. Regardless of moderator
+    ///      status, the owner always retains the ability to resolve
+    ///      disputes.
+    modifier onlyOwnerOrModerator() {
+        require(
+            msg.sender == owner() || moderators[msg.sender],
+            "not authorized"
+        );
         _;
     }
 
@@ -169,7 +174,7 @@ contract DisputeModule is Ownable {
     /// @param employerWins True if the employer prevails.
     function resolve(uint256 jobId, bool employerWins)
         external
-        onlyModerator
+        onlyOwnerOrModerator
     {
         Dispute storage d = disputes[jobId];
         require(d.raisedAt != 0 && !d.resolved, "no dispute");

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -180,6 +180,16 @@ describe("DisputeModule", function () {
       ).to.equal(0);
     });
 
+    it("allows owner to resolve even if not moderator", async () => {
+      await dispute.connect(owner).removeModerator(owner.address);
+      expect(await dispute.moderators(owner.address)).to.equal(false);
+      await registry.connect(agent).dispute(1, "evidence");
+      await time.increase(window);
+      await expect(dispute.connect(owner).resolve(1, true))
+        .to.emit(dispute, "DisputeResolved")
+        .withArgs(1, owner.address, true);
+    });
+
     it("rejects unauthorized resolve attempts", async () => {
       await registry.connect(agent).dispute(1, "evidence");
       await time.increase(window);


### PR DESCRIPTION
## Summary
- permit contract owner to resolve disputes without being a moderator
- add unit test ensuring owner can resolve even when removed as moderator

## Testing
- `npm test test/v2/DisputeModule.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a883bdd8208333b7c23d30a4882c69