### PR TITLE
Reject zero address modules in StakeManager

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -290,7 +290,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice set the dispute module authorized to manage dispute fees
     /// @param module module contract allowed to move dispute fees
     function setDisputeModule(address module) external onlyGovernance {
-        if (IDisputeModule(module).version() != 2) revert InvalidDisputeModule();
+        if (module == address(0) || IDisputeModule(module).version() != 2)
+            revert InvalidDisputeModule();
         disputeModule = module;
         emit DisputeModuleUpdated(module);
     }
@@ -298,7 +299,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice set the validation module used to source validator lists
     /// @param module ValidationModule contract address
     function setValidationModule(address module) external onlyGovernance {
-        if (IValidationModule(module).version() != 2) revert InvalidValidationModule();
+        if (module == address(0) || IValidationModule(module).version() != 2)
+            revert InvalidValidationModule();
         validationModule = IValidationModule(module);
         emit ValidationModuleUpdated(module);
     }

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -168,6 +168,19 @@ describe("Module replacement", function () {
     expect(after.state).to.equal(6); // Finalized
   });
 
+  it("rejects zero address modules", async function () {
+    const env = await deploySystem();
+    const { owner, stake } = env;
+
+    await expect(
+      stake.connect(owner).setDisputeModule(ethers.ZeroAddress)
+    ).to.be.revertedWithCustomError(stake, "InvalidDisputeModule");
+
+    await expect(
+      stake.connect(owner).setValidationModule(ethers.ZeroAddress)
+    ).to.be.revertedWithCustomError(stake, "InvalidValidationModule");
+  });
+
   it("rejects modules with mismatched versions", async function () {
     const env = await deploySystem();
     const { owner, registry, stake, dispute } = env;


### PR DESCRIPTION
## Summary
- prevent setting zero-address dispute or validation modules in StakeManager
- cover zero-address cases with new tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6495470bc8333a7e7df4b6ac6e975