### PR TITLE
refactor: make dispute module governable

### DIFF
--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -8,7 +8,7 @@ interface IDisputeModule {
     event DisputeResolved(uint256 indexed jobId, bool employerWins);
     event ModeratorAdded(address moderator);
     event ModeratorRemoved(address moderator);
-    event CommitteeUpdated(address committee);
+    event GovernanceUpdated(address indexed governance);
 
     function raiseDispute(
         uint256 jobId,
@@ -20,6 +20,6 @@ interface IDisputeModule {
 
     function addModerator(address moderator) external;
     function removeModerator(address moderator) external;
-    function setCommittee(address committee) external;
+    function setGovernance(address governance) external;
 }
 

--- a/docs/api/DisputeModule.md
+++ b/docs/api/DisputeModule.md
@@ -1,12 +1,13 @@
 # DisputeModule API
 
-Handles disputes raised against jobs. A committee multisig manages the list of
-eligible moderators who must reach majority consensus to finalise a case.
+Handles disputes raised against jobs. A governance timelock or multisig manages
+the list of eligible moderators who must reach majority consensus to finalise a
+case.
 
 ## Functions
-- `addModerator(address moderator)` – committee enrols a new moderator.
-- `removeModerator(address moderator)` – committee removes a moderator.
-- `setCommittee(address committee)` – hand off committee control to a new multisig.
+- `addModerator(address moderator)` – governance enrols a new moderator.
+- `removeModerator(address moderator)` – governance removes a moderator.
+- `setGovernance(address governance)` – hand off control to a new timelock or multisig.
 - `raiseDispute(uint256 jobId)` – JobRegistry forwards a dispute from a participant.
 - `resolve(uint256 jobId, bool employerWins)` – moderators vote; majority decides.
 
@@ -15,9 +16,9 @@ eligible moderators who must reach majority consensus to finalise a case.
 - `DisputeResolved(uint256 indexed jobId, bool employerWins)`
 - `ModeratorAdded(address indexed moderator)`
 - `ModeratorRemoved(address indexed moderator)`
-- `CommitteeUpdated(address indexed committee)`
+- `GovernanceUpdated(address indexed governance)`
 
 ## Quorum
 `resolve` requires more than half of `moderatorCount` votes. The default
-deployment boots the committee address as the first moderator, so onboarding
-additional members is the first action for the committee multisig.
+deployment boots the governance address as the first moderator, so onboarding
+additional members is the first action for governance.

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -21,10 +21,10 @@ Deploy each contract **in the order listed below** from the **Write Contract** t
 3. `JobRegistry(validation, stakeMgr, reputation, dispute, certNFT, feePool, taxPolicy, feePct, jobStake)` – leaving `feePct = 0` applies a 5% protocol fee. Supplying a nonzero `taxPolicy` sets the disclaimer at deployment; otherwise the owner may call `setTaxPolicy` later.
 4. `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators, validatorPool)` – zero values default to 1‑day windows and a 1–3 validator set.
 5. `ReputationEngine(stakeManager)` – optional reputation weighting (pass `0` to wire later).
-6. `DisputeModule(jobRegistry, stakeManager, committee, appealFee)` – manages
-   appeals and dispute fees. Pass the committee multisig as the third argument;
-   it is bootstrapped as the initial moderator and is responsible for onboarding
-   additional moderators.
+6. `DisputeModule(jobRegistry, stakeManager, governance, appealFee)` – manages
+   appeals and dispute fees. Pass the governance timelock or multisig as the
+   third argument; it is bootstrapped as the initial moderator and is
+   responsible for onboarding additional moderators.
 7. `CertificateNFT(name, symbol)` – certifies completed work.
 8. `FeePool(token, stakeManager, burnPct, treasury)` – rewards default to platform stakers; use `address(0)` for `token` to fall back to $AGIALPHA` and `burnPct` defaults to `0`.
 9. `PlatformRegistry(stakeManager, reputationEngine, minStake)` – `minStake` may be `0`.
@@ -73,8 +73,8 @@ Owners can retune parameters any time: `StakeManager.setToken`, `setMinStake`, `
 - The disputing agent approves the `StakeManager` for the configured `appealFee` in `$AGIALPHA` and calls `JobRegistry.acknowledgeAndDispute(jobId, evidence)`; no ETH is ever sent.
 - The `DisputeModule` escrows the token fee and releases it to the winner or back to the payer after resolution.
 - A majority of enrolled moderators (`moderatorCount / 2 + 1`) must vote for
-  either outcome. The committee multisig expands or shrinks the moderator set
-  using `addModerator` and `removeModerator`.
+  either outcome. Governance expands or shrinks the moderator set using
+  `addModerator` and `removeModerator`.
 
 ## 8. Final checks
 

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -72,7 +72,7 @@ interface IDisputeModule {
     function resolve(uint256 jobId, bool employerWins) external;
     function addModerator(address moderator) external;
     function removeModerator(address moderator) external;
-    function setCommittee(address committee) external;
+    function setGovernance(address governance) external;
 }
 
 interface ICertificateNFT {


### PR DESCRIPTION
## Summary
- make DisputeModule inherit Governable and gate config with onlyGovernance
- remove direct committee updates and document new governance flow
- test governance transfer and unauthorized moderator changes

## Testing
- `npx hardhat test test/v2/DisputeModuleCore.test.js test/v2/disputeFlowFuzz.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68acfa3255348333ab3e7b3360174f54