### PR TITLE
Remove tx.origin check and support contract employers

### DIFF
--- a/contracts/test/EmployerContract.sol
+++ b/contracts/test/EmployerContract.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IJobRegistry} from "../v2/interfaces/IJobRegistry.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title EmployerContract
+/// @notice Minimal helper contract to act as a job employer in tests.
+contract EmployerContract {
+    /// @notice Approve a spender for a given ERC20 token.
+    function approveToken(address token, address spender, uint256 amount) external {
+        IERC20(token).approve(spender, amount);
+    }
+
+    /// @notice Create a job in the JobRegistry.
+    function createJob(
+        address registry,
+        uint256 reward,
+        uint64 deadline,
+        bytes32 specHash,
+        string calldata uri
+    ) external returns (uint256 jobId) {
+        jobId = IJobRegistry(registry).createJob(reward, deadline, specHash, uri);
+    }
+
+    /// @notice Finalize a job via the JobRegistry.
+    function finalizeJob(address registry, uint256 jobId) external {
+        IJobRegistry(registry).finalize(jobId);
+    }
+}

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1257,9 +1257,10 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
                     }
                 }
 
+                address employerParam = isGov ? job.employer : msg.sender;
                 stakeManager.finalizeJobFunds(
                     jobKey,
-                    job.employer,
+                    employerParam,
                     payee,
                     rewardAfterValidator,
                     fee,

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -1013,7 +1013,6 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         IFeePool _feePool,
         bool byGovernance
     ) external onlyJobRegistry whenNotPaused nonReentrant {
-        if (!byGovernance && employer != tx.origin) revert Unauthorized();
         emit JobFundsFinalized(jobId, employer);
         uint256 pct = getAgentPayoutPct(agent);
         uint256 modified = (reward * pct) / 100;

--- a/test/v2/ContractEmployerFinalize.test.js
+++ b/test/v2/ContractEmployerFinalize.test.js
@@ -6,14 +6,14 @@ const { AGIALPHA } = require('../../scripts/constants');
 
 describe('Job finalization with contract employer', function () {
   let token, stakeManager, registry, employerContract;
-  let owner, employerEOA, agent, treasury, identity;
+  let owner, agent, treasury, identity;
   const reward = 100n;
   const stake = 200n;
   const feePct = 5n; // default fee percentage
 
   beforeEach(async () => {
     await network.provider.send('hardhat_reset');
-    [owner, employerEOA, agent, treasury] = await ethers.getSigners();
+    [owner, , agent, treasury] = await ethers.getSigners();
 
     const artifact = await artifacts.readArtifact(
       'contracts/test/MockERC20.sol:MockERC20'
@@ -132,10 +132,7 @@ describe('Job finalization with contract employer', function () {
       .submit(jobId, ethers.id('res'), 'res', '', []);
 
     await setJobState(jobId, true);
-    await employerContract.finalizeJob(
-      await registry.getAddress(),
-      jobId
-    );
+    await employerContract.finalizeJob(await registry.getAddress(), jobId);
 
     expect(await token.balanceOf(agent.address)).to.equal(reward);
   });

--- a/test/v2/ContractEmployerFinalize.test.js
+++ b/test/v2/ContractEmployerFinalize.test.js
@@ -1,0 +1,164 @@
+const { expect } = require('chai');
+const { ethers, artifacts, network } = require('hardhat');
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
+
+const { AGIALPHA } = require('../../scripts/constants');
+
+describe('Job finalization with contract employer', function () {
+  let token, stakeManager, registry, employerContract;
+  let owner, employerEOA, agent, treasury, identity;
+  const reward = 100n;
+  const stake = 200n;
+  const feePct = 5n; // default fee percentage
+
+  beforeEach(async () => {
+    await network.provider.send('hardhat_reset');
+    [owner, employerEOA, agent, treasury] = await ethers.getSigners();
+
+    const artifact = await artifacts.readArtifact(
+      'contracts/test/MockERC20.sol:MockERC20'
+    );
+    await network.provider.send('hardhat_setCode', [
+      AGIALPHA,
+      artifact.deployedBytecode,
+    ]);
+
+    token = await ethers.getContractAt(
+      'contracts/test/AGIALPHAToken.sol:AGIALPHAToken',
+      AGIALPHA
+    );
+
+    const StakeManager = await ethers.getContractFactory(
+      'contracts/v2/StakeManager.sol:StakeManager'
+    );
+    stakeManager = await StakeManager.deploy(
+      0,
+      0,
+      0,
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      owner.address
+    );
+    await stakeManager.connect(owner).setMinStake(1);
+
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/JobRegistry.sol:JobRegistry'
+    );
+    registry = await Registry.deploy(
+      ethers.ZeroAddress,
+      await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    await stakeManager
+      .connect(owner)
+      .setJobRegistry(await registry.getAddress());
+
+    const Identity = await ethers.getContractFactory(
+      'contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock'
+    );
+    identity = await Identity.deploy();
+    await registry
+      .connect(owner)
+      .setIdentityRegistry(await identity.getAddress());
+    await registry.connect(owner).setJobParameters(0, 0);
+
+    const Employer = await ethers.getContractFactory(
+      'contracts/test/EmployerContract.sol:EmployerContract'
+    );
+    employerContract = await Employer.deploy();
+
+    const fee = (reward * feePct) / 100n;
+    await token.mint(await employerContract.getAddress(), reward + fee);
+    await token.mint(agent.address, stake);
+
+    await employerContract.approveToken(
+      await token.getAddress(),
+      await stakeManager.getAddress(),
+      reward + fee
+    );
+    await token.connect(agent).approve(await stakeManager.getAddress(), stake);
+    await stakeManager.connect(agent).depositStake(0, stake);
+  });
+
+  async function setJobState(jobId, success) {
+    const coder = ethers.AbiCoder.defaultAbiCoder();
+    const base = BigInt(
+      ethers.keccak256(
+        coder.encode(['uint256', 'uint256'], [BigInt(jobId), 4n])
+      )
+    );
+    const slot = base + 3n;
+    const prev = BigInt(
+      await ethers.provider.getStorage(await registry.getAddress(), slot)
+    );
+    const stateOffset = 0n;
+    const successOffset = 8n;
+    const mask = (0xffn << stateOffset) | (0xffn << successOffset);
+    const cleared = prev & ~mask;
+    const value =
+      cleared |
+      (4n << stateOffset) |
+      (BigInt(success ? 1 : 0) << successOffset);
+    await ethers.provider.send('hardhat_setStorageAt', [
+      await registry.getAddress(),
+      ethers.toBeHex(slot),
+      ethers.toBeHex(value, 32),
+    ]);
+  }
+
+  it('allows a contract employer to finalize job', async () => {
+    const deadline = (await time.latest()) + 1000;
+    const specHash = ethers.id('spec');
+    await employerContract.createJob(
+      await registry.getAddress(),
+      reward,
+      deadline,
+      specHash,
+      'uri'
+    );
+    const jobId = 1;
+    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry
+      .connect(agent)
+      .submit(jobId, ethers.id('res'), 'res', '', []);
+
+    await setJobState(jobId, true);
+    await employerContract.finalizeJob(
+      await registry.getAddress(),
+      jobId
+    );
+
+    expect(await token.balanceOf(agent.address)).to.equal(reward);
+  });
+
+  it('allows governance to finalize job for contract employer', async () => {
+    const deadline = (await time.latest()) + 1000;
+    const specHash = ethers.id('spec');
+    await employerContract.createJob(
+      await registry.getAddress(),
+      reward,
+      deadline,
+      specHash,
+      'uri'
+    );
+    const jobId = 1;
+    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry
+      .connect(agent)
+      .submit(jobId, ethers.id('res'), 'res', '', []);
+
+    await setJobState(jobId, true);
+    await registry.connect(owner).finalize(jobId);
+
+    expect(await token.balanceOf(agent.address)).to.equal(reward);
+  });
+});


### PR DESCRIPTION
## Summary
- drop tx.origin dependency in StakeManager finalization
- validate employer in JobRegistry and pass caller through
- add EmployerContract mock and tests for contract employers

## Testing
- `npx hardhat test test/v2/ContractEmployerFinalize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c011fb723483338f028e71eb33eec0