### PR TITLE
refactor: centralize agialpha decimals constant

### DIFF
--- a/contracts/v2/Constants.sol
+++ b/contracts/v2/Constants.sol
@@ -2,4 +2,9 @@
 pragma solidity ^0.8.25;
 
 // Shared AGI Jobs v2 constants.
+
+// Canonical $AGIALPHA token on Ethereum mainnet.
 address constant AGIALPHA = 0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA;
+
+// Standard decimals for $AGIALPHA.
+uint8 constant AGIALPHA_DECIMALS = 18;

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -7,7 +7,7 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {AGIALPHA} from "./Constants.sol";
+import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 /// @title FeePool
@@ -82,7 +82,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
             token = IERC20(DEFAULT_TOKEN);
         } else {
             IERC20Metadata meta = IERC20Metadata(address(_token));
-            require(meta.decimals() == 18, "decimals");
+            require(meta.decimals() == AGIALPHA_DECIMALS, "decimals");
             token = _token;
         }
 

--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -5,7 +5,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {AGIALPHA} from "./Constants.sol";
+import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
@@ -72,7 +72,7 @@ contract GovernanceReward is Ownable {
                 ? IERC20(DEFAULT_TOKEN)
                 : _token;
         require(
-            IERC20Metadata(address(token)).decimals() == 18,
+            IERC20Metadata(address(token)).decimals() == AGIALPHA_DECIMALS,
             "decimals"
         );
 

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -8,7 +8,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
-import {AGIALPHA} from "./Constants.sol";
+import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
 import {IJobRegistryTax} from "./interfaces/IJobRegistryTax.sol";
 import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 import {TaxAcknowledgement} from "./libraries/TaxAcknowledgement.sol";
@@ -173,7 +173,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
             token = IERC20(DEFAULT_TOKEN);
         } else {
             IERC20Metadata meta = IERC20Metadata(address(_token));
-            require(meta.decimals() == 18, "decimals");
+            require(meta.decimals() == AGIALPHA_DECIMALS, "decimals");
             token = _token;
         }
 

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -5,7 +5,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {AGIALPHA} from "../Constants.sol";
+import {AGIALPHA, AGIALPHA_DECIMALS} from "../Constants.sol";
 import {IJobRegistryAck} from "../interfaces/IJobRegistryAck.sol";
 
 interface IRoutingModule {
@@ -72,7 +72,7 @@ contract JobEscrow is Ownable {
             token = IERC20(DEFAULT_TOKEN);
         } else {
             IERC20Metadata meta = IERC20Metadata(address(_token));
-            require(meta.decimals() == 18, "decimals");
+            require(meta.decimals() == AGIALPHA_DECIMALS, "decimals");
             token = _token;
         }
         routingModule = _routing;


### PR DESCRIPTION
## Summary
- centralize AGIALPHA decimals constant for reuse across v2 modules
- reference AGIALPHA_DECIMALS when validating tokens in FeePool, StakeManager, JobEscrow and GovernanceReward

## Testing
- `npm test` *(fails: process did not complete in allotted time)*
- `npx hardhat compile` *(fails: process terminated before output)*

------
https://chatgpt.com/codex/tasks/task_e_68b2216611e083338cd4c98a419156b9