### PR TITLE
feat: add ENS attestation registry

### DIFF
--- a/apps/validator-ui/pages/attest.tsx
+++ b/apps/validator-ui/pages/attest.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { ethers } from 'ethers';
+
+export default function AttestPage() {
+  const [name, setName] = useState('');
+  const [role, setRole] = useState('0');
+  const [who, setWho] = useState('');
+  const [message, setMessage] = useState('');
+
+  async function send(action: 'attest' | 'revoke') {
+    try {
+      if (!(window as any).ethereum) {
+        alert('wallet not found');
+        return;
+      }
+      const provider = new ethers.BrowserProvider((window as any).ethereum);
+      const signer = await provider.getSigner();
+      const registryAddr = process.env.NEXT_PUBLIC_ATTESTATION_ADDRESS;
+      if (!registryAddr) {
+        alert('attestation registry not configured');
+        return;
+      }
+      const abi = [
+        'function attest(bytes32 node, uint8 role, address who)',
+        'function revoke(bytes32 node, uint8 role, address who)'
+      ];
+      const contract = new ethers.Contract(registryAddr, abi, signer);
+      const node = ethers.namehash(name);
+      const tx =
+        action === 'attest'
+          ? await contract.attest(node, Number(role), who)
+          : await contract.revoke(node, Number(role), who);
+      await tx.wait();
+      setMessage(`${action} tx confirmed`);
+    } catch (err) {
+      console.error(err);
+      setMessage('transaction failed');
+    }
+  }
+
+  return (
+    <main>
+      <h1>Manage Attestations</h1>
+      <label>
+        ENS Name:
+        <input value={name} onChange={(e) => setName(e.target.value)} />
+      </label>
+      <label>
+        Role:
+        <select value={role} onChange={(e) => setRole(e.target.value)}>
+          <option value="0">Agent</option>
+          <option value="1">Validator</option>
+        </select>
+      </label>
+      <label>
+        Address:
+        <input value={who} onChange={(e) => setWho(e.target.value)} />
+      </label>
+      <div>
+        <button onClick={() => send('attest')}>Attest</button>
+        <button onClick={() => send('revoke')}>Revoke</button>
+      </div>
+      {message && <p>{message}</p>}
+    </main>
+  );
+}
+

--- a/contracts/legacy/MockENS.sol
+++ b/contracts/legacy/MockENS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.25;
 
 // @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
 

--- a/contracts/legacy/MockNameWrapper.sol
+++ b/contracts/legacy/MockNameWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.25;
 
 // @deprecated Legacy contract for v0; use modules under contracts/v2 instead.
 

--- a/contracts/v2/AttestationRegistry.sol
+++ b/contracts/v2/AttestationRegistry.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IENS} from "./interfaces/IENS.sol";
+import {INameWrapper} from "./interfaces/INameWrapper.sol";
+
+error UnauthorizedAttestor();
+error ZeroAddress();
+
+/// @title AttestationRegistry
+/// @notice Allows ENS name owners to grant and revoke attestations
+/// for specific roles to other addresses.
+contract AttestationRegistry {
+    /// @dev Roles that can be attested for a name.
+    enum Role {
+        Agent,
+        Validator
+    }
+
+    IENS public ens;
+    INameWrapper public nameWrapper;
+
+    /// @notice Mapping of node => role => address => attested
+    mapping(bytes32 => mapping(Role => mapping(address => bool))) public attestations;
+
+    event ENSUpdated(address indexed ens);
+    event NameWrapperUpdated(address indexed nameWrapper);
+    event Attested(bytes32 indexed node, Role indexed role, address indexed who, address attestor);
+    event Revoked(bytes32 indexed node, Role indexed role, address indexed who, address attestor);
+
+    constructor(IENS _ens, INameWrapper _nameWrapper) {
+        ens = _ens;
+        if (address(_ens) != address(0)) {
+            emit ENSUpdated(address(_ens));
+        }
+        nameWrapper = _nameWrapper;
+        if (address(_nameWrapper) != address(0)) {
+            emit NameWrapperUpdated(address(_nameWrapper));
+        }
+    }
+
+    function setENS(address ensAddr) external {
+        if (ensAddr == address(0)) {
+            revert ZeroAddress();
+        }
+        ens = IENS(ensAddr);
+        emit ENSUpdated(ensAddr);
+    }
+
+    function setNameWrapper(address wrapper) external {
+        if (wrapper == address(0)) {
+            revert ZeroAddress();
+        }
+        nameWrapper = INameWrapper(wrapper);
+        emit NameWrapperUpdated(wrapper);
+    }
+
+    function _ownerOf(bytes32 node) internal view returns (address) {
+        if (address(nameWrapper) != address(0)) {
+            try nameWrapper.ownerOf(uint256(node)) returns (address owner) {
+                if (owner != address(0)) {
+                    return owner;
+                }
+            } catch {}
+        }
+        if (address(ens) != address(0)) {
+            try ens.owner(node) returns (address ensOwner) {
+                return ensOwner;
+            } catch {}
+        }
+        return address(0);
+    }
+
+    /// @notice Attest that `who` holds `role` for `node`.
+    function attest(bytes32 node, Role role, address who) external {
+        if (_ownerOf(node) != msg.sender) {
+            revert UnauthorizedAttestor();
+        }
+        attestations[node][role][who] = true;
+        emit Attested(node, role, who, msg.sender);
+    }
+
+    /// @notice Revoke a previously granted attestation.
+    function revoke(bytes32 node, Role role, address who) external {
+        if (_ownerOf(node) != msg.sender) {
+            revert UnauthorizedAttestor();
+        }
+        attestations[node][role][who] = false;
+        emit Revoked(node, role, who, msg.sender);
+    }
+
+    /// @notice Check whether `who` has been attested for `role` on `node`.
+    function isAttested(bytes32 node, Role role, address who) external view returns (bool) {
+        return attestations[node][role][who];
+    }
+}
+

--- a/contracts/v2/interfaces/IENS.sol
+++ b/contracts/v2/interfaces/IENS.sol
@@ -8,4 +8,9 @@ interface IENS {
     /// @param node The ENS node hash.
     /// @return resolverAddr Address of the resolver for `node`.
     function resolver(bytes32 node) external view returns (address resolverAddr);
+
+    /// @notice Get the owner of an ENS node.
+    /// @param node The ENS node hash.
+    /// @return ownerAddr Address of the owner for `node`.
+    function owner(bytes32 node) external view returns (address ownerAddr);
 }

--- a/test/v2/AttestationRegistry.t.sol
+++ b/test/v2/AttestationRegistry.t.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {AttestationRegistry} from "../../contracts/v2/AttestationRegistry.sol";
+import {IdentityRegistry} from "../../contracts/v2/IdentityRegistry.sol";
+import {IENS} from "../../contracts/v2/interfaces/IENS.sol";
+import {INameWrapper} from "../../contracts/v2/interfaces/INameWrapper.sol";
+import {IReputationEngine} from "../../contracts/v2/interfaces/IReputationEngine.sol";
+import {MockENS} from "../../contracts/legacy/MockENS.sol";
+import {MockNameWrapper} from "../../contracts/legacy/MockNameWrapper.sol";
+
+contract AttestationRegistryTest is Test {
+    AttestationRegistry attest;
+    IdentityRegistry identity;
+    MockENS ens;
+    MockNameWrapper wrapper;
+    address owner = address(0x1);
+    address agent = address(0x2);
+    address validator = address(0x3);
+
+    function setUp() public {
+        ens = new MockENS();
+        wrapper = new MockNameWrapper();
+        attest = new AttestationRegistry(IENS(address(ens)), INameWrapper(address(wrapper)));
+        identity = new IdentityRegistry(
+            IENS(address(ens)),
+            INameWrapper(address(wrapper)),
+            IReputationEngine(address(0)),
+            bytes32(0),
+            bytes32(0)
+        );
+        identity.setAttestationRegistry(address(attest));
+    }
+
+    function _node(string memory label) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(bytes32(0), keccak256(bytes(label))));
+    }
+
+    function testAttestAndRevoke() public {
+        bytes32 node = _node("alice");
+        wrapper.setOwner(uint256(node), owner);
+        vm.prank(owner);
+        attest.attest(node, AttestationRegistry.Role.Agent, agent);
+        assertTrue(attest.isAttested(node, AttestationRegistry.Role.Agent, agent));
+        vm.prank(owner);
+        attest.revoke(node, AttestationRegistry.Role.Agent, agent);
+        assertFalse(attest.isAttested(node, AttestationRegistry.Role.Agent, agent));
+    }
+
+    function testIdentityIntegration() public {
+        bytes32 aNode = _node("agent");
+        wrapper.setOwner(uint256(aNode), owner);
+        vm.prank(owner);
+        attest.attest(aNode, AttestationRegistry.Role.Agent, agent);
+        assertTrue(identity.isAuthorizedAgent(agent, "agent", new bytes32[](0)));
+
+        bytes32 vNode = _node("validator");
+        wrapper.setOwner(uint256(vNode), owner);
+        vm.prank(owner);
+        attest.attest(vNode, AttestationRegistry.Role.Validator, validator);
+        assertTrue(identity.isAuthorizedValidator(validator, "validator", new bytes32[](0)));
+    }
+}
+

--- a/test/v2/AttestationRegistry.test.js
+++ b/test/v2/AttestationRegistry.test.js
@@ -1,0 +1,116 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AttestationRegistry", function () {
+  it("allows ENS name owner to attest and revoke", async () => {
+    const [owner, agent, other] = await ethers.getSigners();
+
+    const ENS = await ethers.getContractFactory(
+      "contracts/legacy/MockENS.sol:MockENS"
+    );
+    const ens = await ENS.deploy();
+
+    const Wrapper = await ethers.getContractFactory(
+      "contracts/legacy/MockNameWrapper.sol:MockNameWrapper"
+    );
+    const wrapper = await Wrapper.deploy();
+
+    const Registry = await ethers.getContractFactory(
+      "contracts/v2/AttestationRegistry.sol:AttestationRegistry"
+    );
+    const registry = await Registry.deploy(
+      await ens.getAddress(),
+      await wrapper.getAddress()
+    );
+
+    const label = "alice";
+    const node = ethers.keccak256(
+      ethers.solidityPacked([
+        "bytes32",
+        "bytes32"
+      ], [ethers.ZeroHash, ethers.id(label)])
+    );
+    await wrapper.setOwner(BigInt(node), owner.address);
+
+    await expect(
+      registry.connect(owner).attest(node, 0, agent.address)
+    )
+      .to.emit(registry, "Attested")
+      .withArgs(node, 0, agent.address, owner.address);
+    expect(await registry.isAttested(node, 0, agent.address)).to.equal(true);
+
+    await expect(
+      registry.connect(other).attest(node, 0, other.address)
+    ).to.be.revertedWithCustomError(registry, "UnauthorizedAttestor");
+
+    await registry.connect(owner).revoke(node, 0, agent.address);
+    expect(await registry.isAttested(node, 0, agent.address)).to.equal(false);
+  });
+
+  it("integrates with IdentityRegistry", async () => {
+    const [owner, agent, validator] = await ethers.getSigners();
+
+    const ENS = await ethers.getContractFactory(
+      "contracts/legacy/MockENS.sol:MockENS"
+    );
+    const ens = await ENS.deploy();
+
+    const Wrapper = await ethers.getContractFactory(
+      "contracts/legacy/MockNameWrapper.sol:MockNameWrapper"
+    );
+    const wrapper = await Wrapper.deploy();
+
+    const Attest = await ethers.getContractFactory(
+      "contracts/v2/AttestationRegistry.sol:AttestationRegistry"
+    );
+    const attest = await Attest.deploy(
+      await ens.getAddress(),
+      await wrapper.getAddress()
+    );
+
+    const Identity = await ethers.getContractFactory(
+      "contracts/v2/IdentityRegistry.sol:IdentityRegistry"
+    );
+    const identity = await Identity.deploy(
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+    await identity.setAttestationRegistry(await attest.getAddress());
+
+    const agentLabel = "agent";
+    const agentNode = ethers.keccak256(
+      ethers.solidityPacked(
+        ["bytes32", "bytes32"],
+        [ethers.ZeroHash, ethers.id(agentLabel)]
+      )
+    );
+    await wrapper.setOwner(BigInt(agentNode), owner.address);
+    await attest
+      .connect(owner)
+      .attest(agentNode, 0, agent.address);
+
+    expect(
+      await identity.isAuthorizedAgent(agent.address, agentLabel, [])
+    ).to.equal(true);
+
+    const validatorLabel = "validator";
+    const validatorNode = ethers.keccak256(
+      ethers.solidityPacked(
+        ["bytes32", "bytes32"],
+        [ethers.ZeroHash, ethers.id(validatorLabel)]
+      )
+    );
+    await wrapper.setOwner(BigInt(validatorNode), owner.address);
+    await attest
+      .connect(owner)
+      .attest(validatorNode, 1, validator.address);
+
+    expect(
+      await identity.isAuthorizedValidator(validator.address, validatorLabel, [])
+    ).to.equal(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `AttestationRegistry` contract for ENS-based role attestations
- extend `IdentityRegistry` to honor attestation bits as authorization
- expose simple web UI to manage attestation records and add tests

## Testing
- `npx hardhat test test/v2/AttestationRegistry.test.js` *(fails: process terminated during compilation)*
- `FOUNDRY_VIA_IR=false forge test --match-contract AttestationRegistryTest` *(fails: stack too deep / requires via-ir)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b072d0488333a2a8f78c3ae9bdde