### PR TITLE
docs: expand JobRegistry owner-only setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Record each address during deployment. The defaults below assume the 18‑decima
 | --- | --- |
 | [`AGIALPHAToken`](contracts/test/AGIALPHAToken.sol) *(local testing only)* | `mint`, `burn` |
 | [`StakeManager`](contracts/v2/StakeManager.sol) | `setMinStake`, `setSlashingPercentages`, `setTreasury`, `setMaxStakePerAddress` |
-| [`JobRegistry`](contracts/v2/JobRegistry.sol) | `setModules`, `setFeePool`, `setTaxPolicy`, `setAgentRootNode`, `setAgentMerkleRoot` |
+| [`JobRegistry`](contracts/v2/JobRegistry.sol) | `setModules`, `setFeePool`, `setTaxPolicy`, `setAgentRootNode`, `setAgentMerkleRoot`,<br>`setTreasury`, `setIdentityRegistry` |
 | [`ValidationModule`](contracts/v2/ValidationModule.sol) | `setJobRegistry`, `setCommitWindow`, `setRevealWindow`, `setValidatorBounds`, `setApprovalThreshold`, `setIdentityRegistry` |
 | [`IdentityRegistry`](contracts/v2/IdentityRegistry.sol) | `setENS`, `setNameWrapper`, `setReputationEngine`, `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot`, `setValidatorMerkleRoot`, `setAgentProfileURI` |
 | [`DisputeModule`](contracts/v2/modules/DisputeModule.sol) | `setDisputeFee`, `setTaxPolicy`, `setFeePool` |


### PR DESCRIPTION
## Summary
- document treasury and identity registry setters for JobRegistry
- wrap JobRegistry row for readability

## Testing
- `npm test` *(fails: hangs while downloading Solidity compiler)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4af3248488333ac61b8d0c8e1c947