### PR TITLE
Handle gateway shutdown

### DIFF
--- a/agent-gateway/index.ts
+++ b/agent-gateway/index.ts
@@ -7,6 +7,7 @@ import {
   PORT,
   walletManager,
   startSweeper,
+  stopSweeper,
 } from './utils';
 import { registerEvents } from './events';
 
@@ -34,6 +35,20 @@ async function startGateway(): Promise<void> {
 }
 
 startGateway();
+
+function shutdown(): void {
+  console.log('Shutting down agent gateway...');
+  if (wss) wss.close();
+  stopSweeper();
+  if (server) {
+    server.close(() => process.exit(0));
+  } else {
+    process.exit(0);
+  }
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
 
 export { app };
 export const getServer = () => server;

--- a/agent-gateway/utils.ts
+++ b/agent-gateway/utils.ts
@@ -82,8 +82,15 @@ export function sweepStaleJobs(now = Date.now()): void {
     }
   }
 }
-export function startSweeper(): void {
-  setInterval(() => sweepStaleJobs(), SWEEP_INTERVAL_MS);
+let sweeperInterval: NodeJS.Timeout;
+
+export function startSweeper(): NodeJS.Timeout {
+  sweeperInterval = setInterval(() => sweepStaleJobs(), SWEEP_INTERVAL_MS);
+  return sweeperInterval;
+}
+
+export function stopSweeper(): void {
+  if (sweeperInterval) clearInterval(sweeperInterval);
 }
 const finalizeTimers = new Map<string, NodeJS.Timeout>();
 const expiryTimers = new Map<string, NodeJS.Timeout>();


### PR DESCRIPTION
## Summary
- Close WebSocket, stop sweeper, and shut down HTTP server on SIGINT/SIGTERM
- Expose start/stop functions for sweeper interval

## Testing
- `npm test` *(fails: hangs downloading Hardhat compilers)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c2d27128048333baad843dbcddd5b1