### PR TITLE
docs: document 7-day timelock and exit path

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -4,6 +4,13 @@ Contracts inheriting from `Governable` expect a timelock or multisig
 address. The controller is stored as a contract interface so that direct
 EOA ownership is not possible.
 
+The system uses a **7 day** timelock delay so all privileged operations are
+announced before execution. During this window agents and validators can exit
+by unbonding their stake. Call `StakeManager.requestWithdraw` to start the
+unbonding process and, after the `unbondingPeriod` elapses, use
+`StakeManager.finalizeWithdraw` to retrieve tokens before the proposal is
+executed.
+
 ## Deploying with a timelock
 
 1. Deploy an on-chain controller such as OpenZeppelin's

--- a/docs/thermodynamic-incentives.md
+++ b/docs/thermodynamic-incentives.md
@@ -61,6 +61,15 @@ Higher temperatures flatten the Maxwell–Boltzmann curve so rewards are spread
 more evenly across participants.  Lower temperatures sharpen the distribution,
 concentrating rewards on low‑energy, highly efficient contributors.
 
+## Governance Delay and Exit
+
+Parameter changes for the reward engine and thermostat are queued through the
+governance timelock, which is configured with a **7 day** delay. Agents and
+validators who disagree with a proposed change may leave during this period by
+calling `StakeManager.requestWithdraw` and, after the `unbondingPeriod`
+expires, `StakeManager.finalizeWithdraw` to recover their stake before the new
+settings take effect.
+
 ## Events and Monitoring
 
 `RewardEngineMB` emits a `RewardBudget` event every epoch with the total budget


### PR DESCRIPTION
## Summary
- Document 7-day governance timelock across docs
- Explain how agents and validators can unbond using `StakeManager.requestWithdraw` and `finalizeWithdraw`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5c44e0ad883338e6004e9136b77c7