### PR TITLE
Add monitored telemetry daemon and harden operator service

### DIFF
--- a/deployment-config/energy-telemetry-daemon.service
+++ b/deployment-config/energy-telemetry-daemon.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=AGIJobs Energy Telemetry Daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/agijobs
+Environment=ENERGY_LOG_DIR=/opt/agijobs/logs/energy
+Environment=ENERGY_ORACLE_ADDRESS=0xOracle
+Environment=ENERGY_ORACLE_RPC_URL=https://rpc.example
+Environment=ENERGY_ORACLE_SIGNER_KEY=0xabcdef...
+Environment=TELEMETRY_POLL_INTERVAL_MS=10000
+ExecStart=/usr/bin/env npx ts-node --transpile-only scripts/monitor/energy-telemetry-daemon.ts
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/operator-telemetry.md
+++ b/docs/operator-telemetry.md
@@ -81,6 +81,15 @@ To run without compiling ahead of time you can use `ts-node`:
 npx ts-node apps/operator/telemetry.ts
 ```
 
+For long-running environments the repository also ships a lightweight daemon
+at `scripts/monitor/energy-telemetry-daemon.ts`. It wraps the telemetry service,
+watches the energy log directory for new jobs, and immediately triggers a
+submission cycle when fresh data lands so attestations go out after every job:
+
+```bash
+npx ts-node scripts/monitor/energy-telemetry-daemon.ts
+```
+
 ## Docker deployment
 
 A production container is available via `apps/operator/Dockerfile`. Build and
@@ -124,7 +133,8 @@ changes.
 ## systemd (optional)
 
 For environments using `systemd`, create a unit file similar to the example
-below:
+below (the repository includes `deployment-config/energy-telemetry-daemon.service`
+as a ready-to-adapt template):
 
 ```ini
 [Unit]
@@ -140,7 +150,7 @@ Environment=ENERGY_LOG_DIR=/opt/agijobs/logs/energy
 Environment=ENERGY_ORACLE_ADDRESS=0xOracle
 Environment=ENERGY_ORACLE_RPC_URL=https://rpc.example
 Environment=ENERGY_ORACLE_SIGNER_KEY=0xabcdef...
-ExecStart=/usr/bin/node apps/operator/dist/telemetry.js
+ExecStart=/usr/bin/env npx ts-node --transpile-only scripts/monitor/energy-telemetry-daemon.ts
 Restart=on-failure
 RestartSec=10
 

--- a/scripts/monitor/energy-telemetry-daemon.ts
+++ b/scripts/monitor/energy-telemetry-daemon.ts
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import path from 'path';
+import {
+  createTelemetryService,
+  loadTelemetryConfig,
+  TelemetryService,
+  type TelemetryConfig,
+} from '../../apps/operator/telemetry';
+
+function resolveEnergyLogDir(config: TelemetryConfig): string {
+  const dir = config.energyLogDir || path.resolve(process.cwd(), 'logs/energy');
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function watchEnergyLogs(
+  rootDir: string,
+  service: TelemetryService
+): () => void {
+  const watchers: fs.FSWatcher[] = [];
+  const observed = new Set<string>();
+
+  const ensureWatcher = (dir: string): void => {
+    if (observed.has(dir)) {
+      return;
+    }
+    observed.add(dir);
+    try {
+      const watcher = fs.watch(dir, (eventType, filename) => {
+        if (eventType === 'rename' && filename) {
+          const target = path.join(dir, filename.toString());
+          try {
+            const stats = fs.statSync(target);
+            if (stats.isDirectory()) {
+              ensureWatcher(target);
+            }
+          } catch {
+            // ignore files removed between event and stat
+          }
+        }
+        service.requestImmediateCycle();
+      });
+      watcher.on('error', (err) => {
+        console.warn('Energy telemetry watcher error', { dir, err });
+      });
+      watchers.push(watcher);
+    } catch (err) {
+      console.warn('Failed to watch energy telemetry directory', { dir, err });
+    }
+  };
+
+  ensureWatcher(rootDir);
+  try {
+    const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        ensureWatcher(path.join(rootDir, entry.name));
+      }
+    }
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      console.warn('Unable to enumerate energy telemetry directories', err);
+    }
+  }
+
+  return () => {
+    for (const watcher of watchers) {
+      watcher.close();
+    }
+  };
+}
+
+async function start(): Promise<void> {
+  try {
+    const baseConfig = await loadTelemetryConfig();
+    const service = await createTelemetryService(baseConfig);
+    const energyLogDir = resolveEnergyLogDir(baseConfig);
+    const stopWatching = watchEnergyLogs(energyLogDir, service);
+    const shutdown = () => {
+      console.info('Stopping energy telemetry daemon');
+      stopWatching();
+      service.stop();
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+    service.requestImmediateCycle();
+    await service.start();
+  } catch (err) {
+    console.error('Telemetry daemon failed', err);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  void start();
+}


### PR DESCRIPTION
## Summary
- harden the operator telemetry service with energy log validation, reconnection helpers and an exported factory for reuse
- add a monitor daemon under `scripts/monitor/` with filesystem triggers plus a matching systemd unit template
- document the daemon entrypoint and updated service invocation in the operator telemetry guide

## Testing
- `npx tsc -p apps/operator/tsconfig.json`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8c5f5cf4083338b75708a578d8dfa