### PR TITLE
Store certificate URIs as hashes

### DIFF
--- a/contracts/v2/interfaces/ICertificateNFT.sol
+++ b/contracts/v2/interfaces/ICertificateNFT.sol
@@ -13,7 +13,7 @@ interface ICertificateNFT {
     /// @dev Reverts when an empty metadata URI is supplied
     error EmptyURI();
 
-    event CertificateMinted(address indexed to, uint256 indexed jobId);
+    event CertificateMinted(address indexed to, uint256 indexed jobId, string uri);
 
     /// @notice Mint a completion certificate NFT for a job
     /// @param to Recipient of the certificate

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -14,7 +14,7 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     uint256 public constant version = 1;
 
     address public jobRegistry;
-    mapping(uint256 => string) private _tokenURIs;
+    mapping(uint256 => bytes32) public tokenHashes;
 
     event JobRegistryUpdated(address registry);
 
@@ -42,17 +42,16 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
         uint256 jobId,
         string calldata uri
     ) external onlyJobRegistry returns (uint256 tokenId) {
+        if (bytes(uri).length == 0) revert EmptyURI();
         tokenId = jobId;
         _safeMint(to, tokenId);
-        if (bytes(uri).length != 0) {
-            _tokenURIs[tokenId] = uri;
-        }
-        emit CertificateMinted(to, jobId);
+        tokenHashes[tokenId] = keccak256(bytes(uri));
+        emit CertificateMinted(to, jobId, uri);
     }
 
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         _requireOwned(tokenId);
-        return _tokenURIs[tokenId];
+        revert("Off-chain URI");
     }
 
     /// @notice Confirms this NFT module and owner remain tax neutral.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -73,7 +73,7 @@ For a step-by-step deployment walkthrough with owner-only setters, see [deployme
 | DisputeModule | `addModerator(address, weight)` / `removeModerator(address)` (owner), majority-signed `resolve(jobId, verdict, signatures)`, `setDisputeFee` (`0`), `setJobRegistry` (constructor address) | Configure dispute bond and weighted arbiters; disputes finalize via moderator vote or owner call. |
 | StakeManager | `setToken` (constructor token), `setMinStake` (`0`), `setSlashingPercentages` (`0`, `100`), `setTreasury` (constructor treasury), `setJobRegistry` (0 address), `setDisputeModule` (0 address), `setMaxStakePerAddress` (`0`) | Adjust staking token, minimums, slashing rules, and authorised modules. |
 | ReputationEngine | `setCaller` (`false`), `setStakeManager` (0 address), `setScoringWeights` (`1e18`, `1e18`), `setThreshold` (`0`), `blacklist` (`false`) | Manage scoring weights, authorised callers, and blacklist threshold. |
-| CertificateNFT | `setJobRegistry` (0 address), `setBaseURI` (empty) | Authorise minting registry and metadata base URI. |
+| CertificateNFT | `setJobRegistry` (0 address) | Authorise minting registry; URIs emitted in events with hashes on-chain. |
 
 ## Incentive Mechanics
 Honest participation minimises a system-wide free energy similar to the thermodynamic relation `G = H - T S`.

--- a/test/JobRegistryCertificate.test.js
+++ b/test/JobRegistryCertificate.test.js
@@ -36,8 +36,6 @@ async function deployFixture() {
   await registry.addAdditionalAgent(agent.address);
 
   await cert.setJobRegistry(await registry.getAddress());
-  await cert.setBaseURI("ipfs://");
-
   return { owner, employer, agent, other, reputation, stake, cert, registry };
 }
 
@@ -60,11 +58,12 @@ describe("JobRegistry and CertificateNFT", function () {
     await registry.connect(employer).createJob();
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId);
-    await registry.connect(agent).submit(jobId, "result.json");
+    await registry.connect(agent).submit(jobId, "ipfs://result.json");
     await registry.finalize(jobId);
 
     expect(await cert.ownerOf(jobId)).to.equal(agent.address);
-    expect(await cert.tokenURI(jobId)).to.equal("ipfs://result.json");
+    const hash = await cert.tokenHashes(jobId);
+    expect(hash).to.equal(ethers.keccak256(ethers.toUtf8Bytes("ipfs://result.json")));
     await expect(registry.finalize(jobId)).to.be.revertedWith("not ready");
   });
 

--- a/test/v2/CertificateNFT.test.js
+++ b/test/v2/CertificateNFT.test.js
@@ -14,13 +14,13 @@ describe("CertificateNFT", function () {
   });
 
   it("mints certificates only via JobRegistry", async () => {
-    await expect(
-      nft.connect(jobRegistry).mint(user.address, 1, "ipfs://job/1")
-    )
+    const uri = "ipfs://job/1";
+    await expect(nft.connect(jobRegistry).mint(user.address, 1, uri))
       .to.emit(nft, "CertificateMinted")
-      .withArgs(user.address, 1);
+      .withArgs(user.address, 1, uri);
     expect(await nft.ownerOf(1)).to.equal(user.address);
-    expect(await nft.tokenURI(1)).to.equal("ipfs://job/1");
+    const hash = await nft.tokenHashes(1);
+    expect(hash).to.equal(ethers.keccak256(ethers.toUtf8Bytes(uri)));
     await expect(
       nft.connect(owner).mint(user.address, 2, "ipfs://job/2")
     ).to.be.revertedWith("only JobRegistry");

--- a/test/v2/CertificateNFTMint.test.js
+++ b/test/v2/CertificateNFTMint.test.js
@@ -14,13 +14,13 @@ describe("CertificateNFT minting", function () {
   });
 
   it("mints with jobId tokenId and enforces registry and URI", async () => {
-    await expect(
-      nft.connect(jobRegistry).mint(user.address, 1, "ipfs://1")
-    )
+    const uri = "ipfs://1";
+    await expect(nft.connect(jobRegistry).mint(user.address, 1, uri))
       .to.emit(nft, "CertificateMinted")
-      .withArgs(user.address, 1);
+      .withArgs(user.address, 1, uri);
     expect(await nft.ownerOf(1)).to.equal(user.address);
-    expect(await nft.tokenURI(1)).to.equal("ipfs://1");
+    const hash = await nft.tokenHashes(1);
+    expect(hash).to.equal(ethers.keccak256(ethers.toUtf8Bytes(uri)));
 
     await expect(
       nft.connect(jobRegistry).mint(user.address, 2, "")
@@ -31,13 +31,5 @@ describe("CertificateNFT minting", function () {
     ).to.be.revertedWithCustomError(nft, "NotJobRegistry").withArgs(
       owner.address
     );
-  });
-
-  it("updates base URI and emits event", async () => {
-    await nft.connect(jobRegistry).mint(user.address, 1, "1");
-    await expect(nft.setBaseURI("https://base/"))
-      .to.emit(nft, "BaseURIUpdated")
-      .withArgs("https://base/");
-    expect(await nft.tokenURI(1)).to.equal("https://base/1");
   });
 });

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -112,14 +112,20 @@ describe("Ownable modules", function () {
         (inst, signer) => inst.connect(signer).setScoringWeights(0, 0),
       ],
       [DisputeModule.attach(dispute), (inst, signer) => inst.connect(signer).setDisputeFee(0)],
-      [CertificateNFT.attach(certificate), (inst, signer) => inst.connect(signer).setJobRegistry(ethers.ZeroAddress)],
+      [
+        CertificateNFT.attach(certificate),
+        (inst, signer) => inst.connect(signer).setJobRegistry(other.address),
+      ],
       [PlatformRegistry.attach(platformRegistry), (inst, signer) => inst.connect(signer).setMinPlatformStake(0)],
       [JobRouter.attach(router), (inst, signer) => inst.connect(signer).setRegistrar(ethers.ZeroAddress, false)],
       [PlatformIncentives.attach(incentives), (inst, signer) => inst.connect(signer).setModules(ethers.ZeroAddress, ethers.ZeroAddress, ethers.ZeroAddress)],
       [FeePool.attach(feePool), (inst, signer) => inst.connect(signer).setBurnPct(0)],
       [TaxPolicy.attach(taxPolicy), (inst, signer) => inst.connect(signer).setPolicyURI("ipfs://new")],
       [ENSVerifier.attach(ensVerifier), (inst, signer) => inst.connect(signer).setENS(ethers.ZeroAddress)],
-      [modCert, (inst, signer) => inst.connect(signer).setJobRegistry(ethers.ZeroAddress)],
+      [
+        modCert,
+        (inst, signer) => inst.connect(signer).setJobRegistry(other.address),
+      ],
       [identity, (inst, signer) => inst.connect(signer).setModules(ethers.ZeroAddress, ethers.ZeroAddress)],
     ];
 

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -112,7 +112,7 @@ describe("Ownable modules", function () {
         (inst, signer) => inst.connect(signer).setScoringWeights(0, 0),
       ],
       [DisputeModule.attach(dispute), (inst, signer) => inst.connect(signer).setDisputeFee(0)],
-      [CertificateNFT.attach(certificate), (inst, signer) => inst.connect(signer).setBaseURI("ipfs://new")],
+      [CertificateNFT.attach(certificate), (inst, signer) => inst.connect(signer).setJobRegistry(ethers.ZeroAddress)],
       [PlatformRegistry.attach(platformRegistry), (inst, signer) => inst.connect(signer).setMinPlatformStake(0)],
       [JobRouter.attach(router), (inst, signer) => inst.connect(signer).setRegistrar(ethers.ZeroAddress, false)],
       [PlatformIncentives.attach(incentives), (inst, signer) => inst.connect(signer).setModules(ethers.ZeroAddress, ethers.ZeroAddress, ethers.ZeroAddress)],


### PR DESCRIPTION
## Summary
- replace CertificateNFT URI storage with bytes32 content hashes
- emit full metadata URIs in mint events
- update tests and docs for off-chain URI handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa5cc4c0708333ad63d91d131ff278