### PR TITLE
Add custom errors for JobRegistry pauser and acknowledger validation

### DIFF
--- a/test/v2/JobRegistryAuthCache.test.js
+++ b/test/v2/JobRegistryAuthCache.test.js
@@ -56,6 +56,12 @@ describe('JobRegistry agent auth cache', function () {
       .withArgs(5);
   });
 
+  it('reverts when enabling zero acknowledger', async () => {
+    await expect(
+      registry.connect(owner).setAcknowledger(ethers.ZeroAddress, true)
+    ).to.be.revertedWithCustomError(registry, 'ZeroAcknowledgerAddress');
+  });
+
   async function createJob() {
     const deadline = (await time.latest()) + 100;
     jobId++;

--- a/test/v2/JobRegistryPause.test.js
+++ b/test/v2/JobRegistryPause.test.js
@@ -33,6 +33,18 @@ describe('JobRegistry pause', function () {
     await registry.connect(owner).setJobParameters(0, 0);
   });
 
+  it('restricts pause and unpause to governance or pauser', async () => {
+    await expect(
+      registry.connect(employer).pause()
+    ).to.be.revertedWithCustomError(registry, 'NotGovernanceOrPauser');
+
+    await registry.connect(owner).pause();
+
+    await expect(
+      registry.connect(employer).unpause()
+    ).to.be.revertedWithCustomError(registry, 'NotGovernanceOrPauser');
+  });
+
   it('pauses job creation and applications', async () => {
     const deadline = (await time.latest()) + 100;
     const specHash = ethers.id('spec');


### PR DESCRIPTION
## Summary
- add explicit custom errors in JobRegistry for non-governance/pauser callers and zero acknowledger addresses
- update the pauser modifier and acknowledger setter to use the new errors
- extend Hardhat tests to assert the custom reverts when pausing and when enabling a zero acknowledger

## Testing
- npm run compile
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbff45e84083338dfe226a1ee71c12