### PR TITLE
feat: guard max AGI types

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -46,6 +46,7 @@ error EtherNotAccepted();
 error InvalidTokenDecimals();
 error InvalidFeePool();
 error MaxAGITypesExceeded();
+error MaxAGITypesBelowCurrent();
 
 /// @title StakeManager
 /// @notice Handles staking balances, job escrows and slashing logic.
@@ -378,6 +379,9 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     function setMaxAGITypes(uint256 newMax) external onlyGovernance {
         if (newMax > MAX_AGI_TYPES_CAP) {
             revert MaxAGITypesExceeded();
+        }
+        if (newMax < agiTypes.length) {
+            revert MaxAGITypesBelowCurrent();
         }
         uint256 old = maxAGITypes;
         maxAGITypes = newMax;

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -145,5 +145,17 @@ describe("StakeManager AGIType bonuses", function () {
         .releaseReward(jobId, agent.address, 100)
     ).to.be.revertedWithCustomError(stakeManager, "InsufficientEscrow");
   });
+
+  it("reverts when setting max below current AGI types", async () => {
+    await stakeManager
+      .connect(owner)
+      .addAGIType(await nft1.getAddress(), 150);
+    await expect(
+      stakeManager.connect(owner).setMaxAGITypes(0)
+    ).to.be.revertedWithCustomError(
+      stakeManager,
+      "MaxAGITypesBelowCurrent"
+    );
+  });
 });
 


### PR DESCRIPTION
## Summary
- prevent lowering max AGI types below current count
- add MaxAGITypesBelowCurrent custom error
- test reducing limit below existing AGI types

## Testing
- `npm test -- test/v2/AGITypeEdge.test.js` *(fails: command hung during compiler download)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e9c9eb0c8333a0a8f109e5459278