### PR TITLE
Enhance orchestrator selection with config metadata and staking

### DIFF
--- a/agent-gateway/utils.ts
+++ b/agent-gateway/utils.ts
@@ -74,6 +74,7 @@ const JOB_REGISTRY_ABI = [
 
 const STAKE_MANAGER_ABI = [
   'event RewardPaid(bytes32 indexed jobId,address indexed to,uint256 amount)',
+  'function stake(uint8 role, uint256 amount)',
   'function depositStake(uint8 role, uint256 amount)',
   'function stakeOf(address user, uint8 role) view returns (uint256)',
   'function minStake() view returns (uint256)',


### PR DESCRIPTION
## Summary
- enrich agent profiles with skills, reputation, and energy metadata from config/agents.json and expose reusable match scoring
- add orchestrator-side selection that filters jobs lacking skill coverage or sufficient stake before ranking candidates
- update stake coordination to call StakeManager.stake when topping up and refresh documentation/ABIs to describe the new flow

## Testing
- npm run build:gateway
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8e30390208333ab6a318cb2234cd9