### PR TITLE
feat: verify AGIALPHA constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Verify AGIALPHA constants
+        run: npm run verify:agialpha
       - name: Run lint
         run: npm run lint
       - name: Run tests

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "compile": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/generate-constants.ts && npx hardhat compile",
     "lint": "npx solhint 'contracts/**/*.sol' && npx eslint .",
     "pretest": "npx tsc scripts/constants.ts",
+    "verify:agialpha": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/verify-agialpha.ts",
     "test": "npx hardhat test",
     "gateway": "node agent-gateway/index.js"
   },

--- a/scripts/verify-agialpha.ts
+++ b/scripts/verify-agialpha.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const configPath = path.join(__dirname, '..', 'config', 'agialpha.json');
+const constantsPath = path.join(__dirname, '..', 'contracts', 'v2', 'Constants.sol');
+
+// Read JSON config
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
+  address: string;
+  decimals: number;
+};
+
+// Read Solidity constants
+const constantsSrc = fs.readFileSync(constantsPath, 'utf8');
+const addrMatch = constantsSrc.match(/address constant AGIALPHA = (0x[0-9a-fA-F]{40});/);
+const decMatch = constantsSrc.match(/uint8 constant AGIALPHA_DECIMALS = (\d+);/);
+
+if (!addrMatch || !decMatch) {
+  throw new Error('Failed to parse Constants.sol');
+}
+
+const solAddress = addrMatch[1];
+const solDecimals = parseInt(decMatch[1], 10);
+
+if (config.address.toLowerCase() !== solAddress.toLowerCase()) {
+  console.error(`Address mismatch: config ${config.address} vs contract ${solAddress}`);
+  process.exit(1);
+}
+
+if (config.decimals !== solDecimals) {
+  console.error(`Decimals mismatch: config ${config.decimals} vs contract ${solDecimals}`);
+  process.exit(1);
+}
+
+console.log('AGIALPHA address and decimals match.');
+


### PR DESCRIPTION
## Summary
- add script to ensure AGIALPHA address and decimals in config match constants
- wire verification script into CI and expose npm run verify:agialpha

## Testing
- `npm run verify:agialpha`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3bb2f6dc88333bc9030d46006b4ab