### PR TITLE
docs: add thermodynamic incentive diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 
 `RewardEngineMB` meters energy consumption against a global free‑energy budget and assigns each role a share of that budget. The `Thermostat` normalises per‑task usage while `EnergyOracle` supplies measurements, letting the engine raise reward weight and reputation for energy‑efficient participants.
 
+Each epoch the resulting free‑energy budget is split **65 %** to agents, **15 %** to validators, **15 %** to operators and **5 %** to employers, rewarding low‑energy contributors with more tokens and reputation.
+
 | Energy Used (kJ) | Reward Weight | Reputation Gain |
 | ---------------- | ------------- | --------------- |
 | 20               | 1.0×          | +5              |
@@ -54,13 +56,24 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 An agent cutting its draw from 20 kJ to 10 kJ nearly doubles both its reward weight and reputation.
 
 ```mermaid
-flowchart LR
-    Start[Job completed] --> Oracle(EnergyOracle reports usage)
-    Oracle --> Thermostat{Thermostat compares to role budget}
-    Thermostat --> Engine[RewardEngineMB adjusts weight]
-    Engine --> FeePool((FeePool))
-    FeePool --> Reputation[ReputationEngine updates score]
-    Reputation --> Payout[Agent receives payout]
+graph TD
+    subgraph "Epoch Free-Energy Budgeting"
+        value[Total Value] --> dH["ΔH"]
+        costs[Paid Costs] --> dH
+        u_pre[Uncertainty Before] --> dS["ΔS"]
+        u_post[Uncertainty After] --> dS
+        dH --> G{"Budget = max(0, -(ΔH - T·ΔS))"}
+        dS --> G
+        temp["Tₛ from Thermostat"] --> G
+    end
+    G -->|"65%"| Agents
+    G -->|"15%"| Validators
+    G -->|"15%"| Operators
+    G -->|"5%"| Employers
+    Agents -->|"Lower energy ⇒ higher weight"| Rep["Reputation ↑"]
+    Validators --> Rep
+    Operators --> Rep
+    Employers --> Rep
 ```
 
 ### Deploy defaults

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -30,11 +30,45 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 | 10               | 1.8×          | +9              |
 
 ```mermaid
-flowchart LR
-    Oracle(EnergyOracle) --> Thermostat{Thermostat}
-    Thermostat --> Engine[RewardEngineMB]
-    Engine --> FeePool((FeePool))
-    FeePool --> Reputation[ReputationEngine]
+graph LR
+    Oracle((EnergyOracle)) -- "E_i, g_i attestations" --> Engine[RewardEngineMB]
+    Thermostat((Thermostat)) -- "Tₛ & T_r" --> Engine
+    Engine -- "AGIALPHA rewards" --> FeePool((FeePool))
+    Engine -- "reputation delta" --> Reputation[ReputationEngine]
+    FeePool --> Roles((Agents / Validators / Operators / Employers))
+    Reputation --> Roles
+```
+
+### Reward Settlement Process
+
+```mermaid
+sequenceDiagram
+    participant Employer
+    participant Agent
+    participant Validator
+    participant Oracle as EnergyOracle
+    participant Engine as RewardEngineMB
+    participant Thermostat
+    participant FeePool
+    participant Reputation
+
+    Employer->>Agent: Post job & funds
+    Agent->>Validator: Submit work
+    Validator->>Employer: Approve results
+    Agent->>Oracle: Report energy
+    Oracle-->>Engine: Signed attestation
+    Engine->>Thermostat: Request temperatures
+    Thermostat-->>Engine: Tₛ & T_r
+    Engine->>Engine: Compute ΔG & MB weights
+    Engine->>FeePool: Allocate rewards
+    Engine->>Reputation: Update scores
+    FeePool-->>Agent: Token reward
+    FeePool-->>Validator: Token reward
+    FeePool-->>Operator: Token reward
+    FeePool-->>Employer: Rebate
+    Reputation-->>Agent: Reputation gain
+    Reputation-->>Validator: Reputation gain
+    Reputation-->>Operator: Reputation gain
 ```
 
 Every contract rejects direct ETH and exposes `isTaxExempt()` so neither the contracts nor the owner ever hold taxable revenue. Participants interact only through token transfers.


### PR DESCRIPTION
## Summary
- add free-energy budgeting diagram with role shares and reputation flow
- illustrate RewardEngineMB, Thermostat and EnergyOracle interactions
- document end-to-end reward settlement sequence

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check` *(fails: Code style issues found in 6 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c463da0ff88333b70a99dea6d89365