### PR TITLE
feat: migrate validation module and document upgrade procedure

### DIFF
--- a/docs/module-upgrade-procedure.md
+++ b/docs/module-upgrade-procedure.md
@@ -1,0 +1,26 @@
+# Module Upgrade Procedure
+
+Upgrading a deployed module requires coordination to avoid disrupting
+ongoing jobs. Follow these steps to replace a module while preserving
+state:
+
+1. **Pause**
+   - Call `pause()` on `JobRegistry` and any modules being replaced to
+     prevent new activity during the upgrade.
+2. **Deploy the new module**
+   - Deploy the upgraded contract and configure any constructor
+     parameters. Transfer governance of `JobRegistry` to the
+     `ModuleInstaller` if using the helper.
+3. **Migrate state**
+   - Wire the new module using the installer or a migration script. For
+     validation modules this can be performed with
+     `scripts/v2/migrateValidationModule.ts`, which invokes
+     `ModuleInstaller.replaceValidationModule` to copy references and
+     restore governance.
+4. **Unpause**
+   - After verifying the new module, transfer governance back to the
+     original owner and call `unpause()` on previously paused contracts
+     to resume normal operation.
+
+This process ensures upgrades occur safely with minimal downtime while
+retaining on‑chain state.

--- a/scripts/v2/migrateValidationModule.ts
+++ b/scripts/v2/migrateValidationModule.ts
@@ -1,0 +1,26 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const [caller] = await ethers.getSigners();
+  const installerAddr = process.env.INSTALLER;
+  const registryAddr = process.env.REGISTRY;
+  const newValidationAddr = process.env.NEW_VALIDATION;
+  if (!installerAddr || !registryAddr || !newValidationAddr) {
+    throw new Error("INSTALLER, REGISTRY and NEW_VALIDATION env vars required");
+  }
+
+  const installer = await ethers.getContractAt(
+    "contracts/v2/ModuleInstaller.sol:ModuleInstaller",
+    installerAddr
+  );
+  const tx = await installer
+    .connect(caller)
+    .replaceValidationModule(registryAddr, newValidationAddr, []);
+  await tx.wait();
+  console.log("validation module migrated");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -1,0 +1,161 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+const Role = { Agent: 0, Validator: 1, Platform: 2 };
+
+async function deploySystem() {
+  const [owner, employer, agent] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory(
+    "contracts/mocks/MockERC206Decimals.sol:MockERC206Decimals"
+  );
+  const token = await Token.deploy();
+  await token.waitForDeployment();
+  await token.mint(employer.address, ethers.parseUnits("1000", 6));
+  await token.mint(agent.address, ethers.parseUnits("1000", 6));
+
+  const Stake = await ethers.getContractFactory(
+    "contracts/v2/StakeManager.sol:StakeManager"
+  );
+  const stake = await Stake.deploy(
+    await token.getAddress(),
+    0,
+    0,
+    0,
+    owner.address,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    owner.address
+  );
+  await stake.waitForDeployment();
+
+  const Reputation = await ethers.getContractFactory(
+    "contracts/v2/ReputationEngine.sol:ReputationEngine"
+  );
+  const reputation = await Reputation.deploy(await stake.getAddress());
+  await reputation.waitForDeployment();
+
+  const Identity = await ethers.getContractFactory(
+    "contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock"
+  );
+  const identity = await Identity.deploy();
+  await identity.waitForDeployment();
+  await identity.setReputationEngine(await reputation.getAddress());
+
+  const Validation = await ethers.getContractFactory(
+    "contracts/v2/mocks/ValidationStub.sol:ValidationStub"
+  );
+  const validation = await Validation.deploy();
+  await validation.waitForDeployment();
+
+  const NFT = await ethers.getContractFactory(
+    "contracts/v2/CertificateNFT.sol:CertificateNFT"
+  );
+  const nft = await NFT.deploy("Cert", "CERT");
+  await nft.waitForDeployment();
+
+  const Registry = await ethers.getContractFactory(
+    "contracts/v2/JobRegistry.sol:JobRegistry"
+  );
+  const registry = await Registry.deploy(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroAddress,
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    0,
+    0,
+    [],
+    owner.address
+  );
+  await registry.waitForDeployment();
+
+  const Dispute = await ethers.getContractFactory(
+    "contracts/v2/modules/DisputeModule.sol:DisputeModule"
+  );
+  const dispute = await Dispute.deploy(
+    await registry.getAddress(),
+    0,
+    0,
+    owner.address
+  );
+  await dispute.waitForDeployment();
+
+  await stake.setModules(await registry.getAddress(), await dispute.getAddress());
+  await validation.setJobRegistry(await registry.getAddress());
+  await nft.setJobRegistry(await registry.getAddress());
+  await nft.setStakeManager(await stake.getAddress());
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await dispute.getAddress(),
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    []
+  );
+  await registry.setIdentityRegistry(await identity.getAddress());
+  await reputation.setCaller(await registry.getAddress(), true);
+
+  return { owner, employer, agent, token, stake, reputation, validation, nft, registry, dispute };
+}
+
+describe("Module replacement", function () {
+  it("preserves job state when swapping validation module via installer", async function () {
+    const env = await deploySystem();
+    const { owner, employer, agent, token, stake, reputation, validation, nft, registry, dispute } = env;
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
+    await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
+
+    const reward = ethers.parseUnits("100", 6);
+    const fee = (reward * 5n) / 100n;
+    await token
+      .connect(employer)
+      .approve(await stake.getAddress(), reward + fee);
+    const deadline = BigInt((await time.latest()) + 3600);
+    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+
+    await registry.connect(agent).applyForJob(1, "agent", []);
+    const hash = ethers.id("ipfs://result");
+    await registry
+      .connect(agent)
+      .submit(1, hash, "ipfs://result", "agent", []);
+
+    const before = await registry.jobs(1);
+
+    const Installer = await ethers.getContractFactory(
+      "contracts/v2/ModuleInstaller.sol:ModuleInstaller"
+    );
+    const installer = await Installer.deploy();
+    await installer.waitForDeployment();
+
+    await registry.connect(owner).setGovernance(await installer.getAddress());
+
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/mocks/ValidationStub.sol:ValidationStub"
+    );
+    const newValidation = await Validation.deploy();
+    await newValidation.waitForDeployment();
+
+    await installer
+      .connect(owner)
+      .replaceValidationModule(
+        await registry.getAddress(),
+        await newValidation.getAddress(),
+        []
+      );
+
+    await newValidation.setResult(true);
+    await newValidation.finalize(1);
+
+    const after = await registry.jobs(1);
+    expect(after.employer).to.equal(before.employer);
+    expect(after.agent).to.equal(before.agent);
+    expect(after.state).to.equal(6); // Finalized
+  });
+});


### PR DESCRIPTION
## Summary
- extend ModuleInstaller with replaceValidationModule to wire upgraded validation contracts
- add migration script and module upgrade documentation
- add tests ensuring job state survives validation module swap

## Testing
- `npx hardhat test test/v2/ModuleReplacement.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ac95114cfc83339ee7e057f618c089