### PR TITLE
docs: clarify reward roles and thermostat controls

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -89,12 +89,18 @@ contract RewardEngineMB is Governable {
         _validateRoleShares();
     }
 
+    /// @notice Configure how much of the reward budget a role receives.
+    /// @param r The participant role to adjust.
+    /// @param share Portion of the budget scaled by 1e18.
     function setRoleShare(Role r, uint256 share) external onlyGovernance {
         roleShare[r] = share;
         _validateRoleShares();
         emit RoleShareUpdated(r, share);
     }
 
+    /// @notice Set the chemical potential \(\mu\) used in MB weighting for a role.
+    /// @param r The role whose \(\mu\) is being configured.
+    /// @param _mu Fixed-point chemical potential value.
     function setMu(Role r, int256 _mu) external onlyGovernance {
         mu[r] = _mu;
         emit MuUpdated(r, _mu);
@@ -115,16 +121,24 @@ contract RewardEngineMB is Governable {
     error InvalidProof(address oracle);
     error Replay(address oracle);
 
+    /// @notice Grant or revoke permission to settle reward epochs.
+    /// @param settler Address being updated.
+    /// @param allowed True to authorize the settler, false to revoke.
     function setSettler(address settler, bool allowed) external onlyGovernance {
         settlers[settler] = allowed;
         emit SettlerUpdated(settler, allowed);
     }
 
+    /// @notice Set the treasury address to receive unallocated rewards.
+    /// @param _treasury Destination for leftover budgets.
     function setTreasury(address _treasury) external onlyGovernance {
         treasury = _treasury;
         emit TreasuryUpdated(_treasury);
     }
 
+    /// @notice Distribute rewards for an epoch based on energy attestations.
+    /// @param epoch The epoch identifier to settle.
+    /// @param data Batches of signed attestations and paid cost data.
     function settleEpoch(uint256 epoch, EpochData calldata data) external
         /// #if_succeeds {:msg "budget >= distributed"} budget >= distributed;
     {

--- a/contracts/v2/Thermostat.sol
+++ b/contracts/v2/Thermostat.sol
@@ -40,6 +40,10 @@ contract Thermostat is Governable {
         maxTemp = _max;
     }
 
+    /// @notice Set PID gains for adjusting system temperature.
+    /// @param _kp Proportional gain.
+    /// @param _ki Integral gain.
+    /// @param _kd Derivative gain.
     function setPID(int256 _kp, int256 _ki, int256 _kd) external onlyGovernance {
         kp = _kp;
         ki = _ki;
@@ -47,6 +51,10 @@ contract Thermostat is Governable {
         emit PIDUpdated(_kp, _ki, _kd);
     }
 
+    /// @notice Weight each KPI's contribution to thermal error.
+    /// @param _wEmission Multiplier for emission error.
+    /// @param _wBacklog Multiplier for backlog error.
+    /// @param _wSla Multiplier for SLA error.
     function setKPIWeights(int256 _wEmission, int256 _wBacklog, int256 _wSla)
         external
         onlyGovernance
@@ -58,6 +66,7 @@ contract Thermostat is Governable {
     }
 
     /// @notice Sets a new system temperature within bounds.
+    /// @param temp Desired system temperature.
     function setSystemTemperature(int256 temp) external onlyGovernance {
         require(temp > 0 && temp >= minTemp && temp <= maxTemp, "temp");
         systemTemperature = temp;
@@ -65,6 +74,8 @@ contract Thermostat is Governable {
     }
 
     /// @notice Updates minimum and maximum allowable temperatures.
+    /// @param _min New minimum temperature.
+    /// @param _max New maximum temperature.
     function setTemperatureBounds(int256 _min, int256 _max) external onlyGovernance {
         require(_min > 0 && _max > _min, "bounds");
         minTemp = _min;
@@ -75,6 +86,9 @@ contract Thermostat is Governable {
         emit TemperatureUpdated(systemTemperature);
     }
 
+    /// @notice Override system temperature for a specific role.
+    /// @param r Role to update.
+    /// @param temp New temperature for the role.
     function setRoleTemperature(Role r, int256 temp) external onlyGovernance {
         require(temp > 0 && temp >= minTemp && temp <= maxTemp, "bounds");
         roleTemps[r] = temp;
@@ -82,11 +96,15 @@ contract Thermostat is Governable {
     }
 
     /// @notice Removes a role-specific temperature override.
+    /// @param r Role whose override is cleared.
     function unsetRoleTemperature(Role r) external onlyGovernance {
         delete roleTemps[r];
         emit RoleTemperatureUpdated(r, 0);
     }
 
+    /// @notice Return the temperature applied to a role.
+    /// @param r Role being queried.
+    /// @return Temperature value for the role or system default.
     function getRoleTemperature(Role r) public view returns (int256) {
         int256 t = roleTemps[r];
         if (t == 0) return systemTemperature;


### PR DESCRIPTION
## Summary
- document governance controls in RewardEngineMB
- expand Thermostat function notices for clarity

## Testing
- `npx hardhat docgen` *(fails: Unrecognized task 'docgen')*
- `npx solhint contracts/v2/RewardEngineMB.sol contracts/v2/Thermostat.sol`
- `npx eslint . --ext .js,.ts,.tsx`
- `npm test` *(terminated: setup only)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c1408790833387394955bdc1619c