### PR TITLE
feat: enforce tax policy acknowledgement with custom error

### DIFF
--- a/contracts/v2/libraries/TaxAcknowledgement.sol
+++ b/contracts/v2/libraries/TaxAcknowledgement.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.25;
 import {ITaxPolicy} from "../interfaces/ITaxPolicy.sol";
 
 abstract contract TaxAcknowledgement {
+    error TaxPolicyNotAcknowledged(address account);
+
     modifier requiresTaxAcknowledgement(
         ITaxPolicy policy,
         address account,
@@ -17,10 +19,9 @@ abstract contract TaxAcknowledgement {
             account != exempt2 &&
             address(policy) != address(0)
         ) {
-            require(
-                policy.hasAcknowledged(account),
-                "acknowledge tax policy"
-            );
+            if (!policy.hasAcknowledged(account)) {
+                revert TaxPolicyNotAcknowledged(account);
+            }
         }
         _;
     }

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -118,6 +118,8 @@ describe("JobRegistry agent gating", function () {
     await policy.bumpPolicyVersion();
     await expect(
       registry.connect(agent).applyForJob(jobId, "a", [])
-    ).to.be.revertedWith("acknowledge tax policy");
+    )
+      .to.be.revertedWithCustomError(registry, "TaxPolicyNotAcknowledged")
+      .withArgs(agent.address);
   });
 });

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -375,7 +375,9 @@ describe("StakeManager", function () {
 
     await expect(
       stakeManager.connect(user).depositStake(0, 100)
-    ).to.be.revertedWith("acknowledge tax policy");
+    )
+      .to.be.revertedWithCustomError(stakeManager, "TaxPolicyNotAcknowledged")
+      .withArgs(user.address);
 
     await jobRegistry.connect(user).acknowledgeTaxPolicy();
     await expect(stakeManager.connect(user).depositStake(0, 100)).to.emit(
@@ -386,7 +388,9 @@ describe("StakeManager", function () {
     await taxPolicy.connect(owner).bumpPolicyVersion();
     await expect(
       stakeManager.connect(user).withdrawStake(0, 50)
-    ).to.be.revertedWith("acknowledge tax policy");
+    )
+      .to.be.revertedWithCustomError(stakeManager, "TaxPolicyNotAcknowledged")
+      .withArgs(user.address);
 
     await jobRegistry.connect(user).acknowledgeTaxPolicy();
     await expect(stakeManager.connect(user).withdrawStake(0, 50))

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -90,7 +90,9 @@ describe("StakeManager extras", function () {
       stakeManager
         .connect(user)
         .depositStake(0, ethers.parseEther("100"))
-    ).to.be.revertedWith("acknowledge tax policy");
+    )
+      .to.be.revertedWithCustomError(stakeManager, "TaxPolicyNotAcknowledged")
+      .withArgs(user.address);
   });
 
   it("enforces max stake per address", async () => {

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -68,7 +68,9 @@ describe("JobRegistry tax policy integration", function () {
     const deadline = (await time.latest()) + 1000;
     await expect(
       registry.connect(user).createJob(1, deadline, "uri")
-    ).to.be.revertedWith("acknowledge tax policy");
+    )
+      .to.be.revertedWithCustomError(registry, "TaxPolicyNotAcknowledged")
+      .withArgs(user.address);
     await expect(registry.connect(user).acknowledgeTaxPolicy())
       .to.emit(policy, "PolicyAcknowledged")
       .withArgs(user.address, 2)

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -444,7 +444,9 @@ describe("ValidationModule V2", function () {
 
     await expect(
       validation.connect(val).commitValidation(1, commit, "", [])
-    ).to.be.revertedWith("acknowledge tax policy");
+    )
+      .to.be.revertedWithCustomError(validation, "TaxPolicyNotAcknowledged")
+      .withArgs(val.address);
 
     await jobRegistry.connect(val).acknowledgeTaxPolicy();
     await expect(
@@ -455,7 +457,9 @@ describe("ValidationModule V2", function () {
     await policy.bumpPolicyVersion();
     await expect(
       validation.connect(val).revealValidation(1, true, salt, "", [])
-    ).to.be.revertedWith("acknowledge tax policy");
+    )
+      .to.be.revertedWithCustomError(validation, "TaxPolicyNotAcknowledged")
+      .withArgs(val.address);
 
     await jobRegistry.connect(val).acknowledgeTaxPolicy();
     await expect(

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -250,7 +250,9 @@ describe("comprehensive job flows", function () {
     const deadline = (await time.latest()) + 1000;
     await expect(
       registry.connect(employer).createJob(reward, deadline, "uri")
-    ).to.be.revertedWith("acknowledge tax policy");
+    )
+      .to.be.revertedWithCustomError(registry, "TaxPolicyNotAcknowledged")
+      .withArgs(employer.address);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `TaxPolicyNotAcknowledged` error and use it in `requiresTaxAcknowledgement`
- update tests to expect custom error when tax policy isn't acknowledged

## Testing
- `npx hardhat test` *(fails: npm warn Unknown env config "http-proxy" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fc374c808333932b9eb7145450e3