### PR TITLE
test: scale escrow tests for 18-decimal AGIALPHA

### DIFF
--- a/test/v2/JobEscrowNoEther.test.js
+++ b/test/v2/JobEscrowNoEther.test.js
@@ -2,14 +2,18 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("JobEscrow ether rejection", function () {
-  const { AGIALPHA } = require("../../scripts/constants");
+  const { AGIALPHA, AGIALPHA_DECIMALS } = require("../../scripts/constants");
   let owner, employer, operator, token, routing, escrow;
 
   beforeEach(async () => {
     [owner, employer, operator] = await ethers.getSigners();
 
-    token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
-    await token.mint(employer.address, 1000);
+    token = await ethers.getContractAt(
+      "contracts/test/AGIALPHAToken.sol:AGIALPHAToken",
+      AGIALPHA
+    );
+    const initialBalance = ethers.parseUnits("1", AGIALPHA_DECIMALS);
+    await token.mint(employer.address, initialBalance);
 
     const Routing = await ethers.getContractFactory(
       "contracts/legacy/MockRoutingModule.sol:MockRoutingModule"


### PR DESCRIPTION
## Summary
- use AGIALPHA_DECIMALS to parse unit amounts in JobEscrow tests
- mint and compare rewards using 18-decimal AGIALPHA units

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b36bf6554c8333811dfba5a4b6a1e7