### PR TITLE
feat: add unauthorized agent error

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -10,6 +10,7 @@ import {ENSIdentityVerifier} from "./ENSIdentityVerifier.sol";
 
 error ZeroAddress();
 error InvalidAgentType();
+error UnauthorizedAgent();
 
 /// @title IdentityRegistry
 /// @notice Verifies ENS subdomain ownership and tracks manual allowlists
@@ -182,10 +183,9 @@ contract IdentityRegistry is Ownable2Step {
         bytes32[] calldata proof,
         string calldata uri
     ) external {
-        require(
-            isAuthorizedAgent(msg.sender, subdomain, proof),
-            "Not authorized agent"
-        );
+        if (!isAuthorizedAgent(msg.sender, subdomain, proof)) {
+            revert UnauthorizedAgent();
+        }
         agentProfileURI[msg.sender] = uri;
         emit AgentProfileUpdated(msg.sender, uri);
     }

--- a/test/v2/identity.test.ts
+++ b/test/v2/identity.test.ts
@@ -176,11 +176,18 @@ describe("IdentityRegistry ENS verification", function () {
       .withArgs(alice.address, "ipfs://cap1");
     expect(await id.agentProfileURI(alice.address)).to.equal("ipfs://cap1");
 
+    // alice cannot update profile until authorized
+    await expect(
+      id.connect(alice).updateAgentProfile("sub", [], "ipfs://cap2")
+    ).to.be.revertedWithCustomError(id, "UnauthorizedAgent");
+
     // allow alice as additional agent then self-update profile
     await id.addAdditionalAgent(alice.address);
-    await id
-      .connect(alice)
-      .updateAgentProfile("sub", [], "ipfs://cap2");
+    await expect(
+      id.connect(alice).updateAgentProfile("sub", [], "ipfs://cap2")
+    )
+      .to.emit(id, "AgentProfileUpdated")
+      .withArgs(alice.address, "ipfs://cap2");
     expect(await id.agentProfileURI(alice.address)).to.equal("ipfs://cap2");
   });
 


### PR DESCRIPTION
## Summary
- add `UnauthorizedAgent` custom error for profile updates
- replace `require` check with error revert in `updateAgentProfile`
- test that unauthorized agents revert with `UnauthorizedAgent`

## Testing
- `npm test test/v2/identity.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b600b70990833386ef060d78450f76