### PR TITLE
docs: clarify employer finalization and treasury flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 
 ### Fee handling and treasury
 
-`JobRegistry` routes protocol fees to `FeePool`, which burns a configurable percentage (`burnPct`) and escrows the remainder for platform stakers. Slashed stakes are split between employers and a governance treasury set via `StakeManager.setTreasury`. `FeePool.setTreasury` forwards any undistributed fees to that treasury. The platform never retains fees or burned tokens; it only routes funds per these settings.
+`JobRegistry` routes protocol fees to `FeePool`, which burns a configurable percentage (`burnPct`) when an employer finalizes a job and escrows the remainder for platform stakers. `StakeManager.setTreasury`, `JobRegistry.setTreasury`, and `FeePool.setTreasury` configure a governance-controlled treasury that receives slashed stakes, blacklisted payouts, or undistributed fees. The platform only routes funds and never initiates or profits from burns.
 
 ### Deploy defaults
 

--- a/docs/deployment-production-guide.md
+++ b/docs/deployment-production-guide.md
@@ -115,7 +115,7 @@ Source: [`contracts/v2/FeePool.sol`](../contracts/v2/FeePool.sol)
 
 ### Fee Handling & Treasury
 
-`JobRegistry` forwards protocol fees to `FeePool`. The pool burns the configured `burnPct` and holds the remainder for platform stakers. `StakeManager.setTreasury` and `FeePool.setTreasury` route any slashed stakes or undistributed fees to a governance-controlled treasury. The platform never keeps fees or burned tokens.
+`JobRegistry` forwards protocol fees to `FeePool`. When an employer finalizes a job, the pool burns the configured `burnPct` and holds the remainder for platform stakers. `StakeManager.setTreasury`, `JobRegistry.setTreasury`, and `FeePool.setTreasury` route slashed stakes, blacklisted payouts, or undistributed fees to a governance-controlled treasury. The platform never keeps fees or burned tokens.
 
 ### Owner Updatability
 

--- a/docs/etherscan-guide.md
+++ b/docs/etherscan-guide.md
@@ -21,7 +21,7 @@ For a narrated deployment walkthrough, see [deployment-v2-agialpha.md](deploymen
 
 | Role      | Required function calls                                                                                                                                                                                                                               | Example amounts (18 decimals)                                |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Employer  | `$AGIALPHA.approve(StakeManager, 1_050000000000000000)` → `JobRegistry.acknowledgeTaxPolicy()` → `JobRegistry.createJob(1_000000000000000000, uri)` → `JobRegistry.acknowledgeAndFinalize(jobId)`                                                     | approve `1_050000000000000000` for a 1‑token reward + 5% fee |
+| Employer  | `$AGIALPHA.approve(StakeManager, 1_050000000000000000)` → `JobRegistry.acknowledgeTaxPolicy()` → `JobRegistry.createJob(1_000000000000000000, uri)` → `JobRegistry.acknowledgeAndFinalize(jobId) (employer wallet only)`                                                     | approve `1_050000000000000000` for a 1‑token reward + 5% fee |
 | Agent     | `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` → `JobRegistry.stakeAndApply(jobId, 1_000000000000000000)`                                                                                                                                    | stake `1_000000000000000000`                                 |
 | Validator | `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` → `StakeManager.depositStake(1, 1_000000000000000000)` → `ValidationModule.commitValidation(jobId, hash, sub, proof)` → `ValidationModule.revealValidation(jobId, approve, salt, sub, proof)` | stake `1_000000000000000000`                                 |
 | Disputer  | `$AGIALPHA.approve(StakeManager, 1_000000000000000000)` → `JobRegistry.acknowledgeAndDispute(jobId, evidence)` → `DisputeModule.resolve(jobId, uphold, signatures)` (majority moderators or owner)                                                    | dispute fee `1_000000000000000000`                           |
@@ -48,7 +48,7 @@ For a narrated deployment walkthrough, see [deployment-v2-agialpha.md](deploymen
    stakeAndActivate(1000000000000000000)
    ```
 
-4. **acknowledgeAndFinalize** – employers call `JobRegistry.acknowledgeAndFinalize(jobId)` from their own wallet to settle a validated job and burn the fee portion.
+4. **acknowledgeAndFinalize** – employers must call `JobRegistry.acknowledgeAndFinalize(jobId)` from their own wallet to settle a validated job and burn the fee portion; the platform never finalizes jobs or collects burned tokens.
 
    ```text
    acknowledgeAndFinalize(1)

--- a/docs/job-lifecycle.md
+++ b/docs/job-lifecycle.md
@@ -2,7 +2,7 @@
 
 ## Employer Finalization
 
-After validation succeeds and the reveal and dispute windows close, the employer must finalize the job from their own wallet by calling `acknowledgeAndFinalize(jobId)` on `JobRegistry`. This confirms the tax disclaimer and burns the fee portion of the employer's escrow. The platform never finalizes jobs or collects burned tokens.
+After validation succeeds and the reveal and dispute windows close, only the employer can finalize the job from their own wallet by calling `acknowledgeAndFinalize(jobId)` on `JobRegistry`. This confirms the tax disclaimer and burns the fee portion of the employer's escrow. The platform never initiates finalization nor collects burned tokens.
 
 ## Expiration Handling
 

--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -4,6 +4,7 @@
 
 - Employers, agents, and validators shoulder all tax liability.
 - The smart contracts and deploying corporation remain tax‑exempt everywhere, confirmed by `isTaxExempt()`.
+- Only employers can finalize jobs and trigger token burns; the platform never initiates nor receives burned tokens.
 - Verify the policy on Etherscan: read `taxPolicyDetails`, acknowledge via `acknowledgeTaxPolicy` (which emits `TaxAcknowledged(user, version, acknowledgement)`), and check `isTaxExempt`.
 - The owner edits the policy text or URI with `setPolicyURI`/`setAcknowledgement`, tracks changes via `policyVersion`, and bumps `policyVersion` using `bumpPolicyVersion`.
 - Retrieve per-user acceptance with `acknowledgedVersion(address)`.
@@ -40,8 +41,7 @@ function createJob(uint256 reward, string memory uri)
 
 - Provide the token escrow that funds jobs.
 - Only the employer can finalize jobs by calling `acknowledgeAndFinalize(jobId)` from their own wallet.
-- This finalization burns a portion of the employer's deposit; the protocol never initiates or benefits from burns.
-- When a job finalizes, a portion of the employer's deposit is burned.
+- That finalization burns a portion of the employer's deposit; the protocol never initiates or benefits from burns.
 - Burning is a disposal of property, so employers record any capital gain or loss on the burned amount based on cost basis versus fair market value at burn.
 - Token payments to agents may be deductible business expenses where applicable.
 


### PR DESCRIPTION
## Summary
- Clarify that only employers finalize jobs and burns are never platform-initiated
- Instruct employers to use `acknowledgeAndFinalize(jobId)` from their own wallet in lifecycle guides
- Document fee routing and treasury configuration across README and deployment docs

## Testing
- `npm run lint` *(fails: 30 warnings)*
- `npm test`
- `npm run format:check` *(fails: Code style issues found in 9 files)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4b0359b88333929b59b3a96b5f4f