### PR TITLE
Enforce ENS subdomain validation

### DIFF
--- a/agent-gateway/routes.ts
+++ b/agent-gateway/routes.ts
@@ -97,6 +97,10 @@ app.post(
     if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
     try {
       await checkEnsSubdomain(wallet.address);
+    } catch (err: any) {
+      return res.status(400).json({ error: err.message });
+    }
+    try {
       const tx = await (registry as any)
         .connect(wallet)
         .applyForJob(req.params.id, '', '0x');
@@ -118,6 +122,10 @@ app.post(
     if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
     try {
       await checkEnsSubdomain(wallet.address);
+    } catch (err: any) {
+      return res.status(400).json({ error: err.message });
+    }
+    try {
       const hash = ethers.id(result || '');
       const tx = await (registry as any)
         .connect(wallet)

--- a/agent-gateway/utils.ts
+++ b/agent-gateway/utils.ts
@@ -185,10 +185,9 @@ export async function checkEnsSubdomain(address: string): Promise<void> {
   } catch {
     // ignore lookup errors and fall through to warning
   }
-  const warning =
-    'No valid *.agent.agi.eth or *.club.agi.eth subdomain detected for this address. See docs/ens-identity-setup.md';
-  console.warn(warning);
-  throw new Error(warning);
+  throw new Error(
+    'No valid *.agent.agi.eth or *.club.agi.eth subdomain detected for this address. See docs/ens-identity-setup.md'
+  );
 }
 
 export async function verifyTokenDecimals(): Promise<void> {


### PR DESCRIPTION
## Summary
- Throw an error when no valid agent ENS subdomain is found
- Abort job apply/submit transactions if the subdomain check fails

## Testing
- `npm run build:gateway`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2fb71cd948333b419e2a49c9a97dd