### PR TITLE
docs: detail NFT incentive model and expose boosted stake helper

### DIFF
--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -295,6 +295,16 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard, TaxAcknowledgement {
         emit RewardsClaimed(msg.sender, owed);
     }
 
+    /// @notice Return a user's stake weighted by their NFT multiplier.
+    /// @dev Facilitates off-chain calculations of boosted rewards.
+    /// @param user address being queried
+    /// @return amount stake multiplied by the user's payout percentage
+    function boostedStake(address user) external view returns (uint256 amount) {
+        uint256 stake = stakeManager.stakeOf(user, rewardRole);
+        uint256 pct = stakeManager.getHighestPayoutPct(user);
+        amount = (stake * pct) / 100;
+    }
+
     // ---------------------------------------------------------------------
     // Owner and governance setters (use Etherscan's "Write Contract" tab)
     // ---------------------------------------------------------------------

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -116,7 +116,8 @@ interface IStakeManager {
         bool byGovernance
     ) external;
 
-    /// @notice distribute validator rewards equally among selected validators
+    /// @notice distribute validator rewards among selected validators
+    ///         weighted by their NFT multipliers
     function distributeValidatorRewards(bytes32 jobId, uint256 amount) external;
 
     /// @notice Current burn percentage applied to rewards

--- a/docs/enhanced-nft-incentive-model.md
+++ b/docs/enhanced-nft-incentive-model.md
@@ -4,27 +4,27 @@
 
 The original on-chain manager (v0) granted a single-tier payout boost to agents or validators that owned an eligible ENS subdomain NFT. The bonus increased job costs for employers and did not apply to platform operators.
 
-The v2 architecture introduces a list of `AGIType` entries in `StakeManager` that associates approved NFT contracts with specific payout multipliers. When a participant holds multiple NFTs, only the highest multiplier is applied, preventing reward compounding. Agents already benefit from this mechanism; validators and platform operators will also gain boosts under the enhanced model.
+The v2 architecture introduces a list of `AGIType` entries in `StakeManager` that associates approved NFT contracts with specific payout multipliers. When a participant holds multiple NFTs, only the highest multiplier is applied, preventing reward compounding. Agents already benefit from this mechanism; the enhanced model extends the same logic to validators and platform operators so every core role can earn more when holding an approved NFT.
 
 ## 2. NFT Reward Multiplier Implementation
 
-- **Agents**: continue using `StakeManager.getHighestPayoutPct` (currently `getAgentPayoutPct`) to scale their rewards.
-- **Validators**: `distributeValidatorRewards` will weight payouts by each validator's multiplier rather than splitting the pool evenly.
-- **Platform operators**: fee distributions will be weighted by multipliers so that operators with NFTs earn proportionally more from the `FeePool`.
+- **Agents** – `StakeManager.getHighestPayoutPct` multiplies an agent's base reward by the highest applicable tier. Employers escrow only the base reward; any bonus is covered by reduced burns or fees.
+- **Validators** – `distributeValidatorRewards` weights each validator's share by their multiplier. A 150% NFT counts as weight `150` versus the default `100`.
+- **Platform operators** – the `FeePool` exposes `boostedStake(address)` to reveal a staker's weight (`stake * multiplier / 100`). Off-chain scripts can use this to apportion fee distributions so that operators with NFTs receive a larger portion of the fee pool.
 
-The `getHighestPayoutPct` function becomes a general utility that any module can call to check the top multiplier for a given address.
+The `getHighestPayoutPct` function is a general utility that any module can call to check the top multiplier for a given address and now serves agents, validators and platform participants alike.
 
 ## 3. Game-Theoretic Robustness
 
-Weighting rewards by NFT multipliers removes the equal-split sybil attack among validators and aligns incentives across roles. Caps on multiplier values and selecting the highest tier prevent unbounded gains. Employers are not penalised for hiring NFT holders because extra payouts are subsidised by reduced burns or fees.
+Weighting rewards by NFT multipliers removes the equal‑split sybil attack among validators and aligns incentives across roles. Caps on multiplier values and selecting only the highest tier prevent unbounded gains. Employers are not penalised for hiring NFT holders because extra payouts are subsidised by reduced burns or fees, so the best agents remain attractive hires.
 
 ## 4. Simulation of Reward Outcomes
 
-Simulations show NFT holders consistently earn more than non-holders while total rewards remain conserved. Example: in a four-validator pool with one 150% NFT, the boosted validator receives ~33% of the reward pool compared with 25% under equal split. When multiple validators hold NFTs, shares scale with their tiers but never exceed the pool's total value.
+Simulations show NFT holders consistently earn more than non‑holders while total rewards remain conserved. Example: in a four‑validator pool with one 150% NFT, the boosted validator receives roughly one third of the pool instead of 25% under equal split. When multiple validators hold NFTs, shares scale with their tiers but never exceed the pool's total value. If all validators hold the same tier, the result converges back to an equal split but at a higher absolute payout for everyone.
 
 ## 5. Milestone-Based Implementation Plan
 
-1. **Design finalisation** – approve NFT tiers and payout caps.
-2. **Solidity changes** – generalise `getHighestPayoutPct`, weight validator and platform rewards, and cap extreme multipliers.
-3. **Simulation and audit** – unit tests and economic simulations confirm robustness.
+1. **Design finalisation** – approve NFT tiers, payout caps and the list of supported contracts.
+2. **Solidity changes** – generalise `getHighestPayoutPct`, weight validator rewards, provide `boostedStake` for platform calculations and enforce reasonable multiplier caps.
+3. **Simulation and audit** – unit tests and economic simulations confirm robustness; fix any findings.
 4. **Documentation and deployment** – update guides, deploy upgrades and announce NFT reward boosts to the community.


### PR DESCRIPTION
## Summary
- expose `boostedStake` view in FeePool for NFT-weighted fee splits
- clarify interface docs for NFT-weighted validator rewards
- expand incentive model documentation with platform and validator details

## Testing
- `npm test` *(fails: process did not finish due to long Solidity compilation)*
- `npm run compile` *(fails: process did not finish due to long Solidity compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c53c0a388333a8340957581cd618