### PR TITLE
feat: track job id in slashing

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -64,20 +64,25 @@ contract MockStakeManager is IStakeManager {
     function addAGIType(address, uint256) external override {}
     function removeAGIType(address) external override {}
 
-    function slash(address user, Role role, uint256 amount, address)
-        external
-        override
-    {
+    function slash(
+        bytes32,
+        address user,
+        Role role,
+        uint256 amount,
+        address
+    ) external override {
         uint256 st = _stakes[user][role];
         require(st >= amount, "stake");
         _stakes[user][role] = st - amount;
         totalStakes[role] -= amount;
     }
 
-    function slash(address user, uint256 amount, address)
-        external
-        override
-    {
+    function slash(
+        bytes32,
+        address user,
+        uint256 amount,
+        address
+    ) external override {
         uint256 st = _stakes[user][Role.Validator];
         require(st >= amount, "stake");
         _stakes[user][Role.Validator] = st - amount;

--- a/contracts/v2/ArbitratorCommittee.sol
+++ b/contracts/v2/ArbitratorCommittee.sol
@@ -150,7 +150,7 @@ contract ArbitratorCommittee is Ownable, Pausable {
         for (uint256 i; i < c.jurors.length; ++i) {
             address juror = c.jurors[i];
             if (doSlash && c.commits[juror] != bytes32(0) && !c.revealed[juror]) {
-                disputeModule.slashValidator(juror, absenteeSlash, employer);
+                disputeModule.slashValidator(jobId, juror, absenteeSlash, employer);
             }
             delete c.isJuror[juror];
         }

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1221,6 +1221,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
                 if (job.stake > 0) {
                     if (isGov && treasury != address(0) && agentBlacklisted) {
                         stakeManager.slash(
+                            jobKey,
                             job.agent,
                             IStakeManager.Role.Agent,
                             uint256(job.stake),
@@ -1287,6 +1288,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
                 }
                 if (job.stake > 0) {
                     stakeManager.slash(
+                        jobKey,
                         job.agent,
                         IStakeManager.Role.Agent,
                         uint256(job.stake),

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1205,6 +1205,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
                 uint256 slashAmount = (stake * validatorSlashingPercentage) / 100;
                 if (slashAmount > 0) {
                     stakeManager.slash(
+                        bytes32(jobId),
                         val,
                         IStakeManager.Role.Validator,
                         slashAmount,
@@ -1280,6 +1281,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
             if (!revealed[jobId][val] || votes[jobId][val] != success) {
                 if (slashAmount > 0) {
                     stakeManager.slash(
+                        bytes32(jobId),
                         val,
                         IStakeManager.Role.Validator,
                         slashAmount,

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -15,6 +15,7 @@ interface IDisputeModule {
     function resolve(uint256 jobId, bool employerWins) external;
 
     function slashValidator(
+        uint256 jobId,
         address juror,
         uint256 amount,
         address employer

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -25,10 +25,11 @@ interface IStakeManager {
     event StakeTimeLocked(address indexed user, uint256 amount, uint64 unlockTime);
     event StakeUnlocked(address indexed user, uint256 amount);
     event StakeSlashed(
+        bytes32 indexed jobId,
         address indexed user,
         Role role,
         address indexed employer,
-        address indexed treasury,
+        address treasury,
         uint256 employerShare,
         uint256 treasuryShare,
         uint256 burnShare
@@ -131,13 +132,24 @@ interface IStakeManager {
     /// @param role participant role of the slashed stake
     /// @param amount token amount with 18 decimals to slash
     /// @param employer recipient of the employer share
-    function slash(address user, Role role, uint256 amount, address employer) external;
+    function slash(
+        bytes32 jobId,
+        address user,
+        Role role,
+        uint256 amount,
+        address employer
+    ) external;
 
     /// @notice slash validator stake during dispute resolution
     /// @param user address whose stake will be reduced
     /// @param amount token amount with 18 decimals to slash
     /// @param recipient address receiving the slashed share
-    function slash(address user, uint256 amount, address recipient) external;
+    function slash(
+        bytes32 jobId,
+        address user,
+        uint256 amount,
+        address recipient
+    ) external;
 
     /// @notice owner configuration helpers
     function setMinStake(uint256 _minStake) external;

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -82,7 +82,13 @@ contract ReentrantStakeManager is IStakeManager {
         return IERC20(address(0));
     }
 
-    function slash(address user, Role role, uint256 amount, address) external override {
+    function slash(
+        bytes32,
+        address user,
+        Role role,
+        uint256 amount,
+        address
+    ) external override {
         if (attackSlash) {
             attackSlash = false;
             (bool ok, bytes memory err) = address(validation).call(
@@ -100,7 +106,12 @@ contract ReentrantStakeManager is IStakeManager {
         totalStakes[role] -= amount;
     }
 
-    function slash(address user, uint256 amount, address) external override {
+    function slash(
+        bytes32,
+        address user,
+        uint256 amount,
+        address
+    ) external override {
         if (attackSlash) {
             attackSlash = false;
             (bool ok, bytes memory err) = address(validation).call(

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -264,7 +264,7 @@ contract DisputeModule is Ownable, Pausable {
                 address[] memory validators = IValidationModule(valMod).validators(jobId);
                 for (uint256 i; i < validators.length; ++i) {
                     if (!IValidationModule(valMod).votes(jobId, validators[i])) {
-                        sm.slash(validators[i], fee, employer);
+                        sm.slash(bytes32(jobId), validators[i], fee, employer);
                     }
                 }
             }
@@ -279,6 +279,7 @@ contract DisputeModule is Ownable, Pausable {
     /// @param employer Employer receiving the slashed share.
     /// @dev Only callable by the arbitrator committee.
     function slashValidator(
+        uint256 jobId,
         address juror,
         uint256 amount,
         address employer
@@ -286,7 +287,7 @@ contract DisputeModule is Ownable, Pausable {
         require(msg.sender == committee, "not committee");
         IStakeManager sm = _stakeManager();
         if (address(sm) != address(0) && amount > 0) {
-            sm.slash(juror, amount, employer);
+            sm.slash(bytes32(jobId), juror, amount, employer);
         }
         emit JurorSlashed(juror, amount, employer);
     }

--- a/contracts/v2/modules/KlerosDisputeModule.sol
+++ b/contracts/v2/modules/KlerosDisputeModule.sol
@@ -103,6 +103,7 @@ contract KlerosDisputeModule is IDisputeModule {
 
     /// @inheritdoc IDisputeModule
     function slashValidator(
+        uint256,
         address,
         uint256,
         address

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -101,7 +101,8 @@ describe('StakeManager', function () {
     await expect(
       stakeManager
         .connect(registrySigner)
-        ['slash(address,uint8,uint256,address)'](
+        ['slash(bytes32,address,uint8,uint256,address)'](
+          jobId,
           user.address,
           0,
           100,
@@ -109,7 +110,7 @@ describe('StakeManager', function () {
         )
     )
       .to.emit(stakeManager, 'StakeSlashed')
-      .withArgs(user.address, 0, employer.address, treasury.address, 50, 50, 0);
+      .withArgs(jobId, user.address, 0, employer.address, treasury.address, 50, 50, 0);
     expect(await stakeManager.stakes(user.address, 0)).to.equal(50n);
     expect(await stakeManager.totalStake(0)).to.equal(50n);
     expect(await token.balanceOf(employer.address)).to.equal(750n);
@@ -118,7 +119,8 @@ describe('StakeManager', function () {
     await expect(
       stakeManager
         .connect(registrySigner)
-        ['slash(address,uint8,uint256,address)'](
+        ['slash(bytes32,address,uint8,uint256,address)'](
+          jobId,
           user.address,
           0,
           10,
@@ -160,7 +162,8 @@ describe('StakeManager', function () {
     await expect(
       stakeManager
         .connect(user)
-        ['slash(address,uint8,uint256,address)'](
+        ['slash(bytes32,address,uint8,uint256,address)'](
+          ethers.ZeroHash,
           user.address,
           0,
           10,
@@ -178,7 +181,8 @@ describe('StakeManager', function () {
     await expect(
       stakeManager
         .connect(registrySigner)
-        ['slash(address,uint8,uint256,address)'](
+        ['slash(bytes32,address,uint8,uint256,address)'](
+          ethers.ZeroHash,
           user.address,
           0,
           200,
@@ -237,7 +241,8 @@ describe('StakeManager', function () {
     await expect(
       stakeManager
         .connect(registrySigner)
-        ['slash(address,uint8,uint256,address)'](
+        ['slash(bytes32,address,uint8,uint256,address)'](
+          ethers.ZeroHash,
           user.address,
           0,
           100,
@@ -287,7 +292,8 @@ describe('StakeManager', function () {
       expect(await stakeManager.stakes(user.address, role)).to.equal(100n);
       await stakeManager
         .connect(registrySigner)
-        ['slash(address,uint8,uint256,address)'](
+        ['slash(bytes32,address,uint8,uint256,address)'](
+          ethers.ZeroHash,
           user.address,
           role,
           50,
@@ -341,7 +347,8 @@ describe('StakeManager', function () {
     await expect(
       stakeManager
         .connect(registrySigner)
-        ['slash(address,uint8,uint256,address)'](
+        ['slash(bytes32,address,uint8,uint256,address)'](
+          ethers.ZeroHash,
           user.address,
           3,
           1,
@@ -508,7 +515,8 @@ describe('StakeManager', function () {
     const registrySigner = await ethers.getImpersonatedSigner(registryAddr);
     await stakeManager
       .connect(registrySigner)
-      ['slash(address,uint8,uint256,address)'](
+      ['slash(bytes32,address,uint8,uint256,address)'](
+        ethers.ZeroHash,
         owner.address,
         0,
         100,
@@ -557,7 +565,8 @@ describe('StakeManager', function () {
     const registrySigner = await ethers.getImpersonatedSigner(registryAddr);
     await stakeManager
       .connect(registrySigner)
-      ['slash(address,uint8,uint256,address)'](
+      ['slash(bytes32,address,uint8,uint256,address)'](
+        ethers.ZeroHash,
         owner.address,
         0,
         40,
@@ -589,7 +598,8 @@ describe('StakeManager', function () {
     const registrySigner = await ethers.getImpersonatedSigner(registryAddr);
     await stakeManager
       .connect(registrySigner)
-      ['slash(address,uint8,uint256,address)'](
+      ['slash(bytes32,address,uint8,uint256,address)'](
+        ethers.ZeroHash,
         owner.address,
         0,
         101,
@@ -770,7 +780,8 @@ describe('StakeManager', function () {
     await expect(
       stakeManager
         .connect(registrySigner)
-        ['slash(address,uint8,uint256,address)'](
+        ['slash(bytes32,address,uint8,uint256,address)'](
+          ethers.ZeroHash,
           user.address,
           0,
           100,
@@ -778,7 +789,16 @@ describe('StakeManager', function () {
         )
     )
       .to.emit(stakeManager, 'StakeSlashed')
-      .withArgs(user.address, 0, employer.address, treasury.address, 50, 50, 0)
+      .withArgs(
+        ethers.ZeroHash,
+        user.address,
+        0,
+        employer.address,
+        treasury.address,
+        50,
+        50,
+        0
+      )
       .and.to.emit(stakeManager, 'StakeUnlocked')
       .withArgs(user.address, 100);
 
@@ -856,7 +876,8 @@ describe('StakeManager', function () {
 
     await stakeManager
       .connect(registrySigner)
-      ['slash(address,uint8,uint256,address)'](
+      ['slash(bytes32,address,uint8,uint256,address)'](
+        ethers.ZeroHash,
         user.address,
         0,
         100,
@@ -913,7 +934,8 @@ describe('StakeManager', function () {
 
     await stakeManager
       .connect(registrySigner)
-      ['slash(address,uint8,uint256,address)'](
+      ['slash(bytes32,address,uint8,uint256,address)'](
+        ethers.ZeroHash,
         user.address,
         0,
         amount,

--- a/test/v2/StakeManagerFuzz.t.sol
+++ b/test/v2/StakeManagerFuzz.t.sol
@@ -31,7 +31,7 @@ contract StakeManagerFuzz is Test {
         vm.assume(slash <= deposit);
         _deposit(address(1), deposit, StakeManager.Role.Validator);
         vm.prank(address(this));
-        stake.slash(address(1), StakeManager.Role.Validator, slash, address(this));
+        stake.slash(bytes32(0), address(1), StakeManager.Role.Validator, slash, address(this));
         assertEq(stake.stakeOf(address(1), StakeManager.Role.Validator), deposit - slash);
     }
 

--- a/test/v2/StakeManagerUnbond.t.sol
+++ b/test/v2/StakeManagerUnbond.t.sol
@@ -50,7 +50,7 @@ contract StakeManagerUnbond is Test {
 
     function testJailOnSlash() public {
         _request(5e17);
-        stake.slash(user, StakeManager.Role.Validator, 1e17, address(this));
+        stake.slash(bytes32(0), user, StakeManager.Role.Validator, 1e17, address(this));
         vm.warp(block.timestamp + stake.unbondingPeriod());
         vm.prank(user);
         vm.expectRevert(Jailed.selector);


### PR DESCRIPTION
## Summary
- include job ID in `StakeSlashed` event and slashing methods
- propagate job identifiers through modules and tests

## Testing
- `npm test`
- `forge test` *(fails: Source "forge-std/Test.sol" not found / Yul exception)*

------
https://chatgpt.com/codex/tasks/task_e_68be14a77a1883339d93e597fe383be2