### PR TITLE
thermostat: add KPI weighting

### DIFF
--- a/contracts/v2/Thermostat.sol
+++ b/contracts/v2/Thermostat.sol
@@ -15,6 +15,10 @@ contract Thermostat is Ownable {
     int256 public ki;
     int256 public kd;
 
+    int256 public wEmission = 1;
+    int256 public wBacklog = 1;
+    int256 public wSla = 1;
+
     mapping(Role => int256) private roleTemps;
 
     int256 private integral;
@@ -24,6 +28,7 @@ contract Thermostat is Ownable {
     event RoleTemperatureUpdated(Role role, int256 temp);
     event PIDUpdated(int256 kp, int256 ki, int256 kd);
     event TemperatureBoundsUpdated(int256 minTemp, int256 maxTemp);
+    event KPIWeightsUpdated(int256 wEmission, int256 wBacklog, int256 wSla);
     event Tick(int256 emission, int256 backlog, int256 sla, int256 newTemp);
 
     constructor(int256 _temp, int256 _min, int256 _max) Ownable(msg.sender) {
@@ -38,6 +43,16 @@ contract Thermostat is Ownable {
         ki = _ki;
         kd = _kd;
         emit PIDUpdated(_kp, _ki, _kd);
+    }
+
+    function setKPIWeights(int256 _wEmission, int256 _wBacklog, int256 _wSla)
+        external
+        onlyOwner
+    {
+        wEmission = _wEmission;
+        wBacklog = _wBacklog;
+        wSla = _wSla;
+        emit KPIWeightsUpdated(_wEmission, _wBacklog, _wSla);
     }
 
     /// @notice Sets a new system temperature within bounds.
@@ -81,7 +96,8 @@ contract Thermostat is Ownable {
     /// @param backlog Current backlog age error.
     /// @param sla Current SLA hit rate error.
     function tick(int256 emission, int256 backlog, int256 sla) external onlyOwner {
-        int256 error = emission + backlog + sla;
+        int256 error =
+            wEmission * emission + wBacklog * backlog + wSla * sla;
         integral += error;
         int256 derivative = error - lastError;
         int256 delta = kp * error + ki * integral + kd * derivative;

--- a/docs/thermodynamic-incentives.md
+++ b/docs/thermodynamic-incentives.md
@@ -49,7 +49,9 @@ threshold, ensuring that repeated bad actors are removed from the market.
 ## Temperature Control
 
 `Thermostat.tick` adjusts the global temperature based on three KPI inputs:
-reward emission error, job backlog error and SLA error.  Governance can also set
+reward emission error, job backlog error and SLA error. Each KPI is multiplied
+by a configurable weight set via `setKPIWeights`, allowing governance to
+emphasise particular metrics when tuning the controller. Governance can also set
 role‑specific temperatures with `setRoleTemperature` (and later remove them with
 `unsetRoleTemperature`) to encourage or dampen participation in a given role.
 When no override exists, `getRoleTemperature` falls back to the global system

--- a/test/v2/Thermostat.t.sol
+++ b/test/v2/Thermostat.t.sol
@@ -14,6 +14,16 @@ contract ThermostatTest is Test {
         assertEq(t.systemTemperature(), 1);
     }
 
+    function test_weightedTickAdjustsError() public {
+        Thermostat t = new Thermostat(int256(100), int256(1), int256(200));
+        t.setPID(int256(1), int256(0), int256(0));
+        vm.expectEmit(false, false, false, true, address(t));
+        emit Thermostat.KPIWeightsUpdated(int256(2), int256(1), int256(0));
+        t.setKPIWeights(int256(2), int256(1), int256(0));
+        t.tick(int256(10), int256(10), int256(10));
+        assertEq(t.systemTemperature(), 130);
+    }
+
     function test_roleTemperatureOverride() public {
         Thermostat t = new Thermostat(int256(100), int256(1), int256(200));
         assertEq(t.getRoleTemperature(Thermostat.Role.Agent), 100);


### PR DESCRIPTION
## Summary
- allow governance to weight emission, backlog and SLA KPIs in the Thermostat controller
- document and test weighted KPI behavior

## Testing
- `npm test`
- `forge test` *(fails: Invalid implicit conversion from struct IJobRegistry.Job memory to struct MockJobRegistry.LegacyJob memory in ValidationFinalizeGas.t.sol)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f0e7881c83339090a361eb7606fc