### PR TITLE
feat: add agent profile metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Record each address during deployment. The defaults below assume the 6‑decimal
 | [`StakeManager`](contracts/v2/StakeManager.sol) | `setToken`, `setMinStake`, `setSlashingPercentages`, `setTreasury`, `setMaxStakePerAddress` |
 | [`JobRegistry`](contracts/v2/JobRegistry.sol) | `setModules`, `setFeePool`, `setTaxPolicy`, `setAgentRootNode`, `setAgentMerkleRoot` |
 | [`ValidationModule`](contracts/v2/ValidationModule.sol) | `setJobRegistry`, `setCommitWindow`, `setRevealWindow`, `setValidatorBounds`, `setApprovalThreshold`, `setIdentityRegistry` |
-| [`IdentityRegistry`](contracts/v2/IdentityRegistry.sol) | `setENS`, `setNameWrapper`, `setReputationEngine`, `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot`, `setValidatorMerkleRoot` |
+| [`IdentityRegistry`](contracts/v2/IdentityRegistry.sol) | `setENS`, `setNameWrapper`, `setReputationEngine`, `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot`, `setValidatorMerkleRoot`, `setAgentProfileURI` |
 | [`DisputeModule`](contracts/v2/modules/DisputeModule.sol) | `setDisputeFee`, `setTaxPolicy`, `setFeePool` |
 | [`ReputationEngine`](contracts/v2/ReputationEngine.sol) | `setCaller`, `setWeights`, `blacklist`, `unblacklist` |
 | [`CertificateNFT`](contracts/v2/CertificateNFT.sol) | `setJobRegistry`, `setStakeManager`, `setBaseURI` |

--- a/contracts/v2/interfaces/IIdentityRegistry.sol
+++ b/contracts/v2/interfaces/IIdentityRegistry.sol
@@ -51,5 +51,14 @@ interface IIdentityRegistry {
     function additionalAgents(address account) external view returns (bool);
     function additionalValidators(address account) external view returns (bool);
     function getAgentType(address agent) external view returns (AgentType);
+
+    // profile metadata
+    function setAgentProfileURI(address agent, string calldata uri) external;
+    function updateAgentProfile(
+        string calldata subdomain,
+        bytes32[] calldata proof,
+        string calldata uri
+    ) external;
+    function agentProfileURI(address agent) external view returns (string memory);
 }
 

--- a/contracts/v2/mocks/ReentrantIdentityRegistry.sol
+++ b/contracts/v2/mocks/ReentrantIdentityRegistry.sol
@@ -56,6 +56,19 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
         return true;
     }
 
+    // profile metadata - no-ops
+    function setAgentProfileURI(address, string calldata) external {}
+
+    function updateAgentProfile(
+        string calldata,
+        bytes32[] calldata,
+        string calldata
+    ) external {}
+
+    function agentProfileURI(address) external pure returns (string memory) {
+        return "";
+    }
+
     // owner configuration - no-ops
     function setENS(address) external {}
     function setNameWrapper(address) external {}

--- a/docs/api/IdentityRegistry.md
+++ b/docs/api/IdentityRegistry.md
@@ -1,6 +1,7 @@
 # IdentityRegistry API
 
 Validates ENS ownership and Merkle proofs for agents and validators.
+Maintains optional metadata URIs describing each agent's capabilities.
 
 ## Functions
 - `setENS(address ens)` / `setNameWrapper(address wrapper)` – configure ENS contracts.
@@ -8,6 +9,8 @@ Validates ENS ownership and Merkle proofs for agents and validators.
 - `setAgentRootNode(bytes32 node)` / `setClubRootNode(bytes32 node)` – base ENS nodes for agents and validators.
 - `setAgentMerkleRoot(bytes32 root)` / `setValidatorMerkleRoot(bytes32 root)` – load allowlists.
 - `addAdditionalAgent(address agent)` / `addAdditionalValidator(address validator)` – manual overrides.
+- `setAgentProfileURI(address agent, string uri)` – governance-set capability profile for an agent.
+- `updateAgentProfile(string subdomain, bytes32[] proof, string uri)` – agent updates their own profile after proving control of `subdomain`.
 - `isAuthorizedAgent(address account, bytes32 label, bytes32[] proof)` – check agent eligibility.
 - `isAuthorizedValidator(address account, bytes32 label, bytes32[] proof)` – check validator eligibility.
 - `verifyAgent(bytes32 label, bytes32[] proof, address account)` – external verification helper.
@@ -20,3 +23,4 @@ Validates ENS ownership and Merkle proofs for agents and validators.
 - `AgentMerkleRootUpdated(bytes32 agentMerkleRoot)` / `ValidatorMerkleRootUpdated(bytes32 validatorMerkleRoot)`
 - `AdditionalAgentUpdated(address agent, bool allowed)`
 - `AdditionalValidatorUpdated(address validator, bool allowed)`
+- `AgentProfileUpdated(address agent, string uri)` – emitted whenever an agent profile is set or changed. Off-chain services can listen for this event and fetch the referenced URI (e.g., from IPFS) to match jobs with agents based on declared capabilities.


### PR DESCRIPTION
## Summary
- track optional capability metadata for agents
- allow governance or agents with proof to update profile URIs
- document and test profile metadata and events

## Testing
- `npm test -- test/v2/identity.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af2e6d35688333aac4dddb32ff69e3