### PR TITLE
Document DisputeModule tax policy wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Record each address during deployment. The defaults below assume the 18‑decima
      - any `_ackModules` passed to this call must implement `IJobRegistryAck` and successfully respond to `acknowledgeFor(address(0))`
    - Point modules back to the registry with `StakeManager.setJobRegistry(jobRegistry)`, `ValidationModule.setJobRegistry(jobRegistry)`, `DisputeModule.setJobRegistry(jobRegistry)` and `CertificateNFT.setJobRegistry(jobRegistry)`
    - Authorise cross‑module calls using `StakeManager.setDisputeModule(disputeModule)` and `CertificateNFT.setStakeManager(stakeManager)`
+   - `JobRegistry.setTaxPolicy(taxPolicy)` then `DisputeModule.setTaxPolicy(taxPolicy)`
    - `JobRegistry.setIdentityRegistry(identityRegistry)` and `ValidationModule.setIdentityRegistry(identityRegistry)`
    - Load ENS settings with `IdentityRegistry.setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot` and `setValidatorMerkleRoot`
 3. **Example transactions** – after wiring you can:
@@ -123,7 +124,7 @@ The contract owner can retune live systems from block‑explorer **Write** tabs:
 - **ENS roots** – `IdentityRegistry.setAgentRootNode` / `setClubRootNode`.
 - **Merkle roots** – `IdentityRegistry.setAgentMerkleRoot` / `setValidatorMerkleRoot`.
 - **Timing & fees** – `ValidationModule.setCommitWindow`, `setRevealWindow`, `setValidatorBounds`, and `DisputeModule.setDisputeFee`.
-- **Routing & policies** – `JobRegistry.setModules`, `setFeePool`, and `setTaxPolicy`.
+- **Routing & policies** – `JobRegistry.setModules`, `setFeePool`, `setTaxPolicy`, then `DisputeModule.setTaxPolicy`.
 
 ## Overview of v2 Modular Architecture
 

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -61,7 +61,13 @@ The script prints module addresses and verifies source on Etherscan.
    final constructor argument, then wire modules by calling
    `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, new address[](0))` from the
    governance account.
-9. **Point modules back to `JobRegistry`** by calling `setJobRegistry` on `StakeManager`, `ValidationModule`, `DisputeModule` and `CertificateNFT`, and `setIdentityRegistry` on `ValidationModule`.
+9. **Point modules back to `JobRegistry`** by calling:
+   - `StakeManager.setJobRegistry(jobRegistry)`
+   - `ValidationModule.setJobRegistry(jobRegistry)`
+   - `DisputeModule.setJobRegistry(jobRegistry)`
+   - `CertificateNFT.setJobRegistry(jobRegistry)`
+   - `JobRegistry.setTaxPolicy(taxPolicy)` then `DisputeModule.setTaxPolicy(taxPolicy)`
+   - `ValidationModule.setIdentityRegistry(identityRegistry)`
 10. **Configure ENS and Merkle roots** using `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot` and `setValidatorMerkleRoot` on `IdentityRegistry`.
 11. **Governance setup** – deploy a multisig wallet or timelock controller
     and pass its address to the `StakeManager` and `JobRegistry` constructors.
@@ -81,9 +87,10 @@ After deployment the governance contract can fine‑tune the system without rede
 3. **Update parameters** – adjust economic settings through `setFeePct`,
    `setBurnPct`, `setMinStake`, timing windows and other governance‑only
    setters or the helper script `scripts/updateParams.ts`.
-4. **Publish a tax policy** – call `JobRegistry.setTaxPolicy(uri)` and
-   instruct participants to acknowledge via
-   `JobRegistry.acknowledgeTaxPolicy()` before staking or disputing.
+4. **Publish a tax policy** – call `JobRegistry.setTaxPolicy(taxPolicy)` then
+   `DisputeModule.setTaxPolicy(taxPolicy)` and instruct participants to
+   acknowledge via `JobRegistry.acknowledgeTaxPolicy()` before staking or
+   disputing.
 
 ## Interacting via Etherscan
 Before any user interaction, open `JobRegistry` → **Write Contract** and


### PR DESCRIPTION
## Summary
- document that `DisputeModule` must set the `TaxPolicy` after `JobRegistry`
- note the extra tax policy call when updating routing/policy settings
- expand deployment guide with tax policy steps in the wiring section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b775c0da648333891edfd2e223a5b1