### PR TITLE
Require sender acknowledgment for all non-owner transfers

### DIFF
--- a/contracts/test/AGIALPHAToken.sol
+++ b/contracts/test/AGIALPHAToken.sol
@@ -45,11 +45,11 @@ contract AGIALPHAToken is ERC20, Ownable {
         return _acknowledged[account];
     }
 
-    /// @dev Require acknowledgement for transfers from EOAs, except owner ops.
+    /// @dev Require acknowledgement for non-owner transfers.
     function _update(address from, address to, uint256 value) internal override {
         bool ownerOp = msg.sender == owner() || from == owner() || to == owner();
-        if (!ownerOp && from != address(0) && from.code.length == 0) {
-            require(_acknowledged[from], "AGIALPHA: sender not acknowledged");
+        if (!ownerOp && from != address(0)) {
+            require(hasAcknowledged(from), "AGIALPHA: sender not acknowledged");
         }
         super._update(from, to, value);
     }


### PR DESCRIPTION
## Summary
- enforce terms acknowledgement on any non-owner transfer in AGIALPHAToken

## Testing
- `npm run verify:agialpha`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b48508b1448333bc733d2631b9ef66