### PR TITLE
Invalidate caches on identity registry update

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -392,6 +392,12 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         if (address(registry) == address(0)) revert InvalidIdentityRegistry();
         if (registry.version() != 2) revert InvalidIdentityRegistry();
         identityRegistry = registry;
+        unchecked {
+            agentAuthCacheVersion++;
+        }
+        if (address(validationModule) != address(0)) {
+            try validationModule.bumpValidatorAuthCacheVersion() {} catch {}
+        }
         emit IdentityRegistryUpdated(address(registry));
         emit ModuleUpdated("IdentityRegistry", address(registry));
     }


### PR DESCRIPTION
## Summary
- bump agent auth cache version and validator cache when identity registry changes
- cover cache invalidation on identity registry update in tests

## Testing
- `npx hardhat test test/v2/JobRegistryAuthCache.test.js test/v2/ValidatorAuthCacheInvalidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc997584488333ba013b460dfd111c