### PR TITLE
Make ModuleUpdated newAddress indexed

### DIFF
--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -273,7 +273,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     uint256 public expirationGracePeriod;
 
     // module configuration events
-    event ModuleUpdated(string module, address newAddress);
+    event ModuleUpdated(string module, address indexed newAddress);
     event ValidationModuleUpdated(address module);
     event StakeManagerUpdated(address manager);
     event ReputationEngineUpdated(address engine);

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -55,7 +55,7 @@ interface IJobRegistry {
     error BurnNotConfirmed();
 
     // module configuration
-    event ModuleUpdated(string module, address newAddress);
+    event ModuleUpdated(string module, address indexed newAddress);
     event ValidationModuleUpdated(address module);
     event ReputationEngineUpdated(address engine);
     event StakeManagerUpdated(address manager);

--- a/docs/api/JobRegistry.md
+++ b/docs/api/JobRegistry.md
@@ -36,7 +36,7 @@ Coordinates job posting, assignment and dispute resolution.
 - `BurnConfirmed(uint256 indexed jobId, bytes32 indexed burnTxHash)`
 - `BurnDiscrepancy(uint256 indexed jobId, uint256 receiptAmount, uint256 expectedAmount)`
 - `GovernanceFinalized(uint256 indexed jobId, address indexed caller, bool fundsRedirected)`
-- `ModuleUpdated(string module, address newAddress)`
+- `ModuleUpdated(string module, address indexed newAddress)`
 - `ValidationModuleUpdated(address module)`
 - `StakeManagerUpdated(address manager)`
 - `ReputationEngineUpdated(address engine)`


### PR DESCRIPTION
## Summary
- mark the JobRegistry `ModuleUpdated` event's `newAddress` parameter as indexed for better filtering
- update the JobRegistry interface declaration and API docs to match the indexed parameter

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68cad54c1d488333baf0fee868f271ef