### PR TITLE
feat: add reward and slashing stats events

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -62,6 +62,13 @@ contract RewardEngineMB is Ownable {
     event TreasuryUpdated(address indexed treasury);
     event RoleShareUpdated(Role indexed role, uint256 share);
     event MuUpdated(Role indexed role, int256 muValue);
+    event RewardBudget(
+        uint256 indexed epoch,
+        uint256 minted,
+        uint256 burned,
+        uint256 redistributed,
+        uint256 distributionRatio
+    );
 
     constructor(
         Thermostat _thermostat,
@@ -164,6 +171,8 @@ contract RewardEngineMB is Ownable {
             require(treasury != address(0), "treasury");
             feePool.reward(treasury, leftover);
         }
+        uint256 ratio = budget > 0 ? (distributed * uint256(WAD)) / budget : 0;
+        emit RewardBudget(epoch, budget, 0, distributed, ratio);
         emit EpochSettled(epoch, budget, dH, dS, Tsys, leftover);
     }
 

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -198,6 +198,13 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         uint256 treasuryShare,
         uint256 burnShare
     );
+    event SlashingStats(
+        uint256 timestamp,
+        uint256 minted,
+        uint256 burned,
+        uint256 redistributed,
+        uint256 burnRatio
+    );
     event StakeEscrowLocked(bytes32 indexed jobId, address indexed from, uint256 amount);
     event StakeReleased(bytes32 indexed jobId, address indexed to, uint256 amount);
     /// @notice Emitted when a participant receives a payout in $AGIALPHA.
@@ -1354,7 +1361,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
             // Burned stake originates from the slashed participant, not employer funds.
             _burnToken(bytes32(0), burnShare);
         }
-
+        uint256 redistributed = employerShare + treasuryShare;
+        uint256 ratio = redistributed > 0 ? (burnShare * TOKEN_SCALE) / redistributed : 0;
         emit StakeSlashed(
             user,
             role,
@@ -1364,6 +1372,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
             treasuryShare,
             burnShare
         );
+        emit SlashingStats(block.timestamp, 0, burnShare, redistributed, ratio);
     }
 
     /// @notice slash stake from a user for a specific role and distribute shares

--- a/docs/reward-slashing-events.md
+++ b/docs/reward-slashing-events.md
@@ -1,0 +1,60 @@
+# Reward and Slashing Events
+
+This document describes the `RewardBudget` and `SlashingStats` events emitted by the protocol.
+
+## RewardBudget
+
+Emitted by `RewardEngineMB` when settling an epoch.
+
+```
+event RewardBudget(
+    uint256 indexed epoch,
+    uint256 minted,
+    uint256 burned,
+    uint256 redistributed,
+    uint256 distributionRatio
+);
+```
+
+- `epoch`: Identifier supplied to `settleEpoch`.
+- `minted`: Total tokens minted for rewards during the epoch.
+- `burned`: Tokens destroyed. The current implementation does not burn within the reward engine and this value is `0`.
+- `redistributed`: Sum of tokens paid out to participants.
+- `distributionRatio`: `redistributed / minted` scaled by `1e18`.
+
+## SlashingStats
+
+Emitted by `StakeManager` whenever stake is slashed.
+
+```
+event SlashingStats(
+    uint256 timestamp,
+    uint256 minted,
+    uint256 burned,
+    uint256 redistributed,
+    uint256 burnRatio
+);
+```
+
+- `timestamp`: Block timestamp when the slash occurred.
+- `minted`: New tokens created by the slash (always `0`).
+- `burned`: Amount of stake sent to the burn address.
+- `redistributed`: Stake redistributed to employers or the treasury.
+- `burnRatio`: `burned / redistributed` scaled by `1e18`.
+
+These events enable off-chain monitors to track minting and burning activity per epoch and alert on divergence.
+
+## CLI Aggregation
+
+The repository provides `scripts/aggregate-events.ts`, a simple CLI that aggregates
+`RewardBudget` and `SlashingStats` events over a block range and prints total
+minted, burned, redistributed amounts and ratios. Set `RPC_URL`, contract
+addresses (`REWARD_ENGINE`, `STAKE_MANAGER`) and optional `START_BLOCK`/`END_BLOCK`
+environment variables before running:
+
+```
+RPC_URL=http://localhost:8545 \
+REWARD_ENGINE=0x... \
+STAKE_MANAGER=0x... \
+npx ts-node scripts/aggregate-events.ts
+```

--- a/scripts/aggregate-events.ts
+++ b/scripts/aggregate-events.ts
@@ -1,0 +1,59 @@
+import { JsonRpcProvider, Interface, Contract } from 'ethers';
+
+async function main() {
+  const rpc = process.env.RPC_URL || 'http://localhost:8545';
+  const provider = new JsonRpcProvider(rpc);
+  const rewardAddr = process.env.REWARD_ENGINE || '';
+  const stakeAddr = process.env.STAKE_MANAGER || '';
+  const start = process.env.START_BLOCK ? parseInt(process.env.START_BLOCK) : 0;
+  const end = process.env.END_BLOCK
+    ? parseInt(process.env.END_BLOCK)
+    : 'latest';
+
+  const rewardIface = new Interface([
+    'event RewardBudget(uint256 indexed epoch,uint256 minted,uint256 burned,uint256 redistributed,uint256 distributionRatio)',
+  ]);
+  const slashIface = new Interface([
+    'event SlashingStats(uint256 timestamp,uint256 minted,uint256 burned,uint256 redistributed,uint256 burnRatio)',
+  ]);
+
+  const reward = rewardAddr
+    ? new Contract(rewardAddr, rewardIface, provider)
+    : undefined;
+  const stake = stakeAddr
+    ? new Contract(stakeAddr, slashIface, provider)
+    : undefined;
+
+  let minted = 0n;
+  let burned = 0n;
+  let redistributed = 0n;
+
+  if (reward) {
+    const events = await reward.queryFilter('RewardBudget', start, end);
+    for (const ev of events) {
+      minted += ev.args.minted as bigint;
+      burned += ev.args.burned as bigint;
+      redistributed += ev.args.redistributed as bigint;
+    }
+  }
+
+  if (stake) {
+    const events = await stake.queryFilter('SlashingStats', start, end);
+    for (const ev of events) {
+      burned += ev.args.burned as bigint;
+      redistributed += ev.args.redistributed as bigint;
+    }
+  }
+
+  console.log('=== Aggregate Totals ===');
+  console.log('Minted       :', minted.toString());
+  console.log('Burned       :', burned.toString());
+  console.log('Redistributed:', redistributed.toString());
+  const ratio = burned > 0n ? (redistributed * 10000n) / burned : 0n;
+  console.log('Redistributed/Burned x10000:', ratio.toString());
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- emit `RewardBudget` and `SlashingStats` events with ratio metrics
- document event formats and provide a CLI to aggregate them

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c45e66f2e08333b924cee0876448b3