### PR TITLE
Validate stake manager version in FeePool

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -16,6 +16,8 @@ error NotStakeManager();
 error ZeroAmount();
 error EtherNotAccepted();
 error InvalidTokenDecimals();
+error ZeroAddress();
+error InvalidStakeManagerVersion();
 
 /// @title FeePool
 /// @notice Accumulates job fees and distributes them to stakers proportionally.
@@ -224,6 +226,8 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     /// @notice update StakeManager contract
     /// @param manager contract orchestrating fee deposits and staking
     function setStakeManager(IStakeManager manager) external onlyOwner {
+        if (address(manager) == address(0)) revert ZeroAddress();
+        if (manager.version() != version) revert InvalidStakeManagerVersion();
         stakeManager = manager;
         emit StakeManagerUpdated(address(manager));
         emit ModulesUpdated(address(manager));

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -263,4 +263,23 @@ describe("FeePool", function () {
     expect(await feePool.pendingFees()).to.equal(0);
     expect(await feePool.cumulativePerToken()).to.equal(cumulative);
   });
+
+  it("reverts when setting a zero stake manager", async () => {
+    await expect(
+      feePool.connect(owner).setStakeManager(ethers.ZeroAddress)
+    ).to.be.revertedWithCustomError(feePool, "ZeroAddress");
+  });
+
+  it("reverts when stake manager has wrong version", async () => {
+    const Mock = await ethers.getContractFactory(
+      "contracts/v2/mocks/VersionMock.sol:VersionMock"
+    );
+    const bad = await Mock.deploy(1);
+    await expect(
+      feePool.connect(owner).setStakeManager(await bad.getAddress())
+    ).to.be.revertedWithCustomError(
+      feePool,
+      "InvalidStakeManagerVersion"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- ensure FeePool rejects zero address or wrong version in setStakeManager
- test StakeManager version/zero-address validation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6511235c48333bd48ac35c837a65d