### PR TITLE
feat: explicit post-validation finalization with dispute window

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -930,11 +930,8 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         Job storage job = jobs[jobId];
         if (job.state != State.Submitted) revert NotSubmitted();
         job.success = success;
-        job.state = success ? State.Completed : State.Disputed;
+        job.state = State.Completed;
         emit JobCompleted(jobId, success);
-        if (success) {
-            _finalize(jobId);
-        }
     }
 
     function validationComplete(uint256 jobId, bool success) external whenNotPaused {

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -55,19 +55,30 @@ contract ValidationStub is IValidationModule {
 
     function revealValidation(uint256, bool, bytes32) external override {}
 
-    function finalize(uint256 jobId) external override returns (bool success) {
+    function _sendResult(uint256 jobId) internal returns (bool success) {
         success = result;
         if (jobRegistry != address(0)) {
             IJobRegistry(jobRegistry).onValidationResult(jobId, success, validatorList);
         }
     }
 
+    function finalize(uint256 jobId) public override returns (bool success) {
+        success = _sendResult(jobId);
+        if (jobRegistry != address(0)) {
+            IJobRegistry(jobRegistry).finalize(jobId);
+        }
+    }
+
     function finalizeValidation(uint256 jobId) external override returns (bool success) {
-        return this.finalize(jobId);
+        return finalize(jobId);
     }
 
     function forceFinalize(uint256 jobId) external override returns (bool success) {
-        return this.finalize(jobId);
+        return finalize(jobId);
+    }
+
+    function sendResult(uint256 jobId) external returns (bool success) {
+        return _sendResult(jobId);
     }
 
     function validators(uint256) external view override returns (address[] memory vals) {


### PR DESCRIPTION
## Summary
- require manual finalization after validation results, placing jobs in `Completed` state for both success and failure
- add `sendResult` helper to `ValidationStub` so tests can emulate pending finalization
- cover success and failure paths where jobs can be disputed or finalized after validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb4d07dab08333a210c8764996ce8c