### PR TITLE
Add quadratic voting with token locking and refunds

### DIFF
--- a/contracts/test/GovernanceRewardMock.sol
+++ b/contracts/test/GovernanceRewardMock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+contract GovernanceRewardMock {
+    address[] private _lastVoters;
+    event Recorded(address[] voters);
+
+    function recordVoters(address[] calldata voters) external {
+        _lastVoters = voters;
+        emit Recorded(voters);
+    }
+
+    function getLastVoters() external view returns (address[] memory) {
+        return _lastVoters;
+    }
+}
+

--- a/contracts/v2/QuadraticVoting.sol
+++ b/contracts/v2/QuadraticVoting.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {AGIALPHA} from "./Constants.sol";
+
+interface IGovernanceReward {
+    function recordVoters(address[] calldata voters) external;
+}
+
+/// @title QuadraticVoting
+/// @notice Simple quadratic voting mechanism where voting cost grows with the
+/// square of votes. Tokens are locked when voting and can be refunded after the
+/// proposal is executed. The contract can notify a GovernanceReward contract to
+/// record voters for reward distribution.
+contract QuadraticVoting is Ownable {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable token;
+    IGovernanceReward public governanceReward;
+    address public proposalExecutor;
+
+    // proposalId => executed status
+    mapping(uint256 => bool) public executed;
+    // proposalId => voter => votes cast
+    mapping(uint256 => mapping(address => uint256)) public votes;
+    // proposalId => voter => tokens locked (cost)
+    mapping(uint256 => mapping(address => uint256)) public locked;
+    // proposalId => list of voters (for reward snapshot)
+    mapping(uint256 => address[]) private proposalVoters;
+    // proposalId => voter => has voted
+    mapping(uint256 => mapping(address => bool)) private hasVoted;
+
+    event VoteCast(uint256 indexed proposalId, address indexed voter, uint256 votes, uint256 cost);
+    event ProposalExecuted(uint256 indexed proposalId);
+    event RefundClaimed(uint256 indexed proposalId, address indexed voter, uint256 amount);
+    event GovernanceRewardUpdated(address indexed governanceReward);
+    event ProposalExecutorUpdated(address indexed executor);
+
+    constructor(address _token, address _executor) Ownable(msg.sender) {
+        token = _token == address(0) ? IERC20(AGIALPHA) : IERC20(_token);
+        proposalExecutor = _executor;
+        emit ProposalExecutorUpdated(_executor);
+    }
+
+    /// @notice Set the governance reward contract used for recording voters.
+    function setGovernanceReward(IGovernanceReward reward) external onlyOwner {
+        governanceReward = reward;
+        emit GovernanceRewardUpdated(address(reward));
+    }
+
+    /// @notice Set the address allowed to execute proposals.
+    function setProposalExecutor(address executor) external onlyOwner {
+        proposalExecutor = executor;
+        emit ProposalExecutorUpdated(executor);
+    }
+
+    /// @notice Cast `numVotes` on `proposalId` paying `numVotes^2` tokens.
+    function castVote(uint256 proposalId, uint256 numVotes) external {
+        require(!executed[proposalId], "executed");
+        require(numVotes > 0, "votes");
+        uint256 cost = numVotes * numVotes;
+        token.safeTransferFrom(msg.sender, address(this), cost);
+        locked[proposalId][msg.sender] += cost;
+        votes[proposalId][msg.sender] += numVotes;
+        if (!hasVoted[proposalId][msg.sender]) {
+            hasVoted[proposalId][msg.sender] = true;
+            proposalVoters[proposalId].push(msg.sender);
+        }
+        emit VoteCast(proposalId, msg.sender, numVotes, cost);
+    }
+
+    /// @notice Execute a proposal, enabling refunds and recording voters.
+    function execute(uint256 proposalId) external {
+        require(!executed[proposalId], "executed");
+        require(msg.sender == proposalExecutor || msg.sender == owner(), "exec");
+        executed[proposalId] = true;
+        if (address(governanceReward) != address(0)) {
+            governanceReward.recordVoters(proposalVoters[proposalId]);
+        }
+        emit ProposalExecuted(proposalId);
+    }
+
+    /// @notice Claim back tokens locked for a proposal after execution.
+    function claimRefund(uint256 proposalId) external {
+        require(executed[proposalId], "not executed");
+        uint256 amount = locked[proposalId][msg.sender];
+        require(amount > 0, "no refund");
+        locked[proposalId][msg.sender] = 0;
+        token.safeTransfer(msg.sender, amount);
+        emit RefundClaimed(proposalId, msg.sender, amount);
+    }
+
+    /// @notice Returns number of voters for a proposal.
+    function proposalVoterCount(uint256 proposalId) external view returns (uint256) {
+        return proposalVoters[proposalId].length;
+    }
+}
+

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -48,3 +48,18 @@ executed.
 
 This flow ensures all privileged operations occur only after the
 configured delay or multi-party approval.
+
+## Quadratic Voting
+
+`QuadraticVoting` introduces a voting mechanism where the cost of casting votes
+scales quadratically: committing `n` votes locks `n^2` governance tokens (typically
+AGIALPHA). Locked funds remain in the contract until the proposal is executed by
+the configured executor. After execution, each voter may call `claimRefund` to
+retrieve the exact tokens they locked.
+
+Example: voting with 3 votes costs 9 tokens, while 5 votes costs 25 tokens.
+Voters approve the contract to transfer tokens on their behalf, `castVote` to
+lock the cost, and once `execute` is called they can reclaim funds. The contract
+optionally calls `GovernanceReward.recordVoters` so rewards can be distributed
+based on participation.
+

--- a/test/v2/QuadraticVoting.test.js
+++ b/test/v2/QuadraticVoting.test.js
@@ -1,0 +1,48 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+describe('QuadraticVoting', function () {
+  let token, qv, owner, voter, executor;
+
+  beforeEach(async () => {
+    [owner, voter, executor] = await ethers.getSigners();
+    const MockToken = await ethers.getContractFactory(
+      'contracts/test/MockERC20.sol:MockERC20'
+    );
+    token = await MockToken.deploy();
+    await token.mint(voter.address, 1000);
+    const QuadraticVoting = await ethers.getContractFactory(
+      'contracts/v2/QuadraticVoting.sol:QuadraticVoting'
+    );
+    qv = await QuadraticVoting.deploy(await token.getAddress(), executor.address);
+    await token.connect(voter).approve(await qv.getAddress(), 1000);
+  });
+
+  it('charges quadratic cost and locks tokens', async () => {
+    await qv.connect(voter).castVote(1, 3); // cost 9
+    expect(await token.balanceOf(voter.address)).to.equal(991n);
+    expect(await token.balanceOf(await qv.getAddress())).to.equal(9n);
+    expect(await qv.locked(1, voter.address)).to.equal(9n);
+    expect(await qv.votes(1, voter.address)).to.equal(3n);
+  });
+
+  it('refunds tokens after execution', async () => {
+    await qv.connect(voter).castVote(1, 4); // cost 16
+    await qv.connect(executor).execute(1);
+    await qv.connect(voter).claimRefund(1);
+    expect(await token.balanceOf(voter.address)).to.equal(1000n);
+    expect(await token.balanceOf(await qv.getAddress())).to.equal(0n);
+  });
+
+  it('records voters in governance reward', async () => {
+    const Mock = await ethers.getContractFactory(
+      'contracts/test/GovernanceRewardMock.sol:GovernanceRewardMock'
+    );
+    const reward = await Mock.deploy();
+    await qv.connect(owner).setGovernanceReward(await reward.getAddress());
+    await qv.connect(voter).castVote(1, 2);
+    await expect(qv.connect(executor).execute(1)).to.emit(reward, 'Recorded');
+    const recorded = await reward.getLastVoters();
+    expect(recorded[0]).to.equal(voter.address);
+  });
+});
+

--- a/test/v2/QuadraticVoting.test.js
+++ b/test/v2/QuadraticVoting.test.js
@@ -13,7 +13,10 @@ describe('QuadraticVoting', function () {
     const QuadraticVoting = await ethers.getContractFactory(
       'contracts/v2/QuadraticVoting.sol:QuadraticVoting'
     );
-    qv = await QuadraticVoting.deploy(await token.getAddress(), executor.address);
+    qv = await QuadraticVoting.deploy(
+      await token.getAddress(),
+      executor.address
+    );
     await token.connect(voter).approve(await qv.getAddress(), 1000);
   });
 
@@ -45,4 +48,3 @@ describe('QuadraticVoting', function () {
     expect(recorded[0]).to.equal(voter.address);
   });
 });
-


### PR DESCRIPTION
## Summary
- introduce `QuadraticVoting` contract with quadratic vote costs, token locking, configurable executor, and optional GovernanceReward hook
- add mock governance reward and tests covering voting cost, execution refunds, and voter recording
- document quadratic voting mechanics and examples

## Testing
- `npm test test/v2/QuadraticVoting.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c60893d2ac8333abd7c993fcff5d16