### PR TITLE
Store job URI hash and emit URI

### DIFF
--- a/contracts/mocks/MockV2.sol
+++ b/contracts/mocks/MockV2.sol
@@ -227,6 +227,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
             "duration"
         );
         jobId = ++nextJobId;
+        bytes32 uriHash = keccak256(bytes(uri));
         _jobs[jobId] = Job({
             employer: msg.sender,
             agent: address(0),
@@ -234,7 +235,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
             stake: jobStake,
             success: false,
             status: Status.Created,
-            uri: uri,
+            uriHash: uriHash,
             resultHash: bytes32(0)
         });
         deadlines[jobId] = deadline;
@@ -368,7 +369,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
                     reputationEngine.add(job.agent, 1);
                 }
                 if (address(certificateNFT) != address(0)) {
-                    certificateNFT.mint(job.agent, jobId, job.uri);
+                    certificateNFT.mint(job.agent, jobId, job.uriHash);
                 }
             }
         }
@@ -387,7 +388,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
             reputationEngine.add(job.agent, 1);
         }
         if (address(certificateNFT) != address(0)) {
-            certificateNFT.mint(job.agent, jobId, job.uri);
+            certificateNFT.mint(job.agent, jobId, job.uriHash);
         }
         emit JobFinalized(jobId, job.agent);
     }

--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -67,15 +67,15 @@ contract CertificateNFT is ERC721, Ownable, ReentrancyGuard, ICertificateNFT {
     function mint(
         address to,
         uint256 jobId,
-        string calldata uri
+        bytes32 uriHash
     ) external onlyJobRegistry returns (uint256 tokenId) {
-        if (bytes(uri).length == 0) revert EmptyURI();
+        if (uriHash == bytes32(0)) revert EmptyURI();
         if (to == address(0)) revert ZeroAddress();
         tokenId = jobId;
         if (_ownerOf(tokenId) != address(0)) revert CertificateAlreadyMinted(jobId);
         _safeMint(to, tokenId);
-        tokenHashes[tokenId] = keccak256(bytes(uri));
-        emit CertificateMinted(to, jobId, uri);
+        tokenHashes[tokenId] = uriHash;
+        emit CertificateMinted(to, jobId, uriHash);
     }
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         _requireOwned(tokenId);

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -36,7 +36,7 @@ interface IDisputeModule {
 }
 
 interface ICertificateNFT {
-    function mint(address to, uint256 jobId, string calldata uri) external returns (uint256);
+    function mint(address to, uint256 jobId, bytes32 uriHash) external returns (uint256);
 }
 
 /// @title JobRegistry
@@ -66,7 +66,7 @@ contract JobRegistry is Ownable, ReentrancyGuard, TaxAcknowledgement {
         uint64 assignedAt;
         State state;
         bool success;
-        string uri;
+        bytes32 uriHash;
         bytes32 resultHash;
     }
 
@@ -150,7 +150,8 @@ contract JobRegistry is Ownable, ReentrancyGuard, TaxAcknowledgement {
         address indexed agent,
         uint256 reward,
         uint256 stake,
-        uint256 fee
+        uint256 fee,
+        string uri
     );
     event JobApplied(uint256 indexed jobId, address indexed agent);
     event JobSubmitted(
@@ -467,6 +468,7 @@ contract JobRegistry is Ownable, ReentrancyGuard, TaxAcknowledgement {
         }
         jobId = nextJobId;
         uint32 feePctSnapshot = uint32(feePct);
+        bytes32 uriHash = keccak256(bytes(uri));
         jobs[jobId] = Job({
             employer: msg.sender,
             agent: address(0),
@@ -477,7 +479,7 @@ contract JobRegistry is Ownable, ReentrancyGuard, TaxAcknowledgement {
             assignedAt: 0,
             state: State.Created,
             success: false,
-            uri: uri,
+            uriHash: uriHash,
             resultHash: bytes32(0)
         });
         uint256 fee;
@@ -491,7 +493,8 @@ contract JobRegistry is Ownable, ReentrancyGuard, TaxAcknowledgement {
             address(0),
             reward,
             uint256(jobStake),
-            fee
+            fee,
+            uri
         );
     }
 
@@ -910,7 +913,7 @@ contract JobRegistry is Ownable, ReentrancyGuard, TaxAcknowledgement {
                 }
             }
             if (address(certificateNFT) != address(0)) {
-                certificateNFT.mint(job.agent, jobId, job.uri);
+                certificateNFT.mint(job.agent, jobId, job.uriHash);
             }
         } else {
             if (address(stakeManager) != address(0)) {

--- a/contracts/v2/interfaces/ICertificateNFT.sol
+++ b/contracts/v2/interfaces/ICertificateNFT.sol
@@ -10,21 +10,21 @@ interface ICertificateNFT {
     /// @dev Reverts when attempting to mint more than once for the same job
     error CertificateAlreadyMinted(uint256 jobId);
 
-    /// @dev Reverts when an empty metadata URI is supplied
+    /// @dev Reverts when an empty metadata hash is supplied
     error EmptyURI();
 
-    event CertificateMinted(address indexed to, uint256 indexed jobId, string uri);
+    event CertificateMinted(address indexed to, uint256 indexed jobId, bytes32 uriHash);
 
     /// @notice Mint a completion certificate NFT for a job
     /// @param to Recipient of the certificate
     /// @param jobId Identifier of the job; doubles as the NFT tokenId
-    /// @param uri Metadata URI for the certificate
+    /// @param uriHash Hash of the metadata URI for the certificate
     /// @return tokenId The identifier of the minted certificate
     /// @dev Reverts with {NotJobRegistry} if called by an unauthorised address
     function mint(
         address to,
         uint256 jobId,
-        string calldata uri
+        bytes32 uriHash
     ) external returns (uint256 tokenId);
 }
 

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -22,7 +22,7 @@ interface IJobRegistry {
         uint256 stake;
         bool success;
         Status status;
-        string uri;
+        bytes32 uriHash;
         bytes32 resultHash;
     }
 
@@ -65,7 +65,8 @@ interface IJobRegistry {
         address indexed agent,
         uint256 reward,
         uint256 stake,
-        uint256 fee
+        uint256 fee,
+        string uri
     );
     event JobApplied(uint256 indexed jobId, address indexed agent);
     event JobSubmitted(

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -40,13 +40,13 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     function mint(
         address to,
         uint256 jobId,
-        string calldata uri
+        bytes32 uriHash
     ) external onlyJobRegistry returns (uint256 tokenId) {
-        if (bytes(uri).length == 0) revert EmptyURI();
+        if (uriHash == bytes32(0)) revert EmptyURI();
         tokenId = jobId;
         _safeMint(to, tokenId);
-        tokenHashes[tokenId] = keccak256(bytes(uri));
-        emit CertificateMinted(to, jobId, uri);
+        tokenHashes[tokenId] = uriHash;
+        emit CertificateMinted(to, jobId, uriHash);
     }
 
     function tokenURI(uint256 tokenId) public view override returns (string memory) {

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -18,3 +18,18 @@ For function‑level differences see:
 - [v0 → v2 function map](v0-v2-function-map.md)
 - [v1 → v2 function map](v1-v2-function-map.md)
 
+## Job URI Hash Migration
+
+`JobRegistry` v2 now emits the full job URI in `JobCreated` but only stores a
+`bytes32` hash of the URI on-chain. Existing deployments that previously stored
+the URI string should:
+
+1. Extract historical job URIs from prior `JobCreated` events.
+2. Compute `keccak256(bytes(uri))` for each and persist the resulting hash
+   off-chain for reference.
+3. When redeploying or upgrading, initialise new jobs with the computed hash and
+   supply the original URI when emitting replacement `JobCreated` events if
+   needed.
+4. Update any off-chain services or certificate minting logic to provide the
+   `uriHash` instead of the raw URI.
+

--- a/test/v2/CertificateNFT.test.js
+++ b/test/v2/CertificateNFT.test.js
@@ -15,14 +15,17 @@ describe("CertificateNFT", function () {
 
   it("mints certificates only via JobRegistry", async () => {
     const uri = "ipfs://job/1";
-    await expect(nft.connect(jobRegistry).mint(user.address, 1, uri))
+    const uriHash = ethers.keccak256(ethers.toUtf8Bytes(uri));
+    await expect(nft.connect(jobRegistry).mint(user.address, 1, uriHash))
       .to.emit(nft, "CertificateMinted")
-      .withArgs(user.address, 1, uri);
+      .withArgs(user.address, 1, uriHash);
     expect(await nft.ownerOf(1)).to.equal(user.address);
     const hash = await nft.tokenHashes(1);
-    expect(hash).to.equal(ethers.keccak256(ethers.toUtf8Bytes(uri)));
+    expect(hash).to.equal(uriHash);
     await expect(
-      nft.connect(owner).mint(user.address, 2, "ipfs://job/2")
+      nft
+        .connect(owner)
+        .mint(user.address, 2, ethers.keccak256(ethers.toUtf8Bytes("ipfs://job/2")))
     ).to.be.revertedWith("only JobRegistry");
   });
 });

--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -35,7 +35,11 @@ describe("CertificateNFT marketplace", function () {
     await nft.setJobRegistry(owner.address);
     await nft.setStakeManager(await stake.getAddress());
 
-    await nft.mint(seller.address, 1, "ipfs://1");
+    await nft.mint(
+      seller.address,
+      1,
+      ethers.keccak256(ethers.toUtf8Bytes("ipfs://1"))
+    );
   });
 
   it("lists, purchases, and delists with events", async () => {
@@ -67,7 +71,11 @@ describe("CertificateNFT marketplace", function () {
         buyerStart - price
       );
 
-      await nft.mint(seller.address, 2, "ipfs://2");
+      await nft.mint(
+        seller.address,
+        2,
+        ethers.keccak256(ethers.toUtf8Bytes("ipfs://2"))
+      );
       await nft.connect(seller).list(2, price);
       await expect(nft.connect(seller).delist(2))
         .to.emit(nft, "NFTDelisted")

--- a/test/v2/CertificateNFTMint.test.js
+++ b/test/v2/CertificateNFTMint.test.js
@@ -15,19 +15,26 @@ describe("CertificateNFT minting", function () {
 
   it("mints with jobId tokenId and enforces registry and URI", async () => {
     const uri = "ipfs://1";
-    await expect(nft.connect(jobRegistry).mint(user.address, 1, uri))
+    const uriHash = ethers.keccak256(ethers.toUtf8Bytes(uri));
+    await expect(nft.connect(jobRegistry).mint(user.address, 1, uriHash))
       .to.emit(nft, "CertificateMinted")
-      .withArgs(user.address, 1, uri);
+      .withArgs(user.address, 1, uriHash);
     expect(await nft.ownerOf(1)).to.equal(user.address);
     const hash = await nft.tokenHashes(1);
-    expect(hash).to.equal(ethers.keccak256(ethers.toUtf8Bytes(uri)));
+    expect(hash).to.equal(uriHash);
 
     await expect(
-      nft.connect(jobRegistry).mint(user.address, 2, "")
+      nft.connect(jobRegistry).mint(user.address, 2, ethers.ZeroHash)
     ).to.be.revertedWithCustomError(nft, "EmptyURI");
 
     await expect(
-      nft.connect(owner).mint(user.address, 3, "ipfs://3")
+      nft
+        .connect(owner)
+        .mint(
+          user.address,
+          3,
+          ethers.keccak256(ethers.toUtf8Bytes("ipfs://3"))
+        )
     ).to.be.revertedWithCustomError(nft, "NotJobRegistry").withArgs(
       owner.address
     );

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -126,7 +126,7 @@ describe("DisputeModule", function () {
         stake: 0,
         success: false,
         status: 4, // Completed
-        uri: "",
+        uriHash: ethers.ZeroHash,
         resultHash: ethers.ZeroHash,
       });
     });

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -89,7 +89,7 @@ describe("Validator ENS integration", function () {
       stake: 0,
       success: false,
       status: 3,
-      uri: "",
+      uriHash: ethers.ZeroHash,
       resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, job);
@@ -154,7 +154,7 @@ describe("Validator ENS integration", function () {
       stake: 0,
       success: false,
       status: 3,
-      uri: "",
+      uriHash: ethers.ZeroHash,
       resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, job);
@@ -204,7 +204,7 @@ describe("Validator ENS integration", function () {
       stake: 0,
       success: false,
       status: 3,
-      uri: "",
+      uriHash: ethers.ZeroHash,
       resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, job);

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -181,7 +181,7 @@ describe("Identity verification enforcement", function () {
         stake: 0,
         success: false,
         status: 3,
-        uri: "",
+        uriHash: ethers.ZeroHash,
         resultHash: ethers.ZeroHash,
       };
       await jobRegistry.setJob(1, jobStruct);

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -131,7 +131,15 @@ describe("JobRegistry integration", function () {
     const deadline = (await time.latest()) + 1000;
     await expect(registry.connect(employer).createJob(reward, deadline, "uri"))
       .to.emit(registry, "JobCreated")
-      .withArgs(1, employer.address, ethers.ZeroAddress, reward, stake, 0);
+      .withArgs(
+        1,
+        employer.address,
+        ethers.ZeroAddress,
+        reward,
+        stake,
+        0,
+        "uri"
+      );
     const jobId = 1;
     await expect(registry.connect(agent).applyForJob(jobId, "", []))
       .to.emit(registry, "JobApplied")

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -75,7 +75,7 @@ describe("JobRegistry tax policy integration", function () {
       .withArgs(user.address, 2, "ack");
     await expect(registry.connect(user).createJob(1, deadline, "uri"))
       .to.emit(registry, "JobCreated")
-      .withArgs(1, user.address, ethers.ZeroAddress, 1, 0, 0);
+      .withArgs(1, user.address, ethers.ZeroAddress, 1, 0, 0, "uri");
   });
 
   it("blocks non-owner from setting policy", async () => {

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -68,7 +68,7 @@ describe("ValidationModule V2", function () {
       stake: 0,
       success: false,
       status: 3,
-      uri: "",
+      uriHash: ethers.ZeroHash,
       resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, jobStruct);

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -64,7 +64,7 @@ describe("ValidationModule access controls", function () {
       stake: 0,
       success: false,
       status: 3,
-      uri: "",
+      uriHash: ethers.ZeroHash,
       resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, jobStruct);
@@ -199,7 +199,7 @@ describe("ValidationModule access controls", function () {
       stake: 0,
       success: false,
       status: 3,
-      uri: "",
+      uriHash: ethers.ZeroHash,
       resultHash: ethers.ZeroHash,
     });
     await validation.selectValidators(1);

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -57,7 +57,7 @@ async function setup() {
     stake: 0,
     success: false,
     status: 3,
-    uri: "",
+    uriHash: ethers.ZeroHash,
     resultHash: ethers.ZeroHash,
   };
   await jobRegistry.setJob(1, jobStruct);

--- a/test/v2/ValidatorSelectionDeterministic.test.js
+++ b/test/v2/ValidatorSelectionDeterministic.test.js
@@ -60,7 +60,7 @@ describe("Validator selection determinism", function () {
       stake: 0,
       success: false,
       status: 3,
-      uri: "",
+      uriHash: ethers.ZeroHash,
       resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, jobStruct);


### PR DESCRIPTION
## Summary
- Persist only a bytes32 job URI hash while emitting the full URI in `JobCreated`
- Update certificate NFT and mocks to work with URI hashes
- Adjust tests and add migration guide for URI hash approach

## Testing
- `npx hardhat test`
- `forge test` *(fails: Source "forge-std/Test.sol" not found / compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab93cbc9248333818c2d5b3be738f4