### PR TITLE
Integrate VRF-based randomness into validator selection

### DIFF
--- a/contracts/v2/mocks/VRFMock.sol
+++ b/contracts/v2/mocks/VRFMock.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IVRF} from "../interfaces/IVRF.sol";
+
+/// @notice Minimal VRF mock used for testing randomness flows.
+contract VRFMock is IVRF {
+    uint256 public nextRequestId = 1;
+    mapping(uint256 => address) public consumers;
+    bool public fail;
+
+    function setFail(bool value) external {
+        fail = value;
+    }
+
+    function requestRandomWords() external override returns (uint256 requestId) {
+        require(!fail, "fail");
+        requestId = nextRequestId++;
+        consumers[requestId] = msg.sender;
+    }
+
+    function fulfill(uint256 requestId, uint256 randomness) external {
+        address consumer = consumers[requestId];
+        require(consumer != address(0), "unknown request");
+        (bool ok, ) = consumer.call(
+            abi.encodeWithSignature(
+                "fulfillRandomWords(uint256,uint256)",
+                requestId,
+                randomness
+            )
+        );
+        require(ok, "callback failed");
+    }
+}


### PR DESCRIPTION
## Summary
- add VRF request tracking and callback handling in `ValidationModule`
- derive validator selection seed from VRF with blockhash fallback
- include mock VRF and tests covering fulfillment and failure cases

## Testing
- `npx hardhat test test/v2/ValidatorSelectionDeterministic.test.js test/v2/ValidatorSelectionVRF.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68addf48b2448333ac071481bbfcbe3c