### PR TITLE
Integrate temperature and Hamiltonian metrics into stake tuning

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -91,8 +91,15 @@ contract MockStakeManager is IStakeManager {
         uint256,
         uint256,
         uint256,
+        uint256,
+        int256,
+        int256,
+        uint256,
+        uint256,
         uint256
     ) external override {}
+    function setThermostat(address) external override {}
+    function setHamiltonianFeed(address) external override {}
     function recordDispute() external override {}
     function checkpointStake() external override {}
     function addAGIType(address, uint256) external override {}

--- a/contracts/test/MockHamiltonianFeed.sol
+++ b/contracts/test/MockHamiltonianFeed.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+contract MockHamiltonianFeed {
+    int256 public h;
+
+    function setHamiltonian(int256 _h) external {
+        h = _h;
+    }
+
+    function currentHamiltonian() external view returns (int256) {
+        return h;
+    }
+}
+

--- a/contracts/v2/interfaces/IHamiltonian.sol
+++ b/contracts/v2/interfaces/IHamiltonian.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IHamiltonian {
+    function currentHamiltonian() external view returns (int256);
+}
+

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -70,8 +70,15 @@ interface IStakeManager {
         uint256 downPct,
         uint256 window,
         uint256 floor,
-        uint256 ceil
+        uint256 ceil,
+        int256 tempThreshold,
+        int256 hThreshold,
+        uint256 disputeWeight,
+        uint256 tempWeight,
+        uint256 hamWeight
     );
+    event ThermostatUpdated(address indexed thermostat);
+    event HamiltonianFeedUpdated(address indexed feed);
     event FeePctUpdated(uint256 pct);
     event BurnPctUpdated(uint256 pct);
     event ValidatorRewardPctUpdated(uint256 pct);
@@ -240,8 +247,15 @@ interface IStakeManager {
         uint256 downPct,
         uint256 window,
         uint256 floor,
-        uint256 ceil
+        uint256 ceil,
+        int256 tempThreshold,
+        int256 hThreshold,
+        uint256 disputeWeight,
+        uint256 tempWeight,
+        uint256 hamWeight
     ) external;
+    function setThermostat(address thermostat) external;
+    function setHamiltonianFeed(address feed) external;
     function recordDispute() external;
     function checkpointStake() external;
 

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -89,8 +89,15 @@ contract ReentrantStakeManager is IStakeManager {
         uint256,
         uint256,
         uint256,
+        uint256,
+        int256,
+        int256,
+        uint256,
+        uint256,
         uint256
     ) external override {}
+    function setThermostat(address) external override {}
+    function setHamiltonianFeed(address) external override {}
     function recordDispute() external override {}
     function checkpointStake() external override {}
     function addAGIType(address, uint256) external override {}

--- a/test/v2/StakeManagerAutoTune.test.js
+++ b/test/v2/StakeManagerAutoTune.test.js
@@ -4,7 +4,7 @@ const { time } = require('@nomicfoundation/hardhat-network-helpers');
 
 describe('StakeManager auto stake tuning', function () {
   const { AGIALPHA } = require('../../scripts/constants');
-  let stakeManager, owner, dispute;
+  let stakeManager, owner, dispute, thermostat, hamFeed;
 
   beforeEach(async () => {
     [owner, dispute] = await ethers.getSigners();
@@ -15,6 +15,14 @@ describe('StakeManager auto stake tuning', function () {
       AGIALPHA,
       mock.deployedBytecode,
     ]);
+    const Thermostat = await ethers.getContractFactory(
+      'contracts/v2/Thermostat.sol:Thermostat'
+    );
+    thermostat = await Thermostat.deploy(100, 1, 200, owner.address);
+    const HamFeed = await ethers.getContractFactory(
+      'contracts/test/MockHamiltonianFeed.sol:MockHamiltonianFeed'
+    );
+    hamFeed = await HamFeed.deploy();
     const StakeManager = await ethers.getContractFactory(
       'contracts/v2/StakeManager.sol:StakeManager'
     );
@@ -33,7 +41,7 @@ describe('StakeManager auto stake tuning', function () {
   it('increases min stake when disputes exceed threshold', async () => {
     await stakeManager
       .connect(owner)
-      .configureAutoStake(2, 50, 50, 1000, 10, 0);
+      .configureAutoStake(2, 50, 50, 1000, 10, 0, 0, 0, 1, 0, 0);
 
     await stakeManager.connect(dispute).recordDispute();
     await stakeManager.connect(dispute).recordDispute();
@@ -50,7 +58,7 @@ describe('StakeManager auto stake tuning', function () {
   it('decreases min stake when no disputes occur', async () => {
     await stakeManager
       .connect(owner)
-      .configureAutoStake(1, 50, 50, 1000, 10, 0);
+      .configureAutoStake(1, 50, 50, 1000, 10, 0, 0, 0, 1, 0, 0);
 
     await time.increase(1000);
 
@@ -63,7 +71,7 @@ describe('StakeManager auto stake tuning', function () {
   it('respects floor and ceiling bounds', async () => {
     await stakeManager
       .connect(owner)
-      .configureAutoStake(2, 50, 50, 1000, 80, 120);
+      .configureAutoStake(2, 50, 50, 1000, 80, 120, 0, 0, 1, 0, 0);
 
     await stakeManager.connect(dispute).recordDispute();
     await stakeManager.connect(dispute).recordDispute();
@@ -82,5 +90,35 @@ describe('StakeManager auto stake tuning', function () {
       .to.emit(stakeManager, 'MinStakeUpdated')
       .withArgs(80n);
     expect(await stakeManager.minStake()).to.equal(80n);
+  });
+
+  it('increases min stake when temperature exceeds threshold', async () => {
+    await stakeManager
+      .connect(owner)
+      .setThermostat(await thermostat.getAddress());
+    await stakeManager
+      .connect(owner)
+      .configureAutoStake(0, 50, 50, 1000, 10, 0, 150, 0, 1, 1, 0);
+    await thermostat.connect(owner).setSystemTemperature(200);
+    await time.increase(1000);
+    await expect(stakeManager.checkpointStake())
+      .to.emit(stakeManager, 'MinStakeUpdated')
+      .withArgs(150n);
+    expect(await stakeManager.minStake()).to.equal(150n);
+  });
+
+  it('increases min stake when Hamiltonian exceeds threshold', async () => {
+    await stakeManager
+      .connect(owner)
+      .setHamiltonianFeed(await hamFeed.getAddress());
+    await stakeManager
+      .connect(owner)
+      .configureAutoStake(0, 50, 50, 1000, 10, 0, 0, 1, 1, 0, 1);
+    await hamFeed.setHamiltonian(2);
+    await time.increase(1000);
+    await expect(stakeManager.checkpointStake())
+      .to.emit(stakeManager, 'MinStakeUpdated')
+      .withArgs(150n);
+    expect(await stakeManager.minStake()).to.equal(150n);
   });
 });


### PR DESCRIPTION
## Summary
- reference external Thermostat and Hamiltonian feed for stake tuning
- weigh disputes, temperature and Hamiltonian in auto-tune configuration
- add tests for stake adjustments driven by temperature or Hamiltonian changes

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6ed99cc908333a315a9bcec95b6aa