### PR TITLE
feat: introduce system-wide pausing mechanism

### DIFF
--- a/contracts/v2/SystemPause.sol
+++ b/contracts/v2/SystemPause.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Governable} from "./Governable.sol";
+import {JobRegistry} from "./JobRegistry.sol";
+import {StakeManager} from "./StakeManager.sol";
+import {ValidationModule} from "./ValidationModule.sol";
+import {DisputeModule} from "./modules/DisputeModule.sol";
+
+/// @title SystemPause
+/// @notice Helper contract allowing governance to pause or unpause all core modules.
+contract SystemPause is Governable {
+    JobRegistry public jobRegistry;
+    StakeManager public stakeManager;
+    ValidationModule public validationModule;
+    DisputeModule public disputeModule;
+
+    event ModulesUpdated(
+        address jobRegistry,
+        address stakeManager,
+        address validationModule,
+        address disputeModule
+    );
+
+    constructor(
+        JobRegistry _jobRegistry,
+        StakeManager _stakeManager,
+        ValidationModule _validationModule,
+        DisputeModule _disputeModule,
+        address _governance
+    ) Governable(_governance) {
+        jobRegistry = _jobRegistry;
+        stakeManager = _stakeManager;
+        validationModule = _validationModule;
+        disputeModule = _disputeModule;
+    }
+
+    function setModules(
+        JobRegistry _jobRegistry,
+        StakeManager _stakeManager,
+        ValidationModule _validationModule,
+        DisputeModule _disputeModule
+    ) external onlyGovernance {
+        jobRegistry = _jobRegistry;
+        stakeManager = _stakeManager;
+        validationModule = _validationModule;
+        disputeModule = _disputeModule;
+        emit ModulesUpdated(
+            address(_jobRegistry),
+            address(_stakeManager),
+            address(_validationModule),
+            address(_disputeModule)
+        );
+    }
+
+    /// @notice Pause all core modules.
+    function pauseAll() external onlyGovernance {
+        jobRegistry.pause();
+        stakeManager.pause();
+        validationModule.pause();
+        disputeModule.pause();
+    }
+
+    /// @notice Unpause all core modules.
+    function unpauseAll() external onlyGovernance {
+        jobRegistry.unpause();
+        stakeManager.unpause();
+        validationModule.unpause();
+        disputeModule.unpause();
+    }
+}
+

--- a/test/v2/Deployer.test.js
+++ b/test/v2/Deployer.test.js
@@ -47,6 +47,7 @@ describe("Deployer", function () {
       feePool,
       taxPolicy,
       identityRegistryAddr,
+      systemPause,
     ] = addresses;
 
     const StakeManager = await ethers.getContractFactory(
@@ -85,6 +86,9 @@ describe("Deployer", function () {
     const IdentityRegistry = await ethers.getContractFactory(
       "contracts/v2/IdentityRegistry.sol:IdentityRegistry"
     );
+    const SystemPause = await ethers.getContractFactory(
+      "contracts/v2/SystemPause.sol:SystemPause"
+    );
 
     const stakeC = StakeManager.attach(stake);
     const registryC = JobRegistry.attach(registry);
@@ -98,13 +102,14 @@ describe("Deployer", function () {
     const feePoolC = FeePool.attach(feePool);
     const taxPolicyC = TaxPolicy.attach(taxPolicy);
     const identityRegistryC = IdentityRegistry.attach(identityRegistryAddr);
+    const systemPauseC = SystemPause.attach(systemPause);
 
     // ownership
-    expect(await stakeC.owner()).to.equal(owner.address);
-    expect(await registryC.owner()).to.equal(owner.address);
-    expect(await validationC.owner()).to.equal(owner.address);
+    expect(await stakeC.owner()).to.equal(systemPause);
+    expect(await registryC.owner()).to.equal(systemPause);
+    expect(await validationC.owner()).to.equal(systemPause);
     expect(await reputationC.owner()).to.equal(owner.address);
-    expect(await disputeC.owner()).to.equal(owner.address);
+    expect(await disputeC.owner()).to.equal(systemPause);
     expect(await certificateC.owner()).to.equal(owner.address);
     expect(await platformRegistryC.owner()).to.equal(owner.address);
     expect(await routerC.owner()).to.equal(owner.address);
@@ -112,6 +117,12 @@ describe("Deployer", function () {
     expect(await feePoolC.owner()).to.equal(owner.address);
     expect(await taxPolicyC.owner()).to.equal(owner.address);
     expect(await identityRegistryC.owner()).to.equal(owner.address);
+    expect(await systemPauseC.owner()).to.equal(owner.address);
+
+    expect(await systemPauseC.jobRegistry()).to.equal(registry);
+    expect(await systemPauseC.stakeManager()).to.equal(stake);
+    expect(await systemPauseC.validationModule()).to.equal(validation);
+    expect(await systemPauseC.disputeModule()).to.equal(dispute);
 
     // wiring
     expect(await stakeC.jobRegistry()).to.equal(registry);

--- a/test/v2/SystemPause.test.js
+++ b/test/v2/SystemPause.test.js
@@ -1,0 +1,88 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("SystemPause", function () {
+  it("pauses and unpauses all modules", async function () {
+    const [owner] = await ethers.getSigners();
+    const Deployer = await ethers.getContractFactory(
+      "contracts/v2/Deployer.sol:Deployer"
+    );
+    const deployer = await Deployer.deploy();
+    const econ = {
+      token: ethers.ZeroAddress,
+      feePct: 0,
+      burnPct: 0,
+      employerSlashPct: 0,
+      treasurySlashPct: 0,
+      commitWindow: 0,
+      revealWindow: 0,
+      minStake: 0,
+      jobStake: 0,
+    };
+    const ids = {
+      ens: ethers.ZeroAddress,
+      nameWrapper: ethers.ZeroAddress,
+      clubRootNode: ethers.ZeroHash,
+      agentRootNode: ethers.ZeroHash,
+      validatorMerkleRoot: ethers.ZeroHash,
+      agentMerkleRoot: ethers.ZeroHash,
+    };
+    const addresses = await deployer.deploy.staticCall(econ, ids);
+    await deployer.deploy(econ, ids);
+    const [
+      stakeAddr,
+      registryAddr,
+      validationAddr,
+      ,
+      disputeAddr,
+      ,
+      ,
+      ,
+      ,
+      ,
+      ,
+      ,
+      systemPauseAddr,
+    ] = addresses;
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    const ValidationModule = await ethers.getContractFactory(
+      "contracts/v2/ValidationModule.sol:ValidationModule"
+    );
+    const DisputeModule = await ethers.getContractFactory(
+      "contracts/v2/modules/DisputeModule.sol:DisputeModule"
+    );
+    const SystemPause = await ethers.getContractFactory(
+      "contracts/v2/SystemPause.sol:SystemPause"
+    );
+    const stake = StakeManager.attach(stakeAddr);
+    const registry = JobRegistry.attach(registryAddr);
+    const validation = ValidationModule.attach(validationAddr);
+    const dispute = DisputeModule.attach(disputeAddr);
+    const pause = SystemPause.attach(systemPauseAddr);
+
+    expect(await stake.paused()).to.equal(false);
+    expect(await registry.paused()).to.equal(false);
+    expect(await validation.paused()).to.equal(false);
+    expect(await dispute.paused()).to.equal(false);
+
+    await pause.connect(owner).pauseAll();
+
+    expect(await stake.paused()).to.equal(true);
+    expect(await registry.paused()).to.equal(true);
+    expect(await validation.paused()).to.equal(true);
+    expect(await dispute.paused()).to.equal(true);
+
+    await pause.connect(owner).unpauseAll();
+
+    expect(await stake.paused()).to.equal(false);
+    expect(await registry.paused()).to.equal(false);
+    expect(await validation.paused()).to.equal(false);
+    expect(await dispute.paused()).to.equal(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add SystemPause contract to centrally pause/unpause JobRegistry, StakeManager, ValidationModule and DisputeModule
- wire SystemPause into Deployer and transfer module ownership
- test pausing behavior and updated deployment wiring

## Testing
- `npx hardhat test test/v2/SystemPause.test.js`
- `npx hardhat test test/v2/Deployer.test.js`
- `npx hardhat test test/v2/Ownership.test.js`
- `npx hardhat test test/v2/OwnershipTimelock.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae673c8f04833398ac4ea222952ee1