### PR TITLE
refactor: move mock erc20 to test utils

### DIFF
--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-// @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
+// @dev Test utility token used to provide an ERC20 code stub for AGIALPHA
+// in Hardhat tests. This mock contract deploys a basic ERC20 and allows
+// minting additional tokens during tests.
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/README.md
+++ b/contracts/test/README.md
@@ -1,0 +1,5 @@
+# Test Contracts
+
+This directory contains Solidity contracts used exclusively in the test
+suite. These helpers provide minimal implementations required for tests,
+for example `MockERC20` which acts as a stand-in for the AGIALPHA token.

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,8 +4,9 @@ const { AGIALPHA } = require("../scripts/constants");
 let snapshotId;
 
 before(async function () {
+  // Load the test utility ERC20 used to stub the AGIALPHA token
   const artifact = await artifacts.readArtifact(
-    "contracts/legacy/MockERC20.sol:MockERC20"
+    "contracts/test/MockERC20.sol:MockERC20"
   );
   await network.provider.send("hardhat_setCode", [
     AGIALPHA,


### PR DESCRIPTION
## Summary
- relocate MockERC20 contract to a dedicated test directory and document its usage
- update test setup to load the mock from its new location
- add README explaining test-only contracts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f4b83dc48333ab33b0eb4d591258