### PR TITLE
Deploy RewardEngineMB and Thermostat modules

### DIFF
--- a/docs/testnet-incentives-deployment.md
+++ b/docs/testnet-incentives-deployment.md
@@ -1,0 +1,22 @@
+# Testnet Incentives Deployment
+
+This example shows how to deploy the thermodynamic incentives stack on a public testnet such as Sepolia.
+
+```bash
+npx hardhat run scripts/deploy-v2.ts --network sepolia
+```
+
+Recommended starting parameters used by the script:
+
+- **Thermostat**
+  - initial temperature `1.0` (`1e18`)
+  - min/max temperature `0.5`/`2.0` (`5e17`/`2e18`)
+- **RewardEngineMB role shares**
+  - Agents `65%`
+  - Validators `15%`
+  - Operators `15%`
+  - Employers `5%`
+- **μ defaults** – `0` for all roles
+- **EnergyOracle signers** – add the deploying address as an authorised signer
+
+Adjust parameters and signer addresses as needed for local testing.


### PR DESCRIPTION
## Summary
- deploy Thermostat and RewardEngineMB alongside EnergyOracle in `deploy-v2.ts`
- initialize role shares, μ defaults, temperature bounds, and oracle signer
- document recommended testnet parameters for thermodynamic incentives stack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5af71e5a48333890b2e91cffa6bf4