### PR TITLE
Fix v2 deploy script to use canonical AGIALPHA token

### DIFF
--- a/docs/deployment-addresses.md
+++ b/docs/deployment-addresses.md
@@ -9,5 +9,4 @@ npx hardhat run scripts/v2/deploy.ts --network <network>
 
 Deployments are anchored to the `$AGIALPHA` token at
 `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`, exported from
-[`scripts/constants.ts`](../scripts/constants.ts). Pass `--token <address>` only
-if you intentionally wish to override this default.
+[`scripts/constants.ts`](../scripts/constants.ts) and cannot be overridden.

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -43,10 +43,8 @@ async function main() {
   const governanceSigner = await ethers.getSigner(governance);
 
   // -------------------------------------------------------------------------
-  // staking token: defaults to fixed AGIALPHA unless overridden
+  // staking token: fixed to canonical AGIALPHA address
   // -------------------------------------------------------------------------
-  const tokenAddress =
-    typeof args.token === "string" ? args.token : AGIALPHA;
 
   const Stake = await ethers.getContractFactory(
     "contracts/v2/StakeManager.sol:StakeManager"
@@ -54,7 +52,7 @@ async function main() {
   const treasury =
     typeof args.treasury === "string" ? args.treasury : governance;
   const stake = await Stake.deploy(
-    tokenAddress,
+    AGIALPHA,
     0,
     0,
     0,
@@ -142,7 +140,7 @@ async function main() {
   );
   const burnPct = typeof args.burnPct === "string" ? parseInt(args.burnPct) : 0;
   const feePool = await FeePool.deploy(
-    tokenAddress,
+    AGIALPHA,
     await stake.getAddress(),
     burnPct,
     treasury
@@ -324,7 +322,7 @@ async function main() {
   console.log("PlatformIncentives:", await incentives.getAddress());
 
   const addresses = {
-    token: tokenAddress,
+    token: AGIALPHA,
     stakeManager: await stake.getAddress(),
     jobRegistry: await registry.getAddress(),
     validationModule: await validation.getAddress(),
@@ -345,7 +343,7 @@ async function main() {
   );
 
   await verify(await stake.getAddress(), [
-    tokenAddress,
+    AGIALPHA,
     0,
     0,
     0,
@@ -394,7 +392,7 @@ async function main() {
     "All taxes on participants; contract and owner exempt",
   ]);
   await verify(await feePool.getAddress(), [
-    tokenAddress,
+    AGIALPHA,
     await stake.getAddress(),
     2,
     governance,


### PR DESCRIPTION
## Summary
- remove `--token` option from v2 deploy script and always deploy with AGIALPHA
- document that deployments are anchored to the canonical AGIALPHA token

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2e7a103b48333a4c8791df7389a90