### PR TITLE
test: ensure agent root node update invalidates auth cache

### DIFF
--- a/test/v2/JobRegistryAuthCache.test.js
+++ b/test/v2/JobRegistryAuthCache.test.js
@@ -148,6 +148,69 @@ describe('JobRegistry agent auth cache', function () {
     ).to.be.revertedWithCustomError(registry2, 'NotAuthorizedAgent');
   });
 
+  it('reverts application after agent root node update without re-verification', async () => {
+    const Identity = await ethers.getContractFactory(
+      'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'
+    );
+    const verifier2 = await Identity.connect(owner).deploy();
+    await verifier2.waitForDeployment();
+    await verifier2.setAgentRootNode(ethers.ZeroHash);
+
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/JobRegistry.sol:JobRegistry'
+    );
+    const registry2 = await Registry.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    await registry2.waitForDeployment();
+    await verifier2.connect(owner).setResult(true);
+    await registry2
+      .connect(owner)
+      .setIdentityRegistry(await verifier2.getAddress());
+
+    const Policy = await ethers.getContractFactory(
+      'contracts/v2/TaxPolicy.sol:TaxPolicy'
+    );
+    const policy2 = await Policy.deploy('uri', 'ack');
+    await registry2.connect(owner).setTaxPolicy(await policy2.getAddress());
+    await policy2.connect(employer).acknowledge();
+    await policy2.connect(agent).acknowledge();
+
+    await registry2.connect(owner).setMaxJobReward(1000);
+    await registry2.connect(owner).setJobDurationLimit(1000);
+    await registry2.connect(owner).setFeePct(0);
+    await registry2.connect(owner).setJobParameters(0, 0);
+    await registry2.connect(owner).setAgentAuthCacheDuration(1000);
+
+    let deadline = (await time.latest()) + 100;
+    const specHash = ethers.id('spec');
+    await registry2.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await registry2.connect(agent).applyForJob(1, 'a', []);
+
+    await verifier2.connect(owner).setResult(false);
+
+    await verifier2
+      .connect(owner)
+      .transferOwnership(await registry2.getAddress());
+    await registry2.connect(owner).setAgentRootNode(ethers.id('newrootnode'));
+
+    deadline = (await time.latest()) + 100;
+    await registry2.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await expect(
+      registry2.connect(agent).applyForJob(2, 'a', [])
+    ).to.be.revertedWithCustomError(registry2, 'NotAuthorizedAgent');
+  });
+
   it('requires re-verification when the agent root node changes', async () => {
     const Identity = await ethers.getContractFactory(
       'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'


### PR DESCRIPTION
## Summary
- add regression test for `setAgentRootNode` invalidating the agent auth cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc5398aa0c8333a85f060a359e5ec3