### PR TITLE
Update ENS NameWrapper address to new mainnet value

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -64,7 +64,7 @@ contract IdentityRegistry is Ownable2Step {
     address public constant MAINNET_ENS =
         0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e;
     address public constant MAINNET_NAME_WRAPPER =
-        0x253553366Da8546fC250F225fe3d25d0C782303b;
+        0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401;
     bytes32 public constant MAINNET_AGENT_ROOT_NODE =
         0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d;
     bytes32 public constant MAINNET_CLUB_ROOT_NODE =

--- a/docs/agi-jobs-v2-mainnet.md
+++ b/docs/agi-jobs-v2-mainnet.md
@@ -15,7 +15,7 @@
 - **Etherscan‑first deployment:** The README links to browser‑based deployment docs and lists owner‑only setters and wiring calls (e.g., `JobRegistry.setModules`, `StakeManager.setJobRegistry`, `IdentityRegistry.setENS/*RootNode`). :contentReference[oaicite:2]{index=2}  
 - **ENS mainnet references** (for runtime checks):  
   - ENS **Registry**: `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`. :contentReference[oaicite:3]{index=3}  
-  - ENS **NameWrapper** (widely used address): `0x253553366Da8546fC250F225fe3d25d0C782303b`. :contentReference[oaicite:4]{index=4}  
+  - ENS **NameWrapper** (widely used address): `0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401`. :contentReference[oaicite:4]{index=4}
 - **$AGIALPHA address corroboration (external):** token address matches third‑party explorers. :contentReference[oaicite:5]{index=5}
 - **Burnability preflight:** run `npx ts-node --compiler-options '{"module":"commonjs"}' scripts/check-burnable.ts` to ensure the configured token exposes `burn(uint256)` before mainnet deployment; the script exits with an error if the call reverts or returns no data.
 

--- a/docs/agi-jobs-v2-production-deployment-guide.md
+++ b/docs/agi-jobs-v2-production-deployment-guide.md
@@ -80,7 +80,7 @@ Purpose: StakeManager holds and manages all staked tokens and job escrow funds, 
 ReputationEngine – Parameter: stakeManager address. Provide the address from step 1. This module tracks reputation scores and blacklist status of agents/validators. (No other parameters are needed; it uses sensible internal defaults for reputation calculations.)
 IdentityRegistry (optional, for ENS enforcement) – Parameters:
 \_ensAddress: ENS registry address (use 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e on mainnet, or 0x0 to disable ENS checks).
-\_nameWrapperAddress: ENS NameWrapper address (mainnet: 0x253553366Da8546fC250F225fe3d25d0C782303b, or 0x0 if not using wrapped names).
+\_nameWrapperAddress: ENS NameWrapper address (mainnet: 0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401, or 0x0 if not using wrapped names).
 \_reputationEngine: the ReputationEngine address from step 2 (or 0x0 if you want to deploy IdentityRegistry first and wire reputation later).
 \_agentRootNode and \_clubRootNode: the namehash of agi.eth subdomains for agents and validators. On mainnet, use the provided constants for agent.agi.eth and club.agi.eth (you can find these or use the configureMainnet() function later). If you do not want to enforce ENS at launch, use 0x000...00 for these root nodes to allow anyone to participate (or set up a Merkle allowlist instead).
 Purpose: This module verifies on-chain that a given address owns an ENS subdomain (and checks the ReputationEngine for blacklist). It’s optional – if omitted, you’ll rely on off-chain identity checks or emergency allowlists.

--- a/docs/deployment-production-guide.md
+++ b/docs/deployment-production-guide.md
@@ -14,7 +14,7 @@ All steps are executed directly from Etherscan's web interface—no command line
 - **Ethereum wallet with ETH** for gas (e.g. MetaMask). The deploying wallet becomes the owner of every module – secure it carefully.
 - **$AGIALPHA token address** – mainnet address: `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`.
 - **Burnability preflight** – run `npx ts-node --compiler-options '{"module":"commonjs"}' scripts/check-burnable.ts` to ensure the token supports `burn(uint256)`; the script exits with an error if not.
-- **ENS details (optional)** – if restricting access via ENS subdomains prepare the namehashes for `agent.agi.eth` and `club.agi.eth`, plus the ENS registry (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`) and name wrapper (`0x253553366Da8546fC250F225fe3d25d0C782303b`). Use `0x00` for open access.
+- **ENS details (optional)** – if restricting access via ENS subdomains prepare the namehashes for `agent.agi.eth` and `club.agi.eth`, plus the ENS registry (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`) and name wrapper (`0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401`). Use `0x00` for open access.
 - **Contract source code** – Solidity files live in this repository and must be verified on Etherscan after deployment.
 - **Basic Etherscan familiarity** – you will use the _Write Contract_ tab to deploy and configure modules.
 - **Governance account** – a multisig or timelock that will ultimately own the modules.

--- a/docs/etherscan-deployment.md
+++ b/docs/etherscan-deployment.md
@@ -31,7 +31,7 @@ All token amounts use the 18 decimal base units of $AGIALPHA (e.g., **1 AGIALP
      Remember that 18‑decimal base units are required (e.g. `10.5` tokens = `10_500000000000000000`).
    - `_baseIpfsUrl` – common prefix for job metadata such as `ipfs://`.
    - `_ensAddress` – [ENS Registry](https://etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e).
-   - `_nameWrapperAddress` – [ENS NameWrapper](https://etherscan.io/address/0x253553366Da8546fC250F225fe3d25d0C782303b).
+   - `_nameWrapperAddress` – [ENS NameWrapper](https://etherscan.io/address/0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401).
    - `_clubRootNode` and `_agentRootNode` – namehashes for `club.agi.eth` and `agent.agi.eth`; use
      `0x00` if no ENS gating is desired.
    - `_validatorMerkleRoot` and `_agentMerkleRoot` – allowlist roots or `0x00` for open access.

--- a/docs/legacy/agi-jobs-v2-production-deployment-guide.md
+++ b/docs/legacy/agi-jobs-v2-production-deployment-guide.md
@@ -11,7 +11,7 @@ This guide walks a non-technical operator through deploying the **AGI Jobs v2** 
 
 - **Ethereum wallet** (e.g. MetaMask) with enough ETH for gas; it becomes the owner of all contracts.
 - **$AGIALPHA token address** (canonical mainnet: `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`).
-- **ENS details** if restricting access (namehashes for `agent.agi.eth` and `club.agi.eth`, ENS registry `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`, and name wrapper `0x253553366Da8546fC250F225fe3d25d0C782303b`).
+- **ENS details** if restricting access (namehashes for `agent.agi.eth` and `club.agi.eth`, ENS registry `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`, and name wrapper `0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401`).
 - **Contract sources** from this repository for verification.
 - **Basic familiarity with the “Contract → Deploy” and “Write Contract” tabs** on Etherscan.
 
@@ -30,7 +30,7 @@ Deploy each contract via **Contract → Deploy** on Etherscan, supplying constru
 2. **ReputationEngine** – pass the StakeManager address from step 1.
 3. **IdentityRegistry** _(optional)_
    - `_ensAddress`: ENS registry (mainnet `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`).
-   - `_nameWrapperAddress`: ENS name wrapper (mainnet `0x253553366Da8546fC250F225fe3d25d0C782303b`).
+   - `_nameWrapperAddress`: ENS name wrapper (mainnet `0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401`).
    - `_reputationEngine`: ReputationEngine address.
    - `_agentRootNode` / `_clubRootNode`: namehashes for `agent.agi.eth` and `club.agi.eth` or `0x00..00` for open access.
 4. **ValidationModule**

--- a/docs/legacy/deployment-guide-nontechnical.md
+++ b/docs/legacy/deployment-guide-nontechnical.md
@@ -13,7 +13,7 @@ All steps are executed directly from Etherscan's web interface—no command line
 
 - **Ethereum wallet with ETH** for gas (e.g. MetaMask). The deploying wallet becomes the owner of every module – secure it carefully.
 - **$AGIALPHA token address** – mainnet address: `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`.
-- **ENS details (optional)** – if restricting access via ENS subdomains prepare the namehashes for `agent.agi.eth` and `club.agi.eth`, plus the ENS registry (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`) and name wrapper (`0x253553366Da8546fC250F225fe3d25d0C782303b`). Use `0x00` for open access.
+- **ENS details (optional)** – if restricting access via ENS subdomains prepare the namehashes for `agent.agi.eth` and `club.agi.eth`, plus the ENS registry (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`) and name wrapper (`0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401`). Use `0x00` for open access.
 - **Contract source code** – Solidity files live in this repository and must be verified on Etherscan after deployment.
 - **Basic Etherscan familiarity** – you will use the _Write Contract_ tab to deploy and configure modules.
 

--- a/docs/master-guide.md
+++ b/docs/master-guide.md
@@ -804,7 +804,7 @@ library Constants {
 
     // mainnet ENS
     address constant ENS_REGISTRY = 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e;
-    address constant NAME_WRAPPER = 0x253553366Da8546fC250F225fe3d25d0C782303b;
+    address constant NAME_WRAPPER = 0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401;
     bytes32 constant AGENT_ROOT = 0x0; // namehash("agent.agi.eth")
     bytes32 constant CLUB_ROOT  = 0x0; // namehash("club.agi.eth")
 }

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -2,9 +2,9 @@ import { ethers } from 'hardhat';
 
 // Mainnet ENS registry and NameWrapper addresses
 // ENS registry: 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e
-// NameWrapper: 0x253553366Da8546fC250F225fe3d25d0C782303b
+// NameWrapper: 0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401
 const ENS_REGISTRY = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
-const NAME_WRAPPER = '0x253553366Da8546fC250F225fe3d25d0C782303b';
+const NAME_WRAPPER = '0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401';
 
 async function main() {
   const [deployer] = await ethers.getSigners();

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -5,11 +5,11 @@ import { AGIALPHA, AGIALPHA_DECIMALS } from '../constants';
 
 // Mainnet ENS and NameWrapper configuration
 // ENS registry: 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e
-// NameWrapper: 0x253553366Da8546fC250F225fe3d25d0C782303b
+// NameWrapper: 0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401
 // agent.agi.eth node: 0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d
 // club.agi.eth node: 0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16
 const ENS_REGISTRY = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
-const NAME_WRAPPER = '0x253553366Da8546fC250F225fe3d25d0C782303b';
+const NAME_WRAPPER = '0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401';
 const AGENT_ROOT_NODE = ethers.namehash('agent.agi.eth');
 const CLUB_ROOT_NODE = ethers.namehash('club.agi.eth');
 

--- a/scripts/v2/deployAttestation.ts
+++ b/scripts/v2/deployAttestation.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'hardhat';
 
 const MAINNET_ENS = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
-const MAINNET_NAME_WRAPPER = '0x253553366Da8546fC250F225fe3d25d0C782303b';
+const MAINNET_NAME_WRAPPER = '0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401';
 
 function usage() {
   console.log('Usage:');

--- a/test/v2/IdentityRegistrySetters.test.js
+++ b/test/v2/IdentityRegistrySetters.test.js
@@ -129,4 +129,12 @@ describe('IdentityRegistry setters', function () {
       );
     });
   });
+
+  describe('configureMainnet', function () {
+    it('sets the NameWrapper to the mainnet address', async () => {
+      const mainnetWrapper = await identity.MAINNET_NAME_WRAPPER();
+      await identity.configureMainnet();
+      expect(await identity.nameWrapper()).to.equal(mainnetWrapper);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- update IdentityRegistry MAINNET_NAME_WRAPPER to new mainnet address
- keep deployment scripts and docs in sync with the new ENS NameWrapper
- test that configureMainnet wires the NameWrapper correctly

## Testing
- `npx hardhat test test/v2/IdentityRegistrySetters.test.js`
- `npm run lint` *(warnings: 30, no errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be4013c4e48333afa48a0aa1570400