### PR TITLE
Ensure all modules are governed

### DIFF
--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -65,9 +65,11 @@ The script prints module addresses and verifies source on Etherscan.
 10. **Configure ENS and Merkle roots** using `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot` and `setValidatorMerkleRoot` on `IdentityRegistry`.
 11. **Governance setup** – deploy a multisig wallet or timelock controller
     and pass its address to the `StakeManager` and `JobRegistry` constructors.
-    Other modules remain `Ownable`; transfer their ownership to the governance
-    contract if desired. To rotate governance later, the current authority
-    calls `setGovernance(newGov)`.
+    Transfer ownership of every remaining `Ownable` module
+    (for example `IdentityRegistry`, `CertificateNFT`, `ValidationModule`,
+    `DisputeModule`, `FeePool`, `PlatformRegistry` and related helpers)
+    to this governance contract so no single EOA retains control. To rotate
+    governance later, the current authority calls `setGovernance(newGov)`.
 
 ## Governance Configuration Steps
 After deployment the governance contract can fine‑tune the system without redeploying:

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -156,6 +156,8 @@ async function main() {
   await platformRegistry.transferOwnership(await pause.getAddress());
   await feePool.transferOwnership(await pause.getAddress());
   await reputation.transferOwnership(await pause.getAddress());
+  await nft.transferOwnership(await pause.getAddress());
+  await identity.transferOwnership(await pause.getAddress());
 
   console.log("StakeManager:", await stake.getAddress());
   console.log("ReputationEngine:", await reputation.getAddress());


### PR DESCRIPTION
## Summary
- Transfer CertificateNFT and IdentityRegistry ownership to the SystemPause governance contract in deploy script
- Document that every Ownable module must transfer ownership to governance to avoid EOA control

## Testing
- `npm run lint`
- `npm test`
- `forge test` *(fails: Cannot swap Variable param with Variable param_16: too deep in the stack by 1 slots in ModuleInstaller.sol)*

------
https://chatgpt.com/codex/tasks/task_e_68b62dc4d10883339a451e8b0b3e682f