### PR TITLE
Allowlist initial treasury in FeePool constructor

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -139,9 +139,11 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard, TaxAcknowledgement {
         emit BurnPctUpdated(pct);
 
         if (_treasury != address(0)) {
-            if (_treasury == msg.sender || !treasuryAllowlist[_treasury]) {
+            if (_treasury == msg.sender) {
                 revert InvalidTreasury();
             }
+            treasuryAllowlist[_treasury] = true;
+            emit TreasuryAllowlistUpdated(_treasury, true);
             treasury = _treasury;
         }
         emit TreasuryUpdated(_treasury);

--- a/docs/api/FeePool.md
+++ b/docs/api/FeePool.md
@@ -11,7 +11,7 @@ Holds platform fees and distributes rewards.
 - `governanceWithdraw(address to, uint256 amount)` – governance timelock emergency withdrawal.
 - `setStakeManager(address manager)` – owner wires modules.
 - `setRewardRole(uint8 role)` – choose which stakers earn rewards.
-- `setBurnPct(uint256 pct)` / `setTreasury(address treasury)` – configure fee splits. Treasury defaults to `address(0)` and must be allowlisted via `setTreasuryAllowlist`.
+- `setBurnPct(uint256 pct)` / `setTreasury(address treasury)` – configure fee splits. Passing a non-zero treasury in the constructor auto-allowlists and sets it; otherwise treasury defaults to `address(0)` and later updates require `setTreasuryAllowlist`.
 - `setTreasuryAllowlist(address treasury, bool allowed)` – manage the governance-approved treasury list.
 - `setGovernance(address governance)` – set timelock enabled for withdrawals.
 

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -195,6 +195,17 @@ contract FeePoolTest {
         new FeePool(stakeManager, 0, address(this), ITaxPolicy(address(0)));
     }
 
+    function testConstructorAllowsNonZeroTreasury() public {
+        TestToken impl = new TestToken();
+        vm.etch(AGIALPHA, address(impl).code);
+        token = TestToken(AGIALPHA);
+        stakeManager = new MockStakeManager();
+        address treasuryAddr = address(0xBEEF);
+        FeePool fp = new FeePool(stakeManager, 0, treasuryAddr, ITaxPolicy(address(0)));
+        require(fp.treasury() == treasuryAddr, "treasury");
+        require(fp.treasuryAllowlist(treasuryAddr), "allowlist");
+    }
+
     function testNoStakersBurnsFees() public {
         TestToken impl = new TestToken();
         vm.etch(AGIALPHA, address(impl).code);


### PR DESCRIPTION
## Summary
- auto-allowlist non-zero treasury addresses during FeePool deployment
- test that constructor accepts and allowlists an initial treasury address
- document automatic allowlisting when a treasury is provided

## Testing
- `npm test`
- `npm run lint`
- `forge test` *(fails: Yul exception: Cannot swap Variable param with Variable param_16: too deep in the stack)*

------
https://chatgpt.com/codex/tasks/task_e_68c0566103c083339aeca65fe4d448e8