### PR TITLE
Check for zero addresses in validator pool

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -19,6 +19,7 @@ error InvalidStakeManager();
 error InvalidValidatorBounds();
 error InvalidWindows();
 error PoolLimitExceeded();
+error ZeroValidatorAddress();
 error ZeroIdentityRegistry();
 error InvalidIdentityRegistry();
 error InvalidSampleSize();
@@ -228,6 +229,9 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         onlyOwner
     {
         if (newPool.length > maxValidatorPoolSize) revert PoolLimitExceeded();
+        for (uint256 i = 0; i < newPool.length; i++) {
+            if (newPool[i] == address(0)) revert ZeroValidatorAddress();
+        }
         validatorPool = newPool;
         bumpValidatorAuthCacheVersion();
         emit ValidatorsUpdated(newPool);

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -83,6 +83,14 @@ describe("ValidationModule access controls", function () {
     return validation.selectValidators(jobId, 0);
   }
 
+  it("reverts when validator pool contains zero address", async () => {
+    await expect(
+      validation
+        .connect(owner)
+        .setValidatorPool([v1.address, ethers.ZeroAddress, v3.address])
+    ).to.be.revertedWithCustomError(validation, "ZeroValidatorAddress");
+  });
+
   it("rejects unauthorized validators", async () => {
     const tx = await select(1);
     const receipt = await tx.wait();


### PR DESCRIPTION
## Summary
- prevent zero address entries in validator pool by iterating new pool and reverting with `ZeroValidatorAddress`
- add regression test ensuring `setValidatorPool` rejects zero addresses

## Testing
- ⚠️ `npx hardhat test test/v2/ValidationModuleAccess.test.js` *(hangs while downloading compiler 0.8.25 and 0.8.21)*

------
https://chatgpt.com/codex/tasks/task_e_68b66079512083339ebcd98da108b122