### PR TITLE
Auto-request VRF when starting validation

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -13,6 +13,7 @@ import {IValidationModule} from "./interfaces/IValidationModule.sol";
 import {IIdentityRegistry} from "./interfaces/IIdentityRegistry.sol";
 import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 import {TaxAcknowledgement} from "./libraries/TaxAcknowledgement.sol";
+import {IVRF} from "./interfaces/IVRF.sol";
 
 /// @title ValidationModule
 /// @notice Handles validator selection and commit–reveal voting for jobs.
@@ -26,6 +27,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     IStakeManager public stakeManager;
     IReputationEngine public reputationEngine;
     IIdentityRegistry public identityRegistry;
+    IVRF public vrf;
 
     // timing configuration
     uint256 public commitWindow;
@@ -106,6 +108,8 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     event ValidatorPoolSampleSizeUpdated(uint256 size);
     event MaxValidatorPoolSizeUpdated(uint256 size);
     event ValidatorAuthCacheDurationUpdated(uint256 duration);
+    event VRFUpdated(address vrf);
+    event VRFAutoRequested(uint256 indexed jobId);
     /// @notice Emitted when an additional validator is added or removed.
     /// @param validator Address being updated.
     /// @param allowed True if the validator is whitelisted, false if removed.
@@ -197,12 +201,18 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         emit ModulesUpdated(address(jobRegistry), address(manager));
     }
 
-    // VRF functionality has been removed; randomness is derived on-chain.
+    // Optional VRF integration; randomness is derived on-chain when unset.
 
     /// @notice Update the identity registry used for validator verification.
     function setIdentityRegistry(IIdentityRegistry registry) external onlyOwner {
         identityRegistry = registry;
         emit IdentityRegistryUpdated(address(registry));
+    }
+
+    /// @notice Update the optional VRF provider.
+    function setVRF(IVRF _vrf) external onlyOwner {
+        vrf = _vrf;
+        emit VRFUpdated(address(_vrf));
     }
 
     /// @notice Pause validation operations
@@ -668,6 +678,10 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         return selected;
     }
 
+    function requestVRF(uint256 jobId) internal {
+        vrf.requestVRF(jobId);
+    }
+
     /// @inheritdoc IValidationModule
     function start(uint256 jobId, uint256 entropy)
         external
@@ -677,6 +691,10 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         returns (address[] memory selected)
     {
         Round storage r = rounds[jobId];
+        if (address(vrf) != address(0) && vrf.randomness(jobId) == 0) {
+            requestVRF(jobId);
+            emit VRFAutoRequested(jobId);
+        }
         uint256 n = validatorPool.length;
         require(n >= minValidators, "pool");
         uint256 size = validatorsPerJob;

--- a/contracts/v2/interfaces/IVRF.sol
+++ b/contracts/v2/interfaces/IVRF.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IVRF {
+    function randomness(uint256 jobId) external view returns (uint256);
+    function requestVRF(uint256 jobId) external;
+}

--- a/contracts/v2/mocks/VRFMock.sol
+++ b/contracts/v2/mocks/VRFMock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IVRF} from "../interfaces/IVRF.sol";
+
+contract VRFMock is IVRF {
+    mapping(uint256 => uint256) public override randomness;
+    uint256 public lastRequest;
+
+    function requestVRF(uint256 jobId) external override {
+        lastRequest = jobId;
+    }
+
+    function setRandomness(uint256 jobId, uint256 value) external {
+        randomness[jobId] = value;
+    }
+}

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -102,6 +102,22 @@ describe("ValidationModule V2", function () {
     expect(event.args[1].length).to.equal(3);
   });
 
+  it("auto-requests VRF when missing randomness", async () => {
+    const VRF = await ethers.getContractFactory(
+      "contracts/v2/mocks/VRFMock.sol:VRFMock"
+    );
+    const vrf = await VRF.deploy();
+    await vrf.waitForDeployment();
+    await validation.connect(owner).setVRF(await vrf.getAddress());
+    const tx = await validation.start(1, 0);
+    const receipt = await tx.wait();
+    const auto = receipt.logs.find(
+      (l) => l.fragment && l.fragment.name === "VRFAutoRequested"
+    );
+    expect(auto.args[0]).to.equal(1n);
+    expect(await vrf.lastRequest()).to.equal(1n);
+  });
+
 
   it("reverts when stake manager is unset", async () => {
     await validation.connect(owner).setStakeManager(ethers.ZeroAddress);

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -137,8 +137,12 @@ describe("ValidationModule access controls", function () {
       (l) => l.fragment && l.fragment.name === "ValidatorsSelected"
     ).args[1];
     const val = selected[0];
-    const signer =
-      val.toLowerCase() === v1.address.toLowerCase() ? v1 : v2;
+    const signerMap = {
+      [v1.address.toLowerCase()]: v1,
+      [v2.address.toLowerCase()]: v2,
+      [v3.address.toLowerCase()]: v3,
+    };
+    const signer = signerMap[val.toLowerCase()];
 
     const salt = ethers.keccak256(ethers.toUtf8Bytes("salt"));
     const nonce = await validation.jobNonce(1);


### PR DESCRIPTION
## Summary
- integrate optional VRF provider with setter and auto-request event
- trigger VRF request in `start` when configured randomness is missing
- add VRF mock and unit test covering automatic request path

## Testing
- `npm test test/v2/ValidationModule.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68afc58406e88333bf6c7e5feb2c42da