### PR TITLE
Rename stake lock events

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -122,7 +122,7 @@ contract StakeManager is Ownable, ReentrancyGuard, TaxAcknowledgement {
         uint256 employerShare,
         uint256 treasuryShare
     );
-    event StakeLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
+    event StakeEscrowLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
     event StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount);
     event DisputeFeeLocked(address indexed payer, uint256 amount);
     event DisputeFeePaid(address indexed to, uint256 amount);
@@ -134,7 +134,7 @@ contract StakeManager is Ownable, ReentrancyGuard, TaxAcknowledgement {
     event TreasuryUpdated(address indexed treasury);
     event JobRegistryUpdated(address indexed registry);
     event MaxStakePerAddressUpdated(uint256 maxStake);
-    event StakeLocked(address indexed user, uint256 amount, uint64 unlockTime);
+    event StakeTimeLocked(address indexed user, uint256 amount, uint64 unlockTime);
     event StakeUnlocked(address indexed user, uint256 amount);
     event ModulesUpdated(address indexed jobRegistry, address indexed disputeModule);
     event FeePctUpdated(uint256 pct);
@@ -446,7 +446,7 @@ contract StakeManager is Ownable, ReentrancyGuard, TaxAcknowledgement {
             unlockTime[user] = newUnlock;
         }
         lockedStakes[user] += amount;
-        emit StakeLocked(user, amount, unlockTime[user]);
+        emit StakeTimeLocked(user, amount, unlockTime[user]);
     }
 
     /// @notice release previously locked stake for a user
@@ -693,7 +693,7 @@ contract StakeManager is Ownable, ReentrancyGuard, TaxAcknowledgement {
     {
         token.safeTransferFrom(from, address(this), amount);
         jobEscrows[jobId] += amount;
-        emit StakeLocked(jobId, from, amount);
+        emit StakeEscrowLocked(jobId, from, amount);
     }
 
     /// @notice Generic escrow lock used when job context is managed externally.
@@ -704,7 +704,7 @@ contract StakeManager is Ownable, ReentrancyGuard, TaxAcknowledgement {
     /// @param amount Token amount with 6 decimals to lock.
     function lock(address from, uint256 amount) external onlyJobRegistry {
         token.safeTransferFrom(from, address(this), amount);
-        emit StakeLocked(bytes32(0), from, amount);
+        emit StakeEscrowLocked(bytes32(0), from, amount);
     }
 
     /// @notice release locked job reward to recipient applying any AGI type bonus

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -16,9 +16,9 @@ interface IStakeManager {
 
     event StakeDeposited(address indexed user, Role indexed role, uint256 amount);
     event StakeWithdrawn(address indexed user, Role indexed role, uint256 amount);
-    event StakeLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
+    event StakeEscrowLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
     event StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount);
-    event StakeLocked(address indexed user, uint256 amount, uint64 unlockTime);
+    event StakeTimeLocked(address indexed user, uint256 amount, uint64 unlockTime);
     event StakeUnlocked(address indexed user, uint256 amount);
     event StakeSlashed(
         address indexed user,

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -18,7 +18,7 @@ Handles staking, escrow and slashing of the $AGIALPHA token.
 - `StakeDeposited(address indexed user, Role indexed role, uint256 amount)`
 - `StakeWithdrawn(address indexed user, Role indexed role, uint256 amount)`
 - `StakeSlashed(address indexed user, uint256 amount, address recipient)`
-- `StakeLocked(bytes32 indexed jobId, address indexed from, uint256 amount)`
+- `StakeEscrowLocked(bytes32 indexed jobId, address indexed from, uint256 amount)`
 - `StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount)`
 - `DisputeFeeLocked(address indexed payer, uint256 amount)`
 - `DisputeFeePaid(address indexed to, uint256 amount)`

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -662,7 +662,7 @@ describe("StakeManager", function () {
         .connect(registrySigner)
         .lockStake(user.address, 200, Number(lockDuration))
     )
-      .to.emit(stakeManager, "StakeLocked(address,uint256,uint64)")
+      .to.emit(stakeManager, "StakeTimeLocked(address,uint256,uint64)")
       .withArgs(user.address, 200n, expectedUnlock);
 
     await expect(


### PR DESCRIPTION
## Summary
- rename StakeLocked job escrow event to StakeEscrowLocked
- rename time-locking event to StakeTimeLocked
- update tests and docs for new event names

## Testing
- `npm run compile` *(fails: hangs during Hardhat compile)*
- `npm test` *(fails: hangs during Hardhat compile)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab6e1deb448333a83c3d6450841a77