### PR TITLE
feat: include subdomain in job events

### DIFF
--- a/agent-gateway/index.js
+++ b/agent-gateway/index.js
@@ -91,7 +91,7 @@ if (BOT_WALLET) {
 // Minimal ABI for JobRegistry interactions
 const JOB_REGISTRY_ABI = [
   'event JobCreated(uint256 indexed jobId, address indexed employer, address indexed agent, uint256 reward, uint256 stake, uint256 fee)',
-  'event JobSubmitted(uint256 indexed jobId, address indexed worker, bytes32 resultHash, string resultURI)',
+  'event JobSubmitted(uint256 indexed jobId, address indexed worker, bytes32 resultHash, string resultURI, string subdomain)',
   'function applyForJob(uint256 jobId, string subdomain, bytes proof) external',
   'function submit(uint256 jobId, bytes32 resultHash, string resultURI, string subdomain, bytes proof) external',
   'function cancelExpiredJob(uint256 jobId) external',
@@ -219,12 +219,22 @@ registry.on('JobCreated', (jobId, employer, agentAddr, reward, stake, fee) => {
   scheduleExpiration(job.jobId);
 });
 
-registry.on('JobSubmitted', (jobId, worker, resultHash, resultURI) => {
-  const id = jobId.toString();
-  broadcast({ type: 'JobSubmitted', jobId: id, worker, resultHash, resultURI });
-  scheduleFinalize(id);
-  console.log('JobSubmitted', id);
-});
+registry.on(
+  'JobSubmitted',
+  (jobId, worker, resultHash, resultURI, subdomain) => {
+    const id = jobId.toString();
+    broadcast({
+      type: 'JobSubmitted',
+      jobId: id,
+      worker,
+      resultHash,
+      resultURI,
+      subdomain,
+    });
+    scheduleFinalize(id);
+    console.log('JobSubmitted', id);
+  }
+);
 
 if (validation) {
   validation.on('ValidatorsSelected', (jobId, validators) => {

--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -261,7 +261,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
 
     function applyForJob(
         uint256 jobId,
-        string calldata,
+        string calldata subdomain,
         bytes32[] calldata
     ) public override {
         Job storage job = _jobs[jobId];
@@ -271,7 +271,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         }
         job.agent = msg.sender;
         job.status = Status.Applied;
-        emit JobApplied(jobId, msg.sender);
+        emit JobApplied(jobId, msg.sender, subdomain);
     }
 
     function stakeAndApply(
@@ -295,7 +295,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         uint256 jobId,
         bytes32 resultHash,
         string calldata resultURI,
-        string calldata,
+        string calldata subdomain,
         bytes32[] calldata
     ) public override {
         Job storage job = _jobs[jobId];
@@ -304,7 +304,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         require(block.timestamp <= deadlines[jobId], "deadline");
         job.resultHash = resultHash;
         job.status = Status.Submitted;
-        emit JobSubmitted(jobId, msg.sender, resultHash, resultURI);
+        emit JobSubmitted(jobId, msg.sender, resultHash, resultURI, subdomain);
         if (validationModule != address(0)) {
             IValidationModule(validationModule).start(jobId, 0);
         }

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -225,12 +225,17 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         bytes32 specHash,
         string uri
     );
-    event JobApplied(uint256 indexed jobId, address indexed agent);
+    event JobApplied(
+        uint256 indexed jobId,
+        address indexed agent,
+        string subdomain
+    );
     event JobSubmitted(
         uint256 indexed jobId,
         address indexed worker,
         bytes32 resultHash,
-        string resultURI
+        string resultURI,
+        string subdomain
     );
     event JobCompleted(uint256 indexed jobId, bool success);
     /// @notice Emitted when a job is finalized
@@ -813,7 +818,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         job.agent = msg.sender;
         job.state = State.Applied;
         job.assignedAt = uint64(block.timestamp);
-        emit JobApplied(jobId, msg.sender);
+        emit JobApplied(jobId, msg.sender, subdomain);
     }
 
     function applyForJob(
@@ -912,7 +917,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         }
         job.resultHash = resultHash;
         job.state = State.Submitted;
-        emit JobSubmitted(jobId, msg.sender, resultHash, resultURI);
+        emit JobSubmitted(jobId, msg.sender, resultHash, resultURI, subdomain);
         if (address(validationModule) != address(0)) {
             validationModule.start(
                 jobId,

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -71,12 +71,17 @@ interface IJobRegistry {
         bytes32 specHash,
         string uri
     );
-    event JobApplied(uint256 indexed jobId, address indexed agent);
+    event JobApplied(
+        uint256 indexed jobId,
+        address indexed agent,
+        string subdomain
+    );
     event JobSubmitted(
         uint256 indexed jobId,
         address indexed worker,
         bytes32 resultHash,
-        string resultURI
+        string resultURI,
+        string subdomain
     );
     event JobCompleted(uint256 indexed jobId, bool success);
     /// @notice Emitted when a job is finalized

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -178,14 +178,14 @@ describe('JobRegistry integration', function () {
     const jobId = 1;
     await expect(registry.connect(agent).applyForJob(jobId, '', []))
       .to.emit(registry, 'JobApplied')
-      .withArgs(jobId, agent.address);
+      .withArgs(jobId, agent.address, '');
     await validation.connect(owner).setResult(true);
     const resultHash = ethers.id('result');
     await expect(
       registry.connect(agent).submit(jobId, resultHash, 'result', '', [])
     )
       .to.emit(registry, 'JobSubmitted')
-      .withArgs(jobId, agent.address, resultHash, 'result');
+      .withArgs(jobId, agent.address, resultHash, 'result', '');
     await expect(validation.finalize(jobId))
       .to.emit(registry, 'JobCompleted')
       .withArgs(jobId, true)
@@ -211,7 +211,7 @@ describe('JobRegistry integration', function () {
       .createJob(reward, deadline, specHash, 'uri');
     await expect(registry.connect(newAgent).acknowledgeAndApply(1, '', []))
       .to.emit(registry, 'JobApplied')
-      .withArgs(1, newAgent.address);
+      .withArgs(1, newAgent.address, '');
     expect(await policy.hasAcknowledged(newAgent.address)).to.equal(true);
   });
 

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -101,7 +101,7 @@ describe('JobRegistry agent gating', function () {
     const jobId = await createJob();
     await expect(registry.connect(agent).applyForJob(jobId, 'a', []))
       .to.emit(registry, 'JobApplied')
-      .withArgs(jobId, agent.address);
+      .withArgs(jobId, agent.address, 'a');
   });
 
   it('rejects blacklisted agents', async () => {

--- a/test/v2/JobRegistryPause.test.js
+++ b/test/v2/JobRegistryPause.test.js
@@ -53,7 +53,7 @@ describe('JobRegistry pause', function () {
     await registry.connect(owner).unpause();
     await expect(registry.connect(agent).applyForJob(1, '', []))
       .to.emit(registry, 'JobApplied')
-      .withArgs(1, agent.address);
+      .withArgs(1, agent.address, '');
   });
 
   it('pauses job expiration', async () => {


### PR DESCRIPTION
## Summary
- extend `JobApplied` and `JobSubmitted` events with `string subdomain`
- emit subdomain from `_applyForJob` and `submit`
- update tests and mocks for new event signature

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68bd0235214083339ab0b5eb42d6628a