### PR TITLE
docs: add quickstart scripts and contract API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,27 @@ All modules default to the 6‑decimal `$AGIALPHA` token for payments, stakes an
 
 ## Quick Start
 
-Below is a minimal walkthrough of the job lifecycle using the v2 contracts. All token amounts use six‑decimal base units (`1 token = 1_000000`).
+Use the `examples/ethers-quickstart.js` script to interact with the deployed contracts. Export `RPC_URL`, `PRIVATE_KEY`, `JOB_REGISTRY`, `STAKE_MANAGER` and `VALIDATION_MODULE`.
 
-1. **Post a job** – `JobRegistry.createJob(reward, "ipfs://job")`.
-2. **Agent applies** – stake via `StakeManager.depositStake(0, amount)` then call `JobRegistry.applyForJob(jobId, label, proof)`.
-3. **Work submission** – the agent finishes the task and calls `JobRegistry.submit(jobId, resultHash, "ipfs://result")`.
-4. **Validation** – validators commit and reveal votes with `ValidationModule.commitValidation(jobId, hash, label, proof)` followed by `ValidationModule.revealValidation(jobId, approve, salt)`.
-5. **Finalize** – after the reveal window anyone may call `ValidationModule.finalize(jobId)` which releases rewards and mints a certificate.
-6. **Disputes (optional)** – open a challenge with `JobRegistry.raiseDispute(jobId, evidence)`; the owner resolves it on `DisputeModule.resolve(jobId, employerWins)`.
+### Post a job
+```bash
+node -e "require('./examples/ethers-quickstart').postJob()"
+```
 
+### Stake tokens
+```bash
+node -e "require('./examples/ethers-quickstart').stake(1_000000)"
+```
+
+### Validate a submission
+```bash
+node -e "require('./examples/ethers-quickstart').validate(1, '0xhash', '0xlabel', [], true, '0xsalt')"
+```
+
+### Raise a dispute
+```bash
+node -e "require('./examples/ethers-quickstart').dispute(1, 'ipfs://evidence')"
+```
 ## Step‑by‑Step Deployment with $AGIALPHA
 
 Record each address during deployment. The defaults below assume the 6‑decimal `$AGIALPHA` token and can be adjusted later via [`StakeManager.setToken`](contracts/v2/StakeManager.sol):

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,33 +1,13 @@
 # API Reference
 
-Summary of key AGIJob Manager contract functions and parameters.
+Per‑contract summaries of the AGIJob Manager v2 modules:
 
-## JobRegistry
-- `createJob(uint256 reward, string uri)` – employer posts a job and escrows the reward.
-- `applyForJob(uint256 jobId, bytes32 label, bytes32[] proof)` – agent applies using ENS label and Merkle proof.
-- `submit(uint256 jobId, bytes32 resultHash, string resultURI)` – agent submits work artifact by hash.
-- `finalizeAfterValidation(uint256 jobId, bool success)` – records validation result and releases funds.
-- `raiseDispute(uint256 jobId, string evidence)` – escalates a job to the dispute module.
-
-## StakeManager
-- `depositStake(uint8 role, uint256 amount)` – lock tokens as an agent (`0`) or validator (`1`).
-- `withdrawStake(uint8 role, uint256 amount)` – release previously staked tokens.
-- `lock(address from, uint256 amount)` / `release(address to, uint256 amount)` – JobRegistry hooks for job rewards.
-- `setToken(address newToken)` – owner updates the ERC‑20 used for staking and payments.
-
-## ValidationModule
-- `commitValidation(uint256 jobId, bytes32 hash, bytes32 label, bytes32[] proof)` – validator submits commit hash.
-- `revealValidation(uint256 jobId, bool approve, bytes32 salt)` – reveal vote and salt.
-- `finalize(uint256 jobId)` – tallies reveals and triggers payout.
-
-## DisputeModule
-- `raiseDispute(uint256 jobId)` – open a challenge for the given job.
-- `resolve(uint256 jobId, bool employerWins)` – owner resolves the dispute.
-
-## IdentityRegistry
-- `verifyAgent(bytes32 label, bytes32[] proof, address account)` – check if an address controls an allowed agent subdomain.
-- `verifyValidator(bytes32 label, bytes32[] proof, address account)` – verify validator eligibility.
-
-## CertificateNFT
-- `mint(address to, uint256 jobId, string uri)` – mint completion certificate after finalization.
-
+- [AGIALPHAToken](api/AGIALPHAToken.md)
+- [StakeManager](api/StakeManager.md)
+- [JobRegistry](api/JobRegistry.md)
+- [ValidationModule](api/ValidationModule.md)
+- [DisputeModule](api/DisputeModule.md)
+- [IdentityRegistry](api/IdentityRegistry.md)
+- [ReputationEngine](api/ReputationEngine.md)
+- [CertificateNFT](api/CertificateNFT.md)
+- [FeePool](api/FeePool.md)

--- a/docs/api/AGIALPHAToken.md
+++ b/docs/api/AGIALPHAToken.md
@@ -1,0 +1,11 @@
+# AGIALPHAToken API
+
+ERC‑20 token with 6 decimals used for payments and staking.
+
+## Functions
+- `decimals()` – returns fixed 6 decimal places.
+- `mint(address to, uint256 amount)` – owner mints tokens.
+- `burn(address from, uint256 amount)` – owner burns tokens from an address.
+
+## Events
+Uses standard ERC‑20 `Transfer` and `Approval` events.

--- a/docs/api/CertificateNFT.md
+++ b/docs/api/CertificateNFT.md
@@ -1,0 +1,18 @@
+# CertificateNFT API
+
+ERC‑721 completion certificates with optional marketplace.
+
+## Functions
+- `setJobRegistry(address registry)` / `setStakeManager(address manager)` – owner wires modules.
+- `mint(address to, uint256 jobId, string uri)` – JobRegistry mints certificate.
+- `tokenURI(uint256 tokenId)` – returns metadata URI.
+- `list(uint256 tokenId, uint256 price)` – certificate holder lists for sale.
+- `purchase(uint256 tokenId)` – buy listed certificate.
+- `delist(uint256 tokenId)` – remove listing.
+
+## Events
+- `JobRegistryUpdated(address registry)`
+- `StakeManagerUpdated(address manager)`
+- `NFTListed(uint256 tokenId, address seller, uint256 price)`
+- `NFTPurchased(uint256 tokenId, address buyer, uint256 price)`
+- `NFTDelisted(uint256 tokenId)`

--- a/docs/api/DisputeModule.md
+++ b/docs/api/DisputeModule.md
@@ -1,0 +1,13 @@
+# DisputeModule API
+
+Handles disputes raised against jobs.
+
+## Functions
+- `setModerator(address moderator)` – owner sets privileged moderator.
+- `raiseDispute(uint256 jobId)` – anyone opens a dispute on a job.
+- `resolve(uint256 jobId, bool employerWins)` – moderator settles the dispute and redistributes stakes.
+
+## Events
+- `DisputeRaised(uint256 indexed jobId, address indexed claimant)`
+- `DisputeResolved(uint256 indexed jobId, bool employerWins)`
+- `ModeratorUpdated(address indexed moderator)`

--- a/docs/api/FeePool.md
+++ b/docs/api/FeePool.md
@@ -1,0 +1,25 @@
+# FeePool API
+
+Holds platform fees and distributes rewards.
+
+## Functions
+- `depositFee(uint256 amount)` – StakeManager deposits collected fees.
+- `contribute(uint256 amount)` – anyone can add to the reward pool.
+- `distributeFees()` – move accumulated fees to the reward pool and burn portion.
+- `claimRewards()` – stakers claim their share of rewards.
+- `ownerWithdraw(address to, uint256 amount)` – owner emergency withdrawal.
+- `setToken(address newToken)` / `setStakeManager(address manager)` – owner wires token and modules.
+- `setRewardRole(uint8 role)` – choose which stakers earn rewards.
+- `setBurnPct(uint256 pct)` / `setTreasury(address treasury)` – configure fee splits.
+
+## Events
+- `FeeDeposited(address from, uint256 amount)`
+- `FeesDistributed(uint256 amount)`
+- `Burned(uint256 amount)`
+- `RewardsClaimed(address user, uint256 amount)`
+- `TokenUpdated(address token)` / `StakeManagerUpdated(address stakeManager)`
+- `RewardRoleUpdated(uint8 role)`
+- `BurnPctUpdated(uint256 pct)`
+- `TreasuryUpdated(address treasury)`
+- `OwnerWithdrawal(address to, uint256 amount)`
+- `RewardPoolContribution(address contributor, uint256 amount)`

--- a/docs/api/IdentityRegistry.md
+++ b/docs/api/IdentityRegistry.md
@@ -1,0 +1,22 @@
+# IdentityRegistry API
+
+Validates ENS ownership and Merkle proofs for agents and validators.
+
+## Functions
+- `setENS(address ens)` / `setNameWrapper(address wrapper)` – configure ENS contracts.
+- `setReputationEngine(address engine)` – connect reputation engine.
+- `setAgentRootNode(bytes32 node)` / `setClubRootNode(bytes32 node)` – base ENS nodes for agents and validators.
+- `setAgentMerkleRoot(bytes32 root)` / `setValidatorMerkleRoot(bytes32 root)` – load allowlists.
+- `addAdditionalAgent(address agent)` / `addAdditionalValidator(address validator)` – manual overrides.
+- `isAuthorizedAgent(address account, bytes32 label, bytes32[] proof)` – check agent eligibility.
+- `isAuthorizedValidator(address account, bytes32 label, bytes32[] proof)` – check validator eligibility.
+- `verifyAgent(bytes32 label, bytes32[] proof, address account)` – external verification helper.
+- `verifyValidator(bytes32 label, bytes32[] proof, address account)` – external verification helper.
+
+## Events
+- `ENSUpdated(address ens)` / `NameWrapperUpdated(address nameWrapper)`
+- `ReputationEngineUpdated(address reputationEngine)`
+- `AgentRootNodeUpdated(bytes32 agentRootNode)` / `ClubRootNodeUpdated(bytes32 clubRootNode)`
+- `AgentMerkleRootUpdated(bytes32 agentMerkleRoot)` / `ValidatorMerkleRootUpdated(bytes32 validatorMerkleRoot)`
+- `AdditionalAgentUpdated(address agent, bool allowed)`
+- `AdditionalValidatorUpdated(address validator, bool allowed)`

--- a/docs/api/JobRegistry.md
+++ b/docs/api/JobRegistry.md
@@ -1,0 +1,24 @@
+# JobRegistry API
+
+Coordinates job posting, assignment and dispute resolution.
+
+## Functions
+- `createJob(uint256 reward, string uri)` – employer escrows reward and posts IPFS job metadata.
+- `applyForJob(uint256 jobId, bytes32 label, bytes32[] proof)` – agent applies using ENS label and Merkle proof.
+- `submit(uint256 jobId, bytes32 resultHash, string resultURI)` – agent submits work.
+- `finalize(uint256 jobId)` – releases rewards after validation succeeds.
+- `raiseDispute(uint256 jobId, string evidence)` – escalate to the dispute module.
+- `setModules(address stakeManager, address validationModule, address disputeModule, address certificateNFT, address reputationEngine, address feePool)` – owner wires modules.
+- `setTaxPolicy(address policy)` / `acknowledgeTaxPolicy()` – configure tax policy and acknowledge.
+- `setAgentRootNode(bytes32 node)` / `setAgentMerkleRoot(bytes32 root)` – load ENS allowlists.
+
+## Events
+- `JobCreated(uint256 indexed jobId, address indexed employer, uint256 reward, string uri)`
+- `JobApplied(uint256 indexed jobId, address indexed agent)`
+- `JobSubmitted(uint256 indexed jobId, bytes32 resultHash)`
+- `JobCompleted(uint256 indexed jobId, bool success)`
+- `JobFinalized(uint256 indexed jobId, address worker)`
+- `JobCancelled(uint256 indexed jobId)`
+- `JobExpired(uint256 indexed jobId, address caller)`
+- `JobDisputed(uint256 indexed jobId, address caller)`
+- `DisputeResolved(uint256 indexed jobId, bool employerWins)`

--- a/docs/api/ReputationEngine.md
+++ b/docs/api/ReputationEngine.md
@@ -1,0 +1,24 @@
+# ReputationEngine API
+
+Tracks reputation scores for agents and validators.
+
+## Functions
+- `setCaller(address caller, bool allowed)` – owner designates authorized modules.
+- `setStakeManager(address manager)` – wire stake manager.
+- `setScoringWeights(uint256 stakeWeight, uint256 reputationWeight)` – configure weighting.
+- `setValidationRewardPercentage(uint256 percentage)` – portion of rewards for validators.
+- `setPremiumThreshold(uint256 threshold)` – reputation required for premium access.
+- `setBlacklist(address user, bool status)` – owner blacklist or unblacklist an address.
+- `add(address user, uint256 amount)` / `subtract(address user, uint256 amount)` – adjust scores.
+- `onApply(address user)` / `onFinalize(address user, bool success, uint256 payout, uint256 duration)` – hooks from JobRegistry.
+- `rewardValidator(address validator, uint256 agentGain)` – award reputation to validator.
+- `getReputation(address user)` – view current score.
+
+## Events
+- `ReputationUpdated(address user, int256 delta, uint256 newScore)`
+- `BlacklistUpdated(address user, bool status)`
+- `CallerUpdated(address caller, bool allowed)`
+- `PremiumThresholdUpdated(uint256 newThreshold)`
+- `StakeManagerUpdated(address stakeManager)`
+- `ScoringWeightsUpdated(uint256 stakeWeight, uint256 reputationWeight)`
+- `ValidationRewardPercentageUpdated(uint256 percentage)`

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -1,0 +1,27 @@
+# StakeManager API
+
+Handles staking, escrow and slashing of the $AGIALPHA token.
+
+## Functions
+- `setToken(address newToken)` – owner updates ERC‑20 used for stakes.
+- `setMinStake(uint256 minStake)` / `setMaxStakePerAddress(uint256 maxStake)` – configure stake limits.
+- `setTreasury(address treasury)` / `setFeePool(address feePool)` – wire fee destinations.
+- `setJobRegistry(address registry)` / `setDisputeModule(address module)` / `setValidationModule(address module)` – connect modules.
+- `depositStake(uint8 role, uint256 amount)` – user stakes as agent (`0`) or validator (`1`).
+- `withdrawStake(uint8 role, uint256 amount)` – withdraw previously staked tokens.
+- `lock(address from, uint256 amount)` / `release(address to, uint256 amount)` – JobRegistry hooks for job rewards.
+- `lockDisputeFee(address payer, uint256 amount)` / `payDisputeFee(address to, uint256 amount)` – escrow dispute fees.
+- `slash(address user, uint256 amount, address recipient)` – owner slashes stake and sends to recipient.
+- `stakeOf(address user, uint8 role)` / `totalStake(uint8 role)` – view functions.
+
+## Events
+- `StakeDeposited(address indexed user, Role indexed role, uint256 amount)`
+- `StakeWithdrawn(address indexed user, Role indexed role, uint256 amount)`
+- `StakeSlashed(address indexed user, uint256 amount, address recipient)`
+- `StakeLocked(bytes32 indexed jobId, address indexed from, uint256 amount)`
+- `StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount)`
+- `DisputeFeeLocked(address indexed payer, uint256 amount)`
+- `DisputeFeePaid(address indexed to, uint256 amount)`
+- `TokenUpdated(address indexed newToken)`
+- `FeePctUpdated(uint256 pct)` / `BurnPctUpdated(uint256 pct)` / `ValidatorRewardPctUpdated(uint256 pct)`
+- `ModulesUpdated(address indexed jobRegistry, address indexed disputeModule)`

--- a/docs/api/ValidationModule.md
+++ b/docs/api/ValidationModule.md
@@ -1,0 +1,27 @@
+# ValidationModule API
+
+Manages commit‑reveal voting for submitted jobs.
+
+## Functions
+- `setValidatorPool(address[] newPool)` – owner sets initial validator set.
+- `setJobRegistry(address registry)` / `setStakeManager(address manager)` – wire core modules.
+- `setCommitRevealWindows(uint256 commitDur, uint256 revealDur)` – configure timing.
+- `setValidatorBounds(uint256 minVals, uint256 maxVals)` / `setValidatorsPerJob(uint256 count)` – set validator counts.
+- `setValidatorSlashingPct(uint256 pct)` / `setApprovalThreshold(uint256 pct)` / `setRequiredValidatorApprovals(uint256 count)` – configure slashing and thresholds.
+- `selectValidators(uint256 jobId)` – pseudo‑randomly pick validators for a job.
+- `commitValidation(uint256 jobId, bytes32 commitHash)` – validator commits to a vote.
+- `revealValidation(uint256 jobId, bool approve, bytes32 salt)` – reveal vote.
+- `finalize(uint256 jobId)` – tally reveals and trigger payout.
+- `resetJobNonce(uint256 jobId)` – clear validator commitments for a job.
+
+## Events
+- `ValidatorsUpdated(address[] validators)`
+- `TimingUpdated(uint256 commitWindow, uint256 revealWindow)`
+- `ValidatorBoundsUpdated(uint256 minValidators, uint256 maxValidators)`
+- `ValidatorSlashingPctUpdated(uint256 pct)`
+- `ApprovalThresholdUpdated(uint256 pct)`
+- `ValidatorsPerJobUpdated(uint256 count)`
+- `CommitWindowUpdated(uint256 window)` / `RevealWindowUpdated(uint256 window)`
+- `RequiredValidatorApprovalsUpdated(uint256 count)`
+- `JobRegistryUpdated(address registry)` / `StakeManagerUpdated(address manager)` / `IdentityRegistryUpdated(address registry)`
+- `JobNonceReset(uint256 jobId)`


### PR DESCRIPTION
## Summary
- add script-driven Quick Start walkthrough in README
- document each core contract with dedicated API reference files
- expand ethers.js example to cover staking, validation and disputes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab49a161748333a84cc067e261a794