### PR TITLE
Initialize Ownable2Step base constructors

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {Ownable2Step} from "./utils/Ownable2Step.sol";
 import {IENS} from "./interfaces/IENS.sol";
 import {INameWrapper} from "./interfaces/INameWrapper.sol";
 import {IReputationEngine} from "./interfaces/IReputationEngine.sol";
@@ -83,7 +82,7 @@ contract IdentityRegistry is Ownable2Step {
         IReputationEngine _reputationEngine,
         bytes32 _agentRootNode,
         bytes32 _clubRootNode
-    ) Ownable(msg.sender) {
+    ) Ownable2Step(msg.sender) {
         ens = _ens;
         if (address(_ens) != address(0)) {
             emit ENSUpdated(address(_ens));

--- a/contracts/v2/TaxPolicy.sol
+++ b/contracts/v2/TaxPolicy.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {Ownable2Step} from "./utils/Ownable2Step.sol";
 import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 
 /// @title TaxPolicy
@@ -51,7 +50,7 @@ contract TaxPolicy is Ownable2Step, ITaxPolicy {
     /// @param allowed True if the address is allowed to acknowledge for others.
     event AcknowledgerUpdated(address indexed acknowledger, bool allowed);
 
-    constructor(string memory uri, string memory ack) Ownable(msg.sender) {
+    constructor(string memory uri, string memory ack) Ownable2Step(msg.sender) {
         _policyURI = uri;
         _acknowledgement = ack;
         _version = 1;

--- a/contracts/v2/utils/Ownable2Step.sol
+++ b/contracts/v2/utils/Ownable2Step.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step as OpenZeppelinOwnable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+
+/// @title Ownable2Step
+/// @dev Extends OpenZeppelin's Ownable2Step by exposing a constructor
+/// that forwards the initial owner to the underlying Ownable base.
+abstract contract Ownable2Step is OpenZeppelinOwnable2Step {
+    constructor(address initialOwner) Ownable(initialOwner) {}
+}


### PR DESCRIPTION
## Summary
- ensure TaxPolicy and IdentityRegistry call Ownable2Step with the deployer as initial owner
- expose a local wrapper around OpenZeppelin's Ownable2Step that accepts the initial owner

## Testing
- `npm run lint`
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7252c6208333aa044991534c44b1