### PR TITLE
docs: add thermodynamic incentive diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 
 ### Thermodynamic Incentives
 
-`RewardEngineMB` meters energy consumption against a global free‑energy budget and assigns each role a share of that budget. The `Thermostat` normalises per‑task usage while `EnergyOracle` supplies measurements, letting the engine raise reward weight and reputation for energy‑efficient participants.
+`RewardEngineMB` meters energy consumption against a global free‑energy budget and assigns each role a share of that budget. The `Thermostat` normalises per‑task usage while `EnergyOracle` supplies measurements, letting the engine raise reward weight and reputation for energy‑efficient participants. Role‑level chemical potentials (μᵣ) shift baseline rewards to keep the system in balance.
 
-Each epoch the resulting free‑energy budget is split **65 %** to agents, **15 %** to validators, **15 %** to operators and **5 %** to employers, rewarding low‑energy contributors with more tokens and reputation.
+Each epoch the resulting free‑energy budget is split **65 %** to agents, **15 %** to validators, **15 %** to operators and **5 %** to employers, rewarding low‑energy contributors with more tokens and reputation. See [docs/reward-settlement-process.md](docs/reward-settlement-process.md) for a full settlement walkthrough.
 
 | Energy Used (kJ) | Reward Weight | Reputation Gain |
 | ---------------- | ------------- | --------------- |
@@ -61,6 +61,7 @@ flowchart TB
     EO((EnergyOracle)) -- "E_i, g_i" --> weights
     TH((Thermostat)) -- Tₛ --> T
     TH -- Tᵣ --> weights
+    Mu((μ_r)) -- "chemical potential" --> weights
 
     subgraph Budgeting["Free-Energy Budgeting"]
         V[Total Value] --> dH["ΔH"]
@@ -92,7 +93,7 @@ flowchart TB
     classDef role fill:#e6f2ff,stroke:#0366d6,stroke-width:1px;
     classDef rep fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
 
-    class V,C,Upre,Upost,T,dH,dS,dG,budget,weights,EO,TH thermo;
+    class V,C,Upre,Upost,T,dH,dS,dG,budget,weights,EO,TH,Mu thermo;
     class Agents,Validators,Operators,Employers role;
     class RA,RV,RO,RE rep;
 ```

--- a/docs/reward-settlement-process.md
+++ b/docs/reward-settlement-process.md
@@ -1,0 +1,62 @@
+# Reward Settlement Process
+
+The reward engine settles each epoch by converting reduced free energy into tokens and reputation. The diagrams below illustrate the end-to-end flow from job completion to payouts.
+
+## Free-Energy Flow
+
+```mermaid
+flowchart TD
+    Start((Job Completed)) --> Oracle["EnergyOracle\nattests E_i,g_i,u_pre,u_post,value"]
+    Oracle --> Engine[RewardEngineMB]
+    Engine --> Thermostat
+    Thermostat --> Engine
+    Engine --> Budget["ΔG → κ·budget"]
+    Budget --> Weights["MB weights per role"]
+    Weights --> FeePool
+    Weights --> ReputationEngine
+    FeePool -->|65%| Agent
+    FeePool -->|15%| Validator
+    FeePool -->|15%| Operator
+    FeePool -->|5%| Employer
+    ReputationEngine --> Agent
+    ReputationEngine --> Validator
+    ReputationEngine --> Operator
+    ReputationEngine --> Employer
+    classDef core fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
+    class Engine,Thermostat,Oracle,FeePool,ReputationEngine,Budget,Weights core;
+```
+
+## Settlement Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Employer
+    participant Agent
+    participant Validator
+    participant Operator
+    participant Oracle as EnergyOracle
+    participant Engine as RewardEngineMB
+    participant Thermostat
+    participant FeePool
+    participant Reputation
+
+    Employer->>Agent: Post job & funds
+    Agent->>Validator: Submit work
+    Validator->>Employer: Approve results
+    Agent->>Oracle: Report energy use
+    Oracle-->>Engine: Signed attestation
+    Engine->>Thermostat: Query Tₛ/Tᵣ
+    Thermostat-->>Engine: Temperatures
+    Engine->>Engine: Compute ΔG & weights
+    Engine->>FeePool: Allocate rewards
+    Engine->>Reputation: Update scores
+    FeePool-->>Agent: Token reward
+    FeePool-->>Validator: Token reward
+    FeePool-->>Operator: Token reward
+    FeePool-->>Employer: Rebate
+    Reputation-->>Agent: Reputation ↑
+    Reputation-->>Validator: Reputation ↑
+    Reputation-->>Operator: Reputation ↑
+    Reputation-->>Employer: Reputation ↑
+```

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -31,6 +31,17 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 
 ```mermaid
 flowchart LR
+    EO[EnergyOracle] -->|attests energy| RE[RewardEngineMB]
+    RE -->|usage metrics| TH[Thermostat]
+    TH -->|Tₛ/Tᵣ| RE
+    RE --> FP[FeePool]
+    RE --> REP[ReputationEngine]
+    classDef mod fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
+    class EO,RE,TH,FP,REP mod;
+```
+
+```mermaid
+flowchart LR
     subgraph Inputs["Sensors"]
         EO((EnergyOracle))
     end


### PR DESCRIPTION
## Summary
- illustrate thermodynamic budgeting and role rewards in README
- document RewardEngineMB, Thermostat, and EnergyOracle interactions
- add end-to-end reward settlement flow diagrams

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c48151ff008333abb3f6d4d72d1cf2