### PR TITLE
feat: prevent owner as treasury

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 
 ### Fee handling and treasury
 
-`JobRegistry` routes protocol fees to `FeePool`, which burns a configurable percentage (`burnPct`) when an employer finalizes a job and escrows the remainder for platform stakers. `StakeManager.setTreasury`, `JobRegistry.setTreasury`, and `FeePool.setTreasury` configure a governance-controlled treasury that receives slashed stakes, blacklisted payouts, or undistributed fees. The platform only routes funds and never initiates or profits from burns.
+`JobRegistry` routes protocol fees to `FeePool`, which burns a configurable percentage (`burnPct`) when an employer finalizes a job and escrows the remainder for platform stakers. `StakeManager.setTreasury`, `JobRegistry.setTreasury`, and `FeePool.setTreasury` configure a governance-controlled treasury that receives slashed stakes, blacklisted payouts, or undistributed fees. These setters require a non-zero address distinct from the governance owner. The platform only routes funds and never initiates or profits from burns.
 
 ### Deploy defaults
 

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -343,9 +343,11 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     }
 
     /// @notice update treasury recipient address
+    /// @dev Treasury must be a non-zero address distinct from the contract owner
     /// @param _treasury address receiving treasury slash share
     function setTreasury(address _treasury) external onlyGovernance {
         if (_treasury == address(0)) revert InvalidTreasury();
+        if (_treasury == owner()) revert InvalidTreasury();
         treasury = _treasury;
         emit TreasuryUpdated(_treasury);
     }

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -5,7 +5,7 @@ Handles staking, escrow and slashing of the $AGIALPHA token.
 ## Functions
 
 - `setMinStake(uint256 minStake)` / `setMaxStakePerAddress(uint256 maxStake)` – configure stake limits.
-- `setTreasury(address treasury)` / `setFeePool(address feePool)` – wire fee destinations.
+- `setTreasury(address treasury)` / `setFeePool(address feePool)` – wire fee destinations. Treasury must be non-zero and not the governance owner.
 - `setJobRegistry(address registry)` / `setDisputeModule(address module)` / `setValidationModule(address module)` – connect modules. Staking reverts until a registry is configured.
 - `depositStake(uint8 role, uint256 amount)` – user stakes as agent (`0`) or validator (`1`).
 - `withdrawStake(uint8 role, uint256 amount)` – withdraw previously staked tokens.

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -173,7 +173,7 @@ interface IStakeManager {
         uint256 employerSlashPct,
         uint256 treasurySlashPct
     ) external;
-    function setTreasury(address treasury) external;
+    function setTreasury(address treasury) external; // treasury cannot be zero or owner
 }
 
 interface ICertificateNFT {

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -634,6 +634,12 @@ describe('StakeManager', function () {
     expect(await stakeManager.treasury()).to.equal(user.address);
   });
 
+  it('rejects owner address as treasury', async () => {
+    await expect(
+      stakeManager.connect(owner).setTreasury(owner.address)
+    ).to.be.revertedWithCustomError(stakeManager, 'InvalidTreasury');
+  });
+
   it('enforces stake locks and unlocks after expiry', async () => {
     const JobRegistry = await ethers.getContractFactory(
       'contracts/v2/JobRegistry.sol:JobRegistry'


### PR DESCRIPTION
## Summary
- disallow configuring treasury to the contract owner in `StakeManager`
- document treasury address requirements
- test that owner address is rejected as a treasury

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c00b0f8b2c833382ee06441595a95f