### PR TITLE
Improve gateway request validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "hardhat-gas-reporter": "^2.3.0",
         "prettier": "^2.8.8",
         "solhint": "^6.0.0",
+        "supertest": "^7.1.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
       },
@@ -1936,6 +1937,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3164,6 +3175,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -4033,6 +4051,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4085,6 +4113,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -4340,6 +4375,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -5287,6 +5333,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -5530,6 +5583,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.17"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -10155,6 +10226,54 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "hardhat-gas-reporter": "^2.3.0",
     "prettier": "^2.8.8",
     "solhint": "^6.0.0",
+    "supertest": "^7.1.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"
   },

--- a/test/gateway/routesValidation.test.ts
+++ b/test/gateway/routesValidation.test.ts
@@ -1,0 +1,180 @@
+import { expect } from 'chai';
+import type { Express } from 'express';
+import { ethers } from 'ethers';
+import request from 'supertest';
+
+type CommitCapture = {
+  jobId: string;
+  wallet: string;
+  approve: boolean;
+  salt?: string;
+};
+
+type RevealCapture = {
+  jobId: string;
+  wallet: string;
+  approve?: boolean;
+  salt?: string;
+};
+
+describe('agent gateway request validation', function () {
+  const API_KEY = 'test-key';
+  const WALLET = '0x00000000000000000000000000000000000000A1';
+  const SECOND_WALLET = '0x00000000000000000000000000000000000000B2';
+  let app: Express;
+  let utils: typeof import('../../agent-gateway/utils');
+  let originalWalletManager: typeof import('../../agent-gateway/utils')['walletManager'];
+  let originalCommitHelper: typeof import('../../agent-gateway/utils')['commitHelper'];
+  let originalRevealHelper: typeof import('../../agent-gateway/utils')['revealHelper'];
+  let commitCapture: CommitCapture | undefined;
+  let revealCapture: RevealCapture | undefined;
+  const envBackup: Record<string, string | undefined> = {};
+
+  before(async function () {
+    envBackup.JOB_REGISTRY_ADDRESS = process.env.JOB_REGISTRY_ADDRESS;
+    envBackup.VALIDATION_MODULE_ADDRESS = process.env.VALIDATION_MODULE_ADDRESS;
+    envBackup.STAKE_MANAGER_ADDRESS = process.env.STAKE_MANAGER_ADDRESS;
+    envBackup.KEYSTORE_URL = process.env.KEYSTORE_URL;
+    envBackup.GATEWAY_API_KEY = process.env.GATEWAY_API_KEY;
+
+    process.env.JOB_REGISTRY_ADDRESS = WALLET;
+    process.env.VALIDATION_MODULE_ADDRESS = WALLET;
+    process.env.STAKE_MANAGER_ADDRESS = SECOND_WALLET;
+    process.env.KEYSTORE_URL = 'https://keystore.local/keys';
+    process.env.GATEWAY_API_KEY = API_KEY;
+
+    utils = await import('../../agent-gateway/utils');
+    originalWalletManager = utils.walletManager;
+    originalCommitHelper = utils.commitHelper;
+    originalRevealHelper = utils.revealHelper;
+
+    ({ default: app } = await import('../../agent-gateway/routes'));
+  });
+
+  beforeEach(function () {
+    commitCapture = undefined;
+    revealCapture = undefined;
+    (utils as any).walletManager = {
+      get: (address: string) => {
+        if (!address) {
+          return undefined;
+        }
+        return { address: ethers.getAddress(address) };
+      },
+    };
+    (utils as any).commitHelper = async (
+      jobId: string,
+      wallet: { address: string },
+      approve: boolean,
+      salt?: string
+    ) => {
+      commitCapture = {
+        jobId,
+        wallet: wallet.address,
+        approve,
+        salt,
+      };
+      return { tx: '0x1', salt: salt ?? '0x0', commitHash: '0x2' };
+    };
+    (utils as any).revealHelper = async (
+      jobId: string,
+      wallet: { address: string },
+      approve?: boolean,
+      salt?: string
+    ) => {
+      revealCapture = {
+        jobId,
+        wallet: wallet.address,
+        approve,
+        salt,
+      };
+      return { tx: '0x3' };
+    };
+  });
+
+  afterEach(function () {
+    (utils as any).walletManager = originalWalletManager;
+    (utils as any).commitHelper = originalCommitHelper;
+    (utils as any).revealHelper = originalRevealHelper;
+  });
+
+  after(function () {
+    process.env.JOB_REGISTRY_ADDRESS = envBackup.JOB_REGISTRY_ADDRESS;
+    process.env.VALIDATION_MODULE_ADDRESS = envBackup.VALIDATION_MODULE_ADDRESS;
+    process.env.STAKE_MANAGER_ADDRESS = envBackup.STAKE_MANAGER_ADDRESS;
+    process.env.KEYSTORE_URL = envBackup.KEYSTORE_URL;
+    process.env.GATEWAY_API_KEY = envBackup.GATEWAY_API_KEY;
+  });
+
+  it('coerces string boolean values for commit requests', async function () {
+    const response = await request(app)
+      .post('/jobs/42/commit')
+      .set('X-Api-Key', API_KEY)
+      .send({ address: WALLET, approve: 'false', salt: ' 0x1234 ' });
+
+    expect(response.status).to.equal(200);
+    expect(commitCapture).to.not.equal(undefined);
+    expect(commitCapture?.approve).to.equal(false);
+    expect(commitCapture?.wallet).to.equal(WALLET);
+    expect(commitCapture?.salt).to.equal('0x1234');
+  });
+
+  it('rejects invalid boolean payloads', async function () {
+    const response = await request(app)
+      .post('/jobs/42/commit')
+      .set('X-Api-Key', API_KEY)
+      .send({ address: WALLET, approve: 'definitely' });
+
+    expect(response.status).to.equal(400);
+    expect(response.body.error).to.match(/boolean/i);
+    expect(commitCapture).to.equal(undefined);
+  });
+
+  it('returns 503 when wallet manager is not initialised', async function () {
+    (utils as any).walletManager = undefined;
+
+    const response = await request(app)
+      .post('/jobs/42/commit')
+      .set('X-Api-Key', API_KEY)
+      .send({ address: WALLET, approve: true });
+
+    expect(response.status).to.equal(503);
+    expect(commitCapture).to.equal(undefined);
+  });
+
+  it('returns 400 when wallet is unknown', async function () {
+    (utils as any).walletManager = {
+      get: () => undefined,
+    };
+
+    const response = await request(app)
+      .post('/jobs/42/commit')
+      .set('X-Api-Key', API_KEY)
+      .send({ address: WALLET, approve: true });
+
+    expect(response.status).to.equal(400);
+    expect(commitCapture).to.equal(undefined);
+  });
+
+  it('parses optional approve flag for reveal route', async function () {
+    const response = await request(app)
+      .post('/jobs/42/reveal')
+      .set('X-Api-Key', API_KEY)
+      .send({ address: WALLET.toLowerCase(), approve: 'true' });
+
+    expect(response.status).to.equal(200);
+    expect(revealCapture?.approve).to.equal(true);
+    expect(revealCapture?.wallet).to.equal(WALLET);
+  });
+
+  it('allows reveal without approve override', async function () {
+    const response = await request(app)
+      .post('/jobs/42/reveal')
+      .set('X-Api-Key', API_KEY)
+      .send({ address: WALLET, salt: '0x99' });
+
+    expect(response.status).to.equal(200);
+    expect(revealCapture?.approve).to.equal(undefined);
+    expect(revealCapture?.salt).to.equal('0x99');
+  });
+});


### PR DESCRIPTION
## Summary
- harden the agent gateway commit and reveal routes with strict address, boolean, and wallet-manager checks and centralized error handling
- accept string representations of boolean flags while preventing malformed input from reaching contract helpers
- add supertest-based coverage to ensure the new validation and error paths behave as expected

## Testing
- npm run lint
- npm test *(fails: StakeManager reentrancy and dispute finalization cases in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0523bcc083339ad1decf4294a0cb