### PR TITLE
docs: add ENS subdomain issuance guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ subdomain. Owner‑controlled allowlists
 (`JobRegistry.setAgentMerkleRoot` and `ValidationModule.setValidatorMerkleRoot`)
 exist only for emergencies and should not be relied on by normal users.
 For a detailed walkthrough see
-[docs/ens-identity-setup.md](docs/ens-identity-setup.md).
+[docs/ens-identity-setup.md](docs/ens-identity-setup.md), including operator
+steps for issuing subdomains.
 
 ### Delegate addresses with AttestationRegistry
 

--- a/docs/MASTER_GUIDE.md
+++ b/docs/MASTER_GUIDE.md
@@ -77,6 +77,7 @@
    * Parent domain `agi.eth` under your control.
    * Subroots: `agent.agi.eth`, `club.agi.eth` (you will use **namehash** values).
    * ENS Registry & NameWrapper addresses (mainnet).
+   * Subdomain issuance and resolver setup: see [ens-identity-setup.md](ens-identity-setup.md).
 4. **Constructor inputs** ready (see below).
 5. **Plan for governance** (immediate or post‑setup transfer to multisig/timelock).
 
@@ -206,6 +207,8 @@ After deploy, **wire** modules so they know each other.
 
 * **Agents** must own `*.agent.agi.eth`. **Validators** must own `*.club.agi.eth`.
 * **Subdomains**: Will be **purchased separately in `$AGIALPHA` within the `agi.eth` ecosystem** (outside this deployment). The operator does **not** mint them here; the ecosystem handles issuance/sales.
+  See [ens-identity-setup.md](ens-identity-setup.md) for issuing
+  `<name>.agent.agi.eth`/`<name>.club.agi.eth` and configuring resolver records.
 * **IdentityRegistry** (if used) enforces:
 
   * `setAgentRootNode(namehash(agent.agi.eth))`

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -3,7 +3,8 @@
 `AttestationRegistry` lets ENS subdomain owners pre-authorize other addresses
 to act as agents or validators. Once attested, addresses skip the expensive ENS
 ownership check performed by `IdentityRegistry` and can participate using the
-delegated wallet.
+delegated wallet. For setting up the base ENS records and issuing
+subdomains see [ens-identity-setup.md](ens-identity-setup.md).
 
 ## Granting and revoking
 

--- a/docs/ens-identity-setup.md
+++ b/docs/ens-identity-setup.md
@@ -17,6 +17,34 @@ Agents and validators must prove ownership of specific ENS subdomains before int
 
 Transactions will revert if the calling address does not own the claimed subdomain. Owner‑controlled allowlists and Merkle proofs exist only for emergencies and should not be relied on for normal operation.
 
+## Issuing subdomains
+
+Project operators create subdomains under `agent.agi.eth` or `club.agi.eth` and assign them to participant addresses. Example using the Hardhat console:
+
+```bash
+npx hardhat console --network <network>
+> const wrapper = await ethers.getContractAt('INameWrapper', process.env.NAME_WRAPPER);
+> const resolver = process.env.PUBLIC_RESOLVER; // typically the PublicResolver
+> const parent = ethers.namehash('agent.agi.eth'); // or 'club.agi.eth'
+> const label = ethers.keccak256(ethers.toUtf8Bytes('alice'));
+> await wrapper.setSubnodeRecord(parent, label, '0xAgent', resolver, 0);
+```
+
+After issuing the subdomain, set the resolver `addr` record to the participant’s wallet:
+
+```bash
+> const res = await ethers.getContractAt('IResolver', resolver);
+> const node = ethers.namehash('alice.agent.agi.eth');
+> await res['setAddr(bytes32,address)'](node, '0xAgent');
+```
+
+To confirm ownership on-chain:
+
+```bash
+> const id = await ethers.getContractAt('IdentityRegistry', process.env.IDENTITY_REGISTRY);
+> await id.verifyAgent('0xAgent', 'alice', []); // use verifyValidator for validators
+```
+
 ## Delegating with attestations
 
 An ENS name owner may authorize another address to act on their behalf through the `AttestationRegistry`:

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -30,6 +30,8 @@ For a narrated deployment walkthrough, see [deployment-v2-agialpha.md](deploymen
 
 - Agents need an ENS subdomain ending in `.agent.agi.eth`; validators require `.club.agi.eth`.
 - Membership can be proven off‑chain by calling [`ENSOwnershipVerifier.verifyOwnership`](../contracts/v2/modules/ENSOwnershipVerifier.sol) with your address, subdomain label, and Merkle proof.
+  Project operators can issue subdomains and set resolver records as
+  described in [ens-identity-setup.md](ens-identity-setup.md).
 
 ## Calling Contract Methods via Etherscan
 

--- a/docs/job-validation-lifecycle.md
+++ b/docs/job-validation-lifecycle.md
@@ -1,6 +1,8 @@
 # Single Job Commit–Reveal–Finalize Flow
 
 This guide shows how a validator processes one job from commitment to finalization.
+Validators must own a `*.club.agi.eth` subdomain; see
+[ens-identity-setup.md](ens-identity-setup.md) for issuing and verifying names.
 
 ## Phases and Windows
 

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -7,7 +7,9 @@ Identity for agents and validators is enforced with the
 subdomain—`*.agent.agi.eth` for agents and `*.club.agi.eth` for
 validators—and supply the subdomain label plus Merkle proof when
 interacting. The verifier checks ownership via NameWrapper and the ENS
-resolver, emitting `OwnershipVerified` on success.
+resolver, emitting `OwnershipVerified` on success. Operators can issue
+subdomains and set resolver records as outlined in
+[ens-identity-setup.md](ens-identity-setup.md).
 
 ## Module Responsibilities & Addresses
 


### PR DESCRIPTION
## Summary
- document how operators issue `<name>.agent.agi.eth` and `<name>.club.agi.eth` subdomains
- show CLI steps to set resolver addr records and verify via `IdentityRegistry.verifyAgent`
- cross-link ENS guide from README and other UI/CLI docs

## Testing
- `npm test`
- `npm run lint` *(fails: 5 errors, 28 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7650ad488333999aa0b675057b5c