### PR TITLE
feat: emit events for reward engine governance

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -56,6 +56,8 @@ contract RewardEngineMB is Ownable {
     event RewardIssued(address indexed user, Role role, uint256 amount);
     event KappaUpdated(uint256 newKappa);
     event TreasuryUpdated(address indexed treasury);
+    event RoleShareUpdated(Role indexed role, uint256 share);
+    event MuUpdated(Role indexed role, int256 muValue);
 
     constructor(
         Thermostat _thermostat,
@@ -77,10 +79,12 @@ contract RewardEngineMB is Ownable {
     function setRoleShare(Role r, uint256 share) external onlyOwner {
         roleShare[r] = share;
         _validateRoleShares();
+        emit RoleShareUpdated(r, share);
     }
 
     function setMu(Role r, int256 _mu) external onlyOwner {
         mu[r] = _mu;
+        emit MuUpdated(r, _mu);
     }
 
     /// @notice Set the scaling factor converting free energy to token units.

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -144,6 +144,19 @@ contract RewardEngineMBTest is Test {
         assertEq(pool.total(), 2e18, "scaled budget distributed");
     }
 
+    function test_setRoleShareEmits() public {
+        vm.expectEmit(true, false, false, true);
+        emit RewardEngineMB.RoleShareUpdated(RewardEngineMB.Role.Agent, 65e16);
+        engine.setRoleShare(RewardEngineMB.Role.Agent, 65e16);
+    }
+
+    function test_setMuEmits() public {
+        vm.expectEmit(true, false, false, true);
+        emit RewardEngineMB.MuUpdated(RewardEngineMB.Role.Agent, 1);
+        engine.setMu(RewardEngineMB.Role.Agent, 1);
+        assertEq(engine.mu(RewardEngineMB.Role.Agent), 1);
+    }
+
     function test_reverts_on_negative_energy() public {
         RewardEngineMB.EpochData memory data;
         RewardEngineMB.Proof[] memory a = new RewardEngineMB.Proof[](1);


### PR DESCRIPTION
## Summary
- add events for role share and chemical potential changes in RewardEngineMB
- cover governance events in RewardEngineMB tests

## Testing
- `forge test test/v2/RewardEngineMB.t.sol` *(fails: Invalid type for argument in function call from unrelated tests)*
- `npx hardhat compile` *(process did not produce output before termination)*

------
https://chatgpt.com/codex/tasks/task_e_68c42eb277bc8333afbbcd8113c091c6