### PR TITLE
feat: add epoch and role to energy attestations

### DIFF
--- a/contracts/v2/EnergyOracle.sol
+++ b/contracts/v2/EnergyOracle.sol
@@ -12,7 +12,7 @@ contract EnergyOracle is EIP712, Ownable, IEnergyOracle {
     using ECDSA for bytes32;
 
     bytes32 public constant TYPEHASH = keccak256(
-        "EnergyAttestation(uint256 jobId,address user,int256 energy,uint256 degeneracy,uint256 nonce,uint256 deadline)"
+        "EnergyAttestation(uint256 jobId,address user,int256 energy,uint256 degeneracy,uint256 epochId,uint8 role,uint256 nonce,uint256 deadline)"
     );
 
     mapping(address => bool) public signers;
@@ -40,6 +40,8 @@ contract EnergyOracle is EIP712, Ownable, IEnergyOracle {
                     att.user,
                     att.energy,
                     att.degeneracy,
+                    att.epochId,
+                    att.role,
                     att.nonce,
                     att.deadline
                 )

--- a/contracts/v2/interfaces/IEnergyOracle.sol
+++ b/contracts/v2/interfaces/IEnergyOracle.sol
@@ -7,6 +7,8 @@ interface IEnergyOracle {
         address user;
         int256 energy;
         uint256 degeneracy;
+        uint256 epochId;
+        uint8 role;
         uint256 nonce;
         uint256 deadline;
     }


### PR DESCRIPTION
## Summary
- include `epochId` and `role` in `IEnergyOracle.Attestation`
- hash new attestation fields in `EnergyOracle`
- enforce attested epoch and role in `RewardEngineMB` aggregation
- extend tests for oracle and reward engine to cover new fields

## Testing
- `forge test test/v2/EnergyOracle.t.sol` *(fails: Yul exception: Cannot swap Slot RET with Variable value1: too deep in the stack)*
- `forge test test/v2/RewardEngineMB.t.sol` *(fails: Yul exception: Cannot swap Slot RET with Variable value1: too deep in the stack)*

------
https://chatgpt.com/codex/tasks/task_e_68c4329938a88333a2241fe13dc3cc55