### PR TITLE
Restrict governance withdrawals to burn or treasury

### DIFF
--- a/test/v2/GovernanceReward.integration.test.js
+++ b/test/v2/GovernanceReward.integration.test.js
@@ -88,8 +88,7 @@ describe('Governance reward lifecycle', function () {
       1,
       50
     );
-
-    await feePool.connect(owner).transferOwnership(await reward.getAddress());
+    await feePool.setTreasury(await reward.getAddress());
 
     // stake setup
     await token.mint(voter1.address, 100n * TOKEN);

--- a/test/v2/GovernanceReward.test.js
+++ b/test/v2/GovernanceReward.test.js
@@ -79,8 +79,7 @@ describe('GovernanceReward', function () {
       1,
       50
     );
-
-    await feePool.connect(owner).transferOwnership(await reward.getAddress());
+    await feePool.setTreasury(await reward.getAddress());
 
     await token.mint(voter1.address, 100n * TOKEN);
     await token.mint(voter2.address, 300n * TOKEN);


### PR DESCRIPTION
## Summary
- Enforce fee pool governance withdrawals to only burn address or configured treasury and require tax acknowledgement
- Update governance reward tests to set the reward contract as the fee pool treasury

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c00e0ee3688333b04cf726789f297d