### PR TITLE
chore: align mock token with compiler 0.8.25

### DIFF
--- a/contracts/legacy/MockERC20SixDecimals.sol
+++ b/contracts/legacy/MockERC20SixDecimals.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.25;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-/// @notice ERC20 test token with 6 decimals used to verify
-/// decimal enforcement in modules that require 18-decimal tokens.
+/// @notice ERC20 test token with non‑standard 6 decimals used only in tests
+/// to ensure production modules reject tokens that don't match the
+/// 18‑decimal AGIALPHA requirement.
 contract MockERC20SixDecimals is ERC20 {
     constructor() ERC20("Mock6D", "M6D") {
         _mint(msg.sender, 1e24);


### PR DESCRIPTION
## Summary
- use latest ^0.8.25 pragma for 6-decimal mock token
- clarify mock token comment for AGIALPHA compliance tests

## Testing
- `npm test` *(fails: process timed out before completing)*
- `npm run compile` *(fails: process timed out before completing)*

------
https://chatgpt.com/codex/tasks/task_e_68b23034c0ec8333a1c73f590a4ef569