### PR TITLE
docs: add wiring verification note to production deployment guides

### DIFF
--- a/docs/deployment-guide-nontechnical.md
+++ b/docs/deployment-guide-nontechnical.md
@@ -104,7 +104,7 @@ Almost every operational parameter can be changed by the owner without redeployi
    3. **Validate** – Validators stake (role `1`) then call `ValidationModule.commitValidation` followed later by `ValidationModule.revealValidation`.
    4. **Finalize** – After the reveal window anyone may call `ValidationModule.finalize`; `StakeManager` pays the Agent, sends protocol fees to `FeePool` and burns the configured percentage.
    5. **Dispute** – To test disputes, raise one via `JobRegistry.raiseDispute` and resolve it through `DisputeModule.resolve` (or a moderator/committee if configured).
-- **Final verification.**  Confirm each module reports the correct addresses via their `Read` interfaces.
+- **Final verification.**  Confirm each module reports the correct addresses via their `Read` interfaces or run `npm run verify:wiring` to check automatically.
 - **Record keeping.**  Log all contract addresses and parameter changes.  Update `docs/deployment-addresses.json` with your deployment.
 - **Legal compliance.**  Consult professionals to ensure operations comply with local regulations.
 

--- a/docs/deployment-production-guide.md
+++ b/docs/deployment-production-guide.md
@@ -104,7 +104,7 @@ Almost every operational parameter can be changed by the owner without redeployi
    3. **Validate** – Validators stake (role `1`) then call `ValidationModule.commitValidation` followed later by `ValidationModule.revealValidation`.
    4. **Finalize** – After the reveal window anyone may call `ValidationModule.finalize`; `StakeManager` pays the Agent, sends protocol fees to `FeePool` and burns the configured percentage.
    5. **Dispute** – To test disputes, raise one via `JobRegistry.raiseDispute` and resolve it through `DisputeModule.resolve` (or a moderator/committee if configured).
-- **Final verification.**  Confirm each module reports the correct addresses via their `Read` interfaces.
+- **Final verification.**  Confirm each module reports the correct addresses via their `Read` interfaces or run `npm run verify:wiring` to check automatically.
 - **Record keeping.**  Log all contract addresses and parameter changes.  Update `docs/deployment-addresses.json` with your deployment.
 - **Legal compliance.**  Consult professionals to ensure operations comply with local regulations.
 


### PR DESCRIPTION
## Summary
- mention `npm run verify:wiring` as an optional step to confirm module wiring
- update both production deployment guides accordingly

## Testing
- `npm test` *(fails: compilation ran long and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2262f6a883338b9b1f08108816f9