### PR TITLE
feat: extend agent gateway with wallet and commit-reveal handling

### DIFF
--- a/agent-gateway/index.js
+++ b/agent-gateway/index.js
@@ -2,12 +2,18 @@ const express = require('express');
 const http = require('http');
 const { WebSocketServer } = require('ws');
 const { ethers } = require('ethers');
+const WalletManager = require('./wallet');
 
 // Environment configuration
 const RPC_URL = process.env.RPC_URL || 'http://localhost:8545';
 const JOB_REGISTRY_ADDRESS = process.env.JOB_REGISTRY_ADDRESS || '';
-const AGENT_PRIVATE_KEY = process.env.AGENT_PRIVATE_KEY || '';
+const VALIDATION_MODULE_ADDRESS = process.env.VALIDATION_MODULE_ADDRESS || '';
+const WALLET_KEYS = process.env.WALLET_KEYS || '';
 const PORT = process.env.PORT || 3000;
+
+// Provider and wallet manager
+const provider = new ethers.JsonRpcProvider(RPC_URL);
+const walletManager = new WalletManager(WALLET_KEYS, provider);
 
 // Minimal ABI for JobRegistry interactions
 const JOB_REGISTRY_ABI = [
@@ -16,26 +22,36 @@ const JOB_REGISTRY_ABI = [
   'function submit(uint256 jobId, bytes32 resultHash, string resultURI, string subdomain, bytes proof) external'
 ];
 
-// Provider and signer
-const provider = new ethers.JsonRpcProvider(RPC_URL);
-const signer = AGENT_PRIVATE_KEY ? new ethers.Wallet(AGENT_PRIVATE_KEY, provider) : provider;
+// Minimal ABI for ValidationModule interactions
+const VALIDATION_MODULE_ABI = [
+  'function jobNonce(uint256 jobId) view returns (uint256)',
+  'function commitValidation(uint256 jobId, bytes32 commitHash)',
+  'function revealValidation(uint256 jobId, bool approve, bytes32 salt)'
+];
 
-const registry = new ethers.Contract(JOB_REGISTRY_ADDRESS, JOB_REGISTRY_ABI, signer);
+const registry = new ethers.Contract(JOB_REGISTRY_ADDRESS, JOB_REGISTRY_ABI, provider);
+const validation = VALIDATION_MODULE_ADDRESS
+  ? new ethers.Contract(VALIDATION_MODULE_ADDRESS, VALIDATION_MODULE_ABI, provider)
+  : null;
 
-// In-memory store of open jobs
+// In-memory stores
 const jobs = new Map();
+const agents = new Map(); // id -> {url, wallet}
+const commits = new Map(); // jobId -> { address -> {approve, salt} }
 
 // Listen for JobCreated events
-registry.on('JobCreated', (jobId, employer, agent, reward, stake, fee) => {
+registry.on('JobCreated', (jobId, employer, agentAddr, reward, stake, fee) => {
   const job = {
     jobId: jobId.toString(),
     employer,
+    agent: agentAddr,
     reward: reward.toString(),
     stake: stake.toString(),
     fee: fee.toString()
   };
   jobs.set(job.jobId, job);
   broadcast({ type: 'JobCreated', job });
+  dispatch(job);
   console.log('JobCreated', job);
 });
 
@@ -43,15 +59,32 @@ registry.on('JobCreated', (jobId, employer, agent, reward, stake, fee) => {
 const app = express();
 app.use(express.json());
 
+// Register an agent to receive job dispatches
+app.post('/agents', (req, res) => {
+  const { id, url, wallet } = req.body;
+  if (!id || !url || !wallet) {
+    return res.status(400).json({ error: 'id, url and wallet required' });
+  }
+  agents.set(id, { url, wallet });
+  res.json({ id, url, wallet });
+});
+
+app.get('/agents', (req, res) => {
+  res.json(Array.from(agents.entries()).map(([id, a]) => ({ id, ...a })));
+});
+
 // REST endpoint to list jobs
 app.get('/jobs', (req, res) => {
   res.json(Array.from(jobs.values()));
 });
 
-// Apply for a job
+// Apply for a job with a managed wallet
 app.post('/jobs/:id/apply', async (req, res) => {
+  const { address } = req.body;
+  const wallet = walletManager.get(address);
+  if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
   try {
-    const tx = await registry.applyForJob(req.params.id, '', '0x');
+    const tx = await registry.connect(wallet).applyForJob(req.params.id, '', '0x');
     await tx.wait();
     res.json({ tx: tx.hash });
   } catch (err) {
@@ -61,11 +94,66 @@ app.post('/jobs/:id/apply', async (req, res) => {
 
 // Submit job result
 app.post('/jobs/:id/submit', async (req, res) => {
+  const { address, result } = req.body;
+  const wallet = walletManager.get(address);
+  if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
   try {
-    const { result } = req.body;
     const hash = ethers.id(result || '');
-    const tx = await registry.submit(req.params.id, hash, result || '', '', '0x');
+    const tx = await registry
+      .connect(wallet)
+      .submit(req.params.id, hash, result || '', '', '0x');
     await tx.wait();
+    res.json({ tx: tx.hash });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Commit validation decision
+app.post('/jobs/:id/commit', async (req, res) => {
+  if (!validation) {
+    return res.status(500).json({ error: 'validation module not configured' });
+  }
+  const { address, approve } = req.body;
+  const wallet = walletManager.get(address);
+  if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
+  try {
+    const nonce = await validation.jobNonce(req.params.id);
+    const salt = ethers.hexlify(ethers.randomBytes(32));
+    const commitHash = ethers.solidityPackedKeccak256(
+      ['uint256', 'uint256', 'bool', 'bytes32'],
+      [BigInt(req.params.id), nonce, approve, salt]
+    );
+    const tx = await validation
+      .connect(wallet)
+      .commitValidation(req.params.id, commitHash);
+    await tx.wait();
+    if (!commits.has(req.params.id)) commits.set(req.params.id, {});
+    const jobCommits = commits.get(req.params.id);
+    jobCommits[address.toLowerCase()] = { approve, salt };
+    res.json({ tx: tx.hash, salt });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Reveal validation decision
+app.post('/jobs/:id/reveal', async (req, res) => {
+  if (!validation) {
+    return res.status(500).json({ error: 'validation module not configured' });
+  }
+  const { address } = req.body;
+  const wallet = walletManager.get(address);
+  if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
+  const jobCommits = commits.get(req.params.id) || {};
+  const data = jobCommits[address.toLowerCase()];
+  if (!data) return res.status(400).json({ error: 'no commit found' });
+  try {
+    const tx = await validation
+      .connect(wallet)
+      .revealValidation(req.params.id, data.approve, data.salt);
+    await tx.wait();
+    delete jobCommits[address.toLowerCase()];
     res.json({ tx: tx.hash });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -84,6 +172,18 @@ function broadcast(payload) {
   });
 }
 
+// Dispatch jobs to registered agents via HTTP
+function dispatch(job) {
+  agents.forEach(({ url }) => {
+    fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(job)
+    }).catch((err) => console.error('dispatch error', err));
+  });
+}
+
 server.listen(PORT, () => {
   console.log(`Agent gateway listening on port ${PORT}`);
+  console.log('Wallets:', walletManager.list());
 });

--- a/agent-gateway/wallet.js
+++ b/agent-gateway/wallet.js
@@ -1,0 +1,29 @@
+const { ethers } = require('ethers');
+
+class WalletManager {
+  constructor(keys, provider) {
+    this.provider = provider;
+    this.wallets = new Map();
+    if (keys) {
+      keys
+        .split(',')
+        .map((k) => k.trim())
+        .filter(Boolean)
+        .forEach((key) => {
+          const wallet = new ethers.Wallet(key, provider);
+          this.wallets.set(wallet.address.toLowerCase(), wallet);
+        });
+    }
+  }
+
+  get(address) {
+    if (!address) return undefined;
+    return this.wallets.get(address.toLowerCase());
+  }
+
+  list() {
+    return Array.from(this.wallets.values()).map((w) => w.address);
+  }
+}
+
+module.exports = WalletManager;

--- a/docs/gateway-setup.md
+++ b/docs/gateway-setup.md
@@ -1,0 +1,65 @@
+# Agent Gateway Setup
+
+This gateway listens to on-chain job events and routes work to registered AI agents. It also manages agent wallets and handles the commit–reveal process used by validators.
+
+## Prerequisites
+
+- Node.js v18+
+- A running Ethereum RPC endpoint
+- Deployed `JobRegistry` and `ValidationModule` contracts
+- Private keys for agent or validator wallets
+
+## Installation
+
+Install project dependencies:
+
+```bash
+npm install
+```
+
+## Running the Gateway
+
+Set the required environment variables and start the service:
+
+```bash
+export RPC_URL=http://localhost:8545
+export JOB_REGISTRY_ADDRESS=<job_registry_address>
+export VALIDATION_MODULE_ADDRESS=<validation_module_address>
+export WALLET_KEYS=<comma_separated_private_keys>
+
+npm run gateway
+```
+
+`WALLET_KEYS` accepts multiple comma‑separated private keys. The gateway loads each wallet and exposes them via the REST API.
+
+## Registering Agents
+
+Agents may register an HTTP endpoint to receive job notifications:
+
+```bash
+curl -X POST http://localhost:3000/agents \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"agent1","url":"http://localhost:4000/job","wallet":"0xYourWallet"}'
+```
+
+## Workflow
+
+1. When a `JobCreated` event is emitted, the gateway broadcasts it over WebSocket and POSTs the job payload to every registered agent.
+2. Agents can interact with the registry through the gateway using managed wallets:
+   - `POST /jobs/:id/apply` – apply for a job
+   - `POST /jobs/:id/submit` – submit a result
+   - `POST /jobs/:id/commit` – validators commit to a validation decision
+   - `POST /jobs/:id/reveal` – reveal the committed decision
+
+Each request must include the wallet address in the JSON body, e.g. `{ "address": "0x..." }`.
+
+## WebSocket Stream
+
+Clients can also subscribe to job events:
+
+```javascript
+const ws = new WebSocket('ws://localhost:3000');
+ws.onmessage = (msg) => console.log(JSON.parse(msg.data));
+```
+
+The gateway uses an in-memory store and is intended for local experimentation. Persistent storage and authentication should be added for production deployments.


### PR DESCRIPTION
## Summary
- expand gateway with wallet manager and agent registry
- dispatch job events to registered agents and support commit–reveal
- document gateway setup and usage

## Testing
- `npm run lint`
- `npm test` *(fails: compiler download/in-progress, process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4dc20b708333b1bdeb7c63533f79