### PR TITLE
feat: penalize reputation on job failure

### DIFF
--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -182,8 +182,14 @@ contract ReputationEngine is Ownable {
                 emit BlacklistUpdated(user, false);
             }
         } else {
+            uint256 penalty = calculateReputationPoints(payout, duration);
             uint256 current = reputation[user];
-            if (!blacklisted[user] && current < premiumThreshold) {
+            uint256 newScore = current > penalty ? current - penalty : 0;
+            reputation[user] = newScore;
+            uint256 delta = current - newScore;
+            emit ReputationUpdated(user, -int256(delta), newScore);
+
+            if (!blacklisted[user] && newScore < premiumThreshold) {
                 blacklisted[user] = true;
                 emit BlacklistUpdated(user, true);
             }


### PR DESCRIPTION
## Summary
- deduct reputation using logarithmic penalty when job finalization fails
- emit `ReputationUpdated` and blacklist if score falls below threshold after failure

## Testing
- `npm test test/v2/ReputationEngine.test.js test/v2/ReputationEngineNoEther.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a9f44d09ec833381be55c55915fc7c