### PR TITLE
feat: add custom errors for job creation

### DIFF
--- a/test/v2/JobRegistryDeadlineFuzz.t.sol
+++ b/test/v2/JobRegistryDeadlineFuzz.t.sol
@@ -27,14 +27,15 @@ contract JobRegistryDeadlineFuzz is Test {
             ITaxPolicy(address(0)),
             0,
             0,
-            new address[](0)
+            new address[](0),
+            address(0)
         );
     }
 
     function testFuzz_deadline(uint64 deadline) public {
         uint256 reward = 1;
         if (deadline <= block.timestamp) {
-            vm.expectRevert("deadline");
+            vm.expectRevert(JobRegistry.InvalidDeadline.selector);
             registry.createJob(reward, deadline, "uri");
         } else {
             registry.createJob(reward, deadline, "uri");


### PR DESCRIPTION
## Summary
- define custom errors for job creation validation and swap `require` calls for explicit `revert` patterns
- update job creation fuzz tests to expect custom errors

## Testing
- `npx hardhat test test/v2/JobRegistry.test.js` *(fails: command produced no output in the environment)*
- `forge test --match-path test/v2/JobRegistryDeadlineFuzz.t.sol` *(fails: compilation failed; missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b07fd784048333a3b760bd00b9ad27