### PR TITLE
Use AGIALPHA token for Randao deposits

### DIFF
--- a/contracts/v2/interfaces/IRandaoCoordinator.sol
+++ b/contracts/v2/interfaces/IRandaoCoordinator.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.25;
 
 interface IRandaoCoordinator {
     /// @notice Commit a hash of the sender address, tag and secret.
-    function commit(bytes32 tag, bytes32 commitment) external payable;
+    /// @dev Requires prior approval and transfers the $AGIALPHA deposit.
+    function commit(bytes32 tag, bytes32 commitment) external;
 
     /// @notice Reveal the secret for a given tag.
     function reveal(bytes32 tag, uint256 secret) external;


### PR DESCRIPTION
## Summary
- switch RandaoCoordinator to $AGIALPHA token deposits with ERC-20 refunds/forfeits
- drop payable commit in IRandaoCoordinator interface and block stray ETH via receive/fallback
- update RandaoCoordinator tests to mint, approve and use token transfers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd87207ec08333972f4a5d067a730e