### PR TITLE
feat: use configurable token decimals

### DIFF
--- a/apps/validator-ui/README.md
+++ b/apps/validator-ui/README.md
@@ -2,7 +2,7 @@
 
 A minimal Next.js interface for validators to view pending jobs, commit votes, and automatically reveal them.
 
-Job amounts are formatted with `ethers.formatUnits(..., 18)` when displayed.
+Job amounts are formatted with `ethers.formatUnits(..., decimals)` where `decimals` comes from the `NEXT_PUBLIC_AGIALPHA_DECIMALS` environment variable or defaults to the value in `config/agialpha.json`.
 
 ## Setup
 
@@ -16,6 +16,7 @@ Create a `.env.local` file with:
 NEXT_PUBLIC_GATEWAY_URL=http://localhost:3000
 NEXT_PUBLIC_VALIDATION_MODULE_ADDRESS=0xYourValidationModule
 NEXT_PUBLIC_REVEAL_DELAY_MS=5000
+NEXT_PUBLIC_AGIALPHA_DECIMALS=18
 ```
 
 ## Running

--- a/apps/validator-ui/pages/index.tsx
+++ b/apps/validator-ui/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { ethers } from 'ethers';
 import { generateCommit, scheduleReveal } from '../lib/commit';
+import agiConfig from '../../../config/agialpha.json';
 
 interface Job {
   jobId: string;
@@ -10,6 +11,10 @@ interface Job {
   stake: string;
   fee: string;
 }
+
+const DECIMALS = Number(
+  process.env.NEXT_PUBLIC_AGIALPHA_DECIMALS ?? agiConfig.decimals
+);
 
 export default function Home() {
   const [jobs, setJobs] = useState<Job[]>([]);
@@ -23,9 +28,9 @@ export default function Home() {
         setJobs(
           data.map((job: any) => ({
             ...job,
-            reward: ethers.formatUnits(job.rewardRaw ?? job.reward, 18),
-            stake: ethers.formatUnits(job.stakeRaw ?? job.stake, 18),
-            fee: ethers.formatUnits(job.feeRaw ?? job.fee, 18)
+            reward: ethers.formatUnits(job.rewardRaw ?? job.reward, DECIMALS),
+            stake: ethers.formatUnits(job.stakeRaw ?? job.stake, DECIMALS),
+            fee: ethers.formatUnits(job.feeRaw ?? job.fee, DECIMALS)
           }))
         )
       )


### PR DESCRIPTION
## Summary
- import token decimals from `NEXT_PUBLIC_AGIALPHA_DECIMALS` or `config/agialpha.json`
- document decimals configuration in validator UI README

## Testing
- `npm run build --prefix apps/validator-ui`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b36389c4c4833393e2f2e10dcfdece