### PR TITLE
feat: add governance to energy oracle

### DIFF
--- a/contracts/v2/EnergyOracle.sol
+++ b/contracts/v2/EnergyOracle.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.25;
 
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IEnergyOracle} from "./interfaces/IEnergyOracle.sol";
+import {Governable} from "./Governable.sol";
 
 /// @title EnergyOracle
 /// @notice Verifies signed energy attestations used for reward settlement.
-contract EnergyOracle is EIP712, Ownable, IEnergyOracle {
+contract EnergyOracle is EIP712, Governable, IEnergyOracle {
     using ECDSA for bytes32;
 
     bytes32 public constant TYPEHASH = keccak256(
@@ -18,9 +18,8 @@ contract EnergyOracle is EIP712, Ownable, IEnergyOracle {
     mapping(address => bool) public signers;
     mapping(address => uint256) public nonces;
 
-    constructor() EIP712("EnergyOracle", "1") Ownable(msg.sender) {}
-
-    function setSigner(address signer, bool allowed) external onlyOwner {
+    constructor(address _governance) EIP712("EnergyOracle", "1") Governable(_governance) {}
+    function setSigner(address signer, bool allowed) external onlyGovernance {
         signers[signer] = allowed;
     }
 

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -80,6 +80,12 @@ async function main() {
   await attestation.waitForDeployment();
   await identity.setAttestationRegistry(await attestation.getAddress());
 
+  const EnergyOracle = await ethers.getContractFactory(
+    'contracts/v2/EnergyOracle.sol:EnergyOracle'
+  );
+  const energyOracle = await EnergyOracle.deploy(deployer.address);
+  await energyOracle.waitForDeployment();
+
   const Dispute = await ethers.getContractFactory(
     'contracts/v2/modules/DisputeModule.sol:DisputeModule'
   );
@@ -204,6 +210,7 @@ async function main() {
   await nft.transferOwnership(await pause.getAddress());
   await identity.transferOwnership(await pause.getAddress());
   await attestation.transferOwnership(await pause.getAddress());
+  await energyOracle.setGovernance(await pause.getAddress());
 
   console.log('StakeManager:', await stake.getAddress());
   console.log('ReputationEngine:', await reputation.getAddress());
@@ -212,6 +219,7 @@ async function main() {
   console.log('JobRegistry:', await registry.getAddress());
   console.log('DisputeModule:', await dispute.getAddress());
   console.log('CertificateNFT:', await nft.getAddress());
+  console.log('EnergyOracle:', await energyOracle.getAddress());
   console.log('SystemPause:', await pause.getAddress());
 }
 

--- a/test/v2/EnergyOracle.t.sol
+++ b/test/v2/EnergyOracle.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
 import {EnergyOracle} from "../../contracts/v2/EnergyOracle.sol";
+import {Governable} from "../../contracts/v2/Governable.sol";
 
 contract EnergyOracleTest is Test {
     EnergyOracle oracle;
@@ -10,7 +11,7 @@ contract EnergyOracleTest is Test {
     address signer;
 
     function setUp() public {
-        oracle = new EnergyOracle();
+        oracle = new EnergyOracle(address(this));
         signerPk = 0xA11CE;
         signer = vm.addr(signerPk);
         oracle.setSigner(signer, true);
@@ -110,6 +111,13 @@ contract EnergyOracleTest is Test {
         assertEq(recovered, signer);
         recovered = oracle.verify(att, sig);
         assertEq(recovered, address(0));
+    }
+
+    function test_only_governance_can_set_signer() public {
+        address attacker = address(0xDEAD);
+        vm.expectRevert(Governable.NotGovernance.selector);
+        vm.prank(attacker);
+        oracle.setSigner(attacker, true);
     }
 }
 


### PR DESCRIPTION
## Summary
- refactor EnergyOracle to use Governable and restrict signer updates to governance
- migrate deploy-v2 script to deploy EnergyOracle and hand governance to timelock
- test that only governance can modify oracle signers

## Testing
- `forge test --match-path test/v2/EnergyOracle.t.sol` *(fails: Invalid type for argument in function call in unrelated test)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a022421c8333b8b34c6332b290fb