### PR TITLE
docs: centralize architecture overview

### DIFF
--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -2,6 +2,8 @@
 
 AGIJobs v2 replaces the monolithic v1 manager with immutable, single-purpose modules. Each contract is deployed once, owns its state, and interacts through a minimal interface so storage layouts remain isolated. The owner (ideally a multisig) can retune parameters or swap module addresses without redeploying the entire suite, delivering governance composability while keeping on-chain logic simple enough for block-explorer interactions. Every module inherits `Ownable`, ensuring only the contract owner can perform privileged actions. The design emphasises gas efficiency and game-theoretic soundness while remaining approachable for non-technical users.
 
+For a quick visual overview of the system, see the [architecture overview](architecture.md).
+
 ## Trust assumptions
 
 - **Deterministic randomness** - validator selection uses commit-reveal entropy seeded by the owner and on-chain data. When `block.prevrandao` is unavailable, the module mixes recent block hashes and the caller address, removing any need for off-chain randomness providers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,26 @@
-# Architecture
+# Architecture Overview
+
+This document offers a quick visual summary of the AGI Jobs v2 system for
+readers who want a high-level picture. For a detailed breakdown of module
+responsibilities, owner controls and design rationale, see
+[architecture-v2.md](architecture-v2.md).
 
 ## Modules
 
-- [JobRegistry](../contracts/v2/JobRegistry.sol) – orchestrates job lifecycle and coordinates with external modules.
-- [StakeManager](../contracts/v2/StakeManager.sol) – holds deposits, pays rewards, and slashes stake.
-- [ReputationEngine](../contracts/v2/ReputationEngine.sol) – tracks reputation scores for participants.
-- [ValidationModule](../contracts/v2/ValidationModule.sol) – returns preset validation outcomes for jobs.
-- [CertificateNFT](../contracts/v2/CertificateNFT.sol) – mints ERC721 certificates for successful jobs.
+AGI Jobs v2 decomposes functionality into small, single-purpose contracts. For
+depth on how each component works, jump to the corresponding section in the
+[architecture-v2](architecture-v2.md) guide.
+
+- [JobRegistry](../contracts/v2/JobRegistry.sol) – orchestrates job lifecycle
+  and coordinates with external modules.
+- [StakeManager](../contracts/v2/StakeManager.sol) – holds deposits, pays
+  rewards, and slashes stake.
+- [ReputationEngine](../contracts/v2/ReputationEngine.sol) – tracks reputation
+  scores for participants.
+- [ValidationModule](../contracts/v2/ValidationModule.sol) – returns preset
+  validation outcomes for jobs.
+- [CertificateNFT](../contracts/v2/CertificateNFT.sol) – mints ERC721
+  certificates for successful jobs.
 
 ## Module Interactions
 

--- a/docs/deployment-agialpha.md
+++ b/docs/deployment-agialpha.md
@@ -2,7 +2,7 @@
 
 For the primary production deployment workflow see [deployment-production-guide.md](deployment-production-guide.md).
 
-This walkthrough shows a non‑technical owner how to deploy and wire the modular v2 contracts using the 18‑decimal **$AGIALPHA** token. The canonical token is deployed separately on mainnet; this repository includes [`contracts/test/AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) solely for local testing. By default $AGIALPHA handles all payments, staking, rewards, and dispute deposits. All steps can be executed from a browser via [Etherscan](https://etherscan.io) or any compatible block explorer. For screenshot‑driven instructions, see [etherscan-guide.md](etherscan-guide.md).
+This walkthrough shows a non‑technical owner how to deploy and wire the modular v2 contracts using the 18‑decimal **$AGIALPHA** token. For a deeper explanation of how the modules interact, consult [architecture-v2.md](architecture-v2.md). The canonical token is deployed separately on mainnet; this repository includes [`contracts/test/AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) solely for local testing. By default $AGIALPHA handles all payments, staking, rewards, and dispute deposits. All steps can be executed from a browser via [Etherscan](https://etherscan.io) or any compatible block explorer. For screenshot‑driven instructions, see [etherscan-guide.md](etherscan-guide.md).
 
 ## 1. Prerequisites
 

--- a/docs/deployment-production-guide.md
+++ b/docs/deployment-production-guide.md
@@ -2,7 +2,7 @@
 
 This guide walks a non-technical administrator through deploying the AGI Jobs v2 smart contracts on Ethereum using only a web browser and Etherscan. It also explains best practices such as true token burning, owner updatability and how to record your deployment in this repository.
 
-All steps are executed directly from Etherscan's web interface—no command line tools or local scripts are required.
+All steps are executed directly from Etherscan's web interface—no command line tools or local scripts are required. For a deeper explanation of how the modules interact, see [architecture-v2.md](architecture-v2.md). This guide focuses strictly on deployment steps.
 
 ### Best Practices in AGI Jobs v2
 
@@ -18,22 +18,6 @@ All steps are executed directly from Etherscan's web interface—no command line
 - **Basic Etherscan familiarity** – you will use the _Write Contract_ tab to deploy and configure modules.
 - **Governance account** – a multisig or timelock that will ultimately own the modules.
 - **Etherscan API key & local build** – run `npm install` and `npx hardhat compile` so bytecode matches when verifying with your API key.
-
-## Overview of AGI Jobs v2 Architecture
-
-AGI Jobs v2 is modular. Each contract manages one aspect of the marketplace:
-
-- **StakeManager** – staking, escrow of job rewards and slashing.
-- **JobRegistry** – main registry tracking job lifecycle.
-- **ValidationModule** – validator selection and commit–reveal voting.
-- **DisputeModule** – dispute escalation and resolution.
-- **ReputationEngine** – reputation scores and blacklisting.
-- **CertificateNFT** – NFTs certifying completed jobs.
-- **IdentityRegistry** _(optional)_ – ENS subdomain checks and allowlists.
-- **FeePool** – collects protocol fees and optionally burns a portion.
-- **PlatformRegistry & JobRouter** _(optional)_ – manage multiple front-end platforms and route jobs to them.
-- **PlatformIncentives** _(optional)_ – helper that combines staking and registration for platforms.
-- **TaxPolicy** _(optional)_ – on-chain acknowledgment of terms of service or tax policy.
 
 ## Step 1: Deploy the Core Contracts in Order
 

--- a/docs/deployment-v2-agialpha.md
+++ b/docs/deployment-v2-agialpha.md
@@ -2,7 +2,7 @@
 
 For the full production deployment process see [deployment-production-guide.md](deployment-production-guide.md).
 
-This guide shows how to deploy the modular v2 contracts using the helper script at `scripts/v2/deployDefaults.ts`. The script spins up the full stack assuming the 18‑decimal **$AGIALPHA** token already exists. For local networks without the canonical token, deploy [`contracts/test/AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) and supply its address to the script.
+This guide shows how to deploy the modular v2 contracts using the helper script at `scripts/v2/deployDefaults.ts`. For context on each module's responsibility and how they fit together, see [architecture-v2.md](architecture-v2.md). The script spins up the full stack assuming the 18‑decimal **$AGIALPHA** token already exists. For local networks without the canonical token, deploy [`contracts/test/AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) and supply its address to the script.
 
 ## 1. Run the deployment script
 

--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -1,6 +1,6 @@
 # Etherscan Deployment Quickstart
 
-For complete production deployment guidance see [deployment-production-guide.md](deployment-production-guide.md).
+For complete production deployment guidance see [deployment-production-guide.md](deployment-production-guide.md). For background on contract roles and architecture, review [architecture-v2.md](architecture-v2.md).
 
 For screenshots and a deeper explanation see [etherscan-guide.md](etherscan-guide.md). All owner interactions occur through the explorer's **Write Contract** tabs.
 

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -1,15 +1,6 @@
 # AGIJobs v2 Deployment & Operations Guide
 
-For production deployment steps see [deployment-production-guide.md](deployment-production-guide.md).
-
-## Architecture Overview
-
-AGIJobs v2 decomposes the platform into small, immutable modules wired
-through a central `JobRegistry`. Each module owns a single
-responsibility and exposes governance‑only setters so parameters can be
-tuned without redeploying the whole system. `JobRegistry` and
-`StakeManager` accept a multisig or timelock address during construction
-which becomes the governance authority.
+For production deployment steps see [deployment-production-guide.md](deployment-production-guide.md). For a detailed explanation of the system design, consult [architecture-v2.md](architecture-v2.md).
 
 Identity for agents and validators is enforced with the
 `ENSOwnershipVerifier` library. Participants must control an ENS

--- a/docs/v2-module-deployment-summary.md
+++ b/docs/v2-module-deployment-summary.md
@@ -1,6 +1,6 @@
 # AGIJobs v2 Module Deployment Summary
 
-For detailed production deployment instructions see [deployment-production-guide.md](deployment-production-guide.md).
+For detailed production deployment instructions see [deployment-production-guide.md](deployment-production-guide.md). For an explanation of module responsibilities and how they interact, refer to [architecture-v2.md](architecture-v2.md).
 
 This note outlines a minimal sequence for deploying the modular v2 stack
 and wiring contracts together. The `$AGIALPHA` token, ENS roots, Merkle


### PR DESCRIPTION
## Summary
- Split architecture docs by audience with a concise overview linking to a detailed v2 architecture guide
- Point deployment guides to the canonical architecture document instead of duplicating explanations

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2ca6677c8333904f119cbc649d90