### PR TITLE
Fix AGIALPHA token immutability

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -50,7 +50,6 @@ contract MockStakeManager is IStakeManager {
     function lockDisputeFee(address, uint256) external override {}
     function payDisputeFee(address, uint256) external override {}
 
-    function setToken(IERC20) external override {}
     function setMinStake(uint256) external override {}
     function setSlashingPercentages(uint256, uint256) external override {}
     function setSlashingParameters(uint256, uint256) external override {}

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.25;
 
 import {IFeePool} from "./IFeePool.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @title IStakeManager
 /// @notice Interface for staking balances, job escrows and slashing logic
@@ -35,7 +34,6 @@ interface IStakeManager {
     event DisputeModuleUpdated(address module);
     event ValidationModuleUpdated(address module);
     event ModulesUpdated(address jobRegistry, address disputeModule);
-    event TokenUpdated(address indexed token);
     event MinStakeUpdated(uint256 minStake);
     event SlashingPercentagesUpdated(uint256 employerSlashPct, uint256 treasurySlashPct);
     event TreasuryUpdated(address indexed treasury);
@@ -135,7 +133,6 @@ interface IStakeManager {
     function slash(address user, uint256 amount, address recipient) external;
 
     /// @notice owner configuration helpers
-    function setToken(IERC20 newToken) external;
     function setMinStake(uint256 _minStake) external;
     function setSlashingPercentages(uint256 _employerSlashPct, uint256 _treasurySlashPct) external;
     function setSlashingParameters(uint256 _employerSlashPct, uint256 _treasurySlashPct) external;

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.25;
 import {IStakeManager} from "../interfaces/IStakeManager.sol";
 import {IValidationModule} from "../interfaces/IValidationModule.sol";
 import {IFeePool} from "../interfaces/IFeePool.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @dev Stake manager mock that attempts to reenter ValidationModule calls.
 contract ReentrantStakeManager is IStakeManager {
@@ -49,7 +48,6 @@ contract ReentrantStakeManager is IStakeManager {
     function setModules(address, address) external override {}
     function lockDisputeFee(address, uint256) external override {}
     function payDisputeFee(address, uint256) external override {}
-    function setToken(IERC20) external override {}
     function setMinStake(uint256) external override {}
     function setSlashingPercentages(uint256, uint256) external override {}
     function setSlashingParameters(uint256, uint256) external override {}

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.25;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {AGIALPHA} from "../Constants.sol";
@@ -36,16 +35,13 @@ contract JobEscrow is Ownable {
     }
 
     uint256 public constant TIMEOUT = 3 days;
-    /// @notice default $AGIALPHA token used when no token is specified
-    address public constant DEFAULT_TOKEN = AGIALPHA;
 
-    IERC20 public token;
+    IERC20 public constant token = IERC20(AGIALPHA);
     IRoutingModule public routingModule;
     uint256 public nextJobId;
     mapping(uint256 => Job) public jobs;
     address public jobRegistry;
 
-    event TokenUpdated(address indexed token);
     event RoutingModuleUpdated(address indexed routingModule);
     event JobRegistryUpdated(address indexed jobRegistry);
     /// @notice Emitted when a job is posted.
@@ -65,29 +61,14 @@ contract JobEscrow is Ownable {
     event ResultSubmitted(uint256 indexed jobId, string result);
     event ResultAccepted(uint256 indexed jobId, address caller);
 
-    /// @param _token ERC20 token used for rewards; must have 18 decimals. Pass
-    /// zero address to use the default token.
     /// @param _routing Routing module used to select operators for new jobs.
-    constructor(IERC20 _token, IRoutingModule _routing) Ownable(msg.sender) {
-        token =
-            address(_token) == address(0)
-                ? IERC20(DEFAULT_TOKEN)
-                : _token;
+    constructor(IRoutingModule _routing) Ownable(msg.sender) {
         routingModule = _routing;
     }
     
     // ---------------------------------------------------------------------
     // Owner setters (use Etherscan's "Write Contract" tab)
     // ---------------------------------------------------------------------
-
-    function setToken(IERC20 newToken) external onlyOwner {
-        require(
-            IERC20Metadata(address(newToken)).decimals() == 18,
-            "decimals"
-        );
-        token = newToken;
-        emit TokenUpdated(address(newToken));
-    }
 
     function setRoutingModule(IRoutingModule newRouting) external onlyOwner {
         routingModule = newRouting;

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -24,5 +24,8 @@ module.exports = {
     enabled: true,
     currency: 'USD',
     showTimeSpent: true,
+  },
+  mocha: {
+    require: ['./test/setup.js']
   }
 };

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -1,16 +1,10 @@
 import { ethers } from "hardhat";
 
-// Default $AGIALPHA token on mainnet
-const AGIALPHA = "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA";
-
 async function main() {
   const [deployer] = await ethers.getSigners();
 
-  const tokenAddress = process.env.TOKEN_ADDRESS ?? AGIALPHA;
-
   const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
   const stake = await Stake.deploy(
-    tokenAddress,
     0,
     0,
     0,
@@ -83,7 +77,6 @@ async function main() {
     "contracts/v2/FeePool.sol:FeePool"
   );
   const feePool = await FeePool.deploy(
-    tokenAddress,
     await stake.getAddress(),
     0,
     deployer.address
@@ -123,7 +116,6 @@ async function main() {
   };
 
   await Promise.all([
-    ensureContract(tokenAddress, "Token"),
     ensureContract(await registry.getAddress(), "JobRegistry"),
     ensureContract(await stake.getAddress(), "StakeManager"),
     ensureContract(await validation.getAddress(), "ValidationModule"),
@@ -164,7 +156,6 @@ async function main() {
   await feePool.transferOwnership(await pause.getAddress());
   await reputation.transferOwnership(await pause.getAddress());
 
-  console.log("Token:", tokenAddress);
   console.log("StakeManager:", await stake.getAddress());
   console.log("ReputationEngine:", await reputation.getAddress());
   console.log("IdentityRegistry:", await identity.getAddress());

--- a/scripts/v2/deploy.js
+++ b/scripts/v2/deploy.js
@@ -20,8 +20,6 @@ function parseArgs() {
   return args;
 }
 
-// default staking token (AGIALPHA); override via --token if needed
-const AGIALPHA = "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA";
 
 async function verify(address, args = []) {
   try {
@@ -38,14 +36,10 @@ async function main() {
   const [deployer] = await ethers.getSigners();
   const args = parseArgs();
 
-  const tokenAddress =
-    typeof args.token === "string" ? args.token : AGIALPHA;
-
   const Stake = await ethers.getContractFactory(
     "contracts/v2/StakeManager.sol:StakeManager"
   );
   const stake = await Stake.deploy(
-    tokenAddress,
     0,
     0,
     0,
@@ -113,7 +107,6 @@ async function main() {
     "contracts/v2/FeePool.sol:FeePool"
   );
   const feePool = await FeePool.deploy(
-    tokenAddress,
     await stake.getAddress(),
     0,
     deployer.address
@@ -151,9 +144,8 @@ async function main() {
   console.log("CertificateNFT:", await nft.getAddress());
   console.log("FeePool:", await feePool.getAddress());
   console.log("TaxPolicy:", await tax.getAddress());
-  console.log("Token:", tokenAddress);
 
-  await verify(await stake.getAddress(), [tokenAddress, deployer.address]);
+  await verify(await stake.getAddress(), [0, 0, 0, deployer.address, ethers.ZeroAddress, ethers.ZeroAddress, deployer.address]);
   await verify(await registry.getAddress(), []);
   await verify(await validation.getAddress(), [await registry.getAddress(), await stake.getAddress()]);
   await verify(await reputation.getAddress(), []);

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -22,9 +22,6 @@ function parseArgs() {
   return args;
 }
 
-// default staking token (AGIALPHA); override via --token if needed
-const AGIALPHA = "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA";
-
 async function verify(address: string, args: any[] = []) {
   try {
     await run("verify:verify", {
@@ -44,19 +41,12 @@ async function main() {
     typeof args.governance === "string" ? args.governance : deployer.address;
   const governanceSigner = await ethers.getSigner(governance);
 
-  // -------------------------------------------------------------------------
-  // staking token: defaults to fixed AGIALPHA unless overridden
-  // -------------------------------------------------------------------------
-  const tokenAddress =
-    typeof args.token === "string" ? args.token : AGIALPHA;
-
   const Stake = await ethers.getContractFactory(
     "contracts/v2/StakeManager.sol:StakeManager"
   );
   const treasury =
     typeof args.treasury === "string" ? args.treasury : governance;
   const stake = await Stake.deploy(
-    tokenAddress,
     0,
     0,
     0,
@@ -144,7 +134,6 @@ async function main() {
   );
   const burnPct = typeof args.burnPct === "string" ? parseInt(args.burnPct) : 0;
   const feePool = await FeePool.deploy(
-    tokenAddress,
     await stake.getAddress(),
     burnPct,
     treasury
@@ -326,7 +315,6 @@ async function main() {
   console.log("PlatformIncentives:", await incentives.getAddress());
 
   const addresses = {
-    token: tokenAddress,
     stakeManager: await stake.getAddress(),
     jobRegistry: await registry.getAddress(),
     validationModule: await validation.getAddress(),
@@ -347,7 +335,6 @@ async function main() {
   );
 
   await verify(await stake.getAddress(), [
-    tokenAddress,
     0,
     0,
     0,
@@ -396,7 +383,6 @@ async function main() {
     "All taxes on participants; contract and owner exempt",
   ]);
   await verify(await feePool.getAddress(), [
-    tokenAddress,
     await stake.getAddress(),
     2,
     governance,

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,20 @@
+const { ethers, network, artifacts } = require("hardhat");
+const AGIALPHA = "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA";
+
+before(async () => {
+  const artifact = await artifacts.readArtifact("contracts/legacy/MockERC20.sol:MockERC20");
+  await network.provider.send("hardhat_setCode", [AGIALPHA, artifact.deployedBytecode]);
+  const token = await ethers.getContractAt("contracts/legacy/MockERC20.sol:MockERC20", AGIALPHA);
+  global.agialpha = token;
+  const original = ethers.getContractFactory;
+  ethers.getContractFactory = async (name, ...args) => {
+    if (typeof name === "string" && name.includes("AGIALPHAToken")) {
+      const factory = await original(name, ...args);
+      factory.deploy = async () => token;
+      return factory;
+    }
+    return original(name, ...args);
+  };
+});
+
+module.exports = { AGIALPHA };

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -2,13 +2,11 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("FeePool", function () {
-  let token, token2, stakeManager, jobRegistry, feePool, owner, user1, user2, employer, treasury, registrySigner;
+  let token, stakeManager, jobRegistry, feePool, owner, user1, user2, employer, treasury, registrySigner;
 
   beforeEach(async () => {
     [owner, user1, user2, employer, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC206Decimals");
-    token = await Token.deploy();
-    token2 = await Token.deploy();
+    token = global.agialpha;
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
@@ -192,36 +190,6 @@ describe("FeePool", function () {
     expect((await token.balanceOf(user2.address)) - before2).to.equal(45n);
     const burnAddr = "0x000000000000000000000000000000000000dEaD";
     expect(await token.balanceOf(burnAddr)).to.equal(20n);
-  });
-
-  it("uses new token after token swap", async () => {
-    await stakeManager.connect(owner).setToken(await token2.getAddress());
-    await feePool.connect(owner).setToken(await token2.getAddress());
-
-    await token2.mint(employer.address, 1000);
-    const feeAmount = 100;
-    const jobId = ethers.encodeBytes32String("job3");
-    await token2.connect(employer).approve(await stakeManager.getAddress(), feeAmount);
-    await stakeManager
-      .connect(registrySigner)
-      .lockReward(jobId, employer.address, feeAmount);
-    await stakeManager
-      .connect(registrySigner)
-      .finalizeJobFunds(
-        jobId,
-        user1.address,
-        0,
-        feeAmount,
-        await feePool.getAddress()
-      );
-
-    const before1 = await token2.balanceOf(user1.address);
-    const before2 = await token2.balanceOf(user2.address);
-    await feePool.connect(owner).distributeFees();
-    await feePool.connect(user1).claimRewards();
-    await feePool.connect(user2).claimRewards();
-    expect((await token2.balanceOf(user1.address)) - before1).to.equal(25n);
-    expect((await token2.balanceOf(user2.address)) - before2).to.equal(75n);
   });
 
   it("emits zero payout for owner without stake", async () => {

--- a/test/v2/Integration.t.sol
+++ b/test/v2/Integration.t.sol
@@ -152,8 +152,6 @@ contract IntegrationTest {
 
     function testOwnerReconfigure() public {
         setUp();
-        TestToken token2 = new TestToken();
-        feePool.setToken(token2);
         feePool.setRewardRole(IStakeManager.Role.Validator);
         feePool.setStakeManager(stakeManager);
         feePool.setBurnPct(5);
@@ -163,21 +161,5 @@ contract IntegrationTest {
         require(reverted, "only owner");
     }
 
-    function testFeePoolReentrancy() public {
-        setUp();
-        stakeManager.setStake(platform1, IStakeManager.Role.Platform, 100 * TOKEN);
-        stakeManager.setStake(platform2, IStakeManager.Role.Platform, 200 * TOKEN);
-        ReentrantToken mal = new ReentrantToken(feePool);
-        feePool.setToken(mal);
-        mal.mint(address(feePool), 3000 * TOKEN);
-        vm.prank(address(stakeManager));
-        feePool.depositFee(3000 * TOKEN);
-        feePool.distributeFees();
-        mal.trigger();
-        vm.prank(platform1);
-        feePool.claimRewards();
-        require(mal.balanceOf(platform1) == 1000 * TOKEN, "reenter p1");
-        require(mal.balanceOf(address(feePool)) == 2000 * TOKEN, "reenter pool");
-    }
 }
 

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -8,10 +8,7 @@ describe("JobEscrow", function () {
   beforeEach(async () => {
     [owner, employer, operator] = await ethers.getSigners();
 
-    const Token = await ethers.getContractFactory(
-      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
-    );
-    token = await Token.deploy();
+    token = global.agialpha;
     await token.connect(owner).mint(employer.address, 1000000);
 
     // Mock RoutingModule that always returns operator
@@ -21,23 +18,7 @@ describe("JobEscrow", function () {
     const Escrow = await ethers.getContractFactory(
       "contracts/v2/modules/JobEscrow.sol:JobEscrow"
     );
-    escrow = await Escrow.deploy(await token.getAddress(), await routing.getAddress());
-  });
-
-  it("enforces 18-decimal tokens", async () => {
-    const Bad = await ethers.getContractFactory("MockERC20SixDecimals");
-    const bad = await Bad.deploy();
-    await expect(
-      escrow.connect(owner).setToken(await bad.getAddress())
-    ).to.be.revertedWith("decimals");
-
-    const Good = await ethers.getContractFactory("MockERC206Decimals");
-    const good = await Good.deploy();
-    await expect(
-      escrow.connect(owner).setToken(await good.getAddress())
-    )
-      .to.emit(escrow, "TokenUpdated")
-      .withArgs(await good.getAddress());
+    escrow = await Escrow.deploy(await routing.getAddress());
   });
 
   it("runs normal job flow", async () => {

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -7,15 +7,13 @@ describe("StakeManager", function () {
 
   beforeEach(async () => {
     [owner, user, employer, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC206Decimals");
-    token = await Token.deploy();
+    token = global.agialpha;
     await token.mint(user.address, 1000);
     await token.mint(employer.address, 1000);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       50,
       50,
@@ -392,116 +390,6 @@ describe("StakeManager", function () {
     await expect(stakeManager.connect(user).withdrawStake(0, 50))
       .to.emit(stakeManager, "StakeWithdrawn")
       .withArgs(user.address, 0, 50);
-  });
-
-  it("restricts token updates to owner and enforces 18 decimals", async () => {
-    const Token18 = await ethers.getContractFactory("MockERC20");
-    const token18 = await Token18.deploy();
-    await expect(
-      stakeManager.connect(user).setToken(await token18.getAddress())
-    ).to.be.revertedWith("governance only");
-
-    const Token6 = await ethers.getContractFactory("MockERC20SixDecimals");
-    const token6 = await Token6.deploy();
-    await expect(
-      stakeManager.connect(owner).setToken(await token6.getAddress())
-    ).to.be.revertedWith("decimals");
-
-    await expect(
-      stakeManager.connect(owner).setToken(await token18.getAddress())
-    )
-      .to.emit(stakeManager, "TokenUpdated")
-      .withArgs(await token18.getAddress());
-    expect(await stakeManager.token()).to.equal(await token18.getAddress());
-  });
-
-  it("uses new token for deposits and payouts after update", async () => {
-    const Token2 = await ethers.getContractFactory("MockERC206Decimals");
-    const token2 = await Token2.deploy();
-
-    // wire job registry so user can stake
-    const JobRegistry = await ethers.getContractFactory(
-      "contracts/v2/JobRegistry.sol:JobRegistry"
-    );
-    const jobRegistry = await JobRegistry.deploy(
-      ethers.ZeroAddress,
-      await stakeManager.getAddress(),
-      ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0,
-      [],
-      owner.address
-    );
-    const TaxPolicy = await ethers.getContractFactory(
-      "contracts/v2/TaxPolicy.sol:TaxPolicy"
-    );
-    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
-    await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
-    await stakeManager
-      .connect(owner)
-      .setJobRegistry(await jobRegistry.getAddress());
-    await jobRegistry.connect(user).acknowledgeTaxPolicy();
-
-    // owner updates staking token
-    await stakeManager.connect(owner).setToken(await token2.getAddress());
-
-    // old token approvals have no effect
-    await token.connect(user).approve(await stakeManager.getAddress(), 100);
-    await expect(stakeManager.connect(user).depositStake(0, 100))
-      .to.be.revertedWithCustomError(token2, "ERC20InsufficientAllowance")
-      .withArgs(await stakeManager.getAddress(), 0n, 100n);
-
-    // deposit using the new token
-    await token2.mint(user.address, 200);
-    await token2.connect(user).approve(await stakeManager.getAddress(), 200);
-    await expect(stakeManager.connect(user).depositStake(0, 200))
-      .to.emit(stakeManager, "StakeDeposited")
-      .withArgs(user.address, 0, 200);
-    expect(await stakeManager.stakes(user.address, 0)).to.equal(200n);
-
-    // locking funds with old token fails
-    const registryAddr2 = await jobRegistry.getAddress();
-    await ethers.provider.send("hardhat_setBalance", [
-      registryAddr2,
-      "0x56BC75E2D63100000",
-    ]);
-    const registrySigner2 = await ethers.getImpersonatedSigner(registryAddr2);
-
-    const jobId = ethers.encodeBytes32String("job1");
-    await token.connect(employer).approve(await stakeManager.getAddress(), 100);
-    await expect(
-      stakeManager
-        .connect(registrySigner2)
-        .lockReward(jobId, employer.address, 100)
-    )
-      .to.be.revertedWithCustomError(token2, "ERC20InsufficientAllowance")
-      .withArgs(await stakeManager.getAddress(), 0n, 100n);
-
-    // lock and release using the new token
-    await token2.mint(employer.address, 100);
-    await token2
-      .connect(employer)
-      .approve(await stakeManager.getAddress(), 100);
-    await stakeManager
-      .connect(registrySigner2)
-      .lockReward(jobId, employer.address, 100);
-    await expect(
-      stakeManager
-        .connect(registrySigner2)
-        .releaseReward(jobId, user.address, 100)
-    )
-      .to.emit(stakeManager, "StakeReleased")
-      .withArgs(jobId, user.address, 100);
-
-    // balances reflect only the new token being used
-    expect(await token.balanceOf(user.address)).to.equal(1000n);
-    expect(await token2.balanceOf(user.address)).to.equal(100n);
-    expect(await token.balanceOf(employer.address)).to.equal(1000n);
-    expect(await token2.balanceOf(employer.address)).to.equal(0n);
   });
 
   it("restricts min stake updates to owner", async () => {
@@ -967,44 +855,6 @@ describe("StakeManager", function () {
 
     expect(await stakeManager.stakes(user.address, 0)).to.equal(0n);
     expect(await token.balanceOf(user.address)).to.equal(900n);
-  });
-
-  it("supports token swap for new stakes", async () => {
-    const JobRegistry = await ethers.getContractFactory(
-      "contracts/v2/JobRegistry.sol:JobRegistry"
-    );
-    const jobRegistry = await JobRegistry.deploy(
-      ethers.ZeroAddress,
-      await stakeManager.getAddress(),
-      ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      ethers.ZeroAddress,
-      0,
-      0,
-      [],
-      owner.address
-    );
-    const TaxPolicy = await ethers.getContractFactory(
-      "contracts/v2/TaxPolicy.sol:TaxPolicy"
-    );
-    const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
-    await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
-    await stakeManager
-      .connect(owner)
-      .setJobRegistry(await jobRegistry.getAddress());
-    await jobRegistry.connect(user).acknowledgeTaxPolicy();
-
-    const Token = await ethers.getContractFactory("MockERC206Decimals");
-    const token2 = await Token.deploy();
-    await token2.mint(user.address, 500);
-    await stakeManager.connect(owner).setToken(await token2.getAddress());
-
-    await token2.connect(user).approve(await stakeManager.getAddress(), 200);
-    await expect(stakeManager.connect(user).depositStake(0, 200))
-      .to.emit(stakeManager, "StakeDeposited")
-      .withArgs(user.address, 0, 200);
   });
 
   it("matches 18-decimal slashing math", async () => {

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -8,14 +8,12 @@ describe("StakeManager extras", function () {
 
   beforeEach(async () => {
     [owner, user, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC206Decimals");
-    token = await Token.deploy();
+    token = global.agialpha;
     await token.mint(user.address, 1000);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,
@@ -89,21 +87,5 @@ describe("StakeManager extras", function () {
     ).to.be.revertedWith("max stake");
   });
 
-  it("emits event and accepts new token after token swap", async () => {
-    await setupRegistryAck(user);
-    const Token = await ethers.getContractFactory("MockERC206Decimals");
-    const token2 = await Token.deploy();
-    await token2.mint(user.address, 200);
-    await expect(
-      stakeManager.connect(owner).setToken(await token2.getAddress())
-    )
-      .to.emit(stakeManager, "TokenUpdated")
-      .withArgs(await token2.getAddress());
-    await token2
-      .connect(user)
-      .approve(await stakeManager.getAddress(), 200);
-    await stakeManager.connect(user).depositStake(0, 200);
-    expect(await stakeManager.stakeOf(user.address, 0)).to.equal(200n);
-  });
 });
 


### PR DESCRIPTION
## Summary
- Hardcode AGIALPHA token across StakeManager, FeePool, GovernanceReward, and JobEscrow
- Drop legacy `setToken` helpers and related events/interfaces
- Update deployment scripts and tests to reflect immutable token

## Testing
- `npm test` *(fails: Wrong argument count for function call in Deployer.sol)*
- `forge test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1efc93f748333bac186da68429299