### PR TITLE
Disallow zero minimum stake

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -36,6 +36,7 @@ error JobRegistryNotSet();
 error InvalidUser();
 error InvalidRole();
 error InvalidAmount();
+error InvalidMinStake();
 error InvalidRecipient();
 error TreasuryNotSet();
 error ValidationModuleNotSet();
@@ -231,6 +232,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice update the minimum stake required
     /// @param _minStake minimum token amount with 18 decimals
     function setMinStake(uint256 _minStake) external onlyGovernance {
+        if (_minStake == 0) revert InvalidMinStake();
         minStake = _minStake;
         emit MinStakeUpdated(_minStake);
     }

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -24,7 +24,7 @@ describe("StakeManager AGIType bonuses", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"

--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -36,7 +36,7 @@ describe("CertificateNFT marketplace", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stake.setMinStake(0);
+    await stake.setMinStake(1);
 
     const NFT = await ethers.getContractFactory(
       "contracts/v2/CertificateNFT.sol:CertificateNFT"

--- a/test/v2/DiscoveryModule.test.js
+++ b/test/v2/DiscoveryModule.test.js
@@ -26,7 +26,7 @@ describe("DiscoveryModule", function () {
       await engine.getAddress(),
       0
     );
-    await discovery.connect(owner).setMinStake(0);
+    await discovery.connect(owner).setMinStake(1);
   });
 
   it("orders and paginates platforms by score", async () => {

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -21,7 +21,7 @@ describe("FeePool", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"

--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -25,7 +25,7 @@ describe("JobRegistry governance finalization", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
 
     const Rep = await ethers.getContractFactory(

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -25,7 +25,7 @@ describe("Governance reward lifecycle", function () {
       owner.address
     );
 
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -25,7 +25,7 @@ describe("GovernanceReward", function () {
       owner.address
     );
 
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -24,7 +24,7 @@ describe("Job expiration", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
     const Validation = await ethers.getContractFactory(
       "contracts/v2/mocks/ValidationStub.sol:ValidationStub"

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -24,7 +24,7 @@ describe("Job expiration boundary", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
     const Validation = await ethers.getContractFactory(
       "contracts/v2/mocks/ValidationStub.sol:ValidationStub"

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -27,7 +27,7 @@ describe("JobRegistry integration", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
     await stakeManager.connect(owner).setSlashingPercentages(100, 0);
     const Validation = await ethers.getContractFactory(
       "contracts/v2/mocks/ValidationStub.sol:ValidationStub"

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -26,7 +26,7 @@ async function deploySystem() {
     owner.address
   );
   await stake.waitForDeployment();
-  await stake.setMinStake(0);
+  await stake.setMinStake(1);
 
   const Reputation = await ethers.getContractFactory(
     "contracts/v2/ReputationEngine.sol:ReputationEngine"

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -26,7 +26,7 @@ async function deploySystem() {
     owner.address
   );
   await stake.waitForDeployment();
-  await stake.setMinStake(0);
+  await stake.setMinStake(1);
 
   const Reputation = await ethers.getContractFactory(
     "contracts/v2/ReputationEngine.sol:ReputationEngine"

--- a/test/v2/PlatformIncentivesAck.test.js
+++ b/test/v2/PlatformIncentivesAck.test.js
@@ -22,7 +22,7 @@ describe("PlatformIncentives acknowledge", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const Rep = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -32,7 +32,7 @@ describe("Platform reward flow", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -24,7 +24,7 @@ describe("StakeManager", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
   });
 
   it("reverts when staking without job registry", async () => {
@@ -402,10 +402,16 @@ describe("StakeManager", function () {
     await expect(
       stakeManager.connect(user).setMinStake(1)
     ).to.be.revertedWith("governance only");
-    await expect(stakeManager.connect(owner).setMinStake(1))
+    await expect(stakeManager.connect(owner).setMinStake(2))
       .to.emit(stakeManager, "MinStakeUpdated")
-      .withArgs(1);
-    expect(await stakeManager.minStake()).to.equal(1n);
+      .withArgs(2n);
+    expect(await stakeManager.minStake()).to.equal(2n);
+  });
+
+  it("reverts when setting min stake to zero", async () => {
+    await expect(
+      stakeManager.connect(owner).setMinStake(0)
+    ).to.be.revertedWithCustomError(stakeManager, "InvalidMinStake");
   });
 
   it("enforces min stake on deposits and withdrawals for agent and validator", async () => {

--- a/test/v2/StakeManagerAcknowledgeAndDeposit.test.js
+++ b/test/v2/StakeManagerAcknowledgeAndDeposit.test.js
@@ -35,7 +35,7 @@ describe("StakeManager acknowledgeAndDeposit", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
   });
 
   it("reverts without acknowledgement then succeeds", async () => {

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -26,7 +26,7 @@ describe("StakeManager extras", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
   });
 
   async function setupRegistryAck(signer) {

--- a/test/v2/StakeManagerPause.test.js
+++ b/test/v2/StakeManagerPause.test.js
@@ -27,7 +27,7 @@ describe("StakeManager pause", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
     await token.mint(user.address, ethers.parseEther("1000"));
     await token
       .connect(user)

--- a/test/v2/StakeManagerReentrancy.test.js
+++ b/test/v2/StakeManagerReentrancy.test.js
@@ -28,7 +28,7 @@ describe("StakeManager reentrancy", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/mocks/ReentrantJobRegistry.sol:ReentrantJobRegistry"

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -24,7 +24,7 @@ describe("StakeManager release", function () {
       ethers.ZeroAddress,
       owner.address
     );
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const JobRegistry = await ethers.getContractFactory(
       "contracts/v2/JobRegistry.sol:JobRegistry"

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -36,7 +36,7 @@ describe("comprehensive job flows", function () {
       owner.address
     );
 
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const Validation = await ethers.getContractFactory(
       "contracts/v2/mocks/ValidationStub.sol:ValidationStub"

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -35,7 +35,7 @@ describe("end-to-end job lifecycle", function () {
       owner.address
     );
 
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const Validation = await ethers.getContractFactory(
       "contracts/v2/mocks/ValidationStub.sol:ValidationStub"

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -33,7 +33,7 @@ describe("job finalization integration", function () {
       owner.address
     );
 
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const Validation = await ethers.getContractFactory(
       "contracts/v2/mocks/ValidationStub.sol:ValidationStub"

--- a/test/v2/midJobReplacementFuzz.test.js
+++ b/test/v2/midJobReplacementFuzz.test.js
@@ -21,7 +21,7 @@ async function deploySystem() {
     owner.address
   );
 
-  await stake.setMinStake(0);
+  await stake.setMinStake(1);
 
   const Reputation = await ethers.getContractFactory("contracts/v2/ReputationEngine.sol:ReputationEngine");
   const reputation = await Reputation.deploy(await stake.getAddress());

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -37,7 +37,7 @@ describe("multi-operator job lifecycle", function () {
       owner.address
     );
 
-    await stakeManager.connect(owner).setMinStake(0);
+    await stakeManager.connect(owner).setMinStake(1);
 
     const Validation = await ethers.getContractFactory(
       "contracts/v2/mocks/ValidationStub.sol:ValidationStub"


### PR DESCRIPTION
## Summary
- prevent governance from setting min stake to zero by introducing `InvalidMinStake` error
- update tests to reflect non-zero min stake requirement and cover zero-value reverts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b725172aac83338d52009020d66c00