### PR TITLE
refactor: replace governance require strings with custom errors

### DIFF
--- a/contracts/v2/Governable.sol
+++ b/contracts/v2/Governable.sol
@@ -14,18 +14,24 @@ abstract contract Governable {
 
     event GovernanceUpdated(address indexed newGovernance);
 
+    /// @dev Thrown when a zero address is supplied where a non-zero address is required.
+    error ZeroAddress();
+
+    /// @dev Thrown when the caller is not the governance contract.
+    error NotGovernance();
+
     constructor(address _governance) {
-        require(_governance != address(0), "governance");
+        if (_governance == address(0)) revert ZeroAddress();
         governance = TimelockController(payable(_governance));
     }
 
     modifier onlyGovernance() {
-        require(msg.sender == address(governance), "governance only");
+        if (msg.sender != address(governance)) revert NotGovernance();
         _;
     }
 
     function setGovernance(address _governance) public onlyGovernance {
-        require(_governance != address(0), "governance");
+        if (_governance == address(0)) revert ZeroAddress();
         governance = TimelockController(payable(_governance));
         emit GovernanceUpdated(_governance);
     }

--- a/test/v2/GovernanceHandover.test.js
+++ b/test/v2/GovernanceHandover.test.js
@@ -95,7 +95,7 @@ describe('Governance handover via Timelock', function () {
           ethers.ZeroHash,
           ethers.ZeroHash
         )
-    ).to.be.revertedWith('governance only');
+    ).to.be.revertedWithCustomError(mock, 'NotGovernance');
 
     // new timelock can call
     await tl2

--- a/test/v2/GovernanceTimelock.test.js
+++ b/test/v2/GovernanceTimelock.test.js
@@ -54,8 +54,14 @@ describe('Governance via Timelock', function () {
     );
     await registry.waitForDeployment();
 
-    await expect(stake.setMinStake(1)).to.be.revertedWith('governance only');
-    await expect(registry.setFeePct(1)).to.be.revertedWith('governance only');
+    await expect(stake.setMinStake(1)).to.be.revertedWithCustomError(
+      stake,
+      'NotGovernance'
+    );
+    await expect(registry.setFeePct(1)).to.be.revertedWithCustomError(
+      registry,
+      'NotGovernance'
+    );
 
     const stakeCall = stake.interface.encodeFunctionData('setMinStake', [1]);
     await timelock

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -305,11 +305,11 @@ describe('JobRegistry integration', function () {
           ethers.ZeroAddress,
           []
         )
-    ).to.be.revertedWith('governance only');
+    ).to.be.revertedWithCustomError(registry, 'NotGovernance');
 
     await expect(
       registry.connect(agent).setJobParameters(1, 1)
-    ).to.be.revertedWith('governance only');
+    ).to.be.revertedWithCustomError(registry, 'NotGovernance');
 
     await expect(
       dispute.connect(agent).setDisputeFee(1)

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -147,9 +147,15 @@ describe('Ownable modules', function () {
     ];
 
     for (const [inst, call] of governable) {
-      await expect(call(inst, other)).to.be.revertedWith('governance only');
+      await expect(call(inst, other)).to.be.revertedWithCustomError(
+        inst,
+        'NotGovernance'
+      );
       await inst.connect(systemPauseSigner).setGovernance(other.address);
-      await expect(call(inst, owner)).to.be.revertedWith('governance only');
+      await expect(call(inst, owner)).to.be.revertedWithCustomError(
+        inst,
+        'NotGovernance'
+      );
       await call(inst, other);
       await inst.connect(other).setGovernance(systemPauseSignerAddr);
     }

--- a/test/v2/OwnershipTimelock.test.js
+++ b/test/v2/OwnershipTimelock.test.js
@@ -78,8 +78,14 @@ describe('Timelock ownership', function () {
       .connect(systemPauseSigner)
       .setGovernance(await timelock.getAddress());
 
-    await expect(stake.setFeePct(1)).to.be.revertedWith('governance only');
-    await expect(registry.setFeePct(1)).to.be.revertedWith('governance only');
+    await expect(stake.setFeePct(1)).to.be.revertedWithCustomError(
+      stake,
+      'NotGovernance'
+    );
+    await expect(registry.setFeePct(1)).to.be.revertedWithCustomError(
+      registry,
+      'NotGovernance'
+    );
 
     const stakeData = stake.interface.encodeFunctionData('setFeePct', [1]);
     const registryData = registry.interface.encodeFunctionData('setFeePct', [

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -398,9 +398,9 @@ describe('StakeManager', function () {
   });
 
   it('restricts min stake updates to owner', async () => {
-    await expect(stakeManager.connect(user).setMinStake(1)).to.be.revertedWith(
-      'governance only'
-    );
+    await expect(
+      stakeManager.connect(user).setMinStake(1)
+    ).to.be.revertedWithCustomError(stakeManager, 'NotGovernance');
     await expect(stakeManager.connect(owner).setMinStake(2))
       .to.emit(stakeManager, 'MinStakeUpdated')
       .withArgs(2n);
@@ -474,7 +474,7 @@ describe('StakeManager', function () {
   it('restricts slashing percentage updates to owner', async () => {
     await expect(
       stakeManager.connect(user).setSlashingPercentages(60, 40)
-    ).to.be.revertedWith('governance only');
+    ).to.be.revertedWithCustomError(stakeManager, 'NotGovernance');
     await expect(stakeManager.connect(owner).setSlashingPercentages(60, 40))
       .to.emit(stakeManager, 'SlashingPercentagesUpdated')
       .withArgs(60, 40);
@@ -605,7 +605,7 @@ describe('StakeManager', function () {
   it('restricts treasury updates to owner', async () => {
     await expect(
       stakeManager.connect(user).setTreasury(user.address)
-    ).to.be.revertedWith('governance only');
+    ).to.be.revertedWithCustomError(stakeManager, 'NotGovernance');
     await expect(stakeManager.connect(owner).setTreasury(user.address))
       .to.emit(stakeManager, 'TreasuryUpdated')
       .withArgs(user.address);
@@ -935,9 +935,9 @@ describe('StakeManager', function () {
     await expect(stakeManager.connect(owner).setMinStake(10))
       .to.emit(stakeManager, 'MinStakeUpdated')
       .withArgs(10n);
-    await expect(stakeManager.connect(user).setMinStake(1)).to.be.revertedWith(
-      'governance only'
-    );
+    await expect(
+      stakeManager.connect(user).setMinStake(1)
+    ).to.be.revertedWithCustomError(stakeManager, 'NotGovernance');
     await expect(stakeManager.connect(owner).setSlashingPercentages(40, 60))
       .to.emit(stakeManager, 'SlashingPercentagesUpdated')
       .withArgs(40n, 60n);
@@ -1060,7 +1060,7 @@ describe('StakeManager', function () {
 
     await expect(
       stakeManager.connect(user).acknowledgeAndWithdrawFor(user.address, 0, 50)
-    ).to.be.revertedWith('governance only');
+    ).to.be.revertedWithCustomError(stakeManager, 'NotGovernance');
 
     await stakeManager
       .connect(owner)

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -187,14 +187,14 @@ describe('StakeManager release', function () {
   });
 
   it('restricts fee configuration to owner', async () => {
-    await expect(stakeManager.connect(user1).setFeePct(1)).to.be.revertedWith(
-      'governance only'
-    );
+    await expect(
+      stakeManager.connect(user1).setFeePct(1)
+    ).to.be.revertedWithCustomError(stakeManager, 'NotGovernance');
     await expect(
       stakeManager.connect(user1).setFeePool(await feePool.getAddress())
-    ).to.be.revertedWith('governance only');
-    await expect(stakeManager.connect(user1).setBurnPct(1)).to.be.revertedWith(
-      'governance only'
-    );
+    ).to.be.revertedWithCustomError(stakeManager, 'NotGovernance');
+    await expect(
+      stakeManager.connect(user1).setBurnPct(1)
+    ).to.be.revertedWithCustomError(stakeManager, 'NotGovernance');
   });
 });

--- a/test/v2/SystemPause.test.js
+++ b/test/v2/SystemPause.test.js
@@ -123,8 +123,9 @@ describe('SystemPause', function () {
         committeeAddr
       );
 
-    await expect(pause.connect(other).pauseAll()).to.be.revertedWith(
-      'governance only'
+    await expect(pause.connect(other).pauseAll()).to.be.revertedWithCustomError(
+      pause,
+      'NotGovernance'
     );
 
     expect(await stake.paused()).to.equal(false);
@@ -147,9 +148,9 @@ describe('SystemPause', function () {
     expect(await reputation.paused()).to.equal(true);
     expect(await committee.paused()).to.equal(true);
 
-    await expect(pause.connect(other).unpauseAll()).to.be.revertedWith(
-      'governance only'
-    );
+    await expect(
+      pause.connect(other).unpauseAll()
+    ).to.be.revertedWithCustomError(pause, 'NotGovernance');
 
     await pause.connect(owner).unpauseAll();
 

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -91,7 +91,7 @@ describe('JobRegistry tax policy integration', function () {
   it('blocks non-owner from setting policy', async () => {
     await expect(
       registry.connect(user).setTaxPolicy(await policy.getAddress())
-    ).to.be.revertedWith('governance only');
+    ).to.be.revertedWithCustomError(registry, 'NotGovernance');
   });
 
   it('blocks non-owner from bumping version', async () => {


### PR DESCRIPTION
## Summary
- add `NotGovernance` and related errors in `Governable` and `FeePool`
- switch require messages to custom error reverts
- adjust tests to expect custom errors

## Testing
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0e9be6f08333b0cf42ebe0e43173