### PR TITLE
Use 18-decimal dispute fee and update tests

### DIFF
--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -22,8 +22,12 @@ contract DisputeModule is Ownable, Pausable {
     IJobRegistry public jobRegistry;
     IStakeManager public stakeManager;
 
+    /// @notice Default dispute fee charged when raising a dispute.
+    /// @dev Expressed in token units with 18 decimals; equal to 1 token.
+    uint256 public constant DEFAULT_DISPUTE_FEE = 1e18;
+
     /// @notice Fee required to initiate a dispute, in token units (18 decimals).
-    /// @dev Defaults to 1 token (1e18 units) if zero is provided to the constructor.
+    /// @dev Defaults to `DEFAULT_DISPUTE_FEE` if zero is provided to the constructor.
     uint256 public disputeFee;
 
     /// @notice Time that must elapse before a dispute can be resolved.
@@ -80,7 +84,7 @@ contract DisputeModule is Ownable, Pausable {
         }
         emit ModulesUpdated(address(_jobRegistry), address(0));
 
-        disputeFee = _disputeFee > 0 ? _disputeFee : 1e18;
+        disputeFee = _disputeFee > 0 ? _disputeFee : DEFAULT_DISPUTE_FEE;
         emit DisputeFeeUpdated(disputeFee);
 
         disputeWindow = _disputeWindow > 0 ? _disputeWindow : 1 days;
@@ -158,7 +162,7 @@ contract DisputeModule is Ownable, Pausable {
     }
 
     /// @notice Configure the dispute fee in token units (18 decimals).
-    /// @param fee New dispute fee; 0 disables the fee.
+    /// @param fee New dispute fee in token units (18 decimals); 0 disables the fee.
     function setDisputeFee(uint256 fee)
         external
         onlyOwner

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -1,6 +1,7 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
+const FEE = 10n ** 18n; // 1 token with 18 decimals
 
 describe("DisputeModule", function () {
   describe("owner controls", function () {
@@ -59,14 +60,14 @@ describe("DisputeModule", function () {
       await expect(dispute.connect(owner).pause())
         .to.emit(dispute, "Paused")
         .withArgs(owner.address);
-      await expect(dispute.connect(owner).setDisputeFee(1))
+      await expect(dispute.connect(owner).setDisputeFee(FEE))
         .to.be.revertedWithCustomError(dispute, "EnforcedPause");
       await expect(dispute.connect(owner).unpause())
         .to.emit(dispute, "Unpaused")
         .withArgs(owner.address);
-      await expect(dispute.connect(owner).setDisputeFee(1))
+      await expect(dispute.connect(owner).setDisputeFee(FEE))
         .to.emit(dispute, "DisputeFeeUpdated")
-        .withArgs(1n);
+        .withArgs(FEE);
     });
 
     it("restricts pause to owner", async () => {
@@ -79,7 +80,7 @@ describe("DisputeModule", function () {
   describe("dispute resolution", function () {
     let owner, employer, agent, outsider;
     let token, stakeManager, registry, dispute;
-    const fee = 100n;
+    const fee = FEE;
     const window = 10n;
 
     beforeEach(async () => {


### PR DESCRIPTION
## Summary
- define DEFAULT_DISPUTE_FEE as 1e18 and document 18-decimal units
- enforce 18-decimal dispute fee in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1d636c50c83339ee883e7beaad2d9