### PR TITLE
feat: add subdomain to validation events

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1006,7 +1006,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
             revert AlreadyCommitted();
 
         commitments[jobId][msg.sender][nonce] = commitHash;
-        emit ValidationCommitted(jobId, msg.sender, commitHash);
+        emit ValidationCommitted(jobId, msg.sender, commitHash, subdomain);
     }
 
     function _policy() internal view returns (ITaxPolicy) {
@@ -1084,7 +1084,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         r.revealedCount += 1;
         if (approve) r.approvals += stake; else r.rejections += stake;
 
-        emit ValidationRevealed(jobId, msg.sender, approve);
+        emit ValidationRevealed(jobId, msg.sender, approve, subdomain);
     }
 
     /// @notice Reveal a previously committed validation vote.

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -12,8 +12,18 @@ interface IValidationModule {
         Reservoir
     }
     event ValidatorsSelected(uint256 indexed jobId, address[] validators);
-    event ValidationCommitted(uint256 indexed jobId, address indexed validator, bytes32 commitHash);
-    event ValidationRevealed(uint256 indexed jobId, address indexed validator, bool approve);
+    event ValidationCommitted(
+        uint256 indexed jobId,
+        address indexed validator,
+        bytes32 commitHash,
+        string subdomain
+    );
+    event ValidationRevealed(
+        uint256 indexed jobId,
+        address indexed validator,
+        bool approve,
+        string subdomain
+    );
     event ValidationTallied(
         uint256 indexed jobId,
         bool success,

--- a/docs/api/ValidationModule.md
+++ b/docs/api/ValidationModule.md
@@ -31,7 +31,7 @@ Manages commit‑reveal voting for submitted jobs.
 - `JobRegistryUpdated(address registry)` / `StakeManagerUpdated(address manager)` / `IdentityRegistryUpdated(address registry)`
 - `JobNonceReset(uint256 jobId)`
 - `SelectionStrategyUpdated(SelectionStrategy strategy)`
-- `ValidationCommitted(uint256 jobId, address validator, bytes32 commitHash)`
-- `ValidationRevealed(uint256 jobId, address validator, bool approve)`
+- `ValidationCommitted(uint256 jobId, address validator, bytes32 commitHash, string subdomain)`
+- `ValidationRevealed(uint256 jobId, address validator, bool approve, string subdomain)`
 - `ValidationTallied(uint256 jobId, bool success, uint256 approvals, uint256 rejections)`
 - `ValidationResult(uint256 jobId, bool success)`

--- a/docs/legacy/Guidev0.md
+++ b/docs/legacy/Guidev0.md
@@ -637,7 +637,7 @@ Steps to operate as a Validator:
      - **jobId:** the job ID you are validating.
      - **commitHash:** the hash you calculated (a 66-character hex string starting with 0x).
 
-   - Click **Write** and send the transaction. This will record your commitment without revealing your vote. The contract will emit an event like `ValidationCommitted(jobId, validatorAddress)` (possibly with the hash or not). If you miss the commit window, you might be disqualified for this job’s validation.
+   - Click **Write** and send the transaction. This will record your commitment without revealing your vote. The contract will emit an event like `ValidationCommitted(jobId, validatorAddress, commitHash, subdomain)` (possibly with the hash or not). If you miss the commit window, you might be disqualified for this job’s validation.
 
 5. **Reveal Your Vote (Public Phase):** After committing, wait until the commit phase ends (the platform might define that as soon as all commits are in or after a fixed time). Then you must reveal your actual vote:
 
@@ -646,7 +646,7 @@ Steps to operate as a Validator:
    - **approve:** Enter the actual vote you chose (`true` if you think the job was done well, `false` if not). This must match the hidden vote you committed.
    - **salt:** Enter the secret string or hex you used when computing the commit hash (exactly the same salt). If you used a word, you’ll need to convert it to bytes32 format. Etherscan will accept a string in the field if the parameter is `bytes32` or `string` – check how it’s defined. If it’s `bytes32`, you might need to input the hex representation of your salt. For simplicity, use a numeric or short text salt and find its hex. For example, if salt was `"abc123"`, you can use an online converter to hex (`0x616263313233` in hex for "abc123"). Ensure every detail matches what you used to make the hash.
    - Click **Write**, confirm the transaction. This will reveal your vote. The contract will verify that `keccak(salt, vote)` equals the commit hash you submitted earlier for this job. If it matches, your vote is counted. If it doesn’t (or you reveal a different vote or wrong salt), your reveal might be rejected and you could be penalized for cheating.
-   - Once revealed, an event like `ValidationRevealed(jobId, validator, approve)` might fire, showing how you voted.
+   - Once revealed, an event like `ValidationRevealed(jobId, validator, approve, subdomain)` might fire, showing how you voted.
 
 6. **Outcome Determination:** After the reveal phase, the ValidationModule will finalize the votes (if it wasn’t already done automatically). In some implementations, any validator (or the contract itself) might call a function `finalizeValidation(jobId)` or the JobRegistry might have done so when the agent completed the job (as was hinted in code). In our code, `validationModule.finalize(jobId)` was called immediately on job completion, which is unusual – perhaps it selects validators and _predicts_ outcome or sets a placeholder. However, typically, after reveals:
 

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -260,8 +260,8 @@ To generate proofs:
 | --------------------------------------------------------------------------------------- | ------------------ | ----------------------------------------- |
 | `JobCreated(uint256 jobId, address employer, uint256 reward)`                           | `JobRegistry`      | Employer posted a job and escrowed funds. |
 | `JobApplied(uint256 jobId, address agent)`                                              | `JobRegistry`      | Agent applied for a job.                  |
-| `ValidationCommitted(uint256 jobId, address validator)`                                 | `ValidationModule` | Validator submitted hashed vote.          |
-| `ValidationRevealed(uint256 jobId, address validator, bool approve)`                    | `ValidationModule` | Validator revealed vote.                  |
+| `ValidationCommitted(uint256 jobId, address validator, bytes32 commitHash, string subdomain)` | `ValidationModule` | Validator submitted hashed vote.          |
+| `ValidationRevealed(uint256 jobId, address validator, bool approve, string subdomain)`        | `ValidationModule` | Validator revealed vote.                  |
 | `DisputeRaised(uint256 jobId, address claimant, bytes32 evidenceHash, string evidence)` | `DisputeModule`    | A job result was contested.               |
 | `DisputeResolved(uint256 jobId, bool employerWins)`                                     | `DisputeModule`    | Moderator issued final ruling.            |
 | `CertificateMinted(address to, uint256 jobId)`                                          | `CertificateNFT`   | NFT minted for a completed job.           |
@@ -272,7 +272,7 @@ To generate proofs:
 | `depositStake(uint8 role, uint256 amount)`                                         | `StakeManager`     | Bond tokens for a role.         |
 | `applyForJob(uint256 jobId, string subdomain, bytes32[] proof)`                    | `JobRegistry`      | Enter candidate pool for a job. |
 | `commitValidation(uint256 jobId, bytes32 hash, string subdomain, bytes32[] proof)` | `ValidationModule` | Submit a hidden vote.           |
-| `revealValidation(uint256 jobId, bool approve, bytes32 salt)`                      | `ValidationModule` | Reveal vote.                    |
+| `revealValidation(uint256 jobId, bool approve, bytes32 salt, string subdomain, bytes32[] proof)`                      | `ValidationModule` | Reveal vote.                    |
 | `raiseDispute(uint256 jobId, string reason)`                                       | `JobRegistry`      | Start appeal process.           |
 | `list(uint256 tokenId, uint256 price)`                                             | `CertificateNFT`   | List job certificate for sale.  |
 | `purchase(uint256 tokenId)`                                                        | `CertificateNFT`   | Buy listed certificate.         |

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -119,7 +119,8 @@ describe('Validator ENS integration', function () {
     )
       .to.emit(identity, 'OwnershipVerified')
       .withArgs(validator.address, 'v')
-      .and.to.emit(validation, 'ValidationCommitted');
+      .and.to.emit(validation, 'ValidationCommitted')
+      .withArgs(1, validator.address, ethers.id('h'), 'v');
   });
 
   it('rejects validators without subdomains and emits events on success', async () => {
@@ -156,7 +157,8 @@ describe('Validator ENS integration', function () {
     )
       .to.emit(identity, 'OwnershipVerified')
       .withArgs(validator.address, 'v')
-      .and.to.emit(validation, 'ValidationCommitted');
+      .and.to.emit(validation, 'ValidationCommitted')
+      .withArgs(2, validator.address, ethers.id('h'), 'v');
   });
 
   it('rejects invalid Merkle proofs', async () => {
@@ -221,7 +223,9 @@ describe('Validator ENS integration', function () {
     await identity.addAdditionalValidator(validator.address);
     await expect(
       validation.connect(validator).commitValidation(1, ethers.id('h'), 'v', [])
-    ).to.emit(validation, 'ValidationCommitted');
+    )
+      .to.emit(validation, 'ValidationCommitted')
+      .withArgs(1, validator.address, ethers.id('h'), 'v');
   });
 
   it('skips blacklisted validators', async () => {

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -490,9 +490,7 @@ describe('ValidationModule V2', function () {
       .withArgs(val.address);
 
     await policy.connect(val).acknowledge();
-    await expect(
-      validation.connect(val).commitValidation(1, commit, '', [])
-    )
+    await expect(validation.connect(val).commitValidation(1, commit, '', []))
       .to.emit(validation, 'ValidationCommitted')
       .withArgs(1, val.address, commit, '');
 

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -492,7 +492,9 @@ describe('ValidationModule V2', function () {
     await policy.connect(val).acknowledge();
     await expect(
       validation.connect(val).commitValidation(1, commit, '', [])
-    ).to.emit(validation, 'ValidationCommitted');
+    )
+      .to.emit(validation, 'ValidationCommitted')
+      .withArgs(1, val.address, commit, '');
 
     await advance(61);
     await policy.bumpPolicyVersion();
@@ -505,7 +507,9 @@ describe('ValidationModule V2', function () {
     await policy.connect(val).acknowledge();
     await expect(
       validation.connect(val).revealValidation(1, true, salt, '', [])
-    ).to.emit(validation, 'ValidationRevealed');
+    )
+      .to.emit(validation, 'ValidationRevealed')
+      .withArgs(1, val.address, true, '');
   });
 
   it('updates additional validators individually', async () => {


### PR DESCRIPTION
## Summary
- include subdomain in ValidationCommitted and ValidationRevealed events
- emit subdomain from commit and reveal logic
- assert subdomain in validation event tests and update docs

## Testing
- `npx hardhat compile`
- `npx hardhat test test/v2/ValidationModule.test.js test/v2/ENSValidatorBehavior.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd8e9b6df48333991949a43d0ce566