### PR TITLE
docs: add thermodynamic incentive diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,41 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 Each epoch the resulting free‑energy budget is split **65 %** to agents, **15 %** to validators, **15 %** to operators and **5 %** to employers, rewarding low‑energy contributors with more tokens and reputation. See [docs/reward-settlement-process.md](docs/reward-settlement-process.md) for a full settlement walkthrough.
 
 ```mermaid
-mindmap
-  root((Thermodynamic Incentives))
-    "Free-Energy Budgeting"
-      "G = H - T·S"
-      "Budget = κ·max(0, -ΔG)"
-    "Role Shares"
-      "Agents 65%"
-      "Validators 15%"
-      "Operators 15%"
-      "Employers 5%"
-    "Reputation"
-      "Low energy → Reputation ↑"
-      "High energy → Reputation ↓"
+flowchart LR
+    classDef budget fill:#fff5e6,stroke:#ffa200,stroke-width:1px;
+    classDef share fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;
+    classDef rep fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
+
+    subgraph Budget["Free‑Energy Budgeting"]
+        G["ΔG = (Value − Costs) − Tₛ·ΔS"]:::budget
+        B["Budget = κ·max(0, −ΔG)"]:::budget
+        G --> B
+    end
+
+    subgraph Shares["Role Shares"]
+        AG[Agents 65%]:::share
+        VD[Validators 15%]:::share
+        OP[Operators 15%]:::share
+        EM[Employers 5%]:::share
+    end
+
+    subgraph Reputation["Energy‑Efficient Reputation"]
+        Rplus["Low energy → Reputation ↑"]:::rep
+        Rminus["High energy → Reputation ↓"]:::rep
+    end
+
+    B --> AG
+    B --> VD
+    B --> OP
+    B --> EM
+    AG --> Rplus
+    VD --> Rplus
+    OP --> Rplus
+    EM --> Rplus
+    AG -. high E .-> Rminus
+    VD -. high E .-> Rminus
+    OP -. high E .-> Rminus
+    EM -. high E .-> Rminus
 ```
 
 | Energy Used (kJ) | Reward Weight | Reputation Gain |

--- a/docs/reward-settlement-process.md
+++ b/docs/reward-settlement-process.md
@@ -86,3 +86,48 @@ stateDiagram-v2
     Rewards --> Reputation: Update scores
     Reputation --> [*]
 ```
+
+## Module Interaction Overview
+
+```mermaid
+flowchart LR
+    classDef sensor fill:#dff9fb,stroke:#00a8ff,stroke-width:1px;
+    classDef engine fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
+    classDef dist fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;
+    classDef role fill:#eef9ff,stroke:#004a99,stroke-width:1px;
+
+    subgraph Sensors
+        EO((EnergyOracle)):::sensor
+        TH((Thermostat)):::sensor
+    end
+
+    subgraph Engine["RewardEngineMB"]
+        MB{{MB Weights}}:::engine
+    end
+
+    subgraph Outputs
+        FP((FeePool)):::dist
+        REP((ReputationEngine)):::dist
+    end
+
+    subgraph Roles
+        AG[Agent]:::role
+        VD[Validator]:::role
+        OP[Operator]:::role
+        EM[Employer]:::role
+    end
+
+    EO --> Engine
+    TH --> Engine
+    Engine --> MB
+    MB --> FP
+    MB --> REP
+    FP --> AG
+    FP --> VD
+    FP --> OP
+    FP --> EM
+    REP --> AG
+    REP --> VD
+    REP --> OP
+    REP --> EM
+```

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -29,11 +29,32 @@ flowchart LR
     classDef oracle fill:#dff9fb,stroke:#00a8ff,stroke-width:1px;
     classDef engine fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
     classDef thermo fill:#fff5e6,stroke:#ffa200,stroke-width:1px;
+    classDef out fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;
 
-    EO((EnergyOracle)):::oracle -- attestation --> RE[RewardEngineMB]:::engine
-    RE -- temp query --> TH((Thermostat)):::thermo
-    TH -- Tₛ/Tᵣ --> RE
-    RE -- usage feedback --> TH
+    subgraph EO["EnergyOracle"]
+        EO1[Capture metrics]
+        EO2[Sign attestation]
+    end
+
+    subgraph RE["RewardEngineMB"]
+        RE1[Verify & aggregate]
+        RE2[Compute ΔG & MB weights]
+    end
+
+    subgraph TH["Thermostat"]
+        TH1[(Tₛ/Tᵣ)]
+        TH2[PID adjust]
+    end
+
+    EO1 --> EO2
+    EO2 -->|attestation| RE1
+    RE1 --> RE2
+    RE2 -->|query temp| TH1
+    TH1 --> RE2
+    RE2 -->|usage feedback| TH2
+    TH2 --> TH1
+    RE2 --> FP((FeePool)):::out
+    RE2 --> REP((ReputationEngine)):::out
 ```
 
 | Energy Used (kJ) | Reward Weight | Reputation Gain |


### PR DESCRIPTION
## Summary
- expand README with a detailed thermodynamic incentives flowchart linking free-energy budgeting, role shares and reputation impacts
- illustrate RewardEngineMB, Thermostat and EnergyOracle feedback loop in the incentive architecture docs
- document module interaction overview for end-to-end reward settlement

## Testing
- `npm test` *(fails: solc compilation did not complete)*
- `npx prettier --check README.md docs/universal-platform-incentive-architecture.md docs/reward-settlement-process.md`


------
https://chatgpt.com/codex/tasks/task_e_68c4a489f8248333b55e6cdfebb0f5b7