### PR TITLE
feat: improve validator selection randomness

### DIFF
--- a/test/v2/ValidatorSelectionCache.test.js
+++ b/test/v2/ValidatorSelectionCache.test.js
@@ -41,10 +41,7 @@ describe("Validator selection cache", function () {
     }
     await validation.setValidatorPool(validators);
     await validation.setValidatorsPerJob(3);
-    // Allow extra sampling to account for potential duplicates when hashing
-    // into the validator pool. This avoids rare "insufficient validators"
-    // reverts when the pseudo-random sequence selects the same validator more
-    // than once.
+    // Sample a fixed window for shuffle-based selection.
     await validation.setValidatorPoolSampleSize(10);
   });
 

--- a/test/v2/ValidatorSelectionLargePool.test.js
+++ b/test/v2/ValidatorSelectionLargePool.test.js
@@ -34,7 +34,7 @@ describe("Validator selection with large pool", function () {
   });
 
   it("benchmarks gas usage across pool sizes", async () => {
-    const poolSizes = [10, 50, 200];
+    const poolSizes = [10, 50, 200, 500];
     let jobId = 1;
     for (const poolSize of poolSizes) {
       const validators = [];
@@ -51,7 +51,7 @@ describe("Validator selection with large pool", function () {
       const tx = await validation.selectValidators(jobId++);
       const receipt = await tx.wait();
       console.log(`pool size ${poolSize}: ${receipt.gasUsed}`);
-      expect(receipt.gasUsed).to.be.lt(5000000n);
+      expect(receipt.gasUsed).to.be.lt(6000000n);
       const ev = receipt.logs.find(
         (l) => l.fragment && l.fragment.name === "ValidatorsSelected"
       );


### PR DESCRIPTION
## Summary
- use Fisher–Yates shuffle over a random window to pick validators uniformly
- add governance-controlled validatorPoolSampleSize with input validation
- benchmark selection gas usage and add large-pool fuzz test

## Testing
- `npm test`
- `forge test` *(fails: Compiler run failed: Stack too deep in JobRegistry.sol)*

------
https://chatgpt.com/codex/tasks/task_e_68ae715c874483338c57c63abfa9f405