### PR TITLE
Enforce 18-decimal tokens in JobEscrow constructor

### DIFF
--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -69,10 +69,13 @@ contract JobEscrow is Ownable {
     /// zero address to use the default token.
     /// @param _routing Routing module used to select operators for new jobs.
     constructor(IERC20 _token, IRoutingModule _routing) Ownable(msg.sender) {
-        token =
-            address(_token) == address(0)
-                ? IERC20(DEFAULT_TOKEN)
-                : _token;
+        if (address(_token) == address(0)) {
+            token = IERC20(DEFAULT_TOKEN);
+        } else {
+            IERC20Metadata meta = IERC20Metadata(address(_token));
+            require(meta.decimals() == 18, "decimals");
+            token = _token;
+        }
         routingModule = _routing;
     }
     

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -24,6 +24,17 @@ describe("JobEscrow", function () {
     escrow = await Escrow.deploy(await token.getAddress(), await routing.getAddress());
   });
 
+  it("constructor enforces 18-decimal token", async () => {
+    const Bad = await ethers.getContractFactory("MockERC20SixDecimals");
+    const bad = await Bad.deploy();
+    const Escrow = await ethers.getContractFactory(
+      "contracts/v2/modules/JobEscrow.sol:JobEscrow"
+    );
+    await expect(
+      Escrow.deploy(await bad.getAddress(), await routing.getAddress())
+    ).to.be.revertedWith("decimals");
+  });
+
   it("enforces 18-decimal tokens", async () => {
     const Bad = await ethers.getContractFactory("MockERC20SixDecimals");
     const bad = await Bad.deploy();


### PR DESCRIPTION
## Summary
- validate non-zero reward token's decimals in `JobEscrow` constructor
- add test ensuring constructor rejects 6-decimal tokens

## Testing
- `npx hardhat test test/v2/JobEscrow.test.js --no-compile`


------
https://chatgpt.com/codex/tasks/task_e_68b20c7d38888333b2ae673cf8b89985