### PR TITLE
feat: add stake recommendation setters and tests

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -491,6 +491,19 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         emit MaxStakePerAddressUpdated(maxStake);
     }
 
+    /// @notice set recommended minimum and maximum stake values
+    /// @dev `newMax` may be zero to disable the limit but must not be below `newMin`
+    /// @param newMin recommended minimum stake with 18 decimals
+    /// @param newMax recommended maximum total stake per address with 18 decimals
+    function setStakeRecommendations(uint256 newMin, uint256 newMax) external onlyGovernance {
+        if (newMin == 0) revert InvalidMinStake();
+        if (newMax != 0 && newMax < newMin) revert InvalidParams();
+        minStake = newMin;
+        emit MinStakeUpdated(newMin);
+        maxStakePerAddress = newMax;
+        emit MaxStakePerAddressUpdated(newMax);
+    }
+
     /// @notice Update the maximum number of AGI types allowed
     function setMaxAGITypes(uint256 newMax) external onlyGovernance {
         if (newMax > MAX_AGI_TYPES_CAP) {


### PR DESCRIPTION
## Summary
- allow governance to set recommended min and max stake values in StakeManager
- document periodic stake adjustment policy in stake-adjuster script
- add fuzz tests to ensure recommendations respect min and max stake limits

## Testing
- `forge test` *(fails: Invalid type for argument in test/v2/ValidationFinalizeGas.t.sol)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5969f58048333a0ab37c0df3ae7f1