### PR TITLE
feat: bump v2 module versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2
+- Bumped all `contracts/v2` module `version` constants to `2` and updated related checks and documentation.
+
 ## v1
 - Updated Solidity compiler to version 0.8.21 across contracts, configuration, and docs.
 - Updated dependencies: Node.js 22.x LTS, Hardhat 2.26.1, @nomicfoundation/hardhat-toolbox 6.1.0, and OpenZeppelin Contracts 5.4.0.

--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -15,7 +15,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract MockStakeManager is IStakeManager {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     mapping(address => mapping(Role => uint256)) private _stakes;
     mapping(Role => uint256) public totalStakes;
@@ -103,7 +103,7 @@ contract MockStakeManager is IStakeManager {
 }
 
 contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
     constructor() Ownable(msg.sender) {}
     mapping(uint256 => Job) private _jobs;
     uint256 public taxPolicyVersion;
@@ -419,7 +419,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
 
 contract MockReputationEngine is IReputationEngine {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     mapping(address => uint256) private _rep;
     mapping(address => bool) private _blacklist;

--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -17,7 +17,7 @@ contract CertificateNFT is ERC721, Ownable, ReentrancyGuard, ICertificateNFT {
     using SafeERC20 for IERC20;
 
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     /// @dev Emitted when a zero address is supplied where non-zero is required.
     error ZeroAddress();

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -50,7 +50,7 @@ interface ICertificateNFT {
 /// the owner‑controlled `TaxPolicy` reference.
 contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     error JobParametersUnset();
     error RewardOverflow();
@@ -240,31 +240,31 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         validatorRewardPct = DEFAULT_VALIDATOR_REWARD_PCT;
         emit ValidatorRewardPctUpdated(validatorRewardPct);
         if (address(_validation) != address(0)) {
-            require(_validation.version() == 1, "Invalid validation module");
+            require(_validation.version() == 2, "Invalid validation module");
             validationModule = _validation;
             emit ValidationModuleUpdated(address(_validation));
             emit ModuleUpdated("ValidationModule", address(_validation));
         }
         if (address(_stakeMgr) != address(0)) {
-            require(_stakeMgr.version() == 1, "Invalid stake manager");
+            require(_stakeMgr.version() == 2, "Invalid stake manager");
             stakeManager = _stakeMgr;
             emit StakeManagerUpdated(address(_stakeMgr));
             emit ModuleUpdated("StakeManager", address(_stakeMgr));
         }
         if (address(_reputation) != address(0)) {
-            require(_reputation.version() == 1, "Invalid reputation module");
+            require(_reputation.version() == 2, "Invalid reputation module");
             reputationEngine = _reputation;
             emit ReputationEngineUpdated(address(_reputation));
             emit ModuleUpdated("ReputationEngine", address(_reputation));
         }
         if (address(_dispute) != address(0)) {
-            require(_dispute.version() == 1, "Invalid dispute module");
+            require(_dispute.version() == 2, "Invalid dispute module");
             disputeModule = _dispute;
             emit DisputeModuleUpdated(address(_dispute));
             emit ModuleUpdated("DisputeModule", address(_dispute));
         }
         if (address(_certNFT) != address(0)) {
-            require(_certNFT.version() == 1, "Invalid certificate NFT");
+            require(_certNFT.version() == 2, "Invalid certificate NFT");
             certificateNFT = _certNFT;
             emit CertificateNFTUpdated(address(_certNFT));
             emit ModuleUpdated("CertificateNFT", address(_certNFT));
@@ -309,11 +309,11 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         require(address(_dispute) != address(0), "dispute");
         require(address(_certNFT) != address(0), "nft");
 
-        require(_validation.version() == 1, "Invalid validation module");
-        require(_stakeMgr.version() == 1, "Invalid stake manager");
-        require(_reputation.version() == 1, "Invalid reputation module");
-        require(_dispute.version() == 1, "Invalid dispute module");
-        require(_certNFT.version() == 1, "Invalid certificate NFT");
+        require(_validation.version() == 2, "Invalid validation module");
+        require(_stakeMgr.version() == 2, "Invalid stake manager");
+        require(_reputation.version() == 2, "Invalid reputation module");
+        require(_dispute.version() == 2, "Invalid dispute module");
+        require(_certNFT.version() == 2, "Invalid certificate NFT");
 
         validationModule = _validation;
         stakeManager = _stakeMgr;
@@ -356,7 +356,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     /// @param module Address of the new dispute module contract.
     function setDisputeModule(IDisputeModule module) external onlyGovernance {
         require(address(module) != address(0), "dispute");
-        require(module.version() == 1, "Invalid dispute module");
+        require(module.version() == 2, "Invalid dispute module");
         disputeModule = module;
         emit DisputeModuleUpdated(address(module));
         emit ModuleUpdated("DisputeModule", address(module));

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -12,7 +12,7 @@ import {IStakeManager} from "./interfaces/IStakeManager.sol";
 ///      owner ever custodies assets or incurs tax liabilities.
 contract ReputationEngine is Ownable, Pausable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     mapping(address => uint256) public reputation;
     mapping(address => bool) private blacklisted;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -28,7 +28,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     using SafeERC20 for IERC20;
 
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     /// @notice participant roles
     enum Role {
@@ -257,7 +257,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice set the dispute module authorized to manage dispute fees
     /// @param module module contract allowed to move dispute fees
     function setDisputeModule(address module) external onlyGovernance {
-        require(IDisputeModule(module).version() == 1, "Invalid dispute module");
+        require(IDisputeModule(module).version() == 2, "Invalid dispute module");
         disputeModule = module;
         emit DisputeModuleUpdated(module);
     }
@@ -265,7 +265,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice set the validation module used to source validator lists
     /// @param module ValidationModule contract address
     function setValidationModule(address module) external onlyGovernance {
-        require(IValidationModule(module).version() == 1, "Invalid validation module");
+        require(IValidationModule(module).version() == 2, "Invalid validation module");
         validationModule = IValidationModule(module);
         emit ValidationModuleUpdated(module);
     }
@@ -279,8 +279,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         onlyGovernance
     {
         require(_jobRegistry != address(0) && _disputeModule != address(0), "module");
-        require(IJobRegistry(_jobRegistry).version() == 1, "Invalid job registry");
-        require(IDisputeModule(_disputeModule).version() == 1, "Invalid dispute module");
+        require(IJobRegistry(_jobRegistry).version() == 2, "Invalid job registry");
+        require(IDisputeModule(_disputeModule).version() == 2, "Invalid dispute module");
         jobRegistry = _jobRegistry;
         disputeModule = _disputeModule;
         emit JobRegistryUpdated(_jobRegistry);

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -20,7 +20,7 @@ import {TaxAcknowledgement} from "./libraries/TaxAcknowledgement.sol";
 ///      participating validators and job parties bear tax obligations.
 contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pausable, ReentrancyGuard {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     IJobRegistry public jobRegistry;
     IStakeManager public stakeManager;

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -7,7 +7,7 @@ import {IFeePool} from "../interfaces/IFeePool.sol";
 
 /// @dev Stake manager mock that attempts to reenter ValidationModule calls.
 contract ReentrantStakeManager is IStakeManager {
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     mapping(address => mapping(Role => uint256)) private _stakes;
     mapping(Role => uint256) public totalStakes;

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -7,7 +7,7 @@ import {IJobRegistry} from "../interfaces/IJobRegistry.sol";
 /// @notice Simple validation module stub returning a preset outcome.
 contract ValidationStub is IValidationModule {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     bool public result;
     address public jobRegistry;

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -11,7 +11,7 @@ import {ICertificateNFT} from "../interfaces/ICertificateNFT.sol";
 ///      ether and rejects unsolicited transfers.
 contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     address public jobRegistry;
     mapping(uint256 => bytes32) public tokenHashes;

--- a/contracts/v2/modules/DiscoveryModule.sol
+++ b/contracts/v2/modules/DiscoveryModule.sol
@@ -9,7 +9,7 @@ import {IReputationEngine} from "../interfaces/IReputationEngine.sol";
 /// @notice Ranks registered platforms based on operator scores combining stake and reputation
 contract DiscoveryModule is Ownable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     IStakeManager public stakeManager;
     IReputationEngine public reputationEngine;

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -17,7 +17,7 @@ import {IValidationModule} from "../interfaces/IValidationModule.sol";
 ///      18 decimals (`1 token == 1e18` units).
 contract DisputeModule is Ownable, Pausable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     IJobRegistry public jobRegistry;
     IStakeManager public stakeManager;

--- a/contracts/v2/modules/ENSOwnershipVerifier.sol
+++ b/contracts/v2/modules/ENSOwnershipVerifier.sol
@@ -10,7 +10,7 @@ import {VerifyOwnership} from "./VerifyOwnership.sol";
 /// @notice Verifies ownership of ENS subdomains via Merkle proofs or on-chain lookups
 contract ENSOwnershipVerifier is Ownable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     IENS public ens;
     INameWrapper public nameWrapper;

--- a/contracts/v2/modules/IdentityLib.sol
+++ b/contracts/v2/modules/IdentityLib.sol
@@ -16,7 +16,7 @@ interface IResolver {
 /// @notice Module providing ENS ownership verification for agents and validators.
 contract IdentityLib is Ownable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     IENS public ens;
     INameWrapper public nameWrapper;

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -20,7 +20,7 @@ contract JobEscrow is Ownable {
     using SafeERC20 for IERC20;
 
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     enum State { None, Posted, Submitted, Accepted, Cancelled }
 

--- a/contracts/v2/modules/JobRouter.sol
+++ b/contracts/v2/modules/JobRouter.sol
@@ -9,7 +9,7 @@ import {IPlatformRegistry} from "../interfaces/IPlatformRegistry.sol";
 ///         Falls back to the deployer when no eligible operator exists.
 contract JobRouter is Ownable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     IPlatformRegistry public platformRegistry;
 

--- a/contracts/v2/modules/KlerosDisputeModule.sol
+++ b/contracts/v2/modules/KlerosDisputeModule.sol
@@ -10,7 +10,7 @@ import {IDisputeModule} from "../interfaces/IDisputeModule.sol";
 /// with the final ruling via {resolve}.
 contract KlerosDisputeModule is IDisputeModule {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     /// @notice Address with permission to update module settings.
     address public governance;

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -10,7 +10,7 @@ import {IValidationModule} from "../interfaces/IValidationModule.sol";
 /// @dev Intended for low-stakes jobs where external validation is unnecessary.
 contract NoValidationModule is IValidationModule, Ownable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     IJobRegistry public jobRegistry;
 

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -18,7 +18,7 @@ interface IValidationOracle {
 /// @dev Useful for specialised off-chain evaluation logic.
 contract OracleValidationModule is IValidationModule, Ownable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     IJobRegistry public jobRegistry;
     IValidationOracle public oracle;

--- a/contracts/v2/modules/ReputationEngine.sol
+++ b/contracts/v2/modules/ReputationEngine.sol
@@ -10,7 +10,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 ///      incur tax obligations.
 contract ReputationEngine is Ownable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     /// @notice participant roles
     enum Role {

--- a/contracts/v2/modules/RevenueDistributor.sol
+++ b/contracts/v2/modules/RevenueDistributor.sol
@@ -8,7 +8,7 @@ import {IStakeManager} from "../interfaces/IStakeManager.sol";
 /// @notice Splits incoming job fees among active operators based on stake.
 contract RevenueDistributor is Ownable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     IStakeManager public stakeManager;
     address public treasury;

--- a/contracts/v2/modules/RoutingModule.sol
+++ b/contracts/v2/modules/RoutingModule.sol
@@ -9,7 +9,7 @@ import {IReputationEngine} from "../interfaces/IReputationEngine.sol";
 /// @notice Selects platform operators for jobs weighted by stake and optional reputation.
 contract RoutingModule is Ownable {
     /// @notice Module version for compatibility checks.
-    uint256 public constant version = 1;
+    uint256 public constant version = 2;
 
     IStakeManager public stakeManager;
     IReputationEngine public reputationEngine;

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -1,6 +1,6 @@
 # AGIJobs v2 Module & Interface Reference
 
-This document condenses the production-scale architecture into standalone modules, each with a minimal interface and owner-only governance hooks. It is a companion to `docs/architecture-v2.md` and `docs/deployment-agialpha.md` and focuses on contract boundaries and Solidity structure tips.
+This document condenses the production-scale architecture into standalone modules, each with a minimal interface and owner-only governance hooks. It is a companion to `docs/architecture-v2.md` and `docs/deployment-agialpha.md` and focuses on contract boundaries and Solidity structure tips. All modules now expose `version()` returning **2** so other components can verify compatibility during upgrades.
 
 ## Module Graph
 ```mermaid

--- a/test/v2/JobRegistryModuleVersion.test.js
+++ b/test/v2/JobRegistryModuleVersion.test.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("JobRegistry module version checks", function () {
-  let owner, registry, v1, v2;
+  let owner, registry, good, bad;
 
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
@@ -25,8 +25,8 @@ describe("JobRegistry module version checks", function () {
     const Version = await ethers.getContractFactory(
       "contracts/v2/mocks/VersionMock.sol:VersionMock"
     );
-    v1 = await Version.deploy(1);
-    v2 = await Version.deploy(2);
+    good = await Version.deploy(2);
+    bad = await Version.deploy(3);
   });
 
   it("reverts for mismatched validation module", async function () {
@@ -34,11 +34,11 @@ describe("JobRegistry module version checks", function () {
       registry
         .connect(owner)
         .setModules(
-          await v2.getAddress(),
-          await v1.getAddress(),
-          await v1.getAddress(),
-          await v1.getAddress(),
-          await v1.getAddress(),
+          await bad.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
           ethers.ZeroAddress,
           []
         )
@@ -50,11 +50,11 @@ describe("JobRegistry module version checks", function () {
       registry
         .connect(owner)
         .setModules(
-          await v1.getAddress(),
-          await v2.getAddress(),
-          await v1.getAddress(),
-          await v1.getAddress(),
-          await v1.getAddress(),
+          await good.getAddress(),
+          await bad.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
           ethers.ZeroAddress,
           []
         )
@@ -66,11 +66,11 @@ describe("JobRegistry module version checks", function () {
       registry
         .connect(owner)
         .setModules(
-          await v1.getAddress(),
-          await v1.getAddress(),
-          await v2.getAddress(),
-          await v1.getAddress(),
-          await v1.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
+          await bad.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
           ethers.ZeroAddress,
           []
         )
@@ -82,11 +82,11 @@ describe("JobRegistry module version checks", function () {
       registry
         .connect(owner)
         .setModules(
-          await v1.getAddress(),
-          await v1.getAddress(),
-          await v1.getAddress(),
-          await v2.getAddress(),
-          await v1.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
+          await bad.getAddress(),
+          await good.getAddress(),
           ethers.ZeroAddress,
           []
         )
@@ -98,11 +98,11 @@ describe("JobRegistry module version checks", function () {
       registry
         .connect(owner)
         .setModules(
-          await v1.getAddress(),
-          await v1.getAddress(),
-          await v1.getAddress(),
-          await v1.getAddress(),
-          await v2.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
+          await good.getAddress(),
+          await bad.getAddress(),
           ethers.ZeroAddress,
           []
         )
@@ -113,14 +113,16 @@ describe("JobRegistry module version checks", function () {
     await registry
       .connect(owner)
       .setModules(
-        await v1.getAddress(),
-        await v1.getAddress(),
-        await v1.getAddress(),
-        await v1.getAddress(),
-        await v1.getAddress(),
+        await good.getAddress(),
+        await good.getAddress(),
+        await good.getAddress(),
+        await good.getAddress(),
+        await good.getAddress(),
         ethers.ZeroAddress,
         []
       );
-    expect(await registry.validationModule()).to.equal(await v1.getAddress());
+    expect(await registry.validationModule()).to.equal(
+      await good.getAddress()
+    );
   });
 });

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -163,7 +163,7 @@ describe("Module replacement", function () {
     const Version = await ethers.getContractFactory(
       "contracts/v2/mocks/VersionMock.sol:VersionMock"
     );
-    const bad = await Version.deploy(2);
+    const bad = await Version.deploy(3);
 
     await expect(
       registry.connect(owner).setDisputeModule(await bad.getAddress())


### PR DESCRIPTION
## Summary
- bump all `contracts/v2` module `version` constants to `2`
- adjust compatibility checks and tests for version `2`
- document major version in changelog and module reference

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b320c541408333bd12c426f61b886d