### PR TITLE
docs: add commit-reveal example

### DIFF
--- a/docs/job-validation-lifecycle.md
+++ b/docs/job-validation-lifecycle.md
@@ -6,11 +6,11 @@ Validators must own a `*.club.agi.eth` subdomain; see
 
 ## Phases and Windows
 
-| Phase    | Validator state   | Allowed window                             | Function                                                              |
-| -------- | ----------------- | ------------------------------------------ | --------------------------------------------------------------------- |
-| Commit   | Commitment stored | `commitWindow` seconds after selection     | `ValidationModule.commitValidation(jobId, commitHash, subdomain, proof)`                |
-| Reveal   | Vote disclosed    | `revealWindow` seconds after commit window | `ValidationModule.revealValidation(jobId, approve, salt, subdomain, proof)`             |
-| Finalize | Job settled       | After `revealWindow` closes                | `ValidationModule.finalize(jobId)` then `JobRegistry.finalize(jobId)` |
+| Phase    | Validator state   | Allowed window                             | Function                                                                    |
+| -------- | ----------------- | ------------------------------------------ | --------------------------------------------------------------------------- |
+| Commit   | Commitment stored | `commitWindow` seconds after selection     | `ValidationModule.commitValidation(jobId, commitHash, subdomain, proof)`    |
+| Reveal   | Vote disclosed    | `revealWindow` seconds after commit window | `ValidationModule.revealValidation(jobId, approve, salt, subdomain, proof)` |
+| Finalize | Job settled       | After `revealWindow` closes                | `ValidationModule.finalize(jobId)` then `JobRegistry.finalize(jobId)`       |
 
 `commitWindow` and `revealWindow` are owner‑configurable via `ValidationModule.setCommitRevealWindows`.
 
@@ -26,6 +26,12 @@ validationModule.revealValidation(jobId, true, salt, '', new bytes32[](0));
 validationModule.finalize(jobId);
 jobRegistry.finalize(jobId);
 ```
+
+## Script Example
+
+For a runnable Node.js reference, see
+[examples/commit-reveal.js](../examples/commit-reveal.js) which computes the
+commit hash, calls `commitValidation`, and later invokes `revealValidation`.
 
 ## CLI Example
 

--- a/examples/commit-reveal.js
+++ b/examples/commit-reveal.js
@@ -1,0 +1,66 @@
+// Compute commit hash and reveal votes for job validation
+// Usage:
+//   node examples/commit-reveal.js commit <jobId> <approve> [subdomain]
+//   node examples/commit-reveal.js reveal <jobId> <approve> <salt> [subdomain]
+// Requires RPC_URL, PRIVATE_KEY and VALIDATION_MODULE env vars.
+
+const { ethers } = require('ethers');
+
+const provider = new ethers.JsonRpcProvider(
+  process.env.RPC_URL || 'http://localhost:8545'
+);
+const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
+
+const validationAbi = [
+  'function commitValidation(uint256,bytes32,string,bytes32[])',
+  'function revealValidation(uint256,bool,bytes32,string,bytes32[])',
+];
+
+const validation = new ethers.Contract(
+  process.env.VALIDATION_MODULE,
+  validationAbi,
+  wallet
+);
+
+async function commit(jobId, approve, subdomain, proof) {
+  const salt = ethers.randomBytes(32);
+  const hash = ethers.solidityPackedKeccak256(
+    ['bool', 'bytes32'],
+    [approve, salt]
+  );
+  console.log('Commit hash', hash);
+  console.log('Salt', ethers.hexlify(salt), 'save for reveal');
+  await validation.commitValidation(jobId, hash, subdomain, proof);
+}
+
+async function reveal(jobId, approve, salt, subdomain, proof) {
+  await validation.revealValidation(jobId, approve, salt, subdomain, proof);
+}
+
+async function main() {
+  const [action, jobIdArg, approveArg, arg4, arg5] = process.argv.slice(2);
+  if (!action || !jobIdArg || !approveArg) {
+    console.error(
+      'Usage: node examples/commit-reveal.js commit|reveal jobId approve [salt] [subdomain]'
+    );
+    return;
+  }
+  const jobId = BigInt(jobIdArg);
+  const approve = approveArg === 'true';
+  if (action === 'commit') {
+    const subdomain = arg4 || '';
+    const proof = [];
+    await commit(jobId, approve, subdomain, proof);
+  } else if (action === 'reveal') {
+    const salt = arg4;
+    const subdomain = arg5 || '';
+    const proof = [];
+    await reveal(jobId, approve, salt, subdomain, proof);
+  } else {
+    console.error('Unknown action', action);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+});


### PR DESCRIPTION
## Summary
- add Node.js commit/reveal validation example script
- link script from job validation lifecycle docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdb9e2601c8333bac6ac9aede0f24c