### PR TITLE
Enforce positive bounds in Thermostat

### DIFF
--- a/contracts/v2/Thermostat.sol
+++ b/contracts/v2/Thermostat.sol
@@ -25,6 +25,7 @@ contract Thermostat is Ownable {
     event PIDUpdated(int256 kp, int256 ki, int256 kd);
 
     constructor(int256 _temp, int256 _min, int256 _max) Ownable(msg.sender) {
+        require(_min > 0 && _max > _min, "bounds");
         systemTemperature = _temp;
         minTemp = _min;
         maxTemp = _max;
@@ -38,7 +39,7 @@ contract Thermostat is Ownable {
     }
 
     function setRoleTemperature(Role r, int256 temp) external onlyOwner {
-        require(temp >= minTemp && temp <= maxTemp, "bounds");
+        require(temp > 0 && temp >= minTemp && temp <= maxTemp, "bounds");
         roleTemps[r] = temp;
         emit RoleTemperatureUpdated(r, temp);
     }
@@ -61,6 +62,7 @@ contract Thermostat is Ownable {
         systemTemperature += delta;
         if (systemTemperature < minTemp) systemTemperature = minTemp;
         if (systemTemperature > maxTemp) systemTemperature = maxTemp;
+        require(systemTemperature > 0, "temp");
         lastError = error;
         emit TemperatureUpdated(systemTemperature);
     }

--- a/test/v2/Thermostat.t.sol
+++ b/test/v2/Thermostat.t.sol
@@ -6,19 +6,33 @@ import {Thermostat} from "../../contracts/v2/Thermostat.sol";
 
 contract ThermostatTest is Test {
     function test_tickClampsTemperature() public {
-        Thermostat t = new Thermostat(int256(100), int256(0), int256(200));
+        Thermostat t = new Thermostat(int256(100), int256(1), int256(200));
         t.setPID(int256(1), int256(0), int256(0));
         t.tick(int256(500), 0, 0);
         assertEq(t.systemTemperature(), 200);
         t.tick(int256(-1000), 0, 0);
-        assertEq(t.systemTemperature(), 0);
+        assertEq(t.systemTemperature(), 1);
     }
 
     function test_roleTemperatureOverride() public {
-        Thermostat t = new Thermostat(int256(100), int256(0), int256(200));
+        Thermostat t = new Thermostat(int256(100), int256(1), int256(200));
         assertEq(t.getRoleTemperature(Thermostat.Role.Agent), 100);
         t.setRoleTemperature(Thermostat.Role.Agent, int256(150));
         assertEq(t.getRoleTemperature(Thermostat.Role.Agent), 150);
+    }
+    function test_constructorInvalidBounds() public {
+        vm.expectRevert("bounds");
+        new Thermostat(int256(100), int256(0), int256(200));
+        vm.expectRevert("bounds");
+        new Thermostat(int256(100), int256(10), int256(10));
+    }
+
+    function test_setRoleTemperatureRequiresPositive() public {
+        Thermostat t = new Thermostat(int256(100), int256(1), int256(200));
+        vm.expectRevert("bounds");
+        t.setRoleTemperature(Thermostat.Role.Agent, int256(0));
+        vm.expectRevert("bounds");
+        t.setRoleTemperature(Thermostat.Role.Agent, int256(-1));
     }
 }
 


### PR DESCRIPTION
## Summary
- enforce positive min/max bounds in Thermostat constructor
- guard role temperatures and system ticks from non-positive values
- add tests for invalid bounds and temperature enforcement

## Testing
- `forge test --match-path test/v2/Thermostat.t.sol` *(fails: Invalid type for argument in function call in test/v2/ValidationFinalizeGas.t.sol)*

------
https://chatgpt.com/codex/tasks/task_e_68c416cfdc988333831ed44a5835fec3