### PR TITLE
docs: clean up sprint plan TOC for AGIJobs v2

### DIFF
--- a/docs/AGIJobs-v2-Sprint-Plan-and-Deployment-Guide.md
+++ b/docs/AGIJobs-v2-Sprint-Plan-and-Deployment-Guide.md
@@ -10,7 +10,7 @@
   - [Comprehensive Event Logging and Traceability](#comprehensive-event-logging-and-traceability)
   - [Slashing and Staking Mechanics Optimization](#slashing-and-staking-mechanics-optimization)
   - [$AGIALPHA Burning and Fee Recycling](#agialpha-burning-and-fee-recycling)
-  - [Mainnet Readiness and User Experience](#mainnet-readiness-and-user-experience)
+- [Mainnet Readiness and User Experience](#mainnet-readiness-and-user-experience)
 - [Step-by-Step Deployment Guide (Ethereum Mainnet via Etherscan)](#step-by-step-deployment-guide-ethereum-mainnet-via-etherscan)
 - [End-User Guide: Using AGIJobs via Etherscan](#end-user-guide-using-agijobs-via-etherscan-no-coding-required)
 - [Code and Documentation Quality Improvements](#code-and-documentation-quality-improvements)
@@ -18,8 +18,6 @@
 - [Final Deployment Recommendations](#final-deployment-recommendations)
 
 ---
-
-# AGIJobs v2 Sprint Plan and Deployment Guide
 
 ## Codebase Enhancements and Key Requirements
 


### PR DESCRIPTION
## Summary
- fix table of contents link for deployment guide section
- drop redundant top-level heading in sprint plan doc

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bde449d430833394659f5663fdeb17