### PR TITLE
docs: link sprint plan and deployment guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,5 +239,6 @@ For detailed behaviour and additional modules such as `FeePool`, `TaxPolicy` and
 - [Etherscan interaction guide](docs/etherscan-guide.md)
 - [Deployment walkthrough with $AGIALPHA](docs/deployment-v2-agialpha.md)
 - [Production deployment guide](docs/deployment-guide-production.md)
+- [AGIJobs v2 sprint plan and deployment guide](docs/AGIJobs-v2-Sprint-Plan-and-Deployment-Guide.md)
 - [API reference and SDK snippets](docs/api-reference.md)
 - [Agent gateway example](examples/agent-gateway.js)


### PR DESCRIPTION
## Summary
- add README bullet for AGIJobs v2 sprint plan and deployment guide

## Testing
- `npm test` *(fails: hung after start)*
- `npm run lint` *(fails: hung during update check)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb817ba9c833391f3a38c991587a9