### PR TITLE
enforce validator approval bounds

### DIFF
--- a/test/v2/ValidationModuleApprovals.test.js
+++ b/test/v2/ValidationModuleApprovals.test.js
@@ -1,0 +1,49 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ValidationModule required approvals", function () {
+  let owner;
+  let validation;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/ValidationModule.sol:ValidationModule"
+    );
+    validation = await Validation.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      60,
+      60,
+      3,
+      4,
+      []
+    );
+    await validation.waitForDeployment();
+  });
+
+  it("reverts for invalid counts", async () => {
+    await expect(
+      validation.connect(owner).setRequiredValidatorApprovals(0)
+    ).to.be.revertedWith("approvals");
+    await expect(
+      validation.connect(owner).setRequiredValidatorApprovals(5)
+    ).to.be.revertedWith("approvals");
+  });
+
+  it("updates and clamps to committee size", async () => {
+    await validation.connect(owner).setRequiredValidatorApprovals(2);
+    expect(await validation.requiredValidatorApprovals()).to.equal(2n);
+
+    await validation.connect(owner).setRequiredValidatorApprovals(4);
+    expect(await validation.requiredValidatorApprovals()).to.equal(3n);
+
+    await validation.connect(owner).setValidatorsPerJob(4);
+    await validation.connect(owner).setRequiredValidatorApprovals(4);
+    expect(await validation.requiredValidatorApprovals()).to.equal(4n);
+
+    await validation.connect(owner).setValidatorsPerJob(3);
+    expect(await validation.requiredValidatorApprovals()).to.equal(3n);
+  });
+});
+


### PR DESCRIPTION
## Summary
- clamp required validator approvals to committee size and enforce bounds
- adjust related setters and add tests for approval count validation

## Testing
- `./node_modules/.bin/hardhat --config hh-validation.config.js test test/v2/ValidationModuleApprovals.test.js` (failed: Stack too deep / compilation failed)


------
https://chatgpt.com/codex/tasks/task_e_68b11e361b588333bcc6e3ed021f19c6