### PR TITLE
feat: add payment router abstraction

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -22,6 +22,7 @@ contract MockStakeManager is IStakeManager {
     mapping(Role => uint256) public totalStakes;
     address public disputeModule;
     address public override jobRegistry;
+    IPaymentRouter public override router;
 
     function setJobRegistry(address j) external { jobRegistry = j; }
 
@@ -63,6 +64,7 @@ contract MockStakeManager is IStakeManager {
     function setValidatorRewardPct(uint256) external override {}
     function addAGIType(address, uint256) external override {}
     function removeAGIType(address) external override {}
+
 
     function slash(address user, Role role, uint256 amount, address)
         external

--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -19,6 +19,7 @@ import {IdentityRegistry} from "./IdentityRegistry.sol";
 import {IIdentityRegistry} from "./interfaces/IIdentityRegistry.sol";
 import {PlatformIncentives} from "./PlatformIncentives.sol";
 import {FeePool} from "./FeePool.sol";
+import {PaymentRouter} from "./PaymentRouter.sol";
 import {TaxPolicy} from "./TaxPolicy.sol";
 import {IPlatformRegistryFull} from "./interfaces/IPlatformRegistryFull.sol";
 import {IPlatformRegistry} from "./interfaces/IPlatformRegistry.sol";
@@ -269,6 +270,7 @@ contract Deployer is Ownable {
             treasurySlashPct = 100;
         }
         uint96 jobStake = econ.jobStake;
+        PaymentRouter payRouter = new PaymentRouter(governance);
         StakeManager stake = new StakeManager(
             minStake,
             employerSlashPct,
@@ -276,7 +278,8 @@ contract Deployer is Ownable {
             governance,
             address(0),
             address(0),
-            address(this)
+            address(this),
+            payRouter
         );
         address[] memory ackInit = new address[](1);
         ackInit[0] = address(stake);
@@ -320,6 +323,7 @@ contract Deployer is Ownable {
 
         FeePool pool = new FeePool(
             IStakeManager(address(stake)),
+            payRouter,
             burnPct,
             governance
         );

--- a/contracts/v2/PaymentRouter.sol
+++ b/contracts/v2/PaymentRouter.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Governable} from "./Governable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20Burnable} from "./interfaces/IERC20Burnable.sol";
+import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
+import {IPaymentRouter} from "./interfaces/IPaymentRouter.sol";
+
+error InvalidTokenDecimals();
+error ZeroAddress();
+
+/// @title PaymentRouter
+/// @notice Handles token transfers and allows governance to upgrade the token
+contract PaymentRouter is IPaymentRouter, Governable {
+    using SafeERC20 for IERC20;
+
+    IERC20 private _token;
+
+    event TokenUpdated(address indexed token);
+
+    constructor(address _governance) Governable(_governance) {
+        _setToken(AGIALPHA);
+    }
+
+    function token() public view returns (address) {
+        return address(_token);
+    }
+
+    function updateToken(address newToken) external onlyGovernance {
+        _setToken(newToken);
+    }
+
+    function _setToken(address newToken) internal {
+        if (newToken == address(0)) revert ZeroAddress();
+        if (IERC20Metadata(newToken).decimals() != AGIALPHA_DECIMALS) {
+            revert InvalidTokenDecimals();
+        }
+        _token = IERC20(newToken);
+        emit TokenUpdated(newToken);
+    }
+
+    function transfer(address to, uint256 amount) external {
+        _token.safeTransferFrom(msg.sender, to, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external {
+        _token.safeTransferFrom(from, to, amount);
+    }
+
+    function burn(address from, uint256 amount) external {
+        _token.safeTransferFrom(from, address(this), amount);
+        IERC20Burnable(address(_token)).burn(amount);
+    }
+}
+

--- a/contracts/v2/interfaces/IPaymentRouter.sol
+++ b/contracts/v2/interfaces/IPaymentRouter.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IPaymentRouter {
+    /// @notice ERC20 token used for payments
+    function token() external view returns (address);
+
+    /// @notice Transfer tokens from caller to a recipient
+    /// @param to recipient address
+    /// @param amount token amount with 18 decimals
+    function transfer(address to, uint256 amount) external;
+
+    /// @notice Transfer tokens from one address to another using allowance
+    function transferFrom(address from, address to, uint256 amount) external;
+
+    /// @notice Burn tokens from the specified address using allowance
+    function burn(address from, uint256 amount) external;
+}

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import {IFeePool} from "./IFeePool.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IPaymentRouter} from "./IPaymentRouter.sol";
 
 /// @title IStakeManager
 /// @notice Interface for staking balances, job escrows and slashing logic
@@ -45,6 +46,9 @@ interface IStakeManager {
     event FeePctUpdated(uint256 pct);
     event BurnPctUpdated(uint256 pct);
     event FeePoolUpdated(address indexed feePool);
+
+    /// @notice payment router used for token transfers
+    function router() external view returns (IPaymentRouter);
 
     /// @notice deposit stake for caller for a specific role
     /// @param role participant role receiving credit

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -5,6 +5,7 @@ import {IStakeManager} from "../interfaces/IStakeManager.sol";
 import {IValidationModule} from "../interfaces/IValidationModule.sol";
 import {IFeePool} from "../interfaces/IFeePool.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IPaymentRouter} from "../interfaces/IPaymentRouter.sol";
 
 /// @dev Stake manager mock that attempts to reenter ValidationModule calls.
 contract ReentrantStakeManager is IStakeManager {
@@ -14,6 +15,7 @@ contract ReentrantStakeManager is IStakeManager {
     mapping(Role => uint256) public totalStakes;
     address public override jobRegistry;
     IValidationModule public validation;
+    IPaymentRouter public override router;
 
     bool public attackSlash;
     uint256 public attackJobId;


### PR DESCRIPTION
## Summary
- add `PaymentRouter` for centralized token transfer handling
- wire FeePool and StakeManager to use router for token moves
- update governance reward and certificate flows for router
- introduce interfaces and tests approving router

## Testing
- `npx hardhat test test/v2/StakeManager.test.js` *(fails: no output due to compilation issues)*


------
https://chatgpt.com/codex/tasks/task_e_68b7b461c09c8333b0e7aa99e68ffcd7