### PR TITLE
docs: add incentive mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 Each epoch the resulting free‑energy budget is split **65 %** to agents, **15 %** to validators, **15 %** to operators and **5 %** to employers, rewarding low‑energy contributors with more tokens and reputation. See [docs/reward-settlement-process.md](docs/reward-settlement-process.md) for a full settlement walkthrough.
 
 ```mermaid
+stateDiagram-v2
+    classDef meas fill:#dff9fb,stroke:#00a8ff,stroke-width:1px;
+    classDef calc fill:#fff5e6,stroke:#ffa200,stroke-width:1px;
+    classDef dist fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;
+    classDef rep fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
+
+    [*] --> Metrics
+    Metrics: Measure Eᵢ,gᵢ,ΔS,value
+    Metrics --> Budget: ΔG budget
+    Budget --> Weights: MB weights
+    Weights --> Distribution: Role splits
+    Distribution --> Reputation: Rep updates
+    Reputation --> Metrics
+    class Metrics meas;
+    class Budget calc;
+    class Weights calc;
+    class Distribution dist;
+    class Reputation rep;
+```
+
+```mermaid
 flowchart LR
     classDef budget fill:#fff5e6,stroke:#ffa200,stroke-width:1px;
     classDef share fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;

--- a/docs/reward-settlement-process.md
+++ b/docs/reward-settlement-process.md
@@ -131,3 +131,19 @@ flowchart LR
     REP --> OP
     REP --> EM
 ```
+
+## Participant Journey
+
+```mermaid
+journey
+    title Reward Settlement Journey
+    section Job Lifecycle
+      Post job & fund escrow: 5: Employer
+      Complete work: 5: Agent
+      Validate result: 5: Validator
+    section Incentive Loop
+      Attest energy: 4: EnergyOracle
+      Settle epoch: 4: RewardEngineMB
+      Distribute rewards: 5: FeePool
+      Reputation update: 5: ReputationEngine
+```

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -25,6 +25,34 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 `RewardEngineMB` tracks a free‑energy budget for each role. The `EnergyOracle` reports per‑task consumption and the `Thermostat` compares it with role allocations, adjusting reward weight when usage falls below budget. Efficient agents therefore earn a larger share of fees and gain reputation faster.
 
 ```mermaid
+stateDiagram-v2
+    classDef oracle fill:#dff9fb,stroke:#00a8ff,stroke-width:1px;
+    classDef engine fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
+    classDef thermo fill:#fff5e6,stroke:#ffa200,stroke-width:1px;
+    classDef out fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;
+
+    [*] --> Oracle
+    Oracle --> Engine
+    Engine --> Thermostat
+    Thermostat --> Engine
+    Engine --> Outputs
+    Outputs --> [*]
+
+    state Oracle { [*] --> "Attest energy" }
+    state Engine {
+        [*] --> "Verify metrics"
+        "Verify metrics" --> "ΔG & MB weights"
+    }
+    state Thermostat { [*] --> "PID adjust" }
+    state Outputs { [*] --> "FeePool & Reputation" }
+
+    class Oracle oracle;
+    class Engine engine;
+    class Thermostat thermo;
+    class Outputs out;
+```
+
+```mermaid
 flowchart LR
     classDef oracle fill:#dff9fb,stroke:#00a8ff,stroke-width:1px;
     classDef engine fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;


### PR DESCRIPTION
## Summary
- add incentive loop state diagram to README
- illustrate module control loop in universal platform doc
- document reward settlement journey

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4a7cd38f483338d50cd19bf37ffe1