### PR TITLE
feat: expose CertificateNFT metadata URI

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,9 @@ Mints completion certificates and allows optional marketplace listings.
 
 ### Key Functions
 
+- `setBaseURI(string baseURI)` – One-time configuration of the collection IPFS CID.
 - `mint(address to, uint256 jobId, bytes32 uriHash)` – Mint certificate for a finished job.
+- `tokenURI(uint256 tokenId)` – Return `ipfs://` metadata derived from the base URI and stored hash.
 - `list(uint256 tokenId, uint256 price)` – Offer an owned certificate for sale.
 - `purchase(uint256 tokenId)` – Buy a listed certificate.
 - `delist(uint256 tokenId)` – Cancel an active listing.

--- a/docs/api/CertificateNFT.md
+++ b/docs/api/CertificateNFT.md
@@ -5,8 +5,9 @@ ERC‑721 completion certificates with optional marketplace.
 ## Functions
 
 - `setJobRegistry(address registry)` / `setStakeManager(address manager)` – owner wires modules.
-- `mint(address to, uint256 jobId, string uri)` – JobRegistry mints certificate.
-- `tokenURI(uint256 tokenId)` – returns metadata URI.
+- `setBaseURI(string baseURI)` – permanently configure the IPFS base CID for metadata.
+- `mint(address to, uint256 jobId, bytes32 uriHash)` – JobRegistry mints certificate with metadata hash binding.
+- `tokenURI(uint256 tokenId)` – returns `ipfs://` URI derived from the base CID and stored hash.
 - `list(uint256 tokenId, uint256 price)` – certificate holder lists for sale.
 - `purchase(uint256 tokenId)` – buy listed certificate.
 - `delist(uint256 tokenId)` – remove listing.
@@ -18,3 +19,4 @@ ERC‑721 completion certificates with optional marketplace.
 - `NFTListed(uint256 tokenId, address seller, uint256 price)`
 - `NFTPurchased(uint256 tokenId, address buyer, uint256 price)`
 - `NFTDelisted(uint256 tokenId)`
+- `BaseURISet(string baseURI)`

--- a/test/v2/CertificateNFTMint.test.js
+++ b/test/v2/CertificateNFTMint.test.js
@@ -35,4 +35,37 @@ describe('CertificateNFT minting', function () {
       .to.be.revertedWithCustomError(nft, 'NotJobRegistry')
       .withArgs(owner.address);
   });
+
+  it('exposes metadata URIs once the base CID is configured', async () => {
+    const uri = 'ipfs://1';
+    const uriHash = ethers.keccak256(ethers.toUtf8Bytes(uri));
+    await nft.connect(jobRegistry).mint(user.address, 1, uriHash);
+
+    await expect(nft.tokenURI(1)).to.be.revertedWithCustomError(
+      nft,
+      'BaseURIUnset'
+    );
+
+    const base = 'ipfs://metadata/';
+    await expect(nft.setBaseURI(base))
+      .to.emit(nft, 'BaseURISet')
+      .withArgs(base);
+
+    const expected = `${base}${uriHash.slice(2)}`;
+    expect(await nft.tokenURI(1)).to.equal(expected);
+  });
+
+  it('rejects invalid or repeated base URI configuration', async () => {
+    await expect(nft.setBaseURI(''))
+      .to.be.revertedWithCustomError(nft, 'EmptyBaseURI');
+    await expect(nft.setBaseURI('https://metadata/'))
+      .to.be.revertedWithCustomError(nft, 'InvalidBaseURI');
+
+    const base = 'ipfs://metadata/';
+    await nft.setBaseURI(base);
+    await expect(nft.setBaseURI(base)).to.be.revertedWithCustomError(
+      nft,
+      'BaseURIAlreadySet'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- persist a one-time configurable IPFS base URI for CertificateNFT metadata and expose it through tokenURI
- emit a BaseURISet event and validate CID formatting when configuring the base path
- document the new workflow and extend CertificateNFT tests to cover metadata resolution and guardrails

## Testing
- npx hardhat test test/v2/CertificateNFTMint.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd4a01b64c8333af30542539936eec