### PR TITLE
chore: make token address immutable

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -26,8 +26,8 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     /// @notice default $AGIALPHA token used when no token is specified
     address public constant DEFAULT_TOKEN = AGIALPHA;
 
-    /// @notice ERC20 token used for fees and rewards
-    IERC20 public token;
+    /// @notice ERC20 token used for fees and rewards (immutable)
+    IERC20 public immutable token;
 
     /// @notice StakeManager tracking stakes
     IStakeManager public stakeManager;

--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -29,7 +29,7 @@ contract GovernanceReward is Ownable {
     /// @notice default reward percentage when constructor param is zero
     uint256 public constant DEFAULT_REWARD_PCT = 5;
 
-    IERC20 public token;
+    IERC20 public immutable token;
     IFeePool public feePool;
     IStakeManager public stakeManager;
     IStakeManager.Role public rewardRole;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -48,8 +48,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     address public constant BURN_ADDRESS =
         0x000000000000000000000000000000000000dEaD;
 
-    /// @notice ERC20 token used for staking and payouts
-    IERC20 public token;
+    /// @notice ERC20 token used for staking and payouts (immutable)
+    IERC20 public immutable token;
 
     /// @notice percentage of released amount sent to FeePool (0-100)
     uint256 public feePct;

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -39,7 +39,8 @@ contract JobEscrow is Ownable {
     /// @notice default $AGIALPHA token used when no token is specified
     address public constant DEFAULT_TOKEN = AGIALPHA;
 
-    IERC20 public token;
+    /// @notice ERC20 token used for rewards (immutable)
+    IERC20 public immutable token;
     IRoutingModule public routingModule;
     uint256 public nextJobId;
     mapping(uint256 => Job) public jobs;

--- a/docs/coding-sprint-ens-parity.md
+++ b/docs/coding-sprint-ens-parity.md
@@ -23,7 +23,7 @@ This sprint ports every capability from `legacy/AGIJobManagerv0.sol` into the mo
 
 ### 3. Reputation & Rewards
 - **ReputationEngine**: logarithmic growth formula, premium threshold view, and blacklist storage. Provide `onApply`, `onFinalize`, and `rewardValidator` hooks.
-- **StakeManager**: custody `$AGIALPHA`, owner‑settable token address, minimum stakes, slashing percentages, fee/burn ratios, and AGIType payout bonuses.
+- **StakeManager**: custody `$AGIALPHA` (token address fixed at deployment), minimum stakes, slashing percentages, fee/burn ratios, and AGIType payout bonuses.
 - Pay agents and validators via `StakeManager.release` and update reputation on success; handle slashing and refunds on failure.
 
 ### 4. Administration & Upgradability


### PR DESCRIPTION
## Summary
- mark token references as immutable across FeePool, StakeManager, JobEscrow, GovernanceReward
- clarify ENS sprint doc that StakeManager's token address is fixed at deployment

## Testing
- `npm test`
- `forge test` *(fails: Wrong argument count for function call)*

------
https://chatgpt.com/codex/tasks/task_e_68b23df996888333843f520bee3ac276