### PR TITLE
Add learning pipeline logging, agent cloning workflow, and retraining tooling

### DIFF
--- a/agent-gateway/agentFactory.ts
+++ b/agent-gateway/agentFactory.ts
@@ -1,4 +1,7 @@
-import { listAgentProfiles } from './agentRegistry';
+import fs from 'fs';
+import path from 'path';
+import { listAgentProfiles, type AgentProfile } from './agentRegistry';
+import { registerIdentityFile } from './identity';
 import { secureLogAction } from './security';
 import {
   listSpawnCandidates,
@@ -7,6 +10,7 @@ import {
   type AgentBlueprint,
   spawnDefaults,
 } from '../shared/spawnManager';
+import { walletManager } from './utils';
 
 export interface SpawnCandidateReport extends SpawnCandidate {
   existingAgents: number;
@@ -22,6 +26,68 @@ export interface SpawnBlueprintOptions {
   markConsumed?: boolean;
   includeSaturated?: boolean;
   blueprintDir?: string;
+}
+
+const IDENTITY_DIR = path.resolve(__dirname, '../config/agents');
+const SANDBOX_DIR = path.resolve(__dirname, '../storage/sandbox');
+const DEFAULT_OBSERVATION_THRESHOLD = Number(
+  process.env.AGENT_FACTORY_OBSERVATION_THRESHOLD || '4'
+);
+const DEFAULT_SANDBOX_ENERGY_LIMIT = Number(
+  process.env.AGENT_FACTORY_SANDBOX_MAX_ENERGY || '250000'
+);
+
+interface SampleJobDefinition {
+  id: string;
+  description: string;
+  category: string;
+  reward: number;
+  energyBudget: number;
+  requiredSkills: string[];
+}
+
+interface SandboxScenarioResult {
+  job: SampleJobDefinition;
+  passed: boolean;
+  reasons: string[];
+  metrics: {
+    skillCoverage: number;
+    averageEnergy: number;
+    energyBudget: number;
+    averageReward: number;
+  };
+}
+
+interface SandboxReport {
+  blueprintId: string;
+  blueprintCategory: string;
+  runAt: string;
+  passed: boolean;
+  template?: {
+    address: string;
+    label?: string;
+    successRate: number;
+  } | null;
+  results: SandboxScenarioResult[];
+  reportPath?: string;
+}
+
+export interface CloneAgentOptions extends SpawnBlueprintOptions {
+  threshold?: number;
+  identityDir?: string;
+  sandboxDir?: string;
+  allowSandboxFailure?: boolean;
+  dryRun?: boolean;
+  notes?: string[];
+}
+
+export interface CloneAgentOutcome {
+  blueprint: AgentBlueprint;
+  template?: AgentProfile | null;
+  sandbox: SandboxReport;
+  identityPath?: string;
+  walletAddress?: string;
+  enabled: boolean;
 }
 
 function toKey(value: string): string {
@@ -133,6 +199,411 @@ export async function createSpawnBlueprint(
   });
 
   return blueprint;
+}
+
+function ensureDir(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+async function selectTemplateProfile(
+  categoryKey: string
+): Promise<AgentProfile | null> {
+  const profiles = await listAgentProfiles();
+  let best: AgentProfile | null = null;
+  for (const profile of profiles) {
+    for (const category of profile.categories) {
+      if (toKey(category) !== categoryKey) continue;
+      if (!best || profile.successRate > best.successRate) {
+        best = profile;
+      }
+    }
+  }
+  return best;
+}
+
+function buildSampleJobs(
+  blueprint: AgentBlueprint,
+  template: AgentProfile | null
+): SampleJobDefinition[] {
+  const averageReward = Number.parseFloat(
+    blueprint.metrics.averageReward || '0'
+  );
+  const rewardBaseline = Number.isFinite(averageReward)
+    ? Math.max(averageReward, 1)
+    : 1;
+  const averageEnergy = Number.isFinite(blueprint.metrics.averageEnergy)
+    ? Number(blueprint.metrics.averageEnergy)
+    : 0;
+  const skillSet = template?.skills ?? [];
+  const category = blueprint.category;
+  const energyBudget =
+    averageEnergy > 0 ? averageEnergy * 1.5 : DEFAULT_SANDBOX_ENERGY_LIMIT;
+  const stressBudget =
+    averageEnergy > 0 ? averageEnergy * 2 : DEFAULT_SANDBOX_ENERGY_LIMIT * 1.25;
+  return [
+    {
+      id: `${blueprint.categoryKey}-baseline`,
+      description: `Baseline capability check for ${category}`,
+      category,
+      reward: rewardBaseline,
+      energyBudget: Math.min(DEFAULT_SANDBOX_ENERGY_LIMIT, energyBudget),
+      requiredSkills: skillSet.slice(0, 3),
+    },
+    {
+      id: `${blueprint.categoryKey}-stress`,
+      description: `Stress scenario for ${category}`,
+      category,
+      reward: rewardBaseline * 1.2 + 1,
+      energyBudget: Math.min(DEFAULT_SANDBOX_ENERGY_LIMIT * 1.5, stressBudget),
+      requiredSkills: skillSet.slice(0, 2),
+    },
+  ];
+}
+
+function evaluateSampleJob(
+  job: SampleJobDefinition,
+  blueprint: AgentBlueprint,
+  template: AgentProfile | null
+): SandboxScenarioResult {
+  const reasons: string[] = [];
+  const availableSkills = new Set<string>();
+  if (template) {
+    for (const skill of template.skills) {
+      availableSkills.add(skill.toLowerCase());
+    }
+    for (const category of template.categories) {
+      availableSkills.add(category.toLowerCase());
+    }
+  }
+
+  let matchedSkills = 0;
+  for (const skill of job.requiredSkills) {
+    if (availableSkills.has(skill.toLowerCase())) {
+      matchedSkills += 1;
+    }
+  }
+  let skillCoverage = job.requiredSkills.length
+    ? matchedSkills / job.requiredSkills.length
+    : template
+    ? 1
+    : 0;
+
+  if (job.requiredSkills.length > 0) {
+    if (!template) {
+      reasons.push('No template agent available for skill benchmarking');
+    } else if (matchedSkills < job.requiredSkills.length) {
+      reasons.push(
+        `Template missing ${job.requiredSkills.length - matchedSkills} of ${
+          job.requiredSkills.length
+        } required skills`
+      );
+    }
+  }
+
+  if (template) {
+    const templateCategories = new Set(
+      template.categories.map((category) => category.toLowerCase())
+    );
+    if (!templateCategories.has(job.category.toLowerCase())) {
+      reasons.push(`Template agent has no history in ${job.category}`);
+    }
+  } else {
+    reasons.push('Template agent unavailable for category transfer');
+  }
+
+  const averageEnergy = Number.isFinite(blueprint.metrics.averageEnergy)
+    ? Number(blueprint.metrics.averageEnergy)
+    : 0;
+  if (job.energyBudget > 0 && averageEnergy > job.energyBudget) {
+    reasons.push(
+      `Projected energy ${averageEnergy.toFixed(
+        2
+      )} exceeds sandbox budget ${job.energyBudget.toFixed(2)}`
+    );
+  }
+
+  const averageReward =
+    Number.parseFloat(blueprint.metrics.averageReward || '0') || 0;
+  if (job.reward > 0 && averageReward < job.reward * 0.5) {
+    reasons.push('Historical reward too low for sample economic constraints');
+  }
+
+  return {
+    job,
+    passed: reasons.length === 0,
+    reasons,
+    metrics: {
+      skillCoverage: Number(skillCoverage.toFixed(3)),
+      averageEnergy,
+      energyBudget: job.energyBudget,
+      averageReward,
+    },
+  };
+}
+
+function runSandboxTrials(
+  blueprint: AgentBlueprint,
+  template: AgentProfile | null
+): SandboxReport {
+  const jobs = buildSampleJobs(blueprint, template);
+  const results = jobs.map((job) =>
+    evaluateSampleJob(job, blueprint, template)
+  );
+  const runAt = new Date().toISOString();
+  const passed = results.every((result) => result.passed);
+  return {
+    blueprintId: blueprint.id,
+    blueprintCategory: blueprint.category,
+    runAt,
+    passed,
+    template: template
+      ? {
+          address: template.address,
+          label: template.label,
+          successRate: template.successRate,
+        }
+      : null,
+    results,
+  };
+}
+
+function sandboxReportFilename(report: SandboxReport): string {
+  const timestamp = report.runAt.replace(/[:]/g, '-');
+  const categorySlug = report.blueprintCategory
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-');
+  const idFragment = report.blueprintId.slice(0, 8);
+  return `${timestamp}-${categorySlug || 'agent'}-${idFragment}.json`;
+}
+
+async function persistSandboxReport(
+  report: SandboxReport,
+  dir = SANDBOX_DIR
+): Promise<string> {
+  ensureDir(dir);
+  const filePath = path.join(dir, sandboxReportFilename(report));
+  await fs.promises.writeFile(
+    filePath,
+    JSON.stringify(report, null, 2),
+    'utf8'
+  );
+  return filePath;
+}
+
+function pruneUndefined(
+  input: Record<string, unknown>
+): Record<string, unknown> {
+  const output: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null) continue;
+    output[key] = value;
+  }
+  return output;
+}
+
+async function persistIdentityRecord(
+  blueprint: AgentBlueprint,
+  template: AgentProfile | null,
+  sandbox: SandboxReport,
+  sandboxPath: string,
+  options: { identityDir?: string; notes?: string[] }
+): Promise<string> {
+  const directory = options.identityDir ?? IDENTITY_DIR;
+  ensureDir(directory);
+  const filePath = path.join(directory, `${blueprint.ensLabel}.json`);
+  if (fs.existsSync(filePath)) {
+    throw new Error(`Identity file already exists for ${blueprint.ensLabel}`);
+  }
+  const notes = [
+    ...(Array.isArray(blueprint.metadata?.notes)
+      ? blueprint.metadata.notes.filter((note) => typeof note === 'string')
+      : []),
+    ...(options.notes ?? []),
+  ];
+  const metadata = pruneUndefined({
+    categories: [blueprint.category],
+    skills: template?.skills,
+    template: template
+      ? {
+          address: template.address,
+          label: template.label,
+          successRate: template.successRate,
+        }
+      : undefined,
+    spawn: blueprint.spawn,
+    metrics: blueprint.metrics,
+    blueprint: {
+      id: blueprint.id,
+      persistedTo: blueprint.persistedTo,
+      description: blueprint.metadata?.description,
+      tags: blueprint.metadata?.tags,
+    },
+    sandbox: {
+      passed: sandbox.passed,
+      runAt: sandbox.runAt,
+      report: path.relative(process.cwd(), sandboxPath),
+    },
+    notes: notes.length ? notes : undefined,
+  });
+  const record = {
+    ens: blueprint.ensName,
+    label: blueprint.ensLabel,
+    address: blueprint.wallet.address,
+    privateKey: blueprint.wallet.privateKey,
+    role: 'agent',
+    metadata,
+  };
+  await fs.promises.writeFile(
+    filePath,
+    JSON.stringify(record, null, 2),
+    'utf8'
+  );
+  return filePath;
+}
+
+async function cloneCandidate(
+  candidate: SpawnCandidateReport,
+  options: CloneAgentOptions = {}
+): Promise<CloneAgentOutcome | null> {
+  const threshold = options.threshold ?? DEFAULT_OBSERVATION_THRESHOLD;
+  if (candidate.observed < threshold) {
+    return null;
+  }
+  if (!candidate.available && !options.includeSaturated) {
+    return null;
+  }
+
+  const blueprint = await createBlueprintForCandidate(candidate, {
+    persist: options.dryRun ? false : options.persist ?? true,
+    markConsumed: options.dryRun ? false : options.markConsumed ?? true,
+    blueprintDir: options.blueprintDir,
+  });
+
+  const template = await selectTemplateProfile(candidate.categoryKey);
+  const sandbox = runSandboxTrials(blueprint, template);
+  const sandboxPath = await persistSandboxReport(
+    sandbox,
+    options.sandboxDir ?? SANDBOX_DIR
+  );
+  sandbox.reportPath = sandboxPath;
+
+  await secureLogAction({
+    component: 'agent-factory',
+    action: 'sandbox-evaluation',
+    success: sandbox.passed,
+    metadata: {
+      category: blueprint.category,
+      blueprintId: blueprint.id,
+      template: template?.address,
+      passed: sandbox.passed,
+      report: sandboxPath,
+    },
+  }).catch((err) => {
+    console.warn('Failed to record sandbox evaluation audit log', err);
+  });
+
+  const baseOutcome: CloneAgentOutcome = {
+    blueprint,
+    template: template ?? null,
+    sandbox,
+    enabled: false,
+  };
+
+  if (!sandbox.passed && !options.allowSandboxFailure) {
+    return baseOutcome;
+  }
+
+  if (options.dryRun) {
+    return baseOutcome;
+  }
+
+  let identityPath: string | undefined;
+  try {
+    identityPath = await persistIdentityRecord(
+      blueprint,
+      template,
+      sandbox,
+      sandboxPath,
+      {
+        identityDir: options.identityDir,
+        notes: options.notes,
+      }
+    );
+    baseOutcome.identityPath = identityPath;
+  } catch (err) {
+    console.warn('Failed to persist identity file for new agent', err);
+    return baseOutcome;
+  }
+
+  let walletAddress: string | undefined;
+  try {
+    if (!walletManager) {
+      throw new Error('Wallet manager is not initialised');
+    }
+    walletAddress = walletManager.register(blueprint.wallet.privateKey).address;
+    baseOutcome.walletAddress = walletAddress;
+  } catch (err) {
+    console.warn('Failed to register wallet for cloned agent', err);
+    baseOutcome.walletAddress = blueprint.wallet.address;
+  }
+
+  try {
+    const identity = identityPath
+      ? await registerIdentityFile(identityPath)
+      : null;
+    baseOutcome.enabled = Boolean(identity);
+    if (!baseOutcome.walletAddress && identity?.address) {
+      baseOutcome.walletAddress = identity.address;
+    }
+  } catch (err) {
+    console.warn('Failed to register identity with agent registry', err);
+  }
+
+  await secureLogAction({
+    component: 'agent-factory',
+    action: 'clone-template-agent',
+    success: baseOutcome.enabled,
+    metadata: {
+      category: blueprint.category,
+      blueprintId: blueprint.id,
+      wallet: baseOutcome.walletAddress,
+      identityPath,
+      sandboxReport: sandboxPath,
+    },
+  }).catch((err) => {
+    console.warn('Failed to record clone audit log', err);
+  });
+
+  return baseOutcome;
+}
+
+export async function cloneTemplateAgent(
+  category: string,
+  options: CloneAgentOptions = {}
+): Promise<CloneAgentOutcome | null> {
+  const report = await getSpawnPipelineReport();
+  const key = toKey(category);
+  const candidate = report.find((entry) => entry.categoryKey === key);
+  if (!candidate) {
+    return null;
+  }
+  return cloneCandidate(candidate, { ...options, category });
+}
+
+export async function cloneEligibleAgents(
+  options: CloneAgentOptions = {}
+): Promise<CloneAgentOutcome[]> {
+  const report = await getSpawnPipelineReport();
+  const results: CloneAgentOutcome[] = [];
+  for (const candidate of report) {
+    const outcome = await cloneCandidate(candidate, options);
+    if (outcome) {
+      results.push(outcome);
+    }
+  }
+  return results;
 }
 
 export type { SpawnCandidate, AgentBlueprint } from '../shared/spawnManager';

--- a/agent-gateway/identity.ts
+++ b/agent-gateway/identity.ts
@@ -376,6 +376,24 @@ export async function getEnsIdentity(
   };
 }
 
+export async function registerIdentityFile(
+  filePath: string
+): Promise<AgentIdentity | null> {
+  try {
+    await ensureLocalFilesLoaded();
+    const record = await loadIdentityFile(filePath);
+    if (!record) {
+      return null;
+    }
+    registerIdentity(record);
+    identityCache.delete(record.address.toLowerCase());
+    return refreshIdentity(record.address);
+  } catch (err) {
+    console.warn('Failed to register identity file', filePath, err);
+    return null;
+  }
+}
+
 export async function ensureIdentity(
   wallet: Wallet,
   expectedRole: AgentRole = 'agent'

--- a/agent-gateway/learning.ts
+++ b/agent-gateway/learning.ts
@@ -20,6 +20,8 @@ interface RetrainingTask {
 
 const TRAINING_DIR = path.resolve(__dirname, '../storage/training');
 const RETRAINING_PATH = path.join(TRAINING_DIR, 'retraining-queue.json');
+const LEARNING_DIR = path.resolve(__dirname, '../storage/learning');
+const LEARNING_RECORDS_PATH = path.join(LEARNING_DIR, 'records.jsonl');
 
 function ensureDir(dir: string): void {
   if (!fs.existsSync(dir)) {
@@ -71,6 +73,182 @@ export interface TrainingOutcome {
   resultHash: string;
 }
 
+interface LearningJobRecord {
+  jobId: string;
+  employer: string;
+  agent: string;
+  specHash?: string;
+  uri?: string;
+  category?: string;
+  description?: string;
+  skills?: string[];
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  reward: { raw: string; formatted: string; decimals: number };
+  stake: { raw: string; formatted: string };
+  fee: { raw: string; formatted: string };
+}
+
+interface LearningAgentRecord {
+  address: string;
+  label?: string;
+  ensName?: string;
+  categories: string[];
+  skills: string[];
+  reputationScore: number;
+  successRate: number;
+  totalJobs: number;
+  averageEnergy: number;
+  averageDurationMs: number;
+  stakeBalance?: string;
+  endpoint?: string;
+}
+
+interface LearningAnalysisRecord {
+  jobId: string;
+  employer: string;
+  category?: string;
+  description?: string;
+  skills?: string[];
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  reward: string;
+  stake: string;
+  fee: string;
+  specHash?: string;
+  uri?: string;
+  deadline?: string | number | null;
+}
+
+interface LearningEnergyRecord {
+  estimate?: number | null;
+  durationMs?: number | null;
+  cpuTotalUs?: number | null;
+  memoryRssBytes?: number | null;
+  entropyEstimate?: number | null;
+}
+
+export interface LearningRecord {
+  recordedAt: string;
+  job: LearningJobRecord;
+  agent: LearningAgentRecord;
+  analysis: LearningAnalysisRecord;
+  energy?: LearningEnergyRecord | null;
+  result: {
+    success: boolean;
+    txHash?: string;
+    resultURI?: string;
+    resultHash?: string;
+  };
+}
+
+function normaliseSkills(values?: string[] | null): string[] {
+  if (!values) return [];
+  return values.filter((value): value is string => typeof value === 'string');
+}
+
+function normaliseMetadata(
+  metadata?: unknown
+): Record<string, unknown> | undefined {
+  if (!metadata || typeof metadata !== 'object') {
+    return undefined;
+  }
+  return metadata as Record<string, unknown>;
+}
+
+function formatJobRecord(job: Job, analysis: JobAnalysis): LearningJobRecord {
+  return {
+    jobId: job.jobId,
+    employer: job.employer,
+    agent: job.agent,
+    specHash: job.specHash || undefined,
+    uri: job.uri || undefined,
+    category: analysis.category || undefined,
+    description: analysis.description || undefined,
+    skills: normaliseSkills(analysis.skills),
+    tags: normaliseSkills(analysis.tags),
+    metadata: normaliseMetadata(analysis.metadata),
+    reward: {
+      raw: job.rewardRaw,
+      formatted: job.reward,
+      decimals: TOKEN_DECIMALS,
+    },
+    stake: { raw: job.stakeRaw, formatted: job.stake },
+    fee: { raw: job.feeRaw, formatted: job.fee },
+  };
+}
+
+function formatAgentRecord(profile: AgentProfile): LearningAgentRecord {
+  return {
+    address: profile.address,
+    label: profile.label || undefined,
+    ensName: profile.ensName || undefined,
+    categories: Array.from(profile.categories || []),
+    skills: Array.from(profile.skills || []),
+    reputationScore: profile.reputationScore,
+    successRate: profile.successRate,
+    totalJobs: profile.totalJobs,
+    averageEnergy: profile.averageEnergy,
+    averageDurationMs: profile.averageDurationMs,
+    stakeBalance: profile.stakeBalance?.toString(),
+    endpoint: profile.endpoint,
+  };
+}
+
+function bigintToString(value: bigint | number | undefined): string {
+  if (value === undefined || value === null) {
+    return '0';
+  }
+  try {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.trunc(value).toString();
+    }
+    return String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatAnalysisRecord(analysis: JobAnalysis): LearningAnalysisRecord {
+  return {
+    jobId: analysis.jobId,
+    employer: analysis.employer,
+    category: analysis.category || undefined,
+    description: analysis.description || undefined,
+    skills: normaliseSkills(analysis.skills),
+    tags: normaliseSkills(analysis.tags),
+    metadata: normaliseMetadata(analysis.metadata),
+    reward: bigintToString(analysis.reward),
+    stake: bigintToString(analysis.stake),
+    fee: bigintToString(analysis.fee),
+    specHash: analysis.specHash || undefined,
+    uri: analysis.uri || undefined,
+    deadline: analysis.deadline ?? null,
+  };
+}
+
+function formatEnergyRecord(
+  sample: EnergySample | null
+): LearningEnergyRecord | null {
+  if (!sample) return null;
+  return {
+    estimate: sample.energyEstimate ?? null,
+    durationMs: sample.durationMs ?? null,
+    cpuTotalUs: sample.cpuTotalUs ?? null,
+    memoryRssBytes: sample.memoryRssBytes ?? null,
+    entropyEstimate: sample.entropyEstimate ?? null,
+  };
+}
+
+async function appendLearningRecord(record: LearningRecord): Promise<void> {
+  const line = JSON.stringify(record);
+  ensureDir(LEARNING_DIR);
+  await fs.promises.appendFile(LEARNING_RECORDS_PATH, `${line}\n`, 'utf8');
+}
+
 export async function notifyTrainingOutcome(
   outcome: TrainingOutcome
 ): Promise<void> {
@@ -84,11 +262,31 @@ export async function notifyTrainingOutcome(
     resultURI,
     resultHash,
   } = outcome;
+  const recordedAt = new Date().toISOString();
+  try {
+    const record: LearningRecord = {
+      recordedAt,
+      job: formatJobRecord(job, analysis),
+      agent: formatAgentRecord(profile),
+      analysis: formatAnalysisRecord(analysis),
+      energy: formatEnergyRecord(energy),
+      result: {
+        success,
+        txHash: txHash || undefined,
+        resultURI: resultURI || undefined,
+        resultHash: resultHash || undefined,
+      },
+    };
+    await appendLearningRecord(record);
+  } catch (err) {
+    console.warn('Failed to append learning record', err);
+  }
+
   try {
     await appendTrainingRecord({
       kind: 'sandbox',
       jobId: job.jobId,
-      recordedAt: new Date().toISOString(),
+      recordedAt,
       agent: profile.address,
       employer: job.employer,
       category: analysis.category,

--- a/agent-gateway/wallet.ts
+++ b/agent-gateway/wallet.ts
@@ -27,4 +27,14 @@ export default class WalletManager {
   list(): string[] {
     return Array.from(this.wallets.values()).map((w) => w.address);
   }
+
+  register(privateKey: string): Wallet {
+    const key = privateKey.trim();
+    if (!key) {
+      throw new Error('Private key is required to register a wallet');
+    }
+    const wallet = new ethers.Wallet(key, this.provider);
+    this.wallets.set(wallet.address.toLowerCase(), wallet);
+    return wallet;
+  }
 }

--- a/docs/continuous-learning.md
+++ b/docs/continuous-learning.md
@@ -1,0 +1,74 @@
+# Continuous Learning Pipeline
+
+This document explains how the AGIJobs gateway now captures experience, spins
+up new specialists, and retrains existing agents.
+
+## 1. Capture job outcomes
+
+The gateway records every completed task in `storage/learning/records.jsonl` via
+`agent-gateway/learning.ts`. Each JSON line contains:
+
+* Job specification – category, rewards, stakes, metadata URI/hash.
+* Agent profile – label, ENS, categories, skills, historical success metrics.
+* Energy sample – wall-clock duration, energy estimate, CPU/memory footprint.
+* Execution result – success flag, transaction hash, IPFS result pointer.
+
+These logs are append-only so downstream analytics or model trainers can replay
+history without crawling on-chain data.
+
+## 2. Detect unmet demand
+
+Spawn requests (`storage/training/spawn-requests.json`) are generated whenever a
+job arrives for a category we do not yet cover. Once the observation count hits
+`AGENT_FACTORY_OBSERVATION_THRESHOLD` (default **4**), the agent factory treats
+it as a niche worth cloning.
+
+## 3. Clone and sandbox specialists
+
+`agent-gateway/agentFactory.ts` now provides `cloneTemplateAgent()` and
+`cloneEligibleAgents()`:
+
+1. Select the best-performing template agent for the requested category.
+2. Generate a blueprint (fresh wallet, ENS label, recommended stake/metrics).
+3. Run sandbox simulations against canned sample jobs. Results are stored under
+   `storage/sandbox/<timestamp>-<category>-<id>.json`.
+4. If the sandbox passes (or `allowSandboxFailure` is explicitly set), persist a
+   new identity file at `config/agents/<label>.json` and register the wallet in
+   the gateway's wallet manager.
+
+Sandbox heuristics cover skill transfer, category familiarity, and projected
+energy usage so that only viable clones enter production.
+
+## 4. Update the orchestrator
+
+Identity files include a `metadata` block with blueprint, sandbox, and learning
+state. Once an agent is cloned, the factory automatically:
+
+* writes the identity file;
+* injects the wallet into the in-memory wallet manager; and
+* calls `registerIdentityFile()` so the agent registry refreshes immediately.
+
+## 5. Retrain or rotate agents
+
+`scripts/retrainAgent.ts` reads the JSONL ledger, computes rolling success and
+energy metrics for an agent label/address, and updates the corresponding identity
+file (`metadata.learning`). The script recommends either:
+
+* **fine-tune** – success rate healthy, energy within budget; or
+* **swap** – success rate low or energy budget exceeded.
+
+After updating the file it pings `ORCHESTRATOR_CONTROL_URL` so the orchestrator
+reloads capability matrices without a manual restart.
+
+## 6. Operational checklist
+
+1. Run the gateway – it will log records and spawn requests automatically.
+2. Periodically execute `ts-node scripts/retrainAgent.ts --label <agent>` to
+   refresh learning metadata and trigger orchestrator reloads.
+3. Use `cloneEligibleAgents()` (or the HTTP surface that wraps it) to materialise
+   new specialists when the sandbox results look healthy.
+4. Review sandbox reports and JSONL logs to guide human-in-the-loop fine tuning.
+
+The pipeline is designed to be observable: every stage writes structured
+artifacts (`records.jsonl`, sandbox reports, identity metadata) that make it easy
+to audit why a clone was created or a retraining strategy was chosen.

--- a/internal_docs/meta_agentic_agi_assets_README.md
+++ b/internal_docs/meta_agentic_agi_assets_README.md
@@ -1,0 +1,67 @@
+# Meta Agentic AGI Assets – Continuous Learning Notes
+
+This document inventories the moving pieces that keep the gateway's agent
+population adaptive. It is intended for internal operators who maintain the
+Meta Agentic stack.
+
+## Data acquisition
+
+* `agent-gateway/learning.ts` now emits structured JSONL snapshots under
+  `storage/learning/records.jsonl`. Each line records:
+  * the full on-chain job spec (category, metadata, rewards, stake);
+  * the agent profile applied (label, ENS, skill inventory, historical metrics);
+  * observed energy telemetry for the execution; and
+  * the canonical result artefacts (transaction hash, result URI/hash, success).
+* Records are append-only and timestamped so we can stream them directly into
+  downstream fine-tuning jobs without reindexing the chain.
+* The module still mirrors critical data into the legacy
+  `shared/trainingRecords` aggregator so existing dashboards continue to work.
+
+## Spawn pipeline hooks
+
+* Spawn requests continue to accumulate inside `storage/training/spawn-requests.json`.
+* `agent-gateway/agentFactory.ts` has been extended to:
+  * analyse spawn pressure and pick niche categories once the observation
+    threshold (default `AGENT_FACTORY_OBSERVATION_THRESHOLD=4`) is met;
+  * hydrate the highest performing template agent for that category;
+  * generate a deterministic blueprint (wallet, ENS label, recommended stake);
+  * execute sandbox trials before activation; and
+  * persist identity material plus runtime metadata to `config/agents/<label>.json`.
+* Sandbox runs are logged under `storage/sandbox/` together with the blueprint
+  metadata so we can audit pre-production checks.
+
+## Sandbox gating
+
+* Sandbox scenarios are lightweight heuristics that validate:
+  * category familiarity (template coverage);
+  * skill transfer (at least partial match with the template skill map); and
+  * thermodynamic viability (projected energy within configurable guard rails).
+* Failures block automatic activation unless `allowSandboxFailure` is
+  explicitly set. Results are exported in JSON so analysts can manually inspect
+  why a candidate failed to qualify.
+
+## Retraining surface
+
+* `scripts/retrainAgent.ts` consumes the JSONL ledger and computes rolling
+  success/energy statistics for a given agent label or address.
+* The script stamps the agent's identity file with an updated `metadata.learning`
+  payload (strategy recommendation, dataset digest, recent jobs) and triggers
+  an orchestrator reload webhook (`ORCHESTRATOR_CONTROL_URL`).
+* Strategies are currently binary (`fine-tune` vs `swap`) based on success rate
+  and average energy consumption, but the metadata structure is ready for more
+  nuanced policies.
+
+## Operational loop
+
+1. **Observation** – Gateway appends job outcomes to `storage/learning/records.jsonl`.
+2. **Demand detection** – Spawn requests reach the configured threshold for a
+   category.
+3. **Sandbox** – `cloneEligibleAgents()` materialises blueprints and gates them
+   through sandbox simulations (results stored in `storage/sandbox/`).
+4. **Activation** – Passing agents receive identity files, wallets are injected
+   into the wallet manager, and the orchestrator reloads the registry view.
+5. **Retraining** – Operators run `ts-node scripts/retrainAgent.ts --label <id>`
+   to update metadata and kick off downstream model work.
+
+Keep the JSONL corpus safe; it is the canonical log for model deltas and feeds
+both human review and automated fine-tuning jobs.

--- a/scripts/retrainAgent.ts
+++ b/scripts/retrainAgent.ts
@@ -1,0 +1,373 @@
+import fs from 'fs';
+import path from 'path';
+import { createHash } from 'crypto';
+
+import type { LearningRecord } from '../agent-gateway/learning';
+
+interface CliOptions {
+  identifier?: string;
+  dryRun: boolean;
+  energyThreshold: number;
+}
+
+interface AgentLearningStats {
+  total: number;
+  successRate: number;
+  averageEnergy: number;
+  averageReward: number;
+  averageDurationMs: number;
+  energySamples: number;
+  successes: number;
+  lastRecordedAt?: string;
+  recentJobIds: string[];
+}
+
+interface IdentityFileRecord {
+  ens?: string;
+  label?: string;
+  address?: string;
+  privateKey?: string;
+  role?: string;
+  metadata?: Record<string, unknown> | undefined;
+}
+
+interface IdentityFileHandle {
+  path: string;
+  data: IdentityFileRecord;
+}
+
+const LEARNING_RECORDS_PATH = path.resolve(
+  __dirname,
+  '../storage/learning/records.jsonl'
+);
+const IDENTITY_DIR = path.resolve(__dirname, '../config/agents');
+const DEFAULT_ENERGY_THRESHOLD = Number(
+  process.env.RETRAIN_ENERGY_THRESHOLD || '150000'
+);
+
+function parseArgs(argv: string[]): CliOptions {
+  let identifier: string | undefined;
+  let dryRun = false;
+  let energyThreshold = DEFAULT_ENERGY_THRESHOLD;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--label' || arg === '-l') {
+      identifier = argv[i + 1];
+      i += 1;
+    } else if (arg === '--agent' || arg === '-a' || arg === '--id') {
+      identifier = argv[i + 1];
+      i += 1;
+    } else if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg === '--energy-threshold') {
+      const value = argv[i + 1];
+      if (value) {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed)) {
+          energyThreshold = parsed;
+        }
+        i += 1;
+      }
+    }
+  }
+
+  return { identifier, dryRun, energyThreshold };
+}
+
+async function loadLearningRecords(): Promise<LearningRecord[]> {
+  try {
+    const raw = await fs.promises.readFile(LEARNING_RECORDS_PATH, 'utf8');
+    const lines = raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    const records: LearningRecord[] = [];
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line) as LearningRecord;
+        records.push(parsed);
+      } catch (err) {
+        console.warn('Skipping malformed learning record', err);
+      }
+    }
+    return records;
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+}
+
+function matchIdentifier(record: LearningRecord, identifier: string): boolean {
+  const key = identifier.toLowerCase();
+  if (record.agent.label && record.agent.label.toLowerCase() === key) {
+    return true;
+  }
+  if (record.agent.address.toLowerCase() === key) {
+    return true;
+  }
+  if (record.agent.ensName && record.agent.ensName.toLowerCase() === key) {
+    return true;
+  }
+  return false;
+}
+
+function summariseRecords(records: LearningRecord[]): AgentLearningStats {
+  let successes = 0;
+  let totalReward = 0;
+  let rewardSamples = 0;
+  let totalEnergy = 0;
+  let energySamples = 0;
+  let totalDuration = 0;
+  let durationSamples = 0;
+  let lastRecordedAt: string | undefined;
+  const recentJobIds = records
+    .slice(-5)
+    .map((record) => record.job.jobId)
+    .filter((id) => typeof id === 'string');
+
+  for (const record of records) {
+    if (record.result.success) {
+      successes += 1;
+    }
+    const reward = Number.parseFloat(record.job.reward.formatted || '0');
+    if (Number.isFinite(reward)) {
+      totalReward += reward;
+      rewardSamples += 1;
+    }
+    const energy = record.energy?.estimate;
+    if (energy !== undefined && energy !== null && Number.isFinite(energy)) {
+      totalEnergy += Number(energy);
+      energySamples += 1;
+    }
+    const duration = record.energy?.durationMs;
+    if (
+      duration !== undefined &&
+      duration !== null &&
+      Number.isFinite(duration)
+    ) {
+      totalDuration += Number(duration);
+      durationSamples += 1;
+    }
+    if (!lastRecordedAt || record.recordedAt > lastRecordedAt) {
+      lastRecordedAt = record.recordedAt;
+    }
+  }
+
+  const total = records.length;
+  const successRate = total > 0 ? successes / total : 0;
+  return {
+    total,
+    successes,
+    successRate,
+    averageReward: rewardSamples > 0 ? totalReward / rewardSamples : 0,
+    averageEnergy: energySamples > 0 ? totalEnergy / energySamples : 0,
+    averageDurationMs:
+      durationSamples > 0 ? totalDuration / durationSamples : 0,
+    energySamples,
+    lastRecordedAt,
+    recentJobIds,
+  };
+}
+
+function decideStrategy(
+  stats: AgentLearningStats,
+  energyThreshold: number
+): 'fine-tune' | 'swap' {
+  if (stats.total === 0) {
+    return 'fine-tune';
+  }
+  if (stats.successRate < 0.55) {
+    return 'swap';
+  }
+  if (stats.averageEnergy > energyThreshold) {
+    return 'swap';
+  }
+  return 'fine-tune';
+}
+
+async function resolveIdentityFile(
+  identifier: string
+): Promise<IdentityFileHandle> {
+  const key = identifier.toLowerCase();
+  const directPath = path.join(IDENTITY_DIR, `${key}.json`);
+  try {
+    const raw = await fs.promises.readFile(directPath, 'utf8');
+    return { path: directPath, data: JSON.parse(raw) as IdentityFileRecord };
+  } catch (err: any) {
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(IDENTITY_DIR, {
+      withFileTypes: true,
+    });
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        `Identity directory ${IDENTITY_DIR} is missing. Run identity provisioning first.`
+      );
+    }
+    throw err;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const fullPath = path.join(IDENTITY_DIR, entry.name);
+    try {
+      const raw = await fs.promises.readFile(fullPath, 'utf8');
+      const parsed = JSON.parse(raw) as IdentityFileRecord;
+      const label = parsed.label || entry.name.replace(/\.json$/i, '');
+      const address = parsed.address || '';
+      if (label.toLowerCase() === key || address.toLowerCase() === key) {
+        return { path: fullPath, data: parsed };
+      }
+    } catch (err) {
+      console.warn('Skipping malformed identity file', fullPath, err);
+    }
+  }
+  throw new Error(`Unable to locate identity file for ${identifier}`);
+}
+
+function ensureMetadata(record: IdentityFileRecord): Record<string, unknown> {
+  if (!record.metadata || typeof record.metadata !== 'object') {
+    record.metadata = {};
+  }
+  return record.metadata as Record<string, unknown>;
+}
+
+function computeDatasetDigest(records: LearningRecord[]): string {
+  const hash = createHash('sha256');
+  for (const record of records) {
+    hash.update(record.job.jobId || '');
+    hash.update(record.result.success ? '1' : '0');
+    hash.update(String(record.energy?.estimate ?? ''));
+    hash.update(record.recordedAt);
+  }
+  return hash.digest('hex');
+}
+
+async function notifyOrchestratorReload(label: string): Promise<void> {
+  const url =
+    process.env.ORCHESTRATOR_CONTROL_URL || 'http://localhost:8787/reload';
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        reason: 'agent-retrained',
+        label,
+        timestamp: new Date().toISOString(),
+      }),
+    });
+    if (!res.ok) {
+      console.warn(
+        `Orchestrator reload request failed: ${res.status} ${res.statusText}`
+      );
+    }
+  } catch (err) {
+    console.warn('Failed to notify orchestrator reload endpoint', err);
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (!options.identifier) {
+    console.error(
+      'Usage: ts-node scripts/retrainAgent.ts --label <agent-label>'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const records = await loadLearningRecords();
+  if (records.length === 0) {
+    console.error('No learning records found. Execute jobs before retraining.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const filtered = records.filter((record) =>
+    matchIdentifier(record, options.identifier!)
+  );
+
+  if (filtered.length === 0) {
+    console.error(
+      `No learning samples found for ${options.identifier}. Check the label or run jobs first.`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const stats = summariseRecords(filtered);
+  const strategy = decideStrategy(stats, options.energyThreshold);
+  const datasetDigest = computeDatasetDigest(filtered);
+
+  console.log(`Analysed ${stats.total} job records`);
+  console.log(
+    `Success rate: ${(stats.successRate * 100).toFixed(2)}% (${
+      stats.successes
+    }/${stats.total})`
+  );
+  console.log(
+    `Average energy: ${stats.averageEnergy.toFixed(2)} (from ${
+      stats.energySamples
+    } samples)`
+  );
+  console.log(
+    `Average reward: ${stats.averageReward.toFixed(
+      4
+    )} | Average duration: ${stats.averageDurationMs.toFixed(2)} ms`
+  );
+  console.log(`Recommended strategy: ${strategy}`);
+
+  let identity: IdentityFileHandle;
+  try {
+    identity = await resolveIdentityFile(options.identifier);
+  } catch (err) {
+    console.error(String(err));
+    process.exitCode = 1;
+    return;
+  }
+
+  const metadata = ensureMetadata(identity.data);
+  metadata.learning = {
+    ...(typeof metadata.learning === 'object' ? metadata.learning : {}),
+    lastUpdated: stats.lastRecordedAt || new Date().toISOString(),
+    strategy,
+    successRate: Number(stats.successRate.toFixed(6)),
+    totalRuns: stats.total,
+    averageEnergy: Number(stats.averageEnergy.toFixed(2)),
+    averageReward: Number(stats.averageReward.toFixed(4)),
+    averageDurationMs: Number(stats.averageDurationMs.toFixed(2)),
+    energySamples: stats.energySamples,
+    datasetDigest,
+    recentJobIds: stats.recentJobIds,
+    energyThreshold: options.energyThreshold,
+  };
+
+  const label = (identity.data.label || options.identifier).toLowerCase();
+
+  if (options.dryRun) {
+    console.log('Dry run enabled. Identity file will not be updated.');
+    return;
+  }
+
+  await fs.promises.writeFile(
+    identity.path,
+    JSON.stringify(identity.data, null, 2),
+    'utf8'
+  );
+  console.log(`Updated identity metadata at ${identity.path}`);
+
+  await notifyOrchestratorReload(label);
+}
+
+main().catch((err) => {
+  console.error('Retraining script failed', err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- extend gateway learning module to persist per-job outcomes in storage/learning/records.jsonl alongside retraining queue updates
- expand agent factory with sandbox testing, template cloning, identity persistence, and registry updates
- add retraining CLI plus documentation describing the continuous learning pipeline

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9c978b0a083339e3515b6f3c68f49