### PR TITLE
Revert on zero address in IdentityRegistry setters

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -85,16 +85,25 @@ contract IdentityRegistry is Ownable2Step {
     // ---------------------------------------------------------------------
 
     function setENS(address ensAddr) external onlyOwner {
+        if (ensAddr == address(0)) {
+            revert ZeroAddress();
+        }
         ens = IENS(ensAddr);
         emit ENSUpdated(ensAddr);
     }
 
     function setNameWrapper(address wrapper) external onlyOwner {
+        if (wrapper == address(0)) {
+            revert ZeroAddress();
+        }
         nameWrapper = INameWrapper(wrapper);
         emit NameWrapperUpdated(wrapper);
     }
 
     function setReputationEngine(address engine) external onlyOwner {
+        if (engine == address(0)) {
+            revert ZeroAddress();
+        }
         reputationEngine = IReputationEngine(engine);
         emit ReputationEngineUpdated(engine);
     }

--- a/test/v2/IdentityRegistrySetters.test.js
+++ b/test/v2/IdentityRegistrySetters.test.js
@@ -1,0 +1,108 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("IdentityRegistry setters", function () {
+  let owner;
+  let identity;
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+
+    const Stake = await ethers.getContractFactory(
+      "contracts/legacy/MockV2.sol:MockStakeManager"
+    );
+    const stake = await Stake.deploy();
+
+    const Rep = await ethers.getContractFactory(
+      "contracts/v2/ReputationEngine.sol:ReputationEngine"
+    );
+    const rep = await Rep.deploy(await stake.getAddress());
+
+    const ENS = await ethers.getContractFactory(
+      "contracts/legacy/MockENS.sol:MockENS"
+    );
+    const ens = await ENS.deploy();
+
+    const Wrapper = await ethers.getContractFactory(
+      "contracts/legacy/MockNameWrapper.sol:MockNameWrapper"
+    );
+    const wrapper = await Wrapper.deploy();
+
+    const Identity = await ethers.getContractFactory(
+      "contracts/v2/IdentityRegistry.sol:IdentityRegistry"
+    );
+    identity = await Identity.deploy(
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      await rep.getAddress(),
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+  });
+
+  describe("setENS", function () {
+    it("reverts for zero address", async () => {
+      await expect(
+        identity.setENS(ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(identity, "ZeroAddress");
+    });
+
+    it("updates and emits event for valid address", async () => {
+      const ENS = await ethers.getContractFactory(
+        "contracts/legacy/MockENS.sol:MockENS"
+      );
+      const newEns = await ENS.deploy();
+      await expect(identity.setENS(await newEns.getAddress()))
+        .to.emit(identity, "ENSUpdated")
+        .withArgs(await newEns.getAddress());
+      expect(await identity.ens()).to.equal(await newEns.getAddress());
+    });
+  });
+
+  describe("setNameWrapper", function () {
+    it("reverts for zero address", async () => {
+      await expect(
+        identity.setNameWrapper(ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(identity, "ZeroAddress");
+    });
+
+    it("updates and emits event for valid address", async () => {
+      const Wrapper = await ethers.getContractFactory(
+        "contracts/legacy/MockNameWrapper.sol:MockNameWrapper"
+      );
+      const newWrapper = await Wrapper.deploy();
+      await expect(identity.setNameWrapper(await newWrapper.getAddress()))
+        .to.emit(identity, "NameWrapperUpdated")
+        .withArgs(await newWrapper.getAddress());
+      expect(await identity.nameWrapper()).to.equal(
+        await newWrapper.getAddress()
+      );
+    });
+  });
+
+  describe("setReputationEngine", function () {
+    it("reverts for zero address", async () => {
+      await expect(
+        identity.setReputationEngine(ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(identity, "ZeroAddress");
+    });
+
+    it("updates and emits event for valid address", async () => {
+      const Stake = await ethers.getContractFactory(
+        "contracts/legacy/MockV2.sol:MockStakeManager"
+      );
+      const stake = await Stake.deploy();
+      const Rep = await ethers.getContractFactory(
+        "contracts/v2/ReputationEngine.sol:ReputationEngine"
+      );
+      const newRep = await Rep.deploy(await stake.getAddress());
+      await expect(
+        identity.setReputationEngine(await newRep.getAddress())
+      )
+        .to.emit(identity, "ReputationEngineUpdated")
+        .withArgs(await newRep.getAddress());
+      expect(await identity.reputationEngine()).to.equal(
+        await newRep.getAddress()
+      );
+    });
+  });
+});

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -199,7 +199,7 @@ describe("Ownable modules", function () {
       [
         identityRegistry,
         owner,
-        (inst, signer) => inst.connect(signer).setENS(ethers.ZeroAddress),
+        (inst, signer) => inst.connect(signer).setENS(other.address),
         true,
       ],
       [


### PR DESCRIPTION
## Summary
- revert `setENS`, `setNameWrapper`, and `setReputationEngine` when passed the zero address
- emit update events only after validation
- add coverage for these zero address checks

## Testing
- `npm test --silent test/v2/IdentityRegistrySetters.test.js test/v2/Ownership.test.js`
- `npx solhint contracts/v2/IdentityRegistry.sol`
- `npx eslint test/v2/IdentityRegistrySetters.test.js test/v2/Ownership.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b636890d18833397b1e38a6468884e