### PR TITLE
refactor: drop token from v2 deploy scripts

### DIFF
--- a/scripts/v2/deploy.js
+++ b/scripts/v2/deploy.js
@@ -1,5 +1,4 @@
 const { ethers, run } = require("hardhat");
-const { AGIALPHA, AGIALPHA_DECIMALS } = require("../constants");
 
 // rudimentary CLI flag parser
 function parseArgs() {
@@ -37,14 +36,10 @@ async function main() {
   const [deployer] = await ethers.getSigners();
   const args = parseArgs();
 
-  const tokenAddress =
-    typeof args.token === "string" ? args.token : AGIALPHA;
-
   const Stake = await ethers.getContractFactory(
     "contracts/v2/StakeManager.sol:StakeManager"
   );
   const stake = await Stake.deploy(
-    tokenAddress,
     0,
     0,
     0,
@@ -112,7 +107,6 @@ async function main() {
     "contracts/v2/FeePool.sol:FeePool"
   );
   const feePool = await FeePool.deploy(
-    tokenAddress,
     await stake.getAddress(),
     0,
     deployer.address
@@ -150,9 +144,14 @@ async function main() {
   console.log("CertificateNFT:", await nft.getAddress());
   console.log("FeePool:", await feePool.getAddress());
   console.log("TaxPolicy:", await tax.getAddress());
-  console.log("Token:", tokenAddress);
-
-  await verify(await stake.getAddress(), [tokenAddress, deployer.address]);
+  await verify(await stake.getAddress(), [
+    0,
+    0,
+    0,
+    deployer.address,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+  ]);
   await verify(await registry.getAddress(), []);
   await verify(await validation.getAddress(), [await registry.getAddress(), await stake.getAddress()]);
   await verify(await reputation.getAddress(), []);

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -52,7 +52,6 @@ async function main() {
   const treasury =
     typeof args.treasury === "string" ? args.treasury : governance;
   const stake = await Stake.deploy(
-    AGIALPHA,
     0,
     0,
     0,
@@ -140,7 +139,6 @@ async function main() {
   );
   const burnPct = typeof args.burnPct === "string" ? parseInt(args.burnPct) : 0;
   const feePool = await FeePool.deploy(
-    AGIALPHA,
     await stake.getAddress(),
     burnPct,
     treasury
@@ -343,7 +341,6 @@ async function main() {
   );
 
   await verify(await stake.getAddress(), [
-    AGIALPHA,
     0,
     0,
     0,
@@ -392,10 +389,9 @@ async function main() {
     "All taxes on participants; contract and owner exempt",
   ]);
   await verify(await feePool.getAddress(), [
-    AGIALPHA,
     await stake.getAddress(),
-    2,
-    governance,
+    burnPct,
+    treasury,
   ]);
   await verify(await platformRegistry.getAddress(), [
     await stake.getAddress(),


### PR DESCRIPTION
## Summary
- remove token address constructor arguments from Stake and FeePool in v2 deploy scripts
- update verification calls for new signatures

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b311d812b0833385d2e7e9a41c1908