### PR TITLE
Add nonReentrant to JobRegistry submit

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -851,6 +851,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             address(disputeModule),
             address(validationModule)
         )
+        nonReentrant
     {
         Job storage job = jobs[jobId];
         if (job.state != State.Applied) revert InvalidJobState();


### PR DESCRIPTION
## Summary
- protect JobRegistry `submit` with `nonReentrant`

## Testing
- `npx hardhat test test/v2/JobRegistry.test.js` *(fails: Transaction reverted without a reason string in StakeManager.MAX_AGI_TYPES_CAP)*

------
https://chatgpt.com/codex/tasks/task_e_68bb49e548bc8333a475986bd815ede6