### PR TITLE
Require valid StakeManager in ReputationEngine

### DIFF
--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -58,11 +58,11 @@ contract ReputationEngine is Ownable, Pausable {
     event ModulesUpdated(address indexed stakeManager);
     event ValidationRewardPercentageUpdated(uint256 percentage);
     constructor(IStakeManager _stakeManager) Ownable(msg.sender) {
-        if (address(_stakeManager) != address(0)) {
-            stakeManager = _stakeManager;
-            emit StakeManagerUpdated(address(_stakeManager));
-            emit ModulesUpdated(address(_stakeManager));
-        }
+        require(address(_stakeManager) != address(0), "invalid stake manager");
+        require(_stakeManager.version() == 2, "incompatible version");
+        stakeManager = _stakeManager;
+        emit StakeManagerUpdated(address(_stakeManager));
+        emit ModulesUpdated(address(_stakeManager));
     }
 
     modifier onlyCaller() {
@@ -87,6 +87,8 @@ contract ReputationEngine is Ownable, Pausable {
 
     /// @notice Set the StakeManager used for stake lookups.
     function setStakeManager(IStakeManager manager) external onlyOwner {
+        require(address(manager) != address(0), "invalid stake manager");
+        require(manager.version() == 2, "incompatible version");
         stakeManager = manager;
         emit StakeManagerUpdated(address(manager));
         emit ModulesUpdated(address(manager));

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -14,13 +14,13 @@ This walkthrough shows a non‑technical owner how to deploy and wire the modula
 
 ## 2. Deploy core modules
 
-Deploy each contract **in the order listed below** from the **Write Contract** tabs (the deployer automatically becomes the owner). Addresses for dependent modules may be passed at deployment or left as `0` and wired later. Parameters may be left as `0` to accept the defaults shown below:
+Deploy each contract **in the order listed below** from the **Write Contract** tabs (the deployer automatically becomes the owner). Addresses for dependent modules may be passed at deployment or left as `0` and wired later, except `ReputationEngine` which now requires a valid `StakeManager` address. Parameters may be left as `0` to accept the defaults shown below:
 
 1. Use the existing `$AGIALPHA` token. Deploy [`AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) only on local networks and call `mint(to, amount)` to create a test supply.
 2. `StakeManager(token, minStake, employerPct, treasuryPct, treasury)` – pass `address(0)` for `token` to use the default $AGIALPHA and `0,0` for the slashing percentages to send 100% of any slash to the treasury.
 3. `JobRegistry(validation, stakeMgr, reputation, dispute, certNFT, feePool, taxPolicy, feePct, jobStake)` – leaving `feePct = 0` applies a 5% protocol fee. Supplying a nonzero `taxPolicy` sets the disclaimer at deployment; otherwise the owner may call `setTaxPolicy` later.
 4. `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators, validatorPool)` – zero values default to 1‑day windows and a 1–3 validator set.
-5. `ReputationEngine(stakeManager)` – optional reputation weighting (pass `0` to wire later).
+5. `ReputationEngine(stakeManager)` – requires a valid `StakeManager` address.
 6. `DisputeModule(jobRegistry, disputeFee, disputeWindow, moderator)` – manages
    appeals and dispute fees. The fourth argument optionally seeds an initial
    moderator; the deployer remains owner and can add weighted moderators with

--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -63,7 +63,7 @@ All token amounts use the 18 decimal base units of $AGIALPHA (e.g., **1 AGIALP
 2. Deploy `JobRegistry()`.
 3. Deploy `TaxPolicy(uri, acknowledgement)` and call `JobRegistry.setTaxPolicy(taxPolicy)`.
 4. Deploy `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, 1, 3, [])`.
-5. Deploy `ReputationEngine(stakeManager)` or `ReputationEngine(address(0))` if wiring later.
+5. Deploy `ReputationEngine(stakeManager)`.
 6. Deploy `CertificateNFT("AGI Jobs", "AGIJOB")`.
 7. Deploy `DisputeModule(jobRegistry, 0, owner, owner)`.
 8. Deploy `FeePool(token, stakeManager, burnPct, treasury)`; rewards default to platform stakers.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -72,7 +72,7 @@ For a step-by-step deployment walkthrough with owner-only setters, see [deployme
 | ValidationModule | `setValidatorPool` (empty), `setReputationEngine` (0 address), `setCommitRevealWindows` (`0`, `0`), `setValidatorBounds` (`0`, `0`) | Choose validators and tune commit/reveal timing and committee sizes. |
 | DisputeModule | `addModerator(address, weight)` / `removeModerator(address)` (owner), majority-signed `resolve(jobId, verdict, signatures)`, `setDisputeFee` (`0`), `setJobRegistry` (constructor address) | Configure dispute bond and weighted arbiters; disputes finalize via moderator vote or owner call. |
 | StakeManager | `setMinStake` (`0`), `setSlashingPercentages` (`0`, `100`), `setTreasury` (constructor treasury), `setJobRegistry` (0 address), `setDisputeModule` (0 address), `setMaxStakePerAddress` (`0`) | Adjust staking token, minimums, slashing rules, and authorised modules. |
-| ReputationEngine | `setCaller` (`false`), `setStakeManager` (0 address), `setScoringWeights` (`1e18`, `1e18`), `setThreshold` (`0`), `blacklist` (`false`) | Manage scoring weights, authorised callers, and blacklist threshold. |
+| ReputationEngine | `setCaller` (`false`), `setStakeManager` (constructor address), `setScoringWeights` (`1e18`, `1e18`), `setThreshold` (`0`), `blacklist` (`false`) | Manage scoring weights, authorised callers, and blacklist threshold. |
 | CertificateNFT | `setJobRegistry` (0 address) | Authorise minting registry; URIs emitted in events with hashes on-chain. |
 
 Example of swapping validation logic:

--- a/test/v2/DiscoveryModule.test.js
+++ b/test/v2/DiscoveryModule.test.js
@@ -12,7 +12,7 @@ describe("DiscoveryModule", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy(ethers.ZeroAddress);
+    engine = await Engine.deploy(await stakeManager.getAddress());
     await engine
       .connect(owner)
       .setAuthorizedCaller(owner.address, true);

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -208,7 +208,9 @@ describe("FeePool", function () {
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const rep = await Rep.connect(owner).deploy(ethers.ZeroAddress);
+    const rep = await Rep.connect(owner).deploy(
+      await stakeManager.getAddress()
+    );
     await rep.setStakeManager(await stakeManager.getAddress());
     await rep.setAuthorizedCaller(owner.address, true);
 

--- a/test/v2/ReputationEngine.test.js
+++ b/test/v2/ReputationEngine.test.js
@@ -6,10 +6,12 @@ describe("ReputationEngine", function () {
 
   beforeEach(async () => {
     [owner, caller, user, validator] = await ethers.getSigners();
+    const Stake = await ethers.getContractFactory("MockStakeManager");
+    const stake = await Stake.deploy();
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy(ethers.ZeroAddress);
+    engine = await Engine.deploy(await stake.getAddress());
     await engine.connect(owner).setCaller(caller.address, true);
     await engine.connect(owner).setPremiumThreshold(2);
   });

--- a/test/v2/ReputationEngineNoEther.test.js
+++ b/test/v2/ReputationEngineNoEther.test.js
@@ -6,10 +6,12 @@ describe("ReputationEngine ether rejection", function () {
 
   beforeEach(async () => {
     [owner] = await ethers.getSigners();
+    const Stake = await ethers.getContractFactory("MockStakeManager");
+    const stake = await Stake.deploy();
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy(ethers.ZeroAddress);
+    engine = await Engine.deploy(await stake.getAddress());
     await engine.waitForDeployment();
   });
 

--- a/test/v2/RoutingModule.test.js
+++ b/test/v2/RoutingModule.test.js
@@ -15,7 +15,7 @@ describe("JobRouter", function () {
     const Reputation = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    reputation = await Reputation.deploy(ethers.ZeroAddress);
+    reputation = await Reputation.deploy(await stakeManager.getAddress());
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/PlatformRegistry.sol:PlatformRegistry"

--- a/test/v2/identity.test.ts
+++ b/test/v2/identity.test.ts
@@ -14,10 +14,12 @@ describe("IdentityRegistry ENS verification", function () {
     const Wrapper = await ethers.getContractFactory("MockNameWrapper");
     const wrapper = await Wrapper.deploy();
 
+    const Stake = await ethers.getContractFactory("MockStakeManager");
+    const stake = await Stake.deploy();
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const rep = await Rep.deploy(ethers.ZeroAddress);
+    const rep = await Rep.deploy(await stake.getAddress());
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/IdentityRegistry.sol:IdentityRegistry"
@@ -56,10 +58,12 @@ describe("IdentityRegistry ENS verification", function () {
     const Resolver = await ethers.getContractFactory("MockResolver");
     const resolver = await Resolver.deploy();
 
+    const Stake = await ethers.getContractFactory("MockStakeManager");
+    const stake = await Stake.deploy();
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const rep = await Rep.deploy(ethers.ZeroAddress);
+    const rep = await Rep.deploy(await stake.getAddress());
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/IdentityRegistry.sol:IdentityRegistry"
@@ -105,10 +109,12 @@ describe("IdentityRegistry ENS verification", function () {
     const Wrapper = await ethers.getContractFactory("MockNameWrapper");
     const wrapper = await Wrapper.deploy();
 
+    const Stake = await ethers.getContractFactory("MockStakeManager");
+    const stake = await Stake.deploy();
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const rep = await Rep.deploy(ethers.ZeroAddress);
+    const rep = await Rep.deploy(await stake.getAddress());
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/IdentityRegistry.sol:IdentityRegistry"
@@ -144,10 +150,12 @@ describe("IdentityRegistry ENS verification", function () {
     const Wrapper = await ethers.getContractFactory("MockNameWrapper");
     const wrapper = await Wrapper.deploy();
 
+    const Stake = await ethers.getContractFactory("MockStakeManager");
+    const stake = await Stake.deploy();
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const rep = await Rep.deploy(ethers.ZeroAddress);
+    const rep = await Rep.deploy(await stake.getAddress());
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/IdentityRegistry.sol:IdentityRegistry"
@@ -185,10 +193,12 @@ describe("IdentityRegistry ENS verification", function () {
     const Wrapper = await ethers.getContractFactory("MockNameWrapper");
     const wrapper = await Wrapper.deploy();
 
+    const Stake = await ethers.getContractFactory("MockStakeManager");
+    const stake = await Stake.deploy();
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    const rep = await Rep.deploy(ethers.ZeroAddress);
+    const rep = await Rep.deploy(await stake.getAddress());
 
     const Registry = await ethers.getContractFactory(
       "contracts/v2/IdentityRegistry.sol:IdentityRegistry"


### PR DESCRIPTION
## Summary
- validate StakeManager address and version in ReputationEngine constructor and setter
- update docs and tests for mandatory StakeManager

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5c38b48c48333b163adf54dddadce