### PR TITLE
Add anomaly-aware agent selection heuristics

### DIFF
--- a/agent-gateway/routes.ts
+++ b/agent-gateway/routes.ts
@@ -188,8 +188,10 @@ function collectAgentJobs(
     if (b.totalEnergy !== a.totalEnergy) {
       return b.totalEnergy - a.totalEnergy;
     }
-    if (b.averageEfficiency !== a.averageEfficiency) {
-      return b.averageEfficiency - a.averageEfficiency;
+    const efficiencyA = a.efficiencyScore ?? 0;
+    const efficiencyB = b.efficiencyScore ?? 0;
+    if (efficiencyB !== efficiencyA) {
+      return efficiencyB - efficiencyA;
     }
     if (b.samples !== a.samples) {
       return b.samples - a.samples;


### PR DESCRIPTION
## Summary
- add configurable anomaly decay and risk scoring utilities in telemetry reporting
- expose anomaly snapshots and per-agent risk scores for reuse by other modules
- incorporate anomaly penalties into orchestrator job matching while preserving existing opportunity heuristics
- switch energy insight sorting to use efficiencyScore instead of a non-existent averageEfficiency field

## Testing
- npm run build:gateway

------
https://chatgpt.com/codex/tasks/task_e_68ca132e9a6c8333b79567a07ebc7c8e