### PR TITLE
Make isAuthorizedValidator view-only

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -273,7 +273,7 @@ contract IdentityRegistry is Ownable2Step {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) public returns (bool) {
+    ) public view returns (bool) {
         if (
             address(reputationEngine) != address(0) &&
             reputationEngine.isBlacklisted(claimant)
@@ -281,7 +281,6 @@ contract IdentityRegistry is Ownable2Step {
             return false;
         }
         if (additionalValidators[claimant]) {
-            emit AdditionalValidatorUsed(claimant, subdomain);
             return true;
         }
         if (address(attestationRegistry) != address(0)) {

--- a/contracts/v2/interfaces/IIdentityRegistry.sol
+++ b/contracts/v2/interfaces/IIdentityRegistry.sol
@@ -18,7 +18,7 @@ interface IIdentityRegistry {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) external returns (bool);
+    ) external view returns (bool);
 
     function verifyAgent(
         address claimant,

--- a/contracts/v2/mocks/IdentityRegistryMock.sol
+++ b/contracts/v2/mocks/IdentityRegistryMock.sol
@@ -109,7 +109,7 @@ contract IdentityRegistryMock is Ownable {
         address claimant,
         string calldata,
         bytes32[] calldata
-    ) external returns (bool) {
+    ) external view returns (bool) {
         claimant; // silence unused
         return true;
     }

--- a/contracts/v2/mocks/IdentityRegistryToggle.sol
+++ b/contracts/v2/mocks/IdentityRegistryToggle.sol
@@ -104,7 +104,7 @@ contract IdentityRegistryToggle is Ownable {
         address claimant,
         string calldata,
         bytes32[] calldata
-    ) external returns (bool) {
+    ) external view returns (bool) {
         if (additionalValidators[claimant]) {
             return true;
         }

--- a/contracts/v2/mocks/ReentrantIdentityRegistry.sol
+++ b/contracts/v2/mocks/ReentrantIdentityRegistry.sol
@@ -40,7 +40,7 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
         return true;
     }
 
-    function isAuthorizedValidator(address, string calldata, bytes32[] calldata) external returns (bool) {
+    function isAuthorizedValidator(address, string calldata, bytes32[] calldata) external view returns (bool) {
         return true;
     }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -85,7 +85,7 @@ Verifies ENS ownership and Merkle proofs for agent and validator identities.
 - `verifyAgent(address claimant, string subdomain, bytes32[] proof)` – Validate an agent’s identity.
 - `verifyValidator(address claimant, string subdomain, bytes32[] proof)` – Validate a validator.
 - `isAuthorizedAgent(address claimant, string subdomain, bytes32[] proof)` – Check if an address may act as an agent.
-- `isAuthorizedValidator(address claimant, string subdomain, bytes32[] proof)` – Check if an address may validate.
+- `isAuthorizedValidator(address claimant, string subdomain, bytes32[] proof)` – Read-only helper to check if an address may validate; emits no events.
 
 Successful checks are cached by `JobRegistry` and `ValidationModule` for about a
 day; owners can invalidate these caches when ENS data changes.

--- a/docs/api.md
+++ b/docs/api.md
@@ -81,7 +81,7 @@ Verifies agent and validator eligibility.
 
 - `setAttestationRegistry(address registry)` – configure optional delegated identity support.
 - `isAuthorizedAgent(address claimant, string subdomain, bytes32[] proof)` – check if an address controlling `subdomain.agent.agi.eth` can work.
-- `isAuthorizedValidator(address claimant, string subdomain, bytes32[] proof)` – check validator eligibility for `subdomain.club.agi.eth`.
+- `isAuthorizedValidator(address claimant, string subdomain, bytes32[] proof)` – read-only validator eligibility check for `subdomain.club.agi.eth`; emits no events.
 
 ```javascript
 const ok = await identity.isAuthorizedAgent(user, 'alice', merkleProof); // alice.agent.agi.eth

--- a/docs/api/IdentityRegistry.md
+++ b/docs/api/IdentityRegistry.md
@@ -17,7 +17,7 @@ gas usage.
 - `setAgentProfileURI(address agent, string uri)` – governance-set capability profile for an agent.
 - `updateAgentProfile(string subdomain, bytes32[] proof, string uri)` – agent updates their own profile after proving control of `subdomain`.
  - `isAuthorizedAgent(address claimant, string subdomain, bytes32[] proof)` – check agent eligibility for `subdomain.agent.agi.eth`.
- - `isAuthorizedValidator(address claimant, string subdomain, bytes32[] proof)` – check validator eligibility for `subdomain.club.agi.eth`. Allowlist-based authorizations emit `AdditionalValidatorUsed`.
+- `isAuthorizedValidator(address claimant, string subdomain, bytes32[] proof)` – read-only check for validator eligibility for `subdomain.club.agi.eth`; does not emit events.
 - `verifyAgent(address claimant, string subdomain, bytes32[] proof)` – external verification helper.
 - `verifyValidator(address claimant, string subdomain, bytes32[] proof)` – external verification helper.
 

--- a/docs/internal/coding-sprint-v2-ens-identity.md
+++ b/docs/internal/coding-sprint-v2-ens-identity.md
@@ -16,7 +16,7 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 - Emit `OwnershipVerified` and `RecoveryInitiated` events on success or failed external calls.
 - Store `agentRootNode`, `clubRootNode`, `agentMerkleRoot` and `validatorMerkleRoot`; owner setters (`setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot`, `setValidatorMerkleRoot`) fire `RootNodeUpdated`/`MerkleRootUpdated` events.
 - Provide `addAdditionalAgent`/`addAdditionalValidator` and removal counterparts so the owner can override identity checks.
-- Expose helper `isAuthorizedAgent`/`isAuthorizedValidator` that consults allow‑lists and `ReputationEngine.isBlacklisted` before allowing any action.
+- Expose helper `isAuthorizedAgent`/`isAuthorizedValidator` that consults allow‑lists and `ReputationEngine.isBlacklisted` before allowing any action. These helpers are read-only and emit no events; use `verifyAgent`/`verifyValidator` for event emission when needed.
 
 ### 2. JobRegistry
 
@@ -30,7 +30,7 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 ### 3. ValidationModule
 
 - Select validator committees and record commits & reveals.
-- Accept votes only from identities passing `isAuthorizedValidator` (allow‑list or ENS ownership and not blacklisted).
+- Accept votes only from identities passing the read-only `isAuthorizedValidator` check (allow‑list or ENS ownership and not blacklisted).
 - Finalise results once quorum or the reveal window ends, tallying approvals vs. disapprovals against owner‑set thresholds.
 - Report outcomes back to `JobRegistry` for payout or dispute routing.
 - Use deterministic on‑chain randomness; avoid Chainlink VRF or subscription services.

--- a/test/v2/identity.test.ts
+++ b/test/v2/identity.test.ts
@@ -320,7 +320,10 @@ describe('IdentityRegistry ENS verification', function () {
     expect(await id.isAuthorizedAgent(agent.address, '', [])).to.equal(true);
 
     await id.addAdditionalValidator(validator.address);
-    await expect(id.isAuthorizedValidator(validator.address, '', []))
+    expect(
+      await id.isAuthorizedValidator.staticCall(validator.address, '', [])
+    ).to.equal(true);
+    await expect(id.verifyValidator(validator.address, '', []))
       .to.emit(id, 'AdditionalValidatorUsed')
       .withArgs(validator.address, '');
   });


### PR DESCRIPTION
## Summary
- mark IdentityRegistry.isAuthorizedValidator as public view and remove event emission
- clarify documentation that isAuthorizedValidator is a read-only check with no events
- adjust tests so isAuthorizedValidator can be called without a transaction and verifyValidator still emits events

## Testing
- `npx solhint 'contracts/**/*.sol'`
- `npx eslint .`
- `npx hardhat test test/v2/identity.test.ts test/v2/AttestationRegistry.test.js`
- `forge test` *(fails: Source "forge-std/Test.sol" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff9f61408333ad428681641fe5d5