### PR TITLE
feat: auto-tune stake requirements

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -84,6 +84,17 @@ contract MockStakeManager is IStakeManager {
     function setFeePool(IFeePool) external override {}
     function setBurnPct(uint256) external override {}
     function setValidatorRewardPct(uint256) external override {}
+    function autoTuneStakes(bool) external override {}
+    function configureAutoStake(
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256
+    ) external override {}
+    function recordDispute() external override {}
+    function checkpointStake() external override {}
     function addAGIType(address, uint256) external override {}
     function removeAGIType(address) external override {}
     function syncBoostedStake(address, Role) external override {}

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -53,6 +53,15 @@ interface IStakeManager {
     event AGITypeUpdated(address indexed nft, uint256 payoutPct);
     event AGITypeRemoved(address indexed nft);
     event MaxTotalPayoutPctUpdated(uint256 oldMax, uint256 newMax);
+    event AutoStakeTuningEnabled(bool enabled);
+    event AutoStakeConfigUpdated(
+        uint256 threshold,
+        uint256 upPct,
+        uint256 downPct,
+        uint256 window,
+        uint256 floor,
+        uint256 ceil
+    );
     event FeePctUpdated(uint256 pct);
     event BurnPctUpdated(uint256 pct);
     event ValidatorRewardPctUpdated(uint256 pct);
@@ -214,6 +223,17 @@ interface IStakeManager {
     function setFeePool(IFeePool pool) external;
     function setBurnPct(uint256 pct) external;
     function setValidatorRewardPct(uint256 pct) external;
+    function autoTuneStakes(bool enabled) external;
+    function configureAutoStake(
+        uint256 threshold,
+        uint256 upPct,
+        uint256 downPct,
+        uint256 window,
+        uint256 floor,
+        uint256 ceil
+    ) external;
+    function recordDispute() external;
+    function checkpointStake() external;
 
     /// @notice return total stake deposited by a user for a role
     function stakeOf(address user, Role role) external view returns (uint256);

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -82,6 +82,17 @@ contract ReentrantStakeManager is IStakeManager {
     function setFeePool(IFeePool) external override {}
     function setBurnPct(uint256) external override {}
     function setValidatorRewardPct(uint256) external override {}
+    function autoTuneStakes(bool) external override {}
+    function configureAutoStake(
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256
+    ) external override {}
+    function recordDispute() external override {}
+    function checkpointStake() external override {}
     function addAGIType(address, uint256) external override {}
     function removeAGIType(address) external override {}
     function syncBoostedStake(address, Role) external override {}

--- a/contracts/v2/modules/DisputeModule.sol
+++ b/contracts/v2/modules/DisputeModule.sol
@@ -213,8 +213,11 @@ contract DisputeModule is Ownable, Pausable {
         );
 
         IStakeManager sm = _stakeManager();
-        if (address(sm) != address(0) && disputeFee > 0) {
-            sm.lockDisputeFee(claimant, disputeFee);
+        if (address(sm) != address(0)) {
+            if (disputeFee > 0) {
+                sm.lockDisputeFee(claimant, disputeFee);
+            }
+            sm.recordDispute();
         }
 
         disputes[jobId] =

--- a/docs/api/StakeManager.md
+++ b/docs/api/StakeManager.md
@@ -19,6 +19,9 @@ Handles staking, escrow and slashing of the $AGIALPHA token. NFT ownership boost
 - `addAGIType(address nft, uint256 payoutPct)` – register or update a payout multiplier for holders of `nft`. Only the highest multiplier applies. Each entry is capped at `MAX_PAYOUT_PCT` (200%) and totals are further limited by `maxTotalPayoutPct`.
 - `removeAGIType(address nft)` – delete a previously registered AGI type.
 - `syncBoostedStake(address user, uint8 role)` – recalculate a user's boosted stake after NFT changes. `FeePool.claimRewards` calls this automatically for the reward role.
+- `autoTuneStakes(bool enabled)` – toggles automatic adjustment of `minStake` based on recent dispute activity.
+- `configureAutoStake(uint256 threshold, uint256 upPct, uint256 downPct, uint256 window, uint256 floor, uint256 ceil)` – configures dispute thresholds and bounds for automatic stake tuning.
+- `recordDispute()` / `checkpointStake()` – DisputeModule calls `recordDispute` whenever a dispute is raised; anyone may call `checkpointStake` to evaluate adjustments when no disputes occurred.
 - `stakeOf(address user, uint8 role)` / `totalStake(uint8 role)` / `totalBoostedStake(uint8 role)` / `getTotalPayoutPct(address user)` – view functions. `getTotalPayoutPct` returns the highest `payoutPct` among held NFTs (or `100` when none) capped by `maxTotalPayoutPct`.
 
 ## Events
@@ -38,3 +41,4 @@ Handles staking, escrow and slashing of the $AGIALPHA token. NFT ownership boost
 - `MaxTotalPayoutPctUpdated(uint256 oldMax, uint256 newMax)`
 - `AGITypeUpdated(address indexed nft, uint256 payoutPct)`
 - `AGITypeRemoved(address indexed nft)`
+- `AutoStakeTuningEnabled(bool enabled)` / `AutoStakeConfigUpdated(uint256 threshold, uint256 upPct, uint256 downPct, uint256 window, uint256 floor, uint256 ceil)`


### PR DESCRIPTION
## Summary
- add adaptive minimum stake tuning based on dispute frequency
- expose automatic stake tuning controls via IStakeManager and DisputeModule
- document auto stake functions in StakeManager API docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5dc37dec483338cea623d4545542c