### PR TITLE
feat: add thermodynamic reward scaffold

### DIFF
--- a/contracts/v2/EnergyOracle.sol
+++ b/contracts/v2/EnergyOracle.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title EnergyOracle
+/// @notice Verifies signed energy attestations used for reward settlement.
+contract EnergyOracle is EIP712, Ownable {
+    using ECDSA for bytes32;
+
+    bytes32 public constant TYPEHASH = keccak256(
+        "EnergyAttestation(uint256 jobId,address user,int256 energy,uint256 degeneracy,uint256 nonce,uint256 deadline)"
+    );
+
+    mapping(address => bool) public signers;
+    mapping(address => uint256) public nonces;
+
+    struct Attestation {
+        uint256 jobId;
+        address user;
+        int256 energy;
+        uint256 degeneracy;
+        uint256 nonce;
+        uint256 deadline;
+    }
+
+    constructor() EIP712("EnergyOracle", "1") Ownable(msg.sender) {}
+
+    function setSigner(address signer, bool allowed) external onlyOwner {
+        signers[signer] = allowed;
+    }
+
+    function verify(Attestation calldata att, bytes calldata sig) external view returns (bool) {
+        if (att.deadline < block.timestamp) return false;
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    TYPEHASH,
+                    att.jobId,
+                    att.user,
+                    att.energy,
+                    att.degeneracy,
+                    att.nonce,
+                    att.deadline
+                )
+            )
+        );
+        address signer = ECDSA.recover(digest, sig);
+        return signers[signer];
+    }
+}
+

--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Thermostat} from "./Thermostat.sol";
+import {ThermoMath} from "./libraries/ThermoMath.sol";
+import {IFeePool} from "./interfaces/IFeePool.sol";
+import {IReputationEngineV2} from "./interfaces/IReputationEngineV2.sol";
+
+/// @title RewardEngineMB
+/// @notice Distributes epoch rewards using Maxwell-Boltzmann statistics.
+contract RewardEngineMB is Ownable {
+    using ThermoMath for int256[];
+
+    enum Role {Agent, Validator, Operator, Employer}
+
+    struct RoleData {
+        address[] users;
+        int256[] energies;
+        uint256[] degeneracies;
+    }
+
+    struct EpochData {
+        RoleData agents;
+        RoleData validators;
+        RoleData operators;
+        RoleData employers;
+        uint256 totalValue;
+        uint256 paidCosts;
+        uint256 sumUpre;
+        uint256 sumUpost;
+    }
+
+    Thermostat public thermostat;
+    IFeePool public feePool;
+    IReputationEngineV2 public reputation;
+
+    uint256 public kappa = 1e18; // scaling factor
+    mapping(Role => uint256) public roleShare; // scaled to 1e18
+    mapping(Role => int256) public mu;
+
+    int256 public constant WAD = 1e18;
+
+    event EpochSettled(uint256 indexed epoch, uint256 budget);
+
+    constructor(
+        Thermostat _thermostat,
+        IFeePool _feePool,
+        IReputationEngineV2 _rep
+    ) Ownable(msg.sender) {
+        thermostat = _thermostat;
+        feePool = _feePool;
+        reputation = _rep;
+        roleShare[Role.Agent] = 65e16; // 65%
+        roleShare[Role.Validator] = 15e16;
+        roleShare[Role.Operator] = 15e16;
+        roleShare[Role.Employer] = 5e16;
+    }
+
+    function setRoleShare(Role r, uint256 share) external onlyOwner {
+        roleShare[r] = share;
+    }
+
+    function setMu(Role r, int256 _mu) external onlyOwner {
+        mu[r] = _mu;
+    }
+
+    /// @notice Settle an epoch and distribute rewards.
+    function settleEpoch(uint256 epoch, EpochData calldata data) external onlyOwner {
+        int256 dH = int256(data.totalValue) - int256(data.paidCosts);
+        int256 dS = int256(data.sumUpre) - int256(data.sumUpost);
+        int256 Tsys = thermostat.systemTemperature();
+        int256 free = -(dH - Tsys * dS);
+        if (free < 0) free = 0;
+        uint256 budget = uint256(free) * kappa / uint256(WAD);
+        _distribute(Role.Agent, budget, data.agents);
+        _distribute(Role.Validator, budget, data.validators);
+        _distribute(Role.Operator, budget, data.operators);
+        _distribute(Role.Employer, budget, data.employers);
+        emit EpochSettled(epoch, budget);
+    }
+
+    function _distribute(Role r, uint256 budget, RoleData calldata rd) internal {
+        if (rd.users.length == 0) return;
+        int256 Tr = thermostat.getRoleTemperature(Thermostat.Role(uint8(r)));
+        uint256[] memory weights = ThermoMath.mbWeights(rd.energies, rd.degeneracies, Tr, mu[r]);
+        uint256 bucket = budget * roleShare[r] / uint256(WAD);
+        for (uint256 i = 0; i < rd.users.length; i++) {
+            uint256 amt = bucket * weights[i] / uint256(WAD);
+            feePool.reward(rd.users[i], amt);
+            reputation.update(rd.users[i], -rd.energies[i]);
+        }
+    }
+}
+

--- a/contracts/v2/Thermostat.sol
+++ b/contracts/v2/Thermostat.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Thermostat
+/// @notice PID controller maintaining system temperature for reward distribution.
+contract Thermostat is Ownable {
+    enum Role {Agent, Validator, Operator, Employer}
+
+    int256 public systemTemperature;
+    int256 public minTemp;
+    int256 public maxTemp;
+    int256 public kp;
+    int256 public ki;
+    int256 public kd;
+
+    mapping(Role => int256) private roleTemps;
+
+    int256 private integral;
+    int256 private lastError;
+
+    event TemperatureUpdated(int256 newTemp);
+    event RoleTemperatureUpdated(Role role, int256 temp);
+    event PIDUpdated(int256 kp, int256 ki, int256 kd);
+
+    constructor(int256 _temp, int256 _min, int256 _max) Ownable(msg.sender) {
+        systemTemperature = _temp;
+        minTemp = _min;
+        maxTemp = _max;
+    }
+
+    function setPID(int256 _kp, int256 _ki, int256 _kd) external onlyOwner {
+        kp = _kp;
+        ki = _ki;
+        kd = _kd;
+        emit PIDUpdated(_kp, _ki, _kd);
+    }
+
+    function setRoleTemperature(Role r, int256 temp) external onlyOwner {
+        require(temp >= minTemp && temp <= maxTemp, "bounds");
+        roleTemps[r] = temp;
+        emit RoleTemperatureUpdated(r, temp);
+    }
+
+    function getRoleTemperature(Role r) public view returns (int256) {
+        int256 t = roleTemps[r];
+        if (t == 0) return systemTemperature;
+        return t;
+    }
+
+    /// @notice Update the system temperature based on KPI observations.
+    /// @param emission Current emission growth error.
+    /// @param backlog Current backlog age error.
+    /// @param sla Current SLA hit rate error.
+    function tick(int256 emission, int256 backlog, int256 sla) external onlyOwner {
+        int256 error = emission + backlog + sla;
+        integral += error;
+        int256 derivative = error - lastError;
+        int256 delta = kp * error + ki * integral + kd * derivative;
+        systemTemperature += delta;
+        if (systemTemperature < minTemp) systemTemperature = minTemp;
+        if (systemTemperature > maxTemp) systemTemperature = maxTemp;
+        lastError = error;
+        emit TemperatureUpdated(systemTemperature);
+    }
+}
+

--- a/contracts/v2/interfaces/IFeePool.sol
+++ b/contracts/v2/interfaces/IFeePool.sol
@@ -24,4 +24,9 @@ interface IFeePool {
     /// @param to address receiving the tokens
     /// @param amount token amount with 18 decimals
     function governanceWithdraw(address to, uint256 amount) external;
+
+    /// @notice Transfer reward tokens to a recipient.
+    /// @param to address receiving the reward
+    /// @param amount token amount with 18 decimals
+    function reward(address to, uint256 amount) external;
 }

--- a/contracts/v2/interfaces/IReputationEngineV2.sol
+++ b/contracts/v2/interfaces/IReputationEngineV2.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IReputationEngineV2 {
+    function update(address user, int256 energyDelta) external;
+}

--- a/contracts/v2/libraries/ThermoMath.sol
+++ b/contracts/v2/libraries/ThermoMath.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title ThermoMath
+/// @notice Utility functions for computing approximate Maxwell-Boltzmann weights.
+library ThermoMath {
+    int256 internal constant WAD = 1e18;
+
+    /// @dev simple exponential approximation using 10-term Taylor series
+    function _exp(int256 x) private pure returns (uint256) {
+        int256 term = WAD;
+        int256 sum = WAD;
+        for (uint8 i = 1; i < 10; i++) {
+            term = (term * x) / int256(WAD) / int256(uint256(i));
+            sum += term;
+        }
+        if (sum < 0) return 0;
+        return uint256(sum);
+    }
+
+    /// @notice Computes normalized MB-like weights.
+    function mbWeights(
+        int256[] memory E,
+        uint256[] memory g,
+        int256 T,
+        int256 mu
+    ) internal pure returns (uint256[] memory w) {
+        require(E.length == g.length, "len");
+        uint256 n = E.length;
+        w = new uint256[](n);
+        uint256[] memory raw = new uint256[](n);
+        uint256 sum;
+        for (uint256 i = 0; i < n; i++) {
+            int256 denom = T == 0 ? int256(1) : T;
+            int256 x = ((mu - E[i]) * WAD) / denom;
+            uint256 weight = g[i] * _exp(x);
+            raw[i] = weight;
+            sum += weight;
+        }
+        if (sum == 0) return w;
+        for (uint256 i = 0; i < n; i++) {
+            w[i] = (raw[i] * uint256(WAD)) / sum;
+        }
+    }
+}

--- a/test/v2/ThermoMath.t.sol
+++ b/test/v2/ThermoMath.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {ThermoMath} from "../../contracts/v2/libraries/ThermoMath.sol";
+
+contract ThermoMathTest is Test {
+    function test_weights_normalize() public {
+        int256[] memory E = new int256[](3);
+        uint256[] memory g = new uint256[](3);
+        E[0] = 1e18; E[1] = 2e18; E[2] = 3e18;
+        g[0] = 1; g[1] = 1; g[2] = 1;
+        uint256[] memory w = ThermoMath.mbWeights(E, g, 1e18, 0);
+        uint256 sum;
+        for (uint256 i = 0; i < w.length; i++) sum += w[i];
+        assertEq(sum, 1e18, "normalized");
+    }
+
+    function test_weights_uniform_when_equal_energy() public {
+        int256[] memory E = new int256[](2);
+        uint256[] memory g = new uint256[](2);
+        E[0] = 1e18; E[1] = 1e18;
+        g[0] = 1; g[1] = 1;
+        uint256[] memory w = ThermoMath.mbWeights(E, g, 1e18, 0);
+        assertApproxEqAbs(w[0], 5e17, 1e12);
+        assertApproxEqAbs(w[1], 5e17, 1e12);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Thermostat contract with PID-controlled system temperature
- create RewardEngineMB for Maxwell-Boltzmann reward distribution
- include EnergyOracle for signed energy attestations
- extend FeePool with rewarder role and reward function
- include ThermoMath library and basic tests

## Testing
- `forge test --match-path test/v2/ThermoMath.t.sol` *(failed: Invalid type for argument in function call. Invalid implicit conversion from struct IJobRegistry.Job memory to struct MockJobRegistry.LegacyJob memory requested)*
- `npx hardhat compile --force` *(terminated: no output captured)*

------
https://chatgpt.com/codex/tasks/task_e_68c366efa0408333930cec6419e2de49