### PR TITLE
docs: sync StakeSlashed event documentation

### DIFF
--- a/docs/AGIJobs-v2-Mainnet-Guide.md
+++ b/docs/AGIJobs-v2-Mainnet-Guide.md
@@ -119,12 +119,12 @@
 3. **Burning guarantees:** introduce `IBurnable` interface and **require** success of `burn(amount)` for fee burns/slashing burns. If `$AGIALPHA` were not burnable, functions that would burn **must revert** (documented in NatSpec).
 4. **Events for flows** (index by actors/jobId):
 
-   - `event StakeDeposited(address indexed user, uint8 indexed role, uint256 amount);`
-   - `event StakeWithdrawn(address indexed user, uint8 indexed role, uint256 amount);`
-   - `event StakeSlashed(address indexed user, uint256 amount, uint256 toEmployer, uint256 toTreasury, uint256 burned);`
-   - `event JobFunded(uint256 indexed jobId, address indexed employer, uint256 amount);`
-   - `event RewardPaid(uint256 indexed jobId, address indexed agent, uint256 amount);`
-   - `event FeeAccrued(uint256 indexed jobId, uint256 amount);`
+    - `event StakeDeposited(address indexed user, uint8 indexed role, uint256 amount);`
+    - `event StakeWithdrawn(address indexed user, uint8 indexed role, uint256 amount);`
+    - `event StakeSlashed(address indexed user, uint8 indexed role, address indexed employer, address indexed treasury, uint256 employerShare, uint256 treasuryShare, uint256 burnShare);`
+    - `event JobFunded(uint256 indexed jobId, address indexed employer, uint256 amount);`
+    - `event RewardPaid(uint256 indexed jobId, address indexed agent, uint256 amount);`
+    - `event FeeAccrued(uint256 indexed jobId, uint256 amount);`
    - `event FeesBurned(uint256 amount);`
    - `event FeesDistributed(uint256 amount);`
    - `event DisputeFeePaid(uint256 indexed jobId, address indexed payer, uint256 amount);`

--- a/docs/agi-jobs-v2-mainnet.md
+++ b/docs/agi-jobs-v2-mainnet.md
@@ -70,7 +70,7 @@
 
 - Normalize names & indexed fields across:
   - **Jobs:** `JobCreated(id, employer, reward)`, `JobApplied(id, agent)`, `JobSubmitted(id, agent)`, `JobFinalized(id, success)`.
-  - **Stakes:** `StakeDeposited(user, role, amount)`, `StakeWithdrawn(user, role, amount)`, `StakeSlashed(user, role, amount, toEmployer, toTreasury, burned)`.
+   - **Stakes:** `StakeDeposited(user, role, amount)`, `StakeWithdrawn(user, role, amount)`, `StakeSlashed(user, role, employer, treasury, employerShare, treasuryShare, burnShare)`.
   - **Fees:** `FeeAccrued(jobId, amount)`, `FeesBurned(amount)`, `FeesDistributed(total, perToken)`.
   - **Identity:** `IdentityVerified(user, node, role)`; `AllowlistUsed(user, role, reason)`.
 - Add NatSpec on all events so Etherscan shows helpful tooltips. Acceptance: Events appear consistently, with `indexed` on addresses and IDs; ABI verified. :contentReference[oaicite:13]{index=13}

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -12,14 +12,15 @@ Handles staking, escrow and slashing of the $AGIALPHA token.
 - `withdrawStake(uint8 role, uint256 amount)` – withdraw previously staked tokens.
 - `lock(address from, uint256 amount)` / `release(address to, uint256 amount)` – JobRegistry hooks for job rewards.
 - `lockDisputeFee(address payer, uint256 amount)` / `payDisputeFee(address to, uint256 amount)` – escrow dispute fees.
-- `slash(address user, uint256 amount, address recipient)` – owner slashes stake and sends to recipient. Reverts if `recipient` is the zero address and the employer share is non‑zero.
+- `slash(address user, uint8 role, uint256 amount, address employer)` – JobRegistry slashes the user's stake for a given role and routes the employer share.
+- `slash(address user, uint256 amount, address recipient)` – DisputeModule slashes validator stake during disputes and sends the slashed amount to `recipient`.
 - `stakeOf(address user, uint8 role)` / `totalStake(uint8 role)` – view functions.
 
 ## Events
 
 - `StakeDeposited(address indexed user, Role indexed role, uint256 amount)`
 - `StakeWithdrawn(address indexed user, Role indexed role, uint256 amount)`
-- `StakeSlashed(address indexed user, uint256 amount, address recipient)`
+- `StakeSlashed(address indexed user, Role role, address indexed employer, address indexed treasury, uint256 employerShare, uint256 treasuryShare, uint256 burnShare)`
 - `StakeEscrowLocked(bytes32 indexed jobId, address indexed from, uint256 amount)`
 - `StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount)`
 - `RewardPaid(bytes32 indexed jobId, address indexed to, uint256 amount)`

--- a/docs/master-guide.md
+++ b/docs/master-guide.md
@@ -508,10 +508,10 @@ Create `docs/deployment-addresses.json` (or similar) and keep it updated:
 - **$AGIALPHA‑only (L):** `immutable TOKEN = IERC20(AGIALPHA);` guards on all transfers.
 - **Role minimums (M):** `minStake[Role]` (Agent/Validator/Platform); `setMinStake`; `MinStakeUpdated`.
 - **Locking & withdrawals (M):** lock on assignment (`lockStake(user,role,amount,jobId)`), unlock on finalize/abort; `requestWithdraw` → `executeWithdraw` after `cooldown`.
-- **Slashing (H):** `_slash(user, role, amount, jobId)`  
-  → `{employerPct, treasuryPct}` (sum 100)  
-  → **burn remainder via `TOKEN.burn()`**  
-  → `StakeSlashed(user, role, amount, employerShare, treasuryShare, burnShare, jobId)`.
+  - **Slashing (H):** `_slash(user, role, amount, jobId)`
+    → `{employerPct, treasuryPct}` (sum 100)
+    → **burn remainder via `TOKEN.burn()`**
+    → `StakeSlashed(user, role, employer, treasury, employerShare, treasuryShare, burnShare)`.
 - **Fee remittance (M):** `finalizeJobFunds(jobId, employer, agent, reward, fee, pool, byGovernance)` → net to agent, validator rewards, fee to `FeePool`.
 - **Guards (L):** `nonReentrant` + `whenNotPaused` on state mutators.
 
@@ -595,7 +595,7 @@ event StakeWithdrawalRequested(address indexed user, uint8 indexed role, uint256
 event StakeWithdrawn(address indexed user, uint8 indexed role, uint256 amount);
 event StakeTimeLocked(address indexed user, uint8 indexed role, uint256 amount, uint256 indexed jobId);
 event StakeUnlocked(address indexed user, uint8 indexed role, uint256 amount, uint256 indexed jobId);
-event StakeSlashed(address indexed user, uint8 indexed role, uint256 amount, uint256 employerShare, uint256 treasuryShare, uint256 burnShare, uint256 indexed jobId);
+event StakeSlashed(address indexed user, uint8 indexed role, address indexed employer, address indexed treasury, uint256 employerShare, uint256 treasuryShare, uint256 burnShare);
 
 event JobCreated(uint256 indexed jobId, address indexed employer, uint256 reward, string uri);
 event JobApplied(uint256 indexed jobId, address indexed agent, string agentLabel);


### PR DESCRIPTION
## Summary
- update StakeSlashed event signature across docs to match StakeManager implementation
- document both slash overloads in StakeManager API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c084fd4adc8333a66be155d0a8923b