### PR TITLE
Add normalized employer reputation score

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -170,6 +170,21 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         return (stats.positive, stats.negative);
     }
 
+    /// @notice Compute a normalized employer reputation score.
+    /// @dev Returns the ratio of positive to total outcomes scaled by 1e18.
+    /// A score of 1e18 represents a perfect record, while 0 indicates only
+    /// negative outcomes. If an employer has no history, the score is 0.
+    /// @param employer Address of the employer to query.
+    /// @return score Reputation score in 18-decimal fixed point.
+    function getEmployerScore(address employer) external view returns (uint256 score) {
+        EmployerStats storage stats = employerStats[employer];
+        uint256 total = stats.positive + stats.negative;
+        if (total == 0) {
+            return 0;
+        }
+        return (stats.positive * TOKEN_SCALE) / total;
+    }
+
     /// @notice Confirms previously submitted burn evidence.
     /// @dev Employers must acknowledge the active tax policy before calling.
     function confirmEmployerBurn(uint256 jobId, bytes32 burnTxHash)

--- a/docs/job-lifecycle.md
+++ b/docs/job-lifecycle.md
@@ -14,4 +14,6 @@ The registry tracks a simple reputation score for each employer. When a job
 finalizes successfully, the employer's positive count increases. If a job ends
 in dispute, the negative count increments. Anyone can call
 `getEmployerReputation(address)` on `JobRegistry` to retrieve these counters and
-evaluate an employer's history before engaging.
+`getEmployerScore(address)` for a normalized reputation score between 0 and 1
+(scaled by `1e18`). Evaluating an employer's history before engaging helps
+participants route work toward reliable counterparties.

--- a/test/v2/EmployerReputation.test.js
+++ b/test/v2/EmployerReputation.test.js
@@ -177,6 +177,8 @@ describe('Employer reputation', function () {
     const repStats = await registry.getEmployerReputation(employer.address);
     expect(repStats[0]).to.equal(1n);
     expect(repStats[1]).to.equal(0n);
+    const score = await registry.getEmployerScore(employer.address);
+    expect(score).to.equal(ethers.parseEther('1'));
   });
 
   it('records dispute count when job ends in dispute', async () => {
@@ -203,5 +205,7 @@ describe('Employer reputation', function () {
     const repStats = await registry.getEmployerReputation(employer.address);
     expect(repStats[0]).to.equal(0n);
     expect(repStats[1]).to.equal(1n);
+    const score = await registry.getEmployerScore(employer.address);
+    expect(score).to.equal(0n);
   });
 });


### PR DESCRIPTION
## Summary
- expose a normalized employer reputation score via `JobRegistry.getEmployerScore`
- document employer reputation scoring in job lifecycle docs
- test that employer score reflects positive and negative job outcomes

## Testing
- `npm test test/v2/EmployerReputation.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c72ef97a508333bdd00fad3acdbe9f