### PR TITLE
chore: centralize AGIALPHA decimals in tests

### DIFF
--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -1,14 +1,14 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const { AGIALPHA, AGIALPHA_DECIMALS } = require("../../scripts/constants");
 
 describe("CertificateNFT marketplace", function () {
-  const price = ethers.parseUnits("1", 18);
+  const price = ethers.parseUnits("1", AGIALPHA_DECIMALS);
   let owner, seller, buyer, token, stake, nft;
 
   beforeEach(async () => {
     [owner, seller, buyer] = await ethers.getSigners();
 
-    const { AGIALPHA } = require("../../scripts/constants");
     token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(buyer.address, price);
     await token.mint(seller.address, price);

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -1,17 +1,17 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
+const { AGIALPHA, AGIALPHA_DECIMALS } = require("../../scripts/constants");
 
 const Role = { Agent: 0, Validator: 1, Platform: 2 };
 
 async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
 
-  const { AGIALPHA } = require("../../scripts/constants");
   const token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
-  await token.mint(employer.address, ethers.parseUnits("1000", 18));
-  await token.mint(agent.address, ethers.parseUnits("1000", 18));
-  await token.mint(owner.address, ethers.parseUnits("1000", 18));
+  await token.mint(employer.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
+  await token.mint(agent.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
+  await token.mint(owner.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
 
   const Stake = await ethers.getContractFactory(
     "contracts/v2/StakeManager.sol:StakeManager"
@@ -106,11 +106,11 @@ describe("Mid-job module upgrades", function () {
     const env = await deploySystem();
     const { owner, employer, agent, token, stake, reputation, validation, nft, registry, dispute } = env;
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
     await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
 
-    const reward = ethers.parseUnits("100", 18);
+    const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     const fee = (reward * 5n) / 100n;
     await token
       .connect(employer)

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -1,17 +1,17 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
+const { AGIALPHA, AGIALPHA_DECIMALS } = require("../../scripts/constants");
 
 const Role = { Agent: 0, Validator: 1, Platform: 2 };
 
 async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
 
-  const { AGIALPHA } = require("../../scripts/constants");
   const token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
-  await token.mint(employer.address, ethers.parseUnits("1000", 18));
-  await token.mint(agent.address, ethers.parseUnits("1000", 18));
-  await token.mint(owner.address, ethers.parseUnits("1000", 18));
+  await token.mint(employer.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
+  await token.mint(agent.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
+  await token.mint(owner.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
 
   const Stake = await ethers.getContractFactory(
     "contracts/v2/StakeManager.sol:StakeManager"
@@ -106,11 +106,11 @@ describe("Module replacement", function () {
     const env = await deploySystem();
     const { owner, employer, agent, token, stake, reputation, validation, nft, registry, dispute } = env;
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
     await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
 
-    const reward = ethers.parseUnits("100", 18);
+    const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     const fee = (reward * 5n) / 100n;
     await token
       .connect(employer)

--- a/test/v2/RoutingModule.test.js
+++ b/test/v2/RoutingModule.test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const { AGIALPHA_DECIMALS } = require("../../scripts/constants");
 
 // This test covers JobRouter.selectPlatform even though the file name is
 // RoutingModule.test.js for backward compatibility with the existing suite.
@@ -67,9 +68,9 @@ describe("JobRouter", function () {
   it("computes routing weight based on stake", async () => {
     const w1 = await router.routingWeight(op1.address);
     const w2 = await router.routingWeight(op2.address);
-    const quarter = ethers.parseUnits("0.25", 18);
-    const threeQuarter = ethers.parseUnits("0.75", 18);
-    expect(w1).to.be.closeTo(quarter, ethers.parseUnits("0.05", 18));
-    expect(w2).to.be.closeTo(threeQuarter, ethers.parseUnits("0.05", 18));
+    const quarter = ethers.parseUnits("0.25", AGIALPHA_DECIMALS);
+    const threeQuarter = ethers.parseUnits("0.75", AGIALPHA_DECIMALS);
+    expect(w1).to.be.closeTo(quarter, ethers.parseUnits("0.05", AGIALPHA_DECIMALS));
+    expect(w2).to.be.closeTo(threeQuarter, ethers.parseUnits("0.05", AGIALPHA_DECIMALS));
   });
 });

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -1,10 +1,11 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
+const { AGIALPHA, AGIALPHA_DECIMALS } = require("../../scripts/constants");
 
 describe("comprehensive job flows", function () {
-  const reward = ethers.parseUnits("1000", 18);
-  const stakeRequired = ethers.parseUnits("200", 18);
+  const reward = ethers.parseUnits("1000", AGIALPHA_DECIMALS);
+  const stakeRequired = ethers.parseUnits("200", AGIALPHA_DECIMALS);
   const feePct = 10;
   const disputeFee = 0n;
 
@@ -14,9 +15,8 @@ describe("comprehensive job flows", function () {
   beforeEach(async () => {
     [owner, employer, agent, platform, buyer] = await ethers.getSigners();
 
-    const { AGIALPHA } = require("../../scripts/constants");
     token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
-    const mintAmount = ethers.parseUnits("10000", 18);
+    const mintAmount = ethers.parseUnits("10000", AGIALPHA_DECIMALS);
     await token.mint(employer.address, mintAmount);
     await token.mint(agent.address, mintAmount);
     await token.mint(platform.address, mintAmount);
@@ -158,7 +158,7 @@ describe("comprehensive job flows", function () {
       .submit(jobId, ethers.id("result"), "result", "", []);
     await validation.finalize(jobId);
     expect(await nft.ownerOf(jobId)).to.equal(agent.address);
-    const price = ethers.parseUnits("10", 18);
+    const price = ethers.parseUnits("10", AGIALPHA_DECIMALS);
     await nft.connect(agent).list(jobId, price);
     await token.connect(buyer).approve(await nft.getAddress(), price);
     await nft.connect(buyer).purchase(jobId);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -1,22 +1,22 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
+const { AGIALPHA, AGIALPHA_DECIMALS } = require("../../scripts/constants");
 
 describe("end-to-end job lifecycle", function () {
   let token, stakeManager, rep, validation, nft, registry, dispute, feePool, policy;
   let owner, employer, agent, platform;
-  const reward = ethers.parseUnits("1000", 18);
-  const stakeRequired = ethers.parseUnits("200", 18);
-  const platformStake = ethers.parseUnits("500", 18);
+  const reward = ethers.parseUnits("1000", AGIALPHA_DECIMALS);
+  const stakeRequired = ethers.parseUnits("200", AGIALPHA_DECIMALS);
+  const platformStake = ethers.parseUnits("500", AGIALPHA_DECIMALS);
   const feePct = 10;
   const disputeFee = 0n;
 
   beforeEach(async () => {
     [owner, employer, agent, platform] = await ethers.getSigners();
 
-    const { AGIALPHA } = require("../../scripts/constants");
     token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
-    const mintAmount = ethers.parseUnits("10000", 18);
+    const mintAmount = ethers.parseUnits("10000", AGIALPHA_DECIMALS);
     await token.mint(owner.address, mintAmount);
     await token.mint(employer.address, mintAmount);
     await token.mint(agent.address, mintAmount);

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { AGIALPHA_DECIMALS } from "../../scripts/constants";
 
 enum Role {
   Agent,
@@ -16,7 +17,7 @@ async function deploySystem() {
     "contracts/test/AGIALPHAToken.sol:AGIALPHAToken"
   );
   const token = await Token.deploy();
-  const mint = ethers.parseUnits("1000", 18);
+  const mint = ethers.parseUnits("1000", AGIALPHA_DECIMALS);
   await token.mint(employer.address, mint);
   await token.mint(agent.address, mint);
   await token.mint(validator.address, mint);
@@ -78,7 +79,7 @@ async function deploySystem() {
   const Registry = await ethers.getContractFactory(
     "contracts/v2/JobRegistry.sol:JobRegistry"
   );
-  const stakeAmt = ethers.parseUnits("1", 18);
+  const stakeAmt = ethers.parseUnits("1", AGIALPHA_DECIMALS);
   const registry = await Registry.deploy(
     await validation.getAddress(),
     await stake.getAddress(),
@@ -190,7 +191,7 @@ describe("Commit-reveal job lifecycle", function () {
       .approve(await stake.getAddress(), stakeAmt);
     await stake.connect(validator).depositStake(Role.Validator, stakeAmt);
 
-    const reward = ethers.parseUnits("100", 18);
+    const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
@@ -214,10 +215,10 @@ describe("Commit-reveal job lifecycle", function () {
 
     expect(await nft.ownerOf(1)).to.equal(agent.address);
     expect(await token.balanceOf(agent.address)).to.equal(
-      ethers.parseUnits("1100", 18)
+      ethers.parseUnits("1100", AGIALPHA_DECIMALS)
     );
 
-    const price = ethers.parseUnits("50", 18);
+    const price = ethers.parseUnits("50", AGIALPHA_DECIMALS);
     await nft.connect(agent).list(1, price);
     await token.connect(buyer).approve(await nft.getAddress(), price);
     await nft.connect(buyer).purchase(1);
@@ -261,7 +262,7 @@ describe("Commit-reveal job lifecycle", function () {
       .approve(await stake.getAddress(), stakeAmt);
     await stake.connect(validator).depositStake(Role.Validator, stakeAmt);
 
-    const reward = ethers.parseUnits("100", 18);
+    const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
@@ -293,7 +294,7 @@ describe("Commit-reveal job lifecycle", function () {
 
     expect(await stake.stakeOf(agent.address, Role.Agent)).to.equal(0);
     expect(await token.balanceOf(employer.address)).to.equal(
-      ethers.parseUnits("1001", 18)
+      ethers.parseUnits("1001", AGIALPHA_DECIMALS)
     );
   });
 });

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -1,20 +1,20 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
+const { AGIALPHA, AGIALPHA_DECIMALS } = require("../../scripts/constants");
 
 describe("job finalization integration", function () {
   let token, stakeManager, rep, validation, nft, registry, dispute, feePool, policy;
   let owner, employer, agent, validator1, validator2;
-  const reward = ethers.parseUnits("1000", 18);
-  const stakeRequired = ethers.parseUnits("200", 18);
+  const reward = ethers.parseUnits("1000", AGIALPHA_DECIMALS);
+  const stakeRequired = ethers.parseUnits("200", AGIALPHA_DECIMALS);
   const feePct = 10;
   const validatorRewardPct = 10;
-  const mintAmount = ethers.parseUnits("10000", 18);
+  const mintAmount = ethers.parseUnits("10000", AGIALPHA_DECIMALS);
 
   beforeEach(async () => {
     [owner, employer, agent, validator1, validator2] = await ethers.getSigners();
 
-    const { AGIALPHA } = require("../../scripts/constants");
     token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
     await token.mint(owner.address, mintAmount);
     await token.mint(employer.address, mintAmount);

--- a/test/v2/jobLifecycle.test.ts
+++ b/test/v2/jobLifecycle.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { AGIALPHA_DECIMALS } from "../../scripts/constants";
 
 enum Role {
   Agent,
@@ -13,9 +14,9 @@ async function deploySystem() {
 
   const Token = await ethers.getContractFactory("contracts/test/AGIALPHAToken.sol:AGIALPHAToken");
   const token = await Token.deploy();
-  await token.mint(employer.address, ethers.parseUnits("1000", 18));
-  await token.mint(agent.address, ethers.parseUnits("1000", 18));
-  await token.mint(buyer.address, ethers.parseUnits("1000", 18));
+  await token.mint(employer.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
+  await token.mint(agent.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
+  await token.mint(buyer.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
 
   const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
   const stake = await Stake.deploy(
@@ -108,11 +109,11 @@ describe("Job lifecycle", function () {
     );
     await wrapper.setOwner(BigInt(subnode), agent.address);
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
     await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
 
-    const reward = ethers.parseUnits("100", 18);
+    const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
@@ -125,17 +126,21 @@ describe("Job lifecycle", function () {
     await validation.setResult(true);
     await validation.finalize(1);
 
-    expect(await token.balanceOf(agent.address)).to.equal(ethers.parseUnits("1099", 18));
+    expect(await token.balanceOf(agent.address)).to.equal(
+      ethers.parseUnits("1099", AGIALPHA_DECIMALS)
+    );
     expect(await nft.ownerOf(1)).to.equal(agent.address);
     expect(await reputation.reputation(agent.address)).to.be.gt(0);
 
-    const price = ethers.parseUnits("50", 18);
+    const price = ethers.parseUnits("50", AGIALPHA_DECIMALS);
     await nft.connect(agent).list(1, price);
     await token.connect(buyer).approve(await nft.getAddress(), price);
     await nft.connect(buyer).purchase(1);
 
     expect(await nft.ownerOf(1)).to.equal(buyer.address);
-    expect(await token.balanceOf(agent.address)).to.equal(ethers.parseUnits("1149", 18));
+    expect(await token.balanceOf(agent.address)).to.equal(
+      ethers.parseUnits("1149", AGIALPHA_DECIMALS)
+    );
   });
 
   it("handles validation failure, dispute resolution and blacklisting", async () => {
@@ -148,11 +153,11 @@ describe("Job lifecycle", function () {
     );
     await wrapper.setOwner(BigInt(subnode), agent.address);
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
     await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
 
-    const reward = ethers.parseUnits("100", 18);
+    const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { AGIALPHA_DECIMALS } from "../../scripts/constants";
 
 enum Role {
   Agent,
@@ -13,7 +14,7 @@ async function deployFullSystem() {
 
   const Token = await ethers.getContractFactory("contracts/test/AGIALPHAToken.sol:AGIALPHAToken");
   const token = await Token.deploy();
-  const mint = ethers.parseUnits("1000", 18);
+  const mint = ethers.parseUnits("1000", AGIALPHA_DECIMALS);
   await token.mint(employer.address, mint);
   await token.mint(agent.address, mint);
   await token.mint(v1.address, mint);
@@ -103,7 +104,7 @@ describe("job lifecycle with dispute and validator failure", function () {
     const env = await deployFullSystem();
     const { employer, agent, v1, v2, token, stake, validation, registry, dispute, moderator } = env;
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     for (const signer of [agent, v1, v2]) {
       await token.connect(signer).approve(await stake.getAddress(), stakeAmount);
       const role = signer === agent ? Role.Agent : Role.Validator;
@@ -111,7 +112,7 @@ describe("job lifecycle with dispute and validator failure", function () {
     }
     const initialAgentBalance = await token.balanceOf(agent.address);
 
-    const reward = ethers.parseUnits("100", 18);
+    const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { AGIALPHA_DECIMALS } from "../../scripts/constants";
 
 enum Role {
   Agent,
@@ -16,7 +17,7 @@ async function deploySystem() {
     "contracts/test/AGIALPHAToken.sol:AGIALPHAToken"
   );
   const token = await Token.deploy();
-  const mint = ethers.parseUnits("1000", 18);
+  const mint = ethers.parseUnits("1000", AGIALPHA_DECIMALS);
   for (const s of [employer, agent, v1, v2]) {
     await token.mint(s.address, mint);
   }
@@ -133,7 +134,7 @@ describe("Kleros dispute module", function () {
     const { employer, agent, v1, v2, token, stake, validation, registry, mockArb } =
       env;
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     for (const signer of [agent, v1, v2]) {
       await token.connect(signer).approve(await stake.getAddress(), stakeAmount);
       const role = signer === agent ? Role.Agent : Role.Validator;
@@ -141,7 +142,7 @@ describe("Kleros dispute module", function () {
     }
     const initialAgentBalance = await token.balanceOf(agent.address);
 
-    const reward = ethers.parseUnits("100", 18);
+    const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
     await registry

--- a/test/v2/midJobReplacementFuzz.test.js
+++ b/test/v2/midJobReplacementFuzz.test.js
@@ -1,14 +1,14 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
+const { AGIALPHA, AGIALPHA_DECIMALS } = require("../../scripts/constants");
 
 async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
-  const { AGIALPHA } = require("../../scripts/constants");
   const token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
-  await token.mint(employer.address, ethers.parseUnits("1000", 18));
-  await token.mint(agent.address, ethers.parseUnits("1000", 18));
-  await token.mint(owner.address, ethers.parseUnits("1000", 18));
+  await token.mint(employer.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
+  await token.mint(agent.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
+  await token.mint(owner.address, ethers.parseUnits("1000", AGIALPHA_DECIMALS));
 
   const Stake = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
   const stake = await Stake.deploy(
@@ -79,9 +79,9 @@ describe("Mid-job module replacement fuzz", function () {
       const env = await deploySystem();
       const { owner, employer, agent, token, stake, reputation, validation, nft, registry, dispute } = env;
 
-      const reward = ethers.parseUnits(String(10 + Math.floor(Math.random() * 90)), 18);
+      const reward = ethers.parseUnits(String(10 + Math.floor(Math.random() * 90)), AGIALPHA_DECIMALS);
       const result = Math.random() > 0.5;
-      const stakeAmount = ethers.parseUnits("1", 18);
+      const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
       await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
       await stake.connect(agent).depositStake(0, stakeAmount);
       await token

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -1,23 +1,23 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
+const { AGIALPHA, AGIALPHA_DECIMALS } = require("../../scripts/constants");
 
 describe("multi-operator job lifecycle", function () {
   let token, stakeManager, rep, validation, nft, registry, dispute, feePool, policy;
   let platformRegistry, jobRouter;
   let owner, employer, agent, platform1, platform2;
-  const reward = ethers.parseUnits("1000", 18);
-  const stakeRequired = ethers.parseUnits("200", 18);
-  const platformStake1 = ethers.parseUnits("100", 18);
-  const platformStake2 = ethers.parseUnits("300", 18);
+  const reward = ethers.parseUnits("1000", AGIALPHA_DECIMALS);
+  const stakeRequired = ethers.parseUnits("200", AGIALPHA_DECIMALS);
+  const platformStake1 = ethers.parseUnits("100", AGIALPHA_DECIMALS);
+  const platformStake2 = ethers.parseUnits("300", AGIALPHA_DECIMALS);
   const feePct = 10;
 
   beforeEach(async () => {
     [owner, employer, agent, platform1, platform2] = await ethers.getSigners();
 
-    const { AGIALPHA } = require("../../scripts/constants");
     token = await ethers.getContractAt("contracts/test/AGIALPHAToken.sol:AGIALPHAToken", AGIALPHA);
-    const mintAmount = ethers.parseUnits("10000", 18);
+    const mintAmount = ethers.parseUnits("10000", AGIALPHA_DECIMALS);
     await token.mint(owner.address, mintAmount);
     await token.mint(employer.address, mintAmount);
     await token.mint(agent.address, mintAmount);

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { AGIALPHA_DECIMALS } from "../../scripts/constants";
 
 enum Role {
   Agent,
@@ -13,7 +14,7 @@ async function deploySystem() {
 
   const Token = await ethers.getContractFactory("contracts/test/AGIALPHAToken.sol:AGIALPHAToken");
   const token = await Token.deploy();
-  const mint = ethers.parseUnits("1000", 18);
+  const mint = ethers.parseUnits("1000", AGIALPHA_DECIMALS);
   for (const s of [employer, agent, v1]) {
     await token.mint(s.address, mint);
   }
@@ -100,13 +101,13 @@ describe("regression scenarios", function () {
     const env = await deploySystem();
     const { employer, agent, token, stake, validation, registry } = env;
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
     await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
     // no validators set
     await validation.setValidatorsPerJob(1);
 
-    const reward = ethers.parseUnits("10", 18);
+    const reward = ethers.parseUnits("10", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
@@ -119,7 +120,7 @@ describe("regression scenarios", function () {
     const env = await deploySystem();
     const { employer, agent, v1, token, stake, validation, registry } = env;
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     for (const s of [agent, v1]) {
       await token.connect(s).approve(await stake.getAddress(), stakeAmount);
       const role = s === agent ? Role.Agent : Role.Validator;
@@ -129,7 +130,7 @@ describe("regression scenarios", function () {
     await validation.setValidatorsPerJob(1);
     await validation.setValidatorSlashingPct(100);
 
-    const reward = ethers.parseUnits("10", 18);
+    const reward = ethers.parseUnits("10", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline1 = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline1, "ipfs://job1");
@@ -172,13 +173,13 @@ describe("regression scenarios", function () {
 
     expect(await registry.validationModule()).to.equal(await stub.getAddress());
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     for (const s of [agent]) {
       await token.connect(s).approve(await stake.getAddress(), stakeAmount);
       await stake.connect(s).depositStake(Role.Agent, stakeAmount);
     }
 
-    const reward = ethers.parseUnits("10", 18);
+    const reward = ethers.parseUnits("10", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { AGIALPHA_DECIMALS } from "../../scripts/constants";
 
 enum Role {
   Agent,
@@ -13,7 +14,7 @@ async function deployFullSystem() {
 
   const Token = await ethers.getContractFactory("contracts/test/AGIALPHAToken.sol:AGIALPHAToken");
   const token = await Token.deploy();
-  const mint = ethers.parseUnits("1000", 18);
+  const mint = ethers.parseUnits("1000", AGIALPHA_DECIMALS);
   await token.mint(employer.address, mint);
   await token.mint(agent.address, mint);
   await token.mint(v1.address, mint);
@@ -103,14 +104,14 @@ describe("validator participation", function () {
     const env = await deployFullSystem();
     const { employer, agent, v1, v2, token, stake, validation, registry } = env;
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     for (const signer of [agent, v1, v2]) {
       await token.connect(signer).approve(await stake.getAddress(), stakeAmount);
       const role = signer === agent ? Role.Agent : Role.Validator;
       await stake.connect(signer).depositStake(role, stakeAmount);
     }
 
-    const reward = ethers.parseUnits("100", 18);
+    const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
@@ -139,14 +140,14 @@ describe("validator participation", function () {
     const env = await deployFullSystem();
     const { employer, agent, v1, v2, token, stake, validation, registry, dispute, moderator } = env;
 
-    const stakeAmount = ethers.parseUnits("1", 18);
+    const stakeAmount = ethers.parseUnits("1", AGIALPHA_DECIMALS);
     for (const signer of [agent, v1, v2]) {
       await token.connect(signer).approve(await stake.getAddress(), stakeAmount);
       const role = signer === agent ? Role.Agent : Role.Validator;
       await stake.connect(signer).depositStake(role, stakeAmount);
     }
 
-    const reward = ethers.parseUnits("100", 18);
+    const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");


### PR DESCRIPTION
## Summary
- import AGIALPHA_DECIMALS constant across v2 test files
- use AGIALPHA_DECIMALS instead of hardcoded `18` for `ethers.parseUnits`

## Testing
- `npx hardhat test test/v2/jobLifecycle.test.ts` *(fails: process produced no output, likely environment limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a5543fc8833394641ea3f9141c36