### PR TITLE
docs: update AGIALPHA deployment links

### DIFF
--- a/docs/coding-sprint-agialpha-incentives.md
+++ b/docs/coding-sprint-agialpha-incentives.md
@@ -60,7 +60,7 @@ v2 suite while keeping all flows tax‑neutral, reporting‑free and pseudonymou
    - Extend Hardhat tests for revenue distribution, routing priority,
      governance rewards, slashing and blacklist enforcement.
    - Update `README.md`, `docs/incentive-mechanisms-agialpha.md` and
-     `docs/deployment-agialpha.md` to cover Etherscan flows, owner‑only setters
+    `docs/deployment-v2-agialpha.md` to cover Etherscan flows, owner‑only setters
      and base‑unit conversions.
    - Add a concise Etherscan deployment quickstart to the README so non‑technical
      operators can launch the suite with $AGIALPHA and later retune parameters

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -1,6 +1,6 @@
 # Etherscan Interaction Guide
 
-For a narrated deployment walkthrough, see [deployment-agialpha.md](deployment-agialpha.md).
+For a narrated deployment walkthrough, see [deployment-v2-agialpha.md](deployment-v2-agialpha.md).
 
 ## Quick Links
 - AGIJobManager v0: [Etherscan](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477#code) | [Blockscout](https://blockscout.com/eth/mainnet/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477/contracts)

--- a/docs/modular-architecture-v2.md
+++ b/docs/modular-architecture-v2.md
@@ -114,7 +114,7 @@ The $AGIALPHA token address is fixed at deployment. All amounts must be provided
 
 ## Explorer‑Friendly Design
 All public methods use simple data types so employers, agents and validators can interact through Etherscan's **Write** tab.
-Deployment and configuration steps for $AGIALPHA appear in [docs/deployment-agialpha.md](deployment-agialpha.md).
+Deployment and configuration steps for $AGIALPHA appear in [docs/deployment-v2-agialpha.md](deployment-v2-agialpha.md).
 
 ## Governance & Composability
 - Every module inherits `Ownable`; only the contract owner or its designated multisig can adjust parameters.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -63,7 +63,7 @@ Each contract exposes `isTaxExempt(addr)` and rejects direct ETH to keep value t
 3. Call the desired function and submit the transaction.
 4. Verify emitted events and new state in **Read Contract** or on a second explorer.
 
-For a step-by-step deployment walkthrough with owner-only setters, see [deployment-agialpha.md](deployment-agialpha.md).
+For a step-by-step deployment walkthrough with owner-only setters, see [deployment-v2-agialpha.md](deployment-v2-agialpha.md).
 For a production deployment checklist, consult [deployment-guide-production.md](deployment-guide-production.md).
 
 ### Owner Controls and Defaults

--- a/docs/v2-module-interface-reference.md
+++ b/docs/v2-module-interface-reference.md
@@ -1,6 +1,6 @@
 # AGIJobs v2 Module & Interface Reference
 
-This document condenses the production-scale architecture into standalone modules, each with a minimal interface and owner-only governance hooks. It is a companion to `docs/architecture-v2.md` and `docs/deployment-agialpha.md` and focuses on contract boundaries and Solidity structure tips. All modules now expose `version()` returning **2** so other components can verify compatibility during upgrades. The reputation system is implemented by a single contract, `contracts/v2/ReputationEngine.sol`, which replaces the former module variant.
+This document condenses the production-scale architecture into standalone modules, each with a minimal interface and owner-only governance hooks. It is a companion to `docs/architecture-v2.md` and `docs/deployment-v2-agialpha.md` and focuses on contract boundaries and Solidity structure tips. All modules now expose `version()` returning **2** so other components can verify compatibility during upgrades. The reputation system is implemented by a single contract, `contracts/v2/ReputationEngine.sol`, which replaces the former module variant.
 
 ## Module Graph
 ```mermaid


### PR DESCRIPTION
## Summary
- update AGIALPHA docs to reference `deployment-v2-agialpha.md`

## Testing
- `npx markdown-link-check docs/modular-architecture-v2.md`
- `npx markdown-link-check docs/etherscan-guide.md -c .mlc.config.json`
- `npx markdown-link-check docs/coding-sprint-agialpha-incentives.md -c .mlc.config.json`
- `npx markdown-link-check docs/overview.md -c .mlc.config.json`
- `npx markdown-link-check docs/v2-module-interface-reference.md -c .mlc.config.json`
- `npm run lint`
- `npm test` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bafd3407a4833385e792b881cff77c