### PR TITLE
feat: enforce module version checks

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -105,6 +105,7 @@ contract MockStakeManager is IStakeManager {
 }
 
 contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
+    uint256 public constant version = 1;
     constructor() Ownable(msg.sender) {}
     mapping(uint256 => Job) private _jobs;
     uint256 public taxPolicyVersion;

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -49,6 +49,8 @@ interface ICertificateNFT {
 /// liabilities remain with employers, agents, and validators as expressed by
 /// the owner‑controlled `TaxPolicy` reference.
 contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausable {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 1;
     enum State {
         None,
         Created,
@@ -218,12 +220,6 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         address[] memory _ackModules,
         address _timelock // timelock or multisig controller
     ) Governable(_timelock) {
-        validationModule = _validation;
-        stakeManager = _stakeMgr;
-        reputationEngine = _reputation;
-        disputeModule = _dispute;
-        certificateNFT = _certNFT;
-        feePool = _feePool;
         uint256 pct = _feePct == 0 ? DEFAULT_FEE_PCT : _feePct;
         require(pct <= 100, "pct");
         feePct = pct;
@@ -231,26 +227,37 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         validatorRewardPct = DEFAULT_VALIDATOR_REWARD_PCT;
         emit ValidatorRewardPctUpdated(validatorRewardPct);
         if (address(_validation) != address(0)) {
+            require(_validation.version() == 1, "Invalid validation module");
+            validationModule = _validation;
             emit ValidationModuleUpdated(address(_validation));
             emit ModuleUpdated("ValidationModule", address(_validation));
         }
         if (address(_stakeMgr) != address(0)) {
+            require(_stakeMgr.version() == 1, "Invalid stake manager");
+            stakeManager = _stakeMgr;
             emit StakeManagerUpdated(address(_stakeMgr));
             emit ModuleUpdated("StakeManager", address(_stakeMgr));
         }
         if (address(_reputation) != address(0)) {
+            require(_reputation.version() == 1, "Invalid reputation module");
+            reputationEngine = _reputation;
             emit ReputationEngineUpdated(address(_reputation));
             emit ModuleUpdated("ReputationEngine", address(_reputation));
         }
         if (address(_dispute) != address(0)) {
+            require(_dispute.version() == 1, "Invalid dispute module");
+            disputeModule = _dispute;
             emit DisputeModuleUpdated(address(_dispute));
             emit ModuleUpdated("DisputeModule", address(_dispute));
         }
         if (address(_certNFT) != address(0)) {
+            require(_certNFT.version() == 1, "Invalid certificate NFT");
+            certificateNFT = _certNFT;
             emit CertificateNFTUpdated(address(_certNFT));
             emit ModuleUpdated("CertificateNFT", address(_certNFT));
         }
         if (address(_feePool) != address(0)) {
+            feePool = _feePool;
             emit FeePoolUpdated(address(_feePool));
             emit ModuleUpdated("FeePool", address(_feePool));
         }
@@ -330,6 +337,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     /// @param module Address of the new dispute module contract.
     function setDisputeModule(IDisputeModule module) external onlyGovernance {
         require(address(module) != address(0), "dispute");
+        require(module.version() == 1, "Invalid dispute module");
         disputeModule = module;
         emit DisputeModuleUpdated(address(module));
         emit ModuleUpdated("DisputeModule", address(module));

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -15,6 +15,8 @@ import {TaxAcknowledgement} from "./libraries/TaxAcknowledgement.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
 import {IJobRegistryAck} from "./interfaces/IJobRegistryAck.sol";
 import {IValidationModule} from "./interfaces/IValidationModule.sol";
+import {IDisputeModule} from "./interfaces/IDisputeModule.sol";
+import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 
 /// @title StakeManager
 /// @notice Handles staking balances, job escrows and slashing logic.
@@ -287,6 +289,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice set the dispute module authorized to manage dispute fees
     /// @param module module contract allowed to move dispute fees
     function setDisputeModule(address module) external onlyGovernance {
+        require(IDisputeModule(module).version() == 1, "Invalid dispute module");
         disputeModule = module;
         emit DisputeModuleUpdated(module);
     }
@@ -294,6 +297,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice set the validation module used to source validator lists
     /// @param module ValidationModule contract address
     function setValidationModule(address module) external onlyGovernance {
+        require(IValidationModule(module).version() == 1, "Invalid validation module");
         validationModule = IValidationModule(module);
         emit ValidationModuleUpdated(module);
     }
@@ -307,6 +311,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         onlyGovernance
     {
         require(_jobRegistry != address(0) && _disputeModule != address(0), "module");
+        require(IJobRegistry(_jobRegistry).version() == 1, "Invalid job registry");
+        require(IDisputeModule(_disputeModule).version() == 1, "Invalid dispute module");
         jobRegistry = _jobRegistry;
         disputeModule = _disputeModule;
         emit JobRegistryUpdated(_jobRegistry);

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.25;
 /// @title IJobRegistry
 /// @notice Interface for orchestrating job lifecycles and module coordination
 interface IJobRegistry {
+    /// @notice Module version for compatibility checks.
+    function version() external view returns (uint256);
     enum Status {
         None,
         Created,


### PR DESCRIPTION
## Summary
- validate module versions in JobRegistry constructor and setters
- enforce version checks when updating modules in StakeManager
- test module replacement rejects mismatched versions

## Testing
- `npx hardhat test test/v2/ModuleReplacement.test.js` *(fails: process did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68ae585a9c808333b7d5e6fb61bb47a2