### PR TITLE
Use juror mapping for constant-time membership checks

### DIFF
--- a/test/v2/ArbitratorCommittee.test.js
+++ b/test/v2/ArbitratorCommittee.test.js
@@ -126,6 +126,21 @@ describe("ArbitratorCommittee", function () {
       .to.emit(dispute, "DisputeRaised")
       .withArgs(1, agent.address, evidence);
 
+    const fakeCommit = ethers.keccak256(
+      ethers.solidityPacked(["address", "uint256", "bool", "uint256"], [
+        employer.address,
+        1,
+        true,
+        4n,
+      ])
+    );
+    await expect(
+      committee.connect(employer).commit(1, fakeCommit)
+    ).to.be.revertedWith("not juror");
+    await expect(
+      committee.connect(employer).reveal(1, true, 4n)
+    ).to.be.revertedWith("not juror");
+
     const s1 = 1n,
       s2 = 2n,
       s3 = 3n;


### PR DESCRIPTION
## Summary
- track jurors per case with an `isJuror` mapping for O(1) membership checks
- clean up juror mapping entries on finalization and remove helper loop
- extend committee tests to assert non-jurors cannot vote

## Testing
- `npm test test/v2/ArbitratorCommittee.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9d04f46d8833396e9f55a66ada11e