### PR TITLE
fix: distribute validator remainder

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -1125,10 +1125,16 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
         uint256 totalWeight;
         uint256[] memory weights = new uint256[](count);
+        uint256 maxWeight;
+        uint256 maxIndex;
         for (uint256 i; i < count;) {
             uint256 pct = getHighestPayoutPct(vals[i]);
             weights[i] = pct;
             totalWeight += pct;
+            if (pct > maxWeight) {
+                maxWeight = pct;
+                maxIndex = i;
+            }
             unchecked {
                 ++i;
             }
@@ -1147,8 +1153,9 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
         uint256 remainder = amount - distributed;
         if (remainder > 0) {
-            token.safeTransfer(vals[0], remainder);
-            emit RewardPaid(jobId, vals[0], remainder);
+            // allocate any leftover to the validator with the largest weight
+            token.safeTransfer(vals[maxIndex], remainder);
+            emit RewardPaid(jobId, vals[maxIndex], remainder);
             distributed += remainder;
         }
 

--- a/test/v2/StakeManagerValidatorRewards.test.js
+++ b/test/v2/StakeManagerValidatorRewards.test.js
@@ -1,0 +1,134 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('StakeManager validator reward remainder', function () {
+  const { AGIALPHA } = require('../../scripts/constants');
+  let owner, employer, valHigh, valLow1, valLow2;
+  let token, stakeManager, jobRegistry, registrySigner;
+
+  beforeEach(async () => {
+    [owner, employer, valHigh, valLow1, valLow2] = await ethers.getSigners();
+
+    const artifact = await artifacts.readArtifact(
+      'contracts/test/AGIALPHAToken.sol:AGIALPHAToken'
+    );
+    await network.provider.send('hardhat_setCode', [
+      AGIALPHA,
+      artifact.deployedBytecode,
+    ]);
+    token = await ethers.getContractAt(
+      'contracts/test/AGIALPHAToken.sol:AGIALPHAToken',
+      AGIALPHA
+    );
+    const balanceSlot = ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ['address', 'uint256'],
+        [employer.address, 0]
+      )
+    );
+    await network.provider.send('hardhat_setStorageAt', [
+      AGIALPHA,
+      balanceSlot,
+      ethers.toBeHex(1000n, 32),
+    ]);
+    const supplySlot = '0x' + (2).toString(16).padStart(64, '0');
+    await network.provider.send('hardhat_setStorageAt', [
+      AGIALPHA,
+      supplySlot,
+      ethers.toBeHex(1000n, 32),
+    ]);
+    const ackSlot = ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ['address', 'uint256'],
+        [employer.address, 6]
+      )
+    );
+    await network.provider.send('hardhat_setStorageAt', [
+      AGIALPHA,
+      ackSlot,
+      ethers.toBeHex(1n, 32),
+    ]);
+
+    const StakeManager = await ethers.getContractFactory(
+      'contracts/v2/StakeManager.sol:StakeManager'
+    );
+    stakeManager = await StakeManager.deploy(
+      0,
+      100,
+      0,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      owner.address
+    );
+    await stakeManager.connect(owner).setMinStake(1);
+
+    const stakeAddr = await stakeManager.getAddress();
+    const stakeAckSlot = ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ['address', 'uint256'],
+        [stakeAddr, 6]
+      )
+    );
+    await network.provider.send('hardhat_setStorageAt', [
+      AGIALPHA,
+      stakeAckSlot,
+      ethers.toBeHex(1n, 32),
+    ]);
+
+    const JobReg = await ethers.getContractFactory(
+      'contracts/v2/mocks/VersionMock.sol:VersionMock'
+    );
+    jobRegistry = await JobReg.deploy(2);
+    await stakeManager
+      .connect(owner)
+      .setJobRegistry(await jobRegistry.getAddress());
+    const regAddr = await jobRegistry.getAddress();
+    await ethers.provider.send('hardhat_setBalance', [
+      regAddr,
+      '0x56BC75E2D63100000',
+    ]);
+    registrySigner = await ethers.getImpersonatedSigner(regAddr);
+
+    const Validation = await ethers.getContractFactory(
+      'contracts/v2/mocks/ValidationStub.sol:ValidationStub'
+    );
+    const validation = await Validation.deploy();
+    await validation.setValidators([
+      valLow1.address,
+      valHigh.address,
+      valLow2.address,
+    ]);
+    await stakeManager
+      .connect(owner)
+      .setValidationModule(await validation.getAddress());
+
+    const NFT = await ethers.getContractFactory(
+      'contracts/legacy/MockERC721.sol:MockERC721'
+    );
+    const nft = await NFT.deploy();
+    await stakeManager.connect(owner).addAGIType(await nft.getAddress(), 150);
+    await nft.mint(valHigh.address);
+  });
+
+  it('assigns remainder to the validator with the largest weight', async () => {
+    const jobId = ethers.encodeBytes32String('job1');
+    const amount = 100n;
+
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), amount);
+    await stakeManager
+      .connect(registrySigner)
+      .lockReward(jobId, employer.address, amount);
+    await stakeManager
+      .connect(registrySigner)
+      .distributeValidatorRewards(jobId, amount);
+
+    expect(await token.balanceOf(valLow1.address)).to.equal(28n);
+    expect(await token.balanceOf(valHigh.address)).to.equal(44n);
+    expect(await token.balanceOf(valLow2.address)).to.equal(28n);
+    expect(await stakeManager.jobEscrows(jobId)).to.equal(0n);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure validator reward remainders go to the validator with the greatest weight
- add tests verifying remainder distribution is unbiased

## Testing
- `npx hardhat test test/v2/StakeManagerValidatorRewards.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c0e9b3eb50833391ce800bd711d67a