### PR TITLE
Configure identity registry with mainnet ENS addresses

### DIFF
--- a/scripts/v2/deployDefaults.ts
+++ b/scripts/v2/deployDefaults.ts
@@ -30,10 +30,10 @@ async function main() {
   console.log('Deployer', deployerAddress);
 
   const ids = {
-    ens: ethers.ZeroAddress,
-    nameWrapper: ethers.ZeroAddress,
-    clubRootNode: ethers.ZeroHash,
-    agentRootNode: ethers.ZeroHash,
+    ens: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+    nameWrapper: '0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401',
+    clubRootNode: ethers.namehash('club.agi.eth'),
+    agentRootNode: ethers.namehash('agent.agi.eth'),
     validatorMerkleRoot: ethers.ZeroHash,
     agentMerkleRoot: ethers.ZeroHash,
   };


### PR DESCRIPTION
## Summary
- Use official ENS registry and NameWrapper addresses for IdentityRegistry deployment
- Seed default root nodes for `agent.agi.eth` and `club.agi.eth`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb854d545083338dc7cc775d6563ae