### PR TITLE
fix: update setJobParameters

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -215,7 +215,8 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
 
     function setAgentMerkleRoot(bytes32) external override {}
 
-    function setJobParameters(uint256, uint256 stake) external override {
+    function setJobParameters(uint256 maxReward, uint256 stake) external override {
+        maxJobReward = maxReward;
         jobStake = stake;
     }
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -686,10 +686,11 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         ack = _acknowledge(user);
     }
 
-    function setJobParameters(uint256 reward, uint256 stake) external onlyGovernance {
+    function setJobParameters(uint256 maxReward, uint256 stake) external onlyGovernance {
         if (stake > type(uint96).max) revert StakeOverflow();
         jobStake = uint96(stake);
-        emit JobParametersUpdated(reward, stake, maxJobReward, maxJobDuration);
+        maxJobReward = maxReward;
+        emit JobParametersUpdated(0, stake, maxReward, maxJobDuration);
     }
 
     // ---------------------------------------------------------------------

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -143,9 +143,9 @@ interface IJobRegistry {
     function validationModule() external view returns (address);
 
     /// @notice Owner configuration of job limits
-    /// @param reward Reward paid upon successful job completion
+    /// @param maxReward Maximum allowed reward for a job
     /// @param stake Stake required from the agent to accept a job
-    function setJobParameters(uint256 reward, uint256 stake) external;
+    function setJobParameters(uint256 maxReward, uint256 stake) external;
 
     /// @notice set the required agent stake for each job
     function setJobStake(uint96 stake) external;

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -599,4 +599,19 @@ describe('JobRegistry integration', function () {
       .withArgs(treasury.address, false);
     expect(await identity.additionalAgents(treasury.address)).to.equal(false);
   });
+
+  it('updates defaults via setJobParameters', async () => {
+    const newMaxReward = 5000;
+    const newStake = 300;
+    const duration = await registry.maxJobDuration();
+
+    await expect(
+      registry.connect(owner).setJobParameters(newMaxReward, newStake)
+    )
+      .to.emit(registry, 'JobParametersUpdated')
+      .withArgs(0, newStake, newMaxReward, duration);
+
+    expect(await registry.jobStake()).to.equal(newStake);
+    expect(await registry.maxJobReward()).to.equal(newMaxReward);
+  });
 });


### PR DESCRIPTION
## Summary
- update `setJobParameters` to set `maxJobReward` and emit correct values
- adjust interface and mocks for new parameter
- add test verifying default job parameters update

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0594ae0808333bdbc42e2112bd15e