### PR TITLE
Require moderator approval for disputes

### DIFF
--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -199,10 +199,8 @@ contract DisputeModule is Ownable {
         require(block.timestamp >= d.raisedAt + disputeWindow, "window");
         IJobRegistry.Job memory job = jobRegistry.jobs(jobId);
 
-        if (msg.sender != owner()) {
-            uint256 weight = _verifySignatures(jobId, employerWins, signatures);
-            require(weight * 2 > totalModeratorWeight, "insufficient weight");
-        }
+        uint256 weight = _verifySignatures(jobId, employerWins, signatures);
+        require(weight * 2 > totalModeratorWeight, "insufficient weight");
 
         d.resolved = true;
 

--- a/docs/disputes.md
+++ b/docs/disputes.md
@@ -1,0 +1,7 @@
+# Disputes
+
+All disputes require approval from a majority of registered moderators.
+Callers of `DisputeModule.resolve` must submit signatures from moderators
+whose combined weight exceeds 50% of the total moderator weight. The
+contract owner has no shortcut and must also collect sufficient
+moderator approval before finalizing a dispute.

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -151,8 +151,13 @@ describe("DisputeModule", function () {
 
     it("reverts resolution attempted before window", async () => {
       await registry.connect(agent).dispute(1, "evidence");
+      const hash = ethers.solidityPackedKeccak256(
+        ["address", "uint256", "bool"],
+        [await dispute.getAddress(), 1, true]
+      );
+      const sig = await owner.signMessage(ethers.getBytes(hash));
       await expect(
-        dispute.connect(owner).resolve(1, true, [])
+        dispute.connect(owner).resolve(1, true, [sig])
       ).to.be.revertedWith("window");
     });
 
@@ -163,7 +168,12 @@ describe("DisputeModule", function () {
         await token.balanceOf(await stakeManager.getAddress())
       ).to.equal(fee);
       await time.increase(window);
-      await expect(dispute.connect(owner).resolve(1, true, []))
+      const hash = ethers.solidityPackedKeccak256(
+        ["address", "uint256", "bool"],
+        [await dispute.getAddress(), 1, true]
+      );
+      const sig = await owner.signMessage(ethers.getBytes(hash));
+      await expect(dispute.connect(owner).resolve(1, true, [sig]))
         .to.emit(dispute, "DisputeResolved")
         .withArgs(1, owner.address, true);
       expect(await token.balanceOf(employer.address)).to.equal(
@@ -178,7 +188,12 @@ describe("DisputeModule", function () {
       const agentStart = await token.balanceOf(agent.address);
       await registry.connect(agent).dispute(1, "evidence");
       await time.increase(window);
-      await expect(dispute.connect(owner).resolve(1, false, []))
+      const hash = ethers.solidityPackedKeccak256(
+        ["address", "uint256", "bool"],
+        [await dispute.getAddress(), 1, false]
+      );
+      const sig = await owner.signMessage(ethers.getBytes(hash));
+      await expect(dispute.connect(owner).resolve(1, false, [sig]))
         .to.emit(dispute, "DisputeResolved")
         .withArgs(1, owner.address, false);
       expect(await token.balanceOf(agent.address)).to.equal(agentStart);
@@ -187,14 +202,19 @@ describe("DisputeModule", function () {
       ).to.equal(0);
     });
 
-    it("allows owner to resolve even if not moderator", async () => {
+    it("prevents owner resolution without moderator approval", async () => {
       await dispute.connect(owner).removeModerator(owner.address);
       expect(await dispute.moderatorWeights(owner.address)).to.equal(0n);
       await registry.connect(agent).dispute(1, "evidence");
       await time.increase(window);
-      await expect(dispute.connect(owner).resolve(1, true, []))
-        .to.emit(dispute, "DisputeResolved")
-        .withArgs(1, owner.address, true);
+      const hash = ethers.solidityPackedKeccak256(
+        ["address", "uint256", "bool"],
+        [await dispute.getAddress(), 1, true]
+      );
+      const sig = await owner.signMessage(ethers.getBytes(hash));
+      await expect(
+        dispute.connect(owner).resolve(1, true, [sig])
+      ).to.be.revertedWith("insufficient weight");
     });
 
     it("requires majority signatures for non-owner resolution", async () => {

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -139,7 +139,12 @@ describe("job lifecycle with dispute and validator failure", function () {
     expect(await registry.jobs(1)).to.have.property("state", 5); // Disputed
 
     await registry.connect(agent).dispute(1, "evidence");
-    await dispute.connect(owner).resolve(1, false, []);
+    const hash = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "bool"],
+      [await dispute.getAddress(), 1, false]
+    );
+    const sig = await owner.signMessage(ethers.getBytes(hash));
+    await dispute.connect(owner).resolve(1, false, [sig]);
 
     expect(await registry.jobs(1)).to.have.property("state", 6); // Finalized
     expect(await token.balanceOf(agent.address)).to.be.gt(initialAgentBalance);


### PR DESCRIPTION
## Summary
- remove owner-only bypass from `DisputeModule.resolve`
- update dispute tests to use moderator signatures
- document that resolving disputes always needs moderator approval

## Testing
- ⚠️ `npm test test/v2/DisputeModule.test.js test/v2/DisputeModuleModuleNoEther.test.js test/v2/jobLifecycleWithDispute.integration.test.ts` (compilation did not complete)


------
https://chatgpt.com/codex/tasks/task_e_68ad2b07c7688333b454228d530f9cf3