### PR TITLE
Store dispute evidence hash

### DIFF
--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -4,7 +4,12 @@ pragma solidity ^0.8.25;
 /// @title IDisputeModule
 /// @notice Interface for raising and resolving disputes with moderator voting.
 interface IDisputeModule {
-    event DisputeRaised(uint256 indexed jobId, address indexed claimant);
+    event DisputeRaised(
+        uint256 indexed jobId,
+        address indexed claimant,
+        bytes32 indexed evidenceHash,
+        string evidence
+    );
     event DisputeResolved(uint256 indexed jobId, bool employerWins);
     event ModeratorAdded(address moderator);
     event ModeratorRemoved(address moderator);

--- a/docs/api/DisputeModule.md
+++ b/docs/api/DisputeModule.md
@@ -12,7 +12,7 @@ case.
 - `resolve(uint256 jobId, bool employerWins)` – moderators vote; majority decides.
 
 ## Events
-- `DisputeRaised(uint256 indexed jobId, address indexed claimant)`
+- `DisputeRaised(uint256 indexed jobId, address indexed claimant, bytes32 indexed evidenceHash, string evidence)`
 - `DisputeResolved(uint256 indexed jobId, bool employerWins)`
 - `ModeratorAdded(address indexed moderator)`
 - `ModeratorRemoved(address indexed moderator)`

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -192,7 +192,7 @@ To generate proofs:
 | `JobApplied(uint256 jobId, address agent)` | `JobRegistry` | Agent applied for a job. |
 | `ValidationCommitted(uint256 jobId, address validator)` | `ValidationModule` | Validator submitted hashed vote. |
 | `ValidationRevealed(uint256 jobId, address validator, bool approve)` | `ValidationModule` | Validator revealed vote. |
-| `DisputeRaised(uint256 jobId)` | `DisputeModule` | A job result was contested. |
+| `DisputeRaised(uint256 jobId, address claimant, bytes32 evidenceHash, string evidence)` | `DisputeModule` | A job result was contested. |
 | `DisputeResolved(uint256 jobId, bool employerWins)` | `DisputeModule` | Moderator issued final ruling. |
 | `CertificateMinted(address to, uint256 jobId)` | `CertificateNFT` | NFT minted for a completed job. |
 

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -137,7 +137,7 @@ describe("DisputeModule", function () {
         registry.connect(agent).dispute(1, "evidence")
       )
         .to.emit(dispute, "DisputeRaised")
-        .withArgs(1, agent.address);
+        .withArgs(1, agent.address, ethers.id("evidence"), "evidence");
       await expect(
         registry.connect(agent).dispute(1, "more")
       ).to.be.revertedWith("disputed");


### PR DESCRIPTION
## Summary
- Track disputes with a hashed evidence string instead of storing the full text
- Emit full evidence details when a dispute is raised
- Adjust tests and docs for updated `DisputeRaised` event

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad305499fc83338b7d53ed66b54958