### PR TITLE
feat: add quadratic voting module

### DIFF
--- a/contracts/v2/QuadraticVoting.sol
+++ b/contracts/v2/QuadraticVoting.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Governable} from "./Governable.sol";
+
+/// @title QuadraticVoting
+/// @notice Minimal quadratic voting contract that charges votes squared in tokens.
+/// @dev Tokens used for voting are forwarded to a treasury address. The contract does
+///      not implement proposal execution; it only records aggregated vote counts.
+contract QuadraticVoting is Governable {
+    using SafeERC20 for IERC20;
+
+    /// @notice ERC20 token used for paying voting costs.
+    IERC20 public immutable token;
+    /// @notice Address receiving voting fees.
+    address public treasury;
+
+    struct Proposal {
+        uint256 forVotes;
+        uint256 againstVotes;
+    }
+
+    mapping(uint256 => Proposal) private _proposals;
+
+    event VoteCast(
+        uint256 indexed proposalId,
+        address indexed voter,
+        bool support,
+        uint256 votes,
+        uint256 cost
+    );
+    event TreasuryUpdated(address indexed treasury);
+
+    constructor(IERC20 _token, address _treasury, address _governance)
+        Governable(_governance)
+    {
+        token = _token;
+        treasury = _treasury;
+    }
+
+    /// @notice Update treasury address.
+    function setTreasury(address _treasury) external onlyGovernance {
+        treasury = _treasury;
+        emit TreasuryUpdated(_treasury);
+    }
+
+    /// @notice Returns the token cost to cast a given number of votes.
+    function costForVotes(uint256 votes) public pure returns (uint256) {
+        return votes * votes;
+    }
+
+    /// @notice Cast quadratic votes on a proposal.
+    /// @param proposalId The identifier of the proposal.
+    /// @param support True for in favour, false against.
+    /// @param votes Number of votes to cast. Cost in tokens is votes^2.
+    function vote(uint256 proposalId, bool support, uint256 votes) external {
+        require(treasury != address(0), "treasury");
+        require(votes > 0, "votes");
+
+        uint256 cost = costForVotes(votes);
+        token.safeTransferFrom(msg.sender, treasury, cost);
+
+        Proposal storage p = _proposals[proposalId];
+        if (support) {
+            p.forVotes += votes;
+        } else {
+            p.againstVotes += votes;
+        }
+
+        emit VoteCast(proposalId, msg.sender, support, votes, cost);
+    }
+
+    /// @notice Returns total for and against votes for a proposal.
+    function proposalVotes(uint256 proposalId)
+        external
+        view
+        returns (uint256 forVotes, uint256 againstVotes)
+    {
+        Proposal storage p = _proposals[proposalId];
+        return (p.forVotes, p.againstVotes);
+    }
+}
+

--- a/contracts/v2/mocks/MockERC20.sol
+++ b/contracts/v2/mocks/MockERC20.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title MockERC20
+/// @notice Simple ERC20 token with public mint for testing.
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+

--- a/test/v2/QuadraticVoting.test.js
+++ b/test/v2/QuadraticVoting.test.js
@@ -1,0 +1,39 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('QuadraticVoting', function () {
+  it('charges votes squared in tokens and records tallies', async function () {
+    const [governance, treasury, voter] = await ethers.getSigners();
+
+    // deploy mock token and mint to voter
+    const Token = await ethers.getContractFactory('contracts/v2/mocks/MockERC20.sol:MockERC20');
+    const token = await Token.deploy('Mock', 'MOCK');
+    const supply = ethers.parseUnits('100', 18);
+    await token.mint(voter.address, supply);
+
+    // deploy quadratic voting contract
+    const Voting = await ethers.getContractFactory('contracts/v2/QuadraticVoting.sol:QuadraticVoting');
+    const voting = await Voting.deploy(token, treasury.address, governance.address);
+
+    const votes = 3n;
+    const cost = votes * votes; // 9 tokens
+
+    await token.connect(voter).approve(voting, cost);
+    await voting.connect(voter).vote(1, true, votes);
+
+    expect(await token.balanceOf(treasury.address)).to.equal(cost);
+    const [forVotes, againstVotes] = await voting.proposalVotes(1);
+    expect(forVotes).to.equal(votes);
+    expect(againstVotes).to.equal(0n);
+  });
+
+  it('reports cost for votes', async function () {
+    const [governance, treasury] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory('contracts/v2/mocks/MockERC20.sol:MockERC20');
+    const token = await Token.deploy('Mock', 'MOCK');
+    const Voting = await ethers.getContractFactory('contracts/v2/QuadraticVoting.sol:QuadraticVoting');
+    const voting = await Voting.deploy(token, treasury.address, governance.address);
+    expect(await voting.costForVotes(5)).to.equal(25n);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add minimal QuadraticVoting contract that charges votes squared in tokens
- provide mock ERC20 and tests

## Testing
- ⚠️ `npx hardhat test test/v2/QuadraticVoting.test.js` (execution did not complete in the container)


------
https://chatgpt.com/codex/tasks/task_e_68c5d9d151d48333aa8d724f0c0d57a5