### PR TITLE
Add test for missing treasury in reward leftovers

### DIFF
--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -291,5 +291,17 @@ contract RewardEngineMBTest is Test {
         assertEq(pool.total(), budget, "total budget accounted");
         assertEq(pool.rewards(treasury), leftover, "leftover to treasury");
     }
+
+    function test_leftover_without_treasury_reverts() public {
+        RewardEngineMB.EpochData memory data;
+        RewardEngineMB.Proof[] memory a = new RewardEngineMB.Proof[](2);
+        a[0] = _proof(address(0xA1), int256(1e18), 1, RewardEngineMB.Role.Agent);
+        a[0].att.uPre = 1e18;
+        a[1] = _proof(address(0xA2), int256(2e18), 1, RewardEngineMB.Role.Agent);
+        data.agents = a;
+        engine.setKappa(1);
+        vm.expectRevert(bytes("treasury"));
+        engine.settleEpoch(1, data);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add regression test ensuring RewardEngineMB settlement requires a treasury when leftover rewards remain

## Testing
- `forge test --match-path test/v2/RewardEngineMB.t.sol --match-test leftover_without_treasury_reverts` *(fails: Invalid type for argument in unrelated test file)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e00897308333b6832b6e3814b19b