### PR TITLE
Add FeePool version checks across modules

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -28,6 +28,8 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
 
     uint256 public constant ACCUMULATOR_SCALE = 1e12;
     uint256 public constant DEFAULT_BURN_PCT = 5;
+    /// @notice Module version for compatibility checks.
+    uint256 public constant version = 2;
 
     /// @notice ERC20 token used for fees and rewards (immutable $AGIALPHA)
     IERC20 public immutable token = IERC20(AGIALPHA);

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -315,6 +315,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         require(_reputation.version() == 2, "Invalid reputation module");
         require(_dispute.version() == 2, "Invalid dispute module");
         require(_certNFT.version() == 2, "Invalid certificate NFT");
+        require(address(_feePool) != address(0) && _feePool.version() == 2, "Invalid fee pool");
 
         validationModule = _validation;
         stakeManager = _stakeMgr;
@@ -407,6 +408,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
 
     /// @notice update the FeePool contract used for revenue sharing
     function setFeePool(IFeePool _feePool) external onlyGovernance {
+        require(address(_feePool) != address(0) && _feePool.version() == 2, "Invalid fee pool");
         feePool = _feePool;
         emit FeePoolUpdated(address(_feePool));
         emit ModuleUpdated("FeePool", address(_feePool));

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -340,6 +340,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice update FeePool contract
     /// @param pool FeePool receiving protocol fees
     function setFeePool(IFeePool pool) external onlyGovernance {
+        require(address(pool) != address(0) && pool.version() == 2, "invalid pool");
         feePool = pool;
         emit FeePoolUpdated(address(pool));
     }

--- a/contracts/v2/interfaces/IFeePool.sol
+++ b/contracts/v2/interfaces/IFeePool.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.25;
 /// @title IFeePool
 /// @notice Minimal interface for depositing job fees
 interface IFeePool {
+    /// @notice contract version for compatibility checks
+    function version() external view returns (uint256);
+
     /// @notice notify the pool about newly received fees
     /// @param amount amount of tokens transferred to the pool scaled to 18 decimals
     function depositFee(uint256 amount) external;

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -4,7 +4,7 @@ const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("Job expiration", function () {
   const { AGIALPHA } = require("../../scripts/constants");
-  let token, stakeManager, rep, validation, nft, registry, dispute, policy;
+  let token, stakeManager, rep, validation, nft, registry, dispute, policy, feePool;
   let owner, employer, agent, treasury;
   const reward = 100;
   const stake = 200;
@@ -38,6 +38,14 @@ describe("Job expiration", function () {
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );
     nft = await NFT.deploy("Cert", "CERT");
+    const FeePool = await ethers.getContractFactory(
+      "contracts/v2/FeePool.sol:FeePool"
+    );
+    feePool = await FeePool.deploy(
+      await stakeManager.getAddress(),
+      0,
+      treasury.address
+    );
     const Registry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
@@ -74,7 +82,7 @@ describe("Job expiration", function () {
         await rep.getAddress(),
         await dispute.getAddress(),
         await nft.getAddress(),
-        ethers.ZeroAddress,
+        await feePool.getAddress(),
         []
       );
     await validation.setJobRegistry(await registry.getAddress());
@@ -84,6 +92,9 @@ describe("Job expiration", function () {
     await stakeManager
       .connect(owner)
       .setValidationModule(await validation.getAddress());
+    await stakeManager
+      .connect(owner)
+      .setFeePool(await feePool.getAddress());
     const Identity = await ethers.getContractFactory(
       "contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock"
     );

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -6,6 +6,7 @@ describe("JobRegistry integration", function () {
   let token, stakeManager, rep, validation, nft, registry, dispute, policy, identity;
   const { AGIALPHA } = require("../../scripts/constants");
   let owner, employer, agent, treasury;
+  let feePool;
 
   const reward = 100;
   const stake = 200;
@@ -40,6 +41,14 @@ describe("JobRegistry integration", function () {
       "contracts/v2/modules/CertificateNFT.sol:CertificateNFT"
     );
     nft = await NFT.deploy("Cert", "CERT");
+    const FeePool = await ethers.getContractFactory(
+      "contracts/v2/FeePool.sol:FeePool"
+    );
+    feePool = await FeePool.deploy(
+      await stakeManager.getAddress(),
+      0,
+      treasury.address
+    );
     const Registry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"
     );
@@ -79,7 +88,7 @@ describe("JobRegistry integration", function () {
         await rep.getAddress(),
         await dispute.getAddress(),
         await nft.getAddress(),
-        ethers.ZeroAddress,
+        await feePool.getAddress(),
         []
       );
     await validation.setJobRegistry(await registry.getAddress());
@@ -101,6 +110,9 @@ describe("JobRegistry integration", function () {
     await stakeManager
       .connect(owner)
       .setValidationModule(await validation.getAddress());
+    await stakeManager
+      .connect(owner)
+      .setFeePool(await feePool.getAddress());
     await nft.connect(owner).transferOwnership(await registry.getAddress());
     await registry
       .connect(owner)
@@ -291,7 +303,7 @@ describe("JobRegistry integration", function () {
           await rep.getAddress(),
           await dispute.getAddress(),
           await nft.getAddress(),
-          ethers.ZeroAddress,
+          await feePool.getAddress(),
           []
         )
     )
@@ -323,7 +335,7 @@ describe("JobRegistry integration", function () {
         await rep.getAddress(),
         await dispute.getAddress(),
         await nft.getAddress(),
-        ethers.ZeroAddress,
+        await feePool.getAddress(),
         [treasury.address]
       );
 

--- a/test/v2/JobRegistryModuleVersion.test.js
+++ b/test/v2/JobRegistryModuleVersion.test.js
@@ -39,7 +39,7 @@ describe("JobRegistry module version checks", function () {
           await good.getAddress(),
           await good.getAddress(),
           await good.getAddress(),
-          ethers.ZeroAddress,
+          await good.getAddress(),
           []
         )
     ).to.be.revertedWith("Invalid validation module");
@@ -55,7 +55,7 @@ describe("JobRegistry module version checks", function () {
           await good.getAddress(),
           await good.getAddress(),
           await good.getAddress(),
-          ethers.ZeroAddress,
+          await good.getAddress(),
           []
         )
     ).to.be.revertedWith("Invalid stake manager");
@@ -71,7 +71,7 @@ describe("JobRegistry module version checks", function () {
           await bad.getAddress(),
           await good.getAddress(),
           await good.getAddress(),
-          ethers.ZeroAddress,
+          await good.getAddress(),
           []
         )
     ).to.be.revertedWith("Invalid reputation module");
@@ -87,7 +87,7 @@ describe("JobRegistry module version checks", function () {
           await good.getAddress(),
           await bad.getAddress(),
           await good.getAddress(),
-          ethers.ZeroAddress,
+          await good.getAddress(),
           []
         )
     ).to.be.revertedWith("Invalid dispute module");
@@ -103,7 +103,7 @@ describe("JobRegistry module version checks", function () {
           await good.getAddress(),
           await good.getAddress(),
           await bad.getAddress(),
-          ethers.ZeroAddress,
+          await good.getAddress(),
           []
         )
     ).to.be.revertedWith("Invalid certificate NFT");
@@ -118,7 +118,7 @@ describe("JobRegistry module version checks", function () {
         await good.getAddress(),
         await good.getAddress(),
         await good.getAddress(),
-        ethers.ZeroAddress,
+        await good.getAddress(),
         []
       );
     expect(await registry.validationModule()).to.equal(

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -82,6 +82,16 @@ async function deploySystem() {
   );
   await dispute.waitForDeployment();
 
+  const FeePool = await ethers.getContractFactory(
+    "contracts/v2/FeePool.sol:FeePool"
+  );
+  const feePool = await FeePool.deploy(
+    await stake.getAddress(),
+    0,
+    owner.address
+  );
+  await feePool.waitForDeployment();
+
   await stake.setModules(await registry.getAddress(), await dispute.getAddress());
   await validation.setJobRegistry(await registry.getAddress());
   await nft.setJobRegistry(await registry.getAddress());
@@ -92,13 +102,14 @@ async function deploySystem() {
     await reputation.getAddress(),
     await dispute.getAddress(),
     await nft.getAddress(),
-    ethers.ZeroAddress,
+    await feePool.getAddress(),
     []
   );
   await registry.setIdentityRegistry(await identity.getAddress());
   await reputation.setCaller(await registry.getAddress(), true);
+  await stake.connect(owner).setFeePool(await feePool.getAddress());
 
-  return { owner, employer, agent, token, stake, reputation, validation, nft, registry, dispute };
+  return { owner, employer, agent, token, stake, reputation, validation, nft, registry, dispute, feePool };
 }
 
 describe("Module replacement", function () {

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -187,34 +187,10 @@ describe("StakeManager release", function () {
     );
   });
 
-  it("burns fee when fee pool unset", async () => {
-    const burnAddr = "0x000000000000000000000000000000000000dEaD";
-    await stakeManager.connect(owner).setFeePool(ethers.ZeroAddress);
-
-    const before1 = await token.balanceOf(user1.address);
-    const beforeBurn = await token.balanceOf(burnAddr);
-
+  it("reverts when setting fee pool to zero", async () => {
     await expect(
-      stakeManager
-        .connect(registrySigner)
-        .release(user1.address, ethers.parseEther("100"))
-    )
-      .to.emit(stakeManager, "StakeReleased")
-      .withArgs(ethers.ZeroHash, burnAddr, ethers.parseEther("20"))
-      .and.to.emit(stakeManager, "StakeReleased")
-      .withArgs(ethers.ZeroHash, burnAddr, ethers.parseEther("10"))
-      .and.to.emit(stakeManager, "StakeReleased")
-      .withArgs(ethers.ZeroHash, user1.address, ethers.parseEther("70"));
-
-    expect((await token.balanceOf(user1.address)) - before1).to.equal(
-      ethers.parseEther("70")
-    );
-    expect((await token.balanceOf(burnAddr)) - beforeBurn).to.equal(
-      ethers.parseEther("30")
-    );
-    expect(await token.balanceOf(await feePool.getAddress())).to.equal(
-      ethers.parseEther("0")
-    );
+      stakeManager.connect(owner).setFeePool(ethers.ZeroAddress)
+    ).to.be.revertedWith("invalid pool");
   });
 
   it("restricts fee configuration to owner", async () => {


### PR DESCRIPTION
## Summary
- expose FeePool version constant and interface getter
- enforce FeePool version when configuring StakeManager and JobRegistry
- update tests for new FeePool validation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5be8c2bc883339bdbab9c274f3420