### PR TITLE
feat: add pausable controls

### DIFF
--- a/test/v2/JobRegistryPause.test.js
+++ b/test/v2/JobRegistryPause.test.js
@@ -1,0 +1,55 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("JobRegistry pause", function () {
+  let owner, employer, agent, registry, identity;
+
+  beforeEach(async () => {
+    [owner, employer, agent] = await ethers.getSigners();
+    const Identity = await ethers.getContractFactory(
+      "contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock"
+    );
+    identity = await Identity.deploy();
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Registry.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    await registry.connect(owner).setIdentityRegistry(await identity.getAddress());
+    await registry.connect(owner).setJobParameters(0, 0);
+  });
+
+  it("pauses job creation and applications", async () => {
+    const deadline = (await time.latest()) + 100;
+
+    await registry.connect(owner).pause();
+    await expect(
+      registry.connect(employer).createJob(1, deadline, "uri")
+    ).to.be.revertedWithCustomError(registry, "EnforcedPause");
+
+    await registry.connect(owner).unpause();
+    await registry.connect(employer).createJob(1, deadline, "uri");
+
+    await registry.connect(owner).pause();
+    await expect(
+      registry.connect(agent).applyForJob(1, "", [])
+    ).to.be.revertedWithCustomError(registry, "EnforcedPause");
+
+    await registry.connect(owner).unpause();
+    await expect(registry.connect(agent).applyForJob(1, "", []))
+      .to.emit(registry, "JobApplied")
+      .withArgs(1, agent.address);
+  });
+});

--- a/test/v2/StakeManagerPause.test.js
+++ b/test/v2/StakeManagerPause.test.js
@@ -1,0 +1,50 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("StakeManager pause", function () {
+  let owner, user, token, stakeManager;
+
+  beforeEach(async () => {
+    [owner, user] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockERC206Decimals");
+    token = await Token.deploy();
+    const MockRegistry = await ethers.getContractFactory(
+      "contracts/legacy/MockV2.sol:MockJobRegistry"
+    );
+    const mockReg = await MockRegistry.deploy();
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      0,
+      100,
+      0,
+      owner.address,
+      await mockReg.getAddress(),
+      ethers.ZeroAddress,
+      owner.address
+    );
+    await stakeManager.connect(owner).setMinStake(0);
+    await token.mint(user.address, 1000);
+    await token.connect(user).approve(await stakeManager.getAddress(), 1000);
+  });
+
+  it("pauses deposits and withdrawals", async () => {
+    await stakeManager.connect(owner).pause();
+    await expect(
+      stakeManager.connect(user).depositStake(0, 100)
+    ).to.be.revertedWithCustomError(stakeManager, "EnforcedPause");
+
+    await stakeManager.connect(owner).unpause();
+    await stakeManager.connect(user).depositStake(0, 100);
+
+    await stakeManager.connect(owner).pause();
+    await expect(
+      stakeManager.connect(user).withdrawStake(0, 100)
+    ).to.be.revertedWithCustomError(stakeManager, "EnforcedPause");
+
+    await stakeManager.connect(owner).unpause();
+    await stakeManager.connect(user).withdrawStake(0, 100);
+  });
+});

--- a/test/v2/ValidationModulePause.test.js
+++ b/test/v2/ValidationModulePause.test.js
@@ -1,0 +1,44 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ValidationModule pause", function () {
+  let owner, validator, validation;
+
+  beforeEach(async () => {
+    [owner, validator] = await ethers.getSigners();
+    const MockStakeManager = await ethers.getContractFactory(
+      "contracts/legacy/MockV2.sol:MockStakeManager"
+    );
+    const stakeManager = await MockStakeManager.deploy();
+    await stakeManager.setStake(validator.address, 1, 100);
+    const Identity = await ethers.getContractFactory(
+      "contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock"
+    );
+    const identity = await Identity.deploy();
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/ValidationModule.sol:ValidationModule"
+    );
+    validation = await Validation.deploy(
+      ethers.ZeroAddress,
+      await stakeManager.getAddress(),
+      0,
+      0,
+      1,
+      1,
+      [validator.address]
+    );
+    await validation.setIdentityRegistry(await identity.getAddress());
+  });
+
+  it("pauses validator selection", async () => {
+    await validation.connect(owner).pause();
+    await expect(validation.selectValidators(1)).to.be.revertedWithCustomError(
+      validation,
+      "EnforcedPause"
+    );
+    await validation.connect(owner).unpause();
+    const selected = await validation.selectValidators.staticCall(1);
+    expect(selected.length).to.equal(1);
+    expect(selected[0]).to.equal(validator.address);
+  });
+});


### PR DESCRIPTION
## Summary
- add OpenZeppelin Pausable to JobRegistry, StakeManager, and ValidationModule
- guard critical state-changing functions with `whenNotPaused`
- cover pause/unpause flows with new tests

## Testing
- `npx hardhat test test/v2/JobRegistryPause.test.js`
- `npx hardhat test test/v2/StakeManagerPause.test.js`
- `npx hardhat test test/v2/ValidationModulePause.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68add813eed8833390a6ac79fa74bb76