### PR TITLE
Emit OwnershipVerified on profile update

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -218,7 +218,7 @@ contract IdentityRegistry is Ownable2Step {
         bytes32[] calldata proof,
         string calldata uri
     ) external {
-        if (!isAuthorizedAgent(msg.sender, subdomain, proof)) {
+        if (!verifyAgent(msg.sender, subdomain, proof)) {
             revert UnauthorizedAgent();
         }
         agentProfileURI[msg.sender] = uri;
@@ -315,7 +315,7 @@ contract IdentityRegistry is Ownable2Step {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) external returns (bool) {
+    ) public returns (bool) {
         if (
             address(reputationEngine) != address(0) &&
             reputationEngine.isBlacklisted(claimant)

--- a/test/v2/identity.test.ts
+++ b/test/v2/identity.test.ts
@@ -242,8 +242,12 @@ describe('IdentityRegistry ENS verification', function () {
 
     // allow alice as additional agent then self-update profile
     await id.addAdditionalAgent(alice.address);
-    await expect(id.connect(alice).updateAgentProfile('sub', [], 'ipfs://cap2'))
-      .to.emit(id, 'AgentProfileUpdated')
+    await expect(
+      id.connect(alice).updateAgentProfile('sub', [], 'ipfs://cap2')
+    )
+      .to.emit(id, 'OwnershipVerified')
+      .withArgs(alice.address, 'sub')
+      .and.to.emit(id, 'AgentProfileUpdated')
       .withArgs(alice.address, 'ipfs://cap2');
     expect(await id.agentProfileURI(alice.address)).to.equal('ipfs://cap2');
   });

--- a/test/v2/identity.test.ts
+++ b/test/v2/identity.test.ts
@@ -242,9 +242,7 @@ describe('IdentityRegistry ENS verification', function () {
 
     // allow alice as additional agent then self-update profile
     await id.addAdditionalAgent(alice.address);
-    await expect(
-      id.connect(alice).updateAgentProfile('sub', [], 'ipfs://cap2')
-    )
+    await expect(id.connect(alice).updateAgentProfile('sub', [], 'ipfs://cap2'))
       .to.emit(id, 'OwnershipVerified')
       .withArgs(alice.address, 'sub')
       .and.to.emit(id, 'AgentProfileUpdated')


### PR DESCRIPTION
## Summary
- ensure agent profile updates call verifyAgent and emit OwnershipVerified on success
- update tests to expect OwnershipVerified during profile update

## Testing
- `npm test --silent test/v2/identity.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bd99d96bf483339c94f04e8eeb634c