### PR TITLE
Add job registry configuration tooling and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,4 +315,5 @@ For detailed behaviour and additional modules such as `FeePool`, `TaxPolicy` and
 - [Production deployment guide](docs/deployment-guide-production.md)
 - [AGIJobs v2 sprint plan and deployment guide](docs/agi-jobs-v2-production-deployment-guide.md)
 - [API reference and SDK snippets](docs/api-reference.md)
+- [Job registry configuration guide](docs/job-registry-configuration.md)
 - [Agent gateway example](examples/agent-gateway.js)

--- a/config/job-registry.json
+++ b/config/job-registry.json
@@ -1,0 +1,13 @@
+{
+  "jobStakeTokens": "1",
+  "minAgentStakeTokens": "10",
+  "maxJobRewardTokens": "1000",
+  "jobDurationLimitSeconds": 604800,
+  "maxActiveJobsPerAgent": 3,
+  "expirationGracePeriodSeconds": 86400,
+  "feePct": 5,
+  "validatorRewardPct": 10,
+  "treasury": "0x0000000000000000000000000000000000000000",
+  "taxPolicy": "0x0000000000000000000000000000000000000000",
+  "acknowledgers": {}
+}

--- a/docs/job-registry-configuration.md
+++ b/docs/job-registry-configuration.md
@@ -1,0 +1,92 @@
+# Job Registry Configuration Guide
+
+This guide walks governance operators and support staff through updating the
+`JobRegistry` contract with the canonical configuration committed to this
+repository. The `scripts/v2/updateJobRegistry.ts` helper reads
+`config/job-registry.json`, compares it to on-chain values and either prints the
+required governance calls (dry run) or submits transactions directly when
+executed from the authorised timelock/multisig.
+
+The script is intentionally conservative:
+
+- It validates numeric ranges so the governance transaction cannot revert due to
+  malformed input.
+- It blocks execution when the connected signer is not the Job Registry owner to
+  prevent accidental submissions with an unauthorised account.
+- Dry runs provide the fully-encoded calldata for each call so the operations
+  team can copy/paste into a multisig or timelock queue if desired.
+
+> **Tip:** keep the configuration file in version control. Every dry run prints
+> the file path that was used so you can review change history as part of your
+> deployment checklist.
+
+## 1. Edit `config/job-registry.json`
+
+Field names ending in `Tokens` are interpreted using the `$AGIALPHA` decimals
+(18 by default). For example, a value of `"1.5"` becomes
+`1.5 × 10¹⁸ = 1500000000000000000` on-chain.
+
+| Field                          | Description                                                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `jobStakeTokens`               | Stake required (in tokens) for every new job. Stored as a `uint96`.                                                  |
+| `minAgentStakeTokens`          | Global minimum agent stake required before applying. Stored as a `uint96`.                                           |
+| `maxJobRewardTokens`           | Maximum per-job reward in tokens. Set to `0` to disable the cap.                                                     |
+| `jobDurationLimitSeconds`      | Hard deadline window for new jobs (0 disables the check).                                                            |
+| `maxActiveJobsPerAgent`        | Cap on simultaneous assignments per agent (0 disables the check).                                                    |
+| `expirationGracePeriodSeconds` | Additional grace period after a deadline before a job can expire.                                                    |
+| `feePct`                       | Protocol fee percentage (0–100).                                                                                     |
+| `validatorRewardPct`           | Share of the job reward paid to validators (0–100). The sum of `feePct` and `validatorRewardPct` may not exceed 100. |
+| `treasury`                     | Destination for forfeited funds when employers or agents are blacklisted. Use `"0x000...000"` to burn them.          |
+| `taxPolicy`                    | Optional override of the active `TaxPolicy` contract. Leave as `0x0` to skip updates.                                |
+| `acknowledgers`                | Mapping of addresses to booleans controlling who can call `acknowledgeFor`. Addresses not listed are left untouched. |
+
+## 2. Dry run the update
+
+```bash
+npx hardhat run scripts/v2/updateJobRegistry.ts --network <network>
+```
+
+The command prints the signer, the configuration file in use and a numbered list
+of planned actions. Each action includes the function, arguments and calldata so
+you can stage transactions manually if required.
+
+If the signer is not the Job Registry owner the script automatically stays in
+dry-run mode and prints a warning.
+
+## 3. Execute the transactions (optional)
+
+Once you are satisfied with the dry run output, execute the updates directly by
+connecting the authorised governance signer and passing `--execute`:
+
+```bash
+npx hardhat run scripts/v2/updateJobRegistry.ts --network <network> --execute
+```
+
+The helper submits one transaction per action, waits for confirmation and stops
+immediately if any transaction fails. Keep the console output for governance
+records.
+
+## 4. Using alternate configuration files
+
+To preview or apply settings from another JSON file, supply `--config`:
+
+```bash
+npx hardhat run scripts/v2/updateJobRegistry.ts --network <network> \
+  --config ./deployment-config/mainnet-job-registry.json
+```
+
+This allows per-environment overrides while keeping the default configuration in
+`config/job-registry.json`.
+
+## 5. Troubleshooting
+
+- **`feePct + validatorRewardPct cannot exceed 100`** – adjust the values so the
+  combined percentage is at most 100.
+- **`Signer ... is not the governance owner ...`** – the connected account lacks
+  permission to execute the changes. Switch to the timelock/multisig or run in
+  dry-run mode without `--execute`.
+- **`Job registry address is not configured`** – populate
+  `config/agialpha.json` → `modules.jobRegistry` or pass `--registry <address>`.
+
+For a detailed description of every Job Registry function see the API reference
+in `docs/api-reference.md`.

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -25,6 +25,30 @@ export interface TokenConfigResult {
   network?: SupportedNetwork;
 }
 
+export interface JobRegistryConfig {
+  jobStake?: string;
+  jobStakeTokens?: string | number;
+  minAgentStake?: string;
+  minAgentStakeTokens?: string | number;
+  maxJobReward?: string;
+  maxJobRewardTokens?: string | number;
+  jobDurationLimitSeconds?: number | string;
+  maxActiveJobsPerAgent?: number | string;
+  expirationGracePeriodSeconds?: number | string;
+  feePct?: number | string;
+  validatorRewardPct?: number | string;
+  treasury?: string | null;
+  taxPolicy?: string | null;
+  acknowledgers?: Record<string, boolean>;
+  [key: string]: unknown;
+}
+
+export interface JobRegistryConfigResult {
+  config: JobRegistryConfig;
+  path: string;
+  network?: SupportedNetwork;
+}
+
 export interface EnsRootConfig {
   label: string;
   name: string;
@@ -57,8 +81,12 @@ export interface LoadOptions {
   name?: string;
   context?: any;
   persist?: boolean;
+  path?: string;
 }
 
 export function inferNetworkKey(value: any): SupportedNetwork | undefined;
 export function loadTokenConfig(options?: LoadOptions): TokenConfigResult;
 export function loadEnsConfig(options?: LoadOptions): EnsConfigResult;
+export function loadJobRegistryConfig(
+  options?: LoadOptions
+): JobRegistryConfigResult;

--- a/scripts/v2/updateJobRegistry.ts
+++ b/scripts/v2/updateJobRegistry.ts
@@ -1,0 +1,508 @@
+import { ethers, network } from 'hardhat';
+import type { Contract } from 'ethers';
+import {
+  loadTokenConfig,
+  loadJobRegistryConfig,
+  type JobRegistryConfig,
+} from '../config';
+
+interface CliOptions {
+  execute: boolean;
+  configPath?: string;
+  registryAddress?: string;
+}
+
+interface PlannedAction {
+  label: string;
+  method: string;
+  args: any[];
+  current?: string;
+  desired?: string;
+  notes?: string[];
+}
+
+const MAX_UINT96 = (1n << 96n) - 1n;
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--execute') {
+      options.execute = true;
+    } else if (arg === '--config') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--config requires a file path');
+      }
+      options.configPath = value;
+      i += 1;
+    } else if (arg === '--registry') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--registry requires an address');
+      }
+      options.registryAddress = value;
+      i += 1;
+    }
+  }
+  return options;
+}
+
+function parseTokenAmount(
+  config: JobRegistryConfig,
+  key: string,
+  decimals: number
+): bigint | undefined {
+  const direct = config[key];
+  if (direct !== undefined && direct !== null) {
+    const asString =
+      typeof direct === 'string' ? direct.trim() : String(direct);
+    if (!asString) {
+      return undefined;
+    }
+    const value = BigInt(asString);
+    if (value < 0n) {
+      throw new Error(`${key} cannot be negative`);
+    }
+    return value;
+  }
+  const tokensKey = `${key}Tokens`;
+  const tokenValue = config[tokensKey as keyof JobRegistryConfig];
+  if (tokenValue !== undefined && tokenValue !== null) {
+    const asString =
+      typeof tokenValue === 'string' ? tokenValue.trim() : String(tokenValue);
+    if (!asString) {
+      return undefined;
+    }
+    const parsed = ethers.parseUnits(asString, decimals);
+    if (parsed < 0n) {
+      throw new Error(`${tokensKey} cannot be negative`);
+    }
+    return parsed;
+  }
+  return undefined;
+}
+
+function parseInteger(value: unknown, label: string): bigint | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const asString = typeof value === 'string' ? value.trim() : String(value);
+  if (!asString) {
+    return undefined;
+  }
+  if (!/^[-+]?\d+$/.test(asString)) {
+    throw new Error(`${label} must be an integer`);
+  }
+  const parsed = BigInt(asString);
+  if (parsed < 0n) {
+    throw new Error(`${label} cannot be negative`);
+  }
+  return parsed;
+}
+
+function parsePercentage(value: unknown, label: string): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+  if (!Number.isInteger(numberValue)) {
+    throw new Error(`${label} must be an integer between 0 and 100`);
+  }
+  if (numberValue < 0 || numberValue > 100) {
+    throw new Error(`${label} must be between 0 and 100`);
+  }
+  return numberValue;
+}
+
+function normaliseAddress(
+  value: string | null | undefined
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return ethers.ZeroAddress;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === ethers.ZeroAddress) {
+    return ethers.ZeroAddress;
+  }
+  return ethers.getAddress(trimmed);
+}
+
+function sameAddress(a: string, b: string): boolean {
+  return ethers.getAddress(a) === ethers.getAddress(b);
+}
+
+function formatToken(value: bigint, decimals: number, symbol: string): string {
+  return `${ethers.formatUnits(value, decimals)} ${symbol}`.trim();
+}
+
+function describeArgs(args: any[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'bigint') {
+        return arg.toString();
+      }
+      if (typeof arg === 'string') {
+        return arg;
+      }
+      if (typeof arg === 'boolean') {
+        return arg ? 'true' : 'false';
+      }
+      return JSON.stringify(arg);
+    })
+    .join(', ');
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const { config: tokenConfig } = loadTokenConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
+  const { config: jobConfig, path: jobConfigPath } = loadJobRegistryConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+    path: cli.configPath,
+  });
+
+  const decimals =
+    typeof tokenConfig.decimals === 'number' ? tokenConfig.decimals : 18;
+  const symbol =
+    typeof tokenConfig.symbol === 'string' && tokenConfig.symbol
+      ? tokenConfig.symbol
+      : 'tokens';
+
+  const registryAddressCandidate =
+    cli.registryAddress || tokenConfig.modules?.jobRegistry;
+  if (!registryAddressCandidate) {
+    throw new Error('Job registry address is not configured');
+  }
+  const jobRegistryAddress = ethers.getAddress(registryAddressCandidate);
+  if (jobRegistryAddress === ethers.ZeroAddress) {
+    throw new Error('Job registry address cannot be the zero address');
+  }
+
+  const registry = (await ethers.getContractAt(
+    'contracts/v2/JobRegistry.sol:JobRegistry',
+    jobRegistryAddress
+  )) as Contract;
+
+  const signer = await ethers.getSigner();
+  const ownerAddress = await registry.owner();
+  const signerAddress = await signer.getAddress();
+
+  if (cli.execute && !sameAddress(ownerAddress, signerAddress)) {
+    throw new Error(
+      `Signer ${signerAddress} is not the governance owner ${ownerAddress}`
+    );
+  }
+
+  if (!sameAddress(ownerAddress, signerAddress)) {
+    console.warn(
+      `Warning: connected signer ${signerAddress} is not the governance owner ${ownerAddress}. ` +
+        'Running in dry-run mode.'
+    );
+  }
+
+  const [
+    currentJobStake,
+    currentMaxJobReward,
+    currentMinAgentStake,
+    currentFeePct,
+    currentValidatorRewardPct,
+    currentMaxDuration,
+    currentMaxActiveJobs,
+    currentExpirationGrace,
+    currentTreasury,
+    currentTaxPolicy,
+  ] = await Promise.all([
+    registry.jobStake(),
+    registry.maxJobReward(),
+    registry.minAgentStake(),
+    registry.feePct(),
+    registry.validatorRewardPct(),
+    registry.maxJobDuration(),
+    registry.maxActiveJobsPerAgent(),
+    registry.expirationGracePeriod(),
+    registry.treasury(),
+    registry.taxPolicy(),
+  ]);
+
+  const desiredJobStake = parseTokenAmount(jobConfig, 'jobStake', decimals);
+  const desiredMinAgentStake = parseTokenAmount(
+    jobConfig,
+    'minAgentStake',
+    decimals
+  );
+  const desiredMaxReward = parseTokenAmount(
+    jobConfig,
+    'maxJobReward',
+    decimals
+  );
+  const desiredDuration = parseInteger(
+    jobConfig.jobDurationLimitSeconds,
+    'jobDurationLimitSeconds'
+  );
+  const desiredMaxActive = parseInteger(
+    jobConfig.maxActiveJobsPerAgent,
+    'maxActiveJobsPerAgent'
+  );
+  const desiredExpirationGrace = parseInteger(
+    jobConfig.expirationGracePeriodSeconds,
+    'expirationGracePeriodSeconds'
+  );
+  const desiredFeePct = parsePercentage(jobConfig.feePct, 'feePct');
+  const desiredValidatorPct = parsePercentage(
+    jobConfig.validatorRewardPct,
+    'validatorRewardPct'
+  );
+  const desiredTreasury = normaliseAddress(
+    jobConfig.treasury as string | null | undefined
+  );
+  const desiredTaxPolicy = normaliseAddress(
+    jobConfig.taxPolicy as string | null | undefined
+  );
+
+  const actions: PlannedAction[] = [];
+
+  if (desiredJobStake !== undefined && desiredJobStake !== currentJobStake) {
+    if (desiredJobStake > MAX_UINT96) {
+      throw new Error('jobStake exceeds uint96 range');
+    }
+    actions.push({
+      label: `Update job stake to ${formatToken(
+        desiredJobStake,
+        decimals,
+        symbol
+      )}`,
+      method: 'setJobStake',
+      args: [desiredJobStake],
+      current: formatToken(currentJobStake, decimals, symbol),
+      desired: formatToken(desiredJobStake, decimals, symbol),
+    });
+  }
+
+  if (
+    desiredMinAgentStake !== undefined &&
+    desiredMinAgentStake !== currentMinAgentStake
+  ) {
+    if (desiredMinAgentStake > MAX_UINT96) {
+      throw new Error('minAgentStake exceeds uint96 range');
+    }
+    actions.push({
+      label: `Update minimum agent stake to ${formatToken(
+        desiredMinAgentStake,
+        decimals,
+        symbol
+      )}`,
+      method: 'setMinAgentStake',
+      args: [desiredMinAgentStake],
+      current: formatToken(currentMinAgentStake, decimals, symbol),
+      desired: formatToken(desiredMinAgentStake, decimals, symbol),
+    });
+  }
+
+  if (
+    desiredMaxReward !== undefined &&
+    desiredMaxReward !== currentMaxJobReward
+  ) {
+    actions.push({
+      label: `Update maximum job reward to ${formatToken(
+        desiredMaxReward,
+        decimals,
+        symbol
+      )}`,
+      method: 'setMaxJobReward',
+      args: [desiredMaxReward],
+      current: formatToken(currentMaxJobReward, decimals, symbol),
+      desired: formatToken(desiredMaxReward, decimals, symbol),
+    });
+  }
+
+  if (desiredDuration !== undefined && desiredDuration !== currentMaxDuration) {
+    actions.push({
+      label: `Update job duration limit to ${desiredDuration} seconds`,
+      method: 'setJobDurationLimit',
+      args: [desiredDuration],
+      current: `${currentMaxDuration.toString()} seconds`,
+      desired: `${desiredDuration.toString()} seconds`,
+    });
+  }
+
+  if (
+    desiredMaxActive !== undefined &&
+    desiredMaxActive !== currentMaxActiveJobs
+  ) {
+    actions.push({
+      label: `Update maximum active jobs per agent to ${desiredMaxActive}`,
+      method: 'setMaxActiveJobsPerAgent',
+      args: [desiredMaxActive],
+      current: currentMaxActiveJobs.toString(),
+      desired: desiredMaxActive.toString(),
+    });
+  }
+
+  if (
+    desiredExpirationGrace !== undefined &&
+    desiredExpirationGrace !== currentExpirationGrace
+  ) {
+    actions.push({
+      label: `Update expiration grace period to ${desiredExpirationGrace} seconds`,
+      method: 'setExpirationGracePeriod',
+      args: [desiredExpirationGrace],
+      current: `${currentExpirationGrace.toString()} seconds`,
+      desired: `${desiredExpirationGrace.toString()} seconds`,
+    });
+  }
+
+  const currentFee = Number(currentFeePct);
+  const currentValidator = Number(currentValidatorRewardPct);
+
+  if (desiredFeePct !== undefined) {
+    const validatorTarget =
+      desiredValidatorPct !== undefined
+        ? desiredValidatorPct
+        : currentValidator;
+    if (desiredFeePct + validatorTarget > 100) {
+      throw new Error('feePct + validatorRewardPct cannot exceed 100');
+    }
+    if (desiredFeePct !== currentFee) {
+      actions.push({
+        label: `Update protocol fee percentage to ${desiredFeePct}%`,
+        method: 'setFeePct',
+        args: [desiredFeePct],
+        current: `${currentFee}%`,
+        desired: `${desiredFeePct}%`,
+      });
+    }
+  }
+
+  if (desiredValidatorPct !== undefined) {
+    const feeTarget = desiredFeePct !== undefined ? desiredFeePct : currentFee;
+    if (desiredValidatorPct + feeTarget > 100) {
+      throw new Error('feePct + validatorRewardPct cannot exceed 100');
+    }
+    if (desiredValidatorPct !== currentValidator) {
+      actions.push({
+        label: `Update validator reward percentage to ${desiredValidatorPct}%`,
+        method: 'setValidatorRewardPct',
+        args: [desiredValidatorPct],
+        current: `${currentValidator}%`,
+        desired: `${desiredValidatorPct}%`,
+      });
+    }
+  }
+
+  const currentTreasuryAddress =
+    currentTreasury === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentTreasury);
+  if (
+    desiredTreasury !== undefined &&
+    desiredTreasury !== currentTreasuryAddress
+  ) {
+    actions.push({
+      label: `Update treasury to ${desiredTreasury}`,
+      method: 'setTreasury',
+      args: [desiredTreasury],
+      current: currentTreasuryAddress,
+      desired: desiredTreasury,
+      notes: ['Passing the zero address burns forfeited payouts.'],
+    });
+  }
+
+  const currentTaxPolicyAddress =
+    currentTaxPolicy === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentTaxPolicy);
+  if (
+    desiredTaxPolicy &&
+    desiredTaxPolicy !== ethers.ZeroAddress &&
+    desiredTaxPolicy !== currentTaxPolicyAddress
+  ) {
+    actions.push({
+      label: `Update tax policy to ${desiredTaxPolicy}`,
+      method: 'setTaxPolicy',
+      args: [desiredTaxPolicy],
+      current: currentTaxPolicyAddress,
+      desired: desiredTaxPolicy,
+    });
+  }
+
+  const acknowledgers = jobConfig.acknowledgers || {};
+  const sortedAcks = Object.keys(acknowledgers).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  for (const ack of sortedAcks) {
+    const desired = acknowledgers[ack];
+    const current = await registry.acknowledgers(ack);
+    if (Boolean(desired) !== current) {
+      actions.push({
+        label: `${desired ? 'Enable' : 'Disable'} acknowledger ${ack}`,
+        method: 'setAcknowledger',
+        args: [ack, Boolean(desired)],
+        current: current ? 'allowed' : 'blocked',
+        desired: desired ? 'allowed' : 'blocked',
+      });
+    }
+  }
+
+  console.log('Job Registry:', jobRegistryAddress);
+  console.log('Configuration file:', jobConfigPath);
+
+  if (actions.length === 0) {
+    console.log('All tracked parameters already match the configuration.');
+    return;
+  }
+
+  console.log(`Planned actions (${actions.length}):`);
+  const iface = registry.interface;
+  actions.forEach((action, index) => {
+    const data = iface.encodeFunctionData(action.method, action.args);
+    console.log(`\n${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      console.log(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      console.log(`   Desired: ${action.desired}`);
+    }
+    if (action.notes) {
+      for (const note of action.notes) {
+        console.log(`   Note: ${note}`);
+      }
+    }
+    console.log(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    console.log(`   Calldata: ${data}`);
+  });
+
+  if (!cli.execute || !sameAddress(ownerAddress, signerAddress)) {
+    console.log(
+      '\nDry run complete. Re-run with --execute once ready to submit transactions.'
+    );
+    return;
+  }
+
+  console.log('\nSubmitting transactions...');
+  for (const action of actions) {
+    console.log(`Executing ${action.method}...`);
+    const tx = await (registry as any)[action.method](...action.args);
+    console.log(`   Tx hash: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (receipt?.status !== 1n) {
+      throw new Error(`Transaction for ${action.method} failed`);
+    }
+    console.log('   Confirmed');
+  }
+  console.log('All transactions confirmed.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a canonical `config/job-registry.json` file and loader utilities for normalising JobRegistry settings
- add a Hardhat script that compares configuration values to on-chain state, prints calldata for dry runs, and optionally executes
- document the workflow for non-technical operators and link it from the documentation index

## Testing
- npm run lint
- npm run test *(fails: numerous pre-existing ValidationModule/RewardEngine assertions in the upstream suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d19b7613d88333a5b1f5770598773e