### PR TITLE
fix: lock v2 modules to AGIALPHA token

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -29,7 +29,6 @@ import {IStakeManager} from "./interfaces/IStakeManager.sol";
 import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 import {IENS} from "./interfaces/IENS.sol";
 import {INameWrapper} from "./interfaces/INameWrapper.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IValidationModule} from "./interfaces/IValidationModule.sol";
 import {IReputationEngine as IRInterface} from "./interfaces/IReputationEngine.sol";
@@ -47,7 +46,6 @@ contract Deployer is Ownable {
     /// @dev Zero values use each module's baked-in default such as a 5% fee,
     ///      5% burn, 1-day commit/reveal windows and a 1e18 minimum stake.
     struct EconParams {
-        IERC20 token; // custom token for StakeManager and FeePool (defaults to AGIALPHA)
         uint256 feePct; // protocol fee percentage for JobRegistry
         uint256 burnPct; // portion of fees burned by FeePool
         uint256 employerSlashPct; // slashed stake sent to employer
@@ -264,10 +262,7 @@ contract Deployer is Ownable {
             treasurySlashPct = 100;
         }
         uint96 jobStake = econ.jobStake;
-        IERC20 token = econ.token;
-
         StakeManager stake = new StakeManager(
-            token,
             minStake,
             employerSlashPct,
             treasurySlashPct,
@@ -317,7 +312,6 @@ contract Deployer is Ownable {
         certificate.setJobRegistry(address(registry));
 
         FeePool pool = new FeePool(
-            token,
             IStakeManager(address(stake)),
             burnPct,
             owner_

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -5,9 +5,8 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
+import {AGIALPHA} from "./Constants.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 /// @title FeePool
@@ -23,11 +22,8 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     address public constant BURN_ADDRESS = 0x000000000000000000000000000000000000dEaD;
     uint256 public constant DEFAULT_BURN_PCT = 5;
 
-    /// @notice default $AGIALPHA token used when no token is specified
-    address public constant DEFAULT_TOKEN = AGIALPHA;
-
-    /// @notice ERC20 token used for fees and rewards (immutable)
-    IERC20 public immutable token;
+    /// @notice ERC20 token used for fees and rewards (immutable $AGIALPHA)
+    IERC20 public immutable token = IERC20(AGIALPHA);
 
     /// @notice StakeManager tracking stakes
     IStakeManager public stakeManager;
@@ -63,28 +59,18 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     event RewardPoolContribution(address indexed contributor, uint256 amount);
 
     /// @notice Deploys the FeePool.
-    /// @param _token ERC20 token used for fees and rewards. Must use 18 decimals.
-    /// Defaults to DEFAULT_TOKEN when zero address.
     /// @param _stakeManager StakeManager tracking staker balances.
     /// @param _burnPct Percentage of each fee to burn (0-100). Defaults to
     /// DEFAULT_BURN_PCT when set to zero.
     /// @param _treasury Address receiving rounding dust. Defaults to deployer
     /// when zero address.
     constructor(
-        IERC20 _token,
         IStakeManager _stakeManager,
         uint256 _burnPct,
         address _treasury
     ) Ownable(msg.sender) {
         uint256 pct = _burnPct == 0 ? DEFAULT_BURN_PCT : _burnPct;
         require(pct <= 100, "pct");
-        if (address(_token) == address(0)) {
-            token = IERC20(DEFAULT_TOKEN);
-        } else {
-            IERC20Metadata meta = IERC20Metadata(address(_token));
-            require(meta.decimals() == AGIALPHA_DECIMALS, "decimals");
-            token = _token;
-        }
 
         if (address(_stakeManager) != address(0)) {
             stakeManager = _stakeManager;

--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -3,9 +3,8 @@ pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
+import {AGIALPHA} from "./Constants.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
@@ -20,16 +19,13 @@ contract GovernanceReward is Ownable {
 
     uint256 public constant ACCUMULATOR_SCALE = 1e12;
 
-    /// @notice default $AGIALPHA token used when no token is specified
-    address public constant DEFAULT_TOKEN = AGIALPHA;
-
     /// @notice default epoch length when constructor param is zero
     uint256 public constant DEFAULT_EPOCH_LENGTH = 1 weeks;
 
     /// @notice default reward percentage when constructor param is zero
     uint256 public constant DEFAULT_REWARD_PCT = 5;
 
-    IERC20 public immutable token;
+    IERC20 public immutable token = IERC20(AGIALPHA);
     IFeePool public feePool;
     IStakeManager public stakeManager;
     IStakeManager.Role public rewardRole;
@@ -60,22 +56,12 @@ contract GovernanceReward is Ownable {
     event RewardRoleUpdated(IStakeManager.Role role);
 
     constructor(
-        IERC20 _token,
         IFeePool _feePool,
         IStakeManager _stakeManager,
         IStakeManager.Role _role,
         uint256 _epochLength,
         uint256 _rewardPct
     ) Ownable(msg.sender) {
-        token =
-            address(_token) == address(0)
-                ? IERC20(DEFAULT_TOKEN)
-                : _token;
-        require(
-            IERC20Metadata(address(token)).decimals() == AGIALPHA_DECIMALS,
-            "decimals"
-        );
-
         feePool = _feePool;
         stakeManager = _stakeManager;
         rewardRole = _role;

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -2,10 +2,9 @@
 pragma solidity ^0.8.25;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {AGIALPHA, AGIALPHA_DECIMALS} from "../Constants.sol";
+import {AGIALPHA} from "../Constants.sol";
 import {IJobRegistryAck} from "../interfaces/IJobRegistryAck.sol";
 
 interface IRoutingModule {
@@ -36,11 +35,8 @@ contract JobEscrow is Ownable {
     }
 
     uint256 public constant TIMEOUT = 3 days;
-    /// @notice default $AGIALPHA token used when no token is specified
-    address public constant DEFAULT_TOKEN = AGIALPHA;
-
-    /// @notice ERC20 token used for rewards (immutable)
-    IERC20 public immutable token;
+    /// @notice ERC20 token used for rewards (immutable $AGIALPHA)
+    IERC20 public immutable token = IERC20(AGIALPHA);
     IRoutingModule public routingModule;
     uint256 public nextJobId;
     mapping(uint256 => Job) public jobs;
@@ -65,17 +61,8 @@ contract JobEscrow is Ownable {
     event ResultSubmitted(uint256 indexed jobId, string result);
     event ResultAccepted(uint256 indexed jobId, address caller);
 
-    /// @param _token ERC20 token used for rewards; must have 18 decimals. Pass
-    /// zero address to use the default token.
     /// @param _routing Routing module used to select operators for new jobs.
-    constructor(IERC20 _token, IRoutingModule _routing) Ownable(msg.sender) {
-        if (address(_token) == address(0)) {
-            token = IERC20(DEFAULT_TOKEN);
-        } else {
-            IERC20Metadata meta = IERC20Metadata(address(_token));
-            require(meta.decimals() == AGIALPHA_DECIMALS, "decimals");
-            token = _token;
-        }
+    constructor(IRoutingModule _routing) Ownable(msg.sender) {
         routingModule = _routing;
     }
     

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -20,6 +20,9 @@ module.exports = {
       blockGasLimit: 100000000
     }
   },
+  mocha: {
+    require: ["./test/setup.js"],
+  },
   gasReporter: {
     enabled: true,
     currency: 'USD',

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,7 @@
+const { artifacts, network } = require("hardhat");
+const { AGIALPHA } = require("../scripts/constants");
+
+before(async function () {
+  const artifact = await artifacts.readArtifact("contracts/legacy/MockERC20.sol:MockERC20");
+  await network.provider.send("hardhat_setCode", [AGIALPHA, artifact.deployedBytecode]);
+});

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -9,14 +9,13 @@ describe("StakeManager AGIType bonuses", function () {
   beforeEach(async () => {
     [owner, employer, agent] = await ethers.getSigners();
 
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    const { AGIALPHA } = require("../../scripts/constants");
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -87,15 +87,13 @@ describe("DisputeModule", function () {
       [owner, employer, agent, outsider] = await ethers.getSigners();
 
       // deploy token and stake manager
-      const Token = await ethers.getContractFactory("MockERC20");
-      token = await Token.deploy();
-      await token.waitForDeployment();
+      const { AGIALPHA } = require("../../scripts/constants");
+      token = await ethers.getContractAt("MockERC20", AGIALPHA);
 
       const StakeManager = await ethers.getContractFactory(
         "contracts/v2/StakeManager.sol:StakeManager"
       );
       stakeManager = await StakeManager.deploy(
-        await token.getAddress(),
         0,
         0,
         0,

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -4,16 +4,15 @@ const { ethers } = require("hardhat");
 describe("FeePool", function () {
   let token, stakeManager, jobRegistry, feePool, owner, user1, user2, employer, treasury, registrySigner;
 
+  const { AGIALPHA } = require("../../scripts/constants");
   beforeEach(async () => {
     [owner, user1, user2, employer, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,
@@ -60,7 +59,6 @@ describe("FeePool", function () {
       "contracts/v2/FeePool.sol:FeePool"
     );
     feePool = await FeePool.deploy(
-      await token.getAddress(),
       await stakeManager.getAddress(),
       0,
       treasury.address
@@ -78,22 +76,6 @@ describe("FeePool", function () {
     await token.connect(user2).approve(await stakeManager.getAddress(), 1000);
     await stakeManager.connect(user1).depositStake(2, 100);
     await stakeManager.connect(user2).depositStake(2, 300);
-  });
-
-  it("reverts when token has non-18 decimals", async () => {
-    const Bad = await ethers.getContractFactory("MockERC20SixDecimals");
-    const bad = await Bad.deploy();
-    const FeePoolFactory = await ethers.getContractFactory(
-      "contracts/v2/FeePool.sol:FeePool"
-    );
-    await expect(
-      FeePoolFactory.deploy(
-        await bad.getAddress(),
-        ethers.ZeroAddress,
-        0,
-        treasury.address
-      )
-    ).to.be.revertedWith("decimals");
   });
 
   it("allows direct contributions", async () => {

--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -2,6 +2,7 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
 describe("JobRegistry governance finalization", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let token, stakeManager, rep, registry, identity;
   let owner, employer, agent, treasury;
   const reward = 100n;
@@ -10,14 +11,12 @@ describe("JobRegistry governance finalization", function () {
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
 
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -4,21 +4,18 @@ const { ethers } = require("hardhat");
 const TOKEN = 10n ** 18n; // 1 token with 18 decimals
 
 describe("Governance reward lifecycle", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let owner, voter1, voter2, voter3, token, stakeManager, feePool, reward, treasury;
 
   beforeEach(async () => {
     [owner, voter1, voter2, voter3, treasury] = await ethers.getSigners();
 
-    const Token = await ethers.getContractFactory(
-      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
-    );
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,
@@ -63,7 +60,6 @@ describe("Governance reward lifecycle", function () {
       "contracts/v2/FeePool.sol:FeePool"
     );
     feePool = await FeePool.deploy(
-      await token.getAddress(),
       await stakeManager.getAddress(),
       0,
       treasury.address
@@ -74,7 +70,6 @@ describe("Governance reward lifecycle", function () {
       "contracts/v2/GovernanceReward.sol:GovernanceReward"
     );
     reward = await Reward.deploy(
-      await token.getAddress(),
       await feePool.getAddress(),
       await stakeManager.getAddress(),
       2,

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -4,21 +4,18 @@ const { ethers } = require("hardhat");
 const TOKEN = 10n ** 18n; // 1 token with 18 decimals
 
 describe("GovernanceReward", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let owner, voter1, voter2, token, stakeManager, feePool, reward, treasury;
 
   beforeEach(async () => {
     [owner, voter1, voter2, treasury] = await ethers.getSigners();
 
-    const Token = await ethers.getContractFactory(
-      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
-    );
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,
@@ -62,7 +59,6 @@ describe("GovernanceReward", function () {
       "contracts/v2/FeePool.sol:FeePool"
     );
     feePool = await FeePool.deploy(
-      await token.getAddress(),
       await stakeManager.getAddress(),
       0,
       treasury.address
@@ -73,7 +69,6 @@ describe("GovernanceReward", function () {
       "contracts/v2/GovernanceReward.sol:GovernanceReward"
     );
     reward = await Reward.deploy(
-      await token.getAddress(),
       await feePool.getAddress(),
       await stakeManager.getAddress(),
       2,

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -9,11 +9,9 @@ describe("JobEscrow", function () {
   beforeEach(async () => {
     [owner, employer, operator] = await ethers.getSigners();
 
-    const Token = await ethers.getContractFactory(
-      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
-    );
-    token = await Token.deploy();
-    await token.connect(owner).mint(employer.address, 1000000);
+    const { AGIALPHA } = require("../../scripts/constants");
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    await token.mint(employer.address, 1000000);
 
     // Mock RoutingModule that always returns operator
     const Routing = await ethers.getContractFactory("MockRoutingModule");
@@ -22,18 +20,7 @@ describe("JobEscrow", function () {
     const Escrow = await ethers.getContractFactory(
       "contracts/v2/modules/JobEscrow.sol:JobEscrow"
     );
-    escrow = await Escrow.deploy(await token.getAddress(), await routing.getAddress());
-  });
-
-  it("constructor enforces 18-decimal token", async () => {
-    const Bad = await ethers.getContractFactory("MockERC20SixDecimals");
-    const bad = await Bad.deploy();
-    const Escrow = await ethers.getContractFactory(
-      "contracts/v2/modules/JobEscrow.sol:JobEscrow"
-    );
-    await expect(
-      Escrow.deploy(await bad.getAddress(), await routing.getAddress())
-    ).to.be.revertedWith("decimals");
+    escrow = await Escrow.deploy(await routing.getAddress());
   });
 
   it("runs normal job flow", async () => {

--- a/test/v2/JobEscrowNoEther.test.js
+++ b/test/v2/JobEscrowNoEther.test.js
@@ -2,16 +2,14 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("JobEscrow ether rejection", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let owner, employer, operator, token, routing, escrow;
 
   beforeEach(async () => {
     [owner, employer, operator] = await ethers.getSigners();
 
-    const Token = await ethers.getContractFactory(
-      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
-    );
-    token = await Token.deploy();
-    await token.connect(owner).mint(employer.address, 1000);
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    await token.mint(employer.address, 1000);
 
     const Routing = await ethers.getContractFactory(
       "contracts/legacy/MockRoutingModule.sol:MockRoutingModule"
@@ -21,7 +19,7 @@ describe("JobEscrow ether rejection", function () {
     const Escrow = await ethers.getContractFactory(
       "contracts/v2/modules/JobEscrow.sol:JobEscrow"
     );
-    escrow = await Escrow.deploy(await token.getAddress(), await routing.getAddress());
+    escrow = await Escrow.deploy(await routing.getAddress());
   });
 
   it("reverts on direct ether transfer", async () => {

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -3,6 +3,7 @@ const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("Job expiration", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let token, stakeManager, rep, validation, nft, registry, dispute, policy;
   let owner, employer, agent, treasury;
   const reward = 100;
@@ -10,13 +11,11 @@ describe("Job expiration", function () {
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -3,6 +3,7 @@ const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("Job expiration boundary", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let token, stakeManager, rep, validation, nft, registry, dispute, policy;
   let owner, employer, agent, treasury;
   const reward = 100;
@@ -10,13 +11,11 @@ describe("Job expiration boundary", function () {
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -4,6 +4,7 @@ const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("JobRegistry integration", function () {
   let token, stakeManager, rep, validation, nft, registry, dispute, policy, identity;
+  const { AGIALPHA } = require("../../scripts/constants");
   let owner, employer, agent, treasury;
 
   const reward = 100;
@@ -12,13 +13,11 @@ describe("JobRegistry integration", function () {
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,
@@ -183,7 +182,6 @@ describe("JobRegistry integration", function () {
       "contracts/v2/FeePool.sol:FeePool"
     );
     const feePool = await FeePool.deploy(
-      await token.getAddress(),
       await stakeManager.getAddress(),
       0,
       treasury.address

--- a/test/v2/JobRegistryTreasury.test.js
+++ b/test/v2/JobRegistryTreasury.test.js
@@ -2,20 +2,19 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("JobRegistry Treasury", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let registry, stakeManager, token;
   let owner, treasury;
 
   beforeEach(async function () {
     [owner, treasury] = await ethers.getSigners();
 
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -8,16 +8,14 @@ const STAKE_BOB = 100n * TOKEN; // 100 tokens
 const REWARD = 50n * TOKEN; // job reward 50 tokens
 const FEE = 300n * TOKEN; // fee 300 tokens
 describe("Platform reward flow", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let owner, alice, bob, employer, treasury;
   let token, stakeManager, jobRegistry, platformRegistry, jobRouter, feePool;
 
   beforeEach(async () => {
     [owner, alice, bob, employer, treasury] = await ethers.getSigners();
 
-    const Token = await ethers.getContractFactory(
-      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
-    );
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
     await token.mint(alice.address, 1000n * TOKEN);
     await token.mint(bob.address, 1000n * TOKEN);
     await token.mint(employer.address, 1000n * TOKEN);
@@ -26,7 +24,6 @@ describe("Platform reward flow", function () {
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,
@@ -92,7 +89,6 @@ describe("Platform reward flow", function () {
       "contracts/v2/FeePool.sol:FeePool"
     );
     feePool = await FeePool.deploy(
-      await token.getAddress(),
       await stakeManager.getAddress(),
       0,
       treasury.address

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -3,19 +3,18 @@ const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("StakeManager", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let token, stakeManager, owner, user, employer, treasury;
 
   beforeEach(async () => {
     [owner, user, employer, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
     await token.mint(user.address, 1000);
     await token.mint(employer.address, 1000);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       50,
       50,
@@ -25,26 +24,6 @@ describe("StakeManager", function () {
       owner.address
     );
     await stakeManager.connect(owner).setMinStake(0);
-  });
-
-  it("reverts when token has non-18 decimals", async () => {
-    const Bad = await ethers.getContractFactory("MockERC20SixDecimals");
-    const bad = await Bad.deploy();
-    const StakeManagerFactory = await ethers.getContractFactory(
-      "contracts/v2/StakeManager.sol:StakeManager"
-    );
-    await expect(
-      StakeManagerFactory.deploy(
-        await bad.getAddress(),
-        0,
-        50,
-        50,
-        treasury.address,
-        ethers.ZeroAddress,
-        ethers.ZeroAddress,
-        owner.address
-      )
-    ).to.be.revertedWith("decimals");
   });
 
   it("reverts when staking without job registry", async () => {

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -4,18 +4,17 @@ const { ethers } = require("hardhat");
 // Additional StakeManager unit tests focusing on staking flows and limits
 
 describe("StakeManager extras", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let token, stakeManager, owner, user, treasury;
 
   beforeEach(async () => {
     [owner, user, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
     await token.mint(user.address, 1000);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,

--- a/test/v2/StakeManagerNoEther.test.js
+++ b/test/v2/StakeManagerNoEther.test.js
@@ -2,17 +2,16 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("StakeManager ether rejection", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let owner, token, stakeManager;
 
   beforeEach(async () => {
     [owner] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,

--- a/test/v2/StakeManagerPause.test.js
+++ b/test/v2/StakeManagerPause.test.js
@@ -2,12 +2,12 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("StakeManager pause", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let owner, user, token, stakeManager;
 
   beforeEach(async () => {
     [owner, user] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
     const MockRegistry = await ethers.getContractFactory(
       "contracts/legacy/MockV2.sol:MockJobRegistry"
     );
@@ -16,7 +16,6 @@ describe("StakeManager pause", function () {
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -6,14 +6,13 @@ describe("StakeManager release", function () {
 
   beforeEach(async () => {
     [owner, user1, user2, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory("MockERC20");
-    token = await Token.deploy();
+    const { AGIALPHA } = require("../../scripts/constants");
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       100,
       0,
@@ -55,7 +54,6 @@ describe("StakeManager release", function () {
       "contracts/v2/FeePool.sol:FeePool"
     );
     feePool = await FeePool.deploy(
-      await token.getAddress(),
       await stakeManager.getAddress(),
       0,
       treasury.address

--- a/test/v2/StakeManagerSlashing.test.js
+++ b/test/v2/StakeManagerSlashing.test.js
@@ -2,19 +2,16 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("StakeManager slashing configuration", function () {
+  const { AGIALPHA } = require("../../scripts/constants");
   let owner, treasury, token, stakeManager;
 
   beforeEach(async () => {
     [owner, treasury] = await ethers.getSigners();
-    const Token = await ethers.getContractFactory(
-      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
-    );
-    token = await Token.deploy();
+    token = await ethers.getContractAt("MockERC20", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );
     stakeManager = await StakeManager.deploy(
-      await token.getAddress(),
       0,
       50,
       50,


### PR DESCRIPTION
## Summary
- hard-code AGIALPHA as the staking/reward token across core v2 contracts
- remove token parameter from deployment script and constructors
- update tests to bootstrap AGIALPHA token at a fixed address

## Testing
- `forge test` *(fails: command not found)*
- `npx hardhat test` *(timed out during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68b25716821c8333b6427748f61b4dc0