### PR TITLE
Ensure stake manager presence before validator selection

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -386,6 +386,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement {
         address[] memory pool = validatorPool;
         uint256 n = pool.length;
         require(n > 0, "no validators");
+        require(address(stakeManager) != address(0), "stake manager");
         uint256 sample = validatorPoolSampleSize;
         if (sample > n) sample = n;
         uint256 seed = uint256(

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -79,6 +79,13 @@ describe("ValidationModule V2", function () {
     await ethers.provider.send("evm_mine", []);
   }
 
+  it("reverts when stake manager is unset", async () => {
+    await validation.connect(owner).setStakeManager(ethers.ZeroAddress);
+    await expect(validation.selectValidators(1)).to.be.revertedWith(
+      "stake manager"
+    );
+  });
+
   it("selects stake-weighted validators", async () => {
     const tx = await validation.selectValidators(1);
     const receipt = await tx.wait();


### PR DESCRIPTION
## Summary
- require a configured `stakeManager` before selecting validators
- add test verifying revert when `stakeManager` is unset

## Testing
- `npm run compile`
- `npx hardhat test test/v2/ValidationModule.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac9bbe5e108333b3b99fd7a0cd30ea