### PR TITLE
feat: emit settler update event

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -62,6 +62,7 @@ contract RewardEngineMB is Ownable {
     event TreasuryUpdated(address indexed treasury);
     event RoleShareUpdated(Role indexed role, uint256 share);
     event MuUpdated(Role indexed role, int256 muValue);
+    event SettlerUpdated(address indexed settler, bool allowed);
     event RewardBudget(
         uint256 indexed epoch,
         uint256 minted,
@@ -115,6 +116,7 @@ contract RewardEngineMB is Ownable {
 
     function setSettler(address settler, bool allowed) external onlyOwner {
         settlers[settler] = allowed;
+        emit SettlerUpdated(settler, allowed);
     }
 
     function setTreasury(address _treasury) external onlyOwner {

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -183,6 +183,12 @@ contract RewardEngineMBTest is Test {
         engine.setRoleShare(RewardEngineMB.Role.Agent, 65e16);
     }
 
+    function test_setSettlerEmits() public {
+        vm.expectEmit(true, false, false, true);
+        emit RewardEngineMB.SettlerUpdated(address(0xBEEF), true);
+        engine.setSettler(address(0xBEEF), true);
+    }
+
     function test_setMuEmits() public {
         vm.expectEmit(true, false, false, true);
         emit RewardEngineMB.MuUpdated(RewardEngineMB.Role.Agent, 1);


### PR DESCRIPTION
## Summary
- add `SettlerUpdated` event to `RewardEngineMB` and emit on settler changes
- cover settler update with unit test

## Testing
- `npm test`
- `forge test` *(fails: Invalid type for argument in function call. Invalid implicit conversion from struct IJobRegistry.Job memory to struct MockJobRegistry.LegacyJob memory requested.)*


------
https://chatgpt.com/codex/tasks/task_e_68c4e3fcb6bc83339cb15a98d397efb8