### PR TITLE
feat: centralize AGIALPHA decimals

### DIFF
--- a/agent-gateway/index.js
+++ b/agent-gateway/index.js
@@ -11,7 +11,9 @@ const VALIDATION_MODULE_ADDRESS = process.env.VALIDATION_MODULE_ADDRESS || '';
 const WALLET_KEYS = process.env.WALLET_KEYS || '';
 const PORT = process.env.PORT || 3000;
 const BOT_WALLET = process.env.BOT_WALLET || '';
-const TOKEN_DECIMALS = 18; // $AGIALPHA uses 18 decimal places
+// $AGIALPHA token parameters
+const { AGIALPHA_DECIMALS } = require('../scripts/constants');
+const TOKEN_DECIMALS = AGIALPHA_DECIMALS;
 
 // Provider and wallet manager
 const provider = new ethers.JsonRpcProvider(RPC_URL);

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,4 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.AGIALPHA = void 0;
+exports.AGIALPHA_DECIMALS = exports.AGIALPHA = void 0;
+// Canonical $AGIALPHA token address on Ethereum mainnet.
 exports.AGIALPHA = "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA";
+// Standard decimals for $AGIALPHA.
+exports.AGIALPHA_DECIMALS = 18;

--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -1,1 +1,5 @@
+// Canonical $AGIALPHA token address on Ethereum mainnet.
 export const AGIALPHA = "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA";
+
+// Standard decimals for $AGIALPHA.
+export const AGIALPHA_DECIMALS = 18;

--- a/scripts/v2/deploy.js
+++ b/scripts/v2/deploy.js
@@ -1,5 +1,5 @@
 const { ethers, run } = require("hardhat");
-const { AGIALPHA } = require("../constants");
+const { AGIALPHA, AGIALPHA_DECIMALS } = require("../constants");
 
 // rudimentary CLI flag parser
 function parseArgs() {

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -1,7 +1,7 @@
 import { ethers, run } from "hardhat";
 import { writeFileSync } from "fs";
 import { join } from "path";
-import { AGIALPHA } from "../constants";
+import { AGIALPHA, AGIALPHA_DECIMALS } from "../constants";
 
 // rudimentary CLI flag parser
 function parseArgs() {
@@ -123,7 +123,7 @@ async function main() {
   );
   const appealFee = ethers.parseUnits(
     typeof args.appealFee === "string" ? args.appealFee : "0",
-    18
+    AGIALPHA_DECIMALS
   );
   const disputeWindow =
     typeof args.disputeWindow === "string" ? Number(args.disputeWindow) : 0;
@@ -154,7 +154,7 @@ async function main() {
   );
   const minPlatformStake = ethers.parseUnits(
     typeof args.minPlatformStake === "string" ? args.minPlatformStake : "1000",
-    18
+    AGIALPHA_DECIMALS
   );
   const platformRegistry = await PlatformRegistry.deploy(
     await stake.getAddress(),
@@ -225,7 +225,7 @@ async function main() {
 
   const minStake = ethers.parseUnits(
     typeof args.minStake === "string" ? args.minStake : "0",
-    18
+    AGIALPHA_DECIMALS
   );
   await stake.connect(governanceSigner).setMinStake(minStake);
 


### PR DESCRIPTION
## Summary
- export `AGIALPHA_DECIMALS` for reuse in scripts and gateway
- reference shared token decimals instead of hardcoded values

## Testing
- `npm test` *(fails: process killed/timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b246184ad08333bc5b1087bfe40dbf