### PR TITLE
chore: unify MockERC20 pragma

### DIFF
--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.25;
 
 // @dev Test utility token used to provide an ERC20 code stub for AGIALPHA
 // in Hardhat tests. This mock contract deploys a basic ERC20 and allows


### PR DESCRIPTION
## Summary
- use solidity `^0.8.25` pragma for MockERC20 to match rest of codebase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b39242564c8333906df2945281420e