### PR TITLE
Add voter cap and event-based reward recording

### DIFF
--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -19,6 +19,7 @@ contract GovernanceReward is Ownable {
     using SafeERC20 for IERC20;
 
     uint256 public constant ACCUMULATOR_SCALE = 1e12;
+    uint256 public constant MAX_VOTERS = 100;
 
     /// @notice default epoch length when constructor param is zero
     uint256 public constant DEFAULT_EPOCH_LENGTH = 1 weeks;
@@ -120,6 +121,7 @@ contract GovernanceReward is Ownable {
 
     /// @notice record voters for the current epoch and snapshot their stake
     function recordVoters(address[] calldata voters) external onlyOwner {
+        require(voters.length <= MAX_VOTERS, "voters");
         uint256 epoch = currentEpoch;
         for (uint256 i; i < voters.length; i++) {
             address v = voters[i];

--- a/test/v2/QuadraticVoting.test.js
+++ b/test/v2/QuadraticVoting.test.js
@@ -35,7 +35,7 @@ describe('QuadraticVoting', function () {
   it('refunds only the deposit after execution', async () => {
     const treasuryBefore = await token.balanceOf(owner.address);
     await qv.connect(voter).castVote(1, 4); // cost 16 => deposit 8, fee 8
-    await qv.connect(executor).execute(1);
+    await qv.connect(executor).execute(1, []);
     await qv.connect(voter).claimRefund(1);
     expect(await token.balanceOf(voter.address)).to.equal(992n);
     expect(await token.balanceOf(await qv.getAddress())).to.equal(0n);
@@ -48,9 +48,52 @@ describe('QuadraticVoting', function () {
     );
     const reward = await Mock.deploy();
     await qv.connect(owner).setGovernanceReward(await reward.getAddress());
-    await qv.connect(voter).castVote(1, 2);
-    await expect(qv.connect(executor).execute(1)).to.emit(reward, 'Recorded');
+
+    const tx = await qv.connect(voter).castVote(1, 2);
+    const receipt = await tx.wait();
+    const voterList = receipt.logs
+      .map((log) => {
+        try {
+          return qv.interface.parseLog(log);
+        } catch {
+          return null;
+        }
+      })
+      .filter((p) => p && p.name === 'VoteCast')
+      .map((p) => p.args.voter);
+
+    await expect(qv.connect(executor).execute(1, voterList)).to.emit(
+      reward,
+      'Recorded'
+    );
     const recorded = await reward.getLastVoters();
     expect(recorded[0]).to.equal(voter.address);
+  });
+
+  it('reverts when voter cap exceeded', async () => {
+    const max = Number(await qv.MAX_VOTERS());
+    for (let i = 0; i < max; i++) {
+      const wallet = ethers.Wallet.createRandom().connect(ethers.provider);
+      await owner.sendTransaction({
+        to: wallet.address,
+        value: ethers.parseEther('1'),
+      });
+      await token.mint(wallet.address, 10);
+      await token
+        .connect(wallet)
+        .approve(await qv.getAddress(), 10);
+      await qv.connect(wallet).castVote(1, 1);
+    }
+    const extra = ethers.Wallet.createRandom().connect(ethers.provider);
+    await owner.sendTransaction({
+      to: extra.address,
+      value: ethers.parseEther('1'),
+    });
+    await token.mint(extra.address, 10);
+    await token.connect(extra).approve(await qv.getAddress(), 10);
+    await expect(qv.connect(extra).castVote(1, 1)).to.be.revertedWithCustomError(
+      qv,
+      'VoterCapReached'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- enforce `MAX_VOTERS` on quadratic voting proposals
- remove voter list storage and record voters via calldata
- cap `GovernanceReward.recordVoters` and update tests

## Testing
- `npm test`
- `npm run lint` *(fails: 2 errors, 33 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c6215707fc8333bff410c8537bfb5f