### PR TITLE
Enhance validator selection entropy

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -832,7 +832,12 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
                 jobId,
                 uint256(
                     keccak256(
-                        abi.encodePacked(resultHash, block.timestamp)
+                        abi.encodePacked(
+                            resultHash,
+                            block.timestamp,
+                            block.prevrandao,
+                            blockhash(block.number - 1)
+                        )
                     )
                 )
             );


### PR DESCRIPTION
## Summary
- Mix `block.prevrandao` and previous blockhash into the entropy used when initializing validation to improve validator selection randomness without external or off-chain dependencies.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afb755f0508333a6e51a540e662b50