### PR TITLE
Add on-chain verification to verify-agialpha script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Token parameters are defined once in [`config/agialpha.json`](config/agialpha.js
 
 `npm run compile` validates the configured addresses, ERC‑20 metadata and decimals before writing the Solidity constants. The command halts if the token or burn addresses are malformed, zero (where disallowed), the symbol/name fields are empty or the decimals fall outside the supported `0-255` range, preventing a bad configuration from reaching production contracts.
 
+Run `npm run verify:agialpha -- --rpc <https-url-or-ws-url>` after deployments to cross-check `config/agialpha.json` and `contracts/v2/Constants.sol` against the live `$AGIALPHA` token metadata. The script aborts if the on-chain decimals, symbol or name differ from the committed configuration. Set `VERIFY_RPC_URL` (or `RPC_URL`) to avoid passing `--rpc` on every invocation; use `--timeout <ms>` to override the default 15 s RPC timeout.
+
 ### Fee handling and treasury
 
 `JobRegistry` routes protocol fees to `FeePool`, which burns a configurable percentage (`burnPct`) when an employer finalizes a job and escrows the remainder for platform stakers. By default the `treasury` is unset (`address(0)`), so any rounding dust is burned. Governance may later call `StakeManager.setTreasury`, `JobRegistry.setTreasury`, or `FeePool.setTreasury` to direct funds to a community-controlled treasury. These setters reject the owner address and, for `FeePool`, require the target to be pre-approved via `setTreasuryAllowlist`. The platform only routes funds and never initiates or profits from burns.


### PR DESCRIPTION
## Summary
- extend the verify-agialpha script so it can optionally validate metadata against the live $AGIALPHA token via RPC with timeout handling and CLI flags
- document the new on-chain verification step in the README deployment guidance
- expand the verify-agialpha tests to cover async behaviour and chain mismatch scenarios

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf29bf35248333b3815e208bed3a23