### PR TITLE
chore: configure etherscan verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Environment variables for development
+# Etherscan API key for contract verification
+ETHERSCAN_API_KEY=

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -27,5 +27,8 @@ module.exports = {
     enabled: true,
     currency: 'USD',
     showTimeSpent: true,
+  },
+  etherscan: {
+    apiKey: process.env.ETHERSCAN_API_KEY,
   }
 };


### PR DESCRIPTION
## Summary
- add Etherscan API key configuration to Hardhat
- document `ETHERSCAN_API_KEY` in `.env.example`

## Testing
- `npm test`
- `npm run lint`
- `npx hardhat verify --help`


------
https://chatgpt.com/codex/tasks/task_e_68b508a9d99483339a88edd6a665cc4e