### PR TITLE
Require 18 decimal staking tokens

### DIFF
--- a/contracts/v2/AGIALPHAToken.sol
+++ b/contracts/v2/AGIALPHAToken.sol
@@ -5,13 +5,13 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title AGIALPHAToken
-/// @notice ERC20 token with 6 decimals used across AGI Jobs v2.
-/// @dev Owner can mint or burn to maintain full control. Decimals set to 6
-///      so all staking and payout amounts match on-chain accounting. The
+/// @notice ERC20 token with 18 decimals used across AGI Jobs v2.
+/// @dev Owner can mint or burn to maintain full control. Decimals set to 18
+///      for standard ERC20 compatibility. The
 ///      contract holds no special tax logic and never accepts ether to
 ///      preserve tax neutrality for the owner.
 contract AGIALPHAToken is ERC20, Ownable {
-    uint8 private constant DECIMALS = 6;
+    uint8 private constant DECIMALS = 18;
 
     /// @notice tracks addresses that acknowledged token terms
     mapping(address => bool) private _acknowledged;
@@ -23,7 +23,7 @@ contract AGIALPHAToken is ERC20, Ownable {
         _acknowledged[msg.sender] = true;
     }
 
-    /// @notice Returns token decimals (6).
+    /// @notice Returns token decimals (18).
     function decimals() public pure override returns (uint8) {
         return DECIMALS;
     }
@@ -59,7 +59,7 @@ contract AGIALPHAToken is ERC20, Ownable {
 
     /// @notice Mint new tokens to an address.
     /// @param to recipient of minted tokens
-    /// @param amount token amount with 6 decimals
+    /// @param amount token amount with 18 decimals
     function mint(address to, uint256 amount) external onlyOwner {
         _acknowledged[to] = true;
         _mint(to, amount);
@@ -67,7 +67,7 @@ contract AGIALPHAToken is ERC20, Ownable {
 
     /// @notice Burn tokens from an address.
     /// @param from address holding the tokens
-    /// @param amount token amount with 6 decimals
+    /// @param amount token amount with 18 decimals
     function burn(address from, uint256 amount) external onlyOwner {
         _burn(from, amount);
     }

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -12,7 +12,7 @@ import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 /// @title FeePool
 /// @notice Accumulates job fees and distributes them to stakers proportionally.
-/// @dev All token amounts use 6 decimals. Uses an accumulator scaled by 1e12
+/// @dev All token amounts use 18 decimals. Uses an accumulator scaled by 1e12
 ///      to avoid precision loss when dividing fees by total stake.
 
 contract FeePool is Ownable, Pausable, ReentrancyGuard {
@@ -82,7 +82,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
             token = IERC20(DEFAULT_TOKEN);
         } else {
             IERC20Metadata meta = IERC20Metadata(address(_token));
-            require(meta.decimals() == 6, "decimals");
+            require(meta.decimals() == 18, "decimals");
             token = _token;
         }
         emit TokenUpdated(address(token));
@@ -113,7 +113,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     ///      contract (typically by `StakeManager.finalizeJobFunds`). Only the
     ///      `StakeManager` may call this to keep accounting trustless while the
     ///      registry itself never holds custody of user funds.
-    /// @param amount fee amount scaled to 6 decimals
+    /// @param amount fee amount scaled to 18 decimals
     function depositFee(uint256 amount) external onlyStakeManager nonReentrant {
         require(amount > 0, "amount");
         pendingFees += amount;
@@ -121,7 +121,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     }
 
     /// @notice Contribute tokens directly to the reward pool.
-    /// @param amount fee amount scaled to 6 decimals.
+    /// @param amount fee amount scaled to 18 decimals.
     function contribute(uint256 amount) external nonReentrant {
         require(amount > 0, "amount");
         token.safeTransferFrom(msg.sender, address(this), amount);
@@ -196,19 +196,19 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
 
     /// @notice owner-only emergency escape hatch to withdraw tokens
     /// @dev Intended for stuck-token recovery via Etherscan. Routine fees flow
-    ///      to this pool or the burn address. Amount uses 6 decimal units.
+    ///      to this pool or the burn address. Amount uses 18 decimal units.
     /// @param to recipient address
-    /// @param amount token amount with 6 decimals
+    /// @param amount token amount with 18 decimals
     function ownerWithdraw(address to, uint256 amount) external onlyOwner nonReentrant {
         token.safeTransfer(to, amount);
         emit OwnerWithdrawal(to, amount);
     }
 
     /// @notice update ERC20 token used for payouts
-    /// @param newToken fee/reward token address which must use 6 decimals
+    /// @param newToken fee/reward token address which must use 18 decimals
     function setToken(IERC20 newToken) external onlyOwner {
         IERC20Metadata meta = IERC20Metadata(address(newToken));
-        require(meta.decimals() == 6, "decimals");
+        require(meta.decimals() == 18, "decimals");
         token = newToken;
         emit TokenUpdated(address(newToken));
     }

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -23,10 +23,8 @@ import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 /// @dev Holds only the staking token and rejects direct ether so neither the
 ///      contract nor the owner ever custodies funds that could create tax
 ///      liabilities. All taxes remain the responsibility of employers, agents
-///      and validators. All token amounts are scaled by 1e6 (6 decimals); for
-///      instance `2` tokens should be provided as `2_000_000`. Contracts that
-///      operate on 18‑decimal tokens must downscale by `1e12`, which may cause
-///      precision loss.
+///      and validators. All token amounts use 18 decimals where one token is
+///      represented by `1e18` base units.
 contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausable {
     using SafeERC20 for IERC20;
 
@@ -44,7 +42,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     address public constant DEFAULT_TOKEN = AGIALPHA;
 
     /// @notice default minimum stake when constructor param is zero
-    uint256 public constant DEFAULT_MIN_STAKE = 1e6;
+    uint256 public constant DEFAULT_MIN_STAKE = 1e18;
 
     /// @notice canonical burn address
     address public constant BURN_ADDRESS =
@@ -176,7 +174,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
             token = IERC20(DEFAULT_TOKEN);
         } else {
             IERC20Metadata meta = IERC20Metadata(address(_token));
-            require(meta.decimals() == 6, "decimals");
+            require(meta.decimals() == 18, "decimals");
             token = _token;
         }
         emit TokenUpdated(address(token));
@@ -216,20 +214,20 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     // "Write Contract" tab by the authorized owner.
 
     /// @notice update the staking/payout token
-    /// @param newToken ERC20 token address using 6 decimals
+    /// @param newToken ERC20 token address using 18 decimals
     function setToken(IERC20 newToken) external onlyGovernance {
         if (address(newToken) == address(0)) {
             token = IERC20(DEFAULT_TOKEN);
         } else {
             IERC20Metadata meta = IERC20Metadata(address(newToken));
-            require(meta.decimals() == 6, "decimals");
+            require(meta.decimals() == 18, "decimals");
             token = newToken;
         }
         emit TokenUpdated(address(token));
     }
 
     /// @notice update the minimum stake required
-    /// @param _minStake minimum token amount with 6 decimals
+    /// @param _minStake minimum token amount with 18 decimals
     function setMinStake(uint256 _minStake) external onlyGovernance {
         minStake = _minStake;
         emit MinStakeUpdated(_minStake);
@@ -362,7 +360,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     }
 
     /// @notice set maximum total stake allowed per address (0 disables limit)
-    /// @param maxStake cap on combined stake per address using 6 decimals
+    /// @param maxStake cap on combined stake per address using 18 decimals
     function setMaxStakePerAddress(uint256 maxStake) external onlyGovernance {
         maxStakePerAddress = maxStake;
         emit MaxStakePerAddressUpdated(maxStake);
@@ -460,7 +458,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     /// @notice lock a portion of a user's stake for a period of time
     /// @param user address whose stake is being locked
-    /// @param amount token amount with 6 decimals
+    /// @param amount token amount with 18 decimals
     /// @param lockTime seconds until the stake unlocks
     function lockStake(address user, uint256 amount, uint64 lockTime)
         external
@@ -482,7 +480,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     /// @notice release previously locked stake for a user
     /// @param user address whose stake is being unlocked
-    /// @param amount token amount with 6 decimals to unlock
+    /// @param amount token amount with 18 decimals to unlock
     function releaseStake(address user, uint256 amount)
         external
         onlyJobRegistry
@@ -540,7 +538,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     ///      user must have acknowledged the current tax policy.
     /// @param user address receiving credit for the stake
     /// @param role participant role for the stake
-    /// @param amount token amount with 6 decimals
+    /// @param amount token amount with 18 decimals
     function depositStakeFor(address user, Role role, uint256 amount)
         external
         whenNotPaused
@@ -562,7 +560,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     /// @notice deposit stake for caller for a specific role after approving tokens
     /// @param role participant role for the stake
-    /// @param amount token amount with 6 decimals; caller must approve first
+    /// @param amount token amount with 18 decimals; caller must approve first
     function depositStake(Role role, uint256 amount)
         external
         whenNotPaused
@@ -583,12 +581,11 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     /**
      * @notice Acknowledge the tax policy and deposit $AGIALPHA stake in one call.
-     * @dev Uses 6-decimal base units (1 token = 1_000000). Caller must `approve`
-     *      this contract to transfer at least `amount` $AGIALPHA beforehand.
-     *      Invoking this helper implicitly accepts the current tax policy via the
-     *      associated `JobRegistry`.
+     * @dev Caller must `approve` this contract to transfer at least `amount`
+     *      tokens beforehand. Invoking this helper implicitly accepts the
+     *      current tax policy via the associated `JobRegistry`.
      * @param role Participant role receiving credit for the stake.
-     * @param amount Stake amount in $AGIALPHA with 6 decimals.
+     * @param amount Stake amount in $AGIALPHA with 18 decimals.
      */
     function acknowledgeAndDeposit(Role role, uint256 amount) external whenNotPaused nonReentrant {
         address registry = jobRegistry;
@@ -602,12 +599,12 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /**
      * @notice Acknowledge the tax policy and deposit $AGIALPHA stake on behalf of
      *         a user.
-     * @dev Uses 6-decimal base units. The `user` must `approve` this contract to
-     *      transfer at least `amount` tokens beforehand. Calling this helper
-     *      implicitly acknowledges the current tax policy for the `user`.
+     * @dev The `user` must `approve` this contract to transfer at least `amount`
+     *      tokens beforehand. Calling this helper implicitly acknowledges the
+     *      current tax policy for the `user`.
      * @param user Address receiving credit for the stake.
      * @param role Participant role receiving credit for the stake.
-     * @param amount Stake amount in $AGIALPHA with 6 decimals.
+     * @param amount Stake amount in $AGIALPHA with 18 decimals.
      */
     function acknowledgeAndDepositFor(
         address user,
@@ -656,11 +653,10 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     /**
      * @notice Withdraw previously staked $AGIALPHA for a specific role.
-     * @dev Uses 6-decimal base units (1 token = 1_000000). Stake must be unlocked
-     *      and caller must have deposited tokens beforehand via `approve` +
-     *      deposit.
+     * @dev Stake must be unlocked and caller must have deposited tokens
+     *      beforehand via `approve` + deposit.
      * @param role Participant role of the stake being withdrawn.
-     * @param amount Token amount with 6 decimals to withdraw.
+     * @param amount Token amount with 18 decimals to withdraw.
      */
     function withdrawStake(Role role, uint256 amount)
         external
@@ -679,11 +675,11 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     /**
      * @notice Acknowledge the tax policy and withdraw $AGIALPHA stake in one call.
-     * @dev Uses 6-decimal base units. Caller must have staked tokens previously,
-     *      which required an `approve` for this contract. Invoking this helper
-     *      acknowledges the current tax policy via the associated `JobRegistry`.
+     * @dev Caller must have staked tokens previously, which required an `approve`
+     *      for this contract. Invoking this helper acknowledges the current tax
+     *      policy via the associated `JobRegistry`.
      * @param role Participant role of the stake being withdrawn.
-     * @param amount Withdraw amount in $AGIALPHA with 6 decimals.
+     * @param amount Withdraw amount in $AGIALPHA with 18 decimals.
      */
     function acknowledgeAndWithdraw(Role role, uint256 amount) external whenNotPaused nonReentrant {
         address registry = jobRegistry;
@@ -693,13 +689,14 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     }
 
     /**
-     * @notice Acknowledge the tax policy and withdraw $AGIALPHA stake on behalf of a user.
-     * @dev Uses 6-decimal base units. Caller must be authorized and the `user` must
-     *      have previously staked tokens. Invoking this helper acknowledges the
-     *      current tax policy for the `user` via the associated `JobRegistry`.
+     * @notice Acknowledge the tax policy and withdraw $AGIALPHA stake on behalf
+     *         of a user.
+     * @dev Caller must be authorized and the `user` must have previously staked
+     *      tokens. Invoking this helper acknowledges the current tax policy for
+     *      the `user` via the associated `JobRegistry`.
      * @param user Address whose stake is being withdrawn.
      * @param role Participant role of the stake being withdrawn.
-     * @param amount Withdraw amount in $AGIALPHA with 6 decimals.
+     * @param amount Withdraw amount in $AGIALPHA with 18 decimals.
      */
     function acknowledgeAndWithdrawFor(
         address user,
@@ -721,7 +718,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     ///         `releaseReward` or `finalizeJobFunds`
     /// @param jobId unique job identifier
     /// @param from employer providing the escrow
-    /// @param amount token amount with 6 decimals; employer must approve first
+    /// @param amount token amount with 18 decimals; employer must approve first
     function lockReward(bytes32 jobId, address from, uint256 amount)
         external
         onlyJobRegistry
@@ -737,7 +734,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     ///      tracking a job identifier. The caller is expected to account for the
     ///      escrowed balance.
     /// @param from Address providing the funds; must approve first.
-    /// @param amount Token amount with 6 decimals to lock.
+    /// @param amount Token amount with 18 decimals to lock.
     function lock(address from, uint256 amount) external onlyJobRegistry whenNotPaused {
         token.safeTransferFrom(from, address(this), amount);
         emit StakeEscrowLocked(bytes32(0), from, amount);
@@ -746,7 +743,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice release locked job reward to recipient applying any AGI type bonus
     /// @param jobId unique job identifier
     /// @param to recipient of the release (typically the agent)
-    /// @param amount base token amount with 6 decimals before AGI bonus
+    /// @param amount base token amount with 18 decimals before AGI bonus
     function releaseReward(bytes32 jobId, address to, uint256 amount)
         external
         onlyJobRegistry
@@ -788,7 +785,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @dev Does not adjust job-specific escrows; the caller must ensure
     ///      sufficient balance was locked earlier.
     /// @param to Recipient receiving the tokens.
-    /// @param amount Base token amount with 6 decimals before AGI bonus.
+    /// @param amount Base token amount with 18 decimals before AGI bonus.
     function release(address to, uint256 amount) external onlyJobRegistry whenNotPaused {
         // apply AGI type payout modifier
         uint256 pct = getAgentPayoutPct(to);
@@ -823,8 +820,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice finalize a job by paying the agent and forwarding protocol fees
     /// @param jobId unique job identifier
     /// @param agent recipient of the job reward
-    /// @param reward base amount paid to the agent with 6 decimals before AGI bonus
-    /// @param fee amount forwarded to the fee pool with 6 decimals
+    /// @param reward base amount paid to the agent with 18 decimals before AGI bonus
+    /// @param fee amount forwarded to the fee pool with 18 decimals
     /// @param _feePool fee pool contract receiving protocol fees
     function finalizeJobFunds(
         bytes32 jobId,
@@ -902,7 +899,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice lock the dispute fee from a payer for later payout via
     ///         `payDisputeFee`
     /// @param payer address providing the fee, must approve first
-    /// @param amount token amount with 6 decimals
+    /// @param amount token amount with 18 decimals
     function lockDisputeFee(address payer, uint256 amount)
         external
         onlyDisputeModule
@@ -915,7 +912,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     /// @notice pay a locked dispute fee to the recipient
     /// @param to recipient of the fee payout
-    /// @param amount token amount with 6 decimals
+    /// @param amount token amount with 18 decimals
     function payDisputeFee(address to, uint256 amount)
         external
         onlyDisputeModule
@@ -995,7 +992,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice slash stake from a user for a specific role and distribute shares
     /// @param user address whose stake will be reduced
     /// @param role participant role of the slashed stake
-    /// @param amount token amount with 6 decimals to slash
+    /// @param amount token amount with 18 decimals to slash
     /// @param employer recipient of the employer share
     function slash(
         address user,
@@ -1008,7 +1005,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     /// @notice slash a validator's stake during dispute resolution
     /// @param user address whose stake will be reduced
-    /// @param amount token amount with 6 decimals to slash
+    /// @param amount token amount with 18 decimals to slash
     /// @param recipient address receiving the slashed share
     function slash(address user, uint256 amount, address recipient)
         external

--- a/contracts/v2/interfaces/IFeePool.sol
+++ b/contracts/v2/interfaces/IFeePool.sol
@@ -5,20 +5,20 @@ pragma solidity ^0.8.25;
 /// @notice Minimal interface for depositing job fees
 interface IFeePool {
     /// @notice notify the pool about newly received fees
-    /// @param amount amount of tokens transferred to the pool scaled to 6 decimals
+    /// @param amount amount of tokens transferred to the pool scaled to 18 decimals
     function depositFee(uint256 amount) external;
 
     /// @notice distribute pending fees to stakers
-    /// @dev All fee amounts use 6 decimal units.
+    /// @dev All fee amounts use 18 decimal units.
     function distributeFees() external;
 
     /// @notice claim accumulated rewards for caller
-    /// @dev Rewards use 6 decimal units.
+    /// @dev Rewards use 18 decimal units.
     function claimRewards() external;
 
     /// @notice owner-only emergency withdrawal of tokens from the pool
-    /// @dev Amount uses 6 decimal units.
+    /// @dev Amount uses 18 decimal units.
     /// @param to address receiving the tokens
-    /// @param amount token amount with 6 decimals
+    /// @param amount token amount with 18 decimals
     function ownerWithdraw(address to, uint256 amount) external;
 }

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -172,7 +172,7 @@ interface IJobRegistry {
 
     /// @notice Deposit stake and apply for a job in one call
     /// @param jobId Identifier of the job
-    /// @param amount Stake amount in $AGIALPHA with 6 decimals
+    /// @param amount Stake amount in $AGIALPHA with 18 decimals
     /// @param subdomain ENS subdomain label
     /// @param proof Merkle proof for ENS ownership verification
     function stakeAndApply(

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -49,7 +49,7 @@ interface IStakeManager {
 
     /// @notice deposit stake for caller for a specific role
     /// @param role participant role receiving credit
-    /// @param amount token amount with 6 decimals to deposit
+    /// @param amount token amount with 18 decimals to deposit
     function depositStake(Role role, uint256 amount) external;
 
     /// @notice acknowledge the tax policy and deposit stake in one call
@@ -60,7 +60,7 @@ interface IStakeManager {
 
     /// @notice withdraw available stake for a specific role
     /// @param role participant role of the stake being withdrawn
-    /// @param amount token amount with 6 decimals to withdraw
+    /// @param amount token amount with 18 decimals to withdraw
     function withdrawStake(Role role, uint256 amount) external;
 
     /// @notice acknowledge the tax policy and withdraw stake in one call
@@ -68,7 +68,7 @@ interface IStakeManager {
 
     /// @notice lock a portion of a user's stake for a period of time
     /// @param user address whose stake is being locked
-    /// @param amount token amount with 6 decimals
+    /// @param amount token amount with 18 decimals
     /// @param lockTime seconds until the stake unlocks
     function lockStake(address user, uint256 amount, uint64 lockTime) external;
 
@@ -81,7 +81,7 @@ interface IStakeManager {
     /// @notice release locked job reward to recipient
     /// @param jobId unique job identifier
     /// @param to recipient of the reward
-    /// @param amount base token amount with 6 decimals before bonuses
+    /// @param amount base token amount with 18 decimals before bonuses
     function releaseReward(bytes32 jobId, address to, uint256 amount) external;
 
     /// @notice release previously locked stake for a user
@@ -124,13 +124,13 @@ interface IStakeManager {
     /// @notice slash stake from a user for a specific role
     /// @param user address whose stake will be reduced
     /// @param role participant role of the slashed stake
-    /// @param amount token amount with 6 decimals to slash
+    /// @param amount token amount with 18 decimals to slash
     /// @param employer recipient of the employer share
     function slash(address user, Role role, uint256 amount, address employer) external;
 
     /// @notice slash validator stake during dispute resolution
     /// @param user address whose stake will be reduced
-    /// @param amount token amount with 6 decimals to slash
+    /// @param amount token amount with 18 decimals to slash
     /// @param recipient address receiving the slashed share
     function slash(address user, uint256 amount, address recipient) external;
 

--- a/contracts/v2/modules/DiscoveryModule.sol
+++ b/contracts/v2/modules/DiscoveryModule.sol
@@ -14,7 +14,7 @@ contract DiscoveryModule is Ownable {
     IStakeManager public stakeManager;
     IReputationEngine public reputationEngine;
 
-    uint256 public constant DEFAULT_MIN_STAKE = 1e6;
+    uint256 public constant DEFAULT_MIN_STAKE = 1e18;
 
     uint256 public minStake;
 

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -394,25 +394,25 @@ describe("StakeManager", function () {
       .withArgs(user.address, 0, 50);
   });
 
-  it("restricts token updates to owner and enforces 6 decimals", async () => {
-    const Token6 = await ethers.getContractFactory("MockERC206Decimals");
-    const token6 = await Token6.deploy();
-    await expect(
-      stakeManager.connect(user).setToken(await token6.getAddress())
-    ).to.be.revertedWith("governance only");
-
+  it("restricts token updates to owner and enforces 18 decimals", async () => {
     const Token18 = await ethers.getContractFactory("MockERC20");
     const token18 = await Token18.deploy();
     await expect(
-      stakeManager.connect(owner).setToken(await token18.getAddress())
+      stakeManager.connect(user).setToken(await token18.getAddress())
+    ).to.be.revertedWith("governance only");
+
+    const Token6 = await ethers.getContractFactory("MockERC206Decimals");
+    const token6 = await Token6.deploy();
+    await expect(
+      stakeManager.connect(owner).setToken(await token6.getAddress())
     ).to.be.revertedWith("decimals");
 
     await expect(
-      stakeManager.connect(owner).setToken(await token6.getAddress())
+      stakeManager.connect(owner).setToken(await token18.getAddress())
     )
       .to.emit(stakeManager, "TokenUpdated")
-      .withArgs(await token6.getAddress());
-    expect(await stakeManager.token()).to.equal(await token6.getAddress());
+      .withArgs(await token18.getAddress());
+    expect(await stakeManager.token()).to.equal(await token18.getAddress());
   });
 
   it("uses new token for deposits and payouts after update", async () => {


### PR DESCRIPTION
## Summary
- enforce 18 decimal tokens throughout staking and fee modules
- default minimum stake now `1e18`
- update docs and tests for 18-decimal amounts

## Testing
- `npm test` *(fails: 250 passing, 18 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1baa393b8833396cc854ac465f6c5