### PR TITLE
Add audit anchoring service and REST controls

### DIFF
--- a/agent-gateway/README.md
+++ b/agent-gateway/README.md
@@ -17,6 +17,9 @@ Job financial fields (`reward`, `stake`, and `fee`) are broadcast using `ethers.
 - `ENERGY_ORACLE_URL` endpoint that accepts telemetry payloads (optional – required for operator rewards)
 - `ENERGY_ORACLE_TOKEN` bearer token when publishing telemetry to the oracle (optional)
 - `ENERGY_ORACLE_REQUIRE_SIGNATURE` set to `true` to require cryptographic signing of telemetry payloads; when enabled the orchestrator wallet must own an ENS name under `*.a.agi.eth`
+- `AUDIT_ANCHOR_INTERVAL_MS` cadence for Merkle anchoring the audit log (default `21600000`, i.e. 6 hours)
+- `AUDIT_ANCHOR_MIN_NEW_EVENTS` minimum number of new audit records required before an automated anchor is attempted (default `5`)
+- `AUDIT_ANCHOR_START_DELAY_MS` optional delay before the first anchoring cycle begins (default `0`)
 
 Copy `.env.example` to `.env` and adjust values for your network:
 
@@ -94,6 +97,8 @@ POST /jobs/:id/reveal { address }
 GET  /health
 GET  /efficiency
 GET  /efficiency/:agent[?category=categoryKey]
+GET  /audit/anchors[?limit=25]
+POST /audit/anchors { force?, minNewEvents? }
 ```
 
 The `/efficiency` endpoints expose thermodynamic efficiency analytics derived
@@ -103,5 +108,13 @@ provides an individual breakdown. When a `category` query parameter is
 present, the gateway responds with the metrics for that specialised domain –
 for example, `validation` or a custom agent discipline. ENS names can be used
 in place of raw addresses and are resolved automatically before lookup.
+
+The `/audit/anchors` endpoints manage the Merkle anchoring cadence for the
+gateway's structured audit log. `GET /audit/anchors` returns the recorded
+anchors (newest last) alongside scheduler telemetry, while the authenticated
+`POST /audit/anchors` route forces an anchor cycle or adjusts the minimum
+number of new events required for that cycle. Anchoring requests sign the
+Merkle root with the orchestrator wallet so downstream auditors can verify
+lineage without trusting the gateway.
 
 See `../examples` for SDK usage in Python and TypeScript.

--- a/agent-gateway/auditAnchoring.ts
+++ b/agent-gateway/auditAnchoring.ts
@@ -1,0 +1,258 @@
+import {
+  anchorAuditTrail,
+  readAuditEvents,
+  readAuditAnchors,
+  type AuditAnchorRecord,
+} from '../shared/auditLogger';
+import { secureLogAction } from './security';
+import { orchestratorWallet } from './utils';
+
+function ensureNonNegativeInt(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  if (value < 0) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+const DEFAULT_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const ANCHOR_INTERVAL_MS = ensureNonNegativeInt(
+  Number(process.env.AUDIT_ANCHOR_INTERVAL_MS ?? String(DEFAULT_INTERVAL_MS)),
+  DEFAULT_INTERVAL_MS
+);
+const MIN_NEW_EVENTS_DEFAULT = ensureNonNegativeInt(
+  Number(process.env.AUDIT_ANCHOR_MIN_NEW_EVENTS ?? '5'),
+  1
+);
+const START_DELAY_MS = ensureNonNegativeInt(
+  Number(process.env.AUDIT_ANCHOR_START_DELAY_MS ?? '0'),
+  0
+);
+
+interface TriggerOptions {
+  force?: boolean;
+  minNewEvents?: number;
+}
+
+let anchorTimer: NodeJS.Timeout | null = null;
+let initialTimer: NodeJS.Timeout | null = null;
+let pending: Promise<AuditAnchorRecord | null> | null = null;
+let lastAnchor: AuditAnchorRecord | null = null;
+let lastError: string | null = null;
+let lastSkipReason: string | null = null;
+let lastRunAt: number | null = null;
+let nextRunAt: number | null = null;
+let warnedNoWallet = false;
+
+void readAuditAnchors(1)
+  .then((records) => {
+    if (records.length > 0) {
+      lastAnchor = records[records.length - 1];
+    }
+  })
+  .catch((err) => console.warn('Failed to load last audit anchor', err));
+
+function ensureMinEvents(value: number | undefined): number {
+  if (!Number.isFinite(value)) {
+    return MIN_NEW_EVENTS_DEFAULT;
+  }
+  return Math.max(0, Math.floor(Number(value)));
+}
+
+function scheduleNextRun(base: number): void {
+  if (ANCHOR_INTERVAL_MS > 0) {
+    nextRunAt = base + ANCHOR_INTERVAL_MS;
+  } else {
+    nextRunAt = null;
+  }
+}
+
+export interface AuditAnchoringState {
+  enabled: boolean;
+  intervalMs: number;
+  minNewEvents: number;
+  lastRunAt: string | null;
+  nextRunAt: string | null;
+  pending: boolean;
+  lastError: string | null;
+  lastSkipReason: string | null;
+  lastAnchor: AuditAnchorRecord | null;
+}
+
+export function getAuditAnchoringState(): AuditAnchoringState {
+  return {
+    enabled: ANCHOR_INTERVAL_MS > 0,
+    intervalMs: ANCHOR_INTERVAL_MS,
+    minNewEvents: MIN_NEW_EVENTS_DEFAULT,
+    lastRunAt: lastRunAt ? new Date(lastRunAt).toISOString() : null,
+    nextRunAt: nextRunAt ? new Date(nextRunAt).toISOString() : null,
+    pending: Boolean(pending),
+    lastError,
+    lastSkipReason,
+    lastAnchor,
+  };
+}
+
+async function performAnchor(
+  options: Required<Pick<TriggerOptions, 'force'>> & {
+    minNewEvents: number;
+  }
+): Promise<AuditAnchorRecord | null> {
+  const wallet = orchestratorWallet;
+  if (!wallet) {
+    lastSkipReason = 'wallet-unavailable';
+    lastError = 'No orchestrator wallet configured for audit anchoring';
+    if (!warnedNoWallet) {
+      console.warn(lastError);
+      warnedNoWallet = true;
+    }
+    if (options.force) {
+      throw new Error(lastError);
+    }
+    return null;
+  }
+  warnedNoWallet = false;
+
+  const events = await readAuditEvents();
+  if (!options.force && events.length === 0) {
+    lastSkipReason = 'no-events';
+    lastError = null;
+    return null;
+  }
+
+  const previous = await readAuditAnchors(1);
+  if (previous.length > 0 && !lastAnchor) {
+    lastAnchor = previous[previous.length - 1];
+  }
+  const baseline =
+    previous.length > 0 ? previous[previous.length - 1].count : 0;
+  const newEvents = Math.max(0, events.length - baseline);
+  if (!options.force && newEvents < options.minNewEvents) {
+    lastSkipReason = 'insufficient-new-events';
+    lastError = null;
+    return null;
+  }
+
+  const record = await anchorAuditTrail(wallet, events);
+  lastAnchor = record;
+  lastError = null;
+  lastSkipReason = null;
+
+  try {
+    await secureLogAction(
+      {
+        component: 'audit',
+        action: 'anchor',
+        success: true,
+        metadata: {
+          merkleRoot: record.merkleRoot,
+          digest: record.digest,
+          count: record.count,
+        },
+      },
+      wallet
+    );
+  } catch (err) {
+    console.warn('Failed to record audit anchor event', err);
+  }
+
+  return record;
+}
+
+export async function triggerAuditAnchor(
+  options: TriggerOptions = {}
+): Promise<AuditAnchorRecord | null> {
+  if (pending) {
+    return pending;
+  }
+  const force = Boolean(options.force);
+  const minNewEvents = force ? 0 : ensureMinEvents(options.minNewEvents);
+  const runTimestamp = Date.now();
+  lastRunAt = runTimestamp;
+  scheduleNextRun(runTimestamp);
+
+  pending = performAnchor({ force, minNewEvents })
+    .catch(async (err) => {
+      const error = err instanceof Error ? err.message : String(err);
+      lastError = error;
+      lastSkipReason = null;
+      const wallet = orchestratorWallet;
+      try {
+        await secureLogAction(
+          {
+            component: 'audit',
+            action: 'anchor',
+            success: false,
+            metadata: { error },
+          },
+          wallet
+        );
+      } catch (logErr) {
+        console.warn('Failed to log audit anchor failure', logErr);
+      }
+      throw err;
+    })
+    .finally(() => {
+      pending = null;
+    });
+
+  const inflight = pending!;
+  return inflight;
+}
+
+export async function startAuditAnchoringService(): Promise<void> {
+  if (ANCHOR_INTERVAL_MS <= 0) {
+    console.warn(
+      'Audit anchoring service disabled; set AUDIT_ANCHOR_INTERVAL_MS to a positive value to enable periodic anchoring.'
+    );
+    nextRunAt = null;
+    return;
+  }
+  if (anchorTimer) {
+    return;
+  }
+
+  const schedule = () => {
+    triggerAuditAnchor().catch((err) =>
+      console.warn('audit anchor execution failed', err)
+    );
+  };
+
+  if (START_DELAY_MS === 0) {
+    schedule();
+  } else {
+    nextRunAt = Date.now() + START_DELAY_MS;
+    initialTimer = setTimeout(() => {
+      initialTimer = null;
+      schedule();
+    }, START_DELAY_MS);
+  }
+
+  anchorTimer = setInterval(() => {
+    schedule();
+  }, ANCHOR_INTERVAL_MS);
+}
+
+export function stopAuditAnchoringService(): void {
+  if (anchorTimer) {
+    clearInterval(anchorTimer);
+    anchorTimer = null;
+  }
+  if (initialTimer) {
+    clearTimeout(initialTimer);
+    initialTimer = null;
+  }
+  nextRunAt = null;
+}
+
+export async function listAuditAnchors(
+  limit?: number
+): Promise<AuditAnchorRecord[]> {
+  const records = await readAuditAnchors(limit);
+  if (records.length > 0) {
+    lastAnchor = records[records.length - 1];
+  }
+  return records;
+}

--- a/agent-gateway/index.ts
+++ b/agent-gateway/index.ts
@@ -12,6 +12,10 @@ import {
 import { registerEvents } from './events';
 import { handleJobCreatedEvent } from './orchestrator';
 import { startTelemetryService, stopTelemetryService } from './telemetry';
+import {
+  startAuditAnchoringService,
+  stopAuditAnchoringService,
+} from './auditAnchoring';
 
 let server: http.Server;
 let wss: WebSocketServer;
@@ -20,6 +24,7 @@ async function startGateway(): Promise<void> {
   await verifyTokenDecimals();
   await initWallets();
   await startTelemetryService();
+  await startAuditAnchoringService();
 
   server = http.createServer(app);
   wss = new WebSocketServer({ server });
@@ -44,6 +49,7 @@ function shutdown(): void {
   if (wss) wss.close();
   stopSweeper();
   stopTelemetryService();
+  stopAuditAnchoringService();
   if (server) {
     server.close(() => process.exit(0));
   } else {


### PR DESCRIPTION
## Summary
- add an audit anchoring service that periodically signs and persists Merkle roots for the structured audit log
- expose GET/POST `/audit/anchors` routes and start/stop the anchoring scheduler with the gateway lifecycle
- enhance audit logging utilities to sign anchor payloads, surface stored anchors, and document the new configuration knobs

## Testing
- npm run lint
- npm run build:gateway

------
https://chatgpt.com/codex/tasks/task_e_68c9baaacf148333bfeec80c1fb127c4