### PR TITLE
feat: randomize rotation start

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -495,6 +495,10 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
 
         if (selectionStrategy == IValidationModule.SelectionStrategy.Rotating) {
             uint256 rotationStart = validatorPoolRotation;
+            uint256 offset = uint256(
+                keccak256(abi.encodePacked(randao, bhash))
+            ) % n;
+            rotationStart = (rotationStart + offset) % n;
             uint256 i;
             for (; i < n && candidateCount < sample;) {
                 uint256 idx = (rotationStart + i) % n;

--- a/test/v2/ValidatorSelectionRotation.test.js
+++ b/test/v2/ValidatorSelectionRotation.test.js
@@ -1,0 +1,62 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Validator selection rotating strategy", function () {
+  let validation, stake, identity;
+  const poolSize = 10;
+  const sampleSize = 3;
+
+  beforeEach(async () => {
+    const StakeMock = await ethers.getContractFactory("MockStakeManager");
+    stake = await StakeMock.deploy();
+    await stake.waitForDeployment();
+
+    const Identity = await ethers.getContractFactory(
+      "contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock"
+    );
+    identity = await Identity.deploy();
+    await identity.waitForDeployment();
+    await identity.setClubRootNode(ethers.ZeroHash);
+    await identity.setAgentRootNode(ethers.ZeroHash);
+
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/ValidationModule.sol:ValidationModule"
+    );
+    validation = await Validation.deploy(
+      ethers.ZeroAddress,
+      await stake.getAddress(),
+      1,
+      1,
+      3,
+      10,
+      []
+    );
+    await validation.waitForDeployment();
+    await validation.setIdentityRegistry(await identity.getAddress());
+    await validation.setSelectionStrategy(0);
+    await validation.setValidatorPoolSampleSize(sampleSize);
+
+    const validators = [];
+    for (let i = 0; i < poolSize; i++) {
+      const addr = ethers.Wallet.createRandom().address;
+      validators.push(addr);
+      await stake.setStake(addr, 1, ethers.parseEther("1"));
+      await identity.addAdditionalValidator(addr);
+    }
+    await validation.setValidatorPool(validators);
+  });
+
+  it("randomizes rotation start index between runs", async () => {
+    const starts = new Set();
+    for (let j = 0; j < 5; j++) {
+      const tx = await validation.selectValidators(j + 1, 0);
+      await tx.wait();
+      const rotation = await validation.validatorPoolRotation();
+      const start = Number(
+        (rotation + BigInt(poolSize) - BigInt(sampleSize)) % BigInt(poolSize)
+      );
+      starts.add(start);
+    }
+    expect(starts.size).to.be.gt(1);
+  });
+});


### PR DESCRIPTION
## Summary
- use on-chain entropy to add random offset before rotating validator pool
- track rotation start changes between runs

## Testing
- `npx hardhat test test/v2/ValidatorSelectionRotation.test.js test/v2/ValidationModule.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0580f33d88333bb60cb5f0e66342f