### PR TITLE
feat: emit tick event in thermostat

### DIFF
--- a/contracts/v2/Thermostat.sol
+++ b/contracts/v2/Thermostat.sol
@@ -23,6 +23,7 @@ contract Thermostat is Ownable {
     event TemperatureUpdated(int256 newTemp);
     event RoleTemperatureUpdated(Role role, int256 temp);
     event PIDUpdated(int256 kp, int256 ki, int256 kd);
+    event Tick(int256 emission, int256 backlog, int256 sla, int256 newTemp);
 
     constructor(int256 _temp, int256 _min, int256 _max) Ownable(msg.sender) {
         require(_min > 0 && _max > _min, "bounds");
@@ -65,6 +66,7 @@ contract Thermostat is Ownable {
         require(systemTemperature > 0, "temp");
         lastError = error;
         emit TemperatureUpdated(systemTemperature);
+        emit Tick(emission, backlog, sla, systemTemperature);
     }
 }
 

--- a/test/v2/Thermostat.t.sol
+++ b/test/v2/Thermostat.t.sol
@@ -34,5 +34,16 @@ contract ThermostatTest is Test {
         vm.expectRevert("bounds");
         t.setRoleTemperature(Thermostat.Role.Agent, int256(-1));
     }
+
+    function test_tickEmitsEvent() public {
+        Thermostat t = new Thermostat(int256(100), int256(1), int256(200));
+        t.setPID(int256(1), int256(0), int256(0));
+
+        vm.expectEmit(false, false, false, true, address(t));
+        emit Thermostat.TemperatureUpdated(int256(200));
+        vm.expectEmit(false, false, false, true, address(t));
+        emit Thermostat.Tick(int256(500), int256(0), int256(0), int256(200));
+        t.tick(int256(500), int256(0), int256(0));
+    }
 }
 


### PR DESCRIPTION
## Summary
- add `Tick` event capturing tick inputs and new temperature
- emit event after temperature adjustment
- test event emission in Thermostat tick

## Testing
- `forge test --match-path test/v2/Thermostat.t.sol` *(fails: Invalid type for argument in function call in ValidationFinalizeGas.t.sol)*

------
https://chatgpt.com/codex/tasks/task_e_68c4229f8a148333b85e3395735935aa