### PR TITLE
docs: highlight best practices in production deployment guide

### DIFF
--- a/docs/agi-jobs-v2-production-deployment-guide.md
+++ b/docs/agi-jobs-v2-production-deployment-guide.md
@@ -2,6 +2,10 @@
 
 This guide walks a non-technical operator through deploying the **AGI Jobs v2** smart-contract suite on Ethereum using only a browser and Etherscan.  It also highlights key best practices such as true token burning and owner updatability.
 
+## Key Best Practices in AGI Jobs v2
+- **True token burning:** Both the `StakeManager` and `FeePool` call the `$AGIALPHA` token's `burn` function whenever a burn percentage is configured. This permanently reduces total supply instead of sending tokens to a dead address.
+- **Owner updatability:** Each module inherits access control so the contract owner can adjust parameters (fees, stake limits, time windows, etc.) without redeploying. For production, transfer ownership to a multisig or timelock once setup is confirmed.
+
 ## 1. Prerequisites
 - **Ethereum wallet** (e.g. MetaMask) with enough ETH for gas; it becomes the owner of all contracts.
 - **$AGIALPHA token address** (canonical mainnet: `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`).


### PR DESCRIPTION
## Summary
- emphasize true token burning and owner updatability in AGI Jobs v2 production deployment guide
- document $AGIALPHA burn mechanism and recommend multisig for owner roles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bad9e80c448333914fd375a03aa6e9