### PR TITLE
refactor: segregate internal planning docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+exclude:
+  - internal

--- a/docs/internal/project-purpose.md
+++ b/docs/internal/project-purpose.md
@@ -1,3 +1,5 @@
+> **Note:** This document is for internal planning purposes only.
+
 # Project Purpose
 
 AGIJob Manager is a foundational smart-contract component for the emerging Economy of AGI. The v0 contract coordinates work between **AGI Agents** and **AGI Nodes**, using the $AGI utility token as the medium of exchange. Agents perform computational jobs, Nodes supply the processing power, and $AGI rewards flow through the system to fuel a decentralized network of autonomous services.


### PR DESCRIPTION
## Summary
- move project planning doc into `docs/internal` with internal-use notice
- add docs config to omit `docs/internal` from published docs

## Testing
- `npm test`
- `npm run lint` *(fails: 5 errors, 22 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2f9c0dd48333a036dcae8066c2ca