### PR TITLE
docs: document cumulative NFT boosts and payout formulas

### DIFF
--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -1,6 +1,6 @@
 # StakeManager API
 
-Handles staking, escrow and slashing of the $AGIALPHA token.
+Handles staking, escrow and slashing of the $AGIALPHA token. NFT ownership can boost payouts cumulatively; extra amounts are funded from protocol fees or reduced burns.
 
 ## Functions
 
@@ -15,9 +15,10 @@ Handles staking, escrow and slashing of the $AGIALPHA token.
 - `slash(address user, uint8 role, uint256 amount, address employer)` – JobRegistry slashes the user's stake for a given role and routes the employer share.
 - `slash(address user, uint256 amount, address recipient)` – DisputeModule slashes validator stake during disputes and sends the slashed amount to `recipient`.
 - `setMaxAGITypes(uint256 newMax)` – cap the number of AGI type entries.
-- `addAGIType(address nft, uint256 payoutPct)` – register or update a payout multiplier for holders of `nft`. The percentage is capped at `MAX_PAYOUT_PCT` (200%).
+- `addAGIType(address nft, uint256 payoutPct)` – register or update a payout multiplier for holders of `nft`. Multipliers from multiple NFTs **stack** by adding `payoutPct - 100` for each type. Each entry is capped at `MAX_PAYOUT_PCT` (200%).
 - `removeAGIType(address nft)` – delete a previously registered AGI type.
-- `stakeOf(address user, uint8 role)` / `totalStake(uint8 role)` / `getTotalPayoutPct(address user)` – view functions.
+- `syncBoostedStake(address user, uint8 role)` – recalculate a user's boosted stake after NFT changes. `FeePool.claimRewards` calls this automatically for the reward role.
+- `stakeOf(address user, uint8 role)` / `totalStake(uint8 role)` / `totalBoostedStake(uint8 role)` / `getTotalPayoutPct(address user)` – view functions. `getTotalPayoutPct` returns `100 + Σ(payoutPct_i - 100)` and may exceed `200` when multiple NFTs are held.
 
 ## Events
 

--- a/docs/enhanced-nft-incentive-model.md
+++ b/docs/enhanced-nft-incentive-model.md
@@ -4,20 +4,29 @@
 
 The original on-chain manager (v0) granted a single-tier payout boost to agents or validators that owned an eligible ENS subdomain NFT. The bonus increased job costs for employers and did not apply to platform operators.
 
-The v2 architecture introduces a list of `AGIType` entries in `StakeManager` that associates approved NFT contracts with specific payout multipliers. When a participant holds multiple NFTs, only the highest multiplier is applied, preventing reward compounding. Agents already benefit from this mechanism; the enhanced model extends the same logic to validators and platform operators so every core role can earn more when holding an approved NFT.
+The v2 architecture introduces a list of `AGIType` entries in `StakeManager` that associates approved NFT contracts with specific payout multipliers. **Boosts are cumulative**: for every NFT the user holds, the contract adds `(payoutPct - 100)` to the running total, starting from `100`. Two NFTs at `150%` and `125%` yield `100 + 50 + 25 = 175%`. Agents already benefit from this mechanism; the enhanced model extends the same logic to validators and platform operators so every core role can earn more when holding multiple approved NFTs.
 
 ## 2. NFT Reward Multiplier Implementation
-
 
 - **Agents** – `StakeManager.getTotalPayoutPct` multiplies an agent's base reward by the sum of all applicable tiers. Employers escrow only the base reward; any bonus is covered by reduced burns or fees. If neither fee nor burn is available to absorb the difference, the call reverts with `InsufficientEscrow`.
 - **Validators** – `distributeValidatorRewards` weights each validator's share by their multiplier. A 150% NFT counts as weight `150` versus the default `100`.
 - **Platform operators** – the `FeePool` exposes `boostedStake(address)` to reveal a staker's weight (`stake * multiplier / 100`). Off-chain scripts can use this to apportion fee distributions so that operators with NFTs receive a larger portion of the fee pool. Participants should call `StakeManager.syncBoostedStake` after acquiring or losing an NFT to refresh their weight; `FeePool` invokes this helper automatically for callers when distributing or claiming rewards.
 
+### Example Payouts
+
+- **Single NFT:** Base reward `10` with a `150%` boost pays `15` tokens. The extra `5` tokens are drawn from the reward pool funded by protocol fees and reduced burns.
+- **Multiple NFTs:** Base reward `10`, holder owns `150%` and `125%` NFTs → total multiplier `175%` → payout `17.5` tokens. The additional `7.5` tokens come from the same fee/burn pool. If fee and burn shares together cannot fund the bonus, the transaction reverts.
+
+### Snapshot Rules and Claims
+
+- Reward percentages are snapshot at the moment `releaseReward` or `syncBoostedStake` runs. Acquiring or selling an NFT requires `StakeManager.syncBoostedStake(user, role)` before claiming from the `FeePool` to update the snapshot.
+- `FeePool.claimRewards` automatically syncs and pays out based on the current multiplier, even when the total exceeds `100%`. Agents and validators receive boosted amounts during `releaseReward` with no extra steps.
+
 The `getTotalPayoutPct` function is a general utility that any module can call to check the cumulative multiplier for a given address and now serves agents, validators and platform participants alike.
 
 ## 3. Game-Theoretic Robustness
 
-Weighting rewards by NFT multipliers removes the equal‑split sybil attack among validators and aligns incentives across roles. Multiplier values are capped at 200% and selecting only the highest tier prevents unbounded gains. Employers are not penalised for hiring NFT holders because extra payouts are subsidised by reduced burns or fees, so the best agents remain attractive hires.
+Weighting rewards by cumulative NFT multipliers removes the equal‑split sybil attack among validators and aligns incentives across roles. Each tier is capped at 200%, but totals can exceed `200%` when stacking multiple NFTs. Employers are not penalised for hiring NFT holders because extra payouts are subsidised by reduced burns or fees, so the best agents remain attractive hires.
 
 ## 4. Simulation of Reward Outcomes
 
@@ -26,6 +35,6 @@ Simulations show NFT holders consistently earn more than non‑holders while tot
 ## 5. Milestone-Based Implementation Plan
 
 1. **Design finalisation** – approve NFT tiers, payout caps and the list of supported contracts.
-2. **Solidity changes** – generalise `getTotalPayoutPct`, weight validator rewards, provide `boostedStake` for platform calculations and enforce the 200% multiplier cap.
+2. **Solidity changes** – generalise `getTotalPayoutPct`, weight validator rewards, provide `boostedStake` for platform calculations and enforce the per-tier 200% cap.
 3. **Simulation and audit** – unit tests and economic simulations confirm robustness; fix any findings.
 4. **Documentation and deployment** – update guides, deploy upgrades and announce NFT reward boosts to the community.

--- a/docs/master-guide.md
+++ b/docs/master-guide.md
@@ -308,6 +308,8 @@ All amounts are `$AGIALPHA` **wei** (18 decimals). **Always** `approve` the rele
   - FeePool collects fee; **burnPct** triggers **`burn(...)`** on `$AGIALPHA`.
   - CertificateNFT mints to the Agent.
   - Reputation updates.
+  - **NFT boosts:** payouts scale by the cumulative multiplier returned from `StakeManager.getTotalPayoutPct`. Multiple NFTs add their boosts (`100 + Σ(payoutPct_i - 100)`), so `150%` + `125%` yields `175%`. Extra tokens are taken from fee and burn shares; if those pools lack funds the call reverts with `InsufficientEscrow`.
+  - **Snapshot & claim:** multipliers are checked at payout. Stakers who obtain or lose NFTs should call `StakeManager.syncBoostedStake` before claiming from the `FeePool`. `FeePool.claimRewards()` performs this step automatically and pays boosted rewards even when totals exceed `100%`.
 
 ### 8.5 Disputes
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -63,6 +63,21 @@ const registry = await ethers.getContractAt('JobRegistry', registryAddress);
 await registry.connect(employer).finalize(jobId);
 ```
 
+## 5. Reward Boosts and Claims
+
+Holding approved NFTs increases payouts by adding their percentage boosts. Total multiplier = `100 + Σ(payoutPct_i - 100)`.
+
+Example: with `150%` and `125%` NFTs the multiplier becomes `175%` and a `10` token reward pays `17.5`. Extra tokens are funded from the protocol fee and burn pool; if those pools cannot cover the bonus, finalization reverts with `InsufficientEscrow`.
+
+Stakers who gain or lose NFTs should snapshot their weight before claiming:
+
+```javascript
+// sync-boost.js
+await stake.syncBoostedStake(user.address, role); // 0=agent, 1=validator, 2=platform
+```
+
+`FeePool.claimRewards()` automatically calls this helper and pays out boosted rewards even when totals exceed `100%`.
+
 ## FAQ
 
 **How do I get test tokens?** Use `AGIALPHAToken.mint()` from the deployer


### PR DESCRIPTION
## Summary
- explain how cumulative NFT multipliers are calculated and funded from fee/burn pools
- document syncBoostedStake and boosted stake views in StakeManager API
- guide users through claiming boosted rewards and snapshot rules

## Testing
- `npm run compile`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1b12de700833386efd9cf176a23d8