### PR TITLE
Add immutable IPFS anchoring and batch minting to CertificateNFT

### DIFF
--- a/contracts/v2/interfaces/ICertificateNFT.sol
+++ b/contracts/v2/interfaces/ICertificateNFT.sol
@@ -15,6 +15,18 @@ interface ICertificateNFT {
     /// @dev Reverts when an empty metadata hash is supplied
     error EmptyURI();
 
+    /// @dev Reverts when the immutable base URI has not been configured
+    error BaseURIUnset();
+
+    /// @dev Reverts when batch minting arrays differ in length
+    error ArrayLengthMismatch();
+
+    /// @dev Reverts when attempting to batch mint zero certificates
+    error EmptyBatch();
+
+    /// @dev Reverts when batch minting exceeds the configured limit
+    error BatchMintLimitExceeded(uint256 size, uint256 max);
+
     event CertificateMinted(address indexed to, uint256 indexed jobId, bytes32 uriHash);
 
     /// @notice Mint a completion certificate NFT for a job
@@ -28,5 +40,16 @@ interface ICertificateNFT {
         uint256 jobId,
         bytes32 uriHash
     ) external returns (uint256 tokenId);
+
+    /// @notice Mint multiple completion certificates in a single call
+    /// @param recipients Recipients for each certificate
+    /// @param jobIds Identifiers of the jobs; double as the tokenIds
+    /// @param uriHashes Hashes of the metadata URIs for each certificate
+    /// @return tokenIds Array of minted certificate identifiers
+    function batchMint(
+        address[] calldata recipients,
+        uint256[] calldata jobIds,
+        bytes32[] calldata uriHashes
+    ) external returns (uint256[] memory tokenIds);
 }
 

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {ICertificateNFT} from "../interfaces/ICertificateNFT.sol";
 
 /// @title CertificateNFT (module)
@@ -10,13 +11,23 @@ import {ICertificateNFT} from "../interfaces/ICertificateNFT.sol";
 /// @dev Only participants bear any tax obligations; the contract holds no
 ///      ether and rejects unsolicited transfers.
 contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
+    using Strings for uint256;
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 2;
 
+    error ZeroAddress();
+    error InvalidBaseURI();
+    error BaseURIAlreadySet();
+
     address public jobRegistry;
     mapping(uint256 => bytes32) public tokenHashes;
+    string private _baseURIStorage;
+    bool private _baseURISet;
+
+    uint256 public constant MAX_BATCH_MINT = 20;
 
     event JobRegistryUpdated(address registry);
+    event BaseURISet(string baseURI);
 
     constructor(string memory name_, string memory symbol_)
         ERC721(name_, symbol_)
@@ -37,21 +48,58 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
         emit JobRegistryUpdated(registry);
     }
 
+    function setBaseURI(string calldata baseURI_) external onlyOwner {
+        if (_baseURISet) revert BaseURIAlreadySet();
+        bytes memory uriBytes = bytes(baseURI_);
+        if (uriBytes.length < 7) revert InvalidBaseURI();
+        if (
+            uriBytes[0] != 'i' ||
+            uriBytes[1] != 'p' ||
+            uriBytes[2] != 'f' ||
+            uriBytes[3] != 's' ||
+            uriBytes[4] != ':' ||
+            uriBytes[5] != '/' ||
+            uriBytes[6] != '/'
+        ) {
+            revert InvalidBaseURI();
+        }
+        _baseURIStorage = baseURI_;
+        _baseURISet = true;
+        emit BaseURISet(baseURI_);
+    }
+
     function mint(
         address to,
         uint256 jobId,
         bytes32 uriHash
     ) external onlyJobRegistry returns (uint256 tokenId) {
-        if (uriHash == bytes32(0)) revert EmptyURI();
-        tokenId = jobId;
-        _safeMint(to, tokenId);
-        tokenHashes[tokenId] = uriHash;
-        emit CertificateMinted(to, jobId, uriHash);
+        tokenId = _mintCertificate(to, jobId, uriHash);
+    }
+
+    function batchMint(
+        address[] calldata recipients,
+        uint256[] calldata jobIds,
+        bytes32[] calldata uriHashes
+    ) external onlyJobRegistry returns (uint256[] memory tokenIds) {
+        uint256 length = recipients.length;
+        if (length == 0) revert EmptyBatch();
+        if (length != jobIds.length || length != uriHashes.length) {
+            revert ArrayLengthMismatch();
+        }
+        if (length > MAX_BATCH_MINT) revert BatchMintLimitExceeded(length, MAX_BATCH_MINT);
+        tokenIds = new uint256[](length);
+        for (uint256 i; i < length;) {
+            tokenIds[i] = _mintCertificate(recipients[i], jobIds[i], uriHashes[i]);
+            unchecked {
+                ++i;
+            }
+        }
     }
 
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         _requireOwned(tokenId);
-        revert("Off-chain URI");
+        if (!_baseURISet) revert BaseURIUnset();
+        return string.concat(_baseURIStorage, Strings.toHexString(uint256(tokenHashes[tokenId]), 32));
     }
 
     /// @notice Confirms this NFT module and owner remain tax neutral.
@@ -73,6 +121,25 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
     /// @dev Reject calls with unexpected calldata or funds.
     fallback() external payable {
         revert("CertificateNFT: no ether");
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return _baseURIStorage;
+    }
+
+    function _mintCertificate(
+        address to,
+        uint256 jobId,
+        bytes32 uriHash
+    ) private returns (uint256 tokenId) {
+        if (!_baseURISet) revert BaseURIUnset();
+        if (to == address(0)) revert ZeroAddress();
+        if (uriHash == bytes32(0)) revert EmptyURI();
+        tokenId = jobId;
+        if (_ownerOf(tokenId) != address(0)) revert CertificateAlreadyMinted(jobId);
+        _safeMint(to, tokenId);
+        tokenHashes[tokenId] = uriHash;
+        emit CertificateMinted(to, jobId, uriHash);
     }
 }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,9 @@ Mints completion certificates and allows optional marketplace listings.
 
 ### Key Functions
 
+- `setBaseURI(string baseURI)` – Permanently set the IPFS base for metadata.
 - `mint(address to, uint256 jobId, bytes32 uriHash)` – Mint certificate for a finished job.
+- `batchMint(address[] to, uint256[] jobIds, bytes32[] uriHashes)` – Mint a bounded batch of certificates.
 - `list(uint256 tokenId, uint256 price)` – Offer an owned certificate for sale.
 - `purchase(uint256 tokenId)` – Buy a listed certificate.
 - `delist(uint256 tokenId)` – Cancel an active listing.

--- a/docs/api/CertificateNFT.md
+++ b/docs/api/CertificateNFT.md
@@ -5,8 +5,10 @@ ERC‑721 completion certificates with optional marketplace.
 ## Functions
 
 - `setJobRegistry(address registry)` / `setStakeManager(address manager)` – owner wires modules.
-- `mint(address to, uint256 jobId, string uri)` – JobRegistry mints certificate.
-- `tokenURI(uint256 tokenId)` – returns metadata URI.
+- `setBaseURI(string baseURI)` – owner sets the immutable IPFS base CID.
+- `mint(address to, uint256 jobId, bytes32 uriHash)` – JobRegistry mints a certificate anchored to the provided metadata hash.
+- `batchMint(address[] to, uint256[] jobIds, bytes32[] uriHashes)` – JobRegistry mints multiple certificates (bounded batch).
+- `tokenURI(uint256 tokenId)` – returns `baseURI` concatenated with the stored metadata hash in hex.
 - `list(uint256 tokenId, uint256 price)` – certificate holder lists for sale.
 - `purchase(uint256 tokenId)` – buy listed certificate.
 - `delist(uint256 tokenId)` – remove listing.
@@ -15,6 +17,8 @@ ERC‑721 completion certificates with optional marketplace.
 
 - `JobRegistryUpdated(address registry)`
 - `StakeManagerUpdated(address manager)`
+- `BaseURISet(string baseURI)`
+- `CertificateMinted(address to, uint256 jobId, bytes32 uriHash)`
 - `NFTListed(uint256 tokenId, address seller, uint256 price)`
 - `NFTPurchased(uint256 tokenId, address buyer, uint256 price)`
 - `NFTDelisted(uint256 tokenId)`

--- a/test/v2/CertificateNFT.test.js
+++ b/test/v2/CertificateNFT.test.js
@@ -13,7 +13,16 @@ describe('CertificateNFT', function () {
     await nft.connect(owner).setJobRegistry(jobRegistry.address);
   });
 
+  it('blocks minting until the IPFS base is initialised', async () => {
+    const uriHash = ethers.keccak256(ethers.toUtf8Bytes('ipfs://job/1'));
+    await expect(
+      nft.connect(jobRegistry).mint(user.address, 1, uriHash)
+    ).to.be.revertedWithCustomError(nft, 'BaseURIUnset');
+  });
+
   it('mints certificates only via JobRegistry', async () => {
+    const baseURI = 'ipfs://module/';
+    await nft.connect(owner).setBaseURI(baseURI);
     const uri = 'ipfs://job/1';
     const uriHash = ethers.keccak256(ethers.toUtf8Bytes(uri));
     await expect(nft.connect(jobRegistry).mint(user.address, 1, uriHash))
@@ -22,6 +31,7 @@ describe('CertificateNFT', function () {
     expect(await nft.ownerOf(1)).to.equal(user.address);
     const hash = await nft.tokenHashes(1);
     expect(hash).to.equal(uriHash);
+    expect(await nft.tokenURI(1)).to.equal(`${baseURI}${uriHash}`);
     await expect(
       nft
         .connect(owner)

--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -44,6 +44,7 @@ describe('CertificateNFT marketplace', function () {
     nft = await NFT.deploy('Cert', 'CERT');
     await nft.setJobRegistry(owner.address);
     await nft.setStakeManager(await stake.getAddress());
+    await nft.setBaseURI('ipfs://market/');
 
     await nft.mint(
       seller.address,

--- a/test/v2/CertificateNFTMint.test.js
+++ b/test/v2/CertificateNFTMint.test.js
@@ -13,8 +13,19 @@ describe('CertificateNFT minting', function () {
     await nft.setJobRegistry(jobRegistry.address);
   });
 
-  it('mints with jobId tokenId and enforces registry and URI', async () => {
-    const uri = 'ipfs://1';
+  it('prevents minting until the IPFS base is configured', async () => {
+    const uriHash = ethers.keccak256(ethers.toUtf8Bytes('ipfs://job/1'));
+    await expect(
+      nft.connect(jobRegistry).mint(user.address, 1, uriHash)
+    ).to.be.revertedWithCustomError(nft, 'BaseURIUnset');
+  });
+
+  it('mints with jobId tokenId and enforces registry and URI hash', async () => {
+    const baseURI = 'ipfs://root/';
+    await expect(nft.setBaseURI(baseURI))
+      .to.emit(nft, 'BaseURISet')
+      .withArgs(baseURI);
+    const uri = 'ipfs://job/1';
     const uriHash = ethers.keccak256(ethers.toUtf8Bytes(uri));
     await expect(nft.connect(jobRegistry).mint(user.address, 1, uriHash))
       .to.emit(nft, 'CertificateMinted')
@@ -22,6 +33,7 @@ describe('CertificateNFT minting', function () {
     expect(await nft.ownerOf(1)).to.equal(user.address);
     const hash = await nft.tokenHashes(1);
     expect(hash).to.equal(uriHash);
+    expect(await nft.tokenURI(1)).to.equal(`${baseURI}${uriHash}`);
 
     await expect(
       nft.connect(jobRegistry).mint(user.address, 2, ethers.ZeroHash)
@@ -34,5 +46,88 @@ describe('CertificateNFT minting', function () {
     )
       .to.be.revertedWithCustomError(nft, 'NotJobRegistry')
       .withArgs(owner.address);
+  });
+
+  it('locks the base URI to an IPFS prefix', async () => {
+    await expect(nft.setBaseURI('https://example.com/')).to.be.revertedWithCustomError(
+      nft,
+      'InvalidBaseURI'
+    );
+    await nft.setBaseURI('ipfs://cid/');
+    await expect(nft.setBaseURI('ipfs://second/')).to.be.revertedWithCustomError(
+      nft,
+      'BaseURIAlreadySet'
+    );
+  });
+
+  it('batch mints certificates within the configured limit', async () => {
+    await nft.setBaseURI('ipfs://batch/');
+    const limit = Number(await nft.MAX_BATCH_MINT());
+    const recipients = Array.from({ length: limit }, (_, i) =>
+      i % 2 === 0 ? user.address : owner.address
+    );
+    const jobIds = Array.from({ length: limit }, (_, i) => i + 1);
+    const uriHashes = jobIds.map((id) =>
+      ethers.keccak256(ethers.toUtf8Bytes(`ipfs://job/${id}`))
+    );
+
+    const staticResult = await nft
+      .connect(jobRegistry)
+      .batchMint.staticCall(recipients, jobIds, uriHashes);
+    expect(staticResult.map((bn) => Number(bn))).to.deep.equal(jobIds);
+
+    const tx = await nft
+      .connect(jobRegistry)
+      .batchMint(recipients, jobIds, uriHashes);
+    const receipt = await tx.wait();
+    const parsed = receipt.logs
+      .map((log) => {
+        try {
+          return nft.interface.parseLog(log);
+        } catch (err) {
+          return null;
+        }
+      })
+      .filter(Boolean)
+      .filter((decoded) => decoded.name === 'CertificateMinted');
+    expect(parsed.length).to.equal(limit);
+    for (let i = 0; i < limit; i += 1) {
+      const event = parsed[i];
+      expect(event.args.to).to.equal(recipients[i]);
+      expect(event.args.jobId).to.equal(BigInt(jobIds[i]));
+      expect(event.args.uriHash).to.equal(uriHashes[i]);
+      expect(await nft.ownerOf(jobIds[i])).to.equal(recipients[i]);
+      expect(await nft.tokenURI(jobIds[i])).to.equal(
+        `ipfs://batch/${uriHashes[i]}`
+      );
+    }
+
+    await expect(
+      nft
+        .connect(jobRegistry)
+        .batchMint(
+          recipients,
+          jobIds.slice(0, limit - 1),
+          uriHashes
+        )
+    ).to.be.revertedWithCustomError(nft, 'ArrayLengthMismatch');
+
+    await expect(
+      nft.connect(jobRegistry).batchMint([], [], [])
+    ).to.be.revertedWithCustomError(nft, 'EmptyBatch');
+
+    const tooManyRecipients = recipients.concat(user.address);
+    const tooManyIds = jobIds.concat(limit + 1);
+    const tooManyHashes = uriHashes.concat(
+      ethers.keccak256(ethers.toUtf8Bytes(`ipfs://job/${limit + 1}`))
+    );
+
+    await expect(
+      nft
+        .connect(jobRegistry)
+        .batchMint(tooManyRecipients, tooManyIds, tooManyHashes)
+    )
+      .to.be.revertedWithCustomError(nft, 'BatchMintLimitExceeded')
+      .withArgs(BigInt(limit + 1), BigInt(limit));
   });
 });

--- a/test/v2/EmployerReputation.test.js
+++ b/test/v2/EmployerReputation.test.js
@@ -59,6 +59,7 @@ describe('Employer reputation', function () {
       'contracts/v2/modules/CertificateNFT.sol:CertificateNFT'
     );
     nft = await NFT.deploy('Cert', 'CERT');
+    await nft.connect(owner).setBaseURI('ipfs://module-employer-reputation/');
     const FeePool = await ethers.getContractFactory(
       'contracts/v2/FeePool.sol:FeePool'
     );

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -50,6 +50,7 @@ describe('Job expiration', function () {
       'contracts/v2/modules/CertificateNFT.sol:CertificateNFT'
     );
     nft = await NFT.deploy('Cert', 'CERT');
+    await nft.connect(owner).setBaseURI('ipfs://module-expiration/');
     const FeePool = await ethers.getContractFactory(
       'contracts/v2/FeePool.sol:FeePool'
     );

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -50,6 +50,7 @@ describe('Job expiration boundary', function () {
       'contracts/v2/modules/CertificateNFT.sol:CertificateNFT'
     );
     nft = await NFT.deploy('Cert', 'CERT');
+    await nft.connect(owner).setBaseURI('ipfs://module-boundary/');
     const FeePool = await ethers.getContractFactory(
       'contracts/v2/FeePool.sol:FeePool'
     );

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -60,6 +60,7 @@ describe('JobRegistry integration', function () {
       'contracts/v2/modules/CertificateNFT.sol:CertificateNFT'
     );
     nft = await NFT.deploy('Cert', 'CERT');
+    await nft.connect(owner).setBaseURI('ipfs://module-registry/');
     const FeePool = await ethers.getContractFactory(
       'contracts/v2/FeePool.sol:FeePool'
     );

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -107,6 +107,7 @@ async function deploySystem() {
   await validation.setJobRegistry(await registry.getAddress());
   await nft.setJobRegistry(await registry.getAddress());
   await nft.setStakeManager(await stake.getAddress());
+  await nft.setBaseURI('ipfs://upgrade/');
   await registry.setModules(
     await validation.getAddress(),
     await stake.getAddress(),

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -107,6 +107,7 @@ async function deploySystem() {
   await validation.setJobRegistry(await registry.getAddress());
   await nft.setJobRegistry(await registry.getAddress());
   await nft.setStakeManager(await stake.getAddress());
+  await nft.setBaseURI('ipfs://module-replacement/');
   await registry.setModules(
     await validation.getAddress(),
     await stake.getAddress(),

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -72,6 +72,7 @@ describe('comprehensive job flows', function () {
       'contracts/v2/CertificateNFT.sol:CertificateNFT'
     );
     nft = await NFT.deploy('Cert', 'CERT');
+    await nft.setBaseURI('ipfs://comprehensive/');
 
     const Registry = await ethers.getContractFactory(
       'contracts/v2/JobRegistry.sol:JobRegistry'

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -70,6 +70,7 @@ describe('end-to-end job lifecycle', function () {
       'contracts/v2/modules/CertificateNFT.sol:CertificateNFT'
     );
     nft = await NFT.deploy('Cert', 'CERT');
+    await nft.connect(owner).setBaseURI('ipfs://module-e2e/');
 
     const Registry = await ethers.getContractFactory(
       'contracts/v2/JobRegistry.sol:JobRegistry'

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -84,6 +84,7 @@ async function deploySystem() {
     'contracts/v2/CertificateNFT.sol:CertificateNFT'
   );
   const nft = await NFT.deploy('Cert', 'CERT');
+  await nft.setBaseURI('ipfs://commit-reveal/');
 
   const Registry = await ethers.getContractFactory(
     'contracts/v2/JobRegistry.sol:JobRegistry'

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -68,6 +68,7 @@ describe('job finalization integration', function () {
       'contracts/v2/modules/CertificateNFT.sol:CertificateNFT'
     );
     nft = await NFT.deploy('Cert', 'CERT');
+    await nft.connect(owner).setBaseURI('ipfs://module-finalization/');
 
     const Registry = await ethers.getContractFactory(
       'contracts/v2/JobRegistry.sol:JobRegistry'

--- a/test/v2/jobLifecycle.test.ts
+++ b/test/v2/jobLifecycle.test.ts
@@ -103,6 +103,7 @@ async function deploySystem() {
   await validation.setJobRegistry(await registry.getAddress());
   await nft.setJobRegistry(await registry.getAddress());
   await nft.setStakeManager(await stake.getAddress());
+  await nft.setBaseURI('ipfs://lifecycle/');
   await registry.setModules(
     await validation.getAddress(),
     await stake.getAddress(),

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -65,6 +65,7 @@ async function deployFullSystem() {
     'contracts/v2/CertificateNFT.sol:CertificateNFT'
   );
   const nft = await NFT.deploy('Cert', 'CERT');
+  await nft.setBaseURI('ipfs://dispute-lifecycle/');
 
   const Registry = await ethers.getContractFactory(
     'contracts/v2/JobRegistry.sol:JobRegistry'

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -65,6 +65,7 @@ async function deploySystem() {
     'contracts/v2/CertificateNFT.sol:CertificateNFT'
   );
   const nft = await NFT.deploy('Cert', 'CERT');
+  await nft.setBaseURI('ipfs://kleros/');
 
   const Registry = await ethers.getContractFactory(
     'contracts/v2/JobRegistry.sol:JobRegistry'

--- a/test/v2/midJobReplacementFuzz.test.js
+++ b/test/v2/midJobReplacementFuzz.test.js
@@ -104,6 +104,7 @@ async function deploySystem() {
   await validation.setJobRegistry(await registry.getAddress());
   await nft.setJobRegistry(await registry.getAddress());
   await nft.setStakeManager(await stake.getAddress());
+  await nft.setBaseURI('ipfs://midjob/');
   await registry.setModules(
     await validation.getAddress(),
     await stake.getAddress(),

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -72,6 +72,7 @@ describe('multi-operator job lifecycle', function () {
       'contracts/v2/modules/CertificateNFT.sol:CertificateNFT'
     );
     nft = await NFT.deploy('Cert', 'CERT');
+    await nft.connect(owner).setBaseURI('ipfs://module-multi-operator/');
 
     const Registry = await ethers.getContractFactory(
       'contracts/v2/JobRegistry.sol:JobRegistry'

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -64,6 +64,7 @@ async function deploySystem() {
     'contracts/v2/CertificateNFT.sol:CertificateNFT'
   );
   const nft = await NFT.deploy('Cert', 'CERT');
+  await nft.setBaseURI('ipfs://regression/');
 
   const Registry = await ethers.getContractFactory(
     'contracts/v2/JobRegistry.sol:JobRegistry'

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -65,6 +65,7 @@ async function deployFullSystem() {
     'contracts/v2/CertificateNFT.sol:CertificateNFT'
   );
   const nft = await NFT.deploy('Cert', 'CERT');
+  await nft.setBaseURI('ipfs://validator-participation/');
 
   const Registry = await ethers.getContractFactory(
     'contracts/v2/JobRegistry.sol:JobRegistry'


### PR DESCRIPTION
## Summary
- add immutable IPFS base URI configuration, batch minting, and hex-based tokenURI generation to CertificateNFT and its module variant
- extend the certificate interface and documentation for the new batch mint workflow and base URI semantics
- update contract tests to configure base URIs, cover batch limits, and ensure integration suites use the immutable IPFS base

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd4d7b4ca483338924ec91c634109c