### PR TITLE
feat: emit reward paid event

### DIFF
--- a/contracts/v2/interfaces/IJobEscrow.sol
+++ b/contracts/v2/interfaces/IJobEscrow.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 /// @title IJobEscrow
 /// @notice Minimal interface for job escrow helpers
 interface IJobEscrow {
+    event RewardPaid(uint256 indexed jobId, address indexed operator, uint256 amount);
     /// @notice Post a new job and escrow the reward
     function postJob(uint256 reward, string calldata data, bytes32 seed) external returns (uint256);
 

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -71,6 +71,7 @@ contract JobEscrow is Ownable, ReentrancyGuard {
     );
     event JobCancelled(uint256 indexed jobId);
     event ResultSubmitted(uint256 indexed jobId, string result);
+    event RewardPaid(uint256 indexed jobId, address indexed operator, uint256 amount);
     event ResultAccepted(uint256 indexed jobId, address caller);
 
     /// @param _routing Routing module used to select operators for new jobs.
@@ -158,6 +159,7 @@ contract JobEscrow is Ownable, ReentrancyGuard {
         }
         job.state = State.Accepted;
         token.safeTransfer(job.operator, job.reward);
+        emit RewardPaid(jobId, job.operator, job.reward);
         emit ResultAccepted(jobId, msg.sender);
     }
 

--- a/test/v2/JobEscrow.test.js
+++ b/test/v2/JobEscrow.test.js
@@ -49,8 +49,11 @@ describe('JobEscrow', function () {
     ).args.jobId;
 
     await escrow.connect(operator).submitResult(jobId, 'ipfs://result');
-    await escrow.connect(employer).acceptResult(jobId);
-
+    await expect(escrow.connect(employer).acceptResult(jobId))
+      .to.emit(escrow, 'RewardPaid')
+      .withArgs(jobId, operator.address, reward)
+      .and.to.emit(escrow, 'ResultAccepted')
+      .withArgs(jobId, employer.address);
     expect(await token.balanceOf(operator.address)).to.equal(reward);
   });
 
@@ -74,7 +77,11 @@ describe('JobEscrow', function () {
     ).args.jobId;
     await escrow.connect(operator).submitResult(jobId, 'res');
     await time.increase(3 * 24 * 60 * 60 + 1);
-    await escrow.connect(operator).acceptResult(jobId);
+    await expect(escrow.connect(operator).acceptResult(jobId))
+      .to.emit(escrow, 'RewardPaid')
+      .withArgs(jobId, operator.address, reward)
+      .and.to.emit(escrow, 'ResultAccepted')
+      .withArgs(jobId, operator.address);
     expect(await token.balanceOf(operator.address)).to.equal(reward);
   });
 
@@ -131,7 +138,9 @@ describe('JobEscrow', function () {
     await policy.connect(owner).bumpPolicyVersion();
     expect(await policy.hasAcknowledged(employer.address)).to.equal(false);
     await expect(escrow.connect(employer).acknowledgeAndAcceptResult(jobId))
-      .to.emit(escrow, 'ResultAccepted')
+      .to.emit(escrow, 'RewardPaid')
+      .withArgs(jobId, operator.address, reward)
+      .and.to.emit(escrow, 'ResultAccepted')
       .withArgs(jobId, employer.address);
     expect(await token.balanceOf(operator.address)).to.equal(reward);
     expect(await policy.hasAcknowledged(employer.address)).to.equal(true);


### PR DESCRIPTION
## Summary
- add RewardPaid event to JobEscrow
- emit RewardPaid after paying operator
- test JobEscrow acceptance for RewardPaid events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd9e247f748333a8be9d80f6eba00e