### PR TITLE
feat: add governance flag to deployDefaults script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 
 Token parameters are defined once in [`config/agialpha.json`](config/agialpha.json). Run `npm run compile` after editing this file to regenerate `contracts/v2/Constants.sol` with the canonical token address, decimals, scaling factor and burn address.
 
+### Deploy defaults
+
+Spin up the full stack with a single helper script:
+
+```bash
+npx hardhat run scripts/v2/deployDefaults.ts --network <network> --governance <address>
+```
+
+Provide `--governance` to assign a multisig or timelock owner. Include `--no-tax` to skip deploying `TaxPolicy`.
+
 ## Migrating from legacy
 
 The original v0 and v1 contracts are preserved under the `legacy` git tag for reference only and receive no support. New development should target the v2 modules in `contracts/v2`. See [docs/migration-guide.md](docs/migration-guide.md) for help mapping legacy entry points to their v2 equivalents.

--- a/docs/deployment-v2-agialpha.md
+++ b/docs/deployment-v2-agialpha.md
@@ -8,10 +8,10 @@ This guide shows how to deploy the modular v2 contracts using the helper script 
    ![npm install](https://via.placeholder.com/650x150?text=npm+install)
 2. Execute the helper:
    ```bash
-   npx hardhat run scripts/v2/deployDefaults.ts --network <network>
+   npx hardhat run scripts/v2/deployDefaults.ts --network <network> --governance <address>
    ```
    ![deploy defaults](https://via.placeholder.com/650x150?text=deployDefaults.ts)
-   Use `--no-tax` to omit `TaxPolicy`.
+   Use `--governance` to set the multisig or timelock owner and `--no-tax` to omit `TaxPolicy`.
 3. The script deploys `Deployer.sol`, calls `deployDefaults` (or `deployDefaultsWithoutTaxPolicy`), prints module addresses and verifies each contract on Etherscan.
    ![script output](https://via.placeholder.com/650x150?text=module+addresses)
 


### PR DESCRIPTION
## Summary
- allow passing a `--governance <address>` flag to `deployDefaults.ts`
- pipe governance address to deployment and verification steps
- document new flag usage in README and deployment guide

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b778711f7883338c1ae81d08d5291a