### PR TITLE
refactor(jobregistry): use external interfaces

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -492,6 +492,15 @@ contract MockReputationEngine is IReputationEngine {
         _rep[user] += 1;
     }
 
+    function calculateReputationPoints(uint256, uint256)
+        external
+        pure
+        override
+        returns (uint256)
+    {
+        return 0;
+    }
+
     function getOperatorScore(address user) external view override returns (uint256) {
         return _rep[user];
     }

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -10,39 +10,10 @@ import {IValidationModule} from "./interfaces/IValidationModule.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
 import {IIdentityRegistry} from "./interfaces/IIdentityRegistry.sol";
+import {IReputationEngine} from "./interfaces/IReputationEngine.sol";
+import {IDisputeModule} from "./interfaces/IDisputeModule.sol";
+import {ICertificateNFT} from "./interfaces/ICertificateNFT.sol";
 import {TOKEN_SCALE} from "./Constants.sol";
-
-interface IReputationEngine {
-    function version() external view returns (uint256);
-    function onApply(address user) external;
-    function onFinalize(
-        address user,
-        bool success,
-        uint256 payout,
-        uint256 duration
-    ) external;
-    function rewardValidator(address validator, uint256 agentGain) external;
-    function calculateReputationPoints(
-        uint256 payout,
-        uint256 duration
-    ) external view returns (uint256);
-    function isBlacklisted(address user) external view returns (bool);
-}
-
-interface IDisputeModule {
-    function version() external view returns (uint256);
-    function raiseDispute(
-        uint256 jobId,
-        address claimant,
-        bytes32 evidenceHash
-    ) external;
-    function resolve(uint256 jobId, bool employerWins) external;
-}
-
-interface ICertificateNFT {
-    function version() external view returns (uint256);
-    function mint(address to, uint256 jobId, bytes32 uriHash) external returns (uint256);
-}
 
 /// @title JobRegistry
 /// @notice Coordinates job lifecycle and external modules.

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -80,6 +80,15 @@ interface IReputationEngine {
 
     function rewardValidator(address validator, uint256 agentGain) external;
 
+    /// @notice Compute reputation gain for an agent based on payout and duration.
+    /// @param payout Amount paid to the agent (18-decimal).
+    /// @param duration Job duration in seconds.
+    /// @return Reputation points awarded to the agent.
+    function calculateReputationPoints(uint256 payout, uint256 duration)
+        external
+        view
+        returns (uint256);
+
     /// @notice Retrieve combined operator score using stake and reputation
     /// @param operator Address to query
     /// @return Weighted score used for ranking


### PR DESCRIPTION
## Summary
- replace inline module interfaces with imports in JobRegistry
- expose calculateReputationPoints in IReputationEngine interface
- stub calculateReputationPoints in legacy MockReputationEngine for compatibility

## Testing
- `npx hardhat compile --force`
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4a401f08333afad72c3020ccb1d