### PR TITLE
docs: add identity registry steps

### DIFF
--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -181,6 +181,16 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 ### JobRegistry
 To wire deployed modules, call `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, new address[](0))`. The final array `_ackModules` lists modules that must acknowledge the tax policy before interacting.
 
+#### Link the identity registry
+After wiring modules, the governance/owner account must associate the identity registry by calling:
+
+```
+JobRegistry.setIdentityRegistry(identityRegistry)
+ValidationModule.setIdentityRegistry(identityRegistry)
+```
+
+Linking enables ENS subdomain checks and membership proofs through a shared registry. Once connected, configure the ENS name and its Merkle root within the registry to reflect permitted subdomains and the current member set.
+
 | Function | Parameters | Typical Use Case |
 | --- | --- | --- |
 | `createJob(string details, uint256 reward)` | `details` – off-chain URI, `reward` – escrowed token amount | Employer posts a new job and locks payment. |


### PR DESCRIPTION
## Summary
- document linking an identity registry for JobRegistry and ValidationModule
- note owner-only execution and ENS/Merkle setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b61699c7788333a0e5e8586a14e41f