### PR TITLE
Add boosted stake docs and NFT incentive tests

### DIFF
--- a/docs/api/FeePool.md
+++ b/docs/api/FeePool.md
@@ -8,6 +8,7 @@ Holds platform fees and distributes rewards.
 - `contribute(uint256 amount)` – anyone can add to the reward pool.
 - `distributeFees()` – move accumulated fees to the reward pool and burn portion.
 - `claimRewards()` – stakers claim their share of rewards.
+- `boostedStake(address user)` – view a staker's balance multiplied by any NFT payout bonus.
 - `governanceWithdraw(address to, uint256 amount)` – governance timelock emergency withdrawal.
 - `setStakeManager(address manager)` – owner wires modules.
 - `setRewardRole(uint8 role)` – choose which stakers earn rewards.

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -141,6 +141,19 @@ describe('FeePool', function () {
     expect((await token.balanceOf(user2.address)) - before2).to.equal(75n);
   });
 
+  it('exposes boosted stake for NFT holders', async () => {
+    const MockNFT = await ethers.getContractFactory(
+      'contracts/legacy/MockERC721.sol:MockERC721'
+    );
+    const nft = await MockNFT.deploy();
+    await stakeManager.connect(owner).addAGIType(await nft.getAddress(), 150);
+    await nft.mint(user1.address);
+
+    expect(await feePool.boostedStake(user1.address)).to.equal(150n);
+    // user2 has no NFT and a raw stake of 300
+    expect(await feePool.boostedStake(user2.address)).to.equal(300n);
+  });
+
   it('accounts for NFT multipliers when distributing rewards', async () => {
     const MockNFT = await ethers.getContractFactory(
       'contracts/legacy/MockERC721.sol:MockERC721'

--- a/test/v2/StakeManagerValidatorRewards.test.js
+++ b/test/v2/StakeManagerValidatorRewards.test.js
@@ -31,6 +31,16 @@ describe('StakeManager validator reward remainder', function () {
       balanceSlot,
       ethers.toBeHex(1000n, 32),
     ]);
+    for (const addr of [valHigh.address, valLow1.address, valLow2.address]) {
+      const slot = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(['address', 'uint256'], [addr, 0])
+      );
+      await network.provider.send('hardhat_setStorageAt', [
+        AGIALPHA,
+        slot,
+        ethers.toBeHex(0n, 32),
+      ]);
+    }
     const supplySlot = '0x' + (2).toString(16).padStart(64, '0');
     await network.provider.send('hardhat_setStorageAt', [
       AGIALPHA,


### PR DESCRIPTION
## Summary
- document FeePool `boostedStake` utility for NFT-weighted balances
- cover boosted stake and multi-tier validator weighting in tests
- harden test setup by zeroing mock token balances between runs

## Testing
- `npm test --silent test/v2/FeePool.test.js`
- `npm test --silent test/v2/BurnReduction.test.js`
- `npm test --silent test/v2/StakeManagerValidatorRewards.test.js`
- `npm test --silent test/v2/AGITypeEdge.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1737e603c8333ae9daf458e2f16ad