### PR TITLE
refactor: guard release against reentrancy

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -924,7 +924,12 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     ///      FeePool until `FeePool.distributeFees()` is called separately.
     /// @param to Recipient receiving the tokens.
     /// @param amount Base token amount with 18 decimals before AGI bonus.
-    function release(address to, uint256 amount) external onlyJobRegistry whenNotPaused {
+    function release(address to, uint256 amount)
+        external
+        onlyJobRegistry
+        whenNotPaused
+        nonReentrant
+    {
         // apply AGI type payout modifier
         uint256 pct = getAgentPayoutPct(to);
         uint256 modified = (amount * pct) / 100;


### PR DESCRIPTION
## Summary
- apply `nonReentrant` modifier to `StakeManager.release`
- confirm `release` has no internal call sites to avoid recursion

## Testing
- `npm test -- test/v2/StakeManagerRelease.test.js` *(fails: Transaction reverted without a reason string at StakeManager.MAX_AGI_TYPES_CAP)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5a91fd84833384709b1b615891cc