### PR TITLE
Require tax acknowledgement for burn evidence

### DIFF
--- a/docs/burn-receipts.md
+++ b/docs/burn-receipts.md
@@ -1,13 +1,14 @@
 # Burn receipts
 
-Employers must burn their own $AGIALPHA and provide proof before validators can approve a job. The platform never initiates the burn.
+Employers must burn their own $AGIALPHA and provide proof before validators can approve a job. The platform never initiates the burn. Employers must also acknowledge the active tax policy before submitting any burn evidence.
 
 ## Steps
 
 1. From the employer wallet call `burn(uint256)` on the $AGIALPHA token contract using Etherscan or a compatible wallet.
 2. Copy the resulting transaction hash and block number.
-3. Call `JobRegistry.submitBurnReceipt(jobId, txHash, amount, blockNumber)` from the same employer address.
-4. Confirm the burn by calling `JobRegistry.confirmEmployerBurn(jobId, txHash)`.
-5. Validators include `burnTxHash` in their commit‑reveal cycle. The `ValidationModule` rejects any reveal that does not match a submitted receipt.
+3. Acknowledge the current tax policy if you have not already.
+4. Call `JobRegistry.submitBurnReceipt(jobId, txHash, amount, blockNumber)` from the same employer address.
+5. Confirm the burn by calling `JobRegistry.confirmEmployerBurn(jobId, txHash)`.
+6. Validators include `burnTxHash` in their commit‑reveal cycle. The `ValidationModule` rejects any reveal that does not match a submitted receipt.
 
 This flow keeps token destruction fully on the employer while providing an auditable on‑chain record for validators and observers.

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -139,9 +139,7 @@ describe('JobRegistry tax policy integration', function () {
     await registry.connect(user).createJob(1, deadline, specHash, 'uri');
     await policy.connect(owner).bumpPolicyVersion();
     const burnTxHash = ethers.ZeroHash;
-    await expect(
-      registry.connect(user).submitBurnReceipt(1, burnTxHash, 0, 0)
-    )
+    await expect(registry.connect(user).submitBurnReceipt(1, burnTxHash, 0, 0))
       .to.be.revertedWithCustomError(registry, 'TaxPolicyNotAcknowledged')
       .withArgs(user.address);
   });
@@ -158,9 +156,7 @@ describe('JobRegistry tax policy integration', function () {
     const burnTxHash = ethers.ZeroHash;
     await registry.connect(user).submitBurnReceipt(1, burnTxHash, 0, 0);
     await policy.connect(owner).bumpPolicyVersion();
-    await expect(
-      registry.connect(user).confirmEmployerBurn(1, burnTxHash)
-    )
+    await expect(registry.connect(user).confirmEmployerBurn(1, burnTxHash))
       .to.be.revertedWithCustomError(registry, 'TaxPolicyNotAcknowledged')
       .withArgs(user.address);
   });

--- a/test/v2/TaxPolicyIntegration.test.js
+++ b/test/v2/TaxPolicyIntegration.test.js
@@ -127,4 +127,41 @@ describe('JobRegistry tax policy integration', function () {
       false
     );
   });
+
+  it('rejects burn receipt submission without tax acknowledgement', async () => {
+    await registry.connect(owner).setJobParameters(0, 0);
+    await registry.connect(owner).setMaxJobReward(10);
+    await registry.connect(owner).setJobDurationLimit(86400);
+    await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy.connect(user).acknowledge();
+    const deadline = (await time.latest()) + 1000;
+    const specHash = ethers.id('spec');
+    await registry.connect(user).createJob(1, deadline, specHash, 'uri');
+    await policy.connect(owner).bumpPolicyVersion();
+    const burnTxHash = ethers.ZeroHash;
+    await expect(
+      registry.connect(user).submitBurnReceipt(1, burnTxHash, 0, 0)
+    )
+      .to.be.revertedWithCustomError(registry, 'TaxPolicyNotAcknowledged')
+      .withArgs(user.address);
+  });
+
+  it('rejects burn confirmation without tax acknowledgement', async () => {
+    await registry.connect(owner).setJobParameters(0, 0);
+    await registry.connect(owner).setMaxJobReward(10);
+    await registry.connect(owner).setJobDurationLimit(86400);
+    await registry.connect(owner).setTaxPolicy(await policy.getAddress());
+    await policy.connect(user).acknowledge();
+    const deadline = (await time.latest()) + 1000;
+    const specHash = ethers.id('spec');
+    await registry.connect(user).createJob(1, deadline, specHash, 'uri');
+    const burnTxHash = ethers.ZeroHash;
+    await registry.connect(user).submitBurnReceipt(1, burnTxHash, 0, 0);
+    await policy.connect(owner).bumpPolicyVersion();
+    await expect(
+      registry.connect(user).confirmEmployerBurn(1, burnTxHash)
+    )
+      .to.be.revertedWithCustomError(registry, 'TaxPolicyNotAcknowledged')
+      .withArgs(user.address);
+  });
 });


### PR DESCRIPTION
## Summary
- require tax policy acknowledgement before submitting or confirming burn receipts
- document the need to acknowledge tax policy when submitting burn evidence
- test that unacknowledged employers cannot submit or confirm burn receipts

## Testing
- `npx hardhat test test/v2/TaxPolicyIntegration.test.js`
- `npx hardhat test test/v2/JobRegistry.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c05da0521483339f8dc179da9884b4