### PR TITLE
feat: mint rewards and update budget tracking

### DIFF
--- a/contracts/v2/interfaces/IERC20Mintable.sol
+++ b/contracts/v2/interfaces/IERC20Mintable.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title IERC20Mintable
+/// @notice Minimal interface for ERC20 tokens with mint and burn capabilities.
+interface IERC20Mintable {
+    /// @notice Mint `amount` tokens to `to`.
+    /// @param to recipient address
+    /// @param amount token amount to mint
+    function mint(address to, uint256 amount) external;
+
+    /// @notice Burn `amount` tokens from `from`.
+    /// @param from address whose tokens will be burned
+    /// @param amount token amount to burn
+    function burn(address from, uint256 amount) external;
+}
+


### PR DESCRIPTION
## Summary
- add IERC20Mintable for AGIALPHA tokens
- mint epoch budgets to FeePool and treasury, burning leftovers
- test reward engine budget emission and token minting

## Testing
- `npx hardhat test test/v2/RewardEngineMB.metrics.test.js` *(fails: compilation stalled, manual run terminated)*
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dc7accec8333a58f024ae164e561