### PR TITLE
refactor: rename payout pct helper

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -93,7 +93,7 @@ contract MockStakeManager is IStakeManager {
         return totalStakes[role];
     }
 
-    function getAgentPayoutPct(address) external pure override returns (uint256) {
+    function getHighestPayoutPct(address) external pure override returns (uint256) {
         return 100;
     }
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1333,7 +1333,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             uint256 burnPctStake;
             if (address(stakeManager) != address(0)) {
                 burnPctStake = stakeManager.burnPct();
-                agentPct = stakeManager.getAgentPayoutPct(job.agent);
+                agentPct = stakeManager.getHighestPayoutPct(job.agent);
                 if (address(pool) != address(0) && job.reward > 0) {
                     fee = (uint256(job.reward) * job.feePct) / 100;
                 }

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -521,11 +521,11 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         types = agiTypes;
     }
 
-    /// @notice Determine the payout percentage for an agent based on AGI type NFTs
+    /// @notice Determine the highest payout percentage for an agent based on AGI type NFTs
     /// @dev Iterates through registered AGI types and selects the highest payout
     ///      percentage from NFTs held by the agent. Reverts from malicious NFT
     ///      contracts are ignored.
-    function getAgentPayoutPct(address agent) public view returns (uint256) {
+    function getHighestPayoutPct(address agent) public view returns (uint256) {
         uint256 highest = 100;
         uint256 length = agiTypes.length;
         for (uint256 i; i < length;) {
@@ -937,7 +937,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         address to,
         uint256 amount
     ) external onlyJobRegistry whenNotPaused nonReentrant {
-        uint256 pct = getAgentPayoutPct(to);
+        uint256 pct = getHighestPayoutPct(to);
         uint256 modified = (amount * pct) / 100;
         uint256 feeAmount = (modified * feePct) / 100;
         uint256 burnAmount = (modified * burnPct) / 100;
@@ -982,7 +982,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         nonReentrant
     {
         // apply AGI type payout modifier
-        uint256 pct = getAgentPayoutPct(to);
+        uint256 pct = getHighestPayoutPct(to);
         uint256 modified = (amount * pct) / 100;
 
         // apply protocol fees and burn on the modified amount
@@ -1028,7 +1028,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         bool byGovernance
     ) external onlyJobRegistry whenNotPaused nonReentrant {
         emit JobFundsFinalized(jobId, employer);
-        uint256 pct = getAgentPayoutPct(agent);
+        uint256 pct = getHighestPayoutPct(agent);
         uint256 modified = (reward * pct) / 100;
         uint256 burnAmount = (modified * burnPct) / 100;
         uint256 payout = modified - burnAmount;

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -178,7 +178,7 @@ interface IStakeManager {
     /// @notice address of the JobRegistry authorized to deposit fees
     function jobRegistry() external view returns (address);
 
-    /// @notice Payout percentage for an agent based on AGI type NFTs
-    function getAgentPayoutPct(address agent) external view returns (uint256);
+    /// @notice Highest payout percentage for an agent based on AGI type NFTs
+    function getHighestPayoutPct(address agent) external view returns (uint256);
 }
 

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -71,7 +71,7 @@ contract ReentrantStakeManager is IStakeManager {
         return totalStakes[role];
     }
 
-    function getAgentPayoutPct(address) external pure override returns (uint256) {
+    function getHighestPayoutPct(address) external pure override returns (uint256) {
         return 100;
     }
 

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -76,6 +76,11 @@ describe('StakeManager AGIType bonuses', function () {
     await token.mint(employer.address, 1000);
   });
 
+  it('returns 100 when agent holds no approved NFTs', async () => {
+    await stakeManager.connect(owner).addAGIType(await nft1.getAddress(), 150);
+    expect(await stakeManager.getHighestPayoutPct(agent.address)).to.equal(100n);
+  });
+
   it('applies highest AGIType bonus', async () => {
     await stakeManager.connect(owner).addAGIType(await nft1.getAddress(), 150);
     await stakeManager.connect(owner).addAGIType(await nft2.getAddress(), 175);


### PR DESCRIPTION
## Summary
- rename `getAgentPayoutPct` to `getHighestPayoutPct`
- expose new method in `IStakeManager` interface
- verify default 100% payout without approved NFTs

## Testing
- `npm test` *(fails: process stalled while downloading solc compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b4a9d3c4833386bee3e75ef348b6