### PR TITLE
test: add cache invalidation tests

### DIFF
--- a/test/v2/JobRegistryCache.test.ts
+++ b/test/v2/JobRegistryCache.test.ts
@@ -1,0 +1,100 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
+
+describe('JobRegistry authorization cache', function () {
+  let owner, employer, agent;
+  let registry, identity, policy;
+
+  beforeEach(async () => {
+    [owner, employer, agent] = await ethers.getSigners();
+
+    const Identity = await ethers.getContractFactory(
+      'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'
+    );
+    identity = await Identity.deploy();
+    await identity.waitForDeployment();
+    await identity.setAgentRootNode(ethers.ZeroHash);
+
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/JobRegistry.sol:JobRegistry'
+    );
+    registry = await Registry.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    await registry.waitForDeployment();
+    await registry.connect(owner).setIdentityRegistry(await identity.getAddress());
+
+    const Policy = await ethers.getContractFactory(
+      'contracts/v2/TaxPolicy.sol:TaxPolicy'
+    );
+    policy = await Policy.deploy('uri', 'ack');
+    await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy.connect(employer).acknowledge();
+    await policy.connect(agent).acknowledge();
+
+    await registry.connect(owner).setMaxJobReward(1000);
+    await registry.connect(owner).setJobDurationLimit(1000);
+    await registry.connect(owner).setFeePct(0);
+    await registry.connect(owner).setJobParameters(0, 0);
+  });
+
+  async function createJob() {
+    const deadline = (await time.latest()) + 100;
+    const specHash = ethers.id('spec');
+    const tx = await registry
+      .connect(employer)
+      .createJob(1, deadline, specHash, 'uri');
+    const receipt = await tx.wait();
+    const event = receipt.logs.find(
+      (l) => l.fragment && l.fragment.name === 'JobCreated'
+    );
+    return event.args[0];
+  }
+
+  it('fails once cache duration elapses', async () => {
+    await registry.connect(owner).setAgentAuthCacheDuration(5);
+    await identity.setResult(true);
+
+    const first = await createJob();
+    await registry.connect(agent).applyForJob(first, 'a', []);
+
+    await identity.setResult(false);
+    const second = await createJob();
+    await registry.connect(agent).applyForJob(second, 'a', []);
+
+    await time.increase(6);
+    const third = await createJob();
+    await expect(
+      registry.connect(agent).applyForJob(third, 'a', [])
+    ).to.be.revertedWithCustomError(registry, 'NotAuthorizedAgent');
+  });
+
+  it('re-verifies when cache version is bumped', async () => {
+    await registry.connect(owner).setAgentAuthCacheDuration(1000);
+    await identity.setResult(true);
+
+    const first = await createJob();
+    await registry.connect(agent).applyForJob(first, 'a', []);
+
+    await identity.setResult(false);
+    await identity.transferOwnership(await registry.getAddress());
+    await registry.connect(owner).setAgentMerkleRoot(ethers.ZeroHash);
+
+    const second = await createJob();
+    await expect(
+      registry.connect(agent).applyForJob(second, 'a', [])
+    ).to.be.revertedWithCustomError(registry, 'NotAuthorizedAgent');
+  });
+});
+

--- a/test/v2/ValidationCache.test.ts
+++ b/test/v2/ValidationCache.test.ts
@@ -1,0 +1,84 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
+
+describe('ValidationModule authorization cache', function () {
+  let owner, other, v1, v2, v3;
+  let validation, stake, identity;
+
+  beforeEach(async () => {
+    [owner, other, v1, v2, v3] = await ethers.getSigners();
+
+    const StakeMock = await ethers.getContractFactory('MockStakeManager');
+    stake = await StakeMock.deploy();
+    await stake.waitForDeployment();
+
+    const Identity = await ethers.getContractFactory(
+      'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'
+    );
+    identity = await Identity.deploy();
+    await identity.waitForDeployment();
+    await identity.setAgentRootNode(ethers.ZeroHash);
+    await identity.setClubRootNode(ethers.ZeroHash);
+
+    const Validation = await ethers.getContractFactory(
+      'contracts/v2/ValidationModule.sol:ValidationModule'
+    );
+    validation = await Validation.deploy(
+      ethers.ZeroAddress,
+      await stake.getAddress(),
+      1,
+      1,
+      3,
+      10,
+      []
+    );
+    await validation.waitForDeployment();
+    await validation.setIdentityRegistry(await identity.getAddress());
+
+    const validators = [v1.address, v2.address, v3.address];
+    for (const addr of validators) {
+      await stake.setStake(addr, 1, ethers.parseEther('1'));
+    }
+    await validation.setValidatorPool(validators);
+    await validation.setValidatorsPerJob(3);
+    await validation.setValidatorPoolSampleSize(10);
+  });
+
+  async function finalizeSelect(jobId) {
+    await validation.selectValidators(jobId, 0);
+    await ethers.provider.send('evm_mine', []);
+    return validation.connect(other).selectValidators(jobId, 0);
+    }
+
+  it('fails once validator cache duration elapses', async () => {
+    await validation.setValidatorAuthCacheDuration(5);
+    await identity.setResult(true);
+    await finalizeSelect(1);
+
+    await identity.setResult(false);
+
+    await finalizeSelect(2);
+
+    await time.increase(6);
+    await expect(finalizeSelect(3)).to.be.revertedWithCustomError(
+      validation,
+      'InsufficientValidators'
+    );
+  });
+
+  it('re-verifies validators when cache version bumped', async () => {
+    await validation.setValidatorAuthCacheDuration(1000);
+    await identity.setResult(true);
+    await finalizeSelect(1);
+
+    await identity.setResult(false);
+    await validation.bumpValidatorAuthCacheVersion();
+
+    await expect(finalizeSelect(2)).to.be.revertedWithCustomError(
+      validation,
+      'InsufficientValidators'
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add JobRegistry cache expiration and version bump tests
- add ValidationModule cache expiration and version bump tests

## Testing
- `npx hardhat test test/v2/JobRegistryCache.test.ts test/v2/ValidationCache.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bb9f3176b48333905efc38c191aa60