### PR TITLE
validate AGIALPHA decimals before deployment

### DIFF
--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -42,6 +42,15 @@ async function main() {
     typeof args.governance === "string" ? args.governance : deployer.address;
   const governanceSigner = await ethers.getSigner(governance);
 
+  const token = await ethers.getContractAt(
+    ["function decimals() view returns (uint8)"],
+    AGIALPHA
+  );
+  const decimals = Number(await token.decimals());
+  if (decimals !== 18) {
+    throw new Error(`AGIALPHA token must have 18 decimals, got ${decimals}`);
+  }
+
   // -------------------------------------------------------------------------
   // staking token: fixed to canonical AGIALPHA address
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- verify AGIALPHA token has 18 decimals before deploying contracts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38fdbd7e48333842c966d050f2fcf