### PR TITLE
Expose ENS verification details and emit ENSVerified event

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -792,7 +792,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             agentAuthExpiry[msg.sender] > block.timestamp &&
             agentAuthVersion[msg.sender] == agentAuthCacheVersion;
         if (!authorized) {
-            authorized = identityRegistry.verifyAgent(
+            (authorized, , , ) = identityRegistry.verifyAgent(
                 msg.sender,
                 subdomain,
                 proof
@@ -909,7 +909,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             if (reputationEngine.isBlacklisted(job.employer)) revert BlacklistedEmployer();
         }
         if (address(identityRegistry) == address(0)) revert IdentityRegistryNotSet();
-        bool authorized = identityRegistry.verifyAgent(
+        (bool authorized, , , ) = identityRegistry.verifyAgent(
             msg.sender,
             subdomain,
             proof

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -780,7 +780,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
                 if (!authorized) {
                     string memory subdomain = validatorSubdomains[candidate];
                     bytes32[] memory proof;
-                    authorized = identityRegistry.verifyValidator(
+                    (authorized, , , ) = identityRegistry.verifyValidator(
                         candidate,
                         subdomain,
                         proof
@@ -843,7 +843,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
                 if (!authorized) {
                     string memory subdomain = validatorSubdomains[candidate];
                     bytes32[] memory proof;
-                    authorized = identityRegistry.verifyValidator(
+                    (authorized, , , ) = identityRegistry.verifyValidator(
                         candidate,
                         subdomain,
                         proof
@@ -990,7 +990,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         }
         if (address(identityRegistry) == address(0)) revert ZeroIdentityRegistry();
         if (!_isValidator(jobId, msg.sender)) revert NotValidator();
-        bool authorized = identityRegistry.verifyValidator(
+        (bool authorized, , , ) = identityRegistry.verifyValidator(
             msg.sender,
             subdomain,
             proof
@@ -1055,7 +1055,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
                 revert BlacklistedValidator();
         }
         if (address(identityRegistry) == address(0)) revert ZeroIdentityRegistry();
-        bool authorized = identityRegistry.verifyValidator(
+        (bool authorized, , , ) = identityRegistry.verifyValidator(
             msg.sender,
             subdomain,
             proof

--- a/contracts/v2/interfaces/IIdentityRegistry.sol
+++ b/contracts/v2/interfaces/IIdentityRegistry.sol
@@ -24,13 +24,13 @@ interface IIdentityRegistry {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) external returns (bool);
+    ) external returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle);
 
     function verifyValidator(
         address claimant,
         string calldata subdomain,
         bytes32[] calldata proof
-    ) external returns (bool);
+    ) external returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle);
 
     // owner configuration
     function setENS(address ensAddr) external;

--- a/contracts/v2/mocks/IdentityRegistryMock.sol
+++ b/contracts/v2/mocks/IdentityRegistryMock.sol
@@ -118,18 +118,26 @@ contract IdentityRegistryMock is Ownable {
         address claimant,
         string calldata,
         bytes32[] calldata
-    ) external returns (bool) {
+    )
+        external
+        returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
+    {
         claimant; // silence unused
-        return true;
+        node = bytes32(0);
+        ok = true;
     }
 
     function verifyValidator(
         address claimant,
         string calldata,
         bytes32[] calldata
-    ) external returns (bool) {
+    )
+        external
+        returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
+    {
         claimant; // silence unused
-        return true;
+        node = bytes32(0);
+        ok = true;
     }
 }
 

--- a/contracts/v2/mocks/IdentityRegistryToggle.sol
+++ b/contracts/v2/mocks/IdentityRegistryToggle.sol
@@ -115,22 +115,32 @@ contract IdentityRegistryToggle is Ownable {
         address claimant,
         string calldata,
         bytes32[] calldata
-    ) external returns (bool) {
+    )
+        external
+        returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
+    {
+        node = bytes32(0);
         if (additionalAgents[claimant]) {
-            return true;
+            ok = true;
+        } else {
+            ok = result;
         }
-        return result;
     }
 
     function verifyValidator(
         address claimant,
         string calldata,
         bytes32[] calldata
-    ) external returns (bool) {
+    )
+        external
+        returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
+    {
+        node = bytes32(0);
         if (additionalValidators[claimant]) {
-            return true;
+            ok = true;
+        } else {
+            ok = result;
         }
-        return result;
     }
 }
 

--- a/contracts/v2/mocks/ReentrantIdentityRegistry.sol
+++ b/contracts/v2/mocks/ReentrantIdentityRegistry.sol
@@ -44,11 +44,25 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
         return true;
     }
 
-    function verifyAgent(address, string calldata, bytes32[] calldata) external pure returns (bool) {
-        return true;
+    function verifyAgent(
+        address,
+        string calldata,
+        bytes32[] calldata
+    )
+        external
+        pure
+        returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
+    {
+        node = bytes32(0);
+        ok = true;
     }
 
-    function verifyValidator(address, string calldata, bytes32[] calldata) external returns (bool) {
+    function verifyValidator(
+        address,
+        string calldata,
+        bytes32[] calldata
+    ) external returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle) {
+        node = bytes32(0);
         if (attack == Attack.Commit) {
             attack = Attack.None;
             validation.commitValidation(jobId, commitHash, "", new bytes32[](0));
@@ -56,7 +70,7 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
             attack = Attack.None;
             validation.revealValidation(jobId, approve, salt, "", new bytes32[](0));
         }
-        return true;
+        ok = true;
     }
 
     // profile metadata - no-ops

--- a/test/v2/ENSValidatorBehavior.test.js
+++ b/test/v2/ENSValidatorBehavior.test.js
@@ -178,11 +178,13 @@ describe('Validator ENS integration', function () {
       identity.verifyValidator(validator.address, 'v', badProof)
     ).to.not.emit(identity, 'OwnershipVerified');
     expect(
-      await identity.verifyValidator.staticCall(
-        validator.address,
-        'v',
-        badProof
-      )
+      (
+        await identity.verifyValidator.staticCall(
+          validator.address,
+          'v',
+          badProof
+        )
+      )[0]
     ).to.equal(false);
   });
 

--- a/test/v2/identity.test.ts
+++ b/test/v2/identity.test.ts
@@ -51,10 +51,10 @@ describe('IdentityRegistry ENS verification', function () {
     await wrapper.setOwner(BigInt(subnode), alice.address);
 
     expect(
-      await id.verifyAgent.staticCall(alice.address, subdomain, [])
+      (await id.verifyAgent.staticCall(alice.address, subdomain, []))[0]
     ).to.equal(true);
     expect(
-      await id.verifyAgent.staticCall(bob.address, subdomain, [])
+      (await id.verifyAgent.staticCall(bob.address, subdomain, []))[0]
     ).to.equal(false);
   });
 
@@ -92,10 +92,10 @@ describe('IdentityRegistry ENS verification', function () {
     const vLeaf = leaf(validator.address, '');
     await id.setValidatorMerkleRoot(vLeaf);
     expect(
-      await id.verifyValidator.staticCall(validator.address, '', [])
+      (await id.verifyValidator.staticCall(validator.address, '', []))[0]
     ).to.equal(true);
     expect(
-      await id.verifyValidator.staticCall(validator.address, 'bad', [])
+      (await id.verifyValidator.staticCall(validator.address, 'bad', []))[0]
     ).to.equal(false);
 
     // agent verified via resolver fallback
@@ -108,9 +108,9 @@ describe('IdentityRegistry ENS verification', function () {
     );
     await ens.setResolver(node, await resolver.getAddress());
     await resolver.setAddr(node, agent.address);
-    expect(await id.verifyAgent.staticCall(agent.address, label, [])).to.equal(
-      true
-    );
+    expect(
+      (await id.verifyAgent.staticCall(agent.address, label, []))[0]
+    ).to.equal(true);
   });
 
   it('respects allowlists and blacklists', async () => {
@@ -142,16 +142,16 @@ describe('IdentityRegistry ENS verification', function () {
 
     // blacklist blocks verification even if allowlisted
     await rep.blacklist(alice.address, true);
-    expect(await id.verifyAgent.staticCall(alice.address, '', [])).to.equal(
-      false
-    );
+    expect(
+      (await id.verifyAgent.staticCall(alice.address, '', []))[0]
+    ).to.equal(false);
     await rep.blacklist(alice.address, false);
 
     // additional allowlist bypasses ENS requirements
     await id.addAdditionalAgent(alice.address);
-    expect(await id.verifyAgent.staticCall(alice.address, '', [])).to.equal(
-      true
-    );
+    expect(
+      (await id.verifyAgent.staticCall(alice.address, '', []))[0]
+    ).to.equal(true);
   });
 
   it('authorizes via allowlists and attestations when ENS is unset', async () => {
@@ -180,9 +180,9 @@ describe('IdentityRegistry ENS verification', function () {
 
     // allowlist should succeed without ENS
     await id.addAdditionalAgent(agent.address);
-    expect(await id.verifyAgent.staticCall(agent.address, '', [])).to.equal(
-      true
-    );
+    expect(
+      (await id.verifyAgent.staticCall(agent.address, '', []))[0]
+    ).to.equal(true);
 
     // attestation should also succeed
     const Attest = await ethers.getContractFactory(
@@ -205,7 +205,7 @@ describe('IdentityRegistry ENS verification', function () {
     await attest.connect(owner).attest(node, 1, validator.address);
 
     expect(
-      await id.verifyValidator.staticCall(validator.address, label, [])
+      (await id.verifyValidator.staticCall(validator.address, label, []))[0]
     ).to.equal(true);
   });
 


### PR DESCRIPTION
## Summary
- expand ENSIdentityVerifier to return the ENS node and whether verification used the wrapper or Merkle proof
- emit new ENSVerified event from IdentityRegistry and surface detailed return values from verifyAgent/verifyValidator
- update consumers and tests for the expanded return tuples

## Testing
- `npm test`
- `forge test` *(fails: Yul exception: Cannot swap Variable param with Variable param_16)*

------
https://chatgpt.com/codex/tasks/task_e_68bedc9b97008333af334ba1254486c3