### PR TITLE
feat(gateway): enforce ENS subdomains

### DIFF
--- a/agent-gateway/routes.ts
+++ b/agent-gateway/routes.ts
@@ -96,12 +96,12 @@ app.post(
     const wallet = walletManager.get(address);
     if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
     try {
-      const warning = await checkEnsSubdomain(wallet.address);
+      await checkEnsSubdomain(wallet.address);
       const tx = await (registry as any)
         .connect(wallet)
         .applyForJob(req.params.id, '', '0x');
       await tx.wait();
-      res.json(warning ? { tx: tx.hash, warning } : { tx: tx.hash });
+      res.json({ tx: tx.hash });
     } catch (err: any) {
       res.status(500).json({ error: err.message });
     }
@@ -117,13 +117,13 @@ app.post(
     const wallet = walletManager.get(address);
     if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
     try {
-      const warning = await checkEnsSubdomain(wallet.address);
+      await checkEnsSubdomain(wallet.address);
       const hash = ethers.id(result || '');
       const tx = await (registry as any)
         .connect(wallet)
         .submit(req.params.id, hash, result || '', '', '0x');
       await tx.wait();
-      res.json(warning ? { tx: tx.hash, warning } : { tx: tx.hash });
+      res.json({ tx: tx.hash });
     } catch (err: any) {
       res.status(500).json({ error: err.message });
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ const tsParser = require('@typescript-eslint/parser');
 
 module.exports = [
   {
-    ignores: ['scripts/**/*.js'],
+    ignores: ['scripts/**/*.js', '**/dist/**'],
   },
   {
     files: ['**/*.js'],


### PR DESCRIPTION
## Summary
- throw when wallet lacks required *.agent.agi.eth or *.club.agi.eth ENS subdomain
- halt apply and submit job routes if no valid subdomain
- ignore build artifacts in lint config and fix checkEnsSubdomain formatting

## Testing
- `npm run build:gateway`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c24e8b6e008333872f7514d7a4669f