### PR TITLE
docs: note allowlist emergency-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 
 Agents and validators must own ENS subdomains under `agent.agi.eth` and `club.agi.eth`. All workflows perform on-chain verification and bypass mechanisms are reserved for emergency governance only. See [docs/ens-identity-policy.md](docs/ens-identity-policy.md) for details.
 
+> **Emergency allowlists:** The `IdentityRegistry` owner can directly whitelist addresses using `addAdditionalAgent` or `addAdditionalValidator`. These overrides bypass ENS proofs and should only be used to recover from deployment errors or other emergencies.
+
 ### AGIALPHA configuration
 
 Token parameters are defined once in [`config/agialpha.json`](config/agialpha.json). Run `npm run compile` after editing this file to regenerate `contracts/v2/Constants.sol` with the canonical token address, decimals, scaling factor and burn address. Any change to `config/agialpha.json` must be followed by `npm run compile` or the constants check in CI will fail.


### PR DESCRIPTION
## Summary
- clarify IdentityRegistry allowlist functions are emergency overrides only

## Testing
- `npm test` *(fails: command terminated while downloading compilers)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf413242c8333958ca9d2e89c0f96