### PR TITLE
feat: track burn receipts and validation burn hash

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -129,6 +129,7 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
     uint256 public validatorRewardPct;
     uint256 public nextJobId;
     mapping(uint256 => uint256) public deadlines;
+    mapping(uint256 => mapping(bytes32 => bool)) public burnReceiptMap;
 
     event JobCreated(
         uint256 indexed jobId,
@@ -147,6 +148,25 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
 
     function getSpecHash(uint256) external pure override returns (bytes32) {
         return bytes32(0);
+    }
+
+    function submitBurnReceipt(
+        uint256 jobId,
+        bytes32 burnTxHash,
+        uint256,
+        uint256
+    ) external override {
+        burnReceiptMap[jobId][burnTxHash] = true;
+        emit BurnReceiptSubmitted(jobId, burnTxHash, 0, 0);
+    }
+
+    function hasBurnReceipt(uint256 jobId, bytes32 burnTxHash)
+        external
+        view
+        override
+        returns (bool)
+    {
+        return burnReceiptMap[jobId][burnTxHash];
     }
 
     function acknowledgeTaxPolicy() external {

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -91,6 +91,12 @@ interface IJobRegistry {
     event JobDisputed(uint256 indexed jobId, address indexed caller);
     event JobCancelled(uint256 indexed jobId);
     event DisputeResolved(uint256 indexed jobId, bool employerWins);
+    event BurnReceiptSubmitted(
+        uint256 indexed jobId,
+        bytes32 indexed burnTxHash,
+        uint256 amount,
+        uint256 blockNumber
+    );
 
     // owner wiring of modules
 
@@ -178,6 +184,18 @@ interface IJobRegistry {
     ) external;
 
     function getSpecHash(uint256 jobId) external view returns (bytes32);
+
+    function submitBurnReceipt(
+        uint256 jobId,
+        bytes32 burnTxHash,
+        uint256 amount,
+        uint256 blockNumber
+    ) external;
+
+    function hasBurnReceipt(uint256 jobId, bytes32 burnTxHash)
+        external
+        view
+        returns (bool);
 
     /// @notice Deposit stake and apply for a job in one call
     /// @param jobId Identifier of the job

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -22,6 +22,7 @@ interface IValidationModule {
         uint256 indexed jobId,
         address indexed validator,
         bool approve,
+        bytes32 burnTxHash,
         string subdomain
     );
     event ValidationTallied(
@@ -80,6 +81,7 @@ interface IValidationModule {
     function revealValidation(
         uint256 jobId,
         bool approve,
+        bytes32 burnTxHash,
         bytes32 salt,
         string calldata subdomain,
         bytes32[] calldata proof

--- a/contracts/v2/mocks/ReentrantIdentityRegistry.sol
+++ b/contracts/v2/mocks/ReentrantIdentityRegistry.sol
@@ -14,6 +14,7 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
     bytes32 public commitHash;
     bool public approve;
     bytes32 public salt;
+    bytes32 public burnTxHash;
 
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 2;
@@ -28,10 +29,16 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
         commitHash = _commitHash;
     }
 
-    function attackReveal(uint256 _jobId, bool _approve, bytes32 _salt) external {
+    function attackReveal(
+        uint256 _jobId,
+        bool _approve,
+        bytes32 _burnTxHash,
+        bytes32 _salt
+    ) external {
         attack = Attack.Reveal;
         jobId = _jobId;
         approve = _approve;
+        burnTxHash = _burnTxHash;
         salt = _salt;
     }
 
@@ -68,7 +75,7 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
             validation.commitValidation(jobId, commitHash, "", new bytes32[](0));
         } else if (attack == Attack.Reveal) {
             attack = Attack.None;
-            validation.revealValidation(jobId, approve, salt, "", new bytes32[](0));
+            validation.revealValidation(jobId, approve, burnTxHash, salt, "", new bytes32[](0));
         }
         ok = true;
     }

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -47,6 +47,7 @@ contract ValidationStub is IValidationModule {
         uint256,
         bool,
         bytes32,
+        bytes32,
         string calldata,
         bytes32[] calldata
     ) external override {}

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -62,6 +62,7 @@ contract NoValidationModule is IValidationModule, Ownable {
         uint256,
         bool,
         bytes32,
+        bytes32,
         string calldata,
         bytes32[] calldata
     ) external pure override {}

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -85,6 +85,7 @@ contract OracleValidationModule is IValidationModule, Ownable {
         uint256,
         bool,
         bytes32,
+        bytes32,
         string calldata,
         bytes32[] calldata
     ) external pure override {}

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -211,9 +211,10 @@ describe('Identity verification enforcement', function () {
       await identity.removeAdditionalValidator(val);
       const salt = ethers.keccak256(ethers.toUtf8Bytes('salt'));
       const nonce = await validation.jobNonce(1);
+      const burnTxHash = ethers.keccak256(ethers.toUtf8Bytes('burn'));
       const commit = ethers.solidityPackedKeccak256(
-        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
-        [1n, nonce, true, salt, ethers.ZeroHash]
+        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
+        [1n, nonce, true, burnTxHash, salt, ethers.ZeroHash]
       );
       await expect(
         validation.connect(signer).commitValidation(1, commit, '', [])
@@ -226,7 +227,9 @@ describe('Identity verification enforcement', function () {
       await advance(61);
       await identity.removeAdditionalValidator(val);
       await expect(
-        validation.connect(signer).revealValidation(1, true, salt, '', [])
+        validation
+          .connect(signer)
+          .revealValidation(1, true, burnTxHash, salt, '', [])
       ).to.be.revertedWithCustomError(validation, 'UnauthorizedValidator');
     });
   });

--- a/test/v2/ValidationFinalizeGas.t.sol
+++ b/test/v2/ValidationFinalizeGas.t.sol
@@ -19,6 +19,8 @@ contract ValidationFinalizeGas is Test {
     AGIALPHAToken token;
     MockJobRegistry jobRegistry;
 
+    bytes32 constant burnTxHash = keccak256("burn");
+
     address employer = address(0xE);
     address agent = address(0xA);
     address[3] validators;
@@ -74,6 +76,9 @@ contract ValidationFinalizeGas is Test {
         job.status = IJobRegistry.Status.Submitted;
         jobRegistry.setJob(jobId, job);
 
+        vm.prank(employer);
+        jobRegistry.submitBurnReceipt(jobId, burnTxHash, 0, block.number);
+
         vm.prank(address(jobRegistry));
         validation.start(jobId, 0);
         vm.roll(block.number + 2);
@@ -86,13 +91,13 @@ contract ValidationFinalizeGas is Test {
             bytes32 salt = bytes32(uint256(i + 1));
             uint256 nonce = validation.jobNonce(jobId);
             bytes32 commitHash = keccak256(
-                abi.encodePacked(jobId, nonce, true, salt, bytes32(0))
+                abi.encodePacked(jobId, nonce, true, burnTxHash, salt, bytes32(0))
             );
             vm.prank(val);
             validation.commitValidation(jobId, commitHash, "", new bytes32[](0));
             vm.warp(block.timestamp + 2);
             vm.prank(val);
-            validation.revealValidation(jobId, true, salt, "", new bytes32[](0));
+            validation.revealValidation(jobId, true, burnTxHash, salt, "", new bytes32[](0));
         }
     }
 

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -74,9 +74,7 @@ describe('ValidationModule V2', function () {
       resultHash: ethers.ZeroHash,
     };
     await jobRegistry.setJob(1, jobStruct);
-    await jobRegistry
-      .connect(employer)
-      .submitBurnReceipt(1, burnTxHash, 0, 0);
+    await jobRegistry.connect(employer).submitBurnReceipt(1, burnTxHash, 0, 0);
   });
 
   async function advance(seconds) {
@@ -348,9 +346,7 @@ describe('ValidationModule V2', function () {
     ).wait();
     await advance(61);
     await expect(
-      validation
-        .connect(v1)
-        .revealValidation(1, true, burnTxHash, salt, '', [])
+      validation.connect(v1).revealValidation(1, true, burnTxHash, salt, '', [])
     ).to.be.revertedWithCustomError(validation, 'InvalidReveal');
   });
 

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -215,16 +215,20 @@ describe('Commit-reveal job lifecycle', function () {
     await registry
       .connect(agent)
       .submit(1, ethers.id('ipfs://result'), 'ipfs://result', label, []);
+    const burnTxHash = ethers.keccak256(ethers.toUtf8Bytes('burn'));
+    await registry.connect(employer).submitBurnReceipt(1, burnTxHash, 0, 0);
 
     const nonce = await validation.jobNonce(1);
     const salt = ethers.id('salt');
     const commit = ethers.solidityPackedKeccak256(
-      ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
-      [1n, nonce, true, salt, specHash]
+      ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
+      [1n, nonce, true, burnTxHash, salt, specHash]
     );
     await validation.connect(validator).commitValidation(1, commit, '', []);
     await time.increase(2);
-    await validation.connect(validator).revealValidation(1, true, salt, '', []);
+    await validation
+      .connect(validator)
+      .revealValidation(1, true, burnTxHash, salt, '', []);
     await time.increase(2);
     await validation.finalize(1);
     await registry.connect(employer).finalize(1);
@@ -290,18 +294,20 @@ describe('Commit-reveal job lifecycle', function () {
     await registry
       .connect(agent)
       .submit(1, ethers.id('ipfs://bad'), 'ipfs://bad', label, []);
+    const burnTxHash = ethers.keccak256(ethers.toUtf8Bytes('burn'));
+    await registry.connect(employer).submitBurnReceipt(1, burnTxHash, 0, 0);
 
     const nonce = await validation.jobNonce(1);
     const salt = ethers.id('salt');
     const commit = ethers.solidityPackedKeccak256(
-      ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
-      [1n, nonce, false, salt, specHash]
+      ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
+      [1n, nonce, false, burnTxHash, salt, specHash]
     );
     await validation.connect(validator).commitValidation(1, commit, '', []);
     await time.increase(2);
     await validation
       .connect(validator)
-      .revealValidation(1, false, salt, '', []);
+      .revealValidation(1, false, burnTxHash, salt, '', []);
     await time.increase(2);
     await validation.finalize(1);
 

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -166,27 +166,31 @@ describe('job lifecycle with dispute and validator failure', function () {
     await registry
       .connect(agent)
       .submit(1, ethers.id('ipfs://result'), 'ipfs://result', 'agent', []);
+    const burnTxHash = ethers.keccak256(ethers.toUtf8Bytes('burn'));
+    await registry.connect(employer).submitBurnReceipt(1, burnTxHash, 0, 0);
 
     const nonce = await validation.jobNonce(1);
     const salt1 = ethers.randomBytes(32);
     const commit1 = ethers.keccak256(
       ethers.solidityPacked(
-        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
-        [1n, nonce, true, salt1, specHash]
+        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
+        [1n, nonce, true, burnTxHash, salt1, specHash]
       )
     );
     await validation.connect(v1).commitValidation(1, commit1, '', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
-        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
-        [1n, nonce, false, salt2, specHash]
+        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
+        [1n, nonce, false, burnTxHash, salt2, specHash]
       )
     );
     await validation.connect(v2).commitValidation(1, commit2, '', []);
 
     await time.increase(2);
-    await validation.connect(v1).revealValidation(1, true, salt1, '', []);
+    await validation
+      .connect(v1)
+      .revealValidation(1, true, burnTxHash, salt1, '', []);
     // v2 fails to reveal
     await time.increase(2);
     await validation.finalize(1);

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -178,17 +178,21 @@ describe('regression scenarios', function () {
     await registry
       .connect(agent)
       .submit(1, ethers.id('ipfs://good'), 'ipfs://good', 'agent', []);
+    const burnTxHash = ethers.keccak256(ethers.toUtf8Bytes('burn'));
+    await registry.connect(employer).submitBurnReceipt(1, burnTxHash, 0, 0);
     const nonce = await validation.jobNonce(1);
     const salt = ethers.randomBytes(32);
     const commit = ethers.keccak256(
       ethers.solidityPacked(
-        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
-        [1n, nonce, false, salt, specHash]
+        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
+        [1n, nonce, false, burnTxHash, salt, specHash]
       )
     );
     await validation.connect(v1).commitValidation(1, commit, '', []);
     await time.increase(2);
-    await validation.connect(v1).revealValidation(1, false, salt, '', []);
+    await validation
+      .connect(v1)
+      .revealValidation(1, false, burnTxHash, salt, '', []);
     await time.increase(2);
     await validation.finalize(1);
     await registry.connect(employer).finalize(1);

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -154,28 +154,34 @@ describe('validator participation', function () {
     await registry
       .connect(agent)
       .submit(1, ethers.id('ipfs://result'), 'ipfs://result', 'agent', []);
+    const burnTxHash = ethers.keccak256(ethers.toUtf8Bytes('burn'));
+    await registry.connect(employer).submitBurnReceipt(1, burnTxHash, 0, 0);
 
     const nonce = await validation.jobNonce(1);
     const salt1 = ethers.randomBytes(32);
     const commit1 = ethers.keccak256(
       ethers.solidityPacked(
-        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
-        [1n, nonce, true, salt1, specHash]
+        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
+        [1n, nonce, true, burnTxHash, salt1, specHash]
       )
     );
     await validation.connect(v1).commitValidation(1, commit1, '', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
-        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
-        [1n, nonce, true, salt2, specHash]
+        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
+        [1n, nonce, true, burnTxHash, salt2, specHash]
       )
     );
     await validation.connect(v2).commitValidation(1, commit2, '', []);
 
     await time.increase(2);
-    await validation.connect(v1).revealValidation(1, true, salt1, '', []);
-    await validation.connect(v2).revealValidation(1, true, salt2, '', []);
+    await validation
+      .connect(v1)
+      .revealValidation(1, true, burnTxHash, salt1, '', []);
+    await validation
+      .connect(v2)
+      .revealValidation(1, true, burnTxHash, salt2, '', []);
     await time.increase(2);
     await validation.finalize(1);
     await registry.connect(employer).finalize(1);
@@ -219,28 +225,34 @@ describe('validator participation', function () {
     await registry
       .connect(agent)
       .submit(1, ethers.id('ipfs://bad'), 'ipfs://bad', 'agent', []);
+    const burnTxHash = ethers.keccak256(ethers.toUtf8Bytes('burn'));
+    await registry.connect(employer).submitBurnReceipt(1, burnTxHash, 0, 0);
 
     const nonce = await validation.jobNonce(1);
     const salt1 = ethers.randomBytes(32);
     const commit1 = ethers.keccak256(
       ethers.solidityPacked(
-        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
-        [1n, nonce, false, salt1, specHash]
+        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
+        [1n, nonce, false, burnTxHash, salt1, specHash]
       )
     );
     await validation.connect(v1).commitValidation(1, commit1, '', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
-        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32'],
-        [1n, nonce, false, salt2, specHash]
+        ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
+        [1n, nonce, false, burnTxHash, salt2, specHash]
       )
     );
     await validation.connect(v2).commitValidation(1, commit2, '', []);
 
     await time.increase(2);
-    await validation.connect(v1).revealValidation(1, false, salt1, '', []);
-    await validation.connect(v2).revealValidation(1, false, salt2, '', []);
+    await validation
+      .connect(v1)
+      .revealValidation(1, false, burnTxHash, salt1, '', []);
+    await validation
+      .connect(v2)
+      .revealValidation(1, false, burnTxHash, salt2, '', []);
     await time.increase(2);
     await validation.finalize(1);
 


### PR DESCRIPTION
## Summary
- record burn receipts on JobRegistry and expose lookup
- require burn receipt hash in ValidationModule commit/reveal flow
- adjust tests and mocks for burn receipt support

## Testing
- `npx hardhat test test/v2/ValidationModule.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf7b529b108333956627dc4c0d3266