### PR TITLE
Expand SystemPause to platform, fee, and reputation modules

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -397,6 +397,9 @@ contract Deployer is Ownable {
             stake,
             validation,
             dispute,
+            pRegistry,
+            pool,
+            reputation,
             owner_
         );
         // hand over governance to SystemPause
@@ -405,13 +408,13 @@ contract Deployer is Ownable {
 
         // Transfer ownership
         validation.transferOwnership(address(pause));
-        reputation.transferOwnership(owner_);
+        reputation.transferOwnership(address(pause));
         dispute.transferOwnership(address(pause));
         certificate.transferOwnership(owner_);
-        pRegistry.transferOwnership(owner_);
+        pRegistry.transferOwnership(address(pause));
         router.transferOwnership(owner_);
         incentives.transferOwnership(owner_);
-        pool.transferOwnership(owner_);
+        pool.transferOwnership(address(pause));
         if (address(policy) != address(0)) {
             policy.transferOwnership(owner_);
         }

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -13,7 +14,7 @@ import {IStakeManager} from "./interfaces/IStakeManager.sol";
 /// @dev All token amounts use 6 decimals. Uses an accumulator scaled by 1e12
 ///      to avoid precision loss when dividing fees by total stake.
 
-contract FeePool is Ownable {
+contract FeePool is Ownable, Pausable {
     using SafeERC20 for IERC20;
 
     uint256 public constant ACCUMULATOR_SCALE = 1e12;
@@ -240,6 +241,14 @@ contract FeePool is Ownable {
     /// @notice Confirms the contract and its owner can never incur tax liability.
     function isTaxExempt() external pure returns (bool) {
         return true;
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
     }
 
     /// @dev Reject direct ETH transfers to keep the contract tax neutral.

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IJobRegistryAck} from "./interfaces/IJobRegistryAck.sol";
@@ -18,7 +19,7 @@ interface IReputationEngine {
 ///         reputation-weighted scores for job routing and discovery.
 /// @dev Holds no tokens and rejects ether to remain tax neutral. All values
 ///      use 6 decimals via the `StakeManager`.
-contract PlatformRegistry is Ownable, ReentrancyGuard {
+contract PlatformRegistry is Ownable, ReentrancyGuard, Pausable {
     uint256 public constant DEFAULT_MIN_PLATFORM_STAKE = 1e6;
 
     IStakeManager public stakeManager;
@@ -274,6 +275,14 @@ contract PlatformRegistry is Ownable, ReentrancyGuard {
     /// @notice Confirms the contract and owner are perpetually tax neutral.
     function isTaxExempt() external pure returns (bool) {
         return true;
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
     }
 
     // ---------------------------------------------------------------

--- a/contracts/v2/SystemPause.sol
+++ b/contracts/v2/SystemPause.sol
@@ -6,6 +6,9 @@ import {JobRegistry} from "./JobRegistry.sol";
 import {StakeManager} from "./StakeManager.sol";
 import {ValidationModule} from "./ValidationModule.sol";
 import {DisputeModule} from "./modules/DisputeModule.sol";
+import {PlatformRegistry} from "./PlatformRegistry.sol";
+import {FeePool} from "./FeePool.sol";
+import {ReputationEngine} from "./ReputationEngine.sol";
 
 /// @title SystemPause
 /// @notice Helper contract allowing governance to pause or unpause all core modules.
@@ -14,12 +17,18 @@ contract SystemPause is Governable {
     StakeManager public stakeManager;
     ValidationModule public validationModule;
     DisputeModule public disputeModule;
+    PlatformRegistry public platformRegistry;
+    FeePool public feePool;
+    ReputationEngine public reputationEngine;
 
     event ModulesUpdated(
         address jobRegistry,
         address stakeManager,
         address validationModule,
-        address disputeModule
+        address disputeModule,
+        address platformRegistry,
+        address feePool,
+        address reputationEngine
     );
 
     constructor(
@@ -27,29 +36,44 @@ contract SystemPause is Governable {
         StakeManager _stakeManager,
         ValidationModule _validationModule,
         DisputeModule _disputeModule,
+        PlatformRegistry _platformRegistry,
+        FeePool _feePool,
+        ReputationEngine _reputationEngine,
         address _governance
     ) Governable(_governance) {
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
         validationModule = _validationModule;
         disputeModule = _disputeModule;
+        platformRegistry = _platformRegistry;
+        feePool = _feePool;
+        reputationEngine = _reputationEngine;
     }
 
     function setModules(
         JobRegistry _jobRegistry,
         StakeManager _stakeManager,
         ValidationModule _validationModule,
-        DisputeModule _disputeModule
+        DisputeModule _disputeModule,
+        PlatformRegistry _platformRegistry,
+        FeePool _feePool,
+        ReputationEngine _reputationEngine
     ) external onlyGovernance {
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
         validationModule = _validationModule;
         disputeModule = _disputeModule;
+        platformRegistry = _platformRegistry;
+        feePool = _feePool;
+        reputationEngine = _reputationEngine;
         emit ModulesUpdated(
             address(_jobRegistry),
             address(_stakeManager),
             address(_validationModule),
-            address(_disputeModule)
+            address(_disputeModule),
+            address(_platformRegistry),
+            address(_feePool),
+            address(_reputationEngine)
         );
     }
 
@@ -59,6 +83,9 @@ contract SystemPause is Governable {
         stakeManager.pause();
         validationModule.pause();
         disputeModule.pause();
+        platformRegistry.pause();
+        feePool.pause();
+        reputationEngine.pause();
     }
 
     /// @notice Unpause all core modules.
@@ -67,6 +94,9 @@ contract SystemPause is Governable {
         stakeManager.unpause();
         validationModule.unpause();
         disputeModule.unpause();
+        platformRegistry.unpause();
+        feePool.unpause();
+        reputationEngine.unpause();
     }
 }
 

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -94,6 +94,28 @@ async function main() {
   await registry.setIdentityRegistry(await identity.getAddress());
   await reputation.setCaller(await registry.getAddress(), true);
 
+  const SystemPause = await ethers.getContractFactory(
+    "contracts/v2/SystemPause.sol:SystemPause"
+  );
+  const pause = await SystemPause.deploy(
+    await registry.getAddress(),
+    await stake.getAddress(),
+    await validation.getAddress(),
+    await dispute.getAddress(),
+    await platformRegistry.getAddress(),
+    await feePool.getAddress(),
+    await reputation.getAddress(),
+    deployer.address
+  );
+  await pause.waitForDeployment();
+  await stake.setGovernance(await pause.getAddress());
+  await registry.setGovernance(await pause.getAddress());
+  await validation.transferOwnership(await pause.getAddress());
+  await dispute.transferOwnership(await pause.getAddress());
+  await platformRegistry.transferOwnership(await pause.getAddress());
+  await feePool.transferOwnership(await pause.getAddress());
+  await reputation.transferOwnership(await pause.getAddress());
+
   console.log("Token:", await token.getAddress());
   console.log("StakeManager:", await stake.getAddress());
   console.log("ReputationEngine:", await reputation.getAddress());
@@ -101,6 +123,7 @@ async function main() {
   console.log("JobRegistry:", await registry.getAddress());
   console.log("DisputeModule:", await dispute.getAddress());
   console.log("CertificateNFT:", await nft.getAddress());
+  console.log("SystemPause:", await pause.getAddress());
 }
 
 main().catch((err) => {

--- a/test/v2/Deployer.test.js
+++ b/test/v2/Deployer.test.js
@@ -108,13 +108,13 @@ describe("Deployer", function () {
     expect(await stakeC.owner()).to.equal(systemPause);
     expect(await registryC.owner()).to.equal(systemPause);
     expect(await validationC.owner()).to.equal(systemPause);
-    expect(await reputationC.owner()).to.equal(owner.address);
+    expect(await reputationC.owner()).to.equal(systemPause);
     expect(await disputeC.owner()).to.equal(systemPause);
     expect(await certificateC.owner()).to.equal(owner.address);
-    expect(await platformRegistryC.owner()).to.equal(owner.address);
+    expect(await platformRegistryC.owner()).to.equal(systemPause);
     expect(await routerC.owner()).to.equal(owner.address);
     expect(await incentivesC.owner()).to.equal(owner.address);
-    expect(await feePoolC.owner()).to.equal(owner.address);
+    expect(await feePoolC.owner()).to.equal(systemPause);
     expect(await taxPolicyC.owner()).to.equal(owner.address);
     expect(await identityRegistryC.owner()).to.equal(owner.address);
     expect(await systemPauseC.owner()).to.equal(owner.address);
@@ -123,6 +123,9 @@ describe("Deployer", function () {
     expect(await systemPauseC.stakeManager()).to.equal(stake);
     expect(await systemPauseC.validationModule()).to.equal(validation);
     expect(await systemPauseC.disputeModule()).to.equal(dispute);
+    expect(await systemPauseC.platformRegistry()).to.equal(platformRegistry);
+    expect(await systemPauseC.feePool()).to.equal(feePool);
+    expect(await systemPauseC.reputationEngine()).to.equal(reputation);
 
     // wiring
     expect(await stakeC.jobRegistry()).to.equal(registry);

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -136,7 +136,7 @@ describe("Ownable modules", function () {
       ],
       [
         ReputationEngine.attach(reputation),
-        owner,
+        systemPauseSigner,
         (inst, signer) => inst.connect(signer).setScoringWeights(0, 0),
       ],
       [
@@ -151,7 +151,7 @@ describe("Ownable modules", function () {
       ],
       [
         PlatformRegistry.attach(platformRegistry),
-        owner,
+        systemPauseSigner,
         (inst, signer) => inst.connect(signer).setMinPlatformStake(0),
       ],
       [
@@ -167,7 +167,11 @@ describe("Ownable modules", function () {
             .connect(signer)
             .setModules(ethers.ZeroAddress, ethers.ZeroAddress, ethers.ZeroAddress),
       ],
-      [FeePool.attach(feePool), owner, (inst, signer) => inst.connect(signer).setBurnPct(0)],
+      [
+        FeePool.attach(feePool),
+        systemPauseSigner,
+        (inst, signer) => inst.connect(signer).setBurnPct(0),
+      ],
       [
         TaxPolicy.attach(taxPolicy),
         owner,

--- a/test/v2/SystemPause.test.js
+++ b/test/v2/SystemPause.test.js
@@ -33,13 +33,13 @@ describe("SystemPause", function () {
       stakeAddr,
       registryAddr,
       validationAddr,
-      ,
+      reputationAddr,
       disputeAddr,
       ,
+      platformRegistryAddr,
       ,
       ,
-      ,
-      ,
+      feePoolAddr,
       ,
       ,
       systemPauseAddr,
@@ -56,6 +56,15 @@ describe("SystemPause", function () {
     const DisputeModule = await ethers.getContractFactory(
       "contracts/v2/modules/DisputeModule.sol:DisputeModule"
     );
+    const ReputationEngine = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    const PlatformRegistry = await ethers.getContractFactory(
+      "contracts/v2/PlatformRegistry.sol:PlatformRegistry"
+    );
+    const FeePool = await ethers.getContractFactory(
+      "contracts/v2/FeePool.sol:FeePool"
+    );
     const SystemPause = await ethers.getContractFactory(
       "contracts/v2/SystemPause.sol:SystemPause"
     );
@@ -63,12 +72,18 @@ describe("SystemPause", function () {
     const registry = JobRegistry.attach(registryAddr);
     const validation = ValidationModule.attach(validationAddr);
     const dispute = DisputeModule.attach(disputeAddr);
+    const reputation = ReputationEngine.attach(reputationAddr);
+    const platformRegistry = PlatformRegistry.attach(platformRegistryAddr);
+    const feePool = FeePool.attach(feePoolAddr);
     const pause = SystemPause.attach(systemPauseAddr);
 
     expect(await stake.paused()).to.equal(false);
     expect(await registry.paused()).to.equal(false);
     expect(await validation.paused()).to.equal(false);
     expect(await dispute.paused()).to.equal(false);
+    expect(await platformRegistry.paused()).to.equal(false);
+    expect(await feePool.paused()).to.equal(false);
+    expect(await reputation.paused()).to.equal(false);
 
     await pause.connect(owner).pauseAll();
 
@@ -76,6 +91,9 @@ describe("SystemPause", function () {
     expect(await registry.paused()).to.equal(true);
     expect(await validation.paused()).to.equal(true);
     expect(await dispute.paused()).to.equal(true);
+    expect(await platformRegistry.paused()).to.equal(true);
+    expect(await feePool.paused()).to.equal(true);
+    expect(await reputation.paused()).to.equal(true);
 
     await pause.connect(owner).unpauseAll();
 
@@ -83,6 +101,9 @@ describe("SystemPause", function () {
     expect(await registry.paused()).to.equal(false);
     expect(await validation.paused()).to.equal(false);
     expect(await dispute.paused()).to.equal(false);
+    expect(await platformRegistry.paused()).to.equal(false);
+    expect(await feePool.paused()).to.equal(false);
+    expect(await reputation.paused()).to.equal(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- extend `SystemPause` to manage `PlatformRegistry`, `FeePool`, and `ReputationEngine`
- wire new modules into deployment flow and grant pause governance
- add pausable capability to `PlatformRegistry`, `FeePool`, and `ReputationEngine`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af483f02fc83339a095ab354677230