### PR TITLE
feat: add certificate marketplace and registry hooks

### DIFF
--- a/contracts/CertificateNFT.sol
+++ b/contracts/CertificateNFT.sol
@@ -1,26 +1,100 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.25;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {StakeManager} from "./StakeManager.sol";
 
 /// @title CertificateNFT
-/// @notice ERC721 certificate minted upon successful job completion.
-contract CertificateNFT is ERC721, Ownable {
-    string private baseTokenURI;
+/// @notice ERC721 certificate minted upon successful job completion with a
+///         lightweight marketplace for peer to peer trades.
+contract CertificateNFT is ERC721, Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev Reverts when a zero address is supplied where non-zero is required.
+    error ZeroAddress();
+
+    /// @dev Reverts when caller is not the authorised JobRegistry.
+    error NotJobRegistry(address caller);
+
+    /// @dev Reverts when attempting to mint more than once for the same job.
+    error CertificateAlreadyMinted(uint256 jobId);
+
+    /// @dev Reverts when an empty metadata URI is supplied.
+    error EmptyURI();
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
     address public jobRegistry;
+    string private baseTokenURI;
     mapping(uint256 => string) private _tokenURIs;
+
+    /// @notice StakeManager providing the ERC20 token used for payments.
+    StakeManager public stakeManager;
+
+    /// @notice Listing information for marketplace functionality.
+    struct Listing {
+        address seller;
+        uint256 price;
+        bool active;
+    }
+
+    mapping(uint256 => Listing) public listings;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
 
     event BaseURIUpdated(string newURI);
     event JobRegistryUpdated(address registry);
-    /// @notice Emitted when a certificate is minted.
+    event StakeManagerUpdated(address manager);
     event CertificateMinted(address indexed to, uint256 indexed jobId);
+    event NFTListed(uint256 indexed tokenId, address indexed seller, uint256 price);
+    event NFTPurchased(uint256 indexed tokenId, address indexed buyer, uint256 price);
+    event NFTDelisted(uint256 indexed tokenId);
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
 
     constructor() ERC721("Cert", "CERT") Ownable(msg.sender) {}
 
+    // ---------------------------------------------------------------------
+    // Modifiers
+    // ---------------------------------------------------------------------
+
     modifier onlyJobRegistry() {
-        require(msg.sender == jobRegistry, "only JobRegistry");
+        if (msg.sender != jobRegistry) {
+            revert NotJobRegistry(msg.sender);
+        }
         _;
+    }
+
+    // ---------------------------------------------------------------------
+    // Owner configuration
+    // ---------------------------------------------------------------------
+
+    /// @notice Configure the authorised JobRegistry.
+    function setJobRegistry(address registry) external onlyOwner {
+        if (registry == address(0)) revert ZeroAddress();
+        jobRegistry = registry;
+        emit JobRegistryUpdated(registry);
+    }
+
+    /// @notice Set the StakeManager used to transfer the ERC20 token.
+    function setStakeManager(address manager) external onlyOwner {
+        if (manager == address(0)) revert ZeroAddress();
+        stakeManager = StakeManager(payable(manager));
+        emit StakeManagerUpdated(manager);
     }
 
     /// @notice Update the base token URI.
@@ -29,52 +103,104 @@ contract CertificateNFT is ERC721, Ownable {
         emit BaseURIUpdated(uri);
     }
 
-    /// @notice Configure the authorized JobRegistry.
-    function setJobRegistry(address registry) external onlyOwner {
-        jobRegistry = registry;
-        emit JobRegistryUpdated(registry);
-    }
+    // ---------------------------------------------------------------------
+    // Minting
+    // ---------------------------------------------------------------------
 
     /// @notice Mint a new certificate to `to` for `jobId`.
     /// @dev Only callable by the configured JobRegistry.
-    function mintCertificate(
+    function mint(
         address to,
         uint256 jobId,
         string calldata uri
     ) external onlyJobRegistry returns (uint256 tokenId) {
+        if (bytes(uri).length == 0) revert EmptyURI();
+        if (to == address(0)) revert ZeroAddress();
         tokenId = jobId;
-        _safeMint(to, tokenId);
-        if (bytes(uri).length != 0) {
-            _tokenURIs[tokenId] = uri;
+        if (_ownerOf(tokenId) != address(0)) {
+            revert CertificateAlreadyMinted(jobId);
         }
-        emit CertificateMinted(to, tokenId);
+        _safeMint(to, tokenId);
+        _tokenURIs[tokenId] = uri;
+        emit CertificateMinted(to, jobId);
     }
+
+    // ---------------------------------------------------------------------
+    // Marketplace
+    // ---------------------------------------------------------------------
+
+    /// @notice List a certificate for sale at a given `price`.
+    function list(uint256 tokenId, uint256 price) external {
+        require(ownerOf(tokenId) == msg.sender, "owner");
+        require(price > 0, "price");
+        Listing storage listing = listings[tokenId];
+        require(!listing.active, "listed");
+
+        listing.seller = msg.sender;
+        listing.price = price;
+        listing.active = true;
+
+        emit NFTListed(tokenId, msg.sender, price);
+    }
+
+    /// @notice Purchase a listed certificate using the StakeManager's token.
+    function purchase(uint256 tokenId) external nonReentrant {
+        Listing storage listing = listings[tokenId];
+        require(listing.active, "not listed");
+        address seller = listing.seller;
+        require(seller != msg.sender, "self");
+
+        IERC20 token = stakeManager.token();
+        uint256 price = listing.price;
+        require(token.allowance(msg.sender, address(this)) >= price, "allowance");
+
+        delete listings[tokenId];
+
+        token.safeTransferFrom(msg.sender, seller, price);
+        _safeTransfer(seller, msg.sender, tokenId, "");
+
+        emit NFTPurchased(tokenId, msg.sender, price);
+    }
+
+    /// @notice Remove an active listing.
+    function delist(uint256 tokenId) external {
+        Listing storage listing = listings[tokenId];
+        require(listing.active, "not listed");
+        require(listing.seller == msg.sender, "owner");
+        delete listings[tokenId];
+        emit NFTDelisted(tokenId);
+    }
+
+    // ---------------------------------------------------------------------
+    // Metadata
+    // ---------------------------------------------------------------------
 
     function _baseURI() internal view override returns (string memory) {
         return baseTokenURI;
     }
 
-    function tokenURI(uint256 tokenId)
-        public
-        view
-        override
-        returns (string memory)
-    {
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        _requireOwned(tokenId);
         string memory custom = _tokenURIs[tokenId];
-        if (bytes(custom).length != 0) {
-            string memory base = _baseURI();
-            if (bytes(base).length != 0) {
-                return string(abi.encodePacked(base, custom));
-            }
-            return custom;
+        string memory base = _baseURI();
+        if (bytes(base).length != 0) {
+            return string.concat(base, custom);
         }
-        return super.tokenURI(tokenId);
+        return custom;
     }
+
+    // ---------------------------------------------------------------------
+    // Tax neutrality helpers
+    // ---------------------------------------------------------------------
 
     /// @notice Confirms the contract and owner are tax-exempt.
     function isTaxExempt() external pure returns (bool) {
         return true;
     }
+
+    // ---------------------------------------------------------------------
+    // Ether rejection
+    // ---------------------------------------------------------------------
 
     receive() external payable {
         revert("CertificateNFT: no ether");

--- a/contracts/JobRegistry.sol
+++ b/contracts/JobRegistry.sol
@@ -31,7 +31,7 @@ interface IFeePool {
 }
 
 interface ICertificateNFT {
-    function mintCertificate(
+    function mint(
         address to,
         uint256 jobId,
         string calldata uri
@@ -467,7 +467,7 @@ contract JobRegistry is Ownable, Pausable {
                 reputationEngine.add(job.agent, 1);
             }
             if (address(certificateNFT) != address(0)) {
-                certificateNFT.mintCertificate(job.agent, jobId, job.outputURI);
+                certificateNFT.mint(job.agent, jobId, job.outputURI);
             }
         } else {
             stakeManager.payReward(job.employer, job.reward + job.fee);

--- a/test/JobRegistryCertificate.test.js
+++ b/test/JobRegistryCertificate.test.js
@@ -71,7 +71,9 @@ describe("JobRegistry and CertificateNFT", function () {
   it("restricts minting to authorized minters", async function () {
     const { cert, agent } = await deployFixture();
     await expect(
-      cert.connect(agent).mintCertificate(agent.address, 1, "foo")
-    ).to.be.revertedWith("only JobRegistry");
+      cert.connect(agent).mint(agent.address, 1, "foo")
+    )
+      .to.be.revertedWithCustomError(cert, "NotJobRegistry")
+      .withArgs(agent.address);
   });
 });


### PR DESCRIPTION
## Summary
- allow JobRegistry to mint certificates once per job
- add marketplace to CertificateNFT with SafeERC20 transfers
- wire JobRegistry finalize to new mint flow

## Testing
- `npm run lint`
- `npx hardhat test` *(fails: compiler download did not complete in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c70b2a148333b25831963b137cd7