### PR TITLE
docs: add API reference and quick start guide

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,13 +1,105 @@
 # API Reference
 
-Per‑contract summaries of the AGIJob Manager v2 modules:
+Summary of the primary AGIJobs modules and their most useful functions.
+Each snippet uses [ethers.js](https://docs.ethers.org/) and assumes the
+contracts have already been deployed.  For full details see the individual
+contract pages under `docs/api/`.
 
-- [AGIALPHAToken](api/AGIALPHAToken.md)
-- [StakeManager](api/StakeManager.md)
-- [JobRegistry](api/JobRegistry.md)
-- [ValidationModule](api/ValidationModule.md)
-- [DisputeModule](api/DisputeModule.md)
-- [IdentityRegistry](api/IdentityRegistry.md)
-- [ReputationEngine](api/ReputationEngine.md)
-- [CertificateNFT](api/CertificateNFT.md)
-- [FeePool](api/FeePool.md)
+## AGIALPHAToken
+ERC‑20 utility token used for payments and staking.
+
+```javascript
+const token = await ethers.getContractAt("AGIALPHAToken", tokenAddress);
+await token.mint(user, ethers.parseUnits("1000", 6));
+```
+
+## StakeManager
+Handles token staking, escrow and withdrawals.
+
+- `depositStake(role, amount)` – stake tokens as agent (`0`) or validator (`1`).
+- `withdrawStake(role, amount)` – remove previously staked tokens.
+
+```javascript
+await token.approve(stakeManagerAddress, stakeAmount);
+await stakeManager.depositStake(0, stakeAmount); // agent stake
+```
+
+## JobRegistry
+Coordinates job posting and settlement.
+
+- `createJob(reward, uri)` – employer escrows tokens and posts job metadata.
+- `applyForJob(jobId, label, proof)` – agent applies with ENS label and proof.
+- `submit(jobId, resultHash, resultURI)` – agent submits work for validation.
+- `finalize(jobId)` – release escrowed reward after validation succeeds.
+
+```javascript
+const registry = await ethers.getContractAt("JobRegistry", registryAddress);
+const tx = await registry.createJob(ethers.parseUnits("10", 6), "ipfs://job.json");
+const receipt = await tx.wait();
+const jobId = receipt.logs[0].args.jobId;
+```
+
+## ValidationModule
+Manages commit‑reveal voting by validators.
+
+- `selectValidators(jobId)` – choose validators for a job.
+- `commitValidation(jobId, commitHash)` / `revealValidation(jobId, approve, salt)` – validator vote flow.
+- `finalize(jobId)` – tallies votes and notifies `JobRegistry`.
+
+```javascript
+await validation.commitValidation(jobId, commitHash);
+await validation.revealValidation(jobId, true, salt);
+```
+
+## DisputeModule
+Handles disputes raised against jobs.
+
+- `raiseDispute(jobId)` – open a dispute on a job.
+- `resolve(jobId, employerWins)` – moderator settles the dispute.
+
+```javascript
+await dispute.raiseDispute(jobId);
+await dispute.resolve(jobId, true); // employer wins
+```
+
+## IdentityRegistry
+Verifies agent and validator eligibility.
+
+- `isAuthorizedAgent(account, label, proof)` – check if an address can work.
+- `isAuthorizedValidator(account, label, proof)` – check validator eligibility.
+
+```javascript
+const ok = await identity.isAuthorizedAgent(user, labelHash, merkleProof);
+```
+
+## ReputationEngine
+Tracks reputation scores for participants.
+
+- `onApply(user)` / `onFinalize(user, success, payout, duration)` – hooks from `JobRegistry`.
+- `getReputation(user)` – view current score.
+
+```javascript
+const rep = await reputationEngine.getReputation(user);
+```
+
+## CertificateNFT
+ERC‑721 completion certificates with optional marketplace.
+
+- `mint(to, jobId, uri)` – `JobRegistry` mints certificate.
+- `list(tokenId, price)` / `purchase(tokenId)` – optional secondary market.
+
+```javascript
+await certificate.mint(agent, jobId, "ipfs://cert.json");
+```
+
+## FeePool
+Stores platform fees and distributes rewards.
+
+- `depositFee(amount)` – `StakeManager` deposits collected fees.
+- `claimRewards()` – stakers withdraw accumulated rewards.
+
+```javascript
+await feePool.depositFee(feeAmount);
+await feePool.claimRewards();
+```
+

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,73 @@
+# Quick Start
+
+This guide demonstrates the basic lifecycle of a job on AGIJobs using
+`ethers.js` scripts.  The examples assume the core contracts are already
+deployed and that you have the contract addresses available.
+
+## 1. Post a Job
+Employers escrow the reward and publish job metadata.
+
+```javascript
+// post-job.js
+const token = await ethers.getContractAt("AGIALPHAToken", tokenAddress);
+const stake = await ethers.getContractAt("StakeManager", stakeAddress);
+const registry = await ethers.getContractAt("JobRegistry", registryAddress);
+
+const reward = ethers.parseUnits("10", 6);
+await token.approve(stakeAddress, reward);
+await stake.depositStake(0, reward); // escrow for job
+const tx = await registry.createJob(reward, "ipfs://job.json");
+const receipt = await tx.wait();
+console.log(`Job ID: ${receipt.logs[0].args.jobId}`);
+```
+
+## 2. Apply to the Job
+Agents stake and submit an application.
+
+```javascript
+// apply.js
+const registry = await ethers.getContractAt("JobRegistry", registryAddress);
+await registry.applyForJob(jobId, labelHash, merkleProof);
+```
+
+## 3. Validate the Submission
+Validators commit and reveal votes on the submitted work.
+
+```javascript
+// validate.js
+const validation = await ethers.getContractAt("ValidationModule", validationAddress);
+
+// Commit phase
+await validation.commitValidation(jobId, commitHash);
+
+// Reveal phase
+await validation.revealValidation(jobId, true, salt);
+```
+
+## 4. Finalize
+After validation succeeds, finalize the job to release payment and mint a
+certificate.
+
+```javascript
+// finalize.js
+const registry = await ethers.getContractAt("JobRegistry", registryAddress);
+await registry.finalize(jobId);
+```
+
+## FAQ
+
+**How do I get test tokens?**  Use `AGIALPHAToken.mint()` from the deployer
+account to mint yourself tokens in a development environment.
+
+**Can I reuse these scripts on mainnet?**  Yes, but ensure addresses and gas
+settings are configured for the target network.
+
+## Limitations
+
+- **Centralized control:** Owners can currently change module addresses and a
+  moderator resolves disputes, representing trust points.
+- **Validator selection:** Validators are selected from a predefined pool rather
+  than trustlessly.
+- **Missing features:** No on‑chain governance, fee distribution is simplistic
+  and there is no built‑in user interface.
+


### PR DESCRIPTION
## Summary
- add consolidated API reference with ethers.js examples for each module
- add quick start guide with sample scripts, FAQ, and known limitations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aba1190adc83338b4d7ec8bb339036