### PR TITLE
feat: add moderator committee for disputes

### DIFF
--- a/contracts/v2/DisputeModule.sol
+++ b/contracts/v2/DisputeModule.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 /// @title DisputeModule
 /// @notice Allows job participants to raise disputes and resolves them via
-/// moderator voting or an optional arbitration contract.
+/// moderator voting. Configuration is controlled by a moderator committee
+/// address which is expected to be a multisig or DAO contract.
 /// @dev Dispute claimants may optionally stake an appeal fee via the
 /// StakeManager which is paid out to the winner.  All amounts use 6 decimals
 /// (`1 token == 1e6` units).
-contract DisputeModule is Ownable {
+contract DisputeModule {
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 1;
 
@@ -21,8 +21,8 @@ contract DisputeModule is Ownable {
     /// @notice Contract managing stake and dispute fees.
     IStakeManager public immutable stakeManager;
 
-    /// @notice Optional contract authorised to resolve disputes directly.
-    address public arbitrator;
+    /// @notice Address of the committee authorised to manage moderators.
+    address public committee;
 
     /// @notice Approved moderators eligible to vote on disputes.
     mapping(address => bool) public moderators;
@@ -57,35 +57,36 @@ contract DisputeModule is Ownable {
     /// @notice Emitted when a moderator is added or removed.
     event ModeratorAdded(address indexed moderator);
     event ModeratorRemoved(address indexed moderator);
-
-    /// @notice Emitted when the arbitrator contract is updated.
-    event ArbitratorUpdated(address indexed arbitrator);
+    /// @notice Emitted when the committee address changes.
+    event CommitteeUpdated(address indexed committee);
 
     constructor(
         IJobRegistry _jobRegistry,
         IStakeManager _stakeManager,
-        address _initialModerator,
+        address _committee,
         uint256 _appealFee
-    ) Ownable(msg.sender) {
+    ) {
         require(address(_jobRegistry) != address(0), "registry");
         require(address(_stakeManager) != address(0), "stake mgr");
+        require(_committee != address(0), "committee");
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
         appealFee = _appealFee;
+        committee = _committee;
+        emit CommitteeUpdated(_committee);
 
-        if (_initialModerator != address(0)) {
-            moderators[_initialModerator] = true;
-            moderatorCount = 1;
-            emit ModeratorAdded(_initialModerator);
-        }
+        // bootstrap the committee as the first moderator
+        moderators[_committee] = true;
+        moderatorCount = 1;
+        emit ModeratorAdded(_committee);
     }
 
     // ---------------------------------------------------------------------
-    // Moderator and arbitrator configuration
+    // Moderator configuration
     // ---------------------------------------------------------------------
 
     /// @notice Register a new moderator.
-    function addModerator(address moderator) external onlyOwner {
+    function addModerator(address moderator) external onlyCommittee {
         require(moderator != address(0), "moderator");
         require(!moderators[moderator], "exists");
         moderators[moderator] = true;
@@ -94,23 +95,29 @@ contract DisputeModule is Ownable {
     }
 
     /// @notice Remove an existing moderator.
-    function removeModerator(address moderator) external onlyOwner {
+    function removeModerator(address moderator) external onlyCommittee {
         require(moderators[moderator], "not moderator");
         moderators[moderator] = false;
         moderatorCount -= 1;
         emit ModeratorRemoved(moderator);
     }
 
-    /// @notice Configure an arbitration contract allowed to resolve disputes
-    /// without moderator voting.
-    function setArbitrator(address _arbitrator) external onlyOwner {
-        arbitrator = _arbitrator;
-        emit ArbitratorUpdated(_arbitrator);
+    /// @notice Update the committee multisig address.
+    function setCommittee(address _committee) external onlyCommittee {
+        require(_committee != address(0), "committee");
+        committee = _committee;
+        emit CommitteeUpdated(_committee);
     }
 
     /// @dev Restrict calls to the JobRegistry
     modifier onlyJobRegistry() {
         require(msg.sender == address(jobRegistry), "not registry");
+        _;
+    }
+
+    /// @dev Restrict calls to the committee multisig.
+    modifier onlyCommittee() {
+        require(msg.sender == committee, "not committee");
         _;
     }
 
@@ -144,17 +151,10 @@ contract DisputeModule is Ownable {
     }
 
     /// @notice Resolve a previously raised dispute. Moderators cast votes and
-    /// once a majority is reached the dispute finalises. The arbitrator, if
-    /// set, may resolve directly.
+    /// once a majority is reached the dispute finalises.
     function resolve(uint256 jobId, bool employerWins) external {
         Dispute storage d = disputes[jobId];
         require(d.claimant != address(0) && !d.resolved, "no dispute");
-
-        if (msg.sender == arbitrator) {
-            _finalize(jobId, employerWins);
-            return;
-        }
-
         require(moderators[msg.sender], "not moderator");
         require(!hasVoted[jobId][msg.sender], "voted");
         hasVoted[jobId][msg.sender] = true;

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -8,7 +8,7 @@ interface IDisputeModule {
     event DisputeResolved(uint256 indexed jobId, bool employerWins);
     event ModeratorAdded(address moderator);
     event ModeratorRemoved(address moderator);
-    event ArbitratorUpdated(address arbitrator);
+    event CommitteeUpdated(address committee);
 
     function raiseDispute(
         uint256 jobId,
@@ -20,6 +20,6 @@ interface IDisputeModule {
 
     function addModerator(address moderator) external;
     function removeModerator(address moderator) external;
-    function setArbitrator(address arbitrator) external;
+    function setCommittee(address committee) external;
 }
 

--- a/docs/api/DisputeModule.md
+++ b/docs/api/DisputeModule.md
@@ -1,13 +1,23 @@
 # DisputeModule API
 
-Handles disputes raised against jobs.
+Handles disputes raised against jobs. A committee multisig manages the list of
+eligible moderators who must reach majority consensus to finalise a case.
 
 ## Functions
-- `setModerator(address moderator)` – owner sets privileged moderator.
-- `raiseDispute(uint256 jobId)` – anyone opens a dispute on a job.
-- `resolve(uint256 jobId, bool employerWins)` – moderator settles the dispute and redistributes stakes.
+- `addModerator(address moderator)` – committee enrols a new moderator.
+- `removeModerator(address moderator)` – committee removes a moderator.
+- `setCommittee(address committee)` – hand off committee control to a new multisig.
+- `raiseDispute(uint256 jobId)` – JobRegistry forwards a dispute from a participant.
+- `resolve(uint256 jobId, bool employerWins)` – moderators vote; majority decides.
 
 ## Events
 - `DisputeRaised(uint256 indexed jobId, address indexed claimant)`
 - `DisputeResolved(uint256 indexed jobId, bool employerWins)`
-- `ModeratorUpdated(address indexed moderator)`
+- `ModeratorAdded(address indexed moderator)`
+- `ModeratorRemoved(address indexed moderator)`
+- `CommitteeUpdated(address indexed committee)`
+
+## Quorum
+`resolve` requires more than half of `moderatorCount` votes. The default
+deployment boots the committee address as the first moderator, so onboarding
+additional members is the first action for the committee multisig.

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -21,7 +21,10 @@ Deploy each contract **in the order listed below** from the **Write Contract** t
 3. `JobRegistry(validation, stakeMgr, reputation, dispute, certNFT, feePool, taxPolicy, feePct, jobStake)` – leaving `feePct = 0` applies a 5% protocol fee. Supplying a nonzero `taxPolicy` sets the disclaimer at deployment; otherwise the owner may call `setTaxPolicy` later.
 4. `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators, validatorPool)` – zero values default to 1‑day windows and a 1–3 validator set.
 5. `ReputationEngine(stakeManager)` – optional reputation weighting (pass `0` to wire later).
-6. `DisputeModule(jobRegistry, appealFee, moderator, jury)` – manages appeals and dispute fees.
+6. `DisputeModule(jobRegistry, stakeManager, committee, appealFee)` – manages
+   appeals and dispute fees. Pass the committee multisig as the third argument;
+   it is bootstrapped as the initial moderator and is responsible for onboarding
+   additional moderators.
 7. `CertificateNFT(name, symbol)` – certifies completed work.
 8. `FeePool(token, stakeManager, burnPct, treasury)` – rewards default to platform stakers; use `address(0)` for `token` to fall back to $AGIALPHA` and `burnPct` defaults to `0`.
 9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – `minStake` may be `0`.
@@ -69,6 +72,9 @@ Owners can retune parameters any time: `StakeManager.setToken`, `setMinStake`, `
 
 - The disputing agent approves the `StakeManager` for the configured `appealFee` in `$AGIALPHA` and calls `JobRegistry.acknowledgeAndDispute(jobId, evidence)`; no ETH is ever sent.
 - The `DisputeModule` escrows the token fee and releases it to the winner or back to the payer after resolution.
+- A majority of enrolled moderators (`moderatorCount / 2 + 1`) must vote for
+  either outcome. The committee multisig expands or shrinks the moderator set
+  using `addModerator` and `removeModerator`.
 
 ## 8. Final checks
 

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -68,11 +68,11 @@ interface IReputationEngine {
 }
 
 interface IDisputeModule {
-    function raiseDispute(uint256 jobId, string calldata reason) external;
-    function resolve(uint256 jobId, bool uphold, bytes[] calldata sigs) external;
-    function addModerator(address moderator, uint256 weight) external;
+    function raiseDispute(uint256 jobId, string calldata evidence) external;
+    function resolve(uint256 jobId, bool employerWins) external;
+    function addModerator(address moderator) external;
     function removeModerator(address moderator) external;
-    function setDisputeFee(uint256 fee) external;
+    function setCommittee(address committee) external;
 }
 
 interface ICertificateNFT {

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -63,11 +63,12 @@ async function main() {
   );
   await registry.waitForDeployment();
 
+  const committee = deployer; // replace with multisig for production
   const Dispute = await ethers.getContractFactory("contracts/v2/DisputeModule.sol:DisputeModule");
   const dispute = await Dispute.deploy(
     await registry.getAddress(),
     await stake.getAddress(),
-    deployer.address,
+    committee.address,
     0
   );
   await dispute.waitForDeployment();

--- a/test/v2/DisputeModuleCore.test.js
+++ b/test/v2/DisputeModuleCore.test.js
@@ -30,7 +30,7 @@ describe("DisputeModule core", function () {
   });
 
   describe("moderator management", function () {
-    it("allows owner to add and remove moderators", async function () {
+    it("allows committee to add and remove moderators", async function () {
       await expect(dispute.addModerator(mod1.address))
         .to.emit(dispute, "ModeratorAdded")
         .withArgs(mod1.address);
@@ -91,13 +91,7 @@ describe("DisputeModule core", function () {
       );
     });
 
-    it("allows arbitrator to resolve directly", async function () {
-      await dispute.setArbitrator(outsider.address);
-      await registry.connect(agent).dispute(1, "evidence");
-      await expect(dispute.connect(outsider).resolve(1, true))
-        .to.emit(dispute, "DisputeResolved")
-        .withArgs(1, true);
-    });
+    // arbitrator path removed; disputes require moderator quorum
   });
 });
 


### PR DESCRIPTION
## Summary
- replace owner-based moderator management with committee multisig
- drop unilateral arbitrator path and require majority moderator votes
- document committee onboarding and quorum rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6ad54ff48333a31944a149d8a799