### PR TITLE
enforce tax acknowledgement on withdrawals

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -734,9 +734,20 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     }
 
     /// @notice request withdrawal of staked tokens subject to unbonding period
+    /// @dev Enforces the current tax policy via `requiresTaxAcknowledgement`.
     /// @param role participant role of the stake
     /// @param amount token amount with 18 decimals to withdraw
-    function requestWithdraw(Role role, uint256 amount) external whenNotPaused {
+    function requestWithdraw(Role role, uint256 amount)
+        external
+        whenNotPaused
+        requiresTaxAcknowledgement(
+            _policy(),
+            msg.sender,
+            owner(),
+            address(0),
+            address(0)
+        )
+    {
         if (role > Role.Platform) revert InvalidRole();
         if (amount == 0) revert InvalidAmount();
         uint256 staked = stakes[msg.sender][role];
@@ -763,6 +774,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     }
 
     /// @notice finalize a previously requested withdrawal after unbonding period
+    /// @dev Enforces the current tax policy via `requiresTaxAcknowledgement`.
     /// @param role participant role of the stake being withdrawn
     function finalizeWithdraw(Role role)
         external


### PR DESCRIPTION
## Summary
- require tax policy acknowledgement before requesting stake withdrawals
- document policy enforcement in withdrawal flows

## Testing
- `npm test` *(failed: long-running solc compilation prevented completion)*

------
https://chatgpt.com/codex/tasks/task_e_68c02078f6dc8333a8b6ca503654b9e0