### PR TITLE
feat: prevent job expiration when registry paused

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1161,6 +1161,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     function cancelExpiredJob(uint256 jobId)
         public
         onlyAfterDeadline(jobId)
+        whenNotPaused
         nonReentrant
     {
         Job storage job = jobs[jobId];


### PR DESCRIPTION
## Summary
- add `whenNotPaused` modifier to `cancelExpiredJob`
- test that paused registry blocks job expiration

## Testing
- `npx hardhat test test/v2/JobRegistryPause.test.js`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ae255234508333a4da659a3f7a9711