### PR TITLE
feat: include spec hash in job creation and validation

### DIFF
--- a/contracts/CommitRevealMock.sol
+++ b/contracts/CommitRevealMock.sol
@@ -10,8 +10,15 @@ contract CommitRevealMock {
         commits[jobId][msg.sender] = commitHash;
     }
 
-    function reveal(uint256 jobId, bool approve, bytes32 salt) external returns (bool) {
-        bytes32 expected = keccak256(abi.encodePacked(jobId, nonces[jobId], approve, salt));
+    function reveal(
+        uint256 jobId,
+        bool approve,
+        bytes32 salt,
+        bytes32 specHash
+    ) external returns (bool) {
+        bytes32 expected = keccak256(
+            abi.encodePacked(jobId, nonces[jobId], approve, salt, specHash)
+        );
         require(commits[jobId][msg.sender] == expected, "hash mismatch");
         revealed[jobId][msg.sender] = true;
         nonces[jobId]++;

--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -145,6 +145,10 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         return _jobs[jobId];
     }
 
+    function getSpecHash(uint256) external pure override returns (bytes32) {
+        return bytes32(0);
+    }
+
     function acknowledgeTaxPolicy() external {
         if (address(taxPolicy) != address(0)) {
             taxPolicy.acknowledge();
@@ -217,6 +221,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
     function createJob(
         uint256 reward,
         uint64 deadline,
+        bytes32 /*specHash*/,
         string calldata uri
     ) external override returns (uint256 jobId) {
         require(

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1065,9 +1065,11 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         bytes32 commitHash = commitments[jobId][msg.sender][nonce];
         if (commitHash == bytes32(0)) revert CommitMissing();
         if (revealed[jobId][msg.sender]) revert AlreadyRevealed();
+        bytes32 specHash = jobRegistry.getSpecHash(jobId);
         if (
-            keccak256(abi.encodePacked(jobId, nonce, approve, salt)) !=
-            commitHash
+            keccak256(
+                abi.encodePacked(jobId, nonce, approve, salt, specHash)
+            ) != commitHash
         ) revert InvalidReveal();
 
         uint256 stake = validatorStakes[jobId][msg.sender];

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -68,6 +68,7 @@ interface IJobRegistry {
         uint256 reward,
         uint256 stake,
         uint256 fee,
+        bytes32 specHash,
         string uri
     );
     event JobApplied(uint256 indexed jobId, address indexed agent);
@@ -156,6 +157,7 @@ interface IJobRegistry {
     function createJob(
         uint256 reward,
         uint64 deadline,
+        bytes32 specHash,
         string calldata uri
     ) external returns (uint256 jobId);
 
@@ -169,6 +171,8 @@ interface IJobRegistry {
         string calldata subdomain,
         bytes32[] calldata proof
     ) external;
+
+    function getSpecHash(uint256 jobId) external view returns (bytes32);
 
     /// @notice Deposit stake and apply for a job in one call
     /// @param jobId Identifier of the job

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -223,8 +223,8 @@ describe("Identity verification enforcement", function () {
       const salt = ethers.keccak256(ethers.toUtf8Bytes("salt"));
       const nonce = await validation.jobNonce(1);
       const commit = ethers.solidityPackedKeccak256(
-        ["uint256", "uint256", "bool", "bytes32"],
-        [1n, nonce, true, salt]
+        ["uint256", "uint256", "bool", "bytes32", "bytes32"],
+        [1n, nonce, true, salt, ethers.ZeroHash]
       );
       await expect(
         validation.connect(signer).commitValidation(1, commit, "", [])

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -142,7 +142,12 @@ describe("JobRegistry integration", function () {
   it("runs successful job lifecycle", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
-    await expect(registry.connect(employer).createJob(reward, deadline, "uri"))
+    const specHash = ethers.id("spec");
+    await expect(
+      registry
+        .connect(employer)
+        .createJob(reward, deadline, specHash, "uri")
+    )
       .to.emit(registry, "JobCreated")
       .withArgs(
         1,
@@ -151,8 +156,11 @@ describe("JobRegistry integration", function () {
         reward,
         stake,
         0,
+        specHash,
         "uri"
       );
+    const created = await registry.jobs(1);
+    expect(created.specHash).to.equal(specHash);
     const jobId = 1;
     await expect(registry.connect(agent).applyForJob(jobId, "", []))
       .to.emit(registry, "JobApplied")

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -86,7 +86,16 @@ describe("JobRegistry tax policy integration", function () {
       .withArgs(user.address, 2);
     await expect(registry.connect(user).createJob(1, deadline, "uri"))
       .to.emit(registry, "JobCreated")
-      .withArgs(1, user.address, ethers.ZeroAddress, 1, 0, 0, "uri");
+      .withArgs(
+        1,
+        user.address,
+        ethers.ZeroAddress,
+        1,
+        0,
+        0,
+        ethers.ZeroHash,
+        "uri"
+      );
   });
 
   it("blocks non-owner from setting policy", async () => {

--- a/test/v2/ValidationFinalizeGas.t.sol
+++ b/test/v2/ValidationFinalizeGas.t.sol
@@ -85,7 +85,9 @@ contract ValidationFinalizeGas is Test {
             address val = validators[i];
             bytes32 salt = bytes32(uint256(i + 1));
             uint256 nonce = validation.jobNonce(jobId);
-            bytes32 commitHash = keccak256(abi.encodePacked(jobId, nonce, true, salt));
+            bytes32 commitHash = keccak256(
+                abi.encodePacked(jobId, nonce, true, salt, bytes32(0))
+            );
             vm.prank(val);
             validation.commitValidation(jobId, commitHash);
             vm.warp(block.timestamp + 2);

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -231,18 +231,9 @@ describe("ValidationModule V2", function () {
     const salt2 = ethers.keccak256(ethers.toUtf8Bytes("salt2"));
     const salt3 = ethers.keccak256(ethers.toUtf8Bytes("salt3"));
     const nonce = await validation.jobNonce(1);
-    const commit1 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt1]
-    );
-    const commit2 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt2]
-    );
-    const commit3 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt3]
-    );
+    const commit1 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt1, ethers.ZeroHash]);
+    const commit2 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt2, ethers.ZeroHash]);
+    const commit3 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt3, ethers.ZeroHash]);
     await (
       await validation.connect(v1).commitValidation(1, commit1, "", [])
     ).wait();
@@ -285,18 +276,9 @@ describe("ValidationModule V2", function () {
     const salt2 = ethers.keccak256(ethers.toUtf8Bytes("salt2"));
     const salt3 = ethers.keccak256(ethers.toUtf8Bytes("salt3"));
     const nonce = await validation.jobNonce(1);
-    const commit1 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt1]
-    );
-    const commit2 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt2]
-    );
-    const commit3 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, salt3]
-    );
+    const commit1 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt1, ethers.ZeroHash]);
+    const commit2 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt2, ethers.ZeroHash]);
+    const commit3 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, false, salt3, ethers.ZeroHash]);
     await (
       await validation.connect(v1).commitValidation(1, commit1, "", [])
     ).wait();
@@ -331,10 +313,7 @@ describe("ValidationModule V2", function () {
     await select(1);
     const salt = ethers.keccak256(ethers.toUtf8Bytes("salt"));
     const wrongNonce = (await validation.jobNonce(1)) + 1n;
-    const commit = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, wrongNonce, true, salt]
-    );
+    const commit = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, wrongNonce, true, salt, ethers.ZeroHash]);
     await (
       await validation.connect(v1).commitValidation(1, commit, "", [])
     ).wait();
@@ -355,10 +334,7 @@ describe("ValidationModule V2", function () {
     await select(1);
     const nonce = await validation.jobNonce(1);
     const salt = ethers.keccak256(ethers.toUtf8Bytes("salt"));
-    const commit = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt]
-    );
+    const commit = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt, ethers.ZeroHash]);
     await (
       await validation.connect(v1).commitValidation(1, commit, "", [])
     ).wait();
@@ -383,10 +359,7 @@ describe("ValidationModule V2", function () {
     await select(1);
     const nonce1 = await validation.jobNonce(1);
     const salt = ethers.keccak256(ethers.toUtf8Bytes("salt"));
-    const commit1 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce1, true, salt]
-    );
+    const commit1 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce1, true, salt, ethers.ZeroHash]);
     await (await validation.connect(v1).commitValidation(1, commit1, "", [])).wait();
 
     await expect(
@@ -400,10 +373,7 @@ describe("ValidationModule V2", function () {
     await tx.wait();
     const nonce2 = await validation.jobNonce(1);
     expect(nonce2).to.equal(1n);
-    const commit2 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce2, true, salt]
-    );
+    const commit2 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce2, true, salt, ethers.ZeroHash]);
     await expect(
       validation.connect(v1).commitValidation(1, commit2, "", [])
     ).to.not.be.reverted;
@@ -424,10 +394,7 @@ describe("ValidationModule V2", function () {
     await select(1);
     const nonce = await validation.jobNonce(1);
     const salt = ethers.keccak256(ethers.toUtf8Bytes("salt"));
-    const commit = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt]
-    );
+    const commit = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt, ethers.ZeroHash]);
     await expect(
       validation.connect(v1).commitValidation(1, commit, "", [])
     ).to.be.revertedWithCustomError(validation, "NotValidator");
@@ -492,10 +459,7 @@ describe("ValidationModule V2", function () {
     const val = signerMap[selected[0].toLowerCase()];
     const salt = ethers.keccak256(ethers.toUtf8Bytes("salt"));
     const nonce = await validation.jobNonce(1);
-    const commit = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt]
-    );
+    const commit = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt, ethers.ZeroHash]);
 
     await expect(
       validation.connect(val).commitValidation(1, commit, "", [])

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -118,10 +118,7 @@ describe("ValidationModule access controls", function () {
 
     const salt = ethers.keccak256(ethers.toUtf8Bytes("salt"));
     const nonce = await validation.jobNonce(1);
-    const commit = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt]
-    );
+    const commit = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt, ethers.ZeroHash]);
       await expect(
         validation.connect(signer).commitValidation(1, commit, "", [])
       ).to.be.revertedWithCustomError(validation, "UnauthorizedValidator");
@@ -156,10 +153,7 @@ describe("ValidationModule access controls", function () {
 
     const salt = ethers.keccak256(ethers.toUtf8Bytes("salt"));
     const nonce = await validation.jobNonce(1);
-    const commit = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt]
-    );
+    const commit = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt, ethers.ZeroHash]);
     await reputation.setBlacklist(val, true);
     await expect(
       validation.connect(signer).commitValidation(1, commit, "", [])
@@ -190,18 +184,9 @@ describe("ValidationModule access controls", function () {
     const saltB = ethers.keccak256(ethers.toUtf8Bytes("b"));
     const saltC = ethers.keccak256(ethers.toUtf8Bytes("c"));
     const nonce = await validation.jobNonce(1);
-    const commitA = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, saltA]
-    );
-    const commitB = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, saltB]
-    );
-    const commitC = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, saltC]
-    );
+    const commitA = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, false, saltA, ethers.ZeroHash]);
+    const commitB = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, false, saltB, ethers.ZeroHash]);
+    const commitC = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, false, saltC, ethers.ZeroHash]);
     const signerMap = {
       [v1.address.toLowerCase()]: v1,
       [v2.address.toLowerCase()]: v2,
@@ -260,18 +245,9 @@ describe("ValidationModule access controls", function () {
     const s1 = ethers.keccak256(ethers.toUtf8Bytes("s1"));
     const s2 = ethers.keccak256(ethers.toUtf8Bytes("s2"));
     const s3 = ethers.keccak256(ethers.toUtf8Bytes("s3"));
-    const c1 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce2, true, s1]
-    );
-    const c2 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce2, true, s2]
-    );
-    const c3 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce2, true, s3]
-    );
+    const c1 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce2, true, s1, ethers.ZeroHash]);
+    const c2 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce2, true, s2, ethers.ZeroHash]);
+    const c3 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce2, true, s3, ethers.ZeroHash]);
     await (
       await validation
         .connect(signerMap[vA.toLowerCase()])

--- a/test/v2/ValidationModuleCommitteeSize.test.js
+++ b/test/v2/ValidationModuleCommitteeSize.test.js
@@ -122,14 +122,8 @@ describe("ValidationModule committee size", function () {
     const salt1 = ethers.keccak256(ethers.toUtf8Bytes("salt1"));
     const salt2 = ethers.keccak256(ethers.toUtf8Bytes("salt2"));
     const nonce = await validation.jobNonce(4);
-    const commit1 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [4n, nonce, true, salt1]
-    );
-    const commit2 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [4n, nonce, true, salt2]
-    );
+    const commit1 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[4n, nonce, true, salt1, ethers.ZeroHash]);
+    const commit2 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[4n, nonce, true, salt2, ethers.ZeroHash]);
 
     await validation
       .connect(signerMap[selected[0].toLowerCase()])

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -97,18 +97,9 @@ describe("ValidationModule finalize flows", function () {
     const salt2 = ethers.keccak256(ethers.toUtf8Bytes("s2"));
     const salt3 = ethers.keccak256(ethers.toUtf8Bytes("s3"));
     const nonce = await validation.jobNonce(1);
-    const commit1 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt1]
-    );
-    const commit2 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, salt2]
-    );
-    const commit3 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, salt3]
-    );
+    const commit1 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt1, ethers.ZeroHash]);
+    const commit2 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, false, salt2, ethers.ZeroHash]);
+    const commit3 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, false, salt3, ethers.ZeroHash]);
     await validation.connect(v1).commitValidation(1, commit1, "", []);
     await validation.connect(v2).commitValidation(1, commit2, "", []);
     await validation.connect(v3).commitValidation(1, commit3, "", []);
@@ -130,18 +121,9 @@ describe("ValidationModule finalize flows", function () {
     const salt2 = ethers.keccak256(ethers.toUtf8Bytes("s2"));
     const salt3 = ethers.keccak256(ethers.toUtf8Bytes("s3"));
     const nonce = await validation.jobNonce(1);
-    const commit1 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt1]
-    );
-    const commit2 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt2]
-    );
-    const commit3 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt3]
-    );
+    const commit1 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt1, ethers.ZeroHash]);
+    const commit2 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt2, ethers.ZeroHash]);
+    const commit3 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt3, ethers.ZeroHash]);
     await validation.connect(v1).commitValidation(1, commit1, "", []);
     await validation.connect(v2).commitValidation(1, commit2, "", []);
     await validation.connect(v3).commitValidation(1, commit3, "", []);
@@ -158,18 +140,9 @@ describe("ValidationModule finalize flows", function () {
     const salt2 = ethers.keccak256(ethers.toUtf8Bytes("s2"));
     const salt3 = ethers.keccak256(ethers.toUtf8Bytes("s3"));
     const nonce = await validation.jobNonce(1);
-    const commit1 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, salt1]
-    );
-    const commit2 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, salt2]
-    );
-    const commit3 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt3]
-    );
+    const commit1 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, false, salt1, ethers.ZeroHash]);
+    const commit2 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, false, salt2, ethers.ZeroHash]);
+    const commit3 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt3, ethers.ZeroHash]);
     await validation.connect(v1).commitValidation(1, commit1, "", []);
     await validation.connect(v2).commitValidation(1, commit2, "", []);
     await validation.connect(v3).commitValidation(1, commit3, "", []);
@@ -200,18 +173,9 @@ describe("ValidationModule finalize flows", function () {
     const salt2 = ethers.keccak256(ethers.toUtf8Bytes("s2"));
     const salt3 = ethers.keccak256(ethers.toUtf8Bytes("s3"));
     const nonce = await validation.jobNonce(1);
-    const commit1 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt1]
-    );
-    const commit2 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt2]
-    );
-    const commit3 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt3]
-    );
+    const commit1 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt1, ethers.ZeroHash]);
+    const commit2 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt2, ethers.ZeroHash]);
+    const commit3 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt3, ethers.ZeroHash]);
     await validation.connect(v1).commitValidation(1, commit1, "", []);
     await validation.connect(v2).commitValidation(1, commit2, "", []);
     await validation.connect(v3).commitValidation(1, commit3, "", []);
@@ -288,18 +252,9 @@ describe("ValidationModule finalize flows", function () {
     const salt2 = ethers.keccak256(ethers.toUtf8Bytes("s2"));
     const salt3 = ethers.keccak256(ethers.toUtf8Bytes("s3"));
     const nonce = await validation.jobNonce(1);
-    const commit1 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt1]
-    );
-    const commit2 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, salt2]
-    );
-    const commit3 = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, salt3]
-    );
+    const commit1 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt1, ethers.ZeroHash]);
+    const commit2 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, false, salt2, ethers.ZeroHash]);
+    const commit3 = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, false, salt3, ethers.ZeroHash]);
     await validation.connect(v1).commitValidation(1, commit1, "", []);
     await validation.connect(v2).commitValidation(1, commit2, "", []);
     await validation.connect(v3).commitValidation(1, commit3, "", []);

--- a/test/v2/ValidationModuleReentrancy.test.js
+++ b/test/v2/ValidationModuleReentrancy.test.js
@@ -96,10 +96,7 @@ describe("ValidationModule reentrancy", function () {
     await prepare(1);
     const salt = ethers.keccak256(ethers.toUtf8Bytes("s"));
     const nonce = await validation.jobNonce(1);
-    const commitHash = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt]
-    );
+    const commitHash = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt, ethers.ZeroHash]);
     await identity.attackCommit(1, commitHash);
     await expect(
       validation.connect(validator).commitValidation(1, commitHash, "", [])
@@ -111,10 +108,7 @@ describe("ValidationModule reentrancy", function () {
     await prepare(1);
     const salt = ethers.keccak256(ethers.toUtf8Bytes("s"));
     const nonce = await validation.jobNonce(1);
-    const commitHash = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt]
-    );
+    const commitHash = ethers.solidityPackedKeccak256(["uint256", "uint256", "bool", "bytes32", "bytes32"],[1n, nonce, true, salt, ethers.ZeroHash]);
     await validation
       .connect(validator)
       .commitValidation(1, commitHash, "", []);

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -194,7 +194,10 @@ describe("Commit-reveal job lifecycle", function () {
     const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec1");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, label, []);
     await registry
@@ -204,8 +207,8 @@ describe("Commit-reveal job lifecycle", function () {
     const nonce = await validation.jobNonce(1);
     const salt = ethers.id("salt");
     const commit = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, true, salt]
+      ["uint256", "uint256", "bool", "bytes32", "bytes32"],
+      [1n, nonce, true, salt, specHash]
     );
     await validation.connect(validator).commitValidation(1, commit, "", []);
     await time.increase(2);
@@ -265,7 +268,10 @@ describe("Commit-reveal job lifecycle", function () {
     const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec2");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, label, []);
     await registry
@@ -275,8 +281,8 @@ describe("Commit-reveal job lifecycle", function () {
     const nonce = await validation.jobNonce(1);
     const salt = ethers.id("salt");
     const commit = ethers.solidityPackedKeccak256(
-      ["uint256", "uint256", "bool", "bytes32"],
-      [1n, nonce, false, salt]
+      ["uint256", "uint256", "bool", "bytes32", "bytes32"],
+      [1n, nonce, false, salt, specHash]
     );
     await validation.connect(validator).commitValidation(1, commit, "", []);
     await time.increase(2);

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -124,10 +124,20 @@ describe("job lifecycle with dispute and validator failure", function () {
 
     const nonce = await validation.jobNonce(1);
     const salt1 = ethers.randomBytes(32);
-    const commit1 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, true, salt1]));
+    const commit1 = ethers.keccak256(
+      ethers.solidityPacked(
+        ["uint256","uint256","bool","bytes32","bytes32"],
+        [1n, nonce, true, salt1, ethers.ZeroHash]
+      )
+    );
     await validation.connect(v1).commitValidation(1, commit1);
     const salt2 = ethers.randomBytes(32);
-    const commit2 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, false, salt2]));
+    const commit2 = ethers.keccak256(
+      ethers.solidityPacked(
+        ["uint256","uint256","bool","bytes32","bytes32"],
+        [1n, nonce, false, salt2, ethers.ZeroHash]
+      )
+    );
     await validation.connect(v2).commitValidation(1, commit2);
 
     await time.increase(2);

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -158,16 +158,16 @@ describe("Kleros dispute module", function () {
     const salt1 = ethers.randomBytes(32);
     const commit1 = ethers.keccak256(
       ethers.solidityPacked(
-        ["uint256", "uint256", "bool", "bytes32"],
-        [1n, nonce, true, salt1]
+        ["uint256", "uint256", "bool", "bytes32", "bytes32"],
+        [1n, nonce, true, salt1, ethers.ZeroHash]
       )
     );
     await validation.connect(v1).commitValidation(1, commit1);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
-        ["uint256", "uint256", "bool", "bytes32"],
-        [1n, nonce, false, salt2]
+        ["uint256", "uint256", "bool", "bytes32", "bytes32"],
+        [1n, nonce, false, salt2, ethers.ZeroHash]
       )
     );
     await validation.connect(v2).commitValidation(1, commit2);

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -142,7 +142,12 @@ describe("regression scenarios", function () {
     await registry.connect(agent).submit(1, ethers.id("ipfs://good"), "ipfs://good", "agent", []);
     const nonce = await validation.jobNonce(1);
     const salt = ethers.randomBytes(32);
-    const commit = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, false, salt]));
+    const commit = ethers.keccak256(
+      ethers.solidityPacked(
+        ["uint256","uint256","bool","bytes32","bytes32"],
+        [1n, nonce, false, salt, ethers.ZeroHash]
+      )
+    );
     await validation.connect(v1).commitValidation(1, commit);
     await time.increase(2);
     await validation.connect(v1).revealValidation(1, false, salt);

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -121,10 +121,20 @@ describe("validator participation", function () {
 
     const nonce = await validation.jobNonce(1);
     const salt1 = ethers.randomBytes(32);
-    const commit1 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, true, salt1]));
+    const commit1 = ethers.keccak256(
+      ethers.solidityPacked(
+        ["uint256","uint256","bool","bytes32","bytes32"],
+        [1n, nonce, true, salt1, ethers.ZeroHash]
+      )
+    );
     await validation.connect(v1).commitValidation(1, commit1);
     const salt2 = ethers.randomBytes(32);
-    const commit2 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, true, salt2]));
+    const commit2 = ethers.keccak256(
+      ethers.solidityPacked(
+        ["uint256","uint256","bool","bytes32","bytes32"],
+        [1n, nonce, true, salt2, ethers.ZeroHash]
+      )
+    );
     await validation.connect(v2).commitValidation(1, commit2);
 
     await time.increase(2);
@@ -157,10 +167,20 @@ describe("validator participation", function () {
 
     const nonce = await validation.jobNonce(1);
     const salt1 = ethers.randomBytes(32);
-    const commit1 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, false, salt1]));
+    const commit1 = ethers.keccak256(
+      ethers.solidityPacked(
+        ["uint256","uint256","bool","bytes32","bytes32"],
+        [1n, nonce, false, salt1, ethers.ZeroHash]
+      )
+    );
     await validation.connect(v1).commitValidation(1, commit1);
     const salt2 = ethers.randomBytes(32);
-    const commit2 = ethers.keccak256(ethers.solidityPacked(["uint256","uint256","bool","bytes32"],[1n, nonce, false, salt2]));
+    const commit2 = ethers.keccak256(
+      ethers.solidityPacked(
+        ["uint256","uint256","bool","bytes32","bytes32"],
+        [1n, nonce, false, salt2, ethers.ZeroHash]
+      )
+    );
     await validation.connect(v2).commitValidation(1, commit2);
 
     await time.increase(2);


### PR DESCRIPTION
## Summary
- track `specHash` in job records and expose getter
- add spec hash parameter to job creation and include in events
- incorporate `specHash` into validator reveal checks and commit hashes

## Testing
- `npx hardhat test test/v2/jobCommitRevealFlow.test.ts --grep "full flow"` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b868aebc44833390fab4c4b2839622