### PR TITLE
Ensure FeePool never routes fees to platform owner

### DIFF
--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -102,6 +102,16 @@ contract FeePoolTest {
         require(token.balanceOf(bob) == bobExpected, "bob claim");
     }
 
+    function testOwnerReceivesNoRewards() public {
+        setUp();
+        token.mint(address(feePool), 1 * TOKEN);
+        vm.prank(address(stakeManager));
+        feePool.depositFee(1 * TOKEN);
+        feePool.distributeFees();
+        feePool.claimRewards();
+        require(token.balanceOf(address(this)) == 0, "owner claim");
+    }
+
     function testSupplyDecreasesAfterBurn() public {
         setUp();
         token.mint(address(feePool), TOKEN);


### PR DESCRIPTION
## Summary
- Require deploying contracts to provide a non-owner or burn treasury address
- Burn residual fees when no neutral treasury exists
- Add regression test ensuring platform owner accrues no rewards

## Testing
- `npm test`
- `forge test --match-path test/v2/FeePool.t.sol` *(fails: Yul stack too deep)*

------
https://chatgpt.com/codex/tasks/task_e_68bf25df04b48333b0a52c9ca926bef8