### PR TITLE
Verify AGIALPHA burnability in core contracts

### DIFF
--- a/contracts/test/MockERC20NoBurn.sol
+++ b/contracts/test/MockERC20NoBurn.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev Mock ERC20 token without burn function for constructor tests.
+contract MockERC20NoBurn is ERC20 {
+    constructor() ERC20("MockToken", "MTK") {
+        _mint(msg.sender, 1e24);
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -111,6 +111,10 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard {
         if (IERC20Metadata(address(token)).decimals() != AGIALPHA_DECIMALS) {
             revert InvalidTokenDecimals();
         }
+        try IERC20Burnable(AGIALPHA).burn(0) {
+        } catch {
+            revert TokenNotBurnable();
+        }
         uint256 pct = _burnPct == 0 ? DEFAULT_BURN_PCT : _burnPct;
         if (pct > 100) revert InvalidPercentage();
 

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -238,6 +238,10 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
             revert InvalidTokenDecimals();
         }
         if (BURN_ADDRESS != address(0)) revert BurnAddressNotZero();
+        try IERC20Burnable(AGIALPHA).burn(0) {
+        } catch {
+            revert TokenNotBurnable();
+        }
         minStake = _minStake == 0 ? DEFAULT_MIN_STAKE : _minStake;
         emit MinStakeUpdated(minStake);
         if (_employerSlashPct + _treasurySlashPct == 0) {


### PR DESCRIPTION
## Summary
- ensure StakeManager and FeePool constructors verify AGIALPHA tokens support burning
- add MockERC20NoBurn helper for negative deployment tests
- test successful and failing deployments for burnable/non-burnable tokens

## Testing
- `npx hardhat test test/v2/StakeManager.test.js test/v2/FeePool.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68be1aeffad483338f77ccc280cc4db7