### PR TITLE
Add incentive tests for ReputationEngine

### DIFF
--- a/test/v2/ReputationIncentives.t.sol
+++ b/test/v2/ReputationIncentives.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import "contracts/v2/ReputationEngine.sol";
+import "contracts/legacy/MockV2.sol";
+
+contract ReputationIncentivesTest is Test {
+    ReputationEngine engine;
+    MockStakeManager stake;
+
+    address honestAgent = address(0x1);
+    address cheatAgent = address(0x2);
+    address honestValidator = address(0x3);
+    address cheatValidator = address(0x4);
+
+    function setUp() public {
+        stake = new MockStakeManager();
+        engine = new ReputationEngine(stake);
+        engine.setCaller(address(this), true);
+        engine.setPremiumThreshold(1);
+    }
+
+    function discountedSum(int256[] memory deltas) internal pure returns (int256 sum) {
+        int256 factor = int256(1e18);
+        int256 deltaFactor = int256(9e17); // 0.9
+        for (uint256 i = 0; i < deltas.length; i++) {
+            sum += (deltas[i] * factor) / int256(1e18);
+            factor = (factor * deltaFactor) / int256(1e18);
+        }
+    }
+
+    function testHonestyOutperformsCheating() public {
+        uint256 payout = 100 ether;
+        uint256 duration = 100000;
+        uint256 rounds = 3;
+
+        int256[] memory agentHonest = new int256[](rounds);
+        int256[] memory agentCheat = new int256[](rounds);
+        int256[] memory validatorHonest = new int256[](rounds);
+        int256[] memory validatorCheat = new int256[](rounds);
+
+        uint256 gain = engine.calculateReputationPoints(payout, duration);
+
+        for (uint256 i = 0; i < rounds; i++) {
+            uint256 prev = engine.reputationOf(honestAgent);
+            engine.onFinalize(honestAgent, true, payout, duration);
+            uint256 afterRep = engine.reputationOf(honestAgent);
+            agentHonest[i] = int256(afterRep) - int256(prev);
+
+            prev = engine.reputationOf(honestValidator);
+            engine.rewardValidator(honestValidator, gain);
+            afterRep = engine.reputationOf(honestValidator);
+            validatorHonest[i] = int256(afterRep) - int256(prev);
+
+            prev = engine.reputationOf(cheatAgent);
+            engine.onFinalize(cheatAgent, false, payout, duration);
+            afterRep = engine.reputationOf(cheatAgent);
+            agentCheat[i] = int256(afterRep) - int256(prev);
+
+            prev = engine.reputationOf(cheatValidator);
+            engine.update(cheatValidator, -int256(gain));
+            afterRep = engine.reputationOf(cheatValidator);
+            validatorCheat[i] = int256(afterRep) - int256(prev);
+        }
+
+        int256 honestAgentNPV = discountedSum(agentHonest);
+        int256 cheatAgentNPV = discountedSum(agentCheat);
+        int256 honestValidatorNPV = discountedSum(validatorHonest);
+        int256 cheatValidatorNPV = discountedSum(validatorCheat);
+
+        assertGt(honestAgentNPV, cheatAgentNPV);
+        assertGt(honestValidatorNPV, cheatValidatorNPV);
+    }
+}
+

--- a/test/v2/ReputationIncentives.test.js
+++ b/test/v2/ReputationIncentives.test.js
@@ -2,7 +2,13 @@ const { expect } = require('chai');
 const { ethers } = require('hardhat');
 
 describe('Reputation incentives', function () {
-  let engine, owner, caller, honestAgent, honestValidator, cheatAgent, cheatValidator;
+  let engine,
+    owner,
+    caller,
+    honestAgent,
+    honestValidator,
+    cheatAgent,
+    cheatValidator;
 
   beforeEach(async () => {
     [owner, caller, honestAgent, honestValidator, cheatAgent, cheatValidator] =
@@ -25,7 +31,9 @@ describe('Reputation incentives', function () {
     const duration = 100000;
     const rounds = 3;
     const gamma = 0.9;
-    const gain = Number(await engine.calculateReputationPoints(payout, duration));
+    const gain = Number(
+      await engine.calculateReputationPoints(payout, duration)
+    );
 
     const agentHonest = [];
     const agentCheat = [];
@@ -41,7 +49,9 @@ describe('Reputation incentives', function () {
       agentHonest.push(Number(after - prev));
 
       prev = await engine.reputationOf(honestValidator.address);
-      await engine.connect(caller).rewardValidator(honestValidator.address, gain);
+      await engine
+        .connect(caller)
+        .rewardValidator(honestValidator.address, gain);
       after = await engine.reputationOf(honestValidator.address);
       validatorHonest.push(Number(after - prev));
 
@@ -69,4 +79,3 @@ describe('Reputation incentives', function () {
     expect(honestValidatorNPV).to.be.gt(cheatValidatorNPV);
   });
 });
-

--- a/test/v2/ReputationIncentives.test.js
+++ b/test/v2/ReputationIncentives.test.js
@@ -1,0 +1,72 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('Reputation incentives', function () {
+  let engine, owner, caller, honestAgent, honestValidator, cheatAgent, cheatValidator;
+
+  beforeEach(async () => {
+    [owner, caller, honestAgent, honestValidator, cheatAgent, cheatValidator] =
+      await ethers.getSigners();
+    const Stake = await ethers.getContractFactory('MockStakeManager');
+    const stake = await Stake.deploy();
+    const Engine = await ethers.getContractFactory(
+      'contracts/v2/ReputationEngine.sol:ReputationEngine'
+    );
+    engine = await Engine.deploy(await stake.getAddress());
+    await engine.connect(owner).setCaller(caller.address, true);
+    await engine.connect(owner).setPremiumThreshold(1);
+  });
+
+  const discount = (deltas, delta) =>
+    deltas.reduce((acc, v, i) => acc + v * Math.pow(delta, i), 0);
+
+  it('net utility favors honesty over repeated rounds', async () => {
+    const payout = ethers.parseEther('100');
+    const duration = 100000;
+    const rounds = 3;
+    const gamma = 0.9;
+    const gain = Number(await engine.calculateReputationPoints(payout, duration));
+
+    const agentHonest = [];
+    const agentCheat = [];
+    const validatorHonest = [];
+    const validatorCheat = [];
+
+    for (let i = 0; i < rounds; i++) {
+      let prev = await engine.reputationOf(honestAgent.address);
+      await engine
+        .connect(caller)
+        .onFinalize(honestAgent.address, true, payout, duration);
+      let after = await engine.reputationOf(honestAgent.address);
+      agentHonest.push(Number(after - prev));
+
+      prev = await engine.reputationOf(honestValidator.address);
+      await engine.connect(caller).rewardValidator(honestValidator.address, gain);
+      after = await engine.reputationOf(honestValidator.address);
+      validatorHonest.push(Number(after - prev));
+
+      prev = await engine.reputationOf(cheatAgent.address);
+      await engine
+        .connect(caller)
+        .onFinalize(cheatAgent.address, false, payout, duration);
+      after = await engine.reputationOf(cheatAgent.address);
+      agentCheat.push(Number(after - prev));
+
+      prev = await engine.reputationOf(cheatValidator.address);
+      await engine
+        .connect(caller)
+        .update(cheatValidator.address, -BigInt(gain));
+      after = await engine.reputationOf(cheatValidator.address);
+      validatorCheat.push(Number(after - prev));
+    }
+
+    const honestAgentNPV = discount(agentHonest, gamma);
+    const cheatAgentNPV = discount(agentCheat, gamma);
+    const honestValidatorNPV = discount(validatorHonest, gamma);
+    const cheatValidatorNPV = discount(validatorCheat, gamma);
+
+    expect(honestAgentNPV).to.be.gt(cheatAgentNPV);
+    expect(honestValidatorNPV).to.be.gt(cheatValidatorNPV);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Hardhat test demonstrating honest vs. cheating incentives via ReputationEngine hooks
- include equivalent Foundry test using onFinalize and update to compute reputation changes across rounds
- show that discounted utility (δ≈0.9) favors honest behavior for agents and validators

## Testing
- `npx hardhat test test/v2/ReputationIncentives.test.js`
- `forge test --match-path test/v2/ReputationIncentives.t.sol` *(fails: Invalid type for argument in ValidationFinalizeGas.t.sol)*

------
https://chatgpt.com/codex/tasks/task_e_68c59a02a67083339dbb6f65392610bc