### PR TITLE
Log tax policy version in FeePool events

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -92,7 +92,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard, TaxAcknowledgement {
     event GovernanceWithdrawal(address indexed to, uint256 amount);
     event RewardPoolContribution(address indexed contributor, uint256 amount);
     event PauserUpdated(address indexed pauser);
-    event TaxPolicyUpdated(address indexed policy);
+    event TaxPolicyUpdated(address indexed policy, uint256 version);
 
     modifier onlyOwnerOrPauser() {
         if (msg.sender != owner() && msg.sender != pauser) {
@@ -151,7 +151,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard, TaxAcknowledgement {
         if (address(_taxPolicy) != address(0)) {
             if (!_taxPolicy.isTaxExempt()) revert PolicyNotTaxExempt();
             taxPolicy = _taxPolicy;
-            emit TaxPolicyUpdated(address(_taxPolicy));
+            emit TaxPolicyUpdated(address(_taxPolicy), _taxPolicy.policyVersion());
         }
     }
 
@@ -382,7 +382,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard, TaxAcknowledgement {
         if (address(_policy) == address(0)) revert InvalidTaxPolicy();
         if (!_policy.isTaxExempt()) revert PolicyNotTaxExempt();
         taxPolicy = _policy;
-        emit TaxPolicyUpdated(address(_policy));
+        emit TaxPolicyUpdated(address(_policy), _policy.policyVersion());
     }
 
     /// @notice Confirms the contract and its owner can never incur tax liability.

--- a/docs/api/FeePool.md
+++ b/docs/api/FeePool.md
@@ -14,6 +14,8 @@ Holds platform fees and distributes rewards.
 - `setBurnPct(uint256 pct)` / `setTreasury(address treasury)` – configure fee splits. Passing a non-zero treasury in the constructor auto-allowlists and sets it; otherwise treasury defaults to `address(0)` and later updates require `setTreasuryAllowlist`.
 - `setTreasuryAllowlist(address treasury, bool allowed)` – manage the governance-approved treasury list.
 - `setGovernance(address governance)` – set timelock enabled for withdrawals.
+- `setPauser(address pauser)` – designate an address that can pause or unpause.
+- `setTaxPolicy(address policy)` – update the TaxPolicy reference.
 
 ## Events
 
@@ -29,3 +31,5 @@ Holds platform fees and distributes rewards.
 - `GovernanceUpdated(address governance)`
 - `GovernanceWithdrawal(address to, uint256 amount)`
 - `RewardPoolContribution(address contributor, uint256 amount)`
+- `PauserUpdated(address pauser)`
+- `TaxPolicyUpdated(address policy, uint256 version)`

--- a/test/v2/FeePoolTaxPolicy.test.js
+++ b/test/v2/FeePoolTaxPolicy.test.js
@@ -1,0 +1,25 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('FeePool tax policy event', function () {
+  let owner, policy, pool;
+
+  beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+    const Policy = await ethers.getContractFactory('contracts/v2/TaxPolicy.sol:TaxPolicy');
+    policy = await Policy.deploy('ipfs://policy', 'ack');
+    const FeePool = await ethers.getContractFactory('contracts/v2/FeePool.sol:FeePool');
+    pool = await FeePool.deploy(
+      ethers.ZeroAddress,
+      0,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress
+    );
+  });
+
+  it('emits version when setting tax policy', async () => {
+    await expect(pool.setTaxPolicy(await policy.getAddress()))
+      .to.emit(pool, 'TaxPolicyUpdated')
+      .withArgs(await policy.getAddress(), 1);
+  });
+});


### PR DESCRIPTION
## Summary
- include policy version in FeePool's `TaxPolicyUpdated` event
- document new FeePool events and admin functions
- add unit test covering FeePool tax policy event

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0a4c3cd2c8333b3c12d966655364f