### PR TITLE
feat: guard quadratic voting against reentrancy

### DIFF
--- a/contracts/test/QuadraticVotingAttack.sol
+++ b/contracts/test/QuadraticVotingAttack.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {QuadraticVoting} from "../v2/QuadraticVoting.sol";
+import {ReentrantERC20, IReentrantCaller} from "./ReentrantERC20.sol";
+
+/// @dev Helper contract to trigger reentrancy attacks against QuadraticVoting.
+contract QuadraticVotingAttack is IReentrantCaller {
+    enum AttackType {
+        Cast,
+        Refund
+    }
+
+    QuadraticVoting public qv;
+    ReentrantERC20 public token;
+    uint256 public proposalId;
+    uint256 public deadline;
+    AttackType public attackType;
+
+    constructor(address _qv, address _token, uint256 _proposalId, uint256 _deadline) {
+        qv = QuadraticVoting(_qv);
+        token = ReentrantERC20(_token);
+        proposalId = _proposalId;
+        deadline = _deadline;
+    }
+
+    function attackCast() external {
+        attackType = AttackType.Cast;
+        token.approve(address(qv), type(uint256).max);
+        token.setCaller(address(this));
+        token.setAttack(true);
+        qv.castVote(proposalId, 1, deadline);
+    }
+
+    function attackRefund() external {
+        attackType = AttackType.Refund;
+        token.setCaller(address(this));
+        token.setAttack(true);
+        qv.claimRefund(proposalId);
+    }
+
+    function vote() external {
+        token.approve(address(qv), type(uint256).max);
+        qv.castVote(proposalId, 1, deadline);
+    }
+
+    function reenter() external override {
+        if (attackType == AttackType.Cast) {
+            qv.castVote(proposalId, 1, deadline);
+        } else if (attackType == AttackType.Refund) {
+            qv.claimRefund(proposalId);
+        }
+    }
+}

--- a/contracts/test/ReentrantERC20.sol
+++ b/contracts/test/ReentrantERC20.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface IReentrantCaller {
+    function reenter() external;
+}
+
+/// @dev ERC20 token that attempts to reenter the caller during transfers.
+contract ReentrantERC20 is ERC20 {
+    IReentrantCaller public caller;
+    bool public attack;
+
+    constructor() ERC20("Reentrant", "RENT") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function setCaller(address _caller) external {
+        caller = IReentrantCaller(_caller);
+    }
+
+    function setAttack(bool _attack) external {
+        attack = _attack;
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        bool ok = super.transfer(to, amount);
+        if (attack && address(caller) != address(0)) {
+            attack = false;
+            caller.reenter();
+        }
+        return ok;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        bool ok = super.transferFrom(from, to, amount);
+        if (attack && address(caller) != address(0)) {
+            attack = false;
+            caller.reenter();
+        }
+        return ok;
+    }
+}


### PR DESCRIPTION
## Summary
- inherit ReentrancyGuard in QuadraticVoting
- protect castVote, execute and claimRefund with nonReentrant modifier
- add reentrant ERC20 mock and tests preventing reentry

## Testing
- `npm test --silent test/v2/QuadraticVotingReentrancy.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c6ea0c38dc83339bbae25638f0dfb2