### PR TITLE
docs: add mainnet truffle CLI guide

### DIFF
--- a/docs/deploy-mainnet-truffle-cli.md
+++ b/docs/deploy-mainnet-truffle-cli.md
@@ -21,8 +21,11 @@ in one transaction.
    ```
 4. **Ethereum access** – An RPC endpoint (Infura/Alchemy etc.) and a deployer
    private key with enough ETH.
-5. **Governance address** – Multisig or timelock that will own the system.
-6. **Etherscan API key** – Enables automatic verification.
+ 5. **Governance address** – Multisig or timelock that will own the system.
+ 6. **Etherscan API key** – Enables automatic verification.
+ 7. **Dry-run** – Always run the migration on a public testnet (e.g. Sepolia)
+    with the same environment variables to confirm gas usage and wiring
+    before attempting a mainnet deployment.
 
 ## Environment variables
 

--- a/migrations/2_deploy_agijobs_v2.js
+++ b/migrations/2_deploy_agijobs_v2.js
@@ -1,13 +1,18 @@
 const Deployer = artifacts.require('Deployer');
 
 /**
- * Truffle migration for deploying the full AGIJobs v2 stack.
+ * Truffle migration for deploying the full AGIJobs v2 stack on Ethereum
+ * mainnet. It assumes the canonical $AGIALPHA token and mainnet ENS root
+ * nodes defined in `contracts/v2/Constants.sol` and below.
  *
  * Environment variables:
  *  - GOVERNANCE_ADDRESS : multisig/timelock that will own the system
  *  - NO_TAX             : set to any value to skip TaxPolicy deployment
  *  - FEE_PCT            : protocol fee percentage (default 5)
  *  - BURN_PCT           : fee burn percentage (default 5)
+ *
+ * Run on a testnet first to confirm configuration before mainnet:
+ * `npx truffle migrate --network sepolia`
  */
 module.exports = async function (deployer, network, accounts) {
   const governance = process.env.GOVERNANCE_ADDRESS || accounts[0];


### PR DESCRIPTION
## Summary
- document production-grade Truffle deployment for AGIJobs v2 on Ethereum mainnet
- add testnet dry-run reminder and clarify canonical token/ENS use in deployment script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3230ec9d48333bcd58e6582798083