### PR TITLE
feat: harden validator commit hashing

### DIFF
--- a/test/v2/ValidationFinalizeGas.t.sol
+++ b/test/v2/ValidationFinalizeGas.t.sol
@@ -70,7 +70,7 @@ contract ValidationFinalizeGas is Test {
 
     function _prepareJob() internal returns (uint256 jobId) {
         jobId = 1;
-        IJobRegistry.Job memory job;
+        MockJobRegistry.LegacyJob memory job;
         job.employer = employer;
         job.agent = agent;
         job.status = IJobRegistry.Status.Submitted;
@@ -90,8 +90,18 @@ contract ValidationFinalizeGas is Test {
             address val = validators[i];
             bytes32 salt = bytes32(uint256(i + 1));
             uint256 nonce = validation.jobNonce(jobId);
+            bytes32 outcomeHash = keccak256(
+                abi.encode(jobId, nonce, true, burnTxHash, bytes32(0))
+            );
             bytes32 commitHash = keccak256(
-                abi.encodePacked(jobId, nonce, true, burnTxHash, salt, bytes32(0))
+                abi.encode(
+                    jobId,
+                    outcomeHash,
+                    salt,
+                    val,
+                    block.chainid,
+                    validation.DOMAIN_SEPARATOR()
+                )
             );
             vm.prank(val);
             validation.commitValidation(jobId, commitHash, "", new bytes32[](0));


### PR DESCRIPTION
## Summary
- add an immutable domain separator and typed commit hashing to the validation module
- reject empty commit payloads and strengthen reveal preimage checking against the typed hash
- update the validation gas test harness to build commits with the new domain separated encoding

## Testing
- forge test --match-contract ValidationFinalizeGas *(fails: repository requires via-ir compilation which overflows the stack without via-ir, while via-ir currently triggers a Yul swap depth error in upstream sources)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1b9682348333a84548e4fa0f6d48