### PR TITLE
chore: strengthen validator selection randomness

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -889,10 +889,18 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         emit JobNonceReset(jobId);
     }
 
+    /// @dev Generates a pseudo-random seed using job context and block entropy.
+    /// Incorporates `block.prevrandao` and the previous block hash to make
+    /// validator selection harder to predict in absence of VRF.
     function _fallbackSeed(uint256 jobId) internal view returns (uint256) {
         return uint256(
             keccak256(
-                abi.encodePacked(jobId, jobNonce[jobId], blockhash(block.number - 1))
+                abi.encodePacked(
+                    jobId,
+                    jobNonce[jobId],
+                    block.prevrandao,
+                    blockhash(block.number - 1)
+                )
             )
         );
     }


### PR DESCRIPTION
## Summary
- Improve fallback randomness in ValidationModule by mixing block prevrandao with previous block hash and job context
- Document entropy sources for validator selection

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ae0d35cbd483338e7056c6b5dc3c68