### PR TITLE
Update AGIALPHA token decimal references to 18

### DIFF
--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -96,7 +96,7 @@ contract CertificateNFT is ERC721, Ownable, ReentrancyGuard, ICertificateNFT {
         emit NFTListed(tokenId, msg.sender, price);
     }
 
-    /// @notice Purchase a listed certificate using 6‑decimal $AGIALPHA tokens.
+    /// @notice Purchase a listed certificate using 18‑decimal $AGIALPHA tokens.
     function purchase(uint256 tokenId) external nonReentrant {
         Listing storage listing = listings[tokenId];
         require(listing.active, "not listed");

--- a/docs/legacy/deployment-v0-agialpha.md
+++ b/docs/legacy/deployment-v0-agialpha.md
@@ -2,7 +2,7 @@
 
 # Deployment Guide: AGIJobManager v0 with $AGIALPHA
 
-This guide walks a non‑technical owner through deploying the monolithic **AGIJobManager v0** contract using the 6‑decimal `$AGIALPHA` token for all escrow, staking, validator rewards, and dispute fees. Every parameter can be updated later by the owner without redeploying the contract.
+This guide walks a non‑technical owner through deploying the monolithic **AGIJobManager v0** contract using the 18‑decimal `$AGIALPHA` token for all escrow, staking, validator rewards, and dispute fees. Every parameter can be updated later by the owner without redeploying the contract.
 
 ## Prerequisites
 - `$AGIALPHA` token address.

--- a/docs/legacy/quickstart-v0-agialpha-etherscan.md
+++ b/docs/legacy/quickstart-v0-agialpha-etherscan.md
@@ -3,7 +3,7 @@
 # Quickstart: Deploying AGIJobManager v0 with $AGIALPHA on Etherscan
 
 This abbreviated guide walks an owner through deploying the monolithic
-`AGIJobManager v0` contract and interacting with it using the 6‑decimal
+`AGIJobManager v0` contract and interacting with it using the 18‑decimal
 `$AGIALPHA` token. All parameters—including the token address, ENS
 roots and Merkle roots—remain owner‑configurable after deployment.
 


### PR DESCRIPTION
## Summary
- clarify CertificateNFT purchase uses 18-decimal $AGIALPHA tokens
- update legacy deployment guide to reference 18-decimal $AGIALPHA
- update legacy quickstart guide to reference 18-decimal $AGIALPHA

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b209c1010c83339cdefe6b67599b8e