### PR TITLE
feat: add stake adjustment tooling

### DIFF
--- a/docs/stake-guidelines.md
+++ b/docs/stake-guidelines.md
@@ -1,0 +1,43 @@
+# Stake Adjustment Guidelines
+
+This policy outlines how governance should evaluate staking parameters
+and when to update them.
+
+## Metrics
+
+The `scripts/stake-adjuster.ts` utility reads on‑chain data and reports:
+
+- **Active agents** – unique addresses that deposited stake as agents
+  in the recent block window.
+- **Average job reward** – mean of the `JobFunded` rewards over the
+  same window.
+
+Run the tool with
+
+```bash
+npx ts-node --compiler-options '{"module":"commonjs"}' scripts/stake-adjuster.ts --stake-manager <address> --job-registry <address>
+```
+
+## Recommendations
+
+The script suggests new limits using recent rewards:
+
+- `minStake` ≈ 10% of the average job reward
+- `maxStakePerAddress` ≈ 10 × the average job reward
+
+To immediately apply the recommendation, provide a governance key and
+pass `--apply`:
+
+```bash
+PRIVATE_KEY=0xabc... npx ts-node --compiler-options '{"module":"commonjs"}' scripts/stake-adjuster.ts --stake-manager <address> --job-registry <address> --apply
+```
+
+This invokes `StakeManager.setMinStake` and
+`StakeManager.setMaxStakePerAddress` with the calculated values.
+
+## Schedule
+
+Review these metrics monthly. If the active‑agent count or average
+reward shifts by more than 20% since the last review, update the staking
+limits using the script. Regular adjustments keep staking requirements
+aligned with market conditions.

--- a/scripts/stake-adjuster.ts
+++ b/scripts/stake-adjuster.ts
@@ -1,0 +1,122 @@
+import { ethers } from 'ethers';
+import { config as dotenvConfig } from 'dotenv';
+
+dotenvConfig();
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const args: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        args[key] = next;
+        i++;
+      } else {
+        args[key] = true;
+      }
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs();
+  const rpc = process.env.RPC_URL || 'http://localhost:8545';
+  const provider = new ethers.JsonRpcProvider(rpc);
+
+  const stakeAddress =
+    (args['stake-manager'] as string) || process.env.STAKE_MANAGER;
+  const registryAddress =
+    (args['job-registry'] as string) || process.env.JOB_REGISTRY;
+
+  if (!stakeAddress || !registryAddress) {
+    throw new Error('stake-manager and job-registry addresses are required');
+  }
+
+  const stakeAbi = [
+    'event StakeDeposited(address indexed user,uint8 indexed role,uint256 amount)',
+    'function setMinStake(uint256)',
+    'function setMaxStakePerAddress(uint256)',
+  ];
+
+  const jobAbi = [
+    'event JobFunded(uint256 indexed jobId,address indexed employer,uint256 reward,uint256 fee)',
+  ];
+
+  const stake = new ethers.Contract(stakeAddress, stakeAbi, provider);
+  const registry = new ethers.Contract(registryAddress, jobAbi, provider);
+
+  const latest = await provider.getBlockNumber();
+  const lookback = Number(args['lookback-blocks'] || 50000);
+  const fromBlock = latest - lookback > 0 ? latest - lookback : 0;
+
+  const stakeEvents = await stake.queryFilter(
+    stake.filters.StakeDeposited(null, 0),
+    fromBlock,
+    latest
+  );
+
+  const agents = new Set<string>();
+  for (const ev of stakeEvents) {
+    const user = (ev.args as any)[0] as string;
+    agents.add(user.toLowerCase());
+  }
+
+  const jobEvents = await registry.queryFilter(
+    registry.filters.JobFunded(),
+    fromBlock,
+    latest
+  );
+
+  let total = 0n;
+  for (const ev of jobEvents) {
+    const reward = (ev.args as any)[2] as bigint;
+    total += reward;
+  }
+  const avgReward = jobEvents.length ? total / BigInt(jobEvents.length) : 0n;
+
+  const recommendedMin = avgReward / 10n;
+  const recommendedMax = avgReward * 10n;
+
+  console.log(`Active agents: ${agents.size}`);
+  console.log(
+    `Average reward: ${ethers.formatUnits(avgReward, 18)} tokens over ${
+      jobEvents.length
+    } jobs`
+  );
+  console.log(
+    `Recommended minStake: ${ethers.formatUnits(recommendedMin, 18)} tokens`
+  );
+  console.log(
+    `Recommended maxStakePerAddress: ${ethers.formatUnits(
+      recommendedMax,
+      18
+    )} tokens`
+  );
+
+  if (args['apply']) {
+    const key = process.env.PRIVATE_KEY;
+    if (!key) {
+      throw new Error('PRIVATE_KEY is required to apply changes');
+    }
+    const wallet = new ethers.Wallet(key, provider);
+    const stakeSigned = stake.connect(wallet);
+
+    if (recommendedMin > 0n) {
+      const tx1 = await stakeSigned.setMinStake(recommendedMin);
+      await tx1.wait();
+      console.log(`setMinStake tx: ${tx1.hash}`);
+    }
+    const tx2 = await stakeSigned.setMaxStakePerAddress(recommendedMax);
+    await tx2.wait();
+    console.log(`setMaxStakePerAddress tx: ${tx2.hash}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `stake-adjuster.ts` script to derive min/max stake recommendations from on-chain stats
- allow governance to apply recommendations via `setMinStake` and `setMaxStakePerAddress`
- document staking policy and review schedule

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c57914a3a0833397bf2cefd42d5c67