### PR TITLE
feat: index treasury in StakeSlashed event

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -170,9 +170,9 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     event WithdrawRequested(address indexed user, Role indexed role, uint256 amount, uint64 unlockAt);
     event StakeSlashed(
         address indexed user,
-        Role indexed role,
+        Role role,
         address indexed employer,
-        address treasury,
+        address indexed treasury,
         uint256 employerShare,
         uint256 treasuryShare,
         uint256 burnShare

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -26,11 +26,12 @@ interface IStakeManager {
     event StakeUnlocked(address indexed user, uint256 amount);
     event StakeSlashed(
         address indexed user,
-        Role indexed role,
+        Role role,
         address indexed employer,
-        address treasury,
+        address indexed treasury,
         uint256 employerShare,
-        uint256 treasuryShare
+        uint256 treasuryShare,
+        uint256 burnShare
     );
     event DisputeFeeLocked(address indexed payer, uint256 amount);
     event DisputeFeePaid(address indexed to, uint256 amount);


### PR DESCRIPTION
## Summary
- index treasury in StakeSlashed event and remove role as indexed param to stay within Solidity limits
- update IStakeManager interface accordingly

## Testing
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb322d938833398b4aeb7bcc312d5