### PR TITLE
Add immutable base URI to CertificateNFT metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Record each address during deployment. The defaults below assume the 18‑decima
 | [`IdentityRegistry`](contracts/v2/IdentityRegistry.sol)                    | `setENS`, `setNameWrapper`, `setReputationEngine`, `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot`, `setValidatorMerkleRoot`, `setAgentProfileURI` |
 | [`DisputeModule`](contracts/v2/modules/DisputeModule.sol)                  | `setDisputeFee`, `setTaxPolicy`, `setFeePool`                                                                                                                  |
 | [`ReputationEngine`](contracts/v2/ReputationEngine.sol)                    | `setCaller`, `setWeights`, `blacklist`, `unblacklist`                                                                                                          |
-| [`CertificateNFT`](contracts/v2/CertificateNFT.sol)                        | `setJobRegistry`, `setStakeManager`, `setBaseURI`                                                                                                              |
+| [`CertificateNFT`](contracts/v2/CertificateNFT.sol)                        | `setJobRegistry`, `setStakeManager`, `setBaseURI` _(one-time IPFS prefix)_                                                                                     |
 | [`FeePool`](contracts/v2/FeePool.sol)                                      | `setStakeManager`, `setRewardRole`, `setBurnPct`, `setTreasury`                                                                                                |
 
 ### Etherscan steps
@@ -173,6 +173,7 @@ Record each address during deployment. The defaults below assume the 18‑decima
      - any `_ackModules` passed to this call must implement `IJobRegistryAck` and successfully respond to `acknowledgeFor(address(0))`
    - Point modules back to the registry with `StakeManager.setJobRegistry(jobRegistry)`, `ValidationModule.setJobRegistry(jobRegistry)`, `DisputeModule.setJobRegistry(jobRegistry)` and `CertificateNFT.setJobRegistry(jobRegistry)`
    - Authorise cross‑module calls using `StakeManager.setDisputeModule(disputeModule)` and `CertificateNFT.setStakeManager(stakeManager)`
+   - After wiring, call `CertificateNFT.setBaseURI('ipfs://<CID>/')` once to lock the metadata prefix so `tokenURI(tokenId)` resolves deterministically
    - `JobRegistry.setTaxPolicy(taxPolicy)` then `DisputeModule.setTaxPolicy(taxPolicy)`
    - `JobRegistry.setIdentityRegistry(identityRegistry)` and `ValidationModule.setIdentityRegistry(identityRegistry)`
    - Load ENS settings with `IdentityRegistry.setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot` and `setValidatorMerkleRoot`

--- a/contracts/v2/modules/CertificateNFT.sol
+++ b/contracts/v2/modules/CertificateNFT.sol
@@ -4,19 +4,28 @@ pragma solidity ^0.8.25;
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ICertificateNFT} from "../interfaces/ICertificateNFT.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 /// @title CertificateNFT (module)
 /// @notice ERC721 certificate minted upon successful job completion.
 /// @dev Only participants bear any tax obligations; the contract holds no
 ///      ether and rejects unsolicited transfers.
 contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
+    using Strings for uint256;
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 2;
 
     address public jobRegistry;
     mapping(uint256 => bytes32) public tokenHashes;
+    string private _baseTokenURI;
+    bool private _baseURISet;
 
     event JobRegistryUpdated(address registry);
+    event BaseURISet(string baseURI);
+
+    error EmptyBaseURI();
+    error BaseURIAlreadySet();
+    error BaseURIUnset();
 
     constructor(string memory name_, string memory symbol_)
         ERC721(name_, symbol_)
@@ -37,6 +46,14 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
         emit JobRegistryUpdated(registry);
     }
 
+    function setBaseURI(string calldata baseURI_) external onlyOwner {
+        if (bytes(baseURI_).length == 0) revert EmptyBaseURI();
+        if (_baseURISet) revert BaseURIAlreadySet();
+        _baseTokenURI = baseURI_;
+        _baseURISet = true;
+        emit BaseURISet(baseURI_);
+    }
+
     function mint(
         address to,
         uint256 jobId,
@@ -51,7 +68,8 @@ contract CertificateNFT is ERC721, Ownable, ICertificateNFT {
 
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         _requireOwned(tokenId);
-        revert("Off-chain URI");
+        if (!_baseURISet) revert BaseURIUnset();
+        return string(abi.encodePacked(_baseTokenURI, tokenId.toString()));
     }
 
     /// @notice Confirms this NFT module and owner remain tax neutral.

--- a/docs/api/CertificateNFT.md
+++ b/docs/api/CertificateNFT.md
@@ -5,8 +5,9 @@ ERC‑721 completion certificates with optional marketplace.
 ## Functions
 
 - `setJobRegistry(address registry)` / `setStakeManager(address manager)` – owner wires modules.
+- `setBaseURI(string baseURI)` – owner supplies an immutable IPFS prefix; reverts on second call or empty strings.
 - `mint(address to, uint256 jobId, string uri)` – JobRegistry mints certificate.
-- `tokenURI(uint256 tokenId)` – returns metadata URI.
+- `tokenURI(uint256 tokenId)` – returns `baseURI + tokenId` once the prefix is set.
 - `list(uint256 tokenId, uint256 price)` – certificate holder lists for sale.
 - `purchase(uint256 tokenId)` – buy listed certificate.
 - `delist(uint256 tokenId)` – remove listing.
@@ -15,6 +16,7 @@ ERC‑721 completion certificates with optional marketplace.
 
 - `JobRegistryUpdated(address registry)`
 - `StakeManagerUpdated(address manager)`
+- `BaseURISet(string baseURI)`
 - `NFTListed(uint256 tokenId, address seller, uint256 price)`
 - `NFTPurchased(uint256 tokenId, address buyer, uint256 price)`
 - `NFTDelisted(uint256 tokenId)`

--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -44,6 +44,7 @@ describe('CertificateNFT marketplace', function () {
     nft = await NFT.deploy('Cert', 'CERT');
     await nft.setJobRegistry(owner.address);
     await nft.setStakeManager(await stake.getAddress());
+    await nft.setBaseURI('ipfs://certificates/');
 
     await nft.mint(
       seller.address,
@@ -245,5 +246,13 @@ describe('CertificateNFT marketplace', function () {
       .to.emit(nft, 'NFTPurchased')
       .withArgs(1, await attacker.getAddress(), price);
     expect(await nft.ownerOf(1)).to.equal(await attacker.getAddress());
+  });
+
+  it('exposes deterministic metadata with an immutable base URI', async () => {
+    expect(await nft.tokenURI(1)).to.equal('ipfs://certificates/1');
+    await expect(nft.setBaseURI('ipfs://other/')).to.be.revertedWithCustomError(
+      nft,
+      'BaseURIAlreadySet'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- store an immutable IPFS base URI on CertificateNFT and its lightweight module, emitting a BaseURISet event
- update tokenURI to combine the stored base prefix with the tokenId and surface new custom errors for unset or repeated configuration
- extend CertificateNFT minting, marketplace, and module tests plus docs to reflect the deterministic metadata path

## Testing
- npx hardhat test test/v2/CertificateNFTMint.test.js test/v2/CertificateNFTMarketplace.test.js test/v2/CertificateNFT.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd5c5aa18883339b2650fd02001774