### PR TITLE
Add treasury zero address check in StakeManager

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -267,6 +267,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement {
     /// @notice update treasury recipient address
     /// @param _treasury address receiving treasury slash share
     function setTreasury(address _treasury) external onlyGovernance {
+        require(_treasury != address(0), "treasury");
         treasury = _treasury;
         emit TreasuryUpdated(_treasury);
     }


### PR DESCRIPTION
## Summary
- prevent setting the treasury to the zero address

## Testing
- `npx hardhat compile` *(fails: command hung while downloading solc)*
- `npx hardhat test test/v2/StakeManager*.test.js` *(fails: command hung before running tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acafb656ac833398e258b1bc15a35f