### PR TITLE
feat: allow reward scaling factor adjustment

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -52,6 +52,7 @@ contract RewardEngineMB is Ownable {
 
     event EpochSettled(uint256 indexed epoch, uint256 budget);
     event RewardIssued(address indexed user, Role role, uint256 amount);
+    event KappaUpdated(uint256 newKappa);
 
     constructor(
         Thermostat _thermostat,
@@ -77,6 +78,13 @@ contract RewardEngineMB is Ownable {
 
     function setMu(Role r, int256 _mu) external onlyOwner {
         mu[r] = _mu;
+    }
+
+    /// @notice Set the scaling factor converting free energy to token units.
+    /// @param _kappa New scaling coefficient in 18-decimal fixed point.
+    function setKappa(uint256 _kappa) external onlyOwner {
+        kappa = _kappa;
+        emit KappaUpdated(_kappa);
     }
 
     /// @notice Track highest attestation nonce per user per epoch

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,10 +1,11 @@
-const fs = require('fs');
-const path = require('path');
-
-const configPath = path.join(__dirname, '..', 'config', 'agialpha.json');
-const { address, decimals } = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-
-module.exports = {
-  AGIALPHA: address,
-  AGIALPHA_DECIMALS: decimals,
-};
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AGIALPHA_DECIMALS = exports.AGIALPHA = void 0;
+var fs = require("fs");
+var path = require("path");
+var configPath = path.join(__dirname, '..', 'config', 'agialpha.json');
+var _a = JSON.parse(fs.readFileSync(configPath, 'utf8')), address = _a.address, decimals = _a.decimals;
+// Canonical $AGIALPHA token address on Ethereum mainnet.
+exports.AGIALPHA = address;
+// Standard decimals for $AGIALPHA.
+exports.AGIALPHA_DECIMALS = decimals;

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -117,6 +117,31 @@ contract RewardEngineMBTest is Test {
         assertEq(rep.deltas(agent), -int256(1e18));
     }
 
+    function test_setKappaScalesBudget() public {
+        RewardEngineMB.EpochData memory data;
+        RewardEngineMB.Proof[] memory a = new RewardEngineMB.Proof[](1);
+        a[0] = _proof(agent, int256(1e18));
+        data.agents = a;
+        RewardEngineMB.Proof[] memory v = new RewardEngineMB.Proof[](1);
+        v[0] = _proof(validator, int256(1e18));
+        data.validators = v;
+        RewardEngineMB.Proof[] memory o = new RewardEngineMB.Proof[](1);
+        o[0] = _proof(operator, int256(1e18));
+        data.operators = o;
+        RewardEngineMB.Proof[] memory e = new RewardEngineMB.Proof[](1);
+        e[0] = _proof(employer, int256(1e18));
+        data.employers = e;
+        data.totalValue = 0;
+        data.paidCosts = 1e18;
+        data.sumUpre = 0;
+        data.sumUpost = 0;
+
+        engine.setKappa(2e18);
+        engine.settleEpoch(1, data);
+        // budget should be double with kappa = 2e18
+        assertEq(pool.total(), 2e18, "scaled budget distributed");
+    }
+
     function test_reverts_on_negative_energy() public {
         RewardEngineMB.EpochData memory data;
         RewardEngineMB.Proof[] memory a = new RewardEngineMB.Proof[](1);


### PR DESCRIPTION
## Summary
- allow reward scaling factor to be updated
- test scaling factor influences epoch budget

## Testing
- `forge test --match-path test/v2/RewardEngineMB.t.sol` *(fails: Invalid type for argument in ValidationFinalizeGas.t.sol)*

------
https://chatgpt.com/codex/tasks/task_e_68c409fca0c883339e57568d6d7ba43e