### PR TITLE
Safeguard SystemPause from redundant calls

### DIFF
--- a/contracts/v2/SystemPause.sol
+++ b/contracts/v2/SystemPause.sol
@@ -81,24 +81,52 @@ contract SystemPause is Governable, ReentrancyGuard {
 
     /// @notice Pause all core modules.
     function pauseAll() external onlyGovernance nonReentrant {
-        jobRegistry.pause();
-        stakeManager.pause();
-        validationModule.pause();
-        disputeModule.pause();
-        platformRegistry.pause();
-        feePool.pause();
-        reputationEngine.pause();
+        if (!jobRegistry.paused()) {
+            jobRegistry.pause();
+        }
+        if (!stakeManager.paused()) {
+            stakeManager.pause();
+        }
+        if (!validationModule.paused()) {
+            validationModule.pause();
+        }
+        if (!disputeModule.paused()) {
+            disputeModule.pause();
+        }
+        if (!platformRegistry.paused()) {
+            platformRegistry.pause();
+        }
+        if (!feePool.paused()) {
+            feePool.pause();
+        }
+        if (!reputationEngine.paused()) {
+            reputationEngine.pause();
+        }
     }
 
     /// @notice Unpause all core modules.
     function unpauseAll() external onlyGovernance nonReentrant {
-        jobRegistry.unpause();
-        stakeManager.unpause();
-        validationModule.unpause();
-        disputeModule.unpause();
-        platformRegistry.unpause();
-        feePool.unpause();
-        reputationEngine.unpause();
+        if (jobRegistry.paused()) {
+            jobRegistry.unpause();
+        }
+        if (stakeManager.paused()) {
+            stakeManager.unpause();
+        }
+        if (validationModule.paused()) {
+            validationModule.unpause();
+        }
+        if (disputeModule.paused()) {
+            disputeModule.unpause();
+        }
+        if (platformRegistry.paused()) {
+            platformRegistry.unpause();
+        }
+        if (feePool.paused()) {
+            feePool.unpause();
+        }
+        if (reputationEngine.paused()) {
+            reputationEngine.unpause();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid reverts by checking each module's paused state before calling pause/unpause
- test that repeated pauseAll/unpauseAll invocations succeed

## Testing
- `npx hardhat test test/v2/SystemPause.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b0e6fbb8108333a1eb591a9b75166d