### PR TITLE
Add network-specific token and ENS configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cache/
 # Ignore built scripts
 scripts/**/*.js
 !scripts/constants.js
+!scripts/config/index.js
 
 build/
 lib/

--- a/agent-gateway/ensRegistrar.ts
+++ b/agent-gateway/ensRegistrar.ts
@@ -1,28 +1,15 @@
 import { Contract, Wallet, ethers } from 'ethers';
-import ensConfig from '../config/ens.json';
+import { loadEnsConfig } from '../scripts/config';
 import { provider } from './utils';
 import { secureLogAction } from './security';
 
 export type EnsSpace = 'agent' | 'club' | 'business';
-
-interface RawParentConfig {
-  name?: string;
-  node?: string;
-  resolver?: string;
-  role?: 'agent' | 'validator' | 'business';
-}
 
 interface ResolvedParentConfig {
   name: string;
   node: string;
   resolver: string;
   role: 'agent' | 'validator' | 'business';
-}
-
-interface EnsConfigMap {
-  agent?: RawParentConfig;
-  club?: RawParentConfig;
-  business?: RawParentConfig;
 }
 
 const ENS_REGISTRY_ABI = [
@@ -57,20 +44,29 @@ function normaliseLabel(label: string): string {
   return trimmed;
 }
 
+const {
+  config: ensConfig,
+} = loadEnsConfig({ network: process.env.ENS_NETWORK || process.env.NETWORK });
+
+const ENS_ROOTS = (ensConfig.roots || {}) as Record<string, any>;
+
 function ensureConfiguredAddress(
   value: string | undefined,
-  name: string
+  name: string,
+  { allowZero = false }: { allowZero?: boolean } = {}
 ): string {
-  if (!value) {
+  if (value === undefined || value === null) {
+    if (allowZero) return ethers.ZeroAddress;
     throw new Error(`${name} is not configured`);
   }
   const address = value.trim();
   if (!address) {
+    if (allowZero) return ethers.ZeroAddress;
     throw new Error(`${name} is not configured`);
   }
   const prefixed = address.startsWith('0x') ? address : `0x${address}`;
   const normalised = ethers.getAddress(prefixed);
-  if (normalised === ethers.ZeroAddress) {
+  if (!allowZero && normalised === ethers.ZeroAddress) {
     throw new Error(`${name} cannot be the zero address`);
   }
   return normalised;
@@ -78,52 +74,53 @@ function ensureConfiguredAddress(
 
 function resolveRegistryAddress(): string {
   return ensureConfiguredAddress(
-    process.env.ENS_REGISTRY_ADDRESS,
-    'ENS_REGISTRY_ADDRESS'
+    process.env.ENS_REGISTRY_ADDRESS ?? ensConfig.registry,
+    'ENS registry'
   );
 }
 
 function resolveReverseRegistrarAddress(): string {
   return ensureConfiguredAddress(
-    process.env.ENS_REVERSE_REGISTRAR_ADDRESS,
-    'ENS_REVERSE_REGISTRAR_ADDRESS'
+    process.env.ENS_REVERSE_REGISTRAR_ADDRESS ?? ensConfig.reverseRegistrar,
+    'ENS reverse registrar'
   );
 }
 
 function readParentConfig(space: EnsSpace): ResolvedParentConfig {
-  const mapping = ensConfig as EnsConfigMap;
-  const raw = mapping[space];
-  if (!raw) {
+  const raw = ENS_ROOTS[space];
+  if (!raw || !raw.name || !raw.node) {
     throw new Error(`ENS parent configuration missing for ${space}`);
   }
-  const name = (raw.name ?? '').trim().toLowerCase();
-  if (!name) {
-    throw new Error(`ENS parent name missing for ${space}`);
-  }
-  const resolver = ensureConfiguredAddress(raw.resolver, `${space} resolver`);
-  const node = raw.node
-    ? ethers.hexlify(ethers.getBytes(raw.node))
-    : ethers.namehash(name);
+  const name = String(raw.name).trim().toLowerCase();
+  const resolver = ensureConfiguredAddress(raw.resolver, `${space} resolver`, {
+    allowZero: true,
+  });
+  const normalisedResolver =
+    resolver === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(resolver);
+  const node = ethers.hexlify(ethers.getBytes(raw.node));
   const role: 'agent' | 'validator' | 'business' =
-    raw.role ??
-    (space === 'club'
-      ? 'validator'
-      : space === 'business'
-      ? 'business'
-      : 'agent');
+    raw.role ?? (space === 'club' ? 'validator' : 'agent');
   return {
     name,
     node,
-    resolver,
+    resolver: normalisedResolver,
     role,
   };
 }
 
 function detectSpaceFromParent(parentName: string): EnsSpace | null {
   const normalised = parentName.trim().toLowerCase();
-  if (normalised === 'agent.agi.eth') return 'agent';
-  if (normalised === 'club.agi.eth') return 'club';
-  if (normalised === 'a.agi.eth') return 'business';
+  if (ENS_ROOTS.agent?.name && String(ENS_ROOTS.agent.name).toLowerCase() === normalised) {
+    return 'agent';
+  }
+  if (ENS_ROOTS.club?.name && String(ENS_ROOTS.club.name).toLowerCase() === normalised) {
+    return 'club';
+  }
+  if (ENS_ROOTS.business?.name && String(ENS_ROOTS.business.name).toLowerCase() === normalised) {
+    return 'business';
+  }
   return null;
 }
 

--- a/agent-gateway/ensRegistrar.ts
+++ b/agent-gateway/ensRegistrar.ts
@@ -44,9 +44,9 @@ function normaliseLabel(label: string): string {
   return trimmed;
 }
 
-const {
-  config: ensConfig,
-} = loadEnsConfig({ network: process.env.ENS_NETWORK || process.env.NETWORK });
+const { config: ensConfig } = loadEnsConfig({
+  network: process.env.ENS_NETWORK || process.env.NETWORK,
+});
 
 const ENS_ROOTS = (ensConfig.roots || {}) as Record<string, any>;
 
@@ -112,13 +112,22 @@ function readParentConfig(space: EnsSpace): ResolvedParentConfig {
 
 function detectSpaceFromParent(parentName: string): EnsSpace | null {
   const normalised = parentName.trim().toLowerCase();
-  if (ENS_ROOTS.agent?.name && String(ENS_ROOTS.agent.name).toLowerCase() === normalised) {
+  if (
+    ENS_ROOTS.agent?.name &&
+    String(ENS_ROOTS.agent.name).toLowerCase() === normalised
+  ) {
     return 'agent';
   }
-  if (ENS_ROOTS.club?.name && String(ENS_ROOTS.club.name).toLowerCase() === normalised) {
+  if (
+    ENS_ROOTS.club?.name &&
+    String(ENS_ROOTS.club.name).toLowerCase() === normalised
+  ) {
     return 'club';
   }
-  if (ENS_ROOTS.business?.name && String(ENS_ROOTS.business.name).toLowerCase() === normalised) {
+  if (
+    ENS_ROOTS.business?.name &&
+    String(ENS_ROOTS.business.name).toLowerCase() === normalised
+  ) {
     return 'business';
   }
   return null;

--- a/config/agialpha.mainnet.json
+++ b/config/agialpha.mainnet.json
@@ -1,0 +1,7 @@
+{
+  "address": "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
+  "decimals": 18,
+  "symbol": "AGIALPHA",
+  "name": "AGI ALPHA",
+  "burnAddress": "0x0000000000000000000000000000000000000000"
+}

--- a/config/agialpha.sepolia.json
+++ b/config/agialpha.sepolia.json
@@ -1,0 +1,7 @@
+{
+  "address": "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
+  "decimals": 18,
+  "symbol": "AGIALPHA",
+  "name": "AGI ALPHA",
+  "burnAddress": "0x0000000000000000000000000000000000000000"
+}

--- a/config/ens.mainnet.json
+++ b/config/ens.mainnet.json
@@ -1,0 +1,31 @@
+{
+  "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+  "nameWrapper": "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401",
+  "reverseRegistrar": "0x084b1c3C81545d370f3634392De611CaaBFf8148",
+  "roots": {
+    "agent": {
+      "label": "agent",
+      "name": "agent.agi.eth",
+      "labelhash": "0x314c1dfbbccab41a44cf9fefc21e632eb8e01bc0346d4414114d4c3dd0e9fdf1",
+      "node": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
+      "merkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "role": "agent"
+    },
+    "club": {
+      "label": "club",
+      "name": "club.agi.eth",
+      "labelhash": "0xe1e1884f7473923c2fed5da5f5489310ba525a82307b50b511b8963ee9b20113",
+      "node": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16",
+      "merkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "role": "validator"
+    },
+    "business": {
+      "label": "a",
+      "name": "a.agi.eth",
+      "labelhash": "0x3ac225168df54212a25c1c01fd35bebfea408fdac2e31ddd6f80a4bbf9a5f1cb",
+      "node": "0x5b8fd43b9dbddd6cba9f03bbff224df24e6e592c54456f8e46c4a47433c44403",
+      "merkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "role": "business"
+    }
+  }
+}

--- a/config/ens.sepolia.json
+++ b/config/ens.sepolia.json
@@ -1,0 +1,31 @@
+{
+  "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+  "nameWrapper": "0x0635513f179D50A207757E05759CbD106d7dFcE8",
+  "reverseRegistrar": "0x4F382928805ba0e23B30cFB75fC9E848e82DFD47",
+  "roots": {
+    "agent": {
+      "label": "agent",
+      "name": "agent.agi.eth",
+      "labelhash": "0x314c1dfbbccab41a44cf9fefc21e632eb8e01bc0346d4414114d4c3dd0e9fdf1",
+      "node": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
+      "merkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "role": "agent"
+    },
+    "club": {
+      "label": "club",
+      "name": "club.agi.eth",
+      "labelhash": "0xe1e1884f7473923c2fed5da5f5489310ba525a82307b50b511b8963ee9b20113",
+      "node": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16",
+      "merkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "role": "validator"
+    },
+    "business": {
+      "label": "a",
+      "name": "a.agi.eth",
+      "labelhash": "0x3ac225168df54212a25c1c01fd35bebfea408fdac2e31ddd6f80a4bbf9a5f1cb",
+      "node": "0x5b8fd43b9dbddd6cba9f03bbff224df24e6e592c54456f8e46c4a47433c44403",
+      "merkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "role": "business"
+    }
+  }
+}

--- a/scripts/check-burnable.ts
+++ b/scripts/check-burnable.ts
@@ -1,15 +1,13 @@
 import { JsonRpcProvider, Interface } from 'ethers';
-import * as fs from 'fs';
-import * as path from 'path';
+import { loadTokenConfig } from './config';
 
 async function main() {
   const rpcUrl = process.env.RPC_URL || 'http://localhost:8545';
   const provider = new JsonRpcProvider(rpcUrl);
 
-  const configPath = path.join(__dirname, '..', 'config', 'agialpha.json');
-  const { address } = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
-    address: string;
-  };
+  const {
+    config: { address },
+  } = loadTokenConfig();
 
   const iface = new Interface(['function burn(uint256)']);
   const data = iface.encodeFunctionData('burn', [0n]);

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -1,0 +1,54 @@
+export type SupportedNetwork = 'mainnet' | 'sepolia';
+
+export interface TokenConfig {
+  address: string;
+  decimals: number;
+  symbol: string;
+  name: string;
+  burnAddress?: string;
+  [key: string]: unknown;
+}
+
+export interface TokenConfigResult {
+  config: TokenConfig;
+  path: string;
+  network?: SupportedNetwork;
+}
+
+export interface EnsRootConfig {
+  label: string;
+  name: string;
+  labelhash: string;
+  node: string;
+  merkleRoot: string;
+  role?: string;
+  resolver?: string;
+  [key: string]: unknown;
+}
+
+export interface EnsConfig {
+  registry?: string;
+  nameWrapper?: string;
+  reverseRegistrar?: string;
+  roots: Record<string, EnsRootConfig>;
+  [key: string]: unknown;
+}
+
+export interface EnsConfigResult {
+  config: EnsConfig;
+  path: string;
+  network?: SupportedNetwork;
+  updated: boolean;
+}
+
+export interface LoadOptions {
+  network?: any;
+  chainId?: number | string;
+  name?: string;
+  context?: any;
+  persist?: boolean;
+}
+
+export function inferNetworkKey(value: any): SupportedNetwork | undefined;
+export function loadTokenConfig(options?: LoadOptions): TokenConfigResult;
+export function loadEnsConfig(options?: LoadOptions): EnsConfigResult;

--- a/scripts/config/index.js
+++ b/scripts/config/index.js
@@ -1,0 +1,258 @@
+const fs = require('fs');
+const path = require('path');
+const { ethers } = require('ethers');
+
+const CONFIG_DIR = path.join(__dirname, '..', '..', 'config');
+
+const NETWORK_ALIASES = new Map([
+  ['mainnet', 'mainnet'],
+  ['homestead', 'mainnet'],
+  ['ethereum', 'mainnet'],
+  ['l1', 'mainnet'],
+  ['1', 'mainnet'],
+  ['0x1', 'mainnet'],
+  ['sepolia', 'sepolia'],
+  ['sep', 'sepolia'],
+  ['11155111', 'sepolia'],
+  ['0xaa36a7', 'sepolia'],
+]);
+
+const DEFAULT_ENS_NAMES = {
+  agent: 'agent.agi.eth',
+  club: 'club.agi.eth',
+  business: 'a.agi.eth',
+};
+
+function inferNetworkKey(value) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'object') {
+    const maybeName = inferNetworkKey(value.name ?? value.network);
+    if (maybeName) return maybeName;
+    if (value.chainId !== undefined) {
+      return inferNetworkKey(String(value.chainId));
+    }
+  }
+  const raw = String(value).trim();
+  if (!raw) return undefined;
+  const lower = raw.toLowerCase();
+  if (NETWORK_ALIASES.has(lower)) {
+    return NETWORK_ALIASES.get(lower);
+  }
+  if (lower.startsWith('0x')) {
+    try {
+      const numeric = BigInt(lower).toString();
+      if (NETWORK_ALIASES.has(numeric)) {
+        return NETWORK_ALIASES.get(numeric);
+      }
+    } catch (_) {}
+  }
+  return undefined;
+}
+
+function resolveNetwork(options = {}) {
+  return (
+    inferNetworkKey(options.network) ||
+    inferNetworkKey(options.chainId) ||
+    inferNetworkKey(options.name) ||
+    inferNetworkKey(options.context) ||
+    inferNetworkKey(process.env.AGJ_NETWORK) ||
+    inferNetworkKey(process.env.AGIALPHA_NETWORK) ||
+    inferNetworkKey(process.env.NETWORK) ||
+    inferNetworkKey(process.env.HARDHAT_NETWORK) ||
+    inferNetworkKey(process.env.TRUFFLE_NETWORK) ||
+    inferNetworkKey(process.env.CHAIN_ID)
+  );
+}
+
+function ensureAddress(value, label, { allowZero = false } = {}) {
+  if (value === undefined || value === null) {
+    if (allowZero) return ethers.ZeroAddress;
+    throw new Error(`${label} is not configured`);
+  }
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    if (allowZero) return ethers.ZeroAddress;
+    throw new Error(`${label} is not configured`);
+  }
+  const prefixed = trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`;
+  const address = ethers.getAddress(prefixed);
+  if (!allowZero && address === ethers.ZeroAddress) {
+    throw new Error(`${label} cannot be the zero address`);
+  }
+  return address;
+}
+
+function ensureBytes32(value) {
+  if (value === undefined || value === null) {
+    return ethers.ZeroHash;
+  }
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return ethers.ZeroHash;
+  }
+  const prefixed = trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`;
+  if (!ethers.isHexString(prefixed)) {
+    throw new Error(`Value ${value} is not valid hex data`);
+  }
+  const bytes = ethers.getBytes(prefixed);
+  if (bytes.length !== 32) {
+    throw new Error(`Expected 32-byte value, got ${bytes.length} bytes`);
+  }
+  return ethers.hexlify(prefixed);
+}
+
+function normaliseLabel(value, fallback) {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (trimmed) {
+    return trimmed.toLowerCase();
+  }
+  if (fallback) {
+    return String(fallback).toLowerCase();
+  }
+  throw new Error('ENS root label is missing');
+}
+
+function readJson(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function findConfigPath(baseName, network) {
+  const base = path.join(CONFIG_DIR, `${baseName}.json`);
+  if (network) {
+    const candidate = path.join(CONFIG_DIR, `${baseName}.${network}.json`);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return base;
+}
+
+function loadTokenConfig(options = {}) {
+  const network = resolveNetwork(options);
+  const configPath = findConfigPath('agialpha', network);
+  const config = readJson(configPath);
+  return { config, path: configPath, network };
+}
+
+function normaliseRootEntry(key, root) {
+  const result = { ...root };
+  let changed = false;
+
+  const defaultLabel = key === 'business' ? 'a' : key;
+  const label = normaliseLabel(root?.label, defaultLabel);
+  if (result.label !== label) {
+    result.label = label;
+    changed = true;
+  }
+
+  const defaultName = DEFAULT_ENS_NAMES[key] || result.name;
+  const nameCandidate = typeof root?.name === 'string' ? root.name.trim().toLowerCase() : '';
+  const name = nameCandidate || (defaultName ? defaultName.toLowerCase() : `${label}.agi.eth`);
+  if (result.name !== name) {
+    result.name = name;
+    changed = true;
+  }
+
+  const labelhash = ethers.id(label);
+  if (!result.labelhash || result.labelhash.toLowerCase() !== labelhash.toLowerCase()) {
+    result.labelhash = labelhash;
+    changed = true;
+  }
+
+  const node = ethers.namehash(name);
+  if (!result.node || result.node.toLowerCase() !== node.toLowerCase()) {
+    result.node = node;
+    changed = true;
+  }
+
+  const merkleRoot = ensureBytes32(root?.merkleRoot);
+  if (!result.merkleRoot || result.merkleRoot.toLowerCase() !== merkleRoot.toLowerCase()) {
+    result.merkleRoot = merkleRoot;
+    changed = true;
+  }
+
+  if (root?.resolver !== undefined) {
+    const resolver = ensureAddress(root.resolver, `${key} resolver`, { allowZero: true });
+    if (!result.resolver || result.resolver.toLowerCase() !== resolver.toLowerCase()) {
+      result.resolver = resolver;
+      changed = true;
+    }
+  }
+
+  const defaultRole =
+    root?.role || (key === 'club' ? 'validator' : key === 'business' ? 'business' : 'agent');
+  if (result.role !== defaultRole) {
+    result.role = defaultRole;
+    changed = true;
+  }
+
+  return { root: result, changed };
+}
+
+function normaliseEnsConfig(config) {
+  const updated = { ...config };
+  let changed = false;
+
+  if (updated.registry) {
+    const normalised = ensureAddress(updated.registry, 'ENS registry');
+    if (updated.registry !== normalised) {
+      updated.registry = normalised;
+      changed = true;
+    }
+  }
+  if (updated.nameWrapper) {
+    const normalised = ensureAddress(updated.nameWrapper, 'ENS NameWrapper', { allowZero: true });
+    if (updated.nameWrapper !== normalised) {
+      updated.nameWrapper = normalised;
+      changed = true;
+    }
+  }
+  if (updated.reverseRegistrar) {
+    const normalised = ensureAddress(updated.reverseRegistrar, 'ENS reverse registrar', {
+      allowZero: true,
+    });
+    if (updated.reverseRegistrar !== normalised) {
+      updated.reverseRegistrar = normalised;
+      changed = true;
+    }
+  }
+
+  if (!updated.roots || typeof updated.roots !== 'object') {
+    updated.roots = {};
+  }
+
+  for (const [key, value] of Object.entries(updated.roots)) {
+    const { root, changed: rootChanged } = normaliseRootEntry(key, value || {});
+    if (rootChanged) {
+      updated.roots[key] = root;
+      changed = true;
+    }
+  }
+
+  return { config: updated, changed };
+}
+
+function loadEnsConfig(options = {}) {
+  const network = resolveNetwork(options);
+  const configPath = findConfigPath('ens', network);
+  const rawConfig = readJson(configPath);
+  const { config, changed } = normaliseEnsConfig(rawConfig);
+  const persist = options.persist !== false;
+  if (changed && persist) {
+    writeJson(configPath, config);
+  }
+  return { config, path: configPath, network, updated: Boolean(changed && persist) };
+}
+
+module.exports = {
+  loadTokenConfig,
+  loadEnsConfig,
+  inferNetworkKey,
+};

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -5,14 +5,13 @@ exports.AGIALPHA_NAME =
   exports.AGIALPHA_DECIMALS =
   exports.AGIALPHA =
     void 0;
-var fs = require('fs');
-var path = require('path');
-var configPath = path.join(__dirname, '..', 'config', 'agialpha.json');
-var _a = JSON.parse(fs.readFileSync(configPath, 'utf8')),
-  address = _a.address,
-  decimals = _a.decimals,
-  symbol = _a.symbol,
-  name = _a.name;
+var loadConfig = require('./config').loadTokenConfig;
+var _a = loadConfig(),
+  _b = _a.config,
+  address = _b.address,
+  decimals = _b.decimals,
+  symbol = _b.symbol,
+  name = _b.name;
 // Canonical $AGIALPHA token address on Ethereum mainnet.
 exports.AGIALPHA = address;
 // Standard decimals for $AGIALPHA.

--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -1,10 +1,8 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import { loadTokenConfig } from './config';
 
-const configPath = path.join(__dirname, '..', 'config', 'agialpha.json');
-const { address, decimals, symbol, name } = JSON.parse(
-  fs.readFileSync(configPath, 'utf8')
-) as { address: string; decimals: number; symbol: string; name: string };
+const {
+  config: { address, decimals, symbol, name },
+} = loadTokenConfig();
 
 // Canonical $AGIALPHA token address on Ethereum mainnet.
 export const AGIALPHA = address;

--- a/scripts/generate-constants.ts
+++ b/scripts/generate-constants.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { ethers } from 'ethers';
+import { loadTokenConfig } from './config';
 
 type TokenConfig = {
   address: string;
@@ -66,14 +67,30 @@ function assertName(value: string, label: string): string {
   return trimmed;
 }
 
-const configPath = path.join(__dirname, '..', 'config', 'agialpha.json');
-const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as TokenConfig;
+let networkArg: string | undefined;
+for (let i = 0; i < process.argv.length; i++) {
+  const arg = process.argv[i];
+  if (arg === '--network' && i + 1 < process.argv.length) {
+    networkArg = process.argv[i + 1];
+    break;
+  }
+  if (arg.startsWith('--network=')) {
+    networkArg = arg.slice('--network='.length);
+    break;
+  }
+}
+
+const { config, path: configPath } = loadTokenConfig({ network: networkArg });
 
 const address = assertAddress(config.address, 'AGIALPHA address');
 const decimals = assertDecimals(config.decimals);
-const burnAddress = assertAddress(config.burnAddress, 'burn address', {
-  allowZero: true,
-});
+const burnAddress = assertAddress(
+  config.burnAddress ?? ethers.ZeroAddress,
+  'burn address',
+  {
+    allowZero: true,
+  }
+);
 const symbol = assertSymbol(config.symbol, 'AGIALPHA symbol');
 const name = assertName(config.name, 'AGIALPHA name');
 

--- a/scripts/generate-constants.ts
+++ b/scripts/generate-constants.ts
@@ -3,14 +3,6 @@ import * as path from 'path';
 import { ethers } from 'ethers';
 import { loadTokenConfig } from './config';
 
-type TokenConfig = {
-  address: string;
-  decimals: number;
-  burnAddress: string;
-  symbol: string;
-  name: string;
-};
-
 function assertAddress(
   value: string,
   label: string,
@@ -80,7 +72,7 @@ for (let i = 0; i < process.argv.length; i++) {
   }
 }
 
-const { config, path: configPath } = loadTokenConfig({ network: networkArg });
+const { config } = loadTokenConfig({ network: networkArg });
 
 const address = assertAddress(config.address, 'AGIALPHA address');
 const decimals = assertDecimals(config.decimals);

--- a/scripts/identity/manageEnsKeys.ts
+++ b/scripts/identity/manageEnsKeys.ts
@@ -83,7 +83,9 @@ function normaliseConfigAddress(
   return address;
 }
 
-function createRoleConfig(roots: Record<string, any>): Record<Role, RoleConfig> {
+function createRoleConfig(
+  roots: Record<string, any>
+): Record<Role, RoleConfig> {
   const agentRoot = roots.agent;
   const clubRoot = roots.club;
   if (!agentRoot || !agentRoot.node || !agentRoot.name) {
@@ -92,7 +94,8 @@ function createRoleConfig(roots: Record<string, any>): Record<Role, RoleConfig> 
   if (!clubRoot || !clubRoot.node || !clubRoot.name) {
     throw new Error('ENS configuration is missing the club.agi.eth root');
   }
-  const normaliseNode = (value: string) => ethers.hexlify(ethers.getBytes(value));
+  const normaliseNode = (value: string) =>
+    ethers.hexlify(ethers.getBytes(value));
   const agentNode = normaliseNode(agentRoot.node);
   const clubNode = normaliseNode(clubRoot.node);
   const agentName = String(agentRoot.name).toLowerCase();
@@ -207,7 +210,11 @@ async function registerEnsSubdomain(
   registryAddress: string,
   reverseRegistrar: string
 ): Promise<string> {
-  const registry = new ethers.Contract(registryAddress, REGISTRY_ABI, rootWallet);
+  const registry = new ethers.Contract(
+    registryAddress,
+    REGISTRY_ABI,
+    rootWallet
+  );
   const resolverAddr = await registry.resolver(config.parentNode);
   if (resolverAddr === ethers.ZeroAddress) {
     throw new Error('Parent node has no resolver set');
@@ -230,11 +237,7 @@ async function registerEnsSubdomain(
   const resolver = new ethers.Contract(resolverAddr, RESOLVER_ABI, subWallet);
   await (await resolver.setAddr(node, subWallet.address)).wait();
 
-  const reverse = new ethers.Contract(
-    reverseRegistrar,
-    REVERSE_ABI,
-    subWallet
-  );
+  const reverse = new ethers.Contract(reverseRegistrar, REVERSE_ABI, subWallet);
   await (await reverse.setName(ensName)).wait();
 
   await verifyReverseResolution(provider, subWallet.address, ensName);
@@ -248,9 +251,9 @@ async function main() {
   const rpc = process.env.RPC_URL || 'http://localhost:8545';
   const provider = new ethers.JsonRpcProvider(rpc);
 
-  const {
-    config: ensConfig,
-  } = loadEnsConfig({ network: process.env.ENS_NETWORK || process.env.NETWORK });
+  const { config: ensConfig } = loadEnsConfig({
+    network: process.env.ENS_NETWORK || process.env.NETWORK,
+  });
   setRoleConfig(createRoleConfig(ensConfig.roots || {}));
   const roleConfig = getRoleConfig()[role];
   const registryAddress = normaliseConfigAddress(

--- a/scripts/identity/manageEnsKeys.ts
+++ b/scripts/identity/manageEnsKeys.ts
@@ -2,11 +2,9 @@ import { ethers } from 'ethers';
 import { config as dotenvConfig } from 'dotenv';
 import * as fs from 'fs';
 import * as path from 'path';
+import { loadEnsConfig } from '../config';
 
 dotenvConfig();
-
-const ENS_REGISTRY = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
-const REVERSE_REGISTRAR = '0x084b1c3C81545d370f3634392De611CaaBFf8148';
 
 const REGISTRY_ABI = [
   'function resolver(bytes32 node) view returns (address)',
@@ -17,9 +15,6 @@ const RESOLVER_ABI = ['function setAddr(bytes32 node, address addr) external'];
 const REVERSE_ABI = [
   'function setName(string name) external returns (bytes32)',
 ];
-
-const AGENT_ROOT = ethers.namehash('agent.agi.eth');
-const CLUB_ROOT = ethers.namehash('club.agi.eth');
 
 const IDENTITY_STORAGE_ROOT = path.join(
   __dirname,
@@ -49,26 +44,80 @@ type StoredIdentity = {
 
 const ROLE_VALUES: Role[] = ['agent', 'validator', 'orchestrator'];
 
-const ROLE_CONFIG: Record<Role, RoleConfig> = {
-  agent: {
-    parentNode: AGENT_ROOT,
-    parentName: 'agent.agi.eth',
-    storageDir: path.join(IDENTITY_STORAGE_ROOT, 'agents'),
-    fileName: (label: string) => `${label}.json`,
-  },
-  validator: {
-    parentNode: CLUB_ROOT,
-    parentName: 'club.agi.eth',
-    storageDir: path.join(IDENTITY_STORAGE_ROOT, 'validators'),
-    fileName: (label: string) => `${label}.json`,
-  },
-  orchestrator: {
-    parentNode: AGENT_ROOT,
-    parentName: 'agent.agi.eth',
-    storageDir: IDENTITY_STORAGE_ROOT,
-    fileName: () => 'orchestrator.json',
-  },
-};
+let ROLE_CONFIG: Record<Role, RoleConfig> | null = null;
+
+function setRoleConfig(config: Record<Role, RoleConfig>): void {
+  ROLE_CONFIG = config;
+}
+
+function getRoleConfig(): Record<Role, RoleConfig> {
+  if (!ROLE_CONFIG) {
+    throw new Error('ENS role configuration has not been initialised');
+  }
+  return ROLE_CONFIG;
+}
+
+function normaliseConfigAddress(
+  value: string | undefined,
+  label: string,
+  { allowZero = false }: { allowZero?: boolean } = {}
+): string {
+  if (value === undefined || value === null) {
+    if (allowZero) {
+      return ethers.ZeroAddress;
+    }
+    throw new Error(`${label} is not configured`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    if (allowZero) {
+      return ethers.ZeroAddress;
+    }
+    throw new Error(`${label} is not configured`);
+  }
+  const prefixed = trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`;
+  const address = ethers.getAddress(prefixed);
+  if (!allowZero && address === ethers.ZeroAddress) {
+    throw new Error(`${label} cannot be the zero address`);
+  }
+  return address;
+}
+
+function createRoleConfig(roots: Record<string, any>): Record<Role, RoleConfig> {
+  const agentRoot = roots.agent;
+  const clubRoot = roots.club;
+  if (!agentRoot || !agentRoot.node || !agentRoot.name) {
+    throw new Error('ENS configuration is missing the agent.agi.eth root');
+  }
+  if (!clubRoot || !clubRoot.node || !clubRoot.name) {
+    throw new Error('ENS configuration is missing the club.agi.eth root');
+  }
+  const normaliseNode = (value: string) => ethers.hexlify(ethers.getBytes(value));
+  const agentNode = normaliseNode(agentRoot.node);
+  const clubNode = normaliseNode(clubRoot.node);
+  const agentName = String(agentRoot.name).toLowerCase();
+  const clubName = String(clubRoot.name).toLowerCase();
+  return {
+    agent: {
+      parentNode: agentNode,
+      parentName: agentName,
+      storageDir: path.join(IDENTITY_STORAGE_ROOT, 'agents'),
+      fileName: (label: string) => `${label}.json`,
+    },
+    validator: {
+      parentNode: clubNode,
+      parentName: clubName,
+      storageDir: path.join(IDENTITY_STORAGE_ROOT, 'validators'),
+      fileName: (label: string) => `${label}.json`,
+    },
+    orchestrator: {
+      parentNode: agentNode,
+      parentName: agentName,
+      storageDir: IDENTITY_STORAGE_ROOT,
+      fileName: () => 'orchestrator.json',
+    },
+  };
+}
 
 function parseArgs(): { name: string; role: Role } {
   const argv = process.argv.slice(2);
@@ -106,7 +155,7 @@ function normalizeLabel(input: string): string {
 }
 
 function resolveStoragePath(role: Role, label: string): string {
-  const config = ROLE_CONFIG[role];
+  const config = getRoleConfig()[role];
   fs.mkdirSync(config.storageDir, { recursive: true });
   const fileName = config.fileName(label);
   return path.join(config.storageDir, fileName);
@@ -154,9 +203,11 @@ async function registerEnsSubdomain(
   rootWallet: ethers.Wallet,
   subWallet: ethers.Wallet,
   label: string,
-  config: RoleConfig
+  config: RoleConfig,
+  registryAddress: string,
+  reverseRegistrar: string
 ): Promise<string> {
-  const registry = new ethers.Contract(ENS_REGISTRY, REGISTRY_ABI, rootWallet);
+  const registry = new ethers.Contract(registryAddress, REGISTRY_ABI, rootWallet);
   const resolverAddr = await registry.resolver(config.parentNode);
   if (resolverAddr === ethers.ZeroAddress) {
     throw new Error('Parent node has no resolver set');
@@ -180,7 +231,7 @@ async function registerEnsSubdomain(
   await (await resolver.setAddr(node, subWallet.address)).wait();
 
   const reverse = new ethers.Contract(
-    REVERSE_REGISTRAR,
+    reverseRegistrar,
     REVERSE_ABI,
     subWallet
   );
@@ -194,9 +245,22 @@ async function registerEnsSubdomain(
 async function main() {
   const { name, role } = parseArgs();
   const normalizedLabel = normalizeLabel(name);
-  const roleConfig = ROLE_CONFIG[role];
   const rpc = process.env.RPC_URL || 'http://localhost:8545';
   const provider = new ethers.JsonRpcProvider(rpc);
+
+  const {
+    config: ensConfig,
+  } = loadEnsConfig({ network: process.env.ENS_NETWORK || process.env.NETWORK });
+  setRoleConfig(createRoleConfig(ensConfig.roots || {}));
+  const roleConfig = getRoleConfig()[role];
+  const registryAddress = normaliseConfigAddress(
+    process.env.ENS_REGISTRY_ADDRESS ?? ensConfig.registry,
+    'ENS registry'
+  );
+  const reverseRegistrar = normaliseConfigAddress(
+    process.env.ENS_REVERSE_REGISTRAR_ADDRESS ?? ensConfig.reverseRegistrar,
+    'ENS reverse registrar'
+  );
 
   const rootKey = process.env.ENS_OWNER_KEY;
   if (!rootKey) {
@@ -211,7 +275,9 @@ async function main() {
     rootWallet,
     participantWallet,
     normalizedLabel,
-    roleConfig
+    roleConfig,
+    registryAddress,
+    reverseRegistrar
   );
 
   const outputPath = persistWalletRecord(

--- a/scripts/registerEns.ts
+++ b/scripts/registerEns.ts
@@ -152,7 +152,9 @@ function parseArgs(): CliOptions {
   };
 }
 
-function buildParentMap(roots: Record<string, any>): Record<EnsSpace, ParentConfig> {
+function buildParentMap(
+  roots: Record<string, any>
+): Record<EnsSpace, ParentConfig> {
   const agentRoot = roots.agent;
   const clubRoot = roots.club;
   if (!agentRoot || !agentRoot.node || !agentRoot.name) {
@@ -278,9 +280,9 @@ function persistIdentity(
 async function main(): Promise<void> {
   const options = parseArgs();
   const provider = new ethers.JsonRpcProvider(options.rpcUrl);
-  const {
-    config: ensConfig,
-  } = loadEnsConfig({ network: options.network });
+  const { config: ensConfig } = loadEnsConfig({
+    network: options.network,
+  });
   const parents = buildParentMap(ensConfig.roots || {});
   const registryAddress = normaliseConfigAddress(
     process.env.ENS_REGISTRY_ADDRESS ?? ensConfig.registry,

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -43,14 +43,17 @@ async function main() {
     typeof args.governance === 'string' ? args.governance : deployer.address;
   const governanceSigner = await ethers.getSigner(governance);
 
-  const {
-    config: ensConfig,
-  } = loadEnsConfig({ network: network.name, chainId: network.config?.chainId });
+  const { config: ensConfig } = loadEnsConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
   const roots = ensConfig.roots || {};
   const agentRootNode = roots.agent?.node;
   const clubRootNode = roots.club?.node;
   if (!ensConfig.registry || !agentRootNode || !clubRootNode) {
-    throw new Error('ENS configuration must include registry and agent/club root nodes');
+    throw new Error(
+      'ENS configuration must include registry and agent/club root nodes'
+    );
   }
   const nameWrapperAddress = ensConfig.nameWrapper || ethers.ZeroAddress;
 
@@ -449,7 +452,10 @@ async function main() {
     moderator,
     governance,
   ]);
-  await verify(await attestation.getAddress(), [ensConfig.registry, nameWrapperAddress]);
+  await verify(await attestation.getAddress(), [
+    ensConfig.registry,
+    nameWrapperAddress,
+  ]);
   await verify(await identity.getAddress(), [
     ethers.ZeroAddress,
     ethers.ZeroAddress,

--- a/scripts/v2/deployDefaults.ts
+++ b/scripts/v2/deployDefaults.ts
@@ -46,9 +46,10 @@ async function main() {
   const deployerAddress = await deployer.getAddress();
   console.log('Deployer', deployerAddress);
 
-  const {
-    config: ensConfig,
-  } = loadEnsConfig({ network: network.name, chainId: network.config?.chainId });
+  const { config: ensConfig } = loadEnsConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
   const roots = ensConfig.roots || {};
   const agentRootNode = roots.agent?.node;
   const clubRootNode = roots.club?.node;

--- a/scripts/v2/deployDefaults.ts
+++ b/scripts/v2/deployDefaults.ts
@@ -1,5 +1,6 @@
-import { ethers, run } from 'hardhat';
+import { ethers, run, network } from 'hardhat';
 import { AGIALPHA_DECIMALS } from '../constants';
+import { loadEnsConfig } from '../config';
 
 async function verify(address: string, args: any[] = []) {
   try {
@@ -45,14 +46,26 @@ async function main() {
   const deployerAddress = await deployer.getAddress();
   console.log('Deployer', deployerAddress);
 
+  const {
+    config: ensConfig,
+  } = loadEnsConfig({ network: network.name, chainId: network.config?.chainId });
+  const roots = ensConfig.roots || {};
+  const agentRootNode = roots.agent?.node;
+  const clubRootNode = roots.club?.node;
+  if (!agentRootNode || !clubRootNode) {
+    throw new Error('ENS configuration is missing agent or club root nodes');
+  }
   const ids = {
-    ens: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-    nameWrapper: '0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401',
-    clubRootNode: ethers.namehash('club.agi.eth'),
-    agentRootNode: ethers.namehash('agent.agi.eth'),
-    validatorMerkleRoot: ethers.ZeroHash,
-    agentMerkleRoot: ethers.ZeroHash,
+    ens: ensConfig.registry,
+    nameWrapper: ensConfig.nameWrapper || ethers.ZeroAddress,
+    clubRootNode,
+    agentRootNode,
+    validatorMerkleRoot: roots.club?.merkleRoot || ethers.ZeroHash,
+    agentMerkleRoot: roots.agent?.merkleRoot || ethers.ZeroHash,
   };
+  if (!ids.ens) {
+    throw new Error('ENS registry address missing from configuration');
+  }
 
   const tx = withTax
     ? customEcon

--- a/scripts/verify-agialpha.ts
+++ b/scripts/verify-agialpha.ts
@@ -356,7 +356,9 @@ if (require.main === module) {
 
     if (!configOverride && networkArg) {
       const inferred = inferNetworkKey(networkArg) ?? networkArg;
-      const { path: networkConfigPath } = loadTokenConfig({ network: inferred });
+      const { path: networkConfigPath } = loadTokenConfig({
+        network: inferred,
+      });
       configPath = networkConfigPath;
     }
 

--- a/scripts/verify-agialpha.ts
+++ b/scripts/verify-agialpha.ts
@@ -1,8 +1,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { ethers } from 'ethers';
+import { loadTokenConfig, inferNetworkKey } from './config';
 
-const defaultConfigPath = path.join(__dirname, '..', 'config', 'agialpha.json');
+const { path: defaultConfigPath } = loadTokenConfig();
 const defaultConstantsPath = path.join(
   __dirname,
   '..',
@@ -328,11 +329,14 @@ if (require.main === module) {
     let rpcUrl: string | undefined;
     let timeoutMs: number | undefined;
     let skipOnChain = false;
+    let networkArg: string | undefined;
+    let configOverride = false;
 
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
       if (arg === '--config' && i + 1 < args.length) {
         configPath = args[++i];
+        configOverride = true;
       } else if (arg === '--constants' && i + 1 < args.length) {
         constantsPath = args[++i];
       } else if (arg === '--rpc' && i + 1 < args.length) {
@@ -341,9 +345,19 @@ if (require.main === module) {
         timeoutMs = Number(args[++i]);
       } else if (arg === '--skip-onchain') {
         skipOnChain = true;
+      } else if (arg === '--network' && i + 1 < args.length) {
+        networkArg = args[++i];
+      } else if (arg.startsWith('--network=')) {
+        networkArg = arg.slice('--network='.length);
       } else {
         console.warn(`Unrecognized argument: ${arg}`);
       }
+    }
+
+    if (!configOverride && networkArg) {
+      const inferred = inferNetworkKey(networkArg) ?? networkArg;
+      const { path: networkConfigPath } = loadTokenConfig({ network: inferred });
+      configPath = networkConfigPath;
     }
 
     try {


### PR DESCRIPTION
## Summary
- add per-network AGIALPHA and ENS configuration files and expose a utility loader
- update scripts and agent gateway components to consume the network-aware configs
- tighten gateway token metadata handling and keystore parsing for strict TypeScript builds

## Testing
- npm run build:gateway
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68cf3a6789a08333820ca27089be5d6a