### PR TITLE
Add API reference, SDK snippets, and agent gateway example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The original v0 and v1 contracts are preserved under the `legacy` git tag for re
 
 Use the `examples/ethers-quickstart.js` script to interact with the deployed contracts. Export `RPC_URL`, `PRIVATE_KEY`, `JOB_REGISTRY`, `STAKE_MANAGER` and `VALIDATION_MODULE`.
 
+The [API reference](docs/api-reference.md) describes every public contract function and includes TypeScript and Python snippets. For an event‑driven workflow check the minimal [agent gateway](examples/agent-gateway.js) that listens for `JobCreated` events and applies automatically.
+
 ### Post a job
 ```bash
 node -e "require('./examples/ethers-quickstart').postJob()"
@@ -122,4 +124,6 @@ For detailed behaviour and additional modules such as `FeePool`, `TaxPolicy` and
 - [Module and interface reference](docs/v2-module-interface-reference.md)
 - [Etherscan interaction guide](docs/etherscan-guide.md)
 - [Deployment walkthrough with $AGIALPHA](docs/deployment-v2-agialpha.md)
+- [API reference and SDK snippets](docs/api-reference.md)
+- [Agent gateway example](examples/agent-gateway.js)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,158 @@
+# API Reference
+
+This document outlines the public entry points of the core AGIJob Manager v2 contracts and shows how to call them from SDKs.
+
+## JobRegistry
+
+Coordinates the lifecycle of jobs and mediates between modules.
+
+### Key Functions
+- `createJob(uint256 reward, string uri)` – Post a new job with a reward and metadata URI.
+- `applyForJob(uint256 jobId, string subdomain, bytes proof)` – Agent applies for an open job.
+- `stakeAndApply(uint256 jobId, string subdomain, bytes proof)` – Combine staking and application in one call.
+- `submit(uint256 jobId, bytes32 resultHash, string resultURI, string subdomain, bytes proof)` – Submit work for validation.
+- `finalize(uint256 jobId)` – Release rewards and stakes after validation.
+- `raiseDispute(uint256 jobId, string evidence)` – Escalate a job for moderator resolution.
+- `cancelJob(uint256 jobId)` – Employer cancels an unassigned job.
+
+### Example
+```solidity
+JobRegistry(registry).createJob(1_000000, "ipfs://QmHash");
+```
+
+## StakeManager
+
+Holds token deposits for agents, validators and dispute fees.
+
+### Key Functions
+- `depositStake(uint8 role, uint256 amount)` – Stake tokens for a role (`0`=agent, `1`=validator).
+- `withdrawStake(uint8 role, uint256 amount)` – Withdraw available stake.
+- `acknowledgeAndDeposit(uint8 role, uint256 amount)` – Deposit after acknowledging the tax policy.
+- `acknowledgeAndWithdraw(uint8 role, uint256 amount)` – Withdraw after acknowledging the tax policy.
+- `slash(address user, uint256 amount, address recipient)` – Governance‑only slashing mechanism.
+
+### Example
+```solidity
+StakeManager(stake).depositStake(0, 1_000000);
+```
+
+## ValidationModule
+
+Selects validators and manages commit‑reveal voting on submissions.
+
+### Key Functions
+- `commitValidation(uint256 jobId, bytes32 commitHash, string subdomain, bytes proof)` – Commit to a validation decision.
+- `revealValidation(uint256 jobId, bool approve, bytes32 salt, string subdomain, bytes proof)` – Reveal the decision.
+- `finalize(uint256 jobId)` – Conclude validation after the reveal window.
+
+### Example
+```solidity
+validation.commitValidation(jobId, commitHash, "alice.agent.agi.eth", proof);
+```
+
+## DisputeModule
+
+Escrows dispute fees and resolves conflicts after moderator review.
+
+### Key Functions
+- `raiseDispute(uint256 jobId, address claimant, string evidence)` – Called by `JobRegistry` when a participant disputes.
+- `resolve(uint256 jobId, bool employerWins, bytes[] signatures)` – Moderator or owner resolves a dispute.
+
+### Example
+```solidity
+jobRegistry.raiseDispute(jobId, "ipfs://evidence");
+```
+
+## IdentityRegistry
+
+Verifies ENS ownership and Merkle proofs for agent and validator identities.
+
+### Key Functions
+- `verifyAgent(address agent, string subdomain, bytes proof)` – Validate an agent’s identity.
+- `verifyValidator(address validator, string subdomain, bytes proof)` – Validate a validator.
+- `isAuthorizedAgent(address agent)` – Check if an address is allowed to act as an agent.
+
+## ReputationEngine
+
+Tracks reputation points for agents and validators.
+
+### Key Functions
+- `add(address user, uint256 amount)` – Increase reputation for a user.
+- `subtract(address user, uint256 amount)` – Decrease reputation for a user.
+- `getReputation(address user)` – Current reputation score.
+- `onApply(address user)` – Hook called by `JobRegistry` when an agent applies.
+- `rewardValidator(address validator, uint256 agentGain)` – Share reputation with validators after success.
+
+## CertificateNFT
+
+Mints completion certificates and allows optional marketplace listings.
+
+### Key Functions
+- `mint(address to, uint256 jobId, bytes32 uriHash)` – Mint certificate for a finished job.
+- `list(uint256 tokenId, uint256 price)` – Offer an owned certificate for sale.
+- `purchase(uint256 tokenId)` – Buy a listed certificate.
+- `delist(uint256 tokenId)` – Cancel an active listing.
+
+## FeePool
+
+Collects protocol fees and redistributes them to stakers.
+
+### Key Functions
+- `contribute(uint256 amount)` – Deposit tokens into the pool.
+- `distributeFees()` – Move accumulated fees to rewards.
+- `claimRewards()` – Claim the caller’s accumulated rewards.
+
+---
+
+## SDK Snippets
+
+Below are common flows in TypeScript (ethers.js) and Python (web3.py).
+
+### Post a Job
+```ts
+// TypeScript
+const registry = new ethers.Contract(JOB_REGISTRY, ['function createJob(uint256,string)'], wallet);
+await registry.createJob(1_000000, 'ipfs://QmHash');
+```
+```python
+# Python
+registry = w3.eth.contract(address=JOB_REGISTRY, abi=['function createJob(uint256,string)'])
+tx = registry.functions.createJob(1_000000, 'ipfs://QmHash').transact({'from': acct})
+w3.eth.wait_for_transaction_receipt(tx)
+```
+
+### Stake Tokens
+```ts
+const stake = new ethers.Contract(STAKE_MANAGER, ['function depositStake(uint8,uint256)'], wallet);
+await stake.depositStake(0, 1_000000);
+```
+```python
+stake = w3.eth.contract(address=STAKE_MANAGER, abi=['function depositStake(uint8,uint256)'])
+tx = stake.functions.depositStake(0, 1_000000).transact({'from': acct})
+w3.eth.wait_for_transaction_receipt(tx)
+```
+
+### Validate a Submission
+```ts
+const val = new ethers.Contract(VALIDATION_MODULE, [
+  'function commitValidation(uint256,bytes32,string,bytes)',
+  'function revealValidation(uint256,bool,bytes32,string,bytes)'
+], wallet);
+await val.commitValidation(jobId, commitHash, 'alice.agent.agi.eth', proof);
+await val.revealValidation(jobId, true, salt, 'alice.agent.agi.eth', proof);
+```
+```python
+val = w3.eth.contract(address=VALIDATION_MODULE, abi=[
+  'function commitValidation(uint256,bytes32,string,bytes)',
+  'function revealValidation(uint256,bool,bytes32,string,bytes)'])
+val.functions.commitValidation(job_id, commit_hash, 'alice.agent.agi.eth', proof).transact({'from': acct})
+val.functions.revealValidation(job_id, True, salt, 'alice.agent.agi.eth', proof).transact({'from': acct})
+```
+
+### Raise a Dispute
+```ts
+await registry.raiseDispute(jobId, 'ipfs://evidence');
+```
+```python
+registry.functions.raiseDispute(job_id, 'ipfs://evidence').transact({'from': acct})
+```

--- a/examples/agent-gateway.js
+++ b/examples/agent-gateway.js
@@ -1,0 +1,38 @@
+// Minimal agent gateway that listens for job events and auto-applies
+// Usage: node examples/agent-gateway.js
+// Requires RPC_URL, PRIVATE_KEY and JOB_REGISTRY env vars.
+
+const { ethers } = require('ethers');
+
+const RPC_URL = process.env.RPC_URL || 'http://localhost:8545';
+const JOB_REGISTRY = process.env.JOB_REGISTRY;
+
+if (!JOB_REGISTRY) {
+  console.error('Set JOB_REGISTRY env variable');
+  process.exit(1);
+}
+
+const provider = new ethers.JsonRpcProvider(RPC_URL);
+const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
+
+const REGISTRY_ABI = [
+  'event JobCreated(uint256 indexed jobId, address indexed employer, address indexed agent, uint256 reward, uint256 stake, uint256 fee)',
+  'function applyForJob(uint256 jobId, string subdomain, bytes proof) external'
+];
+
+const registry = new ethers.Contract(JOB_REGISTRY, REGISTRY_ABI, wallet);
+
+console.log('Listening for jobs...');
+registry.on('JobCreated', async (jobId, employer, agent) => {
+  // Only apply if job is unassigned
+  if (agent === ethers.ZeroAddress) {
+    try {
+      console.log(`Applying for job ${jobId}`);
+      const tx = await registry.applyForJob(jobId, '', '0x');
+      await tx.wait();
+      console.log(`Applied in tx ${tx.hash}`);
+    } catch (err) {
+      console.error('applyForJob failed', err);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- document core contract functions and SDK flows in `docs/api-reference.md`
- add event-driven `agent-gateway` example that auto-applies to new jobs
- link new docs and examples from the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac9817c7fc8333862a9a35111efbda