### PR TITLE
feat: protect job finalization from reentrancy

### DIFF
--- a/contracts/mocks/ReentrantERC206.sol
+++ b/contracts/mocks/ReentrantERC206.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface IReentrantCaller {
+    function reenter() external;
+}
+
+/// @dev ERC20 token with 6 decimals that attempts to reenter the caller during transfers.
+contract ReentrantERC206 is ERC20 {
+    IReentrantCaller public caller;
+    bool public attack;
+
+    constructor() ERC20("Reentrant6D", "R6D") {}
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function setCaller(address _caller) external {
+        caller = IReentrantCaller(_caller);
+    }
+
+    function setAttack(bool _attack) external {
+        attack = _attack;
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        bool ok = super.transfer(to, amount);
+        if (attack && address(caller) != address(0)) {
+            attack = false;
+            caller.reenter();
+        }
+        return ok;
+    }
+}
+

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -799,7 +799,7 @@ contract StakeManager is Ownable, ReentrancyGuard, TaxAcknowledgement {
         uint256 reward,
         uint256 fee,
         IFeePool _feePool
-    ) external onlyJobRegistry {
+    ) external onlyJobRegistry nonReentrant {
         uint256 pct = getAgentPayoutPct(agent);
         uint256 modified = (reward * pct) / 100;
         uint256 burnAmount = (modified * burnPct) / 100;
@@ -835,6 +835,7 @@ contract StakeManager is Ownable, ReentrancyGuard, TaxAcknowledgement {
     function distributeValidatorRewards(bytes32 jobId, uint256 amount)
         external
         onlyJobRegistry
+        nonReentrant
     {
         if (amount == 0) return;
         address vm = address(validationModule);

--- a/contracts/v2/mocks/ReentrantJobRegistry.sol
+++ b/contracts/v2/mocks/ReentrantJobRegistry.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IFeePool} from "../interfaces/IFeePool.sol";
+
+interface IStakeManager {
+    function finalizeJobFunds(
+        bytes32 jobId,
+        address agent,
+        uint256 reward,
+        uint256 fee,
+        IFeePool feePool
+    ) external;
+
+    function distributeValidatorRewards(bytes32 jobId, uint256 amount) external;
+
+    function lockReward(bytes32 jobId, address from, uint256 amount) external;
+}
+
+interface IReentrantToken {
+    function setAttack(bool) external;
+}
+
+/// @dev Minimal JobRegistry mock used to attempt reentrancy on StakeManager calls.
+contract ReentrantJobRegistry {
+    IStakeManager public stakeManager;
+    IReentrantToken public token;
+
+    enum AttackType { None, Finalize, Validator }
+    AttackType public attackType;
+    bytes32 public jobId;
+    address public agent;
+    uint256 public reward;
+    uint256 public amount;
+
+    constructor(address sm, address token_) {
+        stakeManager = IStakeManager(sm);
+        token = IReentrantToken(token_);
+    }
+
+    function lockReward(bytes32 _jobId, address from, uint256 _amount) external {
+        stakeManager.lockReward(_jobId, from, _amount);
+    }
+
+    function attackFinalize(bytes32 _jobId, address _agent, uint256 _reward) external {
+        jobId = _jobId;
+        agent = _agent;
+        reward = _reward;
+        attackType = AttackType.Finalize;
+        token.setAttack(true);
+        stakeManager.finalizeJobFunds(jobId, agent, reward, 0, IFeePool(address(0)));
+        attackType = AttackType.None;
+    }
+
+    function attackValidator(bytes32 _jobId, uint256 _amount) external {
+        jobId = _jobId;
+        amount = _amount;
+        attackType = AttackType.Validator;
+        token.setAttack(true);
+        stakeManager.distributeValidatorRewards(jobId, amount);
+        attackType = AttackType.None;
+    }
+
+    // called by the token during transfer to attempt reentrancy
+    function reenter() external {
+        if (attackType == AttackType.Finalize) {
+            stakeManager.finalizeJobFunds(jobId, agent, reward, 0, IFeePool(address(0)));
+        } else if (attackType == AttackType.Validator) {
+            stakeManager.distributeValidatorRewards(jobId, amount);
+        }
+    }
+}
+

--- a/test/v2/StakeManagerReentrancy.test.js
+++ b/test/v2/StakeManagerReentrancy.test.js
@@ -1,0 +1,87 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("StakeManager reentrancy", function () {
+  let owner, employer, agent, validator, treasury;
+  let token, stakeManager, jobRegistry;
+
+  beforeEach(async () => {
+    [owner, employer, agent, validator, treasury] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory(
+      "contracts/mocks/ReentrantERC206.sol:ReentrantERC206"
+    );
+    token = await Token.deploy();
+    await token.mint(employer.address, 1000);
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      0,
+      50,
+      50,
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
+    );
+    await stakeManager.connect(owner).setMinStake(0);
+
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/mocks/ReentrantJobRegistry.sol:ReentrantJobRegistry"
+    );
+    jobRegistry = await JobRegistry.deploy(
+      await stakeManager.getAddress(),
+      await token.getAddress()
+    );
+
+    await token.setCaller(await jobRegistry.getAddress());
+    await stakeManager
+      .connect(owner)
+      .setJobRegistry(await jobRegistry.getAddress());
+  });
+
+  it("guards finalizeJobFunds against reentrancy", async () => {
+    const jobId = ethers.encodeBytes32String("job1");
+    const reward = 100;
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), reward);
+    await jobRegistry.lockReward(jobId, employer.address, reward);
+
+    await expect(
+      jobRegistry.attackFinalize(jobId, agent.address, reward)
+    ).to.be.revertedWithCustomError(
+      stakeManager,
+      "ReentrancyGuardReentrantCall"
+    );
+  });
+
+  it("guards distributeValidatorRewards against reentrancy", async () => {
+    const jobId = ethers.encodeBytes32String("job2");
+    const amount = 100;
+
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/mocks/ValidationStub.sol:ValidationStub"
+    );
+    const validation = await Validation.deploy();
+    await validation.setValidators([validator.address]);
+    await stakeManager
+      .connect(owner)
+      .setValidationModule(await validation.getAddress());
+
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), amount);
+    await jobRegistry.lockReward(jobId, employer.address, amount);
+
+    await expect(
+      jobRegistry.attackValidator(jobId, amount)
+    ).to.be.revertedWithCustomError(
+      stakeManager,
+      "ReentrancyGuardReentrantCall"
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- guard `finalizeJobFunds` and `distributeValidatorRewards` with `nonReentrant`
- add reentrancy attack mocks for StakeManager testing
- test reentrancy defenses on finalization and validator reward payouts

## Testing
- `npx solhint contracts/v2/StakeManager.sol contracts/mocks/ReentrantERC206.sol contracts/v2/mocks/ReentrantJobRegistry.sol`
- `npx eslint test/v2/StakeManagerReentrancy.test.js`
- `npm test test/v2/StakeManagerReentrancy.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ac873be7748333b163d124b749726a