### PR TITLE
feat(gateway): enforce ENS subdomains

### DIFF
--- a/agent-gateway/routes.ts
+++ b/agent-gateway/routes.ts
@@ -96,12 +96,12 @@ app.post(
     const wallet = walletManager.get(address);
     if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
     try {
-      const warning = await checkEnsSubdomain(wallet.address);
+      await checkEnsSubdomain(wallet.address);
       const tx = await (registry as any)
         .connect(wallet)
         .applyForJob(req.params.id, '', '0x');
       await tx.wait();
-      res.json(warning ? { tx: tx.hash, warning } : { tx: tx.hash });
+      res.json({ tx: tx.hash });
     } catch (err: any) {
       res.status(500).json({ error: err.message });
     }
@@ -117,13 +117,13 @@ app.post(
     const wallet = walletManager.get(address);
     if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
     try {
-      const warning = await checkEnsSubdomain(wallet.address);
+      await checkEnsSubdomain(wallet.address);
       const hash = ethers.id(result || '');
       const tx = await (registry as any)
         .connect(wallet)
         .submit(req.params.id, hash, result || '', '', '0x');
       await tx.wait();
-      res.json(warning ? { tx: tx.hash, warning } : { tx: tx.hash });
+      res.json({ tx: tx.hash });
     } catch (err: any) {
       res.status(500).json({ error: err.message });
     }

--- a/agent-gateway/utils.ts
+++ b/agent-gateway/utils.ts
@@ -133,7 +133,7 @@ export async function initWallets(): Promise<void> {
 
 export async function checkEnsSubdomain(
   address: string
-): Promise<string | null> {
+): Promise<void> {
   try {
     const name = await provider.lookupAddress(address);
     if (
@@ -141,7 +141,7 @@ export async function checkEnsSubdomain(
       (name.endsWith('.agent.agi.eth') || name.endsWith('.club.agi.eth')) &&
       name.split('.').length > 3
     ) {
-      return null;
+      return;
     }
   } catch {
     // ignore lookup errors and fall through to warning
@@ -149,7 +149,7 @@ export async function checkEnsSubdomain(
   const warning =
     'No valid *.agent.agi.eth or *.club.agi.eth subdomain detected for this address. See docs/ens-identity-setup.md';
   console.warn(warning);
-  return warning;
+  throw new Error(warning);
 }
 
 export async function verifyTokenDecimals(): Promise<void> {
@@ -287,9 +287,9 @@ export async function commitHelper(
   jobId: string,
   wallet: Wallet,
   approve: boolean
-): Promise<{ tx: string; salt: string; warning?: string }> {
+): Promise<{ tx: string; salt: string }> {
   if (!validation) throw new Error('validation module not configured');
-  const warning = await checkEnsSubdomain(wallet.address);
+  await checkEnsSubdomain(wallet.address);
   const nonce = await validation.jobNonce(jobId);
   const salt = ethers.hexlify(ethers.randomBytes(32));
   const commitHash = ethers.solidityPackedKeccak256(
@@ -303,22 +303,22 @@ export async function commitHelper(
   if (!commits.has(jobId)) commits.set(jobId, {});
   const jobCommits = commits.get(jobId)!;
   jobCommits[wallet.address.toLowerCase()] = { approve, salt };
-  return warning ? { tx: tx.hash, salt, warning } : { tx: tx.hash, salt };
+  return { tx: tx.hash, salt };
 }
 
 export async function revealHelper(
   jobId: string,
   wallet: Wallet
-): Promise<{ tx: string; warning?: string }> {
+): Promise<{ tx: string }> {
   if (!validation) throw new Error('validation module not configured');
   const jobCommits = commits.get(jobId) || {};
   const data = jobCommits[wallet.address.toLowerCase()];
   if (!data) throw new Error('no commit found');
-  const warning = await checkEnsSubdomain(wallet.address);
+  await checkEnsSubdomain(wallet.address);
   const tx = await (validation as any)
     .connect(wallet)
     .revealValidation(jobId, data.approve, data.salt, '', []);
   await tx.wait();
   delete jobCommits[wallet.address.toLowerCase()];
-  return warning ? { tx: tx.hash, warning } : { tx: tx.hash };
+  return { tx: tx.hash };
 }


### PR DESCRIPTION
## Summary
- throw when wallet lacks required *.agent.agi.eth or *.club.agi.eth ENS subdomain
- halt apply and submit job routes if no valid subdomain

## Testing
- `npm run build:gateway`
- `npm test`
- `npm run lint` *(fails: 37 problems (1 error, 36 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c24e8b6e008333872f7514d7a4669f