### PR TITLE
feat: add Hamiltonian state monitor

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -26,3 +26,24 @@ anomalies and epoch summaries to the console.
 
 `ALERT_THRESHOLD` defines the acceptable divergence between minted and burned tokens per epoch.
 A value of `0.1` means the `burned/minted` ratio can differ from `1.0` by up to 10% before an alert is triggered.
+
+## Hamiltonian State Monitor
+
+`scripts/monitor/hamiltonian-state.ts` derives a coarse grained Hamiltonian for the
+protocol economy. For each epoch it aggregates `RewardBudget` and `SlashingStats`
+events, computes dissipation `D = minted + burned - redistributed` and utility
+`U = redistributed`, and reports `H = D - λ·U` where `λ` defaults to `1`.
+
+### Usage
+
+```bash
+RPC_URL=https://rpc.example.org \
+REWARD_ENGINE=0xRewardEngineAddress \
+STAKE_MANAGER=0xStakeManagerAddress \
+LAMBDA=1 \             # optional, scales utility weight
+PORT=3001 \            # optional, exposes JSON metrics
+npx ts-node scripts/monitor/hamiltonian-state.ts
+```
+
+The script logs the Hamiltonian for each processed epoch and serves the latest
+metrics at `http://localhost:PORT`.

--- a/scripts/monitor/hamiltonian-state.ts
+++ b/scripts/monitor/hamiltonian-state.ts
@@ -1,0 +1,94 @@
+import { JsonRpcProvider, Contract, Interface } from 'ethers';
+import express from 'express';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const RPC_URL = process.env.RPC_URL as string;
+const REWARD_ENGINE = process.env.REWARD_ENGINE as string;
+const STAKE_MANAGER = process.env.STAKE_MANAGER as string;
+const LAMBDA = Number(process.env.LAMBDA || '1');
+const PORT = Number(process.env.PORT || '3001');
+
+if (!RPC_URL || !REWARD_ENGINE || !STAKE_MANAGER) {
+  console.error('RPC_URL, REWARD_ENGINE and STAKE_MANAGER must be set');
+  process.exit(1);
+}
+
+const provider = new JsonRpcProvider(RPC_URL);
+
+const rewardIface = new Interface([
+  'event RewardBudget(uint256 indexed epoch,uint256 minted,uint256 burned,uint256 redistributed,uint256 distributionRatio)',
+]);
+const slashIface = new Interface([
+  'event SlashingStats(uint256 timestamp,uint256 minted,uint256 burned,uint256 redistributed,uint256 burnRatio)',
+]);
+
+const reward = new Contract(REWARD_ENGINE, rewardIface, provider);
+const stake = new Contract(STAKE_MANAGER, slashIface, provider);
+
+interface EpochStats {
+  minted: bigint;
+  burned: bigint;
+  redistributed: bigint;
+  h: number;
+}
+const epochs: Record<number, EpochStats> = {};
+let currentEpoch = 0;
+let currentStats: EpochStats | undefined;
+
+function finalizeEpoch(epoch: number) {
+  if (!currentStats) return;
+  const minted = Number(currentStats.minted) / 1e18;
+  const burned = Number(currentStats.burned) / 1e18;
+  const redistributed = Number(currentStats.redistributed) / 1e18;
+  const dissipation = minted + burned - redistributed;
+  const h = dissipation - LAMBDA * redistributed;
+  currentStats.h = h;
+  epochs[epoch] = { ...currentStats };
+  console.log(
+    `Epoch ${epoch} H=${h.toFixed(4)} D=${dissipation.toFixed(
+      4
+    )} U=${redistributed.toFixed(4)}`
+  );
+}
+
+reward.on(
+  'RewardBudget',
+  (epoch: bigint, minted: bigint, burned: bigint, redistributed: bigint) => {
+    if (currentEpoch !== Number(epoch)) {
+      if (currentEpoch !== 0) finalizeEpoch(currentEpoch);
+      currentEpoch = Number(epoch);
+      currentStats = { minted, burned, redistributed, h: 0 };
+    } else if (currentStats) {
+      currentStats.minted += minted;
+      currentStats.burned += burned;
+      currentStats.redistributed += redistributed;
+    }
+  }
+);
+
+stake.on(
+  'SlashingStats',
+  (_ts: bigint, minted: bigint, burned: bigint, redistributed: bigint) => {
+    if (currentStats) {
+      currentStats.minted += minted;
+      currentStats.burned += burned;
+      currentStats.redistributed += redistributed;
+    }
+  }
+);
+
+const app = express();
+app.get('/', (_req, res) => {
+  res.json({ currentEpoch, lambda: LAMBDA, epochs });
+});
+
+app.listen(PORT, () => {
+  console.log(`Hamiltonian monitor running at http://localhost:${PORT}`);
+});
+
+process.on('SIGINT', () => {
+  if (currentEpoch !== 0) finalizeEpoch(currentEpoch);
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary
- add CLI to track Hamiltonian H=D-λ·U from RewardBudget and SlashingStats events
- document Hamiltonian monitor usage alongside existing reward/burn dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5e5ed05a48333b88adceba471b6fa