### PR TITLE
Require tax acknowledgement before cancelling expired jobs

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1009,13 +1009,19 @@ contract JobRegistry is Ownable, ReentrancyGuard, TaxAcknowledgement {
 
     /// @notice Cancel an assigned job that failed to submit before its deadline.
     /// @param jobId Identifier of the job to cancel.
-    function cancelExpiredJob(uint256 jobId) public {
+    function cancelExpiredJob(uint256 jobId)
+        public
+        requiresTaxAcknowledgement(
+            taxPolicy,
+            msg.sender,
+            owner(),
+            address(disputeModule),
+            address(validationModule)
+        )
+    {
         Job storage job = jobs[jobId];
         require(job.state == State.Applied, "cannot expire");
         require(block.timestamp > job.deadline, "not expired");
-        if (address(taxPolicy) != address(0) && !taxPolicy.hasAcknowledged(msg.sender)) {
-            _acknowledge(msg.sender);
-        }
         job.success = false;
         job.state = State.Completed;
         finalize(jobId);

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -141,4 +141,17 @@ describe("Job expiration", function () {
     expect(job.success).to.equal(false);
     expect(await stakeManager.stakes(agent.address, 0)).to.equal(0);
   });
+
+  it("reverts if caller has not acknowledged tax policy", async () => {
+    const deadline = (await time.latest()) + 100;
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, "uri");
+    const jobId = 1;
+    await registry.connect(agent).applyForJob(jobId, "", []);
+    await time.increase(200);
+    await expect(
+      registry.connect(treasury).cancelExpiredJob(jobId)
+    ).to.be.revertedWith("acknowledge tax policy");
+  });
 });


### PR DESCRIPTION
## Summary
- enforce `requiresTaxAcknowledgement` on `cancelExpiredJob` and drop automatic acknowledgements
- test that unacknowledged callers cannot expire jobs

## Testing
- `npx solhint contracts/v2/JobRegistry.sol | tail -n 10`
- `npx eslint test/v2/JobExpiration.test.js`
- `npx hardhat test test/v2/JobExpiration.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ab8b3438a88333a1b0ca776068d2cf