### PR TITLE
guard treasury setter

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -132,6 +132,7 @@ contract RewardEngineMB is Governable {
     /// @notice Set the treasury address to receive unallocated rewards.
     /// @param _treasury Destination for leftover budgets.
     function setTreasury(address _treasury) external onlyGovernance {
+        require(_treasury != address(0), "treasury");
         treasury = _treasury;
         emit TreasuryUpdated(_treasury);
     }

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -159,6 +159,11 @@ contract RewardEngineMBTest is Test {
         assertEq(pool.total(), 2e18, "scaled budget distributed");
     }
 
+    function test_setTreasuryRejectsZero() public {
+        vm.expectRevert("treasury");
+        engine.setTreasury(address(0));
+    }
+
     function test_entropyScalingUsesWad() public {
         RewardEngineMB.EpochData memory data;
         RewardEngineMB.Proof[] memory a = new RewardEngineMB.Proof[](1);


### PR DESCRIPTION
## Summary
- require non-zero treasury address in RewardEngineMB
- add unit test for treasury setter guard

## Testing
- `npm test test/v2/RewardEngineMB.metrics.test.js`
- `forge test --match-path test/v2/RewardEngineMB.t.sol` *(fails: Invalid type for argument in function call)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f27223a8833396cb2a547ae0ee61