### PR TITLE
Move AGIALPHA token contract into test scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labour markets among autonomous agents. The **v2** release under `contracts/v2` is the only supported version. Deprecated v0 artifacts now live in `contracts/legacy/` and were never audited. For help migrating older deployments, see [docs/migration-guide.md](docs/migration-guide.md).
 
-All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes and dispute deposits with the token address fixed at deployment. The canonical address and decimals live in [`config/agialpha.json`](config/agialpha.json) and feed both Solidity and TypeScript consumers.
+All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes and dispute deposits with the token address fixed at deployment. The canonical token is deployed externally; this repository ships [`contracts/test/AGIALPHAToken.sol`](contracts/test/AGIALPHAToken.sol) for local testing only. Token address and decimal configuration live in [`config/agialpha.json`](config/agialpha.json) and feed both Solidity and TypeScript consumers.
 
 ### AGIALPHA configuration
 
@@ -44,7 +44,7 @@ Record each address during deployment. The defaults below assume the 18‑decima
 
 | Module | Owner‑only setters |
 | --- | --- |
-| [`AGIALPHAToken`](contracts/v2/AGIALPHAToken.sol) | `mint`, `burn` |
+| [`AGIALPHAToken`](contracts/test/AGIALPHAToken.sol) *(local testing only)* | `mint`, `burn` |
 | [`StakeManager`](contracts/v2/StakeManager.sol) | `setMinStake`, `setSlashingPercentages`, `setTreasury`, `setMaxStakePerAddress` |
 | [`JobRegistry`](contracts/v2/JobRegistry.sol) | `setModules`, `setFeePool`, `setTaxPolicy`, `setAgentRootNode`, `setAgentMerkleRoot` |
 | [`ValidationModule`](contracts/v2/ValidationModule.sol) | `setJobRegistry`, `setCommitWindow`, `setRevealWindow`, `setValidatorBounds`, `setApprovalThreshold`, `setIdentityRegistry` |
@@ -108,7 +108,7 @@ The contract owner can retune live systems from block‑explorer **Write** tabs:
 
 The v2 release decomposes the monolithic manager into single‑purpose modules. Each contract owns its state and can be replaced without touching the rest of the system. Deploy modules in the following order:
 
-1. [`AGIALPHAToken`](contracts/v2/AGIALPHAToken.sol)
+1. `$AGIALPHA` token – external mainnet contract (use [`contracts/test/AGIALPHAToken.sol`](contracts/test/AGIALPHAToken.sol) on local networks)
 2. [`StakeManager`](contracts/v2/StakeManager.sol)
 3. [`ReputationEngine`](contracts/v2/ReputationEngine.sol)
 4. [`IdentityRegistry`](contracts/v2/IdentityRegistry.sol)

--- a/contracts/test/AGIALPHAToken.sol
+++ b/contracts/test/AGIALPHAToken.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {AGIALPHA_DECIMALS} from "./Constants.sol";
+import {AGIALPHA_DECIMALS} from "../v2/Constants.sol";
 
 /// @title AGIALPHAToken
 /// @notice ERC20 token with 18 decimals used across AGI Jobs v2.

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,7 @@ contracts have already been deployed.  For full details see the individual
 contract pages under `docs/api/`.
 
 ## AGIALPHAToken
-ERC‑20 utility token used for payments and staking.
+ERC‑20 utility token used for payments and staking. The production `$AGIALPHA` token is deployed externally; [`AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) is a mock for local development.
 
 ```javascript
 const token = await ethers.getContractAt("AGIALPHAToken", tokenAddress);

--- a/docs/api/AGIALPHAToken.md
+++ b/docs/api/AGIALPHAToken.md
@@ -1,6 +1,6 @@
 # AGIALPHAToken API
 
-ERC‑20 token with 18 decimals used for payments and staking.
+ERC‑20 token with 18 decimals used for payments and staking. The live `$AGIALPHA` token is external; this contract resides at [`contracts/test/AGIALPHAToken.sol`](../../contracts/test/AGIALPHAToken.sol) for local testing.
 
 ## Functions
 - `decimals()` – returns fixed 18 decimal places.

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -1,6 +1,6 @@
 # Deployment Guide: AGIJobs v2 with $AGIALPHA
 
-This walkthrough shows a non‑technical owner how to deploy and wire the modular v2 contracts using the 18‑decimal **$AGIALPHA** token. By default this token handles all payments, staking, rewards, and dispute deposits. All steps can be executed from a browser via [Etherscan](https://etherscan.io) or any compatible block explorer. For screenshot‑driven instructions, see [etherscan-guide.md](etherscan-guide.md).
+This walkthrough shows a non‑technical owner how to deploy and wire the modular v2 contracts using the 18‑decimal **$AGIALPHA** token. The canonical token is deployed separately on mainnet; this repository includes [`contracts/test/AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) solely for local testing. By default $AGIALPHA handles all payments, staking, rewards, and dispute deposits. All steps can be executed from a browser via [Etherscan](https://etherscan.io) or any compatible block explorer. For screenshot‑driven instructions, see [etherscan-guide.md](etherscan-guide.md).
 
 ## 1. Prerequisites
 
@@ -16,7 +16,7 @@ This walkthrough shows a non‑technical owner how to deploy and wire the modula
 
 Deploy each contract **in the order listed below** from the **Write Contract** tabs (the deployer automatically becomes the owner). Addresses for dependent modules may be passed at deployment or left as `0` and wired later. Parameters may be left as `0` to accept the defaults shown below:
 
-1. `AGIALPHAToken()` – after deployment, call `mint(to, amount)` to create the initial supply.
+1. Use the existing `$AGIALPHA` token. Deploy [`AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) only on local networks and call `mint(to, amount)` to create a test supply.
 2. `StakeManager(token, minStake, employerPct, treasuryPct, treasury)` – pass `address(0)` for `token` to use the default $AGIALPHA and `0,0` for the slashing percentages to send 100% of any slash to the treasury.
 3. `JobRegistry(validation, stakeMgr, reputation, dispute, certNFT, feePool, taxPolicy, feePct, jobStake)` – leaving `feePct = 0` applies a 5% protocol fee. Supplying a nonzero `taxPolicy` sets the disclaimer at deployment; otherwise the owner may call `setTaxPolicy` later.
 4. `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators, validatorPool)` – zero values default to 1‑day windows and a 1–3 validator set.

--- a/docs/deployment-v2-agialpha.md
+++ b/docs/deployment-v2-agialpha.md
@@ -1,6 +1,6 @@
 # Deployment Guide: AGIJobs v2 with $AGIALPHA
 
-This guide shows how to deploy the modular v2 contracts using the helper script at `scripts/v2/deployDefaults.ts`. The script spins up the full stack with the 18‑decimal **$AGIALPHA** token and wires modules automatically.
+This guide shows how to deploy the modular v2 contracts using the helper script at `scripts/v2/deployDefaults.ts`. The script spins up the full stack assuming the 18‑decimal **$AGIALPHA** token already exists. For local networks without the canonical token, deploy [`contracts/test/AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) and supply its address to the script.
 
 ## 1. Run the deployment script
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -13,7 +13,7 @@ All legacy AGIJobManager contracts have been moved to the `legacy/` directory. T
 | `DisputeModule.sol`, `DisputeResolution.sol` | `contracts/v2/modules/DisputeModule.sol` |
 | `ReputationEngine.sol` | `contracts/v2/ReputationEngine.sol` |
 | `CertificateNFT.sol` | `contracts/v2/CertificateNFT.sol` |
-| `AGIALPHAToken.sol` | `contracts/v2/AGIALPHAToken.sol` |
+| `AGIALPHAToken.sol` | `contracts/test/AGIALPHAToken.sol` (local testing only) |
 
 For function‑level differences see:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -2,7 +2,9 @@
 
 This guide demonstrates the basic lifecycle of a job on AGIJobs using
 `ethers.js` scripts.  The examples assume the core contracts are already
-deployed and that you have the contract addresses available.
+deployed and that you have the contract addresses available. The `$AGIALPHA`
+token itself is external; the repository's [`AGIALPHAToken`](../contracts/test/AGIALPHAToken.sol)
+contract is provided only for local testing.
 
 ## 1. Post a Job
 Employers escrow the reward and publish job metadata.

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -13,7 +13,7 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 
 ## Core Modules
 
-- **AGIALPHAToken** – 18‑decimal ERC‑20 used for staking, rewards and dispute bonds. Owner can mint or burn but cannot swap the token used across the system.
+- **AGIALPHAToken** – 18‑decimal ERC‑20 used for staking, rewards and dispute bonds. The production `$AGIALPHA` token lives outside this repository; [`AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) is provided only for local testing.
 - **StakeManager** – records stakes for all roles, escrows job funds and routes protocol fees to the `FeePool`. Owner setters allow changing the minimum stake, slashing percentages and treasury.
 - **PlatformRegistry** – lists operators and computes a routing score derived from stake and reputation. The owner can blacklist addresses or replace the reputation engine.
 - **JobRouter** – selects an operator for new jobs using `PlatformRegistry` scores. Deterministic randomness mixes caller‑supplied seeds with blockhashes; no external oracle is required.

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -18,7 +18,7 @@ resolver, emitting `OwnershipVerified` on success.
 ## Module Responsibilities & Addresses
 | Module | Responsibility | Address |
 | --- | --- | --- |
-| `$AGIALPHA` Token | 18‑decimal ERC‑20 used for payments and staking | `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA` |
+| `$AGIALPHA` Token | 18‑decimal ERC‑20 used for payments and staking (external mainnet contract) | `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA` |
 | StakeManager | Custodies stakes, escrows rewards, slashes misbehaviour | `TBD` |
 | ReputationEngine | Tracks reputation scores and blacklist status | `TBD` |
 | IdentityRegistry | Verifies ENS subdomains and Merkle allowlists | `TBD` |
@@ -50,7 +50,7 @@ To customise the token, protocol fees or ENS roots edit the script to call
 The script prints module addresses and verifies source on Etherscan.
 
 ## Step-by-Step Deployment
-1. **Deploy `$AGIALPHAToken`** (18 decimals) if it does not already exist.
+1. **Ensure `$AGIALPHA` token exists** – use the external address above or deploy [`contracts/test/AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) on local networks for testing.
 2. **Deploy `StakeManager`** pointing at the token and configuring `_minStake`, `_employerSlashPct`, `_treasurySlashPct` and `_treasury`. Leave `_jobRegistry` and `_disputeModule` as `0`.
 3. **Deploy `ReputationEngine`** passing the `StakeManager` address.
 4. **Deploy `IdentityRegistry`** with the ENS registry, NameWrapper, `ReputationEngine` address and the namehashes for `agent.agi.eth` and `club.agi.eth`.

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -10,7 +10,7 @@ describe("StakeManager AGIType bonuses", function () {
     [owner, employer, agent] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -9,7 +9,7 @@ describe("CertificateNFT marketplace", function () {
     [owner, seller, buyer] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(buyer.address, price);
     await token.mint(seller.address, price);
     await token.mint(owner.address, price);

--- a/test/v2/DisputeModule.test.js
+++ b/test/v2/DisputeModule.test.js
@@ -88,7 +88,7 @@ describe("DisputeModule", function () {
 
       // deploy token and stake manager
       const { AGIALPHA } = require("../../scripts/constants");
-      token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+      token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
       const StakeManager = await ethers.getContractFactory(
         "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -7,7 +7,7 @@ describe("FeePool", function () {
   const { AGIALPHA } = require("../../scripts/constants");
   beforeEach(async () => {
     [owner, user1, user2, employer, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -11,7 +11,7 @@ describe("JobRegistry governance finalization", function () {
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -10,7 +10,7 @@ describe("Governance reward lifecycle", function () {
   beforeEach(async () => {
     [owner, voter1, voter2, voter3, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -10,7 +10,7 @@ describe("GovernanceReward", function () {
   beforeEach(async () => {
     [owner, voter1, voter2, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/GovernanceTimelock.test.js
+++ b/test/v2/GovernanceTimelock.test.js
@@ -16,7 +16,7 @@ describe("Governance via Timelock", function () {
     await timelock.grantRole(executorRole, admin.address);
 
     const { AGIALPHA } = require("../../scripts/constants");
-    const token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    const token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(admin.address, 1000);
 
     const Stake = await ethers.getContractFactory(

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -10,7 +10,7 @@ describe("JobEscrow", function () {
     [owner, employer, operator] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(employer.address, 1000000);
 
     // Mock RoutingModule that always returns operator

--- a/test/v2/JobEscrowNoEther.test.js
+++ b/test/v2/JobEscrowNoEther.test.js
@@ -8,7 +8,7 @@ describe("JobEscrow ether rejection", function () {
   beforeEach(async () => {
     [owner, employer, operator] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(employer.address, 1000);
 
     const Routing = await ethers.getContractFactory(

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -11,7 +11,7 @@ describe("Job expiration", function () {
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -11,7 +11,7 @@ describe("Job expiration boundary", function () {
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -13,7 +13,7 @@ describe("JobRegistry integration", function () {
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );

--- a/test/v2/JobRegistryTreasury.test.js
+++ b/test/v2/JobRegistryTreasury.test.js
@@ -9,7 +9,7 @@ describe("JobRegistry Treasury", function () {
   beforeEach(async function () {
     [owner, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
 
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -8,7 +8,7 @@ async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
 
   const { AGIALPHA } = require("../../scripts/constants");
-  const token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+  const token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
   await token.mint(employer.address, ethers.parseUnits("1000", 18));
   await token.mint(agent.address, ethers.parseUnits("1000", 18));
   await token.mint(owner.address, ethers.parseUnits("1000", 18));

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -8,7 +8,7 @@ async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
 
   const { AGIALPHA } = require("../../scripts/constants");
-  const token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+  const token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
   await token.mint(employer.address, ethers.parseUnits("1000", 18));
   await token.mint(agent.address, ethers.parseUnits("1000", 18));
   await token.mint(owner.address, ethers.parseUnits("1000", 18));

--- a/test/v2/PlatformIncentives.t.sol
+++ b/test/v2/PlatformIncentives.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {Test} from "forge-std/Test.sol";
-import {AGIALPHAToken} from "../../contracts/v2/AGIALPHAToken.sol";
+import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
 import {StakeManager} from "../../contracts/v2/StakeManager.sol";
 import {PlatformRegistry} from "../../contracts/v2/PlatformRegistry.sol";
 import {JobRouter} from "../../contracts/v2/modules/JobRouter.sol";

--- a/test/v2/PlatformIncentivesAck.test.js
+++ b/test/v2/PlatformIncentivesAck.test.js
@@ -6,7 +6,7 @@ describe("PlatformIncentives acknowledge", function () {
     const [owner, operator, treasury] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    const token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    const token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(owner.address, 1000);
     await token.mint(operator.address, 1000);
 

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -11,7 +11,7 @@ describe("PlatformRegistry", function () {
     [owner, platform, sybil, treasury] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(platform.address, STAKE);
     await token.mint(owner.address, STAKE);
 

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -15,7 +15,7 @@ describe("Platform reward flow", function () {
   beforeEach(async () => {
     [owner, alice, bob, employer, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(alice.address, 1000n * TOKEN);
     await token.mint(bob.address, 1000n * TOKEN);
     await token.mint(employer.address, 1000n * TOKEN);

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -8,7 +8,7 @@ describe("StakeManager", function () {
 
   beforeEach(async () => {
     [owner, user, employer, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(owner.address, 1000);
     await token.mint(user.address, 1000);
     await token.mint(employer.address, 1000);

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -10,7 +10,7 @@ describe("StakeManager extras", function () {
   beforeEach(async () => {
     [owner, user, treasury] = await ethers.getSigners();
     token = await ethers.getContractAt(
-      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken",
+      "contracts/test/AGIALPHAToken.sol:AGIALPHAToken",
       AGIALPHA
     );
     await token.mint(user.address, ethers.parseEther("1000"));

--- a/test/v2/StakeManagerFuzz.t.sol
+++ b/test/v2/StakeManagerFuzz.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
 import {StakeManager} from "../../contracts/v2/StakeManager.sol";
-import {AGIALPHAToken} from "../../contracts/v2/AGIALPHAToken.sol";
+import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract StakeManagerFuzz is Test {

--- a/test/v2/StakeManagerNoEther.test.js
+++ b/test/v2/StakeManagerNoEther.test.js
@@ -7,7 +7,7 @@ describe("StakeManager ether rejection", function () {
 
   beforeEach(async () => {
     [owner] = await ethers.getSigners();
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );

--- a/test/v2/StakeManagerPause.test.js
+++ b/test/v2/StakeManagerPause.test.js
@@ -8,7 +8,7 @@ describe("StakeManager pause", function () {
   beforeEach(async () => {
     [owner, user] = await ethers.getSigners();
     token = await ethers.getContractAt(
-      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken",
+      "contracts/test/AGIALPHAToken.sol:AGIALPHAToken",
       AGIALPHA
     );
     const MockRegistry = await ethers.getContractFactory(

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -8,7 +8,7 @@ describe("StakeManager release", function () {
     [owner, user1, user2, treasury] = await ethers.getSigners();
     const { AGIALPHA } = require("../../scripts/constants");
     token = await ethers.getContractAt(
-      "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken",
+      "contracts/test/AGIALPHAToken.sol:AGIALPHAToken",
       AGIALPHA
     );
 

--- a/test/v2/StakeManagerSlashing.test.js
+++ b/test/v2/StakeManagerSlashing.test.js
@@ -7,7 +7,7 @@ describe("StakeManager slashing configuration", function () {
 
   beforeEach(async () => {
     [owner, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );

--- a/test/v2/ValidationSlashingFuzz.t.sol
+++ b/test/v2/ValidationSlashingFuzz.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import {ValidationModule} from "../../contracts/v2/ValidationModule.sol";
 import {StakeManager} from "../../contracts/v2/StakeManager.sol";
 import {IdentityRegistryToggle} from "../../contracts/v2/mocks/IdentityRegistryToggle.sol";
-import {AGIALPHAToken} from "../../contracts/v2/AGIALPHAToken.sol";
+import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
 import {IJobRegistry} from "../../contracts/v2/interfaces/IJobRegistry.sol";
 import {IStakeManager} from "../../contracts/v2/interfaces/IStakeManager.sol";
 import {IIdentityRegistry} from "../../contracts/v2/interfaces/IIdentityRegistry.sol";

--- a/test/v2/ValidatorSelectionFuzz.t.sol
+++ b/test/v2/ValidatorSelectionFuzz.t.sol
@@ -8,7 +8,7 @@ import {IdentityRegistryToggle} from "../../contracts/v2/mocks/IdentityRegistryT
 import {IJobRegistry} from "../../contracts/v2/interfaces/IJobRegistry.sol";
 import {IStakeManager} from "../../contracts/v2/interfaces/IStakeManager.sol";
 import {IIdentityRegistry} from "../../contracts/v2/interfaces/IIdentityRegistry.sol";
-import {AGIALPHAToken} from "../../contracts/v2/AGIALPHAToken.sol";
+import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract ValidatorSelectionFuzz is Test {

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -15,7 +15,7 @@ describe("comprehensive job flows", function () {
     [owner, employer, agent, platform, buyer] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const mintAmount = ethers.parseUnits("10000", 18);
     await token.mint(employer.address, mintAmount);
     await token.mint(agent.address, mintAmount);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -15,7 +15,7 @@ describe("end-to-end job lifecycle", function () {
     [owner, employer, agent, platform] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const mintAmount = ethers.parseUnits("10000", 18);
     await token.mint(owner.address, mintAmount);
     await token.mint(employer.address, mintAmount);

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -13,7 +13,7 @@ async function deploySystem() {
     await ethers.getSigners();
 
   const Token = await ethers.getContractFactory(
-    "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    "contracts/test/AGIALPHAToken.sol:AGIALPHAToken"
   );
   const token = await Token.deploy();
   const mint = ethers.parseUnits("1000", 18);

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -15,7 +15,7 @@ describe("job finalization integration", function () {
     [owner, employer, agent, validator1, validator2] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(owner.address, mintAmount);
     await token.mint(employer.address, mintAmount);
     await token.mint(agent.address, mintAmount);

--- a/test/v2/jobLifecycle.test.ts
+++ b/test/v2/jobLifecycle.test.ts
@@ -11,7 +11,7 @@ enum Role {
 async function deploySystem() {
   const [owner, employer, agent, validator, buyer, moderator] = await ethers.getSigners();
 
-  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
+  const Token = await ethers.getContractFactory("contracts/test/AGIALPHAToken.sol:AGIALPHAToken");
   const token = await Token.deploy();
   await token.mint(employer.address, ethers.parseUnits("1000", 18));
   await token.mint(agent.address, ethers.parseUnits("1000", 18));

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -11,7 +11,7 @@ enum Role {
 async function deployFullSystem() {
   const [owner, employer, agent, v1, v2, moderator] = await ethers.getSigners();
 
-  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
+  const Token = await ethers.getContractFactory("contracts/test/AGIALPHAToken.sol:AGIALPHAToken");
   const token = await Token.deploy();
   const mint = ethers.parseUnits("1000", 18);
   await token.mint(employer.address, mint);

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -13,7 +13,7 @@ async function deploySystem() {
     await ethers.getSigners();
 
   const Token = await ethers.getContractFactory(
-    "contracts/v2/AGIALPHAToken.sol:AGIALPHAToken"
+    "contracts/test/AGIALPHAToken.sol:AGIALPHAToken"
   );
   const token = await Token.deploy();
   const mint = ethers.parseUnits("1000", 18);

--- a/test/v2/midJobReplacementFuzz.test.js
+++ b/test/v2/midJobReplacementFuzz.test.js
@@ -5,7 +5,7 @@ const { time } = require("@nomicfoundation/hardhat-network-helpers");
 async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
   const { AGIALPHA } = require("../../scripts/constants");
-  const token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+  const token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
   await token.mint(employer.address, ethers.parseUnits("1000", 18));
   await token.mint(agent.address, ethers.parseUnits("1000", 18));
   await token.mint(owner.address, ethers.parseUnits("1000", 18));

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -16,7 +16,7 @@ describe("multi-operator job lifecycle", function () {
     [owner, employer, agent, platform1, platform2] = await ethers.getSigners();
 
     const { AGIALPHA } = require("../../scripts/constants");
-    token = await ethers.getContractAt("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
+    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     const mintAmount = ethers.parseUnits("10000", 18);
     await token.mint(owner.address, mintAmount);
     await token.mint(employer.address, mintAmount);

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -11,7 +11,7 @@ enum Role {
 async function deploySystem() {
   const [owner, employer, agent, v1, moderator] = await ethers.getSigners();
 
-  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
+  const Token = await ethers.getContractFactory("contracts/test/AGIALPHAToken.sol:AGIALPHAToken");
   const token = await Token.deploy();
   const mint = ethers.parseUnits("1000", 18);
   for (const s of [employer, agent, v1]) {

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -11,7 +11,7 @@ enum Role {
 async function deployFullSystem() {
   const [owner, employer, agent, v1, v2, moderator] = await ethers.getSigners();
 
-  const Token = await ethers.getContractFactory("contracts/v2/AGIALPHAToken.sol:AGIALPHAToken");
+  const Token = await ethers.getContractFactory("contracts/test/AGIALPHAToken.sol:AGIALPHAToken");
   const token = await Token.deploy();
   const mint = ethers.parseUnits("1000", 18);
   await token.mint(employer.address, mint);


### PR DESCRIPTION
## Summary
- move AGIALPHAToken.sol into contracts/test and update imports
- document that the mainnet AGIALPHA token is external and the repo's contract is for local testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b32c7f348c83339708cb08d7a5d61f