### PR TITLE
feat: add pluggable validation modules

### DIFF
--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IJobRegistry} from "../interfaces/IJobRegistry.sol";
+import {IValidationModule} from "../interfaces/IValidationModule.sol";
+
+/// @title NoValidationModule
+/// @notice Bypasses validator selection and automatically approves submissions.
+/// @dev Intended for low-stakes jobs where external validation is unnecessary.
+contract NoValidationModule is IValidationModule, Ownable {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 1;
+
+    IJobRegistry public jobRegistry;
+
+    event JobRegistryUpdated(address registry);
+
+    constructor(IJobRegistry _jobRegistry) Ownable(msg.sender) {
+        if (address(_jobRegistry) != address(0)) {
+            jobRegistry = _jobRegistry;
+            emit JobRegistryUpdated(address(_jobRegistry));
+        }
+    }
+
+    /// @notice Set the JobRegistry reference.
+    function setJobRegistry(IJobRegistry registry) external onlyOwner {
+        jobRegistry = registry;
+        emit JobRegistryUpdated(address(registry));
+    }
+
+    /// @inheritdoc IValidationModule
+    function selectValidators(uint256)
+        external
+        pure
+        override
+        returns (address[] memory validators)
+    {
+        validators = new address[](0);
+    }
+
+    /// @inheritdoc IValidationModule
+    function start(uint256 jobId, string calldata)
+        external
+        override
+        returns (address[] memory validators)
+    {
+        validators = new address[](0);
+        jobRegistry.onValidationResult(jobId, true, validators);
+    }
+
+    /// @inheritdoc IValidationModule
+    function commitValidation(
+        uint256,
+        bytes32,
+        string calldata,
+        bytes32[] calldata
+    ) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function commitValidation(uint256, bytes32)
+        external
+        pure
+        override
+    {}
+
+    /// @inheritdoc IValidationModule
+    function revealValidation(
+        uint256,
+        bool,
+        bytes32,
+        string calldata,
+        bytes32[] calldata
+    ) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function revealValidation(uint256, bool, bytes32)
+        external
+        pure
+        override
+    {}
+
+    /// @inheritdoc IValidationModule
+    function finalize(uint256) external pure override returns (bool) {
+        return true;
+    }
+
+    /// @inheritdoc IValidationModule
+    function finalizeValidation(uint256) external pure override returns (bool) {
+        return true;
+    }
+
+    /// @inheritdoc IValidationModule
+    function setParameters(
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256
+    ) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setValidatorsPerJob(uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setCommitRevealWindows(uint256, uint256)
+        external
+        pure
+        override
+    {}
+
+    /// @inheritdoc IValidationModule
+    function setTiming(uint256, uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setValidatorBounds(uint256, uint256)
+        external
+        pure
+        override
+    {}
+
+    /// @inheritdoc IValidationModule
+    function setRequiredValidatorApprovals(uint256)
+        external
+        pure
+        override
+    {}
+
+    /// @inheritdoc IValidationModule
+    function resetJobNonce(uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setApprovalThreshold(uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setValidatorSlashingPct(uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setValidatorSubdomains(
+        address[] calldata,
+        string[] calldata
+    ) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function validators(uint256)
+        external
+        pure
+        override
+        returns (address[] memory list)
+    {
+        list = new address[](0);
+    }
+
+    /// @inheritdoc IValidationModule
+    function votes(uint256, address)
+        external
+        pure
+        override
+        returns (bool)
+    {
+        return true;
+    }
+}
+

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IJobRegistry} from "../interfaces/IJobRegistry.sol";
+import {IValidationModule} from "../interfaces/IValidationModule.sol";
+
+/// @dev Minimal interface for external oracle decisions.
+interface IValidationOracle {
+    function approve(uint256 jobId, string calldata data)
+        external
+        view
+        returns (bool approved);
+}
+
+/// @title OracleValidationModule
+/// @notice Delegates approval decisions to an external oracle contract.
+/// @dev Useful for specialised off-chain evaluation logic.
+contract OracleValidationModule is IValidationModule, Ownable {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 1;
+
+    IJobRegistry public jobRegistry;
+    IValidationOracle public oracle;
+
+    event JobRegistryUpdated(address registry);
+    event OracleUpdated(address oracle);
+
+    constructor(IJobRegistry _jobRegistry, IValidationOracle _oracle)
+        Ownable(msg.sender)
+    {
+        if (address(_jobRegistry) != address(0)) {
+            jobRegistry = _jobRegistry;
+            emit JobRegistryUpdated(address(_jobRegistry));
+        }
+        if (address(_oracle) != address(0)) {
+            oracle = _oracle;
+            emit OracleUpdated(address(_oracle));
+        }
+    }
+
+    /// @notice Update the JobRegistry reference.
+    function setJobRegistry(IJobRegistry registry) external onlyOwner {
+        jobRegistry = registry;
+        emit JobRegistryUpdated(address(registry));
+    }
+
+    /// @notice Update the oracle used for validation decisions.
+    function setOracle(IValidationOracle _oracle) external onlyOwner {
+        oracle = _oracle;
+        emit OracleUpdated(address(_oracle));
+    }
+
+    /// @inheritdoc IValidationModule
+    function selectValidators(uint256)
+        external
+        pure
+        override
+        returns (address[] memory validators)
+    {
+        validators = new address[](0);
+    }
+
+    /// @inheritdoc IValidationModule
+    function start(uint256 jobId, string calldata data)
+        external
+        override
+        returns (address[] memory validators)
+    {
+        validators = new address[](0);
+        bool approved = oracle.approve(jobId, data);
+        jobRegistry.onValidationResult(jobId, approved, validators);
+    }
+
+    /// @inheritdoc IValidationModule
+    function commitValidation(
+        uint256,
+        bytes32,
+        string calldata,
+        bytes32[] calldata
+    ) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function commitValidation(uint256, bytes32)
+        external
+        pure
+        override
+    {}
+
+    /// @inheritdoc IValidationModule
+    function revealValidation(
+        uint256,
+        bool,
+        bytes32,
+        string calldata,
+        bytes32[] calldata
+    ) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function revealValidation(uint256, bool, bytes32)
+        external
+        pure
+        override
+    {}
+
+    /// @inheritdoc IValidationModule
+    function finalize(uint256) external pure override returns (bool) {
+        return true;
+    }
+
+    /// @inheritdoc IValidationModule
+    function finalizeValidation(uint256) external pure override returns (bool) {
+        return true;
+    }
+
+    /// @inheritdoc IValidationModule
+    function setParameters(
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256
+    ) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setValidatorsPerJob(uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setCommitRevealWindows(uint256, uint256)
+        external
+        pure
+        override
+    {}
+
+    /// @inheritdoc IValidationModule
+    function setTiming(uint256, uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setValidatorBounds(uint256, uint256)
+        external
+        pure
+        override
+    {}
+
+    /// @inheritdoc IValidationModule
+    function setRequiredValidatorApprovals(uint256)
+        external
+        pure
+        override
+    {}
+
+    /// @inheritdoc IValidationModule
+    function resetJobNonce(uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setApprovalThreshold(uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setValidatorSlashingPct(uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setValidatorSubdomains(
+        address[] calldata,
+        string[] calldata
+    ) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function validators(uint256)
+        external
+        pure
+        override
+        returns (address[] memory list)
+    {
+        list = new address[](0);
+    }
+
+    /// @inheritdoc IValidationModule
+    function votes(uint256, address)
+        external
+        pure
+        override
+        returns (bool)
+    {
+        return true;
+    }
+}
+

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -168,6 +168,22 @@ Each module exposes minimal `onlyOwner` setters so governance can tune economics
 
 All setters are accessible through block‑explorer interfaces, keeping administration intuitive for non‑technical owners while preserving contract immutability. These interfaces favour explicit, single‑purpose methods, keeping gas costs predictable and allowing front‑end or Etherscan interactions to remain intuitive.
 
+### Swapping validation modules
+Different validation strategies can be wired into `JobRegistry` by calling `setValidationModule` with the address of the desired implementation:
+
+```solidity
+JobRegistry registry = JobRegistry(<registry>);
+NoValidationModule fast = new NoValidationModule(registry);
+OracleValidationModule oracle = new OracleValidationModule(registry, <oracle>);
+
+// use fast auto‑approval for low‑stakes jobs
+registry.setValidationModule(address(fast));
+
+// later switch to oracle‑driven validation
+registry.setValidationModule(address(oracle));
+```
+
+
 ## User Experience
 Non‑technical employers, agents and validators can call these methods directly through Etherscan's read and write tabs. Every parameter uses human‑readable units (wei for token amounts and seconds for timing) so that wallets and explorers can display values without custom tooling. No external subscription or Chainlink VRF is required; validator selection relies on commit‑reveal randomness seeded by the owner.
 If a result is contested, employers or agents invoke the DisputeModule's `raiseDispute` through the explorer and a moderator or expanded validator jury finalises the job.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -75,6 +75,13 @@ For a step-by-step deployment walkthrough with owner-only setters, see [deployme
 | ReputationEngine | `setCaller` (`false`), `setStakeManager` (0 address), `setScoringWeights` (`1e18`, `1e18`), `setThreshold` (`0`), `blacklist` (`false`) | Manage scoring weights, authorised callers, and blacklist threshold. |
 | CertificateNFT | `setJobRegistry` (0 address) | Authorise minting registry; URIs emitted in events with hashes on-chain. |
 
+Example of swapping validation logic:
+
+```solidity
+NoValidationModule fast = new NoValidationModule(registry);
+registry.setValidationModule(address(fast));
+```
+
 ## Incentive Mechanics
 Honest participation minimises a system-wide free energy similar to the thermodynamic relation `G = H - T S`.
 Slashing raises the enthalpy `H` of dishonest paths, while commit–reveal randomness injects entropy `S`.


### PR DESCRIPTION
## Summary
- add `NoValidationModule` for automatic approval
- add `OracleValidationModule` that delegates to external oracle
- document swapping validation modules via `setValidationModule`

## Testing
- `npx hardhat compile`
- `npx hardhat test` *(fails: process did not complete, warning shown)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa6506c9108333a7dec356fcc9573d