### PR TITLE
feat: expire validator auth cache on identity updates

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -200,6 +200,8 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
 
     event AgentRootNodeUpdated(bytes32 node);
     event AgentMerkleRootUpdated(bytes32 root);
+    event ValidatorRootNodeUpdated(bytes32 node);
+    event ValidatorMerkleRootUpdated(bytes32 root);
     event AgentAuthCacheUpdated(address indexed agent, bool authorized);
     event AgentAuthCacheDurationUpdated(uint256 duration);
 
@@ -424,6 +426,26 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             agentAuthCacheVersion++;
         }
         emit AgentMerkleRootUpdated(root);
+    }
+
+    /// @notice Update the ENS root node used for validator verification.
+    /// @param node Namehash of the validator parent node (e.g. `club.agi.eth`).
+    function setValidatorRootNode(bytes32 node) external onlyGovernance {
+        if (address(identityRegistry) == address(0)) revert IdentityRegistryNotSet();
+        if (address(validationModule) == address(0)) revert InvalidValidationModule();
+        identityRegistry.setClubRootNode(node);
+        validationModule.bumpValidatorAuthCacheVersion();
+        emit ValidatorRootNodeUpdated(node);
+    }
+
+    /// @notice Update the Merkle root for the validator allowlist.
+    /// @param root Merkle root of approved validator addresses.
+    function setValidatorMerkleRoot(bytes32 root) external onlyGovernance {
+        if (address(identityRegistry) == address(0)) revert IdentityRegistryNotSet();
+        if (address(validationModule) == address(0)) revert InvalidValidationModule();
+        identityRegistry.setValidatorMerkleRoot(root);
+        validationModule.bumpValidatorAuthCacheVersion();
+        emit ValidatorMerkleRootUpdated(root);
     }
 
     /// @notice Refresh or invalidate cached agent authorization entries.

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -141,6 +141,9 @@ interface IValidationModule {
     /// @notice Configure the validator sampling strategy.
     function setSelectionStrategy(SelectionStrategy strategy) external;
 
+    /// @notice Invalidate all cached validator authorizations.
+    function bumpValidatorAuthCacheVersion() external;
+
 
     /// @notice Return validators selected for a job
     /// @param jobId Identifier of the job

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -112,5 +112,7 @@ contract ValidationStub is IValidationModule {
 
     function setSelectionStrategy(IValidationModule.SelectionStrategy) external override {}
 
+    function bumpValidatorAuthCacheVersion() external override {}
+
 }
 

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -162,5 +162,7 @@ contract NoValidationModule is IValidationModule, Ownable {
         override
     {}
 
+    function bumpValidatorAuthCacheVersion() external pure override {}
+
 }
 

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -185,5 +185,7 @@ contract OracleValidationModule is IValidationModule, Ownable {
         override
     {}
 
+    function bumpValidatorAuthCacheVersion() external pure override {}
+
 }
 

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -176,7 +176,7 @@ then be performed through the "Write" tabs on each module.
 | `DisputeModule`    | `setDisputeFee(fee)`       | Fee required to raise a dispute                 |
 | `FeePool`          | `setBurnPct(pct)`          | Portion of fees burned before distribution      |
 
-- **Manage allowlists:** on `IdentityRegistry` use `setAgentMerkleRoot(root)`, `setValidatorMerkleRoot(root)`, `addAdditionalAgent(addr)` and `addAdditionalValidator(addr)`; update ENS roots with `setAgentRootNode(node)` and `setClubRootNode(node)`.
+- **Manage allowlists:** use `JobRegistry.setAgentRootNode(node)` / `setAgentMerkleRoot(root)` for agents and `JobRegistry.setValidatorRootNode(node)` / `setValidatorMerkleRoot(root)` for validators. These call the underlying `IdentityRegistry` setters and automatically bump the `ValidationModule` validator auth cache so outdated entries expire. Add individual addresses with `IdentityRegistry.addAdditionalAgent(addr)` and `addAdditionalValidator(addr)`.
 - **Transfer ownership:** hand governance to a multisig or timelock so no
   single key can change parameters:
   - `StakeManager.setGovernance(multisig)`

--- a/test/v2/ValidatorAuthCacheInvalidation.test.js
+++ b/test/v2/ValidatorAuthCacheInvalidation.test.js
@@ -1,0 +1,151 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+
+describe('JobRegistry validator auth cache', function () {
+  let owner, employer, v1, v2, v3;
+  let stakeManager, jobMock, validation, identity, registry;
+
+  beforeEach(async () => {
+    [owner, employer, v1, v2, v3] = await ethers.getSigners();
+
+    const StakeMock = await ethers.getContractFactory('MockStakeManager');
+    stakeManager = await StakeMock.deploy();
+    await stakeManager.waitForDeployment();
+
+    const JobMock = await ethers.getContractFactory('MockJobRegistry');
+    jobMock = await JobMock.deploy();
+    await jobMock.waitForDeployment();
+
+    const Validation = await ethers.getContractFactory(
+      'contracts/v2/ValidationModule.sol:ValidationModule'
+    );
+    validation = await Validation.deploy(
+      await jobMock.getAddress(),
+      await stakeManager.getAddress(),
+      60,
+      60,
+      3,
+      3,
+      []
+    );
+    await validation.waitForDeployment();
+
+    const Identity = await ethers.getContractFactory(
+      'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'
+    );
+    identity = await Identity.deploy();
+    await identity.waitForDeployment();
+    await identity.setClubRootNode(ethers.ZeroHash);
+    await identity.setAgentRootNode(ethers.ZeroHash);
+    await identity.setResult(true);
+
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/JobRegistry.sol:JobRegistry'
+    );
+    registry = await Registry.deploy(
+      await validation.getAddress(),
+      await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    await registry.waitForDeployment();
+
+    await registry
+      .connect(owner)
+      .setIdentityRegistry(await identity.getAddress());
+    await validation
+      .connect(owner)
+      .setIdentityRegistry(await identity.getAddress());
+    await validation
+      .connect(owner)
+      .setValidatorPool([v1.address, v2.address, v3.address]);
+    await validation
+      .connect(owner)
+      .setValidatorAuthCacheDuration(1000);
+
+    await stakeManager.setStake(v1.address, 1, ethers.parseEther('100'));
+    await stakeManager.setStake(v2.address, 1, ethers.parseEther('50'));
+    await stakeManager.setStake(v3.address, 1, ethers.parseEther('25'));
+  });
+
+  async function createJob(id) {
+    const jobStruct = {
+      employer: employer.address,
+      agent: ethers.ZeroAddress,
+      reward: 0,
+      stake: 0,
+      success: false,
+      status: 3,
+      uriHash: ethers.ZeroHash,
+      resultHash: ethers.ZeroHash,
+    };
+    await jobMock.setJob(id, jobStruct);
+  }
+
+  async function select(jobId) {
+    await validation.selectValidators(jobId, 0);
+    await ethers.provider.send('evm_mine', []);
+    return validation.connect(v1).selectValidators(jobId, 0);
+  }
+
+  it('invalidates cache on validator root node update', async () => {
+    await createJob(1);
+    await select(1);
+
+    await identity.connect(owner).setResult(false);
+
+    await createJob(2);
+    await select(2);
+
+    await validation
+      .connect(owner)
+      .transferOwnership(await registry.getAddress());
+    await identity
+      .connect(owner)
+      .transferOwnership(await registry.getAddress());
+
+    await registry
+      .connect(owner)
+      .setValidatorRootNode(ethers.id('newroot'));
+
+    await createJob(3);
+    await expect(select(3)).to.be.revertedWithCustomError(
+      validation,
+      'InsufficientValidators'
+    );
+  });
+
+  it('invalidates cache on validator merkle root update', async () => {
+    await createJob(1);
+    await select(1);
+
+    await identity.connect(owner).setResult(false);
+
+    await createJob(2);
+    await select(2);
+
+    await validation
+      .connect(owner)
+      .transferOwnership(await registry.getAddress());
+    await identity
+      .connect(owner)
+      .transferOwnership(await registry.getAddress());
+
+    await registry
+      .connect(owner)
+      .setValidatorMerkleRoot(ethers.id('newroot'));
+
+    await createJob(3);
+    await expect(select(3)).to.be.revertedWithCustomError(
+      validation,
+      'InsufficientValidators'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- expose `bumpValidatorAuthCacheVersion` in validation interface
- add governance helpers to update validator roots and clear caches
- document identity update workflow
- test validator cache invalidation on root or merkle root changes

## Testing
- `npx hardhat test test/v2/ValidatorAuthCacheInvalidation.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bc3233ca68833384c2ec5e43b38d01