### PR TITLE
Verify AGIALPHA decimals in token modules

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -5,8 +5,9 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {AGIALPHA} from "./Constants.sol";
+import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 /// @title FeePool
@@ -69,6 +70,10 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
         uint256 _burnPct,
         address _treasury
     ) Ownable(msg.sender) {
+        require(
+            IERC20Metadata(AGIALPHA).decimals() == AGIALPHA_DECIMALS,
+            "decimals"
+        );
         uint256 pct = _burnPct == 0 ? DEFAULT_BURN_PCT : _burnPct;
         require(pct <= 100, "pct");
 

--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {AGIALPHA} from "./Constants.sol";
+import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
@@ -62,6 +63,10 @@ contract GovernanceReward is Ownable {
         uint256 _epochLength,
         uint256 _rewardPct
     ) Ownable(msg.sender) {
+        require(
+            IERC20Metadata(AGIALPHA).decimals() == AGIALPHA_DECIMALS,
+            "decimals"
+        );
         feePool = _feePool;
         stakeManager = _stakeManager;
         rewardRole = _role;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -3,11 +3,12 @@ pragma solidity ^0.8.25;
 
 import {Governable} from "./Governable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
-import {AGIALPHA} from "./Constants.sol";
+import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
 import {IJobRegistryTax} from "./interfaces/IJobRegistryTax.sol";
 import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 import {TaxAcknowledgement} from "./libraries/TaxAcknowledgement.sol";
@@ -162,6 +163,10 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         address _disputeModule,
         address _timelock // timelock or multisig controller
     ) Governable(_timelock) {
+        require(
+            IERC20Metadata(AGIALPHA).decimals() == AGIALPHA_DECIMALS,
+            "decimals"
+        );
 
         minStake = _minStake == 0 ? DEFAULT_MIN_STAKE : _minStake;
         emit MinStakeUpdated(minStake);

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.25;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {AGIALPHA} from "../Constants.sol";
+import {AGIALPHA, AGIALPHA_DECIMALS} from "../Constants.sol";
 import {IJobRegistryAck} from "../interfaces/IJobRegistryAck.sol";
 
 interface IRoutingModule {
@@ -63,6 +64,10 @@ contract JobEscrow is Ownable {
 
     /// @param _routing Routing module used to select operators for new jobs.
     constructor(IRoutingModule _routing) Ownable(msg.sender) {
+        require(
+            IERC20Metadata(AGIALPHA).decimals() == AGIALPHA_DECIMALS,
+            "decimals"
+        );
         routingModule = _routing;
     }
     


### PR DESCRIPTION
## Summary
- import IERC20Metadata and AGIALPHA_DECIMALS in token-based contracts
- require runtime decimals match expected before using AGIALPHA

## Testing
- `npm run lint`
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b26d95e7d883338b5ee7bb182154c9