### PR TITLE
refactor: adopt governable for platform and reputation

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -307,7 +307,8 @@ contract Deployer is Ownable {
         );
 
         ReputationEngine reputation = new ReputationEngine(
-            IStakeManager(address(stake))
+            IStakeManager(address(stake)),
+            governance
         );
 
         DisputeModule dispute = new DisputeModule(
@@ -344,7 +345,8 @@ contract Deployer is Ownable {
         PlatformRegistry pRegistry = new PlatformRegistry(
             IStakeManager(address(stake)),
             PRReputationEngine(address(reputation)),
-            0
+            0,
+            governance
         );
 
         JobRouter router = new JobRouter(IPlatformRegistry(address(pRegistry)));
@@ -414,13 +416,13 @@ contract Deployer is Ownable {
         stake.setGovernance(address(pause));
         registry.setGovernance(address(pause));
 
-        // Transfer ownership
+        // Transfer ownership / governance
         validation.transferOwnership(address(pause));
-        reputation.transferOwnership(address(pause));
+        reputation.setGovernance(address(pause));
         dispute.transferOwnership(address(pause));
         committee.transferOwnership(address(pause));
         certificate.transferOwnership(governance);
-        pRegistry.transferOwnership(address(pause));
+        pRegistry.setGovernance(address(pause));
         router.transferOwnership(governance);
         incentives.transferOwnership(governance);
         pool.transferOwnership(address(pause));

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -76,12 +76,13 @@ The script prints module addresses and verifies source on Etherscan.
 12. **Configure ENS and Merkle roots** using `setAgentRootNode`, `setClubRootNode`,
     `setAgentMerkleRoot` and `setValidatorMerkleRoot` on `IdentityRegistry`.
 13. **Governance setup** – deploy a multisig wallet or timelock controller
-    and pass its address to the `StakeManager` and `JobRegistry` constructors.
-    Transfer ownership of every remaining `Ownable` module
+    and pass its address to the `StakeManager`, `JobRegistry`,
+    `ReputationEngine`, `PlatformRegistry` and other governable
+    constructors. Transfer ownership of any remaining `Ownable` modules
     (for example `IdentityRegistry`, `CertificateNFT`, `ValidationModule`,
-    `DisputeModule`, `FeePool`, `PlatformRegistry` and related helpers)
-    to this governance contract so no single EOA retains control. To rotate
-    governance later, the current authority calls `setGovernance(newGov)`.
+    `DisputeModule`, `FeePool` and related helpers) to this governance
+    contract so no single EOA retains control. To rotate governance later,
+    the current authority calls `setGovernance(newGov)`.
 
 ## Governance Configuration Steps
 After deployment the governance contract can fine‑tune the system without redeploying:

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -17,7 +17,10 @@ async function main() {
 
   // Deploy the sole ReputationEngine implementation
   const Reputation = await ethers.getContractFactory("contracts/v2/ReputationEngine.sol:ReputationEngine");
-  const reputation = await Reputation.deploy(await stake.getAddress());
+  const reputation = await Reputation.deploy(
+    await stake.getAddress(),
+    deployer.address
+  );
   await reputation.waitForDeployment();
 
   const ENS = await ethers.getContractFactory("contracts/legacy/MockENS.sol:MockENS");
@@ -98,7 +101,8 @@ async function main() {
   const platformRegistry = await PlatformRegistry.deploy(
     await stake.getAddress(),
     await reputation.getAddress(),
-    0
+    0,
+    deployer.address
   );
   await platformRegistry.waitForDeployment();
 
@@ -163,9 +167,9 @@ async function main() {
   await registry.setGovernance(await pause.getAddress());
   await validation.transferOwnership(await pause.getAddress());
   await dispute.transferOwnership(await pause.getAddress());
-  await platformRegistry.transferOwnership(await pause.getAddress());
+  await platformRegistry.setGovernance(await pause.getAddress());
   await feePool.transferOwnership(await pause.getAddress());
-  await reputation.transferOwnership(await pause.getAddress());
+  await reputation.setGovernance(await pause.getAddress());
   await committee.transferOwnership(await pause.getAddress());
   await nft.transferOwnership(await pause.getAddress());
   await identity.transferOwnership(await pause.getAddress());

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -116,7 +116,10 @@ async function main() {
   const Reputation = await ethers.getContractFactory(
     "contracts/v2/ReputationEngine.sol:ReputationEngine"
   );
-  const reputation = await Reputation.deploy();
+  const reputation = await Reputation.deploy(
+    await stake.getAddress(),
+    governance
+  );
   await reputation.waitForDeployment();
 
   const NFT = await ethers.getContractFactory(
@@ -174,7 +177,8 @@ async function main() {
   const platformRegistry = await PlatformRegistry.deploy(
     await stake.getAddress(),
     await reputation.getAddress(),
-    minPlatformStake
+    minPlatformStake,
+    governance
   );
   await platformRegistry.waitForDeployment();
 
@@ -205,11 +209,11 @@ async function main() {
   await registry.setGovernance(await installer.getAddress());
   await stake.setGovernance(await installer.getAddress());
   await validation.transferOwnership(await installer.getAddress());
-  await reputation.transferOwnership(await installer.getAddress());
+  await reputation.setGovernance(await installer.getAddress());
   await dispute.transferOwnership(await installer.getAddress());
   await nft.transferOwnership(await installer.getAddress());
   await incentives.transferOwnership(await installer.getAddress());
-  await platformRegistry.transferOwnership(await installer.getAddress());
+  await platformRegistry.setGovernance(await installer.getAddress());
   await jobRouter.transferOwnership(await installer.getAddress());
   await feePool.transferOwnership(await installer.getAddress());
   await tax.transferOwnership(await installer.getAddress());
@@ -301,13 +305,13 @@ async function main() {
     .transferOwnership(await pause.getAddress());
   await platformRegistry
     .connect(governanceSigner)
-    .transferOwnership(await pause.getAddress());
+    .setGovernance(await pause.getAddress());
   await feePool
     .connect(governanceSigner)
     .transferOwnership(await pause.getAddress());
   await reputation
     .connect(governanceSigner)
-    .transferOwnership(await pause.getAddress());
+    .setGovernance(await pause.getAddress());
   await committee.transferOwnership(await pause.getAddress());
 
   console.log("JobRegistry deployed to:", await registry.getAddress());
@@ -389,7 +393,10 @@ async function main() {
     await stake.getAddress(),
     governance,
   ]);
-  await verify(await reputation.getAddress(), [governance]);
+  await verify(await reputation.getAddress(), [
+    await stake.getAddress(),
+    governance,
+  ]);
   await verify(await dispute.getAddress(), [
     await registry.getAddress(),
     appealFee,

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -138,6 +138,8 @@ describe("Ownable modules", function () {
     const governable = [
       [StakeManager.attach(stake), (inst, signer) => inst.connect(signer).setFeePct(1)],
       [JobRegistry.attach(registry), (inst, signer) => inst.connect(signer).setFeePct(1)],
+      [ReputationEngine.attach(reputation), (inst, signer) => inst.connect(signer).setScoringWeights(0, 0)],
+      [PlatformRegistry.attach(platformRegistry), (inst, signer) => inst.connect(signer).setMinPlatformStake(0)],
     ];
 
     for (const [inst, call] of governable) {
@@ -156,11 +158,6 @@ describe("Ownable modules", function () {
           inst.connect(signer).setIdentityRegistry(identityRegistryAddr),
       ],
       [
-        ReputationEngine.attach(reputation),
-        systemPauseSigner,
-        (inst, signer) => inst.connect(signer).setScoringWeights(0, 0),
-      ],
-      [
         DisputeModule.attach(dispute),
         systemPauseSigner,
         (inst, signer) => inst.connect(signer).setDisputeFee(0),
@@ -169,11 +166,6 @@ describe("Ownable modules", function () {
         CertificateNFT.attach(certificate),
         owner,
         (inst, signer) => inst.connect(signer).setJobRegistry(other.address),
-      ],
-      [
-        PlatformRegistry.attach(platformRegistry),
-        systemPauseSigner,
-        (inst, signer) => inst.connect(signer).setMinPlatformStake(0),
       ],
       [
         JobRouter.attach(router),

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -42,7 +42,8 @@ describe("PlatformRegistry", function () {
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
     reputationEngine = await Rep.connect(owner).deploy(
-      await stakeManager.getAddress()
+      await stakeManager.getAddress(),
+      owner.address
     );
     await reputationEngine.setStakeManager(await stakeManager.getAddress());
     await reputationEngine.setAuthorizedCaller(owner.address, true);
@@ -53,7 +54,8 @@ describe("PlatformRegistry", function () {
     registry = await Registry.connect(owner).deploy(
       await stakeManager.getAddress(),
       await reputationEngine.getAddress(),
-      STAKE
+      STAKE,
+      owner.address
     );
   });
 

--- a/test/v2/ReputationEngine.test.js
+++ b/test/v2/ReputationEngine.test.js
@@ -11,7 +11,7 @@ describe("ReputationEngine", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy(await stake.getAddress());
+    engine = await Engine.deploy(await stake.getAddress(), owner.address);
     await engine.connect(owner).setCaller(caller.address, true);
     await engine.connect(owner).setPremiumThreshold(2);
   });

--- a/test/v2/ReputationEngineNoEther.test.js
+++ b/test/v2/ReputationEngineNoEther.test.js
@@ -11,7 +11,7 @@ describe("ReputationEngine ether rejection", function () {
     const Engine = await ethers.getContractFactory(
       "contracts/v2/ReputationEngine.sol:ReputationEngine"
     );
-    engine = await Engine.deploy(await stake.getAddress());
+    engine = await Engine.deploy(await stake.getAddress(), owner.address);
     await engine.waitForDeployment();
   });
 


### PR DESCRIPTION
## Summary
- replace Ownable with Governable in PlatformRegistry and ReputationEngine
- wire deployment scripts and docs for governance-aware constructors
- update tests for timelock governance interactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baf8028630833394f7c9b5dd4be64e