### PR TITLE
refactor: use custom errors for FeePool and StakeManager

### DIFF
--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -143,7 +143,7 @@ describe("StakeManager AGIType bonuses", function () {
       stakeManager
         .connect(registrySigner)
         .releaseReward(jobId, agent.address, 100)
-    ).to.be.revertedWith("escrow");
+    ).to.be.revertedWithCustomError(stakeManager, "InsufficientEscrow");
   });
 });
 

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -171,22 +171,22 @@ describe("Module replacement", function () {
 
     await expect(
       stake.connect(owner).setDisputeModule(await bad.getAddress())
-    ).to.be.revertedWith("Invalid dispute module");
+    ).to.be.revertedWithCustomError(stake, "InvalidDisputeModule");
 
     await expect(
       stake.connect(owner).setValidationModule(await bad.getAddress())
-    ).to.be.revertedWith("Invalid validation module");
+    ).to.be.revertedWithCustomError(stake, "InvalidValidationModule");
 
     await expect(
       stake
         .connect(owner)
         .setModules(await bad.getAddress(), await dispute.getAddress())
-    ).to.be.revertedWith("Invalid job registry");
+    ).to.be.revertedWithCustomError(stake, "InvalidJobRegistry");
 
     await expect(
       stake
         .connect(owner)
         .setModules(await registry.getAddress(), await bad.getAddress())
-    ).to.be.revertedWith("Invalid dispute module");
+    ).to.be.revertedWithCustomError(stake, "InvalidDisputeModule");
   });
 });

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -31,7 +31,7 @@ describe("StakeManager", function () {
     await token.connect(user).approve(await stakeManager.getAddress(), 100);
     await expect(
       stakeManager.connect(user).depositStake(0, 100)
-    ).to.be.revertedWith("registry");
+    ).to.be.revertedWithCustomError(stakeManager, "JobRegistryNotSet");
   });
 
   it("handles staking, job escrow and slashing", async () => {
@@ -121,7 +121,7 @@ describe("StakeManager", function () {
           10,
           ethers.ZeroAddress
         )
-    ).to.be.revertedWith("recipient");
+    ).to.be.revertedWithCustomError(stakeManager, "InvalidRecipient");
   });
 
   it("rejects unauthorized slashing and excessive amounts", async () => {
@@ -163,7 +163,7 @@ describe("StakeManager", function () {
           10,
           employer.address
         )
-    ).to.be.revertedWith("only job registry");
+    ).to.be.revertedWithCustomError(stakeManager, "OnlyJobRegistry");
 
     const registryAddr = await jobRegistry.getAddress();
     await ethers.provider.send("hardhat_setBalance", [
@@ -181,7 +181,7 @@ describe("StakeManager", function () {
           200,
           employer.address
         )
-    ).to.be.revertedWith("stake");
+    ).to.be.revertedWithCustomError(stakeManager, "InsufficientStake");
   });
 
   it("reverts when treasury is zero during slashing", async () => {
@@ -239,7 +239,7 @@ describe("StakeManager", function () {
           100,
           employer.address
         )
-    ).to.be.revertedWith("treasury not set");
+    ).to.be.revertedWithCustomError(stakeManager, "TreasuryNotSet");
   });
 
   it("supports staking and slashing for all roles", async () => {
@@ -440,10 +440,10 @@ describe("StakeManager", function () {
     // deposits below min stake revert for both roles
     await expect(
       stakeManager.connect(user).depositStake(0, 50)
-    ).to.be.revertedWith("min stake");
+    ).to.be.revertedWithCustomError(stakeManager, "BelowMinimumStake");
     await expect(
       stakeManager.connect(user).depositStake(1, 50)
-    ).to.be.revertedWith("min stake");
+    ).to.be.revertedWithCustomError(stakeManager, "BelowMinimumStake");
 
     // deposits meeting min stake succeed
     await stakeManager.connect(user).depositStake(0, 100);
@@ -452,10 +452,10 @@ describe("StakeManager", function () {
     // partial withdrawals leaving below min stake revert
     await expect(
       stakeManager.connect(user).withdrawStake(0, 10)
-    ).to.be.revertedWith("min stake");
+    ).to.be.revertedWithCustomError(stakeManager, "BelowMinimumStake");
     await expect(
       stakeManager.connect(user).withdrawStake(1, 10)
-    ).to.be.revertedWith("min stake");
+    ).to.be.revertedWithCustomError(stakeManager, "BelowMinimumStake");
 
     // full withdrawals succeed
     await stakeManager.connect(user).withdrawStake(0, 100);
@@ -476,7 +476,7 @@ describe("StakeManager", function () {
   it("reverts when percentages do not sum to 100", async () => {
     await expect(
       stakeManager.connect(owner).setSlashingPercentages(60, 20)
-    ).to.be.revertedWith("pct");
+    ).to.be.revertedWithCustomError(stakeManager, "InvalidPercentage");
   });
 
   it("slashes full amount when percentages sum to 100", async () => {
@@ -513,19 +513,19 @@ describe("StakeManager", function () {
   it("reverts when slashing percentages sum over 100", async () => {
     await expect(
       stakeManager.connect(owner).setSlashingPercentages(60, 50)
-    ).to.be.revertedWith("pct");
+    ).to.be.revertedWithCustomError(stakeManager, "InvalidPercentage");
   });
 
   it("reverts when slashing percentages sum under 100", async () => {
     await expect(
       stakeManager.connect(owner).setSlashingPercentages(40, 50)
-    ).to.be.revertedWith("pct");
+    ).to.be.revertedWithCustomError(stakeManager, "InvalidPercentage");
   });
 
   it("reverts when individual slashing percentage exceeds 100", async () => {
     await expect(
       stakeManager.connect(owner).setSlashingPercentages(101, 0)
-    ).to.be.revertedWith("pct");
+    ).to.be.revertedWithCustomError(stakeManager, "InvalidPercentage");
   });
 
   it("routes full slashing to treasury when employer share is zero", async () => {
@@ -654,7 +654,7 @@ describe("StakeManager", function () {
 
     await expect(
       stakeManager.connect(user).withdrawStake(0, 1)
-    ).to.be.revertedWith("locked");
+    ).to.be.revertedWithCustomError(stakeManager, "InsufficientLocked");
 
     await time.increase(lockDuration);
 
@@ -805,7 +805,7 @@ describe("StakeManager", function () {
 
     await expect(
       stakeManager.connect(user).depositStake(0, 0)
-    ).to.be.revertedWith("amount");
+    ).to.be.revertedWithCustomError(stakeManager, "InvalidAmount");
   });
 
   it("allows withdrawal after slashing", async () => {

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -108,7 +108,7 @@ describe("StakeManager extras", function () {
       stakeManager
         .connect(user)
         .depositStake(0, ethers.parseEther("100"))
-    ).to.be.revertedWith("max stake");
+    ).to.be.revertedWithCustomError(stakeManager, "MaxStakeExceeded");
   });
 
 });

--- a/test/v2/StakeManagerNoEther.test.js
+++ b/test/v2/StakeManagerNoEther.test.js
@@ -26,7 +26,7 @@ describe("StakeManager ether rejection", function () {
   it("reverts on direct ether transfer", async () => {
     await expect(
       owner.sendTransaction({ to: await stakeManager.getAddress(), value: 1 })
-    ).to.be.revertedWith("StakeManager: no ether");
+    ).to.be.revertedWithCustomError(stakeManager, "EtherNotAccepted");
   });
 
   it("reverts on unknown calldata with value", async () => {
@@ -36,7 +36,7 @@ describe("StakeManager ether rejection", function () {
         data: "0x12345678",
         value: 1,
       })
-    ).to.be.revertedWith("StakeManager: no ether");
+    ).to.be.revertedWithCustomError(stakeManager, "EtherNotAccepted");
   });
 
   it("reports tax exemption", async () => {

--- a/test/v2/StakeManagerSlashing.test.js
+++ b/test/v2/StakeManagerSlashing.test.js
@@ -25,6 +25,6 @@ describe("StakeManager slashing configuration", function () {
   it("rejects percentages that do not sum to 100", async () => {
     await expect(
       stakeManager.setSlashingPercentages(60, 30)
-    ).to.be.revertedWith("pct");
+    ).to.be.revertedWithCustomError(stakeManager, "InvalidPercentage");
   });
 });


### PR DESCRIPTION
## Summary
- replace string-based require messages with custom errors in FeePool and StakeManager
- adjust tests to expect new custom error types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b387d4f99c8333a9d0275acbbc4186