### PR TITLE
feat: harden certificate metadata base

### DIFF
--- a/contracts/v2/interfaces/ICertificateNFT.sol
+++ b/contracts/v2/interfaces/ICertificateNFT.sol
@@ -8,6 +8,12 @@ interface ICertificateNFT {
     function version() external view returns (uint256);
     /// @dev Reverts when caller is not the authorised JobRegistry
     error NotJobRegistry(address caller);
+    error BaseURIAlreadySet();
+    error BaseURINotSet();
+    error InvalidBaseURI();
+    error ArrayLengthMismatch();
+    error BatchSizeTooLarge(uint256 length, uint256 max);
+    error MetadataHashMismatch(uint256 tokenId, bytes32 expected, bytes32 actual);
 
     /// @dev Reverts when attempting to mint more than once for the same job
     error CertificateAlreadyMinted(uint256 jobId);
@@ -15,6 +21,7 @@ interface ICertificateNFT {
     /// @dev Reverts when an empty metadata hash is supplied
     error EmptyURI();
 
+    event BaseURISet(string baseURI);
     event CertificateMinted(address indexed to, uint256 indexed jobId, bytes32 uriHash);
 
     /// @notice Mint a completion certificate NFT for a job
@@ -28,5 +35,15 @@ interface ICertificateNFT {
         uint256 jobId,
         bytes32 uriHash
     ) external returns (uint256 tokenId);
+
+    /// @notice Mint multiple completion certificates in a single transaction.
+    /// @param recipients Addresses receiving certificates.
+    /// @param jobIds Job identifiers that also double as tokenIds.
+    /// @param uriHashes Hashes of the metadata URIs.
+    function mintBatch(
+        address[] calldata recipients,
+        uint256[] calldata jobIds,
+        bytes32[] calldata uriHashes
+    ) external;
 }
 

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {ICertificateNFT} from "../interfaces/ICertificateNFT.sol";
 
 /// @title CertificateNFT (module)
@@ -10,11 +11,17 @@ import {ICertificateNFT} from "../interfaces/ICertificateNFT.sol";
 /// @dev Only participants bear any tax obligations; the contract holds no
 ///      ether and rejects unsolicited transfers.
 contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
+    using Strings for uint256;
+
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 2;
+    uint256 public constant MAX_BATCH_MINT = 32;
 
     address public jobRegistry;
     mapping(uint256 => bytes32) public tokenHashes;
+    string private _baseTokenURI;
+    bool private _baseURISet;
+    mapping(uint256 => bool) private _validatedWithBase;
 
     event JobRegistryUpdated(address registry);
 
@@ -37,6 +44,49 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
         emit JobRegistryUpdated(registry);
     }
 
+    function setBaseURI(string calldata baseURI_) external onlyOwner {
+        if (_baseURISet) revert BaseURIAlreadySet();
+        if (!_isValidIPFSURI(baseURI_)) revert InvalidBaseURI();
+        _baseTokenURI = baseURI_;
+        _baseURISet = true;
+        emit BaseURISet(baseURI_);
+    }
+
+    function _isValidIPFSURI(string calldata baseURI_) private pure returns (bool) {
+        bytes memory data = bytes(baseURI_);
+        bytes memory prefix = bytes("ipfs://");
+        if (data.length <= prefix.length) {
+            return false;
+        }
+        for (uint256 i; i < prefix.length; ) {
+            if (data[i] != prefix[i]) {
+                return false;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        if (data[data.length - 1] != 0x2f) {
+            return false;
+        }
+        return true;
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return _baseTokenURI;
+    }
+
+    function _validateHash(uint256 tokenId, bytes32 uriHash) private view {
+        if (!_baseURISet) {
+            return;
+        }
+        string memory uri = string.concat(_baseTokenURI, tokenId.toString());
+        bytes32 computed = keccak256(bytes(uri));
+        if (computed != uriHash) {
+            revert MetadataHashMismatch(tokenId, uriHash, computed);
+        }
+    }
+
     function mint(
         address to,
         uint256 jobId,
@@ -44,14 +94,55 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     ) external onlyJobRegistry returns (uint256 tokenId) {
         if (uriHash == bytes32(0)) revert EmptyURI();
         tokenId = jobId;
+        _validateHash(tokenId, uriHash);
         _safeMint(to, tokenId);
         tokenHashes[tokenId] = uriHash;
+        if (_baseURISet) {
+            _validatedWithBase[tokenId] = true;
+        }
         emit CertificateMinted(to, jobId, uriHash);
+    }
+
+    function mintBatch(
+        address[] calldata recipients,
+        uint256[] calldata jobIds,
+        bytes32[] calldata uriHashes
+    ) external onlyJobRegistry {
+        uint256 length = recipients.length;
+        if (length == 0) return;
+        if (length != jobIds.length || length != uriHashes.length) {
+            revert ArrayLengthMismatch();
+        }
+        if (length > MAX_BATCH_MINT) revert BatchSizeTooLarge(length, MAX_BATCH_MINT);
+        for (uint256 i; i < length; ) {
+            uint256 tokenId = jobIds[i];
+            bytes32 uriHash = uriHashes[i];
+            if (uriHash == bytes32(0)) revert EmptyURI();
+            _validateHash(tokenId, uriHash);
+            _safeMint(recipients[i], tokenId);
+            tokenHashes[tokenId] = uriHash;
+            if (_baseURISet) {
+                _validatedWithBase[tokenId] = true;
+            }
+            emit CertificateMinted(recipients[i], tokenId, uriHash);
+            unchecked {
+                ++i;
+            }
+        }
     }
 
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         _requireOwned(tokenId);
-        revert("Off-chain URI");
+        if (!_baseURISet) revert BaseURINotSet();
+        string memory uri = super.tokenURI(tokenId);
+        if (_validatedWithBase[tokenId]) {
+            bytes32 expected = tokenHashes[tokenId];
+            bytes32 actual = keccak256(bytes(uri));
+            if (expected != actual) {
+                revert MetadataHashMismatch(tokenId, expected, actual);
+            }
+        }
+        return uri;
     }
 
     /// @notice Confirms this NFT module and owner remain tax neutral.

--- a/test/v2/CertificateNFTMint.test.js
+++ b/test/v2/CertificateNFTMint.test.js
@@ -1,6 +1,8 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
 
+const BASE_URI = 'ipfs://bafybeicert/';
+
 describe('CertificateNFT minting', function () {
   let owner, jobRegistry, user, nft;
 
@@ -14,14 +16,19 @@ describe('CertificateNFT minting', function () {
   });
 
   it('mints with jobId tokenId and enforces registry and URI', async () => {
-    const uri = 'ipfs://1';
-    const uriHash = ethers.keccak256(ethers.toUtf8Bytes(uri));
-    await expect(nft.connect(jobRegistry).mint(user.address, 1, uriHash))
+    const placeholder = ethers.keccak256(ethers.toUtf8Bytes('ipfs://1'));
+    await expect(nft.connect(jobRegistry).mint(user.address, 1, placeholder))
       .to.emit(nft, 'CertificateMinted')
-      .withArgs(user.address, 1, uriHash);
+      .withArgs(user.address, 1, placeholder);
     expect(await nft.ownerOf(1)).to.equal(user.address);
-    const hash = await nft.tokenHashes(1);
-    expect(hash).to.equal(uriHash);
+    await expect(nft.tokenURI(1)).to.be.revertedWithCustomError(
+      nft,
+      'BaseURINotSet'
+    );
+
+    await nft.setBaseURI(BASE_URI);
+    const uri = `${BASE_URI}1`;
+    expect(await nft.tokenURI(1)).to.equal(uri);
 
     await expect(
       nft.connect(jobRegistry).mint(user.address, 2, ethers.ZeroHash)
@@ -30,9 +37,70 @@ describe('CertificateNFT minting', function () {
     await expect(
       nft
         .connect(owner)
-        .mint(user.address, 3, ethers.keccak256(ethers.toUtf8Bytes('ipfs://3')))
+        .mint(user.address, 3, ethers.keccak256(ethers.toUtf8Bytes(`${BASE_URI}3`)))
     )
       .to.be.revertedWithCustomError(nft, 'NotJobRegistry')
       .withArgs(owner.address);
+  });
+
+  it('locks the base URI and enforces IPFS prefix', async () => {
+    await expect(nft.setBaseURI('https://example.com/metadata/'))
+      .to.be.revertedWithCustomError(nft, 'InvalidBaseURI');
+
+    await expect(nft.setBaseURI('ipfs://cid'))
+      .to.be.revertedWithCustomError(nft, 'InvalidBaseURI');
+
+    await expect(nft.setBaseURI(BASE_URI))
+      .to.emit(nft, 'BaseURISet')
+      .withArgs(BASE_URI);
+
+    await expect(nft.setBaseURI(`${BASE_URI}next/`))
+      .to.be.revertedWithCustomError(nft, 'BaseURIAlreadySet');
+  });
+
+  it('rejects mismatched metadata hashes and supports batch minting limits', async () => {
+    await nft.setBaseURI(BASE_URI);
+    const goodHash = ethers.keccak256(ethers.toUtf8Bytes(`${BASE_URI}1`));
+    await expect(
+      nft.connect(jobRegistry).mint(
+        user.address,
+        1,
+        ethers.keccak256(ethers.toUtf8Bytes(`${BASE_URI}2`))
+      )
+    ).to.be.revertedWithCustomError(nft, 'MetadataHashMismatch');
+
+    await expect(nft.connect(jobRegistry).mint(user.address, 1, goodHash))
+      .to.emit(nft, 'CertificateMinted')
+      .withArgs(user.address, 1, goodHash);
+
+    const recipients = [user.address, user.address];
+    const jobIds = [2n, 3n];
+    const hashes = jobIds.map((id) =>
+      ethers.keccak256(ethers.toUtf8Bytes(`${BASE_URI}${id}`))
+    );
+
+    await expect(
+      nft.connect(jobRegistry).mintBatch(recipients, jobIds, hashes)
+    )
+      .to.emit(nft, 'CertificateMinted')
+      .withArgs(user.address, 2, hashes[0]);
+
+    const maxBatch = await nft.MAX_BATCH_MINT();
+    const overSize = Number(maxBatch) + 1;
+    const tooManyRecipients = Array(overSize).fill(user.address);
+    const tooManyIds = Array.from({ length: overSize }, (_, idx) =>
+      BigInt(idx + 4)
+    );
+    const tooManyHashes = tooManyIds.map((id) =>
+      ethers.keccak256(ethers.toUtf8Bytes(`${BASE_URI}${id}`))
+    );
+
+    await expect(
+      nft.connect(jobRegistry).mintBatch(tooManyRecipients, tooManyIds, tooManyHashes)
+    ).to.be.revertedWithCustomError(nft, 'BatchSizeTooLarge');
+
+    await expect(
+      nft.connect(jobRegistry).mintBatch([user.address], [10n, 11n], [hashes[0]])
+    ).to.be.revertedWithCustomError(nft, 'ArrayLengthMismatch');
   });
 });


### PR DESCRIPTION
## Summary
- add immutable IPFS base URI support, metadata hash validation, and bounded batch minting to CertificateNFT
- extend the module variant to expose the same base URI and batch capabilities
- expand CertificateNFTMint tests to cover base URI locking, metadata mismatch checks, and batch size enforcement

## Testing
- npx hardhat test test/v2/CertificateNFTMint.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cce74997408333a4bb91dc0976c607