### PR TITLE
feat: add moderator voting to dispute module

### DIFF
--- a/contracts/v2/DisputeModule.sol
+++ b/contracts/v2/DisputeModule.sol
@@ -6,10 +6,11 @@ import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 /// @title DisputeModule
-/// @notice Allows job participants to raise disputes and enables a moderator
-/// to resolve them by finalising outcomes in the JobRegistry.
+/// @notice Allows job participants to raise disputes and resolves them via
+/// moderator voting or an optional arbitration contract.
 /// @dev Dispute claimants may optionally stake an appeal fee via the
-/// StakeManager which is paid out to the winner.
+/// StakeManager which is paid out to the winner.  All amounts use 6 decimals
+/// (`1 token == 1e6` units).
 contract DisputeModule is Ownable {
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 1;
@@ -20,8 +21,14 @@ contract DisputeModule is Ownable {
     /// @notice Contract managing stake and dispute fees.
     IStakeManager public immutable stakeManager;
 
-    /// @notice Address authorised to resolve disputes.
-    address public moderator;
+    /// @notice Optional contract authorised to resolve disputes directly.
+    address public arbitrator;
+
+    /// @notice Approved moderators eligible to vote on disputes.
+    mapping(address => bool) public moderators;
+
+    /// @notice Total number of registered moderators.
+    uint256 public moderatorCount;
 
     /// @notice Fixed appeal fee in token units (6 decimals) required to raise a
     /// dispute. A value of 0 disables the fee.
@@ -36,42 +43,69 @@ contract DisputeModule is Ownable {
     /// @dev Active disputes keyed by job identifier.
     mapping(uint256 => Dispute) public disputes;
 
+    /// @dev Track moderator votes for each dispute.
+    mapping(uint256 => mapping(address => bool)) public hasVoted;
+    mapping(uint256 => uint256) public employerVotes;
+    mapping(uint256 => uint256) public agentVotes;
+
     /// @notice Emitted when a participant raises a dispute.
     event DisputeRaised(uint256 indexed jobId, address indexed claimant);
 
-    /// @notice Emitted when the moderator resolves a dispute.
+    /// @notice Emitted when a dispute is resolved.
     event DisputeResolved(uint256 indexed jobId, bool employerWins);
 
-    /// @notice Emitted when the moderator address is updated.
-    /// @param moderator Address of the new moderator
-    event ModeratorUpdated(address indexed moderator);
+    /// @notice Emitted when a moderator is added or removed.
+    event ModeratorAdded(address indexed moderator);
+    event ModeratorRemoved(address indexed moderator);
+
+    /// @notice Emitted when the arbitrator contract is updated.
+    event ArbitratorUpdated(address indexed arbitrator);
 
     constructor(
         IJobRegistry _jobRegistry,
         IStakeManager _stakeManager,
-        address _moderator,
+        address _initialModerator,
         uint256 _appealFee
     ) Ownable(msg.sender) {
         require(address(_jobRegistry) != address(0), "registry");
         require(address(_stakeManager) != address(0), "stake mgr");
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
-        moderator = _moderator;
         appealFee = _appealFee;
+
+        if (_initialModerator != address(0)) {
+            moderators[_initialModerator] = true;
+            moderatorCount = 1;
+            emit ModeratorAdded(_initialModerator);
+        }
     }
 
-    /// @notice Update the moderator address.
-    /// @param _moderator New moderator able to resolve disputes.
-    function setModerator(address _moderator) external onlyOwner {
-        require(_moderator != address(0), "moderator");
-        moderator = _moderator;
-        emit ModeratorUpdated(_moderator);
+    // ---------------------------------------------------------------------
+    // Moderator and arbitrator configuration
+    // ---------------------------------------------------------------------
+
+    /// @notice Register a new moderator.
+    function addModerator(address moderator) external onlyOwner {
+        require(moderator != address(0), "moderator");
+        require(!moderators[moderator], "exists");
+        moderators[moderator] = true;
+        moderatorCount += 1;
+        emit ModeratorAdded(moderator);
     }
 
-    /// @dev Restrict calls to the designated moderator.
-    modifier onlyModerator() {
-        require(msg.sender == moderator, "not moderator");
-        _;
+    /// @notice Remove an existing moderator.
+    function removeModerator(address moderator) external onlyOwner {
+        require(moderators[moderator], "not moderator");
+        moderators[moderator] = false;
+        moderatorCount -= 1;
+        emit ModeratorRemoved(moderator);
+    }
+
+    /// @notice Configure an arbitration contract allowed to resolve disputes
+    /// without moderator voting.
+    function setArbitrator(address _arbitrator) external onlyOwner {
+        arbitrator = _arbitrator;
+        emit ArbitratorUpdated(_arbitrator);
     }
 
     /// @dev Restrict calls to the JobRegistry
@@ -109,18 +143,46 @@ contract DisputeModule is Ownable {
         emit DisputeRaised(jobId, claimant);
     }
 
-    /// @notice Resolve a previously raised dispute.
-    /// @param jobId Identifier of the disputed job.
-    /// @param employerWins True if the employer prevails.
-    function resolve(uint256 jobId, bool employerWins)
-        external
-        onlyModerator
-    {
+    /// @notice Resolve a previously raised dispute. Moderators cast votes and
+    /// once a majority is reached the dispute finalises. The arbitrator, if
+    /// set, may resolve directly.
+    function resolve(uint256 jobId, bool employerWins) external {
         Dispute storage d = disputes[jobId];
         require(d.claimant != address(0) && !d.resolved, "no dispute");
+
+        if (msg.sender == arbitrator) {
+            _finalize(jobId, employerWins);
+            return;
+        }
+
+        require(moderators[msg.sender], "not moderator");
+        require(!hasVoted[jobId][msg.sender], "voted");
+        hasVoted[jobId][msg.sender] = true;
+
+        if (employerWins) {
+            employerVotes[jobId] += 1;
+            if (employerVotes[jobId] >= _threshold()) {
+                _finalize(jobId, true);
+            }
+        } else {
+            agentVotes[jobId] += 1;
+            if (agentVotes[jobId] >= _threshold()) {
+                _finalize(jobId, false);
+            }
+        }
+    }
+
+    /// @dev Internal helper returning the number of votes required for
+    /// resolution.
+    function _threshold() internal view returns (uint256) {
+        return moderatorCount / 2 + 1; // majority
+    }
+
+    /// @dev Finalises a dispute and distributes fees.
+    function _finalize(uint256 jobId, bool employerWins) internal {
+        Dispute storage d = disputes[jobId];
         d.resolved = true;
 
-        // Forward outcome to JobRegistry for fund distribution.
         jobRegistry.resolveDispute(jobId, employerWins);
 
         if (appealFee > 0) {
@@ -131,6 +193,9 @@ contract DisputeModule is Ownable {
         }
 
         delete disputes[jobId];
+        delete employerVotes[jobId];
+        delete agentVotes[jobId];
+        // hasVoted mapping entries are left as-is since jobIds are unique.
         emit DisputeResolved(jobId, employerWins);
     }
 }

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -2,35 +2,24 @@
 pragma solidity ^0.8.25;
 
 /// @title IDisputeModule
-/// @notice Interface for raising and resolving disputes
+/// @notice Interface for raising and resolving disputes with moderator voting.
 interface IDisputeModule {
     event DisputeRaised(uint256 indexed jobId, address indexed claimant);
-    event DisputeResolved(
-        uint256 indexed jobId,
-        address indexed resolver,
-        bool employerWins
-    );
-    event DisputeFeeUpdated(uint256 fee);
-    event ModeratorUpdated(address moderator, uint256 weight);
-    event DisputeWindowUpdated(uint256 window);
-    event JobRegistryUpdated(address registry);
-    event StakeManagerUpdated(address manager);
-    event ModulesUpdated(address indexed jobRegistry, address indexed stakeManager);
+    event DisputeResolved(uint256 indexed jobId, bool employerWins);
+    event ModeratorAdded(address moderator);
+    event ModeratorRemoved(address moderator);
+    event ArbitratorUpdated(address arbitrator);
 
     function raiseDispute(
         uint256 jobId,
         address claimant,
         string calldata evidence
     ) external;
-    function resolve(
-        uint256 jobId,
-        bool employerWins,
-        bytes[] calldata signatures
-    ) external;
-    function setDisputeFee(uint256 fee) external;
-    function setDisputeWindow(uint256 window) external;
-    function addModerator(address moderator, uint256 weight) external;
+
+    function resolve(uint256 jobId, bool employerWins) external;
+
+    function addModerator(address moderator) external;
     function removeModerator(address moderator) external;
-    function setJobRegistry(address registry) external;
-    function setStakeManager(address manager) external;
+    function setArbitrator(address arbitrator) external;
 }
+

--- a/test/v2/DisputeModuleCore.test.js
+++ b/test/v2/DisputeModuleCore.test.js
@@ -1,10 +1,12 @@
 const { expect } = require("chai");
+const { ethers } = require("hardhat");
 
 describe("DisputeModule core", function () {
-  let owner, other, registry, stakeManager, dispute;
+  let owner, mod1, mod2, employer, agent, outsider;
+  let registry, stakeManager, dispute;
 
   beforeEach(async function () {
-    [owner, other] = await ethers.getSigners();
+    [owner, mod1, mod2, employer, agent, outsider] = await ethers.getSigners();
 
     const JobMock = await ethers.getContractFactory("MockJobRegistry");
     registry = await JobMock.deploy();
@@ -24,18 +26,78 @@ describe("DisputeModule core", function () {
       0
     );
     await dispute.waitForDeployment();
+    await registry.setDisputeModule(await dispute.getAddress());
   });
 
-  it("emits ModeratorUpdated on setModerator", async function () {
-    await expect(dispute.setModerator(other.address))
-      .to.emit(dispute, "ModeratorUpdated")
-      .withArgs(other.address);
-    expect(await dispute.moderator()).to.equal(other.address);
+  describe("moderator management", function () {
+    it("allows owner to add and remove moderators", async function () {
+      await expect(dispute.addModerator(mod1.address))
+        .to.emit(dispute, "ModeratorAdded")
+        .withArgs(mod1.address);
+      expect(await dispute.moderators(mod1.address)).to.equal(true);
+      await expect(dispute.removeModerator(mod1.address))
+        .to.emit(dispute, "ModeratorRemoved")
+        .withArgs(mod1.address);
+      expect(await dispute.moderators(mod1.address)).to.equal(false);
+    });
+
+    it("reverts on zero address moderator", async function () {
+      await expect(dispute.addModerator(ethers.ZeroAddress)).to.be.revertedWith(
+        "moderator"
+      );
+    });
   });
 
-  it("reverts when moderator is zero address", async function () {
-    await expect(dispute.setModerator(ethers.ZeroAddress)).to.be.revertedWith(
-      "moderator"
-    );
+  describe("voting resolution", function () {
+    beforeEach(async function () {
+      await dispute.addModerator(mod1.address);
+      await dispute.addModerator(mod2.address);
+      await registry.setJob(1, {
+        employer: employer.address,
+        agent: agent.address,
+        reward: 0,
+        stake: 0,
+        success: false,
+        status: 4,
+        uriHash: ethers.ZeroHash,
+        resultHash: ethers.ZeroHash,
+      });
+    });
+
+    it("finalises after majority vote", async function () {
+      await registry.connect(agent).dispute(1, "evidence");
+      await dispute.connect(mod1).resolve(1, true);
+      let info = await dispute.disputes(1);
+      expect(info.resolved).to.equal(false);
+      await expect(dispute.connect(mod2).resolve(1, true))
+        .to.emit(dispute, "DisputeResolved")
+        .withArgs(1, true);
+      info = await dispute.disputes(1);
+      expect(info.claimant).to.equal(ethers.ZeroAddress);
+    });
+
+    it("prevents non-moderators from voting", async function () {
+      await registry.connect(agent).dispute(1, "evidence");
+      await expect(
+        dispute.connect(outsider).resolve(1, true)
+      ).to.be.revertedWith("not moderator");
+    });
+
+    it("prevents double voting", async function () {
+      await registry.connect(agent).dispute(1, "evidence");
+      await dispute.connect(mod1).resolve(1, true);
+      await expect(dispute.connect(mod1).resolve(1, true)).to.be.revertedWith(
+        "voted"
+      );
+    });
+
+    it("allows arbitrator to resolve directly", async function () {
+      await dispute.setArbitrator(outsider.address);
+      await registry.connect(agent).dispute(1, "evidence");
+      await expect(dispute.connect(outsider).resolve(1, true))
+        .to.emit(dispute, "DisputeResolved")
+        .withArgs(1, true);
+    });
   });
 });
+


### PR DESCRIPTION
## Summary
- support multiple moderators with majority voting and optional arbitrator
- expose moderator registration and arbitration functions in IDisputeModule interface
- add tests covering multi-moderator voting and edge cases

## Testing
- `npx hardhat test test/v2/DisputeModuleCore.test.js --no-compile` (fails: HH700: Artifact for contract "MockJobRegistry" not found)


------
https://chatgpt.com/codex/tasks/task_e_68ab9b8c5f448333b36e4d29bde7d755