### PR TITLE
feat: enforce per-epoch nonce checks

### DIFF
--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -134,5 +134,27 @@ contract RewardEngineMBTest is Test {
         vm.expectRevert(bytes("att"));
         engine.settleEpoch(1, data);
     }
+
+    function test_replay_nonce_same_epoch_reverts() public {
+        RewardEngineMB.EpochData memory data;
+        RewardEngineMB.Proof[] memory a = new RewardEngineMB.Proof[](1);
+        a[0] = _proof(agent, int256(1e18));
+        data.agents = a;
+
+        engine.settleEpoch(1, data);
+
+        vm.expectRevert(abi.encodeWithSelector(RewardEngineMB.Replay.selector, address(oracle)));
+        engine.settleEpoch(1, data);
+    }
+
+    function test_same_nonce_different_epochs_ok() public {
+        RewardEngineMB.EpochData memory data;
+        RewardEngineMB.Proof[] memory a = new RewardEngineMB.Proof[](1);
+        a[0] = _proof(agent, int256(1e18));
+        data.agents = a;
+
+        engine.settleEpoch(1, data);
+        engine.settleEpoch(2, data); // should not revert
+    }
 }
 


### PR DESCRIPTION
## Summary
- track used nonces per user per epoch
- verify per-epoch nonce monotonicity during aggregation
- test replay protection across epochs

## Testing
- `forge test --match-path test/v2/RewardEngineMB.t.sol` *(fails: Invalid type for argument in function call)*
- `npx solhint contracts/v2/RewardEngineMB.sol test/v2/RewardEngineMB.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_68c3926cf1388333b53cdf84d77ccb2f