### PR TITLE
docs: expand thermodynamic incentive diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 
 Each epoch the resulting free‑energy budget is split **65 %** to agents, **15 %** to validators, **15 %** to operators and **5 %** to employers, rewarding low‑energy contributors with more tokens and reputation. See [docs/reward-settlement-process.md](docs/reward-settlement-process.md) for a full settlement walkthrough.
 
+```mermaid
+mindmap
+  root((Thermodynamic Incentives))
+    "Free-Energy Budgeting"
+      "G = H - T·S"
+      "Budget = κ·max(0, -ΔG)"
+    "Role Shares"
+      "Agents 65%"
+      "Validators 15%"
+      "Operators 15%"
+      "Employers 5%"
+    "Reputation"
+      "Low energy → Reputation ↑"
+      "High energy → Reputation ↓"
+```
+
 | Energy Used (kJ) | Reward Weight | Reputation Gain |
 | ---------------- | ------------- | --------------- |
 | 20               | 1.0×          | +5              |

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -24,6 +24,18 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 
 `RewardEngineMB` tracks a free‑energy budget for each role. The `EnergyOracle` reports per‑task consumption and the `Thermostat` compares it with role allocations, adjusting reward weight when usage falls below budget. Efficient agents therefore earn a larger share of fees and gain reputation faster.
 
+```mermaid
+flowchart LR
+    classDef oracle fill:#dff9fb,stroke:#00a8ff,stroke-width:1px;
+    classDef engine fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
+    classDef thermo fill:#fff5e6,stroke:#ffa200,stroke-width:1px;
+
+    EO((EnergyOracle)):::oracle -- attestation --> RE[RewardEngineMB]:::engine
+    RE -- temp query --> TH((Thermostat)):::thermo
+    TH -- Tₛ/Tᵣ --> RE
+    RE -- usage feedback --> TH
+```
+
 | Energy Used (kJ) | Reward Weight | Reputation Gain |
 | ---------------- | ------------- | --------------- |
 | 20               | 1.0×          | +5              |


### PR DESCRIPTION
## Summary
- Enrich Thermodynamic Incentives docs with a mind‑map covering free‑energy budgeting, role shares and reputation effects
- Illustrate RewardEngineMB ↔ Thermostat ↔ EnergyOracle dataflow in universal incentive architecture

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4a0f99f0c8333b49010bec2e3fcba