### PR TITLE
Guard stake tuning against pause

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -309,7 +309,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     }
 
     /// @notice record a dispute occurrence for auto stake tuning
-    function recordDispute() external {
+    /// @dev disabled while the contract is paused
+    function recordDispute() external whenNotPaused {
         if (msg.sender != disputeModule) revert OnlyDisputeModule();
         if (!autoStakeTuning) return;
         ++disputeCount;
@@ -317,7 +318,8 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     }
 
     /// @notice trigger stake evaluation if the tuning window has elapsed
-    function checkpointStake() external {
+    /// @dev disabled while the contract is paused
+    function checkpointStake() external whenNotPaused {
         if (!autoStakeTuning) return;
         _maybeAdjustStake();
     }

--- a/test/v2/StakeManagerPause.test.js
+++ b/test/v2/StakeManagerPause.test.js
@@ -24,7 +24,7 @@ describe('StakeManager pause', function () {
       0,
       ethers.ZeroAddress,
       await mockReg.getAddress(),
-      ethers.ZeroAddress,
+      owner.address,
       owner.address
     );
     await stakeManager.connect(owner).setMinStake(1);
@@ -60,5 +60,16 @@ describe('StakeManager pause', function () {
 
     await stakeManager.connect(owner).unpause();
     await stakeManager.connect(user).withdrawStake(0, ethers.parseEther('100'));
+  });
+
+  it('pauses dispute recording and checkpointing', async () => {
+    await stakeManager.connect(owner).autoTuneStakes(true);
+    await stakeManager.connect(owner).pause();
+    await expect(
+      stakeManager.connect(owner).recordDispute()
+    ).to.be.revertedWithCustomError(stakeManager, 'EnforcedPause');
+    await expect(
+      stakeManager.connect(owner).checkpointStake()
+    ).to.be.revertedWithCustomError(stakeManager, 'EnforcedPause');
   });
 });


### PR DESCRIPTION
## Summary
- prevent `recordDispute` and `checkpointStake` from executing while the StakeManager is paused
- test pause behaviour for dispute recording and checkpointing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6c5c1013083339ec365c1cb626a9d