### PR TITLE
chore: remove legacy validation overloads

### DIFF
--- a/agent-gateway/index.js
+++ b/agent-gateway/index.js
@@ -83,8 +83,8 @@ const JOB_REGISTRY_ABI = [
 // Minimal ABI for ValidationModule interactions
 const VALIDATION_MODULE_ABI = [
   'function jobNonce(uint256 jobId) view returns (uint256)',
-  'function commitValidation(uint256 jobId, bytes32 commitHash)',
-  'function revealValidation(uint256 jobId, bool approve, bytes32 salt)',
+  'function commitValidation(uint256 jobId, bytes32 commitHash, string subdomain, bytes32[] proof)',
+  'function revealValidation(uint256 jobId, bool approve, bytes32 salt, string subdomain, bytes32[] proof)',
   'function finalize(uint256 jobId) external returns (bool)',
   'function rounds(uint256 jobId) view returns (address[] validators,address[] participants,uint256 commitDeadline,uint256 revealDeadline,uint256 approvals,uint256 rejections,bool tallied,uint256 committeeSize)',
   'event ValidatorsSelected(uint256 indexed jobId, address[] validators)',
@@ -290,7 +290,7 @@ async function commitHelper(jobId, wallet, approve) {
   );
   const tx = await validation
     .connect(wallet)
-    .commitValidation(jobId, commitHash);
+    .commitValidation(jobId, commitHash, '', []);
   await tx.wait();
   if (!commits.has(jobId)) commits.set(jobId, {});
   const jobCommits = commits.get(jobId);
@@ -305,7 +305,7 @@ async function revealHelper(jobId, wallet) {
   if (!data) throw new Error('no commit found');
   const tx = await validation
     .connect(wallet)
-    .revealValidation(jobId, data.approve, data.salt);
+    .revealValidation(jobId, data.approve, data.salt, '', []);
   await tx.wait();
   delete jobCommits[wallet.address.toLowerCase()];
   return { tx: tx.hash };

--- a/apps/validator-ui/lib/commit.js
+++ b/apps/validator-ui/lib/commit.js
@@ -14,7 +14,7 @@ function scheduleReveal(contract, jobId, approve, salt, delayMs, specHash) {
     setTimeout(async () => {
       try {
         const tx = contract.revealValidation
-          ? await contract.revealValidation(jobId, approve, salt)
+          ? await contract.revealValidation(jobId, approve, salt, '', [])
           : await contract.reveal(jobId, approve, salt, specHash);
         await tx.wait();
         resolve(tx);

--- a/apps/validator-ui/pages/index.tsx
+++ b/apps/validator-ui/pages/index.tsx
@@ -72,8 +72,8 @@ export default function Home() {
     }
     const abi = [
       'function jobNonce(uint256 jobId) view returns (uint256)',
-      'function commitValidation(uint256 jobId, bytes32 commitHash)',
-      'function revealValidation(uint256 jobId, bool approve, bytes32 salt)'
+      'function commitValidation(uint256 jobId, bytes32 commitHash, string subdomain, bytes32[] proof)',
+      'function revealValidation(uint256 jobId, bool approve, bytes32 salt, string subdomain, bytes32[] proof)'
     ];
     const contract = new ethers.Contract(validationAddr, abi, signer);
     const nonce: bigint = await contract.jobNonce(jobId);
@@ -84,7 +84,7 @@ export default function Home() {
       undefined,
       specHash
     );
-    const tx = await contract.commitValidation(jobId, commitHash);
+    const tx = await contract.commitValidation(jobId, commitHash, '', []);
     await tx.wait();
     setMessage('Commit submitted, scheduling reveal');
     const delay = Number(process.env.NEXT_PUBLIC_REVEAL_DELAY_MS || '5000');

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1037,25 +1037,6 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         _commitValidation(jobId, commitHash, subdomain, proof);
     }
 
-    /// @notice Backwards-compatible commit function without ENS parameters.
-    /// @param jobId Identifier of the job.
-    /// @param commitHash Hash of the vote and salt.
-    function commitValidation(uint256 jobId, bytes32 commitHash)
-        public
-        whenNotPaused
-        override
-        nonReentrant
-        requiresTaxAcknowledgement(
-            _policy(),
-            msg.sender,
-            owner(),
-            address(0),
-            address(0)
-        )
-    {
-        bytes32[] memory proof;
-        _commitValidation(jobId, commitHash, "", proof);
-    }
 
     /// @notice Internal reveal logic shared by overloads.
     function _revealValidation(
@@ -1129,26 +1110,6 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         _revealValidation(jobId, approve, salt, subdomain, proof);
     }
 
-    /// @notice Backwards-compatible reveal function without ENS parameters.
-    /// @param jobId Identifier of the job.
-    /// @param approve True to approve, false to reject.
-    /// @param salt Salt used in the original commitment.
-    function revealValidation(uint256 jobId, bool approve, bytes32 salt)
-        public
-        whenNotPaused
-        override
-        nonReentrant
-        requiresTaxAcknowledgement(
-            _policy(),
-            msg.sender,
-            owner(),
-            address(0),
-            address(0)
-        )
-    {
-        bytes32[] memory proof;
-        _revealValidation(jobId, approve, salt, "", proof);
-    }
 
     /// @notice Backwards-compatible wrapper for commitValidation.
     function commitVote(

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -60,8 +60,6 @@ interface IValidationModule {
         bytes32[] calldata proof
     ) external;
 
-    /// @notice Commit a validation hash without ENS parameters (legacy wrapper)
-    function commitValidation(uint256 jobId, bytes32 commitHash) external;
 
     /// @notice Reveal a previously committed validation vote
     /// @param jobId Identifier of the job
@@ -77,8 +75,6 @@ interface IValidationModule {
         bytes32[] calldata proof
     ) external;
 
-    /// @notice Reveal a previously committed validation vote (legacy wrapper)
-    function revealValidation(uint256 jobId, bool approve, bytes32 salt) external;
 
     /// @notice Finalize validation round and slash incorrect validators
     /// @param jobId Identifier of the job

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -43,8 +43,6 @@ contract ValidationStub is IValidationModule {
         bytes32[] calldata
     ) external override {}
 
-    function commitValidation(uint256, bytes32) external override {}
-
     function revealValidation(
         uint256,
         bool,
@@ -52,8 +50,6 @@ contract ValidationStub is IValidationModule {
         string calldata,
         bytes32[] calldata
     ) external override {}
-
-    function revealValidation(uint256, bool, bytes32) external override {}
 
     function finalize(uint256 jobId) external override returns (bool success) {
         success = result;

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -56,12 +56,6 @@ contract NoValidationModule is IValidationModule, Ownable {
         bytes32[] calldata
     ) external pure override {}
 
-    /// @inheritdoc IValidationModule
-    function commitValidation(uint256, bytes32)
-        external
-        pure
-        override
-    {}
 
     /// @inheritdoc IValidationModule
     function revealValidation(
@@ -72,12 +66,6 @@ contract NoValidationModule is IValidationModule, Ownable {
         bytes32[] calldata
     ) external pure override {}
 
-    /// @inheritdoc IValidationModule
-    function revealValidation(uint256, bool, bytes32)
-        external
-        pure
-        override
-    {}
 
     /// @inheritdoc IValidationModule
     function finalize(uint256) external pure override returns (bool) {

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -79,12 +79,6 @@ contract OracleValidationModule is IValidationModule, Ownable {
         bytes32[] calldata
     ) external pure override {}
 
-    /// @inheritdoc IValidationModule
-    function commitValidation(uint256, bytes32)
-        external
-        pure
-        override
-    {}
 
     /// @inheritdoc IValidationModule
     function revealValidation(
@@ -95,12 +89,6 @@ contract OracleValidationModule is IValidationModule, Ownable {
         bytes32[] calldata
     ) external pure override {}
 
-    /// @inheritdoc IValidationModule
-    function revealValidation(uint256, bool, bytes32)
-        external
-        pure
-        override
-    {}
 
     /// @inheritdoc IValidationModule
     function finalize(uint256) external pure override returns (bool) {

--- a/docs/MASTER_GUIDE.md
+++ b/docs/MASTER_GUIDE.md
@@ -281,7 +281,7 @@ All amounts are `$AGIALPHA` **wei** (18 decimals). **Always** `approve` the rele
    * `ValidationModule.commitValidation(jobId, commitHash, subdomainLabel, proof[])`
 3. **Reveal** (during reveal window):
 
-   * `ValidationModule.revealValidation(jobId, approveBool, salt)`
+   * `ValidationModule.revealValidation(jobId, approveBool, salt, subdomain, proof)`
 
 ### 8.4 Finalize & Payouts
 
@@ -393,7 +393,7 @@ Create `docs/deployment-addresses.json` (or similar) and keep it updated:
 **ValidationModule**
 
 * `commitValidation(jobId, commitHash, subdomainLabel, proof[])`
-* `revealValidation(jobId, approve, salt)`
+* `revealValidation(jobId, approve, salt, subdomain, proof)`
 * `finalize(jobId)`
 * Setters: `setJobRegistry(addr)`, `setCommitWindow(sec)`, `setRevealWindow(sec)`, `setIdentityRegistry(addr)`
 

--- a/docs/agialpha-workflows.md
+++ b/docs/agialpha-workflows.md
@@ -16,7 +16,7 @@ This guide summarises Etherscan-based interactions for the $AGIALPHA-powered AGI
 
 1. **Stake** – approve tokens and call `StakeManager.depositStake(1, amount)`.
 2. **Commit** – during the commit window call `ValidationModule.commitValidation(jobId, hash, subdomain, proof)` with your `.club.agi.eth` label.
-3. **Reveal** – when the reveal window opens call `ValidationModule.revealValidation(jobId, approve, salt)`.
+3. **Reveal** – when the reveal window opens call `ValidationModule.revealValidation(jobId, approve, salt, subdomain, proof)`.
 
 ## 4. Raise a Dispute (Anyone)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -42,7 +42,10 @@ StakeManager(stake).depositStake(0, 1_000000000000000000);
 
 ## ValidationModule
 
-Selects validators and manages commit‑reveal voting on submissions.
+Selects validators and manages commit‑reveal voting on submissions. Both
+`commitValidation` and `revealValidation` now **require** ENS `subdomain` and
+Merkle `proof` parameters. Validators without an ENS identity should pass an
+empty string and empty proof array.
 
 ### Key Functions
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,12 +55,12 @@ Manages commit‑reveal voting by validators.
 
 - `start(jobId, entropy)` – select validators and open the commit window.
 - `selectValidators(jobId, entropy)` – choose validators for a job.
-- `commitValidation(jobId, commitHash)` / `revealValidation(jobId, approve, salt)` – validator vote flow.
+- `commitValidation(jobId, commitHash, subdomain, proof)` / `revealValidation(jobId, approve, salt, subdomain, proof)` – validator vote flow.
 - `finalize(jobId)` – tallies votes and notifies `JobRegistry`.
 
 ```javascript
-await validation.commitValidation(jobId, commitHash);
-await validation.revealValidation(jobId, true, salt);
+await validation.commitValidation(jobId, commitHash, '', []);
+await validation.revealValidation(jobId, true, salt, '', []);
 ```
 
 ## DisputeModule

--- a/docs/api/ValidationModule.md
+++ b/docs/api/ValidationModule.md
@@ -12,8 +12,8 @@ Manages commit‑reveal voting for submitted jobs.
 - `setSelectionStrategy(SelectionStrategy strategy)` – choose between a rotating window or reservoir sampling. Governance can adjust this to balance gas cost and fairness.
 - `start(uint256 jobId, uint256 entropy)` – select validators and open the commit window.
 - `selectValidators(uint256 jobId, uint256 entropy)` – pick validators using on-chain randomness; mixes `block.prevrandao` or, if unavailable, recent block hashes with `msg.sender` so no off-chain randomness provider is required.
-- `commitValidation(uint256 jobId, bytes32 commitHash)` – validator commits to a vote.
-- `revealValidation(uint256 jobId, bool approve, bytes32 salt)` – reveal vote.
+- `commitValidation(uint256 jobId, bytes32 commitHash, string subdomain, bytes proof)` – commit to a vote (ENS parameters required).
+- `revealValidation(uint256 jobId, bool approve, bytes32 salt, string subdomain, bytes proof)` – reveal vote (ENS parameters required).
 - `finalize(uint256 jobId)` – tally reveals and trigger payout.
 - `resetJobNonce(uint256 jobId)` – clear validator commitments for a job.
 

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -131,8 +131,8 @@ interface IJobRegistry {
 
 interface IValidationModule {
     function selectValidators(uint256 jobId) external returns (address[] memory);
-    function commitValidation(uint256 jobId, bytes32 commitHash) external;
-    function revealValidation(uint256 jobId, bool approve, bytes32 salt) external;
+    function commitValidation(uint256 jobId, bytes32 commitHash, string calldata subdomain, bytes32[] calldata proof) external;
+    function revealValidation(uint256 jobId, bool approve, bytes32 salt, string calldata subdomain, bytes32[] calldata proof) external;
     function finalize(uint256 jobId) external returns (bool success);
     function setParameters(
         uint256 validatorStakeRequirement,

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -23,7 +23,7 @@ For a narrated deployment walkthrough, see [deployment-v2-agialpha.md](deploymen
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | Employer  | `$AGIALPHA.approve(StakeManager, 1_050000000000000000)` → `JobRegistry.acknowledgeTaxPolicy()` → `JobRegistry.createJob(1_000000000000000000, uri)`                                                                                       | approve `1_050000000000000000` for a 1‑token reward + 5% fee |
 | Agent     | `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` → `JobRegistry.stakeAndApply(jobId, 1_000000000000000000)`                                                                                                                        | stake `1_000000000000000000`                                 |
-| Validator | `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` → `StakeManager.depositStake(1, 1_000000000000000000)` → `ValidationModule.commitValidation(jobId, hash, sub, proof)` → `ValidationModule.revealValidation(jobId, approve, salt)` | stake `1_000000000000000000`                                 |
+| Validator | `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` → `StakeManager.depositStake(1, 1_000000000000000000)` → `ValidationModule.commitValidation(jobId, hash, sub, proof)` → `ValidationModule.revealValidation(jobId, approve, salt, sub, proof)` | stake `1_000000000000000000`                                 |
 | Disputer  | `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` → `JobRegistry.acknowledgeAndDispute(jobId, evidence)` → `DisputeModule.resolve(jobId, uphold, signatures)` (majority moderators or owner)                                        | dispute fee `1_000000000000000000`                           |
 
 ## ENS prerequisites
@@ -158,8 +158,8 @@ Before performing any on-chain action, employers, agents, and validators must ca
    depositStake(1, amount)
    ```
 
-3. During validation, open `ValidationModule`, confirm **isTaxExempt()**, and send hashed votes with **commitValidation(jobId, commitHash)**.
-4. Reveal decisions using **revealValidation(jobId, approve, salt)** before the window closes.
+3. During validation, open `ValidationModule`, confirm **isTaxExempt()**, and send hashed votes with **commitValidation(jobId, commitHash, subdomain, proof)**.
+4. Reveal decisions using **revealValidation(jobId, approve, salt, subdomain, proof)** before the window closes.
 
 ### Tax Policy
 
@@ -213,7 +213,7 @@ The `TaxPolicy` contract is informational only: it never holds funds and imposes
 ### Commit & reveal validation votes
 
 1. During the commit window open `ValidationModule` → **Write** and call **commitValidation(jobId, hash, subdomain, proof)**.
-2. When the reveal window opens, call **revealValidation(jobId, approve, salt)** from the same address.
+2. When the reveal window opens, call **revealValidation(jobId, approve, salt, subdomain, proof)** from the same address.
 
 ### Raise & resolve disputes
 

--- a/docs/job-validation-lifecycle.md
+++ b/docs/job-validation-lifecycle.md
@@ -6,8 +6,8 @@ This guide shows how a validator processes one job from commitment to finalizati
 
 | Phase    | Validator state   | Allowed window                             | Function                                                              |
 | -------- | ----------------- | ------------------------------------------ | --------------------------------------------------------------------- |
-| Commit   | Commitment stored | `commitWindow` seconds after selection     | `ValidationModule.commitValidation(jobId, commitHash)`                |
-| Reveal   | Vote disclosed    | `revealWindow` seconds after commit window | `ValidationModule.revealValidation(jobId, approve, salt)`             |
+| Commit   | Commitment stored | `commitWindow` seconds after selection     | `ValidationModule.commitValidation(jobId, commitHash, subdomain, proof)`                |
+| Reveal   | Vote disclosed    | `revealWindow` seconds after commit window | `ValidationModule.revealValidation(jobId, approve, salt, subdomain, proof)`             |
 | Finalize | Job settled       | After `revealWindow` closes                | `ValidationModule.finalize(jobId)` then `JobRegistry.finalize(jobId)` |
 
 `commitWindow` and `revealWindow` are owner‑configurable via `ValidationModule.setCommitRevealWindows`.
@@ -17,9 +17,9 @@ This guide shows how a validator processes one job from commitment to finalizati
 ```solidity
 bytes32 salt = keccak256(abi.encodePacked(block.timestamp, msg.sender));
 bytes32 commitHash = keccak256(abi.encode(true, salt));
-validationModule.commitValidation(jobId, commitHash);
+validationModule.commitValidation(jobId, commitHash, '', new bytes32[](0));
 // ... wait for the commit window to close
-validationModule.revealValidation(jobId, true, salt);
+validationModule.revealValidation(jobId, true, salt, '', new bytes32[](0));
 // ... wait for the reveal window to close
 validationModule.finalize(jobId);
 jobRegistry.finalize(jobId);
@@ -29,10 +29,10 @@ jobRegistry.finalize(jobId);
 
 ```bash
 # Commit during the commit window
-cast send $VALIDATION_MODULE "commitValidation(uint256,bytes32)" $JOB_ID 0xCOMMIT --from $VALIDATOR
+cast send $VALIDATION_MODULE "commitValidation(uint256,bytes32,string,bytes32[])" $JOB_ID 0xCOMMIT '' [] --from $VALIDATOR
 
 # Reveal after the commit window
-cast send $VALIDATION_MODULE "revealValidation(uint256,bool,bytes32)" $JOB_ID true 0xSALT --from $VALIDATOR
+cast send $VALIDATION_MODULE "revealValidation(uint256,bool,bytes32,string,bytes32[])" $JOB_ID true 0xSALT '' [] --from $VALIDATOR
 
 # Finalize after the reveal window
 cast send $VALIDATION_MODULE "finalize(uint256)" $JOB_ID --from $ANYONE

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -46,10 +46,10 @@ const validation = await ethers.getContractAt(
 );
 
 // Commit phase
-await validation.commitValidation(jobId, commitHash);
+await validation.commitValidation(jobId, commitHash, '', []);
 
 // Reveal phase
-await validation.revealValidation(jobId, true, salt);
+await validation.revealValidation(jobId, true, salt, '', []);
 ```
 
 ## 4. Finalize

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -132,7 +132,8 @@ then be performed through the "Write" tabs on each module.
 
 1. During commit phase, validators call
    `ValidationModule.commitValidation(jobId, commitHash, subdomain, proof)`.
-2. During reveal phase, call `revealValidation(jobId, approve, salt)`.
+2. During reveal phase, call
+   `revealValidation(jobId, approve, salt, subdomain, proof)`.
 3. After reveal, anyone may call `finalize(jobId)`.
 
 ### Dispute

--- a/examples/ethers-quickstart.js
+++ b/examples/ethers-quickstart.js
@@ -15,8 +15,8 @@ const registryAbi = [
 ];
 const stakeAbi = ['function depositStake(uint8 role, uint256 amount)'];
 const validationAbi = [
-  'function commitValidation(uint256 jobId, bytes32 hash, bytes32 label, bytes32[] proof)',
-  'function revealValidation(uint256 jobId, bool approve, bytes32 salt)',
+  'function commitValidation(uint256 jobId, bytes32 hash, string subdomain, bytes32[] proof)',
+  'function revealValidation(uint256 jobId, bool approve, bytes32 salt, string subdomain, bytes32[] proof)',
   'function finalize(uint256 jobId)',
 ];
 
@@ -73,7 +73,7 @@ async function submit(jobId, uri) {
 
 async function validate(jobId, hash, label, proof, approve, salt) {
   await validation.commitValidation(jobId, hash, label, proof);
-  await validation.revealValidation(jobId, approve, salt);
+  await validation.revealValidation(jobId, approve, salt, label, proof);
   await validation.finalize(jobId);
 }
 

--- a/examples/web3py-quickstart.py
+++ b/examples/web3py-quickstart.py
@@ -42,7 +42,7 @@ def commit_and_reveal(job_id, commit_hash, label, proof, approve, salt):
     signed = account.sign_transaction(tx)
     w3.eth.send_raw_transaction(signed.rawTransaction)
 
-    tx2 = validation.functions.revealValidation(job_id, approve, salt).build_transaction({
+    tx2 = validation.functions.revealValidation(job_id, approve, salt, label, proof).build_transaction({
         "from": account.address,
         "nonce": w3.eth.get_transaction_count(account.address)
     })

--- a/test/v2/ValidationFinalizeGas.t.sol
+++ b/test/v2/ValidationFinalizeGas.t.sol
@@ -89,10 +89,10 @@ contract ValidationFinalizeGas is Test {
                 abi.encodePacked(jobId, nonce, true, salt, bytes32(0))
             );
             vm.prank(val);
-            validation.commitValidation(jobId, commitHash);
+            validation.commitValidation(jobId, commitHash, "", new bytes32[](0));
             vm.warp(block.timestamp + 2);
             vm.prank(val);
-            validation.revealValidation(jobId, true, salt);
+            validation.revealValidation(jobId, true, salt, "", new bytes32[](0));
         }
     }
 

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -175,7 +175,7 @@ describe('job lifecycle with dispute and validator failure', function () {
         [1n, nonce, true, salt1, specHash]
       )
     );
-    await validation.connect(v1).commitValidation(1, commit1);
+    await validation.connect(v1).commitValidation(1, commit1, '', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
@@ -183,10 +183,10 @@ describe('job lifecycle with dispute and validator failure', function () {
         [1n, nonce, false, salt2, specHash]
       )
     );
-    await validation.connect(v2).commitValidation(1, commit2);
+    await validation.connect(v2).commitValidation(1, commit2, '', []);
 
     await time.increase(2);
-    await validation.connect(v1).revealValidation(1, true, salt1);
+    await validation.connect(v1).revealValidation(1, true, salt1, '', []);
     // v2 fails to reveal
     await time.increase(2);
     await validation.finalize(1);

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -177,7 +177,7 @@ describe('Kleros dispute module', function () {
         [1n, nonce, true, salt1, specHash]
       )
     );
-    await validation.connect(v1).commitValidation(1, commit1);
+    await validation.connect(v1).commitValidation(1, commit1, '', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
@@ -185,10 +185,10 @@ describe('Kleros dispute module', function () {
         [1n, nonce, false, salt2, specHash]
       )
     );
-    await validation.connect(v2).commitValidation(1, commit2);
+    await validation.connect(v2).commitValidation(1, commit2, '', []);
 
     await time.increase(2);
-    await validation.connect(v1).revealValidation(1, true, salt1);
+    await validation.connect(v1).revealValidation(1, true, salt1, '', []);
     // v2 fails to reveal
     await time.increase(2);
     await validation.finalize(1);

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -186,9 +186,9 @@ describe('regression scenarios', function () {
         [1n, nonce, false, salt, specHash]
       )
     );
-    await validation.connect(v1).commitValidation(1, commit);
+    await validation.connect(v1).commitValidation(1, commit, '', []);
     await time.increase(2);
-    await validation.connect(v1).revealValidation(1, false, salt);
+    await validation.connect(v1).revealValidation(1, false, salt, '', []);
     await time.increase(2);
     await validation.finalize(1);
 

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -163,7 +163,7 @@ describe('validator participation', function () {
         [1n, nonce, true, salt1, specHash]
       )
     );
-    await validation.connect(v1).commitValidation(1, commit1);
+    await validation.connect(v1).commitValidation(1, commit1, '', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
@@ -171,11 +171,11 @@ describe('validator participation', function () {
         [1n, nonce, true, salt2, specHash]
       )
     );
-    await validation.connect(v2).commitValidation(1, commit2);
+    await validation.connect(v2).commitValidation(1, commit2, '', []);
 
     await time.increase(2);
-    await validation.connect(v1).revealValidation(1, true, salt1);
-    await validation.connect(v2).revealValidation(1, true, salt2);
+    await validation.connect(v1).revealValidation(1, true, salt1, '', []);
+    await validation.connect(v2).revealValidation(1, true, salt2, '', []);
     await time.increase(2);
     await validation.finalize(1);
 
@@ -227,7 +227,7 @@ describe('validator participation', function () {
         [1n, nonce, false, salt1, specHash]
       )
     );
-    await validation.connect(v1).commitValidation(1, commit1);
+    await validation.connect(v1).commitValidation(1, commit1, '', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
@@ -235,11 +235,11 @@ describe('validator participation', function () {
         [1n, nonce, false, salt2, specHash]
       )
     );
-    await validation.connect(v2).commitValidation(1, commit2);
+    await validation.connect(v2).commitValidation(1, commit2, '', []);
 
     await time.increase(2);
-    await validation.connect(v1).revealValidation(1, false, salt1);
-    await validation.connect(v2).revealValidation(1, false, salt2);
+    await validation.connect(v1).revealValidation(1, false, salt1, '', []);
+    await validation.connect(v2).revealValidation(1, false, salt2, '', []);
     await time.increase(2);
     await validation.finalize(1);
 


### PR DESCRIPTION
## Summary
- drop commit/reveal overloads without ENS parameters
- update contract interface, examples, apps, and tests to require subdomain and proof
- document ENS requirement for commit/reveal in API reference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2ddc097083339d22f36aa9602295