### PR TITLE
Add acknowledger whitelist to TaxPolicy

### DIFF
--- a/contracts/legacy/BadTaxPolicy.sol
+++ b/contracts/legacy/BadTaxPolicy.sol
@@ -9,6 +9,7 @@ import "../v2/interfaces/ITaxPolicy.sol";
 contract BadTaxPolicy is ITaxPolicy {
     uint256 private _version;
     mapping(address => bool) public acknowledgedUsers;
+    mapping(address => bool) public acknowledgers;
 
     constructor() {
         _version = 1;
@@ -20,6 +21,7 @@ contract BadTaxPolicy is ITaxPolicy {
     }
 
     function acknowledgeFor(address user) external returns (string memory) {
+        require(msg.sender == user || acknowledgers[msg.sender], "not acknowledger");
         acknowledgedUsers[user] = true;
         return "bad";
     }
@@ -50,5 +52,9 @@ contract BadTaxPolicy is ITaxPolicy {
 
     function isTaxExempt() external pure returns (bool) {
         return false;
+    }
+
+    function setAcknowledger(address acknowledger, bool allowed) external {
+        acknowledgers[acknowledger] = allowed;
     }
 }

--- a/contracts/v2/interfaces/ITaxPolicy.sol
+++ b/contracts/v2/interfaces/ITaxPolicy.sol
@@ -13,6 +13,15 @@ interface ITaxPolicy {
     /// @return disclaimer Confirmation text stating the participant bears all tax liability.
     function acknowledgeFor(address user) external returns (string memory disclaimer);
 
+    /// @notice Allow or revoke an acknowledger address.
+    /// @param acknowledger Address granted permission to acknowledge for users.
+    /// @param allowed Whether the address can acknowledge for others.
+    function setAcknowledger(address acknowledger, bool allowed) external;
+
+    /// @notice Returns whether an address may acknowledge for others.
+    /// @param acknowledger Address to check.
+    function acknowledgers(address acknowledger) external view returns (bool);
+
     /// @notice Check if a user has acknowledged the policy.
     /// @param user Address of the participant.
     function hasAcknowledged(address user) external view returns (bool);

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -47,6 +47,9 @@ describe("StakeManager AGIType bonuses", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -44,6 +44,9 @@ describe("FeePool", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager.connect(owner).setJobRegistry(await jobRegistry.getAddress());
     await policy.connect(user1).acknowledge();
     await policy.connect(user2).acknowledge();

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -51,6 +51,9 @@ describe("Governance reward lifecycle", function () {
       "ack"
     );
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager.connect(owner).setJobRegistry(await jobRegistry.getAddress());
     await taxPolicy.connect(voter1).acknowledge();
     await taxPolicy.connect(voter2).acknowledge();

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -51,6 +51,9 @@ describe("GovernanceReward", function () {
       "ack"
     );
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager.connect(owner).setJobRegistry(await jobRegistry.getAddress());
     await taxPolicy.connect(voter1).acknowledge();
     await taxPolicy.connect(voter2).acknowledge();

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -67,6 +67,9 @@ describe("Identity verification enforcement", function () {
       );
       const policy = await Policy.deploy("uri", "ack");
       await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+      await policy
+        .connect(owner)
+        .setAcknowledger(await registry.getAddress(), true);
       await policy.connect(employer).acknowledge();
       await policy.connect(agent).acknowledge();
       await registry.connect(owner).setMaxJobReward(1000);

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -118,6 +118,9 @@ describe("JobEscrow", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await escrow.getAddress(), true);

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -116,6 +116,9 @@ describe("Job expiration", function () {
     );
     policy = await Policy.deploy("ipfs://policy", "ack");
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await policy.connect(owner).acknowledge();
     await policy.connect(employer).acknowledge();
     await policy.connect(agent).acknowledge();

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -116,6 +116,9 @@ describe("Job expiration boundary", function () {
     );
     policy = await Policy.deploy("ipfs://policy", "ack");
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await policy.connect(owner).acknowledge();
     await policy.connect(employer).acknowledge();
     await policy.connect(agent).acknowledge();

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -117,6 +117,9 @@ describe("JobRegistry integration", function () {
     await registry
       .connect(owner)
       .setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await policy.connect(owner).acknowledge();
     await policy.connect(employer).acknowledge();
     await policy.connect(agent).acknowledge();

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -52,6 +52,9 @@ describe("JobRegistry agent gating", function () {
     );
     policy = await Policy.deploy("uri", "ack");
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await policy.connect(employer).acknowledge();
     await policy.connect(agent).acknowledge();
 

--- a/test/v2/JobRegistryAuthCache.test.js
+++ b/test/v2/JobRegistryAuthCache.test.js
@@ -43,6 +43,9 @@ describe("JobRegistry agent auth cache", function () {
     );
     policy = await Policy.deploy("uri", "ack");
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await policy.connect(employer).acknowledge();
     await policy.connect(agent).acknowledge();
 
@@ -123,6 +126,9 @@ describe("JobRegistry agent auth cache", function () {
     );
     const policy2 = await Policy.deploy("uri", "ack");
     await registry2.connect(owner).setTaxPolicy(await policy2.getAddress());
+    await policy2
+      .connect(owner)
+      .setAcknowledger(await registry2.getAddress(), true);
     await policy2.connect(employer).acknowledge();
     await policy2.connect(agent).acknowledge();
 

--- a/test/v2/PlatformIncentivesAck.test.js
+++ b/test/v2/PlatformIncentivesAck.test.js
@@ -76,6 +76,9 @@ describe("PlatformIncentives acknowledge", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await incentives.getAddress(), true);

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -89,6 +89,9 @@ describe("PlatformRegistry", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await registry.getAddress(), true);
@@ -135,6 +138,9 @@ describe("PlatformRegistry", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await registry.getAddress(), true);
@@ -171,6 +177,9 @@ describe("PlatformRegistry", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await registry.getAddress(), true);
@@ -214,6 +223,9 @@ describe("PlatformRegistry", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await registry.getAddress(), true);
@@ -251,6 +263,9 @@ describe("PlatformRegistry", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await registry.getAddress(), true);
@@ -372,6 +387,9 @@ describe("PlatformRegistry", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await registry.getAddress(), true);

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -56,6 +56,9 @@ describe("Platform reward flow", function () {
     );
     taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
 
     await stakeManager.connect(owner).setJobRegistry(await jobRegistry.getAddress());
 

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -56,6 +56,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -146,6 +147,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -206,6 +208,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -264,6 +267,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -315,6 +319,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -368,6 +373,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -440,6 +446,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -636,6 +643,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -697,6 +705,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -749,6 +758,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -808,6 +818,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -840,6 +851,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -891,6 +903,7 @@ describe("StakeManager", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());
@@ -969,6 +982,10 @@ describe("StakeManager", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await stakeManager.getAddress(), true);
@@ -1009,6 +1026,13 @@ describe("StakeManager", function () {
     );
     const policy1 = await TaxPolicy.deploy("ipfs://policy1", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy1.getAddress());
+    await policy1.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
+    await policy1
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
+    await policy1
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await stakeManager.getAddress(), true);
@@ -1021,6 +1045,13 @@ describe("StakeManager", function () {
 
     const policy2 = await TaxPolicy.deploy("ipfs://policy2", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy2.getAddress());
+    await policy2.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
+    await policy2
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
+    await policy2
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
 
     await stakeManager.connect(user).acknowledgeAndWithdraw(0, 50);
     expect(await stakeManager.stakes(user.address, 0)).to.equal(50n);
@@ -1049,6 +1080,7 @@ describe("StakeManager", function () {
     );
     const policy1 = await TaxPolicy.deploy("ipfs://policy1", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy1.getAddress());
+    await policy1.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
     await jobRegistry
       .connect(owner)
       .setAcknowledger(await stakeManager.getAddress(), true);
@@ -1061,6 +1093,7 @@ describe("StakeManager", function () {
 
     const policy2 = await TaxPolicy.deploy("ipfs://policy2", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await policy2.getAddress());
+    await policy2.connect(owner).setAcknowledger(await jobRegistry.getAddress(), true);
 
     await expect(
       stakeManager.connect(user).acknowledgeAndWithdrawFor(user.address, 0, 50)

--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -56,6 +56,9 @@ describe("StakeManager extras", function () {
     await jobRegistry
       .connect(owner)
       .setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -47,6 +47,9 @@ describe("StakeManager release", function () {
     );
     const taxPolicy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await taxPolicy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     await stakeManager
       .connect(owner)
       .setJobRegistry(await jobRegistry.getAddress());

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -50,6 +50,9 @@ describe("JobRegistry tax policy integration", function () {
 
   it("tracks user acknowledgement", async () => {
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await expect(policy.connect(user).acknowledge())
       .to.emit(policy, "PolicyAcknowledged")
       .withArgs(user.address, 1);
@@ -61,6 +64,9 @@ describe("JobRegistry tax policy integration", function () {
     await registry.connect(owner).setMaxJobReward(10);
     await registry.connect(owner).setJobDurationLimit(86400);
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await policy.connect(user).acknowledge();
     await policy.connect(owner).bumpPolicyVersion();
     const deadline = (await time.latest()) + 1000;
@@ -94,6 +100,9 @@ describe("JobRegistry tax policy integration", function () {
 
   it("allows acknowledging for another address", async () => {
     await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await registry.connect(owner).setAcknowledger(owner.address, true);
     await registry.connect(owner).acknowledgeFor(user.address);
     expect(await policy.hasAcknowledged(user.address)).to.equal(true);

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -478,6 +478,9 @@ describe("ValidationModule V2", function () {
     );
     const policy = await TaxPolicy.deploy("ipfs://policy", "ack");
     await jobRegistry.setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await jobRegistry.getAddress(), true);
     const tx = await select(1);
     const receipt = await tx.wait();
     const selected = receipt.logs.find(

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -118,6 +118,9 @@ describe("comprehensive job flows", function () {
     await registry.setFeePct(feePct);
     await registry.setValidatorRewardPct(0);
     await registry.setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await registry.setJobParameters(0, stakeRequired);
     await registry.setMaxJobReward(reward);
     await registry.setJobDurationLimit(86400);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -111,6 +111,9 @@ describe("end-to-end job lifecycle", function () {
     await registry.setFeePct(feePct);
     await registry.setValidatorRewardPct(0);
     await registry.setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await registry.setJobParameters(0, stakeRequired);
     await registry.setMaxJobReward(reward);
     await registry.setJobDurationLimit(86400);

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -107,9 +107,12 @@ describe("job finalization integration", function () {
     []
   );
   await validation.setJobRegistry(await registry.getAddress());
-  await registry.setFeePct(feePct);
+    await registry.setFeePct(feePct);
     await registry.setValidatorRewardPct(validatorRewardPct);
     await registry.setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await registry.setJobParameters(0, stakeRequired);
     await registry.setMaxJobReward(reward);
     await registry.setJobDurationLimit(86400);

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -128,6 +128,9 @@ describe("multi-operator job lifecycle", function () {
     await registry.setFeePct(feePct);
     await registry.setValidatorRewardPct(0);
     await registry.setTaxPolicy(await policy.getAddress());
+    await policy
+      .connect(owner)
+      .setAcknowledger(await registry.getAddress(), true);
     await registry.setJobParameters(0, stakeRequired);
     await registry.setMaxJobReward(reward);
     await registry.setJobDurationLimit(86400);


### PR DESCRIPTION
## Summary
- allow owner to set approved acknowledgers in TaxPolicy
- restrict acknowledgeFor to approved callers or self
- update ITaxPolicy, legacy mock, and tests for new acknowledger flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74936c2f08333b854017ee3ea3884