### PR TITLE
ci: detect stale constants and document compile requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         run: npm ci
       - name: Verify AGIALPHA constants
         run: npm run verify:agialpha
+      - name: Detect ungenerated constants
+        run: npm run compile && git diff --exit-code contracts/v2/Constants.sol
       - name: Verify module wiring
         run: npm run verify:wiring
       - name: Run lint

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 
 ### AGIALPHA configuration
 
-Token parameters are defined once in [`config/agialpha.json`](config/agialpha.json). Run `npm run compile` after editing this file to regenerate `contracts/v2/Constants.sol` with the canonical token address, decimals, scaling factor and burn address.
+Token parameters are defined once in [`config/agialpha.json`](config/agialpha.json). Run `npm run compile` after editing this file to regenerate `contracts/v2/Constants.sol` with the canonical token address, decimals, scaling factor and burn address. Any change to `config/agialpha.json` must be followed by `npm run compile` or the constants check in CI will fail.
 
 ### Deploy defaults
 


### PR DESCRIPTION
## Summary
- check for ungenerated Constants.sol in CI
- clarify need to run `npm run compile` after modifying `config/agialpha.json`

## Testing
- `npm run compile`
- `git diff --exit-code contracts/v2/Constants.sol`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b783dcbf2c8333a01a292e57ae4078