### PR TITLE
feat: add custom errors for fee pool and AGI type cap

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -44,6 +44,8 @@ error InsufficientEscrow();
 error AGITypeNotFound();
 error EtherNotAccepted();
 error InvalidTokenDecimals();
+error InvalidFeePool();
+error MaxAGITypesExceeded();
 
 /// @title StakeManager
 /// @notice Handles staking balances, job escrows and slashing logic.
@@ -340,7 +342,9 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice update FeePool contract
     /// @param pool FeePool receiving protocol fees
     function setFeePool(IFeePool pool) external onlyGovernance {
-        require(address(pool) != address(0) && pool.version() == 2, "invalid pool");
+        if (address(pool) == address(0) || pool.version() != 2) {
+            revert InvalidFeePool();
+        }
         feePool = pool;
         emit FeePoolUpdated(address(pool));
     }
@@ -370,7 +374,9 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     /// @notice Update the maximum number of AGI types allowed
     function setMaxAGITypes(uint256 newMax) external onlyGovernance {
-        require(newMax <= MAX_AGI_TYPES_CAP, "maxAGITypes");
+        if (newMax > MAX_AGI_TYPES_CAP) {
+            revert MaxAGITypesExceeded();
+        }
         uint256 old = maxAGITypes;
         maxAGITypes = newMax;
         emit MaxAGITypesUpdated(old, newMax);

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -190,7 +190,7 @@ describe("StakeManager release", function () {
   it("reverts when setting fee pool to zero", async () => {
     await expect(
       stakeManager.connect(owner).setFeePool(ethers.ZeroAddress)
-    ).to.be.revertedWith("invalid pool");
+    ).to.be.revertedWithCustomError(stakeManager, "InvalidFeePool");
   });
 
   it("restricts fee configuration to owner", async () => {


### PR DESCRIPTION
## Summary
- add InvalidFeePool and MaxAGITypesExceeded custom errors
- validate fee pool address/version and AGI type cap with custom errors
- update StakeManager release tests for new custom error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5ddaae1848333a2d5e4d1fb8650ed