### PR TITLE
chore: add TypeScript linting

### DIFF
--- a/agent-gateway/index.js
+++ b/agent-gateway/index.js
@@ -351,7 +351,7 @@ verifyTokenDecimals()
         let msg;
         try {
           msg = JSON.parse(data);
-        } catch (err) {
+        } catch (_err) {
           return;
         }
         if (msg.type === 'register') {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,6 @@
 const prettierPlugin = require('eslint-plugin-prettier');
+const tsParser = require('@typescript-eslint/parser');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
 
 module.exports = [
   {
@@ -11,7 +13,33 @@ module.exports = [
       prettier: prettierPlugin,
     },
     rules: {
-      'no-unused-vars': 'warn',
+      'no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      'prettier/prettier': 'error',
+    },
+  },
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      prettier: prettierPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
       'prettier/prettier': 'error',
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "6.1.0",
         "@openzeppelin/contracts": "^5.4.0",
+        "@typescript-eslint/eslint-plugin": "^8.42.0",
+        "@typescript-eslint/parser": "^8.42.0",
         "eslint": "^9.32.0",
         "eslint-plugin-prettier": "^4.2.5",
         "hardhat": "^2.26.1",
@@ -1041,7 +1043,6 @@
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -1056,7 +1057,6 @@
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -1067,7 +1067,6 @@
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -2021,6 +2020,277 @@
       "peer": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.42.0.tgz",
+      "integrity": "sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/type-utils": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.42.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.42.0.tgz",
+      "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.42.0.tgz",
+      "integrity": "sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.42.0",
+        "@typescript-eslint/types": "^8.42.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.42.0.tgz",
+      "integrity": "sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.42.0.tgz",
+      "integrity": "sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.42.0.tgz",
+      "integrity": "sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
+      "integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.42.0.tgz",
+      "integrity": "sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.42.0",
+        "@typescript-eslint/tsconfig-utils": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.42.0.tgz",
+      "integrity": "sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.42.0.tgz",
+      "integrity": "sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/abbrev": {
@@ -4272,7 +4542,6 @@
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -4290,7 +4559,6 @@
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4335,7 +4603,6 @@
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -4986,6 +5253,13 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -6133,7 +6407,6 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -6200,7 +6473,6 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -6215,7 +6487,6 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -7258,8 +7529,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -7513,7 +7783,6 @@
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -7581,7 +7850,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -8745,6 +9013,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-command-line-args": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "6.1.0",
     "@openzeppelin/contracts": "^5.4.0",
+    "@typescript-eslint/eslint-plugin": "^8.42.0",
+    "@typescript-eslint/parser": "^8.42.0",
     "eslint": "^9.32.0",
     "eslint-plugin-prettier": "^4.2.5",
     "hardhat": "^2.26.1",

--- a/test/v2/ArbitratorCommittee.test.js
+++ b/test/v2/ArbitratorCommittee.test.js
@@ -194,8 +194,16 @@ describe('ArbitratorCommittee', function () {
   });
 
   it('handles deadline expiry and partial reveals', async () => {
-    const { committee, dispute, registry, agent, employer, v1, v2, v3 } =
-      await setup();
+    const {
+      committee,
+      dispute,
+      registry,
+      agent,
+      employer: _employer,
+      v1,
+      v2,
+      v3: _v3,
+    } = await setup();
 
     await committee.setCommitRevealWindows(3n, 2n);
 

--- a/test/v2/ENSOwnershipVerifier.test.js
+++ b/test/v2/ENSOwnershipVerifier.test.js
@@ -2,10 +2,10 @@ const { expect } = require('chai');
 const { ethers } = require('hardhat');
 
 describe('ENSOwnershipVerifier setters', function () {
-  let owner, other, verifier;
+  let _owner, other, verifier;
 
   beforeEach(async () => {
-    [owner, other] = await ethers.getSigners();
+    [_owner, other] = await ethers.getSigners();
     const Verifier = await ethers.getContractFactory(
       'contracts/v2/modules/ENSOwnershipVerifier.sol:ENSOwnershipVerifier'
     );

--- a/test/v2/IdentityRegistrySetters.test.js
+++ b/test/v2/IdentityRegistrySetters.test.js
@@ -2,10 +2,10 @@ const { expect } = require('chai');
 const { ethers } = require('hardhat');
 
 describe('IdentityRegistry setters', function () {
-  let owner;
+  let _owner;
   let identity;
   beforeEach(async () => {
-    [owner] = await ethers.getSigners();
+    [_owner] = await ethers.getSigners();
 
     const Stake = await ethers.getContractFactory(
       'contracts/legacy/MockV2.sol:MockStakeManager'

--- a/test/v2/JobRegistryTreasury.test.js
+++ b/test/v2/JobRegistryTreasury.test.js
@@ -3,13 +3,13 @@ const { ethers } = require('hardhat');
 
 describe('JobRegistry Treasury', function () {
   const { AGIALPHA } = require('../../scripts/constants');
-  let registry, stakeManager, token;
+  let registry, stakeManager, _token;
   let owner, treasury;
 
   beforeEach(async function () {
     [owner, treasury] = await ethers.getSigners();
 
-    token = await ethers.getContractAt(
+    _token = await ethers.getContractAt(
       'contracts/test/AGIALPHAToken.sol:AGIALPHAToken',
       AGIALPHA
     );

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -142,12 +142,12 @@ describe('Mid-job module upgrades', function () {
       agent,
       token,
       stake,
-      reputation,
-      validation,
-      nft,
+      reputation: _reputation,
+      validation: _validation,
+      nft: _nft,
       registry,
-      dispute,
-      feePool,
+      dispute: _dispute,
+      feePool: _feePool,
     } = env;
 
     const stakeAmount = ethers.parseUnits('1', AGIALPHA_DECIMALS);

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -142,11 +142,11 @@ describe('Module replacement', function () {
       agent,
       token,
       stake,
-      reputation,
-      validation,
-      nft,
+      reputation: _reputation,
+      validation: _validation,
+      nft: _nft,
       registry,
-      dispute,
+      dispute: _dispute,
     } = env;
 
     const stakeAmount = ethers.parseUnits('1', AGIALPHA_DECIMALS);

--- a/test/v2/Ownership.test.js
+++ b/test/v2/Ownership.test.js
@@ -97,7 +97,7 @@ describe('Ownable modules', function () {
     const IdentityRegistry = await ethers.getContractFactory(
       'contracts/v2/IdentityRegistry.sol:IdentityRegistry'
     );
-    const SystemPause = await ethers.getContractFactory(
+    const _SystemPause = await ethers.getContractFactory(
       'contracts/v2/SystemPause.sol:SystemPause'
     );
 

--- a/test/v2/StakeManagerNoEther.test.js
+++ b/test/v2/StakeManagerNoEther.test.js
@@ -3,11 +3,11 @@ const { ethers } = require('hardhat');
 
 describe('StakeManager ether rejection', function () {
   const { AGIALPHA } = require('../../scripts/constants');
-  let owner, token, stakeManager;
+  let owner, _token, stakeManager;
 
   beforeEach(async () => {
     [owner] = await ethers.getSigners();
-    token = await ethers.getContractAt(
+    _token = await ethers.getContractAt(
       'contracts/test/AGIALPHAToken.sol:AGIALPHAToken',
       AGIALPHA
     );

--- a/test/v2/StakeManagerSlashing.test.js
+++ b/test/v2/StakeManagerSlashing.test.js
@@ -3,11 +3,11 @@ const { ethers } = require('hardhat');
 
 describe('StakeManager slashing configuration', function () {
   const { AGIALPHA } = require('../../scripts/constants');
-  let owner, treasury, token, stakeManager;
+  let owner, treasury, _token, stakeManager;
 
   beforeEach(async () => {
     [owner, treasury] = await ethers.getSigners();
-    token = await ethers.getContractAt(
+    _token = await ethers.getContractAt(
       'contracts/test/AGIALPHAToken.sol:AGIALPHAToken',
       AGIALPHA
     );

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -258,7 +258,7 @@ describe('ValidationModule finalize flows', function () {
   it('force finalize only slashes selected validators', async () => {
     const {
       owner,
-      employer,
+      employer: _employer,
       v1,
       v2,
       v3,

--- a/test/v2/ValidatorSelectionRotation.test.js
+++ b/test/v2/ValidatorSelectionRotation.test.js
@@ -65,7 +65,7 @@ describe('Validator selection rotating strategy', function () {
   });
 
   it('emits rotation update event with expected value', async () => {
-    const [owner] = await ethers.getSigners();
+    const [_owner] = await ethers.getSigners();
     await validation.selectValidators(1, 0);
     await ethers.provider.send('evm_mine', []);
     const tx = await validation.connect(other).selectValidators(1, 0);

--- a/test/v2/identity.test.ts
+++ b/test/v2/identity.test.ts
@@ -6,7 +6,7 @@ const { ethers } = hre;
 
 describe('IdentityRegistry ENS verification', function () {
   it('verifies ownership via NameWrapper and rejects others', async () => {
-    const [owner, alice, bob] = await ethers.getSigners();
+    const [_owner, alice, bob] = await ethers.getSigners();
 
     const ENS = await ethers.getContractFactory('MockENS');
     const ens = await ENS.deploy();
@@ -50,7 +50,7 @@ describe('IdentityRegistry ENS verification', function () {
   });
 
   it('supports merkle proofs and resolver fallback', async () => {
-    const [owner, validator, agent] = await ethers.getSigners();
+    const [_owner, validator, agent] = await ethers.getSigners();
 
     const ENS = await ethers.getContractFactory('MockENS');
     const ens = await ENS.deploy();
@@ -105,7 +105,7 @@ describe('IdentityRegistry ENS verification', function () {
   });
 
   it('respects allowlists and blacklists', async () => {
-    const [owner, alice] = await ethers.getSigners();
+    const [_owner, alice] = await ethers.getSigners();
 
     const ENS = await ethers.getContractFactory('MockENS');
     const ens = await ENS.deploy();
@@ -146,7 +146,7 @@ describe('IdentityRegistry ENS verification', function () {
   });
 
   it('allows governance and agents to set capability profiles', async () => {
-    const [owner, alice] = await ethers.getSigners();
+    const [_owner, alice] = await ethers.getSigners();
 
     const ENS = await ethers.getContractFactory('MockENS');
     const ens = await ENS.deploy();

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -141,7 +141,7 @@ describe('job lifecycle with dispute and validator failure', function () {
       validation,
       registry,
       dispute,
-      moderator,
+      moderator: _moderator,
     } = env;
 
     const stakeAmount = ethers.parseUnits('1', AGIALPHA_DECIMALS);

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -10,7 +10,7 @@ enum Role {
 }
 
 async function deploySystem() {
-  const [owner, employer, agent, v1, v2, arbitratorSigner] =
+  const [owner, employer, agent, v1, v2, _arbitratorSigner] =
     await ethers.getSigners();
 
   const Token = await ethers.getContractFactory(

--- a/test/v2/midJobReplacementFuzz.test.js
+++ b/test/v2/midJobReplacementFuzz.test.js
@@ -134,11 +134,11 @@ describe('Mid-job module replacement fuzz', function () {
         token,
         stake,
         reputation,
-        validation,
-        nft,
+        validation: _validation,
+        nft: _nft,
         registry,
-        dispute,
-        feePool,
+        dispute: _dispute,
+        feePool: _feePool,
       } = env;
 
       const reward = ethers.parseUnits(

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -212,7 +212,7 @@ describe('regression scenarios', function () {
       agent,
       token,
       stake,
-      validation,
+      validation: _validation,
       registry,
       dispute,
       reputation,


### PR DESCRIPTION
## Summary
- extend ESLint config to cover TypeScript sources
- mark unused test variables with `_` and ignore underscored catches
- run prettier across touched files

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb330a215483338b2be6010acf8359