### PR TITLE
feat: add moderator quorum tracking

### DIFF
--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -9,6 +9,19 @@ interface IDisputeModule {
     event ModeratorAdded(address moderator);
     event ModeratorRemoved(address moderator);
     event GovernanceUpdated(address indexed governance);
+    event QuorumUpdated(uint256 quorum);
+    event VoteCast(
+        uint256 indexed jobId,
+        address indexed moderator,
+        bool employerWins,
+        uint256 employerVotes,
+        uint256 agentVotes
+    );
+    event VoteTally(
+        uint256 indexed jobId,
+        uint256 employerVotes,
+        uint256 agentVotes
+    );
 
     function raiseDispute(
         uint256 jobId,
@@ -21,5 +34,7 @@ interface IDisputeModule {
     function addModerator(address moderator) external;
     function removeModerator(address moderator) external;
     function setGovernance(address governance) external;
+    function setQuorum(uint256 newQuorum) external;
+    function getModerators() external view returns (address[] memory);
 }
 


### PR DESCRIPTION
## Summary
- track moderators in an on-chain list with a configurable quorum
- tally individual votes and finalize disputes when threshold reached
- expose new vote and quorum events for off-chain auditing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad09d0589083339f99f14020cf6843