### PR TITLE
refactor: centralize burn address constant

### DIFF
--- a/contracts/v2/Constants.sol
+++ b/contracts/v2/Constants.sol
@@ -6,6 +6,9 @@ pragma solidity ^0.8.25;
 // Canonical $AGIALPHA token on Ethereum mainnet.
 address constant AGIALPHA = 0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA;
 
+// Canonical burn address.
+address constant BURN_ADDRESS = 0x000000000000000000000000000000000000dEaD;
+
 // Standard decimals for $AGIALPHA.
 uint8 constant AGIALPHA_DECIMALS = 18;
 

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -6,7 +6,7 @@ import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {AGIALPHA} from "./Constants.sol";
+import {AGIALPHA, BURN_ADDRESS} from "./Constants.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 error InvalidPercentage();
@@ -24,7 +24,6 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     uint256 public constant ACCUMULATOR_SCALE = 1e12;
-    address public constant BURN_ADDRESS = 0x000000000000000000000000000000000000dEaD;
     uint256 public constant DEFAULT_BURN_PCT = 5;
 
     /// @notice ERC20 token used for fees and rewards (immutable $AGIALPHA)

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -7,7 +7,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
-import {AGIALPHA, TOKEN_SCALE} from "./Constants.sol";
+import {AGIALPHA, TOKEN_SCALE, BURN_ADDRESS} from "./Constants.sol";
 import {IJobRegistryTax} from "./interfaces/IJobRegistryTax.sol";
 import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 import {TaxAcknowledgement} from "./libraries/TaxAcknowledgement.sol";
@@ -65,10 +65,6 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     /// @notice default minimum stake when constructor param is zero
     uint256 public constant DEFAULT_MIN_STAKE = TOKEN_SCALE;
-
-    /// @notice canonical burn address
-    address public constant BURN_ADDRESS =
-        0x000000000000000000000000000000000000dEaD;
 
     /// @notice ERC20 token used for staking and payouts (immutable $AGIALPHA)
     IERC20 public immutable token = IERC20(AGIALPHA);


### PR DESCRIPTION
## Summary
- centralize `BURN_ADDRESS` in Constants.sol
- import shared burn address in FeePool and StakeManager

## Testing
- `npm test` *(fails: npm warned about unknown env config and tests did not execute)*


------
https://chatgpt.com/codex/tasks/task_e_68b3c3acbe4883339c61285f3286af43