### PR TITLE
feat: add RewardPaid event for payouts

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -179,6 +179,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     );
     event StakeEscrowLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
     event StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount);
+    /// @notice Emitted when a participant receives a payout in $AGIALPHA.
+    event RewardPaid(bytes32 indexed jobId, address indexed to, uint256 amount);
     event TokensBurned(bytes32 indexed jobId, uint256 amount);
     event DisputeFeeLocked(address indexed payer, uint256 amount);
     event DisputeFeePaid(address indexed to, uint256 amount);
@@ -914,7 +916,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         }
         if (payout > 0) {
             token.safeTransfer(to, payout);
-            emit StakeReleased(jobId, to, payout);
+            emit RewardPaid(jobId, to, payout);
         }
     }
 
@@ -955,7 +957,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         }
         if (payout > 0) {
             token.safeTransfer(to, payout);
-            emit StakeReleased(bytes32(0), to, payout);
+            emit RewardPaid(bytes32(0), to, payout);
         }
     }
 
@@ -982,7 +984,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         jobEscrows[jobId] = escrow - total;
         if (payout > 0) {
             token.safeTransfer(agent, payout);
-            emit StakeReleased(jobId, agent, payout);
+            emit RewardPaid(jobId, agent, payout);
         }
         if (fee > 0) {
             if (address(_feePool) != address(0)) {
@@ -1021,14 +1023,14 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         uint256 remainder = amount - perValidator * count;
         for (uint256 i; i < count;) {
             token.safeTransfer(vals[i], perValidator);
-            emit StakeReleased(jobId, vals[i], perValidator);
+            emit RewardPaid(jobId, vals[i], perValidator);
             unchecked {
                 ++i;
             }
         }
         if (remainder > 0) {
             token.safeTransfer(vals[0], remainder);
-            emit StakeReleased(jobId, vals[0], remainder);
+            emit RewardPaid(jobId, vals[0], remainder);
         }
     }
 

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -20,6 +20,7 @@ interface IStakeManager {
     event StakeWithdrawn(address indexed user, Role indexed role, uint256 amount);
     event StakeEscrowLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
     event StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount);
+    event RewardPaid(bytes32 indexed jobId, address indexed to, uint256 amount);
     event TokensBurned(bytes32 indexed jobId, uint256 amount);
     event StakeTimeLocked(address indexed user, uint256 amount, uint64 unlockTime);
     event StakeUnlocked(address indexed user, uint256 amount);

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -21,6 +21,7 @@ Handles staking, escrow and slashing of the $AGIALPHA token.
 - `StakeSlashed(address indexed user, uint256 amount, address recipient)`
 - `StakeEscrowLocked(bytes32 indexed jobId, address indexed from, uint256 amount)`
 - `StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount)`
+- `RewardPaid(bytes32 indexed jobId, address indexed to, uint256 amount)`
 - `TokensBurned(bytes32 indexed jobId, uint256 amount)`
 - `DisputeFeeLocked(address indexed payer, uint256 amount)`
 - `DisputeFeePaid(address indexed to, uint256 amount)`

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -93,7 +93,7 @@ describe('StakeManager AGIType bonuses', function () {
         .connect(registrySigner)
         .releaseReward(jobId, agent.address, 100)
     )
-      .to.emit(stakeManager, 'StakeReleased')
+      .to.emit(stakeManager, 'RewardPaid')
       .withArgs(jobId, agent.address, 175);
 
     expect(await token.balanceOf(agent.address)).to.equal(175n);
@@ -116,7 +116,7 @@ describe('StakeManager AGIType bonuses', function () {
         .connect(registrySigner)
         .releaseReward(jobId, agent.address, 100)
     )
-      .to.emit(stakeManager, 'StakeReleased')
+      .to.emit(stakeManager, 'RewardPaid')
       .withArgs(jobId, agent.address, 100);
   });
 

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -94,7 +94,7 @@ describe('StakeManager', function () {
         .connect(registrySigner)
         .releaseReward(jobId, user.address, 200)
     )
-      .to.emit(stakeManager, 'StakeReleased')
+      .to.emit(stakeManager, 'RewardPaid')
       .withArgs(jobId, user.address, 200);
     expect(await token.balanceOf(user.address)).to.equal(1050n);
 

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -114,7 +114,7 @@ describe('StakeManager release', function () {
       )
       .and.to.emit(stakeManager, 'TokensBurned')
       .withArgs(ethers.ZeroHash, ethers.parseEther('10'))
-      .and.to.emit(stakeManager, 'StakeReleased')
+      .and.to.emit(stakeManager, 'RewardPaid')
       .withArgs(ethers.ZeroHash, user1.address, ethers.parseEther('70'));
 
     expect((await token.balanceOf(user1.address)) - before1).to.equal(
@@ -156,7 +156,7 @@ describe('StakeManager release', function () {
       .withArgs(jobId, await feePool.getAddress(), ethers.parseEther('20'))
       .and.to.emit(stakeManager, 'TokensBurned')
       .withArgs(jobId, ethers.parseEther('10'))
-      .and.to.emit(stakeManager, 'StakeReleased')
+      .and.to.emit(stakeManager, 'RewardPaid')
       .withArgs(jobId, user1.address, ethers.parseEther('70'));
 
     expect((await token.balanceOf(user1.address)) - before1).to.equal(


### PR DESCRIPTION
## Summary
- emit `RewardPaid` when agents or validators receive AGIALPHA payouts
- document new payout event in StakeManager API
- update tests to track `RewardPaid`

## Testing
- `npm run lint`
- `npm test` *(fails: solc compilation hung; process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bd603724948333a999285689589e9b