### PR TITLE
docs: document identity events and verify tuples

### DIFF
--- a/docs/deployment-production-guide.md
+++ b/docs/deployment-production-guide.md
@@ -33,6 +33,7 @@ Deploy each contract through Etherscan and note its address. Verify the source c
 3. **IdentityRegistry** _(optional)_
    - Parameters: `_ensAddress`, `_nameWrapperAddress`, `_reputationEngine`, `_agentRootNode`, `_clubRootNode`.
    - Use `0x00` for any ENS gates you wish to disable.
+   - `verifyAgent`/`verifyValidator` return `(ok, node, viaWrapper, viaMerkle)` and emit `ENSVerified`; modules that call them re-emit `AgentIdentityVerified` or `ValidatorIdentityVerified`.
 4. **ValidationModule**
    - Parameters: `_jobRegistry` placeholder, `stakeManager`, `commitWindow`, `revealWindow`, `minValidators`, `maxValidators`, `validatorPool` (usually empty array).
    - Recommended defaults: `commitWindow` = `86400`, `revealWindow` = `86400`, `minValidators` = `1`, `maxValidators` = `3`.
@@ -90,6 +91,18 @@ Invoke the following setters from the owner account:
 
 - **Verify contracts on Etherscan.** Publish source for every module so the _Read_ and _Write_ views are available.
 - **Consider multisig/timelock ownership.** Transfer ownership to a governance address once configuration is complete. The repository includes `scripts/transfer-ownership.ts` to batch transfer every module's ownership.
+
+- **Identity sanity check.** On the IdentityRegistry page use the _Read Contract_ tab and call `verifyAgent` or `verifyValidator`. Etherscan shows four return values `(ok, node, viaWrapper, viaMerkle)` and emits `ENSVerified`.
+
+  ```
+  verifyAgent("0xAgent", "alice", [])
+  // 0: bool true
+  // 1: bytes32 0x2641541d3a011e8650c9d362d903c5e4149353eb4cb34761875be4b7455d3aca
+  // 2: bool false   // viaWrapper
+  // 3: bool false   // viaMerkle
+  ```
+
+  When jobs call these helpers the platform also emits `AgentIdentityVerified` or `ValidatorIdentityVerified`.
 
 ### True Token Burning
 

--- a/docs/ens-identity-setup.md
+++ b/docs/ens-identity-setup.md
@@ -13,7 +13,7 @@ Agents and validators must prove ownership of specific ENS subdomains before int
 2. **Point the name to your address** by either:
    - Setting the resolver `addr` record, or
    - Wrapping the name with the ENS NameWrapper so the subdomain NFT is held by your wallet.
-3. **Verify ownership** off-chain using an ENS lookup or on-chain by calling `IdentityRegistry.verifyAgent` or `verifyValidator`.
+3. **Verify ownership** off-chain using an ENS lookup or on-chain by calling `IdentityRegistry.verifyAgent` or `verifyValidator`. Each call returns `(ok, node, viaWrapper, viaMerkle)` and emits `ENSVerified`; successful job or validation actions re‑emit `AgentIdentityVerified` or `ValidatorIdentityVerified`.
 
 Transactions will revert if the calling address does not own the claimed subdomain. Owner‑controlled allowlists and Merkle proofs exist only for emergencies and should not be relied on for normal operation.
 
@@ -63,7 +63,28 @@ To confirm ownership on-chain:
 
 ```bash
 > const id = await ethers.getContractAt('IdentityRegistry', process.env.IDENTITY_REGISTRY);
-> await id.verifyAgent('0xAgent', 'alice', []); // use verifyValidator for validators
+> const [ok, node, viaWrapper, viaMerkle] = await id.verifyAgent('0xAgent', 'alice', []); // use verifyValidator for validators
+> // Etherscan lists: 0: ok, 1: node, 2: viaWrapper, 3: viaMerkle
+```
+
+Example Etherscan call:
+
+```
+verifyAgent("0xAgent", "alice", [])
+0: bool true
+1: bytes32 0x2641541d3a011e8650c9d362d903c5e4149353eb4cb34761875be4b7455d3aca
+2: bool false   // viaWrapper
+3: bool false   // viaMerkle
+```
+
+Similarly for a validator:
+
+```
+verifyValidator("0xValidator", "alice", [])
+0: bool true
+1: bytes32 0xc8c2499427432d9c12ca7e3507602b8f6992a6cee02be12755678f99b17d7e76
+2: bool false   // viaWrapper
+3: bool false   // viaMerkle
 ```
 
 ## Delegating with attestations


### PR DESCRIPTION
## Summary
- document new `ENSVerified`, `AgentIdentityVerified`, and `ValidatorIdentityVerified` events
- describe tuple returns from `verifyAgent` and `verifyValidator`
- update deployment and ENS setup guides with Etherscan examples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bee7540de4833390b2b6dfe8e865bd