### PR TITLE
Reject ETH transfers in dispute and validation modules

### DIFF
--- a/contracts/v2/modules/KlerosDisputeModule.sol
+++ b/contracts/v2/modules/KlerosDisputeModule.sol
@@ -129,6 +129,16 @@ contract KlerosDisputeModule is IDisputeModule {
     function getModerators() external pure returns (address[] memory) {
         return new address[](0);
     }
+
+    /// @dev Reject direct ETH transfers to keep the module tax neutral.
+    receive() external payable {
+        revert("KlerosDisputeModule: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("KlerosDisputeModule: no ether");
+    }
 }
 
 /// @dev External arbitration interface expected by the module.

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -164,5 +164,14 @@ contract NoValidationModule is IValidationModule, Ownable {
 
     function bumpValidatorAuthCacheVersion() external pure override {}
 
+    /// @dev Reject direct ETH transfers to keep the module tax neutral.
+    receive() external payable {
+        revert("NoValidationModule: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("NoValidationModule: no ether");
+    }
 }
 

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -187,5 +187,14 @@ contract OracleValidationModule is IValidationModule, Ownable {
 
     function bumpValidatorAuthCacheVersion() external pure override {}
 
+    /// @dev Reject direct ETH transfers to keep the module tax neutral.
+    receive() external payable {
+        revert("OracleValidationModule: no ether");
+    }
+
+    /// @dev Reject calls with unexpected calldata or funds.
+    fallback() external payable {
+        revert("OracleValidationModule: no ether");
+    }
 }
 

--- a/test/v2/KlerosDisputeModuleNoEther.test.js
+++ b/test/v2/KlerosDisputeModuleNoEther.test.js
@@ -1,0 +1,39 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('KlerosDisputeModule ether rejection', function () {
+  let owner, module;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const JobMock = await ethers.getContractFactory('MockJobRegistry');
+    const registry = await JobMock.deploy();
+    await registry.waitForDeployment();
+    const Module = await ethers.getContractFactory(
+      'contracts/v2/modules/KlerosDisputeModule.sol:KlerosDisputeModule'
+    );
+    module = await Module.deploy(
+      await registry.getAddress(),
+      owner.address,
+      owner.address
+    );
+    await module.waitForDeployment();
+  });
+
+  it('reverts on direct ether transfer', async () => {
+    await expect(
+      owner.sendTransaction({ to: await module.getAddress(), value: 1 })
+    ).to.be.revertedWith('KlerosDisputeModule: no ether');
+  });
+
+  it('reverts on unknown calldata with value', async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await module.getAddress(),
+        data: '0x12345678',
+        value: 1,
+      })
+    ).to.be.revertedWith('KlerosDisputeModule: no ether');
+  });
+});
+

--- a/test/v2/KlerosDisputeModuleNoEther.test.js
+++ b/test/v2/KlerosDisputeModuleNoEther.test.js
@@ -36,4 +36,3 @@ describe('KlerosDisputeModule ether rejection', function () {
     ).to.be.revertedWith('KlerosDisputeModule: no ether');
   });
 });
-

--- a/test/v2/NoValidationModuleNoEther.test.js
+++ b/test/v2/NoValidationModuleNoEther.test.js
@@ -1,0 +1,35 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('NoValidationModule ether rejection', function () {
+  let owner, module;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const JobMock = await ethers.getContractFactory('MockJobRegistry');
+    const registry = await JobMock.deploy();
+    await registry.waitForDeployment();
+    const Module = await ethers.getContractFactory(
+      'contracts/v2/modules/NoValidationModule.sol:NoValidationModule'
+    );
+    module = await Module.deploy(await registry.getAddress());
+    await module.waitForDeployment();
+  });
+
+  it('reverts on direct ether transfer', async () => {
+    await expect(
+      owner.sendTransaction({ to: await module.getAddress(), value: 1 })
+    ).to.be.revertedWith('NoValidationModule: no ether');
+  });
+
+  it('reverts on unknown calldata with value', async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await module.getAddress(),
+        data: '0x12345678',
+        value: 1,
+      })
+    ).to.be.revertedWith('NoValidationModule: no ether');
+  });
+});
+

--- a/test/v2/NoValidationModuleNoEther.test.js
+++ b/test/v2/NoValidationModuleNoEther.test.js
@@ -32,4 +32,3 @@ describe('NoValidationModule ether rejection', function () {
     ).to.be.revertedWith('NoValidationModule: no ether');
   });
 });
-

--- a/test/v2/OracleValidationModuleNoEther.test.js
+++ b/test/v2/OracleValidationModuleNoEther.test.js
@@ -12,7 +12,10 @@ describe('OracleValidationModule ether rejection', function () {
     const Module = await ethers.getContractFactory(
       'contracts/v2/modules/OracleValidationModule.sol:OracleValidationModule'
     );
-    module = await Module.deploy(await registry.getAddress(), ethers.ZeroAddress);
+    module = await Module.deploy(
+      await registry.getAddress(),
+      ethers.ZeroAddress
+    );
     await module.waitForDeployment();
   });
 
@@ -32,4 +35,3 @@ describe('OracleValidationModule ether rejection', function () {
     ).to.be.revertedWith('OracleValidationModule: no ether');
   });
 });
-

--- a/test/v2/OracleValidationModuleNoEther.test.js
+++ b/test/v2/OracleValidationModuleNoEther.test.js
@@ -1,0 +1,35 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('OracleValidationModule ether rejection', function () {
+  let owner, module;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const JobMock = await ethers.getContractFactory('MockJobRegistry');
+    const registry = await JobMock.deploy();
+    await registry.waitForDeployment();
+    const Module = await ethers.getContractFactory(
+      'contracts/v2/modules/OracleValidationModule.sol:OracleValidationModule'
+    );
+    module = await Module.deploy(await registry.getAddress(), ethers.ZeroAddress);
+    await module.waitForDeployment();
+  });
+
+  it('reverts on direct ether transfer', async () => {
+    await expect(
+      owner.sendTransaction({ to: await module.getAddress(), value: 1 })
+    ).to.be.revertedWith('OracleValidationModule: no ether');
+  });
+
+  it('reverts on unknown calldata with value', async () => {
+    await expect(
+      owner.sendTransaction({
+        to: await module.getAddress(),
+        data: '0x12345678',
+        value: 1,
+      })
+    ).to.be.revertedWith('OracleValidationModule: no ether');
+  });
+});
+


### PR DESCRIPTION
## Summary
- disallow ETH transfers to KlerosDisputeModule, NoValidationModule and OracleValidationModule via `receive`/`fallback`
- add unit tests covering ETH transfer rejection for those modules

## Testing
- `npx hardhat test test/v2/KlerosDisputeModuleNoEther.test.js test/v2/NoValidationModuleNoEther.test.js test/v2/OracleValidationModuleNoEther.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bdadaf029c8333804c23d689fd04dc