### PR TITLE
Prevent zero address attestations

### DIFF
--- a/contracts/v2/AttestationRegistry.sol
+++ b/contracts/v2/AttestationRegistry.sol
@@ -74,6 +74,9 @@ contract AttestationRegistry is Ownable {
 
     /// @notice Attest that `who` holds `role` for `node`.
     function attest(bytes32 node, Role role, address who) external {
+        if (who == address(0)) {
+            revert ZeroAddress();
+        }
         if (_ownerOf(node) != msg.sender) {
             revert UnauthorizedAttestor();
         }

--- a/test/v2/AttestationRegistry.t.sol
+++ b/test/v2/AttestationRegistry.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
-import {AttestationRegistry} from "../../contracts/v2/AttestationRegistry.sol";
+import {AttestationRegistry, ZeroAddress} from "../../contracts/v2/AttestationRegistry.sol";
 import {IdentityRegistry} from "../../contracts/v2/IdentityRegistry.sol";
 import {IENS} from "../../contracts/v2/interfaces/IENS.sol";
 import {INameWrapper} from "../../contracts/v2/interfaces/INameWrapper.sol";
@@ -46,6 +46,14 @@ contract AttestationRegistryTest is Test {
         vm.prank(owner);
         attest.revoke(node, AttestationRegistry.Role.Agent, agent);
         assertFalse(attest.isAttested(node, AttestationRegistry.Role.Agent, agent));
+    }
+
+    function testAttestZeroAddressReverts() public {
+        bytes32 node = _node("alice");
+        wrapper.setOwner(uint256(node), owner);
+        vm.expectRevert(ZeroAddress.selector);
+        vm.prank(owner);
+        attest.attest(node, AttestationRegistry.Role.Agent, address(0));
     }
 
     function testIdentityIntegration() public {


### PR DESCRIPTION
## Summary
- prevent attesting to the zero address
- test zero address attest behavior

## Testing
- `forge test --match-path test/v2/AttestationRegistry.t.sol` *(fails: Yul exception too deep in stack)*
- `npx hardhat test test/v2/AttestationRegistry.test.js` *(hangs after npm warning)*

------
https://chatgpt.com/codex/tasks/task_e_68bca202c8f0833391e1525eb001ba3b