### PR TITLE
Use enum for agent type setter

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -9,7 +9,6 @@ import {IReputationEngine} from "./interfaces/IReputationEngine.sol";
 import {ENSIdentityVerifier} from "./ENSIdentityVerifier.sol";
 
 error ZeroAddress();
-error InvalidAgentType();
 error UnauthorizedAgent();
 
 /// @title IdentityRegistry
@@ -34,7 +33,7 @@ contract IdentityRegistry is Ownable2Step {
 
     mapping(address => bool) public additionalAgents;
     mapping(address => bool) public additionalValidators;
-    mapping(address => AgentType) public agentType;
+    mapping(address => AgentType) public agentTypes;
     /// @notice Optional metadata URI describing agent capabilities.
     mapping(address => string) public agentProfileURI;
 
@@ -154,19 +153,16 @@ contract IdentityRegistry is Ownable2Step {
         emit AdditionalValidatorUpdated(validator, false);
     }
 
-    function setAgentType(address agent, uint8 _type) external onlyOwner {
+    function setAgentType(address agent, AgentType agentType) external onlyOwner {
         if (agent == address(0)) {
             revert ZeroAddress();
         }
-        if (_type > uint8(AgentType.AI)) {
-            revert InvalidAgentType();
-        }
-        agentType[agent] = AgentType(_type);
-        emit AgentTypeUpdated(agent, AgentType(_type));
+        agentTypes[agent] = agentType;
+        emit AgentTypeUpdated(agent, agentType);
     }
 
     function getAgentType(address agent) external view returns (AgentType) {
-        return agentType[agent];
+        return agentTypes[agent];
     }
 
     // ---------------------------------------------------------------------

--- a/contracts/v2/interfaces/IIdentityRegistry.sol
+++ b/contracts/v2/interfaces/IIdentityRegistry.sol
@@ -47,7 +47,7 @@ interface IIdentityRegistry {
     function addAdditionalValidator(address validator) external;
     function removeAdditionalValidator(address validator) external;
 
-    function setAgentType(address agent, uint8 agentType) external;
+    function setAgentType(address agent, AgentType agentType) external;
 
     // views
     function additionalAgents(address account) external view returns (bool);

--- a/contracts/v2/mocks/IdentityRegistryMock.sol
+++ b/contracts/v2/mocks/IdentityRegistryMock.sol
@@ -23,7 +23,7 @@ contract IdentityRegistryMock is Ownable {
         Human,
         AI
     }
-    mapping(address => AgentType) public agentType;
+    mapping(address => AgentType) public agentTypes;
 
     constructor() Ownable(msg.sender) {}
 
@@ -87,13 +87,13 @@ contract IdentityRegistryMock is Ownable {
         emit AdditionalValidatorUpdated(validator, false);
     }
 
-    function setAgentType(address agent, uint8 _type) external {
-        agentType[agent] = AgentType(_type);
-        emit AgentTypeUpdated(agent, AgentType(_type));
+    function setAgentType(address agent, AgentType agentType) external {
+        agentTypes[agent] = agentType;
+        emit AgentTypeUpdated(agent, agentType);
     }
 
     function getAgentType(address agent) external view returns (AgentType) {
-        return agentType[agent];
+        return agentTypes[agent];
     }
 
     function isAuthorizedAgent(

--- a/contracts/v2/mocks/IdentityRegistryToggle.sol
+++ b/contracts/v2/mocks/IdentityRegistryToggle.sol
@@ -20,7 +20,7 @@ contract IdentityRegistryToggle is Ownable {
         Human,
         AI
     }
-    mapping(address => AgentType) public agentType;
+    mapping(address => AgentType) public agentTypes;
 
     constructor() Ownable(msg.sender) {}
 
@@ -80,13 +80,13 @@ contract IdentityRegistryToggle is Ownable {
         emit AdditionalValidatorUpdated(validator, false);
     }
 
-    function setAgentType(address agent, uint8 _type) external onlyOwner {
-        agentType[agent] = AgentType(_type);
-        emit AgentTypeUpdated(agent, AgentType(_type));
+    function setAgentType(address agent, AgentType agentType) external onlyOwner {
+        agentTypes[agent] = agentType;
+        emit AgentTypeUpdated(agent, agentType);
     }
 
     function getAgentType(address agent) external view returns (AgentType) {
-        return agentType[agent];
+        return agentTypes[agent];
     }
 
     function isAuthorizedAgent(

--- a/contracts/v2/mocks/ReentrantIdentityRegistry.sol
+++ b/contracts/v2/mocks/ReentrantIdentityRegistry.sol
@@ -87,7 +87,7 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
     function addAdditionalValidator(address) external {}
     function removeAdditionalValidator(address) external {}
 
-    function setAgentType(address, uint8) external {}
+    function setAgentType(address, AgentType) external {}
 
     function additionalAgents(address) external pure returns (bool) {
         return true;


### PR DESCRIPTION
## Summary
- change `setAgentType` to accept the `AgentType` enum directly
- remove manual bounds check and rely on enum typing
- adjust interface and mocks for new signature

## Testing
- `npx hardhat compile`

------
https://chatgpt.com/codex/tasks/task_e_68b730f68ddc83339f503c7cc74b3e3e