### PR TITLE
feat: record base and bonus job payouts

### DIFF
--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -209,7 +209,7 @@ describe('JobRegistry integration', function () {
       .withArgs(jobId, true);
     await expect(registry.connect(employer).finalize(jobId))
       .to.emit(registry, 'JobPayout')
-      .withArgs(jobId, agent.address, reward, 0)
+      .withArgs(jobId, agent.address, reward, 0, 0)
       .and.to.emit(registry, 'JobFinalized')
       .withArgs(jobId, agent.address);
 


### PR DESCRIPTION
## Summary
- emit base and bonus amounts when paying out jobs
- compute agent bonus using StakeManager's `getTotalPayoutPct`
- adjust JobRegistry test for new payout event

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1985077748333aee4ab1d7b5273f4