### PR TITLE
docs: highlight burn-check script

### DIFF
--- a/docs/agi-jobs-v2-production-deployment-guide.md
+++ b/docs/agi-jobs-v2-production-deployment-guide.md
@@ -62,6 +62,7 @@ This section provides a user-friendly, step-by-step guide to deploy the AGIJobs 
 - Ethereum wallet with enough ETH for gas
 - Mainnet `$AGIALPHA` token address `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`
 - Verify on Etherscan that `$AGIALPHA` exposes `burn(uint256)`; the contracts rely on this function
+- Optionally run `npx ts-node --compiler-options '{"module":"commonjs"}' scripts/check-burnable.ts` to programmatically confirm the token exposes a burn function
 - Namehashes for `agent.agi.eth` and `club.agi.eth` if enforcing ENS
 - Multisig or timelock address to assume governance after deployment
 


### PR DESCRIPTION
## Summary
- mention `scripts/check-burnable.ts` in deployment prerequisites for programmatic burnability checks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be32116ab8833385ccbb805132c26b