### PR TITLE
Refine job metadata packing and tests

### DIFF
--- a/apps/orchestrator/bidding.ts
+++ b/apps/orchestrator/bidding.ts
@@ -28,9 +28,64 @@ import { IdentityManager } from './identity';
 
 // Minimal ABIs for required contract interactions
 const JOB_REGISTRY_ABI = [
-  'function jobs(uint256 jobId) view returns (address employer,address agent,uint128 reward,uint96 stake,uint32 feePct,uint32 agentPct,uint8 state,bool success,bool burnConfirmed,uint128 burnReceiptAmount,uint8 agentTypes,uint64 deadline,uint64 assignedAt,bytes32 uriHash,bytes32 resultHash,bytes32 specHash)',
+  'function jobs(uint256 jobId) view returns (address employer,address agent,uint128 reward,uint96 stake,uint128 burnReceiptAmount,bytes32 uriHash,bytes32 resultHash,bytes32 specHash,uint256 packedMetadata)',
   'function applyForJob(uint256 jobId,string subdomain,bytes32[] proof)',
 ];
+
+const JOB_STATE_OFFSET = 0n;
+const JOB_SUCCESS_OFFSET = 3n;
+const JOB_BURN_CONFIRMED_OFFSET = 4n;
+const JOB_AGENT_TYPES_OFFSET = 5n;
+const JOB_FEE_PCT_OFFSET = 13n;
+const JOB_AGENT_PCT_OFFSET = 45n;
+const JOB_DEADLINE_OFFSET = 77n;
+const JOB_ASSIGNED_AT_OFFSET = 141n;
+
+const JOB_STATE_MASK = 0x7n << JOB_STATE_OFFSET;
+const JOB_SUCCESS_MASK = 0x1n << JOB_SUCCESS_OFFSET;
+const JOB_BURN_CONFIRMED_MASK = 0x1n << JOB_BURN_CONFIRMED_OFFSET;
+const JOB_AGENT_TYPES_MASK = 0xffn << JOB_AGENT_TYPES_OFFSET;
+const JOB_FEE_PCT_MASK = 0xffffffffn << JOB_FEE_PCT_OFFSET;
+const JOB_AGENT_PCT_MASK = 0xffffffffn << JOB_AGENT_PCT_OFFSET;
+const JOB_DEADLINE_MASK = 0xffffffffffffffffn << JOB_DEADLINE_OFFSET;
+const JOB_ASSIGNED_AT_MASK = 0xffffffffffffffffn << JOB_ASSIGNED_AT_OFFSET;
+
+function decodePackedJobMetadata(packed: any): {
+  state?: number;
+  success?: boolean;
+  burnConfirmed?: boolean;
+  agentTypes?: number;
+  feePct?: bigint;
+  agentPct?: bigint;
+  deadline?: bigint;
+  assignedAt?: bigint;
+} {
+  if (packed === undefined || packed === null) {
+    return {};
+  }
+  let value: bigint;
+  if (typeof packed === 'bigint') {
+    value = packed;
+  } else if (typeof packed === 'number' && Number.isFinite(packed)) {
+    value = BigInt(packed);
+  } else if (typeof packed === 'string') {
+    value = BigInt(packed);
+  } else if (typeof (packed as any).toString === 'function') {
+    value = BigInt((packed as any).toString());
+  } else {
+    return {};
+  }
+  return {
+    state: Number((value & JOB_STATE_MASK) >> JOB_STATE_OFFSET),
+    success: (value & JOB_SUCCESS_MASK) !== 0n,
+    burnConfirmed: (value & JOB_BURN_CONFIRMED_MASK) !== 0n,
+    agentTypes: Number((value & JOB_AGENT_TYPES_MASK) >> JOB_AGENT_TYPES_OFFSET),
+    feePct: (value & JOB_FEE_PCT_MASK) >> JOB_FEE_PCT_OFFSET,
+    agentPct: (value & JOB_AGENT_PCT_MASK) >> JOB_AGENT_PCT_OFFSET,
+    deadline: (value & JOB_DEADLINE_MASK) >> JOB_DEADLINE_OFFSET,
+    assignedAt: (value & JOB_ASSIGNED_AT_MASK) >> JOB_ASSIGNED_AT_OFFSET,
+  };
+}
 
 const STAKE_MANAGER_ABI = [
   'function stakeOf(address user,uint8 role) view returns (uint256)',
@@ -197,9 +252,10 @@ export async function fetchJobRequirements(
     provider
   );
   const job = await registry.jobs(jobId);
+  const metadata = decodePackedJobMetadata(job.packedMetadata);
   return {
     stake: job.stake as bigint,
-    agentTypes: Number(job.agentTypes),
+    agentTypes: metadata.agentTypes ?? 0,
     reward: job.reward as bigint,
   };
 }

--- a/apps/orchestrator/bidding.ts
+++ b/apps/orchestrator/bidding.ts
@@ -79,7 +79,9 @@ function decodePackedJobMetadata(packed: any): {
     state: Number((value & JOB_STATE_MASK) >> JOB_STATE_OFFSET),
     success: (value & JOB_SUCCESS_MASK) !== 0n,
     burnConfirmed: (value & JOB_BURN_CONFIRMED_MASK) !== 0n,
-    agentTypes: Number((value & JOB_AGENT_TYPES_MASK) >> JOB_AGENT_TYPES_OFFSET),
+    agentTypes: Number(
+      (value & JOB_AGENT_TYPES_MASK) >> JOB_AGENT_TYPES_OFFSET
+    ),
     feePct: (value & JOB_FEE_PCT_MASK) >> JOB_FEE_PCT_OFFSET,
     agentPct: (value & JOB_AGENT_PCT_MASK) >> JOB_AGENT_PCT_OFFSET,
     deadline: (value & JOB_DEADLINE_MASK) >> JOB_DEADLINE_OFFSET,

--- a/apps/orchestrator/service.ts
+++ b/apps/orchestrator/service.ts
@@ -173,7 +173,9 @@ function decodePackedJobMetadata(packed: any): {
     state: Number((value & JOB_STATE_MASK) >> JOB_STATE_OFFSET),
     success: (value & JOB_SUCCESS_MASK) !== 0n,
     burnConfirmed: (value & JOB_BURN_CONFIRMED_MASK) !== 0n,
-    agentTypes: Number((value & JOB_AGENT_TYPES_MASK) >> JOB_AGENT_TYPES_OFFSET),
+    agentTypes: Number(
+      (value & JOB_AGENT_TYPES_MASK) >> JOB_AGENT_TYPES_OFFSET
+    ),
     feePct: (value & JOB_FEE_PCT_MASK) >> JOB_FEE_PCT_OFFSET,
     agentPct: (value & JOB_AGENT_PCT_MASK) >> JOB_AGENT_PCT_OFFSET,
     deadline: (value & JOB_DEADLINE_MASK) >> JOB_DEADLINE_OFFSET,
@@ -1027,15 +1029,6 @@ export class MetaOrchestrator {
         return undefined;
       }
       return undefined;
-    };
-    const toNumber = (value: any): number | undefined => {
-      if (value === null || value === undefined) return undefined;
-      if (typeof value === 'number' && Number.isFinite(value)) return value;
-      if (typeof value === 'bigint') return Number(value);
-      const str = toString(value);
-      if (!str) return undefined;
-      const parsed = Number(str);
-      return Number.isFinite(parsed) ? parsed : undefined;
     };
     const metadata = decodePackedJobMetadata(job?.packedMetadata);
     return {

--- a/apps/validator/index.ts
+++ b/apps/validator/index.ts
@@ -149,7 +149,9 @@ function decodePackedJobMetadata(packed: any): {
     state: Number((value & JOB_STATE_MASK) >> JOB_STATE_OFFSET),
     success: (value & JOB_SUCCESS_MASK) !== 0n,
     burnConfirmed: (value & JOB_BURN_CONFIRMED_MASK) !== 0n,
-    agentTypes: Number((value & JOB_AGENT_TYPES_MASK) >> JOB_AGENT_TYPES_OFFSET),
+    agentTypes: Number(
+      (value & JOB_AGENT_TYPES_MASK) >> JOB_AGENT_TYPES_OFFSET
+    ),
     feePct: (value & JOB_FEE_PCT_MASK) >> JOB_FEE_PCT_OFFSET,
     agentPct: (value & JOB_AGENT_PCT_MASK) >> JOB_AGENT_PCT_OFFSET,
     deadline: (value & JOB_DEADLINE_MASK) >> JOB_DEADLINE_OFFSET,

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1050,8 +1050,11 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         uint256 entropy
     ) external override whenNotPaused nonReentrant returns (address[] memory selected) {
         if (msg.sender != address(jobRegistry)) revert OnlyJobRegistry();
-        if (jobRegistry.jobs(jobId).status != IJobRegistry.Status.Submitted)
-            revert JobNotSubmitted();
+        IJobRegistry.Job memory jobSnapshot = jobRegistry.jobs(jobId);
+        IJobRegistry.JobMetadata memory meta = jobRegistry.decodeJobMetadata(
+            jobSnapshot.packedMetadata
+        );
+        if (meta.status != IJobRegistry.Status.Submitted) revert JobNotSubmitted();
         Round storage r = rounds[jobId];
         uint256 n = validatorPool.length;
         if (n < minValidators) revert ValidatorPoolTooSmall();
@@ -1080,8 +1083,11 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         bytes32[] memory proof
     ) internal whenNotPaused {
         Round storage r = rounds[jobId];
-        if (jobRegistry.jobs(jobId).status != IJobRegistry.Status.Submitted)
-            revert JobNotSubmitted();
+        IJobRegistry.Job memory jobSnapshot = jobRegistry.jobs(jobId);
+        IJobRegistry.JobMetadata memory meta = jobRegistry.decodeJobMetadata(
+            jobSnapshot.packedMetadata
+        );
+        if (meta.status != IJobRegistry.Status.Submitted) revert JobNotSubmitted();
         if (r.commitDeadline == 0 || block.timestamp > r.commitDeadline)
             revert CommitPhaseClosed();
         if (validatorBanUntil[msg.sender] > block.number) revert ValidatorBanned();

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -22,18 +22,22 @@ interface IJobRegistry {
         address agent;
         uint128 reward;
         uint96 stake;
-        uint32 feePct;
-        uint32 agentPct;
-        Status status;
-        bool success;
-        bool burnConfirmed;
         uint128 burnReceiptAmount;
-        uint8 agentTypes;
-        uint64 deadline;
-        uint64 assignedAt;
         bytes32 uriHash;
         bytes32 resultHash;
         bytes32 specHash;
+        uint256 packedMetadata;
+    }
+
+    struct JobMetadata {
+        Status status;
+        bool success;
+        bool burnConfirmed;
+        uint8 agentTypes;
+        uint32 feePct;
+        uint32 agentPct;
+        uint64 deadline;
+        uint64 assignedAt;
     }
 
     /// @dev Reverts when job creation parameters have not been configured
@@ -183,6 +187,12 @@ interface IJobRegistry {
     /// @notice Retrieve the StakeManager contract handling collateral
     /// @return Address of the StakeManager
     function stakeManager() external view returns (address);
+
+    /// @notice Decode packed job metadata into individual fields.
+    function decodeJobMetadata(uint256 packed)
+        external
+        pure
+        returns (JobMetadata memory);
 
     /// @notice Retrieve the ValidationModule managing validator sets
     /// @return Address of the ValidationModule

--- a/test/utils/jobMetadata.js
+++ b/test/utils/jobMetadata.js
@@ -1,0 +1,58 @@
+const STATE_OFFSET = 0n;
+const SUCCESS_OFFSET = 3n;
+const BURN_CONFIRMED_OFFSET = 4n;
+const AGENT_TYPES_OFFSET = 5n;
+const FEE_PCT_OFFSET = 13n;
+const AGENT_PCT_OFFSET = 45n;
+const DEADLINE_OFFSET = 77n;
+const ASSIGNED_AT_OFFSET = 141n;
+
+const STATE_MASK = 0x7n << STATE_OFFSET;
+const SUCCESS_MASK = 0x1n << SUCCESS_OFFSET;
+const BURN_CONFIRMED_MASK = 0x1n << BURN_CONFIRMED_OFFSET;
+const AGENT_TYPES_MASK = 0xffn << AGENT_TYPES_OFFSET;
+const FEE_PCT_MASK = 0xffffffffn << FEE_PCT_OFFSET;
+const AGENT_PCT_MASK = 0xffffffffn << AGENT_PCT_OFFSET;
+const DEADLINE_MASK = 0xffffffffffffffffn << DEADLINE_OFFSET;
+const ASSIGNED_AT_MASK = 0xffffffffffffffffn << ASSIGNED_AT_OFFSET;
+
+function toBigInt(value) {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return BigInt(value);
+  if (typeof value === 'string') return BigInt(value);
+  if (typeof value.toString === 'function') {
+    return BigInt(value.toString());
+  }
+  return undefined;
+}
+
+function decodeJobMetadata(packed) {
+  const value = toBigInt(packed);
+  if (value === undefined) {
+    return {};
+  }
+  return {
+    state: Number((value & STATE_MASK) >> STATE_OFFSET),
+    success: (value & SUCCESS_MASK) !== 0n,
+    burnConfirmed: (value & BURN_CONFIRMED_MASK) !== 0n,
+    agentTypes: Number((value & AGENT_TYPES_MASK) >> AGENT_TYPES_OFFSET),
+    feePct: (value & FEE_PCT_MASK) >> FEE_PCT_OFFSET,
+    agentPct: (value & AGENT_PCT_MASK) >> AGENT_PCT_OFFSET,
+    deadline: (value & DEADLINE_MASK) >> DEADLINE_OFFSET,
+    assignedAt: (value & ASSIGNED_AT_MASK) >> ASSIGNED_AT_OFFSET,
+  };
+}
+
+function enrichJob(job) {
+  const metadata = decodeJobMetadata(job.packedMetadata);
+  return {
+    ...job,
+    ...metadata,
+  };
+}
+
+module.exports = {
+  decodeJobMetadata,
+  enrichJob,
+};

--- a/test/v2/ContractEmployerFinalize.test.js
+++ b/test/v2/ContractEmployerFinalize.test.js
@@ -103,10 +103,7 @@ describe('Job finalization with contract employer', function () {
     const stateMask = 0x7n;
     const successMask = 0x1n << 3n;
     const cleared = prev & ~(stateMask | successMask);
-    const value =
-      cleared |
-      (4n << 0n) |
-      (BigInt(success ? 1 : 0) << 3n);
+    const value = cleared | (4n << 0n) | (BigInt(success ? 1 : 0) << 3n);
     await ethers.provider.send('hardhat_setStorageAt', [
       await registry.getAddress(),
       ethers.toBeHex(slot),

--- a/test/v2/ContractEmployerFinalize.test.js
+++ b/test/v2/ContractEmployerFinalize.test.js
@@ -96,18 +96,17 @@ describe('Job finalization with contract employer', function () {
         coder.encode(['uint256', 'uint256'], [BigInt(jobId), 4n])
       )
     );
-    const slot = base + 3n;
+    const slot = base + 7n;
     const prev = BigInt(
       await ethers.provider.getStorage(await registry.getAddress(), slot)
     );
-    const stateOffset = 32n;
-    const successOffset = 40n;
-    const mask = (0xffn << stateOffset) | (0xffn << successOffset);
-    const cleared = prev & ~mask;
+    const stateMask = 0x7n;
+    const successMask = 0x1n << 3n;
+    const cleared = prev & ~(stateMask | successMask);
     const value =
       cleared |
-      (4n << stateOffset) |
-      (BigInt(success ? 1 : 0) << successOffset);
+      (4n << 0n) |
+      (BigInt(success ? 1 : 0) << 3n);
     await ethers.provider.send('hardhat_setStorageAt', [
       await registry.getAddress(),
       ethers.toBeHex(slot),

--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -114,10 +114,7 @@ describe('JobRegistry governance finalization', function () {
     const stateMask = 0x7n;
     const successMask = 0x1n << 3n;
     const cleared = prev & ~(stateMask | successMask);
-    const value =
-      cleared |
-      (4n << 0n) |
-      (BigInt(success ? 1 : 0) << 3n);
+    const value = cleared | (4n << 0n) | (BigInt(success ? 1 : 0) << 3n);
     await ethers.provider.send('hardhat_setStorageAt', [
       await registry.getAddress(),
       ethers.toBeHex(slot),

--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -107,18 +107,17 @@ describe('JobRegistry governance finalization', function () {
         coder.encode(['uint256', 'uint256'], [BigInt(jobId), 4n])
       )
     );
-    const slot = base + 3n;
+    const slot = base + 7n;
     const prev = BigInt(
       await ethers.provider.getStorage(await registry.getAddress(), slot)
     );
-    const stateOffset = 32n;
-    const successOffset = 40n;
-    const mask = (0xffn << stateOffset) | (0xffn << successOffset);
-    const cleared = prev & ~mask;
+    const stateMask = 0x7n;
+    const successMask = 0x1n << 3n;
+    const cleared = prev & ~(stateMask | successMask);
     const value =
       cleared |
-      (4n << stateOffset) |
-      (BigInt(success ? 1 : 0) << successOffset);
+      (4n << 0n) |
+      (BigInt(success ? 1 : 0) << 3n);
     await ethers.provider.send('hardhat_setStorageAt', [
       await registry.getAddress(),
       ethers.toBeHex(slot),

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
 const { time } = require('@nomicfoundation/hardhat-network-helpers');
+const { enrichJob } = require('../utils/jobMetadata');
 
 describe('Job expiration', function () {
   const { AGIALPHA } = require('../../scripts/constants');
@@ -159,7 +160,7 @@ describe('Job expiration', function () {
 
     expect(await token.balanceOf(employer.address)).to.equal(1200);
     expect(await token.balanceOf(agent.address)).to.equal(800);
-    const job = await registry.jobs(jobId);
+    const job = enrichJob(await registry.jobs(jobId));
     expect(job.state).to.equal(6);
     expect(job.success).to.equal(false);
     expect(await stakeManager.stakes(agent.address, 0)).to.equal(0);

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
 const { time } = require('@nomicfoundation/hardhat-network-helpers');
+const { enrichJob } = require('../utils/jobMetadata');
 
 describe('Job expiration boundary', function () {
   const { AGIALPHA } = require('../../scripts/constants');
@@ -173,7 +174,7 @@ describe('Job expiration boundary', function () {
 
     expect(await token.balanceOf(employer.address)).to.equal(1200);
     expect(await token.balanceOf(agent.address)).to.equal(800);
-    const job = await registry.jobs(jobId);
+    const job = enrichJob(await registry.jobs(jobId));
     expect(job.state).to.equal(6);
     expect(job.success).to.equal(false);
     expect(await stakeManager.stakes(agent.address, 0)).to.equal(0);

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const { ethers, artifacts, network } = require('hardhat');
 const { time } = require('@nomicfoundation/hardhat-network-helpers');
+const { enrichJob } = require('../utils/jobMetadata');
 
 describe('JobRegistry integration', function () {
   let token,
@@ -468,7 +469,7 @@ describe('JobRegistry integration', function () {
     await expect(registry.connect(employer).cancelJob(jobId))
       .to.emit(registry, 'JobCancelled')
       .withArgs(jobId);
-    const job = await registry.jobs(jobId);
+    const job = enrichJob(await registry.jobs(jobId));
     expect(job.state).to.equal(7); // Cancelled enum value
   });
 
@@ -485,7 +486,7 @@ describe('JobRegistry integration', function () {
     await expect(registry.connect(owner).delistJob(jobId))
       .to.emit(registry, 'JobCancelled')
       .withArgs(jobId);
-    const job = await registry.jobs(jobId);
+    const job = enrichJob(await registry.jobs(jobId));
     expect(job.state).to.equal(7);
   });
 

--- a/test/v2/JobRegistrySnapshot.test.js
+++ b/test/v2/JobRegistrySnapshot.test.js
@@ -1,9 +1,11 @@
 const { expect } = require('chai');
 const { ethers, artifacts, network } = require('hardhat');
 const { time } = require('@nomicfoundation/hardhat-network-helpers');
+const { enrichJob } = require('../utils/jobMetadata');
 
 describe('JobRegistry payout snapshot', function () {
   let owner, employer, agent, other;
+
   let token, stakeManager, validation, registry, identity, nft;
 
   beforeEach(async () => {
@@ -111,7 +113,7 @@ describe('JobRegistry payout snapshot', function () {
     await nft.mint(agent.address);
     const { reward, jobId } = await createJob();
     await registry.connect(agent).applyForJob(jobId, '', []);
-    let job = await registry.jobs(jobId);
+    let job = enrichJob(await registry.jobs(jobId));
     expect(job.agentPct).to.equal(150n);
     await nft.connect(agent).transferFrom(agent.address, other.address, 0n);
 
@@ -131,7 +133,7 @@ describe('JobRegistry payout snapshot', function () {
   it('ignores NFTs gained after assignment', async () => {
     const { reward, jobId } = await createJob();
     await registry.connect(agent).applyForJob(jobId, '', []);
-    let job = await registry.jobs(jobId);
+    let job = enrichJob(await registry.jobs(jobId));
     expect(job.agentPct).to.equal(100n);
     await nft.mint(agent.address);
 

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const { ethers } = require('hardhat');
 const { time } = require('@nomicfoundation/hardhat-network-helpers');
 const { AGIALPHA, AGIALPHA_DECIMALS } = require('../../scripts/constants');
+const { enrichJob } = require('../utils/jobMetadata');
 
 const Role = { Agent: 0, Validator: 1, Platform: 2 };
 
@@ -170,7 +171,7 @@ describe('Mid-job module upgrades', function () {
     const hash = ethers.id('ipfs://result');
     await registry.connect(agent).submit(1, hash, 'ipfs://result', 'agent', []);
 
-    const before = await registry.jobs(1);
+    const before = enrichJob(await registry.jobs(1));
 
     const Validation = await ethers.getContractFactory(
       'contracts/v2/mocks/ValidationStub.sol:ValidationStub'
@@ -198,7 +199,7 @@ describe('Mid-job module upgrades', function () {
     await registry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await registry.connect(employer).finalize(1);
 
-    const after = await registry.jobs(1);
+    const after = enrichJob(await registry.jobs(1));
     expect(after.employer).to.equal(before.employer);
     expect(after.agent).to.equal(before.agent);
     expect(after.state).to.equal(6); // Finalized

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const { ethers } = require('hardhat');
 const { time } = require('@nomicfoundation/hardhat-network-helpers');
 const { AGIALPHA, AGIALPHA_DECIMALS } = require('../../scripts/constants');
+const { enrichJob } = require('../utils/jobMetadata');
 
 const Role = { Agent: 0, Validator: 1, Platform: 2 };
 
@@ -169,7 +170,7 @@ describe('Module replacement', function () {
     const hash = ethers.id('ipfs://result');
     await registry.connect(agent).submit(1, hash, 'ipfs://result', 'agent', []);
 
-    const before = await registry.jobs(1);
+    const before = enrichJob(await registry.jobs(1));
 
     const Installer = await ethers.getContractFactory(
       'contracts/v2/ModuleInstaller.sol:ModuleInstaller'
@@ -200,7 +201,7 @@ describe('Module replacement', function () {
     await registry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await registry.connect(employer).finalize(1);
 
-    const after = await registry.jobs(1);
+    const after = enrichJob(await registry.jobs(1));
     expect(after.employer).to.equal(before.employer);
     expect(after.agent).to.equal(before.agent);
     expect(after.state).to.equal(6); // Finalized

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
+const { enrichJob } = require('../utils/jobMetadata');
 
 describe('ValidationModule access controls', function () {
   let owner, employer, v1, v2, v3;
@@ -247,8 +248,8 @@ describe('ValidationModule access controls', function () {
     ).wait();
     await advance(61);
     await validation.finalize(1);
-    let job = await jobRegistry.jobs(1);
-    expect(job.status).to.equal(5); // Disputed
+    let job = enrichJob(await jobRegistry.jobs(1));
+    expect(job.state).to.equal(5); // Disputed
 
     await validation.connect(owner).resetJobNonce(1);
     // reset job status to Submitted
@@ -314,8 +315,8 @@ describe('ValidationModule access controls', function () {
     await validation.finalize(1);
     await jobRegistry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await jobRegistry.connect(employer).finalize(1);
-    job = await jobRegistry.jobs(1);
-    expect(job.status).to.equal(6); // Finalized
+    job = enrichJob(await jobRegistry.jobs(1));
+    expect(job.state).to.equal(6); // Finalized
     expect(job.success).to.equal(true);
   });
 });

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
+const { enrichJob } = require('../utils/jobMetadata');
 
 const abi = ethers.AbiCoder.defaultAbiCoder();
 
@@ -194,8 +195,8 @@ describe('ValidationModule finalize flows', function () {
     await validation.finalize(1);
     await jobRegistry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await jobRegistry.connect(employer).finalize(1);
-    const job = await jobRegistry.jobs(1);
-    expect(job.status).to.equal(6); // Finalized
+    const job = enrichJob(await jobRegistry.jobs(1));
+    expect(job.state).to.equal(6); // Finalized
     expect(job.success).to.equal(true);
   });
 
@@ -302,8 +303,8 @@ describe('ValidationModule finalize flows', function () {
       .revealValidation(1, true, burnTxHash, salt3, '', []);
     await advance(61);
     await validation.finalize(1);
-    const job = await jobRegistry.jobs(1);
-    expect(job.status).to.equal(5); // Disputed
+    const job = enrichJob(await jobRegistry.jobs(1));
+    expect(job.state).to.equal(5); // Disputed
   });
 
   it('disputes when validators fail to reveal', async () => {
@@ -312,8 +313,8 @@ describe('ValidationModule finalize flows', function () {
     await advance(61); // end commit
     await advance(61); // end reveal
     await validation.finalize(1);
-    const job = await jobRegistry.jobs(1);
-    expect(job.status).to.equal(5); // Disputed
+    const job = enrichJob(await jobRegistry.jobs(1));
+    expect(job.state).to.equal(5); // Disputed
   });
 
   it('reverts reveal after the reveal deadline', async () => {
@@ -384,8 +385,8 @@ describe('ValidationModule finalize flows', function () {
     const banV3 = await validation.validatorBanUntil(v3.address);
     expect(banV2).to.be.greaterThan(0n);
     expect(banV3).to.be.greaterThan(0n);
-    const job = await jobRegistry.jobs(1);
-    expect(job.status).to.equal(5); // Disputed
+    const job = enrichJob(await jobRegistry.jobs(1));
+    expect(job.state).to.equal(5); // Disputed
   });
 
   it('allows force finalize after deadline and slashes no-shows', async () => {
@@ -449,8 +450,8 @@ describe('ValidationModule finalize flows', function () {
     await validation.forceFinalize(1);
     await jobRegistry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await jobRegistry.connect(employer).finalize(1);
-    const job = await jobRegistry.jobs(1);
-    expect(job.status).to.equal(6); // Finalized
+    const job = enrichJob(await jobRegistry.jobs(1));
+    expect(job.state).to.equal(6); // Finalized
     expect(await stakeManager.stakeOf(v1.address, 1)).to.equal(
       ethers.parseEther('99.5')
     );
@@ -499,8 +500,8 @@ describe('ValidationModule finalize flows', function () {
     } else {
       expect(afterV4).to.equal(beforeV4);
     }
-    const job = await jobRegistry.jobs(1);
-    expect(job.status).to.equal(6); // Finalized
+    const job = enrichJob(await jobRegistry.jobs(1));
+    expect(job.state).to.equal(6); // Finalized
   });
 
   it('disputes when approvals fall below threshold', async () => {
@@ -549,7 +550,7 @@ describe('ValidationModule finalize flows', function () {
       .revealValidation(1, false, burnTxHash, salt3, '', []);
     await advance(61);
     await validation.finalize(1);
-    const job = await jobRegistry.jobs(1);
-    expect(job.status).to.equal(5); // Disputed
+    const job = enrichJob(await jobRegistry.jobs(1));
+    expect(job.state).to.equal(5); // Disputed
   });
 });

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { AGIALPHA_DECIMALS } from '../../scripts/constants';
-const { decodeJobMetadata } = require('../utils/jobMetadata');
+import { decodeJobMetadata } from '../utils/jobMetadata';
 
 enum Role {
   Agent,

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { AGIALPHA_DECIMALS } from '../../scripts/constants';
-const { decodeJobMetadata } = require('../utils/jobMetadata');
+import { decodeJobMetadata } from '../utils/jobMetadata';
 
 enum Role {
   Agent,

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { AGIALPHA_DECIMALS } from '../../scripts/constants';
+const { decodeJobMetadata } = require('../utils/jobMetadata');
 
 enum Role {
   Agent,
@@ -200,7 +201,11 @@ describe('Kleros dispute module', function () {
     expect(await stake.stakes(v2.address, Role.Validator)).to.be.lt(
       stakeAmount
     );
-    expect(await registry.jobs(1)).to.have.property('state', 5); // Disputed
+    {
+      const job = await registry.jobs(1);
+      const metadata = decodeJobMetadata(job.packedMetadata);
+      expect(metadata.state).to.equal(5); // Disputed
+    }
 
     await registry.connect(agent).dispute(1, ethers.id('evidence'));
     expect(await mockArb.lastJobId()).to.equal(1n);
@@ -209,7 +214,11 @@ describe('Kleros dispute module', function () {
     await registry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await registry.connect(employer).finalize(1);
 
-    expect(await registry.jobs(1)).to.have.property('state', 6); // Finalized
+    {
+      const job = await registry.jobs(1);
+      const metadata = decodeJobMetadata(job.packedMetadata);
+      expect(metadata.state).to.equal(6); // Finalized
+    }
     expect(await token.balanceOf(agent.address)).to.be.gt(initialAgentBalance);
   });
 });

--- a/test/v2/midJobReplacementFuzz.test.js
+++ b/test/v2/midJobReplacementFuzz.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const { ethers, artifacts, network } = require('hardhat');
 const { time } = require('@nomicfoundation/hardhat-network-helpers');
 const { AGIALPHA, AGIALPHA_DECIMALS } = require('../../scripts/constants');
+const { enrichJob } = require('../utils/jobMetadata');
 
 async function deploySystem() {
   const [owner, employer, agent] = await ethers.getSigners();
@@ -198,7 +199,7 @@ describe('Mid-job module replacement fuzz', function () {
         await registry.connect(employer).confirmEmployerBurn(1, burnTxHash);
         await registry.connect(employer).finalize(1);
       }
-      const job = await registry.jobs(1);
+      const job = enrichJob(await registry.jobs(1));
       expect(job.state).to.equal(result ? 6 : 5);
       expect(job.success).to.equal(result);
     }

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { AGIALPHA_DECIMALS } from '../../scripts/constants';
+const { decodeJobMetadata } = require('../utils/jobMetadata');
 
 enum Role {
   Agent,
@@ -265,6 +266,10 @@ describe('regression scenarios', function () {
     await stub.setResult(true);
     await stub.finalize(1);
 
-    expect(await registry.jobs(1)).to.have.property('state', 6);
+    {
+      const job = await registry.jobs(1);
+      const metadata = decodeJobMetadata(job.packedMetadata);
+      expect(metadata.state).to.equal(6);
+    }
   });
 });

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { AGIALPHA_DECIMALS } from '../../scripts/constants';
-const { decodeJobMetadata } = require('../utils/jobMetadata');
+import { decodeJobMetadata } from '../utils/jobMetadata';
 
 enum Role {
   Agent,

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { AGIALPHA_DECIMALS } from '../../scripts/constants';
+const { decodeJobMetadata } = require('../utils/jobMetadata');
 
 enum Role {
   Agent,
@@ -187,7 +188,11 @@ describe('validator participation', function () {
     await registry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await registry.connect(employer).finalize(1);
 
-    expect(await registry.jobs(1)).to.have.property('state', 6);
+    {
+      const job = await registry.jobs(1);
+      const metadata = decodeJobMetadata(job.packedMetadata);
+      expect(metadata.state).to.equal(6);
+    }
   });
 
   it('resolves disputes when validators reject', async () => {
@@ -257,13 +262,21 @@ describe('validator participation', function () {
     await time.increase(2);
     await validation.finalize(1);
 
-    expect(await registry.jobs(1)).to.have.property('state', 5);
+    {
+      const job = await registry.jobs(1);
+      const metadata = decodeJobMetadata(job.packedMetadata);
+      expect(metadata.state).to.equal(5);
+    }
 
     await registry.connect(agent).dispute(1, ethers.id('evidence'));
     await dispute.connect(moderator).resolve(1, false);
     await registry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await registry.connect(employer).finalize(1);
 
-    expect(await registry.jobs(1)).to.have.property('state', 6);
+    {
+      const job = await registry.jobs(1);
+      const metadata = decodeJobMetadata(job.packedMetadata);
+      expect(metadata.state).to.equal(6);
+    }
   });
 });

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { AGIALPHA_DECIMALS } from '../../scripts/constants';
-const { decodeJobMetadata } = require('../utils/jobMetadata');
+import { decodeJobMetadata } from '../utils/jobMetadata';
 
 enum Role {
   Agent,


### PR DESCRIPTION
## Summary
- restructure JobRegistry metadata into a single packed word with helper encode/decode routines and expose decodeJobMetadata
- update IJobRegistry, ValidationModule, and MockV2 to use the packed metadata layout
- refresh JS utilities plus orchestrator/validator code and tests to decode packed metadata and adjust direct storage helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc88b196708333858cdd8efa7b012f