### PR TITLE
refactor: adopt 18-decimal AGIALPHA units

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@ ERC‑20 utility token used for payments and staking.
 
 ```javascript
 const token = await ethers.getContractAt("AGIALPHAToken", tokenAddress);
-await token.mint(user, ethers.parseUnits("1000", 6));
+await token.mint(user, ethers.parseUnits("1000", 18));
 ```
 
 ## StakeManager
@@ -34,7 +34,7 @@ Coordinates job posting and settlement.
 
 ```javascript
 const registry = await ethers.getContractAt("JobRegistry", registryAddress);
-const tx = await registry.createJob(ethers.parseUnits("10", 6), "ipfs://job.json");
+const tx = await registry.createJob(ethers.parseUnits("10", 18), "ipfs://job.json");
 const receipt = await tx.wait();
 const jobId = receipt.logs[0].args.jobId;
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -13,7 +13,7 @@ const token = await ethers.getContractAt("AGIALPHAToken", tokenAddress);
 const stake = await ethers.getContractAt("StakeManager", stakeAddress);
 const registry = await ethers.getContractAt("JobRegistry", registryAddress);
 
-const reward = ethers.parseUnits("10", 6);
+const reward = ethers.parseUnits("10", 18);
 await token.approve(stakeAddress, reward);
 await stake.depositStake(0, reward); // escrow for job
 const tx = await registry.createJob(reward, "ipfs://job.json");

--- a/examples/agent-gateway.js
+++ b/examples/agent-gateway.js
@@ -23,11 +23,11 @@ const REGISTRY_ABI = [
 const registry = new ethers.Contract(JOB_REGISTRY, REGISTRY_ABI, wallet);
 
 console.log('Listening for jobs...');
-registry.on('JobCreated', async (jobId, employer, agent) => {
+registry.on('JobCreated', async (jobId, employer, agent, reward) => {
   // Only apply if job is unassigned
   if (agent === ethers.ZeroAddress) {
     try {
-      console.log(`Applying for job ${jobId}`);
+      console.log(`Applying for job ${jobId} with reward ${ethers.formatEther(reward)}`);
       const tx = await registry.applyForJob(jobId, '', '0x');
       await tx.wait();
       console.log(`Applied in tx ${tx.hash}`);

--- a/examples/ethers-quickstart.js
+++ b/examples/ethers-quickstart.js
@@ -23,7 +23,7 @@ const stakeManager = new ethers.Contract(process.env.STAKE_MANAGER, stakeAbi, si
 const validation = new ethers.Contract(process.env.VALIDATION_MODULE, validationAbi, signer);
 
 async function postJob() {
-  const reward = ethers.parseUnits("1", 6);
+  const reward = ethers.parseEther("1");
   await registry.createJob(reward, "ipfs://job");
 }
 

--- a/examples/web3py-quickstart.py
+++ b/examples/web3py-quickstart.py
@@ -13,7 +13,7 @@ registry = w3.eth.contract(address=os.environ["JOB_REGISTRY"], abi=registry_abi)
 validation = w3.eth.contract(address=os.environ["VALIDATION_MODULE"], abi=validation_abi)
 
 def post_job():
-    reward = 1_000000  # 1 token in 6‑decimal units
+    reward = Web3.to_wei(1, "ether")  # 1 token in 18‑decimal units
     tx = registry.functions.createJob(reward, "ipfs://job").build_transaction({
         "from": account.address,
         "nonce": w3.eth.get_transaction_count(account.address)

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -1,15 +1,16 @@
 import { ethers } from "hardhat";
 
+// Default $AGIALPHA token on mainnet
+const AGIALPHA = "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA";
+
 async function main() {
   const [deployer] = await ethers.getSigners();
 
-  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
-  const token = await Token.deploy();
-  await token.waitForDeployment();
+  const tokenAddress = process.env.TOKEN_ADDRESS ?? AGIALPHA;
 
   const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
   const stake = await Stake.deploy(
-    await token.getAddress(),
+    tokenAddress,
     0,
     0,
     0,
@@ -82,7 +83,7 @@ async function main() {
     "contracts/v2/FeePool.sol:FeePool"
   );
   const feePool = await FeePool.deploy(
-    await token.getAddress(),
+    tokenAddress,
     await stake.getAddress(),
     0,
     deployer.address
@@ -122,6 +123,7 @@ async function main() {
   };
 
   await Promise.all([
+    ensureContract(tokenAddress, "Token"),
     ensureContract(await registry.getAddress(), "JobRegistry"),
     ensureContract(await stake.getAddress(), "StakeManager"),
     ensureContract(await validation.getAddress(), "ValidationModule"),
@@ -162,7 +164,7 @@ async function main() {
   await feePool.transferOwnership(await pause.getAddress());
   await reputation.transferOwnership(await pause.getAddress());
 
-  console.log("Token:", await token.getAddress());
+  console.log("Token:", tokenAddress);
   console.log("StakeManager:", await stake.getAddress());
   console.log("ReputationEngine:", await reputation.getAddress());
   console.log("IdentityRegistry:", await identity.getAddress());

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -131,7 +131,7 @@ async function main() {
   );
   const appealFee = ethers.parseUnits(
     typeof args.appealFee === "string" ? args.appealFee : "0",
-    6
+    18
   );
   const disputeWindow =
     typeof args.disputeWindow === "string" ? Number(args.disputeWindow) : 0;
@@ -162,7 +162,7 @@ async function main() {
   );
   const minPlatformStake = ethers.parseUnits(
     typeof args.minPlatformStake === "string" ? args.minPlatformStake : "1000",
-    6
+    18
   );
   const platformRegistry = await PlatformRegistry.deploy(
     await stake.getAddress(),
@@ -233,7 +233,7 @@ async function main() {
 
   const minStake = ethers.parseUnits(
     typeof args.minStake === "string" ? args.minStake : "0",
-    6
+    18
   );
   await stake.connect(governanceSigner).setMinStake(minStake);
 


### PR DESCRIPTION
## Summary
- remove mock token deployment in `deploy-v2` script; default to mainnet AGIALPHA token or env override
- migrate deployment utilities and examples to 18-decimal token helpers
- update docs to reflect 18-decimal parsing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1dae24ec0833385e72253698012db