### PR TITLE
feat: introduce quadratic voting module

### DIFF
--- a/contracts/v2/QuadraticVoting.sol
+++ b/contracts/v2/QuadraticVoting.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {AGIALPHA} from "./Constants.sol";
+
+/// @title QuadraticVoting
+/// @notice Simple quadratic voting mechanism where casting v votes costs v^2 tokens.
+/// Tokens spent are transferred to a treasury address and are non-refundable.
+contract QuadraticVoting is Ownable {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable token = IERC20(AGIALPHA);
+
+    /// @notice address receiving voting costs
+    address public treasury;
+
+    struct Proposal {
+        bool exists;
+        uint256 forVotes;
+        uint256 againstVotes;
+    }
+
+    mapping(bytes32 => Proposal) private _proposals;
+    mapping(bytes32 => mapping(address => uint256)) public votesFor;
+    mapping(bytes32 => mapping(address => uint256)) public votesAgainst;
+
+    event TreasuryUpdated(address indexed treasury);
+    event ProposalCreated(bytes32 indexed proposalId);
+    event VoteCast(
+        bytes32 indexed proposalId,
+        address indexed voter,
+        bool support,
+        uint256 votes,
+        uint256 cost
+    );
+
+    /// @param _treasury destination for spent voting tokens
+    constructor(address _treasury) Ownable(msg.sender) {
+        require(_treasury != address(0), "treasury");
+        treasury = _treasury;
+    }
+
+    /// @notice set the treasury address receiving voting costs
+    function setTreasury(address _treasury) external onlyOwner {
+        require(_treasury != address(0), "treasury");
+        treasury = _treasury;
+        emit TreasuryUpdated(_treasury);
+    }
+
+    /// @notice create a new proposal
+    /// @param id unique identifier for the proposal
+    function createProposal(bytes32 id) external onlyOwner {
+        Proposal storage p = _proposals[id];
+        require(!p.exists, "exists");
+        p.exists = true;
+        emit ProposalCreated(id);
+    }
+
+    /// @notice cast votes on a proposal
+    /// @param id proposal identifier
+    /// @param support true for support, false for against
+    /// @param votes number of votes to cast (additional votes allowed)
+    function vote(bytes32 id, bool support, uint256 votes) external {
+        require(votes > 0, "votes");
+        Proposal storage p = _proposals[id];
+        require(p.exists, "proposal");
+        uint256 prev;
+        uint256 newTotal;
+        if (support) {
+            prev = votesFor[id][msg.sender];
+            newTotal = prev + votes;
+            votesFor[id][msg.sender] = newTotal;
+            p.forVotes += votes;
+        } else {
+            prev = votesAgainst[id][msg.sender];
+            newTotal = prev + votes;
+            votesAgainst[id][msg.sender] = newTotal;
+            p.againstVotes += votes;
+        }
+        uint256 cost = newTotal * newTotal - prev * prev;
+        token.safeTransferFrom(msg.sender, treasury, cost);
+        emit VoteCast(id, msg.sender, support, votes, cost);
+    }
+
+    /// @notice returns aggregated votes for a proposal
+    function proposalVotes(bytes32 id) external view returns (uint256 forVotes, uint256 againstVotes) {
+        Proposal storage p = _proposals[id];
+        return (p.forVotes, p.againstVotes);
+    }
+}
+

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -48,3 +48,24 @@ executed.
 
 This flow ensures all privileged operations occur only after the
 configured delay or multi-party approval.
+
+## Quadratic Voting
+
+For community proposals that require broad input, the `QuadraticVoting` module
+implements a simple on-chain quadratic voting scheme. Token holders may cast
+`v` votes for or against a proposal, paying a cost of `v^2` $AGIALPHA tokens.
+The spent tokens are transferred to a designated treasury and are not
+refundable. This quadratic cost makes it increasingly expensive for a single
+participant to dominate a vote while still allowing stakeholders to signal the
+intensity of their preferences.
+
+1. Governance creates a proposal using `createProposal(bytes32 id)`.
+2. Voters approve the `QuadraticVoting` contract to spend their tokens and call
+   `vote(id, support, votes)`.
+3. The contract increments the tally and transfers the quadratic cost to the
+   treasury.
+4. Results are retrieved via `proposalVotes(id)` which returns the `for` and
+   `against` totals.
+
+The module is intentionally minimal and can be combined with a timelock or
+other governance process to enact approved proposals.

--- a/test/v2/QuadraticVoting.test.js
+++ b/test/v2/QuadraticVoting.test.js
@@ -1,0 +1,52 @@
+const { expect } = require('chai');
+const { ethers, artifacts, network } = require('hardhat');
+const { AGIALPHA } = require('../../scripts/constants');
+
+describe('QuadraticVoting', function () {
+  let token;
+  beforeEach(async function () {
+    const mock = await artifacts.readArtifact(
+      'contracts/test/MockERC20.sol:MockERC20'
+    );
+    await network.provider.send('hardhat_setCode', [AGIALPHA, mock.deployedBytecode]);
+    token = await ethers.getContractAt('contracts/test/MockERC20.sol:MockERC20', AGIALPHA);
+  });
+
+  it('charges squared cost for votes and tracks tallies', async function () {
+    const [owner, voter1, voter2, treasury] = await ethers.getSigners();
+    const Voting = await ethers.getContractFactory(
+      'contracts/v2/QuadraticVoting.sol:QuadraticVoting'
+    );
+    const voting = await Voting.deploy(treasury.address);
+    await voting.waitForDeployment();
+
+    // prepare tokens
+    await token.mint(voter1.address, 1000n);
+    await token.mint(voter2.address, 1000n);
+    await token.connect(voter1).approve(voting.target, ethers.MaxUint256);
+    await token.connect(voter2).approve(voting.target, ethers.MaxUint256);
+
+    const prop = ethers.id('prop1');
+    await voting.connect(owner).createProposal(prop);
+
+    // voter1 casts 3 votes -> cost 9
+    await expect(voting.connect(voter1).vote(prop, true, 3))
+      .to.emit(voting, 'VoteCast')
+      .withArgs(prop, voter1.address, true, 3, 9);
+    expect(await token.balanceOf(treasury.address)).to.equal(9n);
+    expect(await token.balanceOf(voter1.address)).to.equal(1000n - 9n);
+
+    // voter1 adds 2 more votes -> additional cost 16 (total 25)
+    await voting.connect(voter1).vote(prop, true, 2);
+    expect(await token.balanceOf(treasury.address)).to.equal(25n);
+    expect(await token.balanceOf(voter1.address)).to.equal(1000n - 25n);
+
+    // voter2 votes against with 4 votes -> cost 16
+    await voting.connect(voter2).vote(prop, false, 4);
+    expect(await token.balanceOf(treasury.address)).to.equal(41n);
+    const votes = await voting.proposalVotes(prop);
+    expect(votes.forVotes).to.equal(5n);
+    expect(votes.againstVotes).to.equal(4n);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add on-chain QuadraticVoting contract with v^2 cost and treasury sink
- document quadratic voting flow in governance guide
- cover quadratic voting with unit tests

## Testing
- `npm test test/v2/QuadraticVoting.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c5dfeec0648333a64582bc2253c6f7