### PR TITLE
refactor: use agialpha token in randao coordinator

### DIFF
--- a/contracts/v2/interfaces/IRandaoCoordinator.sol
+++ b/contracts/v2/interfaces/IRandaoCoordinator.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 interface IRandaoCoordinator {
     /// @notice Commit a hash of the sender address, tag and secret.
-    function commit(bytes32 tag, bytes32 commitment) external payable;
+    function commit(bytes32 tag, bytes32 commitment) external;
 
     /// @notice Reveal the secret for a given tag.
     function reveal(bytes32 tag, uint256 secret) external;


### PR DESCRIPTION
## Summary
- require AGIALPHA token deposits in RandaoCoordinator and reject ETH
- update RandaoCoordinator interface and tests accordingly

## Testing
- `npx hardhat test test/v2/RandaoCoordinator.test.js` *(fails: process hung in container)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6f1f138c8333b4979d01275963e1