### PR TITLE
Add wiring verification script and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         run: npm ci
       - name: Verify AGIALPHA constants
         run: npm run verify:agialpha
+      - name: Verify module wiring
+        run: npm run verify:wiring
       - name: Run lint
         run: npm run lint
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ Record each address during deployment. The defaults below assume the 18‑decima
    - `JobRegistry.setTaxPolicy(taxPolicy)` then `DisputeModule.setTaxPolicy(taxPolicy)`
    - `JobRegistry.setIdentityRegistry(identityRegistry)` and `ValidationModule.setIdentityRegistry(identityRegistry)`
    - Load ENS settings with `IdentityRegistry.setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot` and `setValidatorMerkleRoot`
-3. **Example transactions** – after wiring you can:
+3. **Verify wiring** – run `npm run verify:wiring` to confirm on-chain module
+   references match `docs/deployment-addresses.json`.
+4. **Example transactions** – after wiring you can:
    - Approve and stake: `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` then `StakeManager.depositStake(role, 1_000000000000000000)`
    - Post a job: `JobRegistry.createJob(1_000000000000000000, "ipfs://QmHash")`
 

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -68,8 +68,11 @@ The script prints module addresses and verifies source on Etherscan.
    - `CertificateNFT.setJobRegistry(jobRegistry)`
    - `JobRegistry.setTaxPolicy(taxPolicy)` then `DisputeModule.setTaxPolicy(taxPolicy)`
    - `ValidationModule.setIdentityRegistry(identityRegistry)`
-10. **Configure ENS and Merkle roots** using `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot` and `setValidatorMerkleRoot` on `IdentityRegistry`.
-11. **Governance setup** – deploy a multisig wallet or timelock controller
+10. **Verify wiring** – run `npm run verify:wiring` to confirm module getters
+    match the addresses recorded in `docs/deployment-addresses.json`.
+11. **Configure ENS and Merkle roots** using `setAgentRootNode`, `setClubRootNode`,
+    `setAgentMerkleRoot` and `setValidatorMerkleRoot` on `IdentityRegistry`.
+12. **Governance setup** – deploy a multisig wallet or timelock controller
     and pass its address to the `StakeManager` and `JobRegistry` constructors.
     Transfer ownership of every remaining `Ownable` module
     (for example `IdentityRegistry`, `CertificateNFT`, `ValidationModule`,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "npx solhint 'contracts/**/*.sol' && npx eslint .",
     "pretest": "npx tsc scripts/constants.ts",
     "verify:agialpha": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/verify-agialpha.ts",
+    "verify:wiring": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/verify-wiring.ts",
     "test": "npx hardhat test",
     "gateway": "node agent-gateway/index.js"
   },

--- a/scripts/verify-wiring.ts
+++ b/scripts/verify-wiring.ts
@@ -1,0 +1,182 @@
+import hre from "hardhat";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+async function main() {
+  const path = join(__dirname, "..", "docs", "deployment-addresses.json");
+  const addresses = JSON.parse(readFileSync(path, "utf8")) as Record<string, string>;
+  const { ethers } = hre as any;
+  const zero = ethers.ZeroAddress.toLowerCase();
+
+  type Check = { getter: string; expected: string; };
+  type ContractConfig = { address: string; abi: string[]; checks: Check[] };
+
+  const configs: Record<string, ContractConfig> = {
+    jobRegistry: {
+      address: addresses.jobRegistry,
+      abi: [
+        "function stakeManager() view returns (address)",
+        "function validationModule() view returns (address)",
+        "function reputationEngine() view returns (address)",
+        "function disputeModule() view returns (address)",
+        "function certificateNFT() view returns (address)",
+        "function taxPolicy() view returns (address)",
+        "function feePool() view returns (address)",
+        "function identityRegistry() view returns (address)",
+      ],
+      checks: [
+        { getter: "stakeManager", expected: addresses.stakeManager },
+        { getter: "validationModule", expected: addresses.validationModule },
+        { getter: "reputationEngine", expected: addresses.reputationEngine },
+        { getter: "disputeModule", expected: addresses.disputeModule },
+        { getter: "certificateNFT", expected: addresses.certificateNFT },
+        { getter: "taxPolicy", expected: addresses.taxPolicy },
+        { getter: "feePool", expected: addresses.feePool },
+        { getter: "identityRegistry", expected: addresses.identityRegistry },
+      ],
+    },
+    stakeManager: {
+      address: addresses.stakeManager,
+      abi: [
+        "function jobRegistry() view returns (address)",
+        "function disputeModule() view returns (address)",
+      ],
+      checks: [
+        { getter: "jobRegistry", expected: addresses.jobRegistry },
+        { getter: "disputeModule", expected: addresses.disputeModule },
+      ],
+    },
+    validationModule: {
+      address: addresses.validationModule,
+      abi: [
+        "function jobRegistry() view returns (address)",
+        "function stakeManager() view returns (address)",
+        "function identityRegistry() view returns (address)",
+      ],
+      checks: [
+        { getter: "jobRegistry", expected: addresses.jobRegistry },
+        { getter: "stakeManager", expected: addresses.stakeManager },
+        { getter: "identityRegistry", expected: addresses.identityRegistry },
+      ],
+    },
+    disputeModule: {
+      address: addresses.disputeModule,
+      abi: [
+        "function jobRegistry() view returns (address)",
+        "function stakeManager() view returns (address)",
+      ],
+      checks: [
+        { getter: "jobRegistry", expected: addresses.jobRegistry },
+        { getter: "stakeManager", expected: addresses.stakeManager },
+      ],
+    },
+    certificateNFT: {
+      address: addresses.certificateNFT,
+      abi: [
+        "function jobRegistry() view returns (address)",
+        "function stakeManager() view returns (address)",
+      ],
+      checks: [
+        { getter: "jobRegistry", expected: addresses.jobRegistry },
+        { getter: "stakeManager", expected: addresses.stakeManager },
+      ],
+    },
+    feePool: {
+      address: addresses.feePool,
+      abi: ["function stakeManager() view returns (address)"],
+      checks: [{ getter: "stakeManager", expected: addresses.stakeManager }],
+    },
+    platformRegistry: {
+      address: addresses.platformRegistry,
+      abi: [
+        "function stakeManager() view returns (address)",
+        "function reputationEngine() view returns (address)",
+      ],
+      checks: [
+        { getter: "stakeManager", expected: addresses.stakeManager },
+        { getter: "reputationEngine", expected: addresses.reputationEngine },
+      ],
+    },
+    jobRouter: {
+      address: addresses.jobRouter,
+      abi: ["function platformRegistry() view returns (address)"],
+      checks: [
+        { getter: "platformRegistry", expected: addresses.platformRegistry },
+      ],
+    },
+    platformIncentives: {
+      address: addresses.platformIncentives,
+      abi: [
+        "function stakeManager() view returns (address)",
+        "function platformRegistry() view returns (address)",
+        "function jobRouter() view returns (address)",
+      ],
+      checks: [
+        { getter: "stakeManager", expected: addresses.stakeManager },
+        { getter: "platformRegistry", expected: addresses.platformRegistry },
+        { getter: "jobRouter", expected: addresses.jobRouter },
+      ],
+    },
+    systemPause: {
+      address: addresses.systemPause,
+      abi: [
+        "function jobRegistry() view returns (address)",
+        "function stakeManager() view returns (address)",
+        "function validationModule() view returns (address)",
+        "function disputeModule() view returns (address)",
+        "function platformRegistry() view returns (address)",
+        "function feePool() view returns (address)",
+        "function reputationEngine() view returns (address)",
+      ],
+      checks: [
+        { getter: "jobRegistry", expected: addresses.jobRegistry },
+        { getter: "stakeManager", expected: addresses.stakeManager },
+        { getter: "validationModule", expected: addresses.validationModule },
+        { getter: "disputeModule", expected: addresses.disputeModule },
+        { getter: "platformRegistry", expected: addresses.platformRegistry },
+        { getter: "feePool", expected: addresses.feePool },
+        { getter: "reputationEngine", expected: addresses.reputationEngine },
+      ],
+    },
+  };
+
+  let failed = false;
+
+  for (const [name, cfg] of Object.entries(configs)) {
+    const addr = cfg.address?.toLowerCase();
+    if (!addr || addr === zero) {
+      console.log(`Skipping ${name}: no address`);
+      continue;
+    }
+    const code = await ethers.provider.getCode(addr);
+    if (code === "0x") {
+      console.log(`Skipping ${name}: not deployed at ${addr}`);
+      continue;
+    }
+    const contract = new ethers.Contract(addr, cfg.abi, ethers.provider);
+    for (const check of cfg.checks) {
+      const expected = (check.expected || zero).toLowerCase();
+      const actual = ((await contract[check.getter]()) as string).toLowerCase();
+      if (actual !== expected) {
+        failed = true;
+        console.error(
+          `${name}.${check.getter} => ${actual} (expected ${expected})`
+        );
+      } else {
+        console.log(`${name}.${check.getter} OK`);
+      }
+    }
+  }
+
+  if (failed) {
+    console.error("\nModule wiring does not match deployment summary.");
+    process.exit(1);
+  } else {
+    console.log("\nAll module wiring matches deployment summary.");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `scripts/verify-wiring.ts` to compare deployed module getters with `docs/deployment-addresses.json`
- wire the check into CI and document running `npm run verify:wiring` during deployment

## Testing
- `npm run verify:agialpha`
- `npm run verify:wiring`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b77f6edb1483339e8a0f0c525d715f