### PR TITLE
docs: reference TaxPolicy.hasAcknowledged for tax compliance

### DIFF
--- a/docs/coding-sprint-tax-neutrality.md
+++ b/docs/coding-sprint-tax-neutrality.md
@@ -14,10 +14,10 @@ This sprint focuses on keeping the AGI Jobs protocol and its deploying corporati
    - Emit `TaxPolicyURIUpdated` and `AcknowledgementUpdated` events on changes.
    - Reject all ETH via `receive`/`fallback`, expose `policyDetails()` for explorer reads, and return `true` from `isTaxExempt()`.
 2. **JobRegistry integration**
-   - Track the current `taxPolicyVersion` and map each address to its last acknowledged version.
+   - Rely on `TaxPolicy.hasAcknowledged(address)` for per-user tracking instead of a local mapping.
    - Gate user actions with `requiresTaxAcknowledgement` so only acknowledged participants may interact.
    - Surface `taxPolicyDetails()`, `taxAcknowledgement()`, `taxPolicyURI()`, and `isTaxExempt()` for read‑only explorer access.
-   - Allow the owner to update the policy address or force a fresh acknowledgement with `bumpTaxPolicyVersion`.
+   - Allow the owner to update the policy address or force a fresh acknowledgement with `bumpPolicyVersion` on `TaxPolicy`.
 3. **Explorer UX**
    - Document in the README and `etherscan-guide.md` how users call `acknowledgeTaxPolicy` and how the owner updates the policy via `setPolicyURI`, `setAcknowledgement`, or `setPolicy`.
 4. **Testing**

--- a/docs/coding-sprint-v2.md
+++ b/docs/coding-sprint-v2.md
@@ -38,9 +38,9 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
    - Document Etherscan-based deployment and configuration for non‑technical owners.
 7. **Tax Responsibility & Owner Neutrality**
    - Ensure no module ever routes tokens or fees to the owner; the contracts and deploying corporation must remain revenue-free and tax-exempt worldwide.
-   - Require participants to call `acknowledgeTaxPolicy` before interacting with `JobRegistry`, tracking acknowledgements per address.
+   - Require participants to call `acknowledgeTaxPolicy` before interacting with `JobRegistry`, relying on `TaxPolicy.hasAcknowledged(address)` for verification.
    - Wire the owner-controlled `TaxPolicy` into `JobRegistry` and surface `taxPolicyDetails()` so explorers can display the canonical acknowledgement and policy URI.
-   - Guarantee only the owner can update the policy via `setPolicyURI`, `setAcknowledgement`, `setPolicy`, or `bumpTaxPolicyVersion`; unauthorized calls revert.
+   - Guarantee only the owner can update the policy via `setPolicyURI`, `setAcknowledgement`, `setPolicy`, or `bumpPolicyVersion`; unauthorized calls revert.
    - Describe in NatSpec and README that all tax obligations rest solely with AGI Employers, Agents, and Validators; the infrastructure bears no direct, indirect, or theoretical liability.
    - Provide step-by-step Etherscan instructions so non-technical users can view the disclaimer via `acknowledgement`/`acknowledge` and so the owner can update it with `setPolicyURI`/`setAcknowledgement`.
 8. **v1 Feature Parity & ENS Identity**

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -134,7 +134,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 2. In **Read Contract**, call **taxPolicyDetails** to view the canonical policy URI and acknowledgement text. *(Example screenshot: [taxPolicyDetails](https://via.placeholder.com/650x150?text=taxPolicyDetails))*
 3. Still under **Read Contract**, call **isTaxExempt** and confirm it returns `true`.
 4. Switch to **Write Contract**, connect your wallet, and execute **acknowledgeTaxPolicy**. The transaction log will show `TaxAcknowledged(user, version, acknowledgement)` with the disclaimer you accepted.
-5. Back in **Read Contract**, call **taxAcknowledgedVersion(address)** to ensure it matches **taxPolicyVersion**.
+5. Back in **Read Contract**, open the `TaxPolicy` contract and call **hasAcknowledged(address)** to ensure it returns `true`.
 
 #### Owner: update the policy
 1. Open the `TaxPolicy` contract at its deployment address (replace `<TaxPolicyAddress>`): [Etherscan](https://etherscan.io/address/0x0000000000000000000000000000000000000000#writeContract).
@@ -142,7 +142,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 3. Call **setPolicyURI(newURI)** to change only the policy document.
 4. Call **setAcknowledgement(newMessage)** to revise the acknowledgement text.
 5. Call **setPolicy(newURI, newMessage)** to update both fields in one transaction.
-6. After any update, open [`JobRegistry` on Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#writeContract) and call **bumpTaxPolicyVersion** so participants must re‑acknowledge.
+6. After any update, call **bumpPolicyVersion** on `TaxPolicy` so participants must re‑acknowledge.
 
 ### Disputers
 1. Ensure you've acknowledged the tax policy and confirmed **isTaxExempt()** on both `JobRegistry` and `DisputeModule`.

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -5,20 +5,35 @@
 - Employers, agents, and validators shoulder all tax liability.
 - The smart contracts and deploying corporation remain tax‑exempt everywhere, confirmed by `isTaxExempt()`.
 - Verify the policy on Etherscan: read `taxPolicyDetails`, acknowledge via `acknowledgeTaxPolicy` (which emits `TaxAcknowledged(user, version, acknowledgement)`), and check `isTaxExempt`.
-- The owner edits the policy text or URI with `setPolicyURI`/`setAcknowledgement`, tracks changes via `policyVersion`, and bumps `taxPolicyVersion` using `bumpTaxPolicyVersion`.
+- The owner edits the policy text or URI with `setPolicyURI`/`setAcknowledgement`, tracks changes via `policyVersion`, and bumps `policyVersion` using `bumpPolicyVersion`.
 
 The AGI Jobs protocol routes all tax duties to the participants who exchange value and none to the contract owner. The smart contract is inert code: it never charges fees, holds revenue, or transfers tokens to the deploying corporation. Consequently the platform and its owner have no taxable events in any jurisdiction and remain exempt from direct, indirect, or theoretical taxes. This neutrality holds globally—United States, Canada, the European Union, and beyond—because the infrastructure never realises income or disposes of assets. The dedicated [`TaxPolicy`](../contracts/v2/TaxPolicy.sol) contract anchors this principle on‑chain by storing both a canonical policy URI **and** a human‑readable acknowledgement string—each controlled solely by the owner—so non‑technical users can confirm the disclaimer through explorers like Etherscan. Call `policyDetails` to fetch both fields at once, `acknowledgement` (or `acknowledge`) and `policyURI` individually on the `TaxPolicy` contract, or `taxPolicyDetails` on `JobRegistry`. `policyVersion` reveals the current version and `bumpPolicyVersion` increments it without altering text. `isTaxExempt()` on both contracts returns `true` for additional assurance. Only the owner can update these values via `setPolicyURI`, `setAcknowledgement`, `setPolicy`, or `bumpPolicyVersion`; unauthorized calls revert.
 All other core modules—`StakeManager`, `ValidationModule`, `ReputationEngine`, `DisputeModule`, and `CertificateNFT`—likewise expose `isTaxExempt()` helpers so explorers can verify that neither those contracts nor the owner can ever accrue tax liability.
 
-`JobRegistry` maintains an incrementing `taxPolicyVersion` and records the last acknowledged version per address in `taxAcknowledgedVersion`. `TaxPolicy.policyVersion` exposes the canonical version number. Any update or explicit version bump by the owner requires employers, agents, and validators to call `acknowledgeTaxPolicy` again before interacting, keeping the tax disclaimer evergreen while the platform itself remains tax‑exempt.
+`TaxPolicy` records acknowledgement state per address and exposes `hasAcknowledged(address)` alongside the canonical `policyVersion`. Any update or explicit version bump by the owner requires employers, agents, and validators to call `acknowledgeTaxPolicy` again before interacting, keeping the tax disclaimer evergreen while the platform itself remains tax‑exempt. Modules enforce this requirement with the `requiresTaxAcknowledgement` modifier from [`libraries/TaxAcknowledgement.sol`](../contracts/v2/libraries/TaxAcknowledgement.sol):
+
+```solidity
+function createJob(uint256 reward, string memory uri)
+    external
+    requiresTaxAcknowledgement(
+        taxPolicy,
+        msg.sender,
+        owner(),
+        address(disputeModule),
+        address(stakeManager)
+    )
+{
+    // job creation logic
+}
+```
 
 ### Etherscan steps
 
 1. Open the `JobRegistry` address on Etherscan.
-2. Under **Read Contract**, call `taxPolicyDetails` to view the current policy text and URI and check `taxPolicyVersion` against `TaxPolicy.policyVersion`.
+2. Under **Read Contract**, call `taxPolicyDetails` to view the current policy text and URI and check `TaxPolicy.policyVersion`.
 3. Switch to **Write Contract** and call `acknowledgeTaxPolicy` to accept the active version. The transaction emits `TaxAcknowledged(user, version, acknowledgement)` containing the disclaimer text.
-4. Back under **Read Contract**, verify `isTaxExempt` returns `true` and that `taxAcknowledgedVersion(address)` matches `taxPolicyVersion`.
-5. Owners can update the text or URI via `setPolicyURI`, `setAcknowledgement`, `setPolicy`, or `bumpPolicyVersion` on `TaxPolicy`, then enforce a new acknowledgement by calling `bumpTaxPolicyVersion` on `JobRegistry`.
+4. Back under **Read Contract**, verify `isTaxExempt` returns `true` and call `TaxPolicy.hasAcknowledged(address)` to confirm acknowledgement.
+5. Owners can update the text or URI via `setPolicyURI`, `setAcknowledgement`, `setPolicy`, or `bumpPolicyVersion` on `TaxPolicy` to force participants to re‑acknowledge.
 
 ## Employers
 - Provide the token escrow that funds jobs.


### PR DESCRIPTION
## Summary
- document TaxPolicy.hasAcknowledged(address) instead of JobRegistry.taxAcknowledgedVersion
- show how modules invoke `requiresTaxAcknowledgement`
- remove outdated JobRegistry mapping references

## Testing
- `npx eslint .`
- `npx hardhat test --no-compile test/v2/TaxPolicyIntegration.test.js` *(fails: HH700 artifact not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad223cc29c8333a542721f6cbdd34b