### PR TITLE
Enforce kappa bounds and add validation tests

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -55,6 +55,7 @@ contract RewardEngineMB is Governable, ReentrancyGuard {
     mapping(uint256 => bool) public epochSettled;
 
     int256 public constant WAD = 1e18;
+    uint256 public constant MAX_KAPPA = type(uint256).max / 1e18;
 
     error InvalidRoleShareSum(uint256 sum);
     error ProofCountExceeded(uint256 length, uint256 maxLength);
@@ -119,6 +120,8 @@ contract RewardEngineMB is Governable, ReentrancyGuard {
     /// @notice Set the scaling factor converting free energy to token units.
     /// @param _kappa New scaling coefficient in 18-decimal fixed point.
     function setKappa(uint256 _kappa) external onlyGovernance {
+        require(_kappa > 0, "kappa");
+        require(_kappa <= MAX_KAPPA, "kappa overflow");
         kappa = _kappa;
         emit KappaUpdated(_kappa);
     }

--- a/test/v2/RewardEngineMB.kappa.test.js
+++ b/test/v2/RewardEngineMB.kappa.test.js
@@ -1,0 +1,24 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('RewardEngineMB setKappa', function () {
+  it('accepts valid kappa and rejects zero/overflow', async function () {
+    const [admin] = await ethers.getSigners();
+    const Reward = await ethers.getContractFactory('contracts/v2/RewardEngineMB.sol:RewardEngineMB');
+    const reward = await Reward.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      admin.address
+    );
+    await reward.waitForDeployment();
+
+    await expect(reward.setKappa(0)).to.be.revertedWith('kappa');
+    const max = await reward.MAX_KAPPA();
+    await expect(reward.setKappa(max + 1n)).to.be.revertedWith('kappa overflow');
+
+    await reward.setKappa(2n);
+    expect(await reward.kappa()).to.equal(2n);
+  });
+});

--- a/test/v2/RewardEngineMB.kappa.test.js
+++ b/test/v2/RewardEngineMB.kappa.test.js
@@ -4,7 +4,9 @@ const { ethers } = require('hardhat');
 describe('RewardEngineMB setKappa', function () {
   it('accepts valid kappa and rejects zero/overflow', async function () {
     const [admin] = await ethers.getSigners();
-    const Reward = await ethers.getContractFactory('contracts/v2/RewardEngineMB.sol:RewardEngineMB');
+    const Reward = await ethers.getContractFactory(
+      'contracts/v2/RewardEngineMB.sol:RewardEngineMB'
+    );
     const reward = await Reward.deploy(
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -16,7 +18,9 @@ describe('RewardEngineMB setKappa', function () {
 
     await expect(reward.setKappa(0)).to.be.revertedWith('kappa');
     const max = await reward.MAX_KAPPA();
-    await expect(reward.setKappa(max + 1n)).to.be.revertedWith('kappa overflow');
+    await expect(reward.setKappa(max + 1n)).to.be.revertedWith(
+      'kappa overflow'
+    );
 
     await reward.setKappa(2n);
     expect(await reward.kappa()).to.equal(2n);

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -187,6 +187,17 @@ contract RewardEngineMBTest is Test {
         assertEq(pool.total(), 2e18, "scaled budget distributed");
     }
 
+    function test_setKappaRejectsZero() public {
+        vm.expectRevert("kappa");
+        engine.setKappa(0);
+    }
+
+    function test_setKappaRejectsOverflow() public {
+        uint256 maxKappa = engine.MAX_KAPPA();
+        vm.expectRevert("kappa overflow");
+        engine.setKappa(maxKappa + 1);
+    }
+
     function test_setTreasuryRejectsZero() public {
         vm.expectRevert("treasury");
         engine.setTreasury(address(0));


### PR DESCRIPTION
## Summary
- require non-zero kappa and enforce MAX_KAPPA to avoid overflow in budget calculations
- add Foundry tests for kappa zero and overflow
- add Hardhat test for valid and invalid kappa values

## Testing
- `forge test --match-path test/v2/RewardEngineMB.t.sol` *(fails: Invalid type for argument in ValidationFinalizeGas.t.sol)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6bc76e4a48333b01ba212f61c54ea