### PR TITLE
feat: cap NFT payout boost at max

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -136,6 +136,12 @@ contract MockStakeManager is IStakeManager {
         return 0;
     }
 
+    function maxTotalPayoutPct() external pure override returns (uint256) {
+        return 100;
+    }
+
+    function setMaxTotalPayoutPct(uint256) external override {}
+
     // legacy helper for tests
 }
 

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -51,6 +51,7 @@ interface IStakeManager {
     event MaxAGITypesUpdated(uint256 oldMax, uint256 newMax);
     event AGITypeUpdated(address indexed nft, uint256 payoutPct);
     event AGITypeRemoved(address indexed nft);
+    event MaxTotalPayoutPctUpdated(uint256 oldMax, uint256 newMax);
     event FeePctUpdated(uint256 pct);
     event BurnPctUpdated(uint256 pct);
     event FeePoolUpdated(address indexed feePool);
@@ -145,6 +146,9 @@ interface IStakeManager {
     /// @notice Current burn percentage applied to rewards
     function burnPct() external view returns (uint256);
 
+    /// @notice Cap on total payout percentage across AGI types
+    function maxTotalPayoutPct() external view returns (uint256);
+
     /// @notice ERC20 token used for staking operations
     function token() external view returns (IERC20);
 
@@ -188,6 +192,7 @@ interface IStakeManager {
     function setTreasuryAllowlist(address _treasury, bool allowed) external;
     function setMaxStakePerAddress(uint256 maxStake) external;
     function setMaxAGITypes(uint256 newMax) external;
+    function setMaxTotalPayoutPct(uint256 newMax) external;
     function addAGIType(address nft, uint256 payoutPct) external;
     function removeAGIType(address nft) external;
     function setFeePct(uint256 pct) external;

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -114,6 +114,12 @@ contract ReentrantStakeManager is IStakeManager {
         return 0;
     }
 
+    function maxTotalPayoutPct() external pure override returns (uint256) {
+        return 100;
+    }
+
+    function setMaxTotalPayoutPct(uint256) external override {}
+
     function slash(address user, Role role, uint256 amount, address) external override {
         if (attackSlash) {
             attackSlash = false;

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -1,6 +1,6 @@
 # StakeManager API
 
-Handles staking, escrow and slashing of the $AGIALPHA token. NFT ownership can boost payouts cumulatively; extra amounts are funded from protocol fees or reduced burns.
+Handles staking, escrow and slashing of the $AGIALPHA token. NFT ownership boosts payouts by applying the highest approved multiplier; extra amounts are funded from protocol fees or reduced burns.
 
 ## Functions
 
@@ -15,10 +15,11 @@ Handles staking, escrow and slashing of the $AGIALPHA token. NFT ownership can b
 - `slash(address user, uint8 role, uint256 amount, address employer)` – JobRegistry slashes the user's stake for a given role and routes the employer share.
 - `slash(address user, uint256 amount, address recipient)` – DisputeModule slashes validator stake during disputes and sends the slashed amount to `recipient`.
 - `setMaxAGITypes(uint256 newMax)` – cap the number of AGI type entries.
-- `addAGIType(address nft, uint256 payoutPct)` – register or update a payout multiplier for holders of `nft`. Multipliers from multiple NFTs **stack** by adding `payoutPct - 100` for each type. Each entry is capped at `MAX_PAYOUT_PCT` (200%).
+- `setMaxTotalPayoutPct(uint256 newMax)` – cap the total payout percentage across AGI types.
+- `addAGIType(address nft, uint256 payoutPct)` – register or update a payout multiplier for holders of `nft`. Only the highest multiplier applies. Each entry is capped at `MAX_PAYOUT_PCT` (200%) and totals are further limited by `maxTotalPayoutPct`.
 - `removeAGIType(address nft)` – delete a previously registered AGI type.
 - `syncBoostedStake(address user, uint8 role)` – recalculate a user's boosted stake after NFT changes. `FeePool.claimRewards` calls this automatically for the reward role.
-- `stakeOf(address user, uint8 role)` / `totalStake(uint8 role)` / `totalBoostedStake(uint8 role)` / `getTotalPayoutPct(address user)` – view functions. `getTotalPayoutPct` returns `100 + Σ(payoutPct_i - 100)` and may exceed `200` when multiple NFTs are held.
+- `stakeOf(address user, uint8 role)` / `totalStake(uint8 role)` / `totalBoostedStake(uint8 role)` / `getTotalPayoutPct(address user)` – view functions. `getTotalPayoutPct` returns the highest `payoutPct` among held NFTs (or `100` when none) capped by `maxTotalPayoutPct`.
 
 ## Events
 
@@ -34,5 +35,6 @@ Handles staking, escrow and slashing of the $AGIALPHA token. NFT ownership can b
 - `FeePctUpdated(uint256 pct)` / `BurnPctUpdated(uint256 pct)` / `ValidatorRewardPctUpdated(uint256 pct)`
 - `ModulesUpdated(address indexed jobRegistry, address indexed disputeModule)`
 - `MaxAGITypesUpdated(uint256 oldMax, uint256 newMax)`
+- `MaxTotalPayoutPctUpdated(uint256 oldMax, uint256 newMax)`
 - `AGITypeUpdated(address indexed nft, uint256 payoutPct)`
 - `AGITypeRemoved(address indexed nft)`

--- a/docs/enhanced-nft-incentive-model.md
+++ b/docs/enhanced-nft-incentive-model.md
@@ -4,29 +4,29 @@
 
 The original on-chain manager (v0) granted a single-tier payout boost to agents or validators that owned an eligible ENS subdomain NFT. The bonus increased job costs for employers and did not apply to platform operators.
 
-The v2 architecture introduces a list of `AGIType` entries in `StakeManager` that associates approved NFT contracts with specific payout multipliers. **Boosts are cumulative**: for every NFT the user holds, the contract adds `(payoutPct - 100)` to the running total, starting from `100`. Two NFTs at `150%` and `125%` yield `100 + 50 + 25 = 175%`. Agents already benefit from this mechanism; the enhanced model extends the same logic to validators and platform operators so every core role can earn more when holding multiple approved NFTs.
+The v2 architecture introduces a list of `AGIType` entries in `StakeManager` that associates approved NFT contracts with specific payout multipliers. **Only the highest multiplier applies**: the contract tracks the maximum `payoutPct` across all NFTs the user holds, starting from the baseline `100`. With NFTs at `150%` and `125%` the effective multiplier remains `150%`. Agents already benefit from this mechanism; the enhanced model extends the same logic to validators and platform operators so every core role can earn more when holding an approved NFT.
 
 ## 2. NFT Reward Multiplier Implementation
 
-- **Agents** – `StakeManager.getTotalPayoutPct` multiplies an agent's base reward by the sum of all applicable tiers. Employers escrow only the base reward; any bonus is covered by reduced burns or fees. If neither fee nor burn is available to absorb the difference, the call reverts with `InsufficientEscrow`.
+- **Agents** – `StakeManager.getTotalPayoutPct` applies the highest applicable multiplier to an agent's base reward. Employers escrow only the base reward; any bonus is covered by reduced burns or fees. If neither fee nor burn is available to absorb the difference, the call reverts with `InsufficientEscrow`.
 - **Validators** – `distributeValidatorRewards` weights each validator's share by their multiplier. A 150% NFT counts as weight `150` versus the default `100`.
 - **Platform operators** – the `FeePool` exposes `boostedStake(address)` to reveal a staker's weight (`stake * multiplier / 100`). Off-chain scripts can use this to apportion fee distributions so that operators with NFTs receive a larger portion of the fee pool. Participants should call `StakeManager.syncBoostedStake` after acquiring or losing an NFT to refresh their weight; `FeePool` invokes this helper automatically for callers when distributing or claiming rewards.
 
 ### Example Payouts
 
 - **Single NFT:** Base reward `10` with a `150%` boost pays `15` tokens. The extra `5` tokens are drawn from the reward pool funded by protocol fees and reduced burns.
-- **Multiple NFTs:** Base reward `10`, holder owns `150%` and `125%` NFTs → total multiplier `175%` → payout `17.5` tokens. The additional `7.5` tokens come from the same fee/burn pool. If fee and burn shares together cannot fund the bonus, the transaction reverts.
+- **Multiple NFTs:** Base reward `10`, holder owns `150%` and `125%` NFTs → multiplier `150%` → payout `15` tokens. The additional `5` tokens come from the same fee/burn pool. If fee and burn shares together cannot fund the bonus, the transaction reverts.
 
 ### Snapshot Rules and Claims
 
 - Reward percentages are snapshot at the moment `releaseReward` or `syncBoostedStake` runs. Acquiring or selling an NFT requires `StakeManager.syncBoostedStake(user, role)` before claiming from the `FeePool` to update the snapshot.
 - `FeePool.claimRewards` automatically syncs and pays out based on the current multiplier, even when the total exceeds `100%`. Agents and validators receive boosted amounts during `releaseReward` with no extra steps.
 
-The `getTotalPayoutPct` function is a general utility that any module can call to check the cumulative multiplier for a given address and now serves agents, validators and platform participants alike.
+The `getTotalPayoutPct` function is a general utility that any module can call to check the applicable multiplier for a given address and now serves agents, validators and platform participants alike.
 
 ## 3. Game-Theoretic Robustness
 
-Weighting rewards by cumulative NFT multipliers removes the equal‑split sybil attack among validators and aligns incentives across roles. Each tier is capped at 200%, but totals can exceed `200%` when stacking multiple NFTs. Employers are not penalised for hiring NFT holders because extra payouts are subsidised by reduced burns or fees, so the best agents remain attractive hires.
+Weighting rewards by NFT multipliers removes the equal‑split sybil attack among validators and aligns incentives across roles. Each tier is capped at 200%, and a configurable global cap (`maxTotalPayoutPct`, default `200`) prevents payouts from exceeding system limits even if multiple NFTs are held. Employers are not penalised for hiring NFT holders because extra payouts are subsidised by reduced burns or fees, so the best agents remain attractive hires.
 
 ## 4. Simulation of Reward Outcomes
 
@@ -35,6 +35,6 @@ Simulations show NFT holders consistently earn more than non‑holders while tot
 ## 5. Milestone-Based Implementation Plan
 
 1. **Design finalisation** – approve NFT tiers, payout caps and the list of supported contracts.
-2. **Solidity changes** – generalise `getTotalPayoutPct`, weight validator rewards, provide `boostedStake` for platform calculations and enforce the per-tier 200% cap.
+2. **Solidity changes** – generalise `getTotalPayoutPct`, weight validator rewards, provide `boostedStake` for platform calculations and enforce per-tier and global payout caps.
 3. **Simulation and audit** – unit tests and economic simulations confirm robustness; fix any findings.
 4. **Documentation and deployment** – update guides, deploy upgrades and announce NFT reward boosts to the community.

--- a/docs/master-guide.md
+++ b/docs/master-guide.md
@@ -308,7 +308,7 @@ All amounts are `$AGIALPHA` **wei** (18 decimals). **Always** `approve` the rele
   - FeePool collects fee; **burnPct** triggers **`burn(...)`** on `$AGIALPHA`.
   - CertificateNFT mints to the Agent.
   - Reputation updates.
-  - **NFT boosts:** payouts scale by the cumulative multiplier returned from `StakeManager.getTotalPayoutPct`. Multiple NFTs add their boosts (`100 + Σ(payoutPct_i - 100)`), so `150%` + `125%` yields `175%`. Extra tokens are taken from fee and burn shares; if those pools lack funds the call reverts with `InsufficientEscrow`.
+  - **NFT boosts:** payouts scale by the highest multiplier returned from `StakeManager.getTotalPayoutPct`. Holding multiple NFTs uses only the largest `payoutPct` (e.g., `150%` and `125%` yield `150%`). Extra tokens are taken from fee and burn shares; if those pools lack funds the call reverts with `InsufficientEscrow`.
   - **Snapshot & claim:** multipliers are checked at payout. Stakers who obtain or lose NFTs should call `StakeManager.syncBoostedStake` before claiming from the `FeePool`. `FeePool.claimRewards()` performs this step automatically and pays boosted rewards even when totals exceed `100%`.
 
 ### 8.5 Disputes

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -65,9 +65,9 @@ await registry.connect(employer).finalize(jobId);
 
 ## 5. Reward Boosts and Claims
 
-Holding approved NFTs increases payouts by adding their percentage boosts. Total multiplier = `100 + Σ(payoutPct_i - 100)`.
+Holding approved NFTs increases payouts by applying the highest percentage boost. Total multiplier = `max(payoutPct_i, 100)` capped by `maxTotalPayoutPct`.
 
-Example: with `150%` and `125%` NFTs the multiplier becomes `175%` and a `10` token reward pays `17.5`. Extra tokens are funded from the protocol fee and burn pool; if those pools cannot cover the bonus, finalization reverts with `InsufficientEscrow`.
+Example: with `150%` and `125%` NFTs the multiplier remains `150%` and a `10` token reward pays `15`. Extra tokens are funded from the protocol fee and burn pool; if those pools cannot cover the bonus, finalization reverts with `InsufficientEscrow`.
 
 Stakers who gain or lose NFTs should snapshot their weight before claiming:
 
@@ -76,7 +76,7 @@ Stakers who gain or lose NFTs should snapshot their weight before claiming:
 await stake.syncBoostedStake(user.address, role); // 0=agent, 1=validator, 2=platform
 ```
 
-`FeePool.claimRewards()` automatically calls this helper and pays out boosted rewards even when totals exceed `100%`.
+`FeePool.claimRewards()` automatically calls this helper and pays out boosted rewards even when the multiplier exceeds `100%`.
 
 ## FAQ
 

--- a/test/v2/AGITypeEdge.test.js
+++ b/test/v2/AGITypeEdge.test.js
@@ -76,17 +76,17 @@ describe('StakeManager AGIType bonuses', function () {
     await token.mint(employer.address, 1000);
   });
 
-  it('stacks AGIType bonuses', async () => {
+  it('applies highest AGIType bonus', async () => {
     await stakeManager.connect(owner).addAGIType(await nft1.getAddress(), 150);
     await stakeManager.connect(owner).addAGIType(await nft2.getAddress(), 175);
     await nft1.mint(agent.address);
     await nft2.mint(agent.address);
 
     const jobId = ethers.encodeBytes32String('job1');
-    await token.connect(employer).approve(await stakeManager.getAddress(), 225);
+    await token.connect(employer).approve(await stakeManager.getAddress(), 175);
     await stakeManager
       .connect(registrySigner)
-      .lockReward(jobId, employer.address, 225);
+      .lockReward(jobId, employer.address, 175);
 
     await expect(
       stakeManager
@@ -94,10 +94,10 @@ describe('StakeManager AGIType bonuses', function () {
         .releaseReward(jobId, employer.address, agent.address, 100)
     )
       .to.emit(stakeManager, 'RewardPaid')
-      .withArgs(jobId, agent.address, 225);
+      .withArgs(jobId, agent.address, 175);
 
-    expect(await stakeManager.getTotalPayoutPct(agent.address)).to.equal(225n);
-    expect(await token.balanceOf(agent.address)).to.equal(225n);
+    expect(await stakeManager.getTotalPayoutPct(agent.address)).to.equal(175n);
+    expect(await token.balanceOf(agent.address)).to.equal(175n);
     expect(await stakeManager.jobEscrows(jobId)).to.equal(0n);
   });
 
@@ -121,14 +121,22 @@ describe('StakeManager AGIType bonuses', function () {
       .withArgs(jobId, agent.address, 100);
   });
 
-  it('counts each AGIType at most once', async () => {
+  it('ignores duplicate NFTs', async () => {
     await stakeManager.connect(owner).addAGIType(await nft1.getAddress(), 150);
     await stakeManager.connect(owner).addAGIType(await nft2.getAddress(), 175);
     await nft1.mint(agent.address);
     await nft1.mint(agent.address);
     await nft2.mint(agent.address);
 
-    expect(await stakeManager.getTotalPayoutPct(agent.address)).to.equal(225n);
+    expect(await stakeManager.getTotalPayoutPct(agent.address)).to.equal(175n);
+  });
+
+  it('caps total payout percentage', async () => {
+    await stakeManager.connect(owner).addAGIType(await nft1.getAddress(), 180);
+    await nft1.mint(agent.address);
+    await stakeManager.connect(owner).setMaxTotalPayoutPct(150);
+
+    expect(await stakeManager.getTotalPayoutPct(agent.address)).to.equal(150n);
   });
 
   it('reverts when bonus payout exceeds escrow and no fees or burns are set', async () => {


### PR DESCRIPTION
## Summary
- return highest AGIType multiplier instead of stacking boosts
- cap NFT payout percentages with configurable `maxTotalPayoutPct`
- document and test new max-based reward logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c248363a04833393042d2713d379d5