### PR TITLE
feat: ensure treasury address is nonzero

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -401,6 +401,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
 
     /// @notice update the treasury address used for blacklisted payouts
     function setTreasury(address _treasury) external onlyGovernance {
+        require(_treasury != address(0), "treasury");
         treasury = _treasury;
         emit TreasuryUpdated(_treasury);
     }

--- a/test/v2/JobRegistryTreasury.test.js
+++ b/test/v2/JobRegistryTreasury.test.js
@@ -1,0 +1,57 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("JobRegistry Treasury", function () {
+  let registry, stakeManager, token;
+  let owner, treasury;
+
+  beforeEach(async function () {
+    [owner, treasury] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC206Decimals");
+    token = await Token.deploy();
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      0,
+      100,
+      0,
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      owner.address
+    );
+
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/JobRegistry.sol:JobRegistry"
+    );
+    registry = await Registry.deploy(
+      ethers.ZeroAddress,
+      await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+  });
+
+  it("rejects zero treasury address", async function () {
+    await expect(
+      registry.connect(owner).setTreasury(ethers.ZeroAddress)
+    ).to.be.revertedWith("treasury");
+  });
+
+  it("sets a valid treasury address", async function () {
+    await registry.connect(owner).setTreasury(treasury.address);
+    expect(await registry.treasury()).to.equal(treasury.address);
+  });
+});
+


### PR DESCRIPTION
## Summary
- require valid treasury address in `JobRegistry.setTreasury`
- test treasury setter rejects zero address

## Testing
- `npm test --silent test/v2/JobRegistryTreasury.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68afb0a8fa988333add35d8d8c7a9688