### PR TITLE
refactor: use AGIALPHAToken abi in tests

### DIFF
--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -10,7 +10,7 @@ describe("StakeManager AGIType bonuses", function () {
     [owner, employer, agent] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -9,7 +9,7 @@ describe("CertificateNFT marketplace", function () {
     [owner, seller, buyer] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(buyer.address, price);
     await token.mint(seller.address, price);
     await token.mint(owner.address, price);

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -88,7 +88,7 @@ describe("DisputeModule", function () {
 
       // deploy token and stake manager
       const { AGIALPHA } = require("../../scripts/constants");
-      token = await ethers.getContractAt("MockERC20", AGIALPHA);
+      token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
       const StakeManager = await ethers.getContractFactory(
         "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -7,7 +7,7 @@ describe("FeePool", function () {
   const { AGIALPHA } = require("../../scripts/constants");
   beforeEach(async () => {
     [owner, user1, user2, employer, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -11,7 +11,7 @@ describe("JobRegistry governance finalization", function () {
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -10,7 +10,7 @@ describe("Governance reward lifecycle", function () {
   beforeEach(async () => {
     [owner, voter1, voter2, voter3, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -10,7 +10,7 @@ describe("GovernanceReward", function () {
   beforeEach(async () => {
     [owner, voter1, voter2, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/GovernanceTimelock.test.js
+++ b/test/v2/GovernanceTimelock.test.js
@@ -16,7 +16,7 @@ describe("Governance via Timelock", function () {
     await timelock.grantRole(executorRole, admin.address);
 
     const { AGIALPHA } = require("../../scripts/constants");
-    const token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    const token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(admin.address, 1000);
 
     const Stake = await ethers.getContractFactory(

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -10,7 +10,7 @@ describe("JobEscrow", function () {
     [owner, employer, operator] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(employer.address, 1000000);
 
     // Mock RoutingModule that always returns operator

--- a/test/v2/JobEscrowNoEther.test.js
+++ b/test/v2/JobEscrowNoEther.test.js
@@ -8,7 +8,7 @@ describe("JobEscrow ether rejection", function () {
   beforeEach(async () => {
     [owner, employer, operator] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(employer.address, 1000);
 
     const Routing = await ethers.getContractFactory(

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -11,7 +11,7 @@ describe("Job expiration", function () {
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -11,7 +11,7 @@ describe("Job expiration boundary", function () {
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -13,7 +13,7 @@ describe("JobRegistry integration", function () {
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );

--- a/test/v2/JobRegistryTreasury.test.js
+++ b/test/v2/JobRegistryTreasury.test.js
@@ -9,7 +9,7 @@ describe("JobRegistry Treasury", function () {
   beforeEach(async function () {
     [owner, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -8,7 +8,7 @@ async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
 
   const { AGIALPHA } = require("../../scripts/constants");
-  const token = await ethers.getContractAt("MockERC20", AGIALPHA);
+  const token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
   await token.mint(employer.address, ethers.parseUnits("1000", 18));
   await token.mint(agent.address, ethers.parseUnits("1000", 18));
   await token.mint(owner.address, ethers.parseUnits("1000", 18));

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -8,7 +8,7 @@ async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
 
   const { AGIALPHA } = require("../../scripts/constants");
-  const token = await ethers.getContractAt("MockERC20", AGIALPHA);
+  const token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
   await token.mint(employer.address, ethers.parseUnits("1000", 18));
   await token.mint(agent.address, ethers.parseUnits("1000", 18));
   await token.mint(owner.address, ethers.parseUnits("1000", 18));

--- a/test/v2/PlatformIncentivesAck.test.js
+++ b/test/v2/PlatformIncentivesAck.test.js
@@ -6,7 +6,7 @@ describe("PlatformIncentives acknowledge", function () {
     const [owner, operator, treasury] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    const token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    const token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(owner.address, 1000);
     await token.mint(operator.address, 1000);
 

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -11,7 +11,7 @@ describe("PlatformRegistry", function () {
     [owner, platform, sybil, treasury] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(platform.address, STAKE);
     await token.mint(owner.address, STAKE);
 

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -15,7 +15,7 @@ describe("Platform reward flow", function () {
   beforeEach(async () => {
     [owner, alice, bob, employer, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(alice.address, 1000n * TOKEN);
     await token.mint(bob.address, 1000n * TOKEN);
     await token.mint(employer.address, 1000n * TOKEN);

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -8,7 +8,7 @@ describe("StakeManager", function () {
 
   beforeEach(async () => {
     [owner, user, employer, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(owner.address, 1000);
     await token.mint(user.address, 1000);
     await token.mint(employer.address, 1000);

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -9,7 +9,7 @@ describe("StakeManager extras", function () {
 
   beforeEach(async () => {
     [owner, user, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(user.address, 1000);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/StakeManagerNoEther.test.js
+++ b/test/v2/StakeManagerNoEther.test.js
@@ -7,7 +7,7 @@ describe("StakeManager ether rejection", function () {
 
   beforeEach(async () => {
     [owner] = await ethers.getSigners();
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );

--- a/test/v2/StakeManagerPause.test.js
+++ b/test/v2/StakeManagerPause.test.js
@@ -7,7 +7,7 @@ describe("StakeManager pause", function () {
 
   beforeEach(async () => {
     [owner, user] = await ethers.getSigners();
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const MockRegistry = await ethers.getContractFactory(
       "contracts/legacy/MockV2.sol:MockJobRegistry"
     );

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -7,7 +7,7 @@ describe("StakeManager release", function () {
   beforeEach(async () => {
     [owner, user1, user2, treasury] = await ethers.getSigners();
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/StakeManagerSlashing.test.js
+++ b/test/v2/StakeManagerSlashing.test.js
@@ -7,7 +7,7 @@ describe("StakeManager slashing configuration", function () {
 
   beforeEach(async () => {
     [owner, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -15,7 +15,7 @@ describe("comprehensive job flows", function () {
     [owner, employer, agent, platform, buyer] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const mintAmount = ethers.parseUnits("10000", 18);
     await token.mint(employer.address, mintAmount);
     await token.mint(agent.address, mintAmount);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -15,7 +15,7 @@ describe("end-to-end job lifecycle", function () {
     [owner, employer, agent, platform] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const mintAmount = ethers.parseUnits("10000", 18);
     await token.mint(owner.address, mintAmount);
     await token.mint(employer.address, mintAmount);

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -15,7 +15,7 @@ describe("job finalization integration", function () {
     [owner, employer, agent, validator1, validator2] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(owner.address, mintAmount);
     await token.mint(employer.address, mintAmount);
     await token.mint(agent.address, mintAmount);

--- a/test/v2/midJobReplacementFuzz.test.js
+++ b/test/v2/midJobReplacementFuzz.test.js
@@ -5,7 +5,7 @@ const { time } = require("@nomicfoundation/hardhat-network-helpers");
 async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
   const { AGIALPHA } = require("../../scripts/constants");
-  const token = await ethers.getContractAt("MockERC20", AGIALPHA);
+  const token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
   await token.mint(employer.address, ethers.parseUnits("1000", 18));
   await token.mint(agent.address, ethers.parseUnits("1000", 18));
   await token.mint(owner.address, ethers.parseUnits("1000", 18));

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -16,7 +16,7 @@ describe("multi-operator job lifecycle", function () {
     [owner, employer, agent, platform1, platform2] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("MockERC20", AGIALPHA);
+    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const mintAmount = ethers.parseUnits("10000", 18);
     await token.mint(owner.address, mintAmount);
     await token.mint(employer.address, mintAmount);


### PR DESCRIPTION
## Summary
- replace MockERC20 lookups with AGIALPHAToken ABI
- use fully qualified ABI path for AGIALPHAToken

## Testing
- `npx hardhat test test/v2/StakeManagerExtras.test.js` *(fails: process hung, no output)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ec3149ac8333b9b8a2d1ec8b18a5