### PR TITLE
Track job efficiency metrics and tune bidding

### DIFF
--- a/shared/energyInsights.ts
+++ b/shared/energyInsights.ts
@@ -1,0 +1,493 @@
+import fs from 'fs';
+import path from 'path';
+import type { EnergySample } from './energyMonitor';
+
+const TELEMETRY_DIR = path.resolve(__dirname, '../storage/telemetry');
+const INSIGHTS_PATH = path.join(TELEMETRY_DIR, 'energy-insights.json');
+const ANOMALY_LOG_PATH = path.join(TELEMETRY_DIR, 'energy-anomalies.jsonl');
+const MAX_ANOMALY_HISTORY = Number(
+  process.env.ENERGY_ANOMALY_HISTORY_LIMIT || '50'
+);
+
+interface JobRecord {
+  key: string;
+  jobId: string;
+  agent: string;
+  category?: string;
+  rewardValue?: number;
+  energyTotal: number;
+  cpuTimeMs: number;
+  gpuTimeMs: number;
+  wallTimeMs: number;
+  cpuCycles: number;
+  gpuCycles: number;
+  gpuUtilizationTotal: number;
+  samples: number;
+  anomalyCount: number;
+  anomalies?: Array<{ code: string; at: string }>;
+  lastUpdated: string;
+}
+
+interface AgentRecord {
+  agent: string;
+  energyTotal: number;
+  sampleCount: number;
+  anomalyCount: number;
+  jobKeys: string[];
+  lastUpdated: string;
+}
+
+interface InsightsFile {
+  jobs: Record<string, JobRecord>;
+  agents: Record<string, AgentRecord>;
+  updatedAt: string;
+}
+
+export interface AgentEnergyInsight {
+  agent: string;
+  jobCount: number;
+  sampleCount: number;
+  totalEnergy: number;
+  averageEnergy: number;
+  totalReward: number;
+  averageEfficiency: number;
+  efficiencyScore: number;
+  anomalyRate: number;
+  lastUpdated: string;
+}
+
+export interface JobEnergyInsight {
+  jobId: string;
+  agent: string;
+  category?: string;
+  samples: number;
+  totalEnergy: number;
+  averageEnergy: number;
+  averageCpuTimeMs: number;
+  averageGpuTimeMs: number;
+  averageWallTimeMs: number;
+  averageCpuCycles: number;
+  averageGpuCycles: number;
+  averageGpuUtilization: number;
+  rewardValue: number;
+  efficiencyScore: number;
+  anomalyRate: number;
+  anomalyCount: number;
+  lastUpdated: string;
+}
+
+export interface EnergyInsightsSnapshot {
+  agents: Record<string, AgentEnergyInsight>;
+  jobs: Record<string, Record<string, JobEnergyInsight>>;
+  updatedAt: string;
+}
+
+export interface EnergyAnomalyRecord {
+  spanId: string;
+  jobId?: string;
+  agent?: string;
+  timestamp: string;
+  anomalies: string[];
+  energyEstimate: number;
+  cpuTimeMs: number;
+  gpuTimeMs?: number;
+  durationMs: number;
+  rewardValue?: number;
+  efficiencyScore?: number;
+  metadata?: Record<string, unknown>;
+}
+
+function ensureDirectory(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function createEmptyInsights(): InsightsFile {
+  return {
+    jobs: {},
+    agents: {},
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+function readInsightsSync(): InsightsFile {
+  try {
+    const raw = fs.readFileSync(INSIGHTS_PATH, 'utf8');
+    if (!raw) {
+      return createEmptyInsights();
+    }
+    const parsed = JSON.parse(raw) as InsightsFile;
+    parsed.jobs = parsed.jobs ?? {};
+    parsed.agents = parsed.agents ?? {};
+    parsed.updatedAt = parsed.updatedAt ?? new Date(0).toISOString();
+    return parsed;
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return createEmptyInsights();
+    }
+    console.warn('Failed to read energy insights snapshot', err);
+    return createEmptyInsights();
+  }
+}
+
+async function readInsights(): Promise<InsightsFile> {
+  try {
+    const raw = await fs.promises.readFile(INSIGHTS_PATH, 'utf8');
+    if (!raw) {
+      return createEmptyInsights();
+    }
+    const parsed = JSON.parse(raw) as InsightsFile;
+    parsed.jobs = parsed.jobs ?? {};
+    parsed.agents = parsed.agents ?? {};
+    parsed.updatedAt = parsed.updatedAt ?? new Date(0).toISOString();
+    return parsed;
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return createEmptyInsights();
+    }
+    console.warn('Failed to read energy insights', err);
+    return createEmptyInsights();
+  }
+}
+
+async function writeInsights(data: InsightsFile): Promise<void> {
+  ensureDirectory(path.dirname(INSIGHTS_PATH));
+  await fs.promises.writeFile(
+    INSIGHTS_PATH,
+    JSON.stringify(data, null, 2),
+    'utf8'
+  );
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function normaliseAgent(agent?: string | null): string {
+  if (!agent) {
+    return 'unknown';
+  }
+  return agent.toLowerCase();
+}
+
+function composeJobKey(agent: string, jobId: string): string {
+  return `${agent}::${jobId}`;
+}
+
+function splitJobKey(key: string): [string, string] {
+  const idx = key.indexOf('::');
+  if (idx === -1) {
+    return ['unknown', key];
+  }
+  return [key.slice(0, idx), key.slice(idx + 2)];
+}
+
+function sanitiseMetadata(
+  metadata?: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+  const result: Record<string, unknown> = {};
+  const entries = Object.entries(metadata).slice(0, 20);
+  for (const [key, value] of entries) {
+    if (typeof value === 'string') {
+      result[key] = value.length > 256 ? `${value.slice(0, 256)}…` : value;
+    } else if (typeof value === 'number') {
+      if (Number.isFinite(value)) {
+        result[key] = value;
+      }
+    } else if (typeof value === 'boolean') {
+      result[key] = value;
+    }
+  }
+  return Object.keys(result).length ? result : undefined;
+}
+
+function extractRewardValue(sample: EnergySample): number | null {
+  if (
+    typeof sample.rewardValue === 'number' &&
+    Number.isFinite(sample.rewardValue)
+  ) {
+    return sample.rewardValue;
+  }
+  if (sample.metadata) {
+    const candidates = [
+      sample.metadata.rewardValue,
+      sample.metadata.jobReward,
+      sample.metadata.reward,
+    ];
+    for (const candidate of candidates) {
+      const value = toNumber(candidate);
+      if (value > 0) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function appendAnomalyHistory(
+  history: Array<{ code: string; at: string }> | undefined,
+  codes: string[],
+  timestamp: string
+): Array<{ code: string; at: string }> {
+  const next = history ? [...history] : [];
+  for (const code of codes) {
+    next.push({ code, at: timestamp });
+  }
+  if (next.length > MAX_ANOMALY_HISTORY) {
+    return next.slice(next.length - MAX_ANOMALY_HISTORY);
+  }
+  return next;
+}
+
+function toJobInsight(record: JobRecord): JobEnergyInsight {
+  const safeSamples = record.samples > 0 ? record.samples : 1;
+  const averageEnergy = record.energyTotal / safeSamples;
+  const averageCpuTime = record.cpuTimeMs / safeSamples;
+  const averageGpuTime = record.gpuTimeMs / safeSamples;
+  const averageWallTime = record.wallTimeMs / safeSamples;
+  const averageCpuCycles = record.cpuCycles / safeSamples;
+  const averageGpuCycles = record.gpuCycles / safeSamples;
+  const averageGpuUtilisation = record.gpuUtilizationTotal / safeSamples;
+  const rewardValue = record.rewardValue ?? 0;
+  const efficiency =
+    rewardValue > 0 ? rewardValue / Math.max(1, record.energyTotal) : 0;
+  const anomalyRate = record.samples ? record.anomalyCount / record.samples : 0;
+  return {
+    jobId: record.jobId,
+    agent: record.agent,
+    category: record.category,
+    samples: record.samples,
+    totalEnergy: record.energyTotal,
+    averageEnergy,
+    averageCpuTimeMs: averageCpuTime,
+    averageGpuTimeMs: averageGpuTime,
+    averageWallTimeMs: averageWallTime,
+    averageCpuCycles,
+    averageGpuCycles,
+    averageGpuUtilization: averageGpuUtilisation,
+    rewardValue,
+    efficiencyScore: efficiency,
+    anomalyRate,
+    anomalyCount: record.anomalyCount,
+    lastUpdated: record.lastUpdated,
+  };
+}
+
+function toAgentInsight(
+  record: AgentRecord,
+  jobs: Record<string, JobRecord>
+): AgentEnergyInsight {
+  let totalReward = 0;
+  let efficiencyAccumulator = 0;
+  let jobCount = 0;
+  for (const key of record.jobKeys) {
+    const job = jobs[key];
+    if (!job) continue;
+    jobCount += 1;
+    const rewardValue = job.rewardValue ?? 0;
+    totalReward += rewardValue;
+    efficiencyAccumulator +=
+      rewardValue > 0 ? rewardValue / Math.max(1, job.energyTotal) : 0;
+  }
+  const averageEfficiency = jobCount ? efficiencyAccumulator / jobCount : 0;
+  const averageEnergy = record.sampleCount
+    ? record.energyTotal / record.sampleCount
+    : 0;
+  const anomalyRate = record.sampleCount
+    ? record.anomalyCount / record.sampleCount
+    : 0;
+  return {
+    agent: record.agent,
+    jobCount,
+    sampleCount: record.sampleCount,
+    totalEnergy: record.energyTotal,
+    averageEnergy,
+    totalReward,
+    averageEfficiency,
+    efficiencyScore: averageEfficiency,
+    anomalyRate,
+    lastUpdated: record.lastUpdated,
+  };
+}
+
+function sanitiseJobId(jobId: string | number | undefined): string | null {
+  if (jobId === undefined || jobId === null) {
+    return null;
+  }
+  return String(jobId);
+}
+
+async function appendAnomalies(records: EnergyAnomalyRecord[]): Promise<void> {
+  if (!records.length) {
+    return;
+  }
+  ensureDirectory(path.dirname(ANOMALY_LOG_PATH));
+  const lines = records.map((record) => JSON.stringify(record)).join('\n');
+  await fs.promises.appendFile(ANOMALY_LOG_PATH, `${lines}\n`, 'utf8');
+}
+
+export async function updateEnergyInsights(
+  sample: EnergySample
+): Promise<void> {
+  const jobId = sanitiseJobId(sample.jobId ?? sample.metadata?.jobId);
+  if (!jobId) {
+    return;
+  }
+  const agentKey = normaliseAgent(sample.agent ?? sample.metadata?.agent);
+  const jobKey = composeJobKey(agentKey, jobId);
+  const rewardValue = extractRewardValue(sample);
+  const anomalies = sample.anomalies ?? [];
+  const timestamp = sample.finishedAt ?? new Date().toISOString();
+
+  const insights = await readInsights();
+
+  const jobRecord: JobRecord = insights.jobs[jobKey] ?? {
+    key: jobKey,
+    jobId,
+    agent: agentKey,
+    category: sample.category,
+    rewardValue: rewardValue ?? undefined,
+    energyTotal: 0,
+    cpuTimeMs: 0,
+    gpuTimeMs: 0,
+    wallTimeMs: 0,
+    cpuCycles: 0,
+    gpuCycles: 0,
+    gpuUtilizationTotal: 0,
+    samples: 0,
+    anomalyCount: 0,
+    anomalies: [],
+    lastUpdated: timestamp,
+  };
+
+  jobRecord.samples += 1;
+  jobRecord.energyTotal += toNumber(sample.energyEstimate);
+  jobRecord.cpuTimeMs += toNumber(sample.cpuTimeMs);
+  jobRecord.gpuTimeMs += toNumber(sample.gpuTimeMs);
+  jobRecord.wallTimeMs += toNumber(sample.runtimeMs ?? sample.durationMs);
+  jobRecord.cpuCycles += toNumber(sample.cpuCycles);
+  jobRecord.gpuCycles += toNumber(sample.gpuCycles);
+  jobRecord.gpuUtilizationTotal += toNumber(sample.gpuUtilization);
+  jobRecord.lastUpdated = timestamp;
+  if (sample.category) {
+    jobRecord.category = sample.category;
+  }
+  if (rewardValue !== null) {
+    jobRecord.rewardValue = rewardValue;
+  }
+  if (anomalies.length) {
+    jobRecord.anomalyCount += anomalies.length;
+    jobRecord.anomalies = appendAnomalyHistory(
+      jobRecord.anomalies,
+      anomalies,
+      timestamp
+    );
+  }
+  insights.jobs[jobKey] = jobRecord;
+
+  const agentRecord: AgentRecord = insights.agents[agentKey] ?? {
+    agent: agentKey,
+    energyTotal: 0,
+    sampleCount: 0,
+    anomalyCount: 0,
+    jobKeys: [],
+    lastUpdated: timestamp,
+  };
+  agentRecord.energyTotal += toNumber(sample.energyEstimate);
+  agentRecord.sampleCount += 1;
+  agentRecord.anomalyCount += anomalies.length;
+  agentRecord.lastUpdated = timestamp;
+  if (!agentRecord.jobKeys.includes(jobKey)) {
+    agentRecord.jobKeys.push(jobKey);
+  }
+  insights.agents[agentKey] = agentRecord;
+
+  insights.updatedAt = timestamp;
+
+  await writeInsights(insights);
+
+  if (anomalies.length) {
+    const record: EnergyAnomalyRecord = {
+      spanId: sample.spanId,
+      jobId,
+      agent: sample.agent ?? agentKey,
+      timestamp,
+      anomalies,
+      energyEstimate: toNumber(sample.energyEstimate),
+      cpuTimeMs: toNumber(sample.cpuTimeMs),
+      gpuTimeMs: toNumber(sample.gpuTimeMs) || undefined,
+      durationMs: toNumber(sample.runtimeMs ?? sample.durationMs),
+      rewardValue: rewardValue ?? undefined,
+      efficiencyScore: sample.efficiencyScore,
+      metadata: sanitiseMetadata(sample.metadata),
+    };
+    await appendAnomalies([record]);
+  }
+}
+
+export function getEnergyInsightsSnapshot(): EnergyInsightsSnapshot {
+  const raw = readInsightsSync();
+  const agents: Record<string, AgentEnergyInsight> = {};
+  const jobsByAgent: Record<string, Record<string, JobEnergyInsight>> = {};
+
+  for (const [key, record] of Object.entries(raw.jobs)) {
+    const [agentKey, jobId] = splitJobKey(key);
+    const insight = toJobInsight(record);
+    if (!jobsByAgent[agentKey]) {
+      jobsByAgent[agentKey] = {};
+    }
+    jobsByAgent[agentKey][jobId] = insight;
+  }
+
+  for (const [agentKey, record] of Object.entries(raw.agents)) {
+    agents[agentKey] = toAgentInsight(record, raw.jobs);
+  }
+
+  return {
+    agents,
+    jobs: jobsByAgent,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+export function getAgentEnergyInsight(
+  agentId: string,
+  snapshot?: EnergyInsightsSnapshot
+): AgentEnergyInsight | null {
+  if (!agentId) {
+    return null;
+  }
+  const data = snapshot ?? getEnergyInsightsSnapshot();
+  return data.agents[agentId.toLowerCase()] ?? null;
+}
+
+export function getJobEnergyInsight(
+  agentId: string,
+  jobId: string | number,
+  snapshot?: EnergyInsightsSnapshot
+): JobEnergyInsight | null {
+  if (!jobId) {
+    return null;
+  }
+  const agentKey = agentId ? agentId.toLowerCase() : 'unknown';
+  const data = snapshot ?? getEnergyInsightsSnapshot();
+  const agentJobs = data.jobs[agentKey];
+  if (!agentJobs) {
+    return null;
+  }
+  return agentJobs[String(jobId)] ?? null;
+}

--- a/shared/energyMonitor.ts
+++ b/shared/energyMonitor.ts
@@ -1,6 +1,160 @@
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
+import os from 'os';
+import { updateEnergyInsights } from './energyInsights';
+
+export interface GpuSample {
+  timeMs: number;
+  cycles?: number;
+  utilization?: number;
+  timestamp: number;
+}
+
+export type GpuSampler = () => Partial<GpuSample> | GpuSample;
+
+let gpuSampler: GpuSampler | null = null;
+
+export function setGpuSampler(sampler: GpuSampler | null): void {
+  gpuSampler = sampler;
+}
+
+function captureGpuSample(): GpuSample | undefined {
+  if (!gpuSampler) {
+    return undefined;
+  }
+  try {
+    const raw = gpuSampler() || {};
+    const sample: GpuSample = {
+      timeMs: Number.isFinite(raw.timeMs) ? Number(raw.timeMs) : 0,
+      cycles: Number.isFinite(raw.cycles) ? Number(raw.cycles) : 0,
+      utilization: Number.isFinite(raw.utilization)
+        ? Number(raw.utilization)
+        : 0,
+      timestamp: Number.isFinite(raw.timestamp)
+        ? Number(raw.timestamp)
+        : Date.now(),
+    };
+    return sample;
+  } catch (err) {
+    console.warn('GPU sampler failed', err);
+    return {
+      timeMs: 0,
+      cycles: 0,
+      utilization: 0,
+      timestamp: Date.now(),
+    };
+  }
+}
+
+const CPU_SPEED_MHZ = (() => {
+  try {
+    const cores = os.cpus();
+    if (!cores || cores.length === 0) {
+      return 0;
+    }
+    const total = cores.reduce((sum, core) => sum + (core.speed || 0), 0);
+    return total / cores.length;
+  } catch {
+    return 0;
+  }
+})();
+
+const CPU_TIME_ANOMALY_MS = Number(
+  process.env.ENERGY_CPU_TIME_THRESHOLD_MS || '120000'
+);
+const GPU_TIME_ANOMALY_MS = Number(
+  process.env.ENERGY_GPU_TIME_THRESHOLD_MS || '120000'
+);
+const ENERGY_ANOMALY_THRESHOLD = Number(
+  process.env.ENERGY_USAGE_THRESHOLD || '200000'
+);
+const DURATION_ANOMALY_THRESHOLD_MS = Number(
+  process.env.ENERGY_RUNTIME_THRESHOLD_MS || '300000'
+);
+const MEMORY_ANOMALY_THRESHOLD_BYTES = Number(
+  process.env.ENERGY_MEMORY_THRESHOLD_BYTES || String(512 * 1024 * 1024)
+);
+const EFFICIENCY_MIN_THRESHOLD = Number(
+  process.env.ENERGY_EFFICIENCY_MIN_THRESHOLD || '0.0001'
+);
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function estimateCpuCycles(totalMicroseconds: number): number {
+  if (!Number.isFinite(totalMicroseconds) || totalMicroseconds <= 0) {
+    return 0;
+  }
+  if (CPU_SPEED_MHZ > 0) {
+    return totalMicroseconds * CPU_SPEED_MHZ;
+  }
+  return totalMicroseconds * 1000;
+}
+
+function extractReward(metadata: Record<string, unknown>): number | null {
+  const candidates = [
+    metadata.rewardValue,
+    metadata.jobReward,
+    metadata.reward,
+    metadata.expectedReward,
+  ];
+  for (const candidate of candidates) {
+    const value = toNumber(candidate);
+    if (value > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function detectAnomalies(sample: {
+  cpuTimeMs: number;
+  gpuTimeMs: number;
+  durationMs: number;
+  energyEstimate: number;
+  memoryRssBytes: number;
+  efficiencyScore?: number;
+  rewardValue?: number | null;
+}): string[] {
+  const anomalies: string[] = [];
+  if (sample.cpuTimeMs > CPU_TIME_ANOMALY_MS) {
+    anomalies.push('cpu-time-high');
+  }
+  if (sample.gpuTimeMs > GPU_TIME_ANOMALY_MS) {
+    anomalies.push('gpu-time-high');
+  }
+  if (sample.durationMs > DURATION_ANOMALY_THRESHOLD_MS) {
+    anomalies.push('runtime-high');
+  }
+  if (sample.energyEstimate > ENERGY_ANOMALY_THRESHOLD) {
+    anomalies.push('energy-usage-high');
+  }
+  if (sample.memoryRssBytes > MEMORY_ANOMALY_THRESHOLD_BYTES) {
+    anomalies.push('memory-usage-high');
+  }
+  const rewardValue = sample.rewardValue ?? 0;
+  if (rewardValue > 0) {
+    const efficiency =
+      sample.efficiencyScore ??
+      rewardValue / Math.max(sample.energyEstimate, 1);
+    if (efficiency < EFFICIENCY_MIN_THRESHOLD) {
+      anomalies.push('low-efficiency');
+    }
+  }
+  return anomalies;
+}
 
 export interface EnergySpanContext {
   jobId?: string;
@@ -15,6 +169,7 @@ export interface EnergySpan {
   cpuStart: NodeJS.CpuUsage;
   hrtimeStart: bigint;
   context: EnergySpanContext;
+  gpuStart?: GpuSample;
 }
 
 export interface EnergySample extends EnergySpanContext {
@@ -22,12 +177,22 @@ export interface EnergySample extends EnergySpanContext {
   startedAt: string;
   finishedAt: string;
   durationMs: number;
+  runtimeMs: number;
+  cpuTimeMs: number;
+  gpuTimeMs: number;
   cpuUserUs: number;
   cpuSystemUs: number;
   cpuTotalUs: number;
+  cpuCycles: number;
+  gpuCycles: number;
   memoryRssBytes: number;
   energyEstimate: number;
   entropyEstimate?: number;
+  rewardValue?: number;
+  efficiencyScore?: number;
+  anomalyScore?: number;
+  anomalies?: string[];
+  gpuUtilization?: number;
   metadata?: Record<string, unknown>;
 }
 
@@ -47,6 +212,7 @@ export function startEnergySpan(context: EnergySpanContext = {}): EnergySpan {
     cpuStart: process.cpuUsage(),
     hrtimeStart: process.hrtime.bigint(),
     context,
+    gpuStart: captureGpuSample(),
   };
 }
 
@@ -58,26 +224,76 @@ export async function endEnergySpan(
   const finishedAt = new Date().toISOString();
   const durationNs = process.hrtime.bigint() - span.hrtimeStart;
   const durationMs = Number(durationNs) / 1_000_000;
+  const cpuTimeMs = (cpu.user + cpu.system) / 1000;
+  const gpuEnd = captureGpuSample();
+  let gpuTimeMs = 0;
+  let gpuCycles = 0;
+  let gpuUtilization = 0;
+  if (span.gpuStart && gpuEnd) {
+    gpuTimeMs = Math.max(
+      0,
+      toNumber(gpuEnd.timeMs) - toNumber(span.gpuStart.timeMs)
+    );
+    gpuCycles = Math.max(
+      0,
+      toNumber(gpuEnd.cycles) - toNumber(span.gpuStart.cycles)
+    );
+    gpuUtilization = Math.max(0, toNumber(gpuEnd.utilization));
+  }
   const memory = process.memoryUsage();
   const cpuTotalUs = cpu.user + cpu.system;
   const energyEstimate = cpuTotalUs / 1000 + memory.rss / 1_000_000;
   const entropyEstimate =
     Math.log(1 + cpuTotalUs) + Math.log(1 + memory.heapUsed);
+  const cpuCycles = estimateCpuCycles(cpuTotalUs);
+  const rewardValue =
+    extractReward(metadata) ??
+    (typeof span.context === 'object' && span.context
+      ? extractReward(span.context as Record<string, unknown>)
+      : null);
+  const efficiencyScore =
+    rewardValue && rewardValue > 0
+      ? rewardValue / Math.max(1, energyEstimate)
+      : undefined;
+  const anomalies = detectAnomalies({
+    cpuTimeMs,
+    gpuTimeMs,
+    durationMs,
+    energyEstimate,
+    memoryRssBytes: memory.rss,
+    efficiencyScore,
+    rewardValue,
+  });
   const sample: EnergySample = {
     spanId: span.id,
     startedAt: span.startedAt,
     finishedAt,
     durationMs,
+    runtimeMs: durationMs,
+    cpuTimeMs,
+    gpuTimeMs,
     cpuUserUs: cpu.user,
     cpuSystemUs: cpu.system,
     cpuTotalUs,
+    cpuCycles,
+    gpuCycles,
     memoryRssBytes: memory.rss,
     energyEstimate,
     entropyEstimate,
+    rewardValue: rewardValue ?? undefined,
+    efficiencyScore,
+    anomalyScore: anomalies.length ? anomalies.length : undefined,
+    anomalies: anomalies.length ? anomalies : undefined,
+    gpuUtilization: gpuUtilization || undefined,
     metadata,
     ...span.context,
   };
   await logEnergySample(sample);
+  try {
+    await updateEnergyInsights(sample);
+  } catch (err) {
+    console.warn('Failed to update energy insights', err);
+  }
   return sample;
 }
 


### PR DESCRIPTION
## Summary
- extend the energy monitor with GPU sampling hooks, CPU cycle estimates, anomaly detection, and efficiency scoring before persisting spans
- introduce shared energy insights to aggregate per-job and per-agent metrics, log anomalies, and expose synchronous snapshots for selection logic
- feed the new metrics into the task execution metadata and bidding workflow to skip high-anomaly agents and improve diagnostics

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8cdc7ec308333926a55ad06d9af98