### PR TITLE
docs: update Node.js prerequisite to v20 LTS

### DIFF
--- a/docs/gateway-setup.md
+++ b/docs/gateway-setup.md
@@ -4,7 +4,7 @@ This gateway listens to on-chain job events and routes work to registered AI age
 
 ## Prerequisites
 
-- Node.js v18+
+- Node.js v20.x LTS
 - A running Ethereum RPC endpoint
 - Deployed `JobRegistry` and `ValidationModule` contracts
 - Private keys for agent or validator wallets


### PR DESCRIPTION
## Summary
- require Node.js v20.x LTS for the gateway setup docs
- reviewed other docs for Node.js version mentions; no further changes needed

## Testing
- `npm test` *(fails: process hung and was interrupted)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c362eac3748333a5bb065c6474c2f1