### PR TITLE
Gate core setters behind timelock with delay tests

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -89,20 +89,20 @@ contract RewardEngineMB is Governable {
         _validateRoleShares();
     }
 
-    function setRoleShare(Role r, uint256 share) external onlyGovernor {
+    function setRoleShare(Role r, uint256 share) external onlyGovernance {
         roleShare[r] = share;
         _validateRoleShares();
         emit RoleShareUpdated(r, share);
     }
 
-    function setMu(Role r, int256 _mu) external onlyGovernor {
+    function setMu(Role r, int256 _mu) external onlyGovernance {
         mu[r] = _mu;
         emit MuUpdated(r, _mu);
     }
 
     /// @notice Set the scaling factor converting free energy to token units.
     /// @param _kappa New scaling coefficient in 18-decimal fixed point.
-    function setKappa(uint256 _kappa) external onlyGovernor {
+    function setKappa(uint256 _kappa) external onlyGovernance {
         kappa = _kappa;
         emit KappaUpdated(_kappa);
     }
@@ -115,12 +115,12 @@ contract RewardEngineMB is Governable {
     error InvalidProof(address oracle);
     error Replay(address oracle);
 
-    function setSettler(address settler, bool allowed) external onlyGovernor {
+    function setSettler(address settler, bool allowed) external onlyGovernance {
         settlers[settler] = allowed;
         emit SettlerUpdated(settler, allowed);
     }
 
-    function setTreasury(address _treasury) external onlyGovernor {
+    function setTreasury(address _treasury) external onlyGovernance {
         treasury = _treasury;
         emit TreasuryUpdated(_treasury);
     }

--- a/contracts/v2/Thermostat.sol
+++ b/contracts/v2/Thermostat.sol
@@ -40,7 +40,7 @@ contract Thermostat is Governable {
         maxTemp = _max;
     }
 
-    function setPID(int256 _kp, int256 _ki, int256 _kd) external onlyGovernor {
+    function setPID(int256 _kp, int256 _ki, int256 _kd) external onlyGovernance {
         kp = _kp;
         ki = _ki;
         kd = _kd;
@@ -49,7 +49,7 @@ contract Thermostat is Governable {
 
     function setKPIWeights(int256 _wEmission, int256 _wBacklog, int256 _wSla)
         external
-        onlyGovernor
+        onlyGovernance
     {
         wEmission = _wEmission;
         wBacklog = _wBacklog;
@@ -58,14 +58,14 @@ contract Thermostat is Governable {
     }
 
     /// @notice Sets a new system temperature within bounds.
-    function setSystemTemperature(int256 temp) external onlyGovernor {
+    function setSystemTemperature(int256 temp) external onlyGovernance {
         require(temp > 0 && temp >= minTemp && temp <= maxTemp, "temp");
         systemTemperature = temp;
         emit TemperatureUpdated(temp);
     }
 
     /// @notice Updates minimum and maximum allowable temperatures.
-    function setTemperatureBounds(int256 _min, int256 _max) external onlyGovernor {
+    function setTemperatureBounds(int256 _min, int256 _max) external onlyGovernance {
         require(_min > 0 && _max > _min, "bounds");
         minTemp = _min;
         maxTemp = _max;
@@ -75,14 +75,14 @@ contract Thermostat is Governable {
         emit TemperatureUpdated(systemTemperature);
     }
 
-    function setRoleTemperature(Role r, int256 temp) external onlyGovernor {
+    function setRoleTemperature(Role r, int256 temp) external onlyGovernance {
         require(temp > 0 && temp >= minTemp && temp <= maxTemp, "bounds");
         roleTemps[r] = temp;
         emit RoleTemperatureUpdated(r, temp);
     }
 
     /// @notice Removes a role-specific temperature override.
-    function unsetRoleTemperature(Role r) external onlyGovernor {
+    function unsetRoleTemperature(Role r) external onlyGovernance {
         delete roleTemps[r];
         emit RoleTemperatureUpdated(r, 0);
     }
@@ -97,7 +97,7 @@ contract Thermostat is Governable {
     /// @param emission Current emission growth error.
     /// @param backlog Current backlog age error.
     /// @param sla Current SLA hit rate error.
-    function tick(int256 emission, int256 backlog, int256 sla) external onlyGovernor {
+    function tick(int256 emission, int256 backlog, int256 sla) external onlyGovernance {
         int256 error =
             wEmission * emission + wBacklog * backlog + wSla * sla;
         integral += error;

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -71,6 +71,13 @@ Each contract exposes `isTaxExempt(addr)` and rejects direct ETH to keep value t
 For a step-by-step deployment walkthrough with owner-only setters, see [deployment-v2-agialpha.md](deployment-v2-agialpha.md).
 For a production deployment checklist, consult [deployment-guide-production.md](deployment-guide-production.md).
 
+### Governance Timelock
+
+All privileged parameter changes are executed through an
+OpenZeppelin `TimelockController` configured with a **7‑day delay**.
+Transactions must be queued and can only be executed once the delay has
+elapsed, giving the community time to review upcoming changes.
+
 ### Owner Controls and Defaults
 
 | Module           | Owner-only setters (default)                                                                                                                                                                  | Purpose                                                                                           |

--- a/test/v2/TimelockAccess.test.js
+++ b/test/v2/TimelockAccess.test.js
@@ -1,0 +1,108 @@
+const { expect } = require('chai');
+const { ethers, network, artifacts } = require('hardhat');
+const { AGIALPHA } = require('../../scripts/constants');
+
+describe('Timelock access control', function () {
+  it('reverts direct calls and executes after timelock delay', async function () {
+    const [admin] = await ethers.getSigners();
+    const delay = 7 * 24 * 60 * 60; // 7 days
+
+    const Timelock = await ethers.getContractFactory(
+      '@openzeppelin/contracts/governance/TimelockController.sol:TimelockController'
+    );
+    const timelock = await Timelock.deploy(delay, [], [], admin.address);
+    await timelock.waitForDeployment();
+    const proposerRole = await timelock.PROPOSER_ROLE();
+    const executorRole = await timelock.EXECUTOR_ROLE();
+    await timelock.grantRole(proposerRole, admin.address);
+    await timelock.grantRole(executorRole, admin.address);
+
+    // mock staking token at AGIALPHA address
+    const mock = await artifacts.readArtifact('contracts/test/MockERC20.sol:MockERC20');
+    await network.provider.send('hardhat_setCode', [AGIALPHA, mock.deployedBytecode]);
+
+    const Reward = await ethers.getContractFactory(
+      'contracts/v2/RewardEngineMB.sol:RewardEngineMB'
+    );
+    const reward = await Reward.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      await timelock.getAddress()
+    );
+    await reward.waitForDeployment();
+
+    const Stake = await ethers.getContractFactory(
+      'contracts/v2/StakeManager.sol:StakeManager'
+    );
+    const stake = await Stake.deploy(
+      0,
+      0,
+      0,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      await timelock.getAddress()
+    );
+    await stake.waitForDeployment();
+
+    const Thermo = await ethers.getContractFactory(
+      'contracts/v2/Thermostat.sol:Thermostat'
+    );
+    const thermo = await Thermo.deploy(100, 1, 1000, await timelock.getAddress());
+    await thermo.waitForDeployment();
+
+    // direct calls revert
+    await expect(reward.setKappa(2)).to.be.revertedWithCustomError(
+      reward,
+      'NotGovernance'
+    );
+    await expect(stake.setFeePct(1)).to.be.revertedWithCustomError(
+      stake,
+      'NotGovernance'
+    );
+    await expect(thermo.setPID(1, 2, 3)).to.be.revertedWithCustomError(
+      thermo,
+      'NotGovernance'
+    );
+
+    // queue operations
+    const rewardData = reward.interface.encodeFunctionData('setKappa', [2]);
+    const stakeData = stake.interface.encodeFunctionData('setFeePct', [1]);
+    const thermoData = thermo.interface.encodeFunctionData('setPID', [1, 2, 3]);
+
+    const salt1 = ethers.id('reward');
+    const salt2 = ethers.id('stake');
+    const salt3 = ethers.id('thermo');
+
+    await timelock.schedule(reward.target, 0, rewardData, ethers.ZeroHash, salt1, delay);
+    await timelock.schedule(stake.target, 0, stakeData, ethers.ZeroHash, salt2, delay);
+    await timelock.schedule(thermo.target, 0, thermoData, ethers.ZeroHash, salt3, delay);
+
+    // cannot execute before delay
+    await expect(
+      timelock.execute(reward.target, 0, rewardData, ethers.ZeroHash, salt1)
+    ).to.be.reverted;
+    await expect(
+      timelock.execute(stake.target, 0, stakeData, ethers.ZeroHash, salt2)
+    ).to.be.reverted;
+    await expect(
+      timelock.execute(thermo.target, 0, thermoData, ethers.ZeroHash, salt3)
+    ).to.be.reverted;
+
+    await network.provider.send('evm_increaseTime', [delay]);
+    await network.provider.send('evm_mine');
+
+    await timelock.execute(reward.target, 0, rewardData, ethers.ZeroHash, salt1);
+    await timelock.execute(stake.target, 0, stakeData, ethers.ZeroHash, salt2);
+    await timelock.execute(thermo.target, 0, thermoData, ethers.ZeroHash, salt3);
+
+    expect(await reward.kappa()).to.equal(2);
+    expect(await stake.feePct()).to.equal(1);
+    expect(await thermo.kp()).to.equal(1n);
+    expect(await thermo.ki()).to.equal(2n);
+    expect(await thermo.kd()).to.equal(3n);
+  });
+});
+

--- a/test/v2/TimelockAccess.test.js
+++ b/test/v2/TimelockAccess.test.js
@@ -18,8 +18,13 @@ describe('Timelock access control', function () {
     await timelock.grantRole(executorRole, admin.address);
 
     // mock staking token at AGIALPHA address
-    const mock = await artifacts.readArtifact('contracts/test/MockERC20.sol:MockERC20');
-    await network.provider.send('hardhat_setCode', [AGIALPHA, mock.deployedBytecode]);
+    const mock = await artifacts.readArtifact(
+      'contracts/test/MockERC20.sol:MockERC20'
+    );
+    await network.provider.send('hardhat_setCode', [
+      AGIALPHA,
+      mock.deployedBytecode,
+    ]);
 
     const Reward = await ethers.getContractFactory(
       'contracts/v2/RewardEngineMB.sol:RewardEngineMB'
@@ -50,7 +55,12 @@ describe('Timelock access control', function () {
     const Thermo = await ethers.getContractFactory(
       'contracts/v2/Thermostat.sol:Thermostat'
     );
-    const thermo = await Thermo.deploy(100, 1, 1000, await timelock.getAddress());
+    const thermo = await Thermo.deploy(
+      100,
+      1,
+      1000,
+      await timelock.getAddress()
+    );
     await thermo.waitForDeployment();
 
     // direct calls revert
@@ -76,9 +86,30 @@ describe('Timelock access control', function () {
     const salt2 = ethers.id('stake');
     const salt3 = ethers.id('thermo');
 
-    await timelock.schedule(reward.target, 0, rewardData, ethers.ZeroHash, salt1, delay);
-    await timelock.schedule(stake.target, 0, stakeData, ethers.ZeroHash, salt2, delay);
-    await timelock.schedule(thermo.target, 0, thermoData, ethers.ZeroHash, salt3, delay);
+    await timelock.schedule(
+      reward.target,
+      0,
+      rewardData,
+      ethers.ZeroHash,
+      salt1,
+      delay
+    );
+    await timelock.schedule(
+      stake.target,
+      0,
+      stakeData,
+      ethers.ZeroHash,
+      salt2,
+      delay
+    );
+    await timelock.schedule(
+      thermo.target,
+      0,
+      thermoData,
+      ethers.ZeroHash,
+      salt3,
+      delay
+    );
 
     // cannot execute before delay
     await expect(
@@ -94,9 +125,21 @@ describe('Timelock access control', function () {
     await network.provider.send('evm_increaseTime', [delay]);
     await network.provider.send('evm_mine');
 
-    await timelock.execute(reward.target, 0, rewardData, ethers.ZeroHash, salt1);
+    await timelock.execute(
+      reward.target,
+      0,
+      rewardData,
+      ethers.ZeroHash,
+      salt1
+    );
     await timelock.execute(stake.target, 0, stakeData, ethers.ZeroHash, salt2);
-    await timelock.execute(thermo.target, 0, thermoData, ethers.ZeroHash, salt3);
+    await timelock.execute(
+      thermo.target,
+      0,
+      thermoData,
+      ethers.ZeroHash,
+      salt3
+    );
 
     expect(await reward.kappa()).to.equal(2);
     expect(await stake.feePct()).to.equal(1);
@@ -105,4 +148,3 @@ describe('Timelock access control', function () {
     expect(await thermo.kd()).to.equal(3n);
   });
 });
-


### PR DESCRIPTION
## Summary
- Require TimelockController governance for RewardEngineMB and Thermostat setters
- Document 7-day governance delay
- Add tests exercising timelock queue/execute flow

## Testing
- `npx hardhat test test/v2/TimelockAccess.test.js` *(fails: timelock compilation did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a396da4883338b18c67fa8905b4a