### PR TITLE
feat: expand thermostat controls

### DIFF
--- a/contracts/v2/Thermostat.sol
+++ b/contracts/v2/Thermostat.sol
@@ -23,6 +23,7 @@ contract Thermostat is Ownable {
     event TemperatureUpdated(int256 newTemp);
     event RoleTemperatureUpdated(Role role, int256 temp);
     event PIDUpdated(int256 kp, int256 ki, int256 kd);
+    event TemperatureBoundsUpdated(int256 minTemp, int256 maxTemp);
     event Tick(int256 emission, int256 backlog, int256 sla, int256 newTemp);
 
     constructor(int256 _temp, int256 _min, int256 _max) Ownable(msg.sender) {
@@ -39,10 +40,34 @@ contract Thermostat is Ownable {
         emit PIDUpdated(_kp, _ki, _kd);
     }
 
+    /// @notice Sets a new system temperature within bounds.
+    function setSystemTemperature(int256 temp) external onlyOwner {
+        require(temp > 0 && temp >= minTemp && temp <= maxTemp, "temp");
+        systemTemperature = temp;
+        emit TemperatureUpdated(temp);
+    }
+
+    /// @notice Updates minimum and maximum allowable temperatures.
+    function setTemperatureBounds(int256 _min, int256 _max) external onlyOwner {
+        require(_min > 0 && _max > _min, "bounds");
+        minTemp = _min;
+        maxTemp = _max;
+        if (systemTemperature < minTemp) systemTemperature = minTemp;
+        if (systemTemperature > maxTemp) systemTemperature = maxTemp;
+        emit TemperatureBoundsUpdated(_min, _max);
+        emit TemperatureUpdated(systemTemperature);
+    }
+
     function setRoleTemperature(Role r, int256 temp) external onlyOwner {
         require(temp > 0 && temp >= minTemp && temp <= maxTemp, "bounds");
         roleTemps[r] = temp;
         emit RoleTemperatureUpdated(r, temp);
+    }
+
+    /// @notice Removes a role-specific temperature override.
+    function unsetRoleTemperature(Role r) external onlyOwner {
+        delete roleTemps[r];
+        emit RoleTemperatureUpdated(r, 0);
     }
 
     function getRoleTemperature(Role r) public view returns (int256) {

--- a/test/v2/Thermostat.t.sol
+++ b/test/v2/Thermostat.t.sol
@@ -19,20 +19,39 @@ contract ThermostatTest is Test {
         assertEq(t.getRoleTemperature(Thermostat.Role.Agent), 100);
         t.setRoleTemperature(Thermostat.Role.Agent, int256(150));
         assertEq(t.getRoleTemperature(Thermostat.Role.Agent), 150);
+        t.unsetRoleTemperature(Thermostat.Role.Agent);
+        assertEq(t.getRoleTemperature(Thermostat.Role.Agent), 100);
     }
     function test_constructorInvalidBounds() public {
-        vm.expectRevert("bounds");
+        vm.expectRevert(bytes("bounds"));
         new Thermostat(int256(100), int256(0), int256(200));
-        vm.expectRevert("bounds");
+        vm.expectRevert(bytes("bounds"));
         new Thermostat(int256(100), int256(10), int256(10));
     }
 
     function test_setRoleTemperatureRequiresPositive() public {
         Thermostat t = new Thermostat(int256(100), int256(1), int256(200));
-        vm.expectRevert("bounds");
+        vm.expectRevert(bytes("bounds"));
         t.setRoleTemperature(Thermostat.Role.Agent, int256(0));
-        vm.expectRevert("bounds");
+        vm.expectRevert(bytes("bounds"));
         t.setRoleTemperature(Thermostat.Role.Agent, int256(-1));
+    }
+
+    function test_setSystemTemperatureAndBounds() public {
+        Thermostat t = new Thermostat(int256(100), int256(1), int256(200));
+        vm.expectEmit(false, false, false, true, address(t));
+        emit Thermostat.TemperatureUpdated(int256(150));
+        t.setSystemTemperature(int256(150));
+        assertEq(t.systemTemperature(), 150);
+
+        vm.expectRevert(bytes("temp"));
+        t.setSystemTemperature(int256(0));
+
+        t.setTemperatureBounds(int256(50), int256(120));
+        assertEq(t.systemTemperature(), 120); // clamped to new max
+
+        vm.expectRevert(bytes("bounds"));
+        t.setTemperatureBounds(int256(0), int256(10));
     }
 
     function test_tickEmitsEvent() public {


### PR DESCRIPTION
## Summary
- allow governance to set system temperature and bounds in Thermostat
- add ability to remove role-specific overrides
- cover new behaviors in Thermostat tests

## Testing
- ⚠️ `forge test` *(failed: Invalid type for argument in ValidationFinalizeGas.t.sol)*

------
https://chatgpt.com/codex/tasks/task_e_68c43be291648333a039f1cbfa1034bb