### PR TITLE
feat: add operator reward pool

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -43,6 +43,8 @@ contract MockStakeManager is IStakeManager {
     function release(address, address, uint256) external override {}
     function finalizeJobFunds(bytes32, address, address, uint256, uint256, IFeePool, bool) external override {}
     function distributeValidatorRewards(bytes32, uint256) external override {}
+    function fundOperatorRewardPool(uint256) external override {}
+    function withdrawOperatorRewardPool(address, uint256) external override {}
     function setDisputeModule(address module) external override {
         disputeModule = module;
     }
@@ -108,6 +110,10 @@ contract MockStakeManager is IStakeManager {
 
     function token() external pure override returns (IERC20) {
         return IERC20(address(0));
+    }
+
+    function operatorRewardPool() external pure override returns (uint256) {
+        return 0;
     }
 
     // legacy helper for tests

--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -41,7 +41,16 @@ contract MockStakeManager is IStakeManager {
     function releaseReward(bytes32, address, address, uint256) external override {}
     function releaseStake(address, uint256) external override {}
     function release(address, address, uint256) external override {}
-    function finalizeJobFunds(bytes32, address, address, uint256, uint256, IFeePool, bool) external override {}
+    function finalizeJobFunds(
+        bytes32,
+        address,
+        address,
+        uint256,
+        uint256,
+        uint256,
+        IFeePool,
+        bool
+    ) external override {}
     function distributeValidatorRewards(bytes32, uint256) external override {}
     function fundOperatorRewardPool(uint256) external override {}
     function withdrawOperatorRewardPool(address, uint256) external override {}

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1354,6 +1354,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
                     employerParam,
                     payee,
                     rewardAfterValidator,
+                    validatorReward,
                     fee,
                     pool,
                     isGov

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -113,6 +113,7 @@ interface IStakeManager {
         address employer,
         address agent,
         uint256 reward,
+        uint256 validatorReward,
         uint256 fee,
         IFeePool feePool,
         bool byGovernance

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -25,6 +25,8 @@ interface IStakeManager {
     /// @notice Emitted when an employer finalizes a job's funds.
     /// @dev Signals that any subsequent burn events stem from employer action.
     event JobFundsFinalized(bytes32 indexed jobId, address indexed employer);
+    /// @notice Emitted when the operator reward pool balance changes.
+    event RewardPoolUpdated(uint256 balance);
     event StakeTimeLocked(address indexed user, uint256 amount, uint64 unlockTime);
     event StakeUnlocked(address indexed user, uint256 amount);
     event StakeSlashed(
@@ -116,6 +118,12 @@ interface IStakeManager {
         bool byGovernance
     ) external;
 
+    /// @notice fund the operator reward pool
+    function fundOperatorRewardPool(uint256 amount) external;
+
+    /// @notice withdraw tokens from the operator reward pool
+    function withdrawOperatorRewardPool(address to, uint256 amount) external;
+
     /// @notice distribute validator rewards among selected validators
     ///         weighted by their NFT multipliers
     function distributeValidatorRewards(bytes32 jobId, uint256 amount) external;
@@ -125,6 +133,9 @@ interface IStakeManager {
 
     /// @notice ERC20 token used for staking operations
     function token() external view returns (IERC20);
+
+    /// @notice current balance of the operator reward pool
+    function operatorRewardPool() external view returns (uint256);
 
     /// @notice set the dispute module authorized to manage dispute fees
     function setDisputeModule(address module) external;

--- a/contracts/v2/mocks/ReentrantJobRegistry.sol
+++ b/contracts/v2/mocks/ReentrantJobRegistry.sol
@@ -9,6 +9,7 @@ interface IStakeManager {
         address employer,
         address agent,
         uint256 reward,
+        uint256 validatorReward,
         uint256 fee,
         IFeePool feePool,
         bool byGovernance
@@ -56,7 +57,7 @@ contract ReentrantJobRegistry {
         reward = _reward;
         attackType = AttackType.Finalize;
         token.setAttack(true);
-        stakeManager.finalizeJobFunds(jobId, employer, agent, reward, 0, IFeePool(address(0)), false);
+        stakeManager.finalizeJobFunds(jobId, employer, agent, reward, 0, 0, IFeePool(address(0)), false);
         attackType = AttackType.None;
     }
 
@@ -72,7 +73,7 @@ contract ReentrantJobRegistry {
     // called by the token during transfer to attempt reentrancy
     function reenter() external {
         if (attackType == AttackType.Finalize) {
-            stakeManager.finalizeJobFunds(jobId, employer, agent, reward, 0, IFeePool(address(0)), false);
+            stakeManager.finalizeJobFunds(jobId, employer, agent, reward, 0, 0, IFeePool(address(0)), false);
         } else if (attackType == AttackType.Validator) {
             stakeManager.distributeValidatorRewards(jobId, amount);
         }

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -45,6 +45,8 @@ contract ReentrantStakeManager is IStakeManager {
     function release(address, address, uint256) external override {}
     function finalizeJobFunds(bytes32, address, address, uint256, uint256, IFeePool, bool) external override {}
     function distributeValidatorRewards(bytes32, uint256) external override {}
+    function fundOperatorRewardPool(uint256) external override {}
+    function withdrawOperatorRewardPool(address, uint256) external override {}
     function setDisputeModule(address) external override {}
     function setModules(address, address) external override {}
     function lockDisputeFee(address, uint256) external override {}
@@ -86,6 +88,10 @@ contract ReentrantStakeManager is IStakeManager {
 
     function token() external pure override returns (IERC20) {
         return IERC20(address(0));
+    }
+
+    function operatorRewardPool() external pure override returns (uint256) {
+        return 0;
     }
 
     function slash(address user, Role role, uint256 amount, address) external override {

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -43,7 +43,16 @@ contract ReentrantStakeManager is IStakeManager {
     function releaseReward(bytes32, address, address, uint256) external override {}
     function releaseStake(address, uint256) external override {}
     function release(address, address, uint256) external override {}
-    function finalizeJobFunds(bytes32, address, address, uint256, uint256, IFeePool, bool) external override {}
+    function finalizeJobFunds(
+        bytes32,
+        address,
+        address,
+        uint256,
+        uint256,
+        uint256,
+        IFeePool,
+        bool
+    ) external override {}
     function distributeValidatorRewards(bytes32, uint256) external override {}
     function fundOperatorRewardPool(uint256) external override {}
     function withdrawOperatorRewardPool(address, uint256) external override {}

--- a/docs/master-guide.md
+++ b/docs/master-guide.md
@@ -512,7 +512,7 @@ Create `docs/deployment-addresses.json` (or similar) and keep it updated:
     → `{employerPct, treasuryPct}` (sum 100)
     → **burn remainder via `TOKEN.burn()`**
     → `StakeSlashed(user, role, employer, treasury, employerShare, treasuryShare, burnShare)`.
-- **Fee remittance (M):** `finalizeJobFunds(jobId, employer, agent, reward, fee, pool, byGovernance)` → net to agent, validator rewards, fee to `FeePool`.
+- **Fee remittance (M):** `finalizeJobFunds(jobId, employer, agent, reward, validatorReward, fee, pool, byGovernance)` → net to agent, validator rewards, fee to `FeePool`.
 - **Guards (L):** `nonReentrant` + `whenNotPaused` on state mutators.
 
 #### A.2.3 `FeePool`

--- a/test/v2/BurnReduction.test.js
+++ b/test/v2/BurnReduction.test.js
@@ -158,6 +158,7 @@ describe('StakeManager burn reduction', function () {
           employer.address,
           agent.address,
           ethers.parseEther('100'),
+          0,
           ethers.parseEther('20'),
           await feePool.getAddress(),
           false

--- a/test/v2/BurnReduction.test.js
+++ b/test/v2/BurnReduction.test.js
@@ -82,6 +82,11 @@ describe('StakeManager burn reduction', function () {
       .connect(employer)
       .approve(await stakeManager.getAddress(), ethers.parseEther('1000'));
 
+    await token.mint(owner.address, ethers.parseEther('100'));
+    await token
+      .connect(owner)
+      .approve(await stakeManager.getAddress(), ethers.parseEther('100'));
+
     await stakeManager.connect(owner).setFeePool(await feePool.getAddress());
     await stakeManager.connect(owner).setFeePct(20);
     await stakeManager.connect(owner).setBurnPct(10);
@@ -136,10 +141,14 @@ describe('StakeManager burn reduction', function () {
     const jobId = ethers.encodeBytes32String('finalReduce');
     await stakeManager
       .connect(registrySigner)
-      .lockReward(jobId, employer.address, ethers.parseEther('120'));
+      .lockReward(jobId, employer.address, ethers.parseEther('110'));
 
     const beforeAgent = await token.balanceOf(agent.address);
     const afterLockEmployer = await token.balanceOf(employer.address);
+
+    await stakeManager
+      .connect(owner)
+      .fundOperatorRewardPool(ethers.parseEther('100'));
 
     await expect(
       stakeManager
@@ -155,7 +164,7 @@ describe('StakeManager burn reduction', function () {
         )
     )
       .to.emit(stakeManager, 'StakeReleased')
-      .withArgs(jobId, await feePool.getAddress(), ethers.parseEther('3'))
+      .withArgs(jobId, await feePool.getAddress(), ethers.parseEther('10'))
       .and.to.emit(stakeManager, 'RewardPaid')
       .withArgs(jobId, agent.address, ethers.parseEther('117'));
 

--- a/test/v2/FeePool.test.js
+++ b/test/v2/FeePool.test.js
@@ -127,6 +127,7 @@ describe('FeePool', function () {
         registrySigner.address,
         user1.address,
         0,
+        0,
         feeAmount,
         await feePool.getAddress(),
         false
@@ -200,6 +201,7 @@ describe('FeePool', function () {
         registrySigner.address,
         user1.address,
         0,
+        0,
         feeAmount,
         await feePool.getAddress(),
         false
@@ -232,6 +234,7 @@ describe('FeePool', function () {
         registrySigner.address,
         user1.address,
         0,
+        0,
         feeAmount,
         await feePool.getAddress(),
         false
@@ -262,6 +265,7 @@ describe('FeePool', function () {
         jobId,
         registrySigner.address,
         user1.address,
+        0,
         0,
         feeAmount,
         await feePool.getAddress(),
@@ -325,6 +329,7 @@ describe('FeePool', function () {
         jobId,
         registrySigner.address,
         user1.address,
+        0,
         0,
         feeAmount,
         await feePool.getAddress(),

--- a/test/v2/OperatorRewardPool.test.js
+++ b/test/v2/OperatorRewardPool.test.js
@@ -1,0 +1,142 @@
+const { expect } = require('chai');
+const { ethers, artifacts, network } = require('hardhat');
+
+describe('Operator reward pool', function () {
+  let owner, employer, agent, stakeManager, jobRegistry, registrySigner, token;
+  beforeEach(async () => {
+    [owner, employer, agent] = await ethers.getSigners();
+    const { AGIALPHA } = require('../../scripts/constants');
+    const artifact = await artifacts.readArtifact(
+      'contracts/test/MockERC20.sol:MockERC20'
+    );
+    await network.provider.send('hardhat_setCode', [
+      AGIALPHA,
+      artifact.deployedBytecode,
+    ]);
+    token = await ethers.getContractAt(
+      'contracts/test/MockERC20.sol:MockERC20',
+      AGIALPHA
+    );
+
+    const StakeManager = await ethers.getContractFactory(
+      'contracts/v2/StakeManager.sol:StakeManager'
+    );
+    stakeManager = await StakeManager.deploy(
+      0,
+      100,
+      0,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      owner.address
+    );
+    await stakeManager.connect(owner).setMinStake(1);
+
+    const JobRegistry = await ethers.getContractFactory(
+      'contracts/v2/JobRegistry.sol:JobRegistry'
+    );
+    jobRegistry = await JobRegistry.deploy(
+      ethers.ZeroAddress,
+      await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+    const TaxPolicy = await ethers.getContractFactory(
+      'contracts/v2/TaxPolicy.sol:TaxPolicy'
+    );
+    const taxPolicy = await TaxPolicy.deploy('ipfs://policy', 'ack');
+    await jobRegistry.connect(owner).setTaxPolicy(await taxPolicy.getAddress());
+    await stakeManager
+      .connect(owner)
+      .setJobRegistry(await jobRegistry.getAddress());
+    await taxPolicy.connect(agent).acknowledge();
+
+    const registryAddr = await jobRegistry.getAddress();
+    await ethers.provider.send('hardhat_setBalance', [
+      registryAddr,
+      '0x56BC75E2D63100000',
+    ]);
+    registrySigner = await ethers.getImpersonatedSigner(registryAddr);
+
+    await token.mint(employer.address, ethers.parseEther('1000'));
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), ethers.parseEther('1000'));
+
+    const NFT = await ethers.getContractFactory(
+      'contracts/legacy/MockERC721.sol:MockERC721'
+    );
+    const nft = await NFT.deploy();
+    await stakeManager.connect(owner).addAGIType(await nft.getAddress(), 150);
+    await nft.mint(agent.address);
+  });
+
+  it('pays bonus from pool and adds leftover escrow to pool', async () => {
+    await token.mint(owner.address, ethers.parseEther('50'));
+    await token
+      .connect(owner)
+      .approve(await stakeManager.getAddress(), ethers.parseEther('50'));
+    await stakeManager
+      .connect(owner)
+      .fundOperatorRewardPool(ethers.parseEther('50'));
+
+    const jobId = ethers.encodeBytes32String('bonus');
+    const reward = ethers.parseEther('100');
+    await stakeManager
+      .connect(registrySigner)
+      .lockReward(jobId, employer.address, reward + ethers.parseEther('20'));
+
+    const before = await token.balanceOf(agent.address);
+    await stakeManager
+      .connect(registrySigner)
+      .finalizeJobFunds(
+        jobId,
+        employer.address,
+        agent.address,
+        reward,
+        0,
+        ethers.ZeroAddress,
+        false
+      );
+
+    expect(await token.balanceOf(agent.address)).to.equal(
+      before + ethers.parseEther('150')
+    );
+    expect(await stakeManager.operatorRewardPool()).to.equal(
+      ethers.parseEther('20')
+    );
+    expect(await stakeManager.jobEscrows(jobId)).to.equal(0n);
+  });
+
+  it('reverts when pool lacks funds for bonus', async () => {
+    const jobId = ethers.encodeBytes32String('insufficient');
+    const reward = ethers.parseEther('100');
+    await stakeManager
+      .connect(registrySigner)
+      .lockReward(jobId, employer.address, reward);
+
+    await expect(
+      stakeManager
+        .connect(registrySigner)
+        .finalizeJobFunds(
+          jobId,
+          employer.address,
+          agent.address,
+          reward,
+          0,
+          ethers.ZeroAddress,
+          false
+        )
+    ).to.be.revertedWithCustomError(stakeManager, 'InsufficientRewardPool');
+
+    expect(await stakeManager.operatorRewardPool()).to.equal(0n);
+    expect(await stakeManager.jobEscrows(jobId)).to.equal(reward);
+  });
+});

--- a/test/v2/OperatorRewardPool.test.js
+++ b/test/v2/OperatorRewardPool.test.js
@@ -102,6 +102,7 @@ describe('Operator reward pool', function () {
         agent.address,
         reward,
         0,
+        0,
         ethers.ZeroAddress,
         false
       );
@@ -130,6 +131,7 @@ describe('Operator reward pool', function () {
           employer.address,
           agent.address,
           reward,
+          0,
           0,
           ethers.ZeroAddress,
           false

--- a/test/v2/PlatformRewardsFlow.test.js
+++ b/test/v2/PlatformRewardsFlow.test.js
@@ -155,6 +155,7 @@ describe('Platform reward flow', function () {
         registrySigner.address,
         alice.address,
         REWARD,
+        0,
         FEE,
         await feePool.getAddress(),
         false


### PR DESCRIPTION
## Summary
- track operator-funded reward pool and expose balance updates
- pull AGI bonuses from pool during finalization and route leftover escrow to it
- add governance controls and unit tests for operator reward pool

## Testing
- `npm test -- test/v2/OperatorRewardPool.test.js test/v2/BurnReduction.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c18f6018d4833380b84e0540c34d6d