### PR TITLE
Integrate SystemPause deployment

### DIFF
--- a/docs/system-pause.md
+++ b/docs/system-pause.md
@@ -1,0 +1,30 @@
+# System Pause
+
+`SystemPause` lets governance halt or resume the core modules in one
+transaction. After deployment, wire module addresses using
+`setModules` and then use `pauseAll` or `unpauseAll` as needed.
+
+## Hardhat CLI
+```sh
+npx hardhat console --network <network>
+> const pause = await ethers.getContractAt("SystemPause", "<pause>");
+> const gov = await ethers.getSigner("<governance>");
+> await pause.connect(gov).setModules(
+    "<registry>",
+    "<stake>",
+    "<validation>",
+    "<dispute>",
+    "<platformRegistry>",
+    "<feePool>",
+    "<reputation>"
+  );
+> await pause.connect(gov).pauseAll();
+> await pause.connect(gov).unpauseAll();
+```
+
+## Etherscan
+1. Open the SystemPause contract on Etherscan with your governance
+   account connected.
+2. In **Write Contract**, call `setModules` with the module addresses if
+   not already configured.
+3. Invoke `pauseAll` to stop the system or `unpauseAll` to resume.

--- a/test/v2/SystemPause.test.js
+++ b/test/v2/SystemPause.test.js
@@ -77,6 +77,18 @@ describe("SystemPause", function () {
     const feePool = FeePool.attach(feePoolAddr);
     const pause = SystemPause.attach(systemPauseAddr);
 
+    await pause
+      .connect(owner)
+      .setModules(
+        registryAddr,
+        stakeAddr,
+        validationAddr,
+        disputeAddr,
+        platformRegistryAddr,
+        feePoolAddr,
+        reputationAddr
+      );
+
     expect(await stake.paused()).to.equal(false);
     expect(await registry.paused()).to.equal(false);
     expect(await validation.paused()).to.equal(false);


### PR DESCRIPTION
## Summary
- deploy SystemPause in v2 scripts and wire core modules via setModules
- add governance examples for using SystemPause
- test pauseAll/unpauseAll across core modules

## Testing
- `npx hardhat test test/v2/SystemPause.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68afd8ee1b9483339be1a7755ce87b1e