### PR TITLE
feat: validate JobRegistry version

### DIFF
--- a/contracts/test/BadJobRegistry.sol
+++ b/contracts/test/BadJobRegistry.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @notice Job registry mock with outdated version.
+contract BadJobRegistry {
+    uint256 public constant version = 1;
+}

--- a/contracts/v2/CertificateNFT.sol
+++ b/contracts/v2/CertificateNFT.sol
@@ -8,6 +8,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {ICertificateNFT} from "./interfaces/ICertificateNFT.sol";
+import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 import {AGIALPHA} from "./Constants.sol";
 
@@ -30,6 +31,7 @@ contract CertificateNFT is ERC721, Ownable, Pausable, ReentrancyGuard, ICertific
     error NotListed();
     error SelfPurchase();
     error InsufficientAllowance();
+    error InvalidJobRegistryVersion();
     error InvalidStakeManagerVersion();
     error InvalidStakeManagerToken();
 
@@ -68,6 +70,9 @@ contract CertificateNFT is ERC721, Ownable, Pausable, ReentrancyGuard, ICertific
 
     function setJobRegistry(address registry) external onlyOwner {
         if (registry == address(0)) revert ZeroAddress();
+        if (IJobRegistry(registry).version() != version) {
+            revert InvalidJobRegistryVersion();
+        }
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);
     }

--- a/docs/deployment-production-guide.md
+++ b/docs/deployment-production-guide.md
@@ -78,7 +78,7 @@ Invoke the following setters from the owner account:
 - `StakeManager.setJobRegistry(jobRegistry)`
 - `ValidationModule.setJobRegistry(jobRegistry)`
 - `DisputeModule.setJobRegistry(jobRegistry)`
-- `CertificateNFT.setJobRegistry(jobRegistry)`
+- `CertificateNFT.setJobRegistry(jobRegistry)` (requires `JobRegistry.version() == 2`)
 - `CertificateNFT.setStakeManager(stakeManager)`
 - `StakeManager.setDisputeModule(disputeModule)`
 - `JobRegistry.setIdentityRegistry(identityRegistry)` and `ValidationModule.setIdentityRegistry(identityRegistry)` (if used)

--- a/docs/deployment-v2-agialpha.md
+++ b/docs/deployment-v2-agialpha.md
@@ -81,12 +81,14 @@ The default run uses the mainnet `$AGIALPHA` address, a 5% protocol fee and 5% b
    );
    ```
 
-2. On `StakeManager`, `ValidationModule` and `CertificateNFT`, call `setJobRegistry(jobRegistry)`.
+2. On `StakeManager`, `ValidationModule` and `CertificateNFT`, call
+   `setJobRegistry(jobRegistry)`. `CertificateNFT` additionally checks that
+   `JobRegistry.version()` equals `2`.
 
    ```solidity
    stakeManager.setJobRegistry(jobRegistry);
    validationModule.setJobRegistry(jobRegistry);
-   certificateNFT.setJobRegistry(jobRegistry);
+   certificateNFT.setJobRegistry(jobRegistry); // requires JobRegistry.version() == 2
    ```
 
 3. Verify `ModulesUpdated` and `JobRegistrySet` events before allowing user funds.

--- a/test/v2/CertificateNFTJobRegistry.test.js
+++ b/test/v2/CertificateNFTJobRegistry.test.js
@@ -1,0 +1,24 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('CertificateNFT job registry validation', function () {
+  let nft;
+
+  beforeEach(async () => {
+    await ethers.getSigners();
+    const NFT = await ethers.getContractFactory(
+      'contracts/v2/CertificateNFT.sol:CertificateNFT'
+    );
+    nft = await NFT.deploy('Cert', 'CERT');
+  });
+
+  it('rejects job registry with incompatible version', async () => {
+    const BadRegistry = await ethers.getContractFactory(
+      'contracts/test/BadJobRegistry.sol:BadJobRegistry'
+    );
+    const bad = await BadRegistry.deploy();
+    await expect(
+      nft.setJobRegistry(await bad.getAddress())
+    ).to.be.revertedWithCustomError(nft, 'InvalidJobRegistryVersion');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure CertificateNFT only accepts v2 JobRegistry contracts
- test CertificateNFT rejects incompatible JobRegistry versions
- document JobRegistry version requirement during deployment

## Testing
- `npm test test/v2/CertificateNFTJobRegistry.test.js`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68be07ee45a08333a7353ae8da208af1