### PR TITLE
feat: guard VRF requests against reentrancy

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -224,6 +224,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     function requestVRF(uint256 jobId)
         external
         whenNotPaused
+        nonReentrant
         returns (uint256 requestId)
     {
         require(address(vrf) != address(0), "vrf not set");

--- a/contracts/v2/mocks/ReentrantVRF.sol
+++ b/contracts/v2/mocks/ReentrantVRF.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IVRFConsumer} from "../interfaces/IVRFConsumer.sol";
+import {IValidationModule} from "../interfaces/IValidationModule.sol";
+
+/// @dev VRF mock that attempts to reenter ValidationModule.requestVRF.
+contract ReentrantVRF is IVRFConsumer {
+    IValidationModule public validation;
+    bool public attack;
+    uint256 public jobId;
+    uint256 public nextRequestId = 1;
+
+    function setValidationModule(address vm) external {
+        validation = IValidationModule(vm);
+    }
+
+    function attackRequest(uint256 _jobId) external {
+        attack = true;
+        jobId = _jobId;
+    }
+
+    function requestRandomWords() external override returns (uint256 requestId) {
+        requestId = nextRequestId++;
+        if (attack) {
+            attack = false;
+            validation.requestVRF(jobId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- protect `requestVRF` with `nonReentrant`
- add a reentrant VRF mock and tests covering `requestVRF`

## Testing
- `npx hardhat test test/v2/ValidationModuleReentrancy.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68af94b345ec8333b837332ba3f51231