### PR TITLE
chore: update deploy defaults verification args

### DIFF
--- a/scripts/v2/deployDefaults.ts
+++ b/scripts/v2/deployDefaults.ts
@@ -50,13 +50,13 @@ async function main() {
 
   await verify(deployerAddress);
   await verify(stakeManager, [
-    ethers.ZeroAddress,
-    1_000_000,
+    ethers.parseUnits("1", 18),
     0,
     100,
     owner.address,
     ethers.ZeroAddress,
     ethers.ZeroAddress,
+    owner.address,
   ]);
   await verify(jobRegistry, [
     ethers.ZeroAddress,
@@ -90,10 +90,8 @@ async function main() {
     jobRouter,
   ]);
   await verify(feePool, [
-    ethers.ZeroAddress,
     stakeManager,
     2,
-    5,
     owner.address,
   ]);
   if (withTax) {


### PR DESCRIPTION
## Summary
- adjust StakeManager verify args to match constructor order and 18-decimal stake
- streamline FeePool verification arguments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b315d77914833392073d00eb53c236