### PR TITLE
Enforce spec hash for job creation

### DIFF
--- a/apps/validator-ui/lib/commit.js
+++ b/apps/validator-ui/lib/commit.js
@@ -1,6 +1,6 @@
 const { ethers } = require('ethers');
 
-function generateCommit(jobId, nonce, approve, salt, specHash = ethers.ZeroHash) {
+function generateCommit(jobId, nonce, approve, salt, specHash) {
   const actualSalt = salt ?? ethers.hexlify(ethers.randomBytes(32));
   const commitHash = ethers.solidityPackedKeccak256(
     ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
@@ -9,7 +9,7 @@ function generateCommit(jobId, nonce, approve, salt, specHash = ethers.ZeroHash)
   return { commitHash, salt: actualSalt };
 }
 
-function scheduleReveal(contract, jobId, approve, salt, delayMs, specHash = ethers.ZeroHash) {
+function scheduleReveal(contract, jobId, approve, salt, delayMs, specHash) {
   return new Promise((resolve, reject) => {
     setTimeout(async () => {
       try {

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -30,6 +30,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     error RewardTooHigh();
     error InvalidDeadline();
     error InvalidAgentTypes();
+    error InvalidSpecHash();
     error DurationTooLong();
     error InvalidPercentages();
     error BlacklistedEmployer();
@@ -605,6 +606,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         if (maxJobReward != 0 && reward > maxJobReward) revert RewardTooHigh();
         if (deadline <= block.timestamp) revert InvalidDeadline();
         if (agentTypes == 0 || agentTypes > 3) revert InvalidAgentTypes();
+        if (specHash == bytes32(0)) revert InvalidSpecHash();
         if (
             maxJobDuration > 0 &&
             uint256(deadline) - block.timestamp > maxJobDuration
@@ -663,14 +665,6 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         jobId = _createJob(reward, deadline, 3, specHash, uri);
     }
 
-    function createJob(
-        uint256 reward,
-        uint64 deadline,
-        string calldata uri
-    ) external returns (uint256 jobId) {
-        jobId = _createJob(reward, deadline, 3, bytes32(0), uri);
-    }
-
     function createJobWithAgentTypes(
         uint256 reward,
         uint64 deadline,
@@ -679,15 +673,6 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         string calldata uri
     ) external returns (uint256 jobId) {
         jobId = _createJob(reward, deadline, agentTypes, specHash, uri);
-    }
-
-    function createJobWithAgentTypes(
-        uint256 reward,
-        uint64 deadline,
-        uint8 agentTypes,
-        string calldata uri
-    ) external returns (uint256 jobId) {
-        jobId = _createJob(reward, deadline, agentTypes, bytes32(0), uri);
     }
 
     /**
@@ -708,15 +693,6 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         jobId = _createJob(reward, deadline, 3, specHash, uri);
     }
 
-    function acknowledgeAndCreateJob(
-        uint256 reward,
-        uint64 deadline,
-        string calldata uri
-    ) external returns (uint256 jobId) {
-        _acknowledge(msg.sender);
-        jobId = _createJob(reward, deadline, 3, bytes32(0), uri);
-    }
-
     function acknowledgeAndCreateJobWithAgentTypes(
         uint256 reward,
         uint64 deadline,
@@ -726,16 +702,6 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     ) external returns (uint256 jobId) {
         _acknowledge(msg.sender);
         jobId = _createJob(reward, deadline, agentTypes, specHash, uri);
-    }
-
-    function acknowledgeAndCreateJobWithAgentTypes(
-        uint256 reward,
-        uint64 deadline,
-        uint8 agentTypes,
-        string calldata uri
-    ) external returns (uint256 jobId) {
-        _acknowledge(msg.sender);
-        jobId = _createJob(reward, deadline, agentTypes, bytes32(0), uri);
     }
 
     function _applyForJob(

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -111,13 +111,21 @@ Below are common flows in TypeScript (ethers.js) and Python (web3.py).
 ### Post a Job
 ```ts
 // TypeScript
-const registry = new ethers.Contract(JOB_REGISTRY, ['function createJob(uint256,string)'], wallet);
-await registry.createJob(1_000000000000000000, 'ipfs://QmHash');
+const registry = new ethers.Contract(
+  JOB_REGISTRY,
+  ['function createJob(uint256,uint64,bytes32,string)'],
+  wallet
+);
+const deadline = Math.floor(Date.now() / 1000) + 3600;
+const specHash = ethers.id('spec');
+await registry.createJob(1_000000000000000000n, deadline, specHash, 'ipfs://QmHash');
 ```
 ```python
 # Python
-registry = w3.eth.contract(address=JOB_REGISTRY, abi=['function createJob(uint256,string)'])
-tx = registry.functions.createJob(1_000000000000000000, 'ipfs://QmHash').transact({'from': acct})
+registry = w3.eth.contract(address=JOB_REGISTRY, abi=['function createJob(uint256,uint64,bytes32,string)'])
+deadline = int(time.time()) + 3600
+spec_hash = Web3.keccak(text='spec')
+tx = registry.functions.createJob(1_000000000000000000, deadline, spec_hash, 'ipfs://QmHash').transact({'from': acct})
 w3.eth.wait_for_transaction_receipt(tx)
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,14 +27,21 @@ await stakeManager.depositStake(0, stakeAmount); // agent stake
 ## JobRegistry
 Coordinates job posting and settlement.
 
-- `createJob(reward, uri)` – employer escrows tokens and posts job metadata.
+- `createJob(reward, deadline, specHash, uri)` – employer escrows tokens and posts job metadata.
 - `applyForJob(jobId, label, proof)` – agent applies with ENS label and proof.
 - `submit(jobId, resultHash, resultURI)` – agent submits work for validation.
 - `finalize(jobId)` – release escrowed reward after validation succeeds.
 
 ```javascript
 const registry = await ethers.getContractAt("JobRegistry", registryAddress);
-const tx = await registry.createJob(ethers.parseUnits("10", 18), "ipfs://job.json");
+const deadline = Math.floor(Date.now() / 1000) + 3600; // 1 hour
+const specHash = ethers.id("spec");
+const tx = await registry.createJob(
+  ethers.parseUnits("10", 18),
+  deadline,
+  specHash,
+  "ipfs://job.json"
+);
 const receipt = await tx.wait();
 const jobId = receipt.logs[0].args.jobId;
 ```

--- a/examples/ethers-quickstart.js
+++ b/examples/ethers-quickstart.js
@@ -8,7 +8,7 @@ const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 const signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 
 const registryAbi = [
-  "function createJob(uint256 reward, string uri)",
+  "function createJob(uint256 reward, uint64 deadline, bytes32 specHash, string uri)",
   "function applyForJob(uint256 jobId, bytes32 label, bytes32[] proof)",
   "function submit(uint256 jobId, bytes32 resultHash, string resultURI)",
   "function raiseDispute(uint256 jobId, bytes32 evidenceHash)"
@@ -31,7 +31,9 @@ const validation = new ethers.Contract(process.env.VALIDATION_MODULE, validation
 // Amounts are converted using the fixed 18‑decimal configuration.
 async function postJob(amount = "1") {
   const reward = ethers.parseUnits(amount.toString(), TOKEN_DECIMALS);
-  await registry.createJob(reward, "ipfs://job");
+  const deadline = Math.floor(Date.now() / 1000) + 3600;
+  const specHash = ethers.id("spec");
+  await registry.createJob(reward, deadline, specHash, "ipfs://job");
 }
 
 async function stake(amount) {

--- a/examples/web3py-quickstart.py
+++ b/examples/web3py-quickstart.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 from pathlib import Path
 from web3 import Web3
 
@@ -14,7 +15,9 @@ validation = w3.eth.contract(address=os.environ["VALIDATION_MODULE"], abi=valida
 
 def post_job():
     reward = Web3.to_wei(1, "ether")  # 1 token in 18‑decimal units
-    tx = registry.functions.createJob(reward, "ipfs://job").build_transaction({
+    deadline = int(time.time()) + 3600
+    spec_hash = Web3.keccak(text="spec")
+    tx = registry.functions.createJob(reward, deadline, spec_hash, "ipfs://job").build_transaction({
         "from": account.address,
         "nonce": w3.eth.get_transaction_count(account.address)
     })

--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -110,9 +110,10 @@ describe("JobRegistry governance finalization", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
+    const specHash = ethers.id("spec");
     await registry
       .connect(employer)
-      .createJob(reward, deadline, "uri");
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await registry
@@ -139,9 +140,10 @@ describe("JobRegistry governance finalization", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
+    const specHash = ethers.id("spec");
     await registry
       .connect(employer)
-      .createJob(reward, deadline, "uri");
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await registry

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -77,7 +77,10 @@ describe("Identity verification enforcement", function () {
 
     async function createJob() {
       const deadline = (await time.latest()) + 100;
-      await registry.connect(employer).createJob(1, deadline, "uri");
+      const specHash = ethers.id("spec");
+      await registry
+        .connect(employer)
+        .createJob(1, deadline, specHash, "uri");
       return 1;
     }
 

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -132,9 +132,10 @@ describe("Job expiration", function () {
 
   it("allows anyone to expire job after deadline and refunds employer", async () => {
     const deadline = (await time.latest()) + 100;
+    const specHash = ethers.id("spec");
     await registry
       .connect(employer)
-      .createJob(reward, deadline, "uri");
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await time.increase(200);
@@ -156,9 +157,10 @@ describe("Job expiration", function () {
 
   it("reverts if job has not yet expired", async () => {
     const deadline = (await time.latest()) + 100;
+    const specHash = ethers.id("spec");
     await registry
       .connect(employer)
-      .createJob(reward, deadline, "uri");
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await expect(
@@ -169,9 +171,10 @@ describe("Job expiration", function () {
   it("respects non-zero expiration grace period", async () => {
     const deadline = (await time.latest()) + 100;
     await registry.connect(owner).setExpirationGracePeriod(50);
+    const specHash = ethers.id("spec");
     await registry
       .connect(employer)
-      .createJob(reward, deadline, "uri");
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await time.increase(120);

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -134,7 +134,10 @@ describe("Job expiration boundary", function () {
     const deadline = (await time.latest()) + 100;
     const grace = 50;
     await registry.connect(owner).setExpirationGracePeriod(grace);
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await time.increase(deadline + grace - 1 - (await time.latest()));
@@ -147,7 +150,10 @@ describe("Job expiration boundary", function () {
     const deadline = (await time.latest()) + 100;
     const grace = 50;
     await registry.connect(owner).setExpirationGracePeriod(grace);
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await time.increase(deadline + grace - (await time.latest()));

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -190,7 +190,10 @@ describe("JobRegistry integration", function () {
     await registry.connect(owner).setJobParameters(reward, 0);
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     await expect(registry.connect(newAgent).acknowledgeAndApply(1, "", []))
       .to.emit(registry, "JobApplied")
       .withArgs(1, newAgent.address);
@@ -223,7 +226,10 @@ describe("JobRegistry integration", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + reward / 10);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);
@@ -244,7 +250,10 @@ describe("JobRegistry integration", function () {
   it("allows employer to cancel before completion", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await expect(registry.connect(employer).cancelJob(jobId))
       .to.emit(registry, "JobCancelled")
@@ -257,7 +266,10 @@ describe("JobRegistry integration", function () {
   it("allows owner to delist unassigned job", async () => {
     await token.connect(employer).approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await expect(registry.connect(owner).delistJob(jobId))
       .to.emit(registry, "JobCancelled")

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -65,7 +65,10 @@ describe("JobRegistry agent gating", function () {
 
   async function createJob() {
     const deadline = (await time.latest()) + 100;
-    await registry.connect(employer).createJob(1, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(1, deadline, specHash, "uri");
     return 1;
   }
 

--- a/test/v2/JobRegistryAuthCache.test.js
+++ b/test/v2/JobRegistryAuthCache.test.js
@@ -60,7 +60,10 @@ describe("JobRegistry agent auth cache", function () {
   async function createJob() {
     const deadline = (await time.latest()) + 100;
     jobId++;
-    await registry.connect(employer).createJob(1, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(1, deadline, specHash, "uri");
     return jobId;
   }
 
@@ -133,13 +136,18 @@ describe("JobRegistry agent auth cache", function () {
     await registry2.connect(owner).setAgentAuthCacheDuration(1000);
 
     let deadline = (await time.latest()) + 100;
-    await registry2.connect(employer).createJob(1, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry2
+      .connect(employer)
+      .createJob(1, deadline, specHash, "uri");
     await registry2.connect(agent).applyForJob(1, "a", []);
 
     await verifier2.connect(owner).setResult(false);
 
     deadline = (await time.latest()) + 100;
-    await registry2.connect(employer).createJob(1, deadline, "uri");
+    await registry2
+      .connect(employer)
+      .createJob(1, deadline, specHash, "uri");
     await registry2.connect(agent).applyForJob(2, "a", []);
 
     await verifier2
@@ -150,7 +158,9 @@ describe("JobRegistry agent auth cache", function () {
       .setAgentMerkleRoot(ethers.id("newroot"));
 
     deadline = (await time.latest()) + 100;
-    await registry2.connect(employer).createJob(1, deadline, "uri");
+    await registry2
+      .connect(employer)
+      .createJob(1, deadline, specHash, "uri");
     await expect(
       registry2.connect(agent).applyForJob(3, "a", [])
     ).to.be.revertedWithCustomError(registry2, "NotAuthorizedAgent");

--- a/test/v2/JobRegistryDeadlineFuzz.t.sol
+++ b/test/v2/JobRegistryDeadlineFuzz.t.sol
@@ -36,9 +36,9 @@ contract JobRegistryDeadlineFuzz is Test {
         uint256 reward = 1;
         if (deadline <= block.timestamp) {
             vm.expectRevert(JobRegistry.InvalidDeadline.selector);
-            registry.createJob(reward, deadline, "uri");
+            registry.createJob(reward, deadline, bytes32(uint256(1)), "uri");
         } else {
-            registry.createJob(reward, deadline, "uri");
+            registry.createJob(reward, deadline, bytes32(uint256(1)), "uri");
         }
     }
 }

--- a/test/v2/JobRegistryPause.test.js
+++ b/test/v2/JobRegistryPause.test.js
@@ -33,14 +33,17 @@ describe("JobRegistry pause", function () {
 
   it("pauses job creation and applications", async () => {
     const deadline = (await time.latest()) + 100;
+    const specHash = ethers.id("spec");
 
     await registry.connect(owner).pause();
     await expect(
-      registry.connect(employer).createJob(1, deadline, "uri")
+      registry.connect(employer).createJob(1, deadline, specHash, "uri")
     ).to.be.revertedWithCustomError(registry, "EnforcedPause");
 
     await registry.connect(owner).unpause();
-    await registry.connect(employer).createJob(1, deadline, "uri");
+    await registry
+      .connect(employer)
+      .createJob(1, deadline, specHash, "uri");
 
     await registry.connect(owner).pause();
     await expect(
@@ -55,8 +58,11 @@ describe("JobRegistry pause", function () {
 
   it("pauses job expiration", async () => {
     const deadline = (await time.latest()) + 100;
+    const specHash = ethers.id("spec");
 
-    await registry.connect(employer).createJob(1, deadline, "uri");
+    await registry
+      .connect(employer)
+      .createJob(1, deadline, specHash, "uri");
     await registry.connect(agent).applyForJob(1, "", []);
 
     await time.increase(200);

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -127,7 +127,10 @@ describe("Mid-job module upgrades", function () {
       .connect(employer)
       .approve(await stake.getAddress(), reward + fee);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, "agent", []);
     const hash = ethers.id("ipfs://result");

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -127,7 +127,10 @@ describe("Module replacement", function () {
       .connect(employer)
       .approve(await stake.getAddress(), reward + fee);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, "agent", []);
     const hash = ethers.id("ipfs://result");

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -76,15 +76,18 @@ describe("JobRegistry tax policy integration", function () {
     await policy.connect(user).acknowledge();
     await policy.connect(owner).bumpPolicyVersion();
     const deadline = (await time.latest()) + 1000;
+    const specHash = ethers.id("spec");
     await expect(
-      registry.connect(user).createJob(1, deadline, "uri")
+      registry.connect(user).createJob(1, deadline, specHash, "uri")
     )
       .to.be.revertedWithCustomError(registry, "TaxPolicyNotAcknowledged")
       .withArgs(user.address);
     await expect(policy.connect(user).acknowledge())
       .to.emit(policy, "PolicyAcknowledged")
       .withArgs(user.address, 2);
-    await expect(registry.connect(user).createJob(1, deadline, "uri"))
+    await expect(
+      registry.connect(user).createJob(1, deadline, specHash, "uri")
+    )
       .to.emit(registry, "JobCreated")
       .withArgs(
         1,
@@ -93,7 +96,7 @@ describe("JobRegistry tax policy integration", function () {
         1,
         0,
         0,
-        ethers.ZeroHash,
+        specHash,
         "uri"
       );
   });

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -260,6 +260,7 @@ describe("comprehensive job flows", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
+    const specHash = ethers.id("spec");
     await expect(
       registry.connect(employer).createJob(reward, deadline, specHash, "uri")
     )

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -149,7 +149,10 @@ describe("comprehensive job flows", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + fee);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.setResult(true);
@@ -181,7 +184,10 @@ describe("comprehensive job flows", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + fee);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     await expect(
       registry.connect(agent).applyForJob(1, "", [])
     ).to.be.revertedWithCustomError(registry, "NotAuthorizedAgent");
@@ -198,7 +204,10 @@ describe("comprehensive job flows", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + fee);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.setResult(false);
@@ -235,7 +244,10 @@ describe("comprehensive job flows", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + fee);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     await rep.setBlacklist(agent.address, true);
     await expect(
       registry.connect(agent).applyForJob(1, "", [])
@@ -249,7 +261,7 @@ describe("comprehensive job flows", function () {
       .approve(await stakeManager.getAddress(), reward);
     const deadline = (await time.latest()) + 1000;
     await expect(
-      registry.connect(employer).createJob(reward, deadline, "uri")
+      registry.connect(employer).createJob(reward, deadline, specHash, "uri")
     )
       .to.be.revertedWithCustomError(registry, "TaxPolicyNotAcknowledged")
       .withArgs(employer.address);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -148,7 +148,10 @@ describe("end-to-end job lifecycle", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + fee);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -142,7 +142,10 @@ describe("job finalization integration", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + fee);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).acknowledgeAndApply(jobId, "", []);
     await validation.setResult(result);

--- a/test/v2/jobLifecycle.test.ts
+++ b/test/v2/jobLifecycle.test.ts
@@ -116,7 +116,10 @@ describe("Job lifecycle", function () {
     const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, subdomain, []);
     const hash = ethers.id("ipfs://result");
@@ -160,7 +163,10 @@ describe("Job lifecycle", function () {
     const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, subdomain, []);
     await registry

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -115,7 +115,10 @@ describe("job lifecycle with dispute and validator failure", function () {
     const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, "agent", []);
     await registry
@@ -127,7 +130,7 @@ describe("job lifecycle with dispute and validator failure", function () {
     const commit1 = ethers.keccak256(
       ethers.solidityPacked(
         ["uint256","uint256","bool","bytes32","bytes32"],
-        [1n, nonce, true, salt1, ethers.ZeroHash]
+        [1n, nonce, true, salt1, specHash]
       )
     );
     await validation.connect(v1).commitValidation(1, commit1);
@@ -135,7 +138,7 @@ describe("job lifecycle with dispute and validator failure", function () {
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
         ["uint256","uint256","bool","bytes32","bytes32"],
-        [1n, nonce, false, salt2, ethers.ZeroHash]
+        [1n, nonce, false, salt2, specHash]
       )
     );
     await validation.connect(v2).commitValidation(1, commit2);

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -145,9 +145,10 @@ describe("Kleros dispute module", function () {
     const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
+    const specHash = ethers.id("spec");
     await registry
       .connect(employer)
-      .createJob(reward, deadline, "ipfs://job");
+      .createJob(reward, deadline, specHash, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, "agent", []);
     await registry
@@ -159,7 +160,7 @@ describe("Kleros dispute module", function () {
     const commit1 = ethers.keccak256(
       ethers.solidityPacked(
         ["uint256", "uint256", "bool", "bytes32", "bytes32"],
-        [1n, nonce, true, salt1, ethers.ZeroHash]
+        [1n, nonce, true, salt1, specHash]
       )
     );
     await validation.connect(v1).commitValidation(1, commit1);
@@ -167,7 +168,7 @@ describe("Kleros dispute module", function () {
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
         ["uint256", "uint256", "bool", "bytes32", "bytes32"],
-        [1n, nonce, false, salt2, ethers.ZeroHash]
+        [1n, nonce, false, salt2, specHash]
       )
     );
     await validation.connect(v2).commitValidation(1, commit2);

--- a/test/v2/midJobReplacementFuzz.test.js
+++ b/test/v2/midJobReplacementFuzz.test.js
@@ -92,7 +92,10 @@ describe("Mid-job module replacement fuzz", function () {
         .connect(employer)
         .approve(await stake.getAddress(), reward + (reward * 5n) / 100n);
       const deadline = BigInt((await time.latest()) + 3600);
-      await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+      const specHash = ethers.id("spec");
+      await registry
+        .connect(employer)
+        .createJob(reward, deadline, specHash, "ipfs://job");
       await registry.connect(agent).applyForJob(1, "agent", []);
       const hash = ethers.id("ipfs://result");
       await registry

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -178,7 +178,10 @@ describe("multi-operator job lifecycle", function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), reward + fee);
     const deadline = (await time.latest()) + 1000;
-    await registry.connect(employer).createJob(reward, deadline, "uri");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "uri");
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, "", []);
     await validation.connect(owner).setResult(true);

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -110,7 +110,10 @@ describe("regression scenarios", function () {
     const reward = ethers.parseUnits("10", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
     await registry.connect(agent).applyForJob(1, "agent", []);
 
     await validation.selectValidators(1, 1);
@@ -137,7 +140,10 @@ describe("regression scenarios", function () {
     const reward = ethers.parseUnits("10", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline1 = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline1, "ipfs://job1");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline1, specHash, "ipfs://job1");
     await registry.connect(agent).applyForJob(1, "agent", []);
     await registry.connect(agent).submit(1, ethers.id("ipfs://good"), "ipfs://good", "agent", []);
     const nonce = await validation.jobNonce(1);
@@ -145,7 +151,7 @@ describe("regression scenarios", function () {
     const commit = ethers.keccak256(
       ethers.solidityPacked(
         ["uint256","uint256","bool","bytes32","bytes32"],
-        [1n, nonce, false, salt, ethers.ZeroHash]
+        [1n, nonce, false, salt, specHash]
       )
     );
     await validation.connect(v1).commitValidation(1, commit);
@@ -155,7 +161,9 @@ describe("regression scenarios", function () {
     await validation.finalize(1);
 
     const deadline2 = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline2, "ipfs://job2");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline2, specHash, "ipfs://job2");
     await registry.connect(agent).applyForJob(2, "agent", []);
     await validation.selectValidators(2, 1);
     await ethers.provider.send("evm_mine", []);
@@ -195,7 +203,10 @@ describe("regression scenarios", function () {
     const reward = ethers.parseUnits("10", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
     await registry.connect(agent).applyForJob(1, "agent", []);
     await registry
       .connect(agent)

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -114,7 +114,10 @@ describe("validator participation", function () {
     const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, "agent", []);
     await registry.connect(agent).submit(1, ethers.id("ipfs://result"), "ipfs://result", "agent", []);
@@ -124,7 +127,7 @@ describe("validator participation", function () {
     const commit1 = ethers.keccak256(
       ethers.solidityPacked(
         ["uint256","uint256","bool","bytes32","bytes32"],
-        [1n, nonce, true, salt1, ethers.ZeroHash]
+        [1n, nonce, true, salt1, specHash]
       )
     );
     await validation.connect(v1).commitValidation(1, commit1);
@@ -132,7 +135,7 @@ describe("validator participation", function () {
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
         ["uint256","uint256","bool","bytes32","bytes32"],
-        [1n, nonce, true, salt2, ethers.ZeroHash]
+        [1n, nonce, true, salt2, specHash]
       )
     );
     await validation.connect(v2).commitValidation(1, commit2);
@@ -160,7 +163,10 @@ describe("validator participation", function () {
     const reward = ethers.parseUnits("100", AGIALPHA_DECIMALS);
     await token.connect(employer).approve(await stake.getAddress(), reward);
     const deadline = BigInt((await time.latest()) + 3600);
-    await registry.connect(employer).createJob(reward, deadline, "ipfs://job");
+    const specHash = ethers.id("spec");
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, "ipfs://job");
 
     await registry.connect(agent).applyForJob(1, "agent", []);
     await registry.connect(agent).submit(1, ethers.id("ipfs://bad"), "ipfs://bad", "agent", []);
@@ -170,7 +176,7 @@ describe("validator participation", function () {
     const commit1 = ethers.keccak256(
       ethers.solidityPacked(
         ["uint256","uint256","bool","bytes32","bytes32"],
-        [1n, nonce, false, salt1, ethers.ZeroHash]
+        [1n, nonce, false, salt1, specHash]
       )
     );
     await validation.connect(v1).commitValidation(1, commit1);
@@ -178,7 +184,7 @@ describe("validator participation", function () {
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
         ["uint256","uint256","bool","bytes32","bytes32"],
-        [1n, nonce, false, salt2, ethers.ZeroHash]
+        [1n, nonce, false, salt2, specHash]
       )
     );
     await validation.connect(v2).commitValidation(1, commit2);


### PR DESCRIPTION
## Summary
- require non-zero specHash when creating jobs
- remove job creation overloads without specHash and update examples/tests
- keep commit/reveal logic tied to specHash and expose it in helper utilities

## Testing
- `npm test`
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f842e0b4833387c6ab5862161c78