### PR TITLE
feat: emit event on pauser updates

### DIFF
--- a/contracts/v2/ArbitratorCommittee.sol
+++ b/contracts/v2/ArbitratorCommittee.sol
@@ -37,6 +37,7 @@ contract ArbitratorCommittee is Ownable, Pausable {
 
     event TimingUpdated(uint256 commitWindow, uint256 revealWindow);
     event AbsenteeSlashUpdated(uint256 amount);
+    event PauserUpdated(address indexed pauser);
 
     event CaseOpened(uint256 indexed jobId, address[] jurors);
     event VoteCommitted(uint256 indexed jobId, address indexed juror, bytes32 commit);
@@ -53,6 +54,7 @@ contract ArbitratorCommittee is Ownable, Pausable {
 
     function setPauser(address _pauser) external onlyOwner {
         pauser = _pauser;
+        emit PauserUpdated(_pauser);
     }
 
     constructor(IJobRegistry _jobRegistry, IDisputeModule _disputeModule)

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -80,6 +80,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
     event GovernanceUpdated(address indexed governance);
     event GovernanceWithdrawal(address indexed to, uint256 amount);
     event RewardPoolContribution(address indexed contributor, uint256 amount);
+    event PauserUpdated(address indexed pauser);
 
     modifier onlyOwnerOrPauser() {
         if (msg.sender != owner() && msg.sender != pauser) {
@@ -90,6 +91,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
 
     function setPauser(address _pauser) external onlyOwner {
         pauser = _pauser;
+        emit PauserUpdated(_pauser);
     }
 
     /// @notice Deploys the FeePool.

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -130,6 +130,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
 
     function setPauser(address _pauser) external onlyGovernance {
         pauser = _pauser;
+        emit PauserUpdated(_pauser);
     }
 
     // cache successful agent authorizations
@@ -172,6 +173,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     event CertificateNFTUpdated(address nft);
     event IdentityRegistryUpdated(address identityRegistry);
     event ValidatorRewardPctUpdated(uint256 pct);
+    event PauserUpdated(address indexed pauser);
     /// @notice Emitted when the tax policy reference or version changes.
     /// @param policy Address of the TaxPolicy contract.
     /// @param version Incrementing version participants must acknowledge.

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -40,6 +40,7 @@ contract PlatformRegistry is Ownable, ReentrancyGuard, Pausable {
     event Blacklisted(address indexed operator, bool status);
     event RegistrarUpdated(address indexed registrar, bool allowed);
     event Activated(address indexed operator, uint256 amount);
+    event PauserUpdated(address indexed pauser);
 
     modifier onlyOwnerOrPauser() {
         require(
@@ -51,6 +52,7 @@ contract PlatformRegistry is Ownable, ReentrancyGuard, Pausable {
 
     function setPauser(address _pauser) external onlyOwner {
         pauser = _pauser;
+        emit PauserUpdated(_pauser);
     }
 
     /// @notice Deploys the PlatformRegistry.

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -58,6 +58,7 @@ contract ReputationEngine is Ownable, Pausable {
     event ScoringWeightsUpdated(uint256 stakeWeight, uint256 reputationWeight);
     event ModulesUpdated(address indexed stakeManager);
     event ValidationRewardPercentageUpdated(uint256 percentage);
+    event PauserUpdated(address indexed pauser);
 
     modifier onlyOwnerOrPauser() {
         require(
@@ -69,6 +70,7 @@ contract ReputationEngine is Ownable, Pausable {
 
     function setPauser(address _pauser) external onlyOwner {
         pauser = _pauser;
+        emit PauserUpdated(_pauser);
     }
     constructor(IStakeManager _stakeManager) Ownable(msg.sender) {
         require(address(_stakeManager) != address(0), "invalid stake manager");

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -195,6 +195,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     event BurnPctUpdated(uint256 pct);
     event ValidatorRewardPctUpdated(uint256 pct);
     event FeePoolUpdated(address indexed feePool);
+    event PauserUpdated(address indexed pauser);
 
     modifier onlyGovernanceOrPauser() {
         require(
@@ -206,6 +207,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     function setPauser(address _pauser) external onlyGovernance {
         pauser = _pauser;
+        emit PauserUpdated(_pauser);
     }
 
     /// @notice Deploys the StakeManager.

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -175,6 +175,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     event ValidatorAuthCacheDurationUpdated(uint256 duration);
     event ValidatorAuthCacheVersionBumped(uint256 version);
     event SelectionReset(uint256 indexed jobId);
+    event PauserUpdated(address indexed pauser);
 
     modifier onlyOwnerOrPauser() {
         require(
@@ -186,6 +187,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
 
     function setPauser(address _pauser) external onlyOwner {
         pauser = _pauser;
+        emit PauserUpdated(_pauser);
     }
     event ValidatorPoolRotationUpdated(uint256 newRotation);
     event RandaoCoordinatorUpdated(address coordinator);

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -60,6 +60,7 @@ contract DisputeModule is Ownable, Pausable {
         address indexed resolver,
         bool employerWins
     );
+    event PauserUpdated(address indexed pauser);
 
     modifier onlyOwnerOrPauser() {
         require(
@@ -71,6 +72,7 @@ contract DisputeModule is Ownable, Pausable {
 
     function setPauser(address _pauser) external onlyOwner {
         pauser = _pauser;
+        emit PauserUpdated(_pauser);
     }
     event DisputeFeeUpdated(uint256 fee);
     event DisputeWindowUpdated(uint256 window);


### PR DESCRIPTION
## Summary
- emit `PauserUpdated` event in StakeManager, JobRegistry, and other modules
- allow tracking when pauser roles change for governance operations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb3dc24f588333a0d3496d10eb49cd