### PR TITLE
feat: add keeper automation

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -992,6 +992,44 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         return _finalize(jobId);
     }
 
+    /// @notice Check if upkeep is needed for a job based on reveal deadlines.
+    /// @param checkData ABI encoded job identifier.
+    /// @return upkeepNeeded True if performUpkeep should be called.
+    /// @return performData Bytes passed to performUpkeep.
+    function checkUpkeep(bytes calldata checkData)
+        external
+        view
+        returns (bool upkeepNeeded, bytes memory performData)
+    {
+        uint256 jobId = abi.decode(checkData, (uint256));
+        Round storage r = rounds[jobId];
+        upkeepNeeded =
+            !r.tallied &&
+            r.revealDeadline != 0 &&
+            (block.timestamp > r.revealDeadline ||
+                r.participants.length == r.validators.length);
+        performData = checkData;
+    }
+
+    /// @notice Perform automated finalization when upkeep is required.
+    /// @param performData ABI encoded job identifier.
+    function performUpkeep(bytes calldata performData)
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        uint256 jobId = abi.decode(performData, (uint256));
+        Round storage r = rounds[jobId];
+        bool upkeepNeeded =
+            !r.tallied &&
+            r.revealDeadline != 0 &&
+            (block.timestamp > r.revealDeadline ||
+                r.participants.length == r.validators.length);
+        require(upkeepNeeded, "upkeep");
+        bool success = _finalize(jobId);
+        emit UpkeepPerformed(jobId, success);
+    }
+
     function _finalize(uint256 jobId) internal returns (bool success) {
         Round storage r = rounds[jobId];
         require(!r.tallied, "tallied");

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -30,6 +30,10 @@ interface IValidationModule {
         uint256 approvalThreshold,
         uint256 slashingPct
     );
+    /// @notice Emitted after automation performs upkeep.
+    /// @param jobId Identifier of the job finalized.
+    /// @param success True if validation succeeded.
+    event UpkeepPerformed(uint256 indexed jobId, bool success);
 
     /// @notice Select validators for a given job.
     /// @param jobId Identifier of the job.
@@ -94,6 +98,19 @@ interface IValidationModule {
 
     /// @notice Alias for finalize using legacy naming.
     function finalizeValidation(uint256 jobId) external returns (bool success);
+
+    /// @notice Check if automation should finalize a job.
+    /// @param checkData ABI encoded jobId.
+    /// @return upkeepNeeded True if `performUpkeep` should be called.
+    /// @return performData Data to pass to `performUpkeep`.
+    function checkUpkeep(bytes calldata checkData)
+        external
+        view
+        returns (bool upkeepNeeded, bytes memory performData);
+
+    /// @notice Perform automated finalization.
+    /// @param performData ABI encoded jobId produced by `checkUpkeep`.
+    function performUpkeep(bytes calldata performData) external;
 
     /// @notice Batch update core validation parameters
     /// @param committeeSize Number of validators selected per job

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -119,5 +119,17 @@ contract ValidationStub is IValidationModule {
     }
 
     function setSelectionStrategy(IValidationModule.SelectionStrategy) external override {}
+
+    function checkUpkeep(bytes calldata)
+        external
+        pure
+        override
+        returns (bool upkeepNeeded, bytes memory performData)
+    {
+        upkeepNeeded = false;
+        performData = bytes("");
+    }
+
+    function performUpkeep(bytes calldata) external pure override {}
 }
 

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -177,5 +177,19 @@ contract NoValidationModule is IValidationModule, Ownable {
         pure
         override
     {}
+
+    /// @inheritdoc IValidationModule
+    function checkUpkeep(bytes calldata)
+        external
+        pure
+        override
+        returns (bool upkeepNeeded, bytes memory performData)
+    {
+        upkeepNeeded = false;
+        performData = bytes("");
+    }
+
+    /// @inheritdoc IValidationModule
+    function performUpkeep(bytes calldata) external pure override {}
 }
 

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -200,5 +200,19 @@ contract OracleValidationModule is IValidationModule, Ownable {
         pure
         override
     {}
+
+    /// @inheritdoc IValidationModule
+    function checkUpkeep(bytes calldata)
+        external
+        pure
+        override
+        returns (bool upkeepNeeded, bytes memory performData)
+    {
+        upkeepNeeded = false;
+        performData = bytes("");
+    }
+
+    /// @inheritdoc IValidationModule
+    function performUpkeep(bytes calldata) external pure override {}
 }
 

--- a/docs/keeper-automation.md
+++ b/docs/keeper-automation.md
@@ -1,0 +1,21 @@
+# Validation Keeper Deployment
+
+The `ValidationModule` exposes `checkUpkeep` and `performUpkeep` so a
+keeper or Chainlink Automation job can automatically finalise jobs when
+the reveal window closes.
+
+## Registering Automation
+
+1. Deploy the `ValidationModule` and wire it to the rest of the
+   platform as normal.
+2. On the Chainlink Automation UI create a new upkeep pointing at the
+   `ValidationModule` address.
+3. Encode the job identifier in the **check data** field using
+   `abi.encode(uint256 jobId)`.
+4. The automation network calls `checkUpkeep(checkData)` off‑chain. If it
+   returns `upkeepNeeded`, the same `performData` is passed to
+   `performUpkeep` on‑chain.
+5. `performUpkeep` invokes `_finalize(jobId)` which tallies votes and
+   notifies the `JobRegistry`.
+
+Events `UpkeepPerformed(jobId, success)` are emitted for monitoring.

--- a/test/v2/ValidationModuleKeeper.test.js
+++ b/test/v2/ValidationModuleKeeper.test.js
@@ -1,0 +1,141 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+async function setup() {
+  const [owner, employer, v1, v2, v3] = await ethers.getSigners();
+
+  const StakeMock = await ethers.getContractFactory("MockStakeManager");
+  const stakeManager = await StakeMock.deploy();
+  await stakeManager.waitForDeployment();
+
+  const JobMock = await ethers.getContractFactory("MockJobRegistry");
+  const jobRegistry = await JobMock.deploy();
+  await jobRegistry.waitForDeployment();
+
+  const RepMock = await ethers.getContractFactory("MockReputationEngine");
+  const reputation = await RepMock.deploy();
+  await reputation.waitForDeployment();
+
+  const Validation = await ethers.getContractFactory(
+    "contracts/v2/ValidationModule.sol:ValidationModule"
+  );
+  const validation = await Validation.deploy(
+    await jobRegistry.getAddress(),
+    await stakeManager.getAddress(),
+    60,
+    60,
+    3,
+    3,
+    []
+  );
+  await validation.waitForDeployment();
+  await validation
+    .connect(owner)
+    .setReputationEngine(await reputation.getAddress());
+
+  const VRFMock = await ethers.getContractFactory(
+    "contracts/v2/mocks/VRFMock.sol:VRFMock"
+  );
+  const vrf = await VRFMock.deploy();
+  await vrf.waitForDeployment();
+  await validation.setVRF(await vrf.getAddress());
+
+  const Identity = await ethers.getContractFactory(
+    "contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock"
+  );
+  const identity = await Identity.deploy();
+  await identity.waitForDeployment();
+  await validation
+    .connect(owner)
+    .setIdentityRegistry(await identity.getAddress());
+  await identity.setClubRootNode(ethers.ZeroHash);
+  await identity.setAgentRootNode(ethers.ZeroHash);
+  await identity.addAdditionalValidator(v1.address);
+  await identity.addAdditionalValidator(v2.address);
+  await identity.addAdditionalValidator(v3.address);
+
+  await stakeManager.setStake(v1.address, 1, ethers.parseEther("100"));
+  await stakeManager.setStake(v2.address, 1, ethers.parseEther("50"));
+  await stakeManager.setStake(v3.address, 1, ethers.parseEther("25"));
+  await validation
+    .connect(owner)
+    .setValidatorPool([v1.address, v2.address, v3.address]);
+
+  const jobStruct = {
+    employer: employer.address,
+    agent: ethers.ZeroAddress,
+    reward: 0,
+    stake: 0,
+    success: false,
+    status: 3,
+    uriHash: ethers.ZeroHash,
+    resultHash: ethers.ZeroHash,
+  };
+  await jobRegistry.setJob(1, jobStruct);
+  async function select(jobId, randomness = 12345) {
+    await validation.requestVRF(jobId);
+    const req = await validation.vrfRequestIds(jobId);
+    await vrf.fulfill(req, randomness);
+    return validation.selectValidators(jobId, 0);
+  }
+
+  return {
+    owner,
+    employer,
+    v1,
+    v2,
+    v3,
+    validation,
+    stakeManager,
+    jobRegistry,
+    identity,
+    reputation,
+    select,
+  };
+}
+
+async function advance(seconds) {
+  await ethers.provider.send("evm_increaseTime", [seconds]);
+  await ethers.provider.send("evm_mine", []);
+}
+
+describe("ValidationModule automation", function () {
+  it("finalizes after reveal window via keeper", async () => {
+    const { v1, v2, v3, validation, jobRegistry, select } = await setup();
+    await select(1);
+    const salt1 = ethers.keccak256(ethers.toUtf8Bytes("s1"));
+    const salt2 = ethers.keccak256(ethers.toUtf8Bytes("s2"));
+    const salt3 = ethers.keccak256(ethers.toUtf8Bytes("s3"));
+    const nonce = await validation.jobNonce(1);
+    const commit1 = ethers.solidityPackedKeccak256(
+      ["uint256", "uint256", "bool", "bytes32"],
+      [1n, nonce, true, salt1]
+    );
+    const commit2 = ethers.solidityPackedKeccak256(
+      ["uint256", "uint256", "bool", "bytes32"],
+      [1n, nonce, false, salt2]
+    );
+    const commit3 = ethers.solidityPackedKeccak256(
+      ["uint256", "uint256", "bool", "bytes32"],
+      [1n, nonce, false, salt3]
+    );
+    await validation.connect(v1).commitValidation(1, commit1, "", []);
+    await validation.connect(v2).commitValidation(1, commit2, "", []);
+    await validation.connect(v3).commitValidation(1, commit3, "", []);
+    await advance(61);
+    await validation.connect(v1).revealValidation(1, true, salt1, "", []);
+    await validation.connect(v2).revealValidation(1, false, salt2, "", []);
+    await validation.connect(v3).revealValidation(1, false, salt3, "", []);
+    await advance(61);
+    const abi = ethers.AbiCoder.defaultAbiCoder();
+    const checkData = abi.encode(["uint256"], [1]);
+    const [needed, performData] = await validation.checkUpkeep(checkData);
+    expect(needed).to.equal(true);
+    expect(performData).to.equal(checkData);
+    await validation.performUpkeep(performData);
+    const job = await jobRegistry.jobs(1);
+    expect(job.status).to.equal(6);
+    expect(job.success).to.equal(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Chainlink-style `checkUpkeep`/`performUpkeep` to `ValidationModule`
- document keeper deployment and usage
- test automated finalization via mocked keeper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8d6a4d1483339276de8eb7a2318b