### PR TITLE
feat: attestation registry deployment and cli

### DIFF
--- a/scripts/v2/attestEns.ts
+++ b/scripts/v2/attestEns.ts
@@ -2,11 +2,12 @@ import { ethers } from 'hardhat';
 
 function usage() {
   console.log(
-    'Usage: npx hardhat run scripts/v2/attestEns.ts --network <network> <subdomain> <role> <address>'
+    'Usage: npx hardhat run scripts/v2/attestEns.ts --network <network> <attest|revoke> <subdomain> <role> <address>'
   );
-  console.log('  <subdomain> - label before the role, e.g. "alice"');
-  console.log('  <role>      - "agent" or "validator"');
-  console.log('  <address>   - delegate address to attest');
+  console.log('  <attest|revoke> - action to perform');
+  console.log('  <subdomain>     - label before the role, e.g. "alice"');
+  console.log('  <role>          - "agent" or "validator"');
+  console.log('  <address>       - delegate address');
 }
 
 async function ownerOf(node: string, ensAddr: string, wrapperAddr: string) {
@@ -33,10 +34,14 @@ async function ownerOf(node: string, ensAddr: string, wrapperAddr: string) {
 }
 
 async function main() {
-  const [subdomain, roleInput, delegate] = process.argv.slice(2);
-  if (!subdomain || !roleInput || !delegate) {
+  const [action, subdomain, roleInput, delegate] = process.argv.slice(2);
+  if (!action || !subdomain || !roleInput || !delegate) {
     usage();
     throw new Error('missing arguments');
+  }
+  const verb = action.toLowerCase();
+  if (verb !== 'attest' && verb !== 'revoke') {
+    throw new Error('action must be attest or revoke');
   }
 
   const roleMap: Record<string, number> = {
@@ -72,11 +77,14 @@ async function main() {
     throw new Error(`caller ${signer.address} does not own ${ensName}`);
   }
 
-  const tx = await att.attest(node, role, delegateAddr);
+  const tx =
+    verb === 'revoke'
+      ? await att.revoke(node, role, delegateAddr)
+      : await att.attest(node, role, delegateAddr);
   console.log(`tx: ${tx.hash}`);
   await tx.wait();
   console.log(
-    `attested ${delegate} for ${ensName} as ${
+    `${verb === 'revoke' ? 'revoked' : 'attested'} ${delegate} for ${ensName} as ${
       role === 0 ? 'Agent' : 'Validator'
     }`
   );

--- a/scripts/v2/attestEns.ts
+++ b/scripts/v2/attestEns.ts
@@ -84,9 +84,9 @@ async function main() {
   console.log(`tx: ${tx.hash}`);
   await tx.wait();
   console.log(
-    `${verb === 'revoke' ? 'revoked' : 'attested'} ${delegate} for ${ensName} as ${
-      role === 0 ? 'Agent' : 'Validator'
-    }`
+    `${
+      verb === 'revoke' ? 'revoked' : 'attested'
+    } ${delegate} for ${ensName} as ${role === 0 ? 'Agent' : 'Validator'}`
   );
 }
 

--- a/scripts/v2/deployAttestation.ts
+++ b/scripts/v2/deployAttestation.ts
@@ -31,8 +31,16 @@ async function main() {
   const Attestation = await ethers.getContractFactory(
     'contracts/v2/AttestationRegistry.sol:AttestationRegistry'
   );
-  const att = await Attestation.deploy(ensAddr, wrapperAddr);
+
+  // Deploy with zero addresses first, then configure ENS and NameWrapper
+  const att = await Attestation.deploy(
+    ethers.ZeroAddress,
+    ethers.ZeroAddress
+  );
   await att.waitForDeployment();
+
+  await (await att.setENS(ensAddr)).wait();
+  await (await att.setNameWrapper(wrapperAddr)).wait();
 
   const identity = await ethers.getContractAt(
     'contracts/v2/IdentityRegistry.sol:IdentityRegistry',
@@ -41,6 +49,8 @@ async function main() {
   await identity.setAttestationRegistry(await att.getAddress());
 
   console.log('AttestationRegistry:', await att.getAddress());
+  console.log('  ENS:', ensAddr);
+  console.log('  NameWrapper:', wrapperAddr);
   console.log('IdentityRegistry:', identityAddr);
 }
 

--- a/scripts/v2/deployAttestation.ts
+++ b/scripts/v2/deployAttestation.ts
@@ -33,10 +33,7 @@ async function main() {
   );
 
   // Deploy with zero addresses first, then configure ENS and NameWrapper
-  const att = await Attestation.deploy(
-    ethers.ZeroAddress,
-    ethers.ZeroAddress
-  );
+  const att = await Attestation.deploy(ethers.ZeroAddress, ethers.ZeroAddress);
   await att.waitForDeployment();
 
   await (await att.setENS(ensAddr)).wait();


### PR DESCRIPTION
## Summary
- deploy AttestationRegistry with ENS/NameWrapper config and wire into IdentityRegistry
- add CLI script for ENS owners to attest or revoke agent/validator roles

## Testing
- `npm test`
- `npm run lint` *(fails: 2 errors, 29 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdfb73e348333a263bc1699ec953d