### PR TITLE
feat: add payment router

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -34,7 +34,9 @@ import {INameWrapper} from "./interfaces/INameWrapper.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IValidationModule} from "./interfaces/IValidationModule.sol";
 import {IReputationEngine as IRInterface} from "./interfaces/IReputationEngine.sol";
-import {TOKEN_SCALE} from "./Constants.sol";
+import {AGIALPHA, TOKEN_SCALE} from "./Constants.sol";
+import {PaymentRouter} from "./PaymentRouter.sol";
+import {IPaymentRouter} from "./interfaces/IPaymentRouter.sol";
 
 /// @title Deployer
 /// @notice One shot helper that deploys and wires the core module set.
@@ -271,7 +273,9 @@ contract Deployer is Ownable {
             treasurySlashPct = 100;
         }
         uint96 jobStake = econ.jobStake;
+        PaymentRouter payRouter = new PaymentRouter(AGIALPHA, governance);
         StakeManager stake = new StakeManager(
+            IPaymentRouter(address(payRouter)),
             minStake,
             employerSlashPct,
             treasurySlashPct,
@@ -327,6 +331,7 @@ contract Deployer is Ownable {
         certificate.setJobRegistry(address(registry));
 
         FeePool pool = new FeePool(
+            IPaymentRouter(address(payRouter)),
             IStakeManager(address(stake)),
             burnPct,
             governance

--- a/contracts/v2/PaymentRouter.sol
+++ b/contracts/v2/PaymentRouter.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Governable} from "./Governable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {AGIALPHA_DECIMALS} from "./Constants.sol";
+
+/// @title PaymentRouter
+/// @notice Routes ERC20 transfers for the AGI Jobs protocol with a configurable token.
+contract PaymentRouter is Governable {
+    using SafeERC20 for IERC20;
+
+    error InvalidToken();
+    error InvalidTokenDecimals();
+
+    IERC20 private _token;
+
+    event TokenUpdated(address indexed newToken);
+
+    constructor(address token_, address governance_) Governable(governance_) {
+        _setToken(token_);
+    }
+
+    function token() external view returns (IERC20) {
+        return _token;
+    }
+
+    function setToken(address newToken) external onlyGovernance {
+        _setToken(newToken);
+    }
+
+    function transfer(address to, uint256 amount) external {
+        _token.safeTransfer(to, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external {
+        _token.safeTransferFrom(from, to, amount);
+    }
+
+    function _setToken(address newToken) internal {
+        if (newToken == address(0)) revert InvalidToken();
+        if (IERC20Metadata(newToken).decimals() != AGIALPHA_DECIMALS) revert InvalidTokenDecimals();
+        _token = IERC20(newToken);
+        emit TokenUpdated(newToken);
+    }
+}

--- a/contracts/v2/interfaces/IPaymentRouter.sol
+++ b/contracts/v2/interfaces/IPaymentRouter.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IPaymentRouter {
+    function token() external view returns (IERC20);
+    function transfer(address to, uint256 amount) external;
+    function transferFrom(address from, address to, uint256 amount) external;
+}

--- a/test/v2/PaymentRouter.t.sol
+++ b/test/v2/PaymentRouter.t.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {PaymentRouter} from "../../contracts/v2/PaymentRouter.sol";
+import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
+
+interface Vm {
+    function prank(address) external;
+}
+
+contract PaymentRouterTest {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
+
+    PaymentRouter router;
+    AGIALPHAToken token1;
+    AGIALPHAToken token2;
+    address alice = address(0x1);
+    address bob = address(0x2);
+
+    function setUp() public {
+        token1 = new AGIALPHAToken();
+        token2 = new AGIALPHAToken();
+        router = new PaymentRouter(address(token1), address(this));
+        token1.mint(alice, 100e18);
+        vm.prank(alice);
+        token1.approve(address(router), type(uint256).max);
+    }
+
+    function testTransferFrom() public {
+        vm.prank(alice);
+        router.transferFrom(alice, bob, 10e18);
+        require(token1.balanceOf(bob) == 10e18, "transfer");
+    }
+
+    function testTokenSwap() public {
+        vm.prank(alice);
+        router.transferFrom(alice, bob, 10e18);
+        router.setToken(address(token2));
+        token2.mint(alice, 50e18);
+        vm.prank(alice);
+        token2.approve(address(router), type(uint256).max);
+        vm.prank(alice);
+        router.transferFrom(alice, bob, 20e18);
+        require(token2.balanceOf(bob) == 20e18, "swap");
+    }
+
+    function testOnlyGovernanceCanSetToken() public {
+        vm.prank(alice);
+        try router.setToken(address(token2)) {
+            revert("allowed");
+        } catch {
+            // expected revert
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PaymentRouter with governance-controlled token swaps
- route StakeManager and FeePool transfers through PaymentRouter
- deploy router in Deployer and add basic routing test

## Testing
- `forge test --match-path test/v2/PaymentRouter.t.sol` *(fails: Stack too deep / via-ir Yul error)*

------
https://chatgpt.com/codex/tasks/task_e_68b90ac616e4833390f9cdb6a266d890