### PR TITLE
Verify AGIALPHA burn address and add unit coverage

### DIFF
--- a/scripts/verify-agialpha.ts
+++ b/scripts/verify-agialpha.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const configPath = path.join(__dirname, '..', 'config', 'agialpha.json');
-const constantsPath = path.join(
+const defaultConfigPath = path.join(__dirname, '..', 'config', 'agialpha.json');
+const defaultConstantsPath = path.join(
   __dirname,
   '..',
   'contracts',
@@ -10,40 +10,77 @@ const constantsPath = path.join(
   'Constants.sol'
 );
 
-// Read JSON config
-const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
+type TokenConfig = {
   address: string;
   decimals: number;
+  burnAddress: string;
 };
 
-// Read Solidity constants
-const constantsSrc = fs.readFileSync(constantsPath, 'utf8');
-const addrMatch = constantsSrc.match(
-  /address constant AGIALPHA = (0x[0-9a-fA-F]{40});/
-);
-const decMatch = constantsSrc.match(
-  /uint8 constant AGIALPHA_DECIMALS = (\d+);/
-);
-
-if (!addrMatch || !decMatch) {
-  throw new Error('Failed to parse Constants.sol');
+function normaliseAddress(addr: string): string {
+  return addr.toLowerCase();
 }
 
-const solAddress = addrMatch[1];
-const solDecimals = parseInt(decMatch[1], 10);
-
-if (config.address.toLowerCase() !== solAddress.toLowerCase()) {
-  console.error(
-    `Address mismatch: config ${config.address} vs contract ${solAddress}`
+function parseConstants(constantsSrc: string) {
+  const addrMatch = constantsSrc.match(
+    /address constant AGIALPHA = (0x[0-9a-fA-F]{40});/
   );
-  process.exit(1);
-}
-
-if (config.decimals !== solDecimals) {
-  console.error(
-    `Decimals mismatch: config ${config.decimals} vs contract ${solDecimals}`
+  const decMatch = constantsSrc.match(
+    /uint8 constant AGIALPHA_DECIMALS = (\d+);/
   );
-  process.exit(1);
+  const burnMatch = constantsSrc.match(
+    /address constant BURN_ADDRESS = (0x[0-9a-fA-F]{40});/
+  );
+
+  if (!addrMatch || !decMatch || !burnMatch) {
+    throw new Error('Failed to parse Constants.sol');
+  }
+
+  return {
+    address: addrMatch[1],
+    decimals: parseInt(decMatch[1], 10),
+    burnAddress: burnMatch[1],
+  };
 }
 
-console.log('AGIALPHA address and decimals match.');
+export function verifyAgialpha(
+  configPath: string = defaultConfigPath,
+  constantsPath: string = defaultConstantsPath
+): void {
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as TokenConfig;
+  const constantsSrc = fs.readFileSync(constantsPath, 'utf8');
+  const constants = parseConstants(constantsSrc);
+
+  if (
+    normaliseAddress(config.address) !== normaliseAddress(constants.address)
+  ) {
+    throw new Error(
+      `Address mismatch: config ${config.address} vs contract ${constants.address}`
+    );
+  }
+
+  if (config.decimals !== constants.decimals) {
+    throw new Error(
+      `Decimals mismatch: config ${config.decimals} vs contract ${constants.decimals}`
+    );
+  }
+
+  if (
+    normaliseAddress(config.burnAddress) !==
+    normaliseAddress(constants.burnAddress)
+  ) {
+    throw new Error(
+      `Burn address mismatch: config ${config.burnAddress} vs contract ${constants.burnAddress}`
+    );
+  }
+}
+
+if (require.main === module) {
+  try {
+    verifyAgialpha();
+    console.log('AGIALPHA address, decimals, and burn address match.');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(message);
+    process.exit(1);
+  }
+}

--- a/test/scripts/verify-agialpha.test.js
+++ b/test/scripts/verify-agialpha.test.js
@@ -1,0 +1,76 @@
+const { expect } = require('chai');
+const { mkdtempSync, writeFileSync, rmSync } = require('fs');
+const { join } = require('path');
+const os = require('os');
+
+require('ts-node').register({
+  transpileOnly: true,
+  compilerOptions: { module: 'commonjs' },
+});
+
+const { verifyAgialpha } = require('../../scripts/verify-agialpha');
+
+function createConstantsSource({ address, decimals, burnAddress }) {
+  return `// SPDX-License-Identifier: MIT\npragma solidity ^0.8.25;\n\naddress constant AGIALPHA = ${address};\nuint8 constant AGIALPHA_DECIMALS = ${decimals};\nuint256 constant TOKEN_SCALE = 1;\naddress constant BURN_ADDRESS = ${burnAddress};\n`;
+}
+
+function writeFixture({ address, decimals, burnAddress }) {
+  const dir = mkdtempSync(join(os.tmpdir(), 'verify-agialpha-'));
+  const constantsPath = join(dir, 'Constants.sol');
+  const configPath = join(dir, 'agialpha.json');
+  writeFileSync(
+    constantsPath,
+    createConstantsSource({ address, decimals, burnAddress })
+  );
+  writeFileSync(
+    configPath,
+    JSON.stringify({ address, decimals, burnAddress }, null, 2)
+  );
+  return { dir, constantsPath, configPath };
+}
+
+describe('verifyAgialpha script', () => {
+  const address = '0x1111111111111111111111111111111111111111';
+  const burnAddress = '0x0000000000000000000000000000000000000000';
+
+  it('passes when config and constants match', () => {
+    const { dir, constantsPath, configPath } = writeFixture({
+      address,
+      decimals: 18,
+      burnAddress,
+    });
+    try {
+      expect(() => verifyAgialpha(configPath, constantsPath)).to.not.throw();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when burn address differs', () => {
+    const { dir, constantsPath } = writeFixture({
+      address,
+      decimals: 18,
+      burnAddress,
+    });
+    const mismatchedConfig = join(dir, 'agialpha-mismatch.json');
+    writeFileSync(
+      mismatchedConfig,
+      JSON.stringify(
+        {
+          address,
+          decimals: 18,
+          burnAddress: '0x000000000000000000000000000000000000dEaD',
+        },
+        null,
+        2
+      )
+    );
+    try {
+      expect(() => verifyAgialpha(mismatchedConfig, constantsPath)).to.throw(
+        'Burn address mismatch'
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- extend the AGIALPHA verification script to validate the burn address alongside the token address and decimals
- export the verification helper for reuse and keep the CLI entrypoint behaviour unchanged
- add a focused unit test that covers both matching configuration and burn-address mismatches

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf0b2932fc8333ad9af35bd32b5ba8