### PR TITLE
feat: make token decimals configurable

### DIFF
--- a/examples/ethers-quickstart.js
+++ b/examples/ethers-quickstart.js
@@ -1,5 +1,11 @@
 const { ethers } = require("ethers");
 
+// Load token decimals (defaults to config value, typically 18)
+const { decimals: AGIALPHA_DECIMALS } = require("../config/agialpha.json");
+const TOKEN_DECIMALS = Number(
+  process.env.TOKEN_DECIMALS || AGIALPHA_DECIMALS
+);
+
 const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 const signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 
@@ -28,7 +34,8 @@ async function postJob() {
 }
 
 async function stake(amount) {
-  const parsed = ethers.parseUnits(amount.toString(), 18);
+  // Convert using the token's decimal count (previously fixed at 18)
+  const parsed = ethers.parseUnits(amount.toString(), TOKEN_DECIMALS);
   await stakeManager.depositStake(0, parsed);
 }
 


### PR DESCRIPTION
## Summary
- load token decimals from config or `TOKEN_DECIMALS` env var in `ethers-quickstart`
- use configurable decimals in staking amount parsing

## Testing
- `TOKEN_DECIMALS=6 RPC_URL=http://localhost:8545 PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945384fa939f56a268f8677183762e5086fd22 JOB_REGISTRY=0x0000000000000000000000000000000000000001 STAKE_MANAGER=0x0000000000000000000000000000000000000001 VALIDATION_MODULE=0x0000000000000000000000000000000000000001 node - <<'NODE'
const { stake } = require('./examples/ethers-quickstart');
stake('1.5').then(r => console.log('stake result', r)).catch(err => console.log('stake error', err.code || err.message));
NODE`
- `npm test` *(fails: JsonRpcProvider failed to detect network and cannot start up)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b366d15bcc83339fbe4a5e5ffafa54