### PR TITLE
Default v2 modules to AGIALPHA token

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -29,7 +29,6 @@ import {IStakeManager} from "./interfaces/IStakeManager.sol";
 import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 import {IENS} from "./interfaces/IENS.sol";
 import {INameWrapper} from "./interfaces/INameWrapper.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IValidationModule} from "./interfaces/IValidationModule.sol";
 import {IReputationEngine as IRInterface} from "./interfaces/IReputationEngine.sol";
@@ -47,7 +46,6 @@ contract Deployer is Ownable {
     /// @dev Zero values use each module's baked-in default such as a 5% fee,
     ///      5% burn, 1-day commit/reveal windows and a 1e18 minimum stake.
     struct EconParams {
-        IERC20 token; // custom token for StakeManager and FeePool (defaults to AGIALPHA)
         uint256 feePct; // protocol fee percentage for JobRegistry
         uint256 burnPct; // portion of fees burned by FeePool
         uint256 employerSlashPct; // slashed stake sent to employer
@@ -264,10 +262,8 @@ contract Deployer is Ownable {
             treasurySlashPct = 100;
         }
         uint96 jobStake = econ.jobStake;
-        IERC20 token = econ.token;
 
         StakeManager stake = new StakeManager(
-            token,
             minStake,
             employerSlashPct,
             treasurySlashPct,
@@ -317,7 +313,6 @@ contract Deployer is Ownable {
         certificate.setJobRegistry(address(registry));
 
         FeePool pool = new FeePool(
-            token,
             IStakeManager(address(stake)),
             burnPct,
             owner_

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -5,7 +5,6 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {AGIALPHA} from "./Constants.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
@@ -63,28 +62,19 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     event RewardPoolContribution(address indexed contributor, uint256 amount);
 
     /// @notice Deploys the FeePool.
-    /// @param _token ERC20 token used for fees and rewards. Must use 18 decimals.
-    /// Defaults to DEFAULT_TOKEN when zero address.
     /// @param _stakeManager StakeManager tracking staker balances.
     /// @param _burnPct Percentage of each fee to burn (0-100). Defaults to
     /// DEFAULT_BURN_PCT when set to zero.
     /// @param _treasury Address receiving rounding dust. Defaults to deployer
     /// when zero address.
     constructor(
-        IERC20 _token,
         IStakeManager _stakeManager,
         uint256 _burnPct,
         address _treasury
     ) Ownable(msg.sender) {
         uint256 pct = _burnPct == 0 ? DEFAULT_BURN_PCT : _burnPct;
         require(pct <= 100, "pct");
-        if (address(_token) == address(0)) {
-            token = IERC20(DEFAULT_TOKEN);
-        } else {
-            IERC20Metadata meta = IERC20Metadata(address(_token));
-            require(meta.decimals() == 18, "decimals");
-            token = _token;
-        }
+        token = IERC20(DEFAULT_TOKEN);
 
         if (address(_stakeManager) != address(0)) {
             stakeManager = _stakeManager;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.25;
 
 import {Governable} from "./Governable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
@@ -147,8 +146,6 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     event FeePoolUpdated(address indexed feePool);
 
     /// @notice Deploys the StakeManager.
-    /// @param _token ERC20 token used for staking and payouts. Defaults to
-    /// DEFAULT_TOKEN when zero address.
     /// @param _minStake Minimum stake required to participate. Defaults to
     /// DEFAULT_MIN_STAKE when set to zero.
     /// @param _employerSlashPct Percentage of slashed amount sent to employer
@@ -160,7 +157,6 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @param _jobRegistry JobRegistry enforcing tax acknowledgements.
     /// @param _disputeModule Dispute module authorized to manage dispute fees.
     constructor(
-        IERC20 _token,
         uint256 _minStake,
         uint256 _employerSlashPct,
         uint256 _treasurySlashPct,
@@ -169,13 +165,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         address _disputeModule,
         address _timelock // timelock or multisig controller
     ) Governable(_timelock) {
-        if (address(_token) == address(0)) {
-            token = IERC20(DEFAULT_TOKEN);
-        } else {
-            IERC20Metadata meta = IERC20Metadata(address(_token));
-            require(meta.decimals() == 18, "decimals");
-            token = _token;
-        }
+        token = IERC20(DEFAULT_TOKEN);
 
         minStake = _minStake == 0 ? DEFAULT_MIN_STAKE : _minStake;
         emit MinStakeUpdated(minStake);

--- a/docs/deployment-addresses.md
+++ b/docs/deployment-addresses.md
@@ -9,5 +9,4 @@ npx hardhat run scripts/v2/deploy.ts --network <network>
 
 Deployments are anchored to the `$AGIALPHA` token at
 `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`, exported from
-[`scripts/constants.ts`](../scripts/constants.ts). Pass `--token <address>` only
-if you intentionally wish to override this default.
+[`scripts/constants.ts`](../scripts/constants.ts).

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -4,11 +4,10 @@ import { AGIALPHA } from "./constants";
 async function main() {
   const [deployer] = await ethers.getSigners();
 
-  const tokenAddress = process.env.TOKEN_ADDRESS ?? AGIALPHA;
+  const tokenAddress = AGIALPHA;
 
   const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
   const stake = await Stake.deploy(
-    tokenAddress,
     0,
     0,
     0,
@@ -81,7 +80,6 @@ async function main() {
     "contracts/v2/FeePool.sol:FeePool"
   );
   const feePool = await FeePool.deploy(
-    tokenAddress,
     await stake.getAddress(),
     0,
     deployer.address
@@ -121,7 +119,6 @@ async function main() {
   };
 
   await Promise.all([
-    ensureContract(tokenAddress, "Token"),
     ensureContract(await registry.getAddress(), "JobRegistry"),
     ensureContract(await stake.getAddress(), "StakeManager"),
     ensureContract(await validation.getAddress(), "ValidationModule"),

--- a/scripts/v2/deploy.js
+++ b/scripts/v2/deploy.js
@@ -37,14 +37,12 @@ async function main() {
   const [deployer] = await ethers.getSigners();
   const args = parseArgs();
 
-  const tokenAddress =
-    typeof args.token === "string" ? args.token : AGIALPHA;
+  const tokenAddress = AGIALPHA;
 
   const Stake = await ethers.getContractFactory(
     "contracts/v2/StakeManager.sol:StakeManager"
   );
   const stake = await Stake.deploy(
-    tokenAddress,
     0,
     0,
     0,
@@ -112,7 +110,6 @@ async function main() {
     "contracts/v2/FeePool.sol:FeePool"
   );
   const feePool = await FeePool.deploy(
-    tokenAddress,
     await stake.getAddress(),
     0,
     deployer.address
@@ -152,7 +149,15 @@ async function main() {
   console.log("TaxPolicy:", await tax.getAddress());
   console.log("Token:", tokenAddress);
 
-  await verify(await stake.getAddress(), [tokenAddress, deployer.address]);
+  await verify(await stake.getAddress(), [
+    0,
+    0,
+    0,
+    deployer.address,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    deployer.address,
+  ]);
   await verify(await registry.getAddress(), []);
   await verify(await validation.getAddress(), [await registry.getAddress(), await stake.getAddress()]);
   await verify(await reputation.getAddress(), []);

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -42,11 +42,7 @@ async function main() {
     typeof args.governance === "string" ? args.governance : deployer.address;
   const governanceSigner = await ethers.getSigner(governance);
 
-  // -------------------------------------------------------------------------
-  // staking token: defaults to fixed AGIALPHA unless overridden
-  // -------------------------------------------------------------------------
-  const tokenAddress =
-    typeof args.token === "string" ? args.token : AGIALPHA;
+  const tokenAddress = AGIALPHA;
 
   const Stake = await ethers.getContractFactory(
     "contracts/v2/StakeManager.sol:StakeManager"
@@ -54,7 +50,6 @@ async function main() {
   const treasury =
     typeof args.treasury === "string" ? args.treasury : governance;
   const stake = await Stake.deploy(
-    tokenAddress,
     0,
     0,
     0,
@@ -142,7 +137,6 @@ async function main() {
   );
   const burnPct = typeof args.burnPct === "string" ? parseInt(args.burnPct) : 0;
   const feePool = await FeePool.deploy(
-    tokenAddress,
     await stake.getAddress(),
     burnPct,
     treasury
@@ -345,7 +339,6 @@ async function main() {
   );
 
   await verify(await stake.getAddress(), [
-    tokenAddress,
     0,
     0,
     0,
@@ -394,10 +387,9 @@ async function main() {
     "All taxes on participants; contract and owner exempt",
   ]);
   await verify(await feePool.getAddress(), [
-    tokenAddress,
     await stake.getAddress(),
-    2,
-    governance,
+    burnPct,
+    treasury,
   ]);
   await verify(await platformRegistry.getAddress(), [
     await stake.getAddress(),

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -15,9 +15,7 @@ describe("StakeManager AGIType bonuses", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       owner.address,

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -94,9 +94,7 @@ describe("DisputeModule", function () {
       const StakeManager = await ethers.getContractFactory(
         "contracts/v2/StakeManager.sol:StakeManager"
       );
-      stakeManager = await StakeManager.deploy(
-        await token.getAddress(),
-        0,
+      stakeManager = await StakeManager.deploy(0,
         0,
         0,
         owner.address,

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -35,7 +35,7 @@ contract FeePoolTest {
         token = new TestToken();
         stakeManager = new MockStakeManager();
         stakeManager.setJobRegistry(jobRegistry);
-        feePool = new FeePool(token, stakeManager, 0, address(this));
+        feePool = new FeePool(stakeManager, 0, address(this));
         feePool.setRewardRole(IStakeManager.Role.Validator);
         stakeManager.setStake(alice, IStakeManager.Role.Platform, 1_000_000 * TOKEN);
         stakeManager.setStake(bob, IStakeManager.Role.Platform, 2_000_000 * TOKEN);

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -12,9 +12,7 @@ describe("FeePool", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,
@@ -59,9 +57,7 @@ describe("FeePool", function () {
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
     );
-    feePool = await FeePool.deploy(
-      await token.getAddress(),
-      await stakeManager.getAddress(),
+    feePool = await FeePool.deploy(await stakeManager.getAddress(),
       0,
       treasury.address
     );

--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -16,9 +16,7 @@ describe("JobRegistry governance finalization", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -17,9 +17,7 @@ describe("Governance reward lifecycle", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,
@@ -62,9 +60,7 @@ describe("Governance reward lifecycle", function () {
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
     );
-    feePool = await FeePool.deploy(
-      await token.getAddress(),
-      await stakeManager.getAddress(),
+    feePool = await FeePool.deploy(await stakeManager.getAddress(),
       0,
       treasury.address
     );

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -17,9 +17,7 @@ describe("GovernanceReward", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,
@@ -61,9 +59,7 @@ describe("GovernanceReward", function () {
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
     );
-    feePool = await FeePool.deploy(
-      await token.getAddress(),
-      await stakeManager.getAddress(),
+    feePool = await FeePool.deploy(await stakeManager.getAddress(),
       0,
       treasury.address
     );

--- a/test/v2/Integration.t.sol
+++ b/test/v2/Integration.t.sol
@@ -74,7 +74,7 @@ contract IntegrationTest {
         stakeManager = new MockStakeManager();
         stakeManager.setJobRegistry(jobRegistryAddr);
         registry = new MockPlatformRegistry();
-        feePool = new FeePool(token, stakeManager, 0, address(this));
+        feePool = new FeePool(stakeManager, 0, address(this));
         router = new JobRouter(registry, address(this));
     }
 

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -15,9 +15,7 @@ describe("Job expiration", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -15,9 +15,7 @@ describe("Job expiration boundary", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -17,9 +17,7 @@ describe("JobRegistry integration", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,
@@ -182,9 +180,7 @@ describe("JobRegistry integration", function () {
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
     );
-    const feePool = await FeePool.deploy(
-      await token.getAddress(),
-      await stakeManager.getAddress(),
+    const feePool = await FeePool.deploy(await stakeManager.getAddress(),
       0,
       treasury.address
     );

--- a/test/v2/JobRegistryTreasury.test.js
+++ b/test/v2/JobRegistryTreasury.test.js
@@ -14,9 +14,7 @@ describe("JobRegistry Treasury", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,

--- a/test/v2/PlatformIncentives.t.sol
+++ b/test/v2/PlatformIncentives.t.sol
@@ -29,7 +29,7 @@ contract PlatformIncentivesTest is Test {
 
     function setUp() public {
         token = new AGIALPHAToken();
-        stakeManager = new StakeManager(token, 0, 0, 0, address(this), address(0), address(0));
+        stakeManager = new StakeManager(0, 0, 0, address(this), address(0), address(0));
         jobRegistry = new MockJobRegistry();
         jobRegistry.setTaxPolicyVersion(1);
         stakeManager.setJobRegistry(address(jobRegistry));
@@ -40,9 +40,7 @@ contract PlatformIncentivesTest is Test {
             1e18
         );
         jobRouter = new JobRouter(IPlatformRegistry(address(platformRegistry)));
-        feePool = new FeePool(
-            token,
-            IStakeManager(address(stakeManager)),
+        feePool = new FeePool(IStakeManager(address(stakeManager)),
             0,
             address(this)
         );

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -25,9 +25,7 @@ describe("Platform reward flow", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,
@@ -91,9 +89,7 @@ describe("Platform reward flow", function () {
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
     );
-    feePool = await FeePool.deploy(
-      await token.getAddress(),
-      await stakeManager.getAddress(),
+    feePool = await FeePool.deploy(await stakeManager.getAddress(),
       0,
       treasury.address
     );

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -14,9 +14,7 @@ describe("StakeManager", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       50,
       50,
       treasury.address,

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -14,9 +14,7 @@ describe("StakeManager extras", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,

--- a/test/v2/StakeManagerFuzz.t.sol
+++ b/test/v2/StakeManagerFuzz.t.sol
@@ -12,7 +12,7 @@ contract StakeManagerFuzz is Test {
 
     function setUp() public {
         token = new AGIALPHAToken();
-        stake = new StakeManager(IERC20(address(token)), 1e18, 50, 50, address(this), address(this), address(this));
+        stake = new StakeManager(1e18, 50, 50, address(this), address(this), address(this));
     }
 
     function _deposit(address user, uint256 amount, StakeManager.Role role) internal {

--- a/test/v2/StakeManagerNoEther.test.js
+++ b/test/v2/StakeManagerNoEther.test.js
@@ -11,9 +11,7 @@ describe("StakeManager ether rejection", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       owner.address,

--- a/test/v2/StakeManagerPause.test.js
+++ b/test/v2/StakeManagerPause.test.js
@@ -15,9 +15,7 @@ describe("StakeManager pause", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       owner.address,

--- a/test/v2/StakeManagerReentrancy.test.js
+++ b/test/v2/StakeManagerReentrancy.test.js
@@ -17,9 +17,7 @@ describe("StakeManager reentrancy", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       50,
       50,
       treasury.address,

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -12,9 +12,7 @@ describe("StakeManager release", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       100,
       0,
       treasury.address,
@@ -54,9 +52,7 @@ describe("StakeManager release", function () {
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
     );
-    feePool = await FeePool.deploy(
-      await token.getAddress(),
-      await stakeManager.getAddress(),
+    feePool = await FeePool.deploy(await stakeManager.getAddress(),
       0,
       treasury.address
     );

--- a/test/v2/StakeManagerSlashing.test.js
+++ b/test/v2/StakeManagerSlashing.test.js
@@ -13,9 +13,7 @@ describe("StakeManager slashing configuration", function () {
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
-    stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
-      0,
+    stakeManager = await StakeManager.deploy(0,
       50,
       50,
       treasury.address,

--- a/test/v2/ValidationModulePause.test.js
+++ b/test/v2/ValidationModulePause.test.js
@@ -9,8 +9,7 @@ describe("ValidationModule pause", function () {
     const MockStakeManager = await ethers.getContractFactory(
       "contracts/legacy/MockV2.sol:MockStakeManager"
     );
-    const stakeManager = await MockStakeManager.deploy();
-    await stakeManager.setStake(validator.address, 1, 100);
+    const stakeManager = await MockStakeManager.deploy(1, 100);
     await stakeManager.setStake(v2.address, 1, 100);
     await stakeManager.setStake(v3.address, 1, 100);
     const Identity = await ethers.getContractFactory(

--- a/test/v2/ValidationSlashingFuzz.t.sol
+++ b/test/v2/ValidationSlashingFuzz.t.sol
@@ -21,7 +21,7 @@ contract ValidationSlashingFuzz is Test {
 
     function setUp() public {
         token = new AGIALPHAToken();
-        stake = new StakeManager(IERC20(address(token)), 1e18, 0, 100, address(this), address(0), address(0));
+        stake = new StakeManager(1e18, 0, 100, address(this), address(0), address(0));
         jobRegistry = new MockJobRegistry();
         stake.setJobRegistry(address(jobRegistry));
         identity = new IdentityRegistryToggle();

--- a/test/v2/ValidatorSelectionFuzz.t.sol
+++ b/test/v2/ValidatorSelectionFuzz.t.sol
@@ -20,9 +20,7 @@ contract ValidatorSelectionFuzz is Test {
 
     function setUp() public {
         token = new AGIALPHAToken();
-        stake = new StakeManager(
-            IERC20(address(token)),
-            1e18,
+        stake = new StakeManager(1e18,
             0,
             100,
             address(this),

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -87,9 +87,7 @@ describe("comprehensive job flows", function () {
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
     );
-    feePool = await FeePool.deploy(
-      await token.getAddress(),
-      await stakeManager.getAddress(),
+    feePool = await FeePool.deploy(await stakeManager.getAddress(),
       0,
       owner.address
     );

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -86,9 +86,7 @@ describe("end-to-end job lifecycle", function () {
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
     );
-    feePool = await FeePool.deploy(
-      await token.getAddress(),
-      await stakeManager.getAddress(),
+    feePool = await FeePool.deploy(await stakeManager.getAddress(),
       0,
       owner.address
     );

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -85,9 +85,7 @@ describe("job finalization integration", function () {
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
     );
-    feePool = await FeePool.deploy(
-      await token.getAddress(),
-      await stakeManager.getAddress(),
+    feePool = await FeePool.deploy(await stakeManager.getAddress(),
       0,
       owner.address
     );


### PR DESCRIPTION
## Summary
- default StakeManager and FeePool to AGIALPHA without passing a token address
- remove token wiring from Deployer and deployment scripts
- update docs and tests for new constructor signatures

## Testing
- `npm test` *(fails: "StakeManager AGIType bonuses" and other suites fail)*

------
https://chatgpt.com/codex/tasks/task_e_68b21c8649d08333baf7cf1a4e84bd78