### PR TITLE
Enforce IdentityRegistry version compatibility

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -13,6 +13,8 @@ import {ENSIdentityVerifier} from "./ENSIdentityVerifier.sol";
 /// for agents and validators. Provides helper views that also check
 /// reputation blacklists.
 contract IdentityRegistry is Ownable2Step {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 2;
     enum AgentType {
         Human,
         AI

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -348,6 +348,8 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     /// @notice Update the identity registry used for agent verification.
     /// @param registry Address of the IdentityRegistry contract.
     function setIdentityRegistry(IIdentityRegistry registry) external onlyGovernance {
+        require(address(registry) != address(0), "identity reg");
+        require(registry.version() == 2, "Invalid identity registry");
         identityRegistry = registry;
         emit IdentityRegistryUpdated(address(registry));
         emit ModuleUpdated("IdentityRegistry", address(registry));

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -212,6 +212,8 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
 
     /// @notice Update the identity registry used for validator verification.
     function setIdentityRegistry(IIdentityRegistry registry) external onlyOwner {
+        require(address(registry) != address(0), "identity reg");
+        require(registry.version() == 2, "Invalid identity registry");
         identityRegistry = registry;
         emit IdentityRegistryUpdated(address(registry));
     }

--- a/contracts/v2/interfaces/IIdentityRegistry.sol
+++ b/contracts/v2/interfaces/IIdentityRegistry.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.25;
 
 interface IIdentityRegistry {
+    /// @notice Module version for compatibility checks.
+    function version() external view returns (uint256);
     enum AgentType {
         Human,
         AI

--- a/contracts/v2/mocks/IdentityRegistryMock.sol
+++ b/contracts/v2/mocks/IdentityRegistryMock.sol
@@ -5,6 +5,9 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @notice Simple identity registry mock that always authorizes.
 contract IdentityRegistryMock is Ownable {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 2;
+
     address public ens;
     address public nameWrapper;
     address public reputationEngine;

--- a/contracts/v2/mocks/IdentityRegistryToggle.sol
+++ b/contracts/v2/mocks/IdentityRegistryToggle.sol
@@ -5,6 +5,9 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @notice Identity registry mock with toggled verification result.
 contract IdentityRegistryToggle is Ownable {
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 2;
+
     bool public result;
     bytes32 public clubRootNode;
     bytes32 public agentRootNode;

--- a/contracts/v2/mocks/ReentrantIdentityRegistry.sol
+++ b/contracts/v2/mocks/ReentrantIdentityRegistry.sol
@@ -15,6 +15,9 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
     bool public approve;
     bytes32 public salt;
 
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 2;
+
     function setValidationModule(address vm) external {
         validation = IValidationModule(vm);
     }

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -150,7 +150,8 @@ describe("Ownable modules", function () {
       [
         ValidationModule.attach(validation),
         systemPauseSigner,
-        (inst, signer) => inst.connect(signer).setIdentityRegistry(ethers.ZeroAddress),
+        (inst, signer) =>
+          inst.connect(signer).setIdentityRegistry(identityRegistryAddr),
       ],
       [
         ReputationEngine.attach(reputation),


### PR DESCRIPTION
## Summary
- expose `version` getter on IdentityRegistry and require version 2 in dependent modules
- guard `setIdentityRegistry` in JobRegistry and ValidationModule against zero address and mismatched versions
- update reentrant identity registry mock for new interface

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5aba979c08333a2f83c7d308a4497