### PR TITLE
refactor: introduce IAddrResolver interface

### DIFF
--- a/contracts/legacy/MockResolver.sol
+++ b/contracts/legacy/MockResolver.sol
@@ -6,13 +6,13 @@ pragma solidity 0.8.21;
 /// @title MockResolver
 /// @notice Minimal ENS resolver mock allowing adjustable addr records.
 contract MockResolver {
-    mapping(bytes32 => address payable) public addresses;
+    mapping(bytes32 => address) public addresses;
 
-    function addr(bytes32 node) external view returns (address payable) {
+    function addr(bytes32 node) external view returns (address) {
         return addresses[node];
     }
 
-    function setAddr(bytes32 node, address payable addr_) external {
+    function setAddr(bytes32 node, address addr_) external {
         addresses[node] = addr_;
     }
 }

--- a/contracts/v2/ENSIdentityVerifier.sol
+++ b/contracts/v2/ENSIdentityVerifier.sol
@@ -4,15 +4,7 @@ pragma solidity ^0.8.25;
 import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import {IENS} from "./interfaces/IENS.sol";
 import {INameWrapper} from "./interfaces/INameWrapper.sol";
-
-/// @title Resolver interface
-/// @notice Minimal interface to query addresses from ENS records.
-interface IResolver {
-    /// @notice Get the address associated with an ENS node.
-    /// @param node The ENS node hash.
-    /// @return resolvedAddress The resolved payable address for `node`.
-    function addr(bytes32 node) external view returns (address payable resolvedAddress);
-}
+import {IAddrResolver} from "./interfaces/IAddrResolver.sol";
 
 /// @title ENSIdentityVerifier
 /// @notice Library providing ENS ownership verification via Merkle proofs,
@@ -46,8 +38,8 @@ library ENSIdentityVerifier {
         if (address(ens) != address(0)) {
             address resolverAddr = ens.resolver(subnode);
             if (resolverAddr != address(0)) {
-                try IResolver(resolverAddr).addr(subnode) returns (
-                    address payable resolvedAddress
+                try IAddrResolver(resolverAddr).addr(subnode) returns (
+                    address resolvedAddress
                 ) {
                     if (resolvedAddress == claimant) {
                         return true;
@@ -93,9 +85,9 @@ library ENSIdentityVerifier {
         if (address(ens) != address(0)) {
             address resolverAddr = ens.resolver(subnode);
             if (resolverAddr != address(0)) {
-                IResolver resolver = IResolver(resolverAddr);
+                IAddrResolver resolver = IAddrResolver(resolverAddr);
                 try resolver.addr(subnode) returns (
-                    address payable resolvedAddress
+                    address resolvedAddress
                 ) {
                     if (resolvedAddress == claimant) {
                         emit OwnershipVerified(claimant, subdomain);

--- a/contracts/v2/interfaces/IAddrResolver.sol
+++ b/contracts/v2/interfaces/IAddrResolver.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IAddrResolver {
+    function addr(bytes32 node) external view returns (address);
+}

--- a/contracts/v2/modules/VerifyOwnership.sol
+++ b/contracts/v2/modules/VerifyOwnership.sol
@@ -4,11 +4,7 @@ pragma solidity ^0.8.25;
 import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import {IENS} from "../interfaces/IENS.sol";
 import {INameWrapper} from "../interfaces/INameWrapper.sol";
-
-/// @dev Minimal resolver interface for address resolution.
-interface IResolver {
-    function addr(bytes32 node) external view returns (address payable);
-}
+import {IAddrResolver} from "../interfaces/IAddrResolver.sol";
 
 /// @title Ownership verification helpers
 /// @notice Library computing ENS ownership through Merkle proofs and on-chain checks.
@@ -63,8 +59,8 @@ library VerifyOwnership {
         }
         address resolverAddr = ens.resolver(subnode);
         if (resolverAddr != address(0)) {
-            IResolver resolver = IResolver(resolverAddr);
-            try resolver.addr(subnode) returns (address payable resolved) {
+            IAddrResolver resolver = IAddrResolver(resolverAddr);
+            try resolver.addr(subnode) returns (address resolved) {
                 if (resolved == claimant) {
                     return (true, reason);
                 }

--- a/docs/ens-identity-setup.md
+++ b/docs/ens-identity-setup.md
@@ -53,7 +53,7 @@ Once the subdomain token is minted, the owner must update the resolver so the na
 
 ```bash
 npx hardhat console --network <network>
-> const res = await ethers.getContractAt('IResolver', resolver);
+> const res = await ethers.getContractAt('IAddrResolver', resolver);
 > const node = ethers.namehash('alice.agent.agi.eth');
 > await res['setAddr(bytes32,address)'](node, '0xAgent');
 > await res['addr(bytes32)'](node); // verify

--- a/docs/master-guide.md
+++ b/docs/master-guide.md
@@ -836,7 +836,7 @@ function _burnToken(uint256 amount) internal {
 
 ```solidity
 function _ownsEns(bytes32 node, address user) internal view returns (bool) {
-    address res = IResolver(IENS(ENS_REGISTRY).resolver(node)).addr(node);
+    address res = IAddrResolver(IENS(ENS_REGISTRY).resolver(node)).addr(node);
     if (res == user) return true;
     try INameWrapper(NAME_WRAPPER).ownerOf(uint256(node)) returns (address o) { return o == user; } catch {}
     return false;

--- a/test/v2/ENSOwnershipVerifier.t.sol
+++ b/test/v2/ENSOwnershipVerifier.t.sol
@@ -11,7 +11,7 @@ contract MockENS {
 
 contract MockResolver {
     mapping(bytes32 => address) public addrs;
-    function addr(bytes32 node) external view returns (address payable) { return payable(addrs[node]); }
+    function addr(bytes32 node) external view returns (address) { return addrs[node]; }
     function setAddr(bytes32 node, address a) external { addrs[node] = a; }
 }
 


### PR DESCRIPTION
## Summary
- add reusable IAddrResolver interface
- use IAddrResolver in ENS identity verification logic
- align mocks, tests, and docs with new resolver interface

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68bed923e1388333a0a3e287ae75dad4