### PR TITLE
docs: correct JobRegistry.setModules ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Record each address during deployment. The defaults below assume the 18‑decima
 ### Etherscan steps
 1. **Deploy contracts** – open each verified contract → **Contract → Deploy** and provide the constructor parameters listed above.
 2. **Wire modules** – from each contract’s **Write** tab call:
-   - `JobRegistry.setModules(stakeManager, validationModule, disputeModule, certificateNFT, reputationEngine, feePool)`
+   - `JobRegistry.setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, [])`
+     - Parameters must be supplied in the order `(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, ackModules)`.
+     - Replace the final array with acknowledgement modules or use `[]` when none are required.
    - `StakeManager.setJobRegistry(jobRegistry)` and `ValidationModule.setJobRegistry(jobRegistry)`
    - `JobRegistry.setIdentityRegistry(identityRegistry)`
    - `ValidationModule.setIdentityRegistry(identityRegistry)`

--- a/docs/api/JobRegistry.md
+++ b/docs/api/JobRegistry.md
@@ -8,7 +8,7 @@ Coordinates job posting, assignment and dispute resolution.
 - `submit(uint256 jobId, bytes32 resultHash, string resultURI)` – agent submits work.
 - `finalize(uint256 jobId)` – releases rewards after validation succeeds.
 - `raiseDispute(uint256 jobId, string evidence)` – escalate to the dispute module.
-- `setModules(address stakeManager, address validationModule, address disputeModule, address certificateNFT, address reputationEngine, address feePool)` – owner wires modules.
+- `setModules(address validationModule, address stakeManager, address reputationEngine, address disputeModule, address certificateNFT, address feePool, address[] ackModules)` – owner wires modules. Use `[]` for `ackModules` when none are needed.
 - `setTaxPolicy(address policy)` / `acknowledgeTaxPolicy()` – configure tax policy and acknowledge.
 - `setAgentRootNode(bytes32 node)` / `setAgentMerkleRoot(bytes32 root)` – load ENS allowlists.
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -101,10 +101,12 @@ interface IJobRegistry {
     function finalize(uint256 jobId) external;
     function setModules(
         address validation,
-        address reputation,
         address stake,
+        address reputation,
         address dispute,
-        address cert
+        address cert,
+        address feePool,
+        address[] calldata ackModules
     ) external;
     function setJobParameters(uint256 reward, uint256 stake) external;
 }

--- a/docs/deployment-v2-agialpha.md
+++ b/docs/deployment-v2-agialpha.md
@@ -31,7 +31,9 @@ The default run uses the mainnet `$AGIALPHA` address, a 5% protocol fee and 5% b
 
 `deployDefaults.ts` wires modules automatically. If you deploy contracts individually, complete the wiring manually:
 
-1. On `JobRegistry`, call `setModules(stakeManager, validationModule, reputationEngine, disputeModule, certificateNFT, platformRegistry, jobRouter, platformIncentives, feePool, taxPolicy)`.
+1. On `JobRegistry`, call `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, [])`.
+   - Supply parameters exactly in that order: `(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, ackModules)`.
+   - Pass an empty array (`[]`) for `ackModules` when no acknowledgement modules are used.
    ![setModules](https://via.placeholder.com/650x150?text=setModules)
 2. On `StakeManager`, `ValidationModule` and `CertificateNFT`, call `setJobRegistry(jobRegistry)`.
    ![setJobRegistry](https://via.placeholder.com/650x150?text=setJobRegistry)

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -183,7 +183,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 | --- | --- | --- |
 | `createJob(string details, uint256 reward)` | `details` – off-chain URI, `reward` – escrowed token amount | Employer posts a new job and locks payment. |
 | `acknowledgeTaxPolicy()` | none | Participant confirms tax disclaimer before interacting. |
-| `setModules(address validation, address stake, address reputation, address dispute, address certificate)` | module addresses | Owner wires modules after deployment. |
+| `setModules(address validation, address stake, address reputation, address dispute, address certificate, address feePool, address[] ackModules)` | module addresses and acknowledgement modules | Owner wires modules after deployment. Use `[]` when no acknowledgement modules are needed. |
 
 ### StakeManager
 | Function | Parameters | Typical Use Case |

--- a/docs/modular-architecture-v2.md
+++ b/docs/modular-architecture-v2.md
@@ -51,7 +51,9 @@ interface IJobRegistry {
         address stake,
         address reputation,
         address dispute,
-        address certificate
+        address certificate,
+        address feePool,
+        address[] calldata ackModules
     ) external;
 }
 

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -59,8 +59,10 @@ The script prints module addresses and verifies source on Etherscan.
 7. **Deploy `CertificateNFT`** supplying a name and symbol.
 8. **Deploy `JobRegistry`** passing the governance contract address as the
    final constructor argument, then wire modules by calling
-   `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, new address[](0))` from the
+   `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, new address[](0))` from the
    governance account.
+   - Parameter order matters: `(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, ackModules)`.
+   - Use `new address[](0)` for `ackModules` when no acknowledgement modules exist.
 9. **Point modules back to `JobRegistry`** by calling `setJobRegistry` on `StakeManager`, `ValidationModule`, `DisputeModule` and `CertificateNFT`, and `setIdentityRegistry` on `ValidationModule`.
 10. **Configure ENS and Merkle roots** using `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot` and `setValidatorMerkleRoot` on `IdentityRegistry`.
 11. **Governance setup** – deploy a multisig wallet or timelock controller

--- a/docs/v2-module-deployment-summary.md
+++ b/docs/v2-module-deployment-summary.md
@@ -18,8 +18,10 @@ the `StakeManager` address.
 
 ## 2. Wiring
 1. On `JobRegistry` call
-   `setModules(stakeManager, validationModule, reputationEngine,
-   disputeModule, certificateNFT, feePool)`.
+   `setModules(validationModule, stakeManager, reputationEngine,
+   disputeModule, certificateNFT, feePool, [])`.
+   - The arguments must follow `(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, ackModules)`.
+   - Use `[]` for `ackModules` if no acknowledgement modules are required.
 2. Call `setJobRegistry(jobRegistry)` on `StakeManager`,
    `ValidationModule`, `DisputeModule` and `CertificateNFT`.
 3. On `ValidationModule` also call `setIdentityRegistry(identityRegistry)`.

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -35,7 +35,9 @@ interface IJobRegistry {
         address stake,
         address reputation,
         address dispute,
-        address certificate
+        address certificate,
+        address feePool,
+        address[] calldata ackModules
     ) external;
     function addAdditionalAgent(address agent) external;
     function removeAdditionalAgent(address agent) external;


### PR DESCRIPTION
## Summary
- fix JobRegistry.setModules example to use `(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, ackModules)`
- clarify parameter order and `ackModules` usage across deployment docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4d918c42c8333bd43adfef656501c