### PR TITLE
Emit ModulesUpdated from individual module setters

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -554,6 +554,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         }
         jobRegistry = _jobRegistry;
         emit JobRegistryUpdated(_jobRegistry);
+        emit ModulesUpdated(jobRegistry, disputeModule);
     }
 
     /// @notice set the dispute module authorized to manage dispute fees
@@ -564,6 +565,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         }
         disputeModule = module;
         emit DisputeModuleUpdated(module);
+        emit ModulesUpdated(jobRegistry, disputeModule);
     }
 
     /// @notice set the validation module used to source validator lists

--- a/test/v2/StakeManager.test.js
+++ b/test/v2/StakeManager.test.js
@@ -694,6 +694,32 @@ describe('StakeManager', function () {
     ).to.be.revertedWithCustomError(stakeManager, 'InvalidTreasury');
   });
 
+  it('emits ModulesUpdated when updating modules individually', async () => {
+    const VersionMock = await ethers.getContractFactory(
+      'contracts/v2/mocks/VersionMock.sol:VersionMock'
+    );
+    const jobRegistryMock = await VersionMock.deploy(2);
+    const disputeModuleMock = await VersionMock.deploy(2);
+    const jobRegistryAddress = await jobRegistryMock.getAddress();
+    const disputeModuleAddress = await disputeModuleMock.getAddress();
+
+    await expect(
+      stakeManager.connect(owner).setJobRegistry(jobRegistryAddress)
+    )
+      .to.emit(stakeManager, 'JobRegistryUpdated')
+      .withArgs(jobRegistryAddress)
+      .and.to.emit(stakeManager, 'ModulesUpdated')
+      .withArgs(jobRegistryAddress, ethers.ZeroAddress);
+
+    await expect(
+      stakeManager.connect(owner).setDisputeModule(disputeModuleAddress)
+    )
+      .to.emit(stakeManager, 'DisputeModuleUpdated')
+      .withArgs(disputeModuleAddress)
+      .and.to.emit(stakeManager, 'ModulesUpdated')
+      .withArgs(jobRegistryAddress, disputeModuleAddress);
+  });
+
   it('reverts slashing when treasury removed from allowlist', async () => {
     const JobRegistry = await ethers.getContractFactory(
       'contracts/v2/JobRegistry.sol:JobRegistry'


### PR DESCRIPTION
## Summary
- emit ModulesUpdated from setJobRegistry and setDisputeModule so module changes stay in sync
- add unit coverage ensuring each setter emits the aggregated ModulesUpdated event with expected addresses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cae1d834048333a71c8fe5256a8aa4