### PR TITLE
Add validation-driven reputation update hook

### DIFF
--- a/contracts/v2/interfaces/IJobRegistry.sol
+++ b/contracts/v2/interfaces/IJobRegistry.sol
@@ -194,6 +194,15 @@ interface IJobRegistry {
         pure
         returns (JobMetadata memory);
 
+    /// @notice Retrieve validator reward percentage used for reputation context.
+    function validatorRewardPct() external view returns (uint256);
+
+    /// @notice Mark that reputation for a job has been processed externally.
+    function markReputationProcessed(uint256 jobId) external;
+
+    /// @notice Check whether reputation updates for a job were already applied.
+    function reputationProcessed(uint256 jobId) external view returns (bool);
+
     /// @notice Retrieve the ValidationModule managing validator sets
     /// @return Address of the ValidationModule
     function validationModule() external view returns (address);

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -11,6 +11,8 @@ interface IReputationEngine {
 
     /// @dev Reverts when attempting to act on a blacklisted user
     error BlacklistedUser(address user);
+    /// @dev Reverts when array lengths for validator context mismatch
+    error ArrayLengthMismatch();
 
     event ReputationUpdated(address indexed user, int256 delta, uint256 newScore);
     event BlacklistUpdated(address indexed user, bool status);
@@ -90,6 +92,26 @@ interface IReputationEngine {
     function onFinalize(address user, bool success, uint256 payout, uint256 duration) external;
 
     function rewardValidator(address validator, uint256 agentGain) external;
+
+    /// @notice Update agent and validator reputation for a completed job.
+    /// @param jobId Identifier of the job being settled.
+    /// @param agent Address of the agent that executed the job.
+    /// @param validators Validator committee that assessed the job.
+    /// @param success True if the job was approved by validators.
+    /// @param validatorRevealed Flags indicating whether each validator revealed their vote.
+    /// @param validatorVotes Recorded vote for each validator (true = approval).
+    /// @param payout Agent payout expressed with 18 decimals.
+    /// @param duration Time elapsed between assignment and completion in seconds.
+    function updateScores(
+        uint256 jobId,
+        address agent,
+        address[] calldata validators,
+        bool success,
+        bool[] calldata validatorRevealed,
+        bool[] calldata validatorVotes,
+        uint256 payout,
+        uint256 duration
+    ) external;
 
     /// @notice Compute reputation gain for an agent based on payout and duration.
     /// @param payout Amount paid to the agent (18-decimal).


### PR DESCRIPTION
## Summary
- add an updateScores hook to the reputation engine interface and implementation
- trigger the consolidated hook from the validation module with payout, duration and vote context
- track validation-driven reputation handling in the job registry and refresh mocks to match the new API

## Testing
- `npx hardhat test test/v2/ReputationEngine.test.js`
- `npx hardhat test test/v2/ReputationIncentives.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d03491b6cc8333a4d132698e81270a