### PR TITLE
feat: guard JobEscrow with reentrancy protections

### DIFF
--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {AGIALPHA} from "../Constants.sol";
 import {IJobRegistryAck} from "../interfaces/IJobRegistryAck.sol";
 
@@ -11,12 +12,21 @@ interface IRoutingModule {
     function selectOperator(bytes32 jobId, bytes32 seed) external returns (address);
 }
 
+error ZeroReward();
+error ZeroOperator();
+error InvalidState();
+error NotOperator();
+error NotEmployer();
+error InvalidCaller();
+error Timeout();
+error NoEther();
+
 /// @title JobEscrow
 /// @notice Minimal job management with escrowed payments in an 18-decimal
 /// ERC20 token (AGIALPHA by default). Jobs are routed to operators via the
 /// RoutingModule. Rewards are released to the operator once the employer
 /// accepts the submitted result or after a timeout.
-contract JobEscrow is Ownable {
+contract JobEscrow is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     /// @notice Module version for compatibility checks.
@@ -85,10 +95,14 @@ contract JobEscrow is Ownable {
     /// @param data Metadata describing the job.
     /// @param seed Randomness reveal used for operator selection.
     /// @return jobId Identifier of the created job.
-    function postJob(uint256 reward, string calldata data, bytes32 seed) external returns (uint256 jobId) {
-        require(reward > 0, "reward");
+    function postJob(uint256 reward, string calldata data, bytes32 seed)
+        external
+        nonReentrant
+        returns (uint256 jobId)
+    {
+        if (reward == 0) revert ZeroReward();
         address operator = routingModule.selectOperator(bytes32(nextJobId), seed);
-        require(operator != address(0), "operator");
+        if (operator == address(0)) revert ZeroOperator();
         jobId = nextJobId++;
         token.safeTransferFrom(msg.sender, address(this), reward);
         jobs[jobId] = Job({
@@ -106,10 +120,10 @@ contract JobEscrow is Ownable {
     /// @notice Operator submits the result for a job.
     /// @param jobId Identifier of the job.
     /// @param result Result data or URI.
-    function submitResult(uint256 jobId, string calldata result) external {
+    function submitResult(uint256 jobId, string calldata result) external nonReentrant {
         Job storage job = jobs[jobId];
-        require(job.state == State.Posted, "state");
-        require(msg.sender == job.operator, "operator");
+        if (job.state != State.Posted) revert InvalidState();
+        if (msg.sender != job.operator) revert NotOperator();
         job.state = State.Submitted;
         job.submittedAt = block.timestamp;
         job.result = result;
@@ -118,10 +132,10 @@ contract JobEscrow is Ownable {
 
     /// @notice Cancel a job before completion.
     /// @param jobId Identifier of the job.
-    function cancelJob(uint256 jobId) external {
+    function cancelJob(uint256 jobId) external nonReentrant {
         Job storage job = jobs[jobId];
-        require(job.state == State.Posted, "state");
-        require(msg.sender == job.employer, "employer");
+        if (job.state != State.Posted) revert InvalidState();
+        if (msg.sender != job.employer) revert NotEmployer();
         job.state = State.Cancelled;
         token.safeTransfer(job.employer, job.reward);
         emit JobCancelled(jobId);
@@ -129,13 +143,13 @@ contract JobEscrow is Ownable {
 
     function _accept(uint256 jobId) internal {
         Job storage job = jobs[jobId];
-        require(job.state == State.Submitted, "state");
+        if (job.state != State.Submitted) revert InvalidState();
         if (msg.sender == job.employer) {
             // employer approval
         } else if (msg.sender == job.operator) {
-            require(block.timestamp >= job.submittedAt + TIMEOUT, "timeout");
+            if (block.timestamp < job.submittedAt + TIMEOUT) revert Timeout();
         } else {
-            revert("caller");
+            revert InvalidCaller();
         }
         job.state = State.Accepted;
         token.safeTransfer(job.operator, job.reward);
@@ -145,13 +159,13 @@ contract JobEscrow is Ownable {
     /// @notice Accept the job result and release payment.
     /// Employer may call any time after submission. Operator may call after timeout.
     /// @param jobId Identifier of the job.
-    function acceptResult(uint256 jobId) external {
+    function acceptResult(uint256 jobId) external nonReentrant {
         _accept(jobId);
     }
 
     /// @notice Acknowledge the tax policy and accept the job result in one call.
     /// @param jobId Identifier of the job.
-    function acknowledgeAndAcceptResult(uint256 jobId) external {
+    function acknowledgeAndAcceptResult(uint256 jobId) external nonReentrant {
         address registry = jobRegistry;
         if (registry != address(0)) {
             IJobRegistryAck(registry).acknowledgeFor(msg.sender);
@@ -166,12 +180,12 @@ contract JobEscrow is Ownable {
 
     /// @dev Reject direct ETH transfers to keep the escrow token-only.
     receive() external payable {
-        revert("JobEscrow: no ether");
+        revert NoEther();
     }
 
     /// @dev Reject calls with unexpected calldata or funds.
     fallback() external payable {
-        revert("JobEscrow: no ether");
+        revert NoEther();
     }
 }
 

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const { ethers, artifacts, network } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("JobEscrow", function () {
@@ -11,6 +11,13 @@ describe("JobEscrow", function () {
     [owner, employer, operator] = await ethers.getSigners();
 
     const { AGIALPHA, AGIALPHA_DECIMALS } = require("../../scripts/constants");
+    const artifact = await artifacts.readArtifact(
+      "contracts/test/MockERC20.sol:MockERC20"
+    );
+    await network.provider.send("hardhat_setCode", [
+      AGIALPHA,
+      artifact.deployedBytecode,
+    ]);
     token = await ethers.getContractAt(
       "contracts/test/AGIALPHAToken.sol:AGIALPHAToken",
       AGIALPHA
@@ -83,9 +90,9 @@ describe("JobEscrow", function () {
       (l) => l.fragment && l.fragment.name === "JobPosted"
     ).args.jobId;
     await escrow.connect(operator).submitResult(jobId, "res");
-    await expect(escrow.connect(operator).acceptResult(jobId)).to.be.revertedWith(
-      "timeout"
-    );
+    await expect(
+      escrow.connect(operator).acceptResult(jobId)
+    ).to.be.revertedWithCustomError(escrow, "Timeout");
   });
 
   it("acknowledgeAndAcceptResult accepts and records acknowledgement", async () => {


### PR DESCRIPTION
## Summary
- add custom errors and nonReentrant modifiers to JobEscrow
- inherit OpenZeppelin ReentrancyGuard to prevent reentrancy
- update JobEscrow tests for new custom errors

## Testing
- `npm test test/v2/JobEscrow.test.js test/v2/JobEscrowNoEther.test.js` *(fails: expected balances differ, SafeERC20 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a9759b488333a602508363d8eee7