### PR TITLE
Cache validator committees in JobRegistry

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -363,6 +363,24 @@ contract MockJobRegistry is Ownable, IJobRegistry, IJobRegistryTax {
         return bytes32(0);
     }
 
+    function getJobValidators(uint256)
+        external
+        pure
+        override
+        returns (address[] memory validators)
+    {
+        validators = new address[](0);
+    }
+
+    function getJobValidatorVote(uint256, address)
+        external
+        pure
+        override
+        returns (bool)
+    {
+        return false;
+    }
+
     function submitBurnReceipt(
         uint256 jobId,
         bytes32 burnTxHash,

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -1330,10 +1330,17 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         nonReentrant
     {
         if (amount == 0) return;
-        address vm = address(validationModule);
-        if (vm == address(0)) revert ValidationModuleNotSet();
-        address[] memory vals = validationModule.validators(uint256(jobId));
+        address registry = jobRegistry;
+        if (registry == address(0)) revert JobRegistryNotSet();
+
+        address[] memory vals = IJobRegistry(registry).getJobValidators(uint256(jobId));
         uint256 count = vals.length;
+        if (count == 0) {
+            address vm = address(validationModule);
+            if (vm == address(0)) revert ValidationModuleNotSet();
+            vals = validationModule.validators(uint256(jobId));
+            count = vals.length;
+        }
         if (count == 0) revert NoValidators();
         uint256 escrow = jobEscrows[jobId];
         if (escrow < amount) revert InsufficientEscrow();

--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -198,6 +198,12 @@ interface IJobRegistry {
     /// @return Address of the ValidationModule
     function validationModule() external view returns (address);
 
+    /// @notice Retrieve the validator committee cached for a job.
+    function getJobValidators(uint256 jobId) external view returns (address[] memory);
+
+    /// @notice Retrieve the cached approval vote for a validator on a job.
+    function getJobValidatorVote(uint256 jobId, address validator) external view returns (bool);
+
     /// @notice Owner configuration of job limits
     /// @param maxReward Maximum allowed reward for a job
     /// @param stake Stake required from the agent to accept a job


### PR DESCRIPTION
## Summary
- expose cached validator committees and vote results through the JobRegistry interface and mocks
- teach StakeManager to consume the JobRegistry’s cached committee list before falling back to the ValidationModule
- extend the JobRegistry integration test to assert committees are cached after validation and cleared after finalisation

## Testing
- npx hardhat test test/v2/JobRegistry.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cdd5287c8883338b6d23408ff93ee4