### PR TITLE
chore: run forge tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,10 @@ jobs:
         run: npm run lint
       - name: Run tests
         run: npm test
+      - name: Install Foundry
+        run: |
+          curl -L https://foundry.paradigm.xyz | bash
+          ~/.foundry/bin/foundryup
+          echo "$HOME/.foundry/bin" >> $GITHUB_PATH
+      - name: Run Forge tests
+        run: forge test


### PR DESCRIPTION
## Summary
- install Foundry in CI workflow
- run Forge test suite after Hardhat tests

## Testing
- `npm test` (timeout; Hardhat tests did not complete) 
- `forge test` (fails: Source "forge-std/Test.sol" not found)


------
https://chatgpt.com/codex/tasks/task_e_68b396a9e1708333b6ad8e791a163ffd