### PR TITLE
feat: add unauthorized error

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -57,6 +57,7 @@ error Jailed();
 error PendingPenalty();
 error BurnAddressNotZero();
 error TokenNotBurnable();
+error Unauthorized();
 
 /// @title StakeManager
 /// @notice Handles staking balances, job escrows and slashing logic.
@@ -203,10 +204,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     event PauserUpdated(address indexed pauser);
 
     modifier onlyGovernanceOrPauser() {
-        require(
-            msg.sender == address(governance) || msg.sender == pauser,
-            "governance or pauser only"
-        );
+        if (!(msg.sender == address(governance) || msg.sender == pauser))
+            revert Unauthorized();
         _;
     }
 

--- a/test/v2/StakeManagerPause.test.js
+++ b/test/v2/StakeManagerPause.test.js
@@ -34,6 +34,18 @@ describe('StakeManager pause', function () {
       .approve(await stakeManager.getAddress(), ethers.parseEther('1000'));
   });
 
+  it('restricts pause and unpause to governance or pauser', async () => {
+    await expect(stakeManager.connect(user).pause()).to.be.revertedWithCustomError(
+      stakeManager,
+      'Unauthorized'
+    );
+
+    await expect(stakeManager.connect(user).unpause()).to.be.revertedWithCustomError(
+      stakeManager,
+      'Unauthorized'
+    );
+  });
+
   it('pauses deposits and withdrawals', async () => {
     await stakeManager.connect(owner).pause();
     await expect(


### PR DESCRIPTION
## Summary
- add explicit Unauthorized error
- use Unauthorized revert in StakeManager governance/pauser modifier
- test that only governance or pauser can pause/unpause

## Testing
- `npm test`
- `forge test` *(fails: Yul exception in compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc4f1cf90833386f63e82905b3909