### PR TITLE
Add orchestrator gateway with job filtering and ENS tests

### DIFF
--- a/apps/orchestrator/config.ts
+++ b/apps/orchestrator/config.ts
@@ -1,0 +1,5 @@
+export const RPC_URL = process.env.RPC_URL || 'http://localhost:8545';
+export const JOB_REGISTRY_ADDRESS = process.env.JOB_REGISTRY_ADDRESS || '';
+export const STAKE_MANAGER_ADDRESS = process.env.STAKE_MANAGER_ADDRESS || '';
+export const AGENT_ADDRESS = process.env.AGENT_ADDRESS || '';
+export const ORCHESTRATOR_ENDPOINT = process.env.ORCHESTRATOR_ENDPOINT || '';

--- a/apps/orchestrator/gateway.ts
+++ b/apps/orchestrator/gateway.ts
@@ -1,0 +1,96 @@
+import { ethers } from 'ethers';
+import {
+  RPC_URL,
+  JOB_REGISTRY_ADDRESS,
+  STAKE_MANAGER_ADDRESS,
+  AGENT_ADDRESS,
+  ORCHESTRATOR_ENDPOINT,
+} from './config';
+
+const jobRegistryAbi = [
+  'event JobCreated(uint256 indexed jobId,address indexed employer,address agent,uint256 reward,uint256 stake,uint256 fee)',
+];
+
+const stakeManagerAbi = [
+  'function stakeOf(address user,uint8 role) view returns (uint256)',
+];
+
+export async function resolveAddress(
+  provider: ethers.Provider,
+  addrOrName: string
+): Promise<string> {
+  if (ethers.isAddress(addrOrName)) return addrOrName;
+  const resolved = await provider.resolveName(addrOrName);
+  if (!resolved) throw new Error(`Could not resolve ENS name: ${addrOrName}`);
+  return resolved;
+}
+
+export function setupJobListener(
+  jobRegistry: any,
+  stakeManager: { stakeOf(address: string, role: number): Promise<bigint> },
+  agentAddress: string,
+  onJobDetected: (jobId: string, details: any) => void | Promise<void>
+): void {
+  jobRegistry.on(
+    'JobCreated',
+    async (
+      jobId: bigint,
+      employer: string,
+      assignedAgent: string,
+      reward: bigint,
+      stake: bigint,
+      fee: bigint
+    ) => {
+      if (assignedAgent !== ethers.ZeroAddress) return;
+      const balance = await stakeManager.stakeOf(agentAddress, 0);
+      if (balance < stake) return;
+      const details = {
+        employer,
+        reward: reward.toString(),
+        stake: stake.toString(),
+        fee: fee.toString(),
+      };
+      await onJobDetected(jobId.toString(), details);
+    }
+  );
+}
+
+export async function start(
+  onJobDetected: (
+    jobId: string,
+    details: any
+  ) => void | Promise<void> = defaultCallback
+): Promise<void> {
+  const provider = new ethers.JsonRpcProvider(RPC_URL);
+  const jobRegistryAddress = await resolveAddress(
+    provider,
+    JOB_REGISTRY_ADDRESS
+  );
+  const stakeManagerAddress = await resolveAddress(
+    provider,
+    STAKE_MANAGER_ADDRESS
+  );
+  const jobRegistry = new ethers.Contract(
+    jobRegistryAddress,
+    jobRegistryAbi,
+    provider
+  );
+  const stakeManager = new ethers.Contract(
+    stakeManagerAddress,
+    stakeManagerAbi,
+    provider
+  );
+  setupJobListener(jobRegistry, stakeManager, AGENT_ADDRESS, onJobDetected);
+}
+
+export async function defaultCallback(
+  jobId: string,
+  details: any
+): Promise<void> {
+  if (!ORCHESTRATOR_ENDPOINT) return;
+  await fetch(ORCHESTRATOR_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jobId, ...details }),
+  });
+}

--- a/apps/orchestrator/tsconfig.json
+++ b/apps/orchestrator/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "lib": ["ES2020", "DOM"],
+    "moduleResolution": "node",
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["*.ts"]
+}

--- a/test/gateway/orchestratorGateway.test.js
+++ b/test/gateway/orchestratorGateway.test.js
@@ -1,0 +1,75 @@
+const { expect } = require('chai');
+const { EventEmitter } = require('events');
+const { ethers } = require('ethers');
+
+process.env.TS_NODE_PROJECT = 'apps/orchestrator/tsconfig.json';
+require('ts-node/register/transpile-only');
+
+const {
+  setupJobListener,
+  resolveAddress,
+} = require('../../apps/orchestrator/gateway');
+
+describe('orchestrator gateway', function () {
+  it('filters assigned jobs and stake balance', async function () {
+    const jobRegistry = new EventEmitter();
+    const stakeManager = { stakeOf: async () => 100n };
+    const detected = [];
+    setupJobListener(
+      jobRegistry,
+      stakeManager,
+      '0x0000000000000000000000000000000000000001',
+      (jobId, details) => {
+        detected.push({ jobId, details });
+      }
+    );
+    jobRegistry.emit(
+      'JobCreated',
+      1n,
+      '0x0000000000000000000000000000000000000002',
+      ethers.ZeroAddress,
+      10n,
+      50n,
+      0n
+    );
+    jobRegistry.emit(
+      'JobCreated',
+      2n,
+      '0x0000000000000000000000000000000000000002',
+      '0x0000000000000000000000000000000000000003',
+      10n,
+      50n,
+      0n
+    );
+    stakeManager.stakeOf = async () => 10n;
+    jobRegistry.emit(
+      'JobCreated',
+      3n,
+      '0x0000000000000000000000000000000000000002',
+      ethers.ZeroAddress,
+      10n,
+      50n,
+      0n
+    );
+    await new Promise((r) => setImmediate(r));
+    expect(detected).to.have.length(1);
+    expect(detected[0].jobId).to.equal('1');
+  });
+
+  it('resolves ENS names', async function () {
+    const provider = {
+      resolveName: async (name) =>
+        name === 'example.eth'
+          ? '0x0000000000000000000000000000000000000001'
+          : null,
+    };
+    const addr = await resolveAddress(provider, 'example.eth');
+    expect(addr).to.equal('0x0000000000000000000000000000000000000001');
+    try {
+      await resolveAddress(provider, 'bad.eth');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.message).to.include('Could not resolve ENS name');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add orchestrator gateway using ethers to listen for JobCreated events and invoke orchestrator callback
- configure RPC, contract addresses, agent and orchestrator endpoint via environment variables
- test event filtering and ENS address resolution

## Testing
- `npx hardhat test test/gateway/*.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c793ae42e48333ab053231557dc8a4