### PR TITLE
Enforce minimum agent stake during job applications

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -22,6 +22,7 @@ contract MockStakeManager is IStakeManager {
     mapping(Role => uint256) public totalStakes;
     address public disputeModule;
     address public override jobRegistry;
+    uint256 public minStake;
 
     function setJobRegistry(address j) external { jobRegistry = j; }
 
@@ -73,7 +74,9 @@ contract MockStakeManager is IStakeManager {
     function lockDisputeFee(address, uint256) external override {}
     function payDisputeFee(address, uint256) external override {}
 
-    function setMinStake(uint256) external override {}
+    function setMinStake(uint256 value) external override {
+        minStake = value;
+    }
     function setSlashingPercentages(uint256, uint256) external override {}
     function setSlashingParameters(uint256, uint256) external override {}
     function setTreasury(address) external override {}

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -56,6 +56,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
     error BlacklistedAgent();
     error NotAuthorizedAgent();
     error AgentTypeNotAllowed();
+    error AgentStakeTooLow();
     error InvalidJobState();
     error OnlyAgent();
     error DeadlinePassed();
@@ -958,6 +959,13 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             }
         }
         if (!authorized) revert NotAuthorizedAgent();
+        if (address(stakeManager) != address(0)) {
+            uint256 currentStake = stakeManager.stakeOf(
+                msg.sender,
+                IStakeManager.Role.Agent
+            );
+            if (currentStake < stakeManager.minStake()) revert AgentStakeTooLow();
+        }
         if (job.agentTypes > 0) {
             IIdentityRegistry.AgentType aType = identityRegistry.getAgentType(
                 msg.sender

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -177,6 +177,9 @@ interface IStakeManager {
     /// @notice Cap on total payout percentage across AGI types
     function maxTotalPayoutPct() external view returns (uint256);
 
+    /// @notice Minimum stake required for agents and validators
+    function minStake() external view returns (uint256);
+
     /// @notice ERC20 token used for staking operations
     function token() external view returns (IERC20);
 

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -14,6 +14,7 @@ contract ReentrantStakeManager is IStakeManager {
     mapping(Role => uint256) public totalStakes;
     address public override jobRegistry;
     IValidationModule public validation;
+    uint256 public minStake;
 
     bool public attackSlash;
     uint256 public attackJobId;
@@ -71,7 +72,7 @@ contract ReentrantStakeManager is IStakeManager {
     function setModules(address, address) external override {}
     function lockDisputeFee(address, uint256) external override {}
     function payDisputeFee(address, uint256) external override {}
-    function setMinStake(uint256) external override {}
+    function setMinStake(uint256 value) external override { minStake = value; }
     function setSlashingPercentages(uint256, uint256) external override {}
     function setSlashingParameters(uint256, uint256) external override {}
     function setTreasury(address) external override {}

--- a/test/v2/JobRegistryApply.test.js
+++ b/test/v2/JobRegistryApply.test.js
@@ -4,7 +4,7 @@ const { time } = require('@nomicfoundation/hardhat-network-helpers');
 
 describe('JobRegistry agent gating', function () {
   let owner, employer, agent;
-  let registry, rep, verifier, policy;
+  let registry, rep, verifier, policy, stakeManager;
 
   beforeEach(async () => {
     [owner, employer, agent] = await ethers.getSigners();
@@ -12,7 +12,7 @@ describe('JobRegistry agent gating', function () {
     const Stake = await ethers.getContractFactory(
       'contracts/legacy/MockV2.sol:MockStakeManager'
     );
-    const stakeManager = await Stake.deploy();
+    stakeManager = await Stake.deploy();
 
     const Rep = await ethers.getContractFactory(
       'contracts/v2/ReputationEngine.sol:ReputationEngine'
@@ -121,5 +121,21 @@ describe('JobRegistry agent gating', function () {
     await expect(registry.connect(agent).applyForJob(jobId, 'a', []))
       .to.be.revertedWithCustomError(registry, 'TaxPolicyNotAcknowledged')
       .withArgs(agent.address);
+  });
+
+  it('requires agents to meet the minimum stake', async () => {
+    await verifier.addAdditionalAgent(agent.address);
+    await stakeManager.setMinStake(1);
+
+    const jobId = await createJob();
+
+    await expect(registry.connect(agent).applyForJob(jobId, 'a', []))
+      .to.be.revertedWithCustomError(registry, 'AgentStakeTooLow');
+
+    await stakeManager.setStake(agent.address, 0, 1);
+
+    await expect(registry.connect(agent).applyForJob(jobId, 'a', []))
+      .to.emit(registry, 'JobApplied')
+      .withArgs(jobId, agent.address, 'a');
   });
 });


### PR DESCRIPTION
## Summary
- expose the global minimum stake from the stake manager interface and mocks
- guard JobRegistry applications so agents must hold at least the minimum stake
- extend JobRegistryApply tests to cover insufficient and sufficient stake flows

## Testing
- npx hardhat test test/v2/JobRegistryApply.test.js

------
https://chatgpt.com/codex/tasks/task_e_68caf29930508333bd34be4854d01ce3