### PR TITLE
feat: allow validators set subdomain

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -465,6 +465,13 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         }
     }
 
+    /// @notice Map the caller to an ENS subdomain for selection checks.
+    /// @param subdomain ENS label owned by the caller.
+    function setMySubdomain(string calldata subdomain) external {
+        validatorSubdomains[msg.sender] = subdomain;
+        emit ValidatorSubdomainUpdated(msg.sender, subdomain);
+    }
+
     /// @notice Update the commit and reveal windows.
     function setCommitRevealWindows(uint256 commitDur, uint256 revealDur)
         external

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -139,6 +139,9 @@ interface IValidationModule {
         string[] calldata subdomains
     ) external;
 
+    /// @notice Map the caller to an ENS subdomain for selection.
+    function setMySubdomain(string calldata subdomain) external;
+
     /// @notice Configure the validator sampling strategy.
     function setSelectionStrategy(SelectionStrategy strategy) external;
 

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -100,6 +100,8 @@ contract ValidationStub is IValidationModule {
         string[] calldata
     ) external override {}
 
+    function setMySubdomain(string calldata) external override {}
+
     function setParameters(
         uint256,
         uint256,

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -145,6 +145,8 @@ contract NoValidationModule is IValidationModule, Ownable {
         string[] calldata
     ) external pure override {}
 
+    function setMySubdomain(string calldata) external pure override {}
+
     /// @inheritdoc IValidationModule
     function validators(uint256)
         external

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -168,6 +168,8 @@ contract OracleValidationModule is IValidationModule, Ownable {
         string[] calldata
     ) external pure override {}
 
+    function setMySubdomain(string calldata) external pure override {}
+
     /// @inheritdoc IValidationModule
     function validators(uint256)
         external

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -91,12 +91,12 @@ describe('Validator ENS integration', function () {
     await wrapper.setOwner(ethers.toBigInt(node), validator.address);
     await resolver.setAddr(node, validator.address);
 
-    await expect(
-      validation.connect(validator).setMySubdomain('v')
-    )
+    await expect(validation.connect(validator).setMySubdomain('v'))
       .to.emit(validation, 'ValidatorSubdomainUpdated')
       .withArgs(validator.address, 'v');
-    expect(await validation.validatorSubdomains(validator.address)).to.equal('v');
+    expect(await validation.validatorSubdomains(validator.address)).to.equal(
+      'v'
+    );
 
     const job = {
       employer: owner.address,
@@ -115,9 +115,7 @@ describe('Validator ENS integration', function () {
       .reverted;
 
     await expect(
-      validation
-        .connect(validator)
-        .commitValidation(1, ethers.id('h'), 'v', [])
+      validation.connect(validator).commitValidation(1, ethers.id('h'), 'v', [])
     )
       .to.emit(identity, 'OwnershipVerified')
       .withArgs(validator.address, 'v')

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -86,6 +86,44 @@ describe('Validator ENS integration', function () {
     ]);
   });
 
+  it('allows validators to update their own subdomain and use it for selection', async () => {
+    const node = namehash(root, 'v');
+    await wrapper.setOwner(ethers.toBigInt(node), validator.address);
+    await resolver.setAddr(node, validator.address);
+
+    await expect(
+      validation.connect(validator).setMySubdomain('v')
+    )
+      .to.emit(validation, 'ValidatorSubdomainUpdated')
+      .withArgs(validator.address, 'v');
+    expect(await validation.validatorSubdomains(validator.address)).to.equal('v');
+
+    const job = {
+      employer: owner.address,
+      agent: ethers.ZeroAddress,
+      reward: 0,
+      stake: 0,
+      success: false,
+      status: 3,
+      uriHash: ethers.ZeroHash,
+      resultHash: ethers.ZeroHash,
+    };
+    await jobRegistry.setJob(1, job);
+    await validation.selectValidators(1, 0);
+    await ethers.provider.send('evm_mine', []);
+    await expect(validation.connect(v2).selectValidators(1, 0)).to.not.be
+      .reverted;
+
+    await expect(
+      validation
+        .connect(validator)
+        .commitValidation(1, ethers.id('h'), 'v', [])
+    )
+      .to.emit(identity, 'OwnershipVerified')
+      .withArgs(validator.address, 'v')
+      .and.to.emit(validation, 'ValidationCommitted');
+  });
+
   it('rejects validators without subdomains and emits events on success', async () => {
     const job = {
       employer: owner.address,


### PR DESCRIPTION
## Summary
- allow validators to set their own ENS subdomain via `setMySubdomain`
- expose method in `IValidationModule`
- cover validator self-update in selection tests

## Testing
- `npm test --silent -- test/v2/ENSValidatorBehavior.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bba2d7d5908333a6bf8c58350d0091