### PR TITLE
feat: validate slashing recipient

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -954,6 +954,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         }
 
         if (employerShare > 0) {
+            require(recipient != address(0), "recipient");
             if (recipient == address(feePool) && address(feePool) != address(0)) {
                 token.safeTransfer(address(feePool), employerShare);
                 feePool.depositFee(employerShare);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -29,7 +29,7 @@ Holds token deposits for agents, validators and dispute fees.
 - `withdrawStake(uint8 role, uint256 amount)` – Withdraw available stake.
 - `acknowledgeAndDeposit(uint8 role, uint256 amount)` – Deposit after acknowledging the tax policy.
 - `acknowledgeAndWithdraw(uint8 role, uint256 amount)` – Withdraw after acknowledging the tax policy.
-- `slash(address user, uint256 amount, address recipient)` – Governance‑only slashing mechanism.
+- `slash(address user, uint256 amount, address recipient)` – Governance‑only slashing mechanism. Fails if `recipient` is the zero address when the employer share is non‑zero.
 
 ### Example
 ```solidity

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -11,7 +11,7 @@ Handles staking, escrow and slashing of the $AGIALPHA token.
 - `withdrawStake(uint8 role, uint256 amount)` – withdraw previously staked tokens.
 - `lock(address from, uint256 amount)` / `release(address to, uint256 amount)` – JobRegistry hooks for job rewards.
 - `lockDisputeFee(address payer, uint256 amount)` / `payDisputeFee(address to, uint256 amount)` – escrow dispute fees.
-- `slash(address user, uint256 amount, address recipient)` – owner slashes stake and sends to recipient.
+- `slash(address user, uint256 amount, address recipient)` – owner slashes stake and sends to recipient. Reverts if `recipient` is the zero address and the employer share is non‑zero.
 - `stakeOf(address user, uint8 role)` / `totalStake(uint8 role)` – view functions.
 
 ## Events

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -148,7 +148,7 @@ interface IStakeManager {
     function depositStake(Role role, uint256 amount) external;
     function withdrawStake(Role role, uint256 amount) external;
     function lockStake(address user, Role role, uint256 payout) external;
-    function slash(address user, Role role, uint256 payout, address employer) external;
+    function slash(address user, Role role, uint256 payout, address employer) external; // `employer` must not be zero when employer share > 0
     function setToken(address token) external;
     function setMinStake(uint256 minStake) external;
     function setSlashingPercentages(

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -189,7 +189,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 | --- | --- | --- |
 | `depositStake(uint8 role, uint256 amount)` | `role` – 0 Agent, 1 Validator, 2 Platform; `amount` – tokens | Participants bond tokens for their role. |
 | `setToken(address newToken)` | `newToken` – ERC‑20 address | Owner switches the staking and reward token. |
-| `slash(address offender, address beneficiary, uint256 amount)` | offending address, beneficiary address, amount | Owner penalises misbehaviour and redirects stake. |
+| `slash(address offender, address beneficiary, uint256 amount)` | offending address, beneficiary address, amount | Owner penalises misbehaviour and redirects stake. Beneficiary cannot be the zero address if an employer share is due. |
 
 ### ValidationModule
 | Function | Parameters | Typical Use Case |

--- a/docs/modular-architecture-v2.md
+++ b/docs/modular-architecture-v2.md
@@ -60,7 +60,7 @@ interface IStakeManager {
     function depositStake(uint256 amount) external;
     function lockReward(address from, uint256 amount) external;
     function payReward(address to, uint256 amount) external;
-    function slash(address offender, address beneficiary, uint256 amount) external;
+    function slash(address offender, address beneficiary, uint256 amount) external; // `beneficiary` must not be zero when employer share > 0
     function setToken(address newToken) external;
 }
 

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -46,7 +46,7 @@ interface IStakeManager {
     function depositStake(uint256 amount) external;
     function lockReward(address from, uint256 amount) external;
     function payReward(address to, uint256 amount) external;
-    function slash(address offender, address beneficiary, uint256 amount) external;
+    function slash(address offender, address beneficiary, uint256 amount) external; // `beneficiary` must not be zero when employer share > 0
     function setToken(address newToken) external;
 }
 

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -111,6 +111,17 @@ describe("StakeManager", function () {
     expect(await stakeManager.totalStake(0)).to.equal(50n);
     expect(await token.balanceOf(employer.address)).to.equal(750n);
     expect(await token.balanceOf(treasury.address)).to.equal(50n);
+
+    await expect(
+      stakeManager
+        .connect(registrySigner)
+        ["slash(address,uint8,uint256,address)"](
+          user.address,
+          0,
+          10,
+          ethers.ZeroAddress
+        )
+    ).to.be.revertedWith("recipient");
   });
 
   it("rejects unauthorized slashing and excessive amounts", async () => {


### PR DESCRIPTION
## Summary
- prevent slashing to zero address when employer share is non-zero
- document slashing recipient requirements
- cover recipient validation in unit tests

## Testing
- `npm test`
- `npm run lint`
- `forge test` *(fails: Source `forge-std/Test.sol` not found and constructor argument mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68ae32d594ec83339d51919b1604e67b