### PR TITLE
test: extend kappa bounds

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -55,7 +55,7 @@ contract RewardEngineMB is Governable, ReentrancyGuard {
     mapping(uint256 => bool) public epochSettled;
 
     int256 public constant WAD = 1e18;
-    uint256 public constant MAX_KAPPA = type(uint256).max / 1e18;
+    uint256 public constant MAX_KAPPA = type(uint256).max / uint256(WAD);
 
     error InvalidRoleShareSum(uint256 sum);
     error ProofCountExceeded(uint256 length, uint256 maxLength);

--- a/test/v2/RewardEngineMB.kappa.test.js
+++ b/test/v2/RewardEngineMB.kappa.test.js
@@ -17,7 +17,11 @@ describe('RewardEngineMB setKappa', function () {
     await reward.waitForDeployment();
 
     await expect(reward.setKappa(0)).to.be.revertedWith('kappa');
+
     const max = await reward.MAX_KAPPA();
+    await reward.setKappa(max);
+    expect(await reward.kappa()).to.equal(max);
+
     await expect(reward.setKappa(max + 1n)).to.be.revertedWith(
       'kappa overflow'
     );

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -194,6 +194,8 @@ contract RewardEngineMBTest is Test {
 
     function test_setKappaRejectsOverflow() public {
         uint256 maxKappa = engine.MAX_KAPPA();
+        engine.setKappa(maxKappa);
+        assertEq(engine.kappa(), maxKappa);
         vm.expectRevert("kappa overflow");
         engine.setKappa(maxKappa + 1);
     }


### PR DESCRIPTION
## Summary
- derive MAX_KAPPA from WAD to clarify upper limit
- add tests ensuring setKappa accepts MAX_KAPPA and rejects overflow

## Testing
- `npm test`
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d84834908333a97a297ae901a1b8