### PR TITLE
chore: isolate legacy contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AGIJob Manager
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
-AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labour markets among autonomous agents. Only the modular **v2** release located under `contracts/v2` is supported. Earlier v0 and v1 sources are archived under `docs/legacy/` and were never audited. For help migrating older deployments, see [docs/migration-guide.md](docs/migration-guide.md).
+AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labour markets among autonomous agents. The **v2** release under `contracts/v2` is the only supported version. Deprecated v0 artifacts now live in `contracts/legacy/` and were never audited. For help migrating older deployments, see [docs/migration-guide.md](docs/migration-guide.md).
 
 All modules default to the 6‑decimal `$AGIALPHA` token for payments, stakes and dispute deposits. Token addresses can be rotated post‑deployment through owner calls to `StakeManager.setToken` and `FeePool.setToken` without redeploying any module.
 

--- a/contracts/legacy/BadTaxPolicy.sol
+++ b/contracts/legacy/BadTaxPolicy.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 import "../v2/interfaces/ITaxPolicy.sol";
 
 /// @dev Mock implementation that reports non-exempt status.

--- a/contracts/legacy/DisputeRegistryStub.sol
+++ b/contracts/legacy/DisputeRegistryStub.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 interface IDisputeModule {
     function raiseDispute(
         uint256 jobId,

--- a/contracts/legacy/MaliciousERC721.sol
+++ b/contracts/legacy/MaliciousERC721.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 /// @notice Minimal ERC721-like contract that reverts on balanceOf to simulate malicious behavior.
 contract MaliciousERC721 {
     function balanceOf(address) external pure returns (uint256) {

--- a/contracts/legacy/MockENS.sol
+++ b/contracts/legacy/MockENS.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 /// @title MockENS
 /// @notice Basic ENS registry mock returning configurable resolver addresses.
 contract MockENS {

--- a/contracts/legacy/MockERC20.sol
+++ b/contracts/legacy/MockERC20.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract MockERC20 is ERC20 {

--- a/contracts/legacy/MockERC206Decimals.sol
+++ b/contracts/legacy/MockERC206Decimals.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract MockERC206Decimals is ERC20 {

--- a/contracts/legacy/MockERC721.sol
+++ b/contracts/legacy/MockERC721.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 contract MockERC721 is ERC721 {

--- a/contracts/legacy/MockNameWrapper.sol
+++ b/contracts/legacy/MockNameWrapper.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 /// @title MockNameWrapper
 /// @notice Simplified ENS NameWrapper mock returning configurable owners.
 contract MockNameWrapper {

--- a/contracts/legacy/MockResolver.sol
+++ b/contracts/legacy/MockResolver.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 /// @title MockResolver
 /// @notice Minimal ENS resolver mock allowing adjustable addr records.
 contract MockResolver {

--- a/contracts/legacy/MockRoutingModule.sol
+++ b/contracts/legacy/MockRoutingModule.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 contract MockRoutingModule {
     address public operator;
 

--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 import "../v2/interfaces/IStakeManager.sol";
 import "../v2/interfaces/IJobRegistry.sol";
 import "../v2/interfaces/IJobRegistryTax.sol";

--- a/contracts/legacy/ReentrantBuyer.sol
+++ b/contracts/legacy/ReentrantBuyer.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/legacy/ReentrantERC20.sol
+++ b/contracts/legacy/ReentrantERC20.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 interface IJobManager {

--- a/contracts/legacy/ReentrantERC206.sol
+++ b/contracts/legacy/ReentrantERC206.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 interface IReentrantCaller {

--- a/contracts/legacy/RevertingNameWrapper.sol
+++ b/contracts/legacy/RevertingNameWrapper.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 /// @title RevertingNameWrapper
 /// @notice Mock NameWrapper that always reverts.
 contract RevertingNameWrapper {

--- a/contracts/legacy/StubReputationEngine.sol
+++ b/contracts/legacy/StubReputationEngine.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 contract StubReputationEngine {
     mapping(address => uint256) public reputation;
     mapping(address => bool) public _blacklist;

--- a/contracts/legacy/StubStakeManager.sol
+++ b/contracts/legacy/StubStakeManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 contract StubStakeManager {
     mapping(address => uint256) public stakes;
 

--- a/contracts/legacy/TaxExemptHelper.sol
+++ b/contracts/legacy/TaxExemptHelper.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 interface ITaxExempt {
     function isTaxExempt() external view returns (bool);
 }

--- a/contracts/legacy/TimelockControllerHarness.sol
+++ b/contracts/legacy/TimelockControllerHarness.sol
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
+
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
 import "@openzeppelin/contracts/governance/TimelockController.sol";
 
 contract TimelockControllerHarness is TimelockController {

--- a/contracts/legacy/TimelockMock.sol
+++ b/contracts/legacy/TimelockMock.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @dev Minimal timelock-style forwarder used for testing ownership transfer.

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -24,10 +24,10 @@ async function main() {
   const reputation = await Reputation.deploy(await stake.getAddress());
   await reputation.waitForDeployment();
 
-  const ENS = await ethers.getContractFactory("contracts/mocks/MockENS.sol:MockENS");
+  const ENS = await ethers.getContractFactory("contracts/legacy/MockENS.sol:MockENS");
   const ens = await ENS.deploy();
   await ens.waitForDeployment();
-  const Wrapper = await ethers.getContractFactory("contracts/mocks/MockNameWrapper.sol:MockNameWrapper");
+  const Wrapper = await ethers.getContractFactory("contracts/legacy/MockNameWrapper.sol:MockNameWrapper");
   const wrapper = await Wrapper.deploy();
   await wrapper.waitForDeployment();
 

--- a/scripts/v2/deploy.js
+++ b/scripts/v2/deploy.js
@@ -14,7 +14,7 @@ async function verify(address, args = []) {
 async function main() {
   const [deployer] = await ethers.getSigners();
 
-  const Token = await ethers.getContractFactory("contracts/mocks/MockERC20.sol:MockERC20");
+  const Token = await ethers.getContractFactory("contracts/legacy/MockERC20.sol:MockERC20");
   const token = await Token.deploy();
   await token.waitForDeployment();
 

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -49,7 +49,7 @@ async function main() {
     tokenAddress = args.token;
   } else {
     const Token = await ethers.getContractFactory(
-      "contracts/mocks/MockERC20.sol:MockERC20"
+      "contracts/legacy/MockERC20.sol:MockERC20"
     );
     const token = await Token.deploy();
     await token.waitForDeployment();

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -61,13 +61,13 @@ describe("StakeManager AGIType bonuses", function () {
     registrySigner = await ethers.getImpersonatedSigner(registryAddr);
 
     const NFT = await ethers.getContractFactory(
-      "contracts/mocks/MockERC721.sol:MockERC721"
+      "contracts/legacy/MockERC721.sol:MockERC721"
     );
     nft1 = await NFT.deploy();
     nft2 = await NFT.deploy();
 
     const Mal = await ethers.getContractFactory(
-      "contracts/mocks/MaliciousERC721.sol:MaliciousERC721"
+      "contracts/legacy/MaliciousERC721.sol:MaliciousERC721"
     );
     malicious = await Mal.deploy();
 

--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -9,7 +9,7 @@ describe("CertificateNFT marketplace", function () {
     [owner, seller, buyer] = await ethers.getSigners();
 
     const Token = await ethers.getContractFactory(
-      "contracts/mocks/MockERC206Decimals.sol:MockERC206Decimals"
+      "contracts/legacy/MockERC206Decimals.sol:MockERC206Decimals"
     );
     token = await Token.deploy();
     await token.mint(buyer.address, price);
@@ -121,7 +121,7 @@ describe("CertificateNFT marketplace", function () {
       await nft.connect(seller).list(1, price);
 
       const Reenter = await ethers.getContractFactory(
-        "contracts/mocks/ReentrantBuyer.sol:ReentrantBuyer"
+        "contracts/legacy/ReentrantBuyer.sol:ReentrantBuyer"
       );
       const attacker = await Reenter.deploy(await nft.getAddress());
 

--- a/test/v2/ENSOwnershipVerifier.test.js
+++ b/test/v2/ENSOwnershipVerifier.test.js
@@ -220,7 +220,7 @@ describe("ENSOwnershipVerifier verification", function () {
 
   it("emits recovery when NameWrapper reverts", async () => {
     const BadWrapper = await ethers.getContractFactory(
-      "contracts/mocks/RevertingNameWrapper.sol:RevertingNameWrapper"
+      "contracts/legacy/RevertingNameWrapper.sol:RevertingNameWrapper"
     );
     const bad = await BadWrapper.deploy();
     await verifier.setNameWrapper(await bad.getAddress());

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import "contracts/v2/FeePool.sol";
 import "contracts/v2/interfaces/IFeePool.sol";
-import "contracts/mocks/MockV2.sol";
+import "contracts/legacy/MockV2.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 // minimal cheatcode interface

--- a/test/v2/GovernanceTimelock.test.js
+++ b/test/v2/GovernanceTimelock.test.js
@@ -6,7 +6,7 @@ describe("Governance via Timelock", function () {
     const [admin] = await ethers.getSigners();
 
     const Timelock = await ethers.getContractFactory(
-      "contracts/mocks/TimelockControllerHarness.sol:TimelockControllerHarness"
+      "contracts/legacy/TimelockControllerHarness.sol:TimelockControllerHarness"
     );
     const timelock = await Timelock.deploy(admin.address);
     await timelock.waitForDeployment();
@@ -16,7 +16,7 @@ describe("Governance via Timelock", function () {
     await timelock.grantRole(executorRole, admin.address);
 
     const Token = await ethers.getContractFactory(
-      "contracts/mocks/MockERC206Decimals.sol:MockERC206Decimals"
+      "contracts/legacy/MockERC206Decimals.sol:MockERC206Decimals"
     );
     const token = await Token.deploy();
     await token.waitForDeployment();

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -11,7 +11,7 @@ describe("Identity verification enforcement", function () {
       [owner, employer, agent] = await ethers.getSigners();
 
       const Stake = await ethers.getContractFactory(
-        "contracts/mocks/MockV2.sol:MockStakeManager"
+        "contracts/legacy/MockV2.sol:MockStakeManager"
       );
       stakeManager = await Stake.deploy();
 
@@ -21,11 +21,11 @@ describe("Identity verification enforcement", function () {
       rep = await Rep.deploy(await stakeManager.getAddress());
 
       const ENS = await ethers.getContractFactory(
-        "contracts/mocks/MockENS.sol:MockENS"
+        "contracts/legacy/MockENS.sol:MockENS"
       );
       const ens = await ENS.deploy();
       const Wrapper = await ethers.getContractFactory(
-        "contracts/mocks/MockNameWrapper.sol:MockNameWrapper"
+        "contracts/legacy/MockNameWrapper.sol:MockNameWrapper"
       );
       const wrapper = await Wrapper.deploy();
 
@@ -138,11 +138,11 @@ describe("Identity verification enforcement", function () {
         .setReputationEngine(await reputation.getAddress());
 
       const ENS = await ethers.getContractFactory(
-        "contracts/mocks/MockENS.sol:MockENS"
+        "contracts/legacy/MockENS.sol:MockENS"
       );
       const ens = await ENS.deploy();
       const Wrapper = await ethers.getContractFactory(
-        "contracts/mocks/MockNameWrapper.sol:MockNameWrapper"
+        "contracts/legacy/MockNameWrapper.sol:MockNameWrapper"
       );
       const wrapper = await Wrapper.deploy();
       const Identity = await ethers.getContractFactory(

--- a/test/v2/Integration.t.sol
+++ b/test/v2/Integration.t.sol
@@ -6,7 +6,7 @@ import "contracts/v2/modules/JobRouter.sol";
 import "contracts/v2/interfaces/IStakeManager.sol";
 import "contracts/v2/interfaces/IFeePool.sol";
 import "contracts/v2/interfaces/IPlatformRegistry.sol";
-import "contracts/mocks/MockV2.sol";
+import "contracts/legacy/MockV2.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 interface Vm {

--- a/test/v2/JobEscrowNoEther.test.js
+++ b/test/v2/JobEscrowNoEther.test.js
@@ -14,7 +14,7 @@ describe("JobEscrow ether rejection", function () {
     await token.connect(owner).mint(employer.address, 1000);
 
     const Routing = await ethers.getContractFactory(
-      "contracts/mocks/MockRoutingModule.sol:MockRoutingModule"
+      "contracts/legacy/MockRoutingModule.sol:MockRoutingModule"
     );
     routing = await Routing.deploy(operator.address);
 
@@ -44,7 +44,7 @@ describe("JobEscrow ether rejection", function () {
     expect(await escrow.isTaxExempt()).to.equal(true);
 
     const Helper = await ethers.getContractFactory(
-      "contracts/mocks/TaxExemptHelper.sol:TaxExemptHelper"
+      "contracts/legacy/TaxExemptHelper.sol:TaxExemptHelper"
     );
     const helper = await Helper.deploy();
     expect(await helper.check(await escrow.getAddress())).to.equal(true);

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -10,7 +10,7 @@ describe("JobRegistry agent gating", function () {
     [owner, employer, agent] = await ethers.getSigners();
 
     const Stake = await ethers.getContractFactory(
-      "contracts/mocks/MockV2.sol:MockStakeManager"
+      "contracts/legacy/MockV2.sol:MockStakeManager"
     );
     const stakeManager = await Stake.deploy();
 

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -8,7 +8,7 @@ async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
 
   const Token = await ethers.getContractFactory(
-    "contracts/mocks/MockERC206Decimals.sol:MockERC206Decimals"
+    "contracts/legacy/MockERC206Decimals.sol:MockERC206Decimals"
   );
   const token = await Token.deploy();
   await token.waitForDeployment();

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -8,7 +8,7 @@ async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
 
   const Token = await ethers.getContractFactory(
-    "contracts/mocks/MockERC206Decimals.sol:MockERC206Decimals"
+    "contracts/legacy/MockERC206Decimals.sol:MockERC206Decimals"
   );
   const token = await Token.deploy();
   await token.waitForDeployment();

--- a/test/v2/OwnershipTimelock.test.js
+++ b/test/v2/OwnershipTimelock.test.js
@@ -34,7 +34,7 @@ describe("Timelock ownership", function () {
     const stake = StakeManager.attach(stakeAddr);
     const registry = JobRegistry.attach(registryAddr);
 
-    const Timelock = await ethers.getContractFactory("contracts/mocks/TimelockMock.sol:TimelockMock");
+    const Timelock = await ethers.getContractFactory("contracts/legacy/TimelockMock.sol:TimelockMock");
     const timelock = await Timelock.deploy(proposer.address);
 
     await stake.setGovernance(await timelock.getAddress());

--- a/test/v2/PlatformIncentives.t.sol
+++ b/test/v2/PlatformIncentives.t.sol
@@ -12,7 +12,7 @@ import {IPlatformRegistry} from "../../contracts/v2/interfaces/IPlatformRegistry
 import {IReputationEngine} from "../../contracts/v2/interfaces/IReputationEngine.sol";
 import {FeePool} from "../../contracts/v2/FeePool.sol";
 import {PlatformIncentives} from "../../contracts/v2/PlatformIncentives.sol";
-import {MockJobRegistry, MockReputationEngine} from "../../contracts/mocks/MockV2.sol";
+import {MockJobRegistry, MockReputationEngine} from "../../contracts/legacy/MockV2.sol";
 import {IStakeManager} from "../../contracts/v2/interfaces/IStakeManager.sol";
 
 contract PlatformIncentivesTest is Test {

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -31,7 +31,7 @@ describe("PlatformRegistry", function () {
     );
     await stakeManager.connect(platform).setMinStake(STAKE);
     const MockRegistry = await ethers.getContractFactory(
-      "contracts/mocks/MockV2.sol:MockJobRegistry"
+      "contracts/legacy/MockV2.sol:MockJobRegistry"
     );
     const mockRegistry = await MockRegistry.deploy();
     await stakeManager

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -523,7 +523,7 @@ describe("StakeManager", function () {
   it("slashes full amount when percentages sum to 100", async () => {
     await stakeManager.connect(owner).setSlashingPercentages(70, 30);
     const MockRegistry = await ethers.getContractFactory(
-      "contracts/mocks/MockV2.sol:MockJobRegistry"
+      "contracts/legacy/MockV2.sol:MockJobRegistry"
     );
     const mockRegistry = await MockRegistry.deploy();
     await stakeManager
@@ -572,7 +572,7 @@ describe("StakeManager", function () {
   it("routes full slashing to treasury when employer share is zero", async () => {
     await stakeManager.connect(owner).setSlashingPercentages(0, 100);
     const MockRegistry = await ethers.getContractFactory(
-      "contracts/mocks/MockV2.sol:MockJobRegistry"
+      "contracts/legacy/MockV2.sol:MockJobRegistry"
     );
     const mockRegistry = await MockRegistry.deploy();
     await stakeManager
@@ -601,7 +601,7 @@ describe("StakeManager", function () {
   it("burns remainder when slashing with rounding", async () => {
     await stakeManager.connect(owner).setSlashingPercentages(60, 40);
     const MockRegistry = await ethers.getContractFactory(
-      "contracts/mocks/MockV2.sol:MockJobRegistry"
+      "contracts/legacy/MockV2.sol:MockJobRegistry"
     );
     const mockRegistry = await MockRegistry.deploy();
     await stakeManager

--- a/test/v2/StakeManagerReentrancy.test.js
+++ b/test/v2/StakeManagerReentrancy.test.js
@@ -9,7 +9,7 @@ describe("StakeManager reentrancy", function () {
     [owner, employer, agent, validator, treasury] = await ethers.getSigners();
 
     const Token = await ethers.getContractFactory(
-      "contracts/mocks/ReentrantERC206.sol:ReentrantERC206"
+      "contracts/legacy/ReentrantERC206.sol:ReentrantERC206"
     );
     token = await Token.deploy();
     await token.mint(employer.address, 1000);

--- a/test/v2/ValidationSlashingFuzz.t.sol
+++ b/test/v2/ValidationSlashingFuzz.t.sol
@@ -10,7 +10,7 @@ import {IJobRegistry} from "../../contracts/v2/interfaces/IJobRegistry.sol";
 import {IStakeManager} from "../../contracts/v2/interfaces/IStakeManager.sol";
 import {IIdentityRegistry} from "../../contracts/v2/interfaces/IIdentityRegistry.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {MockJobRegistry} from "../../contracts/mocks/MockV2.sol";
+import {MockJobRegistry} from "../../contracts/legacy/MockV2.sol";
 
 contract ValidationSlashingFuzz is Test {
     ValidationModule validation;


### PR DESCRIPTION
## Summary
- move v0 contract mocks under `contracts/legacy`
- highlight v2 as supported and link migration guide
- annotate legacy contracts with @deprecated notices

## Testing
- `npm run lint`
- `npm test`
- `forge test` *(fails: Source "forge-std/Test.sol" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acffdb705883338aa740794e0640ae