### PR TITLE
docs: correct setModules argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Record each address during deployment. The defaults below assume the 18‑decima
 ### Etherscan steps
 1. **Deploy contracts** – open each verified contract → **Contract → Deploy** and provide the constructor parameters listed above.
 2. **Wire modules** – from each contract’s **Write** tab call:
-   - `JobRegistry.setModules(stakeManager, validationModule, disputeModule, certificateNFT, reputationEngine, feePool)`
+   - `JobRegistry.setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, new address[](0))`
    - `StakeManager.setJobRegistry(jobRegistry)` and `ValidationModule.setJobRegistry(jobRegistry)`
    - `JobRegistry.setIdentityRegistry(identityRegistry)`
    - `ValidationModule.setIdentityRegistry(identityRegistry)`

--- a/docs/deployment-v2-agialpha.md
+++ b/docs/deployment-v2-agialpha.md
@@ -31,7 +31,7 @@ The default run uses the mainnet `$AGIALPHA` address, a 5% protocol fee and 5% b
 
 `deployDefaults.ts` wires modules automatically. If you deploy contracts individually, complete the wiring manually:
 
-1. On `JobRegistry`, call `setModules(stakeManager, validationModule, reputationEngine, disputeModule, certificateNFT, platformRegistry, jobRouter, platformIncentives, feePool, taxPolicy)`.
+1. On `JobRegistry`, call `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, new address[](0))`.
    ![setModules](https://via.placeholder.com/650x150?text=setModules)
 2. On `StakeManager`, `ValidationModule` and `CertificateNFT`, call `setJobRegistry(jobRegistry)`.
    ![setJobRegistry](https://via.placeholder.com/650x150?text=setJobRegistry)

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -179,11 +179,13 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 ## Function Reference
 
 ### JobRegistry
+To wire deployed modules, call `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, new address[](0))`. The final array `_ackModules` lists modules that must acknowledge the tax policy before interacting.
+
 | Function | Parameters | Typical Use Case |
 | --- | --- | --- |
 | `createJob(string details, uint256 reward)` | `details` – off-chain URI, `reward` – escrowed token amount | Employer posts a new job and locks payment. |
 | `acknowledgeTaxPolicy()` | none | Participant confirms tax disclaimer before interacting. |
-| `setModules(address validation, address stake, address reputation, address dispute, address certificate)` | module addresses | Owner wires modules after deployment. |
+| `setModules(address validation, address stake, address reputation, address dispute, address certificate, address feePool, address[] ackModules)` | module addresses and ack modules | Owner wires modules and sets acknowledgement requirements. |
 
 ### StakeManager
 | Function | Parameters | Typical Use Case |

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -59,7 +59,7 @@ The script prints module addresses and verifies source on Etherscan.
 7. **Deploy `CertificateNFT`** supplying a name and symbol.
 8. **Deploy `JobRegistry`** passing the governance contract address as the
    final constructor argument, then wire modules by calling
-   `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, new address[](0))` from the
+   `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, new address[](0))` from the
    governance account.
 9. **Point modules back to `JobRegistry`** by calling `setJobRegistry` on `StakeManager`, `ValidationModule`, `DisputeModule` and `CertificateNFT`, and `setIdentityRegistry` on `ValidationModule`.
 10. **Configure ENS and Merkle roots** using `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot` and `setValidatorMerkleRoot` on `IdentityRegistry`.


### PR DESCRIPTION
## Summary
- update module wiring examples to use new `setModules` argument order and include acknowledger array
- document full `setModules` signature in Etherscan guide with `FeePool` and `_ackModules`
- refresh deployment guides to show updated module wiring call

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b610c34adc833380f76f5d7c15e3d1