### PR TITLE
docs: add Truffle mainnet deployment guide

### DIFF
--- a/docs/deploy-mainnet-truffle-cli.md
+++ b/docs/deploy-mainnet-truffle-cli.md
@@ -1,0 +1,86 @@
+# Deploying AGIJobs v2 to Ethereum Mainnet (CLI Guide)
+
+This guide walks through a production‑grade deployment of the AGIJobs v2
+contracts to Ethereum mainnet using the Truffle CLI. It assumes you are
+deploying the canonical $AGIALPHA stack and want all modules wired together
+in one transaction.
+
+## Prerequisites
+
+1. **Node & npm** – Use Node 20.x and npm 10+. A matching `nvm` version is
+   recommended.
+2. **Dependencies** – Clone the repository and install packages:
+   ```bash
+   git clone https://github.com/MontrealAI/AGIJobsv0.git
+   cd AGIJobsv0
+   npm install
+   ```
+3. **Truffle** – Install Truffle globally or use `npx`:
+   ```bash
+   npm install -g truffle
+   ```
+4. **Ethereum access** – An RPC endpoint (Infura/Alchemy etc.) and a deployer
+   private key with enough ETH.
+5. **Governance address** – Multisig or timelock that will own the system.
+6. **Etherscan API key** – Enables automatic verification.
+
+## Environment variables
+
+Create a `.env` file or export the variables before running Truffle:
+
+```bash
+export MAINNET_PRIVATE_KEY="0x..."         # deployer key
+export MAINNET_RPC_URL="https://mainnet.infura.io/v3/<id>"
+export GOVERNANCE_ADDRESS="0xYourMultisig"
+export ETHERSCAN_API_KEY="YourKey"         # optional but recommended
+# Optional overrides
+export FEE_PCT=5                           # protocol fee (0‑100)
+export BURN_PCT=5                          # burn percentage (0‑100)
+export NO_TAX=true                         # set to skip TaxPolicy
+```
+
+The `$AGIALPHA` token address and decimals are fixed in
+`config/agialpha.json` and compiled into the contracts; no extra token
+configuration is required.
+
+## Compile
+
+```bash
+truffle compile
+```
+
+## Deploy
+
+Run the migration for mainnet. The repository already includes a migration that
+deploys and wires the entire module set:
+
+```bash
+truffle migrate --network mainnet
+```
+
+The script prints the addresses for StakeManager, JobRegistry, ValidationModule
+and the rest. Save them for later use.
+
+## Verify
+
+After deployment, verify the contracts on Etherscan. Example:
+
+```bash
+truffle run verify Deployer StakeManager JobRegistry ValidationModule \
+  ReputationEngine DisputeModule CertificateNFT PlatformRegistry JobRouter \
+  PlatformIncentives FeePool TaxPolicy IdentityRegistry SystemPause \
+  --network mainnet
+```
+
+Only include `TaxPolicy` in the command if you did not set `NO_TAX`.
+
+## Post‑deployment checks
+
+1. Confirm each contract is owned by your governance address (or by the
+   `SystemPause` contract where applicable).
+2. Test pausing and unpausing through the `SystemPause` contract.
+3. Optionally run `npm run verify:wiring` to ensure all module addresses point
+   to each other correctly.
+
+With these steps you have a repeatable, production‑ready path for launching
+AGIJobs v2 to Ethereum mainnet using the Truffle CLI.

--- a/migrations/2_deploy_agijobs_v2.js
+++ b/migrations/2_deploy_agijobs_v2.js
@@ -1,5 +1,14 @@
 const Deployer = artifacts.require('Deployer');
 
+/**
+ * Truffle migration for deploying the full AGIJobs v2 stack.
+ *
+ * Environment variables:
+ *  - GOVERNANCE_ADDRESS : multisig/timelock that will own the system
+ *  - NO_TAX             : set to any value to skip TaxPolicy deployment
+ *  - FEE_PCT            : protocol fee percentage (default 5)
+ *  - BURN_PCT           : fee burn percentage (default 5)
+ */
 module.exports = async function (deployer, network, accounts) {
   const governance = process.env.GOVERNANCE_ADDRESS || accounts[0];
   const withTax = !process.env.NO_TAX;
@@ -9,6 +18,7 @@ module.exports = async function (deployer, network, accounts) {
   await deployer.deploy(Deployer);
   const instance = await Deployer.deployed();
 
+  // Mainnet ENS registry, NameWrapper and AGIJobs subdomain roots
   const ids = {
     ens: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     nameWrapper: '0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401',


### PR DESCRIPTION
## Summary
- add user-friendly guide for deploying AGIJobs v2 to Ethereum mainnet using Truffle CLI
- document environment variables and commands for production deployment
- clarify migration script with env var comments and mainnet ENS constants

## Testing
- `npx prettier migrations/2_deploy_agijobs_v2.js docs/deploy-mainnet-truffle-cli.md --check`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c312925f348333810759a3d5be10d6