### PR TITLE
docs: clarify identity registry attestation and subdomain usage

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -79,12 +79,17 @@ await dispute.resolve(jobId, true); // employer wins
 
 Verifies agent and validator eligibility.
 
-- `isAuthorizedAgent(account, label, proof)` – check if an address can work.
-- `isAuthorizedValidator(account, label, proof)` – check validator eligibility.
+- `setAttestationRegistry(address registry)` – configure optional delegated identity support.
+- `isAuthorizedAgent(address claimant, string subdomain, bytes32[] proof)` – check if an address controlling `subdomain.agent.agi.eth` can work.
+- `isAuthorizedValidator(address claimant, string subdomain, bytes32[] proof)` – check validator eligibility for `subdomain.club.agi.eth`.
 
 ```javascript
-const ok = await identity.isAuthorizedAgent(user, labelHash, merkleProof);
+const ok = await identity.isAuthorizedAgent(user, 'alice', merkleProof); // alice.agent.agi.eth
 ```
+
+Successful agent and validator checks are cached inside `JobRegistry` and
+`ValidationModule` for roughly 24 hours to save gas. Owners may adjust these
+durations or invalidate the caches when ENS records change.
 
 ## ReputationEngine
 

--- a/docs/api/IdentityRegistry.md
+++ b/docs/api/IdentityRegistry.md
@@ -2,20 +2,24 @@
 
 Validates ENS ownership and Merkle proofs for agents and validators.
 Maintains optional metadata URIs describing each agent's capabilities.
+When connected to an `AttestationRegistry`, delegated addresses can skip the
+full ENS lookup and successful checks are cached by consumer modules to reduce
+gas usage.
 
 ## Functions
 
 - `setENS(address ens)` / `setNameWrapper(address wrapper)` – configure ENS contracts.
 - `setReputationEngine(address engine)` – connect reputation engine.
+- `setAttestationRegistry(address registry)` – enable off‑chain attestation lookups.
 - `setAgentRootNode(bytes32 node)` / `setClubRootNode(bytes32 node)` – base ENS nodes for agents and validators.
 - `setAgentMerkleRoot(bytes32 root)` / `setValidatorMerkleRoot(bytes32 root)` – load allowlists.
 - `addAdditionalAgent(address agent)` / `addAdditionalValidator(address validator)` – manual overrides.
 - `setAgentProfileURI(address agent, string uri)` – governance-set capability profile for an agent.
 - `updateAgentProfile(string subdomain, bytes32[] proof, string uri)` – agent updates their own profile after proving control of `subdomain`.
-- `isAuthorizedAgent(address account, bytes32 label, bytes32[] proof)` – check agent eligibility.
-- `isAuthorizedValidator(address account, bytes32 label, bytes32[] proof)` – check validator eligibility.
-- `verifyAgent(bytes32 label, bytes32[] proof, address account)` – external verification helper.
-- `verifyValidator(bytes32 label, bytes32[] proof, address account)` – external verification helper.
+- `isAuthorizedAgent(address claimant, string subdomain, bytes32[] proof)` – check agent eligibility for `subdomain.agent.agi.eth`.
+- `isAuthorizedValidator(address claimant, string subdomain, bytes32[] proof)` – check validator eligibility for `subdomain.club.agi.eth`.
+- `verifyAgent(address claimant, string subdomain, bytes32[] proof)` – external verification helper.
+- `verifyValidator(address claimant, string subdomain, bytes32[] proof)` – external verification helper.
 
 ## Events
 

--- a/docs/api/ValidationModule.md
+++ b/docs/api/ValidationModule.md
@@ -12,8 +12,9 @@ Manages commit‑reveal voting for submitted jobs.
 - `setSelectionStrategy(SelectionStrategy strategy)` – choose between a rotating window or reservoir sampling. Governance can adjust this to balance gas cost and fairness.
 - `start(uint256 jobId, uint256 entropy)` – select validators and open the commit window.
 - `selectValidators(uint256 jobId, uint256 entropy)` – pick validators using on-chain randomness; mixes `block.prevrandao` or, if unavailable, recent block hashes with `msg.sender` so no off-chain randomness provider is required.
-- `commitValidation(uint256 jobId, bytes32 commitHash, string subdomain, bytes proof)` – commit to a vote (ENS parameters required).
-- `revealValidation(uint256 jobId, bool approve, bytes32 salt, string subdomain, bytes proof)` – reveal vote (ENS parameters required).
+- `commitValidation(uint256 jobId, bytes32 commitHash, string subdomain, bytes32[] proof)` – commit to a vote (ENS parameters required).
+- `revealValidation(uint256 jobId, bool approve, bytes32 salt, string subdomain, bytes32[] proof)` – reveal vote (ENS parameters required).
+  For both, `subdomain` is the validator's label under `club.agi.eth`.
 - `finalize(uint256 jobId)` – tally reveals and trigger payout.
 - `resetJobNonce(uint256 jobId)` – clear validator commitments for a job.
 

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -6,6 +6,12 @@ ownership check performed by `IdentityRegistry` and can participate using the
 delegated wallet. For setting up the base ENS records and issuing
 subdomains see [ens-identity-setup.md](ens-identity-setup.md).
 
+Hook the registry into `IdentityRegistry` with
+`setAttestationRegistry(address)` so that consumer modules can consult
+attestations. `JobRegistry` and `ValidationModule` cache successful lookups for
+around 24 hours to save gas, but entries automatically expire or invalidate when
+ENS data changes.
+
 ## Granting and revoking
 
 1. Compute the ENS node for the subdomain:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -31,7 +31,7 @@ Agents stake and submit an application.
 ```javascript
 // apply.js
 const registry = await ethers.getContractAt('JobRegistry', registryAddress);
-await registry.applyForJob(jobId, labelHash, merkleProof);
+await registry.applyForJob(jobId, 'alice', merkleProof); // alice.agent.agi.eth
 ```
 
 ## 3. Validate the Submission
@@ -46,10 +46,10 @@ const validation = await ethers.getContractAt(
 );
 
 // Commit phase
-await validation.commitValidation(jobId, commitHash, '', []);
+await validation.commitValidation(jobId, commitHash, 'alice', []); // alice.club.agi.eth
 
 // Reveal phase
-await validation.revealValidation(jobId, true, salt, '', []);
+await validation.revealValidation(jobId, true, salt, 'alice', []);
 ```
 
 ## 4. Finalize

--- a/examples/agent-gateway.js
+++ b/examples/agent-gateway.js
@@ -33,7 +33,8 @@ registry.on('JobCreated', async (jobId, employer, agent, reward) => {
     try {
       const display = ethers.formatUnits(reward, TOKEN_DECIMALS);
       console.log(`Applying for job ${jobId} with reward ${display}`);
-      const tx = await registry.applyForJob(jobId, '', '0x');
+      // Replace 'alice' with your label under agent.agi.eth and supply a proof if required.
+      const tx = await registry.applyForJob(jobId, 'alice', '0x');
       await tx.wait();
       console.log(`Applied in tx ${tx.hash}`);
     } catch (err) {

--- a/examples/ethers-quickstart.js
+++ b/examples/ethers-quickstart.js
@@ -9,7 +9,7 @@ const signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 
 const registryAbi = [
   'function createJob(uint256 reward, uint64 deadline, bytes32 specHash, string uri)',
-  'function applyForJob(uint256 jobId, bytes32 label, bytes32[] proof)',
+  'function applyForJob(uint256 jobId, string subdomain, bytes32[] proof)',
   'function submit(uint256 jobId, bytes32 resultHash, string resultURI)',
   'function raiseDispute(uint256 jobId, bytes32 evidenceHash)',
 ];
@@ -62,8 +62,10 @@ async function stake(amount) {
   await stakeManager.depositStake(0, parsed);
 }
 
-async function apply(jobId, label, proof) {
-  await registry.applyForJob(jobId, label, proof);
+// Apply for a job using a `subdomain` label such as "alice" for
+// `alice.agent.agi.eth`. Supply a Merkle `proof` if allowlists are enabled.
+async function apply(jobId, subdomain, proof) {
+  await registry.applyForJob(jobId, subdomain, proof);
 }
 
 async function submit(jobId, uri) {
@@ -71,9 +73,10 @@ async function submit(jobId, uri) {
   await registry.submit(jobId, hash, uri);
 }
 
-async function validate(jobId, hash, label, proof, approve, salt) {
-  await validation.commitValidation(jobId, hash, label, proof);
-  await validation.revealValidation(jobId, approve, salt, label, proof);
+// Validators pass their `subdomain` label under `club.agi.eth` when voting.
+async function validate(jobId, hash, subdomain, proof, approve, salt) {
+  await validation.commitValidation(jobId, hash, subdomain, proof);
+  await validation.revealValidation(jobId, approve, salt, subdomain, proof);
   await validation.finalize(jobId);
 }
 

--- a/examples/web3py-quickstart.py
+++ b/examples/web3py-quickstart.py
@@ -25,8 +25,9 @@ def post_job():
     w3.eth.send_raw_transaction(signed.rawTransaction)
 
 
-def apply(job_id, label, proof):
-    tx = registry.functions.applyForJob(job_id, label, proof).build_transaction({
+def apply(job_id, subdomain, proof):
+    """Apply for a job using `subdomain` like 'alice' for alice.agent.agi.eth."""
+    tx = registry.functions.applyForJob(job_id, subdomain, proof).build_transaction({
         "from": account.address,
         "nonce": w3.eth.get_transaction_count(account.address)
     })
@@ -34,15 +35,16 @@ def apply(job_id, label, proof):
     w3.eth.send_raw_transaction(signed.rawTransaction)
 
 
-def commit_and_reveal(job_id, commit_hash, label, proof, approve, salt):
-    tx = validation.functions.commitValidation(job_id, commit_hash, label, proof).build_transaction({
+def commit_and_reveal(job_id, commit_hash, subdomain, proof, approve, salt):
+    """Validators pass their `.club.agi.eth` label as `subdomain`."""
+    tx = validation.functions.commitValidation(job_id, commit_hash, subdomain, proof).build_transaction({
         "from": account.address,
         "nonce": w3.eth.get_transaction_count(account.address)
     })
     signed = account.sign_transaction(tx)
     w3.eth.send_raw_transaction(signed.rawTransaction)
 
-    tx2 = validation.functions.revealValidation(job_id, approve, salt, label, proof).build_transaction({
+    tx2 = validation.functions.revealValidation(job_id, approve, salt, subdomain, proof).build_transaction({
         "from": account.address,
         "nonce": w3.eth.get_transaction_count(account.address)
     })


### PR DESCRIPTION
## Summary
- document `setAttestationRegistry` and identity cache behaviour
- describe updated `isAuthorizedAgent`/`isAuthorizedValidator` signatures
- update examples to use `.agent.agi.eth` and `.club.agi.eth` subdomains

## Testing
- `npm test`
- `npm run format:check` *(fails: Code style issues found in 5 files. Forgot to run Prettier?)*


------
https://chatgpt.com/codex/tasks/task_e_68bca8da1bc883339def61d8b1cb746b