### PR TITLE
docs: add thermodynamic incentive diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ flowchart TD
     G --> B{"Budget = κ·max(0, −ΔG)"}:::calc
     B --> MB["Maxwell–Boltzmann Weights\nwᵢ ∝ gᵢ·e((μᵣ−Eᵢ)/Tᵣ)"]:::calc
 
+    MB --> FP((FeePool)):::dist
+    MB --> REP((ReputationEngine)):::rep
+
     subgraph Allocation
         AG[Agents]
         VD[Validators]
@@ -81,10 +84,15 @@ flowchart TD
         EM[Employers]
     end
 
-    MB -->|65%| AG:::dist
-    MB -->|15%| VD:::dist
-    MB -->|15%| OP:::dist
-    MB -->|5%| EM:::dist
+    FP -->|65%| AG:::dist
+    FP -->|15%| VD:::dist
+    FP -->|15%| OP:::dist
+    FP -->|5%| EM:::dist
+
+    REP --> AG
+    REP --> VD
+    REP --> OP
+    REP --> EM
 
     AG --> RAG[Reputation ↑]:::rep
     VD --> RVD[Reputation ↑]:::rep

--- a/docs/reward-settlement-process.md
+++ b/docs/reward-settlement-process.md
@@ -73,3 +73,16 @@ sequenceDiagram
     Reputation-->>Employer: Reputation ↑
     Note over FeePool,Reputation: Rewards and reputation finalised
 ```
+
+## Settlement States
+
+```mermaid
+stateDiagram-v2
+    [*] --> Data
+    Data: Collect job metrics
+    Data --> Budget: Compute ΔH & ΔS
+    Budget --> Weights: Apply MB weights
+    Weights --> Rewards: Distribute tokens
+    Rewards --> Reputation: Update scores
+    Reputation --> [*]
+```

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -122,6 +122,23 @@ flowchart LR
     class A,V,O,E roles;
 ```
 
+```mermaid
+sequenceDiagram
+    autonumber
+    participant EO as EnergyOracle
+    participant RE as RewardEngineMB
+    participant TH as Thermostat
+    loop each epoch
+        EO->>RE: attest(Eᵢ,gᵢ,ΔS,value)
+        RE->>TH: request Tₛ/Tᵣ
+        TH-->>RE: return temperatures
+        RE->>TH: report usage error
+        TH-->>RE: adjust Tₛ/Tᵣ
+        RE->>RE: compute ΔG & weights
+    end
+    Note over EO,TH: PID loop keeps rewards energy-efficient
+```
+
 ### Reward Settlement Process
 
 ```mermaid


### PR DESCRIPTION
## Summary
- illustrate thermodynamic incentive flow in README with role shares and reputation gains
- expand incentive architecture docs with module interaction sequence diagram
- enrich reward settlement guide with state diagram of the settlement lifecycle

## Testing
- `npm test`
- `npx prettier --check README.md docs/universal-platform-incentive-architecture.md docs/reward-settlement-process.md`


------
https://chatgpt.com/codex/tasks/task_e_68c49c1bde588333b6052eb4ba3befdf