### PR TITLE
refactor: remove tx.origin from dispute flow

### DIFF
--- a/contracts/DisputeModule.sol
+++ b/contracts/DisputeModule.sol
@@ -88,8 +88,10 @@ contract DisputeModule is Ownable {
         emit DisputeWindowUpdated(window);
     }
 
-    function raiseDispute(uint256 jobId) external onlyJobRegistry {
-        address claimant = tx.origin;
+    function raiseDispute(uint256 jobId, address claimant)
+        external
+        onlyJobRegistry
+    {
         Dispute storage d = disputes[jobId];
         require(d.claimant == address(0), "disputed");
         IJobRegistry.Job memory job = jobRegistry.jobs(jobId);

--- a/contracts/JobRegistry.sol
+++ b/contracts/JobRegistry.sol
@@ -39,7 +39,7 @@ interface ICertificateNFT {
 }
 
 interface IDisputeModule {
-    function raiseDispute(uint256 jobId) external;
+    function raiseDispute(uint256 jobId, address claimant) external;
     function resolve(uint256 jobId, bool employerWins) external;
 }
 
@@ -417,7 +417,7 @@ contract JobRegistry is Ownable, Pausable {
         }
         job.status = Status.Disputed;
         if (address(disputeModule) != address(0)) {
-            disputeModule.raiseDispute(jobId);
+            disputeModule.raiseDispute(jobId, msg.sender);
         }
         emit JobDisputed(jobId);
     }

--- a/contracts/mocks/DisputeRegistryStub.sol
+++ b/contracts/mocks/DisputeRegistryStub.sol
@@ -2,7 +2,11 @@
 pragma solidity ^0.8.23;
 
 interface IDisputeModule {
-    function raiseDispute(uint256 jobId, string calldata evidence) external;
+    function raiseDispute(
+        uint256 jobId,
+        address claimant,
+        string calldata evidence
+    ) external;
 }
 
 /// @notice Simple job registry stub to interact with DisputeModule in tests
@@ -31,7 +35,11 @@ contract DisputeRegistryStub {
 
     function finalize(uint256) external {}
 
-    function appeal(address module, uint256 jobId, string calldata evidence) external payable {
-        IDisputeModule(module).raiseDispute(jobId, evidence);
+    function appeal(
+        address module,
+        uint256 jobId,
+        string calldata evidence
+    ) external payable {
+        IDisputeModule(module).raiseDispute(jobId, msg.sender, evidence);
     }
 }

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -331,7 +331,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         Job storage job = _jobs[jobId];
         job.status = Status.Disputed;
         if (address(disputeModule) != address(0)) {
-            disputeModule.raiseDispute(jobId, evidence);
+            disputeModule.raiseDispute(jobId, msg.sender, evidence);
         }
         emit JobDisputed(jobId, msg.sender);
     }

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -26,7 +26,11 @@ interface IReputationEngine {
 }
 
 interface IDisputeModule {
-    function raiseDispute(uint256 jobId, string calldata evidence) external;
+    function raiseDispute(
+        uint256 jobId,
+        address claimant,
+        string calldata evidence
+    ) external;
     function resolve(uint256 jobId, bool employerWins) external;
 }
 
@@ -737,7 +741,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
             );
         }
         if (address(disputeModule) != address(0)) {
-            disputeModule.raiseDispute(jobId, evidence);
+            disputeModule.raiseDispute(jobId, msg.sender, evidence);
         }
         emit JobDisputed(jobId, msg.sender);
     }

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -17,7 +17,11 @@ interface IDisputeModule {
     event StakeManagerUpdated(address manager);
     event ModulesUpdated(address indexed jobRegistry, address indexed stakeManager);
 
-    function raiseDispute(uint256 jobId, string calldata evidence) external;
+    function raiseDispute(
+        uint256 jobId,
+        address claimant,
+        string calldata evidence
+    ) external;
     function resolve(uint256 jobId, bool employerWins) external;
     function setDisputeFee(uint256 fee) external;
     function setDisputeWindow(uint256 window) external;

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -148,12 +148,13 @@ contract DisputeModule is Ownable {
 
     /// @notice Raise a dispute by posting the dispute fee.
     /// @param jobId Identifier of the job being disputed.
+    /// @param claimant Address of the participant raising the dispute.
     /// @param evidence Supporting evidence or reason for the dispute.
-    function raiseDispute(uint256 jobId, string calldata evidence)
-        external
-        onlyJobRegistry
-    {
-        address claimant = tx.origin;
+    function raiseDispute(
+        uint256 jobId,
+        address claimant,
+        string calldata evidence
+    ) external onlyJobRegistry {
         Dispute storage d = disputes[jobId];
         require(d.raisedAt == 0, "disputed");
 


### PR DESCRIPTION
## Summary
- pass claimant address to dispute modules instead of relying on `tx.origin`
- update job registry, interfaces, and test mocks accordingly

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aa17e3915483338e6f929a604d3aac