### PR TITLE
Clean up validation data after finalize

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -954,16 +954,11 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         emit ValidationResult(jobId, success);
 
         jobRegistry.onValidationResult(jobId, success, r.validators);
+        _cleanup(jobId);
         return success;
     }
 
-    /// @notice Reset the validation nonce for a job after finalization or dispute resolution.
-    /// @param jobId Identifier of the job
-    function resetJobNonce(uint256 jobId) external override {
-        require(
-            msg.sender == owner() || msg.sender == address(jobRegistry),
-            "not authorized"
-        );
+    function _cleanup(uint256 jobId) internal {
         uint256 nonce = jobNonce[jobId];
         address[] storage vals = rounds[jobId].validators;
         for (uint256 i; i < vals.length;) {
@@ -979,6 +974,16 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         }
         delete rounds[jobId];
         delete jobNonce[jobId];
+    }
+
+    /// @notice Reset the validation nonce for a job after finalization or dispute resolution.
+    /// @param jobId Identifier of the job
+    function resetJobNonce(uint256 jobId) external override {
+        require(
+            msg.sender == owner() || msg.sender == address(jobRegistry),
+            "not authorized"
+        );
+        _cleanup(jobId);
         emit JobNonceReset(jobId);
     }
 


### PR DESCRIPTION
## Summary
- add internal `_cleanup` helper to purge commitments, votes, validator data and nonce
- call cleanup from `_finalize` and reuse in `resetJobNonce`
- test that commitments are cleared once validation is finalized

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af40b51f9883338b263d1ff9a87d1b