### PR TITLE
Guard IdentityRegistry against zero attestation registry

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -111,6 +111,9 @@ contract IdentityRegistry is Ownable2Step {
     }
 
     function setAttestationRegistry(address registry) external onlyOwner {
+        if (registry == address(0)) {
+            revert ZeroAddress();
+        }
         attestationRegistry = AttestationRegistry(registry);
         emit AttestationRegistryUpdated(registry);
     }

--- a/test/v2/IdentityRegistrySetters.test.js
+++ b/test/v2/IdentityRegistrySetters.test.js
@@ -103,4 +103,30 @@ describe('IdentityRegistry setters', function () {
       );
     });
   });
+
+  describe('setAttestationRegistry', function () {
+    it('reverts for zero address', async () => {
+      await expect(
+        identity.setAttestationRegistry(ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(identity, 'ZeroAddress');
+    });
+
+    it('updates and emits event for valid address', async () => {
+      const Registry = await ethers.getContractFactory(
+        'contracts/v2/AttestationRegistry.sol:AttestationRegistry'
+      );
+      const newRegistry = await Registry.deploy(
+        ethers.ZeroAddress,
+        ethers.ZeroAddress
+      );
+      await expect(
+        identity.setAttestationRegistry(await newRegistry.getAddress())
+      )
+        .to.emit(identity, 'AttestationRegistryUpdated')
+        .withArgs(await newRegistry.getAddress());
+      expect(await identity.attestationRegistry()).to.equal(
+        await newRegistry.getAddress()
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `setAttestationRegistry` rejects the zero address
- test attestation registry setter for both zero and valid addresses

## Testing
- `npx hardhat test test/v2/IdentityRegistrySetters.test.js` *(fails: process hung during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9e47265c8333a3f8b571789abd52