### PR TITLE
feat: ensure burn address invariants

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -161,11 +161,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
 
         uint256 burnAmount = (amount * burnPct) / 100;
         if (burnAmount > 0) {
-            try IERC20Burnable(AGIALPHA).burn(burnAmount) {
-                emit Burned(burnAmount);
-            } catch {
-                revert TokenNotBurnable();
-            }
+            _burnFees(burnAmount);
         }
         uint256 distribute = amount - burnAmount;
         uint256 total = stakeManager.totalStake(rewardRole);
@@ -185,6 +181,17 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
             token.safeTransfer(treasury, dust);
         }
         emit FeesDistributed(accounted);
+    }
+
+    function _burnFees(uint256 amt) internal {
+        if (BURN_ADDRESS != address(0)) {
+            revert BurnAddressNotZero();
+        }
+        try IERC20Burnable(address(token)).burn(amt) {
+            emit Burned(amt);
+        } catch {
+            revert TokenNotBurnable();
+        }
     }
 
     /**

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -109,6 +109,12 @@ contract FeePoolTest {
         require(token.totalSupply() == supplyBefore - burnAmount, "supply");
     }
 
+    function testBurnAddressInvariant() public {
+        setUp();
+        require(feePool.burnPct() > 0, "burnPct");
+        require(BURN_ADDRESS == address(0), "burnAddr");
+    }
+
     function testNonBurnableTokenReverts() public {
         NonBurnableToken impl = new NonBurnableToken();
         vm.etch(AGIALPHA, address(impl).code);


### PR DESCRIPTION
## Summary
- add runtime burn address guard in FeePool and centralize burn logic
- test burn invariants to ensure token supply decreases and burn address is zero

## Testing
- `npm run verify:agialpha`
- `npm run compile`
- `npm run verify:wiring`
- `npm run lint`
- `npm test`
- `forge test` *(fails: Yul exception: Cannot swap Variable param...)*
- `npx ts-node --compiler-options '{"module":"commonjs"}' scripts/transfer-ownership.ts --new-owner 0x0000000000000000000000000000000000000000`


------
https://chatgpt.com/codex/tasks/task_e_68b8ab03bf5c8333b672d3c5fd0c657c