### PR TITLE
docs: clarify AGIALPHA as fixed token

### DIFF
--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -5,7 +5,7 @@ AGIJobManager v2 decomposes the monolithic v1 contract into immutable modules wi
 ## Trust assumptions
 
 - **Deterministic randomness** – validator selection uses commit‑reveal entropy seeded by the owner and on-chain data. When `block.prevrandao` is unavailable, the module mixes recent block hashes and the caller address, removing any need for off‑chain randomness providers.
-- **Owner control** – `Ownable` setters let the owner swap tokens or retune parameters at will. Users must trust this address to act in good faith.
+- **Owner control** – `Ownable` setters let the owner retune parameters at will. Users must trust this address to act in good faith.
 - **No external dependencies** – the architecture avoids Chainlink VRF and subscription services entirely.
 
 ## Validator pool sizing & gas costs

--- a/docs/coding-sprint-ens-parity.md
+++ b/docs/coding-sprint-ens-parity.md
@@ -5,7 +5,7 @@ This sprint ports every capability from `legacy/AGIJobManagerv0.sol` into the mo
 ## Goals
 - Mirror v0 behaviour across dedicated v2 modules.
 - Require each agent to own a subdomain of `agent.agi.eth` and each validator a subdomain of `club.agi.eth` (or be owner‑approved).
-- Preserve owner flexibility: token swaps, allowlists, and parameter tuning without redeployment.
+- Preserve owner flexibility: allowlists and parameter tuning without redeployment.
 - Keep explorer interactions simple for non‑technical users.
 
 ## Tasks
@@ -40,6 +40,6 @@ This sprint ports every capability from `legacy/AGIJobManagerv0.sol` into the mo
 
 ## Definition of Done
 - All v0 features available through v2 modules with ENS identity enforcement.
-- Owner can retune or swap tokens via setters without redeployment.
+- Owner can retune parameters via setters without redeployment.
 - Documentation updated (`README.md`, `docs/architecture-v2.md`, and this sprint plan).
 - All tests and linters pass.

--- a/docs/ens-v1-parity-sprint.md
+++ b/docs/ens-v1-parity-sprint.md
@@ -24,7 +24,7 @@ This sprint migrates every capability from the legacy `AGIJobManager` into the m
   - Select eligible validators and tally approvals versus disapprovals.
 - **StakeManager**
   - Handle stake deposits/withdrawals, job reward escrow, fee deductions, validator rewards and AGIType payout bonuses.
-  - Owner setters: payout token, minimum stake, slashing percentages.
+  - Owner setters: minimum stake and slashing percentages.
 - **ReputationEngine**
   - Logarithmic reputation growth (`onApply`, `onFinalize`), premium threshold gating and owner-maintained blacklist.
 - **DisputeModule**
@@ -33,7 +33,7 @@ This sprint migrates every capability from the legacy `AGIJobManager` into the m
   - Mint completion certificates and support `list`, `purchase`, `delist` marketplace actions.
 
 ## 3. Administrative Controls
-- Each module inherits `Ownable`; only the owner can update parameters or swap tokens.
+- Each module inherits `Ownable`; only the owner can update parameters.
 - No module routes funds to the owner; fees go to `FeePool` or are burned to preserve tax neutrality.
 - Events mirror v0 naming where possible (`JobCreated`, `JobApplied`, `JobSubmitted`, `JobFinalized`, etc.).
 

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -13,11 +13,11 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 
 ## Core Modules
 
-- **AGIALPHAToken** – 18‑decimal ERC‑20 used for staking, rewards and dispute bonds. Owner can mint/burn and swap tokens across the system.
-- **StakeManager** – records stakes for all roles, escrows job funds and routes protocol fees to the `FeePool`. Owner setters allow changing the token, minimum stake, slashing percentages and treasury.
+- **AGIALPHAToken** – 18‑decimal ERC‑20 used for staking, rewards and dispute bonds. Owner can mint or burn but cannot swap the token used across the system.
+- **StakeManager** – records stakes for all roles, escrows job funds and routes protocol fees to the `FeePool`. Owner setters allow changing the minimum stake, slashing percentages and treasury.
 - **PlatformRegistry** – lists operators and computes a routing score derived from stake and reputation. The owner can blacklist addresses or replace the reputation engine.
 - **JobRouter** – selects an operator for new jobs using `PlatformRegistry` scores. Deterministic randomness mixes caller‑supplied seeds with blockhashes; no external oracle is required.
-- **FeePool** – receives fees from `StakeManager` and distributes them to staked operators in proportion to their stake. The owner can adjust burn percentage, treasury, reward role or token without redeploying.
+- **FeePool** – receives fees from `StakeManager` and distributes them to staked operators in proportion to their stake. The owner can adjust burn percentage, treasury and reward role without redeploying.
 - **PlatformIncentives** – helper that stakes `$AGIALPHA` on behalf of an operator and registers them with both `PlatformRegistry` and `JobRouter`. The owner (main deployer) may register with `amount = 0` to remain tax neutral and earn no routing or fee share. When routing or fee sharing isn't required, operators can instead call `PlatformRegistry.stakeAndRegister` or `acknowledgeStakeAndRegister` directly.
 
 Every contract rejects direct ETH and exposes `isTaxExempt()` so neither the contracts nor the owner ever hold taxable revenue. Participants interact only through token transfers.


### PR DESCRIPTION
## Summary
- remove references to token swapping across docs
- clarify governance only tunes parameters while token remains fixed AGIALPHA

## Testing
- `npm test`
- `forge test` *(fails: Invalid type for argument / wrong argument count during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68b238bd47288333b1a6971276bd2c39