### PR TITLE
Wire IdentityRegistry to mainnet ENS

### DIFF
--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -2,11 +2,11 @@ import { ethers } from 'hardhat';
 
 // Mainnet ENS registry and NameWrapper addresses
 // ENS registry: 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e
-// NameWrapper: 0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401
+// NameWrapper: 0x253553366Da8546fC250F225fe3d25d0C782303b
 // agent.agi.eth node: 0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d
 // club.agi.eth node: 0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16
 const ENS_REGISTRY = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
-const NAME_WRAPPER = '0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401';
+const NAME_WRAPPER = '0x253553366Da8546fC250F225fe3d25d0C782303b';
 const AGENT_ROOT_NODE = ethers.namehash('agent.agi.eth');
 const CLUB_ROOT_NODE = ethers.namehash('club.agi.eth');
 
@@ -68,13 +68,17 @@ async function main() {
     'contracts/v2/IdentityRegistry.sol:IdentityRegistry'
   );
   const identity = await Identity.deploy(
-    ENS_REGISTRY,
-    NAME_WRAPPER,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
     await reputation.getAddress(),
-    AGENT_ROOT_NODE,
-    CLUB_ROOT_NODE
+    ethers.ZeroHash,
+    ethers.ZeroHash
   );
   await identity.waitForDeployment();
+  await identity.setENS(ENS_REGISTRY);
+  await identity.setNameWrapper(NAME_WRAPPER);
+  await identity.setAgentRootNode(AGENT_ROOT_NODE);
+  await identity.setClubRootNode(CLUB_ROOT_NODE);
 
   const Attestation = await ethers.getContractFactory(
     'contracts/v2/AttestationRegistry.sol:AttestationRegistry'
@@ -141,6 +145,7 @@ async function main() {
     []
   );
   await registry.setIdentityRegistry(await identity.getAddress());
+  await validation.setIdentityRegistry(await identity.getAddress());
   await reputation.setCaller(await registry.getAddress(), true);
 
   const ensureContract = async (addr: string, name: string) => {

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -151,6 +151,10 @@ async function main() {
   const attestation = await Attestation.deploy(ENS_REGISTRY, NAME_WRAPPER);
   await attestation.waitForDeployment();
   await identity.setAttestationRegistry(await attestation.getAddress());
+  await registry
+    .connect(governanceSigner)
+    .setIdentityRegistry(await identity.getAddress());
+  await validation.setIdentityRegistry(await identity.getAddress());
 
   const NFT = await ethers.getContractFactory(
     'contracts/v2/modules/CertificateNFT.sol:CertificateNFT'


### PR DESCRIPTION
## Summary
- initialize IdentityRegistry with mainnet ENS and NameWrapper
- set agent and club ENS root nodes via namehash
- ensure JobRegistry and ValidationModule reference the configured IdentityRegistry

## Testing
- `npm run lint`
- `npm test` *(fails: process terminated before completion)*


------
https://chatgpt.com/codex/tasks/task_e_68bcd7c4b1ac8333a918698df1051994