### PR TITLE
Enforce StakeManager slashing invariants

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -900,6 +900,10 @@ contract StakeManager is Ownable, ReentrancyGuard, TaxAcknowledgement {
         require(role <= Role.Platform, "role");
         uint256 staked = stakes[user][role];
         require(staked >= amount, "stake");
+        require(
+            employerSlashPct + treasurySlashPct == 100,
+            "pct"
+        );
 
         uint256 employerShare = (amount * employerSlashPct) / 100;
         uint256 treasuryShare = (amount * treasurySlashPct) / 100;

--- a/test/v2/StakeManagerSlashing.test.js
+++ b/test/v2/StakeManagerSlashing.test.js
@@ -1,0 +1,32 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("StakeManager slashing configuration", function () {
+  let owner, treasury, token, stakeManager;
+
+  beforeEach(async () => {
+    [owner, treasury] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory(
+      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    );
+    token = await Token.deploy();
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      0,
+      50,
+      50,
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
+    );
+  });
+
+  it("rejects percentages that do not sum to 100", async () => {
+    await expect(
+      stakeManager.setSlashingPercentages(60, 30)
+    ).to.be.revertedWith("pct");
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `_slash` checks slashing percentages sum to 100
- add test confirming `setSlashingPercentages` rejects invalid sums

## Testing
- `npm test`
- `forge test` *(fails: Source "forge-std/Test.sol" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab85bb6b788333a4bc3a893daecf35