### PR TITLE
feat: emit reward engine governance events

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -79,6 +79,9 @@ contract RewardEngineMB is Governable, ReentrancyGuard {
     event RewardBudget(
         uint256 indexed epoch, uint256 minted, uint256 dust, uint256 redistributed, uint256 distributionRatio
     );
+    event MaxProofsUpdated(uint256 maxProofs);
+    event ThermostatUpdated(address indexed thermostat);
+    event ManualTemperatureUpdated(int256 temperature);
 
     constructor(
         Thermostat _thermostat,
@@ -160,12 +163,14 @@ contract RewardEngineMB is Governable, ReentrancyGuard {
     /// @param max Maximum length of each proofs array.
     function setMaxProofs(uint256 max) external onlyGovernance {
         maxProofs = max;
+        emit MaxProofsUpdated(max);
     }
 
     /// @notice Update the Thermostat contract reference.
     /// @param _thermostat New thermostat contract or zero address to disable.
     function setThermostat(Thermostat _thermostat) external onlyGovernance {
         thermostat = _thermostat;
+        emit ThermostatUpdated(address(_thermostat));
     }
 
     /// @notice Set a manual system temperature when no Thermostat is used.
@@ -173,6 +178,7 @@ contract RewardEngineMB is Governable, ReentrancyGuard {
     function setTemperature(int256 temp) external onlyGovernance {
         require(temp > 0, "temp");
         temperature = temp;
+        emit ManualTemperatureUpdated(temp);
     }
 
     /// @notice Distribute rewards for an epoch based on energy attestations.

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -383,6 +383,28 @@ contract RewardEngineMBTest is Test {
         engine.setSettler(address(0xBEEF), true);
     }
 
+    function test_setMaxProofsEmits() public {
+        vm.expectEmit(false, false, false, true);
+        emit RewardEngineMB.MaxProofsUpdated(200);
+        engine.setMaxProofs(200);
+        assertEq(engine.maxProofs(), 200);
+    }
+
+    function test_setThermostatEmits() public {
+        Thermostat newThermo = new Thermostat(int256(1e18), int256(1), int256(2e18), address(this));
+        vm.expectEmit(true, false, false, true);
+        emit RewardEngineMB.ThermostatUpdated(address(newThermo));
+        engine.setThermostat(newThermo);
+        assertEq(address(engine.thermostat()), address(newThermo));
+    }
+
+    function test_setTemperatureEmits() public {
+        vm.expectEmit(false, false, false, true);
+        emit RewardEngineMB.ManualTemperatureUpdated(int256(2e18));
+        engine.setTemperature(int256(2e18));
+        assertEq(engine.temperature(), int256(2e18));
+    }
+
     function test_setMuEmits() public {
         vm.expectEmit(true, false, false, true);
         emit RewardEngineMB.MuUpdated(RewardEngineMB.Role.Agent, 1);


### PR DESCRIPTION
## Summary
- add governance change events for RewardEngineMB configuration updates
- emit the new events when max proofs, thermostat, or manual temperature are updated
- extend RewardEngineMB tests to cover the new event emissions

## Testing
- forge test --match-contract RewardEngineMBTest *(fails: `forge` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d064f39ed88333a679fcdc2cd27875