### PR TITLE
Validate module addresses in SystemPause

### DIFF
--- a/contracts/v2/SystemPause.sol
+++ b/contracts/v2/SystemPause.sol
@@ -23,6 +23,14 @@ contract SystemPause is Governable, ReentrancyGuard {
     FeePool public feePool;
     ReputationEngine public reputationEngine;
 
+    error InvalidJobRegistry(address module);
+    error InvalidStakeManager(address module);
+    error InvalidValidationModule(address module);
+    error InvalidDisputeModule(address module);
+    error InvalidPlatformRegistry(address module);
+    error InvalidFeePool(address module);
+    error InvalidReputationEngine(address module);
+
     event ModulesUpdated(
         address jobRegistry,
         address stakeManager,
@@ -43,6 +51,33 @@ contract SystemPause is Governable, ReentrancyGuard {
         ReputationEngine _reputationEngine,
         address _governance
     ) Governable(_governance) {
+        if (
+            address(_jobRegistry) == address(0) ||
+            address(_jobRegistry).code.length == 0
+        ) revert InvalidJobRegistry(address(_jobRegistry));
+        if (
+            address(_stakeManager) == address(0) ||
+            address(_stakeManager).code.length == 0
+        ) revert InvalidStakeManager(address(_stakeManager));
+        if (
+            address(_validationModule) == address(0) ||
+            address(_validationModule).code.length == 0
+        ) revert InvalidValidationModule(address(_validationModule));
+        if (
+            address(_disputeModule) == address(0) ||
+            address(_disputeModule).code.length == 0
+        ) revert InvalidDisputeModule(address(_disputeModule));
+        if (
+            address(_platformRegistry) == address(0) ||
+            address(_platformRegistry).code.length == 0
+        ) revert InvalidPlatformRegistry(address(_platformRegistry));
+        if (address(_feePool) == address(0) || address(_feePool).code.length == 0)
+            revert InvalidFeePool(address(_feePool));
+        if (
+            address(_reputationEngine) == address(0) ||
+            address(_reputationEngine).code.length == 0
+        ) revert InvalidReputationEngine(address(_reputationEngine));
+
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
         validationModule = _validationModule;
@@ -61,6 +96,33 @@ contract SystemPause is Governable, ReentrancyGuard {
         FeePool _feePool,
         ReputationEngine _reputationEngine
     ) external onlyGovernance {
+        if (
+            address(_jobRegistry) == address(0) ||
+            address(_jobRegistry).code.length == 0
+        ) revert InvalidJobRegistry(address(_jobRegistry));
+        if (
+            address(_stakeManager) == address(0) ||
+            address(_stakeManager).code.length == 0
+        ) revert InvalidStakeManager(address(_stakeManager));
+        if (
+            address(_validationModule) == address(0) ||
+            address(_validationModule).code.length == 0
+        ) revert InvalidValidationModule(address(_validationModule));
+        if (
+            address(_disputeModule) == address(0) ||
+            address(_disputeModule).code.length == 0
+        ) revert InvalidDisputeModule(address(_disputeModule));
+        if (
+            address(_platformRegistry) == address(0) ||
+            address(_platformRegistry).code.length == 0
+        ) revert InvalidPlatformRegistry(address(_platformRegistry));
+        if (address(_feePool) == address(0) || address(_feePool).code.length == 0)
+            revert InvalidFeePool(address(_feePool));
+        if (
+            address(_reputationEngine) == address(0) ||
+            address(_reputationEngine).code.length == 0
+        ) revert InvalidReputationEngine(address(_reputationEngine));
+
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
         validationModule = _validationModule;

--- a/docs/system-pause.md
+++ b/docs/system-pause.md
@@ -4,6 +4,12 @@
 transaction. After deployment, wire module addresses using
 `setModules` and then use `pauseAll` or `unpauseAll` as needed.
 
+Each module address passed to the constructor or `setModules` must be a
+non-zero address pointing to a deployed contract. The contract reverts with
+`InvalidJobRegistry`, `InvalidStakeManager`, `InvalidValidationModule`,
+`InvalidDisputeModule`, `InvalidPlatformRegistry`, `InvalidFeePool`, or
+`InvalidReputationEngine` if validation fails.
+
 ## Hardhat CLI
 ```sh
 npx hardhat console --network <network>

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -115,6 +115,22 @@ async function main() {
   await registry.setIdentityRegistry(await identity.getAddress());
   await reputation.setCaller(await registry.getAddress(), true);
 
+  const ensureContract = async (addr: string, name: string) => {
+    if ((await ethers.provider.getCode(addr)) === "0x") {
+      throw new Error(`${name} must be a deployed contract`);
+    }
+  };
+
+  await Promise.all([
+    ensureContract(await registry.getAddress(), "JobRegistry"),
+    ensureContract(await stake.getAddress(), "StakeManager"),
+    ensureContract(await validation.getAddress(), "ValidationModule"),
+    ensureContract(await dispute.getAddress(), "DisputeModule"),
+    ensureContract(await platformRegistry.getAddress(), "PlatformRegistry"),
+    ensureContract(await feePool.getAddress(), "FeePool"),
+    ensureContract(await reputation.getAddress(), "ReputationEngine"),
+  ]);
+
   const SystemPause = await ethers.getContractFactory(
     "contracts/v2/SystemPause.sol:SystemPause"
   );

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -237,6 +237,22 @@ async function main() {
   );
   await stake.connect(governanceSigner).setMinStake(minStake);
 
+  const ensureContract = async (addr: string, name: string) => {
+    if ((await ethers.provider.getCode(addr)) === "0x") {
+      throw new Error(`${name} must be a deployed contract`);
+    }
+  };
+
+  await Promise.all([
+    ensureContract(await registry.getAddress(), "JobRegistry"),
+    ensureContract(await stake.getAddress(), "StakeManager"),
+    ensureContract(await validation.getAddress(), "ValidationModule"),
+    ensureContract(await dispute.getAddress(), "DisputeModule"),
+    ensureContract(await platformRegistry.getAddress(), "PlatformRegistry"),
+    ensureContract(await feePool.getAddress(), "FeePool"),
+    ensureContract(await reputation.getAddress(), "ReputationEngine"),
+  ]);
+
   const SystemPause = await ethers.getContractFactory(
     "contracts/v2/SystemPause.sol:SystemPause"
   );


### PR DESCRIPTION
## Summary
- require non-zero deployed contract addresses for SystemPause modules
- add custom errors for invalid module references
- document and enforce module validation in deployment scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b121d6263c833385e46eabb767baab