### PR TITLE
feat: validate job registry version

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -278,6 +278,9 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @dev Staking is disabled until a nonzero registry is configured.
     /// @param _jobRegistry registry contract enforcing tax acknowledgements
     function setJobRegistry(address _jobRegistry) external onlyGovernance {
+        if (_jobRegistry == address(0) || IJobRegistry(_jobRegistry).version() != 2) {
+            revert InvalidJobRegistry();
+        }
         jobRegistry = _jobRegistry;
         emit JobRegistryUpdated(_jobRegistry);
     }

--- a/contracts/v2/mocks/ReentrantJobRegistry.sol
+++ b/contracts/v2/mocks/ReentrantJobRegistry.sol
@@ -33,6 +33,10 @@ contract ReentrantJobRegistry {
     uint256 public reward;
     uint256 public amount;
 
+    function version() external pure returns (uint256) {
+        return 2;
+    }
+
     constructor(address sm, address token_) {
         stakeManager = IStakeManager(sm);
         token = IReentrantToken(token_);

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -178,6 +178,10 @@ describe("Module replacement", function () {
     ).to.be.revertedWithCustomError(stake, "InvalidValidationModule");
 
     await expect(
+      stake.connect(owner).setJobRegistry(await bad.getAddress())
+    ).to.be.revertedWithCustomError(stake, "InvalidJobRegistry");
+
+    await expect(
       stake
         .connect(owner)
         .setModules(await bad.getAddress(), await dispute.getAddress())


### PR DESCRIPTION
## Summary
- ensure StakeManager only accepts JobRegistry contracts with version 2
- add test verifying JobRegistry version mismatch is rejected

## Testing
- `npm run verify:agialpha`
- `npm run lint` *(fails: Error checking for updates)*
- `npx hardhat test --no-compile` *(fails: Artifact for contract "contracts/test/MockERC20.sol:MockERC20" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b502b017f48333ba73ebd7317e50bb