### PR TITLE
Add module version checks in JobRegistry

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -14,6 +14,9 @@ import "../v2/interfaces/ITaxPolicy.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract MockStakeManager is IStakeManager {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 1;
+
     mapping(address => mapping(Role => uint256)) private _stakes;
     mapping(Role => uint256) public totalStakes;
     address public disputeModule;
@@ -416,6 +419,9 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
 }
 
 contract MockReputationEngine is IReputationEngine {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 1;
+
     mapping(address => uint256) private _rep;
     mapping(address => bool) private _blacklist;
     uint256 public threshold;

--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -16,6 +16,9 @@ import {ICertificateNFT} from "./interfaces/ICertificateNFT.sol";
 contract CertificateNFT is ERC721, Ownable, ReentrancyGuard, ICertificateNFT {
     using SafeERC20 for IERC20;
 
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 1;
+
     /// @dev Emitted when a zero address is supplied where non-zero is required.
     error ZeroAddress();
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -12,6 +12,7 @@ import {IFeePool} from "./interfaces/IFeePool.sol";
 import {IIdentityRegistry} from "./interfaces/IIdentityRegistry.sol";
 
 interface IReputationEngine {
+    function version() external view returns (uint256);
     function onApply(address user) external;
     function onFinalize(
         address user,
@@ -28,6 +29,7 @@ interface IReputationEngine {
 }
 
 interface IDisputeModule {
+    function version() external view returns (uint256);
     function raiseDispute(
         uint256 jobId,
         address claimant,
@@ -37,6 +39,7 @@ interface IDisputeModule {
 }
 
 interface ICertificateNFT {
+    function version() external view returns (uint256);
     function mint(address to, uint256 jobId, bytes32 uriHash) external returns (uint256);
 }
 
@@ -277,6 +280,12 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         require(address(_reputation) != address(0), "reputation");
         require(address(_dispute) != address(0), "dispute");
         require(address(_certNFT) != address(0), "nft");
+
+        require(_validation.version() == 1, "Invalid validation module");
+        require(_stakeMgr.version() == 1, "Invalid stake manager");
+        require(_reputation.version() == 1, "Invalid reputation module");
+        require(_dispute.version() == 1, "Invalid dispute module");
+        require(_certNFT.version() == 1, "Invalid certificate NFT");
 
         validationModule = _validation;
         stakeManager = _stakeMgr;

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -10,6 +10,9 @@ import {IStakeManager} from "./interfaces/IStakeManager.sol";
 /// @dev Holds no funds and rejects ether so neither the contract nor the
 ///      owner ever custodies assets or incurs tax liabilities.
 contract ReputationEngine is Ownable {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 1;
+
     mapping(address => uint256) public reputation;
     mapping(address => bool) private blacklisted;
     mapping(address => bool) public callers;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -28,6 +28,9 @@ import {IValidationModule} from "./interfaces/IValidationModule.sol";
 contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausable {
     using SafeERC20 for IERC20;
 
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 1;
+
     /// @notice participant roles
     enum Role {
         Agent,

--- a/contracts/v2/interfaces/ICertificateNFT.sol
+++ b/contracts/v2/interfaces/ICertificateNFT.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.25;
 /// @title ICertificateNFT
 /// @notice Interface for minting non-fungible job completion certificates
 interface ICertificateNFT {
+    /// @notice Module version for compatibility checks.
+    function version() external view returns (uint256);
     /// @dev Reverts when caller is not the authorised JobRegistry
     error NotJobRegistry(address caller);
 

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.25;
 /// @title IDisputeModule
 /// @notice Interface for raising and resolving disputes with moderator voting.
 interface IDisputeModule {
+    /// @notice Module version for compatibility checks.
+    function version() external view returns (uint256);
     event DisputeRaised(
         uint256 indexed jobId,
         address indexed claimant,

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.25;
 /// @title IReputationEngine
 /// @notice Interface for tracking and updating participant reputation scores
 interface IReputationEngine {
+    /// @notice Module version for compatibility checks.
+    function version() external view returns (uint256);
     /// @dev Reverts when a caller is not authorised to update reputation
     error UnauthorizedCaller(address caller);
 

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -7,6 +7,8 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /// @title IStakeManager
 /// @notice Interface for staking balances, job escrows and slashing logic
 interface IStakeManager {
+    /// @notice Module version for compatibility checks.
+    function version() external view returns (uint256);
     /// @notice participant roles
     enum Role {
         Agent,

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.25;
 /// @title IValidationModule
 /// @notice Interface for validator selection and commit-reveal voting
 interface IValidationModule {
+    /// @notice Module version for compatibility checks.
+    function version() external view returns (uint256);
     event ValidatorsSelected(uint256 indexed jobId, address[] validators);
     event ValidationCommitted(uint256 indexed jobId, address indexed validator, bytes32 commitHash);
     event ValidationRevealed(uint256 indexed jobId, address indexed validator, bool approve);

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -6,6 +6,9 @@ import {IJobRegistry} from "../interfaces/IJobRegistry.sol";
 
 /// @notice Simple validation module stub returning a preset outcome.
 contract ValidationStub is IValidationModule {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 1;
+
     bool public result;
     address public jobRegistry;
     address[] public validatorList;

--- a/contracts/v2/mocks/VersionMock.sol
+++ b/contracts/v2/mocks/VersionMock.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @notice Minimal contract exposing a configurable `version` value.
+contract VersionMock {
+    uint256 public version;
+
+    constructor(uint256 v) {
+        version = v;
+    }
+}

--- a/contracts/v2/modules/KlerosDisputeModule.sol
+++ b/contracts/v2/modules/KlerosDisputeModule.sol
@@ -9,6 +9,9 @@ import {IDisputeModule} from "../interfaces/IDisputeModule.sol";
 /// arbitration service such as Kleros. The arbitrator is expected to call back
 /// with the final ruling via {resolve}.
 contract KlerosDisputeModule is IDisputeModule {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 1;
+
     /// @notice Address with permission to update module settings.
     address public governance;
 

--- a/test/v2/JobRegistryModuleVersion.test.js
+++ b/test/v2/JobRegistryModuleVersion.test.js
@@ -1,0 +1,126 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobRegistry module version checks", function () {
+  let owner, registry, v1, v2;
+
+  beforeEach(async function () {
+    [owner] = await ethers.getSigners();
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Registry.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    const Version = await ethers.getContractFactory(
+      "contracts/v2/mocks/VersionMock.sol:VersionMock"
+    );
+    v1 = await Version.deploy(1);
+    v2 = await Version.deploy(2);
+  });
+
+  it("reverts for mismatched validation module", async function () {
+    await expect(
+      registry
+        .connect(owner)
+        .setModules(
+          await v2.getAddress(),
+          await v1.getAddress(),
+          await v1.getAddress(),
+          await v1.getAddress(),
+          await v1.getAddress(),
+          ethers.ZeroAddress,
+          []
+        )
+    ).to.be.revertedWith("Invalid validation module");
+  });
+
+  it("reverts for mismatched stake manager", async function () {
+    await expect(
+      registry
+        .connect(owner)
+        .setModules(
+          await v1.getAddress(),
+          await v2.getAddress(),
+          await v1.getAddress(),
+          await v1.getAddress(),
+          await v1.getAddress(),
+          ethers.ZeroAddress,
+          []
+        )
+    ).to.be.revertedWith("Invalid stake manager");
+  });
+
+  it("reverts for mismatched reputation module", async function () {
+    await expect(
+      registry
+        .connect(owner)
+        .setModules(
+          await v1.getAddress(),
+          await v1.getAddress(),
+          await v2.getAddress(),
+          await v1.getAddress(),
+          await v1.getAddress(),
+          ethers.ZeroAddress,
+          []
+        )
+    ).to.be.revertedWith("Invalid reputation module");
+  });
+
+  it("reverts for mismatched dispute module", async function () {
+    await expect(
+      registry
+        .connect(owner)
+        .setModules(
+          await v1.getAddress(),
+          await v1.getAddress(),
+          await v1.getAddress(),
+          await v2.getAddress(),
+          await v1.getAddress(),
+          ethers.ZeroAddress,
+          []
+        )
+    ).to.be.revertedWith("Invalid dispute module");
+  });
+
+  it("reverts for mismatched certificate NFT", async function () {
+    await expect(
+      registry
+        .connect(owner)
+        .setModules(
+          await v1.getAddress(),
+          await v1.getAddress(),
+          await v1.getAddress(),
+          await v1.getAddress(),
+          await v2.getAddress(),
+          ethers.ZeroAddress,
+          []
+        )
+    ).to.be.revertedWith("Invalid certificate NFT");
+  });
+
+  it("succeeds for matching versions", async function () {
+    await registry
+      .connect(owner)
+      .setModules(
+        await v1.getAddress(),
+        await v1.getAddress(),
+        await v1.getAddress(),
+        await v1.getAddress(),
+        await v1.getAddress(),
+        ethers.ZeroAddress,
+        []
+      );
+    expect(await registry.validationModule()).to.equal(await v1.getAddress());
+  });
+});


### PR DESCRIPTION
## Summary
- validate module versions in `JobRegistry.setModules`
- extend module interfaces with `version()` and add constants to implementations
- add unit tests for module version mismatches

## Testing
- `npx hardhat compile`
- `npx hardhat test test/v2/JobRegistryModuleVersion.test.js`
- `npx solhint contracts/v2/JobRegistry.sol contracts/v2/interfaces/IValidationModule.sol contracts/v2/interfaces/IStakeManager.sol contracts/v2/interfaces/IReputationEngine.sol contracts/v2/interfaces/IDisputeModule.sol contracts/v2/interfaces/ICertificateNFT.sol contracts/v2/StakeManager.sol contracts/v2/ReputationEngine.sol contracts/v2/CertificateNFT.sol contracts/v2/modules/KlerosDisputeModule.sol contracts/v2/mocks/ValidationStub.sol contracts/legacy/MockV2.sol contracts/v2/mocks/VersionMock.sol`

------
https://chatgpt.com/codex/tasks/task_e_68ae36c9632c8333ba234f91c0d42b89