### PR TITLE
feat: add quorum-based dispute moderation

### DIFF
--- a/test/v2/DisputeModuleCore.test.js
+++ b/test/v2/DisputeModuleCore.test.js
@@ -1,10 +1,12 @@
 const { expect } = require("chai");
+const { ethers } = require("hardhat");
 
 describe("DisputeModule core", function () {
-  let owner, other, registry, stakeManager, dispute;
+  let owner, other, employer, agent;
+  let registry, stakeManager, dispute;
 
   beforeEach(async function () {
-    [owner, other] = await ethers.getSigners();
+    [owner, other, employer, agent] = await ethers.getSigners();
 
     const JobMock = await ethers.getContractFactory("MockJobRegistry");
     registry = await JobMock.deploy();
@@ -26,16 +28,46 @@ describe("DisputeModule core", function () {
     await dispute.waitForDeployment();
   });
 
-  it("emits ModeratorUpdated on setModerator", async function () {
-    await expect(dispute.setModerator(other.address))
+  it("allows owner to add and remove moderators", async function () {
+    await expect(dispute.addModerator(other.address))
       .to.emit(dispute, "ModeratorUpdated")
-      .withArgs(other.address);
-    expect(await dispute.moderator()).to.equal(other.address);
+      .withArgs(other.address, true);
+    expect(await dispute.moderators(other.address)).to.equal(true);
+    await expect(dispute.removeModerator(other.address))
+      .to.emit(dispute, "ModeratorUpdated")
+      .withArgs(other.address, false);
+    expect(await dispute.moderators(other.address)).to.equal(false);
   });
 
-  it("reverts when moderator is zero address", async function () {
-    await expect(dispute.setModerator(ethers.ZeroAddress)).to.be.revertedWith(
-      "moderator"
+  it("requires quorum signatures to resolve", async function () {
+    await dispute.addModerator(other.address);
+    await registry.setJob(1, {
+      employer: employer.address,
+      agent: agent.address,
+      reward: 0,
+      stake: 0,
+      success: false,
+      status: 5,
+      uri: "",
+      result: "",
+    });
+    await dispute.connect(agent).raiseDispute(1);
+
+    const hash = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "bool"],
+      [await dispute.getAddress(), 1, true]
     );
+    const sigOwner = await owner.signMessage(ethers.getBytes(hash));
+    const sigOther = await other.signMessage(ethers.getBytes(hash));
+
+    await expect(
+      dispute.connect(owner).resolve(1, true, [sigOwner])
+    ).to.be.revertedWith("insufficient approvals");
+
+    await expect(
+      dispute.connect(owner).resolve(1, true, [sigOwner, sigOther])
+    )
+      .to.emit(dispute, "DisputeResolved")
+      .withArgs(1, owner.address, true);
   });
 });

--- a/test/v2/gasProfile.test.ts
+++ b/test/v2/gasProfile.test.ts
@@ -122,7 +122,12 @@ describe("gas profiling", function () {
     expect(receiptFinalize.gasUsed).to.be.lt(1_000_000n);
 
     await registry.connect(agent).dispute(1, "evidence");
-    const txResolve = await dispute.connect(moderator).resolve(1, false);
+    const hash = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "bool"],
+      [await dispute.getAddress(), 1, false]
+    );
+    const sig = await moderator.signMessage(ethers.getBytes(hash));
+    const txResolve = await dispute.connect(moderator).resolve(1, false, [sig]);
     const receiptResolve = await txResolve.wait();
     expect(receiptResolve.gasUsed).to.be.lt(1_000_000n);
   });

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -123,7 +123,12 @@ describe("job lifecycle with dispute and validator failure", function () {
     expect(await registry.jobs(1)).to.have.property("state", 5); // Disputed
 
     await registry.connect(agent).dispute(1, "evidence");
-    await dispute.connect(moderator).resolve(1, false);
+    const hash = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "bool"],
+      [await dispute.getAddress(), 1, false]
+    );
+    const sig = await moderator.signMessage(ethers.getBytes(hash));
+    await dispute.connect(moderator).resolve(1, false, [sig]);
 
     expect(await registry.jobs(1)).to.have.property("state", 6); // Finalized
     expect(await token.balanceOf(agent.address)).to.be.gt(initialAgentBalance);


### PR DESCRIPTION
## Summary
- allow multiple moderators with quorum voting in DisputeModule
- emit events on moderator add/remove and resolution including resolver
- add tests covering moderator management and multi-signature dispute resolution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab397e730c83339f7845a1840bd649