### PR TITLE
feat: add reentrancy protection to StakeManager slashing

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -1137,7 +1137,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         Role role,
         uint256 amount,
         address employer
-    ) external onlyJobRegistry whenNotPaused {
+    ) external onlyJobRegistry whenNotPaused nonReentrant {
         _slash(user, role, amount, employer);
     }
 
@@ -1149,6 +1149,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         external
         onlyDisputeModule
         whenNotPaused
+        nonReentrant
     {
         _slash(user, Role.Validator, amount, recipient);
     }


### PR DESCRIPTION
## Summary
- guard both external `slash` functions with `nonReentrant`

## Testing
- `npm test -- test/v2/StakeManager*.test.js` *(fails: TokenNotBurnable)*
- `forge test --match-path 'test/v2/StakeManager*.t.sol'` *(fails: missing forge-std)*

------
https://chatgpt.com/codex/tasks/task_e_68bb50824f4c8333a8211bf479100ed5