### PR TITLE
Add budget invariant and document audit plans

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -125,7 +125,9 @@ contract RewardEngineMB is Governable {
         emit TreasuryUpdated(_treasury);
     }
 
-    function settleEpoch(uint256 epoch, EpochData calldata data) external {
+    function settleEpoch(uint256 epoch, EpochData calldata data) external
+        /// #if_succeeds {:msg "budget >= distributed"} budget >= distributed;
+    {
         require(settlers[msg.sender], "not settler");
         uint256 totalValue;
         uint256 sumUpre;

--- a/docs/external-audit-plan.md
+++ b/docs/external-audit-plan.md
@@ -1,0 +1,9 @@
+# External Audit Plan
+
+An external security audit is scheduled to review the `RewardEngineMB` contract and related components.
+
+**Focus Areas**
+- Economic security of reward distribution.
+- Validation of oracle signatures used in energy attestations.
+
+The audit will be performed by a third-party firm with findings integrated into future releases.

--- a/docs/slither-report.md
+++ b/docs/slither-report.md
@@ -1,0 +1,20 @@
+# Slither Static Analysis Report
+
+Date: 2025-09-??
+
+## Target
+
+`contracts/v2/RewardEngineMB.sol`
+
+## Findings
+
+- **Divide before multiply:** `_distribute` multiplies after division which may result in precision loss.
+- **Reentrancy warnings:** `_aggregate` and `settleEpoch` call external contracts before updating state.
+- **Uninitialized local variables:** several local variables such as `totalValue`, `sumUpre`, `sumUpost`, and `distributed` rely on default zero initialization.
+- **Missing zero address validation:** `setTreasury` does not enforce a non-zero `_treasury` address.
+- **Calls inside loops:** loops in `_aggregate` and `_distribute` make external calls (`energyOracle.verify`, `feePool.reward`, `reputation.update`).
+- **State variables not immutable:** `thermostat`, `feePool`, `reputation`, and `energyOracle` could be marked `immutable`.
+
+## Notes
+
+`slither` was executed with `--solc-remaps @openzeppelin=node_modules/@openzeppelin/` and `--filter-paths "node_modules"`.


### PR DESCRIPTION
## Summary
- add Scribble post-condition ensuring distributed rewards never exceed budget
- document Slither findings for RewardEngineMB
- note external audit focusing on economic security and oracle signatures

## Testing
- `slither contracts/v2/RewardEngineMB.sol --solc-remaps @openzeppelin=node_modules/@openzeppelin/ --filter-paths "node_modules"`
- `forge build` *(fails: Source "forge-std/Test.sol" not found)*
- `forge test` *(fails: Compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b81c1cf48333a447ef4cc274c422