### PR TITLE
Ensure max validator pool size respects existing limits

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -295,6 +295,9 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     /// @notice Update the maximum allowable size of the validator pool.
     /// @param size Maximum number of validators permitted in the pool.
     function setMaxValidatorPoolSize(uint256 size) external onlyOwner {
+        if (size == 0) revert InvalidSampleSize();
+        if (size < validatorsPerJob) revert InvalidValidatorBounds();
+        if (size < validatorPoolSampleSize) revert InvalidSampleSize();
         maxValidatorPoolSize = size;
         emit MaxValidatorPoolSizeUpdated(size);
     }

--- a/test/v2/ValidationModuleMaxPoolSize.test.js
+++ b/test/v2/ValidationModuleMaxPoolSize.test.js
@@ -1,0 +1,42 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ValidationModule max pool size", function () {
+  let validation;
+
+  beforeEach(async () => {
+    const Validation = await ethers.getContractFactory(
+      "contracts/v2/ValidationModule.sol:ValidationModule"
+    );
+    validation = await Validation.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      1,
+      1,
+      3,
+      10,
+      []
+    );
+    await validation.waitForDeployment();
+  });
+
+  it("reverts when size is zero", async () => {
+    await expect(
+      validation.setMaxValidatorPoolSize(0)
+    ).to.be.revertedWithCustomError(validation, "InvalidSampleSize");
+  });
+
+  it("reverts when size below validatorPoolSampleSize", async () => {
+    await validation.setValidatorPoolSampleSize(10);
+    await expect(
+      validation.setMaxValidatorPoolSize(9)
+    ).to.be.revertedWithCustomError(validation, "InvalidSampleSize");
+  });
+
+  it("reverts when size below validatorsPerJob", async () => {
+    await validation.setValidatorPoolSampleSize(3);
+    await expect(
+      validation.setMaxValidatorPoolSize(2)
+    ).to.be.revertedWithCustomError(validation, "InvalidValidatorBounds");
+  });
+});

--- a/test/v2/ValidatorSelectionLargePool.test.js
+++ b/test/v2/ValidatorSelectionLargePool.test.js
@@ -63,6 +63,7 @@ describe("Validator selection with large pool", function () {
 
   it("reverts when validator pool exceeds max size", async () => {
     const maxSize = 50;
+    await validation.setValidatorPoolSampleSize(maxSize);
     await validation.setMaxValidatorPoolSize(maxSize);
     const poolSize = maxSize + 1;
     const validators = [];


### PR DESCRIPTION
## Summary
- enforce that `setMaxValidatorPoolSize` requires non-zero size no smaller than current sample size or validators-per-job
- adjust large-pool test to align with new max size constraints
- add dedicated tests for zero, below-sample, and below-validator-per-job cases

## Testing
- `npx hardhat test test/v2/ValidationModuleMaxPoolSize.test.js test/v2/ValidatorSelectionLargePool.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b70c193e008333a2e4b2c6a38d2e03