### PR TITLE
docs: fix AGIALPHA unit references

### DIFF
--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -129,8 +129,8 @@ Stakers withdraw accrued fees from the same contract.
 
 ## Token Conversion Reference
 
-- `1.0 AGIALPHA = 1_000_000 units`
-- `0.5 AGIALPHA = 500_000 units`
-- `25 AGIALPHA = 25_000_000 units`
+- `1.0 AGIALPHA = 1_000_000_000_000_000_000 units`
+- `0.5 AGIALPHA =   500_000_000_000_000_000 units`
+- `25 AGIALPHA = 25_000_000_000_000_000_000 units`
 
 Always enter values in base units on Etherscan.


### PR DESCRIPTION
## Summary
- Correct AGIALPHA token conversion examples to use 18‑decimal units in Etherscan deployment guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1fb6db69483339709442e5c62c1fd