### PR TITLE
Prevent double epoch settlement in RewardEngineMB

### DIFF
--- a/test/v2/RewardEngineMB.metrics.test.js
+++ b/test/v2/RewardEngineMB.metrics.test.js
@@ -87,4 +87,71 @@ describe('RewardEngineMB thermodynamic metrics', function () {
 
     expect(await feePool.rewards(treasury.address)).to.equal(leftover);
   });
+
+  it('reverts when settling an epoch twice', async function () {
+    const [owner] = await ethers.getSigners();
+
+    const Thermostat = await ethers.getContractFactory(
+      'contracts/v2/Thermostat.sol:Thermostat'
+    );
+    const thermostat = await Thermostat.deploy(
+      ethers.parseUnits('1', 18),
+      1,
+      ethers.parseUnits('2', 18),
+      owner.address
+    );
+
+    const MockFeePool = await ethers.getContractFactory(
+      'contracts/v2/mocks/RewardEngineMBMocks.sol:MockFeePool'
+    );
+    const feePool = await MockFeePool.deploy();
+
+    const MockReputation = await ethers.getContractFactory(
+      'contracts/v2/mocks/RewardEngineMBMocks.sol:MockReputation'
+    );
+    const rep = await MockReputation.deploy();
+
+    const MockEnergyOracle = await ethers.getContractFactory(
+      'contracts/v2/mocks/RewardEngineMBMocks.sol:MockEnergyOracle'
+    );
+    const oracle = await MockEnergyOracle.deploy();
+
+    const RewardEngine = await ethers.getContractFactory(
+      'contracts/v2/RewardEngineMB.sol:RewardEngineMB'
+    );
+    const engine = await RewardEngine.deploy(
+      thermostat,
+      feePool,
+      rep,
+      oracle,
+      owner.address
+    );
+
+    await engine.setSettler(owner.address, true);
+
+    const att = {
+      jobId: 1,
+      user: owner.address,
+      energy: 0n,
+      degeneracy: 1,
+      epochId: 1,
+      role: 0,
+      nonce: 1,
+      deadline: 0,
+      uPre: 0n,
+      uPost: 0,
+      value: 0,
+    };
+
+    const data = {
+      agents: [{ att, sig: '0x' }],
+      validators: [],
+      operators: [],
+      employers: [],
+      paidCosts: 0n,
+    };
+
+    await engine.settleEpoch(1, data);
+    await expect(engine.settleEpoch(1, data)).to.be.revertedWith('settled');
+  });
 });

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -424,6 +424,17 @@ contract RewardEngineMBTest is Test {
         engine.settleEpoch(1, data); // should succeed
     }
 
+    function test_epoch_cannot_be_settled_twice() public {
+        RewardEngineMB.EpochData memory data;
+        RewardEngineMB.Proof[] memory a = new RewardEngineMB.Proof[](1);
+        a[0] = _proof(agent, int256(1e18), 1, RewardEngineMB.Role.Agent);
+        data.agents = a;
+
+        engine.settleEpoch(1, data);
+        vm.expectRevert(bytes("settled"));
+        engine.settleEpoch(1, data);
+    }
+
     function test_leftover_budget_sent_to_treasury() public {
         RewardEngineMB.EpochData memory data;
         RewardEngineMB.Proof[] memory a = new RewardEngineMB.Proof[](3);


### PR DESCRIPTION
## Summary
- prevent settling the same epoch twice by tracking `epochSettled`
- mark epochs as settled after distribution and reject repeated calls
- add tests ensuring repeated settlement reverts

## Testing
- `forge test --match-path test/v2/RewardEngineMB.t.sol` *(fails: Invalid type for argument in function call...)*
- `npm test -- test/v2/RewardEngineMB.metrics.test.js` *(hangs, no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c60fd9ddf083339fc7059c5ace4de2