### PR TITLE
test: verify token decimals

### DIFF
--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -80,6 +80,22 @@ describe("FeePool", function () {
     await stakeManager.connect(user2).depositStake(2, 300);
   });
 
+  it("reverts when token has non-18 decimals", async () => {
+    const Bad = await ethers.getContractFactory("MockERC20SixDecimals");
+    const bad = await Bad.deploy();
+    const FeePoolFactory = await ethers.getContractFactory(
+      "contracts/v2/FeePool.sol:FeePool"
+    );
+    await expect(
+      FeePoolFactory.deploy(
+        await bad.getAddress(),
+        ethers.ZeroAddress,
+        0,
+        treasury.address
+      )
+    ).to.be.revertedWith("decimals");
+  });
+
   it("allows direct contributions", async () => {
     await token
       .connect(user1)

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -27,6 +27,26 @@ describe("StakeManager", function () {
     await stakeManager.connect(owner).setMinStake(0);
   });
 
+  it("reverts when token has non-18 decimals", async () => {
+    const Bad = await ethers.getContractFactory("MockERC20SixDecimals");
+    const bad = await Bad.deploy();
+    const StakeManagerFactory = await ethers.getContractFactory(
+      "contracts/v2/StakeManager.sol:StakeManager"
+    );
+    await expect(
+      StakeManagerFactory.deploy(
+        await bad.getAddress(),
+        0,
+        50,
+        50,
+        treasury.address,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        owner.address
+      )
+    ).to.be.revertedWith("decimals");
+  });
+
   it("reverts when staking without job registry", async () => {
     await token.connect(user).approve(await stakeManager.getAddress(), 100);
     await expect(


### PR DESCRIPTION
## Summary
- add unit tests ensuring StakeManager and FeePool reject tokens that do not use 18 decimals

## Testing
- `npm test -- test/v2/StakeManager.test.js test/v2/FeePool.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b22600e7788333b4f07f0588a1504a