### PR TITLE
docs: enrich thermodynamic incentive diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ An agent cutting its draw from 20 kJ to 10 kJ nearly doubles both its reward w
 ```mermaid
 flowchart TB
     %% Thermodynamic free-energy budgeting and allocation
+    EO((EnergyOracle)) -- "E_i, g_i" --> weights
+    TH((Thermostat)) -- Tₛ --> T
+    TH -- Tᵣ --> weights
+
     subgraph Budgeting["Free-Energy Budgeting"]
         V[Total Value] --> dH["ΔH"]
         C[Paid Costs] --> dH
@@ -70,11 +74,11 @@ flowchart TB
     end
 
     subgraph MB["Maxwell–Boltzmann Distribution"]
-        budget --> weights["w_i ∝ g_i·exp((mu_r - E_i)/T_r)"]
-        weights --> Agents["Agents 65%"]
-        weights --> Validators["Validators 15%"]
-        weights --> Operators["Operators 15%"]
-        weights --> Employers["Employers 5%"]
+        budget --> weights["w_i ∝ g_i·exp((μ_r - E_i)/T_r)"]
+        weights -->|65%| Agents[Agents]
+        weights -->|15%| Validators[Validators]
+        weights -->|15%| Operators[Operators]
+        weights -->|5%| Employers[Employers]
     end
 
     subgraph Reputation["Energy‑Efficient Reputation"]
@@ -88,7 +92,7 @@ flowchart TB
     classDef role fill:#e6f2ff,stroke:#0366d6,stroke-width:1px;
     classDef rep fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
 
-    class V,C,Upre,Upost,T,dH,dS,dG,budget,weights thermo;
+    class V,C,Upre,Upost,T,dH,dS,dG,budget,weights,EO,TH thermo;
     class Agents,Validators,Operators,Employers role;
     class RA,RV,RO,RE rep;
 ```

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -31,7 +31,7 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 
 ```mermaid
 flowchart LR
-    subgraph Measurement["Measurement"]
+    subgraph Inputs["Sensors"]
         EO((EnergyOracle))
     end
     subgraph Control["Thermostat"]
@@ -41,33 +41,42 @@ flowchart LR
         RE[[RewardEngineMB]]
         MB{{MB Weights}}
     end
-    subgraph Settlement["Settlement"]
+    subgraph Outputs["Distribution"]
         FP((FeePool))
         REP[[ReputationEngine]]
     end
+    subgraph Roles
+        A[(Agent)]
+        V[(Validator)]
+        O[(Operator)]
+        E[(Employer)]
+    end
 
-    EO -- energy & degeneracy --> RE
-    TH -- Tₛ/T_r --> RE
+    EO -- "attest E_i,g_i" --> RE
+    TH -- "Tₛ/Tᵣ" --> RE
     RE --> MB
     MB --> FP
     MB --> REP
-    FP --> Agent((Agent))
-    FP --> Validator((Validator))
-    FP --> Operator((Operator))
-    FP --> Employer((Employer))
-    REP --> Agent
-    REP --> Validator
-    REP --> Operator
-    REP --> Employer
+    FP -->|65%| A
+    FP -->|15%| V
+    FP -->|15%| O
+    FP -->|5%| E
+    REP --> A
+    REP --> V
+    REP --> O
+    REP --> E
 
     classDef meas fill:#fff5e6,stroke:#ffa200,stroke-width:1px;
     classDef ctrl fill:#e6f2ff,stroke:#0366d6,stroke-width:1px;
     classDef engine fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
-    classDef settle fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;
+    classDef out fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;
+    classDef roles fill:#eef9ff,stroke:#004a99,stroke-width:1px;
+
     class EO meas;
     class TH ctrl;
     class RE,MB engine;
-    class FP,REP,Agent,Validator,Operator,Employer settle;
+    class FP,REP out;
+    class A,V,O,E roles;
 ```
 
 ### Reward Settlement Process


### PR DESCRIPTION
## Summary
- extend Thermodynamic Incentives diagram with explicit EnergyOracle and Thermostat inputs and labeled role shares
- clarify RewardEngineMB, Thermostat, and EnergyOracle interactions in incentive architecture doc

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c475d7ed88833384013d90ffa48f22