### PR TITLE
Add burnability check script

### DIFF
--- a/docs/agi-jobs-v2-mainnet.md
+++ b/docs/agi-jobs-v2-mainnet.md
@@ -17,6 +17,7 @@
   - ENS **Registry**: `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`. :contentReference[oaicite:3]{index=3}  
   - ENS **NameWrapper** (widely used address): `0x253553366Da8546fC250F225fe3d25d0C782303b`. :contentReference[oaicite:4]{index=4}  
 - **$AGIALPHA address corroboration (external):** token address matches third‑party explorers. :contentReference[oaicite:5]{index=5}
+- **Burnability preflight:** run `npx ts-node --compiler-options '{"module":"commonjs"}' scripts/check-burnable.ts` to ensure the configured token exposes `burn(uint256)` before mainnet deployment; the script exits with an error if the call reverts or returns no data.
 
 > **Trust model:** Centralized owner control is acceptable here (multisig/timelock recommended). The repo exposes owner‑only setters across modules and documents them for Etherscan use. :contentReference[oaicite:6]{index=6}
 

--- a/docs/deployment-production-guide.md
+++ b/docs/deployment-production-guide.md
@@ -13,6 +13,7 @@ All steps are executed directly from Etherscan's web interface—no command line
 
 - **Ethereum wallet with ETH** for gas (e.g. MetaMask). The deploying wallet becomes the owner of every module – secure it carefully.
 - **$AGIALPHA token address** – mainnet address: `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`.
+- **Burnability preflight** – run `npx ts-node --compiler-options '{"module":"commonjs"}' scripts/check-burnable.ts` to ensure the token supports `burn(uint256)`; the script exits with an error if not.
 - **ENS details (optional)** – if restricting access via ENS subdomains prepare the namehashes for `agent.agi.eth` and `club.agi.eth`, plus the ENS registry (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`) and name wrapper (`0x253553366Da8546fC250F225fe3d25d0C782303b`). Use `0x00` for open access.
 - **Contract source code** – Solidity files live in this repository and must be verified on Etherscan after deployment.
 - **Basic Etherscan familiarity** – you will use the _Write Contract_ tab to deploy and configure modules.

--- a/scripts/check-burnable.ts
+++ b/scripts/check-burnable.ts
@@ -1,0 +1,30 @@
+import { JsonRpcProvider, Interface } from 'ethers';
+import * as fs from 'fs';
+import * as path from 'path';
+
+async function main() {
+  const rpcUrl = process.env.RPC_URL || 'http://localhost:8545';
+  const provider = new JsonRpcProvider(rpcUrl);
+
+  const configPath = path.join(__dirname, '..', 'config', 'agialpha.json');
+  const { address } = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
+    address: string;
+  };
+
+  const iface = new Interface(['function burn(uint256)']);
+  const data = iface.encodeFunctionData('burn', [0n]);
+
+  try {
+    const result = await provider.call({ to: address, data });
+    if (!result || result === '0x') {
+      console.error('burn(0) returned no data');
+      process.exit(1);
+    }
+    console.log('burn(0) call succeeded');
+  } catch (err) {
+    console.error('burn(0) call reverted:', err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add script to check whether configured token exposes a `burn(uint256)` function
- update deployment docs to run burnability check before mainnet deployment

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0f6fcd008333953a34aae91ffcf5