### PR TITLE
require employer burn proof

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -43,6 +43,8 @@ contract MockStakeManager is IStakeManager {
     function release(address, address, uint256) external override {}
     function finalizeJobFunds(bytes32, address, address, uint256, uint256, IFeePool, bool) external override {}
     function distributeValidatorRewards(bytes32, uint256) external override {}
+    function submitBurnProof(bytes32) external override {}
+    function pendingBurn(bytes32, address) external view override returns (uint256) { return 0; }
     function setDisputeModule(address module) external override {
         disputeModule = module;
     }

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -118,6 +118,12 @@ interface IStakeManager {
     /// @notice distribute validator rewards equally among selected validators
     function distributeValidatorRewards(bytes32 jobId, uint256 amount) external;
 
+    /// @notice submit proof that pending burns were executed by the employer
+    function submitBurnProof(bytes32 jobId) external;
+
+    /// @notice pending burn amount for a job and employer
+    function pendingBurn(bytes32 jobId, address employer) external view returns (uint256);
+
     /// @notice Current burn percentage applied to rewards
     function burnPct() external view returns (uint256);
 

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -45,6 +45,8 @@ contract ReentrantStakeManager is IStakeManager {
     function release(address, address, uint256) external override {}
     function finalizeJobFunds(bytes32, address, address, uint256, uint256, IFeePool, bool) external override {}
     function distributeValidatorRewards(bytes32, uint256) external override {}
+    function submitBurnProof(bytes32) external override {}
+    function pendingBurn(bytes32, address) external view override returns (uint256) { return 0; }
     function setDisputeModule(address) external override {}
     function setModules(address, address) external override {}
     function lockDisputeFee(address, uint256) external override {}

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -328,6 +328,12 @@ describe('JobRegistry integration', function () {
     await expect(registry.connect(employer).finalize(jobId))
       .to.emit(stakeManager, 'RewardPaid')
       .withArgs(jobKey, agent.address, 90n)
+      .and.to.emit(stakeManager, 'BurnRecorded')
+      .withArgs(jobKey, employer.address, burn);
+
+    await expect(stakeManager.connect(employer).submitBurnProof(jobKey))
+      .to.emit(stakeManager, 'BurnProofSubmitted')
+      .withArgs(jobKey, employer.address, burn)
       .and.to.emit(stakeManager, 'TokensBurned')
       .withArgs(jobKey, burn);
   });

--- a/test/v2/StakeManagerRelease.test.js
+++ b/test/v2/StakeManagerRelease.test.js
@@ -120,8 +120,8 @@ describe('StakeManager release', function () {
         await feePool.getAddress(),
         ethers.parseEther('20')
       )
-      .and.to.emit(stakeManager, 'TokensBurned')
-      .withArgs(ethers.ZeroHash, ethers.parseEther('10'))
+      .and.to.emit(stakeManager, 'BurnRecorded')
+      .withArgs(ethers.ZeroHash, user2.address, ethers.parseEther('10'))
       .and.to.emit(stakeManager, 'RewardPaid')
       .withArgs(ethers.ZeroHash, user1.address, ethers.parseEther('70'));
 
@@ -129,10 +129,19 @@ describe('StakeManager release', function () {
       ethers.parseEther('70')
     );
     const supplyAfter = await token.totalSupply();
-    expect(supplyBefore - supplyAfter).to.equal(ethers.parseEther('10'));
+    expect(supplyBefore - supplyAfter).to.equal(0n);
     expect(await token.balanceOf(await feePool.getAddress())).to.equal(
       ethers.parseEther('20')
     );
+
+    await expect(stakeManager.connect(user2).submitBurnProof(ethers.ZeroHash))
+      .to.emit(stakeManager, 'BurnProofSubmitted')
+      .withArgs(ethers.ZeroHash, user2.address, ethers.parseEther('10'))
+      .and.to.emit(stakeManager, 'TokensBurned')
+      .withArgs(ethers.ZeroHash, ethers.parseEther('10'));
+
+    const supplyFinal = await token.totalSupply();
+    expect(supplyBefore - supplyFinal).to.equal(ethers.parseEther('10'));
 
     await feePool.connect(user1).claimRewards();
     await feePool.connect(user2).claimRewards();
@@ -167,8 +176,8 @@ describe('StakeManager release', function () {
     )
       .to.emit(stakeManager, 'StakeReleased')
       .withArgs(jobId, await feePool.getAddress(), ethers.parseEther('20'))
-      .and.to.emit(stakeManager, 'TokensBurned')
-      .withArgs(jobId, ethers.parseEther('10'))
+      .and.to.emit(stakeManager, 'BurnRecorded')
+      .withArgs(jobId, user2.address, ethers.parseEther('10'))
       .and.to.emit(stakeManager, 'RewardPaid')
       .withArgs(jobId, user1.address, ethers.parseEther('70'));
 
@@ -176,10 +185,19 @@ describe('StakeManager release', function () {
       ethers.parseEther('70')
     );
     const supplyAfter = await token.totalSupply();
-    expect(supplyBefore - supplyAfter).to.equal(ethers.parseEther('10'));
+    expect(supplyBefore - supplyAfter).to.equal(0n);
     expect(await token.balanceOf(await feePool.getAddress())).to.equal(
       ethers.parseEther('20')
     );
+
+    await expect(stakeManager.connect(user2).submitBurnProof(jobId))
+      .to.emit(stakeManager, 'BurnProofSubmitted')
+      .withArgs(jobId, user2.address, ethers.parseEther('10'))
+      .and.to.emit(stakeManager, 'TokensBurned')
+      .withArgs(jobId, ethers.parseEther('10'));
+
+    const supplyFinal = await token.totalSupply();
+    expect(supplyBefore - supplyFinal).to.equal(ethers.parseEther('10'));
 
     await feePool.connect(user1).claimRewards();
     await feePool.connect(user2).claimRewards();

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -303,6 +303,12 @@ describe('job finalization integration', function () {
     await expect(registry.connect(employer).finalize(jobId))
       .to.emit(stakeManager, 'RewardPaid')
       .withArgs(jobKey, agent.address, agentReward)
+      .and.to.emit(stakeManager, 'BurnRecorded')
+      .withArgs(jobKey, employer.address, burnAmount);
+
+    await expect(stakeManager.connect(employer).submitBurnProof(jobKey))
+      .to.emit(stakeManager, 'BurnProofSubmitted')
+      .withArgs(jobKey, employer.address, burnAmount)
       .and.to.emit(stakeManager, 'TokensBurned')
       .withArgs(jobKey, burnAmount);
   });


### PR DESCRIPTION
## Summary
- track pending burns and require employer-submitted `submitBurnProof`
- gate JobRegistry finalization and refunds on burn proof
- adjust tests for new burn verification flow

## Testing
- `npm run lint`
- `npm test` *(fails: no output/environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68c02c0fc1388333882f3ed751117b25