### PR TITLE
Add juror slashing interface and tests

### DIFF
--- a/contracts/v2/ArbitratorCommittee.sol
+++ b/contracts/v2/ArbitratorCommittee.sol
@@ -6,7 +6,6 @@ import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 import {IDisputeModule} from "./interfaces/IDisputeModule.sol";
 import {IValidationModule} from "./interfaces/IValidationModule.sol";
-import {IStakeManager} from "./interfaces/IStakeManager.sol";
 
 /// @title ArbitratorCommittee
 /// @notice Handles commit-reveal voting by job validators to resolve disputes.
@@ -147,13 +146,11 @@ contract ArbitratorCommittee is Ownable, Pausable {
         bool employerWins = c.reveals > 0 && c.employerVotes * 2 > c.reveals;
         address employer = jobRegistry.jobs(jobId).employer;
         disputeModule.resolve(jobId, employerWins);
-        address smAddr = jobRegistry.stakeManager();
-        IStakeManager sm = IStakeManager(smAddr);
-        bool doSlash = absenteeSlash > 0 && smAddr != address(0);
+        bool doSlash = absenteeSlash > 0;
         for (uint256 i; i < c.jurors.length; ++i) {
             address juror = c.jurors[i];
             if (doSlash && c.commits[juror] != bytes32(0) && !c.revealed[juror]) {
-                sm.slash(juror, absenteeSlash, employer);
+                disputeModule.slashValidator(juror, absenteeSlash, employer);
             }
             delete c.isJuror[juror];
         }

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -13,5 +13,11 @@ interface IDisputeModule {
     ) external;
 
     function resolve(uint256 jobId, bool employerWins) external;
+
+    function slashValidator(
+        address juror,
+        uint256 amount,
+        address employer
+    ) external;
 }
 

--- a/contracts/v2/modules/KlerosDisputeModule.sol
+++ b/contracts/v2/modules/KlerosDisputeModule.sol
@@ -101,6 +101,15 @@ contract KlerosDisputeModule is IDisputeModule {
         emit DisputeResolved(jobId, employerWins);
     }
 
+    /// @inheritdoc IDisputeModule
+    function slashValidator(
+        address,
+        uint256,
+        address
+    ) external pure override {
+        revert Unsupported();
+    }
+
     // ---------------------------------------------------------------------
     // Unused legacy interfaces - maintained for compatibility
     // ---------------------------------------------------------------------

--- a/test/v2/ArbitratorCommittee.test.js
+++ b/test/v2/ArbitratorCommittee.test.js
@@ -232,4 +232,63 @@ describe('ArbitratorCommittee', function () {
       .to.emit(dispute, 'DisputeResolved')
       .withArgs(1, await committee.getAddress(), true);
   });
+
+  it('slashes absentee jurors and emits events', async () => {
+    const {
+      committee,
+      dispute,
+      registry,
+      agent,
+      employer,
+      v1,
+      v2,
+      token,
+      stake,
+    } = await setup();
+
+    await committee.setCommitRevealWindows(3n, 2n);
+    await committee.setAbsenteeSlash(FEE);
+
+    for (const juror of [v1, v2]) {
+      await token.mint(juror.address, FEE);
+      await token
+        .connect(juror)
+        .approve(await stake.getAddress(), FEE);
+      await stake.connect(juror).depositStake(1, FEE);
+    }
+
+    const evidence = ethers.id('evidence');
+    await registry.connect(agent).dispute(1, evidence);
+
+    const s1 = 1n,
+      s2 = 2n;
+    const c1 = ethers.keccak256(
+      ethers.solidityPacked(
+        ['address', 'uint256', 'bool', 'uint256'],
+        [v1.address, 1, true, s1]
+      )
+    );
+    const c2 = ethers.keccak256(
+      ethers.solidityPacked(
+        ['address', 'uint256', 'bool', 'uint256'],
+        [v2.address, 1, true, s2]
+      )
+    );
+
+    await committee.connect(v1).commit(1, c1);
+    await committee.connect(v2).commit(1, c2);
+
+    await time.increase(2n);
+
+    await committee.connect(v1).reveal(1, true, s1);
+
+    await time.increase(3n);
+    await time.increase(10n);
+
+    await expect(committee.finalize(1))
+      .to.emit(dispute, 'JurorSlashed')
+      .withArgs(v2.address, FEE, employer.address);
+
+    expect(await stake.stakeOf(v2.address, 1)).to.equal(0n);
+  });
 });


### PR DESCRIPTION
## Summary
- expose `slashValidator` in `DisputeModule` with `JurorSlashed` event
- have `ArbitratorCommittee.finalize` invoke `slashValidator` instead of `StakeManager`
- extend `IDisputeModule` and tests to cover absentee juror slashing

## Testing
- `npm run compile`
- `npm test -- test/v2/ArbitratorCommittee.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bda80e64748333939beb2c2bd47624