### PR TITLE
docs: add thermodynamic incentive sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 - [Identity policy](#identity-policy)
 - [AGIALPHA configuration](#agialpha-configuration)
 - [Fee handling and treasury](#fee-handling-and-treasury)
+- [Thermodynamic Incentives](#thermodynamic-incentives)
 - [Deploy defaults](#deploy-defaults)
 - [Mainnet Deployment](#mainnet-deployment)
 - [Migrating from legacy](#migrating-from-legacy)
@@ -40,6 +41,27 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 ### Fee handling and treasury
 
 `JobRegistry` routes protocol fees to `FeePool`, which burns a configurable percentage (`burnPct`) when an employer finalizes a job and escrows the remainder for platform stakers. By default the `treasury` is unset (`address(0)`), so any rounding dust is burned. Governance may later call `StakeManager.setTreasury`, `JobRegistry.setTreasury`, or `FeePool.setTreasury` to direct funds to a community-controlled treasury. These setters reject the owner address and, for `FeePool`, require the target to be pre-approved via `setTreasuryAllowlist`. The platform only routes funds and never initiates or profits from burns.
+
+### Thermodynamic Incentives
+
+`RewardEngineMB` meters energy consumption against a global free‑energy budget and assigns each role a share of that budget. The `Thermostat` normalises per‑task usage while `EnergyOracle` supplies measurements, letting the engine raise reward weight and reputation for energy‑efficient participants.
+
+| Energy Used (kJ) | Reward Weight | Reputation Gain |
+| ---------------- | ------------- | --------------- |
+| 20               | 1.0×          | +5              |
+| 10               | 1.8×          | +9              |
+
+An agent cutting its draw from 20 kJ to 10 kJ nearly doubles both its reward weight and reputation.
+
+```mermaid
+flowchart LR
+    Start[Job completed] --> Oracle(EnergyOracle reports usage)
+    Oracle --> Thermostat{Thermostat compares to role budget}
+    Thermostat --> Engine[RewardEngineMB adjusts weight]
+    Engine --> FeePool((FeePool))
+    FeePool --> Reputation[ReputationEngine updates score]
+    Reputation --> Payout[Agent receives payout]
+```
 
 ### Deploy defaults
 

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -20,6 +20,23 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 - **FeePool** – receives fees from `StakeManager` and distributes them to staked operators in proportion to their stake. The owner can adjust burn percentage, treasury and reward role without redeploying.
 - **PlatformIncentives** – helper that stakes `$AGIALPHA` on behalf of an operator and registers them with both `PlatformRegistry` and `JobRouter`. The owner (main deployer) may register with `amount = 0` to remain tax neutral and earn no routing or fee share. When routing or fee sharing isn't required, operators can instead call `PlatformRegistry.stakeAndRegister` or `acknowledgeStakeAndRegister` directly.
 
+### RewardEngineMB, Thermostat & EnergyOracle
+
+`RewardEngineMB` tracks a free‑energy budget for each role. The `EnergyOracle` reports per‑task consumption and the `Thermostat` compares it with role allocations, adjusting reward weight when usage falls below budget. Efficient agents therefore earn a larger share of fees and gain reputation faster.
+
+| Energy Used (kJ) | Reward Weight | Reputation Gain |
+| ---------------- | ------------- | --------------- |
+| 20               | 1.0×          | +5              |
+| 10               | 1.8×          | +9              |
+
+```mermaid
+flowchart LR
+    Oracle(EnergyOracle) --> Thermostat{Thermostat}
+    Thermostat --> Engine[RewardEngineMB]
+    Engine --> FeePool((FeePool))
+    FeePool --> Reputation[ReputationEngine]
+```
+
 Every contract rejects direct ETH and exposes `isTaxExempt()` so neither the contracts nor the owner ever hold taxable revenue. Participants interact only through token transfers.
 
 ## Incentive Flow


### PR DESCRIPTION
## Summary
- document free-energy budgeting and reputation gains in new README section
- describe RewardEngineMB, Thermostat and EnergyOracle interplay
- add mermaid diagrams for reward settlement process

## Testing
- `npm test` *(fails: process hung after env injection)*
- `npm run lint` *(fails: process hung during solhint)*

------
https://chatgpt.com/codex/tasks/task_e_68c461d041b0833382c387dec4d2f1e6