### PR TITLE
docs: add thermodynamic incentive diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 Each epoch the resulting free‑energy budget is split **65 %** to agents, **15 %** to validators, **15 %** to operators and **5 %** to employers, rewarding low‑energy contributors with more tokens and reputation. See [docs/reward-settlement-process.md](docs/reward-settlement-process.md) for a full settlement walkthrough.
 
 ```mermaid
+mindmap
+  root((Thermodynamic Incentives))
+    Free-Energy Budgeting
+      ΔG = (Value − Costs) − Tₛ·ΔS
+      Budget = κ·max(0, −ΔG)
+    Role Shares
+      Agents: 65%
+      Validators: 15%
+      Operators: 15%
+      Employers: 5%
+    Reputation
+      Efficient Work: Reputation↑
+      Wasteful Work: Reputation↓
+```
+
+```mermaid
 stateDiagram-v2
     classDef meas fill:#dff9fb,stroke:#00a8ff,stroke-width:1px;
     classDef calc fill:#fff5e6,stroke:#ffa200,stroke-width:1px;

--- a/docs/reward-settlement-process.md
+++ b/docs/reward-settlement-process.md
@@ -147,3 +147,14 @@ journey
       Distribute rewards: 5: FeePool
       Reputation update: 5: ReputationEngine
 ```
+
+```mermaid
+timeline
+    title Epoch Reward Settlement
+    Job completion: Work finished
+    Energy attestation: Oracle signs metrics
+    Temperature query: Engine pulls Tₛ/Tᵣ
+    Free-energy budget: ΔG evaluated
+    MB distribution: Rewards allocated
+    Reputation update: Efficiency recorded
+```

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -25,6 +25,24 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 `RewardEngineMB` tracks a free‑energy budget for each role. The `EnergyOracle` reports per‑task consumption and the `Thermostat` compares it with role allocations, adjusting reward weight when usage falls below budget. Efficient agents therefore earn a larger share of fees and gain reputation faster.
 
 ```mermaid
+sequenceDiagram
+    autonumber
+    participant EO as EnergyOracle
+    participant RE as RewardEngineMB
+    participant TH as Thermostat
+    participant FP as FeePool
+    participant REP as ReputationEngine
+
+    EO->>RE: attest(Eᵢ,gᵢ,ΔS,value)
+    RE->>TH: request Tₛ/Tᵣ
+    TH-->>RE: temperature supply
+    RE->>RE: compute ΔG & weights
+    RE->>TH: feedback usage
+    RE->>FP: reward allocations
+    RE->>REP: reputation updates
+```
+
+```mermaid
 stateDiagram-v2
     classDef oracle fill:#dff9fb,stroke:#00a8ff,stroke-width:1px;
     classDef engine fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;


### PR DESCRIPTION
## Summary
- expand README with mindmap of free-energy budget, role shares, and energy-efficient reputation gains
- illustrate RewardEngineMB↔Thermostat↔EnergyOracle interactions with new sequence diagram
- extend reward settlement guide with timeline of end-to-end epoch distribution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4b1530bc08333ac9ac2eb0c62a0b6