### PR TITLE
feat: add fetch timeout with abort controller

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 # Environment variables for development
 # Etherscan API key for contract verification
 ETHERSCAN_API_KEY=
+
+# Timeout for outbound fetch requests (ms)
+FETCH_TIMEOUT_MS=5000
+# Client-side timeout for validator UI (ms)
+NEXT_PUBLIC_FETCH_TIMEOUT_MS=5000

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Use the `examples/ethers-quickstart.js` script to interact with the deployed con
 
 The [API reference](docs/api-reference.md) describes every public contract function and includes TypeScript and Python snippets. For an event‑driven workflow check the minimal [agent gateway](examples/agent-gateway.js) that listens for `JobCreated` events and applies automatically.
 
+### Network timeouts
+
+Outbound HTTP requests from the gateway, example agents and validator UI respect the `FETCH_TIMEOUT_MS` environment variable (default `5000` milliseconds). Browser clients read the value from `NEXT_PUBLIC_FETCH_TIMEOUT_MS`.
+
 ### Post a job
 
 ```bash

--- a/examples/gateway-agent.ts
+++ b/examples/gateway-agent.ts
@@ -2,11 +2,28 @@ import WebSocket from 'ws';
 import fetch from 'node-fetch';
 
 const GATEWAY = process.env.GATEWAY_URL || 'http://localhost:3000';
+const FETCH_TIMEOUT_MS = Number(process.env.FETCH_TIMEOUT_MS || '5000');
 const id = 'agent-1';
 const wallet = '0xYourWalletAddress';
 
+async function fetchWithTimeout(url: string, options: any = {}, retries = 1) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } catch (err: any) {
+    if (err.name === 'AbortError' && retries > 0) {
+      console.warn(`Request to ${url} timed out, retrying...`);
+      return fetchWithTimeout(url, options, retries - 1);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function main() {
-  await fetch(`${GATEWAY}/agents`, {
+  await fetchWithTimeout(`${GATEWAY}/agents`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ id, wallet }),
@@ -23,7 +40,7 @@ async function main() {
     if (msg.type === 'job') {
       console.log('job received', msg.job);
       ws.send(JSON.stringify({ type: 'ack', id, jobId: msg.job.jobId }));
-      await fetch(`${GATEWAY}/jobs/${msg.job.jobId}/submit`, {
+      await fetchWithTimeout(`${GATEWAY}/jobs/${msg.job.jobId}/submit`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ address: wallet, result: 'result data' }),


### PR DESCRIPTION
## Summary
- add FETCH_TIMEOUT_MS env var and client equivalent for configurable fetch timeouts
- wrap gateway, example agent, and validator UI fetch calls with AbortController and timeout logic
- log and retry or drop on timeout

## Testing
- `npm test` *(fails: process hung after invoking hardhat)*
- `npx solhint 'contracts/**/*.sol'` *(fails: Error checking for updates)*
- `npx eslint . --ext .js,.ts`
- `npm run format:check` *(fails: Code style issues found in 5 files. Forgot to run Prettier?)*

------
https://chatgpt.com/codex/tasks/task_e_68c2248c69d48333bed9a65ea1a3fc58