### PR TITLE
Allow governance to finalize blacklisted jobs

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -81,6 +81,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement {
     ITaxPolicy public taxPolicy;
     IFeePool public feePool;
     IIdentityRegistry public identityRegistry;
+    address public treasury;
 
 
     /// @notice Addresses allowed to acknowledge the tax policy for others.
@@ -174,6 +175,12 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement {
     event DisputeResolved(uint256 indexed jobId, bool employerWins);
     event FeePoolUpdated(address pool);
     event FeePctUpdated(uint256 feePct);
+    event GovernanceFinalized(
+        uint256 indexed jobId,
+        address indexed caller,
+        bool fundsRedirected
+    );
+    event TreasuryUpdated(address treasury);
 
     constructor(
         IValidationModule _validation,
@@ -311,6 +318,12 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement {
         feePool = _feePool;
         emit FeePoolUpdated(address(_feePool));
         emit ModuleUpdated("FeePool", address(_feePool));
+    }
+
+    /// @notice update the treasury address used for blacklisted payouts
+    function setTreasury(address _treasury) external onlyGovernance {
+        treasury = _treasury;
+        emit TreasuryUpdated(_treasury);
     }
 
     /// @notice update the required agent stake for each job
@@ -819,22 +832,24 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement {
     {
         Job storage job = jobs[jobId];
         require(job.state == State.Completed, "not ready");
+        bool isGov = msg.sender == governance;
+        bool agentBlacklisted;
+        bool employerBlacklisted;
         if (address(reputationEngine) != address(0)) {
-            require(
-                !reputationEngine.isBlacklisted(msg.sender),
-                "Blacklisted"
-            );
-            require(
-                !reputationEngine.isBlacklisted(job.agent),
-                "Blacklisted agent"
-            );
-            require(
-                !reputationEngine.isBlacklisted(job.employer),
-                "Blacklisted employer"
-            );
+            agentBlacklisted = reputationEngine.isBlacklisted(job.agent);
+            employerBlacklisted = reputationEngine.isBlacklisted(job.employer);
+            if (!isGov) {
+                require(
+                    !reputationEngine.isBlacklisted(msg.sender),
+                    "Blacklisted"
+                );
+                require(!agentBlacklisted, "Blacklisted agent");
+                require(!employerBlacklisted, "Blacklisted employer");
+            }
         }
         job.state = State.Finalized;
         bytes32 jobKey = bytes32(jobId);
+        bool redirected;
         if (job.success) {
             IFeePool pool = feePool;
             address[] memory validators;
@@ -854,9 +869,14 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement {
                 if (address(pool) != address(0) && job.reward > 0) {
                     fee = (uint256(job.reward) * job.feePct) / 100;
                 }
+                address payee = job.agent;
+                if (isGov && treasury != address(0) && agentBlacklisted) {
+                    payee = treasury;
+                    redirected = true;
+                }
                 stakeManager.finalizeJobFunds(
                     jobKey,
-                    job.agent,
+                    payee,
                     rewardAfterValidator,
                     fee,
                     pool
@@ -871,13 +891,22 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement {
                     } else {
                         stakeManager.releaseReward(
                             jobKey,
-                            job.employer,
+                            payee,
                             validatorReward
                         );
                     }
                 }
                 if (job.stake > 0) {
-                    stakeManager.releaseStake(job.agent, uint256(job.stake));
+                    if (isGov && treasury != address(0) && agentBlacklisted) {
+                        stakeManager.slash(
+                            job.agent,
+                            IStakeManager.Role.Agent,
+                            uint256(job.stake),
+                            treasury
+                        );
+                    } else {
+                        stakeManager.releaseStake(job.agent, uint256(job.stake));
+                    }
                 }
             }
             if (address(reputationEngine) != address(0)) {
@@ -919,10 +948,15 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement {
         } else {
             if (address(stakeManager) != address(0)) {
                 uint256 fee = (uint256(job.reward) * job.feePct) / 100;
+                address recipient = job.employer;
+                if (isGov && treasury != address(0) && employerBlacklisted) {
+                    recipient = treasury;
+                    redirected = true;
+                }
                 if (job.reward > 0) {
                     stakeManager.releaseReward(
                         jobKey,
-                        job.employer,
+                        recipient,
                         uint256(job.reward) + fee
                     );
                 }
@@ -931,7 +965,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement {
                         job.agent,
                         IStakeManager.Role.Agent,
                         uint256(job.stake),
-                        job.employer
+                        recipient
                     );
                 }
             }
@@ -940,6 +974,9 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement {
             }
         }
         emit JobFinalized(jobId, job.agent);
+        if (isGov) {
+            emit GovernanceFinalized(jobId, msg.sender, redirected);
+        }
     }
 
     /// @notice Acknowledge the tax policy and finalise the job in one call.

--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -1,0 +1,168 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+describe("JobRegistry governance finalization", function () {
+  let token, stakeManager, rep, registry, identity;
+  let owner, employer, agent, treasury;
+  const reward = 100n;
+  const stake = 200n;
+
+  beforeEach(async () => {
+    [owner, employer, agent, treasury] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC206Decimals");
+    token = await Token.deploy();
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      0,
+      100,
+      0,
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      owner.address
+    );
+    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setSlashingPercentages(100, 0);
+
+    const Rep = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    rep = await Rep.deploy(await stakeManager.getAddress());
+
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Registry.deploy(
+      ethers.ZeroAddress,
+      await stakeManager.getAddress(),
+      await rep.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    await registry.connect(owner).setTreasury(treasury.address);
+    await stakeManager.connect(owner).setJobRegistry(await registry.getAddress());
+    await rep
+      .connect(owner)
+      .setAuthorizedCaller(await registry.getAddress(), true);
+    await rep.connect(owner).setThreshold(0);
+
+    const Identity = await ethers.getContractFactory(
+      "contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock"
+    );
+    identity = await Identity.deploy();
+    await registry
+      .connect(owner)
+      .setIdentityRegistry(await identity.getAddress());
+
+    await registry.connect(owner).setJobParameters(reward, stake);
+    await registry.connect(owner).setMaxJobReward(1000000);
+    await registry.connect(owner).setJobDurationLimit(86400);
+    await registry.connect(owner).setFeePct(0);
+    await registry.connect(owner).setValidatorRewardPct(0);
+
+    await token.mint(employer.address, reward);
+    await token.mint(agent.address, reward + stake);
+
+    await token
+      .connect(agent)
+      .approve(await stakeManager.getAddress(), stake);
+    await stakeManager.connect(agent).depositStake(0, stake);
+  });
+
+  async function setJobState(jobId, success) {
+    const coder = ethers.AbiCoder.defaultAbiCoder();
+    const base = BigInt(
+      ethers.keccak256(
+        coder.encode(["uint256", "uint256"], [BigInt(jobId), 1n])
+      )
+    );
+    const slot = base + 3n;
+    const slotHex = ethers.toBeHex(slot);
+    const prev = BigInt(
+      await ethers.provider.getStorageAt(await registry.getAddress(), slotHex)
+    );
+    const mask = ~((0xffn << (8n * 16n)) | (0xffn << (8n * 17n)));
+    const cleared = prev & mask;
+    const value =
+      cleared |
+      (4n << (8n * 16n)) |
+      (BigInt(success ? 1 : 0) << (8n * 17n));
+    await ethers.provider.send("hardhat_setStorageAt", [
+      await registry.getAddress(),
+      slotHex,
+      ethers.toBeHex(value, 32),
+    ]);
+  }
+
+  it("redirects reward and stake when agent blacklisted", async () => {
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), reward);
+    const deadline = (await time.latest()) + 1000;
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, "uri");
+    const jobId = 1;
+    await registry.connect(agent).applyForJob(jobId, "", []);
+    await registry
+      .connect(agent)
+      .submit(jobId, ethers.id("res"), "res", "", []);
+
+    await rep.connect(owner).blacklist(agent.address, true);
+    await setJobState(jobId, true);
+
+    await expect(registry.connect(agent).finalize(jobId)).to.be.revertedWith(
+      "Blacklisted agent"
+    );
+
+    await expect(registry.connect(owner).finalize(jobId))
+      .to.emit(registry, "GovernanceFinalized")
+      .withArgs(jobId, owner.address, true)
+      .and.to.emit(registry, "JobFinalized")
+      .withArgs(jobId, agent.address);
+
+    expect(await token.balanceOf(treasury.address)).to.equal(reward + stake);
+  });
+
+  it("redirects reward when employer blacklisted", async () => {
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), reward);
+    const deadline = (await time.latest()) + 1000;
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, "uri");
+    const jobId = 1;
+    await registry.connect(agent).applyForJob(jobId, "", []);
+    await registry
+      .connect(agent)
+      .submit(jobId, ethers.id("res"), "res", "", []);
+
+    await rep.connect(owner).blacklist(employer.address, true);
+    await setJobState(jobId, false);
+
+    await expect(
+      registry.connect(employer).finalize(jobId)
+    ).to.be.revertedWith("Blacklisted employer");
+
+    await expect(registry.connect(owner).finalize(jobId))
+      .to.emit(registry, "GovernanceFinalized")
+      .withArgs(jobId, owner.address, true)
+      .and.to.emit(registry, "JobFinalized")
+      .withArgs(jobId, agent.address);
+
+    expect(await token.balanceOf(treasury.address)).to.equal(reward + stake);
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow governance to bypass blacklist checks and optionally redirect funds to a treasury when finalizing
- emit `GovernanceFinalized` and support configurable treasury address
- cover governance finalization for blacklisted agent or employer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc3954cf88333a1420f46463b8fc4