### PR TITLE
feat: add slashing rewards and bonds

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -151,6 +151,18 @@ contract MockStakeManager is IStakeManager {
         totalStakes[Role.Validator] -= amount;
     }
 
+    function slashAndReward(
+        address user,
+        uint256 amount,
+        address,
+        bytes32
+    ) external override {
+        uint256 st = _stakes[user][Role.Validator];
+        require(st >= amount, "stake");
+        _stakes[user][Role.Validator] = st - amount;
+        totalStakes[Role.Validator] -= amount;
+    }
+
     function stakeOf(address user, Role role) external view override returns (uint256) {
         return _stakes[user][role];
     }

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -1391,6 +1391,78 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     // slashing logic
     // ---------------------------------------------------------------
 
+    /// @notice slash a validator and reward a challenger
+    /// @param user validator being slashed
+    /// @param amount token amount to slash
+    /// @param challenger recipient of the validator reward
+    /// @param jobId optional job identifier for event indexing
+    function slashAndReward(
+        address user,
+        uint256 amount,
+        address challenger,
+        bytes32 jobId
+    ) external onlyDisputeModule whenNotPaused nonReentrant {
+        uint256 staked = stakes[user][Role.Validator];
+        if (staked < amount) revert InsufficientStake();
+        if (treasury != address(0) && !treasuryAllowlist[treasury]) revert InvalidTreasury();
+
+        uint256 newStake = staked - amount;
+        uint256 pct = getTotalPayoutPct(user);
+        uint256 newBoosted = (newStake * pct) / 100;
+        uint256 oldBoosted = boostedStake[user][Role.Validator];
+        boostedStake[user][Role.Validator] = newBoosted;
+        totalBoostedStakes[Role.Validator] =
+            totalBoostedStakes[Role.Validator] + newBoosted - oldBoosted;
+        stakes[user][Role.Validator] = newStake;
+        totalStakes[Role.Validator] -= amount;
+
+        unbonds[user].jailed = true;
+
+        uint256 locked = lockedStakes[user];
+        if (locked > 0) {
+            if (amount >= locked) {
+                lockedStakes[user] = 0;
+                unlockTime[user] = 0;
+                emit StakeUnlocked(user, locked);
+            } else {
+                lockedStakes[user] = locked - amount;
+            }
+        }
+
+        uint256 validatorShare = amount / 4;
+        uint256 treasuryShare = amount / 4;
+        uint256 burnShare = amount - validatorShare - treasuryShare;
+
+        if (validatorShare > 0) {
+            token.safeTransfer(challenger, validatorShare);
+            emit RewardValidator(challenger, validatorShare, jobId);
+        }
+
+        if (treasuryShare > 0) {
+            if (treasury != address(0)) {
+                token.safeTransfer(treasury, treasuryShare);
+            } else {
+                burnShare += treasuryShare;
+                treasuryShare = 0;
+            }
+        }
+
+        if (burnShare > 0) {
+            _burnToken(jobId, burnShare);
+        }
+
+        emit Slash(user, amount, challenger);
+        emit StakeSlashed(
+            user,
+            Role.Validator,
+            challenger,
+            treasury,
+            0,
+            treasuryShare,
+            burnShare
+        );
+    }
+
     /// @dev internal slashing routine used by dispute and job slashing
     function _slash(address user, Role role, uint256 amount, address recipient, address[] memory validators) internal {
         if (role > Role.Platform) revert InvalidRole();

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -225,6 +225,18 @@ interface IStakeManager {
         address[] calldata validators
     ) external;
 
+    /// @notice slash a validator and reward the challenger
+    /// @param user address of the validator being slashed
+    /// @param amount token amount to slash
+    /// @param challenger recipient of the validator reward
+    /// @param jobId associated job identifier for indexing
+    function slashAndReward(
+        address user,
+        uint256 amount,
+        address challenger,
+        bytes32 jobId
+    ) external;
+
     /// @notice owner configuration helpers
     function setMinStake(uint256 _minStake) external;
     function setSlashingPercentages(uint256 _employerSlashPct, uint256 _treasurySlashPct) external;

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -198,4 +198,16 @@ contract ReentrantStakeManager is IStakeManager {
         _stakes[user][Role.Validator] = st - amount;
         totalStakes[Role.Validator] -= amount;
     }
+
+    function slashAndReward(
+        address user,
+        uint256 amount,
+        address,
+        bytes32
+    ) external override {
+        uint256 st = _stakes[user][Role.Validator];
+        require(st >= amount, "stake");
+        _stakes[user][Role.Validator] = st - amount;
+        totalStakes[Role.Validator] -= amount;
+    }
 }

--- a/test/v2/DisputeRewards.test.js
+++ b/test/v2/DisputeRewards.test.js
@@ -1,0 +1,174 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const { AGIALPHA } = require('../../scripts/constants');
+
+const Role = { Agent: 0, Validator: 1 };
+const ONE = 10n ** 18n;
+
+describe('DisputeModule rewards and bonds', function () {
+  let owner, employer, agent, validator, treasury;
+  let token, stakeManager, jobRegistry, dispute, validation, registrySigner;
+
+  beforeEach(async () => {
+    [owner, employer, agent, validator, treasury] = await ethers.getSigners();
+
+    const artifact = await artifacts.readArtifact(
+      'contracts/test/AGIALPHAToken.sol:AGIALPHAToken'
+    );
+    await network.provider.send('hardhat_setCode', [
+      AGIALPHA,
+      artifact.deployedBytecode,
+    ]);
+    token = await ethers.getContractAt(
+      'contracts/test/AGIALPHAToken.sol:AGIALPHAToken',
+      AGIALPHA
+    );
+
+    const addresses = [
+      employer.address,
+      agent.address,
+      validator.address,
+      treasury.address,
+    ];
+    const supplySlot = '0x' + (2).toString(16).padStart(64, '0');
+    await network.provider.send('hardhat_setStorageAt', [
+      AGIALPHA,
+      supplySlot,
+      ethers.toBeHex(5000n * ONE, 32),
+    ]);
+    for (const addr of addresses) {
+      const balSlot = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(['address', 'uint256'], [addr, 0])
+      );
+      await network.provider.send('hardhat_setStorageAt', [
+        AGIALPHA,
+        balSlot,
+        ethers.toBeHex(1000n * ONE, 32),
+      ]);
+      const ackSlot = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(['address', 'uint256'], [addr, 6])
+      );
+      await network.provider.send('hardhat_setStorageAt', [
+        AGIALPHA,
+        ackSlot,
+        ethers.toBeHex(1n, 32),
+      ]);
+    }
+
+    const JobReg = await ethers.getContractFactory(
+      'contracts/legacy/MockV2.sol:MockJobRegistry'
+    );
+    jobRegistry = await JobReg.deploy();
+    await jobRegistry.waitForDeployment();
+    const regAddr = await jobRegistry.getAddress();
+    await jobRegistry.setJob(1, {
+      employer: employer.address,
+      agent: agent.address,
+      reward: 0,
+      stake: 0,
+      success: false,
+      status: 0,
+      uriHash: ethers.ZeroHash,
+      resultHash: ethers.ZeroHash,
+    });
+
+    const StakeManager = await ethers.getContractFactory(
+      'contracts/v2/StakeManager.sol:StakeManager'
+    );
+    stakeManager = await StakeManager.deploy(
+      0,
+      0,
+      100,
+      treasury.address,
+      regAddr,
+      ethers.ZeroAddress,
+      owner.address
+    );
+    await stakeManager
+      .connect(owner)
+      .setTreasuryAllowlist(treasury.address, true);
+
+    const ValStub = await ethers.getContractFactory(
+      'contracts/v2/mocks/ValidationStub.sol:ValidationStub'
+    );
+    validation = await ValStub.deploy();
+    await validation.waitForDeployment();
+    await validation.setValidators([validator.address]);
+    await validation.setResult(false);
+    await validation.setJobRegistry(regAddr);
+    await jobRegistry.setValidationModule(await validation.getAddress());
+    await stakeManager
+      .connect(owner)
+      .setValidationModule(await validation.getAddress());
+
+    const Dispute = await ethers.getContractFactory(
+      'contracts/v2/modules/DisputeModule.sol:DisputeModule'
+    );
+    dispute = await Dispute.deploy(regAddr, ONE, 0, owner.address);
+    await dispute.waitForDeployment();
+    await dispute.connect(owner).setStakeManager(await stakeManager.getAddress());
+    await stakeManager
+      .connect(owner)
+      .setDisputeModule(await dispute.getAddress());
+    await jobRegistry.setDisputeModule(await dispute.getAddress());
+
+    await ethers.provider.send('hardhat_setBalance', [
+      regAddr,
+      '0x56BC75E2D63100000',
+    ]);
+    registrySigner = await ethers.getImpersonatedSigner(regAddr);
+
+    await token
+      .connect(agent)
+      .approve(await stakeManager.getAddress(), ONE);
+    await token
+      .connect(employer)
+      .approve(await stakeManager.getAddress(), ONE);
+    await token
+      .connect(validator)
+      .approve(await stakeManager.getAddress(), 100n * ONE);
+    await stakeManager
+      .connect(validator)
+      .depositStake(Role.Validator, 100n * ONE);
+  });
+
+  it('refunds bond on successful challenge', async () => {
+    const before = await token.balanceOf(agent.address);
+    await dispute
+      .connect(registrySigner)
+      .raiseDispute(1, agent.address, ethers.ZeroHash);
+    await dispute.connect(owner).resolve(1, false);
+    expect(await token.balanceOf(agent.address)).to.equal(before);
+  });
+
+  it('burns bond on failed challenge', async () => {
+    const supplyBefore = await token.totalSupply();
+    await dispute
+      .connect(registrySigner)
+      .raiseDispute(1, employer.address, ethers.ZeroHash);
+    await dispute.connect(owner).resolve(1, false);
+    expect(await token.totalSupply()).to.equal(supplyBefore - ONE);
+  });
+
+  it('slashes validator and rewards challenger', async () => {
+    const agentBefore = await token.balanceOf(agent.address);
+    const treasuryBefore = await token.balanceOf(treasury.address);
+    const supplyBefore = await token.totalSupply();
+    await dispute
+      .connect(registrySigner)
+      .raiseDispute(1, agent.address, ethers.ZeroHash);
+    const jobIdBytes = ethers.toBeHex(1, 32);
+    await expect(dispute.connect(owner).resolve(1, false))
+      .to.emit(stakeManager, 'RewardValidator')
+      .withArgs(agent.address, ONE / 4n, jobIdBytes)
+      .and.to.emit(stakeManager, 'Slash')
+      .withArgs(validator.address, ONE, agent.address);
+    expect(await token.balanceOf(agent.address)).to.equal(
+      agentBefore + ONE / 4n
+    );
+    expect(await token.balanceOf(treasury.address)).to.equal(
+      treasuryBefore + ONE / 4n
+    );
+    expect(await token.totalSupply()).to.equal(supplyBefore - ONE / 2n);
+  });
+});


### PR DESCRIPTION
## Summary
- require bonded disputes and burn bond on failed challenges
- distribute slashed stake with slashAndReward and emit events
- cover new slashing flows with fuzz and integration tests

## Testing
- `npx hardhat test test/v2/DisputeRewards.test.js --no-compile` *(fails: HH700 artifact not found)*
- `forge test --match-path test/v2/ValidationSlashingFuzz.t.sol --match-test slashAndReward` *(fails: compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_68c7415d59388333acc98b63b6919659