### PR TITLE
feat: log allowlist authorization events

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -233,7 +233,7 @@ contract IdentityRegistry is Ownable2Step {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) public view returns (bool) {
+    ) public returns (bool) {
         if (
             address(reputationEngine) != address(0) &&
             reputationEngine.isBlacklisted(claimant)
@@ -241,6 +241,7 @@ contract IdentityRegistry is Ownable2Step {
             return false;
         }
         if (additionalAgents[claimant]) {
+            emit AdditionalAgentUsed(claimant, subdomain);
             return true;
         }
         if (address(attestationRegistry) != address(0)) {
@@ -273,7 +274,7 @@ contract IdentityRegistry is Ownable2Step {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) public view returns (bool) {
+    ) public returns (bool) {
         if (
             address(reputationEngine) != address(0) &&
             reputationEngine.isBlacklisted(claimant)
@@ -281,6 +282,7 @@ contract IdentityRegistry is Ownable2Step {
             return false;
         }
         if (additionalValidators[claimant]) {
+            emit AdditionalValidatorUsed(claimant, subdomain);
             return true;
         }
         if (address(attestationRegistry) != address(0)) {

--- a/contracts/v2/interfaces/IIdentityRegistry.sol
+++ b/contracts/v2/interfaces/IIdentityRegistry.sol
@@ -12,13 +12,13 @@ interface IIdentityRegistry {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) external view returns (bool);
+    ) external returns (bool);
 
     function isAuthorizedValidator(
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) external view returns (bool);
+    ) external returns (bool);
 
     function verifyAgent(
         address claimant,

--- a/contracts/v2/mocks/IdentityRegistryMock.sol
+++ b/contracts/v2/mocks/IdentityRegistryMock.sol
@@ -100,7 +100,7 @@ contract IdentityRegistryMock is Ownable {
         address claimant,
         string calldata,
         bytes32[] calldata
-    ) external view returns (bool) {
+    ) external returns (bool) {
         claimant; // silence unused
         return true;
     }
@@ -109,7 +109,7 @@ contract IdentityRegistryMock is Ownable {
         address claimant,
         string calldata,
         bytes32[] calldata
-    ) external view returns (bool) {
+    ) external returns (bool) {
         claimant; // silence unused
         return true;
     }

--- a/contracts/v2/mocks/IdentityRegistryToggle.sol
+++ b/contracts/v2/mocks/IdentityRegistryToggle.sol
@@ -93,7 +93,7 @@ contract IdentityRegistryToggle is Ownable {
         address claimant,
         string calldata,
         bytes32[] calldata
-    ) external view returns (bool) {
+    ) external returns (bool) {
         if (additionalAgents[claimant]) {
             return true;
         }
@@ -104,7 +104,7 @@ contract IdentityRegistryToggle is Ownable {
         address claimant,
         string calldata,
         bytes32[] calldata
-    ) external view returns (bool) {
+    ) external returns (bool) {
         if (additionalValidators[claimant]) {
             return true;
         }

--- a/contracts/v2/mocks/ReentrantIdentityRegistry.sol
+++ b/contracts/v2/mocks/ReentrantIdentityRegistry.sol
@@ -36,11 +36,11 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
     }
 
     // IIdentityRegistry stubs
-    function isAuthorizedAgent(address, string calldata, bytes32[] calldata) external pure returns (bool) {
+    function isAuthorizedAgent(address, string calldata, bytes32[] calldata) external returns (bool) {
         return true;
     }
 
-    function isAuthorizedValidator(address, string calldata, bytes32[] calldata) external pure returns (bool) {
+    function isAuthorizedValidator(address, string calldata, bytes32[] calldata) external returns (bool) {
         return true;
     }
 

--- a/docs/api/IdentityRegistry.md
+++ b/docs/api/IdentityRegistry.md
@@ -16,8 +16,8 @@ gas usage.
 - `addAdditionalAgent(address agent)` / `addAdditionalValidator(address validator)` – manual overrides.
 - `setAgentProfileURI(address agent, string uri)` – governance-set capability profile for an agent.
 - `updateAgentProfile(string subdomain, bytes32[] proof, string uri)` – agent updates their own profile after proving control of `subdomain`.
-- `isAuthorizedAgent(address claimant, string subdomain, bytes32[] proof)` – check agent eligibility for `subdomain.agent.agi.eth`.
-- `isAuthorizedValidator(address claimant, string subdomain, bytes32[] proof)` – check validator eligibility for `subdomain.club.agi.eth`.
+ - `isAuthorizedAgent(address claimant, string subdomain, bytes32[] proof)` – check agent eligibility for `subdomain.agent.agi.eth`. Allowlist-based authorizations emit `AdditionalAgentUsed`.
+ - `isAuthorizedValidator(address claimant, string subdomain, bytes32[] proof)` – check validator eligibility for `subdomain.club.agi.eth`. Allowlist-based authorizations emit `AdditionalValidatorUsed`.
 - `verifyAgent(address claimant, string subdomain, bytes32[] proof)` – external verification helper.
 - `verifyValidator(address claimant, string subdomain, bytes32[] proof)` – external verification helper.
 

--- a/docs/ens-identity-policy.md
+++ b/docs/ens-identity-policy.md
@@ -14,9 +14,9 @@ All participation in AGIJobs requires on‑chain proof of ENS subdomain ownershi
 In rare emergencies governance may temporarily bypass the ENS requirement by
 calling `IdentityRegistry.addAdditionalAgent` or `addAdditionalValidator`. Each
 entry should specify an expiration plan and be removed once the issue is
-resolved. The registry emits `AdditionalAgentUsed` and `AdditionalValidatorUsed`
-with the subdomain label whenever these bypasses are exercised, enabling
-off-chain monitoring.
+resolved. Both authorization helpers and verification functions emit
+`AdditionalAgentUsed` and `AdditionalValidatorUsed` with the subdomain label
+whenever these bypasses are exercised, enabling off-chain monitoring.
 
 Governance should review these events and regularly clear expired allowlist
 entries. Run `npx ts-node --compiler-options '{"module":"commonjs"}'

--- a/test/v2/AttestationRegistry.test.js
+++ b/test/v2/AttestationRegistry.test.js
@@ -124,7 +124,7 @@ describe('AttestationRegistry', function () {
     await attest.connect(owner).attest(agentNode, 0, agent.address);
 
     expect(
-      await identity.isAuthorizedAgent(agent.address, agentLabel, [])
+      await identity.isAuthorizedAgent.staticCall(agent.address, agentLabel, [])
     ).to.equal(true);
 
     const validatorLabel = 'validator';
@@ -138,7 +138,7 @@ describe('AttestationRegistry', function () {
     await attest.connect(owner).attest(validatorNode, 1, validator.address);
 
     expect(
-      await identity.isAuthorizedValidator(
+      await identity.isAuthorizedValidator.staticCall(
         validator.address,
         validatorLabel,
         []

--- a/test/v2/identity.test.ts
+++ b/test/v2/identity.test.ts
@@ -287,6 +287,44 @@ describe('IdentityRegistry ENS verification', function () {
       .withArgs(validator.address, '');
   });
 
+  it('emits events from authorization helpers when allowlists apply', async () => {
+    const [owner, agent, validator] = await ethers.getSigners();
+
+    const ENS = await ethers.getContractFactory('MockENS');
+    const ens = await ENS.deploy();
+
+    const Wrapper = await ethers.getContractFactory('MockNameWrapper');
+    const wrapper = await Wrapper.deploy();
+
+    const Stake = await ethers.getContractFactory('MockStakeManager');
+    const stake = await Stake.deploy();
+    const Rep = await ethers.getContractFactory(
+      'contracts/v2/ReputationEngine.sol:ReputationEngine'
+    );
+    const rep = await Rep.deploy(await stake.getAddress());
+
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/IdentityRegistry.sol:IdentityRegistry'
+    );
+    const id = await Registry.deploy(
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      await rep.getAddress(),
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+
+    await id.addAdditionalAgent(agent.address);
+    await expect(id.isAuthorizedAgent(agent.address, '', []))
+      .to.emit(id, 'AdditionalAgentUsed')
+      .withArgs(agent.address, '');
+
+    await id.addAdditionalValidator(validator.address);
+    await expect(id.isAuthorizedValidator(validator.address, '', []))
+      .to.emit(id, 'AdditionalValidatorUsed')
+      .withArgs(validator.address, '');
+  });
+
   it('requires new owner to accept ownership', async () => {
     const [owner, other] = await ethers.getSigners();
 


### PR DESCRIPTION
## Summary
- emit `AdditionalAgentUsed` and `AdditionalValidatorUsed` from allowlist-based authorization helpers
- document authorization event emission in ENS policy and API docs
- test authorization helpers emit allowlist events

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd8b3ec3b08333b34f20cbca854bf4