### PR TITLE
docs: document ENS identity enforcement policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 
 All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes and dispute deposits with the token address fixed at deployment. The canonical token is deployed externally; this repository ships [`contracts/test/AGIALPHAToken.sol`](contracts/test/AGIALPHAToken.sol) for local testing only. Token address and decimal configuration live in [`config/agialpha.json`](config/agialpha.json) and feed both Solidity and TypeScript consumers.
 
+### Identity policy
+
+Agents and validators must own ENS subdomains under `agent.agi.eth` and `club.agi.eth`. All workflows perform on-chain verification and bypass mechanisms are reserved for emergency governance only. See [docs/ens-identity-policy.md](docs/ens-identity-policy.md) for details.
+
 ### AGIALPHA configuration
 
 Token parameters are defined once in [`config/agialpha.json`](config/agialpha.json). Run `npm run compile` after editing this file to regenerate `contracts/v2/Constants.sol` with the canonical token address, decimals, scaling factor and burn address. Any change to `config/agialpha.json` must be followed by `npm run compile` or the constants check in CI will fail.

--- a/docs/ens-identity-policy.md
+++ b/docs/ens-identity-policy.md
@@ -1,0 +1,23 @@
+# ENS Identity Enforcement Policy
+
+All participation in AGIJobs requires on‑chain proof of ENS subdomain ownership. This policy ensures agents and validators cannot bypass identity checks.
+
+## Requirements
+
+- **Agents** must own an ENS subdomain under `agent.agi.eth` and present it when applying for or submitting jobs.
+- **Validators** must own a subdomain under `club.agi.eth` for committing or revealing validation results.
+- Owner controlled allowlists and Merkle proofs exist only for emergency governance and migration. Regular participants are expected to use ENS.
+- Attestations may be recorded in `AttestationRegistry` to cache successful checks and reduce gas usage, but they do not bypass the ENS requirement.
+
+## Testing
+
+Run these commands before pushing changes that touch identity or access control logic:
+
+```bash
+npm run lint
+npm test
+# optionally target identity tests directly
+npx hardhat test test/v2/identity.test.ts
+```
+
+These tests exercise the ENS verification paths in `IdentityRegistry`, `JobRegistry` and `ValidationModule`, preventing regressions that could allow unverified addresses.


### PR DESCRIPTION
## Summary
- add ENS identity enforcement policy detailing mandatory agent and validator subdomains
- link policy from README and provide lint/test commands for contributors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc180030888333b7c3dbdfa3b1ea12