### PR TITLE
fix: align PlatformIncentives test with PlatformRegistry interface

### DIFF
--- a/test/v2/PlatformIncentives.t.sol
+++ b/test/v2/PlatformIncentives.t.sol
@@ -5,12 +5,14 @@ import {Test} from "forge-std/Test.sol";
 import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
 import {AGIALPHA} from "../../contracts/v2/Constants.sol";
 import {StakeManager} from "../../contracts/v2/StakeManager.sol";
-import {PlatformRegistry} from "../../contracts/v2/PlatformRegistry.sol";
+import {
+    PlatformRegistry,
+    IReputationEngine as PlatformReputationEngine
+} from "../../contracts/v2/PlatformRegistry.sol";
 import {JobRouter} from "../../contracts/v2/modules/JobRouter.sol";
 import {IPlatformRegistryFull} from "../../contracts/v2/interfaces/IPlatformRegistryFull.sol";
 import {IJobRouter} from "../../contracts/v2/interfaces/IJobRouter.sol";
 import {IPlatformRegistry} from "../../contracts/v2/interfaces/IPlatformRegistry.sol";
-import {IReputationEngine} from "../../contracts/v2/interfaces/IReputationEngine.sol";
 import {FeePool} from "../../contracts/v2/FeePool.sol";
 import {PlatformIncentives} from "../../contracts/v2/PlatformIncentives.sol";
 import {MockJobRegistry} from "../../contracts/legacy/MockV2.sol";
@@ -36,7 +38,7 @@ contract PlatformIncentivesTest is Test {
         stakeManager = new StakeManager(0, 0, 0, address(this), address(jobRegistry), address(0), address(this));
         platformRegistry = new PlatformRegistry(
             IStakeManager(address(stakeManager)),
-            IReputationEngine(address(0)),
+            PlatformReputationEngine(address(0)),
             1e18
         );
         jobRouter = new JobRouter(IPlatformRegistry(address(platformRegistry)));


### PR DESCRIPTION
## Summary
- fix PlatformIncentives test to import PlatformRegistry's IReputationEngine

## Testing
- `npm test`
- `forge test` *(fails: Stack too deep. Try compiling with `--via-ir` or removing local variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b494f51ef083338de1ffcac5d5e6bf