### PR TITLE
Handle non-burnable tokens gracefully

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -20,6 +20,7 @@ error InvalidTokenDecimals();
 error ZeroAddress();
 error InvalidStakeManagerVersion();
 error BurnAddressNotZero();
+error TokenNotBurnable();
 
 /// @title FeePool
 /// @notice Accumulates job fees and distributes them to stakers proportionally.
@@ -160,8 +161,11 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
 
         uint256 burnAmount = (amount * burnPct) / 100;
         if (burnAmount > 0) {
-            IERC20Burnable(AGIALPHA).burn(burnAmount);
-            emit Burned(burnAmount);
+            try IERC20Burnable(AGIALPHA).burn(burnAmount) {
+                emit Burned(burnAmount);
+            } catch {
+                revert TokenNotBurnable();
+            }
         }
         uint256 distribute = amount - burnAmount;
         uint256 total = stakeManager.totalStake(rewardRole);

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -55,6 +55,7 @@ error UnbondLocked();
 error Jailed();
 error PendingPenalty();
 error BurnAddressNotZero();
+error TokenNotBurnable();
 
 /// @title StakeManager
 /// @notice Handles staking balances, job escrows and slashing logic.
@@ -276,7 +277,10 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     function _burnToken(uint256 amount) internal {
         if (amount == 0) return;
         if (BURN_ADDRESS != address(0)) revert BurnAddressNotZero();
-        IERC20Burnable(AGIALPHA).burn(amount);
+        try IERC20Burnable(AGIALPHA).burn(amount) {
+        } catch {
+            revert TokenNotBurnable();
+        }
     }
 
     /// @notice update slashing percentage splits

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -14,6 +14,7 @@ interface Vm {
     function stopPrank() external;
     function etch(address, bytes memory) external;
     function expectRevert() external;
+    function expectRevert(bytes4) external;
 }
 
 contract TestToken is ERC20 {
@@ -119,7 +120,7 @@ contract FeePoolTest {
         nbToken.mint(address(feePool), TOKEN);
         vm.prank(address(stakeManager));
         feePool.depositFee(TOKEN);
-        vm.expectRevert();
+        vm.expectRevert(TokenNotBurnable.selector);
         feePool.distributeFees();
     }
 

--- a/test/v2/StakeManagerBurn.t.sol
+++ b/test/v2/StakeManagerBurn.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
-import {StakeManager} from "../../contracts/v2/StakeManager.sol";
+import {StakeManager, TokenNotBurnable} from "../../contracts/v2/StakeManager.sol";
 import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
 import {AGIALPHA, BURN_ADDRESS} from "../../contracts/v2/Constants.sol";
 
@@ -50,7 +50,7 @@ contract StakeManagerBurnTest is Test {
     function testBurnTokenRevertsWithoutBurnFunction() public {
         NoBurnToken nb = new NoBurnToken();
         vm.etch(AGIALPHA, address(nb).code);
-        vm.expectRevert();
+        vm.expectRevert(TokenNotBurnable.selector);
         stake.exposedBurn(1);
     }
 


### PR DESCRIPTION
## Summary
- add `TokenNotBurnable` error to FeePool and StakeManager
- guard token burns with try/catch and surface `TokenNotBurnable`
- test non-burnable token cases for FeePool and StakeManager

## Testing
- `npm test`
- `forge test` *(fails: Yul exception:Cannot swap Variable param with Variable param_16: too deep in the stack)*

------
https://chatgpt.com/codex/tasks/task_e_68b887b2aa3c8333bd83d6be834dcd96