### PR TITLE
feat: track failed identity checks

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -64,6 +64,12 @@ contract IdentityRegistry is Ownable2Step {
         bool viaWrapper,
         bool viaMerkle
     );
+    /// @notice Emitted when a verification attempt fails.
+    event IdentityVerificationFailed(
+        address indexed user,
+        AttestationRegistry.Role indexed role,
+        string subdomain
+    );
     event AgentTypeUpdated(address indexed agent, AgentType agentType);
     /// @notice Emitted when an agent updates their profile metadata.
     event AgentProfileUpdated(address indexed agent, string uri);
@@ -406,6 +412,12 @@ contract IdentityRegistry is Ownable2Step {
                 subdomain
             );
             emit ENSVerified(claimant, node, subdomain, viaWrapper, viaMerkle);
+        } else {
+            emit IdentityVerificationFailed(
+                claimant,
+                AttestationRegistry.Role.Agent,
+                subdomain
+            );
         }
     }
 
@@ -456,6 +468,12 @@ contract IdentityRegistry is Ownable2Step {
                 subdomain
             );
             emit ENSVerified(claimant, node, subdomain, viaWrapper, viaMerkle);
+        } else {
+            emit IdentityVerificationFailed(
+                claimant,
+                AttestationRegistry.Role.Validator,
+                subdomain
+            );
         }
     }
 

--- a/docs/api/IdentityRegistry.md
+++ b/docs/api/IdentityRegistry.md
@@ -32,3 +32,6 @@ gas usage.
 - `AdditionalAgentUsed(address agent, string subdomain)` /
   `AdditionalValidatorUsed(address validator, string subdomain)`
 - `AgentProfileUpdated(address agent, string uri)` – emitted whenever an agent profile is set or changed. Off-chain services can listen for this event and fetch the referenced URI (e.g., from IPFS) to match jobs with agents based on declared capabilities.
+- `IdentityVerified(address user, Role role, bytes32 node, string subdomain)` – emitted when verification succeeds.
+- `ENSVerified(address user, bytes32 node, string label, bool viaWrapper, bool viaMerkle)` – low-level trace of the ENS ownership path.
+- `IdentityVerificationFailed(address user, Role role, string subdomain)` – emitted when verification fails.

--- a/test/v2/identity.test.ts
+++ b/test/v2/identity.test.ts
@@ -56,6 +56,9 @@ describe('IdentityRegistry ENS verification', function () {
     expect(
       (await id.verifyAgent.staticCall(bob.address, subdomain, []))[0]
     ).to.equal(false);
+    await expect(id.verifyAgent(bob.address, subdomain, []))
+      .to.emit(id, 'IdentityVerificationFailed')
+      .withArgs(bob.address, 0, subdomain);
   });
 
   it('supports merkle proofs and resolver fallback', async () => {


### PR DESCRIPTION
## Summary
- emit IdentityVerificationFailed to log unsuccessful ENS or attestation lookups
- document new identity verification events
- test failure events in IdentityRegistry

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68c09c70dc788333b5fff3fed175a6f0