### PR TITLE
docs: fix links to v0-v2 function map

### DIFF
--- a/docs/deployment-v2-agialpha.md
+++ b/docs/deployment-v2-agialpha.md
@@ -91,7 +91,7 @@ The default run uses the mainnet `$AGIALPHA` address, a 5% protocol fee and 5% b
 
 3. Verify `ModulesUpdated` and `JobRegistrySet` events before allowing user funds.
 
-For function parity with the legacy contract, compare calls against [v1-v2-function-map.md](v1-v2-function-map.md).
+For function parity with the legacy contract, compare calls against [v0-v2-function-map.md](legacy/v0-v2-function-map.md).
 
 Following this sequence results in a ready‑to‑use v2 deployment running on `$AGIALPHA`.
 

--- a/docs/internal/coding-sprint-v2-ens-identity.md
+++ b/docs/internal/coding-sprint-v2-ens-identity.md
@@ -25,7 +25,7 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 - Require tax policy acknowledgement before any state‑changing action.
 - Enforce owner‑set `maxJobReward` and `maxJobDuration` limits.
 - After successful validation call `StakeManager.release` for payouts, `ReputationEngine.onFinalize` for reputation, and `CertificateNFT.mint` for credentials.
-- Mirror v1 event names and cross‑check `docs/v1-v2-function-map.md` to ensure feature parity.
+- Mirror v1 event names and cross‑check `../legacy/v0-v2-function-map.md` to ensure feature parity.
 
 ### 3. ValidationModule
 
@@ -65,7 +65,7 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 - Update `README.md` with an AGIALPHA deployment guide and Etherscan walkthrough.
 - Add Hardhat tests covering identity checks, job lifecycle, validation, disputes and NFT marketplace.
 - Run `npx solhint 'contracts/**/*.sol'`, `npx eslint .` and `npx hardhat test` until green.
-- Verify coverage against `docs/v1-v2-function-map.md` so every v1 function has a v2 counterpart.
+- Verify coverage against `../legacy/v0-v2-function-map.md` so every v1 function has a v2 counterpart.
 
 ## Definition of Done
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -18,7 +18,6 @@ All legacy AGIJobManager contracts have been moved to the `legacy/` directory. T
 For function‑level differences see:
 
 - [v0 → v2 function map](legacy/v0-v2-function-map.md)
-- [v1 → v2 function map](v1-v2-function-map.md)
 
 ## Job URI Hash Migration
 


### PR DESCRIPTION
## Summary
- update docs to link to `legacy/v0-v2-function-map.md`
- clean up migration guide duplicate entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb2908cf448333a0e535ff4b818c38