### PR TITLE
Use AGIALPHA_DECIMALS in deploy defaults script

### DIFF
--- a/scripts/v2/deployDefaults.ts
+++ b/scripts/v2/deployDefaults.ts
@@ -1,4 +1,5 @@
 import { ethers, run } from "hardhat";
+import { AGIALPHA_DECIMALS } from "../constants";
 
 async function verify(address: string, args: any[] = []) {
   try {
@@ -50,7 +51,7 @@ async function main() {
 
   await verify(deployerAddress);
   await verify(stakeManager, [
-    ethers.parseUnits("1", 18),
+    ethers.parseUnits("1", AGIALPHA_DECIMALS),
     0,
     100,
     owner.address,


### PR DESCRIPTION
## Summary
- import shared AGIALPHA_DECIMALS constant in deployDefaults script
- use AGIALPHA_DECIMALS instead of hardcoded 18 when parsing stake amount

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3b7b02be483339fcd23fe2dca7d01