### PR TITLE
docs: clarify 18-decimal AGIALPHA in legacy guides

### DIFF
--- a/docs/legacy/AGIJobsAlphav0.md
+++ b/docs/legacy/AGIJobsAlphav0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # The Profound “AGI Jobs” Alpha Opportunity
 
 > ✨ *“We choose to free humanity from the bonds of job slavery — not because it is easy, but because our highest destiny demands it.”* 🌌🏆✨

--- a/docs/legacy/AGIJobsVisionv0.md
+++ b/docs/legacy/AGIJobsVisionv0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # AGI Jobs: The Dawn of a Post-Work Civilization
 
 > *“We choose to free humanity from the bonds of job slavery — not because it is easy, but because our highest destiny demands it.”*  

--- a/docs/legacy/AGI_Jobs_v0_Whitepaper_Draft_v0.md
+++ b/docs/legacy/AGI_Jobs_v0_Whitepaper_Draft_v0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # AGI Jobs v0 — Whitepaper
 *A declaration from the frontier of organized intelligence and human freedom*
 

--- a/docs/legacy/AGI_Jobs_v0_Whitepaper_v0.md
+++ b/docs/legacy/AGI_Jobs_v0_Whitepaper_v0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # AGI Jobs v0: The Dawn of Decentralized AGI Labor Markets
 
 *“We choose to free humanity from the bonds of job slavery — not because it is easy, but because our highest destiny demands it.”*  

--- a/docs/legacy/BlueOceanv0.md
+++ b/docs/legacy/BlueOceanv0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # Blue Ocean Strategy Playbook for AGI Jobs Platforms
 
 Launching an **AGI jobs exchange** is the quintessential *blue ocean* move – entering an entirely new market space with virtually no competition. In this playbook, we break down how an AGI labor marketplace can capitalize on a blue ocean opportunity and outline strategic steps to define and dominate this nascent field.

--- a/docs/legacy/Guidev0.md
+++ b/docs/legacy/Guidev0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 [Deploying and Operating AGI Jobs v2 via Etherscan (Ethereum Mainnet)](https://chatgpt.com/s/dr_689a0739557081919afb876e6e9926ad)
 
 # Deploying and Operating AGI Jobs v2 via Etherscan (Ethereum Mainnet)
@@ -482,7 +484,7 @@ As an employer (someone who wants a task done by an AI agent), you will **create
    * In MetaMask, switch to **your address** (the employer’s address).
    * Go to the \$AGIALPHA token’s Etherscan page (address `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`). Click on **Write Contract** and connect your wallet. Locate the `approve(address spender, uint256 amount)` function.
    * For **spender**, enter the **StakeManager contract’s address**. Double-check it’s exact.
-   * For **amount**, enter the reward plus fee in base units. The fee is determined by the platform’s fee percentage (`feePct`). For example, if reward = 50 AGIALPHA and feePct = 5%, then fee = 2.5 AGIALPHA. Total = 52.5 AGIALPHA, which in base units is `52.5 * 1e6 = 52_500000`. If you’re not sure of the fee or want to be safe, you can approve a slightly larger amount than the reward. *(It’s okay to approve a bit more; the contract will only use what is needed.)*
+   * For **amount**, enter the reward plus fee in base units. The fee is determined by the platform’s fee percentage (`feePct`). For example, if reward = 50 AGIALPHA and feePct = 5%, then fee = 2.5 AGIALPHA. Total = 52.5 AGIALPHA, which in base units is `52.5 * 1e18 = 52_500000000000000000`. If you’re not sure of the fee or want to be safe, you can approve a slightly larger amount than the reward. *(It’s okay to approve a bit more; the contract will only use what is needed.)*
    * Click **Write** and confirm the MetaMask transaction. Wait for the approval transaction to succeed (you can check status on Etherscan).
 
 3. **Create the Job on JobRegistry:** Now go to the **JobRegistry** contract’s page, and under **Write Contract**, find `createJob(uint256 reward, string uri)`. This is the function to post a new job.

--- a/docs/legacy/PlanetaryScalev0.md
+++ b/docs/legacy/PlanetaryScalev0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # AGIJobsv0: Toward a Planetary-Scale AGI Labor Coordination Layer
 
 **Introduction:**

--- a/docs/legacy/ProductionScaleAGIJobsPlatformSprintPlanv0.md
+++ b/docs/legacy/ProductionScaleAGIJobsPlatformSprintPlanv0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # Production-Scale AGIJobs Platform Sprint Plan
 
 ## 1. System Architecture Evolution

--- a/docs/legacy/TaxPolicyv0.md
+++ b/docs/legacy/TaxPolicyv0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # Tax Obligations in the AGI Job Platform Ecosystem
 
 ## Overview of the AGI Jobs Token-Burning Scenario

--- a/docs/legacy/Termsv0.md
+++ b/docs/legacy/Termsv0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # Ticker ($): AGIALPHA
 
 **The Emergence of an AGI-Powered Alpha Agent.**

--- a/docs/legacy/Winningv0.md
+++ b/docs/legacy/Winningv0.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # Decentralized Multi-Platform AGI Jobs: Key to Winning the AI Race
 
 ## A “Goldilocks” AI Landscape: No Single Dominance

--- a/docs/legacy/deployment-v0-agialpha.md
+++ b/docs/legacy/deployment-v0-agialpha.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # Deployment Guide: AGIJobManager v0 with $AGIALPHA
 
 This guide walks a non‑technical owner through deploying the monolithic **AGIJobManager v0** contract using the 6‑decimal `$AGIALPHA` token for all escrow, staking, validator rewards, and dispute fees. Every parameter can be updated later by the owner without redeploying the contract.

--- a/docs/legacy/quickstart-v0-agialpha-etherscan.md
+++ b/docs/legacy/quickstart-v0-agialpha-etherscan.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # Quickstart: Deploying AGIJobManager v0 with $AGIALPHA on Etherscan
 
 This abbreviated guide walks an owner through deploying the monolithic

--- a/docs/legacy/v0-v2-function-map.md
+++ b/docs/legacy/v0-v2-function-map.md
@@ -1,3 +1,5 @@
+> **Note:** Current deployments use an 18-decimal AGIALPHA token.
+
 # v0 to v2 Function Map
 
 The table below links common `AGIJobManager v0` functions to their


### PR DESCRIPTION
## Summary
- note 18-decimal AGIALPHA at top of all legacy docs
- replace remaining 6-decimal example in Guidev0 with 18-decimal notation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2042be34083339d598388b07b55b2