### PR TITLE
Invalidate cached ENS authorizations on root updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Record each address during deployment. The defaults below assume the 18‑decima
 | [`AGIALPHAToken`](contracts/test/AGIALPHAToken.sol) _(local testing only)_ | `mint`, `burn`                                                                                                                                                 |
 | [`StakeManager`](contracts/v2/StakeManager.sol)                            | `setMinStake`, `setSlashingPercentages`, `setTreasury`, `setMaxStakePerAddress`                                                                                |
 | [`JobRegistry`](contracts/v2/JobRegistry.sol)                              | `setModules`, `setFeePool`, `setTaxPolicy`, `setAgentRootNode`, `setAgentMerkleRoot`,<br>`setTreasury`, `setIdentityRegistry`                                  |
-| [`ValidationModule`](contracts/v2/ValidationModule.sol)                    | `setJobRegistry`, `setCommitWindow`, `setRevealWindow`, `setValidatorBounds`, `setApprovalThreshold`, `setIdentityRegistry`                                    |
+| [`ValidationModule`](contracts/v2/ValidationModule.sol)                    | `setJobRegistry`, `setCommitWindow`, `setRevealWindow`, `setValidatorBounds`, `setApprovalThreshold`, `setIdentityRegistry`,<br>`setClubRootNode`, `setValidatorMerkleRoot` |
 | [`IdentityRegistry`](contracts/v2/IdentityRegistry.sol)                    | `setENS`, `setNameWrapper`, `setReputationEngine`, `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot`, `setValidatorMerkleRoot`, `setAgentProfileURI` |
 | [`DisputeModule`](contracts/v2/modules/DisputeModule.sol)                  | `setDisputeFee`, `setTaxPolicy`, `setFeePool`                                                                                                                  |
 | [`ReputationEngine`](contracts/v2/ReputationEngine.sol)                    | `setCaller`, `setWeights`, `blacklist`, `unblacklist`                                                                                                          |
@@ -99,7 +99,7 @@ Record each address during deployment. The defaults below assume the 18‑decima
    - Authorise cross‑module calls using `StakeManager.setDisputeModule(disputeModule)` and `CertificateNFT.setStakeManager(stakeManager)`
    - `JobRegistry.setTaxPolicy(taxPolicy)` then `DisputeModule.setTaxPolicy(taxPolicy)`
    - `JobRegistry.setIdentityRegistry(identityRegistry)` and `ValidationModule.setIdentityRegistry(identityRegistry)`
-   - Load ENS settings with `IdentityRegistry.setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot` and `setValidatorMerkleRoot`
+   - Load ENS settings with `JobRegistry.setAgentRootNode`, `ValidationModule.setClubRootNode`, `JobRegistry.setAgentMerkleRoot` and `ValidationModule.setValidatorMerkleRoot`
 3. **Verify wiring** – run `npm run verify:wiring` to confirm on-chain module
    references match `docs/deployment-addresses.json`.
 4. **Example transactions** – after wiring you can:

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -409,6 +409,9 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     function setAgentRootNode(bytes32 node) external onlyGovernance {
         if (address(identityRegistry) == address(0)) revert IdentityRegistryNotSet();
         identityRegistry.setAgentRootNode(node);
+        unchecked {
+            agentAuthCacheVersion++;
+        }
         emit AgentRootNodeUpdated(node);
     }
 

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -302,6 +302,24 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         emit IdentityRegistryUpdated(address(registry));
     }
 
+    /// @notice Update the ENS root node used for validator verification.
+    /// @param node Namehash of the validator parent node (e.g. `club.agi.eth`).
+    function setClubRootNode(bytes32 node) external onlyOwner {
+        if (address(identityRegistry) == address(0)) revert ZeroIdentityRegistry();
+        identityRegistry.setClubRootNode(node);
+        bumpValidatorAuthCacheVersion();
+        emit ClubRootNodeUpdated(node);
+    }
+
+    /// @notice Update the Merkle root for the validator allowlist.
+    /// @param root Merkle root of approved validator addresses.
+    function setValidatorMerkleRoot(bytes32 root) external onlyOwner {
+        if (address(identityRegistry) == address(0)) revert ZeroIdentityRegistry();
+        identityRegistry.setValidatorMerkleRoot(root);
+        bumpValidatorAuthCacheVersion();
+        emit ValidatorMerkleRootUpdated(root);
+    }
+
     /// @notice Set the Randao coordinator used for randomness.
     /// @param coordinator Address of the RandaoCoordinator contract.
     function setRandaoCoordinator(IRandaoCoordinator coordinator)

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -30,6 +30,8 @@ interface IValidationModule {
         uint256 approvalThreshold,
         uint256 slashingPct
     );
+    event ClubRootNodeUpdated(bytes32 node);
+    event ValidatorMerkleRootUpdated(bytes32 root);
 
     /// @notice Select validators for a given job.
     /// @param jobId Identifier of the job.
@@ -144,6 +146,17 @@ interface IValidationModule {
 
     /// @notice Configure the validator sampling strategy.
     function setSelectionStrategy(SelectionStrategy strategy) external;
+
+    /// @notice Update the ENS root node used for validator verification.
+    /// @param node Namehash of the validator parent node (e.g. `club.agi.eth`).
+    function setClubRootNode(bytes32 node) external;
+
+    /// @notice Update the Merkle root for the validator allowlist.
+    /// @param root Merkle root of approved validator addresses.
+    function setValidatorMerkleRoot(bytes32 root) external;
+
+    /// @notice Bump the cached validator authorization version.
+    function bumpValidatorAuthCacheVersion() external;
 
 
     /// @notice Return validators selected for a job

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -116,5 +116,11 @@ contract ValidationStub is IValidationModule {
 
     function setSelectionStrategy(IValidationModule.SelectionStrategy) external override {}
 
+    function setClubRootNode(bytes32) external override {}
+
+    function setValidatorMerkleRoot(bytes32) external override {}
+
+    function bumpValidatorAuthCacheVersion() external override {}
+
 }
 

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -174,5 +174,13 @@ contract NoValidationModule is IValidationModule, Ownable {
         override
     {}
 
+    /// @inheritdoc IValidationModule
+    function setClubRootNode(bytes32) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setValidatorMerkleRoot(bytes32) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function bumpValidatorAuthCacheVersion() external pure override {}
 }
 

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -197,5 +197,13 @@ contract OracleValidationModule is IValidationModule, Ownable {
         override
     {}
 
+    /// @inheritdoc IValidationModule
+    function setClubRootNode(bytes32) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setValidatorMerkleRoot(bytes32) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function bumpValidatorAuthCacheVersion() external pure override {}
 }
 

--- a/test/v2/JobRegistryAuthCache.test.js
+++ b/test/v2/JobRegistryAuthCache.test.js
@@ -81,7 +81,7 @@ describe('JobRegistry agent auth cache', function () {
     expect(gas3).to.be.gt(gas2);
   });
 
-  it('invalidates cached authorization on root update', async () => {
+  it('invalidates cached authorization on Merkle root update', async () => {
     const Identity = await ethers.getContractFactory(
       'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'
     );
@@ -140,6 +140,75 @@ describe('JobRegistry agent auth cache', function () {
       .connect(owner)
       .transferOwnership(await registry2.getAddress());
     await registry2.connect(owner).setAgentMerkleRoot(ethers.id('newroot'));
+
+    deadline = (await time.latest()) + 100;
+    await registry2.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await expect(
+      registry2.connect(agent).applyForJob(3, 'a', [])
+    ).to.be.revertedWithCustomError(registry2, 'NotAuthorizedAgent');
+  });
+
+  it('invalidates cached authorization on root node update', async () => {
+    const Identity = await ethers.getContractFactory(
+      'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'
+    );
+    const verifier2 = await Identity.connect(owner).deploy();
+    await verifier2.waitForDeployment();
+    await verifier2.setAgentRootNode(ethers.ZeroHash);
+
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/JobRegistry.sol:JobRegistry'
+    );
+    const registry2 = await Registry.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    await registry2.waitForDeployment();
+    await verifier2.connect(owner).setResult(true);
+    await registry2
+      .connect(owner)
+      .setIdentityRegistry(await verifier2.getAddress());
+
+    const Policy = await ethers.getContractFactory(
+      'contracts/v2/TaxPolicy.sol:TaxPolicy'
+    );
+    const policy2 = await Policy.deploy('uri', 'ack');
+    await registry2.connect(owner).setTaxPolicy(await policy2.getAddress());
+    await policy2.connect(employer).acknowledge();
+    await policy2.connect(agent).acknowledge();
+
+    await registry2.connect(owner).setMaxJobReward(1000);
+    await registry2.connect(owner).setJobDurationLimit(1000);
+    await registry2.connect(owner).setFeePct(0);
+    await registry2.connect(owner).setJobParameters(0, 0);
+    await registry2.connect(owner).setAgentAuthCacheDuration(1000);
+
+    let deadline = (await time.latest()) + 100;
+    const specHash = ethers.id('spec');
+    await registry2.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await registry2.connect(agent).applyForJob(1, 'a', []);
+
+    await verifier2.connect(owner).setResult(false);
+
+    deadline = (await time.latest()) + 100;
+    await registry2.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await registry2.connect(agent).applyForJob(2, 'a', []);
+
+    await verifier2
+      .connect(owner)
+      .transferOwnership(await registry2.getAddress());
+    await registry2
+      .connect(owner)
+      .setAgentRootNode(ethers.id('newroot'));
 
     deadline = (await time.latest()) + 100;
     await registry2.connect(employer).createJob(1, deadline, specHash, 'uri');

--- a/test/v2/ValidatorSelectionCache.test.js
+++ b/test/v2/ValidatorSelectionCache.test.js
@@ -3,11 +3,12 @@ const { ethers } = require('hardhat');
 const { time } = require('@nomicfoundation/hardhat-network-helpers');
 
 describe('Validator selection cache', function () {
-  let validation, stake, identity, other;
+  let validation, stake, identity, owner, other;
 
   beforeEach(async () => {
-    const [_, o] = await ethers.getSigners();
-    other = o;
+    const [o1, o2] = await ethers.getSigners();
+    owner = o1;
+    other = o2;
 
     const StakeMock = await ethers.getContractFactory('MockStakeManager');
     stake = await StakeMock.deploy();
@@ -72,5 +73,61 @@ describe('Validator selection cache', function () {
     const tx3 = await select(3);
     const gas3 = (await tx3.wait()).gasUsed;
     expect(gas3).to.be.gt(gas2);
+  });
+
+  it('invalidates cached validator authorization on club root update', async () => {
+    const StakeMock = await ethers.getContractFactory('MockStakeManager');
+    const stake2 = await StakeMock.deploy();
+    await stake2.waitForDeployment();
+
+    const Identity = await ethers.getContractFactory(
+      'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'
+    );
+    const identity2 = await Identity.deploy();
+    await identity2.waitForDeployment();
+    await identity2.setClubRootNode(ethers.ZeroHash);
+    await identity2.setAgentRootNode(ethers.ZeroHash);
+
+    const Validation = await ethers.getContractFactory(
+      'contracts/v2/ValidationModule.sol:ValidationModule'
+    );
+    const validation2 = await Validation.deploy(
+      ethers.ZeroAddress,
+      await stake2.getAddress(),
+      1,
+      1,
+      1,
+      10,
+      []
+    );
+    await validation2.waitForDeployment();
+    await validation2.setIdentityRegistry(await identity2.getAddress());
+    await validation2.setValidatorsPerJob(1);
+
+    const validator = ethers.Wallet.createRandom().address;
+    await stake2.setStake(validator, 1, ethers.parseEther('1'));
+    await identity2.addAdditionalValidator(validator);
+    await validation2.setValidatorPool([validator]);
+
+    await identity2.setResult(true);
+
+    await validation2.selectValidators(1, 0);
+    await ethers.provider.send('evm_mine', []);
+    await validation2.connect(other).selectValidators(1, 0);
+
+    await identity2.setResult(false);
+
+    await validation2.selectValidators(2, 0);
+    await ethers.provider.send('evm_mine', []);
+    await validation2.connect(other).selectValidators(2, 0);
+
+    await identity2.transferOwnership(await validation2.getAddress());
+    await validation2.setClubRootNode(ethers.id('newclub'));
+
+    await validation2.selectValidators(3, 0);
+    await ethers.provider.send('evm_mine', []);
+    await expect(
+      validation2.connect(other).selectValidators(3, 0)
+    ).to.be.revertedWithCustomError(validation2, 'InsufficientValidators');
   });
 });


### PR DESCRIPTION
## Summary
- Bump agent auth cache when JobRegistry ENS root updates
- Add setter wrappers in ValidationModule for club root and validator allowlist
- Document new identity cache invalidation behaviour and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbb165a2748333b8f6ba79e8696ac2