### PR TITLE
feat: add job expiration grace period

### DIFF
--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -155,4 +155,25 @@ describe("Job expiration", function () {
       registry.connect(treasury).cancelExpiredJob(jobId)
     ).to.be.revertedWith("not expired");
   });
+
+  it("applies expiration grace period", async () => {
+    const deadline = (await time.latest()) + 100;
+    await registry
+      .connect(owner)
+      .setJobExpirationGracePeriod(100);
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, "uri");
+    const jobId = 1;
+    await registry.connect(agent).applyForJob(jobId, "", []);
+    await time.increase(100);
+    await expect(
+      registry.connect(treasury).cancelExpiredJob(jobId)
+    ).to.be.revertedWith("not expired");
+    await time.increase(100);
+    await expect(registry.connect(treasury).cancelExpiredJob(jobId)).to.emit(
+      registry,
+      "JobExpired"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- allow governance to configure a grace period before jobs can be expired
- test that expiration respects the configured grace period

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae45a3aca88333b70480019152fa3f