### PR TITLE
Optimize validator and payout loops for gas efficiency

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -417,7 +417,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     function getAgentPayoutPct(address agent) public view returns (uint256) {
         uint256 highest = 100;
         uint256 length = agiTypes.length;
-        for (uint256 i; i < length; ++i) {
+        for (uint256 i; i < length;) {
             AGIType memory t = agiTypes[i];
             try IERC721(t.nft).balanceOf(agent) returns (uint256 bal) {
                 if (bal > 0 && t.payoutPct > highest) {
@@ -425,6 +425,9 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
                 }
             } catch {
                 // ignore tokens with failing balanceOf
+            }
+            unchecked {
+                ++i;
             }
         }
         return highest;

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -309,9 +309,12 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         string[] calldata subdomains
     ) external onlyOwner {
         require(accounts.length == subdomains.length, "length");
-        for (uint256 i; i < accounts.length; ++i) {
+        for (uint256 i; i < accounts.length;) {
             validatorSubdomains[accounts[i]] = subdomains[i];
             emit ValidatorSubdomainUpdated(accounts[i], subdomains[i]);
+            unchecked {
+                ++i;
+            }
         }
     }
 
@@ -877,12 +880,15 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         );
         uint256 nonce = jobNonce[jobId];
         address[] storage vals = rounds[jobId].validators;
-        for (uint256 i; i < vals.length; ++i) {
+        for (uint256 i; i < vals.length;) {
             address val = vals[i];
             delete commitments[jobId][val][nonce];
             delete revealed[jobId][val];
             delete votes[jobId][val];
             delete validatorStakes[jobId][val];
+            unchecked {
+                ++i;
+            }
         }
         delete rounds[jobId];
         delete jobNonce[jobId];
@@ -907,8 +913,11 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
 
     function _isValidator(uint256 jobId, address val) internal view returns (bool) {
         address[] storage list = rounds[jobId].validators;
-        for (uint256 i; i < list.length; ++i) {
+        for (uint256 i; i < list.length;) {
             if (list[i] == val) return true;
+            unchecked {
+                ++i;
+            }
         }
         return false;
     }


### PR DESCRIPTION
## Summary
- use unchecked increments in ValidationModule's validator management loops
- apply unchecked increment in StakeManager's payout loop for AGI type NFTs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1fbb53908333bd8702e729c1c416