### PR TITLE
Enforce validator pool size limit

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -174,6 +174,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         external
         onlyOwner
     {
+        require(newPool.length <= maxValidatorPoolSize, "pool limit");
         validatorPool = newPool;
         emit ValidatorsUpdated(newPool);
     }

--- a/test/v2/ValidatorSelectionLargePool.test.js
+++ b/test/v2/ValidatorSelectionLargePool.test.js
@@ -67,12 +67,10 @@ describe("Validator selection with large pool", function () {
     for (let i = 0; i < poolSize; i++) {
       const addr = ethers.Wallet.createRandom().address;
       validators.push(addr);
-      await stake.setStake(addr, 1, ethers.parseEther("1"));
-      await identity.addAdditionalValidator(addr);
     }
-    await validation.setValidatorPool(validators);
-    await validation.setValidatorsPerJob(3);
-    await expect(validation.selectValidators(1, 0)).to.be.revertedWith("pool limit");
+    await expect(
+      validation.setValidatorPool(validators)
+    ).to.be.revertedWith("pool limit");
   });
 });
 


### PR DESCRIPTION
## Summary
- enforce maxValidatorPoolSize when updating validator pool
- test that setValidatorPool reverts for oversized pools

## Testing
- `npx hardhat test test/v2/ValidatorSelectionLargePool.test.js` *(fails: npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.)*

------
https://chatgpt.com/codex/tasks/task_e_68b06d62f6588333b9daaba138273296