### PR TITLE
Allow public job expiration handling

### DIFF
--- a/docs/job-lifecycle.md
+++ b/docs/job-lifecycle.md
@@ -1,0 +1,5 @@
+# Job Lifecycle
+
+## Expiration Handling
+
+When an assigned job misses its deadline without submission, anyone may call `cancelExpiredJob` to finalize the job. The caller does not need to be the employer, agent, or a tax policy acknowledger—**any address can trigger expiration handling** once the deadline has passed.


### PR DESCRIPTION
## Summary
- Drop tax acknowledgement requirement for `cancelExpiredJob`
- Extract internal `_finalize` and gate cancellation by `onlyAfterDeadline`
- Document that any address may trigger job expiration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb91775d88333a9e9489072316335