### PR TITLE
Add nonce replay protection to EnergyOracle

### DIFF
--- a/contracts/v2/EnergyOracle.sol
+++ b/contracts/v2/EnergyOracle.sol
@@ -27,11 +27,11 @@ contract EnergyOracle is EIP712, Ownable, IEnergyOracle {
     /// @inheritdoc IEnergyOracle
     function verify(IEnergyOracle.Attestation calldata att, bytes calldata sig)
         external
-        view
         override
         returns (address signer)
     {
         if (att.deadline < block.timestamp) return address(0);
+        if (att.nonce <= nonces[att.user]) return address(0);
         bytes32 digest = _hashTypedDataV4(
             keccak256(
                 abi.encode(
@@ -47,6 +47,7 @@ contract EnergyOracle is EIP712, Ownable, IEnergyOracle {
         );
         signer = ECDSA.recover(digest, sig);
         if (!signers[signer]) return address(0);
+        nonces[att.user] = att.nonce;
     }
 }
 

--- a/contracts/v2/interfaces/IEnergyOracle.sol
+++ b/contracts/v2/interfaces/IEnergyOracle.sol
@@ -12,6 +12,6 @@ interface IEnergyOracle {
     }
 
     /// @return signer Address of oracle signer if signature valid, zero address otherwise
-    function verify(Attestation calldata att, bytes calldata sig) external view returns (address signer);
+    function verify(Attestation calldata att, bytes calldata sig) external returns (address signer);
 }
 

--- a/test/v2/EnergyOracle.t.sol
+++ b/test/v2/EnergyOracle.t.sol
@@ -76,5 +76,16 @@ contract EnergyOracleTest is Test {
         address recovered = oracle.verify(att, sig);
         assertEq(recovered, address(0));
     }
+
+    function test_verify_rejects_replay() public {
+        EnergyOracle.Attestation memory att = _att();
+        bytes32 digest = _hash(att);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+        address recovered = oracle.verify(att, sig);
+        assertEq(recovered, signer);
+        recovered = oracle.verify(att, sig);
+        assertEq(recovered, address(0));
+    }
 }
 


### PR DESCRIPTION
## Summary
- enforce per-user nonce monotonicity in `EnergyOracle.verify`
- allow state-changing verification in `IEnergyOracle`
- test replay rejection in `EnergyOracle.t.sol`

## Testing
- `forge test --root .tmpfoundry`

------
https://chatgpt.com/codex/tasks/task_e_68c4144ed24c83339fa1ccfdc9209a7d