### PR TITLE
Document multisig ownership transfer and add timelock tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Record each address during deployment. The defaults below assume the 6‑decimal
    - Post a job: `JobRegistry.createJob(1_000000, "ipfs://QmHash")`
    - Rotate tokens later via `StakeManager.setToken(newToken)` and `FeePool.setToken(newToken)`
 
+### Transfer ownership to a multisig or timelock
+After deployment hand control of each module to a governance contract so no
+single key can change parameters:
+
+1. Deploy a multisig wallet or an OpenZeppelin
+   `TimelockController`.
+2. From the deployer account call
+   `transferOwnership(multisig)` on every module such as
+   `JobRegistry`, `StakeManager`, and `ValidationModule`.
+3. To rotate governance later, the current multisig executes
+   `transferOwnership(newOwner)` and the new address assumes control after the
+   `OwnershipTransferred` event. Timelock contracts must schedule and execute
+   the call; direct EOA transactions will revert once ownership has moved.
+
 ### ENS subdomain prerequisites
 - Agents must control an ENS subdomain ending in `.agent.agi.eth`.
 - Validators require `.club.agi.eth`.

--- a/contracts/mocks/TimelockMock.sol
+++ b/contracts/mocks/TimelockMock.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @dev Minimal timelock-style forwarder used for testing ownership transfer.
+contract TimelockMock is Ownable {
+    constructor(address admin) Ownable(admin) {}
+
+    function execute(address target, bytes calldata data) external onlyOwner {
+        (bool ok, ) = target.call(data);
+        require(ok, "exec failed");
+    }
+}

--- a/docs/deployment-v2-agialpha.md
+++ b/docs/deployment-v2-agialpha.md
@@ -40,3 +40,18 @@ The default run uses the mainnet `$AGIALPHA` address, a 5% protocol fee and 5% b
 For function parity with the legacy contract, compare calls against [v1-v2-function-map.md](v1-v2-function-map.md).
 
 Following this sequence results in a ready‑to‑use v2 deployment running on `$AGIALPHA`.
+
+## 4. Transfer ownership to a multisig or timelock
+
+Immediately after wiring, delegate control of every module to a governance
+contract:
+
+1. Deploy a multisig wallet or OpenZeppelin `TimelockController`.
+2. From the deployer account call `transferOwnership(multisig)` on
+   `JobRegistry`, `StakeManager`, `ValidationModule` and all other modules.
+3. To rotate owners, the current multisig schedules and executes
+   `transferOwnership(newOwner)` and the new address takes effect once the
+   `OwnershipTransferred` event is emitted.
+
+Calls sent directly by EOAs will revert after ownership has moved; timelocks
+must queue and execute transactions to invoke privileged setters.

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -59,7 +59,11 @@ The script prints module addresses and verifies source on Etherscan.
    `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, new address[](0))`.
 9. **Point modules back to `JobRegistry`** by calling `setJobRegistry` on `StakeManager`, `ValidationModule`, `DisputeModule` and `CertificateNFT`, and `setIdentityRegistry` on `ValidationModule`.
 10. **Configure ENS and Merkle roots** using `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot` and `setValidatorMerkleRoot` on `IdentityRegistry`.
-11. **Transfer ownership** of each module to a multisig with `transferOwnership` if desired and verify events before accepting user funds.
+11. **Transfer ownership** – deploy a multisig wallet or timelock controller
+    and call `transferOwnership(multisig)` on every module. Only the new
+    owner will be able to call privileged setters. To rotate governance
+    later, have the current multisig execute `transferOwnership(newOwner)`
+    and confirm the `OwnershipTransferred` event before proceeding.
 
 ## Owner Configuration Steps
 After deployment the owner can fine‑tune the system without redeploying:
@@ -136,7 +140,11 @@ then be performed through the "Write" tabs on each module.
 - **Swap the token:** call `StakeManager.setToken(newToken)` (and any mirrored module setters) from the owner account.
 - **Adjust parameters:** examples include `StakeManager.setMinStake(amount)`, `JobRegistry.setFeePct(pct)`, `ValidationModule.setCommitWindow(seconds)`, `ValidationModule.setRevealWindow(seconds)` and `DisputeModule.setDisputeFee(fee)`.
 - **Manage allowlists:** on `IdentityRegistry` use `setAgentMerkleRoot(root)`, `setValidatorMerkleRoot(root)`, `addAdditionalAgent(addr)` and `addAdditionalValidator(addr)`; update ENS roots with `setAgentRootNode(node)` and `setClubRootNode(node)`.
-- **Transfer ownership:** every module inherits `Ownable`; call `transferOwnership(multisig)` to hand control to a multisig.
+- **Transfer ownership:** every module inherits `Ownable`; call
+  `transferOwnership(multisig)` to hand control to a multisig or timelock.
+  To rotate later, the current owner invokes `transferOwnership(newOwner)`
+  and waits for the `OwnershipTransferred` event before using the new
+  address.
 
 ## Token Configuration
 - Default staking/reward token: `$AGIALPHA` at

--- a/test/v2/OwnershipTimelock.test.js
+++ b/test/v2/OwnershipTimelock.test.js
@@ -1,0 +1,55 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Timelock ownership", function () {
+  it("only timelock can call privileged setters after transfer", async function () {
+    const [owner, proposer] = await ethers.getSigners();
+    const Deployer = await ethers.getContractFactory("contracts/v2/Deployer.sol:Deployer");
+    const deployer = await Deployer.deploy();
+    const econ = {
+      token: ethers.ZeroAddress,
+      feePct: 0,
+      burnPct: 0,
+      employerSlashPct: 0,
+      treasurySlashPct: 0,
+      commitWindow: 0,
+      revealWindow: 0,
+      minStake: 0,
+      jobStake: 0,
+    };
+    const ids = {
+      ens: ethers.ZeroAddress,
+      nameWrapper: ethers.ZeroAddress,
+      clubRootNode: ethers.ZeroHash,
+      agentRootNode: ethers.ZeroHash,
+      validatorMerkleRoot: ethers.ZeroHash,
+      agentMerkleRoot: ethers.ZeroHash,
+    };
+    const addresses = await deployer.deploy.staticCall(econ, ids);
+    await deployer.deploy(econ, ids);
+    const [stakeAddr, registryAddr] = addresses;
+
+    const StakeManager = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
+    const JobRegistry = await ethers.getContractFactory("contracts/v2/JobRegistry.sol:JobRegistry");
+    const stake = StakeManager.attach(stakeAddr);
+    const registry = JobRegistry.attach(registryAddr);
+
+    const Timelock = await ethers.getContractFactory("contracts/mocks/TimelockMock.sol:TimelockMock");
+    const timelock = await Timelock.deploy(proposer.address);
+
+    await stake.transferOwnership(await timelock.getAddress());
+    await registry.transferOwnership(await timelock.getAddress());
+
+    await expect(stake.setFeePct(1)).to.be.reverted;
+    await expect(registry.setFeePct(1)).to.be.reverted;
+
+    const stakeData = stake.interface.encodeFunctionData("setFeePct", [1]);
+    const registryData = registry.interface.encodeFunctionData("setFeePct", [1]);
+
+    await timelock.connect(proposer).execute(stake.target, stakeData);
+    expect(await stake.feePct()).to.equal(1);
+
+    await timelock.connect(proposer).execute(registry.target, registryData);
+    expect(await registry.feePct()).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- document transferring contract ownership to multisig or timelock and rotating owners
- add minimal timelock mock and tests ensuring only governance contracts call privileged setters

## Testing
- `npm run lint`
- `npx hardhat test test/v2/Ownership.test.js test/v2/OwnershipTimelock.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac795c57b08333bca47ddee78b7e7f