### PR TITLE
Use StakeManager interface in CertificateNFT

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.23;
 // @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
 
 import "../v2/interfaces/IStakeManager.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../v2/interfaces/IJobRegistry.sol";
 import "../v2/interfaces/IJobRegistryTax.sol";
 import "../v2/interfaces/IReputationEngine.sol";
@@ -97,6 +98,10 @@ contract MockStakeManager is IStakeManager {
 
     function burnPct() external pure override returns (uint256) {
         return 0;
+    }
+
+    function token() external pure override returns (IERC20) {
+        return IERC20(address(0));
     }
 
     // legacy helper for tests

--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -6,8 +6,8 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
-import {StakeManager} from "./StakeManager.sol";
 import {ICertificateNFT} from "./interfaces/ICertificateNFT.sol";
+import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 /// @title CertificateNFT
 /// @notice ERC721 certificate minted upon successful job completion.
@@ -25,7 +25,7 @@ contract CertificateNFT is ERC721, Ownable, ReentrancyGuard, ICertificateNFT {
     address public jobRegistry;
     mapping(uint256 => bytes32) public tokenHashes;
 
-    StakeManager public stakeManager;
+    IStakeManager public stakeManager;
 
     struct Listing {
         address seller;
@@ -63,7 +63,7 @@ contract CertificateNFT is ERC721, Ownable, ReentrancyGuard, ICertificateNFT {
 
     function setStakeManager(address manager) external onlyOwner {
         if (manager == address(0)) revert ZeroAddress();
-        stakeManager = StakeManager(payable(manager));
+        stakeManager = IStakeManager(manager);
         emit StakeManagerUpdated(manager);
     }
 

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -104,6 +104,9 @@ interface IStakeManager {
     /// @notice Current burn percentage applied to rewards
     function burnPct() external view returns (uint256);
 
+    /// @notice ERC20 token used for staking operations
+    function token() external view returns (IERC20);
+
     /// @notice set the dispute module authorized to manage dispute fees
     function setDisputeModule(address module) external;
 

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import {IStakeManager} from "../interfaces/IStakeManager.sol";
 import {IValidationModule} from "../interfaces/IValidationModule.sol";
 import {IFeePool} from "../interfaces/IFeePool.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @dev Stake manager mock that attempts to reenter ValidationModule calls.
 contract ReentrantStakeManager is IStakeManager {
@@ -75,6 +76,10 @@ contract ReentrantStakeManager is IStakeManager {
 
     function burnPct() external pure override returns (uint256) {
         return 0;
+    }
+
+    function token() external pure override returns (IERC20) {
+        return IERC20(address(0));
     }
 
     function slash(address user, Role role, uint256 amount, address) external override {


### PR DESCRIPTION
## Summary
- expose token() in IStakeManager interface
- reference IStakeManager from CertificateNFT instead of implementation
- update mock stake managers to satisfy new interface

## Testing
- `npx hardhat compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b45f1c1b288333b259c637699d6a96