### PR TITLE
Guard v2 setters with owner checks and event logging

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -74,6 +74,7 @@ contract ValidationModule is IValidationModule, Ownable {
     event JobRegistryUpdated(address registry);
     event StakeManagerUpdated(address manager);
     event ModulesUpdated(address indexed jobRegistry, address indexed stakeManager);
+    event IdentityRegistryUpdated(address registry);
     event JobNonceReset(uint256 indexed jobId);
     /// @notice Emitted when an additional validator is added or removed.
     /// @param validator Address being updated.
@@ -184,6 +185,7 @@ contract ValidationModule is IValidationModule, Ownable {
     /// @notice Update the identity registry used for validator verification.
     function setIdentityRegistry(IIdentityRegistry registry) external onlyOwner {
         identityRegistry = registry;
+        emit IdentityRegistryUpdated(address(registry));
     }
 
     /// @notice Batch update core validation parameters.

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -13,6 +13,8 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     address public jobRegistry;
     mapping(uint256 => string) private _tokenURIs;
 
+    event JobRegistryUpdated(address registry);
+
     constructor(string memory name_, string memory symbol_)
         ERC721(name_, symbol_)
         Ownable(msg.sender)
@@ -29,6 +31,7 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
 
     function setJobRegistry(address registry) external onlyOwner {
         jobRegistry = registry;
+        emit JobRegistryUpdated(registry);
     }
 
     function mint(

--- a/contracts/v2/modules/IdentityLib.sol
+++ b/contracts/v2/modules/IdentityLib.sol
@@ -40,6 +40,7 @@ contract IdentityLib is Ownable {
     event MerkleRootUpdated(string root, bytes32 newRoot);
     event AdditionalAgentUpdated(address indexed agent, bool allowed);
     event AdditionalValidatorUpdated(address indexed validator, bool allowed);
+    event ModulesUpdated(address jobRegistry, address validationModule);
 
     constructor(
         IENS _ens,
@@ -93,6 +94,7 @@ contract IdentityLib is Ownable {
     function setModules(address _jobRegistry, address _validationModule) external onlyOwner {
         jobRegistry = _jobRegistry;
         validationModule = _validationModule;
+        emit ModulesUpdated(_jobRegistry, _validationModule);
     }
 
     modifier onlyAuthorized() {

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -82,10 +82,31 @@ describe("Ownable modules", function () {
       "contracts/v2/modules/ENSOwnershipVerifier.sol:ENSOwnershipVerifier"
     );
 
+    const ModCertificateNFT = await ethers.getContractFactory(
+      "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
+    );
+    const IdentityLib = await ethers.getContractFactory(
+      "contracts/v2/modules/IdentityLib.sol:IdentityLib"
+    );
+
+    const modCert = await ModCertificateNFT.deploy("Cert", "CRT");
+    await modCert.waitForDeployment();
+    const identity = await IdentityLib.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+    await identity.waitForDeployment();
+
     const modules = [
       [StakeManager.attach(stake), (inst, signer) => inst.connect(signer).setFeePct(1)],
       [JobRegistry.attach(registry), (inst, signer) => inst.connect(signer).setFeePct(1)],
-      [ValidationModule.attach(validation), (inst, signer) => inst.connect(signer).setCommitWindow(1)],
+      [
+        ValidationModule.attach(validation),
+        (inst, signer) => inst.connect(signer).setIdentityRegistry(ethers.ZeroAddress),
+      ],
       [
         ReputationEngine.attach(reputation),
         (inst, signer) => inst.connect(signer).setScoringWeights(0, 0),
@@ -98,6 +119,8 @@ describe("Ownable modules", function () {
       [FeePool.attach(feePool), (inst, signer) => inst.connect(signer).setBurnPct(0)],
       [TaxPolicy.attach(taxPolicy), (inst, signer) => inst.connect(signer).setPolicyURI("ipfs://new")],
       [ENSVerifier.attach(ensVerifier), (inst, signer) => inst.connect(signer).setENS(ethers.ZeroAddress)],
+      [modCert, (inst, signer) => inst.connect(signer).setJobRegistry(ethers.ZeroAddress)],
+      [identity, (inst, signer) => inst.connect(signer).setModules(ethers.ZeroAddress, ethers.ZeroAddress)],
     ];
 
     for (const [inst, call] of modules) {


### PR DESCRIPTION
## Summary
- emit `IdentityRegistryUpdated` from ValidationModule and wire event into setter
- log JobRegistry and module updates in CertificateNFT and IdentityLib modules
- extend ownership tests to cover new setters

## Testing
- `npm run lint`
- `npx hardhat test test/v2/Ownership.test.js --no-compile` *(fails: EOF while parsing an object)*

------
https://chatgpt.com/codex/tasks/task_e_68a8945e9be88333a3ecd9ce1f876a76