### PR TITLE
Centralize module ownership to pause or governance

### DIFF
--- a/scripts/v2/deployDefaults.ts
+++ b/scripts/v2/deployDefaults.ts
@@ -25,8 +25,8 @@ async function main() {
   console.log("Deployer", deployerAddress);
 
   const tx = withTax
-    ? await deployer.deployDefaults()
-    : await deployer.deployDefaultsWithoutTaxPolicy();
+    ? await deployer.deployDefaults(owner.address)
+    : await deployer.deployDefaultsWithoutTaxPolicy(owner.address);
   const receipt = await tx.wait();
   const log = receipt.logs.find((l) => l.address === deployerAddress)!;
   const decoded = deployer.interface.decodeEventLog(

--- a/test/v2/OwnershipTimelock.test.js
+++ b/test/v2/OwnershipTimelock.test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
-const { ethers, network } = require("hardhat");
+const { ethers, network, artifacts } = require("hardhat");
+const { AGIALPHA } = require("../../scripts/constants");
 
 describe("Timelock ownership", function () {
   it("only timelock can call privileged setters after transfer", async function () {
@@ -25,9 +26,23 @@ describe("Timelock ownership", function () {
       validatorMerkleRoot: ethers.ZeroHash,
       agentMerkleRoot: ethers.ZeroHash,
     };
-    const addresses = await deployer.deploy.staticCall(econ, ids);
-    await deployer.deploy(econ, ids);
-    const [stakeAddr, registryAddr, , , , , , , , , , , systemPauseAddr] = addresses;
+    const artifact = await artifacts.readArtifact(
+      "contracts/test/MockERC20.sol:MockERC20"
+    );
+    await network.provider.send("hardhat_setCode", [
+      AGIALPHA,
+      artifact.deployedBytecode,
+    ]);
+    const tx = await deployer.deploy(econ, ids, owner.address);
+    const receipt = await tx.wait();
+    const deployerAddress = await deployer.getAddress();
+    const log = receipt.logs.find((l) => l.address === deployerAddress);
+    const decoded = deployer.interface.decodeEventLog(
+      "Deployed",
+      log.data,
+      log.topics
+    );
+    const [stakeAddr, registryAddr, , , , , , , , , , , systemPauseAddr] = decoded;
 
     const StakeManager = await ethers.getContractFactory("contracts/v2/StakeManager.sol:StakeManager");
     const JobRegistry = await ethers.getContractFactory("contracts/v2/JobRegistry.sol:JobRegistry");

--- a/test/v2/SystemPause.test.js
+++ b/test/v2/SystemPause.test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const { ethers, artifacts, network } = require("hardhat");
+const { AGIALPHA } = require("../../scripts/constants");
 
 describe("SystemPause", function () {
   it("pauses and unpauses all modules", async function () {
@@ -27,8 +28,22 @@ describe("SystemPause", function () {
       validatorMerkleRoot: ethers.ZeroHash,
       agentMerkleRoot: ethers.ZeroHash,
     };
-    const addresses = await deployer.deploy.staticCall(econ, ids);
-    await deployer.deploy(econ, ids);
+    const artifact = await artifacts.readArtifact(
+      "contracts/test/MockERC20.sol:MockERC20"
+    );
+    await network.provider.send("hardhat_setCode", [
+      AGIALPHA,
+      artifact.deployedBytecode,
+    ]);
+    const tx = await deployer.deploy(econ, ids, owner.address);
+    const receipt = await tx.wait();
+    const deployerAddress = await deployer.getAddress();
+    const log = receipt.logs.find((l) => l.address === deployerAddress);
+    const decoded = deployer.interface.decodeEventLog(
+      "Deployed",
+      log.data,
+      log.topics
+    );
     const [
       stakeAddr,
       registryAddr,
@@ -43,7 +58,7 @@ describe("SystemPause", function () {
       ,
       ,
       systemPauseAddr,
-    ] = addresses;
+    ] = decoded;
     const StakeManager = await ethers.getContractFactory(
       "contracts/v2/StakeManager.sol:StakeManager"
     );


### PR DESCRIPTION
## Summary
- route Deployer ownership transfers through a supplied governance address
- update default deployment script to pass governance address
- add regression test covering post-deployment ownership for all modules

## Testing
- `npm test test/v2/Deployer.test.js test/v2/Ownership.test.js test/v2/OwnershipTimelock.test.js test/v2/SystemPause.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b4f43b6abc8333b5b04d1f729f3ce2