### PR TITLE
Format job amounts with 18 decimals

### DIFF
--- a/agent-gateway/README.md
+++ b/agent-gateway/README.md
@@ -2,6 +2,8 @@
 
 The agent gateway bridges on-chain job events to off-chain agents. It watches the `JobRegistry` contract and dispatches jobs to registered agents over WebSocket or HTTP. The gateway also monitors job submissions and validation rounds, scheduling follow-up actions such as finalizing results or cancelling expired jobs.
 
+Job financial fields (`reward`, `stake`, and `fee`) are broadcast using `ethers.formatUnits(..., 18)` and include both formatted and raw values.
+
 ## Environment Variables
 
 - `RPC_URL` (default `http://localhost:8545`)

--- a/agent-gateway/index.js
+++ b/agent-gateway/index.js
@@ -125,9 +125,13 @@ registry.on('JobCreated', (jobId, employer, agentAddr, reward, stake, fee) => {
     jobId: jobId.toString(),
     employer,
     agent: agentAddr,
-    reward: reward.toString(),
-    stake: stake.toString(),
-    fee: fee.toString()
+    // include raw values alongside 18-decimal formatted strings
+    rewardRaw: reward.toString(),
+    reward: ethers.formatUnits(reward, 18),
+    stakeRaw: stake.toString(),
+    stake: ethers.formatUnits(stake, 18),
+    feeRaw: fee.toString(),
+    fee: ethers.formatUnits(fee, 18)
   };
   jobs.set(job.jobId, job);
   broadcast({ type: 'JobCreated', job });

--- a/apps/validator-ui/README.md
+++ b/apps/validator-ui/README.md
@@ -2,6 +2,8 @@
 
 A minimal Next.js interface for validators to view pending jobs, commit votes, and automatically reveal them.
 
+Job amounts are formatted with `ethers.formatUnits(..., 18)` when displayed.
+
 ## Setup
 
 ```bash

--- a/apps/validator-ui/pages/index.tsx
+++ b/apps/validator-ui/pages/index.tsx
@@ -19,7 +19,16 @@ export default function Home() {
     const url = process.env.NEXT_PUBLIC_GATEWAY_URL || 'http://localhost:3000';
     fetch(`${url}/jobs`)
       .then((res) => res.json())
-      .then(setJobs)
+      .then((data) =>
+        setJobs(
+          data.map((job: any) => ({
+            ...job,
+            reward: ethers.formatUnits(job.rewardRaw ?? job.reward, 18),
+            stake: ethers.formatUnits(job.stakeRaw ?? job.stake, 18),
+            fee: ethers.formatUnits(job.feeRaw ?? job.fee, 18)
+          }))
+        )
+      )
       .catch(console.error);
   }, []);
 
@@ -57,7 +66,7 @@ export default function Home() {
       <ul>
         {jobs.map((job) => (
           <li key={job.jobId}>
-            Job {job.jobId}{' '}
+            Job {job.jobId} — reward {job.reward} stake {job.stake} fee {job.fee}{' '}
             <button onClick={() => vote(job.jobId, true)}>Approve</button>{' '}
             <button onClick={() => vote(job.jobId, false)}>Reject</button>
           </li>


### PR DESCRIPTION
## Summary
- Broadcast job reward, stake and fee using 18-decimal formatting and include raw values
- Format job amounts in validator UI before rendering and show them in the list
- Document 18-decimal formatting in gateway and validator UI READMEs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1e2b9f7f08333b7ea6b9400b3189f