### PR TITLE
Improve gateway configuration validation

### DIFF
--- a/test/gateway/configValidation.test.js
+++ b/test/gateway/configValidation.test.js
@@ -1,0 +1,83 @@
+const { expect } = require('chai');
+const path = require('path');
+
+const { compileAndRequireTsModule } = require('../utils/tsLoader');
+
+const MODULE_PATH = '../../agent-gateway/utils';
+const utilsTsPath = path.join(__dirname, MODULE_PATH + '.ts');
+const DUMMY_ADDRESS = '0x0000000000000000000000000000000000000001';
+
+function clearModuleCache() {
+  try {
+    const resolved = require.resolve(MODULE_PATH);
+    delete require.cache[resolved];
+  } catch {
+    // Ignore when module hasn't been loaded yet.
+  }
+}
+
+function loadUtils() {
+  clearModuleCache();
+  return compileAndRequireTsModule(utilsTsPath);
+}
+
+describe('agent gateway configuration validation', function () {
+  const envBackup = {};
+
+  beforeEach(function () {
+    envBackup.RPC_URL = process.env.RPC_URL;
+    envBackup.PORT = process.env.PORT;
+    envBackup.FETCH_TIMEOUT_MS = process.env.FETCH_TIMEOUT_MS;
+    envBackup.STALE_JOB_MS = process.env.STALE_JOB_MS;
+    envBackup.SWEEP_INTERVAL_MS = process.env.SWEEP_INTERVAL_MS;
+    envBackup.KEYSTORE_URL = process.env.KEYSTORE_URL;
+    envBackup.JOB_REGISTRY_ADDRESS = process.env.JOB_REGISTRY_ADDRESS;
+    envBackup.VALIDATION_MODULE_ADDRESS = process.env.VALIDATION_MODULE_ADDRESS;
+
+    process.env.RPC_URL = 'http://localhost:8545';
+    process.env.PORT = '3000';
+    process.env.FETCH_TIMEOUT_MS = '5000';
+    process.env.STALE_JOB_MS = String(60 * 60 * 1000);
+    process.env.SWEEP_INTERVAL_MS = String(60 * 1000);
+    process.env.KEYSTORE_URL = 'https://keystore.local/keys';
+    process.env.JOB_REGISTRY_ADDRESS = DUMMY_ADDRESS;
+    process.env.VALIDATION_MODULE_ADDRESS = DUMMY_ADDRESS;
+  });
+
+  afterEach(function () {
+    process.env.RPC_URL = envBackup.RPC_URL;
+    process.env.PORT = envBackup.PORT;
+    process.env.FETCH_TIMEOUT_MS = envBackup.FETCH_TIMEOUT_MS;
+    process.env.STALE_JOB_MS = envBackup.STALE_JOB_MS;
+    process.env.SWEEP_INTERVAL_MS = envBackup.SWEEP_INTERVAL_MS;
+    process.env.KEYSTORE_URL = envBackup.KEYSTORE_URL;
+    process.env.JOB_REGISTRY_ADDRESS = envBackup.JOB_REGISTRY_ADDRESS;
+    process.env.VALIDATION_MODULE_ADDRESS = envBackup.VALIDATION_MODULE_ADDRESS;
+
+    clearModuleCache();
+  });
+
+  it('rejects RPC URLs with unsupported schemes', function () {
+    process.env.RPC_URL = 'ftp://example.com';
+
+    expect(() => loadUtils()).to.throw(/RPC_URL/);
+  });
+
+  it('rejects non-numeric port values', function () {
+    process.env.PORT = 'not-a-number';
+
+    expect(() => loadUtils()).to.throw(/PORT/);
+  });
+
+  it('enforces positive fetch timeout', function () {
+    process.env.FETCH_TIMEOUT_MS = '0';
+
+    expect(() => loadUtils()).to.throw(/FETCH_TIMEOUT_MS/);
+  });
+
+  it('enforces sane stale job timeout floor', function () {
+    process.env.STALE_JOB_MS = '1000';
+
+    expect(() => loadUtils()).to.throw(/STALE_JOB_MS/);
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,12 @@
 const { artifacts, network } = require('hardhat');
 const { AGIALPHA } = require('../scripts/constants');
 
+process.env.RPC_URL = 'http://localhost:8545';
+process.env.FETCH_TIMEOUT_MS = '5000';
+process.env.PORT = '3000';
+process.env.STALE_JOB_MS = String(60 * 60 * 1000);
+process.env.SWEEP_INTERVAL_MS = String(60 * 1000);
+
 let snapshotId;
 
 before(async function () {

--- a/test/utils/tsLoader.js
+++ b/test/utils/tsLoader.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const ts = require('typescript');
+
+function compileAndRequireTsModule(tsPath) {
+  const source = fs.readFileSync(tsPath, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      target: 'ES2020',
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+      resolveJsonModule: true,
+    },
+    fileName: tsPath,
+  });
+
+  const moduleExports = { exports: {} };
+
+  const localRequire = (specifier) => {
+    if (specifier.startsWith('.') || specifier.startsWith('/')) {
+      const baseDir = path.dirname(tsPath);
+      const joined = path.join(baseDir, specifier);
+      try {
+        const resolved = require.resolve(joined);
+        return require(resolved);
+      } catch (err) {
+        const withTsExtension =
+          joined.endsWith('.ts') || joined.endsWith('.tsx')
+            ? joined
+            : `${joined}.ts`;
+        if (fs.existsSync(withTsExtension)) {
+          return compileAndRequireTsModule(withTsExtension);
+        }
+        throw err;
+      }
+    }
+    return require(specifier);
+  };
+
+  const evaluator = new Function(
+    'require',
+    'module',
+    'exports',
+    '__filename',
+    '__dirname',
+    outputText
+  );
+
+  evaluator(
+    localRequire,
+    moduleExports,
+    moduleExports.exports,
+    tsPath,
+    path.dirname(tsPath)
+  );
+
+  return moduleExports.exports;
+}
+
+module.exports = { compileAndRequireTsModule };


### PR DESCRIPTION
## Summary
- tighten agent gateway environment validation by normalising RPC URLs, enforcing allowed protocols and validating numeric timeouts
- add dedicated configuration regression tests with a reusable TypeScript loader utility and update existing gateway wallet tests to use it
- set deterministic default environment values in the shared Hardhat test setup so suite executions run against valid gateway settings

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf2f9580c08333a08aee8650f00825