### PR TITLE
Sign telemetry payloads for Energy Oracle integration

### DIFF
--- a/agent-gateway/README.md
+++ b/agent-gateway/README.md
@@ -14,6 +14,9 @@ Job financial fields (`reward`, `stake`, and `fee`) are broadcast using `ethers.
 - `PORT` (default `3000`)
 - `BOT_WALLET` address of a managed wallet used for automated finalize/cancel actions (optional). If a tax policy is active, this wallet must first call `JobRegistry.acknowledgeTaxPolicy()`.
 - `GATEWAY_API_KEY` shared secret for API-key authentication (optional)
+- `ENERGY_ORACLE_URL` endpoint that accepts telemetry payloads (optional – required for operator rewards)
+- `ENERGY_ORACLE_TOKEN` bearer token when publishing telemetry to the oracle (optional)
+- `ENERGY_ORACLE_REQUIRE_SIGNATURE` set to `true` to require cryptographic signing of telemetry payloads; when enabled the orchestrator wallet must own an ENS name under `*.a.agi.eth`
 
 Copy `.env.example` to `.env` and adjust values for your network:
 
@@ -37,6 +40,12 @@ its deadline it invokes `JobRegistry.cancelExpiredJob`. These automated
 transactions use the wallet specified by `BOT_WALLET` or the first wallet
 returned by the keystore if none is provided. If a tax policy is configured,
 that wallet must acknowledge it before these calls will succeed.
+
+When operator telemetry is enabled (`ENERGY_ORACLE_URL` configured) the
+gateway batches energy samples and forwards them to the oracle. If
+`ENERGY_ORACLE_REQUIRE_SIGNATURE=true` the payload is signed by the
+orchestrator wallet, including its ENS name when available, so operators can
+provide cryptographically verifiable energy reports for reward claims.
 
 If one of the managed wallets owns a validator ENS identity under
 `*.club.agi.eth`, the gateway now participates in commit–reveal validation

--- a/agent-gateway/telemetry.ts
+++ b/agent-gateway/telemetry.ts
@@ -1,12 +1,17 @@
 import fs from 'fs';
 import path from 'path';
+import { ethers } from 'ethers';
 import { EnergySample } from '../shared/energyMonitor';
+import { orchestratorWallet } from './utils';
+import { getCachedIdentity, refreshIdentity } from './identity';
 
 export const ENERGY_ORACLE_URL = process.env.ENERGY_ORACLE_URL || '';
 export const ENERGY_ORACLE_TOKEN = process.env.ENERGY_ORACLE_TOKEN || '';
 const TELEMETRY_FLUSH_INTERVAL_MS = Number(
   process.env.TELEMETRY_FLUSH_INTERVAL_MS || '60000'
 );
+const REQUIRE_TELEMETRY_SIGNATURE =
+  process.env.ENERGY_ORACLE_REQUIRE_SIGNATURE === 'true';
 
 const TELEMETRY_DIR = path.resolve(__dirname, '../storage/telemetry');
 const TELEMETRY_OUTBOX = path.join(TELEMETRY_DIR, 'telemetry-queue.json');
@@ -16,6 +21,16 @@ let loaded = false;
 let flushing = false;
 let flushTimer: NodeJS.Timeout | null = null;
 let warnedNoOracle = false;
+let warnedMissingSigner = false;
+
+export interface TelemetryEnvelope {
+  samples: EnergySample[];
+  submittedAt: string;
+  signer?: string;
+  ens?: string;
+  digest?: string;
+  signature?: string;
+}
 
 function ensureDir(dir: string): void {
   if (!fs.existsSync(dir)) {
@@ -46,6 +61,95 @@ async function persistQueue(): Promise<void> {
   );
 }
 
+async function resolveSignerMetadata(): Promise<{
+  address: string;
+  ens?: string;
+}> {
+  const wallet = orchestratorWallet;
+  if (!wallet) {
+    if (REQUIRE_TELEMETRY_SIGNATURE && !warnedMissingSigner) {
+      warnedMissingSigner = true;
+      console.error(
+        'ENERGY_ORACLE_REQUIRE_SIGNATURE is true but no orchestrator wallet is configured; telemetry will not be signed.'
+      );
+    }
+    throw new Error('No orchestrator wallet configured for telemetry signing');
+  }
+
+  const cached = getCachedIdentity(wallet.address);
+  if (cached?.ensName) {
+    return { address: wallet.address, ens: cached.ensName };
+  }
+  try {
+    const refreshed = await refreshIdentity(wallet.address);
+    return { address: wallet.address, ens: refreshed.ensName };
+  } catch (err) {
+    console.warn('Failed to refresh orchestrator identity for telemetry', err);
+    return { address: wallet.address };
+  }
+}
+
+function canonicaliseEnvelope(envelope: TelemetryEnvelope): string {
+  const entries: [string, unknown][] = [
+    ['samples', envelope.samples],
+    ['submittedAt', envelope.submittedAt],
+  ];
+  if (envelope.signer) entries.push(['signer', envelope.signer]);
+  if (envelope.ens) entries.push(['ens', envelope.ens]);
+  return JSON.stringify(Object.fromEntries(entries));
+}
+
+async function buildTelemetryEnvelope(
+  samples: EnergySample[]
+): Promise<TelemetryEnvelope> {
+  const submittedAt = new Date().toISOString();
+  const base: TelemetryEnvelope = { samples, submittedAt };
+  if (!orchestratorWallet) {
+    if (REQUIRE_TELEMETRY_SIGNATURE) {
+      throw new Error(
+        'Telemetry signing required but orchestrator wallet is unavailable'
+      );
+    }
+    return base;
+  }
+
+  const signer = await resolveSignerMetadata().catch((err) => {
+    if (REQUIRE_TELEMETRY_SIGNATURE) {
+      throw err;
+    }
+    console.warn('Continuing without signer metadata for telemetry', err);
+    return null;
+  });
+
+  if (!signer) {
+    return base;
+  }
+
+  const envelope: TelemetryEnvelope = {
+    samples,
+    submittedAt,
+    signer: signer.address,
+    ens: signer.ens,
+  };
+
+  try {
+    const canonical = canonicaliseEnvelope(envelope);
+    const digest = ethers.hashMessage(canonical);
+    const signature = await orchestratorWallet.signMessage(canonical);
+    envelope.digest = digest;
+    envelope.signature = signature;
+  } catch (err) {
+    if (REQUIRE_TELEMETRY_SIGNATURE) {
+      throw new Error(
+        `Failed to sign telemetry payload: ${(err as Error).message}`
+      );
+    }
+    console.warn('Telemetry payload signing failed, submitting unsigned', err);
+  }
+
+  return envelope;
+}
+
 async function sendToOracle(samples: EnergySample[]): Promise<void> {
   if (!ENERGY_ORACLE_URL) {
     if (!warnedNoOracle) {
@@ -56,6 +160,7 @@ async function sendToOracle(samples: EnergySample[]): Promise<void> {
     }
     return;
   }
+  const payload = await buildTelemetryEnvelope(samples);
   const res = await fetch(ENERGY_ORACLE_URL, {
     method: 'POST',
     headers: {
@@ -64,7 +169,7 @@ async function sendToOracle(samples: EnergySample[]): Promise<void> {
         ? { Authorization: `Bearer ${ENERGY_ORACLE_TOKEN}` }
         : {}),
     },
-    body: JSON.stringify({ samples }),
+    body: JSON.stringify(payload),
   });
   if (!res.ok) {
     throw new Error(


### PR DESCRIPTION
## Summary
- add optional signed telemetry envelopes that include orchestrator ENS metadata before posting to the Energy Oracle
- document new ENERGY_ORACLE_* environment variables and describe signed telemetry behaviour in the gateway README

## Testing
- npm run build:gateway
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8ab306a78833383f9a31551b4e5da