### PR TITLE
feat: track VRF requests per job

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -232,6 +232,8 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         uint256 jobId = vrfRequestJob[requestId];
         require(jobId != 0, "unknown request");
         vrfRandomness[jobId] = randomWords[0];
+        delete vrfRequestIds[jobId];
+        delete vrfRequestJob[requestId];
         emit VRFFulfilled(jobId, requestId);
     }
 
@@ -464,11 +466,6 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
             require(randomness != 0, "VRF pending");
             seed = randomness;
             delete vrfRandomness[jobId];
-            uint256 reqId = vrfRequestIds[jobId];
-            if (reqId != 0) {
-                delete vrfRequestIds[jobId];
-                delete vrfRequestJob[reqId];
-            }
         } else {
             jobNonce[jobId] += 1;
             seed = _fallbackSeed(jobId);


### PR DESCRIPTION
## Summary
- ensure VRF randomness is tracked per job and clear requests once fulfilled
- add VRF test proving different VRF outputs lead to different validator selections

## Testing
- `npm test`
- `npx hardhat test test/v2/ValidatorSelectionVRF.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae75ba2cc08333ac8f7a80b5db0155