### PR TITLE
docs: add thermodynamic incentive diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,41 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 Each epoch the resulting free‑energy budget is split **65 %** to agents, **15 %** to validators, **15 %** to operators and **5 %** to employers, rewarding low‑energy contributors with more tokens and reputation. See [docs/reward-settlement-process.md](docs/reward-settlement-process.md) for a full settlement walkthrough.
 
 ```mermaid
+flowchart TD
+    classDef role fill:#eef9ff,stroke:#004a99,stroke-width:1px;
+    classDef meas fill:#dff9fb,stroke:#00a8ff,stroke-width:1px;
+    classDef budget fill:#fff5e6,stroke:#ffa200,stroke-width:1px;
+    classDef share fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;
+    classDef rep fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
+
+    subgraph Participants
+        A[Agent]:::role --> M
+        V[Validator]:::role --> M
+        O[Operator]:::role --> M
+        E[Employer]:::role --> M
+    end
+
+    M[(EnergyOracle\n+ Thermostat)]:::meas --> B["Budget = κ·max(0, −((Value − Costs) − Tₛ·ΔS))"]:::budget
+
+    subgraph Shares
+        B -->|65%| SA[Agents]:::share
+        B -->|15%| SV[Validators]:::share
+        B -->|15%| SO[Operators]:::share
+        B -->|5%| SE[Employers]:::share
+    end
+
+    SA --> RA["Reputation↑ if low energy"]:::rep
+    SV --> RV["Reputation↑ if low energy"]:::rep
+    SO --> RO["Reputation↑ if low energy"]:::rep
+    SE --> REp["Reputation↑ if low energy"]:::rep
+
+    RA -.-> M
+    RV -.-> M
+    RO -.-> M
+    REp -.-> M
+```
+
+```mermaid
 mindmap
   root((Thermodynamic Incentives))
     Free-Energy Budgeting

--- a/docs/reward-settlement-process.md
+++ b/docs/reward-settlement-process.md
@@ -2,6 +2,38 @@
 
 The reward engine settles each epoch by converting reduced free energy into tokens and reputation. The diagrams below illustrate the end-to-end flow from job completion to payouts.
 
+## End-to-End Overview
+
+```mermaid
+flowchart LR
+    classDef role fill:#eef9ff,stroke:#004a99,stroke-width:1px;
+    classDef step fill:#fff5e6,stroke:#ffa200,stroke-width:1px;
+    classDef out fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;
+    classDef rep fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
+
+    subgraph Job["Job Lifecycle"]
+        E1[Employer posts job]:::role --> A1[Agent submits work]:::role --> V1[Validator approves]:::role
+    end
+
+    subgraph Energy["Energy Accounting"]
+        V1 --> OR[EnergyOracle attests metrics]:::step --> RE[RewardEngineMB computes ΔG]:::step --> TH[Thermostat adjusts T]:::step
+    end
+
+    subgraph Distribution
+        RE --> FP[FeePool allocates tokens]:::out
+        RE --> REP[ReputationEngine updates scores]:::rep
+    end
+
+    FP --> A2[Agent reward]:::role
+    FP --> V2[Validator reward]:::role
+    FP --> O2[Operator reward]:::role
+    FP --> E2[Employer rebate]:::role
+    REP --> A2
+    REP --> V2
+    REP --> O2
+    REP --> E2
+```
+
 ## Free-Energy Flow
 
 ```mermaid

--- a/docs/universal-platform-incentive-architecture.md
+++ b/docs/universal-platform-incentive-architecture.md
@@ -25,6 +25,21 @@ The AGI Jobs v2 suite implements a single, stake‑based framework that treats t
 `RewardEngineMB` tracks a free‑energy budget for each role. The `EnergyOracle` reports per‑task consumption and the `Thermostat` compares it with role allocations, adjusting reward weight when usage falls below budget. Efficient agents therefore earn a larger share of fees and gain reputation faster.
 
 ```mermaid
+flowchart LR
+    classDef oracle fill:#dff9fb,stroke:#00a8ff,stroke-width:1px;
+    classDef engine fill:#e8ffe8,stroke:#2e7d32,stroke-width:1px;
+    classDef thermo fill:#fff5e6,stroke:#ffa200,stroke-width:1px;
+    classDef out fill:#fdf5ff,stroke:#8e24aa,stroke-width:1px;
+
+    EO[EnergyOracle]:::oracle --> RE[RewardEngineMB]:::engine
+    RE -->|query Tₛ/Tᵣ| TH[Thermostat]:::thermo
+    TH -->|temperatures| RE
+    RE -->|usage feedback| TH
+    RE --> FP[FeePool]:::out
+    RE --> REP[ReputationEngine]:::out
+```
+
+```mermaid
 sequenceDiagram
     autonumber
     participant EO as EnergyOracle


### PR DESCRIPTION
## Summary
- illustrate role flows for thermodynamic incentives in README
- visualise RewardEngineMB, Thermostat and EnergyOracle interplay
- map end-to-end reward settlement journey

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4b6b84fb88333be01a321adef731f