### PR TITLE
feat: add two-step ownership for tax policy

### DIFF
--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 
 /// @title TaxPolicy
@@ -12,7 +13,7 @@ import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 /// provides only an on-chain pointer for off-chain responsibilities. AGI
 /// Employers, AGI Agents, and Validators bear all tax obligations while the
 /// infrastructure and its owner remain perpetually exempt.
-contract TaxPolicy is Ownable, ITaxPolicy {
+contract TaxPolicy is Ownable2Step, ITaxPolicy {
     /// @notice Off-chain document describing tax responsibilities.
     string private _policyURI;
 

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -394,7 +394,6 @@ async function main() {
   }
   await verify(await nft.getAddress(), ["Cert", "CERT", governance]);
   await verify(await tax.getAddress(), [
-    governance,
     "ipfs://policy",
     "All taxes on participants; contract and owner exempt",
   ]);

--- a/test/v2/Deployer.test.js
+++ b/test/v2/Deployer.test.js
@@ -119,6 +119,7 @@ describe("Deployer", function () {
 
     // ownership
     await identityRegistryC.connect(governance).acceptOwnership();
+    await taxPolicyC.connect(governance).acceptOwnership();
     expect(await stakeC.owner()).to.equal(systemPause);
     expect(await registryC.owner()).to.equal(systemPause);
     expect(await validationC.owner()).to.equal(systemPause);

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -195,6 +195,7 @@ describe("Ownable modules", function () {
         TaxPolicy.attach(taxPolicy),
         owner,
         (inst, signer) => inst.connect(signer).setPolicyURI("ipfs://new"),
+        true,
       ],
       [
         identityRegistry,

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -120,7 +120,9 @@ describe("Ownable modules", function () {
     await identity.waitForDeployment();
 
     const identityRegistry = IdentityRegistry.attach(identityRegistryAddr);
+    const taxPolicyC = TaxPolicy.attach(taxPolicy);
     await identityRegistry.connect(owner).acceptOwnership();
+    await taxPolicyC.connect(owner).acceptOwnership();
 
     const systemPauseSignerAddr = systemPause;
     await network.provider.send("hardhat_setBalance", [
@@ -192,7 +194,7 @@ describe("Ownable modules", function () {
         (inst, signer) => inst.connect(signer).setBurnPct(0),
       ],
       [
-        TaxPolicy.attach(taxPolicy),
+        taxPolicyC,
         owner,
         (inst, signer) => inst.connect(signer).setPolicyURI("ipfs://new"),
         true,


### PR DESCRIPTION
## Summary
- use Ownable2Step in TaxPolicy for safer ownership transfers
- update deploy script and ownership tests for two-step flow

## Testing
- `npm test` *(fails: process terminated while downloading compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68b76c26129c83339dac0bf4864b0e87