### PR TITLE
feat: add slash and validator reward events

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -234,7 +234,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         uint256 treasuryShare,
         uint256 burnShare
     );
-    event ValidatorSlashReward(address indexed validator, uint256 amount);
+    event Slash(address indexed agent, uint256 amount, address indexed validator);
+    event RewardValidator(address indexed validator, uint256 amount, bytes32 indexed jobId);
     event SlashingStats(
         uint256 timestamp,
         uint256 minted,
@@ -1488,7 +1489,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
                         if (reward > 0) {
                             remaining -= reward;
                             token.safeTransfer(validators[i], reward);
-                            emit ValidatorSlashReward(validators[i], reward);
+                            emit RewardValidator(validators[i], reward, bytes32(0));
                         }
                     }
                     if (remaining > 0) {
@@ -1527,6 +1528,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         }
         uint256 redistributed = employerShare + treasuryShare + validatorShare;
         uint256 ratio = redistributed > 0 ? (burnShare * TOKEN_SCALE) / redistributed : 0;
+        emit Slash(user, amount, validators.length > 0 ? validators[0] : recipient);
         emit StakeSlashed(
             user,
             role,

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -38,7 +38,17 @@ interface IStakeManager {
         uint256 treasuryShare,
         uint256 burnShare
     );
-    event ValidatorSlashReward(address indexed validator, uint256 amount);
+    /// @notice Emitted when stake is slashed from a participant.
+    /// @param agent Address whose stake was reduced.
+    /// @param amount Total amount slashed from the agent.
+    /// @param validator Address of the validator or recipient that triggered the slash.
+    event Slash(address indexed agent, uint256 amount, address indexed validator);
+
+    /// @notice Emitted when a validator receives a reward from slashing.
+    /// @param validator Address of the validator being rewarded.
+    /// @param amount Amount of tokens transferred to the validator.
+    /// @param jobId Optional job identifier associated with the reward.
+    event RewardValidator(address indexed validator, uint256 amount, bytes32 indexed jobId);
     event DisputeFeeLocked(address indexed payer, uint256 amount);
     event DisputeFeePaid(address indexed to, uint256 amount);
     event DisputeModuleUpdated(address module);

--- a/test/v2/StakeManagerSlashing.test.js
+++ b/test/v2/StakeManagerSlashing.test.js
@@ -178,10 +178,12 @@ describe('StakeManager multi-validator slashing', function () {
           [val1.address, val2.address]
         )
     )
-      .to.emit(stakeManager, 'ValidatorSlashReward')
-      .withArgs(val1.address, 2n * ONE)
-      .and.to.emit(stakeManager, 'ValidatorSlashReward')
-      .withArgs(val2.address, 6n * ONE);
+      .to.emit(stakeManager, 'RewardValidator')
+      .withArgs(val1.address, 2n * ONE, ethers.ZeroHash)
+      .and.to.emit(stakeManager, 'RewardValidator')
+      .withArgs(val2.address, 6n * ONE, ethers.ZeroHash)
+      .and.to.emit(stakeManager, 'Slash')
+      .withArgs(agent.address, 40n * ONE, val1.address);
 
     expect(await token.balanceOf(val1.address)).to.equal(902n * ONE);
     expect(await token.balanceOf(val2.address)).to.equal(706n * ONE);

--- a/test/v2/StakeManagerValidatorRewards.test.js
+++ b/test/v2/StakeManagerValidatorRewards.test.js
@@ -140,10 +140,12 @@ describe('StakeManager validator slash rewards', function () {
           [val1.address, val2.address]
         )
     )
-      .to.emit(stakeManager, 'ValidatorSlashReward')
-      .withArgs(val1.address, 2n * ONE)
-      .and.to.emit(stakeManager, 'ValidatorSlashReward')
-      .withArgs(val2.address, 6n * ONE);
+      .to.emit(stakeManager, 'RewardValidator')
+      .withArgs(val1.address, 2n * ONE, ethers.ZeroHash)
+      .and.to.emit(stakeManager, 'RewardValidator')
+      .withArgs(val2.address, 6n * ONE, ethers.ZeroHash)
+      .and.to.emit(stakeManager, 'Slash')
+      .withArgs(agent.address, 40n * ONE, val1.address);
 
     expect(await token.balanceOf(val1.address)).to.equal(902n * ONE);
     expect(await token.balanceOf(val2.address)).to.equal(706n * ONE);


### PR DESCRIPTION
## Summary
- add Slash and RewardValidator events for transparent slashing and validator rewards
- emit new events and update tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5f4f8fe98833382469508783542b1