### PR TITLE
feat: use custom error for module installer init

### DIFF
--- a/contracts/v2/ModuleInstaller.sol
+++ b/contracts/v2/ModuleInstaller.sol
@@ -23,6 +23,8 @@ interface IOwnable {
     function transferOwnership(address newOwner) external;
 }
 
+error AlreadyInitialized();
+
 /// @title ModuleInstaller
 /// @notice Optional helper wiring deployed modules in a single transaction.
 /// @dev Core contracts now accept zero addresses in their constructors so
@@ -86,7 +88,7 @@ contract ModuleInstaller is Ownable {
         bytes32 agentMerkleRoot,
         address[] calldata _ackModules
     ) external onlyOwner {
-        require(!initialized, "init");
+        if (initialized) revert AlreadyInitialized();
         initialized = true;
 
         jobRegistry.setModules(

--- a/test/v2/ModuleInstaller.test.js
+++ b/test/v2/ModuleInstaller.test.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const { network } = require('hardhat');
 
 describe('ModuleInstaller', function () {
   it('restricts initialize to owner and reports tax exemption', async function () {
@@ -34,5 +35,47 @@ describe('ModuleInstaller', function () {
     ).to.be.revertedWithCustomError(installer, 'OwnableUnauthorizedAccount');
 
     expect(await installer.isTaxExempt()).to.equal(true);
+  });
+
+  it('reverts when initialized twice', async function () {
+    const Installer = await ethers.getContractFactory(
+      'contracts/v2/ModuleInstaller.sol:ModuleInstaller'
+    );
+    const installer = await Installer.deploy();
+    await installer.waitForDeployment();
+
+    const addr = await installer.getAddress();
+    const owner = await installer.owner();
+    const value = ethers.hexlify(
+      ethers.zeroPadValue(
+        ethers.solidityPacked(['bool', 'address'], [true, owner]),
+        32
+      )
+    );
+    await network.provider.send('hardhat_setStorageAt', [addr, '0x0', value]);
+
+    expect(await installer.initialized()).to.equal(true);
+
+    await expect(
+      installer.initialize(
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        ethers.ZeroHash,
+        ethers.ZeroHash,
+        ethers.ZeroHash,
+        ethers.ZeroHash,
+        []
+      )
+    ).to.be.revertedWithCustomError(installer, 'AlreadyInitialized');
   });
 });


### PR DESCRIPTION
## Summary
- declare `AlreadyInitialized` custom error in ModuleInstaller and replace `require` with `revert`
- add test covering double initialization

## Testing
- `npx hardhat test test/v2/ModuleInstaller.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb5433620833396c478373ddc5315