### PR TITLE
Add stake manager guard and include seller in NFTPurchased event

### DIFF
--- a/docs/api/CertificateNFT.md
+++ b/docs/api/CertificateNFT.md
@@ -16,5 +16,5 @@ ERC‑721 completion certificates with optional marketplace.
 - `JobRegistryUpdated(address registry)`
 - `StakeManagerUpdated(address manager)`
 - `NFTListed(uint256 tokenId, address seller, uint256 price)`
-- `NFTPurchased(uint256 tokenId, address buyer, uint256 price)`
+- `NFTPurchased(uint256 tokenId, address buyer, address seller, uint256 price)`
 - `NFTDelisted(uint256 tokenId)`


### PR DESCRIPTION
## Summary
- add `StakeManagerNotSet` error and guard in `purchase`
- include seller address in `NFTPurchased` event
- document and test updated marketplace behavior

## Testing
- `npm test`
- `npm run lint` *(fails: 30 warnings)*
- `npm run format:check` *(fails: Code style issues found in 8 files. Forgot to run Prettier?)*

------
https://chatgpt.com/codex/tasks/task_e_68be0a6ff83c8333b8e43d343b536d8e