### PR TITLE
Add job submission check to validator selection

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -465,8 +465,13 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         public
         override
         whenNotPaused
+        nonReentrant
         returns (address[] memory selected)
     {
+        require(
+            jobRegistry.jobs(jobId).status == IJobRegistry.Status.Submitted,
+            "not submitted"
+        );
         Round storage r = rounds[jobId];
         // Ensure validators are only chosen once per round to prevent
         // re-selection or commit replay.

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -134,6 +134,23 @@ describe("ValidationModule V2", function () {
     await expect(start(2, 0)).to.be.revertedWith("not submitted");
   });
 
+  it("reverts if selecting before submission", async () => {
+    const jobStruct = {
+      employer: employer.address,
+      agent: ethers.ZeroAddress,
+      reward: 0,
+      stake: 0,
+      success: false,
+      status: 2,
+      uriHash: ethers.ZeroHash,
+      resultHash: ethers.ZeroHash,
+    };
+    await jobRegistry.setJob(2, jobStruct);
+    await expect(validation.selectValidators(2, 0)).to.be.revertedWith(
+      "not submitted"
+    );
+  });
+
 
   it("reverts when stake manager is unset", async () => {
     await validation.connect(owner).setStakeManager(ethers.ZeroAddress);

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -111,8 +111,13 @@ describe("regression scenarios", function () {
     const deadline = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
     await registry.connect(agent).applyForJob(1, "agent", []);
+    await registry
+      .connect(agent)
+      .submit(1, ethers.id("ipfs://res"), "ipfs://res", "agent", []);
 
-    await expect(validation.selectValidators(1, 1)).to.be.revertedWith("insufficient validators");
+    await expect(validation.selectValidators(1, 1)).to.be.revertedWith(
+      "insufficient validators"
+    );
   });
 
   it("prevents validation after stake exhaustion", async () => {
@@ -147,7 +152,12 @@ describe("regression scenarios", function () {
     const deadline2 = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline2, "ipfs://job2");
     await registry.connect(agent).applyForJob(2, "agent", []);
-    await expect(validation.selectValidators(2, 1)).to.be.revertedWith("insufficient validators");
+    await registry
+      .connect(agent)
+      .submit(2, ethers.id("ipfs://res2"), "ipfs://res2", "agent", []);
+    await expect(validation.selectValidators(2, 1)).to.be.revertedWith(
+      "insufficient validators"
+    );
   });
 
   it("supports validation module replacement", async () => {


### PR DESCRIPTION
## Summary
- guard `selectValidators` with `nonReentrant`
- ensure jobs are submitted before selecting validators
- adjust validator selection tests for new status requirement

## Testing
- `npx hardhat test test/v2/ValidationModule.test.js test/v2/ValidationModulePause.test.js test/v2/ValidatorSelectionReservoir.test.js test/v2/ValidatorSelectionRotation.test.js test/v2/ValidatorWeightedSelection.test.js test/v2/ValidatorSelectionLargePool.test.js test/v2/ValidatorSelectionCache.test.js`
- ⚠️ `npx hardhat test test/v2/regression.integration.test.ts` (SyntaxError: Unexpected reserved word)
- ⚠️ `forge test --match-path test/v2/ValidatorSelectionFuzz.t.sol` (Compilation failed: source not found / wrong argument count)


------
https://chatgpt.com/codex/tasks/task_e_68b12a3b9c888333b802f53d5f6aa75f