### PR TITLE
Add Solidity 0.8.28 compiler

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,6 +6,10 @@ module.exports = {
   solidity: {
     compilers: [
       {
+        version: '0.8.28',
+        settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true },
+      },
+      {
         version: '0.8.25',
         settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true },
       },


### PR DESCRIPTION
## Summary
- add Solidity 0.8.28 compiler configuration at top of Hardhat config

## Testing
- `npm run lint`
- `npm test` *(fails: YulException variable stack too deep)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d805d498833388cbafa9598f27dc