### PR TITLE
Restrict AttestationRegistry setters to owner

### DIFF
--- a/contracts/v2/AttestationRegistry.sol
+++ b/contracts/v2/AttestationRegistry.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import {IENS} from "./interfaces/IENS.sol";
 import {INameWrapper} from "./interfaces/INameWrapper.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 error UnauthorizedAttestor();
 error ZeroAddress();
@@ -10,7 +11,7 @@ error ZeroAddress();
 /// @title AttestationRegistry
 /// @notice Allows ENS name owners to grant and revoke attestations
 /// for specific roles to other addresses.
-contract AttestationRegistry {
+contract AttestationRegistry is Ownable {
     /// @dev Roles that can be attested for a name.
     enum Role {
         Agent,
@@ -28,7 +29,7 @@ contract AttestationRegistry {
     event Attested(bytes32 indexed node, Role indexed role, address indexed who, address attestor);
     event Revoked(bytes32 indexed node, Role indexed role, address indexed who, address attestor);
 
-    constructor(IENS _ens, INameWrapper _nameWrapper) {
+    constructor(IENS _ens, INameWrapper _nameWrapper) Ownable(msg.sender) {
         ens = _ens;
         if (address(_ens) != address(0)) {
             emit ENSUpdated(address(_ens));
@@ -39,7 +40,7 @@ contract AttestationRegistry {
         }
     }
 
-    function setENS(address ensAddr) external {
+    function setENS(address ensAddr) external onlyOwner {
         if (ensAddr == address(0)) {
             revert ZeroAddress();
         }
@@ -47,7 +48,7 @@ contract AttestationRegistry {
         emit ENSUpdated(ensAddr);
     }
 
-    function setNameWrapper(address wrapper) external {
+    function setNameWrapper(address wrapper) external onlyOwner {
         if (wrapper == address(0)) {
             revert ZeroAddress();
         }

--- a/test/v2/AttestationRegistry.t.sol
+++ b/test/v2/AttestationRegistry.t.sol
@@ -61,5 +61,23 @@ contract AttestationRegistryTest is Test {
         attest.attest(vNode, AttestationRegistry.Role.Validator, validator);
         assertTrue(identity.isAuthorizedValidator(validator, "validator", new bytes32[](0)));
     }
+
+    function testSetENSUnauthorized() public {
+        address caller = address(0xBEEF);
+        vm.expectRevert(
+            abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", caller)
+        );
+        vm.prank(caller);
+        attest.setENS(address(ens));
+    }
+
+    function testSetNameWrapperUnauthorized() public {
+        address caller = address(0xBEEF);
+        vm.expectRevert(
+            abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", caller)
+        );
+        vm.prank(caller);
+        attest.setNameWrapper(address(wrapper));
+    }
 }
 


### PR DESCRIPTION
## Summary
- make `AttestationRegistry` inherit from OpenZeppelin `Ownable`
- limit `setENS` and `setNameWrapper` to contract owner
- add tests for unauthorized callers of setters

## Testing
- `npx hardhat test test/v2/AttestationRegistry.test.js`
- `forge test --match-path test/v2/AttestationRegistry.t.sol` *(fails: Yul exception: Cannot swap Variable param with Variable param_16: too deep in the stack by 1 slots)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8fa9fb44833394fc6e3bd8fcccb0