### PR TITLE
docs: add ENS identity setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Transactions will revert if the address does not own the supplied
 subdomain. Owner‑controlled allowlists
 (`JobRegistry.setAgentMerkleRoot` and `ValidationModule.setValidatorMerkleRoot`)
 exist only for emergencies and should not be relied on by normal users.
+For a detailed walkthrough see
+[docs/ens-identity-setup.md](docs/ens-identity-setup.md).
 
 ### Delegate addresses with AttestationRegistry
 

--- a/docs/ens-identity-setup.md
+++ b/docs/ens-identity-setup.md
@@ -1,0 +1,35 @@
+# ENS Identity Setup
+
+Agents and validators must prove ownership of specific ENS subdomains before interacting with the AGIJobs platform. This guide walks through obtaining a name, configuring records, and optionally delegating access.
+
+## Required subdomains
+
+- **Agents:** `<name>.agent.agi.eth`
+- **Validators:** `<name>.club.agi.eth`
+
+## Register and configure
+
+1. **Request a subdomain** from the AGI operators or the provided registration dApp.
+2. **Point the name to your address** by either:
+   - Setting the resolver `addr` record, or
+   - Wrapping the name with the ENS NameWrapper so the subdomain NFT is held by your wallet.
+3. **Verify ownership** off-chain using an ENS lookup or on-chain by calling `IdentityRegistry.verifyAgent` or `verifyValidator`.
+
+Transactions will revert if the calling address does not own the claimed subdomain. Owner‑controlled allowlists and Merkle proofs exist only for emergencies and should not be relied on for normal operation.
+
+## Delegating with attestations
+
+An ENS name owner may authorize another address to act on their behalf through the `AttestationRegistry`:
+
+```bash
+npx hardhat console --network <network>
+> const att = await ethers.getContractAt('AttestationRegistry', process.env.ATTESTATION_REGISTRY);
+> const node = ethers.namehash('alice.agent.agi.eth');
+> await att.attest(node, 0, '0xDelegate'); // 0 = Agent, 1 = Validator
+```
+
+The delegated address may then interact with `JobRegistry` or `ValidationModule` without holding the ENS name directly. See [docs/attestation.md](attestation.md) for detailed commands.
+
+## Keep records current
+
+If a subdomain is transferred or its resolver changes, the new owner must update the platform by re‑attesting or letting the cache expire. Otherwise subsequent actions will fail the identity check.


### PR DESCRIPTION
## Summary
- document step-by-step ENS subdomain setup for agents and validators
- link README identity section to new guide

## Testing
- `npm test` *(timeout: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bbae5bc3008333a961c9013ce1aa6d