### PR TITLE
feat: adapt stake tuning to system entropy

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -79,6 +79,7 @@ contract MockStakeManager is IStakeManager {
     function setTreasury(address) external override {}
     function setTreasuryAllowlist(address, bool) external override {}
     function setMaxStakePerAddress(uint256) external override {}
+    function setMaxStakePct(uint256) external override {}
     function setMaxAGITypes(uint256) external override {}
     function setFeePct(uint256) external override {}
     function setFeePool(IFeePool) external override {}

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -158,6 +158,9 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @notice maximum total stake allowed per address
     uint256 public maxStakePerAddress;
 
+    /// @notice maximum stake share per address as a percentage of total stakes
+    uint256 public maxStakePct;
+
     /// @notice escrowed job funds
     mapping(bytes32 => uint256) public jobEscrows;
 
@@ -285,6 +288,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     event TreasuryAllowlistUpdated(address indexed treasury, bool allowed);
     event JobRegistryUpdated(address indexed registry);
     event MaxStakePerAddressUpdated(uint256 maxStake);
+    event MaxStakePctUpdated(uint256 pct);
     event StakeTimeLocked(address indexed user, uint256 amount, uint64 unlockTime);
     event StakeUnlocked(address indexed user, uint256 amount);
     event ModulesUpdated(address indexed jobRegistry, address indexed disputeModule);
@@ -391,23 +395,22 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     function _maybeAdjustStake() internal {
         if (block.timestamp < lastStakeTune + stakeTuneWindow) return;
         uint256 oldMin = minStake;
-        uint256 score = disputeCount * disputeWeight;
-        if (address(thermostat) != address(0) && temperatureWeight > 0 && stakeTempThreshold != 0) {
-            int256 t = thermostat.systemTemperature();
-            if (t >= stakeTempThreshold) score += temperatureWeight;
+        bool tempHigh;
+        bool hamHigh;
+        if (address(thermostat) != address(0) && stakeTempThreshold != 0) {
+            tempHigh = thermostat.systemTemperature() >= stakeTempThreshold;
         }
-        if (address(hamiltonianFeed) != address(0) && hamiltonianWeight > 0 && stakeHamiltonianThreshold != 0) {
-            int256 h = hamiltonianFeed.currentHamiltonian();
-            if (h >= stakeHamiltonianThreshold) score += hamiltonianWeight;
+        if (address(hamiltonianFeed) != address(0) && stakeHamiltonianThreshold != 0) {
+            hamHigh = hamiltonianFeed.currentHamiltonian() >= stakeHamiltonianThreshold;
         }
-        uint256 thresholdScore = stakeDisputeThreshold * disputeWeight;
-        if ((thresholdScore == 0 && score > 0) || (thresholdScore > 0 && score >= thresholdScore)) {
+        bool disputeHigh = stakeDisputeThreshold > 0 ? disputeCount >= stakeDisputeThreshold : disputeCount > 0;
+        if (disputeHigh || tempHigh || hamHigh) {
             uint256 inc = (minStake * stakeIncreasePct) / 100;
             if (inc == 0) inc = 1;
             uint256 newMin = minStake + inc;
             if (maxMinStake != 0 && newMin > maxMinStake) newMin = maxMinStake;
             minStake = newMin;
-        } else if (score == 0 && minStake > minStakeFloor) {
+        } else if (disputeCount == 0 && !tempHigh && !hamHigh && minStake > minStakeFloor) {
             uint256 dec = (minStake * stakeDecreasePct) / 100;
             uint256 newMin = minStake > dec ? minStake - dec : minStakeFloor;
             if (newMin < minStakeFloor) newMin = minStakeFloor;
@@ -650,6 +653,14 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         emit MaxStakePerAddressUpdated(maxStake);
     }
 
+    /// @notice set maximum stake percentage per address relative to total stakes
+    /// @param pct percentage cap (0 disables the check)
+    function setMaxStakePct(uint256 pct) external onlyGovernance {
+        if (pct > 100) revert InvalidPercentage();
+        maxStakePct = pct;
+        emit MaxStakePctUpdated(pct);
+    }
+
     /// @notice set recommended minimum and maximum stake values
     /// @dev `newMax` may be zero to disable the limit but must not be below `newMin`
     /// @param newMin recommended minimum stake with 18 decimals
@@ -807,10 +818,20 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         uint256 oldStake = stakes[user][role];
         uint256 newStake = oldStake + amount;
         if (newStake < minStake) revert BelowMinimumStake();
-        if (maxStakePerAddress > 0) {
-            uint256 total =
-                stakes[user][Role.Agent] + stakes[user][Role.Validator] + stakes[user][Role.Platform] + amount;
-            if (total > maxStakePerAddress) revert MaxStakeExceeded();
+        uint256 total =
+            stakes[user][Role.Agent] + stakes[user][Role.Validator] + stakes[user][Role.Platform];
+        uint256 newTotal = total + amount;
+        if (maxStakePerAddress > 0 && newTotal > maxStakePerAddress) {
+            revert MaxStakeExceeded();
+        }
+        if (maxStakePct > 0) {
+            uint256 globalTotal =
+                totalStakes[Role.Agent] +
+                totalStakes[Role.Validator] +
+                totalStakes[Role.Platform] +
+                amount;
+            uint256 cap = (globalTotal * maxStakePct) / 100;
+            if (newTotal > cap) revert MaxStakeExceeded();
         }
         uint256 pct = getTotalPayoutPct(user);
         uint256 newBoosted = (newStake * pct) / 100;

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -59,6 +59,7 @@ interface IStakeManager {
     event TreasuryUpdated(address indexed treasury);
     event TreasuryAllowlistUpdated(address indexed treasury, bool allowed);
     event MaxStakePerAddressUpdated(uint256 maxStake);
+    event MaxStakePctUpdated(uint256 pct);
     event MaxAGITypesUpdated(uint256 oldMax, uint256 newMax);
     event AGITypeUpdated(address indexed nft, uint256 payoutPct);
     event AGITypeRemoved(address indexed nft);
@@ -232,6 +233,7 @@ interface IStakeManager {
     function setTreasury(address _treasury) external;
     function setTreasuryAllowlist(address _treasury, bool allowed) external;
     function setMaxStakePerAddress(uint256 maxStake) external;
+    function setMaxStakePct(uint256 pct) external;
     function setMaxAGITypes(uint256 newMax) external;
     function setMaxTotalPayoutPct(uint256 newMax) external;
     function addAGIType(address nft, uint256 payoutPct) external;

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -77,6 +77,7 @@ contract ReentrantStakeManager is IStakeManager {
     function setTreasury(address) external override {}
     function setTreasuryAllowlist(address, bool) external override {}
     function setMaxStakePerAddress(uint256) external override {}
+    function setMaxStakePct(uint256) external override {}
     function setMaxAGITypes(uint256) external override {}
     function setFeePct(uint256) external override {}
     function setFeePool(IFeePool) external override {}

--- a/test/v2/StakeManagerTuning.test.js
+++ b/test/v2/StakeManagerTuning.test.js
@@ -1,0 +1,65 @@
+const { expect } = require('chai');
+const { ethers, artifacts } = require('hardhat');
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
+
+const { AGIALPHA } = require('../../scripts/constants');
+
+describe('StakeManager tuning regression', function () {
+  let stakeManager, owner, dispute, thermostat;
+
+  beforeEach(async () => {
+    [owner, dispute] = await ethers.getSigners();
+    const mock = await artifacts.readArtifact(
+      'contracts/test/MockERC20.sol:MockERC20'
+    );
+    await ethers.provider.send('hardhat_setCode', [
+      AGIALPHA,
+      mock.deployedBytecode,
+    ]);
+    const Thermostat = await ethers.getContractFactory(
+      'contracts/v2/Thermostat.sol:Thermostat'
+    );
+    thermostat = await Thermostat.deploy(100, 1, 200, owner.address);
+    const StakeManager = await ethers.getContractFactory(
+      'contracts/v2/StakeManager.sol:StakeManager'
+    );
+    stakeManager = await StakeManager.deploy(
+      100,
+      50,
+      50,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      dispute.address,
+      owner.address
+    );
+    await stakeManager.autoTuneStakes(true);
+    await stakeManager.setThermostat(await thermostat.getAddress());
+  });
+
+  it('responds to high and low entropy periods', async () => {
+    await stakeManager
+      .connect(owner)
+      .configureAutoStake(1, 50, 50, 1000, 50, 0, 150, 0, 1, 0, 0);
+
+    // high temperature -> increase min stake
+    await thermostat.connect(owner).setSystemTemperature(200);
+    await time.increase(1000);
+    await expect(stakeManager.checkpointStake())
+      .to.emit(stakeManager, 'MinStakeUpdated')
+      .withArgs(150n);
+
+    // low temperature with no disputes -> decrease
+    await thermostat.connect(owner).setSystemTemperature(100);
+    await time.increase(1000);
+    await expect(stakeManager.checkpointStake())
+      .to.emit(stakeManager, 'MinStakeUpdated')
+      .withArgs(75n);
+
+    // dispute spike despite low temperature -> increase again
+    await time.increase(1000);
+    await expect(stakeManager.connect(dispute).recordDispute())
+      .to.emit(stakeManager, 'MinStakeUpdated')
+      .withArgs(112n);
+  });
+});
+


### PR DESCRIPTION
## Summary
- adjust min stake automatically when disputes or system temperature rise
- cap individual stakes by configurable percentage of total stakes
- add tests covering high and low entropy stake tuning

## Testing
- `npm test test/v2/StakeManagerTuning.test.js`
- `npm run lint` *(fails: 1 error, 35 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c74e8f1cd88333a409d3bf4183c96b