### PR TITLE
refactor: rename tax policy acknowledgement and add job delisting

### DIFF
--- a/contracts/mocks/BadTaxPolicy.sol
+++ b/contracts/mocks/BadTaxPolicy.sol
@@ -17,7 +17,7 @@ contract BadTaxPolicy is ITaxPolicy {
         return "bad";
     }
 
-    function acknowledged(address user) external view returns (bool) {
+    function hasAcknowledged(address user) external view returns (bool) {
         return acknowledgedUsers[user];
     }
 

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -214,7 +214,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         );
         if (address(taxPolicy) != address(0)) {
             require(
-                taxPolicy.acknowledged(msg.sender),
+                taxPolicy.hasAcknowledged(msg.sender),
                 "acknowledge tax policy"
             );
         }

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -93,7 +93,7 @@ contract TaxPolicy is Ownable, ITaxPolicy {
     }
 
     /// @notice Check if a user has acknowledged the policy.
-    function acknowledged(address user)
+    function hasAcknowledged(address user)
         external
         view
         override

--- a/contracts/v2/interfaces/ITaxPolicy.sol
+++ b/contracts/v2/interfaces/ITaxPolicy.sol
@@ -11,7 +11,7 @@ interface ITaxPolicy {
 
     /// @notice Check if a user has acknowledged the policy.
     /// @param user Address of the participant.
-    function acknowledged(address user) external view returns (bool);
+    function hasAcknowledged(address user) external view returns (bool);
 
     /// @notice Returns the acknowledgement text without recording acceptance.
     /// @return disclaimer Confirms all taxes fall on employers, agents, and validators.

--- a/test/taxPolicy.ts
+++ b/test/taxPolicy.ts
@@ -11,11 +11,7 @@ describe("TaxPolicy", function () {
     const Factory = await ethers.getContractFactory(
       "contracts/v2/TaxPolicy.sol:TaxPolicy"
     );
-    tax = await Factory.deploy(
-      owner.address,
-      "ipfs://initial",
-      "initial ack"
-    );
+    tax = await Factory.deploy("ipfs://initial", "initial ack");
     await tax.waitForDeployment();
   });
 
@@ -78,7 +74,7 @@ describe("TaxPolicy", function () {
     await expect(tax.connect(user).acknowledge(user.address))
       .to.emit(tax, "PolicyAcknowledged")
       .withArgs(user.address);
-    expect(await tax.acknowledged(user.address)).to.equal(true);
+    expect(await tax.hasAcknowledged(user.address)).to.equal(true);
   });
 
   it("tracks policy version bumps", async () => {

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -223,12 +223,12 @@ describe("JobRegistry integration", function () {
     expect(await token.balanceOf(employer.address)).to.equal(1000);
   });
 
-  it("allows owner to force cancel unassigned job", async () => {
+  it("allows owner to delist unassigned job", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
     await registry.connect(employer).createJob(reward, deadline, "uri");
     const jobId = 1;
-    await expect(registry.connect(owner).forceCancel(jobId))
+    await expect(registry.connect(owner).delistJob(jobId))
       .to.emit(registry, "JobCancelled")
       .withArgs(jobId);
     const job = await registry.jobs(jobId);

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -55,7 +55,7 @@ describe("JobRegistry tax policy integration", function () {
       .and.to.emit(registry, "TaxAcknowledged")
       .withArgs(user.address, 1, "ack");
     expect(await registry.taxAcknowledgedVersion(user.address)).to.equal(1);
-    expect(await policy.acknowledged(user.address)).to.equal(true);
+    expect(await policy.hasAcknowledged(user.address)).to.equal(true);
   });
 
   it("requires re-acknowledgement after version bump", async () => {


### PR DESCRIPTION
## Summary
- require `TaxPolicy.hasAcknowledged` when gating actions
- allow owner to `delistJob` while restricting `cancelJob` to employers
- update tests and mocks for new tax policy interface

## Testing
- `npm test test/taxPolicy.ts test/v2/TaxPolicyIntegration.test.js test/v2/JobRegistry.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a9010bd39c8333bd6edd6b0b81d3c2