### PR TITLE
feat: emit caller on fee burns

### DIFF
--- a/docs/api/FeePool.md
+++ b/docs/api/FeePool.md
@@ -16,7 +16,7 @@ Holds platform fees and distributes rewards.
 ## Events
 - `FeeDeposited(address from, uint256 amount)`
 - `FeesDistributed(uint256 amount)`
-- `Burned(uint256 amount)`
+- `FeesBurned(address caller, uint256 amount)`
 - `RewardsClaimed(address user, uint256 amount)`
 - `StakeManagerUpdated(address stakeManager)`
 - `RewardRoleUpdated(uint8 role)`


### PR DESCRIPTION
## Summary
- expose caller in `FeesBurned` event and add clearer `BadBurnAddress` error
- update FeePool docs for renamed event

## Testing
- `curl -L -X POST https://api.github.com/repos/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/dispatches -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -d '{"ref":"main"}'` (fails: Bad credentials)
- `npm run compile`
- `npm test`
- `forge test` (fails: Compiler run failed: Yul exception)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8b4479e3c8333b597bda09cff8dde