### PR TITLE
Add employer rating metric and stats update event

### DIFF
--- a/test/v2/EmployerReputation.test.js
+++ b/test/v2/EmployerReputation.test.js
@@ -173,10 +173,14 @@ describe('Employer reputation', function () {
       .connect(agent)
       .submit(jobId, ethers.id('res'), 'res', '', []);
     await validation.finalize(jobId);
-    await registry.connect(employer).finalize(jobId);
+    await expect(registry.connect(employer).finalize(jobId))
+      .to.emit(registry, "EmployerStatsUpdated")
+      .withArgs(employer.address, 1n, 0n);
     const repStats = await registry.getEmployerReputation(employer.address);
     expect(repStats[0]).to.equal(1n);
     expect(repStats[1]).to.equal(0n);
+    const rating = await registry.getEmployerRating(employer.address);
+    expect(rating).to.equal(ethers.parseEther("1"));
   });
 
   it('records dispute count when job ends in dispute', async () => {
@@ -199,9 +203,13 @@ describe('Employer reputation', function () {
     await dispute.connect(owner).setCommittee(owner.address);
     await dispute.connect(owner).setDisputeWindow(0);
     await dispute.connect(owner).resolve(jobId, true);
-    await registry.connect(employer).finalize(jobId);
+    await expect(registry.connect(employer).finalize(jobId))
+      .to.emit(registry, "EmployerStatsUpdated")
+      .withArgs(employer.address, 0n, 1n);
     const repStats = await registry.getEmployerReputation(employer.address);
     expect(repStats[0]).to.equal(0n);
     expect(repStats[1]).to.equal(1n);
+    const rating = await registry.getEmployerRating(employer.address);
+    expect(rating).to.equal(0n);
   });
 });


### PR DESCRIPTION
## Summary
- expose employer reputation as a normalized rating via `getEmployerRating`
- emit `EmployerStatsUpdated` whenever a job is finalized to track positive/negative counts

## Testing
- `npm test`
- `npm run lint` *(fails: 3 errors, 35 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c72849dff88333bfc8a501cd83752b