### PR TITLE
chore: guard releaseReward against reentrancy

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -751,6 +751,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         external
         onlyJobRegistry
         whenNotPaused
+        nonReentrant
     {
         uint256 pct = getAgentPayoutPct(to);
         uint256 modified = (amount * pct) / 100;


### PR DESCRIPTION
## Summary
- protect `StakeManager.releaseReward` with `nonReentrant`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af52960ae483339899c5623ec5f8f5