### PR TITLE
refactor: throw errors from wallet init

### DIFF
--- a/agent-gateway/index.ts
+++ b/agent-gateway/index.ts
@@ -15,26 +15,24 @@ let server: http.Server;
 let wss: WebSocketServer;
 
 async function startGateway(): Promise<void> {
-  try {
-    await verifyTokenDecimals();
-    await initWallets();
+  await verifyTokenDecimals();
+  await initWallets();
 
-    server = http.createServer(app);
-    wss = new WebSocketServer({ server });
-    registerEvents(wss);
-    startSweeper();
+  server = http.createServer(app);
+  wss = new WebSocketServer({ server });
+  registerEvents(wss);
+  startSweeper();
 
-    server.listen(PORT, () => {
-      console.log(`Agent gateway listening on port ${PORT}`);
-      console.log('Wallets:', walletManager.list());
-    });
-  } catch (err) {
-    console.error('Gateway startup failed', err);
-    process.exit(1);
-  }
+  server.listen(PORT, () => {
+    console.log(`Agent gateway listening on port ${PORT}`);
+    console.log('Wallets:', walletManager.list());
+  });
 }
 
-startGateway();
+startGateway().catch((err) => {
+  console.error('Gateway startup failed', err);
+  process.exit(1);
+});
 
 function shutdown(): void {
   console.log('Shutting down agent gateway...');

--- a/agent-gateway/utils.ts
+++ b/agent-gateway/utils.ts
@@ -166,9 +166,8 @@ export async function initWallets(): Promise<void> {
       const [first] = walletManager.list();
       if (first) automationWallet = walletManager.get(first);
     }
-  } catch (err) {
-    console.error('Failed to initialize wallets', err);
-    throw err;
+  } catch (err: any) {
+    throw new Error(`Failed to initialize wallets: ${err.message}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- throw initialization errors from `initWallets`
- handle gateway startup failures by catching at the top level

## Testing
- `npm run build:gateway`
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c2fe04867083338ffa3ec6d5b1ab92