### PR TITLE
feat: replace requires with custom errors

### DIFF
--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -102,7 +102,7 @@ describe("Validator ENS integration", function () {
     await ethers.provider.send("evm_mine", []);
     await expect(
       validation.selectValidators(1, 0)
-    ).to.be.revertedWith("insufficient validators");
+    ).to.be.revertedWithCustomError(validation, "InsufficientValidators");
 
     await validation.setValidatorSubdomains([validator.address], ["v"]);
     await wrapper.setOwner(
@@ -182,7 +182,7 @@ describe("Validator ENS integration", function () {
       validation
         .connect(validator)
         .commitValidation(1, ethers.id("h"), "v", [])
-    ).to.be.revertedWith("Not authorized validator");
+    ).to.be.revertedWithCustomError(validation, "UnauthorizedValidator");
 
     // non-owner cannot override
     await expect(
@@ -232,6 +232,6 @@ describe("Validator ENS integration", function () {
     await ethers.provider.send("evm_mine", []);
     await expect(
       validation.selectValidators(1, 0)
-    ).to.be.revertedWith("insufficient validators");
+    ).to.be.revertedWithCustomError(validation, "InsufficientValidators");
   });
 });

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -228,7 +228,7 @@ describe("Identity verification enforcement", function () {
       );
       await expect(
         validation.connect(signer).commitValidation(1, commit, "", [])
-      ).to.be.revertedWith("Not authorized validator");
+      ).to.be.revertedWithCustomError(validation, "UnauthorizedValidator");
 
       await identity.addAdditionalValidator(val);
       await (
@@ -242,7 +242,7 @@ describe("Identity verification enforcement", function () {
         validation
           .connect(signer)
           .revealValidation(1, true, salt, "", [])
-      ).to.be.revertedWith("Not authorized validator");
+      ).to.be.revertedWithCustomError(validation, "UnauthorizedValidator");
     });
   });
 });

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -116,7 +116,10 @@ describe("ValidationModule V2", function () {
   });
 
   it("reverts when called by non-registry", async () => {
-    await expect(validation.start(1, 0)).to.be.revertedWith("only registry");
+    await expect(validation.start(1, 0)).to.be.revertedWithCustomError(
+      validation,
+      "OnlyJobRegistry"
+    );
   });
 
   it("reverts if job not submitted", async () => {
@@ -131,7 +134,10 @@ describe("ValidationModule V2", function () {
       resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(2, jobStruct);
-    await expect(start(2, 0)).to.be.revertedWith("not submitted");
+    await expect(start(2, 0)).to.be.revertedWithCustomError(
+      validation,
+      "JobNotSubmitted"
+    );
   });
 
 
@@ -158,8 +164,9 @@ describe("ValidationModule V2", function () {
 
     await unconfigured.selectValidators(1, 0);
     await ethers.provider.send("evm_mine", []);
-    await expect(unconfigured.selectValidators(1, 0)).to.be.revertedWith(
-      "stake manager"
+    await expect(unconfigured.selectValidators(1, 0)).to.be.revertedWithCustomError(
+      unconfigured,
+      "StakeManagerNotSet"
     );
   });
 
@@ -172,13 +179,13 @@ describe("ValidationModule V2", function () {
   it("rejects validators less than three via setParameters", async () => {
     await expect(
       validation.connect(owner).setParameters(2, 60, 60)
-    ).to.be.revertedWith("validators");
+    ).to.be.revertedWithCustomError(validation, "InvalidValidatorBounds");
   });
 
   it("rejects validator bounds below three", async () => {
     await expect(
       validation.connect(owner).setValidatorBounds(2, 3)
-    ).to.be.revertedWith("bounds");
+    ).to.be.revertedWithCustomError(validation, "InvalidValidatorBounds");
   });
 
   it("selects stake-weighted validators", async () => {
@@ -315,7 +322,7 @@ describe("ValidationModule V2", function () {
       validation
         .connect(v1)
         .revealValidation(1, true, salt, "", [])
-    ).to.be.revertedWith("invalid reveal");
+    ).to.be.revertedWithCustomError(validation, "InvalidReveal");
   });
 
   it("clears commitments after finalization", async () => {
@@ -363,7 +370,7 @@ describe("ValidationModule V2", function () {
 
     await expect(
       validation.connect(v1).commitValidation(1, commit1, "", [])
-    ).to.be.revertedWith("already committed");
+    ).to.be.revertedWithCustomError(validation, "AlreadyCommitted");
 
     await validation.connect(owner).resetJobNonce(1);
     expect(await validation.jobNonce(1)).to.equal(0n);
@@ -402,7 +409,7 @@ describe("ValidationModule V2", function () {
     );
     await expect(
       validation.connect(v1).commitValidation(1, commit, "", [])
-    ).to.be.revertedWith("not validator");
+    ).to.be.revertedWithCustomError(validation, "NotValidator");
   });
 
   it("allows owner to reassign registry and stake manager", async () => {
@@ -438,7 +445,7 @@ describe("ValidationModule V2", function () {
 
     await expect(
       validation.selectValidators(1, 0)
-    ).to.be.revertedWith("already selected");
+    ).to.be.revertedWithCustomError(validation, "ValidatorsAlreadySelected");
 
     await validation.connect(owner).resetJobNonce(1);
     await expect(select(1)).to.not.be.reverted;

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -114,9 +114,9 @@ describe("ValidationModule access controls", function () {
       ["uint256", "uint256", "bool", "bytes32"],
       [1n, nonce, true, salt]
     );
-    await expect(
-      validation.connect(signer).commitValidation(1, commit, "", [])
-    ).to.be.revertedWith("Not authorized validator");
+      await expect(
+        validation.connect(signer).commitValidation(1, commit, "", [])
+      ).to.be.revertedWithCustomError(validation, "UnauthorizedValidator");
 
     // allow commit then block reveal
     await identity.addAdditionalValidator(val);
@@ -127,9 +127,9 @@ describe("ValidationModule access controls", function () {
     await advance(61);
     await identity.removeAdditionalValidator(val);
     await toggle.setResult(false);
-    await expect(
-      validation.connect(signer).revealValidation(1, true, salt, "", [])
-    ).to.be.revertedWith("Not authorized validator");
+      await expect(
+        validation.connect(signer).revealValidation(1, true, salt, "", [])
+      ).to.be.revertedWithCustomError(validation, "UnauthorizedValidator");
   });
 
   it("rejects blacklisted validators", async () => {
@@ -155,7 +155,7 @@ describe("ValidationModule access controls", function () {
     await reputation.setBlacklist(val, true);
     await expect(
       validation.connect(signer).commitValidation(1, commit, "", [])
-    ).to.be.revertedWith("Blacklisted validator");
+    ).to.be.revertedWithCustomError(validation, "BlacklistedValidator");
 
     await reputation.setBlacklist(val, false);
     await (
@@ -165,7 +165,7 @@ describe("ValidationModule access controls", function () {
     await reputation.setBlacklist(val, true);
     await expect(
       validation.connect(signer).revealValidation(1, true, salt, "", [])
-    ).to.be.revertedWith("Blacklisted validator");
+    ).to.be.revertedWithCustomError(validation, "BlacklistedValidator");
   });
 
   it("finalize updates job registry based on tally", async () => {

--- a/test/v2/ValidationModuleApprovals.test.js
+++ b/test/v2/ValidationModuleApprovals.test.js
@@ -25,10 +25,10 @@ describe("ValidationModule required approvals", function () {
   it("reverts for invalid counts", async () => {
     await expect(
       validation.connect(owner).setRequiredValidatorApprovals(0)
-    ).to.be.revertedWith("approvals");
+    ).to.be.revertedWithCustomError(validation, "InvalidApprovals");
     await expect(
       validation.connect(owner).setRequiredValidatorApprovals(5)
-    ).to.be.revertedWith("approvals");
+    ).to.be.revertedWithCustomError(validation, "InvalidApprovals");
   });
 
   it("updates and clamps to committee size", async () => {

--- a/test/v2/ValidationModuleCommitteeSize.test.js
+++ b/test/v2/ValidationModuleCommitteeSize.test.js
@@ -102,10 +102,10 @@ describe("ValidationModule committee size", function () {
 
     await expect(
       validation.connect(owner).setValidatorsPerJob(2)
-    ).to.be.revertedWith("bounds");
+    ).to.be.revertedWithCustomError(validation, "InvalidValidatorBounds");
     await expect(
       validation.connect(owner).setValidatorsPerJob(10)
-    ).to.be.revertedWith("bounds");
+    ).to.be.revertedWithCustomError(validation, "InvalidValidatorBounds");
   });
 
   it("uses stored committee size for quorum", async () => {

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -145,7 +145,10 @@ describe("ValidationModule finalize flows", function () {
     await validation.connect(v1).commitValidation(1, commit1, "", []);
     await validation.connect(v2).commitValidation(1, commit2, "", []);
     await validation.connect(v3).commitValidation(1, commit3, "", []);
-    await expect(validation.finalize(1)).to.be.revertedWith("reveal pending");
+    await expect(validation.finalize(1)).to.be.revertedWithCustomError(
+      validation,
+      "RevealPending"
+    );
   });
 
   it("records majority rejection as dispute", async () => {

--- a/test/v2/ValidatorSelectionLargePool.test.js
+++ b/test/v2/ValidatorSelectionLargePool.test.js
@@ -72,7 +72,7 @@ describe("Validator selection with large pool", function () {
     }
     await expect(
       validation.setValidatorPool(validators)
-    ).to.be.revertedWith("pool limit");
+    ).to.be.revertedWithCustomError(validation, "PoolLimitExceeded");
   });
 });
 

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -113,7 +113,10 @@ describe("regression scenarios", function () {
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
     await registry.connect(agent).applyForJob(1, "agent", []);
 
-    await expect(validation.selectValidators(1, 1)).to.be.revertedWith("insufficient validators");
+    await expect(validation.selectValidators(1, 1)).to.be.revertedWithCustomError(
+      validation,
+      "InsufficientValidators"
+    );
   });
 
   it("prevents validation after stake exhaustion", async () => {
@@ -148,7 +151,10 @@ describe("regression scenarios", function () {
     const deadline2 = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline2, "ipfs://job2");
     await registry.connect(agent).applyForJob(2, "agent", []);
-    await expect(validation.selectValidators(2, 1)).to.be.revertedWith("insufficient validators");
+    await expect(validation.selectValidators(2, 1)).to.be.revertedWithCustomError(
+      validation,
+      "InsufficientValidators"
+    );
   });
 
   it("supports validation module replacement", async () => {


### PR DESCRIPTION
## Summary
- add explicit custom errors to ValidationModule
- replace `require` checks with `if`/`revert` using those errors
- update tests to validate new error paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b65af839688333bd4120a801ab36c0