### PR TITLE
chore: add solc 0.8.29

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,6 +6,10 @@ module.exports = {
   solidity: {
     compilers: [
       {
+        version: '0.8.29',
+        settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true },
+      },
+      {
         version: '0.8.25',
         settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true },
       },


### PR DESCRIPTION
## Summary
- add Solidity 0.8.29 compiler to Hardhat config to support latest contracts

## Testing
- `npm test` *(fails: hangs while downloading compiler 0.8.21)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ba90a0d08333890f9ee2209f1335