### PR TITLE
test: guard dispute module access

### DIFF
--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -142,6 +142,12 @@ describe("DisputeModule", function () {
       ).to.be.revertedWith("disputed");
     });
 
+    it("reverts when raiseDispute is called directly", async () => {
+      await expect(
+        dispute.connect(agent).raiseDispute(1, agent.address, "evidence")
+      ).to.be.revertedWith("not registry");
+    });
+
     it("reverts resolution attempted before window", async () => {
       await registry.connect(agent).dispute(1, "evidence");
       await expect(


### PR DESCRIPTION
## Summary
- add regression test ensuring DisputeModule accepts disputes only from JobRegistry

## Testing
- `npx hardhat test test/v2/DisputeModule.test.js` *(fails: compilation did not complete within allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7e95028883339f4fd9e5081f8b41