### PR TITLE
Implement treasury-based quadratic voting rewards

### DIFF
--- a/contracts/test/QuadraticVotingAttack.sol
+++ b/contracts/test/QuadraticVotingAttack.sol
@@ -8,7 +8,7 @@ import {ReentrantERC20, IReentrantCaller} from "./ReentrantERC20.sol";
 contract QuadraticVotingAttack is IReentrantCaller {
     enum AttackType {
         Cast,
-        Refund
+        Reward
     }
 
     QuadraticVoting public qv;
@@ -32,11 +32,11 @@ contract QuadraticVotingAttack is IReentrantCaller {
         qv.castVote(proposalId, 1, deadline);
     }
 
-    function attackRefund() external {
-        attackType = AttackType.Refund;
+    function attackReward() external {
+        attackType = AttackType.Reward;
         token.setCaller(address(this));
         token.setAttack(true);
-        qv.claimRefund(proposalId);
+        qv.claimReward(proposalId);
     }
 
     function vote() external {
@@ -47,8 +47,8 @@ contract QuadraticVotingAttack is IReentrantCaller {
     function reenter() external override {
         if (attackType == AttackType.Cast) {
             qv.castVote(proposalId, 1, deadline);
-        } else if (attackType == AttackType.Refund) {
-            qv.claimRefund(proposalId);
+        } else if (attackType == AttackType.Reward) {
+            qv.claimReward(proposalId);
         }
     }
 }

--- a/contracts/v2/QuadraticVoting.sol
+++ b/contracts/v2/QuadraticVoting.sol
@@ -5,20 +5,20 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {AGIALPHA, BURN_ADDRESS} from "./Constants.sol";
-import {IERC20Burnable} from "./interfaces/IERC20Burnable.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {AGIALPHA} from "./Constants.sol";
 
 interface IGovernanceReward {
     function recordVoters(address[] calldata voters) external;
 }
 
-error TokenNotBurnable();
-
 /// @title QuadraticVoting
 /// @notice Simple quadratic voting mechanism where voting cost grows with the
-/// square of votes. Tokens are locked when voting and can be refunded after the
-/// proposal is executed or after the voting deadline expires. The contract can
-/// notify a GovernanceReward contract to record voters for reward distribution.
+/// square of votes. Tokens are sent to a treasury when voting and can be
+/// claimed back as rewards after the proposal is executed. Rewards are
+/// distributed proportionally to the square root of the voting cost. The
+/// contract can notify a GovernanceReward contract to record voters for reward
+/// distribution.
 contract QuadraticVoting is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
@@ -26,33 +26,32 @@ contract QuadraticVoting is Ownable, ReentrancyGuard {
     IGovernanceReward public governanceReward;
     address public proposalExecutor;
     address public treasury;
-    /// @notice percentage of vote cost refunded (0-100)
-    uint256 public refundPct = 100;
 
     // proposalId => executed status
     mapping(uint256 => bool) public executed;
     // proposalId => voting deadline
     mapping(uint256 => uint256) public proposalDeadline;
-    // proposalId => marked expired
-    mapping(uint256 => bool) public expired;
     // proposalId => voter => votes cast
     mapping(uint256 => mapping(address => uint256)) public votes;
-    // proposalId => voter => tokens locked (cost)
-    mapping(uint256 => mapping(address => uint256)) public locked;
+    // proposalId => voter => total cost paid
+    mapping(uint256 => mapping(address => uint256)) public costs;
+    // proposalId => total cost paid by all voters
+    mapping(uint256 => uint256) public totalCost;
+    // proposalId => sum of sqrt(cost) for all voters
+    mapping(uint256 => uint256) public totalSqrtCost;
     // proposalId => list of voters (for reward snapshot)
     mapping(uint256 => address[]) private proposalVoters;
     // proposalId => voter => has voted
     mapping(uint256 => mapping(address => bool)) private hasVoted;
+    // proposalId => voter => reward claimed
+    mapping(uint256 => mapping(address => bool)) public rewardClaimed;
 
     event VoteCast(uint256 indexed proposalId, address indexed voter, uint256 votes, uint256 cost);
     event ProposalExecuted(uint256 indexed proposalId);
-    event ProposalExpired(uint256 indexed proposalId);
-    event RefundClaimed(uint256 indexed proposalId, address indexed voter, uint256 amount);
+    event RewardClaimed(uint256 indexed proposalId, address indexed voter, uint256 amount);
     event GovernanceRewardUpdated(address indexed governanceReward);
     event ProposalExecutorUpdated(address indexed executor);
     event TreasuryUpdated(address indexed treasury);
-    event RefundPctUpdated(uint256 refundPct);
-    event TokensBurned(uint256 amount);
 
     constructor(address _token, address _executor) Ownable(msg.sender) {
         token = _token == address(0) ? IERC20(AGIALPHA) : IERC20(_token);
@@ -78,17 +77,11 @@ contract QuadraticVoting is Ownable, ReentrancyGuard {
         emit TreasuryUpdated(_treasury);
     }
 
-    /// @notice Update refundable percentage of vote cost.
-    function setRefundPct(uint256 pct) external onlyOwner {
-        require(pct <= 100, "pct");
-        refundPct = pct;
-        emit RefundPctUpdated(pct);
-    }
-
     /// @notice Cast `numVotes` on `proposalId` paying `numVotes^2` tokens with a voting deadline.
     function castVote(uint256 proposalId, uint256 numVotes, uint256 deadline) external nonReentrant {
         require(!executed[proposalId], "executed");
         require(numVotes > 0, "votes");
+        require(treasury != address(0), "treasury");
         uint256 d = proposalDeadline[proposalId];
         if (d == 0) {
             require(deadline > block.timestamp, "deadline");
@@ -97,17 +90,15 @@ contract QuadraticVoting is Ownable, ReentrancyGuard {
             require(block.timestamp <= d, "expired");
         }
         uint256 cost = numVotes * numVotes;
-        token.safeTransferFrom(msg.sender, address(this), cost);
+        token.safeTransferFrom(msg.sender, treasury, cost);
 
-        uint256 deposit = (cost * refundPct) / 100;
-        uint256 fee = cost - deposit;
-        if (fee > 0) {
-            if (treasury != address(0)) token.safeTransfer(treasury, fee);
-            else _burnToken(fee);
-        }
-        if (deposit > 0) {
-            locked[proposalId][msg.sender] += deposit;
-        }
+        uint256 oldCost = costs[proposalId][msg.sender];
+        uint256 newCost = oldCost + cost;
+        costs[proposalId][msg.sender] = newCost;
+        totalCost[proposalId] += cost;
+        uint256 prevSqrt = Math.sqrt(oldCost);
+        uint256 newSqrt = Math.sqrt(newCost);
+        totalSqrtCost[proposalId] = totalSqrtCost[proposalId] + newSqrt - prevSqrt;
         votes[proposalId][msg.sender] += numVotes;
         if (!hasVoted[proposalId][msg.sender]) {
             hasVoted[proposalId][msg.sender] = true;
@@ -116,7 +107,7 @@ contract QuadraticVoting is Ownable, ReentrancyGuard {
         emit VoteCast(proposalId, msg.sender, numVotes, cost);
     }
 
-    /// @notice Execute a proposal, enabling refunds and recording voters.
+    /// @notice Execute a proposal, enabling reward claims and recording voters.
     function execute(uint256 proposalId) external nonReentrant {
         require(!executed[proposalId], "executed");
         require(msg.sender == proposalExecutor || msg.sender == owner(), "exec");
@@ -127,40 +118,21 @@ contract QuadraticVoting is Ownable, ReentrancyGuard {
         emit ProposalExecuted(proposalId);
     }
 
-    /// @notice Claim back tokens locked for a proposal after execution or expiry.
-    function claimRefund(uint256 proposalId) external nonReentrant {
-        uint256 amount = locked[proposalId][msg.sender];
-        require(amount > 0, "no refund");
-        if (!executed[proposalId]) {
-            uint256 d = proposalDeadline[proposalId];
-            require(d != 0 && block.timestamp > d, "inactive");
-            if (!expired[proposalId]) {
-                expired[proposalId] = true;
-                emit ProposalExpired(proposalId);
-            }
-        }
-        locked[proposalId][msg.sender] = 0;
-        token.safeTransfer(msg.sender, amount);
-        emit RefundClaimed(proposalId, msg.sender, amount);
+    /// @notice Claim reward proportional to `sqrt(cost)` after proposal execution.
+    function claimReward(uint256 proposalId) external nonReentrant {
+        require(executed[proposalId], "inactive");
+        uint256 userCost = costs[proposalId][msg.sender];
+        require(userCost > 0, "no reward");
+        require(!rewardClaimed[proposalId][msg.sender], "claimed");
+        rewardClaimed[proposalId][msg.sender] = true;
+        uint256 reward = (totalCost[proposalId] * Math.sqrt(userCost)) / totalSqrtCost[proposalId];
+        token.safeTransferFrom(treasury, msg.sender, reward);
+        emit RewardClaimed(proposalId, msg.sender, reward);
     }
 
     /// @notice Returns number of voters for a proposal.
     function proposalVoterCount(uint256 proposalId) external view returns (uint256) {
         return proposalVoters[proposalId].length;
-    }
-
-    function _burnToken(uint256 amount) internal {
-        if (amount == 0) return;
-        if (BURN_ADDRESS == address(0)) {
-            try IERC20Burnable(address(token)).burn(amount) {
-                emit TokensBurned(amount);
-            } catch {
-                revert TokenNotBurnable();
-            }
-        } else {
-            token.safeTransfer(BURN_ADDRESS, amount);
-            emit TokensBurned(amount);
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- route quadratic vote costs directly to the treasury
- distribute post-vote rewards from treasury based on sqrt(cost)
- update tests and reentrancy checks for new reward flow

## Testing
- `npx solhint contracts/v2/QuadraticVoting.sol contracts/test/QuadraticVotingAttack.sol`
- `npx eslint test/v2/QuadraticVoting.test.js test/v2/QuadraticVotingReentrancy.test.js`
- `npx hardhat test test/v2/QuadraticVoting.test.js test/v2/QuadraticVotingReentrancy.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c771cac2a48333926ed68d1bb301d1