### PR TITLE
Burn escrowed fees during job finalization

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -1291,7 +1291,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
             }
         }
         if (burnAmount > 0) {
-            token.safeTransfer(employer, burnAmount);
+            _burnToken(jobId, burnAmount);
         }
     }
 


### PR DESCRIPTION
## Summary
- burn StakeManager finalize job balances rather than returning the burn share to employers
- remove the JobRegistry burn receipt gating and only emit discrepancies for analytics
- extend the Hardhat regression covering finalize burns and fake receipt handling

## Testing
- npx hardhat test test/v2/JobRegistryBurnReceipt.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb378c239c8333a1c58e3b3eda11af