### PR TITLE
docs: clarify governance transfer steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,18 @@ single key can change parameters:
 
 1. Deploy a multisig wallet or an OpenZeppelin
    `TimelockController`.
-2. From the deployer account call
-   `transferOwnership(multisig)` on every module such as
-   `JobRegistry`, `StakeManager`, and `ValidationModule`.
+2. From the deployer account hand over control of each module:
+   - `StakeManager.setGovernance(multisig)`
+   - `JobRegistry.setGovernance(multisig)`
+   - `transferOwnership(multisig)` on all other modules such as
+     `ValidationModule`, `ReputationEngine`, `IdentityRegistry`,
+     `CertificateNFT`, `DisputeModule`, `FeePool`, `PlatformRegistry`,
+     `JobRouter`, `PlatformIncentives`, `TaxPolicy` and `SystemPause`.
 3. To rotate governance later, the current multisig executes
-   `transferOwnership(newOwner)` and the new address assumes control after the
-   `OwnershipTransferred` event. Timelock contracts must schedule and execute
-   the call; direct EOA transactions will revert once ownership has moved.
+   `setGovernance(newOwner)` or `transferOwnership(newOwner)` as
+   appropriate and the new address assumes control after the relevant
+   event. Timelock contracts must schedule and execute the call; direct EOA
+   transactions will revert once ownership has moved.
 
 ### ENS subdomain prerequisites
 - Agents must control an ENS subdomain ending in `.agent.agi.eth`.

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -142,11 +142,17 @@ then be performed through the "Write" tabs on each module.
 ## Owner Administration
 - **Adjust parameters:** examples include `StakeManager.setMinStake(amount)`, `JobRegistry.setFeePct(pct)`, `ValidationModule.setCommitWindow(seconds)`, `ValidationModule.setRevealWindow(seconds)` and `DisputeModule.setDisputeFee(fee)`.
 - **Manage allowlists:** on `IdentityRegistry` use `setAgentMerkleRoot(root)`, `setValidatorMerkleRoot(root)`, `addAdditionalAgent(addr)` and `addAdditionalValidator(addr)`; update ENS roots with `setAgentRootNode(node)` and `setClubRootNode(node)`.
-- **Transfer ownership:** every module inherits `Ownable`; call
-  `transferOwnership(multisig)` to hand control to a multisig or timelock.
-  To rotate later, the current owner invokes `transferOwnership(newOwner)`
-  and waits for the `OwnershipTransferred` event before using the new
-  address.
+- **Transfer ownership:** hand governance to a multisig or timelock so no
+  single key can change parameters:
+  - `StakeManager.setGovernance(multisig)`
+  - `JobRegistry.setGovernance(multisig)`
+  - `transferOwnership(multisig)` on `ValidationModule`, `ReputationEngine`,
+    `IdentityRegistry`, `CertificateNFT`, `DisputeModule`, `FeePool`,
+    `PlatformRegistry`, `JobRouter`, `PlatformIncentives`, `TaxPolicy` and
+    `SystemPause`.
+  To rotate later, the current governance executes `setGovernance(newOwner)`
+  or `transferOwnership(newOwner)` and waits for the corresponding event
+  before using the new address.
 
 ## Token Configuration
 - Default staking/reward token: `$AGIALPHA` at


### PR DESCRIPTION
## Summary
- document governance handover with explicit calls for StakeManager and JobRegistry
- list all v2 modules requiring `transferOwnership`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b62a3be9148333b61d742c49e6a170