### PR TITLE
Use hashed job results

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Below is a minimal walkthrough of the job lifecycle using the v2 contracts. All 
 
 1. **Post a job** – `JobRegistry.createJob(reward, "ipfs://job")`.
 2. **Agent applies** – stake via `StakeManager.depositStake(0, amount)` then call `JobRegistry.applyForJob(jobId, label, proof)`.
-3. **Work submission** – the agent finishes the task and calls `JobRegistry.submit(jobId, "ipfs://result")`.
+3. **Work submission** – the agent finishes the task and calls `JobRegistry.submit(jobId, resultHash, "ipfs://result")`.
 4. **Validation** – validators commit and reveal votes with `ValidationModule.commitValidation(jobId, hash, label, proof)` followed by `ValidationModule.revealValidation(jobId, approve, salt)`.
 5. **Finalize** – after the reveal window anyone may call `ValidationModule.finalize(jobId)` which releases rewards and mints a certificate.
 6. **Disputes (optional)** – open a challenge with `JobRegistry.raiseDispute(jobId, evidence)`; the owner resolves it on `DisputeModule.resolve(jobId, employerWins)`.

--- a/agent-gateway/index.js
+++ b/agent-gateway/index.js
@@ -13,7 +13,7 @@ const PORT = process.env.PORT || 3000;
 const JOB_REGISTRY_ABI = [
   'event JobCreated(uint256 indexed jobId, address indexed employer, address indexed agent, uint256 reward, uint256 stake, uint256 fee)',
   'function applyForJob(uint256 jobId, string subdomain, bytes proof) external',
-  'function submit(uint256 jobId, string result, string subdomain, bytes proof) external'
+  'function submit(uint256 jobId, bytes32 resultHash, string resultURI, string subdomain, bytes proof) external'
 ];
 
 // Provider and signer
@@ -63,7 +63,8 @@ app.post('/jobs/:id/apply', async (req, res) => {
 app.post('/jobs/:id/submit', async (req, res) => {
   try {
     const { result } = req.body;
-    const tx = await registry.submit(req.params.id, result || '', '', '0x');
+    const hash = ethers.id(result || '');
+    const tx = await registry.submit(req.params.id, hash, result || '', '', '0x');
     await tx.wait();
     res.json({ tx: tx.hash });
   } catch (err) {

--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -235,7 +235,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
             success: false,
             status: Status.Created,
             uri: uri,
-            result: ""
+            resultHash: bytes32(0)
         });
         deadlines[jobId] = deadline;
         if (address(_stakeManager) != address(0) && reward > 0) {
@@ -278,7 +278,8 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
 
     function submit(
         uint256 jobId,
-        string calldata result,
+        bytes32 resultHash,
+        string calldata resultURI,
         string calldata,
         bytes32[] calldata
     ) public override {
@@ -286,21 +287,22 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         require(job.status == Status.Applied, "state");
         require(msg.sender == job.agent, "agent");
         require(block.timestamp <= deadlines[jobId], "deadline");
-        job.result = result;
+        job.resultHash = resultHash;
         job.status = Status.Submitted;
-        emit JobSubmitted(jobId, msg.sender, result);
+        emit JobSubmitted(jobId, msg.sender, resultHash, resultURI);
         if (validationModule != address(0)) {
-            IValidationModule(validationModule).start(jobId, result);
+            IValidationModule(validationModule).start(jobId, resultURI);
         }
     }
 
     function acknowledgeAndSubmit(
         uint256 jobId,
-        string calldata result,
+        bytes32 resultHash,
+        string calldata resultURI,
         string calldata subdomain,
         bytes32[] calldata proof
     ) external override {
-        submit(jobId, result, subdomain, proof);
+        submit(jobId, resultHash, resultURI, subdomain, proof);
     }
 
     function finalizeAfterValidation(uint256 jobId, bool success) public override {

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -23,7 +23,7 @@ interface IJobRegistry {
         bool success;
         Status status;
         string uri;
-        string result;
+        bytes32 resultHash;
     }
 
     /// @dev Reverts when job creation parameters have not been configured
@@ -68,7 +68,12 @@ interface IJobRegistry {
         uint256 fee
     );
     event JobApplied(uint256 indexed jobId, address indexed agent);
-    event JobSubmitted(uint256 indexed jobId, address indexed worker, string result);
+    event JobSubmitted(
+        uint256 indexed jobId,
+        address indexed worker,
+        bytes32 resultHash,
+        string resultURI
+    );
     event JobCompleted(uint256 indexed jobId, bool success);
     /// @notice Emitted when a job is finalized
     /// @param jobId Identifier of the job
@@ -186,24 +191,28 @@ interface IJobRegistry {
 
     /// @notice Agent submits completed work for validation.
     /// @param jobId Identifier of the job being submitted
-    /// @param result Metadata URI of the submission
+    /// @param resultHash Hash of the submission
+    /// @param resultURI Metadata URI of the submission
     /// @param subdomain ENS subdomain label
     /// @param proof Merkle proof for ENS ownership verification
     function submit(
         uint256 jobId,
-        string calldata result,
+        bytes32 resultHash,
+        string calldata resultURI,
         string calldata subdomain,
         bytes32[] calldata proof
     ) external;
 
     /// @notice Acknowledge tax policy and submit work in one call
     /// @param jobId Identifier of the job being submitted
-    /// @param result Metadata URI of the submission
+    /// @param resultHash Hash of the submission
+    /// @param resultURI Metadata URI of the submission
     /// @param subdomain ENS subdomain label
     /// @param proof Merkle proof for ENS ownership verification
     function acknowledgeAndSubmit(
         uint256 jobId,
-        string calldata result,
+        bytes32 resultHash,
+        string calldata resultURI,
         string calldata subdomain,
         bytes32[] calldata proof
     ) external;

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,7 @@ Summary of key AGIJob Manager contract functions and parameters.
 ## JobRegistry
 - `createJob(uint256 reward, string uri)` – employer posts a job and escrows the reward.
 - `applyForJob(uint256 jobId, bytes32 label, bytes32[] proof)` – agent applies using ENS label and Merkle proof.
-- `submit(uint256 jobId, string result)` – agent submits work artifact.
+- `submit(uint256 jobId, bytes32 resultHash, string resultURI)` – agent submits work artifact by hash.
 - `finalizeAfterValidation(uint256 jobId, bool success)` – records validation result and releases funds.
 - `raiseDispute(uint256 jobId, string evidence)` – escalates a job to the dispute module.
 

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -116,7 +116,7 @@ Before performing any on-chain action, employers, agents, and validators must ca
 1. On `JobRegistry`, execute **acknowledgeTaxPolicy** and verify **isTaxExempt()**. Check the emitted `TaxAcknowledged` event for the recorded disclaimer.
 2. Open `StakeManager`; in **Read Contract** confirm **isTaxExempt()**, then stake with **depositStake(0, amount)** (role `0` = Agent).
    ![agent stake](https://via.placeholder.com/650x150?text=depositStake)
-3. Use **applyForJob** then **submit(jobId, uri)** when work is ready.
+3. Use **applyForJob** then **submit(jobId, resultHash, uri)** when work is ready.
 4. After validators reveal votes, call **ValidationModule.finalize(jobId)**; the module records the outcome in `JobRegistry`.
 
 ### Validators

--- a/docs/job-lifecycle-audit.md
+++ b/docs/job-lifecycle-audit.md
@@ -6,7 +6,7 @@ This document cross-checks key `JobRegistry` entry points with the v1 `AGIJobMan
 |-------------|-------------|------------------|---------------|---------------|
 | `createJob` | `createJob` | `reward`, `deadline`, `uri` retained. | `None -> Created` | `JobCreated` |
 | `applyForJob` | `applyForJob` | `jobId`, ENS `subdomain`, `proof`. | `Created -> Applied` | `JobApplied` |
-| `requestJobCompletion` | `submit` | `jobId`, `result`, ENS proof. | `Applied -> Submitted` | `JobSubmitted` |
+| `requestJobCompletion` | `submit` | `jobId`, `resultHash`, `resultURI`, ENS proof. | `Applied -> Submitted` | `JobSubmitted` |
 | `resolveStalledJob` / `finalizeJob` | `finalize` | `jobId`. | `Completed -> Finalized` or refunds on failure. | `JobFinalized` |
 | `cancelJob` | `cancelJob` | `jobId`. | `Created -> Cancelled` | `JobCancelled` |
 | `disputeJob` | `raiseDispute`/`dispute` | `jobId`, `evidence`. | `Completed -> Disputed` | `JobDisputed` |

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -99,8 +99,8 @@ then be performed through the "Write" tabs on each module.
 3. `JobApplied(jobId, agent)` will be emitted.
 
 ### Submitting Work
-1. The selected agent calls `JobRegistry.submit(jobId, resultURI)` when the task is complete.
-2. `JobSubmitted(jobId, resultURI)` confirms the submission and triggers validation.
+1. The selected agent calls `JobRegistry.submit(jobId, resultHash, resultURI)` when the task is complete.
+2. `JobSubmitted(jobId, resultHash, resultURI)` confirms the submission and triggers validation.
 
 ### Validation
 1. During commit phase, validators call

--- a/examples/ethers-quickstart.js
+++ b/examples/ethers-quickstart.js
@@ -6,7 +6,7 @@ const signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 const registryAbi = [
   "function createJob(uint256 reward, string uri)",
   "function applyForJob(uint256 jobId, bytes32 label, bytes32[] proof)",
-  "function submit(uint256 jobId, string result)"
+  "function submit(uint256 jobId, bytes32 resultHash, string resultURI)"
 ];
 const validationAbi = [
   "function commitValidation(uint256 jobId, bytes32 hash, bytes32 label, bytes32[] proof)",
@@ -27,7 +27,8 @@ async function apply(jobId, label, proof) {
 }
 
 async function submit(jobId, uri) {
-  await registry.submit(jobId, uri);
+  const hash = ethers.id(uri);
+  await registry.submit(jobId, hash, uri);
 }
 
 async function validate(jobId, hash, label, proof, approve, salt) {

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -127,7 +127,7 @@ describe("DisputeModule", function () {
         success: false,
         status: 4, // Completed
         uri: "",
-        result: "",
+        resultHash: ethers.ZeroHash,
       });
     });
 

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -90,7 +90,7 @@ describe("Validator ENS integration", function () {
       success: false,
       status: 3,
       uri: "",
-      result: "",
+      resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, job);
     await expect(validation.selectValidators(1)).to.be.revertedWith(
@@ -155,7 +155,7 @@ describe("Validator ENS integration", function () {
       success: false,
       status: 3,
       uri: "",
-      result: "",
+      resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, job);
     await validation.selectValidators(1);
@@ -205,7 +205,7 @@ describe("Validator ENS integration", function () {
       success: false,
       status: 3,
       uri: "",
-      result: "",
+      resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, job);
     await expect(validation.selectValidators(1)).to.be.revertedWith(

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -93,7 +93,9 @@ describe("Identity verification enforcement", function () {
       await registry.connect(agent).applyForJob(jobId, "a", []);
       await identity.removeAdditionalAgent(agent.address);
       await expect(
-        registry.connect(agent).submit(jobId, "res", "a", [])
+        registry
+          .connect(agent)
+          .submit(jobId, ethers.id("res"), "res", "a", [])
       ).to.be.revertedWith("Not authorized agent");
     });
   });
@@ -180,7 +182,7 @@ describe("Identity verification enforcement", function () {
         success: false,
         status: 3,
         uri: "",
-        result: "",
+        resultHash: ethers.ZeroHash,
       };
       await jobRegistry.setJob(1, jobStruct);
     });

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -137,9 +137,12 @@ describe("JobRegistry integration", function () {
       .to.emit(registry, "JobApplied")
       .withArgs(jobId, agent.address);
     await validation.connect(owner).setResult(true);
-    await expect(registry.connect(agent).submit(jobId, "result", "", []))
+    const resultHash = ethers.id("result");
+    await expect(
+      registry.connect(agent).submit(jobId, resultHash, "result", "", [])
+    )
       .to.emit(registry, "JobSubmitted")
-      .withArgs(jobId, agent.address, "result");
+      .withArgs(jobId, agent.address, resultHash, "result");
     await expect(validation.finalize(jobId))
       .to.emit(registry, "JobCompleted")
       .withArgs(jobId, true)
@@ -195,7 +198,9 @@ describe("JobRegistry integration", function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);
-    await registry.connect(agent).submit(jobId, "result", "", []);
+    await registry
+      .connect(agent)
+      .submit(jobId, ethers.id("result"), "result", "", []);
     await validation.finalize(jobId);
 
     // platform operator should be able to claim fee

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -67,9 +67,9 @@ describe("ValidationModule V2", function () {
       reward: 0,
       stake: 0,
       success: false,
-       status: 3,
+      status: 3,
       uri: "",
-      result: "",
+      resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, jobStruct);
   });

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -65,7 +65,7 @@ describe("ValidationModule access controls", function () {
       success: false,
       status: 3,
       uri: "",
-      result: "",
+      resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, jobStruct);
   });
@@ -200,7 +200,7 @@ describe("ValidationModule access controls", function () {
       success: false,
       status: 3,
       uri: "",
-      result: "",
+      resultHash: ethers.ZeroHash,
     });
     await validation.selectValidators(1);
     const nonce2 = await validation.jobNonce(1);

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -58,7 +58,7 @@ async function setup() {
     success: false,
     status: 3,
     uri: "",
-    result: "",
+    resultHash: ethers.ZeroHash,
   };
   await jobRegistry.setJob(1, jobStruct);
   return {

--- a/test/v2/ValidatorSelectionDeterministic.test.js
+++ b/test/v2/ValidatorSelectionDeterministic.test.js
@@ -61,7 +61,7 @@ describe("Validator selection determinism", function () {
       success: false,
       status: 3,
       uri: "",
-      result: "",
+      resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, jobStruct);
   });

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -152,7 +152,9 @@ describe("comprehensive job flows", function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.setResult(true);
-    await registry.connect(agent).submit(jobId, "result", "", []);
+    await registry
+      .connect(agent)
+      .submit(jobId, ethers.id("result"), "result", "", []);
     await validation.finalize(jobId);
     expect(await nft.ownerOf(jobId)).to.equal(agent.address);
     const price = ethers.parseUnits("10", 6);
@@ -199,7 +201,9 @@ describe("comprehensive job flows", function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.setResult(false);
-    await registry.connect(agent).submit(jobId, "bad", "", []);
+    await registry
+      .connect(agent)
+      .submit(jobId, ethers.id("bad"), "bad", "", []);
     await validation.finalize(jobId);
     // fund and impersonate dispute module to resolve
     await network.provider.send("hardhat_setBalance", [

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -152,7 +152,9 @@ describe("end-to-end job lifecycle", function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);
-    await registry.connect(agent).submit(jobId, "result", "", []);
+    await registry
+      .connect(agent)
+      .submit(jobId, ethers.id("result"), "result", "", []);
     await validation.finalize(jobId);
 
     // fee distributed to stakers

--- a/test/v2/gasProfile.test.ts
+++ b/test/v2/gasProfile.test.ts
@@ -104,7 +104,9 @@ describe("gas profiling", function () {
     expect(receiptCreate.gasUsed).to.be.lt(1_000_000n);
 
     await registry.connect(agent).applyForJob(1, "agent", []);
-    await registry.connect(agent).submit(1, "ipfs://result", "agent", []);
+    await registry
+      .connect(agent)
+      .submit(1, ethers.id("ipfs://result"), "ipfs://result", "agent", []);
 
     const nonce = await validation.jobNonce(1);
     const salt1 = ethers.randomBytes(32);

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -196,7 +196,7 @@ describe("Commit-reveal job lifecycle", function () {
     await registry.connect(agent).applyForJob(1, label, []);
     await registry
       .connect(agent)
-      .submit(1, "ipfs://result", label, []);
+      .submit(1, ethers.id("ipfs://result"), "ipfs://result", label, []);
 
     const nonce = await validation.jobNonce(1);
     const salt = ethers.id("salt");
@@ -267,7 +267,7 @@ describe("Commit-reveal job lifecycle", function () {
     await registry.connect(agent).applyForJob(1, label, []);
     await registry
       .connect(agent)
-      .submit(1, "ipfs://bad", label, []);
+      .submit(1, ethers.id("ipfs://bad"), "ipfs://bad", label, []);
 
     const nonce = await validation.jobNonce(1);
     const salt = ethers.id("salt");

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -146,7 +146,9 @@ describe("job finalization integration", function () {
     const jobId = 1;
     await registry.connect(agent).acknowledgeAndApply(jobId, "", []);
     await validation.setResult(result);
-    await registry.connect(agent).submit(jobId, "result", "", []);
+    await registry
+      .connect(agent)
+      .submit(jobId, ethers.id("result"), "result", "", []);
     return { jobId, fee, vReward };
   }
 

--- a/test/v2/jobLifecycle.test.ts
+++ b/test/v2/jobLifecycle.test.ts
@@ -116,7 +116,10 @@ describe("Job lifecycle", function () {
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, subdomain, []);
-    await registry.connect(agent).submit(1, "ipfs://result", subdomain, []);
+    const hash = ethers.id("ipfs://result");
+    await registry
+      .connect(agent)
+      .submit(1, hash, "ipfs://result", subdomain, []);
     await validation.setResult(true);
     await validation.finalize(1);
 
@@ -153,7 +156,9 @@ describe("Job lifecycle", function () {
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, subdomain, []);
-    await registry.connect(agent).submit(1, "ipfs://bad", subdomain, []);
+    await registry
+      .connect(agent)
+      .submit(1, ethers.id("ipfs://bad"), "ipfs://bad", subdomain, []);
     await validation.setResult(false);
     await validation.finalize(1);
 

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -103,7 +103,9 @@ describe("job lifecycle with dispute and validator failure", function () {
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, "agent", []);
-    await registry.connect(agent).submit(1, "ipfs://result", "agent", []);
+    await registry
+      .connect(agent)
+      .submit(1, ethers.id("ipfs://result"), "ipfs://result", "agent", []);
 
     const nonce = await validation.jobNonce(1);
     const salt1 = ethers.randomBytes(32);

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -181,7 +181,9 @@ describe("multi-operator job lifecycle", function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);
-    await registry.connect(agent).submit(jobId, "result", "", []);
+    await registry
+      .connect(agent)
+      .submit(jobId, ethers.id("result"), "result", "", []);
     await validation.finalize(jobId);
 
     expect(await feePool.pendingFees()).to.equal(0);


### PR DESCRIPTION
## Summary
- use `bytes32 resultHash` in JobRegistry and interface
- update submit flow to emit result hashes and store URIs only in events
- refactor clients and tests to pass result hashes

## Testing
- `npx hardhat test` *(fails: process did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ab411b26d48333ba5fb981ee55add0