### PR TITLE
docs: consolidate v2 deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,6 @@ For detailed behaviour and additional modules such as `FeePool`, `TaxPolicy` and
 - [Etherscan interaction guide](docs/etherscan-guide.md)
 - [Deployment walkthrough with $AGIALPHA](docs/deployment-v2-agialpha.md)
 - [Production deployment guide](docs/deployment-guide-production.md)
-- [AGIJobs v2 sprint plan and deployment guide](docs/AGIJobs-v2-Sprint-Plan-and-Deployment-Guide.md)
+- [AGIJobs v2 sprint plan and deployment guide](docs/agi-jobs-v2-production-deployment-guide.md)
 - [API reference and SDK snippets](docs/api-reference.md)
 - [Agent gateway example](examples/agent-gateway.js)

--- a/docs/agi-jobs-v2-production-deployment-guide.md
+++ b/docs/agi-jobs-v2-production-deployment-guide.md
@@ -1,5 +1,7 @@
 # AGIJobs v2 Sprint Plan and Deployment Guide
 
+This document consolidates the final sprint plan with the operational deployment guide and reflects the production-ready configuration for AGIJobs v2.
+
 ## Table of Contents
 
 - [Codebase Enhancements and Key Requirements](#codebase-enhancements-and-key-requirements)


### PR DESCRIPTION
## Summary
- rename and enhance AGIJobs v2 deployment guide for production use
- update README to reference the consolidated guide

## Testing
- `npx prettier --write docs/agi-jobs-v2-production-deployment-guide.md`
- `npx prettier --write README.md`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be1e215dd083339e01ce0c226bdf8b