### PR TITLE
Guard StakeManager lock against ERC777 reentrancy

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -738,7 +738,12 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     ///      escrowed balance.
     /// @param from Address providing the funds; must approve first.
     /// @param amount Token amount with 6 decimals to lock.
-    function lock(address from, uint256 amount) external onlyJobRegistry whenNotPaused {
+    function lock(address from, uint256 amount)
+        external
+        onlyJobRegistry
+        whenNotPaused
+        nonReentrant
+    {
         token.safeTransferFrom(from, address(this), amount);
         emit StakeEscrowLocked(bytes32(0), from, amount);
     }

--- a/contracts/v2/mocks/ReentrantERC777.sol
+++ b/contracts/v2/mocks/ReentrantERC777.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface IReentrantCaller {
+    function reenter() external;
+}
+
+/// @dev ERC20 token with ERC777-style send hook that attempts to reenter the caller.
+contract ReentrantERC777 is ERC20 {
+    IReentrantCaller public caller;
+    bool public attack;
+
+    constructor() ERC20("Reentrant777", "R777") {}
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function setCaller(address _caller) external {
+        caller = IReentrantCaller(_caller);
+    }
+
+    function setAttack(bool _attack) external {
+        attack = _attack;
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (attack && address(caller) != address(0)) {
+            attack = false;
+            caller.reenter();
+        }
+        super._update(from, to, value);
+    }
+}
+

--- a/test/v2/StakeManagerLockReentrancy.test.js
+++ b/test/v2/StakeManagerLockReentrancy.test.js
@@ -1,0 +1,60 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("StakeManager lock reentrancy", function () {
+  let owner, employer, treasury;
+  let token, stakeManager, jobRegistry;
+
+  beforeEach(async () => {
+    [owner, employer, treasury] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory(
+      "contracts/v2/mocks/ReentrantERC777.sol:ReentrantERC777"
+    );
+    token = await Token.deploy();
+    await token.mint(employer.address, 1000);
+
+    const StakeManager = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    stakeManager = await StakeManager.deploy(
+      await token.getAddress(),
+      0,
+      50,
+      50,
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      owner.address
+    );
+    await stakeManager.connect(owner).setMinStake(0);
+
+    const JobRegistry = await ethers.getContractFactory(
+      "contracts/v2/mocks/ReentrantJobRegistry.sol:ReentrantJobRegistry"
+    );
+    jobRegistry = await JobRegistry.deploy(
+      await stakeManager.getAddress(),
+      await token.getAddress()
+    );
+
+    await token.setCaller(await jobRegistry.getAddress());
+    await stakeManager
+      .connect(owner)
+      .setJobRegistry(await jobRegistry.getAddress());
+  });
+
+  it("guards lock against reentrancy", async () => {
+    const amount = 100;
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), amount);
+
+    await expect(
+      jobRegistry.attackLock(employer.address, amount)
+    ).to.be.revertedWithCustomError(
+      stakeManager,
+      "ReentrancyGuardReentrantCall"
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add nonReentrant guard to StakeManager.lock
- add ERC777-style token and reentrant job registry attack
- test lock reentrancy with malicious token

## Testing
- `npx hardhat test test/v2/StakeManagerReentrancy.test.js test/v2/StakeManagerLockReentrancy.test.js`
- `npx hardhat test`
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dfdb3358833396410b1c8f59f69b