### PR TITLE
Expose AGI type controls in StakeManager interface

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -56,6 +56,9 @@ contract MockStakeManager is IStakeManager {
     function setFeePct(uint256) external override {}
     function setFeePool(IFeePool) external override {}
     function setBurnPct(uint256) external override {}
+    function setValidatorRewardPct(uint256) external override {}
+    function addAGIType(address, uint256) external override {}
+    function removeAGIType(address) external override {}
 
     function slash(address user, Role role, uint256 amount, address)
         external

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -39,12 +39,16 @@ interface IStakeManager {
     event TreasuryUpdated(address indexed treasury);
     event MaxStakePerAddressUpdated(uint256 maxStake);
     event MaxAGITypesUpdated(uint256 oldMax, uint256 newMax);
+    event AGITypeUpdated(address indexed nft, uint256 payoutPct);
+    event AGITypeRemoved(address indexed nft);
     event SlashPercentSumEnforcementUpdated(bool enforced);
     event FeePctUpdated(uint256 pct);
     event BurnPctUpdated(uint256 pct);
     event FeePoolUpdated(address indexed feePool);
 
     /// @notice deposit stake for caller for a specific role
+    /// @param role participant role receiving credit
+    /// @param amount token amount with 6 decimals to deposit
     function depositStake(Role role, uint256 amount) external;
 
     /// @notice acknowledge the tax policy and deposit stake in one call
@@ -54,6 +58,8 @@ interface IStakeManager {
     function depositStakeFor(address user, Role role, uint256 amount) external;
 
     /// @notice withdraw available stake for a specific role
+    /// @param role participant role of the stake being withdrawn
+    /// @param amount token amount with 6 decimals to withdraw
     function withdrawStake(Role role, uint256 amount) external;
 
     /// @notice acknowledge the tax policy and withdraw stake in one call
@@ -72,6 +78,9 @@ interface IStakeManager {
     function lock(address from, uint256 amount) external;
 
     /// @notice release locked job reward to recipient
+    /// @param jobId unique job identifier
+    /// @param to recipient of the reward
+    /// @param amount base token amount with 6 decimals before bonuses
     function releaseReward(bytes32 jobId, address to, uint256 amount) external;
 
     /// @notice release previously locked stake for a user
@@ -111,9 +120,16 @@ interface IStakeManager {
     function payDisputeFee(address to, uint256 amount) external;
 
     /// @notice slash stake from a user for a specific role
+    /// @param user address whose stake will be reduced
+    /// @param role participant role of the slashed stake
+    /// @param amount token amount with 6 decimals to slash
+    /// @param employer recipient of the employer share
     function slash(address user, Role role, uint256 amount, address employer) external;
 
     /// @notice slash validator stake during dispute resolution
+    /// @param user address whose stake will be reduced
+    /// @param amount token amount with 6 decimals to slash
+    /// @param recipient address receiving the slashed share
     function slash(address user, uint256 amount, address recipient) external;
 
     /// @notice toggle enforcement requiring slashing percentages to sum to 100
@@ -127,9 +143,12 @@ interface IStakeManager {
     function setTreasury(address _treasury) external;
     function setMaxStakePerAddress(uint256 maxStake) external;
     function setMaxAGITypes(uint256 newMax) external;
+    function addAGIType(address nft, uint256 payoutPct) external;
+    function removeAGIType(address nft) external;
     function setFeePct(uint256 pct) external;
     function setFeePool(IFeePool pool) external;
     function setBurnPct(uint256 pct) external;
+    function setValidatorRewardPct(uint256 pct) external;
 
     /// @notice return total stake deposited by a user for a role
     function stakeOf(address user, Role role) external view returns (uint256);

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import "contracts/v2/FeePool.sol";
 import "contracts/v2/interfaces/IFeePool.sol";
+import "contracts/mocks/MockV2.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 // minimal cheatcode interface
@@ -16,46 +17,6 @@ contract TestToken is ERC20 {
     constructor() ERC20("Test", "TST") {}
     function decimals() public pure override returns (uint8) { return 6; }
     function mint(address to, uint256 amount) external { _mint(to, amount); }
-}
-
-contract MockStakeManager is IStakeManager {
-    mapping(address => uint256) public stakes;
-    uint256 public totalStakeAmount;
-    address public override jobRegistry;
-
-    function setJobRegistry(address j) external { jobRegistry = j; }
-
-    function setStake(address user, uint256 amount) external {
-        totalStakeAmount = totalStakeAmount - stakes[user] + amount;
-        stakes[user] = amount;
-    }
-
-    function depositStake(Role, uint256) external override {}
-    function acknowledgeAndDeposit(Role, uint256) external override {}
-    function depositStakeFor(address, Role, uint256) external override {}
-    function acknowledgeAndWithdraw(Role, uint256) external override {}
-    function withdrawStake(Role, uint256) external override {}
-    function lockReward(bytes32, address, uint256) external override {}
-    function releaseReward(bytes32, address, uint256) external override {}
-    function releaseStake(address, uint256) external override {}
-    function release(address, uint256) external override {}
-    function finalizeJobFunds(bytes32, address, uint256, uint256, IFeePool) external override {}
-    function distributeValidatorRewards(bytes32, uint256) external override {}
-    function setDisputeModule(address) external override {}
-    function setValidationModule(address) external override {}
-    function lockDisputeFee(address, uint256) external override {}
-    function payDisputeFee(address, uint256) external override {}
-    function slash(address, Role, uint256, address) external override {}
-    function slash(address, uint256, address) external override {}
-    function setSlashPercentSumEnforcement(bool) external override {}
-
-    function totalStake(Role) external view override returns (uint256) {
-        return totalStakeAmount;
-    }
-
-    function stakeOf(address user, Role) external view override returns (uint256) {
-        return stakes[user];
-    }
 }
 
 contract FeePoolTest {
@@ -74,8 +35,8 @@ contract FeePoolTest {
         stakeManager.setJobRegistry(jobRegistry);
         feePool = new FeePool(token, stakeManager, 0, address(this));
         feePool.setRewardRole(IStakeManager.Role.Validator);
-        stakeManager.setStake(alice, 1_000_000);
-        stakeManager.setStake(bob, 2_000_000);
+        stakeManager.setStake(alice, IStakeManager.Role.Platform, 1_000_000);
+        stakeManager.setStake(bob, IStakeManager.Role.Platform, 2_000_000);
     }
 
     function testDepositFee() public {

--- a/test/v2/Integration.t.sol
+++ b/test/v2/Integration.t.sol
@@ -6,6 +6,7 @@ import "contracts/v2/modules/JobRouter.sol";
 import "contracts/v2/interfaces/IStakeManager.sol";
 import "contracts/v2/interfaces/IFeePool.sol";
 import "contracts/v2/interfaces/IPlatformRegistry.sol";
+import "contracts/mocks/MockV2.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 interface Vm {
@@ -50,41 +51,6 @@ contract MockPlatformRegistry is IPlatformRegistry {
     }
     function getScore(address op) external view returns (uint256) {
         return registered[op] ? scores[op] : 0;
-    }
-}
-
-contract MockStakeManager is IStakeManager {
-    mapping(address => mapping(Role => uint256)) public stakes;
-    mapping(Role => uint256) public totals;
-    address public jobRegistry;
-    function setJobRegistry(address j) external { jobRegistry = j; }
-    function setStake(address user, Role role, uint256 amount) external {
-        totals[role] = totals[role] - stakes[user][role] + amount;
-        stakes[user][role] = amount;
-    }
-    function depositStake(Role, uint256) external override {}
-    function acknowledgeAndDeposit(Role, uint256) external override {}
-    function depositStakeFor(address, Role, uint256) external override {}
-    function acknowledgeAndWithdraw(Role, uint256) external override {}
-    function withdrawStake(Role, uint256) external override {}
-    function lockReward(bytes32, address, uint256) external override {}
-    function releaseReward(bytes32, address, uint256) external override {}
-    function releaseStake(address, uint256) external override {}
-    function release(address, uint256) external override {}
-    function finalizeJobFunds(bytes32, address, uint256, uint256, IFeePool) external override {}
-    function distributeValidatorRewards(bytes32, uint256) external override {}
-    function setDisputeModule(address) external override {}
-    function setValidationModule(address) external override {}
-    function lockDisputeFee(address, uint256) external override {}
-    function payDisputeFee(address, uint256) external override {}
-    function slash(address, Role, uint256, address) external override {}
-    function slash(address, uint256, address) external override {}
-    function setSlashPercentSumEnforcement(bool) external override {}
-    function stakeOf(address user, Role role) external view override returns (uint256) {
-        return stakes[user][role];
-    }
-    function totalStake(Role role) external view override returns (uint256) {
-        return totals[role];
     }
 }
 


### PR DESCRIPTION
## Summary
- detail 6-decimal expectations for stake and reward functions
- expose add/remove AGI type hooks and validator reward percentage setter on `IStakeManager`
- use shared `MockStakeManager` in tests

## Testing
- `npm test`
- `forge test` *(fails: Source "forge-std/Script.sol" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b845f9a483339b74e1543a2da949