### PR TITLE
Add ThermoMath negative energy test

### DIFF
--- a/contracts/v2/mocks/ThermoMathHarness.sol
+++ b/contracts/v2/mocks/ThermoMathHarness.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ThermoMath} from "../libraries/ThermoMath.sol";
+
+/// @title ThermoMathHarness
+/// @notice Exposes ThermoMath.mbWeights for testing via Hardhat
+contract ThermoMathHarness {
+    function weights(
+        int256[] memory E,
+        uint256[] memory g,
+        int256 T,
+        int256 mu
+    ) external pure returns (uint256[] memory) {
+        return ThermoMath.mbWeights(E, g, T, mu);
+    }
+}
+

--- a/test/v2/ThermoMathNegative.test.js
+++ b/test/v2/ThermoMathNegative.test.js
@@ -1,0 +1,25 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('ThermoMath negative energy', function () {
+  it('normalizes weights with negative energies', async function () {
+    const Harness = await ethers.getContractFactory(
+      'contracts/v2/mocks/ThermoMathHarness.sol:ThermoMathHarness'
+    );
+    const harness = await Harness.deploy();
+    await harness.waitForDeployment();
+
+    const E = [ethers.parseUnits('-20', 18), ethers.parseUnits('20', 18)];
+    const g = [1n, 1n];
+    const T = ethers.parseUnits('1', 18);
+    const mu = 0n;
+
+    const w = await harness.weights(E, g, T, mu);
+    const sum = w[0] + w[1];
+    const one = ethers.parseUnits('1', 18);
+    const diff = sum > one ? sum - one : one - sum;
+    expect(diff).to.be.lte(1n);
+    expect(w[0]).to.be.gt(w[1]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- expose `ThermoMath.mbWeights` via test harness
- cover negative-energy cases ensuring weights normalize and low energy dominates

## Testing
- `npm test test/v2/ThermoMathNegative.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c5c87357108333bdd9368f27cbe4f2