### PR TITLE
feat: validate stake manager on certificate NFT

### DIFF
--- a/contracts/test/BadStakeManager.sol
+++ b/contracts/test/BadStakeManager.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {AGIALPHA} from "../v2/Constants.sol";
+
+/// @notice Stake manager mock with outdated version but canonical token.
+contract BadStakeManager {
+    uint256 public constant version = 1;
+
+    function token() external pure returns (IERC20) {
+        return IERC20(AGIALPHA);
+    }
+}
+

--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -9,6 +9,7 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {ICertificateNFT} from "./interfaces/ICertificateNFT.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
+import {AGIALPHA} from "./Constants.sol";
 
 /// @title CertificateNFT
 /// @notice ERC721 certificate minted upon successful job completion.
@@ -29,6 +30,8 @@ contract CertificateNFT is ERC721, Ownable, Pausable, ReentrancyGuard, ICertific
     error NotListed();
     error SelfPurchase();
     error InsufficientAllowance();
+    error InvalidStakeManagerVersion();
+    error InvalidStakeManagerToken();
 
     address public jobRegistry;
     mapping(uint256 => bytes32) public tokenHashes;
@@ -71,6 +74,12 @@ contract CertificateNFT is ERC721, Ownable, Pausable, ReentrancyGuard, ICertific
 
     function setStakeManager(address manager) external onlyOwner {
         if (manager == address(0)) revert ZeroAddress();
+        if (IStakeManager(manager).version() != version) {
+            revert InvalidStakeManagerVersion();
+        }
+        if (IStakeManager(manager).token() != IERC20(AGIALPHA)) {
+            revert InvalidStakeManagerToken();
+        }
         stakeManager = IStakeManager(manager);
         emit StakeManagerUpdated(manager);
     }

--- a/docs/AGIJobs-v2-Sprint-Plan-and-Deployment-Guide.md
+++ b/docs/AGIJobs-v2-Sprint-Plan-and-Deployment-Guide.md
@@ -115,7 +115,10 @@ On JobRegistry: setModules(validationModule, stakeManager, reputationEngine, dis
 On StakeManager: setJobRegistry(jobRegistry) to let the StakeManager know the JobRegistry address. Also call setDisputeModule(disputeModule) so StakeManager trusts the DisputeModule for slashing operations.
 On ValidationModule: setJobRegistry(jobRegistry) to connect it to the registry, and setIdentityRegistry(identityRegistry) if you are using ENS identities.
 On DisputeModule: setJobRegistry(jobRegistry) and setTaxPolicy(taxPolicy) if a TaxPolicy is used.
-On CertificateNFT: setJobRegistry(jobRegistry) and setStakeManager(stakeManager) so it knows who can mint certificates and who can verify staking.
+On CertificateNFT: setJobRegistry(jobRegistry) and setStakeManager(stakeManager)
+— the latter now reverts unless the manager reports version 2 and the
+canonical `$AGIALPHA` token — so it knows who can mint certificates and
+who can verify staking.
 On JobRegistry: if not already done via setModules, also call setIdentityRegistry(identityRegistry) to enforce ENS checks on job applications, and setTaxPolicy(taxPolicy) if applicable.
 If you deployed PlatformRegistry/JobRouter/PlatformIncentives: call PlatformRegistry.setRegistrar(platformIncentives, true) and JobRouter.setRegistrar(platformIncentives, true) to link the incentives module (or follow any specific instructions in their docs).
 After manual wiring, double-check each module’s state via the Read Contract functions or events to ensure addresses have been set correctly. The repository provides a script (npm run verify:wiring) that can also confirm on-chain that each module has the expected references.

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -65,6 +65,8 @@ The script prints module addresses and verifies source on Etherscan.
    - `ValidationModule.setJobRegistry(jobRegistry)`
    - `DisputeModule.setJobRegistry(jobRegistry)`
    - `CertificateNFT.setJobRegistry(jobRegistry)`
+   - `CertificateNFT.setStakeManager(stakeManager)` – reverts unless the manager
+     reports version 2 and uses the canonical `$AGIALPHA` token
    - `JobRegistry.setTaxPolicy(taxPolicy)` then `DisputeModule.setTaxPolicy(taxPolicy)`
    - `ValidationModule.setIdentityRegistry(identityRegistry)`
 10. **Verify source code** – publish each contract on the block explorer using

--- a/test/v2/CertificateNFTStakeManager.test.js
+++ b/test/v2/CertificateNFTStakeManager.test.js
@@ -2,10 +2,10 @@ const { expect } = require('chai');
 const { ethers } = require('hardhat');
 
 describe('CertificateNFT stake manager validation', function () {
-  let nft, owner;
+  let nft;
 
   beforeEach(async () => {
-    [owner] = await ethers.getSigners();
+    await ethers.getSigners();
     const NFT = await ethers.getContractFactory(
       'contracts/v2/CertificateNFT.sol:CertificateNFT'
     );
@@ -32,4 +32,3 @@ describe('CertificateNFT stake manager validation', function () {
     ).to.be.revertedWithCustomError(nft, 'InvalidStakeManagerToken');
   });
 });
-

--- a/test/v2/CertificateNFTStakeManager.test.js
+++ b/test/v2/CertificateNFTStakeManager.test.js
@@ -1,0 +1,35 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('CertificateNFT stake manager validation', function () {
+  let nft, owner;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const NFT = await ethers.getContractFactory(
+      'contracts/v2/CertificateNFT.sol:CertificateNFT'
+    );
+    nft = await NFT.deploy('Cert', 'CERT');
+  });
+
+  it('rejects stake manager with incompatible version', async () => {
+    const BadStake = await ethers.getContractFactory(
+      'contracts/test/BadStakeManager.sol:BadStakeManager'
+    );
+    const bad = await BadStake.deploy();
+    await expect(
+      nft.setStakeManager(await bad.getAddress())
+    ).to.be.revertedWithCustomError(nft, 'InvalidStakeManagerVersion');
+  });
+
+  it('rejects stake manager with wrong token', async () => {
+    const MockStake = await ethers.getContractFactory(
+      'contracts/legacy/MockV2.sol:MockStakeManager'
+    );
+    const mock = await MockStake.deploy();
+    await expect(
+      nft.setStakeManager(await mock.getAddress())
+    ).to.be.revertedWithCustomError(nft, 'InvalidStakeManagerToken');
+  });
+});
+


### PR DESCRIPTION
## Summary
- require v2 StakeManager with canonical $AGIALPHA token when wiring CertificateNFT
- test stake manager version and token validation
- document CertificateNFT StakeManager validation in deployment guides

## Testing
- `npx tsc scripts/constants.ts`
- `npx hardhat test test/v2/CertificateNFTStakeManager.test.js test/v2/CertificateNFTMarketplace.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be02b9386883339ccac4bf852b182e