### PR TITLE
Cache boosted stake totals

### DIFF
--- a/test/v2/StakeManagerExtras.test.js
+++ b/test/v2/StakeManagerExtras.test.js
@@ -97,4 +97,19 @@ describe('StakeManager extras', function () {
       stakeManager.connect(user).depositStake(0, ethers.parseEther('100'))
     ).to.be.revertedWithCustomError(stakeManager, 'MaxStakeExceeded');
   });
+
+  it('updates total boosted stake cache on stake changes', async () => {
+    await setupRegistryAck(user);
+    await token
+      .connect(user)
+      .approve(await stakeManager.getAddress(), ethers.parseEther('200'));
+    await stakeManager.connect(user).depositStake(0, ethers.parseEther('200'));
+    expect(await stakeManager.totalBoostedStake(0)).to.equal(
+      ethers.parseEther('200')
+    );
+    await stakeManager.connect(user).withdrawStake(0, ethers.parseEther('50'));
+    expect(await stakeManager.totalBoostedStake(0)).to.equal(
+      ethers.parseEther('150')
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- cache boosted stake per role and staker to avoid iterating staker lists on every call
- update deposit, withdraw, and slashing logic to maintain boosted stake cache
- add regression test covering boosted stake totals

## Testing
- `npm test`
- `npm run lint`
- `forge test` *(fails: Yul exception:Cannot swap Variable param with Variable param_16: too deep in the stack by 1 slots)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ef3163988333b284a3c77f601fc0