### PR TITLE
feat(orchestrator): integrate trend-aware bidding safeguards

### DIFF
--- a/apps/orchestrator/__tests__/trendScoring.test.ts
+++ b/apps/orchestrator/__tests__/trendScoring.test.ts
@@ -41,7 +41,10 @@ const defaultFloor = 0.05;
 
 const warmTrend = makeTrend({ status: 'warming', energyMomentumRatio: 0.18 });
 const hotTrend = makeTrend({ status: 'overheating', energyMomentumRatio: 0.6 });
-const coolingTrend = makeTrend({ status: 'cooling', energyMomentumRatio: -0.12 });
+const coolingTrend = makeTrend({
+  status: 'cooling',
+  energyMomentumRatio: -0.12,
+});
 
 // parseTrendStatuses should default to blocking overheating
 const defaultStatuses = parseTrendStatuses(undefined);
@@ -65,14 +68,23 @@ assert.equal(overheating.reason, 'status:overheating');
 // Warming trend within momentum threshold should increase profit floor
 const warm = evaluateTrendForAgent(warmTrend, defaultFloor, baseOptions);
 assert(!warm.blocked, 'warming trend within limit should not block');
-assert(warm.profitFloor > defaultFloor, 'warming trend should raise profit floor');
+assert(
+  warm.profitFloor > defaultFloor,
+  'warming trend should raise profit floor'
+);
 assert(warm.penalty > 0, 'warming trend should apply penalty');
 
 // Cooling trend should lower profit floor but respect minimum bound
 const cooling = evaluateTrendForAgent(coolingTrend, defaultFloor, baseOptions);
 assert(!cooling.blocked, 'cooling trend should not block');
-assert(cooling.profitFloor <= defaultFloor, 'cooling trend should reduce floor');
-assert(cooling.profitFloor >= baseOptions.minProfitFloor, 'floor should respect minimum');
+assert(
+  cooling.profitFloor <= defaultFloor,
+  'cooling trend should reduce floor'
+);
+assert(
+  cooling.profitFloor >= baseOptions.minProfitFloor,
+  'floor should respect minimum'
+);
 assert(cooling.bonus > 0, 'cooling trend should earn bonus');
 
 // Excessive momentum should block even if status allowed

--- a/apps/orchestrator/__tests__/trendScoring.test.ts
+++ b/apps/orchestrator/__tests__/trendScoring.test.ts
@@ -1,0 +1,95 @@
+import { strict as assert } from 'assert';
+import {
+  evaluateTrendForAgent,
+  parseTrendStatuses,
+  type TrendEvaluationOptions,
+} from '../trendScoring';
+import type { AgentEnergyTrend } from '../../../shared/energyTrends';
+
+function makeTrend(overrides: Partial<AgentEnergyTrend>): AgentEnergyTrend {
+  return {
+    agent: overrides.agent ?? '0xagent',
+    sampleCount: overrides.sampleCount ?? 10,
+    anomalyCount: overrides.anomalyCount ?? 0,
+    anomalyRate: overrides.anomalyRate ?? 0,
+    shortTermEnergy: overrides.shortTermEnergy ?? 120,
+    longTermEnergy: overrides.longTermEnergy ?? 100,
+    energyMomentum: overrides.energyMomentum ?? 20,
+    energyMomentumRatio: overrides.energyMomentumRatio ?? 0.2,
+    shortTermEfficiency: overrides.shortTermEfficiency ?? 0.4,
+    longTermEfficiency: overrides.longTermEfficiency ?? 0.35,
+    efficiencyMomentum: overrides.efficiencyMomentum ?? 0.05,
+    totalReward: overrides.totalReward ?? 400,
+    averageReward: overrides.averageReward ?? 40,
+    status: overrides.status ?? 'warming',
+    notes: overrides.notes ?? [],
+    lastUpdated: overrides.lastUpdated ?? new Date().toISOString(),
+    lastAnomalyAt: overrides.lastAnomalyAt,
+    lastSample: overrides.lastSample,
+  };
+}
+
+const baseOptions: TrendEvaluationOptions = {
+  maxMomentumRatio: 0.3,
+  profitWeight: 0.25,
+  coolingBonusWeight: 0.15,
+  minProfitFloor: 0.02,
+  blockedStatuses: new Set(['overheating']),
+};
+
+const defaultFloor = 0.05;
+
+const warmTrend = makeTrend({ status: 'warming', energyMomentumRatio: 0.18 });
+const hotTrend = makeTrend({ status: 'overheating', energyMomentumRatio: 0.6 });
+const coolingTrend = makeTrend({ status: 'cooling', energyMomentumRatio: -0.12 });
+
+// parseTrendStatuses should default to blocking overheating
+const defaultStatuses = parseTrendStatuses(undefined);
+assert(defaultStatuses.has('overheating'), 'default should block overheating');
+
+// parseTrendStatuses should ignore invalid entries and accept valid ones
+const parsed = parseTrendStatuses('warming,invalid, COOLING');
+assert(parsed.has('warming'), 'should include warming status');
+assert(parsed.has('cooling'), 'should include cooling status');
+assert(!parsed.has('overheating'), 'should not include overheating implicitly');
+
+// parseTrendStatuses should allow disabling filtering
+const none = parseTrendStatuses('none');
+assert.equal(none.size, 0, 'none should disable all blocked statuses');
+
+// Overheating trend should be blocked
+const overheating = evaluateTrendForAgent(hotTrend, defaultFloor, baseOptions);
+assert(overheating.blocked, 'overheating status should block agent');
+assert.equal(overheating.reason, 'status:overheating');
+
+// Warming trend within momentum threshold should increase profit floor
+const warm = evaluateTrendForAgent(warmTrend, defaultFloor, baseOptions);
+assert(!warm.blocked, 'warming trend within limit should not block');
+assert(warm.profitFloor > defaultFloor, 'warming trend should raise profit floor');
+assert(warm.penalty > 0, 'warming trend should apply penalty');
+
+// Cooling trend should lower profit floor but respect minimum bound
+const cooling = evaluateTrendForAgent(coolingTrend, defaultFloor, baseOptions);
+assert(!cooling.blocked, 'cooling trend should not block');
+assert(cooling.profitFloor <= defaultFloor, 'cooling trend should reduce floor');
+assert(cooling.profitFloor >= baseOptions.minProfitFloor, 'floor should respect minimum');
+assert(cooling.bonus > 0, 'cooling trend should earn bonus');
+
+// Excessive momentum should block even if status allowed
+const optionsNoBlockStatus: TrendEvaluationOptions = {
+  ...baseOptions,
+  blockedStatuses: new Set(['cooling']),
+};
+const aggressiveMomentum = evaluateTrendForAgent(
+  makeTrend({ status: 'stable', energyMomentumRatio: 0.9 }),
+  defaultFloor,
+  optionsNoBlockStatus
+);
+assert(aggressiveMomentum.blocked, 'momentum beyond max should block');
+assert.equal(
+  aggressiveMomentum.reason,
+  'momentum:0.9000',
+  'reason should include formatted momentum'
+);
+
+console.log('trendScoring tests passed');

--- a/apps/orchestrator/bidding.ts
+++ b/apps/orchestrator/bidding.ts
@@ -277,58 +277,58 @@ export async function selectAgent(
     }
   }
 
-interface EvaluatedAgent {
-  agent: AgentInfo;
-  reputation: bigint;
-  predictedEnergy: number;
-  efficiency: number;
-  skillMatches: number;
-  profitMargin: number;
-  profitable: boolean;
-  stakeSufficient: boolean;
-  anomalyRate: number;
-  energySource: string;
-  efficiencySource: string;
-  trendStatus: string;
-  energyMomentumRatio: number;
-  profitThreshold: number;
-  trendPenalty: number;
-  trendBonus: number;
-}
+  interface EvaluatedAgent {
+    agent: AgentInfo;
+    reputation: bigint;
+    predictedEnergy: number;
+    efficiency: number;
+    skillMatches: number;
+    profitMargin: number;
+    profitable: boolean;
+    stakeSufficient: boolean;
+    anomalyRate: number;
+    energySource: string;
+    efficiencySource: string;
+    trendStatus: string;
+    energyMomentumRatio: number;
+    profitThreshold: number;
+    trendPenalty: number;
+    trendBonus: number;
+  }
 
-const formatDiagnostics = (
-  entries: EvaluatedAgent[]
-): SelectionDiagnosticsEntry[] =>
-  entries.map((entry) => ({
-    address: entry.agent.address,
-    reputation: entry.reputation.toString(),
-    predictedEnergy: entry.predictedEnergy,
-    efficiency: entry.efficiency,
-    skillMatches: entry.skillMatches,
-    profitMargin: Number.isFinite(entry.profitMargin)
-      ? entry.profitMargin.toFixed(6)
-      : 'Infinity',
-    profitable: entry.profitable,
-    stakeSufficient: entry.stakeSufficient,
-    anomalyRate: entry.anomalyRate,
-    energySource: entry.energySource,
-    efficiencySource: entry.efficiencySource,
-    trendStatus: entry.trendStatus,
-    energyMomentumRatio: Number.isFinite(entry.energyMomentumRatio)
-      ? entry.energyMomentumRatio.toFixed(4)
-      : undefined,
-    profitThreshold: Number.isFinite(entry.profitThreshold)
-      ? entry.profitThreshold.toFixed(6)
-      : undefined,
-    trendPenalty:
-      entry.trendPenalty > 0 && Number.isFinite(entry.trendPenalty)
-        ? entry.trendPenalty.toFixed(6)
+  const formatDiagnostics = (
+    entries: EvaluatedAgent[]
+  ): SelectionDiagnosticsEntry[] =>
+    entries.map((entry) => ({
+      address: entry.agent.address,
+      reputation: entry.reputation.toString(),
+      predictedEnergy: entry.predictedEnergy,
+      efficiency: entry.efficiency,
+      skillMatches: entry.skillMatches,
+      profitMargin: Number.isFinite(entry.profitMargin)
+        ? entry.profitMargin.toFixed(6)
+        : 'Infinity',
+      profitable: entry.profitable,
+      stakeSufficient: entry.stakeSufficient,
+      anomalyRate: entry.anomalyRate,
+      energySource: entry.energySource,
+      efficiencySource: entry.efficiencySource,
+      trendStatus: entry.trendStatus,
+      energyMomentumRatio: Number.isFinite(entry.energyMomentumRatio)
+        ? entry.energyMomentumRatio.toFixed(4)
         : undefined,
-    trendBonus:
-      entry.trendBonus > 0 && Number.isFinite(entry.trendBonus)
-        ? entry.trendBonus.toFixed(6)
+      profitThreshold: Number.isFinite(entry.profitThreshold)
+        ? entry.profitThreshold.toFixed(6)
         : undefined,
-  }));
+      trendPenalty:
+        entry.trendPenalty > 0 && Number.isFinite(entry.trendPenalty)
+          ? entry.trendPenalty.toFixed(6)
+          : undefined,
+      trendBonus:
+        entry.trendBonus > 0 && Number.isFinite(entry.trendBonus)
+          ? entry.trendBonus.toFixed(6)
+          : undefined,
+    }));
 
   const evaluated: EvaluatedAgent[] = [];
   const energyInsights = getEnergyInsightsSnapshot();
@@ -610,8 +610,7 @@ function resolveTrendOptions(
     profitWeight: overrides?.profitWeight ?? DEFAULT_TREND_PROFIT_WEIGHT,
     coolingBonusWeight:
       overrides?.coolingBonusWeight ?? DEFAULT_TREND_COOLING_WEIGHT,
-    minProfitFloor:
-      overrides?.minProfitFloor ?? DEFAULT_TREND_MIN_PROFIT_FLOOR,
+    minProfitFloor: overrides?.minProfitFloor ?? DEFAULT_TREND_MIN_PROFIT_FLOOR,
     blockedStatuses: overrides?.blockedStatuses
       ? new Set(overrides.blockedStatuses)
       : new Set(DEFAULT_BLOCKED_TREND_STATUSES),

--- a/apps/orchestrator/service.ts
+++ b/apps/orchestrator/service.ts
@@ -600,7 +600,7 @@ export class MetaOrchestrator {
           spec?.thermodynamics?.minProfitMargin ??
           classification.spec?.thermodynamics?.minProfitMargin ??
           this.energyPolicy?.getBaseProfitMargin();
-        const selectionOptions = {
+        const selectionOptions: SelectAgentOptions = {
           provider,
           jobId: summary.jobId,
           minEfficiencyScore:
@@ -611,7 +611,7 @@ export class MetaOrchestrator {
           requiredStake: requirements.stake,
           stakeManagerAddress: this.config.stakeManagerAddress,
           energyPolicy: this.energyPolicy ?? undefined,
-        } satisfies SelectAgentOptions;
+        };
         if (baseProfitMargin !== undefined) {
           selectionOptions.minProfitMargin = baseProfitMargin;
         }

--- a/apps/orchestrator/trendScoring.ts
+++ b/apps/orchestrator/trendScoring.ts
@@ -142,7 +142,8 @@ export function evaluateTrendForAgent(
     penalty = momentumRatio * Math.max(0, options.profitWeight);
     profitFloor += penalty;
   } else if (momentumRatio < 0 && isFiniteNumber(options.coolingBonusWeight)) {
-    const rawBonus = Math.abs(momentumRatio) * Math.max(0, options.coolingBonusWeight);
+    const rawBonus =
+      Math.abs(momentumRatio) * Math.max(0, options.coolingBonusWeight);
     const maxReduction = profitFloor - minProfitFloor;
     if (maxReduction > 0) {
       bonus = Math.min(rawBonus, maxReduction);

--- a/apps/orchestrator/trendScoring.ts
+++ b/apps/orchestrator/trendScoring.ts
@@ -1,0 +1,169 @@
+import type {
+  AgentEnergyTrend,
+  EnergyTrendStatus,
+} from '../../shared/energyTrends';
+
+export interface TrendEvaluationOptions {
+  maxMomentumRatio: number;
+  profitWeight: number;
+  coolingBonusWeight: number;
+  minProfitFloor: number;
+  blockedStatuses: ReadonlySet<EnergyTrendStatus>;
+}
+
+export interface TrendEvaluationResult {
+  blocked: boolean;
+  reason?: string;
+  profitFloor: number;
+  status: EnergyTrendStatus | 'unknown';
+  momentumRatio: number;
+  penalty: number;
+  bonus: number;
+}
+
+const VALID_TREND_STATUSES: ReadonlyArray<EnergyTrendStatus> = [
+  'cooling',
+  'stable',
+  'warming',
+  'overheating',
+];
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function sanitiseBaseProfit(value: number, minimum: number): number {
+  if (!isFiniteNumber(value)) {
+    return minimum;
+  }
+  if (value < minimum) {
+    return minimum;
+  }
+  return value;
+}
+
+function normaliseMomentum(value: unknown): number {
+  if (!isFiniteNumber(value)) {
+    return 0;
+  }
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return value;
+}
+
+export function parseTrendStatuses(
+  raw: string | undefined
+): Set<EnergyTrendStatus> {
+  if (!raw || !raw.trim()) {
+    return new Set<EnergyTrendStatus>(['overheating']);
+  }
+  const tokens = raw
+    .split(',')
+    .map((token) => token.trim().toLowerCase())
+    .filter((token) => token.length > 0);
+  if (
+    tokens.some((token) =>
+      ['none', 'off', 'allow-all', 'disabled'].includes(token)
+    )
+  ) {
+    return new Set();
+  }
+  const statuses = new Set<EnergyTrendStatus>();
+  for (const token of tokens) {
+    if ((VALID_TREND_STATUSES as string[]).includes(token)) {
+      statuses.add(token as EnergyTrendStatus);
+    }
+  }
+  if (statuses.size === 0) {
+    return new Set<EnergyTrendStatus>(['overheating']);
+  }
+  return statuses;
+}
+
+export function evaluateTrendForAgent(
+  trend: AgentEnergyTrend | null | undefined,
+  baseProfitFloor: number,
+  options: TrendEvaluationOptions
+): TrendEvaluationResult {
+  const minProfitFloor = isFiniteNumber(options.minProfitFloor)
+    ? Math.max(0, options.minProfitFloor)
+    : 0;
+  const blockedStatuses = options.blockedStatuses ?? new Set();
+  const baseFloor = sanitiseBaseProfit(baseProfitFloor, minProfitFloor);
+
+  if (!trend) {
+    return {
+      blocked: false,
+      profitFloor: baseFloor,
+      status: 'unknown',
+      momentumRatio: 0,
+      penalty: 0,
+      bonus: 0,
+    };
+  }
+
+  const status = trend.status;
+  const momentumRatio = normaliseMomentum(trend.energyMomentumRatio);
+
+  if (blockedStatuses.has(status)) {
+    return {
+      blocked: true,
+      reason: `status:${status}`,
+      profitFloor: baseFloor,
+      status,
+      momentumRatio,
+      penalty: 0,
+      bonus: 0,
+    };
+  }
+
+  if (
+    isFiniteNumber(options.maxMomentumRatio) &&
+    options.maxMomentumRatio >= 0 &&
+    momentumRatio > options.maxMomentumRatio
+  ) {
+    return {
+      blocked: true,
+      reason: `momentum:${momentumRatio.toFixed(4)}`,
+      profitFloor: baseFloor,
+      status,
+      momentumRatio,
+      penalty: 0,
+      bonus: 0,
+    };
+  }
+
+  let profitFloor = baseFloor;
+  let penalty = 0;
+  let bonus = 0;
+
+  if (momentumRatio > 0 && isFiniteNumber(options.profitWeight)) {
+    penalty = momentumRatio * Math.max(0, options.profitWeight);
+    profitFloor += penalty;
+  } else if (momentumRatio < 0 && isFiniteNumber(options.coolingBonusWeight)) {
+    const rawBonus = Math.abs(momentumRatio) * Math.max(0, options.coolingBonusWeight);
+    const maxReduction = profitFloor - minProfitFloor;
+    if (maxReduction > 0) {
+      bonus = Math.min(rawBonus, maxReduction);
+      profitFloor -= bonus;
+    }
+  }
+
+  if (!isFiniteNumber(profitFloor)) {
+    profitFloor = baseFloor;
+  }
+
+  if (profitFloor < minProfitFloor) {
+    profitFloor = minProfitFloor;
+  }
+
+  return {
+    blocked: false,
+    profitFloor,
+    status,
+    momentumRatio,
+    penalty,
+    bonus,
+  };
+}


### PR DESCRIPTION
## Summary
- extend orchestrator bidding to consult energy trend snapshots, dynamically adjust profit floors, and skip overheating agents
- add a reusable trend scoring utility that parses configuration and evaluates agent momentum penalties/bonuses
- cover the new logic with targeted unit tests for trend evaluation behaviours

## Testing
- npx tsc -p apps/orchestrator/tsconfig.json
- npx ts-node --project apps/orchestrator/tsconfig.json apps/orchestrator/__tests__/trendScoring.test.ts
- npx ts-node --project apps/orchestrator/tsconfig.json apps/orchestrator/__tests__/energyPolicy.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ca2df864088333ab608c5bfa09342d