### PR TITLE
feat: require multiple entropy contributors for validator selection

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -141,6 +141,13 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     // Block number whose hash will be used to finalize committee selection.
     mapping(uint256 => uint256) public selectionBlock;
 
+    // Track unique entropy contributors for each job and round
+    mapping(uint256 => uint256) public entropyContributorCount;
+    mapping(uint256 => uint256) public entropyRound;
+    mapping(uint256 => mapping(uint256 => mapping(address => bool)))
+        private entropyContributed;
+    uint256 public constant MIN_ENTROPY_CONTRIBUTORS = 2;
+
     event ValidatorsUpdated(address[] validators);
     event ReputationEngineUpdated(address engine);
     event TimingUpdated(uint256 commitWindow, uint256 revealWindow);
@@ -543,6 +550,9 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
                 keccak256(abi.encodePacked(msg.sender, entropy))
             );
             selectionBlock[jobId] = block.number + 1;
+            entropyRound[jobId] += 1;
+            entropyContributorCount[jobId] = 1;
+            entropyContributed[jobId][entropyRound[jobId]][msg.sender] = true;
             return selected;
         }
 
@@ -552,16 +562,37 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
             pendingEntropy[jobId] ^= uint256(
                 keccak256(abi.encodePacked(msg.sender, entropy))
             );
+            uint256 round = entropyRound[jobId];
+            if (!entropyContributed[jobId][round][msg.sender]) {
+                entropyContributed[jobId][round][msg.sender] = true;
+                unchecked {
+                    entropyContributorCount[jobId] += 1;
+                }
+            }
             return selected;
         }
 
         // Finalization path using the stored entropy and future blockhash.
         if (block.number <= selectionBlock[jobId]) revert AwaitBlockhash();
-        bytes32 bhash = blockhash(selectionBlock[jobId]);
-        if (bhash == bytes32(0)) {
+        if (entropyContributorCount[jobId] < MIN_ENTROPY_CONTRIBUTORS) {
+            entropyRound[jobId] += 1;
             pendingEntropy[jobId] = uint256(
                 keccak256(abi.encodePacked(msg.sender, entropy))
             );
+            entropyContributorCount[jobId] = 1;
+            entropyContributed[jobId][entropyRound[jobId]][msg.sender] = true;
+            selectionBlock[jobId] = block.number + 1;
+            emit SelectionReset(jobId);
+            return selected;
+        }
+        bytes32 bhash = blockhash(selectionBlock[jobId]);
+        if (bhash == bytes32(0)) {
+            entropyRound[jobId] += 1;
+            pendingEntropy[jobId] = uint256(
+                keccak256(abi.encodePacked(msg.sender, entropy))
+            );
+            entropyContributorCount[jobId] = 1;
+            entropyContributed[jobId][entropyRound[jobId]][msg.sender] = true;
             selectionBlock[jobId] = block.number + 1;
             emit SelectionReset(jobId);
             return selected;

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -101,7 +101,7 @@ describe("Validator ENS integration", function () {
     await validation.selectValidators(1, 0);
     await ethers.provider.send("evm_mine", []);
     await expect(
-      validation.selectValidators(1, 0)
+      validation.connect(v2).selectValidators(1, 0)
     ).to.be.revertedWithCustomError(validation, "InsufficientValidators");
 
     await validation.setValidatorSubdomains([validator.address], ["v"]);
@@ -114,7 +114,7 @@ describe("Validator ENS integration", function () {
     await jobRegistry.setJob(2, job);
     await validation.selectValidators(2, 99999);
     await ethers.provider.send("evm_mine", []);
-    await validation.selectValidators(2, 0);
+    await validation.connect(v2).selectValidators(2, 0);
     await expect(
       validation
         .connect(validator)
@@ -174,7 +174,7 @@ describe("Validator ENS integration", function () {
     await jobRegistry.setJob(1, job);
     await validation.selectValidators(1, 11111);
     await ethers.provider.send("evm_mine", []);
-    await validation.selectValidators(1, 0);
+    await validation.connect(v2).selectValidators(1, 0);
 
     // transfer ENS ownership
     await wrapper.setOwner(ethers.toBigInt(node), other.address);
@@ -231,7 +231,7 @@ describe("Validator ENS integration", function () {
     await validation.selectValidators(1, 22222);
     await ethers.provider.send("evm_mine", []);
     await expect(
-      validation.selectValidators(1, 0)
+      validation.connect(v2).selectValidators(1, 0)
     ).to.be.revertedWithCustomError(validation, "InsufficientValidators");
   });
 });

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -197,7 +197,7 @@ describe("Identity verification enforcement", function () {
     async function select(jobId, entropy = 0) {
       await validation.selectValidators(jobId, entropy);
       await ethers.provider.send("evm_mine", []);
-      return validation.selectValidators(jobId, 0);
+      return validation.connect(v1).selectValidators(jobId, 0);
     }
 
     async function advance(seconds) {

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -82,7 +82,7 @@ describe("ValidationModule V2", function () {
   async function select(jobId, entropy = 0) {
     await validation.selectValidators(jobId, entropy);
     await ethers.provider.send("evm_mine", []);
-    return validation.selectValidators(jobId, 0);
+    return validation.connect(v1).selectValidators(jobId, 0);
   }
 
   async function start(jobId, entropy = 0) {
@@ -93,7 +93,7 @@ describe("ValidationModule V2", function () {
     await validation.connect(registry).start(jobId, entropy);
     await ethers.provider.send("hardhat_stopImpersonatingAccount", [addr]);
     await ethers.provider.send("evm_mine", []);
-    return validation.selectValidators(jobId, 0);
+    return validation.connect(v1).selectValidators(jobId, 0);
   }
 
   it("selects validators", async () => {
@@ -164,10 +164,9 @@ describe("ValidationModule V2", function () {
 
     await unconfigured.selectValidators(1, 0);
     await ethers.provider.send("evm_mine", []);
-    await expect(unconfigured.selectValidators(1, 0)).to.be.revertedWithCustomError(
-      unconfigured,
-      "StakeManagerNotSet"
-    );
+    await expect(
+      unconfigured.connect(v1).selectValidators(1, 0)
+    ).to.be.revertedWithCustomError(unconfigured, "StakeManagerNotSet");
   });
 
   it("requires multiple entropy contributors before finalization", async () => {

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -80,7 +80,7 @@ describe("ValidationModule access controls", function () {
   async function select(jobId, entropy = 0) {
     await validation.selectValidators(jobId, entropy);
     await ethers.provider.send("evm_mine", []);
-    return validation.selectValidators(jobId, 0);
+    return validation.connect(v1).selectValidators(jobId, 0);
   }
 
   it("reverts when validator pool contains zero address", async () => {

--- a/test/v2/ValidationModuleCommitteeSize.test.js
+++ b/test/v2/ValidationModuleCommitteeSize.test.js
@@ -84,7 +84,7 @@ describe("ValidationModule committee size", function () {
     await validation.connect(registry).start(jobId, entropy);
     await ethers.provider.send("hardhat_stopImpersonatingAccount", [addr]);
     await ethers.provider.send("evm_mine", []);
-    return validation.selectValidators(jobId, 0);
+    return validation.connect(v1).selectValidators(jobId, 0);
   }
 
   it("respects validator count bounds", async () => {

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -66,7 +66,7 @@ async function setup() {
   async function select(jobId, entropy = 0) {
     await validation.selectValidators(jobId, entropy);
     await ethers.provider.send("evm_mine", []);
-    return validation.selectValidators(jobId, 0);
+    return validation.connect(v1).selectValidators(jobId, 0);
   }
 
   return {

--- a/test/v2/ValidationModulePause.test.js
+++ b/test/v2/ValidationModulePause.test.js
@@ -43,7 +43,7 @@ describe("ValidationModule pause", function () {
     await validation.connect(owner).unpause();
     await validation.selectValidators(1, 0);
     await ethers.provider.send("evm_mine", []);
-    await validation.selectValidators(1, 0);
+    await validation.connect(v2).selectValidators(1, 0);
     const selected = await validation.validators(1);
     expect(selected.length).to.equal(3);
     expect(selected).to.include(validator.address);

--- a/test/v2/ValidationModuleReentrancy.test.js
+++ b/test/v2/ValidationModuleReentrancy.test.js
@@ -76,7 +76,7 @@ async function setup() {
     await validation.connect(registry).start(jobId, entropy);
     await ethers.provider.send("hardhat_stopImpersonatingAccount", [addr]);
     await ethers.provider.send("evm_mine", []);
-    return validation.selectValidators(jobId, 0);
+    return validation.connect(validator).selectValidators(jobId, 0);
   }
 
   return {

--- a/test/v2/ValidatorSelectionCache.test.js
+++ b/test/v2/ValidatorSelectionCache.test.js
@@ -3,9 +3,12 @@ const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("Validator selection cache", function () {
-  let validation, stake, identity;
+  let validation, stake, identity, other;
 
   beforeEach(async () => {
+    const [_, o] = await ethers.getSigners();
+    other = o;
+
     const StakeMock = await ethers.getContractFactory("MockStakeManager");
     stake = await StakeMock.deploy();
     await stake.waitForDeployment();
@@ -49,7 +52,7 @@ describe("Validator selection cache", function () {
   async function select(jobId, entropy = 0) {
     await validation.selectValidators(jobId, entropy);
     await ethers.provider.send("evm_mine", []);
-    return validation.selectValidators(jobId, 0);
+    return validation.connect(other).selectValidators(jobId, 0);
   }
 
   it("skips repeat ENS checks and expires cache", async () => {

--- a/test/v2/ValidatorSelectionLargePool.test.js
+++ b/test/v2/ValidatorSelectionLargePool.test.js
@@ -2,9 +2,12 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("Validator selection with large pool", function () {
-  let validation, stake, identity;
+  let validation, stake, identity, other;
 
   beforeEach(async () => {
+    const [_, o] = await ethers.getSigners();
+    other = o;
+
     const StakeMock = await ethers.getContractFactory("MockStakeManager");
     stake = await StakeMock.deploy();
     await stake.waitForDeployment();
@@ -50,7 +53,7 @@ describe("Validator selection with large pool", function () {
       await validation.setValidatorPoolSampleSize(Math.min(poolSize, 50));
       await validation.selectValidators(jobId, 12345);
       await ethers.provider.send("evm_mine", []);
-      const tx = await validation.selectValidators(jobId++, 0);
+      const tx = await validation.connect(other).selectValidators(jobId++, 0);
       const receipt = await tx.wait();
       console.log(`pool size ${poolSize}: ${receipt.gasUsed}`);
       expect(receipt.gasUsed).to.be.lt(6000000n);

--- a/test/v2/ValidatorSelectionReservoir.test.js
+++ b/test/v2/ValidatorSelectionReservoir.test.js
@@ -2,13 +2,16 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("Validator selection reservoir strategy", function () {
-  let validation, stake, identity;
+  let validation, stake, identity, other;
   let validators;
   const poolSize = 150;
   const sampleSize = 50;
   const committeeSize = 3;
 
   beforeEach(async () => {
+    const [_, o] = await ethers.getSigners();
+    other = o;
+
     const StakeMock = await ethers.getContractFactory("MockStakeManager");
     stake = await StakeMock.deploy();
     await stake.waitForDeployment();
@@ -56,7 +59,7 @@ describe("Validator selection reservoir strategy", function () {
     for (let i = 0; i < iterations; i++) {
       await validation.selectValidators(i + 1, i + 12345);
       await ethers.provider.send("evm_mine", []);
-      await validation.selectValidators(i + 1, 0);
+      await validation.connect(other).selectValidators(i + 1, 0);
       const selected = await validation.validators(i + 1);
       for (const v of selected) {
         counts[v] = (counts[v] || 0) + 1;

--- a/test/v2/ValidatorWeightedSelection.test.js
+++ b/test/v2/ValidatorWeightedSelection.test.js
@@ -3,9 +3,11 @@ const { ethers } = require("hardhat");
 
 describe("Validator selection weighted by stake", function () {
   let validation, stake, identity;
-  let validators;
+  let validators, other;
 
   beforeEach(async () => {
+    const [_, o] = await ethers.getSigners();
+    other = o;
     const StakeMock = await ethers.getContractFactory("MockStakeManager");
     stake = await StakeMock.deploy();
     await stake.waitForDeployment();
@@ -55,7 +57,7 @@ describe("Validator selection weighted by stake", function () {
   async function select(jobId, entropy) {
     await validation.selectValidators(jobId, entropy);
     await ethers.provider.send("evm_mine", []);
-    await validation.selectValidators(jobId, 0);
+    await validation.connect(other).selectValidators(jobId, 0);
     return await validation.validators(jobId);
   }
 

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -113,10 +113,11 @@ describe("regression scenarios", function () {
     await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
     await registry.connect(agent).applyForJob(1, "agent", []);
 
-    await expect(validation.selectValidators(1, 1)).to.be.revertedWithCustomError(
-      validation,
-      "InsufficientValidators"
-    );
+    await validation.selectValidators(1, 1);
+    await ethers.provider.send("evm_mine", []);
+    await expect(
+      validation.connect(employer).selectValidators(1, 0)
+    ).to.be.revertedWithCustomError(validation, "InsufficientValidators");
   });
 
   it("prevents validation after stake exhaustion", async () => {
@@ -151,10 +152,11 @@ describe("regression scenarios", function () {
     const deadline2 = BigInt((await time.latest()) + 3600);
     await registry.connect(employer).createJob(reward, deadline2, "ipfs://job2");
     await registry.connect(agent).applyForJob(2, "agent", []);
-    await expect(validation.selectValidators(2, 1)).to.be.revertedWithCustomError(
-      validation,
-      "InsufficientValidators"
-    );
+    await validation.selectValidators(2, 1);
+    await ethers.provider.send("evm_mine", []);
+    await expect(
+      validation.connect(employer).selectValidators(2, 0)
+    ).to.be.revertedWithCustomError(validation, "InsufficientValidators");
   });
 
   it("supports validation module replacement", async () => {


### PR DESCRIPTION
## Summary
- enforce minimum entropy contributors before validator selection finalization
- track contributor rounds and reset selection if too few contributors
- test that a single address cannot finalize validator selection alone

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b71afb26ec83339a4d25af13a75323