### PR TITLE
Add lifecycle, fuzz, and gas profiling tests

### DIFF
--- a/test/v2/StakeManagerFuzz.t.sol
+++ b/test/v2/StakeManagerFuzz.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {StakeManager} from "../../contracts/v2/StakeManager.sol";
+import {AGIALPHAToken} from "../../contracts/v2/AGIALPHAToken.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract StakeManagerFuzz is Test {
+    StakeManager stake;
+    AGIALPHAToken token;
+
+    function setUp() public {
+        token = new AGIALPHAToken();
+        stake = new StakeManager(IERC20(address(token)), 1e6, 50, 50, address(this), address(this), address(this));
+    }
+
+    function _deposit(address user, uint256 amount, StakeManager.Role role) internal {
+        token.mint(user, amount);
+        vm.prank(user);
+        token.approve(address(stake), amount);
+        vm.prank(user);
+        stake.depositStake(role, amount);
+    }
+
+    function testFuzz_slashWithinStake(uint256 deposit, uint256 slash) public {
+        vm.assume(deposit >= stake.minStake() && deposit < 1e24);
+        vm.assume(slash <= deposit);
+        _deposit(address(1), deposit, StakeManager.Role.Validator);
+        vm.prank(address(this));
+        stake.slash(address(1), StakeManager.Role.Validator, slash, address(this));
+        assertEq(stake.stakeOf(address(1), StakeManager.Role.Validator), deposit - slash);
+    }
+
+    function testFuzz_maxStakePerAddress(uint256 limit, uint256 first, uint256 second) public {
+        vm.assume(limit >= stake.minStake());
+        vm.assume(first >= stake.minStake());
+        vm.assume(second >= stake.minStake());
+        stake.setMaxStakePerAddress(limit);
+        vm.assume(first <= limit);
+        _deposit(address(2), first, StakeManager.Role.Agent);
+        uint256 remaining = limit - first;
+        vm.assume(second > remaining);
+        token.mint(address(2), second);
+        vm.prank(address(2));
+        token.approve(address(stake), second);
+        vm.prank(address(2));
+        vm.expectRevert("max stake");
+        stake.depositStake(StakeManager.Role.Agent, second);
+    }
+}

--- a/test/v2/ValidatorSelectionFuzz.t.sol
+++ b/test/v2/ValidatorSelectionFuzz.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {StakeManager} from "../../contracts/v2/StakeManager.sol";
+import {ValidationModule} from "../../contracts/v2/ValidationModule.sol";
+import {IdentityRegistryToggle} from "../../contracts/v2/mocks/IdentityRegistryToggle.sol";
+import {IJobRegistry} from "../../contracts/v2/interfaces/IJobRegistry.sol";
+import {IStakeManager} from "../../contracts/v2/interfaces/IStakeManager.sol";
+import {IIdentityRegistry} from "../../contracts/v2/interfaces/IIdentityRegistry.sol";
+import {AGIALPHAToken} from "../../contracts/v2/AGIALPHAToken.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract ValidatorSelectionFuzz is Test {
+    StakeManager stake;
+    ValidationModule validation;
+    IdentityRegistryToggle identity;
+    AGIALPHAToken token;
+
+    function setUp() public {
+        token = new AGIALPHAToken();
+        stake = new StakeManager(IERC20(address(token)), 1e6, 0, 100, address(this), address(0), address(0));
+        identity = new IdentityRegistryToggle();
+        validation = new ValidationModule(
+            IJobRegistry(address(0)),
+            IStakeManager(address(stake)),
+            1,
+            1,
+            1,
+            10,
+            new address[](0)
+        );
+        validation.setIdentityRegistry(IIdentityRegistry(address(identity)));
+    }
+
+    function testFuzz_validatorSelection(uint8 poolSize, uint8 selectCount) public {
+        vm.assume(poolSize > 0 && poolSize <= 10);
+        vm.assume(selectCount > 0 && selectCount <= poolSize);
+        address[] memory pool = new address[](poolSize);
+        for (uint8 i; i < poolSize; i++) {
+            address val = address(uint160(uint256(keccak256(abi.encode(i + 1)))));
+            pool[i] = val;
+            identity.addAdditionalValidator(val);
+            token.mint(val, 1e6);
+            vm.prank(val);
+            token.approve(address(stake), 1e6);
+            vm.prank(val);
+            stake.depositStake(StakeManager.Role.Validator, 1e6);
+        }
+        validation.setValidatorPool(pool);
+        validation.setValidatorsPerJob(selectCount);
+        address[] memory selected = validation.selectValidators(1);
+        assertEq(selected.length, selectCount);
+        for (uint256 i; i < selected.length; i++) {
+            for (uint256 j = i + 1; j < selected.length; j++) {
+                assertTrue(selected[i] != selected[j]);
+            }
+        }
+    }
+}

--- a/test/v2/gasProfile.test.ts
+++ b/test/v2/gasProfile.test.ts
@@ -1,0 +1,129 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+enum Role {
+  Agent,
+  Validator,
+  Platform,
+}
+
+async function deployFullSystem() {
+  const [owner, employer, agent, v1, v2, moderator] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
+  const token = await Token.deploy();
+  const mint = ethers.parseUnits("1000", 6);
+  await token.mint(employer.address, mint);
+  await token.mint(agent.address, mint);
+  await token.mint(v1.address, mint);
+  await token.mint(v2.address, mint);
+
+  const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
+  const stake = await Stake.deploy(await token.getAddress(), 0, 0, 0, owner.address, ethers.ZeroAddress, ethers.ZeroAddress);
+
+  const Reputation = await ethers.getContractFactory("contracts/v2/ReputationEngine.sol:ReputationEngine");
+  const reputation = await Reputation.deploy(await stake.getAddress());
+
+  const Identity = await ethers.getContractFactory("contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle");
+  const identity = await Identity.deploy();
+  await identity.setResult(true);
+
+  const Validation = await ethers.getContractFactory("contracts/v2/ValidationModule.sol:ValidationModule");
+  const validation = await Validation.deploy(
+    ethers.ZeroAddress,
+    await stake.getAddress(),
+    1,
+    1,
+    1,
+    5,
+    []
+  );
+
+  const NFT = await ethers.getContractFactory("contracts/v2/CertificateNFT.sol:CertificateNFT");
+  const nft = await NFT.deploy("Cert", "CERT");
+
+  const Registry = await ethers.getContractFactory("contracts/v2/JobRegistry.sol:JobRegistry");
+  const registry = await Registry.deploy(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroAddress,
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    0,
+    0,
+    []
+  );
+
+  const Dispute = await ethers.getContractFactory("contracts/v2/DisputeModule.sol:DisputeModule");
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    await stake.getAddress(),
+    moderator.address,
+    0
+  );
+
+  await stake.setModules(await registry.getAddress(), await dispute.getAddress());
+  await validation.setJobRegistry(await registry.getAddress());
+  await validation.setIdentityRegistry(await identity.getAddress());
+  await validation.setValidatorPool([v1.address, v2.address]);
+  await validation.setValidatorsPerJob(2);
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await dispute.getAddress(),
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    []
+  );
+  await reputation.setCaller(await registry.getAddress(), true);
+
+  return { owner, employer, agent, v1, v2, moderator, token, stake, validation, registry, dispute };
+}
+
+describe("gas profiling", function () {
+  it("keeps job lifecycle tx within limits", async () => {
+    const env = await deployFullSystem();
+    const { employer, agent, v1, v2, token, stake, validation, registry, dispute, moderator } = env;
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    for (const signer of [agent, v1, v2]) {
+      await token.connect(signer).approve(await stake.getAddress(), stakeAmount);
+      const role = signer === agent ? Role.Agent : Role.Validator;
+      await stake.connect(signer).depositStake(role, stakeAmount);
+    }
+
+    const reward = ethers.parseUnits("100", 6);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline = BigInt((await time.latest()) + 3600);
+    const txCreate = await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const receiptCreate = await txCreate.wait();
+    expect(receiptCreate.gasUsed).to.be.lt(1_000_000n);
+
+    await registry.connect(agent).applyForJob(1, "agent", []);
+    await registry.connect(agent).submit(1, "ipfs://result", "agent", []);
+
+    const nonce = await validation.jobNonce(1);
+    const salt1 = ethers.randomBytes(32);
+    const commit1 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, true, salt1]));
+    await validation.connect(v1).commitValidation(1, commit1);
+    const salt2 = ethers.randomBytes(32);
+    const commit2 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, false, salt2]));
+    await validation.connect(v2).commitValidation(1, commit2);
+
+    await time.increase(2);
+    await validation.connect(v1).revealValidation(1, true, salt1);
+    await time.increase(2);
+    const txFinalize = await validation.finalize(1);
+    const receiptFinalize = await txFinalize.wait();
+    expect(receiptFinalize.gasUsed).to.be.lt(1_000_000n);
+
+    await registry.connect(agent).dispute(1, "evidence");
+    const txResolve = await dispute.connect(moderator).resolve(1, false);
+    const receiptResolve = await txResolve.wait();
+    expect(receiptResolve.gasUsed).to.be.lt(1_000_000n);
+  });
+});

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -1,0 +1,131 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+enum Role {
+  Agent,
+  Validator,
+  Platform,
+}
+
+async function deployFullSystem() {
+  const [owner, employer, agent, v1, v2, moderator] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
+  const token = await Token.deploy();
+  const mint = ethers.parseUnits("1000", 6);
+  await token.mint(employer.address, mint);
+  await token.mint(agent.address, mint);
+  await token.mint(v1.address, mint);
+  await token.mint(v2.address, mint);
+
+  const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
+  const stake = await Stake.deploy(await token.getAddress(), 0, 0, 0, owner.address, ethers.ZeroAddress, ethers.ZeroAddress);
+
+  const Reputation = await ethers.getContractFactory("contracts/v2/ReputationEngine.sol:ReputationEngine");
+  const reputation = await Reputation.deploy(await stake.getAddress());
+
+  const Identity = await ethers.getContractFactory("contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle");
+  const identity = await Identity.deploy();
+  await identity.setResult(true);
+
+  const Validation = await ethers.getContractFactory("contracts/v2/ValidationModule.sol:ValidationModule");
+  const validation = await Validation.deploy(
+    ethers.ZeroAddress,
+    await stake.getAddress(),
+    1,
+    1,
+    1,
+    5,
+    []
+  );
+
+  const NFT = await ethers.getContractFactory("contracts/v2/CertificateNFT.sol:CertificateNFT");
+  const nft = await NFT.deploy("Cert", "CERT");
+
+  const Registry = await ethers.getContractFactory("contracts/v2/JobRegistry.sol:JobRegistry");
+  const registry = await Registry.deploy(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroAddress,
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    0,
+    0,
+    []
+  );
+
+  const Dispute = await ethers.getContractFactory("contracts/v2/DisputeModule.sol:DisputeModule");
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    await stake.getAddress(),
+    moderator.address,
+    0
+  );
+
+  await stake.setModules(await registry.getAddress(), await dispute.getAddress());
+  await validation.setJobRegistry(await registry.getAddress());
+  await validation.setIdentityRegistry(await identity.getAddress());
+  await validation.setValidatorPool([v1.address, v2.address]);
+  await validation.setValidatorsPerJob(2);
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await dispute.getAddress(),
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    []
+  );
+  await reputation.setCaller(await registry.getAddress(), true);
+
+  return { owner, employer, agent, v1, v2, moderator, token, stake, validation, registry, dispute };
+}
+
+describe("job lifecycle with dispute and validator failure", function () {
+  it("handles validator non-participation and dispute resolution", async () => {
+    const env = await deployFullSystem();
+    const { employer, agent, v1, v2, token, stake, validation, registry, dispute, moderator } = env;
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    for (const signer of [agent, v1, v2]) {
+      await token.connect(signer).approve(await stake.getAddress(), stakeAmount);
+      const role = signer === agent ? Role.Agent : Role.Validator;
+      await stake.connect(signer).depositStake(role, stakeAmount);
+    }
+    const initialAgentBalance = await token.balanceOf(agent.address);
+
+    const reward = ethers.parseUnits("100", 6);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+
+    await registry.connect(agent).applyForJob(1, "agent", []);
+    await registry.connect(agent).submit(1, "ipfs://result", "agent", []);
+
+    const nonce = await validation.jobNonce(1);
+    const salt1 = ethers.randomBytes(32);
+    const commit1 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, true, salt1]));
+    await validation.connect(v1).commitValidation(1, commit1);
+    const salt2 = ethers.randomBytes(32);
+    const commit2 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, false, salt2]));
+    await validation.connect(v2).commitValidation(1, commit2);
+
+    await time.increase(2);
+    await validation.connect(v1).revealValidation(1, true, salt1);
+    // v2 fails to reveal
+    await time.increase(2);
+    await validation.finalize(1);
+
+    expect((await stake.stakes(v2.address, Role.Validator))).to.be.lt(stakeAmount);
+    expect(await registry.jobs(1)).to.have.property("state", 5); // Disputed
+
+    await registry.connect(agent).dispute(1, "evidence");
+    await dispute.connect(moderator).resolve(1, false);
+
+    expect(await registry.jobs(1)).to.have.property("state", 6); // Finalized
+    expect(await token.balanceOf(agent.address)).to.be.gt(initialAgentBalance);
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test covering job lifecycle with validator failure and dispute resolution
- introduce Foundry fuzz tests for slashing, staking limits, and validator selection
- add gas profiling tests ensuring core operations stay under 1M gas

## Testing
- `forge test --match-path test/v2/StakeManagerFuzz.t.sol` *(fails: compilation errors in unrelated tests)*
- `npx hardhat test test/v2/jobLifecycleWithDispute.integration.test.ts` *(no output; process terminated)*


------
https://chatgpt.com/codex/tasks/task_e_68aa698066a883339a1e89c710686fdb