### PR TITLE
docs: replace placeholder images

### DIFF
--- a/docs/deployment-v2-agialpha.md
+++ b/docs/deployment-v2-agialpha.md
@@ -5,15 +5,27 @@ This guide shows how to deploy the modular v2 contracts using the helper script 
 ## 1. Run the deployment script
 
 1. Install dependencies with `npm install`.
-   ![npm install](https://via.placeholder.com/650x150?text=npm+install)
+
+   ```bash
+   npm install
+   ```
 2. Execute the helper:
+
    ```bash
    npx hardhat run scripts/v2/deployDefaults.ts --network <network> --governance <address>
    ```
-   ![deploy defaults](https://via.placeholder.com/650x150?text=deployDefaults.ts)
+
    Use `--governance` to set the multisig or timelock owner and `--no-tax` to omit `TaxPolicy`.
 3. The script deploys `Deployer.sol`, calls `deployDefaults` (or `deployDefaultsWithoutTaxPolicy`), prints module addresses and verifies each contract on Etherscan.
-   ![script output](https://via.placeholder.com/650x150?text=module+addresses)
+
+   Example output:
+
+   ```text
+   Deployer deployed at: 0xDeployer
+   JobRegistry: 0xRegistry
+   StakeManager: 0xStake
+   ...
+   ```
 
 ## 2. Configure token, ENS roots and fees
 
@@ -24,7 +36,25 @@ The default run uses the mainnet `$AGIALPHA` address, a 5% protocol fee and 5% b
   - `econ.feePct` / `econ.burnPct` – protocol fee and burn percentages (whole numbers, e.g. `5` for 5%).
   - `ids.agentRootNode` / `ids.clubRootNode` – namehashes for `agent.agi.eth` and `club.agi.eth`.
   - `ids.agentMerkleRoot` / `ids.validatorMerkleRoot` – optional allowlists for off‑chain membership proofs.
-  ![config script](https://via.placeholder.com/650x150?text=configure+econ+ids)
+
+  Example custom configuration:
+
+  ```ts
+  const econ = {
+    token: "0xYourToken",
+    feePct: 5,
+    burnPct: 5,
+  };
+
+  const ids = {
+    agentRootNode: namehash("agent.agi.eth"),
+    clubRootNode: namehash("club.agi.eth"),
+    agentMerkleRoot: ZeroHash,
+    validatorMerkleRoot: ZeroHash,
+  };
+
+  await deployer.deploy(econ, ids);
+  ```
 - After deployment the owner can still adjust parameters on‑chain with `JobRegistry.setFeePct` and `FeePool.setBurnPct`.
 
 ## 3. Post-deploy wiring
@@ -32,9 +62,26 @@ The default run uses the mainnet `$AGIALPHA` address, a 5% protocol fee and 5% b
 `deployDefaults.ts` wires modules automatically. If you deploy contracts individually, complete the wiring manually:
 
 1. On `JobRegistry`, call `setModules(validationModule, stakeManager, reputationEngine, disputeModule, certificateNFT, feePool, new address[](0))`.
-   ![setModules](https://via.placeholder.com/650x150?text=setModules)
+
+   ```solidity
+   jobRegistry.setModules(
+     validationModule,
+     stakeManager,
+     reputationEngine,
+     disputeModule,
+     certificateNFT,
+     feePool,
+     new address[](0)
+   );
+   ```
+
 2. On `StakeManager`, `ValidationModule` and `CertificateNFT`, call `setJobRegistry(jobRegistry)`.
-   ![setJobRegistry](https://via.placeholder.com/650x150?text=setJobRegistry)
+
+   ```solidity
+   stakeManager.setJobRegistry(jobRegistry);
+   validationModule.setJobRegistry(jobRegistry);
+   certificateNFT.setJobRegistry(jobRegistry);
+   ```
 3. Verify `ModulesUpdated` and `JobRegistrySet` events before allowing user funds.
 
 For function parity with the legacy contract, compare calls against [v1-v2-function-map.md](v1-v2-function-map.md).

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -29,16 +29,27 @@ For a narrated deployment walkthrough, see [deployment-agialpha.md](deployment-a
 
 ## Calling Contract Methods via Etherscan
 
-1. **Connect to Web3** – open the contract on Etherscan, select the **Write Contract** tab, click **Connect to Web3**, and approve the connection.
-   ![connect-web3](https://via.placeholder.com/650x150?text=Connect+to+Web3)
-2. **depositStake** – on `StakeManager`, enter the role and amount (18‑decimal base units) in `depositStake(role, amount)`.
-   ![deposit-stake](https://via.placeholder.com/650x150?text=depositStake)
+1. **Connect to Web3** – open the contract on Etherscan, select the **Write Contract** tab, click **Connect to Web3**, and approve the connection. The page displays your wallet address once connected.
+2. **depositStake** – on `StakeManager`, enter the role and amount (18‑decimal base units) in `depositStake(role, amount)` and click **Write**.
+
+   ```text
+   depositStake(1, 1000000000000000000)
+   ```
 3. **stakeAndActivate** – visit the `PlatformIncentives` address, connect, enter the stake amount, and press **Write** on `stakeAndActivate(amount)`.
-   ![stake-and-activate](https://via.placeholder.com/650x150?text=stakeAndActivate)
+
+   ```text
+   stakeAndActivate(1000000000000000000)
+   ```
 4. **distributeFees** – on the `FeePool` contract, call `distributeFees()` to allocate pending fees to stakers.
-   ![distribute-fees](https://via.placeholder.com/650x150?text=distributeFees)
+
+   ```text
+   distributeFees()
+   ```
 5. **claimRewards** – still in `FeePool`, execute `claimRewards()` to withdraw accrued rewards.
-   ![claim-rewards](https://via.placeholder.com/650x150?text=claimRewards)
+
+   ```text
+   claimRewards()
+   ```
 6. **acknowledgeAndDispute** – if contesting a job, approve the `StakeManager` for the `appealFee` and call `JobRegistry.acknowledgeAndDispute(jobId, evidence)`.
 
 ### Sample Owner Parameters
@@ -116,14 +127,20 @@ Before performing any on-chain action, employers, agents, and validators must ca
 ### Agents
 1. On `JobRegistry`, execute **acknowledgeTaxPolicy** and verify **isTaxExempt()**. Check the emitted `TaxAcknowledged` event for the recorded disclaimer.
 2. Open `StakeManager`; in **Read Contract** confirm **isTaxExempt()**, then stake with **depositStake(0, amount)** (role `0` = Agent).
-   ![agent stake](https://via.placeholder.com/650x150?text=depositStake)
+
+   ```text
+   depositStake(0, amount)
+   ```
 3. Use **applyForJob** then **submit(jobId, resultHash, uri)** when work is ready.
 4. After validators reveal votes, call **ValidationModule.finalize(jobId)**; the module records the outcome in `JobRegistry`.
 
 ### Validators
 1. On `JobRegistry`, execute **acknowledgeTaxPolicy** and verify **isTaxExempt()**. Inspect the `TaxAcknowledged` event log for the acknowledgement text.
 2. Stake required AGI via **StakeManager.depositStake(1, amount)** after confirming **StakeManager.isTaxExempt()**.
-   ![validator stake](https://via.placeholder.com/650x150?text=depositStake)
+
+   ```text
+   depositStake(1, amount)
+   ```
 3. During validation, open `ValidationModule`, confirm **isTaxExempt()**, and send hashed votes with **commitValidation(jobId, commitHash)**.
 4. Reveal decisions using **revealValidation(jobId, approve, salt)** before the window closes.
 
@@ -132,7 +149,11 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 
 #### Participants: verify and acknowledge
 1. Open [`JobRegistry` on Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#readContract).
-2. In **Read Contract**, call **taxPolicyDetails** to view the canonical policy URI and acknowledgement text. *(Example screenshot: [taxPolicyDetails](https://via.placeholder.com/650x150?text=taxPolicyDetails))*
+2. In **Read Contract**, call **taxPolicyDetails** to view the canonical policy URI and acknowledgement text.
+
+   ```text
+   taxPolicyDetails() => (version, "ipfs://QmPolicyHash", "Acknowledgement text")
+   ```
 3. Still under **Read Contract**, call **isTaxExempt** and confirm it returns `true`.
 4. Switch to **Write Contract**, connect your wallet, and execute **acknowledgeTaxPolicy**. The transaction log will show `TaxAcknowledged(user, version, acknowledgement)` with the disclaimer you accepted.
 5. Back in **Read Contract**, open the `TaxPolicy` contract and call **hasAcknowledged(address)** to ensure it returns `true`.


### PR DESCRIPTION
## Summary
- replace deployment-v2-agialpha screenshots with code examples and wiring steps
- convert Etherscan guide placeholders to textual instructions and code snippets

## Testing
- `npm test` *(fails: command not found)*
- `apt-get install -y nodejs npm` *(packages unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bafb6216488333a29e1a48ed45b338