### PR TITLE
Allow quadratic vote refunds after proposal expiry

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -57,13 +57,18 @@ typically denominated in AGIALPHA. A configurable percentage of this cost is
 locked as a refundable deposit while the remainder is charged as a fee. The fee
 is sent to the configured `treasury` or burned if the treasury is unset.
 Deposits remain in the contract until the proposal is executed by the configured
-executor. After execution, each voter may call `claimRefund` to retrieve only the
-locked deposit – the fee portion is always deducted.
+executor or the voting deadline expires. Each proposal stores a `deadline`
+timestamp supplied with the first `castVote` call. Further votes are rejected
+once the deadline passes.
+
+After execution or once the deadline has elapsed, each voter may call
+`claimRefund` to retrieve only the locked deposit – the fee portion is always
+deducted.
 
 Example: with a 50% refundable rate, voting with 4 votes costs 16 tokens. Eight
 tokens are locked as a refundable deposit and the other eight are immediately
-sent to the treasury. After `execute`, calling `claimRefund` returns the locked
-eight tokens but the voter permanently paid the eight token fee. The contract
-optionally calls `GovernanceReward.recordVoters` so rewards can be distributed
-based on participation.
+sent to the treasury. After `execute` **or once the deadline expires**, calling
+`claimRefund` returns the locked eight tokens but the voter permanently paid the
+eight token fee. The contract optionally calls `GovernanceReward.recordVoters`
+so rewards can be distributed based on participation.
 

--- a/test/v2/QuadraticVoting.test.js
+++ b/test/v2/QuadraticVoting.test.js
@@ -25,9 +25,7 @@ describe('QuadraticVoting', function () {
   it('charges quadratic cost, locks deposit and sends fee', async () => {
     const treasuryBefore = await token.balanceOf(owner.address);
     const block = await ethers.provider.getBlock('latest');
-    await qv
-      .connect(voter)
-      .castVote(1, 3, block.timestamp + 100); // cost 9 => deposit 4, fee 5
+    await qv.connect(voter).castVote(1, 3, block.timestamp + 100); // cost 9 => deposit 4, fee 5
     expect(await token.balanceOf(voter.address)).to.equal(991n);
     expect(await token.balanceOf(await qv.getAddress())).to.equal(4n);
     expect(await qv.locked(1, voter.address)).to.equal(4n);
@@ -38,9 +36,7 @@ describe('QuadraticVoting', function () {
   it('refunds only the deposit after execution', async () => {
     const treasuryBefore = await token.balanceOf(owner.address);
     const block = await ethers.provider.getBlock('latest');
-    await qv
-      .connect(voter)
-      .castVote(1, 4, block.timestamp + 100); // cost 16 => deposit 8, fee 8
+    await qv.connect(voter).castVote(1, 4, block.timestamp + 100); // cost 16 => deposit 8, fee 8
     await qv.connect(executor).execute(1);
     await qv.connect(voter).claimRefund(1);
     expect(await token.balanceOf(voter.address)).to.equal(992n);

--- a/test/v2/QuadraticVoting.test.js
+++ b/test/v2/QuadraticVoting.test.js
@@ -24,7 +24,10 @@ describe('QuadraticVoting', function () {
 
   it('charges quadratic cost, locks deposit and sends fee', async () => {
     const treasuryBefore = await token.balanceOf(owner.address);
-    await qv.connect(voter).castVote(1, 3); // cost 9 => deposit 4, fee 5
+    const block = await ethers.provider.getBlock('latest');
+    await qv
+      .connect(voter)
+      .castVote(1, 3, block.timestamp + 100); // cost 9 => deposit 4, fee 5
     expect(await token.balanceOf(voter.address)).to.equal(991n);
     expect(await token.balanceOf(await qv.getAddress())).to.equal(4n);
     expect(await qv.locked(1, voter.address)).to.equal(4n);
@@ -34,7 +37,10 @@ describe('QuadraticVoting', function () {
 
   it('refunds only the deposit after execution', async () => {
     const treasuryBefore = await token.balanceOf(owner.address);
-    await qv.connect(voter).castVote(1, 4); // cost 16 => deposit 8, fee 8
+    const block = await ethers.provider.getBlock('latest');
+    await qv
+      .connect(voter)
+      .castVote(1, 4, block.timestamp + 100); // cost 16 => deposit 8, fee 8
     await qv.connect(executor).execute(1);
     await qv.connect(voter).claimRefund(1);
     expect(await token.balanceOf(voter.address)).to.equal(992n);
@@ -48,9 +54,30 @@ describe('QuadraticVoting', function () {
     );
     const reward = await Mock.deploy();
     await qv.connect(owner).setGovernanceReward(await reward.getAddress());
-    await qv.connect(voter).castVote(1, 2);
+    const block = await ethers.provider.getBlock('latest');
+    await qv.connect(voter).castVote(1, 2, block.timestamp + 100);
     await expect(qv.connect(executor).execute(1)).to.emit(reward, 'Recorded');
     const recorded = await reward.getLastVoters();
     expect(recorded[0]).to.equal(voter.address);
+  });
+
+  it('reverts refund before deadline without execution', async () => {
+    const block = await ethers.provider.getBlock('latest');
+    await qv.connect(voter).castVote(1, 2, block.timestamp + 100);
+    await expect(qv.connect(voter).claimRefund(1)).to.be.revertedWith(
+      'inactive'
+    );
+  });
+
+  it('allows refund after deadline without execution', async () => {
+    const block = await ethers.provider.getBlock('latest');
+    const deadline = block.timestamp + 100;
+    await qv.connect(voter).castVote(1, 2, deadline);
+    await ethers.provider.send('evm_increaseTime', [101]);
+    await ethers.provider.send('evm_mine');
+    await expect(qv.connect(voter).claimRefund(1))
+      .to.emit(qv, 'ProposalExpired')
+      .withArgs(1);
+    expect(await token.balanceOf(voter.address)).to.equal(998n);
   });
 });


### PR DESCRIPTION
## Summary
- add per-proposal deadlines and expiration tracking
- allow voters to reclaim deposits after deadline via `claimRefund`
- emit `ProposalExpired` event and document deadline behavior
- expand tests for deadline enforcement and refund after expiry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6b0c467588333983bcd6104357825