### PR TITLE
docs: switch to 18-decimal AGIALPHA token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Updated dependencies: Node.js 22.x LTS, Hardhat 2.26.1, @nomicfoundation/hardhat-toolbox 6.1.0, and OpenZeppelin Contracts 5.4.0.
 - Introduced AGIJobManagerV1 contract and updated deployment script.
 - Expanded README with security notice and toolchain verification steps.
+- Standardised on 18‑decimal `$AGIALPHA` token at `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`; token swapping instructions marked as legacy.
 
 ## v0
 - Initial release of AGIJobManager with core job management, reputation, and NFT marketplace features.

--- a/docs/agialpha-workflows.md
+++ b/docs/agialpha-workflows.md
@@ -1,6 +1,6 @@
 # $AGIALPHA Operational Workflows
 
-This guide summarises Etherscan-based interactions for the $AGIALPHA-powered AGIJobs v2 suite. All token amounts use 6‑decimal base units (`1 AGIALPHA = 1_000000`). Agents must control a subdomain ending in `.agent.agi.eth`; validators require `.club.agi.eth`. Replace bracketed addresses with deployment values before transacting.
+This guide summarises Etherscan-based interactions for the $AGIALPHA-powered AGIJobs v2 suite. All token amounts use 18‑decimal base units (`1 AGIALPHA = 1_000000000000000000`). Agents must control a subdomain ending in `.agent.agi.eth`; validators require `.club.agi.eth`. Replace bracketed addresses with deployment values before transacting.
 
 ## 1. Post a Job (Employer)
 1. **Approve reward** – open the [$AGIALPHA token Write tab](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA#writeContract) and call `approve(spender, amount)` where `spender` is the `StakeManager` and `amount` is `reward + fee` in base units.
@@ -16,12 +16,12 @@ This guide summarises Etherscan-based interactions for the $AGIALPHA-powered AGI
 3. **Reveal** – when the reveal window opens call `ValidationModule.revealValidation(jobId, approve, salt)`.
 
 ## 4. Raise a Dispute (Anyone)
-1. **Approve fee** – approve the dispute fee for `StakeManager` (e.g., `10_000000` for 10 tokens).
+1. **Approve fee** – approve the dispute fee for `StakeManager` (e.g., `10_000000000000000000` for 10 tokens).
 2. **Raise** – on [`DisputeModule` Write](https://etherscan.io/address/<DisputeModuleAddress>#writeContract) call `raiseDispute(jobId, evidence)` before the window ends.
 3. **Resolve** – after the window a majority of moderators (or the owner) calls `resolve(jobId, verdict, signatures)`.
 
 ## 5. Trade a Certificate (Peer to Peer)
-1. **List** – certificate owner calls `list(tokenId, price)` on [`CertificateNFT` Write](https://etherscan.io/address/<CertificateNFTAddress>#writeContract)` using 6‑decimal pricing.
+1. **List** – certificate owner calls `list(tokenId, price)` on [`CertificateNFT` Write](https://etherscan.io/address/<CertificateNFTAddress>#writeContract)` using 18‑decimal pricing.
 2. **Purchase** – buyer approves the NFT contract for `price` tokens and calls `purchase(tokenId)`.
 3. **Delist** – seller may remove a listing with `delist(tokenId)`.
 
@@ -31,9 +31,9 @@ This guide summarises Etherscan-based interactions for the $AGIALPHA-powered AGI
 
 ### Base‑Unit Examples
 ```
-1.0 AGIALPHA  = 1_000000
-0.5 AGIALPHA  =   500000
-25  AGIALPHA  = 25_000000
+1.0 AGIALPHA  = 1_000000000000000000
+0.5 AGIALPHA  =   500000000000000000
+25  AGIALPHA  = 25_000000000000000000
 ```
 
 Verify all addresses on multiple explorers and keep owner keys in secure wallets. All modules reject direct ETH and rely solely on $AGIALPHA for value transfer.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,7 +17,7 @@ Coordinates the lifecycle of jobs and mediates between modules.
 
 ### Example
 ```solidity
-JobRegistry(registry).createJob(1_000000, "ipfs://QmHash");
+JobRegistry(registry).createJob(1_000000000000000000, "ipfs://QmHash");
 ```
 
 ## StakeManager
@@ -33,7 +33,7 @@ Holds token deposits for agents, validators and dispute fees.
 
 ### Example
 ```solidity
-StakeManager(stake).depositStake(0, 1_000000);
+StakeManager(stake).depositStake(0, 1_000000000000000000);
 ```
 
 ## ValidationModule
@@ -112,23 +112,23 @@ Below are common flows in TypeScript (ethers.js) and Python (web3.py).
 ```ts
 // TypeScript
 const registry = new ethers.Contract(JOB_REGISTRY, ['function createJob(uint256,string)'], wallet);
-await registry.createJob(1_000000, 'ipfs://QmHash');
+await registry.createJob(1_000000000000000000, 'ipfs://QmHash');
 ```
 ```python
 # Python
 registry = w3.eth.contract(address=JOB_REGISTRY, abi=['function createJob(uint256,string)'])
-tx = registry.functions.createJob(1_000000, 'ipfs://QmHash').transact({'from': acct})
+tx = registry.functions.createJob(1_000000000000000000, 'ipfs://QmHash').transact({'from': acct})
 w3.eth.wait_for_transaction_receipt(tx)
 ```
 
 ### Stake Tokens
 ```ts
 const stake = new ethers.Contract(STAKE_MANAGER, ['function depositStake(uint8,uint256)'], wallet);
-await stake.depositStake(0, 1_000000);
+await stake.depositStake(0, 1_000000000000000000);
 ```
 ```python
 stake = w3.eth.contract(address=STAKE_MANAGER, abi=['function depositStake(uint8,uint256)'])
-tx = stake.functions.depositStake(0, 1_000000).transact({'from': acct})
+tx = stake.functions.depositStake(0, 1_000000000000000000).transact({'from': acct})
 w3.eth.wait_for_transaction_receipt(tx)
 ```
 

--- a/docs/api/AGIALPHAToken.md
+++ b/docs/api/AGIALPHAToken.md
@@ -1,9 +1,9 @@
 # AGIALPHAToken API
 
-ERC‑20 token with 6 decimals used for payments and staking.
+ERC‑20 token with 18 decimals used for payments and staking.
 
 ## Functions
-- `decimals()` – returns fixed 6 decimal places.
+- `decimals()` – returns fixed 18 decimal places.
 - `mint(address to, uint256 amount)` – owner mints tokens.
 - `burn(address from, uint256 amount)` – owner burns tokens from an address.
 

--- a/docs/api/FeePool.md
+++ b/docs/api/FeePool.md
@@ -8,7 +8,7 @@ Holds platform fees and distributes rewards.
 - `distributeFees()` – move accumulated fees to the reward pool and burn portion.
 - `claimRewards()` – stakers claim their share of rewards.
 - `ownerWithdraw(address to, uint256 amount)` – owner emergency withdrawal.
-- `setToken(address newToken)` / `setStakeManager(address manager)` – owner wires token and modules.
+- `setToken(address newToken)` (legacy) / `setStakeManager(address manager)` – owner wires token and modules.
 - `setRewardRole(uint8 role)` – choose which stakers earn rewards.
 - `setBurnPct(uint256 pct)` / `setTreasury(address treasury)` – configure fee splits.
 

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -3,7 +3,7 @@
 Handles staking, escrow and slashing of the $AGIALPHA token.
 
 ## Functions
-- `setToken(address newToken)` – owner updates ERC‑20 used for stakes.
+- `setToken(address newToken)` – legacy function to update the ERC‑20 used for stakes.
 - `setMinStake(uint256 minStake)` / `setMaxStakePerAddress(uint256 maxStake)` – configure stake limits.
 - `setTreasury(address treasury)` / `setFeePool(address feePool)` – wire fee destinations.
 - `setJobRegistry(address registry)` / `setDisputeModule(address module)` / `setValidationModule(address module)` – connect modules. Staking reverts until a registry is configured.

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -28,7 +28,7 @@ Each component is immutable once deployed yet configurable by the owner through 
 
 ### Token Configuration
 
-`StakeManager` holds the address of the ERC‑20 used for all payments, staking and dispute fees. The owner may replace this token at any time via `setToken` without redeploying the rest of the system. The default deployment references the $AGIALPHA token at `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`, which operates with **6 decimals**. All economic parameters (stakes, rewards, fees) must therefore be provided in base units of this token (e.g., `100_000000` for 100 AGIALPHA). Modules do not assume a specific decimal count, preserving compatibility with future currencies. The `DisputeModule` pulls its `disputeFee` from `StakeManager`, so dispute resolution also uses the selected ERC‑20.
+`StakeManager` holds the address of the ERC‑20 used for all payments, staking and dispute fees. Earlier versions allowed the owner to swap this token via `setToken`, but v2 deployments fix the token to $AGIALPHA at `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`, which operates with **18 decimals**. All economic parameters (stakes, rewards, fees) must therefore be provided in base units of this token (e.g., `100_000000000000000000` for 100 AGIALPHA). The `DisputeModule` pulls its `disputeFee` from `StakeManager`, so dispute resolution also uses this ERC‑20.
 
 | Module | Core responsibility | Owner‑controllable parameters |
 | --- | --- | --- |
@@ -48,7 +48,7 @@ All public methods accept plain `uint256` values (wei and seconds) so they can b
 - Every setter is gated by `onlyOwner`, ensuring a single governance address (or multisig) tunes parameters.
 - `JobRegistry` can re‑point to replacement modules via `setModules`, enabling upgrades without migrating state.
 - Functions use primitive types and include NatSpec comments so Etherscan displays human‑readable names and prompts.
-- `StakeManager.setToken` lets the owner swap the payment currency—including dispute fees—without redeploying other contracts.
+- `StakeManager.setToken` (legacy) previously let the owner swap the payment currency—including dispute fees—without redeploying other contracts.
 
 ## Module Interactions
 ```mermaid
@@ -149,7 +149,7 @@ interface IStakeManager {
     function withdrawStake(Role role, uint256 amount) external;
     function lockStake(address user, Role role, uint256 payout) external;
     function slash(address user, Role role, uint256 payout, address employer) external; // `employer` must not be zero when employer share > 0
-    function setToken(address token) external;
+    function setToken(address token) external; // legacy
     function setMinStake(uint256 minStake) external;
     function setSlashingPercentages(
         uint256 employerSlashPct,
@@ -171,7 +171,7 @@ Each module exposes minimal `onlyOwner` setters so governance can tune economics
 | JobRegistry | `setValidationModule`, `setReputationEngine`, `setStakeManager`, `setCertificateNFT`, `setDisputeModule`, `setJobParameters` | Wire module addresses and set per‑job rewards/stake |
 | ValidationModule | `setParameters` | Adjust stake ratios, rewards, slashing and timing windows |
 | DisputeModule | `setAppealParameters` | Configure dispute fees, jury size and moderator address |
-| StakeManager | `setToken`, `setMinStake`, `setSlashingPercentages`, `setTreasury` | Tune minimum stake, slashing shares and treasury |
+| StakeManager | `setToken` (legacy), `setMinStake`, `setSlashingPercentages`, `setTreasury` | Tune minimum stake, slashing shares and treasury |
 | ReputationEngine | `setCaller`, `setThreshold`, `setBlacklist` | Authorise callers, set reputation floors, manage blacklist |
 | CertificateNFT | `setJobRegistry` | Configure authorized JobRegistry |
 

--- a/docs/coding-sprint-agialpha-incentives.md
+++ b/docs/coding-sprint-agialpha-incentives.md
@@ -10,8 +10,8 @@ v2 suite while keeping all flows tax‑neutral, reporting‑free and pseudonymou
 - Align governance with rewards and ensure all parameters remain owner‑configurable.
 - Embed sybil resistance and regulatory‑flag mitigation through staking gates,
   blacklists and burn sinks.
-- Keep all value flows on‑chain in $AGIALPHA (6 decimals) so the owner can swap
-  the token or tune parameters without redeploying contracts.
+- Keep all value flows on‑chain in $AGIALPHA (18 decimals). The token is fixed
+  across modules; rotation is treated as a legacy capability.
 
 ## Tasks
 1. **FeePool Contract**

--- a/docs/coding-sprint-platform-incentives.md
+++ b/docs/coding-sprint-platform-incentives.md
@@ -13,7 +13,7 @@ configurable by the contract owner.
 ## Tasks
 1. **StakeManager integration**
    - Deploy `StakeManager(token, owner, treasury)` and wire to `JobRegistry`.
-   - Implement `setToken` so the owner may swap the staking token later.
+   - Implement `setToken` (legacy) so the owner may swap the staking token later if migrating.
 2. **PlatformRegistry & JobRouter**
    - Require `minPlatformStake` for registration.
    - Compute routing scores from stake and reputation; allow owner to blacklist.

--- a/docs/coding-sprint-v2-ens-identity.md
+++ b/docs/coding-sprint-v2-ens-identity.md
@@ -32,7 +32,7 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 - Use deterministic on‑chain randomness; avoid Chainlink VRF or subscription services.
 
 ### 4. StakeManager
-- Custody all funds in $AGIALPHA (6 decimals) with owner‑settable token address.
+- Custody all funds in $AGIALPHA (18 decimals) with a fixed token address (legacy `setToken` calls retained only for migrations).
 - Handle deposits, withdrawals, escrow locking, releases and slashing.
 - Apply protocol fees and validator rewards; support AGIType payout bonuses and per‑job validator splits.
 - Provide a `contribute` function for reward‑pool top‑ups to match v1's `contributeToRewardPool` and emit `RewardPoolContribution`.
@@ -50,7 +50,7 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 ### 7. CertificateNFT & Marketplace
 - Mint one certificate per completed job to the worker.
 - Add `list`, `purchase`, and `delist` functions using $AGIALPHA`; transfer proceeds to the seller.
-- Owner can set base URI, `JobRegistry` address, and swap payout token via `StakeManager.setToken`.
+- Owner can set base URI, `JobRegistry` address, and (legacy) swap payout token via `StakeManager.setToken`.
 
 ### 8. Documentation & Tests
 - Update `README.md` with an AGIALPHA deployment guide and Etherscan walkthrough.

--- a/docs/coding-sprint-v2.md
+++ b/docs/coding-sprint-v2.md
@@ -6,7 +6,7 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
 - Implement immutable, ownable modules for job coordination, validation, staking, reputation, disputes and certificate NFTs.
 - Optimise for gas efficiency and composability while keeping explorer interactions simple for non‑technical users.
 - Align incentives so honest behaviour is the dominant strategy for agents, validators and employers.
-- Default to the $AGIALPHA token (6 decimals) for all payments, stakes and dispute fees while allowing the owner to swap tokens via `StakeManager.setToken`.
+- Default to the $AGIALPHA token (18 decimals) for all payments, stakes and dispute fees. Token swapping via `StakeManager.setToken` is legacy.
 - Publish an on-chain tax disclaimer that leaves all liabilities with employers, agents and validators while the owner remains exempt.
 
 ## Tasks
@@ -20,7 +20,7 @@ This sprint turns the v2 architecture into production-ready code. Each task refe
    - `ReputationEngine`: reputation tracking, threshold enforcement, owner-managed blacklist.
    - `DisputeModule`: optional dispute flow and final ruling with dispute fees paid in the configured ERC‑20.
    - `CertificateNFT`: ERC‑721 minting with owner‑settable base URI.
-   - Wire `StakeManager` into all modules and expose `setToken` so the owner can replace $AGIALPHA without redeploying.
+   - Wire `StakeManager` into all modules. `setToken` exists for legacy migrations but new deployments should keep the fixed $AGIALPHA token.
 3. **Incentive Calibration**
    - Implement owner setters for stake ratios, rewards, slashing, timing windows and reputation thresholds.
    - Ensure slashing percentages exceed potential dishonest gains.

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -17,7 +17,7 @@ This walkthrough shows a non‑technical owner how to deploy and wire the modula
 Deploy each contract **in the order listed below** from the **Write Contract** tabs (the deployer automatically becomes the owner). Addresses for dependent modules may be passed at deployment or left as `0` and wired later. Parameters may be left as `0` to accept the defaults shown below:
 
 1. `AGIALPHAToken()` – after deployment, call `mint(to, amount)` to create the initial supply.
-2. `StakeManager(token, minStake, employerPct, treasuryPct, treasury)` – pass `address(0)` for `token` to use the default $AGIALPHA and `0,0` for the slashing percentages to send 100% of any slash to the treasury. The owner can later swap to a different ERC‑20 with `StakeManager.setToken`.
+2. `StakeManager(token, minStake, employerPct, treasuryPct, treasury)` – pass `address(0)` for `token` to use the default $AGIALPHA and `0,0` for the slashing percentages to send 100% of any slash to the treasury. `StakeManager.setToken` remains only for legacy migrations and should not be used in new deployments.
 3. `JobRegistry(validation, stakeMgr, reputation, dispute, certNFT, feePool, taxPolicy, feePct, jobStake)` – leaving `feePct = 0` applies a 5% protocol fee. Supplying a nonzero `taxPolicy` sets the disclaimer at deployment; otherwise the owner may call `setTaxPolicy` later.
 4. `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators, validatorPool)` – zero values default to 1‑day windows and a 1–3 validator set.
 5. `ReputationEngine(stakeManager)` – optional reputation weighting (pass `0` to wire later).
@@ -44,7 +44,7 @@ ModuleInstaller.initialize(jobRegistry, stakeManager, validationModule, reputati
 
 This `onlyOwner` call sets cross‑links, assigns the fee pool and optional tax policy, registers `PlatformIncentives` with both the `PlatformRegistry` and `JobRouter`, then automatically transfers ownership of all modules back to you.
 
-Owners can retune parameters any time: `StakeManager.setToken`, `setMinStake`, `FeePool.setBurnPct`, `PlatformRegistry.setBlacklist`, etc. No redeployments are required when swapping tokens or adjusting fees.
+Owners can retune parameters any time: `setMinStake`, `FeePool.setBurnPct`, `PlatformRegistry.setBlacklist`, etc. Token swapping via `StakeManager.setToken` is legacy; adjusting fees does not require redeployment.
 
 ## 4. One-call helper summary
 
@@ -57,7 +57,7 @@ Owners can retune parameters any time: `StakeManager.setToken`, `setMinStake`, `
 
 ## 5. Stake and register a platform
 
-1. In `$AGIALPHA`, approve the `StakeManager` for the desired amount (`1 token = 1_000000`, `0.1 token = 100000`).
+1. In `$AGIALPHA`, approve the `StakeManager` for the desired amount (`1 token = 1_000000000000000000`, `0.1 token = 100000000000000000`).
 2. Call `PlatformIncentives.stakeAndActivate(amount)` from the operator's address to register and enable routing. The helper stakes tokens, registers the platform in `PlatformRegistry`, and enrolls it with `JobRouter` for routing priority.
 3. If routing is unnecessary, call `PlatformRegistry.stakeAndRegister(amount)` or `acknowledgeStakeAndRegister(amount)` instead.
 4. The owner may register with `amount = 0` to appear in registries without fee or routing boosts.

--- a/docs/deployment-v2-agialpha.md
+++ b/docs/deployment-v2-agialpha.md
@@ -1,6 +1,6 @@
 # Deployment Guide: AGIJobs v2 with $AGIALPHA
 
-This guide shows how to deploy the modular v2 contracts using the helper script at `scripts/v2/deployDefaults.ts`. The script spins up the full stack with the 6‑decimal **$AGIALPHA** token and wires modules automatically.
+This guide shows how to deploy the modular v2 contracts using the helper script at `scripts/v2/deployDefaults.ts`. The script spins up the full stack with the 18‑decimal **$AGIALPHA** token and wires modules automatically.
 
 ## 1. Run the deployment script
 
@@ -25,7 +25,7 @@ The default run uses the mainnet `$AGIALPHA` address, a 5% protocol fee and 5% b
   - `ids.agentRootNode` / `ids.clubRootNode` – namehashes for `agent.agi.eth` and `club.agi.eth`.
   - `ids.agentMerkleRoot` / `ids.validatorMerkleRoot` – optional allowlists for off‑chain membership proofs.
   ![config script](https://via.placeholder.com/650x150?text=configure+econ+ids)
-- After deployment the owner can still adjust parameters on‑chain with `StakeManager.setToken`, `FeePool.setToken`, `JobRegistry.setFeePct` and `FeePool.setBurnPct`.
+- After deployment the owner can still adjust parameters on‑chain with `JobRegistry.setFeePct` and `FeePool.setBurnPct`. `StakeManager.setToken` and `FeePool.setToken` are legacy functions retained only for migrations.
 
 ## 3. Post-deploy wiring
 

--- a/docs/ens-v1-parity-sprint.md
+++ b/docs/ens-v1-parity-sprint.md
@@ -46,7 +46,7 @@ This sprint migrates every capability from the legacy `AGIJobManager` into the m
 - Run `npx hardhat test`, `forge test`, `npx solhint 'contracts/**/*.sol'` and `npx eslint .` until all pass.
 
 ## 5. Deployment Notes
-- Default token is `$AGIALPHA` (6 decimals). The owner may swap to any ERC‑20 via `StakeManager.setToken`.
+- Default token is `$AGIALPHA` (18 decimals). Token swapping via `StakeManager.setToken` is a legacy capability and not part of v2.
 - Document Etherscan-based deployment: deploy modules, call `setModules` on `JobRegistry`, then update Merkle roots and root nodes.
 
 Completion of this sprint yields a v2 system with full feature parity, ENS identity enforcement and owner-controlled configurability without contract redeployment.

--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -23,8 +23,8 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
    [AGIJobManager v0 contract](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code)
    on Etherscan and select **Contract → Deploy**.
 2. Supply constructor parameters:
-   - `_agiTokenAddress` – [$AGIALPHA token](https://etherscan.io/token/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D).
-     Remember that 6‑decimal base units are required (e.g. `10.5` tokens = `10_500000`).
+   - `_agiTokenAddress` – [$AGIALPHA token](https://etherscan.io/token/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA).
+     Remember that 18‑decimal base units are required (e.g. `10.5` tokens = `10_500000000000000000`).
    - `_baseIpfsUrl` – common prefix for job metadata such as `ipfs://`.
    - `_ensAddress` – [ENS Registry](https://etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e).
    - `_nameWrapperAddress` – [ENS NameWrapper](https://etherscan.io/address/0x253553366Da8546fC250F225fe3d25d0C782303b).
@@ -33,19 +33,17 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
    - `_validatorMerkleRoot` and `_agentMerkleRoot` – allowlist roots or `0x00` for open access.
 3. Submit the transaction; the deploying wallet becomes the owner.
 4. Post‑deployment owner actions appear under **Write Contract**:
-   - `updateAGITokenAddress(newToken)` swaps the payout token without redeploying
-     ([example](https://etherscan.io/tx/0x9efa2044bc0d0112f21724baacecf72719297c9db1d97e49a9281863684a668a)).
+   - `updateAGITokenAddress(newToken)` (legacy) swapped the payout token without redeploying
+     ([example](https://etherscan.io/tx/0x9efa2044bc0d0112f21724baacecf72719297c9db1d97e49a9281863684a668a)). v2 deployments assume a fixed token.
    - `setRootNodes(clubRootNode, agentRootNode)` and `setMerkleRoots(validatorRoot, agentRoot)` adjust
      ENS and Merkle allowlists as policies evolve.
    - `addAdditionalAgent(address)` whitelists specific addresses; the paired `addAdditionalValidator`
      provides similar overrides.
    - `blacklist(address, true)` blocks misbehaving agents or validators.
-   - Token transfers and payouts use 6‑decimal units, as illustrated by
-     [this 10 666.56 AGIALPHA transfer](https://etherscan.io/tx/0x7d16c9a27d2d852c04ccca086d32fcc03f6931635ff63a7ab37dc8d24f659fee).
-5. These setters mirror module controls in the v2 architecture—`StakeManager.setToken`,
+   - Token transfers and payouts use 18‑decimal units.
+5. These setters mirror module controls in the v2 architecture—`StakeManager.setToken` (legacy),
    `ENSOwnershipVerifier.setRootNodes`, `IdentityRegistry.setMerkleRoots`, `JobRegistry.addAdditionalAgent`,
-   and `ReputationEngine.blacklist`—demonstrating that the owner can retune parameters or swap tokens
-   without redeploying contracts.
+   and `ReputationEngine.blacklist`—demonstrating that the owner can retune parameters without redeploying contracts.
 
 ## One-click Etherscan deployment
 
@@ -94,7 +92,7 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 
 ### Owner-only setters
 
-- `StakeManager.setToken(newToken)`
+- `StakeManager.setToken(newToken)` (legacy)
 - `StakeManager.setMinStake(amount)`
 - `JobRegistry.setFeePct(fee)`
 - `ValidationModule.setCommitRevealWindows(commitWindow, revealWindow)`
@@ -109,7 +107,7 @@ All token amounts use the 6 decimal base units of $AGIALPHA (e.g., **1 AGIALPH
 - [ ] `setMerkleRoots(validatorRoot, agentRoot)`
 
 ### v2
-- [ ] `StakeManager.setToken(newToken)` and `FeePool.setToken(newToken)`
+- [ ] (legacy) `StakeManager.setToken(newToken)` and `FeePool.setToken(newToken)`
 - [ ] `ENSOwnershipVerifier.setRootNodes(clubRootNode, agentRootNode)`
 - [ ] `IdentityRegistry.setMerkleRoots(validatorRoot, agentRoot)`
 - [ ] `JobRegistry.setModules(...)`

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -4,24 +4,24 @@ For a narrated deployment walkthrough, see [deployment-agialpha.md](deployment-a
 
 ## Quick Links
 - AGIJobManager v0: [Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code) | [Blockscout](https://blockscout.com/eth/mainnet/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477/contracts)
-- $AGI Token: [Etherscan](https://etherscan.io/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D#code) | [Blockscout](https://eth.blockscout.com/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D?tab=contract)
+- $AGIALPHA Token: [Etherscan](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA#code) | [Blockscout](https://eth.blockscout.com/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA?tab=contract)
 
 > **Tax Note:** The contracts and their owner are globally tax‑exempt; employers, agents, and validators shoulder all tax duties. Each module exposes `isTaxExempt()` for verification.
 
-> **Base units:** $AGIALPHA uses 6 decimals. Enter amounts as integers (`1` token = `1_000000`, `0.5` token = `500000`, `0.1` token = `100000`).
+> **Base units:** $AGIALPHA uses 18 decimals. Enter amounts as integers (`1` token = `1_000000000000000000`, `0.5` token = `500000000000000000`, `0.1` token = `100000000000000000`).
 
 ## Deploy v2 Modules
 1. Open the [`Deployer`](../contracts/v2/Deployer.sol) contract on Etherscan and connect a wallet under **Write Contract**.
 2. Execute **deployDefaults(ids)**; blank fields use `$AGIALPHA` and baked‑in economics while wiring all modules. The caller becomes the owner.
-3. To retune payouts, the owner calls [`StakeManager.setToken(newToken)`](../contracts/v2/StakeManager.sol) and [`FeePool.setToken(newToken)`](../contracts/v2/FeePool.sol) – emitting `TokenUpdated` proves the swap. No module redeployment is needed.
+3. Legacy deployments allowed token swaps via [`StakeManager.setToken(newToken)`](../contracts/v2/StakeManager.sol) and [`FeePool.setToken(newToken)`](../contracts/v2/FeePool.sol). New systems assume a fixed token and should not invoke these functions.
 
 ## Role Function Quick Reference
-| Role | Required function calls | Example amounts (6 decimals) |
+| Role | Required function calls | Example amounts (18 decimals) |
 | --- | --- | --- |
-| Employer | `$AGIALPHA.approve(StakeManager, 1_050000)` → `JobRegistry.acknowledgeTaxPolicy()` → `JobRegistry.createJob(1_000000, uri)` | approve `1_050000` for a 1‑token reward + 5% fee |
-| Agent | `$AGIALPHA.approve(StakeManager, 1_000000)` → `JobRegistry.stakeAndApply(jobId, 1_000000)` | stake `1_000000` |
-| Validator | `$AGIALPHA.approve(StakeManager, 1_000000)` → `StakeManager.depositStake(1, 1_000000)` → `ValidationModule.commitValidation(jobId, hash, sub, proof)` → `ValidationModule.revealValidation(jobId, approve, salt)` | stake `1_000000` |
-| Disputer | `$AGIALPHA.approve(StakeManager, 1_000000)` → `JobRegistry.acknowledgeAndDispute(jobId, evidence)` → `DisputeModule.resolve(jobId, uphold, signatures)` (majority moderators or owner) | dispute fee `1_000000` |
+| Employer | `$AGIALPHA.approve(StakeManager, 1_050000000000000000)` → `JobRegistry.acknowledgeTaxPolicy()` → `JobRegistry.createJob(1_000000000000000000, uri)` | approve `1_050000000000000000` for a 1‑token reward + 5% fee |
+| Agent | `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` → `JobRegistry.stakeAndApply(jobId, 1_000000000000000000)` | stake `1_000000000000000000` |
+| Validator | `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` → `StakeManager.depositStake(1, 1_000000000000000000)` → `ValidationModule.commitValidation(jobId, hash, sub, proof)` → `ValidationModule.revealValidation(jobId, approve, salt)` | stake `1_000000000000000000` |
+| Disputer | `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` → `JobRegistry.acknowledgeAndDispute(jobId, evidence)` → `DisputeModule.resolve(jobId, uphold, signatures)` (majority moderators or owner) | dispute fee `1_000000000000000000` |
 
 ## ENS prerequisites
 - Agents need an ENS subdomain ending in `.agent.agi.eth`; validators require `.club.agi.eth`.
@@ -31,7 +31,7 @@ For a narrated deployment walkthrough, see [deployment-agialpha.md](deployment-a
 
 1. **Connect to Web3** – open the contract on Etherscan, select the **Write Contract** tab, click **Connect to Web3**, and approve the connection.
    ![connect-web3](https://via.placeholder.com/650x150?text=Connect+to+Web3)
-2. **depositStake** – on `StakeManager`, enter the role and amount (6‑decimal base units) in `depositStake(role, amount)`.
+2. **depositStake** – on `StakeManager`, enter the role and amount (18‑decimal base units) in `depositStake(role, amount)`.
    ![deposit-stake](https://via.placeholder.com/650x150?text=depositStake)
 3. **stakeAndActivate** – visit the `PlatformIncentives` address, connect, enter the stake amount, and press **Write** on `stakeAndActivate(amount)`.
    ![stake-and-activate](https://via.placeholder.com/650x150?text=stakeAndActivate)
@@ -50,7 +50,7 @@ When using the **Write Contract** tab as the owner, populate fields with explici
 | `StakeManager` | `setFeePct(pct)` | `20` |
 | `JobRegistry` | `setFeePct(pct)` | `5` |
 | `TaxPolicy` | `setPolicyURI("ipfs://Qm...")` | `ipfs://QmPolicyHash` |
-| `FeePool` | `ownerWithdraw(to, amount)` | `0x1111111111111111111111111111111111111111`, `1000000` |
+| `FeePool` | `ownerWithdraw(to, amount)` | `0x1111111111111111111111111111111111111111`, `1000000000000000000` |
 
 ## Module Addresses & Roles
 | Module | Address | Role |
@@ -152,7 +152,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 ## Common Etherscan Flows
 ### Approve $AGIALPHA
 1. Navigate to the [$AGIALPHA token](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA#writeContract).
-2. In **Write Contract**, connect your wallet and call **approve(spender, amount)**. Use 6‑decimal base units (e.g., `1_000000` for one token).
+2. In **Write Contract**, connect your wallet and call **approve(spender, amount)**. Use 18‑decimal base units (e.g., `1_000000000000000000` for one token).
 
 ### Acknowledge the tax policy
 1. Open `JobRegistry` → **Write**.
@@ -188,7 +188,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 | Function | Parameters | Typical Use Case |
 | --- | --- | --- |
 | `depositStake(uint8 role, uint256 amount)` | `role` – 0 Agent, 1 Validator, 2 Platform; `amount` – tokens | Participants bond tokens for their role. |
-| `setToken(address newToken)` | `newToken` – ERC‑20 address | Owner switches the staking and reward token. |
+| `setToken(address newToken)` | `newToken` – ERC‑20 address | Legacy: owner swapped the staking and reward token. |
 | `slash(address offender, address beneficiary, uint256 amount)` | offending address, beneficiary address, amount | Owner penalises misbehaviour and redirects stake. Beneficiary cannot be the zero address if an employer share is due. |
 
 ### ValidationModule
@@ -236,7 +236,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 - [ ] Confirm addresses and bytecode match official releases.
 - [ ] Cross-check transactions on at least two block explorers.
 - [ ] Review parameter settings via read functions before calling write methods.
-- [ ] Ensure the AGI token address `0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D` matches the token in your wallet.
+- [ ] Ensure the AGIALPHA token address `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA` matches the token in your wallet.
 
 ---
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -30,7 +30,7 @@ EOA ownership is not possible.
 ## Upgrading through the timelock
 
 1. Encode the desired function call on the target contract (for example
-   `setToken(newToken)` on `StakeManager`).
+   `setToken(newToken)` on `StakeManager` for legacy migrations).
 2. Submit the call to the timelock or multisig:
    - For OpenZeppelin timelocks, use `schedule` with the target, value,
      data, predecessor, salt and delay parameters.

--- a/docs/incentive-mechanisms-agialpha.md
+++ b/docs/incentive-mechanisms-agialpha.md
@@ -1,6 +1,6 @@
 # Incentive Mechanisms for Decentralized AGI Jobs v2 Platforms
 
-This note details how $AGIALPHA (6 decimals) powers a tax‑neutral, reporting‑free rollout of AGI Jobs marketplaces. All mechanisms are implemented on‑chain so operators interact only through pseudonymous addresses.
+This note details how $AGIALPHA (18 decimals) powers a tax‑neutral, reporting‑free rollout of AGI Jobs marketplaces. All mechanisms are implemented on‑chain so operators interact only through pseudonymous addresses.
 
 ## 1. Revenue Sharing via Staking
 - Platform operators stake $AGIALPHA in `StakeManager`.
@@ -26,10 +26,10 @@ Token burns may be configured on every fee so a portion of payouts is destroyed,
 - On-chain tax acknowledgements and blacklist thresholds are owner‑tuned, letting deployments adapt to local compliance signals while keeping addresses pseudonymous.
 - Because the protocol never takes custody or issues off‑chain payouts, there is no centralized revenue that would trigger reporting duties.
 
-All modules expose simple `Ownable` setters so the contract owner can retune fees, stakes, burn rates or even swap the token address through Etherscan without redeploying contracts.
+All modules expose simple `Ownable` setters so the contract owner can retune fees, stakes and burn rates through Etherscan without redeploying contracts. Token rotation is considered legacy and is not part of normal operations.
 
 ## 5. Owner Controls & User Experience
-- The contract owner may update fees, burn rates, stake thresholds, and even swap the token address via `StakeManager.setToken`.
+- The contract owner may update fees, burn rates and stake thresholds. Token swapping via `StakeManager.setToken` is a legacy feature and should be avoided in new deployments.
 - All interactions rely on simple data types, enabling non‑technical users to operate entirely through Etherscan.
 - Each module exposes an `isTaxExempt()` view and rejects direct ETH to prevent the contracts or owner from ever holding taxable funds.
 - Reward flows never touch off‑chain accounts, keeping operators pseudonymous and outside traditional reporting regimes.

--- a/docs/legacy/Guidev0.md
+++ b/docs/legacy/Guidev0.md
@@ -67,9 +67,9 @@ P1a["🦊 MetaMask on Ethereum Mainnet"]:::step
 P1b["🔗 Etherscan → Connect to Web3 (sign popups)"]:::step
 P1c["⛽ Hold ETH for gas"]:::step
 P1d["💠 Acquire $AGIALPHA & add as Custom Token"]:::step
-P1e["🧮 Remember: $AGIALPHA has 6 decimals
-• 10.0 = 10_000000
-• 0.5 = 500_000"]:::info
+P1e["🧮 Remember: $AGIALPHA has 18 decimals
+• 10.0 = 10_000000000000000000
+• 0.5 = 500_000000000000000"]:::info
 end
 class P1 phase
 
@@ -185,7 +185,7 @@ class P7 phase
 subgraph LEG["🧭 Legend & Golden Rules"]
 direction TB
 L1["Role IDs → Agent=0 • Validator=1 • Platform=2"]:::info
-L2["$AGIALPHA uses 6 decimals (base units)"]:::info
+L2["$AGIALPHA uses 18 decimals (base units)"]:::info
 L3["All interactions are Etherscan ‘Write’ calls, authorized by wallet signatures"]:::info
 L4["Owner-only steps live in Phases 2–4"]:::info
 L5["Optional modules: DisputeModule, JobRouter/PlatformRegistry"]:::info
@@ -221,17 +221,17 @@ LEG --> P7
 
 * **ETH for Gas:** Make sure your MetaMask wallet has a sufficient amount of **ETH** to pay for gas fees on mainnet. Every contract deployment and function call will consume gas (paid in ETH).
 
-* **\$AGIALPHA Tokens:** Acquire some **\$AGIALPHA** – the ERC-20 token used for payments, staking, and rewards in AGI Jobs v2. You will need \$AGIALPHA to post job bounties and to stake as an agent/validator/platform. \$AGIALPHA has **6 decimal places**, *not* the usual 18. For example, `1.0 AGIALPHA = 1,000,000` in base units. The official \$AGIALPHA token contract is at **`0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`** (you can verify this on Etherscan). Add this token to your MetaMask using the contract address.
+* **\$AGIALPHA Tokens:** Acquire some **\$AGIALPHA** – the ERC-20 token used for payments, staking, and rewards in AGI Jobs v2. You will need \$AGIALPHA to post job bounties and to stake as an agent/validator/platform. \$AGIALPHA has **18 decimal places**. For example, `1.0 AGIALPHA = 1_000000000000000000` in base units. The official \$AGIALPHA token contract is at **`0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`** (you can verify this on Etherscan). Add this token to your MetaMask using the contract address.
 
   *How to get \$AGIALPHA?* If it’s publicly available, you might swap for it on a DEX (like Uniswap) by inputting the token address. Otherwise, obtain it through the project’s official channels. Ensure you have enough tokens for the actions you plan (e.g. posting job rewards or staking collateral).
 
 * **Add Token to Wallet:** In MetaMask, add a **Custom Token** for \$AGIALPHA using the address above so you can see your balance.
 
-* **Important Units Reminder:** All **token amounts** in this guide (rewards, stakes, fees) must be input in the token’s smallest units (with 6 decimals). For example:
+* **Important Units Reminder:** All **token amounts** in this guide (rewards, stakes, fees) must be input in the token’s smallest units (with 18 decimals). For example:
 
-  * `10 AGIALPHA` = **`10_000000`** in the input field.
-  * `0.5 AGIALPHA` = **`500_000`**.
-  * `100 AGIALPHA` = **`100_000000`**.
+  * `10 AGIALPHA` = **`10_000000000000000000`** in the input field.
+  * `0.5 AGIALPHA` = **`500_000000000000000`**.
+  * `100 AGIALPHA` = **`100_000000000000000000`**.
 
 Keep this conversion in mind whenever you enter token amounts in Etherscan forms.
 
@@ -417,7 +417,7 @@ After linking, all modules should now reference each other correctly. The JobReg
 
 Next, set initial parameters like required stakes, fee percentages, and slashing rates. As the owner, you can adjust these using the following functions on the respective contracts (via Etherscan Write):
 
-* **StakeManager – Minimum Stake:** It’s wise to require a minimum stake for agents/validators to prevent Sybil attacks. On **StakeManager**, call `setMinStake(uint256 _minStake)` to set the minimum staking amount (in \$AGIALPHA base units). For example, to require at least 5 AGIALPHA, input `5_000000`. This applies to both agents and validators typically (and possibly platform operators, unless PlatformRegistry has its own minimum).
+* **StakeManager – Minimum Stake:** It’s wise to require a minimum stake for agents/validators to prevent Sybil attacks. On **StakeManager**, call `setMinStake(uint256 _minStake)` to set the minimum staking amount (in \$AGIALPHA base units). For example, to require at least 5 AGIALPHA, input `5_000000000000000000`. This applies to both agents and validators typically (and possibly platform operators, unless PlatformRegistry has its own minimum).
 
 * **StakeManager – Slashing Percentages:** Call `setSlashingPercentages(uint256 employerSlashPct, uint256 treasurySlashPct)` on StakeManager to define how a slashed stake is divided. For instance, you might want that when an agent is slashed for a failed job, part of their staked collateral goes back to the employer as compensation and part goes to the platform treasury. If you set employerSlashPct = 50 and treasurySlashPct = 50, half of the slashed amount goes to the employer and half to the `treasury` address set in StakeManager. (Ensure the two percentages sum to ≤100; any remainder stays with the contract if not enforced to exactly 100.)
 
@@ -425,7 +425,7 @@ Next, set initial parameters like required stakes, fee percentages, and slashing
 
 * **JobRegistry – Job Parameters:** On **JobRegistry**, there may be a function like `setJobParameters(uint256 reward, uint256 stake)` or individual ones to set default job requirements. For instance, if `setJobParameters` exists, it might define the **default job reward and required agent stake** for jobs. However, in this v2, the job reward is specified per job when created, and `jobStake` (the required agent collateral for each job) is a parameter we likely set. Check if `JobRegistry.setJobParameters` or similar exists:
 
-  * If **JobRegistry.setJobParameters**(reward, stake) exists, you could use it to set a template. Otherwise, look for `setJobStake(uint96 stake)` in JobRegistry (the code shows `jobStake` as a public variable). If a function is present (maybe named `updateJobStake` or included in `JobParametersUpdated` event), call it to set how much an agent must stake to take a job. For example, if every job requires the agent to stake 1 AGIALPHA, set jobStake = `1_000000`. If the job poster (employer) can specify any reward, you might not need to set a default reward.
+  * If **JobRegistry.setJobParameters**(reward, stake) exists, you could use it to set a template. Otherwise, look for `setJobStake(uint96 stake)` in JobRegistry (the code shows `jobStake` as a public variable). If a function is present (maybe named `updateJobStake` or included in `JobParametersUpdated` event), call it to set how much an agent must stake to take a job. For example, if every job requires the agent to stake 1 AGIALPHA, set jobStake = `1_000000000000000000`. If the job poster (employer) can specify any reward, you might not need to set a default reward.
   * Also note `feePct` in JobRegistry, which is the percentage of each job’s reward that will be taken as a protocol fee (and sent to FeePool). You can set this via `JobRegistry.setFeePct(uint256 _feePct)`. For example, to take a 5% fee from each job, input `5`. (Ensure you do this **after** linking FeePool, since it only matters if a FeePool is set).
 
 * **ValidationModule – Validation Parameters:** The ValidationModule likely has a function `setParameters(...)` to set how validation works (e.g. number of validators per job, commit/reveal durations, reward/slash rates for validators). On **ValidationModule**, find `setParameters` and input the desired values:

--- a/docs/legacy/deployment-v0-agialpha.md
+++ b/docs/legacy/deployment-v0-agialpha.md
@@ -22,10 +22,10 @@ This guide walks a non‑technical owner through deploying the monolithic **AGIJ
    - Tune parameters like `setRequiredValidatorApprovals`, `setValidationRewardPercentage`, `setMaxJobPayout`, and blacklist users.
 
 ## Usage Notes
-- All token amounts use 6‑decimal units (`1 token = 1_000000`).
+- All token amounts use 18‑decimal units (`1 token = 1_000000000000000000`).
 - Employers post jobs with `createJob` after approving the token.
 - Agents call `applyForJob` with their subdomain and optional Merkle proof.
 - Validators vote through `validateJob` or `disapproveJob` and earn rewards once `_completeJob` runs.
 - The owner may refund or slash parties through dispute functions without ever redeploying the contract.
 
-By keeping `$AGIALPHA` configurable through `updateAGITokenAddress`, the deployment stays flexible while offering a simple explorer‑based workflow for non‑technical participants.
+By keeping `$AGIALPHA` configurable through `updateAGITokenAddress` (legacy), the deployment stays flexible while offering a simple explorer‑based workflow for non‑technical participants.

--- a/docs/legacy/quickstart-v0-agialpha-etherscan.md
+++ b/docs/legacy/quickstart-v0-agialpha-etherscan.md
@@ -20,7 +20,7 @@ roots and Merkle roots—remain owner‑configurable after deployment.
    retune any parameter via the contract's write methods.
 
 ## 2. Approve tokens and stake
-All token amounts use 6‑decimal units (`1 AGIALPHA = 1_000000`).
+All token amounts use 18‑decimal units (`1 AGIALPHA = 1_000000000000000000`).
 
 1. **Employers** approve the job reward on `$AGIALPHA` then call
    `createJob` with `reward` and a metadata URI.
@@ -38,6 +38,6 @@ All token amounts use 6‑decimal units (`1 AGIALPHA = 1_000000`).
    `resolveDispute` finalises the outcome.
 
 Throughout the lifecycle the owner may update the payout token with
-`updateAGITokenAddress`, adjust ENS roots or Merkle proofs, and tweak
+`updateAGITokenAddress` (legacy), adjust ENS roots or Merkle proofs, and tweak
 limits such as `setMaxJobPayout` or `setValidationRewardPercentage`
 without redeploying the contract.

--- a/docs/modular-architecture-v2.md
+++ b/docs/modular-architecture-v2.md
@@ -25,7 +25,7 @@ graph LR
 | Module | Core responsibility | Owner abilities |
 | --- | --- | --- |
 | **JobRegistry** | canonical registry for job metadata and state transitions; routes calls to companion modules | swap module addresses with `setModules`, pause job creation, and adjust global settings |
-| **StakeManager** | holds escrowed rewards and participant stakes; executes payouts and slashing | change ERC‑20 token via `setToken`, tune minimum stakes and slashing percentages |
+| **StakeManager** | holds escrowed rewards and participant stakes; executes payouts and slashing | `setToken` (legacy), tune minimum stakes and slashing percentages |
 | **ValidationModule** | selects validators and runs the commit‑reveal finalization | update committee size and timing windows through `setParameters` |
 | **ReputationEngine** | accrues or subtracts reputation; enforces blacklists | alter reputation weights, thresholds and blacklist entries |
 | **DisputeModule** | optional dispute layer for contested jobs | set dispute fees and moderator/jury addresses |
@@ -61,7 +61,7 @@ interface IStakeManager {
     function lockReward(address from, uint256 amount) external;
     function payReward(address to, uint256 amount) external;
     function slash(address offender, address beneficiary, uint256 amount) external; // `beneficiary` must not be zero when employer share > 0
-    function setToken(address newToken) external;
+    function setToken(address newToken) external; // legacy
 }
 
 interface IValidationModule {
@@ -110,9 +110,9 @@ rendering deviation economically unattractive.
 
 ## Token Configuration
 The `StakeManager` stores the ERC‑20 used for rewards, staking and dispute fees.  By default it references
-[`$AGIALPHA`](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA) (6 decimals), but the owner can switch
-currencies via `setToken(newToken)` without redeploying other modules.  All amounts must be provided in base units (1 token =
-1e6 units).
+[`$AGIALPHA`](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA) (18 decimals). Token rotation via
+`setToken(newToken)` is a legacy feature and should not be used in new deployments.  All amounts must be provided in base units
+(1 token = 1e18 units).
 
 ## Explorer‑Friendly Design
 All public methods use simple data types so employers, agents and validators can interact through Etherscan's **Write** tab.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -71,7 +71,7 @@ For a step-by-step deployment walkthrough with owner-only setters, see [deployme
 | JobRegistry | `setModules` (none set), `setJobParameters` (`reward=0`, `stake=0`), `setFeePool` (0 address), `setFeePct` (`0`), `setTaxPolicy` (0 address) | Wire modules, set template stake/reward, and configure fees/tax policy. |
 | ValidationModule | `setValidatorPool` (empty), `setReputationEngine` (0 address), `setCommitRevealWindows` (`0`, `0`), `setValidatorBounds` (`0`, `0`) | Choose validators and tune commit/reveal timing and committee sizes. |
 | DisputeModule | `addModerator(address, weight)` / `removeModerator(address)` (owner), majority-signed `resolve(jobId, verdict, signatures)`, `setDisputeFee` (`0`), `setJobRegistry` (constructor address) | Configure dispute bond and weighted arbiters; disputes finalize via moderator vote or owner call. |
-| StakeManager | `setToken` (constructor token), `setMinStake` (`0`), `setSlashingPercentages` (`0`, `100`), `setTreasury` (constructor treasury), `setJobRegistry` (0 address), `setDisputeModule` (0 address), `setMaxStakePerAddress` (`0`) | Adjust staking token, minimums, slashing rules, and authorised modules. |
+| StakeManager | `setToken` (constructor token, legacy), `setMinStake` (`0`), `setSlashingPercentages` (`0`, `100`), `setTreasury` (constructor treasury), `setJobRegistry` (0 address), `setDisputeModule` (0 address), `setMaxStakePerAddress` (`0`) | Adjust staking token, minimums, slashing rules, and authorised modules. |
 | ReputationEngine | `setCaller` (`false`), `setStakeManager` (0 address), `setScoringWeights` (`1e18`, `1e18`), `setThreshold` (`0`), `blacklist` (`false`) | Manage scoring weights, authorised callers, and blacklist threshold. |
 | CertificateNFT | `setJobRegistry` (0 address) | Authorise minting registry; URIs emitted in events with hashes on-chain. |
 
@@ -92,7 +92,7 @@ When calibrated so that honest behaviour yields the lowest `G`, deviations carry
 | Contract | Network | Address |
 | --- | --- | --- |
 | AGIJobManager v0 | Ethereum mainnet | [0x0178b6bad606aaf908f72135b8ec32fc1d5ba477](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477) |
-| $AGI Token | Ethereum mainnet | [0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D](https://etherscan.io/address/0xf0780F43b86c13B3d0681B1Cf6DaeB1499e7f14D) |
+| $AGIALPHA Token | Ethereum mainnet | [0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA) |
 
 ## Quick Start
 1. Clone the repository and install dependencies:

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -46,7 +46,7 @@ The main deployer follows the same process but typically stakes `0`. With zero s
 
 All modules are `Ownable`. The owner can:
 
-- Swap out the staking token (`StakeManager.setToken` and related setters).
+- Swap out the staking token (`StakeManager.setToken` and related setters) – legacy only.
 - Adjust minimum stakes, slashing percentages and burn rates.
 - Replace auxiliary modules like the reputation engine or dispute handler.
 - Authorise helpers (`PlatformRegistry.setRegistrar`, `JobRouter.setRegistrar`).

--- a/docs/v1-v2-function-map.md
+++ b/docs/v1-v2-function-map.md
@@ -23,7 +23,7 @@ The table below maps common public functions from the monolithic `AGIJobManagerV
 | `listNFT` | `CertificateNFT` | `list` |
 | `purchaseNFT` | `CertificateNFT` | `purchase` |
 | `delistNFT` | `CertificateNFT` | `delist` |
-| `updateAGITokenAddress` | `StakeManager` / `FeePool` | `setToken` on each module |
+| `updateAGITokenAddress` | `StakeManager` / `FeePool` | `setToken` on each module (legacy) |
 | `blacklistAgent` / `clearAgentBlacklist` | `ReputationEngine` | `blacklist(user, status)` |
 | `blacklistValidator` / `clearValidatorBlacklist` | `ReputationEngine` | `blacklist(user, status)` |
 | `addModerator` / `removeModerator` | `DisputeModule` | `addModerator` / `removeModerator` |

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -18,7 +18,7 @@ resolver, emitting `OwnershipVerified` on success.
 ## Module Responsibilities & Addresses
 | Module | Responsibility | Address |
 | --- | --- | --- |
-| `$AGIALPHA` Token | 6‑decimal ERC‑20 used for payments and staking | `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA` |
+| `$AGIALPHA` Token | 18‑decimal ERC‑20 used for payments and staking | `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA` |
 | StakeManager | Custodies stakes, escrows rewards, slashes misbehaviour | `TBD` |
 | ReputationEngine | Tracks reputation scores and blacklist status | `TBD` |
 | IdentityRegistry | Verifies ENS subdomains and Merkle allowlists | `TBD` |
@@ -50,7 +50,7 @@ To customise the token, protocol fees or ENS roots edit the script to call
 The script prints module addresses and verifies source on Etherscan.
 
 ## Step-by-Step Deployment
-1. **Deploy `$AGIALPHA` token** with 6 decimals if it does not already exist.
+1. **Deploy `$AGIALPHAToken`** (18 decimals) if it does not already exist.
 2. **Deploy `StakeManager`** pointing at the token and configuring `_minStake`, `_employerSlashPct`, `_treasurySlashPct` and `_treasury`. Leave `_jobRegistry` and `_disputeModule` as `0`.
 3. **Deploy `ReputationEngine`** passing the `StakeManager` address.
 4. **Deploy `IdentityRegistry`** with the ENS registry, NameWrapper, `ReputationEngine` address and the namehashes for `agent.agi.eth` and `club.agi.eth`.
@@ -72,8 +72,7 @@ The script prints module addresses and verifies source on Etherscan.
 ## Governance Configuration Steps
 After deployment the governance contract can fine‑tune the system without redeploying:
 
-1. **Configure `$AGIALPHA`** – ensure `StakeManager` and `FeePool` point
-   to the desired ERC‑20 via `setToken`.
+1. **Configure `$AGIALPHA`** – `StakeManager` and `FeePool` assume this fixed token; `setToken` is retained only for legacy migrations.
 2. **Set ENS roots** – on `IdentityRegistry` call `setAgentRootNode`,
    `setClubRootNode` and, if using allowlists, `setAgentMerkleRoot` and
    `setValidatorMerkleRoot`.
@@ -132,7 +131,7 @@ then be performed through the "Write" tabs on each module.
 | Action | Contract / Function | Notes |
 | --- | --- | --- |
 | Accept tax terms | `JobRegistry.acknowledgeTaxPolicy()` | Must be called once before staking or disputing |
-| Stake as agent | `StakeManager.depositStake(0, amount)` | `amount` uses 6‑decimal `$AGIALPHA` units |
+| Stake as agent | `StakeManager.depositStake(0, amount)` | `amount` uses 18‑decimal `$AGIALPHA` units |
 | Post a job | `JobRegistry.createJob(reward, uri)` | `reward` in base units; token must be approved |
 | Commit vote | `ValidationModule.commitValidation(jobId, hash, subdomain, proof)` | `hash = keccak256(approve, salt)` |
 | Reveal vote | `ValidationModule.revealValidation(jobId, approve, salt)` | Call after commit phase closes |
@@ -141,7 +140,7 @@ then be performed through the "Write" tabs on each module.
 | Buy certificate | `CertificateNFT.purchase(tokenId)` | Buyer approves token first |
 
 ## Owner Administration
-- **Swap the token:** call `StakeManager.setToken(newToken)` (and any mirrored module setters) from the owner account.
+- **Swap the token:** `StakeManager.setToken(newToken)` remains for legacy deployments but should not be used in new systems.
 - **Adjust parameters:** examples include `StakeManager.setMinStake(amount)`, `JobRegistry.setFeePct(pct)`, `ValidationModule.setCommitWindow(seconds)`, `ValidationModule.setRevealWindow(seconds)` and `DisputeModule.setDisputeFee(fee)`.
 - **Manage allowlists:** on `IdentityRegistry` use `setAgentMerkleRoot(root)`, `setValidatorMerkleRoot(root)`, `addAdditionalAgent(addr)` and `addAdditionalValidator(addr)`; update ENS roots with `setAgentRootNode(node)` and `setClubRootNode(node)`.
 - **Transfer ownership:** every module inherits `Ownable`; call
@@ -152,10 +151,9 @@ then be performed through the "Write" tabs on each module.
 
 ## Token Configuration
 - Default staking/reward token: `$AGIALPHA` at
-  `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA` (6 decimals).
-- To swap the token, the owner calls
-  `StakeManager.setToken(newToken)`; emit `TokenUpdated(newToken)` to
-  verify.
+  `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA` (18 decimals).
+- Token swapping via `StakeManager.setToken(newToken)` is legacy and not
+  part of standard operations.
 
 ## Troubleshooting
 - **Missing subdomain proof** – ensure your ENS label and Merkle proof
@@ -165,7 +163,7 @@ then be performed through the "Write" tabs on each module.
 - **Tax policy** – users must call `acknowledgeTaxPolicy()` on
   `JobRegistry` before staking or disputing.
 - **Wrong decimals** – `setToken` only accepts ERC‑20 tokens with
-  exactly 6 decimals.
+  exactly 18 decimals.
 
 ## Identity Requirements & Merkle Proofs
 Agents must control an `*.agent.agi.eth` subdomain and validators a `*.club.agi.eth` subdomain. When applying or validating, supply the subdomain label and a Merkle proof showing your address is allow‑listed.

--- a/docs/v2-module-deployment-summary.md
+++ b/docs/v2-module-deployment-summary.md
@@ -27,8 +27,8 @@ the `StakeManager` address.
    user funds.
 
 ## 3. Post-deploy configuration
-1. **Token rotation** – the owner may change the staking token by calling
-   `setToken(newToken)` on `StakeManager` and `FeePool`.
+1. **Token rotation** – legacy deployments may change the staking token by calling
+   `setToken(newToken)` on `StakeManager` and `FeePool`, but new systems use a fixed `$AGIALPHA` token.
 2. **ENS & Merkle updates** – adjust namehashes and allowlists through
    `IdentityRegistry.setAgentRootNode`, `setClubRootNode`,
    `setAgentMerkleRoot` and `setValidatorMerkleRoot`.

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -47,7 +47,7 @@ interface IStakeManager {
     function lockReward(address from, uint256 amount) external;
     function payReward(address to, uint256 amount) external;
     function slash(address offender, address beneficiary, uint256 amount) external; // `beneficiary` must not be zero when employer share > 0
-    function setToken(address newToken) external;
+    function setToken(address newToken) external; // legacy
 }
 
 interface IValidationModule {
@@ -101,7 +101,7 @@ interface ICertificateNFT {
 Stakes form potential energy \(H\); commit–reveal voting injects entropy \(S\). Owner‑tuned parameters act as temperature \(T\). The network evolves toward minimum Gibbs free energy \(G = H - TS\), making honest behaviour the dominant, low‑energy strategy. Slashing raises \(H\) for cheaters, while random validator selection increases \(S\), keeping collusion energetically unfavourable.
 
 ## Owner Control & Token Flexibility
-All setters are `onlyOwner`. `StakeManager.setToken` lets the owner swap the payment/staking token (default [$AGIALPHA](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA), 6 decimals) without redeploying other modules. All amounts are supplied in base units (1 token = 1e6). For example `0.1` token is `100_000` and `12` tokens are `12_000_000`. When interacting with 18‑decimal tokens, divide values by `1e12` to fit this format; any remainder beyond six decimals will be truncated.
+All setters are `onlyOwner`. Legacy versions exposed `StakeManager.setToken` to swap the payment/staking token, but v2 assumes the 18‑decimal [$AGIALPHA](https://etherscan.io/address/0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA) token for all modules. All amounts are supplied in base units (1 token = 1e18). For example `0.1` token is `100_000000000000000` and `12` tokens are `12_000000000000000000`.
 
 ## Governance Composability
 - Modules are immutable once deployed; to upgrade a component the owner deploys a new module and calls `JobRegistry.setModules` with the replacement address.


### PR DESCRIPTION
## Summary
- replace 6-decimal token references with 18-decimal AGIALPHA address
- mark `setToken` flows as legacy and update examples
- note token migration in changelog

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1e5c9eda48333aa98b607eebaf5e8