### PR TITLE
Add opportunity forecasting pipeline and API

### DIFF
--- a/agent-gateway/README.md
+++ b/agent-gateway/README.md
@@ -106,6 +106,8 @@ POST /jobs/:id/reveal { address }
 GET  /health
 GET  /efficiency
 GET  /efficiency/:agent[?category=categoryKey]
+GET  /opportunities[?limit=25]
+GET  /opportunities/:jobId
 GET  /audit/anchors[?limit=25]
 POST /audit/anchors { force?, minNewEvents? }
 ```
@@ -117,6 +119,14 @@ provides an individual breakdown. When a `category` query parameter is
 present, the gateway responds with the metrics for that specialised domain –
 for example, `validation` or a custom agent discipline. ENS names can be used
 in place of raw addresses and are resolved automatically before lookup.
+
+The `/opportunities` endpoints expose the orchestrator's bidding forecasts.
+`GET /opportunities` returns the most recent opportunity assessments (newest
+first) while `GET /opportunities/:jobId` retrieves the stored forecast for a
+specific job identifier. Forecasts include the orchestrator's recommended
+agent, projected thermodynamic efficiency, expected net reward, and any
+actions—such as staking adjustments—that were suggested when the job was
+evaluated.
 
 The `/audit/anchors` endpoints manage the Merkle anchoring cadence for the
 gateway's structured audit log. `GET /audit/anchors` returns the recorded

--- a/agent-gateway/opportunities.ts
+++ b/agent-gateway/opportunities.ts
@@ -1,0 +1,119 @@
+import fs from 'fs';
+import path from 'path';
+import { JobOpportunityForecast } from '../shared/opportunityModel';
+
+const ANALYTICS_DIR = path.resolve(__dirname, '../storage/analytics');
+const FORECAST_PATH = path.join(ANALYTICS_DIR, 'opportunities.json');
+const HISTORY_LIMIT = Math.max(
+  1,
+  Number(process.env.OPPORTUNITY_HISTORY_LIMIT || '200')
+);
+
+export interface StoredOpportunityForecast extends JobOpportunityForecast {
+  storedAt: string;
+}
+
+let loaded = false;
+let cache: StoredOpportunityForecast[] = [];
+const cacheByJob = new Map<string, StoredOpportunityForecast>();
+
+function ensureDirectory(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+async function readForecastFile(): Promise<StoredOpportunityForecast[]> {
+  try {
+    const raw = await fs.promises.readFile(FORECAST_PATH, 'utf8');
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as StoredOpportunityForecast[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+}
+
+async function writeForecastFile(
+  records: StoredOpportunityForecast[]
+): Promise<void> {
+  ensureDirectory(path.dirname(FORECAST_PATH));
+  await fs.promises.writeFile(
+    FORECAST_PATH,
+    JSON.stringify(records, null, 2),
+    'utf8'
+  );
+}
+
+async function ensureLoaded(): Promise<void> {
+  if (loaded) return;
+  cache = await readForecastFile();
+  cacheByJob.clear();
+  for (const record of cache) {
+    cacheByJob.set(record.jobId, record);
+  }
+  loaded = true;
+}
+
+export async function recordOpportunityForecast(
+  forecast: JobOpportunityForecast
+): Promise<void> {
+  await ensureLoaded();
+  const stored: StoredOpportunityForecast = {
+    ...forecast,
+    storedAt: new Date().toISOString(),
+  };
+  const existing = cacheByJob.get(forecast.jobId);
+  if (existing) {
+    const index = cache.findIndex((entry) => entry.jobId === forecast.jobId);
+    if (index !== -1) {
+      cache[index] = stored;
+    } else {
+      cache.push(stored);
+    }
+  } else {
+    cache.push(stored);
+  }
+  cacheByJob.set(forecast.jobId, stored);
+  if (cache.length > HISTORY_LIMIT) {
+    const overflow = cache.length - HISTORY_LIMIT;
+    const removed = cache.splice(0, overflow);
+    for (const record of removed) {
+      if (record.jobId !== forecast.jobId) {
+        cacheByJob.delete(record.jobId);
+      }
+    }
+  }
+  await writeForecastFile(cache);
+}
+
+export async function listOpportunityForecasts(
+  limit?: number
+): Promise<StoredOpportunityForecast[]> {
+  await ensureLoaded();
+  const records = cache.slice();
+  records.sort((a, b) => b.storedAt.localeCompare(a.storedAt));
+  if (typeof limit === 'number' && Number.isFinite(limit) && limit > 0) {
+    return records.slice(0, limit);
+  }
+  return records;
+}
+
+export async function getOpportunityForecast(
+  jobId: string
+): Promise<StoredOpportunityForecast | null> {
+  await ensureLoaded();
+  const key = jobId.toString();
+  return cacheByJob.get(key) ?? null;
+}
+
+export function clearOpportunityCache(): void {
+  loaded = false;
+  cache = [];
+  cacheByJob.clear();
+}

--- a/shared/opportunityModel.ts
+++ b/shared/opportunityModel.ts
@@ -1,0 +1,376 @@
+import { ethers } from 'ethers';
+import agialpha from '../config/agialpha.json';
+import type { EfficiencyBreakdown } from './efficiencyMetrics';
+
+const TOKEN_DECIMALS = Number.isFinite(Number(agialpha.decimals))
+  ? Number(agialpha.decimals)
+  : 18;
+
+function safeFormatUnits(value: bigint): number {
+  try {
+    return Number.parseFloat(ethers.formatUnits(value, TOKEN_DECIMALS));
+  } catch {
+    return 0;
+  }
+}
+
+function round(value: number, precision = 6): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+function clamp(value: number, min = 0, max = 1): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function normaliseCategoryAffinity(
+  jobCategory: string | undefined,
+  candidateCategories: string[]
+): number {
+  if (!jobCategory) {
+    return 0.5;
+  }
+  const key = jobCategory.trim().toLowerCase();
+  if (!key) {
+    return 0.5;
+  }
+  if (candidateCategories.length === 0) {
+    return 0.3;
+  }
+  for (const category of candidateCategories) {
+    const value = category.trim().toLowerCase();
+    if (!value) continue;
+    if (value === key) {
+      return 1;
+    }
+    if (value.includes(key) || key.includes(value)) {
+      return 0.75;
+    }
+  }
+  return 0.35;
+}
+
+function toLowerSet(values: string[] | undefined): Set<string> {
+  const set = new Set<string>();
+  if (!values) return set;
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed) {
+      set.add(trimmed);
+    }
+  }
+  return set;
+}
+
+export interface OpportunityCandidateInput {
+  address: string;
+  ensName?: string;
+  label?: string;
+  reputationScore: number;
+  successRate: number;
+  totalJobs: number;
+  averageEnergy: number;
+  averageDurationMs: number;
+  stakeBalance?: bigint;
+  categories: string[];
+  thermodynamics?: EfficiencyBreakdown;
+  matchScore?: number;
+  reasons?: string[];
+}
+
+export interface OpportunityJobContext {
+  jobId: string;
+  reward: bigint;
+  stake: bigint;
+  fee: bigint;
+  category?: string;
+  metadata?: Record<string, unknown>;
+  tags?: string[];
+}
+
+export interface CandidateProjection {
+  agent: string;
+  ensName?: string;
+  label?: string;
+  opportunityScore: number;
+  matchScore: number;
+  successRate: number;
+  expectedReward: number;
+  projectedReward: number;
+  projectedNet: number;
+  expectedEnergy: number;
+  energyPenalty: number;
+  rewardDensity: number;
+  thermodynamicScore: number;
+  efficiency: number;
+  confidence: number;
+  sampleSize: number;
+  expectedDurationMs?: number;
+  stakeAdequate: boolean;
+  stakeCoverage: number;
+  stakeShortfallRaw: string;
+  stakeShortfallValue: number;
+  stakeBalanceRaw: string;
+  stakeBalanceValue: number;
+  reasons: string[];
+  notes: string[];
+}
+
+export interface JobOpportunityForecast {
+  jobId: string;
+  generatedAt: string;
+  rewardRaw: string;
+  rewardValue: number;
+  stakeRaw: string;
+  stakeValue: number;
+  feeRaw: string;
+  feeValue: number;
+  category?: string;
+  metadata?: Record<string, unknown>;
+  tags?: string[];
+  candidateCount: number;
+  candidates: CandidateProjection[];
+  bestCandidate?: CandidateProjection;
+  recommendations: string[];
+}
+
+interface ProjectionContext {
+  rewardValue: number;
+  stakeValue: number;
+  feeValue: number;
+  rewardRaw: bigint;
+  stakeRaw: bigint;
+  feeRaw: bigint;
+  jobCategory?: string;
+}
+
+function computeCandidateProjection(
+  context: ProjectionContext,
+  candidate: OpportunityCandidateInput
+): CandidateProjection {
+  const matchScore = clamp(candidate.matchScore ?? 0, 0, 1);
+  const categoryAffinity = normaliseCategoryAffinity(
+    context.jobCategory,
+    candidate.categories
+  );
+
+  const thermo = candidate.thermodynamics;
+  const sampleSize = Math.max(0, thermo?.jobs ?? 0, candidate.totalJobs ?? 0);
+  const successRate = clamp(
+    typeof thermo?.successRate === 'number'
+      ? thermo.successRate
+      : candidate.successRate,
+    0,
+    1
+  );
+  const expectedReward = Math.max(
+    0,
+    typeof thermo?.averageReward === 'number'
+      ? thermo.averageReward
+      : context.rewardValue || context.feeValue || 0
+  );
+  const expectedEnergy = Math.max(
+    0,
+    typeof thermo?.averageEnergy === 'number'
+      ? thermo.averageEnergy
+      : candidate.averageEnergy
+  );
+  const thermodynamicScore = clamp(thermo?.efficiencyScore ?? 0, 0, 1);
+  const rewardDensity =
+    expectedEnergy > 0 ? expectedReward / expectedEnergy : 0;
+  const projectedReward = successRate * expectedReward;
+  const energyPenalty =
+    Math.log1p(expectedEnergy) *
+    (context.rewardValue > 0
+      ? Math.min(0.2, context.rewardValue * 0.05)
+      : 0.05);
+  const projectedNet = Math.max(0, projectedReward - energyPenalty);
+  const efficiency = expectedEnergy > 0 ? projectedReward / expectedEnergy : 0;
+  const reputationComponent = clamp(candidate.reputationScore, 0, 1);
+  const sampleConfidence = sampleSize > 0 ? Math.min(1, sampleSize / 25) : 0;
+  const confidence = round(
+    sampleConfidence * 0.5 +
+      successRate * 0.2 +
+      matchScore * 0.15 +
+      reputationComponent * 0.15,
+    6
+  );
+  const densityScore = clamp(rewardDensity / 10, 0, 1);
+  const netScore = clamp(
+    projectedNet /
+      Math.max(
+        1,
+        context.rewardValue > 0 ? context.rewardValue : expectedReward
+      ),
+    0,
+    1
+  );
+  const opportunityScore = round(
+    matchScore * 0.2 +
+      successRate * 0.15 +
+      thermodynamicScore * 0.1 +
+      densityScore * 0.1 +
+      netScore * 0.2 +
+      reputationComponent * 0.1 +
+      categoryAffinity * 0.05 +
+      confidence * 0.1,
+    6
+  );
+
+  const stakeBalance = candidate.stakeBalance ?? 0n;
+  const stakeBalanceValue = safeFormatUnits(stakeBalance);
+  const stakeRequiredRaw = context.stakeRaw;
+  const stakeShortfallRaw =
+    stakeRequiredRaw > stakeBalance ? stakeRequiredRaw - stakeBalance : 0n;
+  const stakeShortfallValue = safeFormatUnits(stakeShortfallRaw);
+  const stakeAdequate = stakeShortfallRaw === 0n;
+  const stakeCoverage =
+    context.stakeValue > 0
+      ? clamp(stakeBalanceValue / context.stakeValue, 0, 1)
+      : 1;
+
+  const notes = new Set<string>();
+  if (!stakeAdequate) notes.add('stake-shortfall');
+  if (successRate < 0.5) notes.add('low-success-rate');
+  if (confidence < 0.35) notes.add('low-confidence');
+  if (thermodynamicScore < 0.3) notes.add('thermo-risk');
+  if (expectedEnergy > 15000) notes.add('high-energy');
+  if (projectedNet <= 0 && context.rewardValue > 0) notes.add('negative-net');
+  const expectedDuration = Number.isFinite(candidate.averageDurationMs)
+    ? Math.max(0, candidate.averageDurationMs)
+    : undefined;
+  if (expectedDuration !== undefined && expectedDuration > 30 * 60 * 1000) {
+    notes.add('long-duration');
+  }
+
+  const reasonSet = new Set<string>(candidate.reasons || []);
+  reasonSet.add(`opportunity:${opportunityScore.toFixed(3)}`);
+  if (!stakeAdequate) {
+    reasonSet.add('stake-insufficient');
+  }
+
+  return {
+    agent: candidate.address.toLowerCase(),
+    ensName: candidate.ensName,
+    label: candidate.label,
+    opportunityScore,
+    matchScore,
+    successRate: round(successRate, 6),
+    expectedReward: round(expectedReward, 6),
+    projectedReward: round(projectedReward, 6),
+    projectedNet: round(projectedNet, 6),
+    expectedEnergy: round(expectedEnergy, 6),
+    energyPenalty: round(energyPenalty, 6),
+    rewardDensity: round(rewardDensity, 6),
+    thermodynamicScore: round(thermodynamicScore, 6),
+    efficiency: round(efficiency, 6),
+    confidence,
+    sampleSize,
+    expectedDurationMs: expectedDuration,
+    stakeAdequate,
+    stakeCoverage: round(stakeCoverage, 6),
+    stakeShortfallRaw: stakeShortfallRaw.toString(),
+    stakeShortfallValue: round(stakeShortfallValue, 6),
+    stakeBalanceRaw: stakeBalance.toString(),
+    stakeBalanceValue: round(stakeBalanceValue, 6),
+    reasons: Array.from(reasonSet),
+    notes: Array.from(notes),
+  };
+}
+
+function deriveRecommendations(forecast: JobOpportunityForecast): string[] {
+  const recommendations = new Set<string>();
+  if (!forecast.bestCandidate) {
+    recommendations.add('no-eligible-agent');
+    if (forecast.rewardValue <= 0) {
+      recommendations.add('skip-zero-reward');
+    }
+    return Array.from(recommendations);
+  }
+  const top = forecast.bestCandidate;
+  if (!top.stakeAdequate) {
+    recommendations.add(`increase-stake:${top.agent}`);
+  }
+  if (top.notes.includes('high-energy')) {
+    recommendations.add(`optimize-energy:${top.agent}`);
+  }
+  if (top.notes.includes('low-confidence')) {
+    recommendations.add(`collect-training-data:${top.agent}`);
+  }
+  if (top.projectedNet <= 0 && forecast.rewardValue > 0) {
+    recommendations.add('seek-external-agent');
+  }
+  if (forecast.rewardValue <= 0) {
+    recommendations.add('skip-low-reward');
+  }
+  return Array.from(recommendations);
+}
+
+export function buildOpportunityForecast(
+  context: OpportunityJobContext,
+  candidates: OpportunityCandidateInput[]
+): JobOpportunityForecast {
+  const rewardValue = safeFormatUnits(context.reward);
+  const stakeValue = safeFormatUnits(context.stake);
+  const feeValue = safeFormatUnits(context.fee);
+  const projectionContext: ProjectionContext = {
+    rewardValue,
+    stakeValue,
+    feeValue,
+    rewardRaw: context.reward,
+    stakeRaw: context.stake,
+    feeRaw: context.fee,
+    jobCategory: context.category,
+  };
+
+  const projections = candidates.map((candidate) =>
+    computeCandidateProjection(projectionContext, candidate)
+  );
+  projections.sort((a, b) => b.opportunityScore - a.opportunityScore);
+
+  const bestCandidate = projections[0];
+
+  let metadata: Record<string, unknown> | undefined = context.metadata
+    ? { ...context.metadata }
+    : undefined;
+  if (context.tags && context.tags.length > 0) {
+    const tagSet = Array.from(toLowerSet(context.tags));
+    if (tagSet.length > 0) {
+      if (metadata) {
+        metadata.tags = tagSet;
+      } else {
+        metadata = { tags: tagSet };
+      }
+    }
+  }
+
+  const forecast: JobOpportunityForecast = {
+    jobId: context.jobId,
+    generatedAt: new Date().toISOString(),
+    rewardRaw: context.reward.toString(),
+    rewardValue: round(rewardValue, 6),
+    stakeRaw: context.stake.toString(),
+    stakeValue: round(stakeValue, 6),
+    feeRaw: context.fee.toString(),
+    feeValue: round(feeValue, 6),
+    category: context.category,
+    metadata,
+    tags: context.tags,
+    candidateCount: projections.length,
+    candidates: projections,
+    bestCandidate,
+    recommendations: [],
+  };
+
+  forecast.recommendations = deriveRecommendations(forecast);
+  return forecast;
+}


### PR DESCRIPTION
## Summary
- add shared opportunity modeling utilities to score agent matches using existing efficiency metrics
- persist opportunity forecasts for recent jobs and expose them through new REST endpoints
- wire the orchestrator into the forecasting pipeline so bidding decisions log and respect projected value

## Testing
- npm run build:gateway
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca03c750888333a4114493c0129c48