### PR TITLE
Add TestAGIALPHA mock deployment for Sepolia

### DIFF
--- a/contracts/mocks/TestAGIALPHA.sol
+++ b/contracts/mocks/TestAGIALPHA.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title TestAGIALPHA
+/// @notice Minimal IERC20-compatible token used for testnet deployments.
+/// @dev Decimals are immutable and an initial supply is minted in the constructor
+///      to the provided recipient. No additional minting functionality is exposed
+///      to keep behaviour deterministic across environments.
+contract TestAGIALPHA is ERC20 {
+    /// @notice Immutable decimals value returned by the token.
+    uint8 private immutable _decimals;
+
+    /// @param name_ ERC-20 name for the mock token.
+    /// @param symbol_ ERC-20 symbol for the mock token.
+    /// @param decimals_ Number of decimals used for token accounting.
+    /// @param initialRecipient Address that receives the initial supply.
+    /// @param initialSupply Amount of tokens minted to the initial recipient.
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_,
+        address initialRecipient,
+        uint256 initialSupply
+    ) ERC20(name_, symbol_) {
+        require(initialRecipient != address(0), "TestAGIALPHA: zero recipient");
+        _decimals = decimals_;
+        _mint(initialRecipient, initialSupply);
+    }
+
+    /// @inheritdoc ERC20
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+}

--- a/migrations/2_deploy_agijobs_v2.js
+++ b/migrations/2_deploy_agijobs_v2.js
@@ -39,12 +39,13 @@ module.exports = async function (deployer, network, accounts) {
       ? parseInt(process.env.AGIALPHA_MOCK_DECIMALS, 10)
       : 18;
     if (!Number.isInteger(decimals) || decimals < 0 || decimals > 255) {
-      throw new Error('AGIALPHA_MOCK_DECIMALS must be an integer between 0 and 255');
+      throw new Error(
+        'AGIALPHA_MOCK_DECIMALS must be an integer between 0 and 255'
+      );
     }
     const supplyTokens = process.env.AGIALPHA_MOCK_SUPPLY || '1000000';
-    const initialSupply = (
-      BigInt(supplyTokens) * BigInt(10) ** BigInt(decimals)
-    ).toString();
+    const decimalsFactor = 10n ** BigInt(decimals);
+    const initialSupply = (BigInt(supplyTokens) * decimalsFactor).toString();
 
     await deployer.deploy(
       TestAGIALPHA,
@@ -56,24 +57,21 @@ module.exports = async function (deployer, network, accounts) {
     );
     mockToken = await TestAGIALPHA.deployed();
 
-    const {
-      path: tokenConfigPath,
-      config: tokenConfig,
-    } = loadTokenConfig({ network });
+    const { path: tokenConfigPath, config: tokenConfig } = loadTokenConfig({
+      network,
+    });
     const updatedConfig = {
       ...tokenConfig,
       address: mockToken.address,
       decimals,
     };
+    const relativePath = path.relative(process.cwd(), tokenConfigPath);
     fs.writeFileSync(
       tokenConfigPath,
       `${JSON.stringify(updatedConfig, null, 2)}\n`
     );
     console.log(
-      `Deployed TestAGIALPHA to ${mockToken.address} and updated ${path.relative(
-        process.cwd(),
-        tokenConfigPath
-      )}`
+      `Deployed TestAGIALPHA to ${mockToken.address} and updated ${relativePath}`
     );
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated `TestAGIALPHA` ERC-20 mock with immutable decimals and constructor mint for testnets
- extend the Sepolia migration to deploy the mock token when running on that network and persist the address to `config/agialpha.sepolia.json`
- allow overriding mock decimals/supply via env vars while keeping existing metadata values

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68cf44cc6ba48333a4276619caeab156