### PR TITLE
feat: add maxwell boltzmann job rewards

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -16,6 +16,7 @@ import {ICertificateNFT} from "./interfaces/ICertificateNFT.sol";
 import {IJobRegistryAck} from "./interfaces/IJobRegistryAck.sol";
 import {TOKEN_SCALE} from "./Constants.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ThermoMath} from "./libraries/ThermoMath.sol";
 
 /// @title JobRegistry
 /// @notice Coordinates job lifecycle and external modules.
@@ -122,6 +123,14 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
 
     mapping(address => EmployerStats) public employerStats;
 
+    // ---------------------------------------------------------------
+    // Maxwell-Boltzmann reward parameters
+    // ---------------------------------------------------------------
+    bool public useMBRewards;
+    int256 public mbTemperature = 1e18; // WAD
+    mapping(uint256 => int256) public jobAgentEnergy;
+    mapping(uint256 => int256) public jobValidatorEnergy;
+
     function getSpecHash(uint256 jobId) external view returns (bytes32) {
         return jobs[jobId].specHash;
     }
@@ -168,6 +177,31 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     {
         EmployerStats storage stats = employerStats[employer];
         return (stats.positive, stats.negative);
+    }
+
+    /// ---------------------------------------------------------------
+    /// Maxwell-Boltzmann reward configuration
+    /// ---------------------------------------------------------------
+
+    /// @notice Enable or disable MB-based reward sharing.
+    function setMBRewardEnabled(bool enabled) external onlyGovernance {
+        useMBRewards = enabled;
+    }
+
+    /// @notice Set the temperature parameter used for MB weighting.
+    function setMBTemperature(int256 temp) external onlyGovernance {
+        require(temp > 0, "temp");
+        mbTemperature = temp;
+    }
+
+    /// @notice Provide energy metrics for a job.
+    function setJobEnergies(
+        uint256 jobId,
+        int256 agentE,
+        int256 validatorE
+    ) external onlyGovernance {
+        jobAgentEnergy[jobId] = agentE;
+        jobValidatorEnergy[jobId] = validatorE;
     }
 
     /// @notice Confirms previously submitted burn evidence.
@@ -1346,13 +1380,26 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         if (job.success) {
             IFeePool pool = feePool;
             uint256 validatorReward;
-            if (validators.length > 0 && validatorRewardPct > 0) {
-                validatorReward =
-                    (uint256(job.reward) * validatorRewardPct) / 100;
-            }
+            uint256 rewardAfterValidator;
+            if (useMBRewards && validators.length > 0) {
+                int256[] memory E = new int256[](2);
+                uint256[] memory g = new uint256[](2);
+                E[0] = jobAgentEnergy[jobId];
+                E[1] = jobValidatorEnergy[jobId];
+                g[0] = 1;
+                g[1] = 1;
+                uint256[] memory w = ThermoMath.mbWeights(E, g, mbTemperature, 0);
+                validatorReward = (uint256(job.reward) * w[1]) / 1e18;
+                rewardAfterValidator = uint256(job.reward) - validatorReward;
+            } else {
+                if (validators.length > 0 && validatorRewardPct > 0) {
+                    validatorReward =
+                        (uint256(job.reward) * validatorRewardPct) / 100;
+                }
 
-            uint256 rewardAfterValidator =
-                uint256(job.reward) - validatorReward;
+                rewardAfterValidator =
+                    uint256(job.reward) - validatorReward;
+            }
             uint256 fee;
             uint256 agentPct = job.agentPct == 0 ? 100 : job.agentPct;
             if (address(stakeManager) != address(0)) {

--- a/docs/incentive-mechanisms-agialpha.md
+++ b/docs/incentive-mechanisms-agialpha.md
@@ -40,3 +40,7 @@ All modules expose simple `Ownable` setters so the contract owner can retune fee
 - Reward flows never touch off‑chain accounts, keeping operators pseudonymous and outside traditional reporting regimes.
 
 These incentives encourage honest participation, amplify $AGIALPHA demand, and keep all flows pseudonymous and globally tax‑neutral.
+
+## 6. Maxwell–Boltzmann Reward Splitting
+
+Job rewards may be divided between the executing agent and participating validators using a Maxwell–Boltzmann weighting. When governance enables the feature through `JobRegistry.setMBRewardEnabled`, a configurable temperature governs how strongly efficiency differences affect payouts. Per-job energy metrics are supplied via `setJobEnergies`, and the contract allocates the reward in proportion to `exp(-E/T)` for each participant, favouring lower-energy (more efficient) work. If the feature is disabled, the registry falls back to the standard fixed-percentage distribution.

--- a/test/v2/JobRegistryMBReward.test.js
+++ b/test/v2/JobRegistryMBReward.test.js
@@ -1,0 +1,82 @@
+const { expect } = require('chai');
+const { ethers, artifacts, network } = require('hardhat');
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
+
+const { address: AGIALPHA } = require('../../config/agialpha.json');
+
+describe('JobRegistry Maxwell-Boltzmann rewards', function () {
+  let token, stakeManager, validation, registry, identity;
+  let owner, employer, agent, validator;
+  const reward = 100n;
+  const WAD = 10n ** 18n;
+
+  beforeEach(async function () {
+    [owner, employer, agent, validator] = await ethers.getSigners();
+    const artifact = await artifacts.readArtifact('contracts/test/MockERC20.sol:MockERC20');
+    await network.provider.send('hardhat_setCode', [AGIALPHA, artifact.deployedBytecode]);
+    token = await ethers.getContractAt('contracts/test/MockERC20.sol:MockERC20', AGIALPHA);
+
+    const StakeManager = await ethers.getContractFactory('contracts/v2/StakeManager.sol:StakeManager');
+    stakeManager = await StakeManager.deploy(0, 100, 0, ethers.ZeroAddress, ethers.ZeroAddress, ethers.ZeroAddress, owner.address);
+    await stakeManager.connect(owner).setMinStake(0);
+
+    const Validation = await ethers.getContractFactory('contracts/v2/mocks/ValidationStub.sol:ValidationStub');
+    validation = await Validation.deploy();
+
+    const Identity = await ethers.getContractFactory('contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock');
+    identity = await Identity.deploy();
+
+    const Registry = await ethers.getContractFactory('contracts/v2/JobRegistry.sol:JobRegistry');
+    registry = await Registry.deploy(
+      await validation.getAddress(),
+      await stakeManager.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+
+    await validation.setJobRegistry(await registry.getAddress());
+    await validation.setValidators([validator.address]);
+    await stakeManager.connect(owner).setJobRegistry(await registry.getAddress());
+    await stakeManager.connect(owner).setValidationModule(await validation.getAddress());
+    await registry.connect(owner).setIdentityRegistry(await identity.getAddress());
+    await registry.connect(owner).setJobParameters(Number(reward), 0);
+    await registry.connect(owner).setValidatorRewardPct(0);
+    await registry.connect(owner).setMBRewardEnabled(true);
+    await registry.connect(owner).setMBTemperature(WAD);
+
+    for (const signer of [employer, agent, validator]) {
+      await token.mint(signer.address, 1000);
+      await token.connect(signer).approve(await stakeManager.getAddress(), 1000);
+    }
+  });
+
+  it('splits reward using Maxwell-Boltzmann weights', async function () {
+    await token.connect(employer).approve(await stakeManager.getAddress(), reward);
+    const deadline = (await time.latest()) + 1000;
+    const specHash = ethers.id('spec');
+    await registry
+      .connect(employer)
+      ['createJob(uint256,uint64,bytes32,string)'](reward, deadline, specHash, 'uri');
+    const jobId = 1;
+    await registry.connect(agent).applyForJob(jobId, '', []);
+    const resultHash = ethers.id('result');
+    await registry.connect(agent).submit(jobId, resultHash, 'result', '', []);
+    await validation.setResult(true);
+    await validation.finalize(jobId);
+
+    const ln2 = BigInt(Math.round(Math.log(2) * 1e18));
+    await registry.connect(owner).setJobEnergies(jobId, 0n, ln2);
+
+    await registry.connect(employer).finalize(jobId);
+
+    expect(await token.balanceOf(agent.address)).to.equal(1000n + 67n);
+    expect(await token.balanceOf(validator.address)).to.equal(1000n + 33n);
+  });
+});


### PR DESCRIPTION
## Summary
- add Maxwell-Boltzmann based reward splitting to `JobRegistry`
- document MB reward configuration and controls
- add unit test covering MB reward distribution between agent and validator

## Testing
- `npx hardhat test test/v2/JobRegistryMBReward.test.js` *(fails: process did not complete in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c719880d5c83339c0cd64756cb31e9