### PR TITLE
Use VRF randomness for validator selection

### DIFF
--- a/contracts/v2/VRFConsumer.sol
+++ b/contracts/v2/VRFConsumer.sol
@@ -7,10 +7,11 @@ import {IVRF} from "./interfaces/IVRF.sol";
 import {ValidationModule} from "./ValidationModule.sol";
 
 /// @title VRFConsumer
-/// @notice Bridges Chainlink VRF responses to the ValidationModule.
-/// @dev This contract wraps the Chainlink VRF coordinator. The ValidationModule
-///      requests randomness via {requestRandomWords}. When fulfilled, the random
-///      word is forwarded to the ValidationModule's {fulfillRandomWords}.
+    /// @notice Bridges Chainlink VRF responses to the ValidationModule.
+    /// @dev This contract wraps the Chainlink VRF coordinator. The ValidationModule
+    ///      requests randomness via {requestRandomWords}. When fulfilled, the
+    ///      random words are forwarded to the ValidationModule's
+    ///      {fulfillRandomWords}.
 contract VRFConsumer is IVRFConsumer, Ownable {
     IVRF public immutable coordinator;
     ValidationModule public validation;
@@ -70,6 +71,6 @@ contract VRFConsumer is IVRFConsumer, Ownable {
     /// @notice Called by the VRF coordinator with the randomness result.
     function rawFulfillRandomWords(uint256 requestId, uint256[] memory randomWords) external {
         require(msg.sender == address(coordinator), "only coord");
-        validation.fulfillRandomWords(requestId, randomWords[0]);
+        validation.fulfillRandomWords(requestId, randomWords);
     }
 }

--- a/contracts/v2/mocks/VRFMock.sol
+++ b/contracts/v2/mocks/VRFMock.sol
@@ -22,11 +22,13 @@ contract VRFMock is IVRFConsumer {
     function fulfill(uint256 requestId, uint256 randomness) external {
         address consumer = consumers[requestId];
         require(consumer != address(0), "unknown request");
+        uint256[] memory words = new uint256[](1);
+        words[0] = randomness;
         (bool ok, ) = consumer.call(
             abi.encodeWithSignature(
-                "fulfillRandomWords(uint256,uint256)",
+                "fulfillRandomWords(uint256,uint256[])",
                 requestId,
-                randomness
+                words
             )
         );
         require(ok, "callback failed");

--- a/test/v2/ValidatorSelectionCache.test.js
+++ b/test/v2/ValidatorSelectionCache.test.js
@@ -41,7 +41,11 @@ describe("Validator selection cache", function () {
     }
     await validation.setValidatorPool(validators);
     await validation.setValidatorsPerJob(3);
-    await validation.setValidatorPoolSampleSize(3);
+    // Allow extra sampling to account for potential duplicates when hashing
+    // into the validator pool. This avoids rare "insufficient validators"
+    // reverts when the pseudo-random sequence selects the same validator more
+    // than once.
+    await validation.setValidatorPoolSampleSize(10);
   });
 
   it("skips repeat ENS checks when cached", async () => {

--- a/test/v2/ValidatorSelectionVRF.test.js
+++ b/test/v2/ValidatorSelectionVRF.test.js
@@ -97,4 +97,8 @@ describe("Validator selection VRF integration", function () {
       "VRF pending"
     );
   });
+
+  it("reverts on unknown VRF fulfillment", async () => {
+    await expect(vrf.fulfill(999, 1)).to.be.revertedWith("unknown request");
+  });
 });


### PR DESCRIPTION
## Summary
- use first VRF word to seed validator selection, avoiding sequential pool scans
- forward full VRF responses to the module and mock
- expand VRF integration tests to cover unknown fulfillments

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae617cb8088333a426a9f15038a68e