### PR TITLE
feat: support burn address forwarding

### DIFF
--- a/docs/tax-obligations.md
+++ b/docs/tax-obligations.md
@@ -59,8 +59,8 @@ function createJob(uint256 reward, string memory uri)
 ## Platform Owner and Contract
 
 - Collect no fees and never take custody of tokens.
-- Any fee remainder is burned or sent to a community-controlled address;
-  the owner cannot receive leftover tokens.
+- Any fee remainder is burned or forwarded to a community-controlled or
+  dedicated burn address; the owner cannot receive leftover tokens.
 - Do not mint, burn, or transfer tokens for themselves.
 - Never finalize jobs or receive burned tokens; burns only destroy employer deposits.
 - Provide infrastructure without consideration, so no sales/VAT/GST applies.


### PR DESCRIPTION
## Summary
- allow StakeManager to transfer burned amounts to a configured burn address
- forward FeePool burns to a burn address when set and clarify docs on neutral fee handling

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bf5ddb40788333aa30421522130bc4