### PR TITLE
feat: aggregate NFT payout percentages

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -98,7 +98,7 @@ contract MockStakeManager is IStakeManager {
         return totalStakes[role];
     }
 
-    function getHighestPayoutPct(address) external pure override returns (uint256) {
+    function getTotalPayoutPct(address) external pure override returns (uint256) {
         return 100;
     }
 

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -290,7 +290,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard, TaxAcknowledgement {
             emit RewardsClaimed(msg.sender, 0);
             return;
         }
-        uint256 pct = stakeManager.getHighestPayoutPct(msg.sender);
+        uint256 pct = stakeManager.getTotalPayoutPct(msg.sender);
         uint256 boosted = (stake * pct) / 100;
         uint256 cumulative = (boosted * cumulativePerToken) / ACCUMULATOR_SCALE;
         uint256 owed = cumulative - userCheckpoint[msg.sender];
@@ -305,7 +305,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard, TaxAcknowledgement {
     /// @return amount stake multiplied by the user's payout percentage
     function boostedStake(address user) external view returns (uint256 amount) {
         uint256 stake = stakeManager.stakeOf(user, rewardRole);
-        uint256 pct = stakeManager.getHighestPayoutPct(user);
+        uint256 pct = stakeManager.getTotalPayoutPct(user);
         amount = (stake * pct) / 100;
     }
 

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1333,7 +1333,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             uint256 burnPctStake;
             if (address(stakeManager) != address(0)) {
                 burnPctStake = stakeManager.burnPct();
-                agentPct = stakeManager.getHighestPayoutPct(job.agent);
+                agentPct = stakeManager.getTotalPayoutPct(job.agent);
                 if (address(pool) != address(0) && job.reward > 0) {
                     fee = (uint256(job.reward) * job.feePct) / 100;
                 }

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -187,8 +187,8 @@ interface IStakeManager {
     /// @notice address of the JobRegistry authorized to deposit fees
     function jobRegistry() external view returns (address);
 
-    /// @notice Highest payout percentage for a participant based on AGI type NFTs
+    /// @notice Total payout percentage for a participant based on AGI type NFTs
     /// @dev Returns 100 when the user holds no approved NFTs.
-    function getHighestPayoutPct(address user) external view returns (uint256);
+    function getTotalPayoutPct(address user) external view returns (uint256);
 }
 

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -76,7 +76,7 @@ contract ReentrantStakeManager is IStakeManager {
         return totalStakes[role];
     }
 
-    function getHighestPayoutPct(address) external pure override returns (uint256) {
+    function getTotalPayoutPct(address) external pure override returns (uint256) {
         return 100;
     }
 

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -17,7 +17,7 @@ Handles staking, escrow and slashing of the $AGIALPHA token.
 - `setMaxAGITypes(uint256 newMax)` – cap the number of AGI type entries.
 - `addAGIType(address nft, uint256 payoutPct)` – register or update a payout multiplier for holders of `nft`. The percentage is capped at `MAX_PAYOUT_PCT` (200%).
 - `removeAGIType(address nft)` – delete a previously registered AGI type.
-- `stakeOf(address user, uint8 role)` / `totalStake(uint8 role)` / `getHighestPayoutPct(address user)` – view functions.
+- `stakeOf(address user, uint8 role)` / `totalStake(uint8 role)` / `getTotalPayoutPct(address user)` – view functions.
 
 ## Events
 

--- a/docs/enhanced-nft-incentive-model.md
+++ b/docs/enhanced-nft-incentive-model.md
@@ -8,11 +8,12 @@ The v2 architecture introduces a list of `AGIType` entries in `StakeManager` tha
 
 ## 2. NFT Reward Multiplier Implementation
 
-- **Agents** – `StakeManager.getHighestPayoutPct` multiplies an agent's base reward by the highest applicable tier. Employers escrow only the base reward; any bonus is covered by reduced burns or fees. If neither fee nor burn is available to absorb the difference, the call reverts with `InsufficientEscrow`.
+
+- **Agents** – `StakeManager.getTotalPayoutPct` multiplies an agent's base reward by the sum of all applicable tiers. Employers escrow only the base reward; any bonus is covered by reduced burns or fees. If neither fee nor burn is available to absorb the difference, the call reverts with `InsufficientEscrow`.
 - **Validators** – `distributeValidatorRewards` weights each validator's share by their multiplier. A 150% NFT counts as weight `150` versus the default `100`.
 - **Platform operators** – the `FeePool` exposes `boostedStake(address)` to reveal a staker's weight (`stake * multiplier / 100`). Off-chain scripts can use this to apportion fee distributions so that operators with NFTs receive a larger portion of the fee pool. Participants should call `StakeManager.syncBoostedStake` after acquiring or losing an NFT to refresh their weight; `FeePool` invokes this helper automatically for callers when distributing or claiming rewards.
 
-The `getHighestPayoutPct` function is a general utility that any module can call to check the top multiplier for a given address and now serves agents, validators and platform participants alike.
+The `getTotalPayoutPct` function is a general utility that any module can call to check the cumulative multiplier for a given address and now serves agents, validators and platform participants alike.
 
 ## 3. Game-Theoretic Robustness
 
@@ -25,6 +26,6 @@ Simulations show NFT holders consistently earn more than non‑holders while tot
 ## 5. Milestone-Based Implementation Plan
 
 1. **Design finalisation** – approve NFT tiers, payout caps and the list of supported contracts.
-2. **Solidity changes** – generalise `getHighestPayoutPct`, weight validator rewards, provide `boostedStake` for platform calculations and enforce the 200% multiplier cap.
+2. **Solidity changes** – generalise `getTotalPayoutPct`, weight validator rewards, provide `boostedStake` for platform calculations and enforce the 200% multiplier cap.
 3. **Simulation and audit** – unit tests and economic simulations confirm robustness; fix any findings.
 4. **Documentation and deployment** – update guides, deploy upgrades and announce NFT reward boosts to the community.

--- a/docs/internal/coding-sprint-v2-ens-identity.md
+++ b/docs/internal/coding-sprint-v2-ens-identity.md
@@ -39,7 +39,7 @@ This sprint modularises all behaviour from `AGIJobManagerv0.sol` into the v2 arc
 
 - Custody all funds in $AGIALPHA (18 decimals) with a fixed token address.
 - Handle deposits, withdrawals, escrow locking, releases and slashing.
-- Apply protocol fees and validator rewards; expose `getHighestPayoutPct` for NFT boosts and weight per‑job validator splits by this multiplier.
+- Apply protocol fees and validator rewards; expose `getTotalPayoutPct` for NFT boosts and weight per‑job validator splits by this multiplier.
 - Provide a `contribute` function for reward‑pool top‑ups to match v1's `contributeToRewardPool` and emit `RewardPoolContribution`.
 
 ### 5. ReputationEngine

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -76,17 +76,19 @@ describe('StakeManager AGIType bonuses', function () {
     await token.mint(employer.address, 1000);
   });
 
-  it('applies highest AGIType bonus', async () => {
+  it('stacks AGIType bonuses', async () => {
     await stakeManager.connect(owner).addAGIType(await nft1.getAddress(), 150);
     await stakeManager.connect(owner).addAGIType(await nft2.getAddress(), 175);
     await nft1.mint(agent.address);
     await nft2.mint(agent.address);
 
     const jobId = ethers.encodeBytes32String('job1');
-    await token.connect(employer).approve(await stakeManager.getAddress(), 200);
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), 225);
     await stakeManager
       .connect(registrySigner)
-      .lockReward(jobId, employer.address, 200);
+      .lockReward(jobId, employer.address, 225);
 
     await expect(
       stakeManager
@@ -94,10 +96,11 @@ describe('StakeManager AGIType bonuses', function () {
         .releaseReward(jobId, employer.address, agent.address, 100)
     )
       .to.emit(stakeManager, 'RewardPaid')
-      .withArgs(jobId, agent.address, 175);
+      .withArgs(jobId, agent.address, 225);
 
-    expect(await token.balanceOf(agent.address)).to.equal(175n);
-    expect(await stakeManager.jobEscrows(jobId)).to.equal(25n);
+    expect(await stakeManager.getTotalPayoutPct(agent.address)).to.equal(225n);
+    expect(await token.balanceOf(agent.address)).to.equal(225n);
+    expect(await stakeManager.jobEscrows(jobId)).to.equal(0n);
   });
 
   it('ignores NFTs with failing balanceOf', async () => {
@@ -118,6 +121,16 @@ describe('StakeManager AGIType bonuses', function () {
     )
       .to.emit(stakeManager, 'RewardPaid')
       .withArgs(jobId, agent.address, 100);
+  });
+
+  it('counts each AGIType at most once', async () => {
+    await stakeManager.connect(owner).addAGIType(await nft1.getAddress(), 150);
+    await stakeManager.connect(owner).addAGIType(await nft2.getAddress(), 175);
+    await nft1.mint(agent.address);
+    await nft1.mint(agent.address);
+    await nft2.mint(agent.address);
+
+    expect(await stakeManager.getTotalPayoutPct(agent.address)).to.equal(225n);
   });
 
   it('reverts when bonus payout exceeds escrow and no fees or burns are set', async () => {

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -83,9 +83,7 @@ describe('StakeManager AGIType bonuses', function () {
     await nft2.mint(agent.address);
 
     const jobId = ethers.encodeBytes32String('job1');
-    await token
-      .connect(employer)
-      .approve(await stakeManager.getAddress(), 225);
+    await token.connect(employer).approve(await stakeManager.getAddress(), 225);
     await stakeManager
       .connect(registrySigner)
       .lockReward(jobId, employer.address, 225);


### PR DESCRIPTION
## Summary
- sum payout percentages from all eligible AGIType NFTs via `getTotalPayoutPct`
- update FeePool, JobRegistry, StakeManager, and interface to use cumulative multipliers
- test stacked NFT boosts and per-type counting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1892894e083338d4430524e2e324f