### PR TITLE
feat: include arbitrator committee in system pause

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -13,6 +13,7 @@ import {ReputationEngine} from "./ReputationEngine.sol";
 import {DisputeModule} from "./modules/DisputeModule.sol";
 import {CertificateNFT} from "./CertificateNFT.sol";
 import {SystemPause} from "./SystemPause.sol";
+import {ArbitratorCommittee} from "./ArbitratorCommittee.sol";
 import {PlatformRegistry, IReputationEngine as PRReputationEngine} from "./PlatformRegistry.sol";
 import {JobRouter} from "./modules/JobRouter.sol";
 import {IdentityRegistry} from "./IdentityRegistry.sol";
@@ -26,6 +27,7 @@ import {IJobRouter} from "./interfaces/IJobRouter.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
 import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
+import {IDisputeModule} from "./interfaces/IDisputeModule.sol";
 import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 import {IENS} from "./interfaces/IENS.sol";
 import {INameWrapper} from "./interfaces/INameWrapper.sol";
@@ -312,8 +314,14 @@ contract Deployer is Ownable {
             IJobRegistry(address(registry)),
             0,
             0,
-            governance
+            address(0)
         );
+
+        ArbitratorCommittee committee = new ArbitratorCommittee(
+            IJobRegistry(address(registry)),
+            IDisputeModule(address(dispute))
+        );
+        dispute.setCommittee(address(committee));
 
         CertificateNFT certificate = new CertificateNFT("Cert", "CERT");
         certificate.setJobRegistry(address(registry));
@@ -399,6 +407,7 @@ contract Deployer is Ownable {
             pRegistry,
             pool,
             reputation,
+            committee,
             governance
         );
         // hand over governance to SystemPause
@@ -409,6 +418,7 @@ contract Deployer is Ownable {
         validation.transferOwnership(address(pause));
         reputation.transferOwnership(address(pause));
         dispute.transferOwnership(address(pause));
+        committee.transferOwnership(address(pause));
         certificate.transferOwnership(governance);
         pRegistry.transferOwnership(address(pause));
         router.transferOwnership(governance);

--- a/contracts/v2/SystemPause.sol
+++ b/contracts/v2/SystemPause.sol
@@ -9,6 +9,7 @@ import {DisputeModule} from "./modules/DisputeModule.sol";
 import {PlatformRegistry} from "./PlatformRegistry.sol";
 import {FeePool} from "./FeePool.sol";
 import {ReputationEngine} from "./ReputationEngine.sol";
+import {ArbitratorCommittee} from "./ArbitratorCommittee.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /// @title SystemPause
@@ -22,6 +23,7 @@ contract SystemPause is Governable, ReentrancyGuard {
     PlatformRegistry public platformRegistry;
     FeePool public feePool;
     ReputationEngine public reputationEngine;
+    ArbitratorCommittee public arbitratorCommittee;
 
     error InvalidJobRegistry(address module);
     error InvalidStakeManager(address module);
@@ -30,6 +32,7 @@ contract SystemPause is Governable, ReentrancyGuard {
     error InvalidPlatformRegistry(address module);
     error InvalidFeePool(address module);
     error InvalidReputationEngine(address module);
+    error InvalidArbitratorCommittee(address module);
 
     event ModulesUpdated(
         address jobRegistry,
@@ -38,7 +41,8 @@ contract SystemPause is Governable, ReentrancyGuard {
         address disputeModule,
         address platformRegistry,
         address feePool,
-        address reputationEngine
+        address reputationEngine,
+        address arbitratorCommittee
     );
 
     constructor(
@@ -49,6 +53,7 @@ contract SystemPause is Governable, ReentrancyGuard {
         PlatformRegistry _platformRegistry,
         FeePool _feePool,
         ReputationEngine _reputationEngine,
+        ArbitratorCommittee _arbitratorCommittee,
         address _governance
     ) Governable(_governance) {
         if (
@@ -77,6 +82,10 @@ contract SystemPause is Governable, ReentrancyGuard {
             address(_reputationEngine) == address(0) ||
             address(_reputationEngine).code.length == 0
         ) revert InvalidReputationEngine(address(_reputationEngine));
+        if (
+            address(_arbitratorCommittee) == address(0) ||
+            address(_arbitratorCommittee).code.length == 0
+        ) revert InvalidArbitratorCommittee(address(_arbitratorCommittee));
 
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
@@ -85,6 +94,7 @@ contract SystemPause is Governable, ReentrancyGuard {
         platformRegistry = _platformRegistry;
         feePool = _feePool;
         reputationEngine = _reputationEngine;
+        arbitratorCommittee = _arbitratorCommittee;
     }
 
     function setModules(
@@ -94,7 +104,8 @@ contract SystemPause is Governable, ReentrancyGuard {
         DisputeModule _disputeModule,
         PlatformRegistry _platformRegistry,
         FeePool _feePool,
-        ReputationEngine _reputationEngine
+        ReputationEngine _reputationEngine,
+        ArbitratorCommittee _arbitratorCommittee
     ) external onlyGovernance {
         if (
             address(_jobRegistry) == address(0) ||
@@ -122,6 +133,10 @@ contract SystemPause is Governable, ReentrancyGuard {
             address(_reputationEngine) == address(0) ||
             address(_reputationEngine).code.length == 0
         ) revert InvalidReputationEngine(address(_reputationEngine));
+        if (
+            address(_arbitratorCommittee) == address(0) ||
+            address(_arbitratorCommittee).code.length == 0
+        ) revert InvalidArbitratorCommittee(address(_arbitratorCommittee));
 
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
@@ -130,6 +145,7 @@ contract SystemPause is Governable, ReentrancyGuard {
         platformRegistry = _platformRegistry;
         feePool = _feePool;
         reputationEngine = _reputationEngine;
+        arbitratorCommittee = _arbitratorCommittee;
         emit ModulesUpdated(
             address(_jobRegistry),
             address(_stakeManager),
@@ -137,7 +153,8 @@ contract SystemPause is Governable, ReentrancyGuard {
             address(_disputeModule),
             address(_platformRegistry),
             address(_feePool),
-            address(_reputationEngine)
+            address(_reputationEngine),
+            address(_arbitratorCommittee)
         );
     }
 
@@ -150,6 +167,7 @@ contract SystemPause is Governable, ReentrancyGuard {
         platformRegistry.pause();
         feePool.pause();
         reputationEngine.pause();
+        arbitratorCommittee.pause();
     }
 
     /// @notice Unpause all core modules.
@@ -161,6 +179,7 @@ contract SystemPause is Governable, ReentrancyGuard {
         platformRegistry.unpause();
         feePool.unpause();
         reputationEngine.unpause();
+        arbitratorCommittee.unpause();
     }
 }
 

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -140,9 +140,18 @@ async function main() {
     await registry.getAddress(),
     appealFee,
     disputeWindow,
-    moderator
+    ethers.ZeroAddress
   );
   await dispute.waitForDeployment();
+  const Committee = await ethers.getContractFactory(
+    "contracts/v2/ArbitratorCommittee.sol:ArbitratorCommittee"
+  );
+  const committee = await Committee.deploy(
+    await registry.getAddress(),
+    await dispute.getAddress()
+  );
+  await committee.waitForDeployment();
+  await dispute.setCommittee(await committee.getAddress());
 
   const FeePool = await ethers.getContractFactory(
     "contracts/v2/FeePool.sol:FeePool"
@@ -262,6 +271,7 @@ async function main() {
     await platformRegistry.getAddress(),
     await feePool.getAddress(),
     await reputation.getAddress(),
+    await committee.getAddress(),
     governance
   );
   await pause.waitForDeployment();
@@ -274,7 +284,8 @@ async function main() {
       await dispute.getAddress(),
       await platformRegistry.getAddress(),
       await feePool.getAddress(),
-      await reputation.getAddress()
+      await reputation.getAddress(),
+      await committee.getAddress()
     );
   await stake
     .connect(governanceSigner)
@@ -297,6 +308,7 @@ async function main() {
   await reputation
     .connect(governanceSigner)
     .transferOwnership(await pause.getAddress());
+  await committee.transferOwnership(await pause.getAddress());
 
   console.log("JobRegistry deployed to:", await registry.getAddress());
   console.log("ValidationModule:", await validation.getAddress());

--- a/test/v2/Deployer.test.js
+++ b/test/v2/Deployer.test.js
@@ -99,6 +99,9 @@ describe("Deployer", function () {
     const IdentityRegistry = await ethers.getContractFactory(
       "contracts/v2/IdentityRegistry.sol:IdentityRegistry"
     );
+    const Committee = await ethers.getContractFactory(
+      "contracts/v2/ArbitratorCommittee.sol:ArbitratorCommittee"
+    );
     const SystemPause = await ethers.getContractFactory(
       "contracts/v2/SystemPause.sol:SystemPause"
     );
@@ -115,6 +118,8 @@ describe("Deployer", function () {
     const feePoolC = FeePool.attach(feePool);
     const taxPolicyC = TaxPolicy.attach(taxPolicy);
     const identityRegistryC = IdentityRegistry.attach(identityRegistryAddr);
+    const committee = await disputeC.committee();
+    const committeeC = Committee.attach(committee);
     const systemPauseC = SystemPause.attach(systemPause);
 
     // ownership
@@ -125,6 +130,7 @@ describe("Deployer", function () {
     expect(await validationC.owner()).to.equal(systemPause);
     expect(await reputationC.owner()).to.equal(systemPause);
     expect(await disputeC.owner()).to.equal(systemPause);
+    expect(await committeeC.owner()).to.equal(systemPause);
     expect(await certificateC.owner()).to.equal(governance.address);
     expect(await platformRegistryC.owner()).to.equal(systemPause);
     expect(await routerC.owner()).to.equal(governance.address);
@@ -141,6 +147,7 @@ describe("Deployer", function () {
     expect(await systemPauseC.platformRegistry()).to.equal(platformRegistry);
     expect(await systemPauseC.feePool()).to.equal(feePool);
     expect(await systemPauseC.reputationEngine()).to.equal(reputation);
+    expect(await systemPauseC.arbitratorCommittee()).to.equal(committee);
 
     // wiring
     expect(await stakeC.jobRegistry()).to.equal(registry);

--- a/test/v2/SystemPause.test.js
+++ b/test/v2/SystemPause.test.js
@@ -80,6 +80,9 @@ describe("SystemPause", function () {
     const FeePool = await ethers.getContractFactory(
       "contracts/v2/FeePool.sol:FeePool"
     );
+    const Committee = await ethers.getContractFactory(
+      "contracts/v2/ArbitratorCommittee.sol:ArbitratorCommittee"
+    );
     const SystemPause = await ethers.getContractFactory(
       "contracts/v2/SystemPause.sol:SystemPause"
     );
@@ -90,18 +93,34 @@ describe("SystemPause", function () {
     const reputation = ReputationEngine.attach(reputationAddr);
     const platformRegistry = PlatformRegistry.attach(platformRegistryAddr);
     const feePool = FeePool.attach(feePoolAddr);
+    const committeeAddr = await dispute.committee();
+    const committee = Committee.attach(committeeAddr);
     const pause = SystemPause.attach(systemPauseAddr);
 
-    await pause
-      .connect(owner)
-      .setModules(
+    await expect(
+      pause
+        .connect(owner)
+        .setModules(
+          registryAddr,
+          stakeAddr,
+          validationAddr,
+          disputeAddr,
+          platformRegistryAddr,
+          feePoolAddr,
+          reputationAddr,
+          committeeAddr
+        )
+    )
+      .to.emit(pause, "ModulesUpdated")
+      .withArgs(
         registryAddr,
         stakeAddr,
         validationAddr,
         disputeAddr,
         platformRegistryAddr,
         feePoolAddr,
-        reputationAddr
+        reputationAddr,
+        committeeAddr
       );
 
     expect(await stake.paused()).to.equal(false);
@@ -111,6 +130,7 @@ describe("SystemPause", function () {
     expect(await platformRegistry.paused()).to.equal(false);
     expect(await feePool.paused()).to.equal(false);
     expect(await reputation.paused()).to.equal(false);
+    expect(await committee.paused()).to.equal(false);
 
     await pause.connect(owner).pauseAll();
 
@@ -121,6 +141,7 @@ describe("SystemPause", function () {
     expect(await platformRegistry.paused()).to.equal(true);
     expect(await feePool.paused()).to.equal(true);
     expect(await reputation.paused()).to.equal(true);
+    expect(await committee.paused()).to.equal(true);
 
     await pause.connect(owner).unpauseAll();
 
@@ -131,6 +152,7 @@ describe("SystemPause", function () {
     expect(await platformRegistry.paused()).to.equal(false);
     expect(await feePool.paused()).to.equal(false);
     expect(await reputation.paused()).to.equal(false);
+    expect(await committee.paused()).to.equal(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- extend SystemPause to manage ArbitratorCommittee alongside other core modules
- deploy and wire ArbitratorCommittee in Deployer, transferring ownership to SystemPause
- update tests and scripts for new committee parameter

## Testing
- `npx hardhat test test/v2/SystemPause.test.js test/v2/Deployer.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b8d05f551883339aeb9a6177f38fdc