### PR TITLE
docs: add AttestationRegistry usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The original v0 and v1 contracts are preserved under the `legacy` git tag for re
 
 ## Quick Start
 
-Use the `examples/ethers-quickstart.js` script to interact with the deployed contracts. Export `RPC_URL`, `PRIVATE_KEY`, `JOB_REGISTRY`, `STAKE_MANAGER` and `VALIDATION_MODULE`.
+Use the `examples/ethers-quickstart.js` script to interact with the deployed contracts. Export `RPC_URL`, `PRIVATE_KEY`, `JOB_REGISTRY`, `STAKE_MANAGER`, `VALIDATION_MODULE` and `ATTESTATION_REGISTRY`.
 
 The [API reference](docs/api-reference.md) describes every public contract function and includes TypeScript and Python snippets. For an event‑driven workflow check the minimal [agent gateway](examples/agent-gateway.js) that listens for `JobCreated` events and applies automatically.
 
@@ -156,6 +156,15 @@ Transactions will revert if the address does not own the supplied
 subdomain. Owner‑controlled allowlists
 (`JobRegistry.setAgentMerkleRoot` and `ValidationModule.setValidatorMerkleRoot`)
 exist only for emergencies and should not be relied on by normal users.
+
+### Delegate addresses with AttestationRegistry
+
+`AttestationRegistry` lets ENS name owners pre-authorize other addresses for
+agent or validator roles. Authorized addresses skip expensive on-chain ENS lookups
+and can use the platform without holding the ENS name directly. Owners call
+`attest(node, role, address)` to grant access and `revoke(node, role, address)` to
+remove it. See [docs/attestation.md](docs/attestation.md) for a walkthrough and
+CLI examples.
 
 ### Quickstart flow
 

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -1,0 +1,54 @@
+# Attestation Registry
+
+`AttestationRegistry` lets ENS subdomain owners pre-authorize other addresses
+to act as agents or validators. Once attested, addresses skip the expensive ENS
+ownership check performed by `IdentityRegistry` and can participate using the
+delegated wallet.
+
+## Granting and revoking
+
+1. Compute the ENS node for the subdomain:
+
+   ```js
+   const node = ethers.namehash('alice.agent.agi.eth');
+   ```
+
+2. From the ENS name owner's wallet call:
+
+   ```bash
+   npx hardhat console --network <network>
+   > const att = await ethers.getContractAt('AttestationRegistry', process.env.ATTESTATION_REGISTRY);
+   > const node = ethers.namehash('alice.agent.agi.eth');
+   > await att.attest(node, 0, '0xDelegate'); // 0 = Agent, 1 = Validator
+   ```
+
+3. To revoke the authorization:
+
+   ```bash
+   > await att.revoke(node, 0, '0xDelegate');
+   ```
+
+## Verifying before use
+
+Delegated addresses should confirm that an attestation exists before using the
+platform:
+
+```bash
+npx hardhat console --network <network>
+> await att.isAttested(node, 0, '0xDelegate');
+```
+
+If the call returns `true` the address may interact with `JobRegistry` and
+`ValidationModule`.
+
+## Script helpers
+
+`examples/ethers-quickstart.js` exports convenience helpers:
+
+```bash
+node -e "require('./examples/ethers-quickstart').attest('alice.agent.agi.eth', 0, '0xDelegate')"
+node -e "require('./examples/ethers-quickstart').revoke('alice.agent.agi.eth', 0, '0xDelegate')"
+```
+
+Set `ATTESTATION_REGISTRY` in your environment to the deployed contract address
+before running these commands.

--- a/examples/ethers-quickstart.js
+++ b/examples/ethers-quickstart.js
@@ -20,6 +20,11 @@ const validationAbi = [
   'function finalize(uint256 jobId)',
 ];
 
+const attestAbi = [
+  'function attest(bytes32 node, uint8 role, address who)',
+  'function revoke(bytes32 node, uint8 role, address who)',
+];
+
 const registry = new ethers.Contract(
   process.env.JOB_REGISTRY,
   registryAbi,
@@ -33,6 +38,12 @@ const stakeManager = new ethers.Contract(
 const validation = new ethers.Contract(
   process.env.VALIDATION_MODULE,
   validationAbi,
+  signer
+);
+
+const attestation = new ethers.Contract(
+  process.env.ATTESTATION_REGISTRY,
+  attestAbi,
   signer
 );
 
@@ -71,4 +82,23 @@ async function dispute(jobId, evidence) {
   await registry.raiseDispute(jobId, evidenceHash);
 }
 
-module.exports = { postJob, stake, apply, submit, validate, dispute };
+async function attest(name, role, delegate) {
+  const node = ethers.namehash(name);
+  await attestation.attest(node, role, delegate);
+}
+
+async function revoke(name, role, delegate) {
+  const node = ethers.namehash(name);
+  await attestation.revoke(node, role, delegate);
+}
+
+module.exports = {
+  postJob,
+  stake,
+  apply,
+  submit,
+  validate,
+  dispute,
+  attest,
+  revoke,
+};


### PR DESCRIPTION
## Summary
- document AttestationRegistry purpose and usage
- explain how to attest and revoke delegate addresses
- extend ethers quickstart script with attestation helpers

## Testing
- `npm test` *(fails: terminated during Hardhat compilation)*
- `npm run lint` *(fails: 7 errors, 28 warnings)*
- `npx prettier --check README.md docs/attestation.md examples/ethers-quickstart.js`

------
https://chatgpt.com/codex/tasks/task_e_68bb9c3b0afc8333b246b62f6031dcf8