### PR TITLE
feat: add v2 deployment script and tests

### DIFF
--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -1,0 +1,103 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
+  const token = await Token.deploy();
+  await token.waitForDeployment();
+
+  const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
+  const stake = await Stake.deploy(
+    await token.getAddress(),
+    0,
+    0,
+    0,
+    deployer.address,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress
+  );
+  await stake.waitForDeployment();
+
+  const Reputation = await ethers.getContractFactory("contracts/v2/ReputationEngine.sol:ReputationEngine");
+  const reputation = await Reputation.deploy(await stake.getAddress());
+  await reputation.waitForDeployment();
+
+  const ENS = await ethers.getContractFactory("contracts/mocks/MockENS.sol:MockENS");
+  const ens = await ENS.deploy();
+  await ens.waitForDeployment();
+  const Wrapper = await ethers.getContractFactory("contracts/mocks/MockNameWrapper.sol:MockNameWrapper");
+  const wrapper = await Wrapper.deploy();
+  await wrapper.waitForDeployment();
+
+  const Identity = await ethers.getContractFactory("contracts/v2/IdentityRegistry.sol:IdentityRegistry");
+  const identity = await Identity.deploy(
+    await ens.getAddress(),
+    await wrapper.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroHash,
+    ethers.ZeroHash
+  );
+  await identity.waitForDeployment();
+
+  const Validation = await ethers.getContractFactory("contracts/v2/mocks/ValidationStub.sol:ValidationStub");
+  const validation = await Validation.deploy();
+  await validation.waitForDeployment();
+
+  const NFT = await ethers.getContractFactory("contracts/v2/CertificateNFT.sol:CertificateNFT");
+  const nft = await NFT.deploy("Cert", "CERT");
+  await nft.waitForDeployment();
+
+  const Registry = await ethers.getContractFactory("contracts/v2/JobRegistry.sol:JobRegistry");
+  const registry = await Registry.deploy(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroAddress,
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    0,
+    0,
+    []
+  );
+  await registry.waitForDeployment();
+
+  const Dispute = await ethers.getContractFactory("contracts/v2/DisputeModule.sol:DisputeModule");
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    await stake.getAddress(),
+    deployer.address,
+    0
+  );
+  await dispute.waitForDeployment();
+
+  await stake.setModules(await registry.getAddress(), await dispute.getAddress());
+  await validation.setJobRegistry(await registry.getAddress());
+  await nft.setJobRegistry(await registry.getAddress());
+  await nft.setStakeManager(await stake.getAddress());
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await dispute.getAddress(),
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    []
+  );
+  await registry.setIdentityRegistry(await identity.getAddress());
+  await reputation.setCaller(await registry.getAddress(), true);
+
+  console.log("Token:", await token.getAddress());
+  console.log("StakeManager:", await stake.getAddress());
+  console.log("ReputationEngine:", await reputation.getAddress());
+  console.log("IdentityRegistry:", await identity.getAddress());
+  console.log("JobRegistry:", await registry.getAddress());
+  console.log("DisputeModule:", await dispute.getAddress());
+  console.log("CertificateNFT:", await nft.getAddress());
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/test/v2/identity.test.ts
+++ b/test/v2/identity.test.ts
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+// Tests for ENS ownership verification through IdentityRegistry
+
+describe("IdentityRegistry ENS verification", function () {
+  it("verifies ownership via NameWrapper and rejects others", async () => {
+    const [owner, alice, bob] = await ethers.getSigners();
+
+    const ENS = await ethers.getContractFactory("MockENS");
+    const ens = await ENS.deploy();
+
+    const Wrapper = await ethers.getContractFactory("MockNameWrapper");
+    const wrapper = await Wrapper.deploy();
+
+    const Rep = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    const rep = await Rep.deploy(ethers.ZeroAddress);
+
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/IdentityRegistry.sol:IdentityRegistry"
+    );
+    const id = await Registry.deploy(
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      await rep.getAddress(),
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+
+    const subdomain = "alice";
+    const subnode = ethers.keccak256(
+      ethers.solidityPacked(["bytes32", "bytes32"], [ethers.ZeroHash, ethers.id(subdomain)])
+    );
+    await wrapper.setOwner(BigInt(subnode), alice.address);
+
+    expect(await id.verifyAgent(alice.address, subdomain, [])).to.equal(true);
+    expect(await id.verifyAgent(bob.address, subdomain, [])).to.equal(false);
+  });
+});

--- a/test/v2/jobLifecycle.test.ts
+++ b/test/v2/jobLifecycle.test.ts
@@ -1,0 +1,166 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+enum Role {
+  Agent,
+  Validator,
+  Platform,
+}
+
+async function deploySystem() {
+  const [owner, employer, agent, validator, buyer, moderator] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
+  const token = await Token.deploy();
+  await token.mint(employer.address, ethers.parseUnits("1000", 6));
+  await token.mint(agent.address, ethers.parseUnits("1000", 6));
+  await token.mint(buyer.address, ethers.parseUnits("1000", 6));
+
+  const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
+  const stake = await Stake.deploy(
+    await token.getAddress(),
+    0,
+    0,
+    0,
+    owner.address,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress
+  );
+
+  const Reputation = await ethers.getContractFactory("contracts/v2/ReputationEngine.sol:ReputationEngine");
+  const reputation = await Reputation.deploy(await stake.getAddress());
+
+  const ENS = await ethers.getContractFactory("MockENS");
+  const ens = await ENS.deploy();
+  const Wrapper = await ethers.getContractFactory("MockNameWrapper");
+  const wrapper = await Wrapper.deploy();
+
+  const Identity = await ethers.getContractFactory("contracts/v2/IdentityRegistry.sol:IdentityRegistry");
+  const identity = await Identity.deploy(
+    await ens.getAddress(),
+    await wrapper.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroHash,
+    ethers.ZeroHash
+  );
+
+  const Validation = await ethers.getContractFactory("contracts/v2/mocks/ValidationStub.sol:ValidationStub");
+  const validation = await Validation.deploy();
+
+  const NFT = await ethers.getContractFactory("contracts/v2/CertificateNFT.sol:CertificateNFT");
+  const nft = await NFT.deploy("Cert", "CERT");
+
+  const Registry = await ethers.getContractFactory("contracts/v2/JobRegistry.sol:JobRegistry");
+  const registry = await Registry.deploy(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroAddress,
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    0,
+    0,
+    []
+  );
+
+  const Dispute = await ethers.getContractFactory("contracts/v2/DisputeModule.sol:DisputeModule");
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    await stake.getAddress(),
+    moderator.address,
+    0
+  );
+
+  await stake.setModules(await registry.getAddress(), await dispute.getAddress());
+  await validation.setJobRegistry(await registry.getAddress());
+  await nft.setJobRegistry(await registry.getAddress());
+  await nft.setStakeManager(await stake.getAddress());
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await dispute.getAddress(),
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    []
+  );
+  await registry.setIdentityRegistry(await identity.getAddress());
+  await reputation.setCaller(await registry.getAddress(), true);
+  await reputation.setPremiumThreshold(10);
+
+  return { owner, employer, agent, validator, buyer, moderator, token, stake, reputation, wrapper, identity, validation, nft, registry, dispute };
+}
+
+describe("Job lifecycle", function () {
+  it("runs full happy path and marketplace interactions", async () => {
+    const env = await deploySystem();
+    const { token, stake, reputation, wrapper, validation, nft, registry, employer, agent, buyer } = env;
+
+    const subdomain = "agent";
+    const subnode = ethers.keccak256(
+      ethers.solidityPacked(["bytes32", "bytes32"], [ethers.ZeroHash, ethers.id(subdomain)])
+    );
+    await wrapper.setOwner(BigInt(subnode), agent.address);
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
+    await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
+
+    const reward = ethers.parseUnits("100", 6);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+
+    await registry.connect(agent).applyForJob(1, subdomain, []);
+    await registry.connect(agent).submit(1, "ipfs://result", subdomain, []);
+    await validation.setResult(true);
+    await validation.finalize(1);
+
+    expect(await token.balanceOf(agent.address)).to.equal(ethers.parseUnits("1099", 6));
+    expect(await nft.ownerOf(1)).to.equal(agent.address);
+    expect(await reputation.reputation(agent.address)).to.be.gt(0);
+
+    const price = ethers.parseUnits("50", 6);
+    await nft.connect(agent).list(1, price);
+    await token.connect(buyer).approve(await nft.getAddress(), price);
+    await nft.connect(buyer).purchase(1);
+
+    expect(await nft.ownerOf(1)).to.equal(buyer.address);
+    expect(await token.balanceOf(agent.address)).to.equal(ethers.parseUnits("1149", 6));
+  });
+
+  it("handles validation failure, dispute resolution and blacklisting", async () => {
+    const env = await deploySystem();
+    const { token, stake, reputation, wrapper, validation, registry, dispute, employer, agent, moderator } = env;
+
+    const subdomain = "agent";
+    const subnode = ethers.keccak256(
+      ethers.solidityPacked(["bytes32", "bytes32"], [ethers.ZeroHash, ethers.id(subdomain)])
+    );
+    await wrapper.setOwner(BigInt(subnode), agent.address);
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
+    await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
+
+    const reward = ethers.parseUnits("100", 6);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+
+    await registry.connect(agent).applyForJob(1, subdomain, []);
+    await registry.connect(agent).submit(1, "ipfs://bad", subdomain, []);
+    await validation.setResult(false);
+    await validation.finalize(1);
+
+    await registry.connect(employer).dispute(1, "evidence");
+    await dispute.connect(moderator).resolve(1, true); // employer wins
+
+    expect(await reputation.isBlacklisted(agent.address)).to.equal(true);
+
+    await reputation.add(agent.address, 20);
+    expect(await reputation.isBlacklisted(agent.address)).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add deploy-v2 script wiring modules with default token and ENS settings
- add ENS identity verification tests
- cover job lifecycle, dispute resolution, reputation and NFT marketplace

## Testing
- `npx hardhat test test/v2/*.ts` *(fails: compiler download stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68a9178d0e9c8333b64d3db4e8d28206