### PR TITLE
refactor: use custom errors in JobRegistry

### DIFF
--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -122,9 +122,8 @@ describe("JobRegistry governance finalization", function () {
     await rep.connect(owner).blacklist(agent.address, true);
     await setJobState(jobId, true);
 
-    await expect(registry.connect(agent).finalize(jobId)).to.be.revertedWith(
-      "Blacklisted"
-    );
+    await expect(registry.connect(agent).finalize(jobId))
+      .to.be.revertedWithCustomError(registry, "Blacklisted");
 
     await expect(registry.connect(owner).finalize(jobId))
       .to.emit(registry, "GovernanceFinalized")
@@ -154,7 +153,7 @@ describe("JobRegistry governance finalization", function () {
 
     await expect(
       registry.connect(employer).finalize(jobId)
-    ).to.be.revertedWith("Blacklisted");
+    ).to.be.revertedWithCustomError(registry, "Blacklisted");
 
     await expect(registry.connect(owner).finalize(jobId))
       .to.emit(registry, "GovernanceFinalized")

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -85,7 +85,7 @@ describe("Identity verification enforcement", function () {
       const jobId = await createJob();
       await expect(
         registry.connect(agent).applyForJob(jobId, "a", [])
-      ).to.be.revertedWith("Not authorized agent");
+      ).to.be.revertedWithCustomError(registry, "NotAuthorizedAgent");
     });
 
     it("rejects unauthorized agent submissions", async () => {
@@ -97,7 +97,7 @@ describe("Identity verification enforcement", function () {
         registry
           .connect(agent)
           .submit(jobId, ethers.id("res"), "res", "a", [])
-      ).to.be.revertedWith("Not authorized agent");
+      ).to.be.revertedWithCustomError(registry, "NotAuthorizedAgent");
     });
   });
 

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -163,7 +163,7 @@ describe("Job expiration", function () {
     await registry.connect(agent).applyForJob(jobId, "", []);
     await expect(
       registry.connect(treasury).cancelExpiredJob(jobId)
-    ).to.be.revertedWith("not expired");
+    ).to.be.revertedWithCustomError(registry, "DeadlineNotReached");
   });
 
   it("respects non-zero expiration grace period", async () => {
@@ -177,7 +177,7 @@ describe("Job expiration", function () {
     await time.increase(120);
     await expect(
       registry.connect(treasury).cancelExpiredJob(jobId)
-    ).to.be.revertedWith("not expired");
+    ).to.be.revertedWithCustomError(registry, "DeadlineNotReached");
     await time.increase(60);
     await expect(
       registry.connect(treasury).cancelExpiredJob(jobId)

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -140,7 +140,7 @@ describe("Job expiration boundary", function () {
     await time.increase(deadline + grace - 1 - (await time.latest()));
     await expect(
       registry.connect(treasury).cancelExpiredJob(jobId)
-    ).to.be.revertedWith("not expired");
+    ).to.be.revertedWithCustomError(registry, "DeadlineNotReached");
   });
 
   it("cancels at deadline + grace and updates state and balances", async () => {

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -286,11 +286,11 @@ describe("JobRegistry integration", function () {
     await registry.connect(owner).setValidatorRewardPct(60);
     await expect(
       registry.connect(owner).setFeePct(50)
-    ).to.be.revertedWith("pct");
+    ).to.be.revertedWithCustomError(registry, "InvalidPercentage");
     await registry.connect(owner).setFeePct(40);
     await expect(
       registry.connect(owner).setValidatorRewardPct(70)
-    ).to.be.revertedWith("pct");
+    ).to.be.revertedWithCustomError(registry, "InvalidPercentage");
   });
 
   it("emits events when setting modules", async () => {

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -93,7 +93,7 @@ describe("JobRegistry agent gating", function () {
     const jobId = await createJob();
     await expect(
       registry.connect(agent).applyForJob(jobId, "a", [])
-    ).to.be.revertedWith("Not authorized agent");
+    ).to.be.revertedWithCustomError(registry, "NotAuthorizedAgent");
   });
 
   it("allows manual allowlisted agents", async () => {
@@ -110,7 +110,7 @@ describe("JobRegistry agent gating", function () {
     const jobId = await createJob();
     await expect(
       registry.connect(agent).applyForJob(jobId, "a", [])
-    ).to.be.revertedWith("Blacklisted agent");
+    ).to.be.revertedWithCustomError(registry, "BlacklistedAgent");
   });
 
   it("rejects agents without acknowledging tax policy", async () => {

--- a/test/v2/JobRegistryAuthCache.test.js
+++ b/test/v2/JobRegistryAuthCache.test.js
@@ -153,6 +153,6 @@ describe("JobRegistry agent auth cache", function () {
     await registry2.connect(employer).createJob(1, deadline, "uri");
     await expect(
       registry2.connect(agent).applyForJob(3, "a", [])
-    ).to.be.revertedWith("Not authorized agent");
+    ).to.be.revertedWithCustomError(registry2, "NotAuthorizedAgent");
   });
 });

--- a/test/v2/JobRegistryModuleVersion.test.js
+++ b/test/v2/JobRegistryModuleVersion.test.js
@@ -42,7 +42,7 @@ describe("JobRegistry module version checks", function () {
           await good.getAddress(),
           []
         )
-    ).to.be.revertedWith("Invalid validation module");
+    ).to.be.revertedWithCustomError(registry, "InvalidValidationModule");
   });
 
   it("reverts for mismatched stake manager", async function () {
@@ -58,7 +58,7 @@ describe("JobRegistry module version checks", function () {
           await good.getAddress(),
           []
         )
-    ).to.be.revertedWith("Invalid stake manager");
+    ).to.be.revertedWithCustomError(registry, "InvalidStakeManager");
   });
 
   it("reverts for mismatched reputation module", async function () {
@@ -74,7 +74,7 @@ describe("JobRegistry module version checks", function () {
           await good.getAddress(),
           []
         )
-    ).to.be.revertedWith("Invalid reputation module");
+    ).to.be.revertedWithCustomError(registry, "InvalidReputationModule");
   });
 
   it("reverts for mismatched dispute module", async function () {
@@ -90,7 +90,7 @@ describe("JobRegistry module version checks", function () {
           await good.getAddress(),
           []
         )
-    ).to.be.revertedWith("Invalid dispute module");
+    ).to.be.revertedWithCustomError(registry, "InvalidDisputeModule");
   });
 
   it("reverts for mismatched certificate NFT", async function () {
@@ -106,7 +106,7 @@ describe("JobRegistry module version checks", function () {
           await good.getAddress(),
           []
         )
-    ).to.be.revertedWith("Invalid certificate NFT");
+    ).to.be.revertedWithCustomError(registry, "InvalidCertificateNFT");
   });
 
   it("succeeds for matching versions", async function () {

--- a/test/v2/JobRegistryTreasury.test.js
+++ b/test/v2/JobRegistryTreasury.test.js
@@ -45,7 +45,7 @@ describe("JobRegistry Treasury", function () {
   it("rejects zero treasury address", async function () {
     await expect(
       registry.connect(owner).setTreasury(ethers.ZeroAddress)
-    ).to.be.revertedWith("treasury");
+    ).to.be.revertedWithCustomError(registry, "InvalidTreasury");
   });
 
   it("sets a valid treasury address", async function () {

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -178,7 +178,7 @@ describe("Module replacement", function () {
 
     await expect(
       registry.connect(owner).setDisputeModule(await bad.getAddress())
-    ).to.be.revertedWith("Invalid dispute module");
+    ).to.be.revertedWithCustomError(registry, "InvalidDisputeModule");
 
     await expect(
       stake.connect(owner).setDisputeModule(await bad.getAddress())

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -978,7 +978,7 @@ describe("StakeManager", function () {
     expect(await policy.hasAcknowledged(user.address)).to.equal(false);
     await expect(
       jobRegistry.connect(user).acknowledgeFor(user.address)
-    ).to.be.revertedWith("acknowledger");
+    ).to.be.revertedWithCustomError(jobRegistry, "NotAcknowledger");
   });
 
   it("acknowledgeAndWithdraw re-acknowledges and withdraws", async () => {

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -184,7 +184,7 @@ describe("comprehensive job flows", function () {
     await registry.connect(employer).createJob(reward, deadline, "uri");
     await expect(
       registry.connect(agent).applyForJob(1, "", [])
-    ).to.be.revertedWith("Not authorized agent");
+    ).to.be.revertedWithCustomError(registry, "NotAuthorizedAgent");
   });
 
   it("resolves disputes with stake slashing", async () => {
@@ -239,7 +239,7 @@ describe("comprehensive job flows", function () {
     await rep.setBlacklist(agent.address, true);
     await expect(
       registry.connect(agent).applyForJob(1, "", [])
-    ).to.be.revertedWith("Blacklisted agent");
+    ).to.be.revertedWithCustomError(registry, "BlacklistedAgent");
   });
 
   it("enforces fresh tax policy acknowledgements", async () => {


### PR DESCRIPTION
## Summary
- define descriptive custom errors in JobRegistry
- replace string-based require() checks with error reverts
- adjust tests to expect custom errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5ea0c94c88333904c572b1c4f8f58