### PR TITLE
feat: enforce tax policy in fee pool

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -326,10 +326,19 @@ contract Deployer is Ownable {
         CertificateNFT certificate = new CertificateNFT("Cert", "CERT");
         certificate.setJobRegistry(address(registry));
 
+        TaxPolicy policy;
+        if (withTaxPolicy) {
+            policy = new TaxPolicy(
+                "ipfs://policy",
+                "All taxes on participants; contract and owner exempt"
+            );
+        }
+
         FeePool pool = new FeePool(
             IStakeManager(address(stake)),
             burnPct,
-            governance
+            governance,
+            ITaxPolicy(address(policy))
         );
 
         IdentityRegistry identity = new IdentityRegistry(
@@ -354,14 +363,6 @@ contract Deployer is Ownable {
             IPlatformRegistryFull(address(pRegistry)),
             IJobRouter(address(router))
         );
-
-        TaxPolicy policy;
-        if (withTaxPolicy) {
-            policy = new TaxPolicy(
-                "ipfs://policy",
-                "All taxes on participants; contract and owner exempt"
-            );
-        }
 
         // Wire modules
         address[] memory acks = new address[](0);

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -101,13 +101,23 @@ async function main() {
   await dispute.setCommittee(await committee.getAddress());
   await dispute.setStakeManager(await stake.getAddress());
 
+  const TaxPolicy = await ethers.getContractFactory(
+    'contracts/v2/TaxPolicy.sol:TaxPolicy'
+  );
+  const tax = await TaxPolicy.deploy(
+    'ipfs://policy',
+    'All taxes on participants; contract and owner exempt'
+  );
+  await tax.waitForDeployment();
+
   const FeePool = await ethers.getContractFactory(
     'contracts/v2/FeePool.sol:FeePool'
   );
   const feePool = await FeePool.deploy(
     await stake.getAddress(),
     0,
-    deployer.address
+    deployer.address,
+    await tax.getAddress()
   );
   await feePool.waitForDeployment();
 

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -194,7 +194,8 @@ async function main() {
   const feePool = await FeePool.deploy(
     await stake.getAddress(),
     burnPct,
-    treasury
+    treasury,
+    await tax.getAddress()
   );
   await feePool.waitForDeployment();
 

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -6,6 +6,7 @@ import "contracts/v2/interfaces/IFeePool.sol";
 import "contracts/legacy/MockV2.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {AGIALPHA} from "contracts/v2/Constants.sol";
+import {ITaxPolicy} from "contracts/v2/interfaces/ITaxPolicy.sol";
 
 // minimal cheatcode interface
 interface Vm {
@@ -48,7 +49,7 @@ contract FeePoolTest {
         token = TestToken(AGIALPHA);
         stakeManager = new MockStakeManager();
         stakeManager.setJobRegistry(jobRegistry);
-        feePool = new FeePool(stakeManager, 0, address(0));
+        feePool = new FeePool(stakeManager, 0, address(0), ITaxPolicy(address(0)));
         stakeManager.setStake(alice, IStakeManager.Role.Platform, 1 * TOKEN);
         stakeManager.setStake(bob, IStakeManager.Role.Platform, 2 * TOKEN);
     }
@@ -135,7 +136,7 @@ contract FeePoolTest {
         NonBurnableToken nbToken = NonBurnableToken(AGIALPHA);
         stakeManager = new MockStakeManager();
         stakeManager.setJobRegistry(jobRegistry);
-        feePool = new FeePool(stakeManager, 0, address(0));
+        feePool = new FeePool(stakeManager, 0, address(0), ITaxPolicy(address(0)));
         stakeManager.setStake(alice, IStakeManager.Role.Platform, 1 * TOKEN);
         nbToken.mint(address(feePool), TOKEN);
         vm.prank(address(stakeManager));
@@ -191,7 +192,7 @@ contract FeePoolTest {
         token = TestToken(AGIALPHA);
         stakeManager = new MockStakeManager();
         vm.expectRevert(InvalidTreasury.selector);
-        new FeePool(stakeManager, 0, address(this));
+        new FeePool(stakeManager, 0, address(this), ITaxPolicy(address(0)));
     }
 
     function testNoStakersBurnsFees() public {
@@ -200,7 +201,7 @@ contract FeePoolTest {
         token = TestToken(AGIALPHA);
         stakeManager = new MockStakeManager();
         stakeManager.setJobRegistry(jobRegistry);
-        feePool = new FeePool(stakeManager, 0, address(0));
+        feePool = new FeePool(stakeManager, 0, address(0), ITaxPolicy(address(0)));
         token.mint(address(feePool), TOKEN);
         uint256 supplyBefore = token.totalSupply();
         vm.prank(address(stakeManager));

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -79,7 +79,8 @@ describe('FeePool', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
     await feePool.setBurnPct(0);
 
@@ -252,6 +253,7 @@ describe('FeePool', function () {
     const burnPool = await FeePool.deploy(
       await emptyStakeManager.getAddress(),
       0,
+      ethers.ZeroAddress,
       ethers.ZeroAddress
     );
     await token.connect(user1).approve(await burnPool.getAddress(), 100);
@@ -423,7 +425,8 @@ describe('FeePool with no stakers', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
     await feePool.setBurnPct(0);
   });
@@ -452,6 +455,7 @@ describe('FeePool with no stakers', function () {
     const burnPool = await BurnFeePool.deploy(
       await stakeManager.getAddress(),
       0,
+      ethers.ZeroAddress,
       ethers.ZeroAddress
     );
     await burnPool.setBurnPct(0);

--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -72,7 +72,8 @@ describe('Governance reward lifecycle', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
     await feePool.setBurnPct(0);
     await feePool.setGovernance(owner.address);

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -63,7 +63,8 @@ describe('GovernanceReward', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
     await feePool.setBurnPct(0);
     await feePool.setGovernance(owner.address);

--- a/test/v2/Integration.t.sol
+++ b/test/v2/Integration.t.sol
@@ -9,6 +9,7 @@ import "contracts/v2/interfaces/IPlatformRegistry.sol";
 import "contracts/legacy/MockV2.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {AGIALPHA} from "contracts/v2/Constants.sol";
+import {ITaxPolicy} from "contracts/v2/interfaces/ITaxPolicy.sol";
 
 interface Vm {
     function prank(address) external;
@@ -78,7 +79,7 @@ contract IntegrationTest {
         stakeManager = new MockStakeManager();
         stakeManager.setJobRegistry(jobRegistryAddr);
         registry = new MockPlatformRegistry();
-        feePool = new FeePool(stakeManager, 0, address(this));
+        feePool = new FeePool(stakeManager, 0, address(this), ITaxPolicy(address(0)));
         router = new JobRouter(registry);
     }
 

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -55,7 +55,8 @@ describe('Job expiration', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
     const Registry = await ethers.getContractFactory(
       'contracts/v2/JobRegistry.sol:JobRegistry'

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -55,7 +55,8 @@ describe('Job expiration boundary', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
     const Registry = await ethers.getContractFactory(
       'contracts/v2/JobRegistry.sol:JobRegistry'

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -65,7 +65,8 @@ describe('JobRegistry integration', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
     const Registry = await ethers.getContractFactory(
       'contracts/v2/JobRegistry.sol:JobRegistry'
@@ -239,7 +240,8 @@ describe('JobRegistry integration', function () {
     const feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
     await feePool.setBurnPct(0);
     await registry.connect(owner).setFeePool(await feePool.getAddress());

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -94,6 +94,7 @@ async function deploySystem() {
   const feePool = await FeePool.deploy(
     await stake.getAddress(),
     0,
+    ethers.ZeroAddress,
     ethers.ZeroAddress
   );
   await feePool.waitForDeployment();

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -94,6 +94,7 @@ async function deploySystem() {
   const feePool = await FeePool.deploy(
     await stake.getAddress(),
     0,
+    ethers.ZeroAddress,
     ethers.ZeroAddress
   );
   await feePool.waitForDeployment();

--- a/test/v2/PlatformIncentives.t.sol
+++ b/test/v2/PlatformIncentives.t.sol
@@ -17,6 +17,7 @@ import {FeePool} from "../../contracts/v2/FeePool.sol";
 import {PlatformIncentives} from "../../contracts/v2/PlatformIncentives.sol";
 import {MockJobRegistry} from "../../contracts/legacy/MockV2.sol";
 import {IStakeManager} from "../../contracts/v2/interfaces/IStakeManager.sol";
+import {ITaxPolicy} from "../../contracts/v2/interfaces/ITaxPolicy.sol";
 
 contract PlatformIncentivesTest is Test {
     AGIALPHAToken token;
@@ -42,7 +43,12 @@ contract PlatformIncentivesTest is Test {
             1e18
         );
         jobRouter = new JobRouter(IPlatformRegistry(address(platformRegistry)));
-        feePool = new FeePool(IStakeManager(address(stakeManager)), 0, address(this));
+        feePool = new FeePool(
+            IStakeManager(address(stakeManager)),
+            0,
+            address(this),
+            ITaxPolicy(address(0))
+        );
         incentives = new PlatformIncentives(
             IStakeManager(address(stakeManager)),
             IPlatformRegistryFull(address(platformRegistry)),

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -338,7 +338,8 @@ describe('PlatformRegistry', function () {
     const feePool = await FeePool.connect(owner).deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
 
     const Incentives = await ethers.getContractFactory(

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -95,7 +95,8 @@ describe('Platform reward flow', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
     await feePool.setBurnPct(0);
   });

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -67,7 +67,8 @@ describe('StakeManager release', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
-      treasury.address
+      treasury.address,
+      ethers.ZeroAddress
     );
     await feePool.connect(owner).setBurnPct(0);
 

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -100,6 +100,7 @@ describe('comprehensive job flows', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
+      ethers.ZeroAddress,
       ethers.ZeroAddress
     );
     await feePool.setBurnPct(0);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -97,6 +97,7 @@ describe('end-to-end job lifecycle', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
+      ethers.ZeroAddress,
       ethers.ZeroAddress
     );
     await feePool.setBurnPct(0);

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -97,6 +97,7 @@ describe('job finalization integration', function () {
     feePool = await FeePool.deploy(
       await stakeManager.getAddress(),
       0,
+      ethers.ZeroAddress,
       ethers.ZeroAddress
     );
     await feePool.setBurnPct(0);

--- a/test/v2/midJobReplacementFuzz.test.js
+++ b/test/v2/midJobReplacementFuzz.test.js
@@ -85,6 +85,7 @@ async function deploySystem() {
   const feePool = await FeePool.deploy(
     await stake.getAddress(),
     0,
+    ethers.ZeroAddress,
     ethers.ZeroAddress
   );
 

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -98,6 +98,7 @@ describe('multi-operator job lifecycle', function () {
     feePool = await FeePoolF.deploy(
       await stakeManager.getAddress(),
       0,
+      ethers.ZeroAddress,
       ethers.ZeroAddress
     );
     await feePool.setBurnPct(0);


### PR DESCRIPTION
## Summary
- integrate TaxPolicy into FeePool and require acknowledgement for contributions and claims
- wire tax policy through deployment scripts and tests

## Testing
- `npx hardhat test test/v2/FeePool.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf75b895cc8333b617cd70f01974c6