### PR TITLE
Add lifecycle integration and fuzz tests

### DIFF
--- a/test/v2/JobRegistryDeadlineFuzz.t.sol
+++ b/test/v2/JobRegistryDeadlineFuzz.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {
+    JobRegistry,
+    IValidationModule,
+    IStakeManager,
+    IReputationEngine,
+    IDisputeModule,
+    ICertificateNFT,
+    IFeePool,
+    ITaxPolicy
+} from "../../contracts/v2/JobRegistry.sol";
+
+contract JobRegistryDeadlineFuzz is Test {
+    JobRegistry registry;
+
+    function setUp() public {
+        registry = new JobRegistry(
+            IValidationModule(address(0)),
+            IStakeManager(address(0)),
+            IReputationEngine(address(0)),
+            IDisputeModule(address(0)),
+            ICertificateNFT(address(0)),
+            IFeePool(address(0)),
+            ITaxPolicy(address(0)),
+            0,
+            0,
+            new address[](0)
+        );
+    }
+
+    function testFuzz_deadline(uint64 deadline) public {
+        uint256 reward = 1;
+        if (deadline <= block.timestamp) {
+            vm.expectRevert("deadline");
+            registry.createJob(reward, deadline, "uri");
+        } else {
+            registry.createJob(reward, deadline, "uri");
+        }
+    }
+}
+

--- a/test/v2/ValidationSlashingFuzz.t.sol
+++ b/test/v2/ValidationSlashingFuzz.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {ValidationModule} from "../../contracts/v2/ValidationModule.sol";
+import {StakeManager} from "../../contracts/v2/StakeManager.sol";
+import {IdentityRegistryToggle} from "../../contracts/v2/mocks/IdentityRegistryToggle.sol";
+import {AGIALPHAToken} from "../../contracts/v2/AGIALPHAToken.sol";
+import {IJobRegistry} from "../../contracts/v2/interfaces/IJobRegistry.sol";
+import {IStakeManager} from "../../contracts/v2/interfaces/IStakeManager.sol";
+import {IIdentityRegistry} from "../../contracts/v2/interfaces/IIdentityRegistry.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract ValidationSlashingFuzz is Test {
+    ValidationModule validation;
+    StakeManager stake;
+    IdentityRegistryToggle identity;
+    AGIALPHAToken token;
+
+    function setUp() public {
+        token = new AGIALPHAToken();
+        stake = new StakeManager(IERC20(address(token)), 1e6, 0, 100, address(this), address(0), address(0));
+        identity = new IdentityRegistryToggle();
+        validation = new ValidationModule(
+            IJobRegistry(address(0)),
+            IStakeManager(address(stake)),
+            1,
+            1,
+            1,
+            10,
+            new address[](0)
+        );
+        validation.setIdentityRegistry(IIdentityRegistry(address(identity)));
+    }
+
+    function testFuzz_slashingPercentage(uint8 pct) public {
+        pct = uint8(bound(uint256(pct), 0, 100));
+        validation.setValidatorSlashingPct(pct);
+        assertEq(validation.validatorSlashingPercentage(), pct);
+    }
+
+    function testFuzz_validatorPool(uint8 size) public {
+        size = uint8(bound(uint256(size), 0, 10));
+        address[] memory pool = new address[](size);
+        for (uint8 i; i < size; i++) {
+            address val = address(uint160(uint256(keccak256(abi.encode(i + 1)))));
+            pool[i] = val;
+            identity.addAdditionalValidator(val);
+            token.mint(val, 1e6);
+            vm.prank(val);
+            token.approve(address(stake), 1e6);
+            vm.prank(val);
+            stake.depositStake(StakeManager.Role.Validator, 1e6);
+        }
+        validation.setValidatorPool(pool);
+        for (uint8 i; i < size; i++) {
+            assertEq(validation.validatorPool(i), pool[i]);
+        }
+    }
+}
+

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -1,0 +1,181 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+enum Role {
+  Agent,
+  Validator,
+  Platform,
+}
+
+async function deploySystem() {
+  const [owner, employer, agent, v1, moderator] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
+  const token = await Token.deploy();
+  const mint = ethers.parseUnits("1000", 6);
+  for (const s of [employer, agent, v1]) {
+    await token.mint(s.address, mint);
+  }
+
+  const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
+  const stake = await Stake.deploy(await token.getAddress(), 0, 0, 0, owner.address, ethers.ZeroAddress, ethers.ZeroAddress);
+
+  const Reputation = await ethers.getContractFactory("contracts/v2/ReputationEngine.sol:ReputationEngine");
+  const reputation = await Reputation.deploy(await stake.getAddress());
+
+  const Identity = await ethers.getContractFactory("contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle");
+  const identity = await Identity.deploy();
+  await identity.setResult(true);
+
+  const Validation = await ethers.getContractFactory("contracts/v2/ValidationModule.sol:ValidationModule");
+  const validation = await Validation.deploy(
+    ethers.ZeroAddress,
+    await stake.getAddress(),
+    1,
+    1,
+    1,
+    5,
+    []
+  );
+
+  const NFT = await ethers.getContractFactory("contracts/v2/CertificateNFT.sol:CertificateNFT");
+  const nft = await NFT.deploy("Cert", "CERT");
+
+  const Registry = await ethers.getContractFactory("contracts/v2/JobRegistry.sol:JobRegistry");
+  const registry = await Registry.deploy(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroAddress,
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    0,
+    0,
+    []
+  );
+
+  const Dispute = await ethers.getContractFactory("contracts/v2/DisputeModule.sol:DisputeModule");
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    await stake.getAddress(),
+    moderator.address,
+    0
+  );
+
+  await stake.setModules(await registry.getAddress(), await dispute.getAddress());
+  await validation.setJobRegistry(await registry.getAddress());
+  await validation.setIdentityRegistry(await identity.getAddress());
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await dispute.getAddress(),
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    []
+  );
+  await reputation.setCaller(await registry.getAddress(), true);
+
+  return { owner, employer, agent, v1, moderator, token, stake, validation, registry, dispute, reputation, nft };
+}
+
+describe("regression scenarios", function () {
+  it("reverts when no validators are available", async () => {
+    const env = await deploySystem();
+    const { employer, agent, token, stake, validation, registry } = env;
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
+    await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
+    // no validators set
+    await validation.setValidatorsPerJob(1);
+
+    const reward = ethers.parseUnits("10", 6);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    await registry.connect(agent).applyForJob(1, "agent", []);
+
+    await expect(validation.selectValidators(1)).to.be.revertedWith("insufficient validators");
+  });
+
+  it("prevents validation after stake exhaustion", async () => {
+    const env = await deploySystem();
+    const { employer, agent, v1, token, stake, validation, registry } = env;
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    for (const s of [agent, v1]) {
+      await token.connect(s).approve(await stake.getAddress(), stakeAmount);
+      const role = s === agent ? Role.Agent : Role.Validator;
+      await stake.connect(s).depositStake(role, stakeAmount);
+    }
+    await validation.setValidatorPool([v1.address]);
+    await validation.setValidatorsPerJob(1);
+    await validation.setValidatorSlashingPct(100);
+
+    const reward = ethers.parseUnits("10", 6);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline1 = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline1, "ipfs://job1");
+    await registry.connect(agent).applyForJob(1, "agent", []);
+    await registry.connect(agent).submit(1, ethers.id("ipfs://good"), "ipfs://good", "agent", []);
+    const nonce = await validation.jobNonce(1);
+    const salt = ethers.randomBytes(32);
+    const commit = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, false, salt]));
+    await validation.connect(v1).commitValidation(1, commit);
+    await time.increase(2);
+    await validation.connect(v1).revealValidation(1, false, salt);
+    await time.increase(2);
+    await validation.finalize(1);
+
+    const deadline2 = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline2, "ipfs://job2");
+    await registry.connect(agent).applyForJob(2, "agent", []);
+    await expect(validation.selectValidators(2)).to.be.revertedWith("insufficient validators");
+  });
+
+  it("supports validation module replacement", async () => {
+    const env = await deploySystem();
+    const { owner, employer, agent, token, stake, validation, registry, dispute, reputation, nft } = env;
+
+    const Stub = await ethers.getContractFactory("contracts/v2/mocks/ValidationStub.sol:ValidationStub");
+    const stub = await Stub.deploy();
+    await stub.setJobRegistry(await registry.getAddress());
+
+    await registry
+      .connect(owner)
+      .setModules(
+        await stub.getAddress(),
+        await stake.getAddress(),
+        await reputation.getAddress(),
+        await dispute.getAddress(),
+        await nft.getAddress(),
+        ethers.ZeroAddress,
+        []
+      );
+
+    expect(await registry.validationModule()).to.equal(await stub.getAddress());
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    for (const s of [agent]) {
+      await token.connect(s).approve(await stake.getAddress(), stakeAmount);
+      await stake.connect(s).depositStake(Role.Agent, stakeAmount);
+    }
+
+    const reward = ethers.parseUnits("10", 6);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    await registry.connect(agent).applyForJob(1, "agent", []);
+    await registry
+      .connect(agent)
+      .submit(1, ethers.id("ipfs://res"), "ipfs://res", "agent", []);
+    await stub.setResult(true);
+    await stub.finalize(1);
+
+    expect(await registry.jobs(1)).to.have.property("state", 6);
+  });
+});
+

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -1,0 +1,165 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+enum Role {
+  Agent,
+  Validator,
+  Platform,
+}
+
+async function deployFullSystem() {
+  const [owner, employer, agent, v1, v2, moderator] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
+  const token = await Token.deploy();
+  const mint = ethers.parseUnits("1000", 6);
+  await token.mint(employer.address, mint);
+  await token.mint(agent.address, mint);
+  await token.mint(v1.address, mint);
+  await token.mint(v2.address, mint);
+
+  const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
+  const stake = await Stake.deploy(await token.getAddress(), 0, 0, 0, owner.address, ethers.ZeroAddress, ethers.ZeroAddress);
+
+  const Reputation = await ethers.getContractFactory("contracts/v2/ReputationEngine.sol:ReputationEngine");
+  const reputation = await Reputation.deploy(await stake.getAddress());
+
+  const Identity = await ethers.getContractFactory("contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle");
+  const identity = await Identity.deploy();
+  await identity.setResult(true);
+
+  const Validation = await ethers.getContractFactory("contracts/v2/ValidationModule.sol:ValidationModule");
+  const validation = await Validation.deploy(
+    ethers.ZeroAddress,
+    await stake.getAddress(),
+    1,
+    1,
+    1,
+    5,
+    []
+  );
+
+  const NFT = await ethers.getContractFactory("contracts/v2/CertificateNFT.sol:CertificateNFT");
+  const nft = await NFT.deploy("Cert", "CERT");
+
+  const Registry = await ethers.getContractFactory("contracts/v2/JobRegistry.sol:JobRegistry");
+  const registry = await Registry.deploy(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroAddress,
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    0,
+    0,
+    []
+  );
+
+  const Dispute = await ethers.getContractFactory("contracts/v2/DisputeModule.sol:DisputeModule");
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    await stake.getAddress(),
+    moderator.address,
+    0
+  );
+
+  await stake.setModules(await registry.getAddress(), await dispute.getAddress());
+  await validation.setJobRegistry(await registry.getAddress());
+  await validation.setIdentityRegistry(await identity.getAddress());
+  await validation.setValidatorPool([v1.address, v2.address]);
+  await validation.setValidatorsPerJob(2);
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await dispute.getAddress(),
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    []
+  );
+  await reputation.setCaller(await registry.getAddress(), true);
+
+  return { owner, employer, agent, v1, v2, moderator, token, stake, validation, registry, dispute };
+}
+
+describe("validator participation", function () {
+  it("finalizes job when validators approve", async () => {
+    const env = await deployFullSystem();
+    const { employer, agent, v1, v2, token, stake, validation, registry } = env;
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    for (const signer of [agent, v1, v2]) {
+      await token.connect(signer).approve(await stake.getAddress(), stakeAmount);
+      const role = signer === agent ? Role.Agent : Role.Validator;
+      await stake.connect(signer).depositStake(role, stakeAmount);
+    }
+
+    const reward = ethers.parseUnits("100", 6);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+
+    await registry.connect(agent).applyForJob(1, "agent", []);
+    await registry.connect(agent).submit(1, ethers.id("ipfs://result"), "ipfs://result", "agent", []);
+
+    const nonce = await validation.jobNonce(1);
+    const salt1 = ethers.randomBytes(32);
+    const commit1 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, true, salt1]));
+    await validation.connect(v1).commitValidation(1, commit1);
+    const salt2 = ethers.randomBytes(32);
+    const commit2 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, true, salt2]));
+    await validation.connect(v2).commitValidation(1, commit2);
+
+    await time.increase(2);
+    await validation.connect(v1).revealValidation(1, true, salt1);
+    await validation.connect(v2).revealValidation(1, true, salt2);
+    await time.increase(2);
+    await validation.finalize(1);
+
+    expect(await registry.jobs(1)).to.have.property("state", 6);
+  });
+
+  it("resolves disputes when validators reject", async () => {
+    const env = await deployFullSystem();
+    const { employer, agent, v1, v2, token, stake, validation, registry, dispute, moderator } = env;
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    for (const signer of [agent, v1, v2]) {
+      await token.connect(signer).approve(await stake.getAddress(), stakeAmount);
+      const role = signer === agent ? Role.Agent : Role.Validator;
+      await stake.connect(signer).depositStake(role, stakeAmount);
+    }
+
+    const reward = ethers.parseUnits("100", 6);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+
+    await registry.connect(agent).applyForJob(1, "agent", []);
+    await registry.connect(agent).submit(1, ethers.id("ipfs://bad"), "ipfs://bad", "agent", []);
+
+    const nonce = await validation.jobNonce(1);
+    const salt1 = ethers.randomBytes(32);
+    const commit1 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, false, salt1]));
+    await validation.connect(v1).commitValidation(1, commit1);
+    const salt2 = ethers.randomBytes(32);
+    const commit2 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, false, salt2]));
+    await validation.connect(v2).commitValidation(1, commit2);
+
+    await time.increase(2);
+    await validation.connect(v1).revealValidation(1, false, salt1);
+    await validation.connect(v2).revealValidation(1, false, salt2);
+    await time.increase(2);
+    await validation.finalize(1);
+
+    expect(await registry.jobs(1)).to.have.property("state", 5);
+
+    await registry.connect(agent).dispute(1, "evidence");
+    await dispute.connect(moderator).resolve(1, false);
+
+    expect(await registry.jobs(1)).to.have.property("state", 6);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add integration tests for validator participation and dispute flows
- cover regression scenarios: zero validators, stake exhaustion, module replacement
- add fuzz tests for slashing percentage, validator pools, and job deadlines

## Testing
- `npm test`
- `forge test` *(fails: Wrong argument count for function call in existing Integration.t.sol)*

------
https://chatgpt.com/codex/tasks/task_e_68ab456c513483338eb85516c8de365e