### PR TITLE
Add IPFS base URI and batch minting to CertificateNFT

### DIFF
--- a/contracts/v2/interfaces/ICertificateNFT.sol
+++ b/contracts/v2/interfaces/ICertificateNFT.sol
@@ -15,7 +15,23 @@ interface ICertificateNFT {
     /// @dev Reverts when an empty metadata hash is supplied
     error EmptyURI();
 
+    /// @dev Reverts when attempting to configure an invalid base URI
+    error InvalidBaseURI();
+
+    /// @dev Reverts when attempting to update the base URI after initial set
+    error BaseURIAlreadySet();
+
+    /// @dev Reverts when querying metadata before a base URI has been set
+    error BaseURINotSet();
+
+    /// @dev Reverts when batch mint parameters exceed the supported bound
+    error BatchSizeExceeded(uint256 attempted, uint256 maxAllowed);
+
+    /// @dev Reverts when batch mint parameter lengths do not match
+    error ArrayLengthMismatch();
+
     event CertificateMinted(address indexed to, uint256 indexed jobId, bytes32 uriHash);
+    event BaseURISet(string baseURI);
 
     /// @notice Mint a completion certificate NFT for a job
     /// @param to Recipient of the certificate
@@ -28,5 +44,19 @@ interface ICertificateNFT {
         uint256 jobId,
         bytes32 uriHash
     ) external returns (uint256 tokenId);
+
+    /// @notice Mint multiple completion certificates in a bounded batch
+    /// @param recipients Recipients for each certificate
+    /// @param jobIds Identifiers for the corresponding jobs / tokenIds
+    /// @param uriHashes Metadata hashes for each certificate
+    /// @return tokenIds Array of minted token identifiers
+    function mintBatch(
+        address[] calldata recipients,
+        uint256[] calldata jobIds,
+        bytes32[] calldata uriHashes
+    ) external returns (uint256[] memory tokenIds);
+
+    /// @notice Returns the immutable base token URI
+    function baseURI() external view returns (string memory);
 }
 

--- a/test/v2/CertificateNFT.test.js
+++ b/test/v2/CertificateNFT.test.js
@@ -3,6 +3,7 @@ const { ethers } = require('hardhat');
 
 describe('CertificateNFT', function () {
   let nft, owner, jobRegistry, user;
+  const baseURI = 'ipfs://complete-certificates/';
 
   beforeEach(async () => {
     [owner, jobRegistry, user] = await ethers.getSigners();
@@ -14,22 +15,83 @@ describe('CertificateNFT', function () {
   });
 
   it('mints certificates only via JobRegistry', async () => {
-    const uri = 'ipfs://job/1';
+    const uri = `${baseURI}1.json`;
     const uriHash = ethers.keccak256(ethers.toUtf8Bytes(uri));
+    await nft.connect(owner).setBaseURI(baseURI);
     await expect(nft.connect(jobRegistry).mint(user.address, 1, uriHash))
       .to.emit(nft, 'CertificateMinted')
       .withArgs(user.address, 1, uriHash);
     expect(await nft.ownerOf(1)).to.equal(user.address);
     const hash = await nft.tokenHashes(1);
     expect(hash).to.equal(uriHash);
+    expect(await nft.tokenURI(1)).to.equal(uri);
+    await expect(
+      nft.connect(owner).setBaseURI(`${baseURI}override/`)
+    ).to.be.revertedWithCustomError(nft, 'BaseURIAlreadySet');
     await expect(
       nft
         .connect(owner)
         .mint(
           user.address,
           2,
-          ethers.keccak256(ethers.toUtf8Bytes('ipfs://job/2'))
+          ethers.keccak256(ethers.toUtf8Bytes(`${baseURI}2.json`))
         )
     ).to.be.revertedWith('only JobRegistry');
+  });
+
+  it('reverts when querying metadata before base URI configuration', async () => {
+    const uri = `${baseURI}1.json`;
+    const uriHash = ethers.keccak256(ethers.toUtf8Bytes(uri));
+    await expect(nft.connect(jobRegistry).mint(user.address, 1, uriHash))
+      .to.emit(nft, 'CertificateMinted')
+      .withArgs(user.address, 1, uriHash);
+    await expect(nft.tokenURI(1)).to.be.revertedWithCustomError(
+      nft,
+      'BaseURINotSet'
+    );
+  });
+
+  it('validates base URI formatting and batch size bounds', async () => {
+    await expect(
+      nft.connect(owner).setBaseURI('https://example/')
+    ).to.be.revertedWithCustomError(nft, 'InvalidBaseURI');
+    await expect(
+      nft.connect(owner).setBaseURI('ipfs://missing-trailing-slash')
+    ).to.be.revertedWithCustomError(nft, 'InvalidBaseURI');
+    await nft.connect(owner).setBaseURI(baseURI);
+
+    const recipients = [user.address, jobRegistry.address];
+    const jobIds = [1, 2];
+    const uriHashes = jobIds.map((id) =>
+      ethers.keccak256(ethers.toUtf8Bytes(`${baseURI}${id}.json`))
+    );
+    await expect(
+      nft.connect(jobRegistry).mintBatch(recipients, jobIds, uriHashes)
+    )
+      .to.emit(nft, 'CertificateMinted')
+      .withArgs(jobRegistry.address, 2, uriHashes[1]);
+    expect(await nft.ownerOf(1)).to.equal(user.address);
+    expect(await nft.ownerOf(2)).to.equal(jobRegistry.address);
+
+    const maxBatch = Number(await nft.MAX_BATCH_MINT());
+    const overflow = maxBatch + 1;
+    const overflowRecipients = Array.from({ length: overflow }, () => user.address);
+    const overflowJobIds = Array.from({ length: overflow }, (_, i) => i + 3);
+    const overflowHashes = overflowJobIds.map((id) =>
+      ethers.keccak256(ethers.toUtf8Bytes(`${baseURI}${id}.json`))
+    );
+    await expect(
+      nft
+        .connect(jobRegistry)
+        .mintBatch(overflowRecipients, overflowJobIds, overflowHashes)
+    )
+      .to.be.revertedWithCustomError(nft, 'BatchSizeExceeded')
+      .withArgs(overflow, maxBatch);
+
+    await expect(
+      nft
+        .connect(jobRegistry)
+        .mintBatch([user.address], [999, 1000], [ethers.ZeroHash])
+    ).to.be.revertedWithCustomError(nft, 'ArrayLengthMismatch');
   });
 });

--- a/test/v2/CertificateNFTMint.test.js
+++ b/test/v2/CertificateNFTMint.test.js
@@ -3,6 +3,7 @@ const { ethers } = require('hardhat');
 
 describe('CertificateNFT minting', function () {
   let owner, jobRegistry, user, nft;
+  const baseURI = 'ipfs://proof-of-completion/';
 
   beforeEach(async () => {
     [owner, jobRegistry, user] = await ethers.getSigners();
@@ -14,7 +15,8 @@ describe('CertificateNFT minting', function () {
   });
 
   it('mints with jobId tokenId and enforces registry and URI', async () => {
-    const uri = 'ipfs://1';
+    await nft.connect(owner).setBaseURI(baseURI);
+    const uri = `${baseURI}1.json`;
     const uriHash = ethers.keccak256(ethers.toUtf8Bytes(uri));
     await expect(nft.connect(jobRegistry).mint(user.address, 1, uriHash))
       .to.emit(nft, 'CertificateMinted')
@@ -22,6 +24,7 @@ describe('CertificateNFT minting', function () {
     expect(await nft.ownerOf(1)).to.equal(user.address);
     const hash = await nft.tokenHashes(1);
     expect(hash).to.equal(uriHash);
+    expect(await nft.tokenURI(1)).to.equal(uri);
 
     await expect(
       nft.connect(jobRegistry).mint(user.address, 2, ethers.ZeroHash)
@@ -30,9 +33,53 @@ describe('CertificateNFT minting', function () {
     await expect(
       nft
         .connect(owner)
-        .mint(user.address, 3, ethers.keccak256(ethers.toUtf8Bytes('ipfs://3')))
+        .mint(
+          user.address,
+          3,
+          ethers.keccak256(ethers.toUtf8Bytes(`${baseURI}3.json`))
+        )
     )
       .to.be.revertedWithCustomError(nft, 'NotJobRegistry')
       .withArgs(owner.address);
+  });
+
+  it('supports bounded batch minting with strict validation', async () => {
+    await nft.connect(owner).setBaseURI(baseURI);
+    const recipients = [user.address, owner.address];
+    const jobIds = [1, 2];
+    const uriHashes = jobIds.map((id) =>
+      ethers.keccak256(ethers.toUtf8Bytes(`${baseURI}${id}.json`))
+    );
+    const tx = await nft
+      .connect(jobRegistry)
+      .mintBatch(recipients, jobIds, uriHashes);
+    const receipt = await tx.wait();
+    expect(
+      receipt.logs.filter((log) => log.eventName === 'CertificateMinted')
+    ).to.have.length(2);
+    expect(await nft.ownerOf(1)).to.equal(user.address);
+    expect(await nft.ownerOf(2)).to.equal(owner.address);
+    expect(await nft.tokenURI(2)).to.equal(`${baseURI}2.json`);
+
+    await expect(
+      nft
+        .connect(jobRegistry)
+        .mintBatch([ethers.ZeroAddress], [3], [uriHashes[0]])
+    ).to.be.revertedWithCustomError(nft, 'ZeroAddress');
+
+    const maxBatch = Number(await nft.MAX_BATCH_MINT());
+    const overflow = maxBatch + 1;
+    const overflowRecipients = Array.from({ length: overflow }, () => user.address);
+    const overflowJobIds = Array.from({ length: overflow }, (_, i) => i + 10);
+    const overflowHashes = overflowJobIds.map((id) =>
+      ethers.keccak256(ethers.toUtf8Bytes(`${baseURI}${id}.json`))
+    );
+    await expect(
+      nft
+        .connect(jobRegistry)
+        .mintBatch(overflowRecipients, overflowJobIds, overflowHashes)
+    )
+      .to.be.revertedWithCustomError(nft, 'BatchSizeExceeded')
+      .withArgs(overflow, maxBatch);
   });
 });


### PR DESCRIPTION
## Summary
- require CertificateNFT implementations to use a single-set IPFS base URI and expose it for clients
- add bounded batch minting utilities and base URI validation to both module and marketplace-aware contracts
- extend CertificateNFT tests to cover base immutability, metadata access, and batch constraints

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cced95b768833396c0ac90cce00846