### PR TITLE
docs: add module upgrade guide and installer script

### DIFF
--- a/docs/module-installer.md
+++ b/docs/module-installer.md
@@ -1,0 +1,27 @@
+# Module Installer Usage
+
+`ModuleInstaller` wires deployed modules together in a single transaction.
+This is helpful when dependencies are unknown at deploy time.
+
+## Initialize and return ownership
+1. Deploy `ModuleInstaller`. The deployer is the temporary owner.
+2. Transfer ownership to the governance address if the deployer should not
+   perform initialization.
+3. From the governance account, call `ModuleInstaller.initialize` with the
+   addresses of all modules. Ownership of each module is automatically
+   returned to the installer owner.
+
+### Hardhat script
+The repository includes `scripts/v2/initializeInstaller.ts` which
+transfers ownership and invokes `initialize`:
+
+```sh
+npx hardhat run scripts/v2/initializeInstaller.ts --network <network> \
+  --installer <installer> --governance <gov> --registry <registry> \
+  --stake <stake> --validation <validation> --reputation <reputation> \
+  --dispute <dispute> --nft <nft> --incentives <incentives> \
+  --platformRegistry <platformRegistry> --jobRouter <jobRouter> \
+  --feePool <feePool> --identity <identity>
+```
+
+After execution, each module is configured and owned by governance.

--- a/docs/upgrade-strategy.md
+++ b/docs/upgrade-strategy.md
@@ -1,22 +1,31 @@
 # Upgrade Strategy
 
 Upgrades to deployed modules should minimize disruption and preserve
-on-chain state. A typical sequence is:
+on-chain state. Follow this sequence whenever replacing a module:
 
-1. **Pause operations** – call `pause()` on the `JobRegistry` and any
-   related modules to prevent new jobs or disputes during the migration.
+1. **Pause activity** – call `pause()` on the `JobRegistry` and every
+   affected module. Pausing halts new jobs or disputes while keeping
+   existing state accessible.
 2. **Deploy the replacement module** – deploy the new contract version
-   and configure it using values read from the old module so behaviour is
+   and initialise it with values read from the old module so behaviour is
    preserved.
-3. **Migrate state** – if the module maintains persistent state (e.g.
-   configuration values or active records), copy that data from the old
-   module into the new one. Use helper scripts, such as
-   `scripts/migrateDisputeModule.ts`, to automate the process.
-4. **Update references** – point the `JobRegistry` or other coordinating
-   contracts at the new module address.
-5. **Resume service** – once checks confirm the new module is functioning
-   correctly, call `unpause()` on previously paused contracts to restore
-   normal operation.
+3. **Migrate state (if required)** – copy configuration or live records
+   from the old module to the new one. Helper scripts such as
+   `scripts/migrateDisputeModule.ts` can automate this process.
+4. **Re-point `JobRegistry`** – update references to the new module. This
+   can be done directly via `JobRegistry.setModules` or by wiring
+   everything at once through `ModuleInstaller.initialize` (see
+   `scripts/v2/initializeInstaller.ts`).
+5. **Transfer ownership back to governance** – once modules are wired,
+   reclaim ownership using each module's `transferOwnership` function.
+6. **Resume service** – after verifying the new module, call `unpause()`
+   on previously paused contracts to restore normal operation.
+
+> **Warning**
+> Upgrading while a job is in progress can lead to unexpected behaviour
+> if state is not migrated correctly. The test
+> `test/v2/MidJobUpgrade.test.js` demonstrates swapping the validation
+> module mid-job and asserts that job data remains intact.
 
 Following this strategy allows upgrades to occur safely while maintaining
 compatibility with existing on-chain data.

--- a/scripts/v2/initializeInstaller.ts
+++ b/scripts/v2/initializeInstaller.ts
@@ -1,0 +1,67 @@
+import { ethers } from "hardhat";
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const args: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith("--")) {
+        args[key] = next;
+        i++;
+      } else {
+        args[key] = "";
+      }
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs();
+  if (!args.installer) throw new Error("--installer required");
+  if (!args.governance) throw new Error("--governance required");
+
+  const installer = await ethers.getContractAt(
+    "contracts/v2/ModuleInstaller.sol:ModuleInstaller",
+    args.installer
+  );
+
+  const currentOwner = await installer.owner();
+  if (currentOwner.toLowerCase() !== args.governance.toLowerCase()) {
+    const tx = await installer.transferOwnership(args.governance);
+    await tx.wait();
+  }
+
+  const gov = await ethers.getSigner(args.governance);
+  const tx = await installer
+    .connect(gov)
+    .initialize(
+      args.registry,
+      args.stake,
+      args.validation,
+      args.reputation,
+      args.dispute,
+      args.nft,
+      args.incentives,
+      args.platformRegistry,
+      args.jobRouter,
+      args.feePool,
+      args.taxPolicy || ethers.ZeroAddress,
+      args.identity,
+      args.clubRootNode || ethers.ZeroHash,
+      args.agentRootNode || ethers.ZeroHash,
+      args.validatorMerkleRoot || ethers.ZeroHash,
+      args.agentMerkleRoot || ethers.ZeroHash,
+      []
+    );
+  await tx.wait();
+  console.log("modules initialized and ownership returned to governance");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -1,0 +1,157 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+const Role = { Agent: 0, Validator: 1, Platform: 2 };
+
+async function deploySystem() {
+  const [owner, employer, agent] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory(
+    "contracts/mocks/MockERC206Decimals.sol:MockERC206Decimals"
+  );
+  const token = await Token.deploy();
+  await token.waitForDeployment();
+  await token.mint(employer.address, ethers.parseUnits("1000", 6));
+  await token.mint(agent.address, ethers.parseUnits("1000", 6));
+
+  const Stake = await ethers.getContractFactory(
+    "contracts/v2/StakeManager.sol:StakeManager"
+  );
+  const stake = await Stake.deploy(
+    await token.getAddress(),
+    0,
+    0,
+    0,
+    owner.address,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress
+  );
+  await stake.waitForDeployment();
+
+  const Reputation = await ethers.getContractFactory(
+    "contracts/v2/ReputationEngine.sol:ReputationEngine"
+  );
+  const reputation = await Reputation.deploy(await stake.getAddress());
+  await reputation.waitForDeployment();
+
+  const Identity = await ethers.getContractFactory(
+    "contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock"
+  );
+  const identity = await Identity.deploy();
+  await identity.waitForDeployment();
+  await identity.setReputationEngine(await reputation.getAddress());
+
+  const Validation = await ethers.getContractFactory(
+    "contracts/v2/mocks/ValidationStub.sol:ValidationStub"
+  );
+  const validation = await Validation.deploy();
+  await validation.waitForDeployment();
+
+  const NFT = await ethers.getContractFactory(
+    "contracts/v2/CertificateNFT.sol:CertificateNFT"
+  );
+  const nft = await NFT.deploy("Cert", "CERT");
+  await nft.waitForDeployment();
+
+  const Registry = await ethers.getContractFactory(
+    "contracts/v2/JobRegistry.sol:JobRegistry"
+  );
+  const registry = await Registry.deploy(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroAddress,
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    0,
+    0,
+    []
+  );
+  await registry.waitForDeployment();
+
+  const Dispute = await ethers.getContractFactory(
+    "contracts/v2/modules/DisputeModule.sol:DisputeModule"
+  );
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    0,
+    0,
+    owner.address
+  );
+  await dispute.waitForDeployment();
+
+  await stake.setModules(await registry.getAddress(), await dispute.getAddress());
+  await validation.setJobRegistry(await registry.getAddress());
+  await nft.setJobRegistry(await registry.getAddress());
+  await nft.setStakeManager(await stake.getAddress());
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await dispute.getAddress(),
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    []
+  );
+  await registry.setIdentityRegistry(await identity.getAddress());
+  await reputation.setCaller(await registry.getAddress(), true);
+
+  return { owner, employer, agent, token, stake, reputation, validation, nft, registry, dispute };
+}
+
+describe("Mid-job module upgrades", function () {
+  it("retains job state when swapping validation module mid-job", async function () {
+    const env = await deploySystem();
+    const { owner, employer, agent, token, stake, reputation, validation, nft, registry, dispute } = env;
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
+    await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
+
+    const reward = ethers.parseUnits("100", 6);
+    const fee = (reward * 5n) / 100n;
+    await token
+      .connect(employer)
+      .approve(await stake.getAddress(), reward + fee);
+    const deadline = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+
+    await registry.connect(agent).applyForJob(1, "agent", []);
+    const hash = ethers.id("ipfs://result");
+    await registry
+      .connect(agent)
+      .submit(1, hash, "ipfs://result", "agent", []);
+
+    const before = await registry.jobs(1);
+
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/mocks/ValidationStub.sol:ValidationStub"
+    );
+    const newValidation = await Validation.deploy();
+    await newValidation.waitForDeployment();
+    await newValidation.setJobRegistry(await registry.getAddress());
+
+    await registry
+      .connect(owner)
+      .setModules(
+        await newValidation.getAddress(),
+        await stake.getAddress(),
+        await reputation.getAddress(),
+        await dispute.getAddress(),
+        await nft.getAddress(),
+        ethers.ZeroAddress,
+        []
+      );
+
+    await newValidation.setResult(true);
+    await newValidation.finalize(1);
+
+    const after = await registry.jobs(1);
+    expect(after.employer).to.equal(before.employer);
+    expect(after.agent).to.equal(before.agent);
+    expect(after.state).to.equal(6); // Finalized
+  });
+});
+


### PR DESCRIPTION
## Summary
- document step-by-step module upgrade process and warn about mid-job swaps
- add module installer initialization script and usage docs
- cover mid-job upgrades with a state-continuity test

## Testing
- `npm run lint`
- `npx hardhat test test/v2/MidJobUpgrade.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab59adfd288333906f6bd37637d1c9