### PR TITLE
Allow human-readable staking amounts in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ node -e "require('./examples/ethers-quickstart').postJob()"
 
 ### Stake tokens
 ```bash
-node -e "require('./examples/ethers-quickstart').stake(1_000000000000000000)"
+node -e "require('./examples/ethers-quickstart').stake('1')"
 ```
 
 ### Validate a submission

--- a/examples/ethers-quickstart.js
+++ b/examples/ethers-quickstart.js
@@ -28,7 +28,8 @@ async function postJob() {
 }
 
 async function stake(amount) {
-  await stakeManager.depositStake(0, amount);
+  const parsed = ethers.parseUnits(amount.toString(), 18);
+  await stakeManager.depositStake(0, parsed);
 }
 
 async function apply(jobId, label, proof) {


### PR DESCRIPTION
## Summary
- convert stake helper to parse human-readable amounts before depositing
- update README quickstart to stake using `'1'` token instead of 18-decimal value

## Testing
- `npm test` *(fails: Unknown env config "http-proxy" and hangs while running Hardhat)*
- `npm run lint` *(fails: Error checking for updates)*

------
https://chatgpt.com/codex/tasks/task_e_68b270431a348333b8a6c37fdcdc3767