### PR TITLE
chore: cap default validator pool size

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -52,8 +52,10 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     address[] public validatorPool;
     // maximum number of pool entries to sample on-chain
     uint256 public validatorPoolSampleSize = 100;
-    // hard cap on validator pool size
-    uint256 public maxValidatorPoolSize = type(uint256).max;
+    // hard cap on validator pool size; default chosen to keep on-chain
+    // iteration within practical gas limits while allowing governance to
+    // raise or lower it via the existing setter.
+    uint256 public maxValidatorPoolSize = 1000;
 
     /// @notice Current strategy used for validator sampling.
     IValidationModule.SelectionStrategy public selectionStrategy;


### PR DESCRIPTION
## Summary
- limit default `maxValidatorPoolSize` to 1000 to avoid unbounded gas use
- document rationale that governance can adjust via setter

## Testing
- `npm run lint` (warnings: `no-unused-vars`)
- `npm test` *(fails: Downloading compiler 0.8.25/0.8.21)*

------
https://chatgpt.com/codex/tasks/task_e_68b0aef8493083339d55aaf7a4c97b60