### PR TITLE
feat: add kleros dispute module

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -305,6 +305,15 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement {
         emit ModuleUpdated("IdentityRegistry", address(registry));
     }
 
+    /// @notice Switch the active dispute module.
+    /// @param module Address of the new dispute module contract.
+    function setDisputeModule(IDisputeModule module) external onlyGovernance {
+        require(address(module) != address(0), "dispute");
+        disputeModule = module;
+        emit DisputeModuleUpdated(address(module));
+        emit ModuleUpdated("DisputeModule", address(module));
+    }
+
     /// @notice Update the ENS root node used for agent verification.
     /// @param node Namehash of the agent parent node (e.g. `agent.agi.eth`).
     function setAgentRootNode(bytes32 node) external onlyGovernance {

--- a/contracts/v2/mocks/MockArbitrator.sol
+++ b/contracts/v2/mocks/MockArbitrator.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title MockArbitrator
+/// @notice Simplified external arbitration service used for testing
+/// KlerosDisputeModule. It records dispute requests and allows the test to
+/// deliver rulings which call back into the dispute module.
+contract MockArbitrator {
+    address public disputeModule;
+    uint256 public lastJobId;
+    address public lastClaimant;
+    bytes32 public lastEvidence;
+
+    event ArbitrationRequested(uint256 indexed jobId, address indexed claimant, bytes32 evidenceHash);
+
+    function setDisputeModule(address module) external {
+        disputeModule = module;
+    }
+
+    function createDispute(uint256 jobId, address claimant, bytes32 evidenceHash) external returns (uint256) {
+        lastJobId = jobId;
+        lastClaimant = claimant;
+        lastEvidence = evidenceHash;
+        emit ArbitrationRequested(jobId, claimant, evidenceHash);
+        return jobId;
+    }
+
+    function deliverResult(uint256 jobId, bool employerWins) external {
+        IKlerosModule(disputeModule).resolve(jobId, employerWins);
+    }
+}
+
+interface IKlerosModule {
+    function resolve(uint256 jobId, bool employerWins) external;
+}

--- a/contracts/v2/modules/KlerosDisputeModule.sol
+++ b/contracts/v2/modules/KlerosDisputeModule.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IJobRegistry} from "../interfaces/IJobRegistry.sol";
+import {IDisputeModule} from "../interfaces/IDisputeModule.sol";
+
+/// @title KlerosDisputeModule
+/// @notice Minimal dispute module that forwards disputes to an external
+/// arbitration service such as Kleros. The arbitrator is expected to call back
+/// with the final ruling via {resolve}.
+contract KlerosDisputeModule is IDisputeModule {
+    /// @notice Address with permission to update module settings.
+    address public governance;
+
+    /// @notice Job registry that created disputes originate from.
+    IJobRegistry public immutable jobRegistry;
+
+    /// @notice External arbitration service responsible for resolving disputes.
+    address public arbitrator;
+
+    /// @dev Restrict functions to governance.
+    modifier onlyGovernance() {
+        require(msg.sender == governance, "only governance");
+        _;
+    }
+
+    /// @dev Restrict functions to the associated JobRegistry.
+    modifier onlyJobRegistry() {
+        require(msg.sender == address(jobRegistry), "only registry");
+        _;
+    }
+
+    /// @dev Restrict functions to the external arbitrator.
+    modifier onlyArbitrator() {
+        require(msg.sender == arbitrator, "only arbitrator");
+        _;
+    }
+
+    /// @param _jobRegistry Address of the JobRegistry using this module.
+    /// @param _arbitrator Address of the external arbitration service.
+    /// @param _governance Address allowed to update governance settings.
+    constructor(
+        IJobRegistry _jobRegistry,
+        address _arbitrator,
+        address _governance
+    ) {
+        jobRegistry = _jobRegistry;
+        arbitrator = _arbitrator;
+        governance = _governance;
+    }
+
+    /// @notice Update governance address.
+    function setGovernance(address _governance) external override onlyGovernance {
+        governance = _governance;
+        emit GovernanceUpdated(_governance);
+    }
+
+    /// @notice Update the arbitration service address.
+    function setArbitrator(address _arbitrator) external onlyGovernance {
+        arbitrator = _arbitrator;
+    }
+
+    /// @inheritdoc IDisputeModule
+    function raiseDispute(
+        uint256 jobId,
+        address claimant,
+        bytes32 evidenceHash
+    ) external override onlyJobRegistry {
+        require(evidenceHash != bytes32(0), "evidence");
+        if (arbitrator != address(0)) {
+            IArbitrationService(arbitrator).createDispute(jobId, claimant, evidenceHash);
+        }
+        emit DisputeRaised(jobId, claimant, evidenceHash);
+    }
+
+    /// @inheritdoc IDisputeModule
+    function resolve(uint256 jobId, bool employerWins)
+        external
+        override
+        onlyArbitrator
+    {
+        jobRegistry.resolveDispute(jobId, employerWins);
+        emit DisputeResolved(jobId, employerWins);
+    }
+
+    // ---------------------------------------------------------------------
+    // Unused legacy interfaces - maintained for compatibility
+    // ---------------------------------------------------------------------
+
+    function addModerator(address) external pure override {
+        revert("unsupported");
+    }
+
+    function removeModerator(address) external pure override {
+        revert("unsupported");
+    }
+
+    function setQuorum(uint256) external pure override {
+        revert("unsupported");
+    }
+
+    function getModerators() external pure override returns (address[] memory) {
+        return new address[](0);
+    }
+}
+
+/// @dev External arbitration interface expected by the module.
+interface IArbitrationService {
+    function createDispute(
+        uint256 jobId,
+        address claimant,
+        bytes32 evidenceHash
+    ) external returns (uint256);
+}

--- a/docs/disputes.md
+++ b/docs/disputes.md
@@ -1,7 +1,14 @@
 # Disputes
 
-All disputes require approval from a majority of registered moderators.
-Callers of `DisputeModule.resolve` must submit signatures from moderators
-whose combined weight exceeds 50% of the total moderator weight. The
-contract owner has no shortcut and must also collect sufficient
-moderator approval before finalizing a dispute.
+Jobs may be contested by either the employer or the agent. The
+`JobRegistry` forwards disputes to whichever `IDisputeModule` is
+currently active. The default moderator-driven module requires majority
+approval from a set of trusted moderators before a dispute can be
+resolved.
+
+For external arbitration the project includes `KlerosDisputeModule`.
+Governance can deploy this contract and activate it via
+`JobRegistry.setDisputeModule`. It relays disputes to an off-chain
+arbitration service such as Kleros and expects the arbitrator to call
+back with the final ruling. Once a ruling is returned the job is
+finalised and escrowed funds are distributed according to the decision.

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -1,0 +1,193 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+enum Role {
+  Agent,
+  Validator,
+  Platform,
+}
+
+async function deploySystem() {
+  const [owner, employer, agent, v1, v2, arbitratorSigner] =
+    await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory(
+    "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+  );
+  const token = await Token.deploy();
+  const mint = ethers.parseUnits("1000", 6);
+  for (const s of [employer, agent, v1, v2]) {
+    await token.mint(s.address, mint);
+  }
+
+  const Stake = await ethers.getContractFactory(
+    "contracts/v2/StakeManager.sol:StakeManager"
+  );
+  const stake = await Stake.deploy(
+    await token.getAddress(),
+    0,
+    0,
+    0,
+    owner.address,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    owner.address
+  );
+
+  const Reputation = await ethers.getContractFactory(
+    "contracts/v2/ReputationEngine.sol:ReputationEngine"
+  );
+  const reputation = await Reputation.deploy(await stake.getAddress());
+
+  const Identity = await ethers.getContractFactory(
+    "contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle"
+  );
+  const identity = await Identity.deploy();
+  await identity.setResult(true);
+
+  const Validation = await ethers.getContractFactory(
+    "contracts/v2/ValidationModule.sol:ValidationModule"
+  );
+  const validation = await Validation.deploy(
+    ethers.ZeroAddress,
+    await stake.getAddress(),
+    1,
+    1,
+    1,
+    5,
+    []
+  );
+
+  const NFT = await ethers.getContractFactory(
+    "contracts/v2/CertificateNFT.sol:CertificateNFT"
+  );
+  const nft = await NFT.deploy("Cert", "CERT");
+
+  const Registry = await ethers.getContractFactory(
+    "contracts/v2/JobRegistry.sol:JobRegistry"
+  );
+  const registry = await Registry.deploy(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    ethers.ZeroAddress,
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    0,
+    0,
+    [],
+    owner.address
+  );
+
+  const MockArb = await ethers.getContractFactory(
+    "contracts/v2/mocks/MockArbitrator.sol:MockArbitrator"
+  );
+  const mockArb = await MockArb.deploy();
+
+  const Kleros = await ethers.getContractFactory(
+    "contracts/v2/modules/KlerosDisputeModule.sol:KlerosDisputeModule"
+  );
+  const kleros = await Kleros.deploy(
+    await registry.getAddress(),
+    await mockArb.getAddress(),
+    owner.address
+  );
+  await mockArb.setDisputeModule(await kleros.getAddress());
+
+  await stake.setModules(await registry.getAddress(), await kleros.getAddress());
+  await validation.setJobRegistry(await registry.getAddress());
+  await validation.setIdentityRegistry(await identity.getAddress());
+  await validation.setValidatorPool([v1.address, v2.address]);
+  await validation.setValidatorsPerJob(2);
+  await registry.setModules(
+    await validation.getAddress(),
+    await stake.getAddress(),
+    await reputation.getAddress(),
+    await kleros.getAddress(),
+    await nft.getAddress(),
+    ethers.ZeroAddress,
+    []
+  );
+  await reputation.setCaller(await registry.getAddress(), true);
+
+  return {
+    owner,
+    employer,
+    agent,
+    v1,
+    v2,
+    token,
+    stake,
+    validation,
+    registry,
+    kleros,
+    mockArb,
+  };
+}
+
+describe("Kleros dispute module", function () {
+  it("handles dispute and external arbitration", async () => {
+    const env = await deploySystem();
+    const { employer, agent, v1, v2, token, stake, validation, registry, mockArb } =
+      env;
+
+    const stakeAmount = ethers.parseUnits("1", 6);
+    for (const signer of [agent, v1, v2]) {
+      await token.connect(signer).approve(await stake.getAddress(), stakeAmount);
+      const role = signer === agent ? Role.Agent : Role.Validator;
+      await stake.connect(signer).depositStake(role, stakeAmount);
+    }
+    const initialAgentBalance = await token.balanceOf(agent.address);
+
+    const reward = ethers.parseUnits("100", 6);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline = BigInt((await time.latest()) + 3600);
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, "ipfs://job");
+
+    await registry.connect(agent).applyForJob(1, "agent", []);
+    await registry
+      .connect(agent)
+      .submit(1, ethers.id("ipfs://result"), "ipfs://result", "agent", []);
+
+    const nonce = await validation.jobNonce(1);
+    const salt1 = ethers.randomBytes(32);
+    const commit1 = ethers.keccak256(
+      ethers.solidityPacked(
+        ["uint256", "uint256", "bool", "bytes32"],
+        [1n, nonce, true, salt1]
+      )
+    );
+    await validation.connect(v1).commitValidation(1, commit1);
+    const salt2 = ethers.randomBytes(32);
+    const commit2 = ethers.keccak256(
+      ethers.solidityPacked(
+        ["uint256", "uint256", "bool", "bytes32"],
+        [1n, nonce, false, salt2]
+      )
+    );
+    await validation.connect(v2).commitValidation(1, commit2);
+
+    await time.increase(2);
+    await validation.connect(v1).revealValidation(1, true, salt1);
+    // v2 fails to reveal
+    await time.increase(2);
+    await validation.finalize(1);
+
+    expect((await stake.stakes(v2.address, Role.Validator))).to.be.lt(
+      stakeAmount
+    );
+    expect(await registry.jobs(1)).to.have.property("state", 5); // Disputed
+
+    await registry.connect(agent).dispute(1, ethers.id("evidence"));
+    expect(await mockArb.lastJobId()).to.equal(1n);
+
+    await mockArb.deliverResult(1, false); // agent wins
+
+    expect(await registry.jobs(1)).to.have.property("state", 6); // Finalized
+    expect(await token.balanceOf(agent.address)).to.be.gt(initialAgentBalance);
+  });
+});


### PR DESCRIPTION
## Summary
- implement KlerosDisputeModule to route disputes to external arbitrator
- allow governance to swap dispute modules and document arbitration flow
- add integration test for Kleros-based dispute resolution

## Testing
- `npm test`
- `npm run lint` *(fails: 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68adccd2bf508333bbf19cffbad7febc