### PR TITLE
feat: add job funding event for analytics

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -215,6 +215,12 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     );
 
     // job lifecycle events
+    event JobFunded(
+        uint256 indexed jobId,
+        address indexed employer,
+        uint256 reward,
+        uint256 fee
+    );
     event JobCreated(
         uint256 indexed jobId,
         address indexed employer,
@@ -698,6 +704,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         if (address(stakeManager) != address(0) && reward > 0) {
             fee = (reward * feePctSnapshot) / 100;
             stakeManager.lockReward(bytes32(jobId), msg.sender, reward + fee);
+            emit JobFunded(jobId, msg.sender, reward, fee);
         }
         emit JobCreated(
             jobId,

--- a/docs/api/JobRegistry.md
+++ b/docs/api/JobRegistry.md
@@ -15,9 +15,10 @@ Coordinates job posting, assignment and dispute resolution.
 
 ## Events
 
-- `JobCreated(uint256 indexed jobId, address indexed employer, uint256 reward, string uri)`
-- `JobApplied(uint256 indexed jobId, address indexed agent)`
-- `JobSubmitted(uint256 indexed jobId, bytes32 resultHash)`
+- `JobFunded(uint256 indexed jobId, address indexed employer, uint256 reward, uint256 fee)`
+- `JobCreated(uint256 indexed jobId, address indexed employer, address indexed agent, uint256 reward, uint256 stake, uint256 fee, bytes32 specHash, string uri)`
+- `JobApplied(uint256 indexed jobId, address indexed agent, string subdomain)`
+- `JobSubmitted(uint256 indexed jobId, address indexed worker, bytes32 resultHash, string resultURI, string subdomain)`
 - `JobCompleted(uint256 indexed jobId, bool success)`
 - `JobFinalized(uint256 indexed jobId, address worker)`
 - `JobCancelled(uint256 indexed jobId)`

--- a/test/v2/JobFundedEvent.test.js
+++ b/test/v2/JobFundedEvent.test.js
@@ -5,10 +5,14 @@ const { time } = require('@nomicfoundation/hardhat-network-helpers');
 describe('JobFunded event', function () {
   it('emits when job is created with reward', async () => {
     const [owner, employer] = await ethers.getSigners();
-    const StakeMock = await ethers.getContractFactory('contracts/legacy/MockV2.sol:MockStakeManager');
+    const StakeMock = await ethers.getContractFactory(
+      'contracts/legacy/MockV2.sol:MockStakeManager'
+    );
     const stakeManager = await StakeMock.deploy();
 
-    const Registry = await ethers.getContractFactory('contracts/v2/JobRegistry.sol:JobRegistry');
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/JobRegistry.sol:JobRegistry'
+    );
     const registry = await Registry.deploy(
       ethers.ZeroAddress,
       await stakeManager.getAddress(),

--- a/test/v2/JobFundedEvent.test.js
+++ b/test/v2/JobFundedEvent.test.js
@@ -1,0 +1,36 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
+
+describe('JobFunded event', function () {
+  it('emits when job is created with reward', async () => {
+    const [owner, employer] = await ethers.getSigners();
+    const StakeMock = await ethers.getContractFactory('contracts/legacy/MockV2.sol:MockStakeManager');
+    const stakeManager = await StakeMock.deploy();
+
+    const Registry = await ethers.getContractFactory('contracts/v2/JobRegistry.sol:JobRegistry');
+    const registry = await Registry.deploy(
+      ethers.ZeroAddress,
+      await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    await registry.connect(owner).setFeePct(0);
+
+    const reward = 100;
+    const deadline = (await time.latest()) + 1000;
+    const specHash = ethers.id('spec');
+    await expect(
+      registry.connect(employer).createJob(reward, deadline, specHash, 'uri')
+    )
+      .to.emit(registry, 'JobFunded')
+      .withArgs(1, employer.address, reward, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- emit `JobFunded` when rewards are escrowed for a job
- document new funding event in JobRegistry API docs
- test JobFunded emission when creating a job

## Testing
- `npm test test/v2/JobFundedEvent.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bd72df667483339099a42fee116a1d