### PR TITLE
docs: clarify employer finalization and treasury fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 
 - [Identity policy](#identity-policy)
 - [AGIALPHA configuration](#agialpha-configuration)
+- [Fee handling and treasury](#fee-handling-and-treasury)
 - [Deploy defaults](#deploy-defaults)
 - [Etherscan deployment](#etherscan-deployment)
 - [Migrating from legacy](#migrating-from-legacy)
@@ -30,6 +31,10 @@ Agents and validators must own ENS subdomains under `agent.agi.eth` and `club.ag
 ### AGIALPHA configuration
 
 Token parameters are defined once in [`config/agialpha.json`](config/agialpha.json). Run `npm run compile` after editing this file to regenerate `contracts/v2/Constants.sol` with the canonical token address, decimals, scaling factor and burn address. Any change to `config/agialpha.json` must be followed by `npm run compile` or the constants check in CI will fail.
+
+### Fee handling and treasury
+
+`JobRegistry` routes protocol fees to `FeePool`, which burns a configurable percentage (`burnPct`) and escrows the remainder for platform stakers. Slashed stakes are split between employers and a governance treasury set via `StakeManager.setTreasury`. `FeePool.setTreasury` forwards any undistributed fees to that treasury. The platform never retains fees or burned tokens; it only routes funds per these settings.
 
 ### Deploy defaults
 

--- a/docs/deployment-production-guide.md
+++ b/docs/deployment-production-guide.md
@@ -113,6 +113,10 @@ Invoke the following setters from the owner account:
 On the **FeePool** contract's Etherscan page use the _Write Contract_ tab and call `setBurnPct` with the new percentage value (e.g. `5` for 5%).
 Source: [`contracts/v2/FeePool.sol`](../contracts/v2/FeePool.sol)
 
+### Fee Handling & Treasury
+
+`JobRegistry` forwards protocol fees to `FeePool`. The pool burns the configured `burnPct` and holds the remainder for platform stakers. `StakeManager.setTreasury` and `FeePool.setTreasury` route any slashed stakes or undistributed fees to a governance-controlled treasury. The platform never keeps fees or burned tokens.
+
 ### Owner Updatability
 
 Almost every operational parameter can be changed by the owner without redeploying. Adjust fees, stake requirements, burn percentages, validation windows or allowlists through `set...` functions such as `JobRegistry.setFeePct`, `StakeManager.setMinStake...` or `ValidationModule.setCommitWindow`.
@@ -132,7 +136,7 @@ Source: [`contracts/v2/JobRegistry.sol`](../contracts/v2/JobRegistry.sol)
   1.  **Post a job** – From an employer wallet approve the reward to `StakeManager` and call `JobRegistry.createJob` or `acknowledgeAndCreateJob` with the reward amount and metadata URI.
   2.  **Stake & apply** – An Agent calls `StakeManager.depositStake` (role `0`) and then `JobRegistry.applyForJob` or `stakeAndApply` supplying any ENS subdomain data or empty values if ENS is disabled.
   3.  **Validate** – Validators stake (role `1`) then call `ValidationModule.commitValidation` followed later by `ValidationModule.revealValidation`.
-  4.  **Finalize** – After the reveal window anyone may call `ValidationModule.finalize`; `StakeManager` pays the Agent, sends protocol fees to `FeePool` and burns the configured percentage.
+  4.  **Finalize** – The employer calls `JobRegistry.acknowledgeAndFinalize(jobId)` from their own wallet; `StakeManager` pays the Agent, sends protocol fees to `FeePool` and burns the configured percentage.
   5.  **Dispute** – To test disputes, raise one via `JobRegistry.raiseDispute` and resolve it through `DisputeModule.resolve` (or a moderator/committee if configured).
 - **Final verification.** Confirm each module reports the correct addresses via their `Read` interfaces or run `npm run verify:wiring` to check automatically.
 - **Record keeping.** Log all contract addresses and parameter changes, updating [`deployment-addresses.json`](deployment-addresses.json) and noting changes in commit messages or the changelog whenever any parameter or address changes. Maintain an admin log of post-deployment actions for auditability. For scripted deployments see [`deployment-addresses.md`](deployment-addresses.md).

--- a/docs/job-lifecycle.md
+++ b/docs/job-lifecycle.md
@@ -1,5 +1,9 @@
 # Job Lifecycle
 
+## Employer Finalization
+
+After validation succeeds and the reveal and dispute windows close, the employer must finalize the job from their own wallet by calling `acknowledgeAndFinalize(jobId)` on `JobRegistry`. This confirms the tax disclaimer and burns the fee portion of the employer's escrow. The platform never finalizes jobs or collects burned tokens.
+
 ## Expiration Handling
 
 When an assigned job misses its deadline without submission, anyone may call `cancelExpiredJob` to finalize the job. The caller does not need to be the employer, agent, or a tax policy acknowledger—**any address can trigger expiration handling** once the deadline has passed.

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -39,6 +39,8 @@ function createJob(uint256 reward, string memory uri)
 ## Employers
 
 - Provide the token escrow that funds jobs.
+- Only the employer can finalize jobs by calling `acknowledgeAndFinalize(jobId)` from their own wallet.
+- This finalization burns a portion of the employer's deposit; the protocol never initiates or benefits from burns.
 - When a job finalizes, a portion of the employer's deposit is burned.
 - Burning is a disposal of property, so employers record any capital gain or loss on the burned amount based on cost basis versus fair market value at burn.
 - Token payments to agents may be deductible business expenses where applicable.
@@ -58,6 +60,7 @@ function createJob(uint256 reward, string memory uri)
 
 - Collect no fees and never take custody of tokens.
 - Do not mint, burn, or transfer tokens for themselves.
+- Never finalize jobs or receive burned tokens; burns only destroy employer deposits.
 - Provide infrastructure without consideration, so no sales/VAT/GST applies.
 - Therefore incur zero direct, indirect, or theoretical tax liability worldwide.
 - May update the `TaxPolicy` URI and acknowledgement (individually or atomically) but remain tax‑exempt regardless of jurisdiction.


### PR DESCRIPTION
## Summary
- note that only employers finalize jobs and burns are never platform initiated
- guide employers to call `acknowledgeAndFinalize(jobId)` from their own wallet
- document fee handling and treasury configuration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf4804cdc883339441da6c3cd30a04