### PR TITLE
Add Thermostat tick utility script and document temperature effects

### DIFF
--- a/docs/thermodynamic-incentives.md
+++ b/docs/thermodynamic-incentives.md
@@ -55,6 +55,9 @@ role‑specific temperatures with `setRoleTemperature` (and later remove them wi
 When no override exists, `getRoleTemperature` falls back to the global system
 temperature.  All temperature changes are constrained within the `[minTemp,
 maxTemp]` bounds to prevent extreme rewards.
+Higher temperatures flatten the Maxwell–Boltzmann curve so rewards are spread
+more evenly across participants.  Lower temperatures sharpen the distribution,
+concentrating rewards on low‑energy, highly efficient contributors.
 
 ## Events and Monitoring
 

--- a/scripts/thermostat-tick.ts
+++ b/scripts/thermostat-tick.ts
@@ -1,0 +1,45 @@
+import hre from 'hardhat';
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const args: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = argv[i + 1];
+      if (value && !value.startsWith('--')) {
+        args[key] = value;
+        i++;
+      }
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs();
+  const address = args['thermostat'];
+  if (!address) throw new Error('--thermostat <address> required');
+
+  const emission = BigInt(args['emission'] ?? '0');
+  const backlog = BigInt(args['backlog'] ?? '0');
+  const sla = BigInt(args['sla'] ?? '0');
+
+  const { ethers } = hre as any;
+  const [signer] = await ethers.getSigners();
+
+  const abi = ['function tick(int256,int256,int256)'];
+  const thermostat = new ethers.Contract(address, abi, signer);
+
+  const tx = await thermostat.tick(emission, backlog, sla);
+  console.log(`tick tx: ${tx.hash}`);
+  await tx.wait();
+  const current = await thermostat.systemTemperature();
+  console.log(`systemTemperature: ${current}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add script to invoke `Thermostat.tick` with KPI inputs
- clarify docs on how temperature shifts reward distribution

## Testing
- `forge test --match-path test/v2/Thermostat.t.sol` *(fails: command not found: forge)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ee26c4bc833380f3d4bfd54e9bed