### PR TITLE
docs: add truffle mainnet deployment guide

### DIFF
--- a/docs/deploying-agijobs-v2-mainnet-cli-guide.md
+++ b/docs/deploying-agijobs-v2-mainnet-cli-guide.md
@@ -6,6 +6,21 @@ This guide explains how to deploy the production AGIJobs v2 contract suite to Et
 
 AGIJobs v2 coordinates trustless labour markets between autonomous agents. The repository (named `AGIJobsv0`) contains all contracts and a migration that deploys StakeManager, JobRegistry, ReputationEngine and other modules in one transaction. The steps below follow best practices for a production launch: using a governance multisig, verifying source code and keeping pause controls ready.
 
+```mermaid
+%%{init: {'theme':'forest', 'themeVariables': { 'primaryColor': '#ffecd1', 'secondaryColor': '#c1fba4', 'tertiaryColor': '#a7f3d0', 'fontSize': '16px', 'textColor': '#1f2937', 'lineColor': '#4b5563'}}}%%
+flowchart LR
+    A[Configure Environment\nkeys, RPC, governance]:::prep --> B[Compile Contracts]:::compile
+    B --> C[Run Migration]:::deploy
+    C --> D[Verify on Etherscan]:::verify
+    D --> E[Post-Deployment Checks]:::post
+
+    classDef prep fill:#ffecd1,stroke:#d97706,color:#1f2937;
+    classDef compile fill:#c1fba4,stroke:#16a34a,color:#1f2937;
+    classDef deploy fill:#a7f3d0,stroke:#0d9488,color:#1f2937;
+    classDef verify fill:#bfdbfe,stroke:#1d4ed8,color:#1f2937;
+    classDef post fill:#e9d5ff,stroke:#7c3aed,color:#1f2937;
+```
+
 ## Prerequisites & setup
 
 - **Node & npm** – install Node.js 20.x and npm 10+. The repo includes an `.nvmrc` to help match versions.
@@ -23,6 +38,7 @@ AGIJobs v2 coordinates trustless labour markets between autonomous agents. The r
   export GOVERNANCE_ADDRESS="0x<multisig_or_timelock>"
   export ETHERSCAN_API_KEY="<key>"
   ```
+- **Funding** – ensure the deployer account holds sufficient ETH to cover gas for all contract creations.
 - **Token & ENS** – `$AGIALPHA` lives at `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`. Ensure you control `agi.eth` if enforcing ENS subdomains or adjust the migration.
 - **Dry‑run** – test the process on a public testnet (Sepolia/Goerli) before mainnet to confirm gas usage and environment variables.
 

--- a/migrations/2_deploy_agijobs_v2.js
+++ b/migrations/2_deploy_agijobs_v2.js
@@ -11,6 +11,11 @@ const Deployer = artifacts.require('Deployer');
  *  - FEE_PCT            : protocol fee percentage (default 5)
  *  - BURN_PCT           : fee burn percentage (default 5)
  *
+ * After deployment, verify contracts with:
+ * `npx truffle run verify Deployer StakeManager JobRegistry ValidationModule ReputationEngine DisputeModule CertificateNFT PlatformRegistry JobRouter PlatformIncentives FeePool IdentityRegistry SystemPause --network mainnet`
+ * (include TaxPolicy if deployed)
+ * See docs/deploying-agijobs-v2-mainnet-cli-guide.md for full instructions.
+ *
  * Run on a testnet first to confirm configuration before mainnet:
  * `npx truffle migrate --network sepolia`
  */


### PR DESCRIPTION
## Summary
- add colorful mermaid-driven CLI instructions for Truffle mainnet deployments
- document funding requirement and Etherscan verification steps
- annotate migration with post-deployment verification guidance

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c32fbbbecc83338ad7894b6d05715e