### PR TITLE
chore: add pause checks to fee pool

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -128,7 +128,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     ///      `StakeManager` may call this to keep accounting trustless while the
     ///      registry itself never holds custody of user funds.
     /// @param amount fee amount with 18 decimals
-    function depositFee(uint256 amount) external onlyStakeManager nonReentrant {
+    function depositFee(uint256 amount) external onlyStakeManager whenNotPaused nonReentrant {
         if (amount == 0) revert ZeroAmount();
         pendingFees += amount;
         emit FeeDeposited(msg.sender, amount);
@@ -136,7 +136,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
 
     /// @notice Contribute tokens directly to the reward pool.
     /// @param amount token amount with 18 decimals.
-    function contribute(uint256 amount) external nonReentrant {
+    function contribute(uint256 amount) external whenNotPaused nonReentrant {
         if (amount == 0) revert ZeroAmount();
         token.safeTransferFrom(msg.sender, address(this), amount);
         pendingFees += amount;
@@ -148,7 +148,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     ///      pending or when no stake is present; in the latter case funds are
     ///      burned/forwarded to the treasury so non-technical callers never see
     ///      a revert.
-    function distributeFees() public nonReentrant {
+    function distributeFees() public whenNotPaused nonReentrant {
         _distributeFees();
     }
 

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -150,5 +150,32 @@ contract FeePoolTest {
             "sum"
         );
     }
+
+    function testDepositFeePausedReverts() public {
+        setUp();
+        feePool.pause();
+        token.mint(address(feePool), TOKEN);
+        vm.prank(address(stakeManager));
+        vm.expectRevert();
+        feePool.depositFee(TOKEN);
+    }
+
+    function testContributePausedReverts() public {
+        setUp();
+        feePool.pause();
+        token.mint(alice, TOKEN);
+        vm.startPrank(alice);
+        token.approve(address(feePool), TOKEN);
+        vm.expectRevert();
+        feePool.contribute(TOKEN);
+        vm.stopPrank();
+    }
+
+    function testDistributeFeesPausedReverts() public {
+        setUp();
+        feePool.pause();
+        vm.expectRevert();
+        feePool.distributeFees();
+    }
 }
 


### PR DESCRIPTION
## Summary
- guard fee deposits and fee distribution against paused state
- test FeePool deposit, contribute and distribution revert when paused

## Testing
- `forge test --match-path test/v2/FeePool.t.sol -vvv` *(fails: Yul exception: Cannot swap Variable param with Variable param_16)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c7570f9c8333866d9ff8b2976e15