### PR TITLE
chore: update AGIALPHA address

### DIFF
--- a/contracts/v2/Constants.sol
+++ b/contracts/v2/Constants.sol
@@ -2,4 +2,4 @@
 pragma solidity ^0.8.25;
 
 // Shared AGI Jobs v2 constants.
-address constant AGIALPHA = 0x2e8Fb54C3eC41F55F06C1F082C081a609EaA4ebe;
+address constant AGIALPHA = 0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA;

--- a/docs/agialpha-workflows.md
+++ b/docs/agialpha-workflows.md
@@ -3,7 +3,7 @@
 This guide summarises Etherscan-based interactions for the $AGIALPHA-powered AGIJobs v2 suite. All token amounts use 6‑decimal base units (`1 AGIALPHA = 1_000000`). Agents must control a subdomain ending in `.agent.agi.eth`; validators require `.club.agi.eth`. Replace bracketed addresses with deployment values before transacting.
 
 ## 1. Post a Job (Employer)
-1. **Approve reward** – open the [$AGIALPHA token Write tab](https://etherscan.io/address/0x2e8fb54C3EC41F55F06C1F082C081A609eAA4EbE#writeContract) and call `approve(spender, amount)` where `spender` is the `StakeManager` and `amount` is `reward + fee` in base units.
+1. **Approve reward** – open the [$AGIALPHA token Write tab](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA#writeContract) and call `approve(spender, amount)` where `spender` is the `StakeManager` and `amount` is `reward + fee` in base units.
 2. **Create job** – on [`JobRegistry` Write](https://etherscan.io/address/<JobRegistryAddress>#writeContract) call `acknowledgeAndCreateJob(reward, uri)`.
 
 ## 2. Apply for a Job (Agent)

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -28,7 +28,7 @@ Each component is immutable once deployed yet configurable by the owner through 
 
 ### Token Configuration
 
-`StakeManager` holds the address of the ERC‑20 used for all payments, staking and dispute fees. The owner may replace this token at any time via `setToken` without redeploying the rest of the system. The default deployment references the $AGIALPHA token at `0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe`, which operates with **6 decimals**. All economic parameters (stakes, rewards, fees) must therefore be provided in base units of this token (e.g., `100_000000` for 100 AGIALPHA). Modules do not assume a specific decimal count, preserving compatibility with future currencies. The `DisputeModule` pulls its `disputeFee` from `StakeManager`, so dispute resolution also uses the selected ERC‑20.
+`StakeManager` holds the address of the ERC‑20 used for all payments, staking and dispute fees. The owner may replace this token at any time via `setToken` without redeploying the rest of the system. The default deployment references the $AGIALPHA token at `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`, which operates with **6 decimals**. All economic parameters (stakes, rewards, fees) must therefore be provided in base units of this token (e.g., `100_000000` for 100 AGIALPHA). Modules do not assume a specific decimal count, preserving compatibility with future currencies. The `DisputeModule` pulls its `disputeFee` from `StakeManager`, so dispute resolution also uses the selected ERC‑20.
 
 | Module | Core responsibility | Owner‑controllable parameters |
 | --- | --- | --- |

--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -53,7 +53,7 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 
 | Parameter | Recommended value |
 | --- | --- |
-| `token` | `0x2e8fb54C3EC41F55F06C1f082C081A609eAA4EbE` |
+| `token` | `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA` |
 | `feePct` | `5` (protocol fee percentage) |
 | `burnPct` | `0` (no burn) |
 | `commitWindow` | `86400` seconds (24h) |

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -151,7 +151,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 
 ## Common Etherscan Flows
 ### Approve $AGIALPHA
-1. Navigate to the [$AGIALPHA token](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe#writeContract).
+1. Navigate to the [$AGIALPHA token](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA#writeContract).
 2. In **Write Contract**, connect your wallet and call **approve(spender, amount)**. Use 6‑decimal base units (e.g., `1_000000` for one token).
 
 ### Acknowledge the tax policy

--- a/docs/legacy/Guidev0.md
+++ b/docs/legacy/Guidev0.md
@@ -221,7 +221,7 @@ LEG --> P7
 
 * **ETH for Gas:** Make sure your MetaMask wallet has a sufficient amount of **ETH** to pay for gas fees on mainnet. Every contract deployment and function call will consume gas (paid in ETH).
 
-* **\$AGIALPHA Tokens:** Acquire some **\$AGIALPHA** – the ERC-20 token used for payments, staking, and rewards in AGI Jobs v2. You will need \$AGIALPHA to post job bounties and to stake as an agent/validator/platform. \$AGIALPHA has **6 decimal places**, *not* the usual 18. For example, `1.0 AGIALPHA = 1,000,000` in base units. The official \$AGIALPHA token contract is at **`0x2e8fb54C3EC41F55F06C1f082C081A609eAA4EbE`** (you can verify this on Etherscan). Add this token to your MetaMask using the contract address.
+* **\$AGIALPHA Tokens:** Acquire some **\$AGIALPHA** – the ERC-20 token used for payments, staking, and rewards in AGI Jobs v2. You will need \$AGIALPHA to post job bounties and to stake as an agent/validator/platform. \$AGIALPHA has **6 decimal places**, *not* the usual 18. For example, `1.0 AGIALPHA = 1,000,000` in base units. The official \$AGIALPHA token contract is at **`0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`** (you can verify this on Etherscan). Add this token to your MetaMask using the contract address.
 
   *How to get \$AGIALPHA?* If it’s publicly available, you might swap for it on a DEX (like Uniswap) by inputting the token address. Otherwise, obtain it through the project’s official channels. Ensure you have enough tokens for the actions you plan (e.g. posting job rewards or staking collateral).
 
@@ -480,7 +480,7 @@ As an employer (someone who wants a task done by an AI agent), you will **create
 2. **Approve StakeManager to Spend Your Tokens:** When you create a job, the system will take the reward (and fee) from your account and escrow it. For security, ERC-20 tokens require an **approve** before a contract can transfer your tokens. So you must approve the StakeManager to pull your reward amount.
 
    * In MetaMask, switch to **your address** (the employer’s address).
-   * Go to the \$AGIALPHA token’s Etherscan page (address `0x2e8fb54C3EC41F55F06C1f082C081A609eAA4EbE`). Click on **Write Contract** and connect your wallet. Locate the `approve(address spender, uint256 amount)` function.
+   * Go to the \$AGIALPHA token’s Etherscan page (address `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`). Click on **Write Contract** and connect your wallet. Locate the `approve(address spender, uint256 amount)` function.
    * For **spender**, enter the **StakeManager contract’s address**. Double-check it’s exact.
    * For **amount**, enter the reward plus fee in base units. The fee is determined by the platform’s fee percentage (`feePct`). For example, if reward = 50 AGIALPHA and feePct = 5%, then fee = 2.5 AGIALPHA. Total = 52.5 AGIALPHA, which in base units is `52.5 * 1e6 = 52_500000`. If you’re not sure of the fee or want to be safe, you can approve a slightly larger amount than the reward. *(It’s okay to approve a bit more; the contract will only use what is needed.)*
    * Click **Write** and confirm the MetaMask transaction. Wait for the approval transaction to succeed (you can check status on Etherscan).

--- a/docs/modular-architecture-v2.md
+++ b/docs/modular-architecture-v2.md
@@ -110,7 +110,7 @@ rendering deviation economically unattractive.
 
 ## Token Configuration
 The `StakeManager` stores the ERC‑20 used for rewards, staking and dispute fees.  By default it references
-[`$AGIALPHA`](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe) (6 decimals), but the owner can switch
+[`$AGIALPHA`](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA) (6 decimals), but the owner can switch
 currencies via `setToken(newToken)` without redeploying other modules.  All amounts must be provided in base units (1 token =
 1e6 units).
 

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -18,7 +18,7 @@ resolver, emitting `OwnershipVerified` on success.
 ## Module Responsibilities & Addresses
 | Module | Responsibility | Address |
 | --- | --- | --- |
-| `$AGIALPHA` Token | 6‑decimal ERC‑20 used for payments and staking | `0x2e8fb54C3eC41F55F06c1F082c081A609eAa4eBE` |
+| `$AGIALPHA` Token | 6‑decimal ERC‑20 used for payments and staking | `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA` |
 | StakeManager | Custodies stakes, escrows rewards, slashes misbehaviour | `TBD` |
 | ReputationEngine | Tracks reputation scores and blacklist status | `TBD` |
 | IdentityRegistry | Verifies ENS subdomains and Merkle allowlists | `TBD` |
@@ -152,7 +152,7 @@ then be performed through the "Write" tabs on each module.
 
 ## Token Configuration
 - Default staking/reward token: `$AGIALPHA` at
-  `0x2e8fb54C3eC41F55F06c1F082c081A609eAa4eBE` (6 decimals).
+  `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA` (6 decimals).
 - To swap the token, the owner calls
   `StakeManager.setToken(newToken)`; emit `TokenUpdated(newToken)` to
   verify.

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -101,7 +101,7 @@ interface ICertificateNFT {
 Stakes form potential energy \(H\); commit–reveal voting injects entropy \(S\). Owner‑tuned parameters act as temperature \(T\). The network evolves toward minimum Gibbs free energy \(G = H - TS\), making honest behaviour the dominant, low‑energy strategy. Slashing raises \(H\) for cheaters, while random validator selection increases \(S\), keeping collusion energetically unfavourable.
 
 ## Owner Control & Token Flexibility
-All setters are `onlyOwner`. `StakeManager.setToken` lets the owner swap the payment/staking token (default [$AGIALPHA](https://etherscan.io/address/0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe), 6 decimals) without redeploying other modules. All amounts are supplied in base units (1 token = 1e6). For example `0.1` token is `100_000` and `12` tokens are `12_000_000`. When interacting with 18‑decimal tokens, divide values by `1e12` to fit this format; any remainder beyond six decimals will be truncated.
+All setters are `onlyOwner`. `StakeManager.setToken` lets the owner swap the payment/staking token (default [$AGIALPHA](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA), 6 decimals) without redeploying other modules. All amounts are supplied in base units (1 token = 1e6). For example `0.1` token is `100_000` and `12` tokens are `12_000_000`. When interacting with 18‑decimal tokens, divide values by `1e12` to fit this format; any remainder beyond six decimals will be truncated.
 
 ## Governance Composability
 - Modules are immutable once deployed; to upgrade a component the owner deploys a new module and calls `JobRegistry.setModules` with the replacement address.


### PR DESCRIPTION
## Summary
- set `AGIALPHA` constant to `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`
- refresh docs to reference the new address

## Testing
- `npm test`
- `forge test` *(fails: Invalid type for argument in function call)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ab3bb1ec83338d6d738927a1e4cf