### PR TITLE
docs: update JobRegistry API for burn flow

### DIFF
--- a/docs/api/JobRegistry.md
+++ b/docs/api/JobRegistry.md
@@ -4,14 +4,18 @@ Coordinates job posting, assignment and dispute resolution.
 
 ## Functions
 
-- `createJob(uint256 reward, string uri)` – employer escrows reward and posts IPFS job metadata.
-- `applyForJob(uint256 jobId, bytes32 label, bytes32[] proof)` – agent applies using ENS label and Merkle proof.
-- `submit(uint256 jobId, bytes32 resultHash, string resultURI)` – agent submits work.
-- `finalize(uint256 jobId)` – releases rewards after validation succeeds.
-- `raiseDispute(uint256 jobId, string evidence)` – escalate to the dispute module.
-- `setModules(address stakeManager, address validationModule, address disputeModule, address certificateNFT, address reputationEngine, address feePool)` – owner wires modules.
-- `setTaxPolicy(address policy)` / `acknowledgeTaxPolicy()` – configure tax policy and acknowledge.
-- `setAgentRootNode(bytes32 node)` / `setAgentMerkleRoot(bytes32 root)` – load ENS allowlists.
+- `createJob(uint256 reward, uint64 deadline, bytes32 specHash, string uri)` – employer escrows reward, sets a deadline and spec hash, and posts IPFS metadata.
+- `createJobWithAgentTypes(uint256 reward, uint64 deadline, uint8 agentTypes, bytes32 specHash, string uri)` – variant that restricts which agent types can apply.
+- `submitBurnReceipt(uint256 jobId, bytes32 burnTxHash, uint256 amount, uint256 blockNumber)` – employer records proof of the protocol fee and burn payment for a completed job.
+- `confirmEmployerBurn(uint256 jobId, bytes32 burnTxHash)` – employer confirms the burn evidence and records the paid amount required before non-governance finalization can settle funds.
+- `applyForJob(uint256 jobId, string subdomain, bytes32[] proof)` – agent applies using ENS subdomain and Merkle proof validation.
+- `submit(uint256 jobId, bytes32 resultHash, string resultURI, string subdomain, bytes32[] proof)` – agent submits work after re-verifying their identity against the registry.
+- `finalize(uint256 jobId)` – employer (or governance) finalizes a completed job. Employers must have a confirmed burn receipt when protocol fees or burns apply.
+- `dispute(uint256 jobId, bytes32 evidenceHash)` / `raiseDispute(uint256 jobId, bytes32 evidenceHash)` – escalate to the dispute module with hashed evidence payloads.
+- `setModules(IValidationModule validationModule, IStakeManager stakeManager, IReputationEngine reputationEngine, IDisputeModule disputeModule, ICertificateNFT certificateNFT, IFeePool feePool, address[] ackModules)` – governance wires core modules and authorised acknowledgement helpers.
+- `setTaxPolicy(ITaxPolicy policy)` / `acknowledgeTaxPolicy()` – configure the tax policy contract and record participant acknowledgements.
+- `setAgentRootNode(bytes32 node)` / `setAgentMerkleRoot(bytes32 root)` – load ENS allowlists for agent verification.
+- `setIdentityRegistry(IIdentityRegistry registry)` – swap the on-chain identity registry and refresh cached authorizations.
 
 ## Events
 
@@ -21,9 +25,37 @@ Coordinates job posting, assignment and dispute resolution.
 - `JobApplied(uint256 indexed jobId, address indexed agent, string subdomain)`
 - `JobSubmitted(uint256 indexed jobId, address indexed worker, bytes32 resultHash, string resultURI, string subdomain)`
 - `JobCompleted(uint256 indexed jobId, bool success)`
-- `JobPayout(uint256 indexed jobId, address indexed worker, uint256 netPaid, uint256 fee)`
+- `JobPayout(uint256 indexed jobId, address indexed worker, uint256 base, uint256 bonus, uint256 fee)`
 - `JobFinalized(uint256 indexed jobId, address indexed worker)`
 - `JobCancelled(uint256 indexed jobId)`
-- `JobExpired(uint256 indexed jobId, address caller)`
-- `JobDisputed(uint256 indexed jobId, address caller)`
+- `JobExpired(uint256 indexed jobId, address indexed caller)`
+- `JobDisputed(uint256 indexed jobId, address indexed caller)`
 - `DisputeResolved(uint256 indexed jobId, bool employerWins)`
+- `JobParametersUpdated(uint256 reward, uint256 stake, uint256 maxJobReward, uint256 maxJobDuration)`
+- `BurnReceiptSubmitted(uint256 indexed jobId, bytes32 indexed burnTxHash, uint256 amount, uint256 blockNumber)`
+- `BurnConfirmed(uint256 indexed jobId, bytes32 indexed burnTxHash)`
+- `BurnDiscrepancy(uint256 indexed jobId, uint256 receiptAmount, uint256 expectedAmount)`
+- `GovernanceFinalized(uint256 indexed jobId, address indexed caller, bool fundsRedirected)`
+- `ModuleUpdated(string module, address newAddress)`
+- `ValidationModuleUpdated(address module)`
+- `StakeManagerUpdated(address manager)`
+- `ReputationEngineUpdated(address engine)`
+- `DisputeModuleUpdated(address module)`
+- `CertificateNFTUpdated(address nft)`
+- `IdentityRegistryUpdated(address identityRegistry)`
+- `AgentRootNodeUpdated(bytes32 node)`
+- `AgentMerkleRootUpdated(bytes32 root)`
+- `ValidatorRootNodeUpdated(bytes32 node)`
+- `ValidatorMerkleRootUpdated(bytes32 root)`
+- `AgentAuthCacheUpdated(address indexed agent, bool authorized)`
+- `AgentAuthCacheDurationUpdated(uint256 duration)`
+- `AgentAuthCacheVersionBumped(uint256 version)`
+- `TaxPolicyUpdated(address policy, uint256 version)`
+- `TaxAcknowledged(address indexed user, uint256 version, string acknowledgement)`
+- `AcknowledgerUpdated(address indexed acknowledger, bool allowed)`
+- `FeePoolUpdated(address pool)`
+- `FeePctUpdated(uint256 feePct)`
+- `ValidatorRewardPctUpdated(uint256 pct)`
+- `ExpirationGracePeriodUpdated(uint256 period)`
+- `PauserUpdated(address indexed pauser)`
+- `TreasuryUpdated(address treasury)`


### PR DESCRIPTION
## Summary
- update JobRegistry function descriptions for the burn receipt flow and current signatures
- document new burn receipt helpers and module wiring events
- correct JobPayout parameters and add newly emitted events to the API reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad1ae5d488333b3af69378275a429