### PR TITLE
Add persistent validator commit store and dispute listeners

### DIFF
--- a/agent-gateway/routes.ts
+++ b/agent-gateway/routes.ts
@@ -311,14 +311,20 @@ app.post(
   '/jobs/:id/commit',
   authMiddleware,
   async (req: express.Request, res: express.Response) => {
-    const { address, approve } = req.body as {
+    const { address, approve, salt } = req.body as {
       address: string;
       approve: boolean;
+      salt?: string;
     };
     const wallet = walletManager.get(address);
     if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
     try {
-      const result = await commitHelper(req.params.id, wallet, approve);
+      const result = await commitHelper(
+        req.params.id,
+        wallet,
+        approve,
+        salt
+      );
       res.json(result);
     } catch (err: any) {
       res.status(500).json({ error: err.message });
@@ -331,11 +337,20 @@ app.post(
   '/jobs/:id/reveal',
   authMiddleware,
   async (req: express.Request, res: express.Response) => {
-    const { address } = req.body as { address: string };
+    const { address, approve, salt } = req.body as {
+      address: string;
+      approve?: boolean;
+      salt?: string;
+    };
     const wallet = walletManager.get(address);
     if (!wallet) return res.status(400).json({ error: 'unknown wallet' });
     try {
-      const result = await revealHelper(req.params.id, wallet);
+      const result = await revealHelper(
+        req.params.id,
+        wallet,
+        approve,
+        salt
+      );
       res.json(result);
     } catch (err: any) {
       res.status(500).json({ error: err.message });

--- a/agent-gateway/utils.ts
+++ b/agent-gateway/utils.ts
@@ -3,6 +3,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import agialpha from '../config/agialpha.json';
 import WalletManager from './wallet';
 import { Job, AgentInfo, CommitData } from './types';
+import { loadCommitRecord, updateCommitRecord } from './validationStore';
 
 // Environment configuration
 export const RPC_URL = process.env.RPC_URL || 'http://localhost:8545';
@@ -10,6 +11,8 @@ export const JOB_REGISTRY_ADDRESS = process.env.JOB_REGISTRY_ADDRESS || '';
 export const STAKE_MANAGER_ADDRESS = process.env.STAKE_MANAGER_ADDRESS || '';
 export const VALIDATION_MODULE_ADDRESS =
   process.env.VALIDATION_MODULE_ADDRESS || '';
+export const DISPUTE_MODULE_ADDRESS =
+  process.env.DISPUTE_MODULE_ADDRESS || '';
 export const KEYSTORE_URL = process.env.KEYSTORE_URL || '';
 export const KEYSTORE_TOKEN = process.env.KEYSTORE_TOKEN || '';
 export const BOT_WALLET = process.env.BOT_WALLET || '';
@@ -35,6 +38,9 @@ function validateEnvConfig(): void {
     );
   }
   checkAddress(VALIDATION_MODULE_ADDRESS, 'VALIDATION_MODULE_ADDRESS');
+  if (DISPUTE_MODULE_ADDRESS) {
+    checkAddress(DISPUTE_MODULE_ADDRESS, 'DISPUTE_MODULE_ADDRESS');
+  }
   if (!KEYSTORE_URL) {
     throw new Error('KEYSTORE_URL is required');
   }
@@ -91,6 +97,12 @@ const VALIDATION_MODULE_ABI = [
   'event ValidatorsSelected(uint256 indexed jobId, address[] validators)',
 ];
 
+const DISPUTE_MODULE_ABI = [
+  'event DisputeRaised(uint256 indexed jobId, address indexed claimant, bytes32 indexed evidenceHash)',
+  'event DisputeResolved(uint256 indexed jobId, address indexed resolver, bool employerWins)',
+  'function disputes(uint256 jobId) view returns (tuple(address claimant,uint256 raisedAt,bool resolved,uint256 fee,bytes32 evidenceHash))',
+];
+
 export const registry = new Contract(
   JOB_REGISTRY_ADDRESS,
   JOB_REGISTRY_ABI,
@@ -101,6 +113,9 @@ export const validation = VALIDATION_MODULE_ADDRESS
   : null;
 export const stakeManager = STAKE_MANAGER_ADDRESS
   ? new Contract(STAKE_MANAGER_ADDRESS, STAKE_MANAGER_ABI, provider)
+  : null;
+export const dispute = DISPUTE_MODULE_ADDRESS
+  ? new Contract(DISPUTE_MODULE_ADDRESS, DISPUTE_MODULE_ABI, provider)
   : null;
 
 // In-memory stores
@@ -368,18 +383,39 @@ export function dispatch(wss: WebSocketServer | undefined, job: Job): void {
   });
 }
 
+function normaliseSalt(value: string): string {
+  const candidate = value.startsWith('0x') ? value : `0x${value}`;
+  const bytes = ethers.getBytes(candidate);
+  if (bytes.length !== 32) {
+    throw new Error('salt must be a 32-byte hex string');
+  }
+  return ethers.hexlify(bytes);
+}
+
 export async function commitHelper(
   jobId: string,
   wallet: Wallet,
-  approve: boolean
-): Promise<{ tx: string; salt: string }> {
+  approve: boolean,
+  saltOverride?: string
+): Promise<{ tx: string; salt: string; commitHash: string }> {
   if (!validation) throw new Error('validation module not configured');
   await checkEnsSubdomain(wallet.address);
   const nonce = await validation.jobNonce(jobId);
-  const salt = ethers.hexlify(ethers.randomBytes(32));
+  let salt: string;
+  if (saltOverride) {
+    try {
+      salt = normaliseSalt(saltOverride);
+    } catch (err: any) {
+      throw new Error(`invalid salt provided: ${err?.message || err}`);
+    }
+  } else {
+    salt = ethers.hexlify(ethers.randomBytes(32));
+  }
+  const jobBigInt = ethers.getBigInt(jobId);
+  const nonceBigInt = ethers.getBigInt(nonce);
   const commitHash = ethers.solidityPackedKeccak256(
     ['uint256', 'uint256', 'bool', 'bytes32'],
-    [BigInt(jobId), nonce, approve, salt]
+    [jobBigInt, nonceBigInt, approve, salt]
   );
   const tx = await (validation as any)
     .connect(wallet)
@@ -388,22 +424,86 @@ export async function commitHelper(
   if (!commits.has(jobId)) commits.set(jobId, {});
   const jobCommits = commits.get(jobId)!;
   jobCommits[wallet.address.toLowerCase()] = { approve, salt };
-  return { tx: tx.hash, salt };
+
+  let validatorEns: string | undefined;
+  let validatorLabel: string | undefined;
+  try {
+    const lookup = await provider.lookupAddress(wallet.address);
+    if (lookup) {
+      validatorEns = lookup;
+      validatorLabel = lookup.split('.')[0];
+    }
+  } catch (err) {
+    console.warn('ENS lookup failed during commitHelper', err);
+  }
+
+  try {
+    updateCommitRecord(jobId, wallet.address, {
+      approve,
+      salt,
+      commitHash,
+      commitTx: tx.hash,
+      committedAt: new Date().toISOString(),
+      validatorEns,
+      validatorLabel,
+    });
+  } catch (err) {
+    console.warn('failed to persist validator commit record', err);
+  }
+
+  return { tx: tx.hash, salt, commitHash };
 }
 
 export async function revealHelper(
   jobId: string,
-  wallet: Wallet
+  wallet: Wallet,
+  approveOverride?: boolean,
+  saltOverride?: string
 ): Promise<{ tx: string }> {
   if (!validation) throw new Error('validation module not configured');
-  const jobCommits = commits.get(jobId) || {};
-  const data = jobCommits[wallet.address.toLowerCase()];
-  if (!data) throw new Error('no commit found');
+  let jobCommits = commits.get(jobId);
+  if (!jobCommits) {
+    jobCommits = {};
+    commits.set(jobId, jobCommits);
+  }
+  let data = jobCommits[wallet.address.toLowerCase()];
+  let storedRecord = loadCommitRecord(jobId, wallet.address);
+  if (!data && storedRecord) {
+    data = {
+      approve: storedRecord.approve,
+      salt: storedRecord.salt,
+    };
+    jobCommits[wallet.address.toLowerCase()] = { ...data };
+  }
+  const approve =
+    typeof approveOverride === 'boolean'
+      ? approveOverride
+      : data?.approve;
+  const saltSource = saltOverride ?? data?.salt;
+  if (approve === undefined || !saltSource) {
+    throw new Error('no commit found');
+  }
+  let salt: string;
+  try {
+    salt = normaliseSalt(saltSource);
+  } catch (err: any) {
+    throw new Error(`invalid salt provided: ${err?.message || err}`);
+  }
   await checkEnsSubdomain(wallet.address);
   const tx = await (validation as any)
     .connect(wallet)
-    .revealValidation(jobId, data.approve, data.salt, '', []);
+    .revealValidation(jobId, approve, salt, '', []);
   await tx.wait();
   delete jobCommits[wallet.address.toLowerCase()];
+
+  try {
+    updateCommitRecord(jobId, wallet.address, {
+      revealTx: tx.hash,
+      revealedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.warn('failed to update validator commit record on reveal', err);
+  }
+
   return { tx: tx.hash };
 }

--- a/agent-gateway/validationStore.ts
+++ b/agent-gateway/validationStore.ts
@@ -1,0 +1,210 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface DisputeRecord {
+  claimant: string;
+  evidenceHash: string;
+  recordedAt: string;
+}
+
+export interface DisputeResolutionRecord {
+  resolver: string;
+  employerWins: boolean;
+  resolvedAt: string;
+}
+
+export interface StoredCommitRecord {
+  jobId: string;
+  validator: string;
+  validatorEns?: string;
+  validatorLabel?: string;
+  approve: boolean;
+  salt: string;
+  commitHash: string;
+  committedAt: string;
+  commitTx?: string;
+  revealTx?: string;
+  revealedAt?: string;
+  evaluation?: unknown;
+  submission?: unknown;
+  dispute?: DisputeRecord;
+  resolution?: DisputeResolutionRecord;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CommitRecordUpdate {
+  approve?: boolean;
+  salt?: string;
+  commitHash?: string;
+  committedAt?: string;
+  commitTx?: string;
+  revealTx?: string;
+  revealedAt?: string;
+  validatorEns?: string;
+  validatorLabel?: string;
+  evaluation?: unknown;
+  submission?: unknown;
+  dispute?: DisputeRecord | null;
+  resolution?: DisputeResolutionRecord | null;
+  metadata?: Record<string, unknown>;
+}
+
+const STORAGE_ROOT = path.resolve(__dirname, '../storage/validation');
+
+function ensureStorageRoot(): void {
+  if (!fs.existsSync(STORAGE_ROOT)) {
+    fs.mkdirSync(STORAGE_ROOT, { recursive: true, mode: 0o700 });
+    return;
+  }
+  try {
+    const stats = fs.statSync(STORAGE_ROOT);
+    if (!stats.isDirectory()) {
+      throw new Error(`${STORAGE_ROOT} is not a directory`);
+    }
+    if ((stats.mode & 0o777) !== 0o700) {
+      fs.chmodSync(STORAGE_ROOT, 0o700);
+    }
+  } catch (err) {
+    console.warn('validation storage permission check failed', err);
+  }
+}
+
+function recordPath(jobId: string | number, validator: string): string {
+  const safeJobId = jobId.toString();
+  const safeValidator = validator.toLowerCase();
+  return path.join(STORAGE_ROOT, `${safeJobId}-${safeValidator}.json`);
+}
+
+function writeRecord(file: string, record: StoredCommitRecord): void {
+  ensureStorageRoot();
+  fs.writeFileSync(file, JSON.stringify(record, null, 2), { mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch (err) {
+    console.warn('validation storage chmod failed', file, err);
+  }
+}
+
+export function loadCommitRecord(
+  jobId: string | number,
+  validator: string
+): StoredCommitRecord | null {
+  const file = recordPath(jobId, validator);
+  try {
+    const raw = fs.readFileSync(file, 'utf8');
+    return JSON.parse(raw) as StoredCommitRecord;
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      console.warn('failed to load commit record', file, err);
+    }
+    return null;
+  }
+}
+
+function mergeRecords(
+  existing: StoredCommitRecord,
+  update: CommitRecordUpdate
+): StoredCommitRecord {
+  const next: StoredCommitRecord = { ...existing };
+  if (typeof update.approve === 'boolean') {
+    next.approve = update.approve;
+  }
+  if (typeof update.salt === 'string' && update.salt.length > 0) {
+    next.salt = update.salt;
+  }
+  if (typeof update.commitHash === 'string' && update.commitHash.length > 0) {
+    next.commitHash = update.commitHash;
+  }
+  if (typeof update.committedAt === 'string' && update.committedAt.length > 0) {
+    next.committedAt = update.committedAt;
+  }
+  if (typeof update.commitTx === 'string' && update.commitTx.length > 0) {
+    next.commitTx = update.commitTx;
+  }
+  if (typeof update.revealTx === 'string' && update.revealTx.length > 0) {
+    next.revealTx = update.revealTx;
+  }
+  if (typeof update.revealedAt === 'string' && update.revealedAt.length > 0) {
+    next.revealedAt = update.revealedAt;
+  }
+  if (update.validatorEns !== undefined) {
+    next.validatorEns = update.validatorEns || undefined;
+  }
+  if (update.validatorLabel !== undefined) {
+    next.validatorLabel = update.validatorLabel || undefined;
+  }
+  if (update.evaluation !== undefined) {
+    next.evaluation = update.evaluation;
+  }
+  if (update.submission !== undefined) {
+    next.submission = update.submission;
+  }
+  if (update.dispute !== undefined) {
+    next.dispute = update.dispute ?? undefined;
+  }
+  if (update.resolution !== undefined) {
+    next.resolution = update.resolution ?? undefined;
+  }
+  if (update.metadata) {
+    next.metadata = {
+      ...(existing.metadata ?? {}),
+      ...update.metadata,
+    };
+  }
+  return next;
+}
+
+export function updateCommitRecord(
+  jobId: string | number,
+  validator: string,
+  update: CommitRecordUpdate
+): StoredCommitRecord {
+  const file = recordPath(jobId, validator);
+  const existing = loadCommitRecord(jobId, validator);
+  if (!existing) {
+    if (
+      typeof update.approve !== 'boolean' ||
+      typeof update.salt !== 'string' ||
+      update.salt.length === 0 ||
+      typeof update.commitHash !== 'string' ||
+      update.commitHash.length === 0
+    ) {
+      throw new Error(
+        `commit record for job ${jobId} and validator ${validator} is missing required base fields`
+      );
+    }
+    const committedAt =
+      (typeof update.committedAt === 'string' && update.committedAt.length > 0)
+        ? update.committedAt
+        : new Date().toISOString();
+    const base: StoredCommitRecord = {
+      jobId: jobId.toString(),
+      validator: validator.toLowerCase(),
+      approve: update.approve,
+      salt: update.salt,
+      commitHash: update.commitHash,
+      committedAt,
+    };
+    const record = mergeRecords(base, update);
+    writeRecord(file, record);
+    return record;
+  }
+  const merged = mergeRecords(existing, update);
+  writeRecord(file, merged);
+  return merged;
+}
+
+export function deleteCommitRecord(
+  jobId: string | number,
+  validator: string
+): void {
+  const file = recordPath(jobId, validator);
+  try {
+    fs.rmSync(file);
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      console.warn('failed to delete commit record', file, err);
+    }
+  }
+}
+

--- a/agent-gateway/validator.ts
+++ b/agent-gateway/validator.ts
@@ -7,6 +7,7 @@ import {
   walletManager,
   FETCH_TIMEOUT_MS,
   TOKEN_DECIMALS,
+  agents,
 } from './utils';
 import { ensureIdentity, AgentIdentity } from './identity';
 import { ROLE_VALIDATOR, ensureStake } from './stakeCoordinator';
@@ -19,6 +20,7 @@ import { publishEnergySample } from './telemetry';
 import { appendTrainingRecord } from '../shared/trainingRecords';
 import { secureLogAction } from './security';
 import { summarizeContent } from '../shared/worldModel';
+import { loadCommitRecord, updateCommitRecord } from './validationStore';
 
 interface SubmissionInfo {
   jobId: string;
@@ -74,6 +76,8 @@ interface ValidationAssignment {
   processing?: boolean;
   scheduledReveal?: NodeJS.Timeout | null;
   energySample?: EnergySample;
+  notifiedAt?: string;
+  notificationDelivered?: boolean;
 }
 
 interface RoundMetadata {
@@ -105,6 +109,8 @@ interface ValidatorAssignmentSnapshot {
   energy?: EnergySample | undefined;
   round?: RoundMetadata;
   archived?: boolean;
+  notifiedAt?: string;
+  notificationDelivered?: boolean;
 }
 
 const assignments = new Map<string, Map<string, ValidationAssignment>>();
@@ -167,7 +173,175 @@ function toSnapshot(
     revealedAt: assignment.reveal?.revealedAt,
     energy: assignment.energySample,
     round: assignment.round,
+    notifiedAt: assignment.notifiedAt,
+    notificationDelivered: assignment.notificationDelivered,
   };
+}
+
+async function sendToValidatorAgent(
+  walletAddress: string,
+  message: Record<string, unknown>
+): Promise<boolean> {
+  const lower = walletAddress.toLowerCase();
+  const payload = JSON.stringify(message);
+  const matches = Array.from(agents.entries()).filter(
+    ([, info]) => info.wallet.toLowerCase() === lower
+  );
+  if (matches.length === 0) {
+    return false;
+  }
+  let delivered = false;
+  for (const [, info] of matches) {
+    try {
+      if (info.ws && info.ws.readyState === 1) {
+        info.ws.send(payload);
+        delivered = true;
+        continue;
+      }
+      if (info.url) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+        try {
+          const res = await fetch(info.url, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: payload,
+            signal: controller.signal,
+          });
+          if (res.ok) {
+            delivered = true;
+          } else {
+            console.warn(
+              'validator HTTP dispatch failed',
+              info.url,
+              res.status,
+              res.statusText
+            );
+          }
+        } catch (err: any) {
+          if (err?.name === 'AbortError') {
+            console.warn('validator HTTP dispatch timed out', info.url);
+          } else {
+            console.warn('validator HTTP dispatch error', info.url, err);
+          }
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+    } catch (err) {
+      console.warn('validator message dispatch error', err);
+    }
+  }
+  return delivered;
+}
+
+async function notifyDomainAgent(
+  submission: SubmissionInfo,
+  assignment: ValidationAssignment
+): Promise<void> {
+  if (assignment.notifiedAt) {
+    return;
+  }
+  const message = {
+    type: 'ValidationAwaiting',
+    jobId: submission.jobId,
+    worker: submission.worker,
+    resultHash: submission.resultHash,
+    resultURI: submission.resultURI,
+    subdomain: submission.subdomain,
+    receivedAt: submission.receivedAt,
+    validator: {
+      address: assignment.wallet.address,
+      ens: assignment.identity.ensName,
+      label: assignment.identity.label,
+      categories: assignment.identity.manifestCategories,
+    },
+  };
+  const delivered = await sendToValidatorAgent(assignment.wallet.address, message);
+  assignment.notifiedAt = new Date().toISOString();
+  assignment.notificationDelivered = delivered;
+  if (!delivered) {
+    console.warn(
+      'No online domain agent registered for validator',
+      assignment.wallet.address
+    );
+  }
+  try {
+    await secureLogAction({
+      component: 'validator',
+      action: 'awaiting-validation',
+      jobId: submission.jobId,
+      agent: assignment.wallet.address,
+      metadata: {
+        delivered,
+        worker: submission.worker,
+        resultURI: submission.resultURI,
+        subdomain: submission.subdomain,
+      },
+      success: delivered,
+    });
+  } catch (err) {
+    console.warn('validator notification logging failed', err);
+  }
+  try {
+    updateCommitRecord(submission.jobId, assignment.wallet.address, {
+      metadata: {
+        notifiedAt: assignment.notifiedAt,
+        notificationDelivered: delivered,
+      },
+    });
+  } catch (err) {
+    // commit record may not exist yet; ignore but log at debug level
+    if (err instanceof Error && /missing required base fields/.test(err.message)) {
+      return;
+    }
+    console.warn('failed to persist validator notification metadata', err);
+  }
+}
+
+function rehydrateAssignmentFromStore(
+  jobId: string,
+  assignment: ValidationAssignment
+): void {
+  const record = loadCommitRecord(jobId, assignment.wallet.address);
+  if (!record) return;
+  const storedEvaluation = record.evaluation as
+    | ValidationEvaluation
+    | undefined;
+  const storedSubmission = record.submission as SubmissionInfo | undefined;
+  const evaluation: ValidationEvaluation =
+    storedEvaluation ??
+    assignment.commit?.evaluation ?? {
+      approve: record.approve,
+      reasons: ['restored-from-storage'],
+      hashMatches: false,
+      resultAvailable: Boolean(storedSubmission?.resultURI),
+      worker: storedSubmission?.worker ?? '',
+      resultURI: storedSubmission?.resultURI ?? '',
+    };
+  assignment.commit = {
+    txHash: record.commitTx || assignment.commit?.txHash || '',
+    salt: record.salt,
+    approve: record.approve,
+    committedAt: record.committedAt,
+    evaluation,
+  };
+  if (record.revealTx) {
+    assignment.reveal = {
+      txHash: record.revealTx,
+      revealedAt: record.revealedAt || new Date().toISOString(),
+    };
+    assignment.status = 'revealed';
+  } else {
+    assignment.status = 'committed';
+  }
+  const metadata = record.metadata ?? {};
+  if (typeof metadata.notifiedAt === 'string') {
+    assignment.notifiedAt = metadata.notifiedAt;
+  }
+  if (typeof metadata.notificationDelivered === 'boolean') {
+    assignment.notificationDelivered = metadata.notificationDelivered;
+  }
 }
 
 async function loadLocalResult(
@@ -401,8 +575,41 @@ async function revealValidation(
   assignment: ValidationAssignment
 ): Promise<void> {
   if (!validation) return;
-  if (!assignment.commit) return;
   if (assignment.status === 'revealed') return;
+  let commitInfo = assignment.commit;
+  if (!commitInfo) {
+    const record = loadCommitRecord(jobId, assignment.wallet.address);
+    if (record) {
+      const storedEvaluation = record.evaluation as
+        | ValidationEvaluation
+        | undefined;
+      const storedSubmission = record.submission as
+        | SubmissionInfo
+        | undefined;
+      const evaluation: ValidationEvaluation =
+        storedEvaluation ??
+        assignment.commit?.evaluation ?? {
+          approve: record.approve,
+          reasons: ['restored-from-storage'],
+          hashMatches: false,
+          resultAvailable: Boolean(storedSubmission?.resultURI),
+          worker: storedSubmission?.worker ?? '',
+          resultURI: storedSubmission?.resultURI ?? '',
+        };
+      commitInfo = {
+        txHash: record.commitTx || assignment.commit?.txHash || '',
+        salt: record.salt,
+        approve: record.approve,
+        committedAt: record.committedAt,
+        evaluation,
+      };
+      assignment.commit = commitInfo;
+    }
+  }
+  if (!commitInfo) {
+    console.warn('Validator assignment missing commit data for reveal', jobId);
+    return;
+  }
   const label = assignment.identity.label || assignment.identity.ensName;
   if (!label) {
     throw new Error('Validator identity missing label');
@@ -412,8 +619,8 @@ async function revealValidation(
       .connect(assignment.wallet)
       .revealValidation(
         jobId,
-        assignment.commit.approve,
-        assignment.commit.salt,
+        commitInfo.approve,
+        commitInfo.salt,
         label,
         []
       );
@@ -423,12 +630,27 @@ async function revealValidation(
       revealedAt: new Date().toISOString(),
     };
     assignment.status = 'revealed';
+    try {
+      updateCommitRecord(jobId, assignment.wallet.address, {
+        revealTx: tx.hash,
+        revealedAt: assignment.reveal.revealedAt,
+        metadata: assignment.notifiedAt
+          ? {
+              notifiedAt: assignment.notifiedAt,
+              notificationDelivered:
+                assignment.notificationDelivered ?? false,
+            }
+          : undefined,
+      });
+    } catch (err) {
+      console.warn('failed to persist validator reveal metadata', err);
+    }
     await secureLogAction({
       component: 'validator',
       action: 'reveal',
       jobId,
       agent: assignment.wallet.address,
-      metadata: { txHash: tx.hash, approve: assignment.commit.approve },
+      metadata: { txHash: tx.hash, approve: commitInfo.approve },
       success: true,
     });
   } catch (err: any) {
@@ -506,6 +728,13 @@ async function evaluateAndCommit(
   assignment.processing = true;
   assignment.attempts += 1;
   assignment.status = 'evaluating';
+  if (!assignment.notifiedAt) {
+    try {
+      await notifyDomainAgent(submission, assignment);
+    } catch (err) {
+      console.warn('validator notification failed', err);
+    }
+  }
   const span = startEnergySpan({
     jobId: submission.jobId,
     agent: assignment.wallet.address,
@@ -579,6 +808,28 @@ async function evaluateAndCommit(
       evaluation,
     };
     assignment.status = 'committed';
+    try {
+      updateCommitRecord(submission.jobId, assignment.wallet.address, {
+        approve: evaluation.approve,
+        salt,
+        commitHash,
+        commitTx: tx.hash,
+        committedAt: assignment.commit.committedAt,
+        evaluation,
+        submission,
+        validatorEns: assignment.identity.ensName,
+        validatorLabel: assignment.identity.label,
+        metadata: assignment.notifiedAt
+          ? {
+              notifiedAt: assignment.notifiedAt,
+              notificationDelivered:
+                assignment.notificationDelivered ?? false,
+            }
+          : undefined,
+      });
+    } catch (err) {
+      console.warn('failed to persist validator commit state', err);
+    }
     await secureLogAction({
       component: 'validator',
       action: 'commit',
@@ -655,6 +906,7 @@ export async function handleValidatorSelection(
         createdAt: new Date().toISOString(),
         attempts: 0,
       };
+      rehydrateAssignmentFromStore(jobId, assignment);
       bucket.set(lower, assignment);
       await secureLogAction({
         component: 'validator',
@@ -664,8 +916,20 @@ export async function handleValidatorSelection(
         metadata: { validators },
         success: true,
       });
+      if (assignment.status === 'committed' && !assignment.scheduledReveal) {
+        try {
+          await scheduleReveal(jobId, assignment);
+        } catch (err) {
+          console.warn('Failed to reschedule reveal for restored validator', err);
+        }
+      }
       const submission = submissions.get(jobId);
       if (submission) {
+        try {
+          await notifyDomainAgent(submission, assignment);
+        } catch (err) {
+          console.warn('validator notification during selection failed', err);
+        }
         await evaluateAndCommit(submission, assignment);
       }
     } catch (err: any) {
@@ -682,16 +946,23 @@ export async function handleValidatorSelection(
   }
 }
 
-export async function handleJobSubmissionForValidators(
+export async function handleJobAwaitingValidation(
   submission: SubmissionInfo
 ): Promise<void> {
   submissions.set(submission.jobId, submission);
   const bucket = assignments.get(submission.jobId);
   if (!bucket) return;
   for (const assignment of bucket.values()) {
+    try {
+      await notifyDomainAgent(submission, assignment);
+    } catch (err) {
+      console.warn('validator notification failed', err);
+    }
     await evaluateAndCommit(submission, assignment);
   }
 }
+
+export const handleJobSubmissionForValidators = handleJobAwaitingValidation;
 
 export function handleJobCompletionForValidators(jobId: string): void {
   submissions.delete(jobId);
@@ -702,12 +973,124 @@ export function handleJobCompletionForValidators(jobId: string): void {
       clearTimeout(assignment.scheduledReveal);
       assignment.scheduledReveal = null;
     }
+    try {
+      const metadata: Record<string, unknown> = {
+        completedAt: new Date().toISOString(),
+      };
+      if (assignment.notifiedAt) {
+        metadata.notifiedAt = assignment.notifiedAt;
+        metadata.notificationDelivered =
+          assignment.notificationDelivered ?? false;
+      }
+      updateCommitRecord(jobId, assignment.wallet.address, { metadata });
+    } catch (err) {
+      if (
+        !(err instanceof Error && /missing required base fields/.test(err.message))
+      ) {
+        console.warn('failed to persist validator completion metadata', err);
+      }
+    }
     assignment.status =
       assignment.status === 'revealed' ? 'revealed' : 'completed';
     storeHistory(toSnapshot(assignment));
     bucket.delete(address);
   }
   assignments.delete(jobId);
+}
+
+export async function handleDisputeRaised(
+  jobId: string,
+  claimant: string,
+  evidenceHash: string
+): Promise<void> {
+  const timestamp = new Date().toISOString();
+  for (const address of walletManager.list()) {
+    const record = loadCommitRecord(jobId, address);
+    if (!record) continue;
+    try {
+      updateCommitRecord(jobId, address, {
+        dispute: { claimant, evidenceHash, recordedAt: timestamp },
+      });
+    } catch (err) {
+      console.warn('failed to persist validator dispute record', err);
+    }
+    try {
+      await secureLogAction({
+        component: 'validator',
+        action: 'dispute-raised',
+        jobId,
+        agent: address,
+        metadata: { claimant, evidenceHash },
+        success: true,
+      });
+    } catch (err) {
+      console.warn('validator dispute logging failed', err);
+    }
+    const assignment = assignments.get(jobId)?.get(address.toLowerCase());
+    const message = {
+      type: 'ValidationDispute',
+      jobId,
+      claimant,
+      evidenceHash,
+      validator: {
+        address,
+        ens: assignment?.identity.ensName ?? record.validatorEns,
+        label: assignment?.identity.label ?? record.validatorLabel,
+      },
+    };
+    try {
+      await sendToValidatorAgent(address, message);
+    } catch (err) {
+      console.warn('validator dispute notification failed', err);
+    }
+  }
+}
+
+export async function handleDisputeResolved(
+  jobId: string,
+  resolver: string,
+  employerWins: boolean
+): Promise<void> {
+  const timestamp = new Date().toISOString();
+  for (const address of walletManager.list()) {
+    const record = loadCommitRecord(jobId, address);
+    if (!record) continue;
+    try {
+      updateCommitRecord(jobId, address, {
+        resolution: { resolver, employerWins, resolvedAt: timestamp },
+      });
+    } catch (err) {
+      console.warn('failed to persist validator dispute resolution', err);
+    }
+    try {
+      await secureLogAction({
+        component: 'validator',
+        action: 'dispute-resolved',
+        jobId,
+        agent: address,
+        metadata: { resolver, employerWins },
+        success: true,
+      });
+    } catch (err) {
+      console.warn('validator dispute resolution logging failed', err);
+    }
+    const message = {
+      type: 'ValidationDisputeResolved',
+      jobId,
+      resolver,
+      employerWins,
+      validator: {
+        address,
+        ens: record.validatorEns,
+        label: record.validatorLabel,
+      },
+    };
+    try {
+      await sendToValidatorAgent(address, message);
+    } catch (err) {
+      console.warn('validator dispute resolution notification failed', err);
+    }
+  }
 }
 
 export function listValidatorAssignments(): {

--- a/examples/commit-reveal.js
+++ b/examples/commit-reveal.js
@@ -1,10 +1,24 @@
-// Compute commit hash and reveal votes for job validation
-// Usage:
-//   node examples/commit-reveal.js commit <jobId> <approve> [subdomain]
-//   node examples/commit-reveal.js reveal <jobId> <approve> <salt> [subdomain]
-// Requires RPC_URL, PRIVATE_KEY and VALIDATION_MODULE env vars.
+/**
+ * Commit and reveal validation votes while persisting the salt locally.
+ *
+ * Usage:
+ *   node examples/commit-reveal.js commit <jobId> <approve> [salt] [subdomain]
+ *   node examples/commit-reveal.js reveal <jobId> [approve] [salt] [subdomain]
+ *
+ * Environment:
+ *   RPC_URL, PRIVATE_KEY, VALIDATION_MODULE
+ */
 
+const fs = require('fs');
+const path = require('path');
 const { ethers } = require('ethers');
+
+if (!process.env.VALIDATION_MODULE) {
+  throw new Error('VALIDATION_MODULE env var is required');
+}
+if (!process.env.PRIVATE_KEY) {
+  throw new Error('PRIVATE_KEY env var is required');
+}
 
 const provider = new ethers.JsonRpcProvider(
   process.env.RPC_URL || 'http://localhost:8545'
@@ -12,6 +26,7 @@ const provider = new ethers.JsonRpcProvider(
 const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 
 const validationAbi = [
+  'function jobNonce(uint256) view returns (uint256)',
   'function commitValidation(uint256,bytes32,string,bytes32[])',
   'function revealValidation(uint256,bool,bytes32,string,bytes32[])',
 ];
@@ -22,45 +37,137 @@ const validation = new ethers.Contract(
   wallet
 );
 
-async function commit(jobId, approve, subdomain, proof) {
-  const salt = ethers.randomBytes(32);
-  const hash = ethers.solidityPackedKeccak256(
-    ['bool', 'bytes32'],
-    [approve, salt]
-  );
-  console.log('Commit hash', hash);
-  console.log('Salt', ethers.hexlify(salt), 'save for reveal');
-  await validation.commitValidation(jobId, hash, subdomain, proof);
+const STORAGE_ROOT = path.resolve(__dirname, '../storage/validation');
+
+function ensureStorage(): void {
+  if (!fs.existsSync(STORAGE_ROOT)) {
+    fs.mkdirSync(STORAGE_ROOT, { recursive: true, mode: 0o700 });
+  }
 }
 
-async function reveal(jobId, approve, salt, subdomain, proof) {
-  await validation.revealValidation(jobId, approve, salt, subdomain, proof);
+function storagePath(jobId, address) {
+  const suffix = address.toLowerCase();
+  return path.join(STORAGE_ROOT, `${jobId}-${suffix}.json`);
+}
+
+function loadRecord(jobId, address) {
+  try {
+    const raw = fs.readFileSync(storagePath(jobId, address), 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      console.warn('Failed to read commit record', err.message || err);
+    }
+    return {};
+  }
+}
+
+function saveRecord(jobId, address, update) {
+  ensureStorage();
+  const file = storagePath(jobId, address);
+  const existing = loadRecord(jobId, address);
+  const record = { ...existing, ...update };
+  fs.writeFileSync(file, JSON.stringify(record, null, 2), { mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch (err) {
+    console.warn('chmod failed for commit record', err);
+  }
+  return record;
+}
+
+function isHexSalt(value) {
+  return (
+    typeof value === 'string' && /^0x?[0-9a-fA-F]{64}$/.test(value.trim())
+  );
+}
+
+function normaliseSalt(value) {
+  const candidate = value.startsWith('0x') ? value : `0x${value}`;
+  const bytes = ethers.getBytes(candidate);
+  if (bytes.length !== 32) {
+    throw new Error('salt must be 32 bytes');
+  }
+  return ethers.hexlify(bytes);
+}
+
+async function commit(jobId, approve, saltArg, subdomain, proof) {
+  const nonce = await validation.jobNonce(jobId);
+  const salt = saltArg ? normaliseSalt(saltArg) : ethers.hexlify(ethers.randomBytes(32));
+  const commitHash = ethers.solidityPackedKeccak256(
+    ['uint256', 'uint256', 'bool', 'bytes32'],
+    [ethers.getBigInt(jobId), ethers.getBigInt(nonce), approve, salt]
+  );
+  const tx = await validation.commitValidation(jobId, commitHash, subdomain, proof);
+  await tx.wait();
+  const record = saveRecord(jobId, wallet.address, {
+    jobId: jobId.toString(),
+    validator: wallet.address,
+    approve,
+    salt,
+    commitHash,
+    commitTx: tx.hash,
+    committedAt: new Date().toISOString(),
+  });
+  console.log('Committed validation', tx.hash);
+  console.log('Stored salt at', storagePath(jobId, wallet.address));
+  console.log('Record:', record);
+}
+
+async function reveal(jobId, approveArg, saltArg, subdomain, proof) {
+  const record = loadRecord(jobId, wallet.address);
+  const approve =
+    typeof approveArg === 'boolean' ? approveArg : record.approve;
+  if (typeof approve !== 'boolean') {
+    throw new Error('Approve flag missing. Provide it or commit first.');
+  }
+  const saltSource = saltArg || record.salt;
+  if (!saltSource) {
+    throw new Error('Salt missing. Provide it or ensure commit record exists.');
+  }
+  const salt = normaliseSalt(saltSource);
+  const tx = await validation.revealValidation(jobId, approve, salt, subdomain, proof);
+  await tx.wait();
+  const updated = saveRecord(jobId, wallet.address, {
+    approve,
+    salt,
+    revealTx: tx.hash,
+    revealedAt: new Date().toISOString(),
+  });
+  console.log('Revealed validation', tx.hash);
+  console.log('Updated record:', updated);
 }
 
 async function main() {
   const [action, jobIdArg, approveArg, arg4, arg5] = process.argv.slice(2);
-  if (!action || !jobIdArg || !approveArg) {
+  if (!action || !jobIdArg) {
     console.error(
       'Usage: node examples/commit-reveal.js commit|reveal jobId approve [salt] [subdomain]'
     );
-    return;
+    process.exit(1);
   }
   const jobId = BigInt(jobIdArg);
-  const approve = approveArg === 'true';
+  const approveValue =
+    typeof approveArg === 'undefined' ? undefined : approveArg === 'true';
+  const proof = [];
   if (action === 'commit') {
-    const subdomain = arg4 || '';
-    const proof = [];
-    await commit(jobId, approve, subdomain, proof);
+    if (approveValue === undefined) {
+      throw new Error('Approve flag required for commit');
+    }
+    const saltInput = isHexSalt(arg4) ? arg4 : undefined;
+    const subdomain = isHexSalt(arg4) ? arg5 || '' : arg4 || '';
+    await commit(jobId, approveValue, saltInput, subdomain, proof);
   } else if (action === 'reveal') {
-    const salt = arg4;
-    const subdomain = arg5 || '';
-    const proof = [];
-    await reveal(jobId, approve, salt, subdomain, proof);
+    const saltInput = isHexSalt(arg4) ? arg4 : undefined;
+    const subdomain = isHexSalt(arg4) ? arg5 || '' : arg4 || '';
+    await reveal(jobId, approveValue, saltInput, subdomain, proof);
   } else {
     console.error('Unknown action', action);
+    process.exit(1);
   }
 }
 
 main().catch((err) => {
   console.error(err);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- add a dedicated `validationStore` module and persist commit/reveal metadata for validators
- notify validator agents when jobs reach the awaiting-validation state, restore commits from disk, and react to dispute events
- document the validation lifecycle and update the example commit/reveal script to use stored salts

## Testing
- npm run build:gateway *(fails: missing ipfs-http-client module)*
- npm run lint *(Solhint reports existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c96e28f2088333be3eff7971676548