### PR TITLE
Configure IdentityRegistry for mainnet during deployment

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,9 @@
+# Deployment Notes
+
+After deploying the `IdentityRegistry` contract, you must call `configureMainnet()` to apply the canonical Ethereum mainnet ENS settings. This helper configures the ENS registry, NameWrapper, and required root nodes for `agent.agi.eth` and `club.agi.eth`.
+
+```ts
+await identityRegistry.configureMainnet();
+```
+
+Without this step, the registry will not enforce the proper mainnet ENS identity rules.

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -3,12 +3,8 @@ import { ethers } from 'hardhat';
 // Mainnet ENS registry and NameWrapper addresses
 // ENS registry: 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e
 // NameWrapper: 0x253553366Da8546fC250F225fe3d25d0C782303b
-// agent.agi.eth node: 0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d
-// club.agi.eth node: 0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16
 const ENS_REGISTRY = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
 const NAME_WRAPPER = '0x253553366Da8546fC250F225fe3d25d0C782303b';
-const AGENT_ROOT_NODE = ethers.namehash('agent.agi.eth');
-const CLUB_ROOT_NODE = ethers.namehash('club.agi.eth');
 
 async function main() {
   const [deployer] = await ethers.getSigners();
@@ -75,10 +71,7 @@ async function main() {
     ethers.ZeroHash
   );
   await identity.waitForDeployment();
-  await identity.setENS(ENS_REGISTRY);
-  await identity.setNameWrapper(NAME_WRAPPER);
-  await identity.setAgentRootNode(AGENT_ROOT_NODE);
-  await identity.setClubRootNode(CLUB_ROOT_NODE);
+  await identity.configureMainnet();
 
   const Attestation = await ethers.getContractFactory(
     'contracts/v2/AttestationRegistry.sol:AttestationRegistry'

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -140,10 +140,7 @@ async function main() {
     ethers.ZeroHash
   );
   await identity.waitForDeployment();
-  await identity.setENS(ENS_REGISTRY);
-  await identity.setNameWrapper(NAME_WRAPPER);
-  await identity.setAgentRootNode(AGENT_ROOT_NODE);
-  await identity.setClubRootNode(CLUB_ROOT_NODE);
+  await identity.configureMainnet();
 
   const Attestation = await ethers.getContractFactory(
     'contracts/v2/AttestationRegistry.sol:AttestationRegistry'


### PR DESCRIPTION
## Summary
- invoke `configureMainnet()` after deploying IdentityRegistry so scripts automatically set canonical ENS values
- document that `configureMainnet()` must be called to enable mainnet ENS configuration

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8237983c8333a982addd1c6f456f