### PR TITLE
Add extra entropy to validation start

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -298,7 +298,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         job.status = Status.Submitted;
         emit JobSubmitted(jobId, msg.sender, resultHash, resultURI);
         if (validationModule != address(0)) {
-            IValidationModule(validationModule).start(jobId, 0);
+            IValidationModule(validationModule).start(jobId, 0, 0);
         }
     }
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -830,6 +830,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         if (address(validationModule) != address(0)) {
             validationModule.start(
                 jobId,
+                0,
                 uint256(
                     keccak256(
                         abi.encodePacked(

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -683,13 +683,11 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     }
 
     /// @inheritdoc IValidationModule
-    function start(uint256 jobId, uint256 entropy)
-        external
-        override
-        whenNotPaused
-        nonReentrant
-        returns (address[] memory selected)
-    {
+    function start(
+        uint256 jobId,
+        uint256 entropy,
+        uint256 extraEntropy
+    ) external override whenNotPaused nonReentrant returns (address[] memory selected) {
         Round storage r = rounds[jobId];
         if (address(vrf) != address(0) && vrf.randomness(jobId) == 0) {
             requestVRF(jobId);
@@ -702,7 +700,11 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         if (size > maxValidators) size = maxValidators;
         if (size > n) size = n;
         r.committeeSize = size;
-        selected = selectValidators(jobId, entropy);
+        uint256 ent = entropy;
+        if (ent == 0) {
+            ent = extraEntropy;
+        }
+        selected = selectValidators(jobId, ent);
     }
 
     /// @notice Internal commit logic shared by overloads.

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -45,11 +45,14 @@ interface IValidationModule {
 
     /// @notice Start validation for a job and select validators
     /// @param jobId Identifier of the job
-    /// @param entropy Optional caller-provided entropy
+    /// @param entropy VRF-supplied randomness if available, otherwise 0
+    /// @param extraEntropy Additional caller-provided entropy mixed in when VRF is absent
     /// @return validators Array of selected validator addresses
-    function start(uint256 jobId, uint256 entropy)
-        external
-        returns (address[] memory validators);
+    function start(
+        uint256 jobId,
+        uint256 entropy,
+        uint256 extraEntropy
+    ) external returns (address[] memory validators);
 
     /// @notice Commit a validation hash for a job
     /// @param jobId Identifier of the job being voted on

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -29,12 +29,12 @@ contract ValidationStub is IValidationModule {
         return validatorList;
     }
 
-    function start(uint256 jobId, uint256 /*entropy*/)
-        external
-        override
-        returns (address[] memory vals)
-    {
-        vals = selectValidators(jobId, 0);
+    function start(
+        uint256 jobId,
+        uint256 /*entropy*/,
+        uint256 extraEntropy
+    ) external override returns (address[] memory vals) {
+        vals = selectValidators(jobId, extraEntropy);
     }
 
     function commitValidation(

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -40,11 +40,11 @@ contract NoValidationModule is IValidationModule, Ownable {
     }
 
     /// @inheritdoc IValidationModule
-    function start(uint256 jobId, uint256 /*entropy*/)
-        external
-        override
-        returns (address[] memory vals)
-    {
+    function start(
+        uint256 jobId,
+        uint256 /*entropy*/,
+        uint256 /*extraEntropy*/
+    ) external override returns (address[] memory vals) {
         vals = new address[](0);
         jobRegistry.onValidationResult(jobId, true, vals);
     }

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -62,11 +62,11 @@ contract OracleValidationModule is IValidationModule, Ownable {
     }
 
     /// @inheritdoc IValidationModule
-    function start(uint256 jobId, uint256 /*entropy*/)
-        external
-        override
-        returns (address[] memory vals)
-    {
+    function start(
+        uint256 jobId,
+        uint256 /*entropy*/,
+        uint256 /*extraEntropy*/
+    ) external override returns (address[] memory vals) {
         vals = new address[](0);
         bool approved = oracle.approve(jobId, "");
         jobRegistry.onValidationResult(jobId, approved, vals);

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,8 +42,8 @@ const jobId = receipt.logs[0].args.jobId;
 ## ValidationModule
 Manages commit‑reveal voting by validators.
 
-- `start(jobId, entropy)` – select validators and open the commit window.
-- `selectValidators(jobId, entropy)` – choose validators for a job.
+ - `start(jobId, entropy, extraEntropy)` – select validators and open the commit window. `extraEntropy` is mixed in when VRF randomness is unavailable.
+ - `selectValidators(jobId, entropy)` – choose validators for a job.
 - `commitValidation(jobId, commitHash)` / `revealValidation(jobId, approve, salt)` – validator vote flow.
 - `finalize(jobId)` – tallies votes and notifies `JobRegistry`.
 

--- a/docs/api/ValidationModule.md
+++ b/docs/api/ValidationModule.md
@@ -9,8 +9,8 @@ Manages commit‑reveal voting for submitted jobs.
 - `setValidatorBounds(uint256 minVals, uint256 maxVals)` / `setValidatorsPerJob(uint256 count)` – configure validator bounds and default committee size.
 - `setValidatorSlashingPct(uint256 pct)` / `setApprovalThreshold(uint256 pct)` / `setRequiredValidatorApprovals(uint256 count)` – configure slashing and thresholds.
 - `setSelectionStrategy(SelectionStrategy strategy)` – choose between a rotating window or reservoir sampling. Governance can adjust this to balance gas cost and fairness.
- - `start(uint256 jobId, uint256 entropy)` – select validators and open the commit window.
- - `selectValidators(uint256 jobId, uint256 entropy)` – pick validators using on-chain randomness.
+- `start(uint256 jobId, uint256 entropy, uint256 extraEntropy)` – select validators and open the commit window. `extraEntropy` is mixed in when VRF randomness is unavailable.
+- `selectValidators(uint256 jobId, uint256 entropy)` – pick validators using on-chain randomness.
 - `commitValidation(uint256 jobId, bytes32 commitHash)` – validator commits to a vote.
 - `revealValidation(uint256 jobId, bool approve, bytes32 salt)` – reveal vote.
 - `finalize(uint256 jobId)` – tally reveals and trigger payout.

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -94,7 +94,7 @@ describe("ValidationModule V2", function () {
   });
 
   it("starts validation", async () => {
-    const tx = await validation.start(1, 0);
+    const tx = await validation.start(1, 0, 0);
     const receipt = await tx.wait();
     const event = receipt.logs.find(
       (l) => l.fragment && l.fragment.name === "ValidatorsSelected"
@@ -109,7 +109,7 @@ describe("ValidationModule V2", function () {
     const vrf = await VRF.deploy();
     await vrf.waitForDeployment();
     await validation.connect(owner).setVRF(await vrf.getAddress());
-    const tx = await validation.start(1, 0);
+    const tx = await validation.start(1, 0, 0);
     const receipt = await tx.wait();
     const auto = receipt.logs.find(
       (l) => l.fragment && l.fragment.name === "VRFAutoRequested"

--- a/test/v2/ValidationModuleCommitteeSize.test.js
+++ b/test/v2/ValidationModuleCommitteeSize.test.js
@@ -77,7 +77,7 @@ describe("ValidationModule committee size", function () {
   }
 
   async function start(jobId, entropy = 0) {
-    return validation.start(jobId, entropy);
+    return validation.start(jobId, 0, entropy);
   }
 
   it("respects validator count bounds", async () => {

--- a/test/v2/ValidationModuleReentrancy.test.js
+++ b/test/v2/ValidationModuleReentrancy.test.js
@@ -69,7 +69,7 @@ async function setup() {
   await jobRegistry.setJob(1, jobStruct);
 
   async function prepare(jobId, entropy = 0) {
-    return validation.start(jobId, entropy);
+    return validation.start(jobId, 0, entropy);
   }
 
   return {


### PR DESCRIPTION
## Summary
- extend `start` to accept an `extraEntropy` argument and use it for validator selection when VRF randomness is missing
- forward extra entropy from `JobRegistry` and update stub modules
- document the new parameter in ValidationModule API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afcc7405fc8333b6b2e58689cb8232