### PR TITLE
Document ValidationRevealed burnTxHash parameter

### DIFF
--- a/docs/api/ValidationModule.md
+++ b/docs/api/ValidationModule.md
@@ -33,6 +33,6 @@ Manages commit‑reveal voting for submitted jobs.
 - `SelectionStrategyUpdated(SelectionStrategy strategy)`
 - `ValidatorIdentityVerified(address indexed validator, bytes32 indexed node, string label, bool viaWrapper, bool viaMerkle)`
 - `ValidationCommitted(uint256 jobId, address validator, bytes32 commitHash, string subdomain)`
-- `ValidationRevealed(uint256 jobId, address validator, bool approve, string subdomain)`
+- `ValidationRevealed(uint256 jobId, address validator, bool approve, bytes32 burnTxHash, string subdomain)`
 - `ValidationTallied(uint256 jobId, bool success, uint256 approvals, uint256 rejections)`
 - `ValidationResult(uint256 jobId, bool success)`

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -264,7 +264,7 @@ To generate proofs:
 | `JobCreated(uint256 jobId, address employer, uint256 reward)`                                 | `JobRegistry`      | Employer posted a job and escrowed funds. |
 | `JobApplied(uint256 jobId, address agent)`                                                    | `JobRegistry`      | Agent applied for a job.                  |
 | `ValidationCommitted(uint256 jobId, address validator, bytes32 commitHash, string subdomain)` | `ValidationModule` | Validator submitted hashed vote.          |
-| `ValidationRevealed(uint256 jobId, address validator, bool approve, string subdomain)`        | `ValidationModule` | Validator revealed vote.                  |
+| `ValidationRevealed(uint256 jobId, address validator, bool approve, bytes32 burnTxHash, string subdomain)` | `ValidationModule` | Validator revealed vote.                  |
 | `DisputeRaised(uint256 jobId, address claimant, bytes32 evidenceHash, string evidence)`       | `DisputeModule`    | A job result was contested.               |
 | `DisputeResolved(uint256 jobId, bool employerWins)`                                           | `DisputeModule`    | Moderator issued final ruling.            |
 | `CertificateMinted(address to, uint256 jobId)`                                                | `CertificateNFT`   | NFT minted for a completed job.           |


### PR DESCRIPTION
## Summary
- update the deployment and operations event glossary to include the burnTxHash parameter on ValidationRevealed
- extend the ValidationModule API docs to show the burnTxHash argument in the event signature

## Testing
- npm run format:check (fails: Prettier reports existing formatting issues across unrelated docs)


------
https://chatgpt.com/codex/tasks/task_e_68cacf46a4188333aa29703b389a743f