### PR TITLE
feat: add pseudo randomness for validator selection

### DIFF
--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -93,6 +93,17 @@ describe("ValidationModule V2", function () {
     return validation.selectValidators(jobId);
   }
 
+  it("selects validators without VRF provider", async () => {
+    await validation.setVRF(ethers.ZeroAddress);
+    const tx = await validation.selectValidators(1);
+    const receipt = await tx.wait();
+    const event = receipt.logs.find(
+      (l) => l.fragment && l.fragment.name === "ValidatorsSelected"
+    );
+    const selected = event.args[1];
+    expect(selected.length).to.equal(2);
+  });
+
   it("reverts when stake manager is unset", async () => {
     await validation.connect(owner).setStakeManager(ethers.ZeroAddress);
     await expect(select(1)).to.be.revertedWith(


### PR DESCRIPTION
## Summary
- support validator selection when no VRF provider is set
- derive pseudo-random seed from block entropy and job id
- cover non-VRF selection in ValidationModule tests

## Testing
- `npm test --silent test/v2/ValidationModule.test.js`
- `npx solhint contracts/v2/ValidationModule.sol`
- `npx eslint test/v2/ValidationModule.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af31a7dd888333953fd9183bb3c84a