### PR TITLE
feat: refine reputation threshold and blacklist handling

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -450,7 +450,7 @@ contract MockReputationEngine is IReputationEngine {
         threshold = t;
     }
 
-    function setPremiumReputationThreshold(uint256 t) external override {
+    function setPremiumThreshold(uint256 t) external override {
         threshold = t;
     }
 

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -64,7 +64,7 @@ interface IReputationEngine {
     function setThreshold(uint256 newThreshold) external;
 
     /// @notice Set premium reputation threshold
-    function setPremiumReputationThreshold(uint256 newThreshold) external;
+    function setPremiumThreshold(uint256 newThreshold) external;
 
     /// @notice Add or remove a user from the blacklist
     /// @param user Address to update

--- a/test/v2/ReputationEngine.test.js
+++ b/test/v2/ReputationEngine.test.js
@@ -11,9 +11,7 @@ describe("ReputationEngine", function () {
     );
     engine = await Engine.deploy(ethers.ZeroAddress);
     await engine.connect(owner).setCaller(caller.address, true);
-    await engine
-      .connect(owner)
-      .setPremiumReputationThreshold(2);
+    await engine.connect(owner).setPremiumThreshold(2);
   });
 
   it("rewards validators based on agent gain", async () => {


### PR DESCRIPTION
## Summary
- rename reputation storage to `reputation` with `blacklisted` and `premiumThreshold`
- add owner setters and lifecycle hooks emitting updates
- expose `isBlacklisted` view and reward validators

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a90eef4a38833388c3fb84a8bdc8da