### PR TITLE
feat: add Hamiltonian monitoring script

### DIFF
--- a/docs/hamiltonian-monitor.md
+++ b/docs/hamiltonian-monitor.md
@@ -1,0 +1,29 @@
+# Hamiltonian Monitor
+
+This script computes a simple Hamiltonian metric for reward epochs.
+
+It queries `EpochSettled` events from `RewardEngineMB` and reports the
+value
+
+\[ H = \Delta H - \lambda R \]
+
+where `\Delta H` is the enthalpy change emitted by the contract,
+`R` is the reward budget and `\lambda` is a scaling coefficient passed on
+the command line. A free‑energy estimate is also shown using the epoch's
+entropy data.
+
+## Usage
+
+```
+npx ts-node --compiler-options '{"module":"commonjs"}' scripts/hamiltonian-tracker.ts \
+  --engine <reward_engine_address> [--from <block>] [--to <block>] [--lambda <scale>]
+```
+
+Each matching epoch prints a line:
+
+```
+epoch 1 h=123 free=45
+```
+
+The output can be ingested by monitoring systems or governance dashboards
+to track approach toward equilibrium.

--- a/scripts/hamiltonian-tracker.ts
+++ b/scripts/hamiltonian-tracker.ts
@@ -1,0 +1,55 @@
+import hre from 'hardhat';
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const args: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = argv[i + 1];
+      if (value && !value.startsWith('--')) {
+        args[key] = value;
+        i++;
+      }
+    }
+  }
+  return args;
+}
+
+const WAD = 10n ** 18n;
+
+async function main() {
+  const args = parseArgs();
+  const engine = args['engine'];
+  if (!engine) throw new Error('--engine <address> required');
+  const fromBlock = args['from'] ? parseInt(args['from']) : 0;
+  const toBlock = args['to']
+    ? parseInt(args['to'])
+    : await hre.ethers.provider.getBlockNumber();
+  const lambda = BigInt(args['lambda'] ?? '1');
+
+  const abi = [
+    'event EpochSettled(uint256 indexed epoch,uint256 budget,int256 dH,int256 dS,int256 systemTemperature,uint256 leftover)',
+  ];
+  const contract = new hre.ethers.Contract(engine, abi, hre.ethers.provider);
+  const events = await contract.queryFilter(
+    contract.filters.EpochSettled(),
+    fromBlock,
+    toBlock
+  );
+
+  for (const ev of events) {
+    const { epoch, budget, dH, dS, systemTemperature } = ev.args as any;
+    const h = BigInt(dH) - lambda * BigInt(budget);
+    const free = BigInt(dH) - (BigInt(systemTemperature) * BigInt(dS)) / WAD;
+    console.log(
+      `epoch ${epoch.toString()} h=${h.toString()} free=${free.toString()}`
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add TypeScript script to compute Hamiltonian and free-energy metrics from RewardEngineMB epochs
- document usage of the Hamiltonian monitor for governance dashboards
- format Hamiltonian tracker to satisfy repository lint rules

## Testing
- `node_modules/.bin/solhint contracts/**/*.sol`
- `node_modules/.bin/eslint . --ext .js,.ts,.tsx`
- `npm test` *(fails: process did not complete in allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c8fd0f2083338357ae9ad329a1d9