### PR TITLE
Refactor ownership to governance interface

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -260,6 +260,7 @@ contract Deployer is Ownable {
         IERC20 token = econ.token;
 
         StakeManager stake = new StakeManager(
+            owner_,
             token,
             minStake,
             employerSlashPct,
@@ -271,6 +272,7 @@ contract Deployer is Ownable {
         address[] memory ackInit = new address[](1);
         ackInit[0] = address(stake);
         JobRegistry registry = new JobRegistry(
+            owner_,
             IValidationModule(address(0)),
             IStakeManager(address(0)),
             JIReputationEngine(address(0)),
@@ -384,8 +386,8 @@ contract Deployer is Ownable {
         reputation.setAuthorizedCaller(address(validation), true);
 
         // Transfer ownership
-        registry.transferOwnership(owner_);
-        stake.transferOwnership(owner_);
+        registry.transferGovernance(owner_);
+        stake.transferGovernance(owner_);
         validation.transferOwnership(owner_);
         reputation.transferOwnership(owner_);
         dispute.transferOwnership(owner_);

--- a/contracts/v2/DisputeModule.sol
+++ b/contracts/v2/DisputeModule.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Governable} from "./Governable.sol";
 import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
@@ -10,7 +10,7 @@ import {IStakeManager} from "./interfaces/IStakeManager.sol";
 /// to resolve them by finalising outcomes in the JobRegistry.
 /// @dev Dispute claimants may optionally stake an appeal fee via the
 /// StakeManager which is paid out to the winner.
-contract DisputeModule is Ownable {
+contract DisputeModule is Governable {
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 1;
 
@@ -46,11 +46,12 @@ contract DisputeModule is Ownable {
     event ModeratorUpdated(address indexed moderator);
 
     constructor(
+        address _governance,
         IJobRegistry _jobRegistry,
         IStakeManager _stakeManager,
         address _moderator,
         uint256 _appealFee
-    ) Ownable(msg.sender) {
+    ) Governable(_governance) {
         require(address(_jobRegistry) != address(0), "registry");
         require(address(_stakeManager) != address(0), "stake mgr");
         jobRegistry = _jobRegistry;
@@ -61,7 +62,7 @@ contract DisputeModule is Ownable {
 
     /// @notice Update the moderator address.
     /// @param _moderator New moderator able to resolve disputes.
-    function setModerator(address _moderator) external onlyOwner {
+    function setModerator(address _moderator) external onlyGovernance {
         require(_moderator != address(0), "moderator");
         moderator = _moderator;
         emit ModeratorUpdated(_moderator);

--- a/contracts/v2/Governable.sol
+++ b/contracts/v2/Governable.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title Governable
+/// @notice Minimal governance control compatible with multisig or timelock.
+/// @dev Replaces direct Ownable usage allowing any address to act as
+///      governance, including multisig or timelock contracts.
+abstract contract Governable {
+    /// @notice Address authorized to manage the contract.
+    address public governance;
+
+    /// @notice Emitted when governance is transferred.
+    event GovernanceTransferred(
+        address indexed previousGovernance,
+        address indexed newGovernance
+    );
+
+    error NotGovernance();
+    error InvalidGovernance();
+
+    /// @param initialGovernance Address of the initial governance contract.
+    constructor(address initialGovernance) {
+        if (initialGovernance == address(0)) revert InvalidGovernance();
+        governance = initialGovernance;
+        emit GovernanceTransferred(address(0), initialGovernance);
+    }
+
+    /// @notice Restrict a function to governance only.
+    modifier onlyGovernance() {
+        if (msg.sender != governance) revert NotGovernance();
+        _;
+    }
+
+    /// @notice Transfer governance to a new address.
+    /// @param newGovernance Address of the new governance contract.
+    function transferGovernance(address newGovernance) public onlyGovernance {
+        if (newGovernance == address(0)) revert InvalidGovernance();
+        emit GovernanceTransferred(governance, newGovernance);
+        governance = newGovernance;
+    }
+}
+

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Governable} from "./Governable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 import {IValidationModule} from "./interfaces/IValidationModule.sol";
@@ -43,7 +43,7 @@ interface ICertificateNFT {
 /// @dev Tax obligations never accrue to this registry or its owner. All
 /// liabilities remain with employers, agents, and validators as expressed by
 /// the owner‑controlled `TaxPolicy` reference.
-contract JobRegistry is Ownable, ReentrancyGuard {
+contract JobRegistry is Governable, ReentrancyGuard {
     enum State {
         None,
         Created,
@@ -89,7 +89,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     /// version for callers other than the owner, dispute module, or validation module.
     modifier requiresTaxAcknowledgement() {
         if (
-            msg.sender != owner() &&
+            msg.sender != governance &&
             msg.sender != address(disputeModule) &&
             msg.sender != address(validationModule)
         ) {
@@ -184,6 +184,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     event FeePctUpdated(uint256 feePct);
 
     constructor(
+        address _governance,
         IValidationModule _validation,
         IStakeManager _stakeMgr,
         IReputationEngine _reputation,
@@ -194,7 +195,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         uint256 _feePct,
         uint96 _jobStake,
         address[] memory _ackModules
-    ) Ownable(msg.sender) {
+    ) Governable(_governance) {
         validationModule = _validation;
         stakeManager = _stakeMgr;
         reputationEngine = _reputation;
@@ -244,7 +245,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     }
 
     // ---------------------------------------------------------------------
-    // Owner configuration
+    // Governance configuration
     // ---------------------------------------------------------------------
     // Setters below are executed manually via Etherscan's "Write Contract"
     // tab using the authorized owner account.
@@ -256,7 +257,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         ICertificateNFT _certNFT,
         IFeePool _feePool,
         address[] calldata _ackModules
-    ) external onlyOwner {
+    ) external onlyGovernance {
         require(address(_validation) != address(0), "validation");
         require(address(_stakeMgr) != address(0), "stake");
         require(address(_reputation) != address(0), "reputation");
@@ -291,7 +292,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
 
     /// @notice Update the identity registry used for agent verification.
     /// @param registry Address of the IdentityRegistry contract.
-    function setIdentityRegistry(IIdentityRegistry registry) external onlyOwner {
+    function setIdentityRegistry(IIdentityRegistry registry) external onlyGovernance {
         identityRegistry = registry;
         emit IdentityRegistryUpdated(address(registry));
         emit ModuleUpdated("IdentityRegistry", address(registry));
@@ -299,7 +300,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
 
     /// @notice Update the ENS root node used for agent verification.
     /// @param node Namehash of the agent parent node (e.g. `agent.agi.eth`).
-    function setAgentRootNode(bytes32 node) external onlyOwner {
+    function setAgentRootNode(bytes32 node) external onlyGovernance {
         require(address(identityRegistry) != address(0), "identity reg");
         identityRegistry.setAgentRootNode(node);
         emit AgentRootNodeUpdated(node);
@@ -307,27 +308,27 @@ contract JobRegistry is Ownable, ReentrancyGuard {
 
     /// @notice Update the Merkle root for the agent allowlist.
     /// @param root Merkle root of approved agent addresses.
-    function setAgentMerkleRoot(bytes32 root) external onlyOwner {
+    function setAgentMerkleRoot(bytes32 root) external onlyGovernance {
         require(address(identityRegistry) != address(0), "identity reg");
         identityRegistry.setAgentMerkleRoot(root);
         emit AgentMerkleRootUpdated(root);
     }
 
     /// @notice update the FeePool contract used for revenue sharing
-    function setFeePool(IFeePool _feePool) external onlyOwner {
+    function setFeePool(IFeePool _feePool) external onlyGovernance {
         feePool = _feePool;
         emit FeePoolUpdated(address(_feePool));
         emit ModuleUpdated("FeePool", address(_feePool));
     }
 
     /// @notice update the required agent stake for each job
-    function setJobStake(uint96 stake) external onlyOwner {
+    function setJobStake(uint96 stake) external onlyGovernance {
         jobStake = stake;
         emit JobParametersUpdated(0, stake, maxJobReward, maxJobDuration);
     }
 
     /// @notice update the percentage of each job reward taken as a protocol fee
-    function setFeePct(uint256 _feePct) external onlyOwner {
+    function setFeePct(uint256 _feePct) external onlyGovernance {
         require(_feePct <= 100, "pct");
         require(_feePct + validatorRewardPct <= 100, "pct");
         feePct = _feePct;
@@ -335,7 +336,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     }
 
     /// @notice update validator reward percentage of job reward
-    function setValidatorRewardPct(uint256 pct) external onlyOwner {
+    function setValidatorRewardPct(uint256 pct) external onlyGovernance {
         require(pct <= 100, "pct");
         require(feePct + pct <= 100, "pct");
         validatorRewardPct = pct;
@@ -343,13 +344,13 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     }
 
     /// @notice set the maximum allowed job reward
-    function setMaxJobReward(uint256 maxReward) external onlyOwner {
+    function setMaxJobReward(uint256 maxReward) external onlyGovernance {
         maxJobReward = maxReward;
         emit JobParametersUpdated(0, jobStake, maxReward, maxJobDuration);
     }
 
     /// @notice set the maximum allowed job duration in seconds
-    function setJobDurationLimit(uint256 limit) external onlyOwner {
+    function setJobDurationLimit(uint256 limit) external onlyGovernance {
         maxJobDuration = limit;
         emit JobParametersUpdated(0, jobStake, maxJobReward, limit);
     }
@@ -357,7 +358,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     /// @notice Sets the TaxPolicy contract holding the canonical disclaimer.
     /// @dev Only callable by the owner; the policy address cannot be zero and
     /// must explicitly report tax exemption.
-    function setTaxPolicy(ITaxPolicy _policy) external onlyOwner {
+    function setTaxPolicy(ITaxPolicy _policy) external onlyGovernance {
         require(address(_policy) != address(0), "policy");
         require(_policy.isTaxExempt(), "not tax exempt");
         taxPolicy = _policy;
@@ -399,7 +400,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     /// @notice Allow or revoke an acknowledger address.
     /// @param acknowledger Address granted permission to acknowledge for users.
     /// @param allowed True to allow the address, false to revoke.
-    function setAcknowledger(address acknowledger, bool allowed) external onlyOwner {
+    function setAcknowledger(address acknowledger, bool allowed) external onlyGovernance {
         acknowledgers[acknowledger] = allowed;
         emit AcknowledgerUpdated(acknowledger, allowed);
     }
@@ -429,7 +430,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         ack = _acknowledge(user);
     }
 
-    function setJobParameters(uint256 reward, uint256 stake) external onlyOwner {
+    function setJobParameters(uint256 reward, uint256 stake) external onlyGovernance {
         require(stake <= type(uint96).max, "overflow");
         jobStake = uint96(stake);
         emit JobParametersUpdated(reward, stake, maxJobReward, maxJobDuration);
@@ -962,7 +963,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
 
     /// @notice Owner can delist an unassigned job and refund the employer.
     /// @param jobId Identifier of the job to delist.
-    function delistJob(uint256 jobId) external onlyOwner {
+    function delistJob(uint256 jobId) external onlyGovernance {
         _cancelJob(jobId);
     }
 

--- a/contracts/v2/ModuleInstaller.sol
+++ b/contracts/v2/ModuleInstaller.sol
@@ -113,8 +113,8 @@ contract ModuleInstaller is Ownable {
         jobRouter.setRegistrar(address(platformIncentives), true);
 
         address moduleOwner = owner();
-        jobRegistry.transferOwnership(moduleOwner);
-        stakeManager.transferOwnership(moduleOwner);
+        jobRegistry.transferGovernance(moduleOwner);
+        stakeManager.transferGovernance(moduleOwner);
         IOwnable(address(validationModule)).transferOwnership(moduleOwner);
         IOwnable(address(reputationEngine)).transferOwnership(moduleOwner);
         IOwnable(address(disputeModule)).transferOwnership(moduleOwner);

--- a/scripts/v2/deploy-governance.ts
+++ b/scripts/v2/deploy-governance.ts
@@ -1,0 +1,70 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const governance = deployer.address;
+
+  const Token = await ethers.getContractFactory(
+    "contracts/mocks/MockERC20.sol:MockERC20"
+  );
+  const token = await Token.deploy();
+  await token.waitForDeployment();
+
+  const Stake = await ethers.getContractFactory(
+    "contracts/v2/StakeManager.sol:StakeManager"
+  );
+  const stake = await Stake.deploy(
+    governance,
+    await token.getAddress(),
+    0,
+    0,
+    0,
+    governance,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress
+  );
+  await stake.waitForDeployment();
+
+  const Registry = await ethers.getContractFactory(
+    "contracts/v2/JobRegistry.sol:JobRegistry"
+  );
+  const registry = await Registry.deploy(
+    governance,
+    ethers.ZeroAddress,
+    await stake.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    0,
+    0,
+    []
+  );
+  await registry.waitForDeployment();
+
+  const Dispute = await ethers.getContractFactory(
+    "contracts/v2/DisputeModule.sol:DisputeModule"
+  );
+  const dispute = await Dispute.deploy(
+    governance,
+    await registry.getAddress(),
+    await stake.getAddress(),
+    governance,
+    0
+  );
+  await dispute.waitForDeployment();
+
+  console.log("StakeManager:", await stake.getAddress());
+  console.log("JobRegistry:", await registry.getAddress());
+  console.log("DisputeModule:", await dispute.getAddress());
+
+  await registry.setFeePct(1);
+  await dispute.setModerator(governance);
+  console.log("Governance actions executed");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/test/v2/DisputeModuleCore.test.js
+++ b/test/v2/DisputeModuleCore.test.js
@@ -18,6 +18,7 @@ describe("DisputeModule core", function () {
       "contracts/v2/DisputeModule.sol:DisputeModule"
     );
     dispute = await Dispute.deploy(
+      owner.address,
       await registry.getAddress(),
       await stakeManager.getAddress(),
       owner.address,

--- a/test/v2/Governance.test.js
+++ b/test/v2/Governance.test.js
@@ -1,0 +1,69 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Governable modules", function () {
+  it("allows only governance to perform restricted actions", async function () {
+    const [gov, other] = await ethers.getSigners();
+
+    const Stake = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    const stake = await Stake.deploy(
+      gov.address,
+      ethers.ZeroAddress,
+      0,
+      0,
+      0,
+      gov.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
+    );
+    await stake.waitForDeployment();
+
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const registry = await Registry.deploy(
+      gov.address,
+      ethers.ZeroAddress,
+      await stake.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      []
+    );
+    await registry.waitForDeployment();
+
+    const Dispute = await ethers.getContractFactory(
+      "contracts/v2/DisputeModule.sol:DisputeModule"
+    );
+    const dispute = await Dispute.deploy(
+      gov.address,
+      await registry.getAddress(),
+      await stake.getAddress(),
+      gov.address,
+      0
+    );
+    await dispute.waitForDeployment();
+
+    // Governance restricted calls
+    await expect(stake.connect(other).setMinStake(1)).to.be.reverted;
+    await stake.setMinStake(1);
+
+    await expect(registry.connect(other).setFeePct(1)).to.be.reverted;
+    await registry.setFeePct(1);
+
+    await expect(dispute.connect(other).setModerator(other.address)).to.be
+      .reverted;
+    await dispute.setModerator(other.address);
+
+    // Transfer governance
+    await stake.transferGovernance(other.address);
+    await expect(stake.setMinStake(2)).to.be.reverted;
+    await stake.connect(other).setMinStake(2);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `Governable` to support multisig/timelock governance
- refactor StakeManager, JobRegistry and DisputeModule to use governance address
- add deployment script and test showcasing governance actions

## Testing
- `npm test -- test/v2/Governance.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ab3b4cd4dc8333a0d1b5dddebffdec