### PR TITLE
feat: allow acknowledging tax policy for other users

### DIFF
--- a/contracts/legacy/BadTaxPolicy.sol
+++ b/contracts/legacy/BadTaxPolicy.sol
@@ -19,6 +19,11 @@ contract BadTaxPolicy is ITaxPolicy {
         return "bad";
     }
 
+    function acknowledgeFor(address user) external returns (string memory) {
+        acknowledgedUsers[user] = true;
+        return "bad";
+    }
+
     function hasAcknowledged(address user) external view returns (bool) {
         return acknowledgedUsers[user];
     }

--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -156,8 +156,8 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         taxPolicy = ITaxPolicy(policy);
     }
 
-    function setTaxPolicyVersion(uint256 version) external {
-        taxPolicyVersion = version;
+    function setTaxPolicyVersion(uint256 _version) external {
+        taxPolicyVersion = _version;
     }
 
     function setValidationModule(address module) external override {

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -98,6 +98,19 @@ contract TaxPolicy is Ownable, ITaxPolicy {
         return _acknowledgement;
     }
 
+    /// @notice Record that `user` acknowledges the current tax policy.
+    /// @param user Address of the participant acknowledging the policy.
+    /// @return disclaimer Confirms all taxes fall on employers, agents, and validators.
+    function acknowledgeFor(address user)
+        external
+        override
+        returns (string memory disclaimer)
+    {
+        _acknowledgedVersion[user] = _version;
+        emit PolicyAcknowledged(user, _version);
+        return _acknowledgement;
+    }
+
     /// @notice Check if a user has acknowledged the policy.
     function hasAcknowledged(address user)
         external

--- a/contracts/v2/interfaces/ITaxPolicy.sol
+++ b/contracts/v2/interfaces/ITaxPolicy.sol
@@ -8,6 +8,11 @@ interface ITaxPolicy {
     /// @return disclaimer Confirmation text stating the caller bears all tax liability.
     function acknowledge() external returns (string memory disclaimer);
 
+    /// @notice Record that `user` has acknowledged the current policy.
+    /// @param user Address of the participant.
+    /// @return disclaimer Confirmation text stating the participant bears all tax liability.
+    function acknowledgeFor(address user) external returns (string memory disclaimer);
+
     /// @notice Check if a user has acknowledged the policy.
     /// @param user Address of the participant.
     function hasAcknowledged(address user) external view returns (bool);

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -134,6 +134,8 @@ describe("JobEscrow", function () {
       (l) => l.fragment && l.fragment.name === "JobPosted"
     ).args.jobId;
     await escrow.connect(operator).submitResult(jobId, "ipfs://result");
+    await policy.connect(owner).bumpPolicyVersion();
+    expect(await policy.hasAcknowledged(employer.address)).to.equal(false);
     await expect(
       escrow.connect(employer).acknowledgeAndAcceptResult(jobId)
     )

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -182,7 +182,6 @@ describe("JobRegistry integration", function () {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
     await registry.connect(employer).createJob(reward, deadline, "uri");
-    await policy.connect(newAgent).acknowledge();
     await expect(registry.connect(newAgent).acknowledgeAndApply(1, "", []))
       .to.emit(registry, "JobApplied")
       .withArgs(1, newAgent.address);

--- a/test/v2/PlatformIncentivesAck.test.js
+++ b/test/v2/PlatformIncentivesAck.test.js
@@ -89,7 +89,6 @@ describe("PlatformIncentives acknowledge", function () {
       .connect(operator)
       .approve(await stakeManager.getAddress(), STAKE);
 
-    await policy.connect(operator).acknowledge();
     await incentives.connect(operator).acknowledgeStakeAndActivate(STAKE);
     expect(await policy.hasAcknowledged(operator.address)).to.equal(true);
   });

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -386,6 +386,7 @@ describe("PlatformRegistry", function () {
       .to.emit(registry, "Deregistered")
       .withArgs(platform.address);
     expect(await registry.registered(platform.address)).to.equal(false);
+    expect(await policy.hasAcknowledged(platform.address)).to.equal(true);
   });
 
   it("allows operator to deregister", async () => {

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -972,10 +972,10 @@ describe("StakeManager", function () {
 
     await token.connect(user).approve(await stakeManager.getAddress(), 100);
     await stakeManager.connect(user).acknowledgeAndDeposit(0, 100);
+    expect(await policy.hasAcknowledged(user.address)).to.equal(true);
     expect(
       await policy.hasAcknowledged(await jobRegistry.getAddress())
-    ).to.equal(true);
-    expect(await policy.hasAcknowledged(user.address)).to.equal(false);
+    ).to.equal(false);
     await expect(
       jobRegistry.connect(user).acknowledgeFor(user.address)
     ).to.be.revertedWithCustomError(jobRegistry, "NotAcknowledger");
@@ -1011,7 +1011,6 @@ describe("StakeManager", function () {
       .setJobRegistry(await jobRegistry.getAddress());
 
     await token.connect(user).approve(await stakeManager.getAddress(), 100);
-    await policy1.connect(user).acknowledge();
     await stakeManager.connect(user).acknowledgeAndDeposit(0, 100);
 
     const policy2 = await TaxPolicy.deploy("ipfs://policy2", "ack");
@@ -1019,10 +1018,7 @@ describe("StakeManager", function () {
 
     await stakeManager.connect(user).acknowledgeAndWithdraw(0, 50);
     expect(await stakeManager.stakes(user.address, 0)).to.equal(50n);
-    expect(await policy2.hasAcknowledged(user.address)).to.equal(false);
-    expect(
-      await policy2.hasAcknowledged(await jobRegistry.getAddress())
-    ).to.equal(true);
+    expect(await policy2.hasAcknowledged(user.address)).to.equal(true);
   });
 
   it("acknowledgeAndWithdrawFor requires authorization and re-acknowledges", async () => {
@@ -1055,7 +1051,6 @@ describe("StakeManager", function () {
       .setJobRegistry(await jobRegistry.getAddress());
 
     await token.connect(user).approve(await stakeManager.getAddress(), 100);
-    await policy1.connect(user).acknowledge();
     await stakeManager.connect(user).acknowledgeAndDeposit(0, 100);
 
     const policy2 = await TaxPolicy.deploy("ipfs://policy2", "ack");
@@ -1069,9 +1064,6 @@ describe("StakeManager", function () {
       .connect(owner)
       .acknowledgeAndWithdrawFor(user.address, 0, 50);
     expect(await stakeManager.stakes(user.address, 0)).to.equal(50n);
-    expect(await policy2.hasAcknowledged(user.address)).to.equal(false);
-    expect(
-      await policy2.hasAcknowledged(await jobRegistry.getAddress())
-    ).to.equal(true);
+    expect(await policy2.hasAcknowledged(user.address)).to.equal(true);
   });
 });

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -92,13 +92,13 @@ describe("JobRegistry tax policy integration", function () {
       .withArgs(user.address);
   });
 
-  it("prevents acknowledging for another address", async () => {
+  it("allows acknowledging for another address", async () => {
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
     await registry.connect(owner).setAcknowledger(owner.address, true);
     await registry.connect(owner).acknowledgeFor(user.address);
-    expect(await policy.hasAcknowledged(user.address)).to.equal(false);
+    expect(await policy.hasAcknowledged(user.address)).to.equal(true);
     expect(await policy.hasAcknowledged(await registry.getAddress())).to.equal(
-      true
+      false
     );
   });
 });


### PR DESCRIPTION
## Summary
- allow acknowledging tax policy for an arbitrary user
- propagate new acknowledgeFor flow through JobRegistry and helpers
- verify helpers record acknowledgement in TaxPolicy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b702124ee88333b42470dede815f16