### PR TITLE
Restrict job finalization to employers

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -41,7 +41,7 @@ contract MockStakeManager is IStakeManager {
     function releaseReward(bytes32, address, uint256) external override {}
     function releaseStake(address, uint256) external override {}
     function release(address, uint256) external override {}
-    function finalizeJobFunds(bytes32, address, address, uint256, uint256, IFeePool) external override {}
+    function finalizeJobFunds(bytes32, address, address, uint256, uint256, IFeePool, bool) external override {}
     function distributeValidatorRewards(bytes32, uint256) external override {}
     function setDisputeModule(address module) external override {
         disputeModule = module;

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -983,15 +983,17 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @param reward base amount paid to the agent with 18 decimals before AGI bonus
     /// @param fee amount forwarded to the fee pool with 18 decimals
     /// @param _feePool fee pool contract receiving protocol fees
+    /// @param byGovernance true when governance is forcing finalization
     function finalizeJobFunds(
         bytes32 jobId,
         address employer,
         address agent,
         uint256 reward,
         uint256 fee,
-        IFeePool _feePool
+        IFeePool _feePool,
+        bool byGovernance
     ) external onlyJobRegistry whenNotPaused nonReentrant {
-        if (employer != tx.origin) revert Unauthorized();
+        if (!byGovernance && employer != tx.origin) revert Unauthorized();
         emit JobFundsFinalized(jobId, employer);
         uint256 pct = getAgentPayoutPct(agent);
         uint256 modified = (reward * pct) / 100;

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -102,7 +102,8 @@ interface IStakeManager {
         address agent,
         uint256 reward,
         uint256 fee,
-        IFeePool feePool
+        IFeePool feePool,
+        bool byGovernance
     ) external;
 
     /// @notice distribute validator rewards equally among selected validators

--- a/contracts/v2/mocks/ReentrantJobRegistry.sol
+++ b/contracts/v2/mocks/ReentrantJobRegistry.sol
@@ -10,7 +10,8 @@ interface IStakeManager {
         address agent,
         uint256 reward,
         uint256 fee,
-        IFeePool feePool
+        IFeePool feePool,
+        bool byGovernance
     ) external;
 
     function distributeValidatorRewards(bytes32 jobId, uint256 amount) external;
@@ -55,7 +56,7 @@ contract ReentrantJobRegistry {
         reward = _reward;
         attackType = AttackType.Finalize;
         token.setAttack(true);
-        stakeManager.finalizeJobFunds(jobId, employer, agent, reward, 0, IFeePool(address(0)));
+        stakeManager.finalizeJobFunds(jobId, employer, agent, reward, 0, IFeePool(address(0)), false);
         attackType = AttackType.None;
     }
 
@@ -71,7 +72,7 @@ contract ReentrantJobRegistry {
     // called by the token during transfer to attempt reentrancy
     function reenter() external {
         if (attackType == AttackType.Finalize) {
-            stakeManager.finalizeJobFunds(jobId, employer, agent, reward, 0, IFeePool(address(0)));
+            stakeManager.finalizeJobFunds(jobId, employer, agent, reward, 0, IFeePool(address(0)), false);
         } else if (attackType == AttackType.Validator) {
             stakeManager.distributeValidatorRewards(jobId, amount);
         }

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -43,7 +43,7 @@ contract ReentrantStakeManager is IStakeManager {
     function releaseReward(bytes32, address, uint256) external override {}
     function releaseStake(address, uint256) external override {}
     function release(address, uint256) external override {}
-    function finalizeJobFunds(bytes32, address, address, uint256, uint256, IFeePool) external override {}
+    function finalizeJobFunds(bytes32, address, address, uint256, uint256, IFeePool, bool) external override {}
     function distributeValidatorRewards(bytes32, uint256) external override {}
     function setDisputeModule(address) external override {}
     function setModules(address, address) external override {}

--- a/docs/job-lifecycle.md
+++ b/docs/job-lifecycle.md
@@ -6,4 +6,4 @@ After validation succeeds and the reveal and dispute windows close, only the emp
 
 ## Expiration Handling
 
-When an assigned job misses its deadline without submission, anyone may call `cancelExpiredJob` to finalize the job. The caller does not need to be the employer, agent, or a tax policy acknowledger—**any address can trigger expiration handling** once the deadline has passed.
+When an assigned job misses its deadline without submission, only the employer or governance may call `cancelExpiredJob` to finalize the job. This keeps the burn under the employer's control while still allowing governance to handle edge cases such as blacklisted participants.

--- a/docs/master-guide.md
+++ b/docs/master-guide.md
@@ -495,7 +495,7 @@ Create `docs/deployment-addresses.json` (or similar) and keep it updated:
   → `{employerPct, treasuryPct}` (sum 100)  
   → **burn remainder via `TOKEN.burn()`**  
   → `StakeSlashed(user, role, amount, employerShare, treasuryShare, burnShare, jobId)`.
-- **Fee remittance (M):** `finalizeJobFunds(jobId, employer, reward, feeBps)` → net to agent, validator rewards, fee to `FeePool`.
+- **Fee remittance (M):** `finalizeJobFunds(jobId, employer, agent, reward, fee, pool, byGovernance)` → net to agent, validator rewards, fee to `FeePool`.
 - **Guards (L):** `nonReentrant` + `whenNotPaused` on state mutators.
 
 #### A.2.3 `FeePool`

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -122,7 +122,8 @@ describe('FeePool', function () {
         user1.address,
         0,
         feeAmount,
-        await feePool.getAddress()
+        await feePool.getAddress(),
+        false
       );
 
     const before1 = await token.balanceOf(user1.address);
@@ -158,7 +159,8 @@ describe('FeePool', function () {
         user1.address,
         0,
         feeAmount,
-        await feePool.getAddress()
+        await feePool.getAddress(),
+        false
       );
 
     const before1 = await token.balanceOf(user1.address);
@@ -189,7 +191,8 @@ describe('FeePool', function () {
         user1.address,
         0,
         feeAmount,
-        await feePool.getAddress()
+        await feePool.getAddress(),
+        false
       );
 
     const before1 = await token.balanceOf(user1.address);
@@ -219,7 +222,8 @@ describe('FeePool', function () {
         user1.address,
         0,
         feeAmount,
-        await feePool.getAddress()
+        await feePool.getAddress(),
+        false
       );
     await feePool.connect(owner).distributeFees();
     const before = await token.balanceOf(owner.address);
@@ -280,7 +284,8 @@ describe('FeePool', function () {
         user1.address,
         0,
         feeAmount,
-        await feePool.getAddress()
+        await feePool.getAddress(),
+        false
       );
     await feePool.connect(owner).distributeFees();
     await feePool.connect(user1).claimRewards();

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -149,7 +149,7 @@ describe('Job expiration boundary', function () {
     await registry.connect(agent).applyForJob(jobId, '', []);
     await time.increase(deadline + grace - 1 - (await time.latest()));
     await expect(
-      registry.connect(treasury).cancelExpiredJob(jobId)
+      registry.connect(employer).cancelExpiredJob(jobId)
     ).to.be.revertedWithCustomError(registry, 'DeadlineNotReached');
   });
 
@@ -164,9 +164,9 @@ describe('Job expiration boundary', function () {
     const jobId = 1;
     await registry.connect(agent).applyForJob(jobId, '', []);
     await time.increase(deadline + grace - (await time.latest()));
-    await expect(registry.connect(treasury).cancelExpiredJob(jobId))
+    await expect(registry.connect(employer).cancelExpiredJob(jobId))
       .to.emit(registry, 'JobExpired')
-      .withArgs(jobId, treasury.address)
+      .withArgs(jobId, employer.address)
       .and.to.emit(registry, 'JobFinalized')
       .withArgs(jobId, agent.address);
 

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -155,7 +155,8 @@ describe('Platform reward flow', function () {
         alice.address,
         REWARD,
         FEE,
-        await feePool.getAddress()
+        await feePool.getAddress(),
+        false
       );
     expect(await token.balanceOf(alice.address)).to.equal(
       aliceBeforeReward + REWARD


### PR DESCRIPTION
## Summary
- enforce employer-originated burns by passing employer address to StakeManager and verifying `tx.origin`
- limit `cancelExpiredJob` to the employer or governance and update docs
- adapt tests and mocks for new `finalizeJobFunds` signature

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf5913ca108333a3e5df3ba095bbb4