### PR TITLE
Refactor authorization helpers to public

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -167,7 +167,7 @@ contract IdentityRegistry is Ownable {
         string calldata uri
     ) external {
         require(
-            this.isAuthorizedAgent(msg.sender, subdomain, proof),
+            isAuthorizedAgent(msg.sender, subdomain, proof),
             "Not authorized agent"
         );
         agentProfileURI[msg.sender] = uri;
@@ -182,7 +182,7 @@ contract IdentityRegistry is Ownable {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) external view returns (bool) {
+    ) public view returns (bool) {
         if (
             address(reputationEngine) != address(0) &&
             reputationEngine.isBlacklisted(claimant)
@@ -208,7 +208,7 @@ contract IdentityRegistry is Ownable {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) external view returns (bool) {
+    ) public view returns (bool) {
         if (
             address(reputationEngine) != address(0) &&
             reputationEngine.isBlacklisted(claimant)


### PR DESCRIPTION
## Summary
- make authorization helper functions public and call directly

## Testing
- `npm run compile` (fails: Declaration "TOKEN_SCALE" not found)
- `npm test` (fails: Declaration "TOKEN_SCALE" not found)


------
https://chatgpt.com/codex/tasks/task_e_68b4c0f386d88333b15d45c5ffddebe5