### PR TITLE
Clarify NFT bonus funding edge case

### DIFF
--- a/docs/enhanced-nft-incentive-model.md
+++ b/docs/enhanced-nft-incentive-model.md
@@ -8,7 +8,7 @@ The v2 architecture introduces a list of `AGIType` entries in `StakeManager` tha
 
 ## 2. NFT Reward Multiplier Implementation
 
-- **Agents** – `StakeManager.getHighestPayoutPct` multiplies an agent's base reward by the highest applicable tier. Employers escrow only the base reward; any bonus is covered by reduced burns or fees.
+- **Agents** – `StakeManager.getHighestPayoutPct` multiplies an agent's base reward by the highest applicable tier. Employers escrow only the base reward; any bonus is covered by reduced burns or fees. If neither fee nor burn is available to absorb the difference, the call reverts with `InsufficientEscrow`.
 - **Validators** – `distributeValidatorRewards` weights each validator's share by their multiplier. A 150% NFT counts as weight `150` versus the default `100`.
 - **Platform operators** – the `FeePool` exposes `boostedStake(address)` to reveal a staker's weight (`stake * multiplier / 100`). Off-chain scripts can use this to apportion fee distributions so that operators with NFTs receive a larger portion of the fee pool.
 

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -120,7 +120,7 @@ describe('StakeManager AGIType bonuses', function () {
       .withArgs(jobId, agent.address, 100);
   });
 
-  it('reverts when bonus payout exceeds escrow', async () => {
+  it('reverts when bonus payout exceeds escrow and no fees or burns are set', async () => {
     await stakeManager.connect(owner).addAGIType(await nft1.getAddress(), 150);
     await nft1.mint(agent.address);
 


### PR DESCRIPTION
## Summary
- Document that NFT bonuses revert if no fee or burn is available to cover the payout
- Rename edge-case test to highlight missing fee/burn when escrow is insufficient

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0fa737574833392242b63708c86a8