### PR TITLE
feat: add weighted moderator consensus

### DIFF
--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -11,7 +11,7 @@ interface IDisputeModule {
         bool employerWins
     );
     event DisputeFeeUpdated(uint256 fee);
-    event ModeratorUpdated(address moderator, bool enabled);
+    event ModeratorUpdated(address moderator, uint256 weight);
     event DisputeWindowUpdated(uint256 window);
     event JobRegistryUpdated(address registry);
     event StakeManagerUpdated(address manager);
@@ -22,10 +22,14 @@ interface IDisputeModule {
         address claimant,
         string calldata evidence
     ) external;
-    function resolve(uint256 jobId, bool employerWins) external;
+    function resolve(
+        uint256 jobId,
+        bool employerWins,
+        bytes[] calldata signatures
+    ) external;
     function setDisputeFee(uint256 fee) external;
     function setDisputeWindow(uint256 window) external;
-    function addModerator(address moderator) external;
+    function addModerator(address moderator, uint256 weight) external;
     function removeModerator(address moderator) external;
     function setJobRegistry(address registry) external;
     function setStakeManager(address manager) external;

--- a/docs/agialpha-workflows.md
+++ b/docs/agialpha-workflows.md
@@ -18,7 +18,7 @@ This guide summarises Etherscan-based interactions for the $AGIALPHA-powered AGI
 ## 4. Raise a Dispute (Anyone)
 1. **Approve fee** – approve the dispute fee for `StakeManager` (e.g., `10_000000` for 10 tokens).
 2. **Raise** – on [`DisputeModule` Write](https://etherscan.io/address/<DisputeModuleAddress>#writeContract) call `raiseDispute(jobId, evidence)` before the window ends.
-3. **Resolve** – after the window an authorised arbiter calls `resolve(jobId)`.
+3. **Resolve** – after the window a majority of moderators (or the owner) calls `resolve(jobId, verdict, signatures)`.
 
 ## 5. Trade a Certificate (Peer to Peer)
 1. **List** – certificate owner calls `list(tokenId, price)` on [`CertificateNFT` Write](https://etherscan.io/address/<CertificateNFTAddress>#writeContract)` using 6‑decimal pricing.

--- a/docs/coding-sprint-v2-ens-identity.md
+++ b/docs/coding-sprint-v2-ens-identity.md
@@ -44,8 +44,8 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 
 ### 6. DisputeModule
 - Allow `JobRegistry.dispute` to escrow dispute fees and trigger resolution.
-- Moderator‑based `resolve(jobId, employerWins)` that directs `StakeManager` to refund or release.
-- Owner setter to manage moderator addresses and dispute fee size.
+- Majority‑signed `resolve(jobId, employerWins, signatures)` directing `StakeManager` to refund or release.
+- Owner setter to manage moderator addresses, weights, and dispute fee size.
 
 ### 7. CertificateNFT & Marketplace
 - Mint one certificate per completed job to the worker.

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -21,7 +21,7 @@ For a narrated deployment walkthrough, see [deployment-agialpha.md](deployment-a
 | Employer | `$AGIALPHA.approve(StakeManager, 1_050000)` → `JobRegistry.acknowledgeTaxPolicy()` → `JobRegistry.createJob(1_000000, uri)` | approve `1_050000` for a 1‑token reward + 5% fee |
 | Agent | `$AGIALPHA.approve(StakeManager, 1_000000)` → `JobRegistry.stakeAndApply(jobId, 1_000000)` | stake `1_000000` |
 | Validator | `$AGIALPHA.approve(StakeManager, 1_000000)` → `StakeManager.depositStake(1, 1_000000)` → `ValidationModule.commitValidation(jobId, hash, sub, proof)` → `ValidationModule.revealValidation(jobId, approve, salt)` | stake `1_000000` |
-| Disputer | `$AGIALPHA.approve(StakeManager, 1_000000)` → `JobRegistry.acknowledgeAndDispute(jobId, evidence)` → owner `DisputeModule.resolve(jobId, uphold)` | dispute fee `1_000000` |
+| Disputer | `$AGIALPHA.approve(StakeManager, 1_000000)` → `JobRegistry.acknowledgeAndDispute(jobId, evidence)` → `DisputeModule.resolve(jobId, uphold, signatures)` (majority moderators or owner) | dispute fee `1_000000` |
 
 ## ENS prerequisites
 - Agents need an ENS subdomain ending in `.agent.agi.eth`; validators require `.club.agi.eth`.
@@ -169,7 +169,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 ### Raise & resolve disputes
 1. Approve the dispute fee on `$AGIALPHA`.
 2. On `JobRegistry` → **Write**, call **acknowledgeAndDispute(jobId, evidence)**.
-3. The owner finalizes by calling **resolve(jobId, uphold)** on `DisputeModule`.
+3. A majority of moderators (or the owner) finalizes by calling **resolve(jobId, uphold, signatures)** on `DisputeModule`.
 
 ### List & purchase NFTs
 1. To list a certificate, open `CertificateNFT` → **Write** and call **approve(marketplace, tokenId)** or **setApprovalForAll(operator, true)**.
@@ -202,7 +202,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 | Function | Parameters | Typical Use Case |
 | --- | --- | --- |
 | `raiseDispute(uint256 jobId, string reason)` | jobId, reason URI | Participant appeals a validation outcome. |
-| `resolve(uint256 jobId, bool uphold)` | jobId, `uphold` – sustain original result? | Moderator issues a final ruling. |
+| `resolve(uint256 jobId, bool uphold, bytes[] signatures)` | jobId, ruling, moderator approvals | Finalise dispute via majority vote or owner override. |
 | `setDisputeFee(uint256 fee)` | fee amount | Owner adjusts the dispute bond charged on disputes. |
 
 ## Parameter Glossary

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -70,7 +70,7 @@ For a step-by-step deployment walkthrough with owner-only setters, see [deployme
 | --- | --- | --- |
 | JobRegistry | `setModules` (none set), `setJobParameters` (`reward=0`, `stake=0`), `setFeePool` (0 address), `setFeePct` (`0`), `setTaxPolicy` (0 address) | Wire modules, set template stake/reward, and configure fees/tax policy. |
 | ValidationModule | `setValidatorPool` (empty), `setReputationEngine` (0 address), `setCommitRevealWindows` (`0`, `0`), `setValidatorBounds` (`0`, `0`), `setVRF` (0 address) | Choose validators and tune commit/reveal timing and committee sizes. |
-| DisputeModule | `addModerator` / `removeModerator` (owner), `setAppealJury` (owner), `setDisputeFee` (`0`), `setJobRegistry` (constructor address) | Configure dispute bond and arbiters. |
+| DisputeModule | `addModerator(address, weight)` / `removeModerator(address)` (owner), majority-signed `resolve(jobId, verdict, signatures)`, `setDisputeFee` (`0`), `setJobRegistry` (constructor address) | Configure dispute bond and weighted arbiters; disputes finalize via moderator vote or owner call. |
 | StakeManager | `setToken` (constructor token), `setMinStake` (`0`), `setSlashingPercentages` (`0`, `100`), `setTreasury` (constructor treasury), `setJobRegistry` (0 address), `setDisputeModule` (0 address), `setMaxStakePerAddress` (`0`) | Adjust staking token, minimums, slashing rules, and authorised modules. |
 | ReputationEngine | `setCaller` (`false`), `setStakeManager` (0 address), `setScoringWeights` (`1e18`, `1e18`), `setThreshold` (`0`), `blacklist` (`false`) | Manage scoring weights, authorised callers, and blacklist threshold. |
 | CertificateNFT | `setJobRegistry` (0 address), `setBaseURI` (empty) | Authorise minting registry and metadata base URI. |

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -111,7 +111,7 @@ then be performed through the "Write" tabs on each module.
 ### Dispute
 1. Approve the dispute fee on `$AGIALPHA`.
 2. Call `JobRegistry.raiseDispute(jobId, evidence)`.
-3. Owner resolves via `DisputeModule.resolve(jobId, uphold)`.
+3. Owner or a majority of moderators resolves via `DisputeModule.resolve(jobId, uphold, signatures)`.
 4. Monitor `DisputeRaised` and `DisputeResolved` events.
 
 ### NFT Marketplace

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -69,7 +69,9 @@ interface IReputationEngine {
 
 interface IDisputeModule {
     function raiseDispute(uint256 jobId, string calldata reason) external;
-    function resolve(uint256 jobId, bool uphold) external;
+    function resolve(uint256 jobId, bool uphold, bytes[] calldata sigs) external;
+    function addModerator(address moderator, uint256 weight) external;
+    function removeModerator(address moderator) external;
     function setDisputeFee(uint256 fee) external;
 }
 

--- a/test/systemIntegration.test.js
+++ b/test/systemIntegration.test.js
@@ -162,7 +162,7 @@ describe("Full system integration", function () {
     await validation.setResult(false);
     await registry.connect(agent).completeJob(jobId);
     await registry.connect(agent).raiseDispute(jobId, "evidence");
-    await dispute.connect(owner).resolve(jobId, false);
+    await dispute.connect(owner).resolve(jobId, false, []);
     await registry.connect(owner).finalize(jobId);
 
     expect(await token.balanceOf(agent.address)).to.equal(900n);
@@ -175,7 +175,7 @@ describe("Full system integration", function () {
     await validation.setResult(false);
     await registry.connect(agent).completeJob(jobId);
     await registry.connect(agent).raiseDispute(jobId, "evidence");
-    await dispute.connect(owner).resolve(jobId, true);
+    await dispute.connect(owner).resolve(jobId, true, []);
     await registry.connect(owner).finalize(jobId);
 
     expect(await token.balanceOf(agent.address)).to.equal(800n);

--- a/test/v2/ProtocolFeatures.test.js
+++ b/test/v2/ProtocolFeatures.test.js
@@ -150,7 +150,7 @@ describe("Protocol core features", function () {
     expect(disputeInfo.fee).to.equal(5);
     const block = await ethers.provider.getBlock(rcpt.blockNumber);
     const expected = (BigInt(block.hash) ^ BigInt(jobId)) % 2n === 0n;
-    await expect(dispute.connect(owner).resolve(jobId, expected))
+    await expect(dispute.connect(owner).resolve(jobId, expected, []))
       .to.emit(dispute, "DisputeResolved")
       .withArgs(jobId, owner.address, expected);
     const cleared = await dispute.disputes(jobId);

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -282,7 +282,12 @@ describe("Commit-reveal job lifecycle", function () {
     await validation.finalize(1);
 
     await registry.connect(agent).dispute(1, "evidence");
-    await env.dispute.connect(moderator).resolve(1, true);
+    const hash = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "bool"],
+      [await env.dispute.getAddress(), 1, true]
+    );
+    const sig = await moderator.signMessage(ethers.getBytes(hash));
+    await env.dispute.connect(moderator).resolve(1, true, [sig]);
 
     expect(await stake.stakeOf(agent.address, Role.Agent)).to.equal(0);
     expect(await token.balanceOf(employer.address)).to.equal(

--- a/test/v2/jobLifecycle.test.ts
+++ b/test/v2/jobLifecycle.test.ts
@@ -158,7 +158,12 @@ describe("Job lifecycle", function () {
     await validation.finalize(1);
 
     await registry.connect(employer).dispute(1, "evidence");
-    await dispute.connect(moderator).resolve(1, true); // employer wins
+    const hash = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "bool"],
+      [await dispute.getAddress(), 1, true]
+    );
+    const sig = await moderator.signMessage(ethers.getBytes(hash));
+    await dispute.connect(moderator).resolve(1, true, [sig]); // employer wins
 
     expect(await reputation.isBlacklisted(agent.address)).to.equal(true);
 


### PR DESCRIPTION
## Summary
- allow governance to assign weighted moderators for disputes
- require majority of moderator signatures to resolve a dispute when not called by the owner
- document weighted dispute flow and update tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4db56db08333a5b0f68584623124