### PR TITLE
Add thermodynamic telemetry and energy dashboard

### DIFF
--- a/agent-gateway/orchestrator.ts
+++ b/agent-gateway/orchestrator.ts
@@ -204,9 +204,7 @@ export async function selectAgentForJob(job: Job): Promise<MatchResult | null> {
         stats && Number.isFinite(stats.successRate) ? stats.successRate : null;
 
       const energyPenalty =
-        averageEnergy !== null
-          ? Math.log1p(averageEnergy / 1000) * 0.2
-          : 0;
+        averageEnergy !== null ? Math.log1p(averageEnergy / 1000) * 0.2 : 0;
       const efficiencyBoost =
         averageEfficiency !== null ? Math.min(1, averageEfficiency) * 0.3 : 0;
       const reliabilityBoost =
@@ -240,9 +238,9 @@ export async function selectAgentForJob(job: Job): Promise<MatchResult | null> {
         const { averageEnergy, averageEfficiency, dominantComplexity } =
           selectedEntry.stats;
         selectedEntry.match.reasons.push(
-          `energy-metrics:${averageEnergy.toFixed(2)}:${averageEfficiency.toFixed(
-            3
-          )}:${dominantComplexity}`
+          `energy-metrics:${averageEnergy.toFixed(
+            2
+          )}:${averageEfficiency.toFixed(3)}:${dominantComplexity}`
         );
       }
       return selectedEntry.match;

--- a/agent-gateway/orchestrator.ts
+++ b/agent-gateway/orchestrator.ts
@@ -11,6 +11,7 @@ import {
 } from './agentRegistry';
 import { ensureStake, ROLE_AGENT } from './stakeCoordinator';
 import { executeJob } from './taskExecution';
+import { getAgentEfficiencyStats } from './telemetry';
 import {
   recordAgentFailure,
   recordAgentSuccess,
@@ -186,6 +187,66 @@ export async function selectAgentForJob(job: Job): Promise<MatchResult | null> {
   if (matches.length === 0) {
     console.warn('No viable agent match found for job', job.jobId);
     return null;
+  }
+  const efficiencyStats = await getAgentEfficiencyStats();
+  if (efficiencyStats.size > 0) {
+    const decorated = matches.map((match) => {
+      const stats = efficiencyStats.get(match.profile.address.toLowerCase());
+      const averageEnergy =
+        stats && Number.isFinite(stats.averageEnergy)
+          ? Math.max(0, stats.averageEnergy)
+          : null;
+      const averageEfficiency =
+        stats && Number.isFinite(stats.averageEfficiency)
+          ? Math.max(0, stats.averageEfficiency)
+          : null;
+      const successRate =
+        stats && Number.isFinite(stats.successRate) ? stats.successRate : null;
+
+      const energyPenalty =
+        averageEnergy !== null
+          ? Math.log1p(averageEnergy / 1000) * 0.2
+          : 0;
+      const efficiencyBoost =
+        averageEfficiency !== null ? Math.min(1, averageEfficiency) * 0.3 : 0;
+      const reliabilityBoost =
+        successRate !== null ? Math.max(0, successRate) * 0.05 : 0;
+
+      const finalScore =
+        match.score + efficiencyBoost + reliabilityBoost - energyPenalty;
+
+      return {
+        match,
+        stats,
+        finalScore,
+        averageEnergy:
+          averageEnergy !== null ? averageEnergy : Number.POSITIVE_INFINITY,
+      };
+    });
+
+    decorated.sort((a, b) => {
+      if (b.finalScore !== a.finalScore) {
+        return b.finalScore - a.finalScore;
+      }
+      if (a.averageEnergy !== b.averageEnergy) {
+        return a.averageEnergy - b.averageEnergy;
+      }
+      return b.match.score - a.match.score;
+    });
+
+    const selectedEntry = decorated[0];
+    if (selectedEntry) {
+      if (selectedEntry.stats) {
+        const { averageEnergy, averageEfficiency, dominantComplexity } =
+          selectedEntry.stats;
+        selectedEntry.match.reasons.push(
+          `energy-metrics:${averageEnergy.toFixed(2)}:${averageEfficiency.toFixed(
+            3
+          )}:${dominantComplexity}`
+        );
+      }
+      return selectedEntry.match;
+    }
   }
   return matches[0];
 }

--- a/agent-gateway/telemetry.ts
+++ b/agent-gateway/telemetry.ts
@@ -89,8 +89,10 @@ function estimateAlgorithmicComplexity(
   outputSizeBytes: number,
   cpuCount: number
 ): ComplexityEstimate {
-  const safeCpuTime = Number.isFinite(cpuTimeMs) && cpuTimeMs > 0 ? cpuTimeMs : 0;
-  const safeGpuTime = Number.isFinite(gpuTimeMs) && gpuTimeMs > 0 ? gpuTimeMs : 0;
+  const safeCpuTime =
+    Number.isFinite(cpuTimeMs) && cpuTimeMs > 0 ? cpuTimeMs : 0;
+  const safeGpuTime =
+    Number.isFinite(gpuTimeMs) && gpuTimeMs > 0 ? gpuTimeMs : 0;
   const threads = Number.isFinite(cpuCount) && cpuCount > 0 ? cpuCount : 1;
 
   const cpuOperations = safeCpuTime * CPU_OPERATION_WEIGHT * threads;
@@ -244,7 +246,8 @@ function updateAgentAggregate(record: EnergyMetricRecord): void {
   }
   aggregate.complexityTotal += complexityIndex(record.algorithmicComplexity);
   aggregate.complexitySamples += 1;
-  aggregate.lastUpdated = record.finishedAt || record.startedAt || aggregate.lastUpdated;
+  aggregate.lastUpdated =
+    record.finishedAt || record.startedAt || aggregate.lastUpdated;
 
   agentEfficiencyAggregates.set(key, aggregate);
 }
@@ -457,16 +460,14 @@ export async function getAgentEfficiencyStats(): Promise<
   const snapshot = new Map<string, AgentEfficiencyStats>();
   for (const [agent, aggregate] of agentEfficiencyAggregates.entries()) {
     const jobCount = aggregate.jobCount;
-    const averageEnergy =
-      jobCount > 0 ? aggregate.totalEnergy / jobCount : 0;
+    const averageEnergy = jobCount > 0 ? aggregate.totalEnergy / jobCount : 0;
     const averageEfficiency =
       jobCount > 0 ? aggregate.totalEfficiency / jobCount : 0;
     const averageCpuTimeMs =
       jobCount > 0 ? aggregate.totalCpuTime / jobCount : 0;
     const averageGpuTimeMs =
       jobCount > 0 ? aggregate.totalGpuTime / jobCount : 0;
-    const successRate =
-      jobCount > 0 ? aggregate.successCount / jobCount : 0;
+    const successRate = jobCount > 0 ? aggregate.successCount / jobCount : 0;
     const complexityAverageIndex =
       aggregate.complexitySamples > 0
         ? aggregate.complexityTotal / aggregate.complexitySamples

--- a/agent-gateway/telemetry.ts
+++ b/agent-gateway/telemetry.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { ethers } from 'ethers';
 import { EnergySample } from '../shared/energyMonitor';
@@ -22,6 +23,476 @@ let flushing = false;
 let flushTimer: NodeJS.Timeout | null = null;
 let warnedNoOracle = false;
 let warnedMissingSigner = false;
+
+const ENERGY_METRICS_PATH = path.resolve(
+  __dirname,
+  '../data/energy-metrics.jsonl'
+);
+
+const COMPLEXITY_ORDER = [
+  'O(1)',
+  'O(log n)',
+  'O(n)',
+  'O(n log n)',
+  'O(n^2)',
+  'O(n^3)',
+  'O(2^n)',
+];
+
+const CPU_OPERATION_WEIGHT = Number(
+  process.env.TELEMETRY_CPU_OPERATION_WEIGHT || '1000'
+);
+const GPU_OPERATION_WEIGHT = Number(
+  process.env.TELEMETRY_GPU_OPERATION_WEIGHT || '500'
+);
+
+type LoadAverages = [number, number, number];
+
+function readLoadAverage(): LoadAverages {
+  try {
+    const values = os.loadavg();
+    if (!Array.isArray(values) || values.length < 3) {
+      return [0, 0, 0];
+    }
+    return [values[0] || 0, values[1] || 0, values[2] || 0];
+  } catch {
+    return [0, 0, 0];
+  }
+}
+
+function estimateSize(payload: unknown): number {
+  if (payload === null || payload === undefined) {
+    return 0;
+  }
+  if (typeof payload === 'string') {
+    return Buffer.byteLength(payload, 'utf8');
+  }
+  if (payload instanceof Uint8Array || Buffer.isBuffer(payload)) {
+    return payload.length;
+  }
+  try {
+    return Buffer.byteLength(JSON.stringify(payload), 'utf8');
+  } catch {
+    return 0;
+  }
+}
+
+interface ComplexityEstimate {
+  algorithmicComplexity: string;
+  estimatedOperations: number;
+}
+
+function estimateAlgorithmicComplexity(
+  cpuTimeMs: number,
+  gpuTimeMs: number,
+  inputSizeBytes: number,
+  outputSizeBytes: number,
+  cpuCount: number
+): ComplexityEstimate {
+  const safeCpuTime = Number.isFinite(cpuTimeMs) && cpuTimeMs > 0 ? cpuTimeMs : 0;
+  const safeGpuTime = Number.isFinite(gpuTimeMs) && gpuTimeMs > 0 ? gpuTimeMs : 0;
+  const threads = Number.isFinite(cpuCount) && cpuCount > 0 ? cpuCount : 1;
+
+  const cpuOperations = safeCpuTime * CPU_OPERATION_WEIGHT * threads;
+  const gpuOperations = safeGpuTime * GPU_OPERATION_WEIGHT;
+  const estimatedOperations = Math.max(
+    1,
+    Math.round(cpuOperations + gpuOperations)
+  );
+
+  const scale = Math.max(1, inputSizeBytes, outputSizeBytes);
+  const ratio = estimatedOperations / scale;
+
+  let algorithmicComplexity = 'O(1)';
+  if (ratio <= 2) {
+    algorithmicComplexity = 'O(1)';
+  } else if (ratio <= 10) {
+    algorithmicComplexity = 'O(n)';
+  } else if (ratio <= 25) {
+    algorithmicComplexity = 'O(n log n)';
+  } else if (ratio <= 60) {
+    algorithmicComplexity = 'O(n^2)';
+  } else if (ratio <= 120) {
+    algorithmicComplexity = 'O(n^3)';
+  } else {
+    algorithmicComplexity = 'O(2^n)';
+  }
+
+  return { algorithmicComplexity, estimatedOperations };
+}
+
+export interface JobInvocationSpan {
+  jobId: string;
+  agent: string;
+  startedAt: string;
+  cpuStart: NodeJS.CpuUsage;
+  hrtimeStart: bigint;
+  loadAverageStart: LoadAverages;
+  cpuCount: number;
+  inputSizeBytes: number;
+  metadata?: Record<string, unknown>;
+  resourceStart?: NodeJS.ResourceUsage;
+}
+
+export interface JobInvocationMetrics {
+  jobId: string;
+  agent: string;
+  startedAt: string;
+  finishedAt: string;
+  wallTimeMs: number;
+  cpuTimeMs: number;
+  cpuUserUs: number;
+  cpuSystemUs: number;
+  cpuCount: number;
+  inputSizeBytes: number;
+  outputSizeBytes: number;
+  estimatedOperations: number;
+  algorithmicComplexity: string;
+  loadAverageStart: LoadAverages;
+  loadAverageEnd: LoadAverages;
+  invocationSuccess: boolean;
+  errorMessage?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EnergyMetricRecord extends JobInvocationMetrics {
+  spanId: string;
+  jobSuccess: boolean;
+  energyEstimate: number;
+  gpuTimeMs: number;
+  memoryRssBytes: number;
+  rewardValue?: number;
+  efficiencyScore?: number;
+  loadAverageDelta: LoadAverages;
+  entropyEstimate?: number;
+  anomalies?: string[];
+  anomalyScore?: number;
+}
+
+interface AgentEfficiencyAggregate {
+  agent: string;
+  jobCount: number;
+  totalEnergy: number;
+  totalEfficiency: number;
+  totalCpuTime: number;
+  totalGpuTime: number;
+  successCount: number;
+  complexityTotal: number;
+  complexitySamples: number;
+  lastUpdated: string | null;
+}
+
+export interface AgentEfficiencyStats {
+  agent: string;
+  jobCount: number;
+  averageEnergy: number;
+  averageEfficiency: number;
+  averageCpuTimeMs: number;
+  averageGpuTimeMs: number;
+  successRate: number;
+  dominantComplexity: string;
+  lastUpdated: string | null;
+}
+
+const agentEfficiencyAggregates = new Map<string, AgentEfficiencyAggregate>();
+let energyMetricsLoaded = false;
+let energyMetricsLoadPromise: Promise<void> | null = null;
+
+function normaliseAgent(agent: string | undefined): string {
+  if (!agent) {
+    return 'unknown';
+  }
+  return agent.toLowerCase();
+}
+
+function complexityIndex(label: string): number {
+  const idx = COMPLEXITY_ORDER.indexOf(label);
+  return idx === -1 ? 0 : idx;
+}
+
+function updateAgentAggregate(record: EnergyMetricRecord): void {
+  const key = normaliseAgent(record.agent);
+  const existing = agentEfficiencyAggregates.get(key);
+  const aggregate: AgentEfficiencyAggregate = existing ?? {
+    agent: key,
+    jobCount: 0,
+    totalEnergy: 0,
+    totalEfficiency: 0,
+    totalCpuTime: 0,
+    totalGpuTime: 0,
+    successCount: 0,
+    complexityTotal: 0,
+    complexitySamples: 0,
+    lastUpdated: null,
+  };
+
+  aggregate.jobCount += 1;
+  if (Number.isFinite(record.energyEstimate)) {
+    aggregate.totalEnergy += record.energyEstimate;
+  }
+  if (Number.isFinite(record.efficiencyScore ?? 0)) {
+    aggregate.totalEfficiency += record.efficiencyScore ?? 0;
+  }
+  if (Number.isFinite(record.cpuTimeMs)) {
+    aggregate.totalCpuTime += record.cpuTimeMs;
+  }
+  if (Number.isFinite(record.gpuTimeMs)) {
+    aggregate.totalGpuTime += record.gpuTimeMs;
+  }
+  if (record.jobSuccess) {
+    aggregate.successCount += 1;
+  }
+  aggregate.complexityTotal += complexityIndex(record.algorithmicComplexity);
+  aggregate.complexitySamples += 1;
+  aggregate.lastUpdated = record.finishedAt || record.startedAt || aggregate.lastUpdated;
+
+  agentEfficiencyAggregates.set(key, aggregate);
+}
+
+async function ensureEnergyMetricsLoaded(): Promise<void> {
+  if (energyMetricsLoaded) {
+    return;
+  }
+  if (energyMetricsLoadPromise) {
+    return energyMetricsLoadPromise;
+  }
+  energyMetricsLoadPromise = (async () => {
+    try {
+      const raw = await fs.promises.readFile(ENERGY_METRICS_PATH, 'utf8');
+      if (!raw) {
+        return;
+      }
+      const lines = raw
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      for (const line of lines) {
+        try {
+          const parsed = JSON.parse(line) as EnergyMetricRecord;
+          if (parsed && parsed.agent) {
+            updateAgentAggregate(parsed);
+          }
+        } catch (err) {
+          console.warn('Skipping malformed energy metric entry', err);
+        }
+      }
+    } catch (err: any) {
+      if (err.code !== 'ENOENT') {
+        console.warn('Failed to load energy metrics history', err);
+      }
+    } finally {
+      energyMetricsLoaded = true;
+      energyMetricsLoadPromise = null;
+    }
+  })();
+  return energyMetricsLoadPromise;
+}
+
+async function appendEnergyMetric(record: EnergyMetricRecord): Promise<void> {
+  await ensureEnergyMetricsLoaded();
+  updateAgentAggregate(record);
+  ensureDir(path.dirname(ENERGY_METRICS_PATH));
+  await fs.promises.appendFile(
+    ENERGY_METRICS_PATH,
+    `${JSON.stringify(record)}\n`,
+    'utf8'
+  );
+}
+
+function mergeMetadata(
+  ...entries: Array<Record<string, unknown> | undefined>
+): Record<string, unknown> | undefined {
+  const merged: Record<string, unknown> = {};
+  for (const entry of entries) {
+    if (!entry) continue;
+    for (const [key, value] of Object.entries(entry)) {
+      if (value === undefined) continue;
+      merged[key] = value;
+    }
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function computeLoadDelta(
+  start: LoadAverages,
+  end: LoadAverages
+): LoadAverages {
+  return [
+    Number((end[0] || 0) - (start[0] || 0)),
+    Number((end[1] || 0) - (start[1] || 0)),
+    Number((end[2] || 0) - (start[2] || 0)),
+  ];
+}
+
+export function startJobInvocationMetrics(options: {
+  jobId: string;
+  agent: string;
+  payload: unknown;
+  metadata?: Record<string, unknown>;
+}): JobInvocationSpan {
+  return {
+    jobId: options.jobId,
+    agent: options.agent,
+    startedAt: new Date().toISOString(),
+    cpuStart: process.cpuUsage(),
+    hrtimeStart: process.hrtime.bigint(),
+    loadAverageStart: readLoadAverage(),
+    cpuCount: os.cpus()?.length ?? 1,
+    inputSizeBytes: estimateSize(options.payload),
+    metadata: options.metadata,
+    resourceStart:
+      typeof process.resourceUsage === 'function'
+        ? process.resourceUsage()
+        : undefined,
+  };
+}
+
+export function finishJobInvocationMetrics(
+  span: JobInvocationSpan,
+  options: {
+    output: unknown;
+    success: boolean;
+    error?: Error;
+    metadata?: Record<string, unknown>;
+  }
+): JobInvocationMetrics {
+  const cpu = process.cpuUsage(span.cpuStart);
+  const durationNs = process.hrtime.bigint() - span.hrtimeStart;
+  const wallTimeMs = Number(durationNs) / 1_000_000;
+  const outputSizeBytes = estimateSize(options.output);
+  const complexity = estimateAlgorithmicComplexity(
+    (cpu.user + cpu.system) / 1000,
+    0,
+    span.inputSizeBytes,
+    outputSizeBytes,
+    span.cpuCount
+  );
+  const loadAverageEnd = readLoadAverage();
+  const metadata = mergeMetadata(span.metadata, options.metadata);
+
+  return {
+    jobId: span.jobId,
+    agent: span.agent,
+    startedAt: span.startedAt,
+    finishedAt: new Date().toISOString(),
+    wallTimeMs,
+    cpuTimeMs: (cpu.user + cpu.system) / 1000,
+    cpuUserUs: cpu.user,
+    cpuSystemUs: cpu.system,
+    cpuCount: span.cpuCount,
+    inputSizeBytes: span.inputSizeBytes,
+    outputSizeBytes,
+    estimatedOperations: complexity.estimatedOperations,
+    algorithmicComplexity: complexity.algorithmicComplexity,
+    loadAverageStart: span.loadAverageStart,
+    loadAverageEnd,
+    invocationSuccess: options.success,
+    errorMessage: options.error?.message,
+    metadata,
+  };
+}
+
+export async function recordJobEnergyMetrics(params: {
+  invocation: JobInvocationMetrics;
+  energy: EnergySample;
+  rewardValue?: number;
+  jobSuccess: boolean;
+  metadata?: Record<string, unknown>;
+}): Promise<EnergyMetricRecord> {
+  await ensureEnergyMetricsLoaded();
+  const reward = params.rewardValue ?? params.energy.rewardValue;
+  const energyEstimate = Number(params.energy.energyEstimate ?? 0);
+  const gpuTimeMs = Number(params.energy.gpuTimeMs ?? 0);
+  const efficiencyScore =
+    reward && energyEstimate > 0
+      ? reward / Math.max(1, energyEstimate)
+      : undefined;
+
+  const complexity = estimateAlgorithmicComplexity(
+    params.invocation.cpuTimeMs,
+    gpuTimeMs,
+    params.invocation.inputSizeBytes,
+    params.invocation.outputSizeBytes,
+    params.invocation.cpuCount
+  );
+
+  const loadAverageDelta = computeLoadDelta(
+    params.invocation.loadAverageStart,
+    params.invocation.loadAverageEnd
+  );
+
+  const metadata = mergeMetadata(
+    params.invocation.metadata,
+    params.metadata,
+    params.energy.metadata
+  );
+
+  const record: EnergyMetricRecord = {
+    ...params.invocation,
+    algorithmicComplexity: complexity.algorithmicComplexity,
+    estimatedOperations: complexity.estimatedOperations,
+    spanId: params.energy.spanId,
+    jobSuccess: params.jobSuccess,
+    energyEstimate,
+    gpuTimeMs,
+    memoryRssBytes: Number(params.energy.memoryRssBytes ?? 0),
+    rewardValue:
+      reward && Number.isFinite(reward) && reward > 0 ? reward : undefined,
+    efficiencyScore,
+    loadAverageDelta,
+    entropyEstimate: params.energy.entropyEstimate,
+    anomalies: params.energy.anomalies,
+    anomalyScore: params.energy.anomalyScore,
+    metadata,
+  };
+
+  await appendEnergyMetric(record);
+  return record;
+}
+
+export async function getAgentEfficiencyStats(): Promise<
+  Map<string, AgentEfficiencyStats>
+> {
+  await ensureEnergyMetricsLoaded();
+  const snapshot = new Map<string, AgentEfficiencyStats>();
+  for (const [agent, aggregate] of agentEfficiencyAggregates.entries()) {
+    const jobCount = aggregate.jobCount;
+    const averageEnergy =
+      jobCount > 0 ? aggregate.totalEnergy / jobCount : 0;
+    const averageEfficiency =
+      jobCount > 0 ? aggregate.totalEfficiency / jobCount : 0;
+    const averageCpuTimeMs =
+      jobCount > 0 ? aggregate.totalCpuTime / jobCount : 0;
+    const averageGpuTimeMs =
+      jobCount > 0 ? aggregate.totalGpuTime / jobCount : 0;
+    const successRate =
+      jobCount > 0 ? aggregate.successCount / jobCount : 0;
+    const complexityAverageIndex =
+      aggregate.complexitySamples > 0
+        ? aggregate.complexityTotal / aggregate.complexitySamples
+        : 0;
+    const complexityLabel =
+      COMPLEXITY_ORDER[
+        Math.min(
+          COMPLEXITY_ORDER.length - 1,
+          Math.max(0, Math.round(complexityAverageIndex))
+        )
+      ] || COMPLEXITY_ORDER[0];
+
+    snapshot.set(agent, {
+      agent,
+      jobCount,
+      averageEnergy,
+      averageEfficiency,
+      averageCpuTimeMs,
+      averageGpuTimeMs,
+      successRate,
+      dominantComplexity: complexityLabel,
+      lastUpdated: aggregate.lastUpdated,
+    });
+  }
+  return snapshot;
+}
 
 export interface TelemetryEnvelope {
   samples: EnergySample[];

--- a/scripts/energy-dashboard.ts
+++ b/scripts/energy-dashboard.ts
@@ -104,13 +104,16 @@ async function readMetricsFile(): Promise<EnergyMetricRecord[]> {
 }
 
 function summariseAgents(records: EnergyMetricRecord[]): AgentRow[] {
-  const aggregates = new Map<string, AgentRow & {
-    totalEnergy: number;
-    totalEfficiency: number;
-    totalCpuMs: number;
-    totalGpuMs: number;
-    successCount: number;
-  }>();
+  const aggregates = new Map<
+    string,
+    AgentRow & {
+      totalEnergy: number;
+      totalEfficiency: number;
+      totalCpuMs: number;
+      totalGpuMs: number;
+      successCount: number;
+    }
+  >();
   for (const record of records) {
     const key = record.agent.toLowerCase();
     if (!aggregates.has(key)) {
@@ -148,7 +151,10 @@ function summariseAgents(records: EnergyMetricRecord[]): AgentRow[] {
       aggregate.successCount += 1;
     }
     const timestamp = record.finishedAt || record.startedAt;
-    if (timestamp && (!aggregate.lastUpdated || timestamp > aggregate.lastUpdated)) {
+    if (
+      timestamp &&
+      (!aggregate.lastUpdated || timestamp > aggregate.lastUpdated)
+    ) {
       aggregate.lastUpdated = timestamp;
     }
   }
@@ -225,11 +231,15 @@ function printRecent(records: EnergyMetricRecord[], options: CliOptions): void {
       ? (record.efficiencyScore ?? 0).toFixed(3)
       : '0.000';
     console.log(
-      `- [${record.finishedAt}] job=${record.jobId} agent=${record.agent} energy=${formatEnergy(
+      `- [${record.finishedAt}] job=${record.jobId} agent=${
+        record.agent
+      } energy=${formatEnergy(
         record.energyEstimate
-      )} efficiency=${efficiency} complexity=${record.algorithmicComplexity} cpuMs=${record.cpuTimeMs.toFixed(
+      )} efficiency=${efficiency} complexity=${
+        record.algorithmicComplexity
+      } cpuMs=${record.cpuTimeMs.toFixed(1)} gpuMs=${record.gpuTimeMs.toFixed(
         1
-      )} gpuMs=${record.gpuTimeMs.toFixed(1)}`
+      )}`
     );
   }
 }

--- a/scripts/energy-dashboard.ts
+++ b/scripts/energy-dashboard.ts
@@ -1,0 +1,254 @@
+import fs from 'fs';
+import path from 'path';
+
+interface EnergyMetricRecord {
+  jobId: string;
+  agent: string;
+  startedAt: string;
+  finishedAt: string;
+  wallTimeMs: number;
+  cpuTimeMs: number;
+  cpuUserUs: number;
+  cpuSystemUs: number;
+  cpuCount: number;
+  inputSizeBytes: number;
+  outputSizeBytes: number;
+  estimatedOperations: number;
+  algorithmicComplexity: string;
+  loadAverageStart: [number, number, number];
+  loadAverageEnd: [number, number, number];
+  invocationSuccess: boolean;
+  errorMessage?: string;
+  metadata?: Record<string, unknown>;
+  spanId: string;
+  jobSuccess: boolean;
+  energyEstimate: number;
+  gpuTimeMs: number;
+  memoryRssBytes: number;
+  rewardValue?: number;
+  efficiencyScore?: number;
+  loadAverageDelta: [number, number, number];
+  entropyEstimate?: number;
+  anomalies?: string[];
+  anomalyScore?: number;
+}
+
+interface AgentRow {
+  agent: string;
+  jobs: number;
+  avgEnergy: number;
+  avgEfficiency: number;
+  avgCpuMs: number;
+  avgGpuMs: number;
+  successRate: number;
+  lastUpdated: string | null;
+}
+
+interface CliOptions {
+  tail: number;
+  agent?: string;
+}
+
+const METRICS_PATH = path.resolve(__dirname, '../data/energy-metrics.jsonl');
+
+function parseArgs(argv: string[]): CliOptions {
+  let tail = 10;
+  let agent: string | undefined;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--tail' || arg === '-t') {
+      const value = argv[i + 1];
+      if (value) {
+        const parsed = Number.parseInt(value, 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          tail = parsed;
+        }
+        i += 1;
+      }
+    } else if (arg === '--agent' || arg === '-a') {
+      const value = argv[i + 1];
+      if (value) {
+        agent = value.toLowerCase();
+        i += 1;
+      }
+    }
+  }
+  return { tail, agent };
+}
+
+async function readMetricsFile(): Promise<EnergyMetricRecord[]> {
+  try {
+    const raw = await fs.promises.readFile(METRICS_PATH, 'utf8');
+    const lines = raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    const records: EnergyMetricRecord[] = [];
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line) as EnergyMetricRecord;
+        if (parsed?.jobId && parsed?.agent) {
+          records.push(parsed);
+        }
+      } catch (err) {
+        console.warn('Skipping malformed metric line', err);
+      }
+    }
+    return records;
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+}
+
+function summariseAgents(records: EnergyMetricRecord[]): AgentRow[] {
+  const aggregates = new Map<string, AgentRow & {
+    totalEnergy: number;
+    totalEfficiency: number;
+    totalCpuMs: number;
+    totalGpuMs: number;
+    successCount: number;
+  }>();
+  for (const record of records) {
+    const key = record.agent.toLowerCase();
+    if (!aggregates.has(key)) {
+      aggregates.set(key, {
+        agent: key,
+        jobs: 0,
+        avgEnergy: 0,
+        avgEfficiency: 0,
+        avgCpuMs: 0,
+        avgGpuMs: 0,
+        successRate: 0,
+        lastUpdated: null,
+        totalEnergy: 0,
+        totalEfficiency: 0,
+        totalCpuMs: 0,
+        totalGpuMs: 0,
+        successCount: 0,
+      });
+    }
+    const aggregate = aggregates.get(key)!;
+    aggregate.jobs += 1;
+    if (Number.isFinite(record.energyEstimate)) {
+      aggregate.totalEnergy += record.energyEstimate;
+    }
+    if (Number.isFinite(record.efficiencyScore ?? 0)) {
+      aggregate.totalEfficiency += record.efficiencyScore ?? 0;
+    }
+    if (Number.isFinite(record.cpuTimeMs)) {
+      aggregate.totalCpuMs += record.cpuTimeMs;
+    }
+    if (Number.isFinite(record.gpuTimeMs)) {
+      aggregate.totalGpuMs += record.gpuTimeMs;
+    }
+    if (record.jobSuccess) {
+      aggregate.successCount += 1;
+    }
+    const timestamp = record.finishedAt || record.startedAt;
+    if (timestamp && (!aggregate.lastUpdated || timestamp > aggregate.lastUpdated)) {
+      aggregate.lastUpdated = timestamp;
+    }
+  }
+
+  return Array.from(aggregates.values()).map((aggregate) => {
+    const jobs = aggregate.jobs || 1;
+    return {
+      agent: aggregate.agent,
+      jobs: aggregate.jobs,
+      avgEnergy: aggregate.totalEnergy / jobs,
+      avgEfficiency: aggregate.totalEfficiency / jobs,
+      avgCpuMs: aggregate.totalCpuMs / jobs,
+      avgGpuMs: aggregate.totalGpuMs / jobs,
+      successRate: aggregate.successCount / jobs,
+      lastUpdated: aggregate.lastUpdated,
+    };
+  });
+}
+
+function formatPercentage(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '0.0%';
+  }
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatEnergy(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '0.00';
+  }
+  return value.toFixed(2);
+}
+
+function printAgentTable(rows: AgentRow[]): void {
+  if (rows.length === 0) {
+    console.log('No agent efficiency statistics recorded yet.');
+    return;
+  }
+  const table = rows
+    .sort((a, b) => a.avgEnergy - b.avgEnergy)
+    .map((row) => ({
+      Agent: row.agent,
+      Jobs: row.jobs,
+      'Avg Energy': formatEnergy(row.avgEnergy),
+      'Avg Efficiency': row.avgEfficiency.toFixed(3),
+      'CPU ms': row.avgCpuMs.toFixed(1),
+      'GPU ms': row.avgGpuMs.toFixed(1),
+      'Success Rate': formatPercentage(row.successRate),
+      Updated: row.lastUpdated ?? '-',
+    }));
+  console.table(table);
+}
+
+function printRecent(records: EnergyMetricRecord[], options: CliOptions): void {
+  if (records.length === 0) {
+    console.log('No job execution metrics recorded yet.');
+    return;
+  }
+  const filtered = options.agent
+    ? records.filter((record) => record.agent.toLowerCase() === options.agent)
+    : records;
+  if (filtered.length === 0) {
+    console.log(`No runs recorded for agent ${options.agent}`);
+    return;
+  }
+  const tail = options.tail > 0 ? filtered.slice(-options.tail) : filtered;
+  console.log(
+    `Most recent ${tail.length} runs${
+      options.agent ? ` for ${options.agent}` : ''
+    }:`
+  );
+  for (const record of tail) {
+    const efficiency = Number.isFinite(record.efficiencyScore ?? 0)
+      ? (record.efficiencyScore ?? 0).toFixed(3)
+      : '0.000';
+    console.log(
+      `- [${record.finishedAt}] job=${record.jobId} agent=${record.agent} energy=${formatEnergy(
+        record.energyEstimate
+      )} efficiency=${efficiency} complexity=${record.algorithmicComplexity} cpuMs=${record.cpuTimeMs.toFixed(
+        1
+      )} gpuMs=${record.gpuTimeMs.toFixed(1)}`
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const records = await readMetricsFile();
+  if (records.length === 0) {
+    console.log('No thermodynamic metrics have been captured yet.');
+    console.log(`Expected log file at ${METRICS_PATH}`);
+    return;
+  }
+  console.log('Thermodynamic efficiency snapshot by agent:');
+  printAgentTable(summariseAgents(records));
+  console.log('');
+  printRecent(records, options);
+}
+
+main().catch((err) => {
+  console.error('Failed to render energy dashboard', err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- extend the gateway telemetry layer with CPU/GPU span tracking, efficiency aggregation, and JSONL persistence
- instrument agent execution to capture invocation metrics, compute reward/energy efficiency, and forward data to the telemetry index
- prefer low-energy agents when selecting job runners, add an energy metrics dashboard script, and document the thermodynamic incentives pipeline

## Testing
- npm run build:gateway

------
https://chatgpt.com/codex/tasks/task_e_68c98d2d00c88333bdaeb123569dd2fe