### PR TITLE
Split vote cost into refundable deposit and fee

### DIFF
--- a/contracts/v2/QuadraticVoting.sol
+++ b/contracts/v2/QuadraticVoting.sol
@@ -4,11 +4,14 @@ pragma solidity ^0.8.25;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {AGIALPHA} from "./Constants.sol";
+import {AGIALPHA, BURN_ADDRESS} from "./Constants.sol";
+import {IERC20Burnable} from "./interfaces/IERC20Burnable.sol";
 
 interface IGovernanceReward {
     function recordVoters(address[] calldata voters) external;
 }
+
+error TokenNotBurnable();
 
 /// @title QuadraticVoting
 /// @notice Simple quadratic voting mechanism where voting cost grows with the
@@ -21,6 +24,9 @@ contract QuadraticVoting is Ownable {
     IERC20 public immutable token;
     IGovernanceReward public governanceReward;
     address public proposalExecutor;
+    address public treasury;
+    /// @notice percentage of vote cost refunded (0-100)
+    uint256 public refundPct = 100;
 
     // proposalId => executed status
     mapping(uint256 => bool) public executed;
@@ -38,6 +44,9 @@ contract QuadraticVoting is Ownable {
     event RefundClaimed(uint256 indexed proposalId, address indexed voter, uint256 amount);
     event GovernanceRewardUpdated(address indexed governanceReward);
     event ProposalExecutorUpdated(address indexed executor);
+    event TreasuryUpdated(address indexed treasury);
+    event RefundPctUpdated(uint256 refundPct);
+    event TokensBurned(uint256 amount);
 
     constructor(address _token, address _executor) Ownable(msg.sender) {
         token = _token == address(0) ? IERC20(AGIALPHA) : IERC20(_token);
@@ -57,13 +66,35 @@ contract QuadraticVoting is Ownable {
         emit ProposalExecutorUpdated(executor);
     }
 
+    /// @notice Update the treasury address receiving fees.
+    function setTreasury(address _treasury) external onlyOwner {
+        treasury = _treasury;
+        emit TreasuryUpdated(_treasury);
+    }
+
+    /// @notice Update refundable percentage of vote cost.
+    function setRefundPct(uint256 pct) external onlyOwner {
+        require(pct <= 100, "pct");
+        refundPct = pct;
+        emit RefundPctUpdated(pct);
+    }
+
     /// @notice Cast `numVotes` on `proposalId` paying `numVotes^2` tokens.
     function castVote(uint256 proposalId, uint256 numVotes) external {
         require(!executed[proposalId], "executed");
         require(numVotes > 0, "votes");
         uint256 cost = numVotes * numVotes;
         token.safeTransferFrom(msg.sender, address(this), cost);
-        locked[proposalId][msg.sender] += cost;
+
+        uint256 deposit = (cost * refundPct) / 100;
+        uint256 fee = cost - deposit;
+        if (fee > 0) {
+            if (treasury != address(0)) token.safeTransfer(treasury, fee);
+            else _burnToken(fee);
+        }
+        if (deposit > 0) {
+            locked[proposalId][msg.sender] += deposit;
+        }
         votes[proposalId][msg.sender] += numVotes;
         if (!hasVoted[proposalId][msg.sender]) {
             hasVoted[proposalId][msg.sender] = true;
@@ -96,6 +127,20 @@ contract QuadraticVoting is Ownable {
     /// @notice Returns number of voters for a proposal.
     function proposalVoterCount(uint256 proposalId) external view returns (uint256) {
         return proposalVoters[proposalId].length;
+    }
+
+    function _burnToken(uint256 amount) internal {
+        if (amount == 0) return;
+        if (BURN_ADDRESS == address(0)) {
+            try IERC20Burnable(address(token)).burn(amount) {
+                emit TokensBurned(amount);
+            } catch {
+                revert TokenNotBurnable();
+            }
+        } else {
+            token.safeTransfer(BURN_ADDRESS, amount);
+            emit TokensBurned(amount);
+        }
     }
 }
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -52,14 +52,18 @@ configured delay or multi-party approval.
 ## Quadratic Voting
 
 `QuadraticVoting` introduces a voting mechanism where the cost of casting votes
-scales quadratically: committing `n` votes locks `n^2` governance tokens (typically
-AGIALPHA). Locked funds remain in the contract until the proposal is executed by
-the configured executor. After execution, each voter may call `claimRefund` to
-retrieve the exact tokens they locked.
+scales quadratically: committing `n` votes costs `n^2` governance tokens
+typically denominated in AGIALPHA. A configurable percentage of this cost is
+locked as a refundable deposit while the remainder is charged as a fee. The fee
+is sent to the configured `treasury` or burned if the treasury is unset.
+Deposits remain in the contract until the proposal is executed by the configured
+executor. After execution, each voter may call `claimRefund` to retrieve only the
+locked deposit – the fee portion is always deducted.
 
-Example: voting with 3 votes costs 9 tokens, while 5 votes costs 25 tokens.
-Voters approve the contract to transfer tokens on their behalf, `castVote` to
-lock the cost, and once `execute` is called they can reclaim funds. The contract
+Example: with a 50% refundable rate, voting with 4 votes costs 16 tokens. Eight
+tokens are locked as a refundable deposit and the other eight are immediately
+sent to the treasury. After `execute`, calling `claimRefund` returns the locked
+eight tokens but the voter permanently paid the eight token fee. The contract
 optionally calls `GovernanceReward.recordVoters` so rewards can be distributed
 based on participation.
 

--- a/test/v2/QuadraticVoting.test.js
+++ b/test/v2/QuadraticVoting.test.js
@@ -17,23 +17,33 @@ describe('QuadraticVoting', function () {
       await token.getAddress(),
       executor.address
     );
+    await qv.connect(owner).setTreasury(owner.address);
+    await qv.connect(owner).setRefundPct(50);
     await token.connect(voter).approve(await qv.getAddress(), 1000);
   });
 
-  it('charges quadratic cost and locks tokens', async () => {
-    await qv.connect(voter).castVote(1, 3); // cost 9
+  it('charges quadratic cost, locks deposit and sends fee', async () => {
+    const treasuryBefore = await token.balanceOf(owner.address);
+    await qv.connect(voter).castVote(1, 3); // cost 9 => deposit 4, fee 5
     expect(await token.balanceOf(voter.address)).to.equal(991n);
-    expect(await token.balanceOf(await qv.getAddress())).to.equal(9n);
-    expect(await qv.locked(1, voter.address)).to.equal(9n);
+    expect(await token.balanceOf(await qv.getAddress())).to.equal(4n);
+    expect(await qv.locked(1, voter.address)).to.equal(4n);
     expect(await qv.votes(1, voter.address)).to.equal(3n);
+    expect(await token.balanceOf(owner.address)).to.equal(
+      treasuryBefore + 5n
+    );
   });
 
-  it('refunds tokens after execution', async () => {
-    await qv.connect(voter).castVote(1, 4); // cost 16
+  it('refunds only the deposit after execution', async () => {
+    const treasuryBefore = await token.balanceOf(owner.address);
+    await qv.connect(voter).castVote(1, 4); // cost 16 => deposit 8, fee 8
     await qv.connect(executor).execute(1);
     await qv.connect(voter).claimRefund(1);
-    expect(await token.balanceOf(voter.address)).to.equal(1000n);
+    expect(await token.balanceOf(voter.address)).to.equal(992n);
     expect(await token.balanceOf(await qv.getAddress())).to.equal(0n);
+    expect(await token.balanceOf(owner.address)).to.equal(
+      treasuryBefore + 8n
+    );
   });
 
   it('records voters in governance reward', async () => {

--- a/test/v2/QuadraticVoting.test.js
+++ b/test/v2/QuadraticVoting.test.js
@@ -29,9 +29,7 @@ describe('QuadraticVoting', function () {
     expect(await token.balanceOf(await qv.getAddress())).to.equal(4n);
     expect(await qv.locked(1, voter.address)).to.equal(4n);
     expect(await qv.votes(1, voter.address)).to.equal(3n);
-    expect(await token.balanceOf(owner.address)).to.equal(
-      treasuryBefore + 5n
-    );
+    expect(await token.balanceOf(owner.address)).to.equal(treasuryBefore + 5n);
   });
 
   it('refunds only the deposit after execution', async () => {
@@ -41,9 +39,7 @@ describe('QuadraticVoting', function () {
     await qv.connect(voter).claimRefund(1);
     expect(await token.balanceOf(voter.address)).to.equal(992n);
     expect(await token.balanceOf(await qv.getAddress())).to.equal(0n);
-    expect(await token.balanceOf(owner.address)).to.equal(
-      treasuryBefore + 8n
-    );
+    expect(await token.balanceOf(owner.address)).to.equal(treasuryBefore + 8n);
   });
 
   it('records voters in governance reward', async () => {


### PR DESCRIPTION
## Summary
- Split quadratic voting cost into refundable deposit and fee
- Add configurable treasury and refund percentage
- Document vote fee and refund behavior and update tests

## Testing
- `npx hardhat test test/v2/QuadraticVoting.test.js` *(failed: process did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c6183bc028833384d7d347444c794c