### PR TITLE
Invalidate agent auth cache on root node change

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -409,6 +409,9 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     function setAgentRootNode(bytes32 node) external onlyGovernance {
         if (address(identityRegistry) == address(0)) revert IdentityRegistryNotSet();
         identityRegistry.setAgentRootNode(node);
+        unchecked {
+            agentAuthCacheVersion++;
+        }
         emit AgentRootNodeUpdated(node);
     }
 


### PR DESCRIPTION
## Summary
- increment JobRegistry's cache version when agent root node updates
- add regression test requiring agents to re-verify after root node change

## Testing
- `npm test test/v2/JobRegistryAuthCache.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bc2b4fa4c083338074813e3a52a038