### PR TITLE
docs: add v0 quickstart and v2 deployment summary

### DIFF
--- a/docs/quickstart-v0-agialpha-etherscan.md
+++ b/docs/quickstart-v0-agialpha-etherscan.md
@@ -1,0 +1,43 @@
+# Quickstart: Deploying AGIJobManager v0 with $AGIALPHA on Etherscan
+
+This abbreviated guide walks an owner through deploying the monolithic
+`AGIJobManager v0` contract and interacting with it using the 6‑decimal
+`$AGIALPHA` token. All parameters—including the token address, ENS
+roots and Merkle roots—remain owner‑configurable after deployment.
+
+## 1. Deploy the contract
+1. Open the verified `AGIJobManager v0` code on Etherscan and choose
+   **Contract → Deploy**.
+2. Enter constructor parameters:
+   - `_agiTokenAddress` – `$AGIALPHA` token address.
+   - `_baseIpfsUrl` – prefix for job result URIs, e.g. `ipfs://`.
+   - `_ensAddress` / `_nameWrapperAddress` – official ENS contracts.
+   - `_clubRootNode` / `_agentRootNode` – namehashes for `club.agi.eth`
+     and `agent.agi.eth` or `0x00` to disable ENS gating.
+   - `_validatorMerkleRoot` / `_agentMerkleRoot` – allowlist roots or
+     `0x00` for open access.
+3. Submit the transaction; the sender becomes `owner` and may later
+   retune any parameter via the contract's write methods.
+
+## 2. Approve tokens and stake
+All token amounts use 6‑decimal units (`1 AGIALPHA = 1_000000`).
+
+1. **Employers** approve the job reward on `$AGIALPHA` then call
+   `createJob` with `reward` and a metadata URI.
+2. **Agents** stake via `stakeAgent(amount)` and apply with
+   `applyForJob(jobId, subdomain, proof)`.
+3. **Validators** stake with `stake(amount)` and later validate jobs.
+
+## 3. Typical job flow
+1. **Create job** – employer calls `createJob` after approving tokens.
+2. **Apply** – agent calls `applyForJob` with ENS subdomain and optional
+   Merkle proof.
+3. **Validate** – selected validators call `validateJob` or
+   `disapproveJob` after the agent submits results.
+4. **Dispute** – if necessary, `disputeJob` escrows the dispute fee and
+   `resolveDispute` finalises the outcome.
+
+Throughout the lifecycle the owner may update the payout token with
+`updateAGITokenAddress`, adjust ENS roots or Merkle proofs, and tweak
+limits such as `setMaxJobPayout` or `setValidationRewardPercentage`
+without redeploying the contract.

--- a/docs/v0-v2-function-map.md
+++ b/docs/v0-v2-function-map.md
@@ -1,0 +1,26 @@
+# v0 to v2 Function Map
+
+The table below links common `AGIJobManager v0` functions to their
+replacements in the modular v2 architecture. Only job lifecycle,
+blacklist and NFT marketplace functions are listed.
+
+| v0 function | v2 module | v2 function |
+| --- | --- | --- |
+| `createJob` | `JobRegistry` | `createJob` |
+| `applyForJob` | `JobRegistry` | `applyForJob` |
+| `validateJob` | `ValidationModule` | `revealValidation(approve=true)` |
+| `disapproveJob` | `ValidationModule` | `revealValidation(approve=false)` |
+| `disputeJob` | `JobRegistry` | `raiseDispute` |
+| `resolveDispute` | `DisputeModule` | `resolve` |
+| `stakeAgent` | `StakeManager` | `depositStake(Role.Agent)` |
+| `stake` (validator) | `StakeManager` | `depositStake(Role.Validator)` |
+| `withdrawAgentStake` | `StakeManager` | `withdrawStake(Role.Agent)` |
+| `withdrawStake` (validator) | `StakeManager` | `withdrawStake(Role.Validator)` |
+| `blacklistAgent` / `clearAgentBlacklist` | `ReputationEngine` | `blacklist(user, status)` |
+| `blacklistValidator` / `clearValidatorBlacklist` | `ReputationEngine` | `blacklist(user, status)` |
+| `listNFT` | `CertificateNFT` | `list` |
+| `purchaseNFT` | `CertificateNFT` | `purchase` |
+| `delistNFT` | `CertificateNFT` | `delist` |
+
+All other parameters—including the staking token and identity roots—are
+exposed through owner‑only setters on the relevant v2 modules.

--- a/docs/v2-module-deployment-summary.md
+++ b/docs/v2-module-deployment-summary.md
@@ -1,0 +1,40 @@
+# AGIJobs v2 Module Deployment Summary
+
+This note outlines a minimal sequence for deploying the modular v2 stack
+and wiring contracts together. The `$AGIALPHA` token, ENS roots, Merkle
+roots and all numeric parameters can be updated later by the owner.
+
+## 1. Deployment order
+1. **StakeManager** – pass the staking token and treasury details.
+2. **ReputationEngine** – constructor accepts the `StakeManager` address.
+3. **IdentityRegistry** – supply ENS registry, NameWrapper, `StakeManager`
+   and the initial root nodes or `0x00`.
+4. **ValidationModule** – deploy with placeholder `jobRegistry = 0` and
+the `StakeManager` address.
+5. **DisputeModule** – deploy with `jobRegistry = 0` and desired fee.
+6. **CertificateNFT** – deploy with name and symbol.
+7. **FeePool** – point at the staking token and `StakeManager`.
+8. **JobRegistry** – no constructor args.
+
+## 2. Wiring
+1. On `JobRegistry` call
+   `setModules(stakeManager, validationModule, reputationEngine,
+   disputeModule, certificateNFT, feePool)`.
+2. Call `setJobRegistry(jobRegistry)` on `StakeManager`,
+   `ValidationModule`, `DisputeModule` and `CertificateNFT`.
+3. On `ValidationModule` also call `setIdentityRegistry(identityRegistry)`.
+4. Verify `ModulesUpdated` and `JobRegistrySet` events before allowing
+   user funds.
+
+## 3. Post-deploy configuration
+1. **Token rotation** – the owner may change the staking token by calling
+   `setToken(newToken)` on `StakeManager` and `FeePool`.
+2. **ENS & Merkle updates** – adjust namehashes and allowlists through
+   `IdentityRegistry.setAgentRootNode`, `setClubRootNode`,
+   `setAgentMerkleRoot` and `setValidatorMerkleRoot`.
+3. **Parameter tuning** – each module exposes `onlyOwner` setters such as
+   `StakeManager.setMinStake`, `JobRegistry.setFeePct` and
+   `ValidationModule.setCommitWindow`.
+
+Following this order ensures a functioning deployment while keeping all
+critical addresses and parameters modifiable by the contract owner.


### PR DESCRIPTION
## Summary
- add quickstart guide for deploying v0 with $AGIALPHA via Etherscan
- summarize v2 module deployment order and post-deploy wiring
- map v0 functions to v2 modules for job lifecycle, blacklists, and NFTs

## Testing
- `npm test` *(fails: contract compilation warning causes process to hang)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9dca79d788333b32e59c678a7fa10