### PR TITLE
Centralize tax acknowledgement checks

### DIFF
--- a/contracts/v2/libraries/TaxAcknowledgement.sol
+++ b/contracts/v2/libraries/TaxAcknowledgement.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ITaxPolicy} from "../interfaces/ITaxPolicy.sol";
+
+abstract contract TaxAcknowledgement {
+    modifier requiresTaxAcknowledgement(
+        ITaxPolicy policy,
+        address account,
+        address owner,
+        address exempt1,
+        address exempt2
+    ) {
+        if (
+            account != owner &&
+            account != exempt1 &&
+            account != exempt2 &&
+            address(policy) != address(0)
+        ) {
+            require(
+                policy.hasAcknowledged(account),
+                "acknowledge tax policy"
+            );
+        }
+        _;
+    }
+}


### PR DESCRIPTION
## Summary
- add shared `requiresTaxAcknowledgement` modifier in a new TaxAcknowledgement base contract
- apply centralized tax acknowledgement across JobRegistry, StakeManager, and ValidationModule
- test JobRegistry to ensure agents without acknowledgement cannot apply

## Testing
- `npx hardhat test test/v2/StakeManager.test.js --grep "enforces tax acknowledgement"`
- `npx hardhat test test/v2/ValidationModule.test.js --grep "enforces tax acknowledgement"`
- `npx hardhat test test/v2/JobRegistryApply.test.js --grep "acknowledging tax policy"`


------
https://chatgpt.com/codex/tasks/task_e_68ab5ea4716083339cfe8623419cc774