### PR TITLE
chore: pin solc version for foundry

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,5 @@
 [profile.default]
+solc_version = "0.8.25"
 src = 'contracts/v2'
 test = 'test/v2'
 libs = ['lib', 'node_modules']


### PR DESCRIPTION
## Summary
- pin Foundry `solc_version` to 0.8.25

## Testing
- `forge build` *(fails: Yul exception: Cannot swap Variable param with Variable param_16: too deep in the stack)*
- `npm test` *(fails: process hung during solc compile)*

------
https://chatgpt.com/codex/tasks/task_e_68b78cd773b883339c0133ee96c36953