### PR TITLE
Bind validator commits to job specification

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -244,6 +244,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
             stake: jobStake,
             success: false,
             status: Status.Created,
+            specHash: uriHash,
             uriHash: uriHash,
             resultHash: bytes32(0)
         });

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -30,6 +30,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     error RewardTooHigh();
     error InvalidDeadline();
     error InvalidAgentTypes();
+    error InvalidSpecification();
     error DurationTooLong();
     error InvalidPercentages();
     error BlacklistedEmployer();
@@ -91,6 +92,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         uint8 agentTypes;
         uint64 deadline;
         uint64 assignedAt;
+        bytes32 specHash;
         bytes32 uriHash;
         bytes32 resultHash;
     }
@@ -198,6 +200,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         uint256 reward,
         uint256 stake,
         uint256 fee,
+        bytes32 specHash,
         string uri
     );
     event JobApplied(uint256 indexed jobId, address indexed agent);
@@ -579,6 +582,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         uint256 reward,
         uint64 deadline,
         uint8 agentTypes,
+        bytes32 specHash,
         string calldata uri
     )
         internal
@@ -598,6 +602,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         if (maxJobReward != 0 && reward > maxJobReward) revert RewardTooHigh();
         if (deadline <= block.timestamp) revert InvalidDeadline();
         if (agentTypes == 0 || agentTypes > 3) revert InvalidAgentTypes();
+        if (specHash == bytes32(0)) revert InvalidSpecification();
         if (
             maxJobDuration > 0 &&
             uint256(deadline) - block.timestamp > maxJobDuration
@@ -625,6 +630,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             assignedAt: 0,
             state: State.Created,
             success: false,
+            specHash: specHash,
             uriHash: uriHash,
             resultHash: bytes32(0),
             agentTypes: agentTypes
@@ -641,6 +647,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             reward,
             uint256(jobStake),
             fee,
+            specHash,
             uri
         );
     }
@@ -648,18 +655,20 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     function createJob(
         uint256 reward,
         uint64 deadline,
+        bytes32 specHash,
         string calldata uri
     ) external returns (uint256 jobId) {
-        jobId = _createJob(reward, deadline, 3, uri);
+        jobId = _createJob(reward, deadline, 3, specHash, uri);
     }
 
     function createJobWithAgentTypes(
         uint256 reward,
         uint64 deadline,
         uint8 agentTypes,
+        bytes32 specHash,
         string calldata uri
     ) external returns (uint256 jobId) {
-        jobId = _createJob(reward, deadline, agentTypes, uri);
+        jobId = _createJob(reward, deadline, agentTypes, specHash, uri);
     }
 
     /**
@@ -673,10 +682,51 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     function acknowledgeAndCreateJob(
         uint256 reward,
         uint64 deadline,
+        bytes32 specHash,
         string calldata uri
     ) external returns (uint256 jobId) {
         _acknowledge(msg.sender);
-        jobId = _createJob(reward, deadline, 3, uri);
+        jobId = _createJob(reward, deadline, 3, specHash, uri);
+    }
+
+    function acknowledgeAndCreateJobWithAgentTypes(
+        uint256 reward,
+        uint64 deadline,
+        uint8 agentTypes,
+        bytes32 specHash,
+        string calldata uri
+    ) external returns (uint256 jobId) {
+        _acknowledge(msg.sender);
+        jobId = _createJob(reward, deadline, agentTypes, specHash, uri);
+    }
+
+    function createJob(
+        uint256 reward,
+        uint64 deadline,
+        string calldata uri
+    ) external returns (uint256 jobId) {
+        bytes32 specHash = keccak256(bytes(uri));
+        jobId = _createJob(reward, deadline, 3, specHash, uri);
+    }
+
+    function createJobWithAgentTypes(
+        uint256 reward,
+        uint64 deadline,
+        uint8 agentTypes,
+        string calldata uri
+    ) external returns (uint256 jobId) {
+        bytes32 specHash = keccak256(bytes(uri));
+        jobId = _createJob(reward, deadline, agentTypes, specHash, uri);
+    }
+
+    function acknowledgeAndCreateJob(
+        uint256 reward,
+        uint64 deadline,
+        string calldata uri
+    ) external returns (uint256 jobId) {
+        _acknowledge(msg.sender);
+        bytes32 specHash = keccak256(bytes(uri));
+        jobId = _createJob(reward, deadline, 3, specHash, uri);
     }
 
     function acknowledgeAndCreateJobWithAgentTypes(
@@ -686,7 +736,8 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         string calldata uri
     ) external returns (uint256 jobId) {
         _acknowledge(msg.sender);
-        jobId = _createJob(reward, deadline, agentTypes, uri);
+        bytes32 specHash = keccak256(bytes(uri));
+        jobId = _createJob(reward, deadline, agentTypes, specHash, uri);
     }
 
     function _applyForJob(

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1065,9 +1065,11 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         bytes32 commitHash = commitments[jobId][msg.sender][nonce];
         if (commitHash == bytes32(0)) revert CommitMissing();
         if (revealed[jobId][msg.sender]) revert AlreadyRevealed();
+        bytes32 specHash = jobRegistry.jobs(jobId).specHash;
         if (
-            keccak256(abi.encodePacked(jobId, nonce, approve, salt)) !=
-            commitHash
+            keccak256(
+                abi.encodePacked(jobId, specHash, nonce, approve, salt)
+            ) != commitHash
         ) revert InvalidReveal();
 
         uint256 stake = validatorStakes[jobId][msg.sender];

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -24,6 +24,7 @@ interface IJobRegistry {
         uint256 stake;
         bool success;
         Status status;
+        bytes32 specHash;
         bytes32 uriHash;
         bytes32 resultHash;
     }
@@ -68,6 +69,7 @@ interface IJobRegistry {
         uint256 reward,
         uint256 stake,
         uint256 fee,
+        bytes32 specHash,
         string uri
     );
     event JobApplied(uint256 indexed jobId, address indexed agent);

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -11,6 +11,7 @@ describe("JobRegistry integration", function () {
   const reward = 100;
   const stake = 200;
   const disputeFee = 0;
+  const specHash = ethers.id("spec");
 
   beforeEach(async () => {
     [owner, employer, agent, treasury] = await ethers.getSigners();
@@ -142,7 +143,9 @@ describe("JobRegistry integration", function () {
   it("runs successful job lifecycle", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
-    await expect(registry.connect(employer).createJob(reward, deadline, "uri"))
+    await expect(
+      registry.connect(employer).createJob(reward, deadline, specHash, "uri")
+    )
       .to.emit(registry, "JobCreated")
       .withArgs(
         1,
@@ -151,6 +154,7 @@ describe("JobRegistry integration", function () {
         reward,
         stake,
         0,
+        specHash,
         "uri"
       );
     const jobId = 1;
@@ -181,7 +185,7 @@ describe("JobRegistry integration", function () {
     await registry.connect(owner).setJobParameters(reward, 0);
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    await registry.connect(employer).createJob(reward, deadline, specHash, "uri");
     await expect(registry.connect(newAgent).acknowledgeAndApply(1, "", []))
       .to.emit(registry, "JobApplied")
       .withArgs(1, newAgent.address);
@@ -214,7 +218,7 @@ describe("JobRegistry integration", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + reward / 10);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    await registry.connect(employer).createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);
@@ -235,7 +239,7 @@ describe("JobRegistry integration", function () {
   it("allows employer to cancel before completion", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    await registry.connect(employer).createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await expect(registry.connect(employer).cancelJob(jobId))
       .to.emit(registry, "JobCancelled")
@@ -248,7 +252,7 @@ describe("JobRegistry integration", function () {
   it("allows owner to delist unassigned job", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    await registry.connect(employer).createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await expect(registry.connect(owner).delistJob(jobId))
       .to.emit(registry, "JobCancelled")

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -5,6 +5,7 @@ const { time } = require("@nomicfoundation/hardhat-network-helpers");
 describe("JobRegistry agent gating", function () {
   let owner, employer, agent;
   let registry, rep, verifier, policy;
+  const specHash = ethers.id("spec");
 
   beforeEach(async () => {
     [owner, employer, agent] = await ethers.getSigners();
@@ -65,7 +66,7 @@ describe("JobRegistry agent gating", function () {
 
   async function createJob() {
     const deadline = (await time.latest()) + 100;
-    await registry.connect(employer).createJob(1, deadline, "uri");
+    await registry.connect(employer).createJob(1, deadline, specHash, "uri");
     return 1;
   }
 

--- a/test/v2/JobRegistryAuthCache.test.js
+++ b/test/v2/JobRegistryAuthCache.test.js
@@ -6,6 +6,7 @@ describe("JobRegistry agent auth cache", function () {
   let owner, employer, agent;
   let registry, verifier, policy;
   let jobId = 0;
+  const specHash = ethers.id("spec");
 
   beforeEach(async () => {
     [owner, employer, agent] = await ethers.getSigners();
@@ -60,7 +61,7 @@ describe("JobRegistry agent auth cache", function () {
   async function createJob() {
     const deadline = (await time.latest()) + 100;
     jobId++;
-    await registry.connect(employer).createJob(1, deadline, "uri");
+    await registry.connect(employer).createJob(1, deadline, specHash, "uri");
     return jobId;
   }
 
@@ -133,13 +134,13 @@ describe("JobRegistry agent auth cache", function () {
     await registry2.connect(owner).setAgentAuthCacheDuration(1000);
 
     let deadline = (await time.latest()) + 100;
-    await registry2.connect(employer).createJob(1, deadline, "uri");
+    await registry2.connect(employer).createJob(1, deadline, specHash, "uri");
     await registry2.connect(agent).applyForJob(1, "a", []);
 
     await verifier2.connect(owner).setResult(false);
 
     deadline = (await time.latest()) + 100;
-    await registry2.connect(employer).createJob(1, deadline, "uri");
+    await registry2.connect(employer).createJob(1, deadline, specHash, "uri");
     await registry2.connect(agent).applyForJob(2, "a", []);
 
     await verifier2
@@ -150,7 +151,7 @@ describe("JobRegistry agent auth cache", function () {
       .setAgentMerkleRoot(ethers.id("newroot"));
 
     deadline = (await time.latest()) + 100;
-    await registry2.connect(employer).createJob(1, deadline, "uri");
+    await registry2.connect(employer).createJob(1, deadline, specHash, "uri");
     await expect(
       registry2.connect(agent).applyForJob(3, "a", [])
     ).to.be.revertedWithCustomError(registry2, "NotAuthorizedAgent");

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -4,6 +4,7 @@ const { ethers } = require("hardhat");
 describe("ValidationModule access controls", function () {
   let owner, employer, v1, v2, v3;
   let validation, stakeManager, jobRegistry, reputation, identity;
+  const specHash = ethers.ZeroHash;
 
   beforeEach(async () => {
     [owner, employer, v1, v2, v3] = await ethers.getSigners();
@@ -66,6 +67,7 @@ describe("ValidationModule access controls", function () {
       stake: 0,
       success: false,
       status: 3,
+      specHash: ethers.ZeroHash,
       uriHash: ethers.ZeroHash,
       resultHash: ethers.ZeroHash,
     };

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -203,9 +203,10 @@ describe("Commit-reveal job lifecycle", function () {
 
     const nonce = await validation.jobNonce(1);
     const salt = ethers.id("salt");
+    const specHash = ethers.id("ipfs://job");
     const commit = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt]
+      ["uint256", "bytes32", "uint256", "bool", "bytes32"],
+      [1n, specHash, nonce, true, salt]
     );
     await validation.connect(validator).commitValidation(1, commit, "", []);
     await time.increase(2);
@@ -274,9 +275,10 @@ describe("Commit-reveal job lifecycle", function () {
 
     const nonce = await validation.jobNonce(1);
     const salt = ethers.id("salt");
+    const specHash2 = ethers.id("ipfs://job");
     const commit = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, salt]
+      ["uint256", "bytes32", "uint256", "bool", "bytes32"],
+      [1n, specHash2, nonce, false, salt]
     );
     await validation.connect(validator).commitValidation(1, commit, "", []);
     await time.increase(2);


### PR DESCRIPTION
## Summary
- track `specHash` for each job and include it in creation events
- require non-zero specification hash when creating jobs
- bind validation reveal checks to `{jobId, specHash, ...}` commitments

## Testing
- `npx hardhat test test/v2/jobCommitRevealFlow.test.ts` *(fails: no output produced)*

------
https://chatgpt.com/codex/tasks/task_e_68b8604936b08333a572dd9810f73c98