### PR TITLE
test: cover auth cache expiration and version bumps

### DIFF
--- a/test/v2/JobRegistryAuthCache.test.js
+++ b/test/v2/JobRegistryAuthCache.test.js
@@ -171,6 +171,132 @@ describe('JobRegistry agent auth cache', function () {
     ).to.be.revertedWithCustomError(registry, 'NotAuthorizedAgent');
   });
 
+  it('requires re-verification after agent cache expiration', async () => {
+    const Identity = await ethers.getContractFactory(
+      'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'
+    );
+    const identity = await Identity.connect(owner).deploy();
+    await identity.waitForDeployment();
+    await identity.setAgentRootNode(ethers.ZeroHash);
+    await identity.setResult(true);
+
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/JobRegistry.sol:JobRegistry'
+    );
+    const reg = await Registry.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    await reg.waitForDeployment();
+    await reg.connect(owner).setIdentityRegistry(await identity.getAddress());
+
+    const Policy = await ethers.getContractFactory(
+      'contracts/v2/TaxPolicy.sol:TaxPolicy'
+    );
+    const pol = await Policy.deploy('uri', 'ack');
+    await reg.connect(owner).setTaxPolicy(await pol.getAddress());
+    await pol.connect(employer).acknowledge();
+    await pol.connect(agent).acknowledge();
+
+    await reg.connect(owner).setMaxJobReward(1000);
+    await reg.connect(owner).setJobDurationLimit(1000);
+    await reg.connect(owner).setFeePct(0);
+    await reg.connect(owner).setJobParameters(0, 0);
+    await reg.connect(owner).setAgentAuthCacheDuration(5);
+
+    let deadline = (await time.latest()) + 100;
+    const specHash = ethers.id('spec');
+    await reg.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await reg.connect(agent).applyForJob(1, 'a', []);
+
+    await identity.connect(owner).setResult(false);
+
+    deadline = (await time.latest()) + 100;
+    await reg.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await expect(
+      reg.connect(agent).applyForJob(2, 'a', [])
+    ).to.not.be.reverted;
+
+    await time.increase(6);
+
+    deadline = (await time.latest()) + 100;
+    await reg.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await expect(
+      reg.connect(agent).applyForJob(3, 'a', [])
+    ).to.be.revertedWithCustomError(reg, 'NotAuthorizedAgent');
+  });
+
+  it('invalidates cache on manual agent version bump', async () => {
+    const Identity = await ethers.getContractFactory(
+      'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'
+    );
+    const identity = await Identity.connect(owner).deploy();
+    await identity.waitForDeployment();
+    await identity.setAgentRootNode(ethers.ZeroHash);
+    await identity.setResult(true);
+
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/JobRegistry.sol:JobRegistry'
+    );
+    const reg = await Registry.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    await reg.waitForDeployment();
+    await reg.connect(owner).setIdentityRegistry(await identity.getAddress());
+
+    const Policy = await ethers.getContractFactory(
+      'contracts/v2/TaxPolicy.sol:TaxPolicy'
+    );
+    const pol = await Policy.deploy('uri', 'ack');
+    await reg.connect(owner).setTaxPolicy(await pol.getAddress());
+    await pol.connect(employer).acknowledge();
+    await pol.connect(agent).acknowledge();
+
+    await reg.connect(owner).setMaxJobReward(1000);
+    await reg.connect(owner).setJobDurationLimit(1000);
+    await reg.connect(owner).setFeePct(0);
+    await reg.connect(owner).setJobParameters(0, 0);
+    await reg.connect(owner).setAgentAuthCacheDuration(1000);
+
+    let deadline = (await time.latest()) + 100;
+    const specHash = ethers.id('spec');
+    await reg.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await reg.connect(agent).applyForJob(1, 'a', []);
+
+    await identity.connect(owner).setResult(false);
+
+    deadline = (await time.latest()) + 100;
+    await reg.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await reg.connect(agent).applyForJob(2, 'a', []);
+
+    await reg.connect(owner).bumpAgentAuthCacheVersion();
+
+    deadline = (await time.latest()) + 100;
+    await reg.connect(employer).createJob(1, deadline, specHash, 'uri');
+    await expect(
+      reg.connect(agent).applyForJob(3, 'a', [])
+    ).to.be.revertedWithCustomError(reg, 'NotAuthorizedAgent');
+  });
+
   it('reverts application after agent root node update without re-verification', async () => {
     const Identity = await ethers.getContractFactory(
       'contracts/v2/mocks/IdentityRegistryToggle.sol:IdentityRegistryToggle'

--- a/test/v2/ValidatorAuthCacheInvalidation.test.js
+++ b/test/v2/ValidatorAuthCacheInvalidation.test.js
@@ -176,4 +176,22 @@ describe('JobRegistry validator auth cache', function () {
       'InsufficientValidators'
     );
   });
+
+  it('invalidates cache on manual version bump', async () => {
+    await createJob(1);
+    await select(1);
+
+    await identity.connect(owner).setResult(false);
+
+    await createJob(2);
+    await select(2);
+
+    await validation.connect(owner).bumpValidatorAuthCacheVersion();
+
+    await createJob(3);
+    await expect(select(3)).to.be.revertedWithCustomError(
+      validation,
+      'InsufficientValidators'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- ensure agent auth cache expiration triggers JobRegistry re-verification
- invalidate stale agent cache entries via bumpAgentAuthCacheVersion
- cover validator auth cache version bump invalidation

## Testing
- `npx hardhat test test/v2/JobRegistryAuthCache.test.js test/v2/ValidatorAuthCacheInvalidation.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bce58844b08333a712e0b87808bd8a