### PR TITLE
Verify ENS identity before sending transactions

### DIFF
--- a/apps/validator-ui/lib/ens.ts
+++ b/apps/validator-ui/lib/ens.ts
@@ -1,0 +1,20 @@
+import { ethers } from 'ethers';
+
+export async function verifyEnsSubdomain(
+  provider: ethers.Provider,
+  address: string
+): Promise<string | null> {
+  try {
+    const name = await provider.lookupAddress(address);
+    if (
+      name &&
+      (name.endsWith('.agent.agi.eth') || name.endsWith('.club.agi.eth')) &&
+      name.split('.').length > 3
+    ) {
+      return null;
+    }
+  } catch {
+    // ignore lookup errors
+  }
+  return 'No valid *.agent.agi.eth or *.club.agi.eth subdomain found for this address. See docs/ens-identity-setup.md';
+}

--- a/apps/validator-ui/pages/attest.tsx
+++ b/apps/validator-ui/pages/attest.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { ethers } from 'ethers';
+import { verifyEnsSubdomain } from '../lib/ens';
 
 export default function AttestPage() {
   const [name, setName] = useState('');
@@ -15,6 +16,9 @@ export default function AttestPage() {
       }
       const provider = new ethers.BrowserProvider((window as any).ethereum);
       const signer = await provider.getSigner();
+      const addr = await signer.getAddress();
+      const warning = await verifyEnsSubdomain(provider, addr);
+      if (warning) alert(warning);
       const registryAddr = process.env.NEXT_PUBLIC_ATTESTATION_ADDRESS;
       if (!registryAddr) {
         alert('attestation registry not configured');

--- a/apps/validator-ui/pages/index.tsx
+++ b/apps/validator-ui/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { ethers } from 'ethers';
 import { generateCommit, scheduleReveal } from '../lib/commit';
+import { verifyEnsSubdomain } from '../lib/ens';
 import agiConfig from '../../../config/agialpha.json';
 
 interface Job {
@@ -65,6 +66,9 @@ export default function Home() {
     }
     const provider = new ethers.BrowserProvider((window as any).ethereum);
     const signer = await provider.getSigner();
+    const addr = await signer.getAddress();
+    const warning = await verifyEnsSubdomain(provider, addr);
+    if (warning) alert(warning);
     const validationAddr = process.env.NEXT_PUBLIC_VALIDATION_MODULE_ADDRESS;
     if (!validationAddr) {
       alert('validation module not configured');


### PR DESCRIPTION
## Summary
- verify wallet ENS subdomain before agent-gateway transactions
- warn validator UI users lacking `*.agent.agi.eth` or `*.club.agi.eth` names
- document ENS subdomain check in agent-gateway example

## Testing
- `npm run lint`
- `npm test` *(fails: process did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68bcea0282908333b1b617bf53003c5b