### PR TITLE
Add validator UI with commit/reveal flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 .env
 artifacts/
 cache/
+
+.next/

--- a/apps/validator-ui/README.md
+++ b/apps/validator-ui/README.md
@@ -1,0 +1,33 @@
+# Validator UI
+
+A minimal Next.js interface for validators to view pending jobs, commit votes, and automatically reveal them.
+
+## Setup
+
+```bash
+npm install --prefix apps/validator-ui
+```
+
+Create a `.env.local` file with:
+
+```
+NEXT_PUBLIC_GATEWAY_URL=http://localhost:3000
+NEXT_PUBLIC_VALIDATION_MODULE_ADDRESS=0xYourValidationModule
+NEXT_PUBLIC_REVEAL_DELAY_MS=5000
+```
+
+## Running
+
+```bash
+npm run dev --prefix apps/validator-ui
+```
+
+Connect a browser wallet and use the interface to approve or reject jobs. Commits are signed with a random salt and the reveal transaction is scheduled automatically.
+
+## Testing
+
+Run the commit/reveal integration test against a local Hardhat network:
+
+```bash
+npx hardhat test test/validator-ui/commitReveal.test.js
+```

--- a/apps/validator-ui/lib/commit.js
+++ b/apps/validator-ui/lib/commit.js
@@ -1,0 +1,26 @@
+const { ethers } = require('ethers');
+
+function generateCommit(jobId, nonce, approve, salt) {
+  const actualSalt = salt ?? ethers.hexlify(ethers.randomBytes(32));
+  const commitHash = ethers.solidityPackedKeccak256(
+    ['uint256', 'uint256', 'bool', 'bytes32'],
+    [jobId, nonce, approve, actualSalt]
+  );
+  return { commitHash, salt: actualSalt };
+}
+
+function scheduleReveal(contract, jobId, approve, salt, delayMs) {
+  return new Promise((resolve, reject) => {
+    setTimeout(async () => {
+      try {
+        const tx = await contract.reveal(jobId, approve, salt);
+        await tx.wait();
+        resolve(tx);
+      } catch (err) {
+        reject(err);
+      }
+    }, delayMs);
+  });
+}
+
+module.exports = { generateCommit, scheduleReveal };

--- a/apps/validator-ui/next-env.d.ts
+++ b/apps/validator-ui/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/apps/validator-ui/next.config.js
+++ b/apps/validator-ui/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+module.exports = nextConfig;

--- a/apps/validator-ui/package.json
+++ b/apps/validator-ui/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "validator-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "ethers": "^6.15.0",
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/apps/validator-ui/pages/index.tsx
+++ b/apps/validator-ui/pages/index.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { ethers } from 'ethers';
+import { generateCommit, scheduleReveal } from '../lib/commit';
+
+interface Job {
+  jobId: string;
+  employer: string;
+  agent: string;
+  reward: string;
+  stake: string;
+  fee: string;
+}
+
+export default function Home() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const url = process.env.NEXT_PUBLIC_GATEWAY_URL || 'http://localhost:3000';
+    fetch(`${url}/jobs`)
+      .then((res) => res.json())
+      .then(setJobs)
+      .catch(console.error);
+  }, []);
+
+  async function vote(jobId: string, approve: boolean) {
+    if (!(window as any).ethereum) {
+      alert('wallet not found');
+      return;
+    }
+    const provider = new ethers.BrowserProvider((window as any).ethereum);
+    const signer = await provider.getSigner();
+    const validationAddr = process.env.NEXT_PUBLIC_VALIDATION_MODULE_ADDRESS;
+    if (!validationAddr) {
+      alert('validation module not configured');
+      return;
+    }
+    const abi = [
+      'function jobNonce(uint256 jobId) view returns (uint256)',
+      'function commitValidation(uint256 jobId, bytes32 commitHash)',
+      'function revealValidation(uint256 jobId, bool approve, bytes32 salt)'
+    ];
+    const contract = new ethers.Contract(validationAddr, abi, signer);
+    const nonce: bigint = await contract.jobNonce(jobId);
+    const { commitHash, salt } = generateCommit(BigInt(jobId), nonce, approve);
+    const tx = await contract.commitValidation(jobId, commitHash);
+    await tx.wait();
+    setMessage('Commit submitted, scheduling reveal');
+    const delay = Number(process.env.NEXT_PUBLIC_REVEAL_DELAY_MS || '5000');
+    await scheduleReveal(contract, BigInt(jobId), approve, salt, delay);
+    setMessage('Reveal submitted');
+  }
+
+  return (
+    <main>
+      <h1>Pending Jobs</h1>
+      <ul>
+        {jobs.map((job) => (
+          <li key={job.jobId}>
+            Job {job.jobId}{' '}
+            <button onClick={() => vote(job.jobId, true)}>Approve</button>{' '}
+            <button onClick={() => vote(job.jobId, false)}>Reject</button>
+          </li>
+        ))}
+      </ul>
+      {message && <p>{message}</p>}
+    </main>
+  );
+}

--- a/apps/validator-ui/tsconfig.json
+++ b/apps/validator-ui/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/contracts/CommitRevealMock.sol
+++ b/contracts/CommitRevealMock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+contract CommitRevealMock {
+    mapping(uint256 => uint256) public nonces;
+    mapping(uint256 => mapping(address => bytes32)) public commits;
+    mapping(uint256 => mapping(address => bool)) public revealed;
+
+    function commit(uint256 jobId, bytes32 commitHash) external {
+        commits[jobId][msg.sender] = commitHash;
+    }
+
+    function reveal(uint256 jobId, bool approve, bytes32 salt) external returns (bool) {
+        bytes32 expected = keccak256(abi.encodePacked(jobId, nonces[jobId], approve, salt));
+        require(commits[jobId][msg.sender] == expected, "hash mismatch");
+        revealed[jobId][msg.sender] = true;
+        nonces[jobId]++;
+        return approve;
+    }
+}

--- a/test/validator-ui/commitReveal.test.js
+++ b/test/validator-ui/commitReveal.test.js
@@ -1,0 +1,19 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const { generateCommit, scheduleReveal } = require('../../apps/validator-ui/lib/commit');
+
+describe('validator-ui commit/reveal', function () {
+  it('commits and reveals a vote', async function () {
+    const [v] = await ethers.getSigners();
+    const factory = await ethers.getContractFactory('CommitRevealMock');
+    const contract = await factory.deploy();
+    await contract.waitForDeployment();
+    const jobId = 1n;
+    const nonce = await contract.nonces(jobId);
+    const { commitHash, salt } = generateCommit(jobId, nonce, true);
+    await (await contract.connect(v).commit(jobId, commitHash)).wait();
+    await scheduleReveal(contract.connect(v), jobId, true, salt, 0);
+    const revealed = await contract.revealed(jobId, v.address);
+    expect(revealed).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Next.js validator interface to browse jobs and submit commit/reveal votes
- generate salted commit hashes and auto-schedule reveal transactions
- document validator onboarding and provide integration test using mock commit/reveal contract

## Testing
- `npx hardhat test test/validator-ui/commitReveal.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ae6ee4da3c8333bdfe3db86c2511be