### PR TITLE
feat: add manual agent auth cache invalidation

### DIFF
--- a/test/v2/JobRegistryAuthCacheExpiry.test.js
+++ b/test/v2/JobRegistryAuthCacheExpiry.test.js
@@ -98,4 +98,23 @@ describe('JobRegistry auth cache invalidation', function () {
       registry.connect(agent).applyForJob(second, 'a', [])
     ).to.be.revertedWithCustomError(registry, 'NotAuthorizedAgent');
   });
+
+  it('invalidates cache on manual version bump', async () => {
+    await registry.connect(owner).setAgentAuthCacheDuration(1000);
+
+    const first = await createJob();
+    await registry.connect(agent).applyForJob(first, 'a', []);
+
+    await identity.connect(owner).setResult(false);
+
+    const second = await createJob();
+    await registry.connect(agent).applyForJob(second, 'a', []);
+
+    await registry.connect(owner).bumpAgentAuthCacheVersion();
+
+    const third = await createJob();
+    await expect(
+      registry.connect(agent).applyForJob(third, 'a', [])
+    ).to.be.revertedWithCustomError(registry, 'NotAuthorizedAgent');
+  });
 });


### PR DESCRIPTION
## Summary
- allow governance to bump agent authorization cache version
- emit AgentAuthCacheVersionBumped and wire into registry setters
- test that manual version bumps invalidate cached agent auth

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcc2b7533483339e89efd1d32974b9