### PR TITLE
feat: add tokens burned event

### DIFF
--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -20,6 +20,7 @@ interface IStakeManager {
     event StakeWithdrawn(address indexed user, Role indexed role, uint256 amount);
     event StakeEscrowLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
     event StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount);
+    event TokensBurned(bytes32 indexed jobId, uint256 amount);
     event StakeTimeLocked(address indexed user, uint256 amount, uint64 unlockTime);
     event StakeUnlocked(address indexed user, uint256 amount);
     event StakeSlashed(

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -21,6 +21,7 @@ Handles staking, escrow and slashing of the $AGIALPHA token.
 - `StakeSlashed(address indexed user, uint256 amount, address recipient)`
 - `StakeEscrowLocked(bytes32 indexed jobId, address indexed from, uint256 amount)`
 - `StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount)`
+- `TokensBurned(bytes32 indexed jobId, uint256 amount)`
 - `DisputeFeeLocked(address indexed payer, uint256 amount)`
 - `DisputeFeePaid(address indexed to, uint256 amount)`
 - `FeePctUpdated(uint256 pct)` / `BurnPctUpdated(uint256 pct)` / `ValidatorRewardPctUpdated(uint256 pct)`

--- a/test/v2/StakeManagerBurn.t.sol
+++ b/test/v2/StakeManagerBurn.t.sol
@@ -12,7 +12,7 @@ contract StakeManagerBurnHarness is StakeManager {
     {}
 
     function exposedBurn(uint256 amt) external {
-        _burnToken(amt);
+        _burnToken(bytes32(0), amt);
     }
 }
 

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -112,8 +112,8 @@ describe('StakeManager release', function () {
         await feePool.getAddress(),
         ethers.parseEther('20')
       )
-      .and.to.emit(stakeManager, 'StakeReleased')
-      .withArgs(ethers.ZeroHash, ethers.ZeroAddress, ethers.parseEther('10'))
+      .and.to.emit(stakeManager, 'TokensBurned')
+      .withArgs(ethers.ZeroHash, ethers.parseEther('10'))
       .and.to.emit(stakeManager, 'StakeReleased')
       .withArgs(ethers.ZeroHash, user1.address, ethers.parseEther('70'));
 
@@ -154,8 +154,8 @@ describe('StakeManager release', function () {
     )
       .to.emit(stakeManager, 'StakeReleased')
       .withArgs(jobId, await feePool.getAddress(), ethers.parseEther('20'))
-      .and.to.emit(stakeManager, 'StakeReleased')
-      .withArgs(jobId, ethers.ZeroAddress, ethers.parseEther('10'))
+      .and.to.emit(stakeManager, 'TokensBurned')
+      .withArgs(jobId, ethers.parseEther('10'))
       .and.to.emit(stakeManager, 'StakeReleased')
       .withArgs(jobId, user1.address, ethers.parseEther('70'));
 


### PR DESCRIPTION
## Summary
- add `TokensBurned` event to StakeManager and interface
- emit burn events directly from `_burnToken` and stop using `StakeReleased` for burns
- update docs and tests for the new burn event

## Testing
- `npm test`
- `forge test` *(fails: Yul exception: Cannot swap Variable param with Variable param_16)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5ec2fa308333a75e567f6021d499