### PR TITLE
Strengthen validation penalties and typed commits

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -54,6 +54,8 @@ error InvalidBurnReceipt();
 error AlreadyTallied();
 error RevealPending();
 error UnauthorizedCaller();
+error ValidatorBanned();
+error InvalidPenalty();
 
 /// @title ValidationModule
 /// @notice Handles validator selection and commit–reveal voting for jobs.
@@ -65,6 +67,9 @@ error UnauthorizedCaller();
 contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pausable, ReentrancyGuard {
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 2;
+
+    /// @notice Domain separator used for typed commit hashes.
+    bytes32 public immutable DOMAIN_SEPARATOR;
 
     IJobRegistry public jobRegistry;
     IStakeManager public stakeManager;
@@ -133,6 +138,8 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         uint256 revealedCount;
         bool tallied;
         uint256 committeeSize;
+        uint64 earlyFinalizeEligibleAt;
+        bool earlyFinalized;
     }
 
     mapping(uint256 => Round) public rounds;
@@ -156,6 +163,21 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         private entropyContributed;
     uint256 public constant MIN_ENTROPY_CONTRIBUTORS = 2;
 
+    /// @notice Selection seed captured for each job to prevent post-selection manipulation.
+    mapping(uint256 => bytes32) public selectionSeeds;
+
+    /// @notice Basis points slashed from validator stake when they fail to reveal.
+    uint256 public nonRevealPenaltyBps = 50; // 0.5%
+
+    /// @notice Number of blocks a validator is banned from new committees after failing to reveal.
+    uint256 public nonRevealBanBlocks = 7_200; // ~1 day assuming 12s blocks
+
+    /// @notice Cool-off delay before an early finalize may be triggered once quorum is met.
+    uint256 public earlyFinalizeDelay = 5 minutes;
+
+    /// @notice Block number until which a validator is banned from committee selection.
+    mapping(address => uint256) public validatorBanUntil;
+
     event ValidatorsUpdated(address[] validators);
     event ReputationEngineUpdated(address engine);
     event TimingUpdated(uint256 commitWindow, uint256 revealWindow);
@@ -177,6 +199,10 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     event ValidatorAuthCacheVersionBumped(uint256 version);
     event SelectionReset(uint256 indexed jobId);
     event PauserUpdated(address indexed pauser);
+    event NonRevealPenaltyUpdated(uint256 penaltyBps, uint256 banBlocks);
+    event EarlyFinalizeDelayUpdated(uint256 delay);
+    event ValidatorBanApplied(address indexed validator, uint256 untilBlock);
+    event SelectionSeedRecorded(uint256 indexed jobId, bytes32 seed);
     /// @notice Emitted when a validator's ENS identity is verified.
     event ValidatorIdentityVerified(
         address indexed validator,
@@ -198,6 +224,26 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         pauser = _pauser;
         emit PauserUpdated(_pauser);
     }
+
+    /// @notice Update non-reveal penalty parameters.
+    /// @param penaltyBps Slash applied in basis points of validator stake.
+    /// @param banBlocks Number of blocks a validator is banned from new committees.
+    function setNonRevealPenalty(uint256 penaltyBps, uint256 banBlocks)
+        external
+        onlyOwner
+    {
+        if (penaltyBps > 1_000) revert InvalidPenalty();
+        nonRevealPenaltyBps = penaltyBps;
+        nonRevealBanBlocks = banBlocks;
+        emit NonRevealPenaltyUpdated(penaltyBps, banBlocks);
+    }
+
+    /// @notice Update the cool-off delay before early finalization is permitted.
+    /// @param delay Seconds to wait after quorum is met before allowing finalize.
+    function setEarlyFinalizeDelay(uint256 delay) external onlyOwner {
+        earlyFinalizeDelay = delay;
+        emit EarlyFinalizeDelayUpdated(delay);
+    }
     event ValidatorPoolRotationUpdated(uint256 newRotation);
     event RandaoCoordinatorUpdated(address coordinator);
     event MaxValidatorsPerJobUpdated(uint256 maxValidators);
@@ -216,6 +262,17 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         uint256 _maxValidators,
         address[] memory _validatorPool
     ) Ownable(msg.sender) {
+        DOMAIN_SEPARATOR =
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        "ValidationModule(string version,address verifyingContract,uint256 chainId)"
+                    ),
+                    keccak256(bytes("1")),
+                    address(this),
+                    block.chainid
+                )
+            );
         if (address(_jobRegistry) != address(0)) {
             jobRegistry = _jobRegistry;
             emit JobRegistryUpdated(address(_jobRegistry));
@@ -712,19 +769,20 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
             rcRand = randaoCoordinator.random(bytes32(jobId));
         }
 
-        uint256 seed = uint256(
-            keccak256(
-                abi.encodePacked(
-                    jobId,
-                    jobNonce[jobId],
-                    pendingEntropy[jobId],
-                    randaoValue,
-                    bhash,
-                    address(this),
-                    rcRand
-                )
+        bytes32 seed = keccak256(
+            abi.encode(
+                jobId,
+                jobNonce[jobId],
+                pendingEntropy[jobId],
+                randaoValue,
+                bhash,
+                address(this),
+                rcRand
             )
         );
+        selectionSeeds[jobId] = seed;
+        emit SelectionSeedRecorded(jobId, seed);
+        uint256 randomSeed = uint256(seed);
 
         uint256 n = validatorPool.length;
         if (n == 0) revert InsufficientValidators();
@@ -760,6 +818,13 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
             for (; i < n && candidateCount < sample;) {
                 uint256 idx = (rotationStart + i) % n;
                 address candidate = validatorPool[idx];
+
+                if (validatorBanUntil[candidate] > block.number) {
+                    unchecked {
+                        ++i;
+                    }
+                    continue;
+                }
 
                 uint256 stake = stakeManager.stakeOf(
                     candidate,
@@ -824,6 +889,13 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
             for (uint256 i; i < n;) {
                 address candidate = validatorPool[i];
 
+                if (validatorBanUntil[candidate] > block.number) {
+                    unchecked {
+                        ++i;
+                    }
+                    continue;
+                }
+
                 uint256 stake = stakeManager.stakeOf(
                     candidate,
                     IStakeManager.Role.Validator
@@ -884,8 +956,8 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
                         ++candidateCount;
                     }
                 } else {
-                    seed = uint256(keccak256(abi.encodePacked(seed, i)));
-                    uint256 j = seed % eligible;
+                    randomSeed = uint256(keccak256(abi.encode(randomSeed, i)));
+                    uint256 j = randomSeed % eligible;
                     if (j < sample) {
                         totalStake =
                             totalStake - candidateStakes[j] + stake;
@@ -903,8 +975,8 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         if (candidateCount < size) revert InsufficientValidators();
 
         for (uint256 i; i < size;) {
-            seed = uint256(keccak256(abi.encodePacked(seed, i)));
-            uint256 pick = seed % totalStake;
+            randomSeed = uint256(keccak256(abi.encode(randomSeed, i)));
+            uint256 pick = randomSeed % totalStake;
             uint256 cumulative;
             uint256 chosen;
             for (uint256 j; j < candidateCount;) {
@@ -993,6 +1065,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
             revert JobNotSubmitted();
         if (r.commitDeadline == 0 || block.timestamp > r.commitDeadline)
             revert CommitPhaseClosed();
+        if (validatorBanUntil[msg.sender] > block.number) revert ValidatorBanned();
         if (address(reputationEngine) != address(0)) {
             if (reputationEngine.isBlacklisted(msg.sender))
                 revert BlacklistedValidator();
@@ -1068,6 +1141,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         if (block.timestamp <= r.commitDeadline) revert CommitPhaseActive();
         if (block.timestamp > r.revealDeadline) revert RevealPhaseClosed();
         if (!_isValidator(jobId, msg.sender)) revert NotValidator();
+        if (validatorBanUntil[msg.sender] > block.number) revert ValidatorBanned();
         if (address(reputationEngine) != address(0)) {
             if (reputationEngine.isBlacklisted(msg.sender))
                 revert BlacklistedValidator();
@@ -1098,8 +1172,21 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         if (!jobRegistry.hasBurnReceipt(jobId, burnTxHash))
             revert InvalidBurnReceipt();
         bytes32 specHash = jobRegistry.getSpecHash(jobId);
-        if (
-            keccak256(
+        bytes32 outcomeHash = keccak256(
+            abi.encode(nonce, specHash, approve, burnTxHash)
+        );
+        bytes32 expected = keccak256(
+            abi.encode(
+                jobId,
+                outcomeHash,
+                salt,
+                msg.sender,
+                block.chainid,
+                DOMAIN_SEPARATOR
+            )
+        );
+        if (commitHash != expected) {
+            bytes32 legacy = keccak256(
                 abi.encodePacked(
                     jobId,
                     nonce,
@@ -1108,8 +1195,9 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
                     salt,
                     specHash
                 )
-            ) != commitHash
-        ) revert InvalidReveal();
+            );
+            if (commitHash != legacy) revert InvalidReveal();
+        }
 
         uint256 stake = validatorStakes[jobId][msg.sender];
         if (stake == 0) revert NoStake();
@@ -1118,6 +1206,18 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         r.participants.push(msg.sender);
         r.revealedCount += 1;
         if (approve) r.approvals += stake; else r.rejections += stake;
+        uint256 committee = r.committeeSize == 0
+            ? validatorsPerJob
+            : r.committeeSize;
+        if (committee > maxValidatorsPerJob) committee = maxValidatorsPerJob;
+        if (
+            r.earlyFinalizeEligibleAt == 0 &&
+            r.revealedCount >= committee
+        ) {
+            r.earlyFinalizeEligibleAt = uint64(
+                block.timestamp + earlyFinalizeDelay
+            );
+        }
 
         emit ValidationRevealed(jobId, msg.sender, approve, burnTxHash, subdomain);
     }
@@ -1232,6 +1332,8 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         if (r.revealedCount >= size) {
             return _finalize(jobId);
         }
+        r.earlyFinalizeEligibleAt = 0;
+
         IJobRegistry.Job memory job = jobRegistry.jobs(jobId);
         uint256 vlen = r.validators.length;
         if (vlen > maxValidatorsPerJob) vlen = maxValidatorsPerJob;
@@ -1239,14 +1341,19 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
             address val = r.validators[i];
             if (!revealed[jobId][val]) {
                 uint256 stake = validatorStakes[jobId][val];
-                uint256 slashAmount = (stake * validatorSlashingPercentage) / 100;
-                if (slashAmount > 0) {
+                uint256 penalty = (stake * nonRevealPenaltyBps) / 10_000;
+                if (penalty > 0) {
                     stakeManager.slash(
                         val,
                         IStakeManager.Role.Validator,
-                        slashAmount,
+                        penalty,
                         job.employer
                     );
+                }
+                if (nonRevealBanBlocks != 0) {
+                    uint256 untilBlock = block.number + nonRevealBanBlocks;
+                    validatorBanUntil[val] = untilBlock;
+                    emit ValidatorBanApplied(val, untilBlock);
                 }
                 if (address(reputationEngine) != address(0)) {
                     reputationEngine.subtract(val, 1);
@@ -1267,8 +1374,12 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     function _finalize(uint256 jobId) internal returns (bool success) {
         Round storage r = rounds[jobId];
         if (r.tallied) revert AlreadyTallied();
+        bool earlyWindowReached =
+            r.earlyFinalizeEligibleAt != 0 &&
+            block.timestamp >= r.earlyFinalizeEligibleAt;
         if (r.revealedCount != r.validators.length) {
-            if (block.timestamp <= r.revealDeadline) revert RevealPending();
+            if (!earlyWindowReached && block.timestamp <= r.revealDeadline)
+                revert RevealPending();
         }
 
         uint256 total = r.approvals + r.rejections;
@@ -1314,7 +1425,25 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
             address val = r.validators[i];
             uint256 stake = validatorStakes[jobId][val];
             uint256 slashAmount = (stake * validatorSlashingPercentage) / 100;
-            if (!revealed[jobId][val] || votes[jobId][val] != success) {
+            if (!revealed[jobId][val]) {
+                uint256 penalty = (stake * nonRevealPenaltyBps) / 10_000;
+                if (penalty > 0) {
+                    stakeManager.slash(
+                        val,
+                        IStakeManager.Role.Validator,
+                        penalty,
+                        job.employer
+                    );
+                }
+                if (nonRevealBanBlocks != 0) {
+                    uint256 untilBlock = block.number + nonRevealBanBlocks;
+                    validatorBanUntil[val] = untilBlock;
+                    emit ValidatorBanApplied(val, untilBlock);
+                }
+                if (address(reputationEngine) != address(0)) {
+                    reputationEngine.subtract(val, 1);
+                }
+            } else if (votes[jobId][val] != success) {
                 if (slashAmount > 0) {
                     stakeManager.slash(
                         val,
@@ -1361,6 +1490,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         r.revealedCount = 0;
         delete rounds[jobId];
         delete jobNonce[jobId];
+        delete selectionSeeds[jobId];
     }
 
     /// @notice Reset the validation nonce for a job after finalization or dispute resolution.

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -141,6 +141,12 @@ interface IValidationModule {
     /// @notice Update percentage of stake slashed for incorrect validator votes
     function setValidatorSlashingPct(uint256 pct) external;
 
+    /// @notice Configure the penalty applied when validators fail to reveal.
+    function setNonRevealPenalty(uint256 penaltyBps, uint256 banBlocks) external;
+
+    /// @notice Update the cool-off delay before early finalization is permitted.
+    function setEarlyFinalizeDelay(uint256 delay) external;
+
     /// @notice Map validators to ENS subdomains for selection
     function setValidatorSubdomains(
         address[] calldata accounts,

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -92,6 +92,10 @@ contract ValidationStub is IValidationModule {
 
     function setValidatorSlashingPct(uint256) external override {}
 
+    function setNonRevealPenalty(uint256, uint256) external override {}
+
+    function setEarlyFinalizeDelay(uint256) external override {}
+
     function setValidatorSubdomains(
         address[] calldata,
         string[] calldata

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -129,6 +129,12 @@ contract NoValidationModule is IValidationModule, Ownable {
     function setValidatorSlashingPct(uint256) external pure override {}
 
     /// @inheritdoc IValidationModule
+    function setNonRevealPenalty(uint256, uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setEarlyFinalizeDelay(uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
     function setValidatorSubdomains(
         address[] calldata,
         string[] calldata

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -152,6 +152,12 @@ contract OracleValidationModule is IValidationModule, Ownable {
     function setValidatorSlashingPct(uint256) external pure override {}
 
     /// @inheritdoc IValidationModule
+    function setNonRevealPenalty(uint256, uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
+    function setEarlyFinalizeDelay(uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
     function setValidatorSubdomains(
         address[] calldata,
         string[] calldata

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -1,6 +1,30 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
 
+const abi = ethers.AbiCoder.defaultAbiCoder();
+
+function typedCommit(
+  jobId,
+  nonce,
+  validator,
+  approve,
+  burnTxHash,
+  salt,
+  specHash,
+  domain,
+  chainId
+) {
+  const outcomeHash = ethers.keccak256(
+    abi.encode(['uint256', 'bytes32', 'bool', 'bytes32'], [nonce, specHash, approve, burnTxHash])
+  );
+  return ethers.keccak256(
+    abi.encode(
+      ['uint256', 'bytes32', 'bytes32', 'address', 'uint256', 'bytes32'],
+      [jobId, outcomeHash, salt, validator, chainId, domain]
+    )
+  );
+}
+
 async function setup() {
   const [owner, employer, v1, v2, v3] = await ethers.getSigners();
 
@@ -110,22 +134,49 @@ describe('ValidationModule finalize flows', function () {
     const salt1 = ethers.keccak256(ethers.toUtf8Bytes('s1'));
     const salt2 = ethers.keccak256(ethers.toUtf8Bytes('s2'));
     const salt3 = ethers.keccak256(ethers.toUtf8Bytes('s3'));
+    const domain = await validation.DOMAIN_SEPARATOR();
+    const { chainId } = await ethers.provider.getNetwork();
+    const specHash = await jobRegistry.getSpecHash(1);
     const nonce = await validation.jobNonce(1);
-    const commit1 = ethers.solidityPackedKeccak256(
-      ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
-      [1n, nonce, true, burnTxHash, salt1, ethers.ZeroHash]
+    const commit1 = typedCommit(
+      1,
+      nonce,
+      v1.address,
+      true,
+      burnTxHash,
+      salt1,
+      specHash,
+      domain,
+      chainId
     );
-    const commit2 = ethers.solidityPackedKeccak256(
-      ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
-      [1n, nonce, false, burnTxHash, salt2, ethers.ZeroHash]
+    const commit2 = typedCommit(
+      1,
+      nonce,
+      v2.address,
+      false,
+      burnTxHash,
+      salt2,
+      specHash,
+      domain,
+      chainId
     );
-    const commit3 = ethers.solidityPackedKeccak256(
-      ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
-      [1n, nonce, false, burnTxHash, salt3, ethers.ZeroHash]
+    const commit3 = typedCommit(
+      1,
+      nonce,
+      v3.address,
+      false,
+      burnTxHash,
+      salt3,
+      specHash,
+      domain,
+      chainId
     );
     await validation.connect(v1).commitValidation(1, commit1, '', []);
     await validation.connect(v2).commitValidation(1, commit2, '', []);
     await validation.connect(v3).commitValidation(1, commit3, '', []);
+    expect(await validation.validatorStakes(1, v1.address)).to.equal(
+      ethers.parseEther('100')
+    );
     await advance(61);
     await validation
       .connect(v1)
@@ -146,23 +197,47 @@ describe('ValidationModule finalize flows', function () {
   });
 
   it('reverts finalize before any reveals', async () => {
-    const { v1, v2, v3, validation, select, burnTxHash } = await setup();
+    const { v1, v2, v3, validation, jobRegistry, select, burnTxHash } = await setup();
     await select(1);
     const salt1 = ethers.keccak256(ethers.toUtf8Bytes('s1'));
     const salt2 = ethers.keccak256(ethers.toUtf8Bytes('s2'));
     const salt3 = ethers.keccak256(ethers.toUtf8Bytes('s3'));
+    const domain = await validation.DOMAIN_SEPARATOR();
+    const { chainId } = await ethers.provider.getNetwork();
+    const specHash = await jobRegistry.getSpecHash(1);
     const nonce = await validation.jobNonce(1);
-    const commit1 = ethers.solidityPackedKeccak256(
-      ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
-      [1n, nonce, true, burnTxHash, salt1, ethers.ZeroHash]
+    const commit1 = typedCommit(
+      1,
+      nonce,
+      v1.address,
+      true,
+      burnTxHash,
+      salt1,
+      specHash,
+      domain,
+      chainId
     );
-    const commit2 = ethers.solidityPackedKeccak256(
-      ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
-      [1n, nonce, true, burnTxHash, salt2, ethers.ZeroHash]
+    const commit2 = typedCommit(
+      1,
+      nonce,
+      v2.address,
+      true,
+      burnTxHash,
+      salt2,
+      specHash,
+      domain,
+      chainId
     );
-    const commit3 = ethers.solidityPackedKeccak256(
-      ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
-      [1n, nonce, true, burnTxHash, salt3, ethers.ZeroHash]
+    const commit3 = typedCommit(
+      1,
+      nonce,
+      v3.address,
+      true,
+      burnTxHash,
+      salt3,
+      specHash,
+      domain,
+      chainId
     );
     await validation.connect(v1).commitValidation(1, commit1, '', []);
     await validation.connect(v2).commitValidation(1, commit2, '', []);
@@ -296,11 +371,15 @@ describe('ValidationModule finalize flows', function () {
       ethers.parseEther('50')
     );
     expect(await stakeManager.stakeOf(v2.address, 1)).to.equal(
-      ethers.parseEther('25')
+      ethers.parseEther('49.75')
     );
     expect(await stakeManager.stakeOf(v3.address, 1)).to.equal(
-      ethers.parseEther('12.5')
+      ethers.parseEther('24.875')
     );
+    const banV2 = await validation.validatorBanUntil(v2.address);
+    const banV3 = await validation.validatorBanUntil(v3.address);
+    expect(banV2).to.be.greaterThan(0n);
+    expect(banV3).to.be.greaterThan(0n);
     const job = await jobRegistry.jobs(1);
     expect(job.status).to.equal(5); // Disputed
   });
@@ -318,6 +397,49 @@ describe('ValidationModule finalize flows', function () {
       burnTxHash,
     } = await setup();
     await select(1);
+    const domain = await validation.DOMAIN_SEPARATOR();
+    const { chainId } = await ethers.provider.getNetwork();
+    const specHash = await jobRegistry.getSpecHash(1);
+    const nonce = await validation.jobNonce(1);
+    const salt1 = ethers.keccak256(ethers.toUtf8Bytes('s1'));
+    const salt2 = ethers.keccak256(ethers.toUtf8Bytes('s2'));
+    const salt3 = ethers.keccak256(ethers.toUtf8Bytes('s3'));
+    const commit1 = typedCommit(
+      1,
+      nonce,
+      v1.address,
+      true,
+      burnTxHash,
+      salt1,
+      specHash,
+      domain,
+      chainId
+    );
+    const commit2 = typedCommit(
+      1,
+      nonce,
+      v2.address,
+      true,
+      burnTxHash,
+      salt2,
+      specHash,
+      domain,
+      chainId
+    );
+    const commit3 = typedCommit(
+      1,
+      nonce,
+      v3.address,
+      true,
+      burnTxHash,
+      salt3,
+      specHash,
+      domain,
+      chainId
+    );
+    await validation.connect(v1).commitValidation(1, commit1, '', []);
+    await validation.connect(v2).commitValidation(1, commit2, '', []);
+    await validation.connect(v3).commitValidation(1, commit3, '', []);
     await advance(61); // end commit
     await advance(61 + 3600 + 1); // end reveal + grace
     await validation.forceFinalize(1);
@@ -326,13 +448,13 @@ describe('ValidationModule finalize flows', function () {
     const job = await jobRegistry.jobs(1);
     expect(job.status).to.equal(6); // Finalized
     expect(await stakeManager.stakeOf(v1.address, 1)).to.equal(
-      ethers.parseEther('50')
+      ethers.parseEther('99.5')
     );
     expect(await stakeManager.stakeOf(v2.address, 1)).to.equal(
-      ethers.parseEther('25')
+      ethers.parseEther('49.75')
     );
     expect(await stakeManager.stakeOf(v3.address, 1)).to.equal(
-      ethers.parseEther('12.5')
+      ethers.parseEther('24.875')
     );
   });
 
@@ -368,7 +490,8 @@ describe('ValidationModule finalize flows', function () {
     const isV4Selected = chosen.includes(v4.address);
     const afterV4 = await stakeManager.stakeOf(v4.address, 1);
     if (isV4Selected) {
-      expect(afterV4).to.equal(beforeV4 / 2n);
+      const penalty = (beforeV4 * 50n) / 10000n;
+      expect(afterV4).to.equal(beforeV4 - penalty);
     } else {
       expect(afterV4).to.equal(beforeV4);
     }


### PR DESCRIPTION
## Summary
- add domain separated commit hashing, selection seed tracking, and validator ban logic to ValidationModule
- expose non-reveal penalty controls through the interface and stub implementations
- update validation flow tests to cover new penalties, bans, and typed commit helpers

## Testing
- npx hardhat test test/v2/ValidationModuleFlow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb1f39b3748333add4e5927a4f6361