### PR TITLE
feat: adjust reward engine weights and settlement

### DIFF
--- a/test/v2/RewardEngineMB.metrics.test.js
+++ b/test/v2/RewardEngineMB.metrics.test.js
@@ -99,7 +99,7 @@ describe('RewardEngineMB thermodynamic metrics', function () {
     const budget = ethers.parseUnits('2', 18);
     const agentShare = (budget * 65n) / 100n;
     const dust = budget - agentShare;
-    const minted = budget * 2n;
+    const minted = budget;
 
     const esEvent = receipt.logs.find(
       (l) => l.fragment && l.fragment.name === 'EpochSettled'
@@ -118,10 +118,11 @@ describe('RewardEngineMB thermodynamic metrics', function () {
     expect(rbEvent.args.dust).to.equal(dust);
     expect(rbEvent.args.redistributed).to.equal(budget);
 
-    expect(await token.totalSupply()).to.equal(budget * 2n);
-    expect(await token.balanceOf(treasury.address)).to.equal(budget);
+    expect(await token.totalSupply()).to.equal(budget);
+    expect(await token.balanceOf(treasury.address)).to.equal(0n);
     expect(await token.balanceOf(await feePool.getAddress())).to.equal(budget);
     expect(await feePool.rewards(owner.address)).to.equal(agentShare);
+    expect(await feePool.rewards(treasury.address)).to.equal(dust);
   });
 
   it('reverts when settling an epoch twice', async function () {

--- a/test/v2/RewardEngineMB.test.js
+++ b/test/v2/RewardEngineMB.test.js
@@ -217,8 +217,6 @@ describe('RewardEngineMB', function () {
     expect(await token.balanceOf(await feePool.getAddress())).to.equal(
       feePoolBalBefore + budget
     );
-    expect(await token.balanceOf(treasury.address)).to.equal(
-      treasuryBalBefore
-    );
+    expect(await token.balanceOf(treasury.address)).to.equal(treasuryBalBefore);
   });
 });

--- a/test/v2/RewardEngineMB.test.js
+++ b/test/v2/RewardEngineMB.test.js
@@ -213,12 +213,12 @@ describe('RewardEngineMB', function () {
     expect(rT).to.equal(3n);
     expect(r1 + r2 + rT).to.equal(budget);
     expect(await feePool.total()).to.equal(budget);
-    expect(await token.totalSupply()).to.equal(supplyBefore + budget * 2n);
+    expect(await token.totalSupply()).to.equal(supplyBefore + budget);
     expect(await token.balanceOf(await feePool.getAddress())).to.equal(
       feePoolBalBefore + budget
     );
     expect(await token.balanceOf(treasury.address)).to.equal(
-      treasuryBalBefore + budget
+      treasuryBalBefore
     );
   });
 });


### PR DESCRIPTION
## Summary
- compute Maxwell-Boltzmann weights using `ThermoMath.expWad`
- mint epoch budget to fee pool and route rounding dust to treasury
- test reward shares and conservation of value

## Testing
- `npm test test/v2/RewardEngineMB.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c6ff0dd8e88333ab063a4219da61be