### PR TITLE
feat: emit moderator update event

### DIFF
--- a/contracts/v2/DisputeModule.sol
+++ b/contracts/v2/DisputeModule.sol
@@ -38,6 +38,10 @@ contract DisputeModule is Ownable {
     /// @notice Emitted when the moderator resolves a dispute.
     event DisputeResolved(uint256 indexed jobId, bool employerWins);
 
+    /// @notice Emitted when the moderator address is updated.
+    /// @param moderator Address of the new moderator
+    event ModeratorUpdated(address indexed moderator);
+
     constructor(
         IJobRegistry _jobRegistry,
         IStakeManager _stakeManager,
@@ -55,7 +59,9 @@ contract DisputeModule is Ownable {
     /// @notice Update the moderator address.
     /// @param _moderator New moderator able to resolve disputes.
     function setModerator(address _moderator) external onlyOwner {
+        require(_moderator != address(0), "moderator");
         moderator = _moderator;
+        emit ModeratorUpdated(_moderator);
     }
 
     /// @dev Restrict calls to the designated moderator.

--- a/test/v2/DisputeModuleCore.test.js
+++ b/test/v2/DisputeModuleCore.test.js
@@ -1,0 +1,41 @@
+const { expect } = require("chai");
+
+describe("DisputeModule core", function () {
+  let owner, other, registry, stakeManager, dispute;
+
+  beforeEach(async function () {
+    [owner, other] = await ethers.getSigners();
+
+    const JobMock = await ethers.getContractFactory("MockJobRegistry");
+    registry = await JobMock.deploy();
+    await registry.waitForDeployment();
+
+    const StakeMock = await ethers.getContractFactory("MockStakeManager");
+    stakeManager = await StakeMock.deploy();
+    await stakeManager.waitForDeployment();
+
+    const Dispute = await ethers.getContractFactory(
+      "contracts/v2/DisputeModule.sol:DisputeModule"
+    );
+    dispute = await Dispute.deploy(
+      await registry.getAddress(),
+      await stakeManager.getAddress(),
+      owner.address,
+      0
+    );
+    await dispute.waitForDeployment();
+  });
+
+  it("emits ModeratorUpdated on setModerator", async function () {
+    await expect(dispute.setModerator(other.address))
+      .to.emit(dispute, "ModeratorUpdated")
+      .withArgs(other.address);
+    expect(await dispute.moderator()).to.equal(other.address);
+  });
+
+  it("reverts when moderator is zero address", async function () {
+    await expect(dispute.setModerator(ethers.ZeroAddress)).to.be.revertedWith(
+      "moderator"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- emit `ModeratorUpdated` event when updating dispute moderator
- prevent setting the moderator to the zero address
- add tests covering moderator update behavior

## Testing
- `npx hardhat test test/v2/DisputeModuleCore.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa1e81ce148333b4962272a6e6045f