### PR TITLE
feat: enforce slashing percentage bounds

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -233,6 +233,10 @@ contract StakeManager is Ownable, ReentrancyGuard, TaxAcknowledgement {
         uint256 _employerSlashPct,
         uint256 _treasurySlashPct
     ) internal {
+        require(
+            _employerSlashPct <= 100 && _treasurySlashPct <= 100,
+            "pct"
+        );
         require(_employerSlashPct + _treasurySlashPct == 100, "pct");
         employerSlashPct = _employerSlashPct;
         treasurySlashPct = _treasurySlashPct;
@@ -896,7 +900,6 @@ contract StakeManager is Ownable, ReentrancyGuard, TaxAcknowledgement {
         require(role <= Role.Platform, "role");
         uint256 staked = stakes[user][role];
         require(staked >= amount, "stake");
-        require(employerSlashPct + treasurySlashPct == 100, "pct");
 
         uint256 employerShare = (amount * employerSlashPct) / 100;
         uint256 treasuryShare = (amount * treasurySlashPct) / 100;

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -549,6 +549,18 @@ describe("StakeManager", function () {
     ).to.be.revertedWith("pct");
   });
 
+  it("reverts when slashing percentages sum under 100", async () => {
+    await expect(
+      stakeManager.connect(owner).setSlashingPercentages(40, 50)
+    ).to.be.revertedWith("pct");
+  });
+
+  it("reverts when individual slashing percentage exceeds 100", async () => {
+    await expect(
+      stakeManager.connect(owner).setSlashingPercentages(101, 0)
+    ).to.be.revertedWith("pct");
+  });
+
   it("routes full slashing to treasury when employer share is zero", async () => {
     await stakeManager.connect(owner).setSlashingPercentages(0, 100);
     const MockRegistry = await ethers.getContractFactory(


### PR DESCRIPTION
## Summary
- validate StakeManager slashing percentages are each <=100 and sum to 100
- remove redundant runtime check in `_slash`
- add unit tests covering invalid slashing configuration

## Testing
- `npm test test/v2/StakeManager.test.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab8328f76083339fd150389003c45c