### PR TITLE
chore: align tests with immutable AGIALPHA token

### DIFF
--- a/test/v2/Integration.t.sol
+++ b/test/v2/Integration.t.sol
@@ -8,12 +8,14 @@ import "contracts/v2/interfaces/IFeePool.sol";
 import "contracts/v2/interfaces/IPlatformRegistry.sol";
 import "contracts/legacy/MockV2.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {AGIALPHA} from "contracts/v2/Constants.sol";
 
 interface Vm {
     function prank(address) external;
     function startPrank(address) external;
     function stopPrank() external;
     function prevrandao(bytes32) external;
+    function etch(address, bytes memory) external;
 }
 
 contract TestToken is ERC20 {
@@ -70,12 +72,14 @@ contract IntegrationTest {
     uint256 constant TOKEN = 1e18;
 
     function setUp() public {
-        token = new TestToken();
+        TestToken impl = new TestToken();
+        vm.etch(AGIALPHA, address(impl).code);
+        token = TestToken(AGIALPHA);
         stakeManager = new MockStakeManager();
         stakeManager.setJobRegistry(jobRegistryAddr);
         registry = new MockPlatformRegistry();
-        feePool = new FeePool(token, stakeManager, 0, address(this));
-        router = new JobRouter(registry, address(this));
+        feePool = new FeePool(stakeManager, 0, address(this));
+        router = new JobRouter(registry);
     }
 
     function testLifecycle() public {

--- a/test/v2/StakeManagerFuzz.t.sol
+++ b/test/v2/StakeManagerFuzz.t.sol
@@ -5,14 +5,17 @@ import "forge-std/Test.sol";
 import {StakeManager} from "../../contracts/v2/StakeManager.sol";
 import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {AGIALPHA} from "../../contracts/v2/Constants.sol";
 
 contract StakeManagerFuzz is Test {
     StakeManager stake;
     AGIALPHAToken token;
 
     function setUp() public {
-        token = new AGIALPHAToken();
-        stake = new StakeManager(IERC20(address(token)), 1e18, 50, 50, address(this), address(this), address(this));
+        AGIALPHAToken impl = new AGIALPHAToken();
+        vm.etch(AGIALPHA, address(impl).code);
+        token = AGIALPHAToken(AGIALPHA);
+        stake = new StakeManager(1e18, 50, 50, address(this), address(this), address(this), address(this));
     }
 
     function _deposit(address user, uint256 amount, StakeManager.Role role) internal {

--- a/test/v2/ValidationSlashingFuzz.t.sol
+++ b/test/v2/ValidationSlashingFuzz.t.sol
@@ -11,6 +11,7 @@ import {IStakeManager} from "../../contracts/v2/interfaces/IStakeManager.sol";
 import {IIdentityRegistry} from "../../contracts/v2/interfaces/IIdentityRegistry.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {MockJobRegistry} from "../../contracts/legacy/MockV2.sol";
+import {AGIALPHA} from "../../contracts/v2/Constants.sol";
 
 contract ValidationSlashingFuzz is Test {
     ValidationModule validation;
@@ -20,8 +21,10 @@ contract ValidationSlashingFuzz is Test {
     MockJobRegistry jobRegistry;
 
     function setUp() public {
-        token = new AGIALPHAToken();
-        stake = new StakeManager(IERC20(address(token)), 1e18, 0, 100, address(this), address(0), address(0));
+        AGIALPHAToken impl = new AGIALPHAToken();
+        vm.etch(AGIALPHA, address(impl).code);
+        token = AGIALPHAToken(AGIALPHA);
+        stake = new StakeManager(1e18, 0, 100, address(this), address(0), address(0), address(this));
         jobRegistry = new MockJobRegistry();
         stake.setJobRegistry(address(jobRegistry));
         identity = new IdentityRegistryToggle();

--- a/test/v2/ValidatorSelectionFuzz.t.sol
+++ b/test/v2/ValidatorSelectionFuzz.t.sol
@@ -10,6 +10,7 @@ import {IStakeManager} from "../../contracts/v2/interfaces/IStakeManager.sol";
 import {IIdentityRegistry} from "../../contracts/v2/interfaces/IIdentityRegistry.sol";
 import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {AGIALPHA} from "../../contracts/v2/Constants.sol";
 
 contract ValidatorSelectionFuzz is Test {
     StakeManager stake;
@@ -19,9 +20,10 @@ contract ValidatorSelectionFuzz is Test {
     mapping(address => uint256) index;
 
     function setUp() public {
-        token = new AGIALPHAToken();
+        AGIALPHAToken impl = new AGIALPHAToken();
+        vm.etch(AGIALPHA, address(impl).code);
+        token = AGIALPHAToken(AGIALPHA);
         stake = new StakeManager(
-            IERC20(address(token)),
             1e18,
             0,
             100,


### PR DESCRIPTION
## Summary
- update Solidity tests to stub the AGIALPHA token at its canonical address
- remove legacy constructor args and use 18-decimal token amounts throughout tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b36e4102788333a269a31d35198002