### PR TITLE
feat: incorporate entropy penalties into reputation routing

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -568,6 +568,7 @@ contract MockReputationEngine is IReputationEngine {
     uint256 public constant version = 2;
 
     mapping(address => uint256) private _rep;
+    mapping(address => uint256) private _entropy;
     mapping(address => bool) private _blacklist;
     uint256 public threshold;
 
@@ -578,6 +579,7 @@ contract MockReputationEngine is IReputationEngine {
     function subtract(address user, uint256 amount) external override {
         uint256 rep = _rep[user];
         _rep[user] = rep > amount ? rep - amount : 0;
+        _entropy[user] += amount;
     }
 
     function reputation(address user) external view override returns (uint256) {
@@ -590,6 +592,18 @@ contract MockReputationEngine is IReputationEngine {
 
     function reputationOf(address user) external view override returns (uint256) {
         return _rep[user];
+    }
+
+    function entropy(address user) external view override returns (uint256) {
+        return _entropy[user];
+    }
+
+    function getEntropy(address user) external view override returns (uint256) {
+        return _entropy[user];
+    }
+
+    function entropyOf(address user) external view override returns (uint256) {
+        return _entropy[user];
     }
 
     function isBlacklisted(address user) external view override returns (bool) {

--- a/contracts/v2/PlatformRegistry.sol
+++ b/contracts/v2/PlatformRegistry.sol
@@ -10,6 +10,7 @@ import {TOKEN_SCALE} from "./Constants.sol";
 
 interface IReputationEngine {
     function reputation(address user) external view returns (uint256);
+    function entropy(address user) external view returns (uint256);
     function isBlacklisted(address user) external view returns (bool);
     function stakeWeight() external view returns (uint256);
     function reputationWeight() external view returns (uint256);
@@ -252,6 +253,12 @@ contract PlatformRegistry is Ownable, ReentrancyGuard, Pausable {
         // Deployer may register without staking but receives no routing boost.
         if (operator == owner() && stake == 0) return 0;
         uint256 rep = reputationEngine.reputation(operator);
+        uint256 ent = reputationEngine.entropy(operator);
+        if (rep > ent) {
+            rep -= ent;
+        } else {
+            rep = 0;
+        }
         uint256 stakeW = reputationEngine.stakeWeight();
         uint256 repW = reputationEngine.reputationWeight();
         return ((stake * stakeW) + (rep * repW)) / TOKEN_SCALE;

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -42,6 +42,17 @@ interface IReputationEngine {
     /// @notice Alternate view to mirror v1 naming
     function reputationOf(address user) external view returns (uint256);
 
+    /// @notice Retrieve accumulated entropy penalties for a user
+    /// @param user Address to query
+    /// @return The current entropy score of the user
+    function entropy(address user) external view returns (uint256);
+
+    /// @notice Alias for {entropy}
+    function getEntropy(address user) external view returns (uint256);
+
+    /// @notice Alternate view for legacy naming
+    function entropyOf(address user) external view returns (uint256);
+
     /// @notice Check if a user is blacklisted
     /// @param user Address to query
     /// @return True if the user is blacklisted

--- a/test/v2/ReputationEntropy.test.js
+++ b/test/v2/ReputationEntropy.test.js
@@ -1,0 +1,47 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+const TOKEN_SCALE = 10n ** 18n;
+
+describe('Reputation entropy integration', function () {
+  let engine, registry, owner, caller, operator, stake;
+
+  beforeEach(async () => {
+    [owner, caller, operator] = await ethers.getSigners();
+    const Stake = await ethers.getContractFactory('MockStakeManager');
+    stake = await Stake.deploy();
+    const Engine = await ethers.getContractFactory(
+      'contracts/v2/ReputationEngine.sol:ReputationEngine'
+    );
+    engine = await Engine.deploy(await stake.getAddress());
+    await engine.connect(owner).setCaller(caller.address, true);
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/PlatformRegistry.sol:PlatformRegistry'
+    );
+    registry = await Registry.deploy(
+      await stake.getAddress(),
+      await engine.getAddress(),
+      0
+    );
+  });
+
+  it('does not adjust entropy on positive updates', async () => {
+    await engine.connect(caller).update(operator.address, 5);
+    expect(await engine.getEntropy(operator.address)).to.equal(0n);
+    const rep = await engine.reputation(operator.address);
+    const repW = await engine.reputationWeight();
+    const score = await registry.getScore(operator.address);
+    expect(score).to.equal((rep * repW) / TOKEN_SCALE);
+  });
+
+  it('tracks entropy on negative updates and reduces routing score', async () => {
+    await engine.connect(caller).update(operator.address, 10);
+    await engine.connect(caller).update(operator.address, -3);
+    expect(await engine.getEntropy(operator.address)).to.equal(3n);
+    const rep = await engine.reputation(operator.address);
+    const repW = await engine.reputationWeight();
+    const adjusted = rep > 3n ? rep - 3n : 0n;
+    const score = await registry.getScore(operator.address);
+    expect(score).to.equal((adjusted * repW) / TOKEN_SCALE);
+  });
+});


### PR DESCRIPTION
## Summary
- track cumulative entropy penalties in ReputationEngine and expose getters
- adjust PlatformRegistry scoring to subtract entropy from reputation
- cover positive and negative entropy flows with dedicated tests

## Testing
- `npm test test/v2/ReputationEntropy.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c7398e00c88333925aa819775f4814