### PR TITLE
refactor: centralize token scale constant

### DIFF
--- a/contracts/v2/Constants.sol
+++ b/contracts/v2/Constants.sol
@@ -8,3 +8,6 @@ address constant AGIALPHA = 0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA;
 
 // Standard decimals for $AGIALPHA.
 uint8 constant AGIALPHA_DECIMALS = 18;
+
+// Scaling factor for token amounts.
+uint256 constant TOKEN_SCALE = 10 ** AGIALPHA_DECIMALS;

--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -32,6 +32,7 @@ import {INameWrapper} from "./interfaces/INameWrapper.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IValidationModule} from "./interfaces/IValidationModule.sol";
 import {IReputationEngine as IRInterface} from "./interfaces/IReputationEngine.sol";
+import {TOKEN_SCALE} from "./Constants.sol";
 
 /// @title Deployer
 /// @notice One shot helper that deploys and wires the core module set.
@@ -44,7 +45,7 @@ contract Deployer is Ownable {
 
     /// @notice Economic configuration applied during deployment.
     /// @dev Zero values use each module's baked-in default such as a 5% fee,
-    ///      5% burn, 1-day commit/reveal windows and a 1e18 minimum stake.
+    ///      5% burn, 1-day commit/reveal windows and a TOKEN_SCALE minimum stake.
     struct EconParams {
         uint256 feePct; // protocol fee percentage for JobRegistry
         uint256 burnPct; // portion of fees burned by FeePool
@@ -156,7 +157,7 @@ contract Deployer is Ownable {
     }
 
     /// @notice Deploy and wire all modules using module defaults.
-    /// @dev Mirrors module constants: 5% fee, 5% burn and a 1e18 minimum stake.
+    /// @dev Mirrors module constants: 5% fee, 5% burn and a TOKEN_SCALE minimum stake.
     /// @return stakeManager Address of the StakeManager
     /// @return jobRegistry Address of the JobRegistry
     /// @return validationModule Address of the ValidationModule
@@ -192,7 +193,7 @@ contract Deployer is Ownable {
     }
 
     /// @notice Deploy and wire modules with defaults and no TaxPolicy.
-    /// @dev Mirrors module constants: 5% fee, 5% burn and a 1e18 minimum stake.
+    /// @dev Mirrors module constants: 5% fee, 5% burn and a TOKEN_SCALE minimum stake.
     /// @return stakeManager Address of the StakeManager
     /// @return jobRegistry Address of the JobRegistry
     /// @return validationModule Address of the ValidationModule
@@ -255,7 +256,7 @@ contract Deployer is Ownable {
             econ.commitWindow == 0 ? 1 days : econ.commitWindow;
         uint256 revealWindow =
             econ.revealWindow == 0 ? 1 days : econ.revealWindow;
-        uint256 minStake = econ.minStake == 0 ? 1e18 : econ.minStake;
+        uint256 minStake = econ.minStake == 0 ? TOKEN_SCALE : econ.minStake;
         uint256 employerSlashPct = econ.employerSlashPct;
         uint256 treasurySlashPct = econ.treasurySlashPct;
         if (employerSlashPct + treasurySlashPct == 0) {

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -10,6 +10,7 @@ import {IValidationModule} from "./interfaces/IValidationModule.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
 import {IIdentityRegistry} from "./interfaces/IIdentityRegistry.sol";
+import {TOKEN_SCALE} from "./Constants.sol";
 
 interface IReputationEngine {
     function version() external view returns (uint256);
@@ -126,7 +127,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
 
     // default agent stake requirement configured by owner
     uint96 public jobStake;
-    uint96 public constant DEFAULT_JOB_STAKE = 1e18;
+    uint96 public constant DEFAULT_JOB_STAKE = uint96(TOKEN_SCALE);
     uint256 public feePct;
     uint256 public constant DEFAULT_FEE_PCT = 5;
     uint256 public maxJobReward;

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -6,6 +6,7 @@ import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IJobRegistryAck} from "./interfaces/IJobRegistryAck.sol";
+import {TOKEN_SCALE} from "./Constants.sol";
 
 interface IReputationEngine {
     function reputation(address user) external view returns (uint256);
@@ -20,7 +21,7 @@ interface IReputationEngine {
 /// @dev Holds no tokens and rejects ether to remain tax neutral. All values
 ///      use 18 decimals via the `StakeManager`.
 contract PlatformRegistry is Ownable, ReentrancyGuard, Pausable {
-    uint256 public constant DEFAULT_MIN_PLATFORM_STAKE = 1e18;
+    uint256 public constant DEFAULT_MIN_PLATFORM_STAKE = TOKEN_SCALE;
 
     IStakeManager public stakeManager;
     IReputationEngine public reputationEngine;
@@ -238,7 +239,7 @@ contract PlatformRegistry is Ownable, ReentrancyGuard, Pausable {
         uint256 rep = reputationEngine.reputation(operator);
         uint256 stakeW = reputationEngine.stakeWeight();
         uint256 repW = reputationEngine.reputationWeight();
-        return ((stake * stakeW) + (rep * repW)) / 1e18;
+        return ((stake * stakeW) + (rep * repW)) / TOKEN_SCALE;
     }
 
     // ---------------------------------------------------------------

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -7,7 +7,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
-import {AGIALPHA} from "./Constants.sol";
+import {AGIALPHA, TOKEN_SCALE} from "./Constants.sol";
 import {IJobRegistryTax} from "./interfaces/IJobRegistryTax.sol";
 import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 import {TaxAcknowledgement} from "./libraries/TaxAcknowledgement.sol";
@@ -23,7 +23,7 @@ import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 ///      contract nor the owner ever custodies funds that could create tax
 ///      liabilities. All taxes remain the responsibility of employers, agents
 ///      and validators. All token amounts use 18 decimals where one token is
-///      represented by `1e18` base units.
+///      represented by `TOKEN_SCALE` base units.
 contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausable {
     using SafeERC20 for IERC20;
 
@@ -38,7 +38,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     }
 
     /// @notice default minimum stake when constructor param is zero
-    uint256 public constant DEFAULT_MIN_STAKE = 1e18;
+    uint256 public constant DEFAULT_MIN_STAKE = TOKEN_SCALE;
 
     /// @notice canonical burn address
     address public constant BURN_ADDRESS =

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -90,8 +90,8 @@ interface IReputationEngine {
     function setStakeManager(address manager) external;
 
     /// @notice Update weighting factors for stake and reputation contributions
-    /// @param stakeWeight Weight applied to stake (scaled by 1e18)
-    /// @param reputationWeight Weight applied to reputation (scaled by 1e18)
+    /// @param stakeWeight Weight applied to stake (scaled by TOKEN_SCALE)
+    /// @param reputationWeight Weight applied to reputation (scaled by TOKEN_SCALE)
     function setScoringWeights(uint256 stakeWeight, uint256 reputationWeight) external;
 }
 

--- a/contracts/v2/modules/DiscoveryModule.sol
+++ b/contracts/v2/modules/DiscoveryModule.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IStakeManager} from "../interfaces/IStakeManager.sol";
 import {IReputationEngine} from "../interfaces/IReputationEngine.sol";
+import {TOKEN_SCALE} from "../Constants.sol";
 
 /// @title DiscoveryModule
 /// @notice Ranks registered platforms based on operator scores combining stake and reputation
@@ -14,7 +15,7 @@ contract DiscoveryModule is Ownable {
     IStakeManager public stakeManager;
     IReputationEngine public reputationEngine;
 
-    uint256 public constant DEFAULT_MIN_STAKE = 1e18;
+    uint256 public constant DEFAULT_MIN_STAKE = TOKEN_SCALE;
 
     uint256 public minStake;
 

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -8,13 +8,14 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 import {IJobRegistry} from "../interfaces/IJobRegistry.sol";
 import {IStakeManager} from "../interfaces/IStakeManager.sol";
 import {IValidationModule} from "../interfaces/IValidationModule.sol";
+import {TOKEN_SCALE} from "../Constants.sol";
 
 /// @title DisputeModule
 /// @notice Allows job participants to raise disputes and resolves them after a
 /// dispute window.
 /// @dev Maintains tax neutrality by rejecting ether and escrowing only token
 ///      based dispute fees via the StakeManager. Assumes all token amounts use
-///      18 decimals (`1 token == 1e18` units).
+///      18 decimals (`1 token == TOKEN_SCALE` units).
 contract DisputeModule is Ownable, Pausable {
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 2;
@@ -24,7 +25,7 @@ contract DisputeModule is Ownable, Pausable {
 
     /// @notice Default dispute fee charged when raising a dispute.
     /// @dev Expressed in token units with 18 decimals; equal to 1 token.
-    uint256 public constant DEFAULT_DISPUTE_FEE = 1e18;
+    uint256 public constant DEFAULT_DISPUTE_FEE = TOKEN_SCALE;
 
     /// @notice Fee required to initiate a dispute, in token units (18 decimals).
     /// @dev Defaults to `DEFAULT_DISPUTE_FEE` if zero is provided to the constructor.
@@ -69,7 +70,7 @@ contract DisputeModule is Ownable, Pausable {
     event ModulesUpdated(address indexed jobRegistry, address indexed stakeManager);
 
     /// @param _jobRegistry Address of the JobRegistry contract.
-    /// @param _disputeFee Initial dispute fee in token units (18 decimals); defaults to 1e18.
+    /// @param _disputeFee Initial dispute fee in token units (18 decimals); defaults to TOKEN_SCALE.
     /// @param _disputeWindow Minimum time in seconds before resolution; defaults to 1 day.
     /// @param _moderator Optional moderator address; defaults to the deployer.
     constructor(

--- a/contracts/v2/modules/JobRouter.sol
+++ b/contracts/v2/modules/JobRouter.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IPlatformRegistry} from "../interfaces/IPlatformRegistry.sol";
+import {TOKEN_SCALE} from "../Constants.sol";
 
 /// @title JobRouter
 /// @notice Routes jobs to registered platform operators based on stake and reputation scores.
@@ -89,7 +90,7 @@ contract JobRouter is Ownable {
     }
 
     /// @notice Compute routing weight for an operator as a fraction of total score.
-    /// @dev Returned value is scaled by 1e18 for precision.
+    /// @dev Returned value is scaled by TOKEN_SCALE for precision.
     function routingWeight(address operator) public view returns (uint256) {
         if (!registered[operator] || !platformRegistry.registered(operator)) return 0;
         uint256 score = platformRegistry.getScore(operator);
@@ -104,7 +105,7 @@ contract JobRouter is Ownable {
             total += s;
         }
         if (total == 0) return 0;
-        return (score * 1e18) / total;
+        return (score * TOKEN_SCALE) / total;
     }
 
     /// @notice Select a platform using blockhash/seed based randomness weighted by score.

--- a/contracts/v2/modules/ReputationEngine.sol
+++ b/contracts/v2/modules/ReputationEngine.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {TOKEN_SCALE} from "../Constants.sol";
 
 /// @title ReputationEngine (module)
 /// @notice Tracks reputation for agents and validators with premium gating
@@ -160,7 +161,7 @@ contract ReputationEngine is Ownable {
 
     /// @notice Compute reputation gain based on payout and duration.
     function calculateReputationPoints(uint256 payout, uint256 duration) public pure returns (uint256) {
-        uint256 scaledPayout = payout / 1e18;
+        uint256 scaledPayout = payout / TOKEN_SCALE;
         uint256 payoutPoints = (scaledPayout ** 3) / 1e5;
         return log2(1 + payoutPoints * 1e6) + duration / 10000;
     }
@@ -198,10 +199,10 @@ contract ReputationEngine is Ownable {
     /// @notice Apply diminishing returns and cap to reputation growth using v1 formula.
     function _enforceReputationGrowth(uint256 current, uint256 points) internal pure returns (uint256) {
         uint256 newReputation = current + points;
-        uint256 numerator = newReputation * newReputation * 1e18;
+        uint256 numerator = newReputation * newReputation * TOKEN_SCALE;
         uint256 denominator = maxReputation * maxReputation;
-        uint256 factor = 1e18 + (numerator / denominator);
-        uint256 diminishedReputation = (newReputation * 1e18) / factor;
+        uint256 factor = TOKEN_SCALE + (numerator / denominator);
+        uint256 diminishedReputation = (newReputation * TOKEN_SCALE) / factor;
         if (diminishedReputation > maxReputation) {
             return maxReputation;
         }


### PR DESCRIPTION
## Summary
- introduce shared TOKEN_SCALE constant derived from AGIALPHA_DECIMALS
- replace hard-coded 1e18 with TOKEN_SCALE across v2 contracts

## Testing
- `npm test`
- `forge test` *(fails: invalid argument types in StakeManager constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68b360be9f688333b8ef1818a74e9a0c