### PR TITLE
docs: visualise reward engine flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ flowchart TB
     class RA,RV,RO,RE rep;
 ```
 
+Default role shares for the epoch budget are shown below:
+
+```mermaid
+pie showData
+    title Role Share Distribution
+    "Agents" : 65
+    "Validators" : 15
+    "Operators" : 15
+    "Employers" : 5
+```
+
 #### Reward Settlement Flow
 
 ```mermaid

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -52,6 +52,11 @@ flowchart LR
         E[(Employer)]
     end
 
+    A -. "energy use" .-> EO
+    V -. "energy use" .-> EO
+    O -. "energy use" .-> EO
+    E -. "energy use" .-> EO
+
     EO -- "attest E_i,g_i" --> RE
     TH -- "Tₛ/Tᵣ" --> RE
     RE --> MB


### PR DESCRIPTION
## Summary
- illustrate epoch role share distribution
- depict how roles report energy metrics to the oracle

## Testing
- `npm test` *(fails: npm warned about http-proxy and exited after downloading compiler)*


------
https://chatgpt.com/codex/tasks/task_e_68c47a724aa483338b9f6ba76e6f58e2