### PR TITLE
feat: add stake manager governance configurator

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,4 +316,5 @@ For detailed behaviour and additional modules such as `FeePool`, `TaxPolicy` and
 - [AGIJobs v2 sprint plan and deployment guide](docs/agi-jobs-v2-production-deployment-guide.md)
 - [API reference and SDK snippets](docs/api-reference.md)
 - [Job registry configuration guide](docs/job-registry-configuration.md)
+- [StakeManager configuration guide](docs/stake-manager-configuration.md)
 - [Agent gateway example](examples/agent-gateway.js)

--- a/config/stake-manager.json
+++ b/config/stake-manager.json
@@ -1,0 +1,39 @@
+{
+  "minStakeTokens": "10",
+  "employerSlashPct": 50,
+  "treasurySlashPct": 50,
+  "feePct": 5,
+  "burnPct": 5,
+  "validatorRewardPct": 10,
+  "treasury": "0x0000000000000000000000000000000000000000",
+  "treasuryAllowlist": {},
+  "unbondingPeriodSeconds": 604800,
+  "maxStakePerAddressTokens": "0",
+  "stakeRecommendations": {
+    "minTokens": "10",
+    "maxTokens": "0"
+  },
+  "autoStake": {
+    "enabled": false,
+    "threshold": 10,
+    "increasePct": 20,
+    "decreasePct": 10,
+    "windowSeconds": 604800,
+    "floorTokens": "10",
+    "ceilingTokens": "0",
+    "temperatureThreshold": 0,
+    "hamiltonianThreshold": 0,
+    "disputeWeight": 1,
+    "temperatureWeight": 1,
+    "hamiltonianWeight": 1
+  },
+  "pauser": "0x0000000000000000000000000000000000000000",
+  "jobRegistry": "0x0000000000000000000000000000000000000000",
+  "disputeModule": "0x0000000000000000000000000000000000000000",
+  "validationModule": "0x0000000000000000000000000000000000000000",
+  "thermostat": "0x0000000000000000000000000000000000000000",
+  "hamiltonianFeed": "0x0000000000000000000000000000000000000000",
+  "feePool": "0x0000000000000000000000000000000000000000",
+  "maxAGITypes": 50,
+  "maxTotalPayoutPct": 200
+}

--- a/docs/stake-manager-configuration.md
+++ b/docs/stake-manager-configuration.md
@@ -1,0 +1,112 @@
+# StakeManager Configuration Guide
+
+This guide enables governance operators to align the on-chain `StakeManager`
+parameters with the canonical configuration tracked in this repository. The
+`scripts/v2/updateStakeManager.ts` helper reads `config/stake-manager.json`,
+compares every supported field to live contract state and prints the required
+governance calls. When run with `--execute` the script submits those
+transactions directly from the authorised timelock or multisig owner.
+
+The helper is defensive by design:
+
+- It validates all numeric ranges so transactions cannot revert because of
+  malformed input (e.g., fee percentages summing above 100%).
+- It refuses to submit transactions if the connected signer is not the
+  StakeManager owner, falling back to a dry run with a warning.
+- Dry runs emit method names, arguments and ABI-encoded calldata for every
+  action so teams can queue transactions in an external multisig or timelock
+  if desired.
+
+> **Tip:** keep `config/stake-manager.json` under version control. Each dry run
+> prints the path in use so reviewers can audit the change history before
+> dispatching governance transactions.
+
+## 1. Edit `config/stake-manager.json`
+
+Fields ending in `Tokens` are interpreted using the `$AGIALPHA` decimals (18 by
+default). For instance, `"1.5"` becomes `1.5 × 10¹⁸ = 1500000000000000000`
+base units on-chain.
+
+| Field                                                                 | Description                                                                                                                                                                                   |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `minStakeTokens`                                                      | Minimum stake required for any participant. Must be greater than zero.                                                                                                                        |
+| `maxStakePerAddressTokens`                                            | Optional cap on the combined stake an address can hold. Use `"0"` to disable the limit.                                                                                                       |
+| `feePct`                                                              | Protocol fee percentage deducted from every reward (0–100).                                                                                                                                   |
+| `burnPct`                                                             | Percentage of rewards burned during payout (0–100).                                                                                                                                           |
+| `validatorRewardPct`                                                  | Portion of rewards routed to validators (0–100). The sum of the three percentages above may not exceed 100.                                                                                   |
+| `employerSlashPct`                                                    | Share of a slashed stake returned to the employer (0–100).                                                                                                                                    |
+| `treasurySlashPct`                                                    | Share of a slashed stake sent to the treasury (0–100). `employerSlashPct + treasurySlashPct ≤ 100`.                                                                                           |
+| `treasury`                                                            | Destination for slashed treasury funds. Use the zero address to burn them; cannot equal the owner address.                                                                                    |
+| `treasuryAllowlist`                                                   | Mapping of addresses to booleans controlling who may receive treasury payouts. Unlisted addresses remain unchanged.                                                                           |
+| `unbondingPeriodSeconds`                                              | Length of the withdrawal cooldown window. Must be greater than zero.                                                                                                                          |
+| `stakeRecommendations.minTokens` / `maxTokens`                        | Optional helper that calls `setStakeRecommendations` to update both the recommended minimum and maximum stake in one transaction. `maxTokens` may be `"0"` to disable the recommendation cap. |
+| `autoStake.enabled`                                                   | Enables or disables automatic stake tuning driven by disputes and thermodynamic metrics.                                                                                                      |
+| `autoStake.threshold`                                                 | Dispute count required before increasing the minimum stake.                                                                                                                                   |
+| `autoStake.increasePct` / `decreasePct`                               | Percent increments/decrements applied by the tuning algorithm (0–100).                                                                                                                        |
+| `autoStake.windowSeconds`                                             | Observation window for dispute counts.                                                                                                                                                        |
+| `autoStake.floorTokens`                                               | Minimum value the automatically tuned `minStake` can reach. Provide `"0"` to keep the current floor.                                                                                          |
+| `autoStake.ceilingTokens`                                             | Optional ceiling for the tuned `minStake`. Set to `"0"` to disable the cap.                                                                                                                   |
+| `autoStake.temperatureThreshold` / `hamiltonianThreshold`             | Signed thresholds for incorporating Thermostat temperature and Hamiltonian feed readings.                                                                                                     |
+| `autoStake.disputeWeight` / `temperatureWeight` / `hamiltonianWeight` | Weights applied to each signal when computing the tuning score.                                                                                                                               |
+| `pauser`                                                              | Optional address allowed to pause/unpause alongside governance. Use the zero address to remove the delegate.                                                                                  |
+| `jobRegistry`                                                         | Job Registry address (must expose `version() == 2`). Leave as `0x0` to skip updates.                                                                                                          |
+| `disputeModule`                                                       | Dispute Module address (`version() == 2`). Leave `0x0` to skip.                                                                                                                               |
+| `validationModule`                                                    | Validation Module address (`version() == 2`). Leave `0x0` to skip.                                                                                                                            |
+| `feePool`                                                             | FeePool address (`version() == 2`). Leave `0x0` to skip.                                                                                                                                      |
+| `thermostat` / `hamiltonianFeed`                                      | Optional telemetry feeds for automatic stake tuning.                                                                                                                                          |
+| `maxAGITypes`                                                         | Maximum number of AGI type NFT entries the StakeManager accepts (1–50). Must be at least the current on-chain count.                                                                          |
+| `maxTotalPayoutPct`                                                   | Upper bound on AGI type multipliers (100–200).                                                                                                                                                |
+
+## 2. Dry run the update
+
+```bash
+npx hardhat run scripts/v2/updateStakeManager.ts --network <network>
+```
+
+The command prints the signer, the configuration file used and a numbered list
+of planned actions. Each action includes the method, arguments and calldata so
+you can stage transactions manually if desired.
+
+If the connected account is not the StakeManager owner the script automatically
+stays in dry-run mode and emits a warning.
+
+## 3. Execute the transactions (optional)
+
+Once you are satisfied with the dry run output, execute the changes by
+connecting the authorised governance signer and adding `--execute`:
+
+```bash
+npx hardhat run scripts/v2/updateStakeManager.ts --network <network> --execute
+```
+
+The script submits one transaction per action, waits for confirmation and stops
+immediately if any transaction fails. Preserve the console output for your
+operations log.
+
+## 4. Use alternate configuration files
+
+To preview or apply parameters from another JSON file, supply `--config`:
+
+```bash
+npx hardhat run scripts/v2/updateStakeManager.ts --network <network> \
+  --config ./deployment-config/mainnet-stake-manager.json
+```
+
+This workflow supports per-environment overrides while keeping the default
+settings in `config/stake-manager.json`.
+
+## 5. Troubleshooting
+
+- **`feePct + burnPct + validatorRewardPct cannot exceed 100`** – adjust the
+  percentages so their sum stays within 100.
+- **`Signer ... is not the governance owner ...`** – connect the timelock or
+  multisig that owns the StakeManager before using `--execute`, or rerun without
+  `--execute` for a dry run.
+- **`Stake manager address is not configured`** – populate
+  `config/agialpha.json → modules.stakeManager` or pass `--stake-manager
+  <address>`.
+- **`maxAGITypes cannot be below the current AGI type count`** – remove AGI type
+  entries on-chain before tightening the limit.
+
+For detailed descriptions of every StakeManager function refer to the API
+reference in `docs/api/StakeManager.md`.

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -49,6 +49,65 @@ export interface JobRegistryConfigResult {
   network?: SupportedNetwork;
 }
 
+export interface StakeRecommendationsConfig {
+  min?: string;
+  minTokens?: string | number;
+  max?: string | null;
+  maxTokens?: string | number | null;
+  [key: string]: unknown;
+}
+
+export interface AutoStakeConfig {
+  enabled?: boolean | string;
+  threshold?: number | string;
+  increasePct?: number | string;
+  decreasePct?: number | string;
+  windowSeconds?: number | string;
+  floor?: string;
+  floorTokens?: string | number;
+  ceiling?: string | number | null;
+  ceilingTokens?: string | number | null;
+  temperatureThreshold?: number | string;
+  hamiltonianThreshold?: number | string;
+  disputeWeight?: number | string;
+  temperatureWeight?: number | string;
+  hamiltonianWeight?: number | string;
+  [key: string]: unknown;
+}
+
+export interface StakeManagerConfig {
+  minStake?: string;
+  minStakeTokens?: string | number;
+  feePct?: number | string;
+  burnPct?: number | string;
+  validatorRewardPct?: number | string;
+  employerSlashPct?: number | string;
+  treasurySlashPct?: number | string;
+  treasury?: string | null;
+  treasuryAllowlist?: Record<string, boolean>;
+  unbondingPeriodSeconds?: number | string;
+  maxStakePerAddress?: string;
+  maxStakePerAddressTokens?: string | number;
+  stakeRecommendations?: StakeRecommendationsConfig;
+  autoStake?: AutoStakeConfig;
+  pauser?: string | null;
+  jobRegistry?: string | null;
+  disputeModule?: string | null;
+  validationModule?: string | null;
+  thermostat?: string | null;
+  hamiltonianFeed?: string | null;
+  feePool?: string | null;
+  maxAGITypes?: number | string;
+  maxTotalPayoutPct?: number | string;
+  [key: string]: unknown;
+}
+
+export interface StakeManagerConfigResult {
+  config: StakeManagerConfig;
+  path: string;
+  network?: SupportedNetwork;
+}
+
 export interface EnsRootConfig {
   label: string;
   name: string;
@@ -90,3 +149,6 @@ export function loadEnsConfig(options?: LoadOptions): EnsConfigResult;
 export function loadJobRegistryConfig(
   options?: LoadOptions
 ): JobRegistryConfigResult;
+export function loadStakeManagerConfig(
+  options?: LoadOptions
+): StakeManagerConfigResult;

--- a/scripts/v2/updateStakeManager.ts
+++ b/scripts/v2/updateStakeManager.ts
@@ -1,0 +1,1026 @@
+import { ethers, network } from 'hardhat';
+import type { Contract } from 'ethers';
+import { loadTokenConfig, loadStakeManagerConfig } from '../config';
+
+interface CliOptions {
+  execute: boolean;
+  configPath?: string;
+  stakeManagerAddress?: string;
+}
+
+interface PlannedAction {
+  label: string;
+  method: string;
+  args: any[];
+  current?: string;
+  desired?: string;
+  notes?: string[];
+}
+
+const MAX_AGI_TYPES_CAP = 50;
+const MAX_PAYOUT_PCT = 200;
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--execute') {
+      options.execute = true;
+    } else if (arg === '--config') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--config requires a file path');
+      }
+      options.configPath = value;
+      i += 1;
+    } else if (arg === '--stake-manager' || arg === '--stakeManager') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--stake-manager requires an address');
+      }
+      options.stakeManagerAddress = value;
+      i += 1;
+    }
+  }
+  return options;
+}
+
+function parseTokenValue(
+  baseValue: unknown,
+  tokensValue: unknown,
+  decimals: number,
+  label: string
+): bigint | undefined {
+  if (baseValue !== undefined && baseValue !== null) {
+    const asString =
+      typeof baseValue === 'string' ? baseValue.trim() : String(baseValue);
+    if (!asString) {
+      return undefined;
+    }
+    if (!/^[-+]?\d+$/.test(asString)) {
+      throw new Error(`${label} must be an integer`);
+    }
+    const parsed = BigInt(asString);
+    if (parsed < 0n) {
+      throw new Error(`${label} cannot be negative`);
+    }
+    return parsed;
+  }
+  if (tokensValue !== undefined && tokensValue !== null) {
+    const asString =
+      typeof tokensValue === 'string'
+        ? tokensValue.trim()
+        : String(tokensValue);
+    if (!asString) {
+      return undefined;
+    }
+    const parsed = ethers.parseUnits(asString, decimals);
+    if (parsed < 0n) {
+      throw new Error(`${label}Tokens cannot be negative`);
+    }
+    return parsed;
+  }
+  return undefined;
+}
+
+function parseInteger(value: unknown, label: string): bigint | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const asString = typeof value === 'string' ? value.trim() : String(value);
+  if (!asString) {
+    return undefined;
+  }
+  if (!/^[-+]?\d+$/.test(asString)) {
+    throw new Error(`${label} must be an integer`);
+  }
+  const parsed = BigInt(asString);
+  if (parsed < 0n) {
+    throw new Error(`${label} cannot be negative`);
+  }
+  return parsed;
+}
+
+function parseSignedInteger(value: unknown, label: string): bigint | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const asString = typeof value === 'string' ? value.trim() : String(value);
+  if (!asString) {
+    return undefined;
+  }
+  if (!/^[-+]?\d+$/.test(asString)) {
+    throw new Error(`${label} must be an integer`);
+  }
+  return BigInt(asString);
+}
+
+function parsePercentage(value: unknown, label: string): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+  if (!Number.isInteger(numberValue)) {
+    throw new Error(`${label} must be an integer between 0 and 100`);
+  }
+  if (numberValue < 0 || numberValue > 100) {
+    throw new Error(`${label} must be between 0 and 100`);
+  }
+  return numberValue;
+}
+
+function parseBoolean(value: unknown, label: string): boolean | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  const asString = String(value).trim().toLowerCase();
+  if (!asString) {
+    return undefined;
+  }
+  if (['true', '1', 'yes', 'y', 'on', 'enable', 'enabled'].includes(asString)) {
+    return true;
+  }
+  if (
+    ['false', '0', 'no', 'n', 'off', 'disable', 'disabled'].includes(asString)
+  ) {
+    return false;
+  }
+  throw new Error(`${label} must be a boolean value`);
+}
+
+function sameAddress(a?: string, b?: string): boolean {
+  if (!a || !b) return false;
+  return ethers.getAddress(a) === ethers.getAddress(b);
+}
+
+function formatToken(value: bigint, decimals: number, symbol: string): string {
+  return `${ethers.formatUnits(value, decimals)} ${symbol}`.trim();
+}
+
+function describeArgs(args: any[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'bigint') {
+        return arg.toString();
+      }
+      if (typeof arg === 'string') {
+        return arg;
+      }
+      if (typeof arg === 'boolean') {
+        return arg ? 'true' : 'false';
+      }
+      return JSON.stringify(arg);
+    })
+    .join(', ');
+}
+
+async function ensureModuleVersion(
+  address: string,
+  artifact: string,
+  label: string
+): Promise<void> {
+  const contract = await ethers.getContractAt(artifact, address);
+  const version = await contract.version();
+  if (version !== 2n) {
+    throw new Error(
+      `${label} at ${address} reports version ${version}, expected 2`
+    );
+  }
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const { config: tokenConfig } = loadTokenConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
+  const { config: stakeConfig, path: stakeConfigPath } = loadStakeManagerConfig(
+    {
+      network: network.name,
+      chainId: network.config?.chainId,
+      path: cli.configPath,
+    }
+  );
+
+  const decimals =
+    typeof tokenConfig.decimals === 'number' ? tokenConfig.decimals : 18;
+  const symbol =
+    typeof tokenConfig.symbol === 'string' && tokenConfig.symbol
+      ? tokenConfig.symbol
+      : 'tokens';
+
+  const stakeManagerCandidate =
+    cli.stakeManagerAddress || tokenConfig.modules?.stakeManager;
+  if (!stakeManagerCandidate) {
+    throw new Error('Stake manager address is not configured');
+  }
+  const stakeManagerAddress = ethers.getAddress(stakeManagerCandidate);
+  if (stakeManagerAddress === ethers.ZeroAddress) {
+    throw new Error('Stake manager address cannot be the zero address');
+  }
+
+  const stakeManager = (await ethers.getContractAt(
+    'contracts/v2/StakeManager.sol:StakeManager',
+    stakeManagerAddress
+  )) as Contract;
+
+  const signer = await ethers.getSigner();
+  const ownerAddress = await stakeManager.owner();
+  const signerAddress = await signer.getAddress();
+
+  if (cli.execute && !sameAddress(ownerAddress, signerAddress)) {
+    throw new Error(
+      `Signer ${signerAddress} is not the governance owner ${ownerAddress}`
+    );
+  }
+
+  if (!sameAddress(ownerAddress, signerAddress)) {
+    console.warn(
+      `Warning: connected signer ${signerAddress} is not the governance owner ${ownerAddress}. ` +
+        'Running in dry-run mode.'
+    );
+  }
+
+  const [
+    currentMinStake,
+    currentFeePct,
+    currentBurnPct,
+    currentValidatorRewardPct,
+    currentEmployerSlashPct,
+    currentTreasurySlashPct,
+    currentTreasury,
+    currentFeePool,
+    currentUnbondingPeriod,
+    currentMaxStakePerAddress,
+    currentAutoStakeEnabled,
+    currentDisputeThreshold,
+    currentIncreasePct,
+    currentDecreasePct,
+    currentWindow,
+    currentFloor,
+    currentMaxMinStake,
+    currentTempThreshold,
+    currentHamThreshold,
+    currentDisputeWeight,
+    currentTempWeight,
+    currentHamWeight,
+    currentThermostat,
+    currentHamiltonianFeed,
+    currentJobRegistry,
+    currentDisputeModule,
+    currentValidationModule,
+    currentPauser,
+    currentMaxAGITypes,
+    currentMaxTotalPayoutPct,
+    currentAGITypes,
+  ] = await Promise.all([
+    stakeManager.minStake(),
+    stakeManager.feePct(),
+    stakeManager.burnPct(),
+    stakeManager.validatorRewardPct(),
+    stakeManager.employerSlashPct(),
+    stakeManager.treasurySlashPct(),
+    stakeManager.treasury(),
+    stakeManager.feePool(),
+    stakeManager.unbondingPeriod(),
+    stakeManager.maxStakePerAddress(),
+    stakeManager.autoStakeTuning(),
+    stakeManager.stakeDisputeThreshold(),
+    stakeManager.stakeIncreasePct(),
+    stakeManager.stakeDecreasePct(),
+    stakeManager.stakeTuneWindow(),
+    stakeManager.minStakeFloor(),
+    stakeManager.maxMinStake(),
+    stakeManager.stakeTempThreshold(),
+    stakeManager.stakeHamiltonianThreshold(),
+    stakeManager.disputeWeight(),
+    stakeManager.temperatureWeight(),
+    stakeManager.hamiltonianWeight(),
+    stakeManager.thermostat(),
+    stakeManager.hamiltonianFeed(),
+    stakeManager.jobRegistry(),
+    stakeManager.disputeModule(),
+    stakeManager.validationModule(),
+    stakeManager.pauser(),
+    stakeManager.maxAGITypes(),
+    stakeManager.maxTotalPayoutPct(),
+    stakeManager.getAGITypes(),
+  ]);
+
+  const currentAgiTypeCount = Array.isArray(currentAGITypes)
+    ? currentAGITypes.length
+    : Number((currentAGITypes as any)?.length ?? 0);
+
+  const desiredMinStake = parseTokenValue(
+    stakeConfig.minStake,
+    stakeConfig.minStakeTokens,
+    decimals,
+    'minStake'
+  );
+  const desiredMaxStake = parseTokenValue(
+    stakeConfig.maxStakePerAddress,
+    stakeConfig.maxStakePerAddressTokens,
+    decimals,
+    'maxStakePerAddress'
+  );
+  const desiredFeePct = parsePercentage(stakeConfig.feePct, 'feePct');
+  const desiredBurnPct = parsePercentage(stakeConfig.burnPct, 'burnPct');
+  const desiredValidatorPct = parsePercentage(
+    stakeConfig.validatorRewardPct,
+    'validatorRewardPct'
+  );
+  const desiredEmployerSlashPct = parsePercentage(
+    stakeConfig.employerSlashPct,
+    'employerSlashPct'
+  );
+  const desiredTreasurySlashPct = parsePercentage(
+    stakeConfig.treasurySlashPct,
+    'treasurySlashPct'
+  );
+  const desiredUnbondingPeriod = parseInteger(
+    stakeConfig.unbondingPeriodSeconds,
+    'unbondingPeriodSeconds'
+  );
+
+  const recommendations = (stakeConfig.stakeRecommendations || {}) as Record<
+    string,
+    unknown
+  >;
+  const desiredRecMin = parseTokenValue(
+    recommendations.min,
+    recommendations.minTokens,
+    decimals,
+    'stakeRecommendations.min'
+  );
+  const desiredRecMax = parseTokenValue(
+    recommendations.max,
+    recommendations.maxTokens,
+    decimals,
+    'stakeRecommendations.max'
+  );
+
+  const autoConfig = (stakeConfig.autoStake || {}) as Record<string, unknown>;
+  const desiredAutoEnabled = parseBoolean(
+    autoConfig.enabled,
+    'autoStake.enabled'
+  );
+  const desiredAutoThreshold = parseInteger(
+    autoConfig.threshold,
+    'autoStake.threshold'
+  );
+  const desiredAutoIncrease = parsePercentage(
+    autoConfig.increasePct,
+    'autoStake.increasePct'
+  );
+  const desiredAutoDecrease = parsePercentage(
+    autoConfig.decreasePct,
+    'autoStake.decreasePct'
+  );
+  const desiredAutoWindow = parseInteger(
+    autoConfig.windowSeconds,
+    'autoStake.windowSeconds'
+  );
+  const desiredAutoFloor = parseTokenValue(
+    autoConfig.floor,
+    autoConfig.floorTokens,
+    decimals,
+    'autoStake.floor'
+  );
+  const desiredAutoCeil = parseTokenValue(
+    autoConfig.ceiling,
+    autoConfig.ceilingTokens,
+    decimals,
+    'autoStake.ceiling'
+  );
+  const desiredTempThreshold = parseSignedInteger(
+    autoConfig.temperatureThreshold,
+    'autoStake.temperatureThreshold'
+  );
+  const desiredHamThreshold = parseSignedInteger(
+    autoConfig.hamiltonianThreshold,
+    'autoStake.hamiltonianThreshold'
+  );
+  const desiredDisputeWeight = parseInteger(
+    autoConfig.disputeWeight,
+    'autoStake.disputeWeight'
+  );
+  const desiredTempWeight = parseInteger(
+    autoConfig.temperatureWeight,
+    'autoStake.temperatureWeight'
+  );
+  const desiredHamWeight = parseInteger(
+    autoConfig.hamiltonianWeight,
+    'autoStake.hamiltonianWeight'
+  );
+
+  const desiredTreasury =
+    stakeConfig.treasury !== undefined
+      ? ethers.getAddress(stakeConfig.treasury as string)
+      : undefined;
+  const desiredPauser =
+    stakeConfig.pauser !== undefined
+      ? ethers.getAddress(stakeConfig.pauser as string)
+      : undefined;
+  const desiredThermostat =
+    stakeConfig.thermostat !== undefined
+      ? ethers.getAddress(stakeConfig.thermostat as string)
+      : undefined;
+  const desiredHamiltonianFeed =
+    stakeConfig.hamiltonianFeed !== undefined
+      ? ethers.getAddress(stakeConfig.hamiltonianFeed as string)
+      : undefined;
+  const desiredJobRegistry =
+    stakeConfig.jobRegistry !== undefined &&
+    stakeConfig.jobRegistry !== ethers.ZeroAddress
+      ? ethers.getAddress(stakeConfig.jobRegistry as string)
+      : undefined;
+  const desiredDisputeModule =
+    stakeConfig.disputeModule !== undefined &&
+    stakeConfig.disputeModule !== ethers.ZeroAddress
+      ? ethers.getAddress(stakeConfig.disputeModule as string)
+      : undefined;
+  const desiredValidationModule =
+    stakeConfig.validationModule !== undefined &&
+    stakeConfig.validationModule !== ethers.ZeroAddress
+      ? ethers.getAddress(stakeConfig.validationModule as string)
+      : undefined;
+  const desiredFeePool =
+    stakeConfig.feePool !== undefined &&
+    stakeConfig.feePool !== ethers.ZeroAddress
+      ? ethers.getAddress(stakeConfig.feePool as string)
+      : undefined;
+
+  const desiredMaxAGITypes =
+    stakeConfig.maxAGITypes !== undefined
+      ? Number(stakeConfig.maxAGITypes)
+      : undefined;
+  const desiredMaxTotalPayoutPct =
+    stakeConfig.maxTotalPayoutPct !== undefined
+      ? Number(stakeConfig.maxTotalPayoutPct)
+      : undefined;
+
+  const actions: PlannedAction[] = [];
+  const percentageActions: Array<PlannedAction & { delta: number }> = [];
+
+  const currentTreasuryAddress =
+    currentTreasury === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentTreasury);
+  if (
+    desiredTreasury !== undefined &&
+    !sameAddress(desiredTreasury, currentTreasuryAddress)
+  ) {
+    if (
+      desiredTreasury !== ethers.ZeroAddress &&
+      sameAddress(desiredTreasury, ownerAddress)
+    ) {
+      throw new Error('Treasury cannot be set to the owner address');
+    }
+    actions.push({
+      label: `Update treasury to ${desiredTreasury}`,
+      method: 'setTreasury',
+      args: [desiredTreasury],
+      current: currentTreasuryAddress,
+      desired: desiredTreasury,
+      notes: [
+        'Passing the zero address burns the treasury share of slashed stake.',
+      ],
+    });
+  }
+
+  const allowlist = (stakeConfig.treasuryAllowlist || {}) as Record<
+    string,
+    boolean
+  >;
+  const sortedAllowlist = Object.keys(allowlist).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  for (const addr of sortedAllowlist) {
+    const desired = Boolean(allowlist[addr]);
+    const current = await stakeManager.treasuryAllowlist(addr);
+    if (current !== desired) {
+      actions.push({
+        label: `${desired ? 'Allow' : 'Block'} treasury ${addr}`,
+        method: 'setTreasuryAllowlist',
+        args: [addr, desired],
+        current: current ? 'allowed' : 'blocked',
+        desired: desired ? 'allowed' : 'blocked',
+      });
+    }
+  }
+
+  const currentPauserAddress =
+    currentPauser === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentPauser);
+  if (
+    desiredPauser !== undefined &&
+    !sameAddress(desiredPauser, currentPauserAddress)
+  ) {
+    actions.push({
+      label: `Update pauser to ${desiredPauser}`,
+      method: 'setPauser',
+      args: [desiredPauser],
+      current: currentPauserAddress,
+      desired: desiredPauser,
+    });
+  }
+
+  if (
+    desiredThermostat !== undefined &&
+    !sameAddress(desiredThermostat, currentThermostat)
+  ) {
+    actions.push({
+      label: `Update thermostat to ${desiredThermostat}`,
+      method: 'setThermostat',
+      args: [desiredThermostat],
+      current: ethers.getAddress(currentThermostat),
+      desired: desiredThermostat,
+    });
+  }
+
+  if (
+    desiredHamiltonianFeed !== undefined &&
+    !sameAddress(desiredHamiltonianFeed, currentHamiltonianFeed)
+  ) {
+    actions.push({
+      label: `Update Hamiltonian feed to ${desiredHamiltonianFeed}`,
+      method: 'setHamiltonianFeed',
+      args: [desiredHamiltonianFeed],
+      current: ethers.getAddress(currentHamiltonianFeed),
+      desired: desiredHamiltonianFeed,
+    });
+  }
+
+  if (desiredJobRegistry) {
+    await ensureModuleVersion(
+      desiredJobRegistry,
+      'contracts/v2/interfaces/IJobRegistry.sol:IJobRegistry',
+      'JobRegistry'
+    );
+    const currentJobRegistryAddress =
+      currentJobRegistry === ethers.ZeroAddress
+        ? ethers.ZeroAddress
+        : ethers.getAddress(currentJobRegistry);
+    if (!sameAddress(desiredJobRegistry, currentJobRegistryAddress)) {
+      actions.push({
+        label: `Update JobRegistry to ${desiredJobRegistry}`,
+        method: 'setJobRegistry',
+        args: [desiredJobRegistry],
+        current: currentJobRegistryAddress,
+        desired: desiredJobRegistry,
+      });
+    }
+  }
+
+  if (desiredDisputeModule) {
+    await ensureModuleVersion(
+      desiredDisputeModule,
+      'contracts/v2/interfaces/IDisputeModule.sol:IDisputeModule',
+      'DisputeModule'
+    );
+    const currentDisputeModuleAddress =
+      currentDisputeModule === ethers.ZeroAddress
+        ? ethers.ZeroAddress
+        : ethers.getAddress(currentDisputeModule);
+    if (!sameAddress(desiredDisputeModule, currentDisputeModuleAddress)) {
+      actions.push({
+        label: `Update DisputeModule to ${desiredDisputeModule}`,
+        method: 'setDisputeModule',
+        args: [desiredDisputeModule],
+        current: currentDisputeModuleAddress,
+        desired: desiredDisputeModule,
+      });
+    }
+  }
+
+  if (desiredValidationModule) {
+    await ensureModuleVersion(
+      desiredValidationModule,
+      'contracts/v2/interfaces/IValidationModule.sol:IValidationModule',
+      'ValidationModule'
+    );
+    const currentValidationModuleAddress = ethers.getAddress(
+      currentValidationModule
+    );
+    if (!sameAddress(desiredValidationModule, currentValidationModuleAddress)) {
+      actions.push({
+        label: `Update ValidationModule to ${desiredValidationModule}`,
+        method: 'setValidationModule',
+        args: [desiredValidationModule],
+        current: currentValidationModuleAddress,
+        desired: desiredValidationModule,
+      });
+    }
+  }
+
+  if (desiredFeePool) {
+    await ensureModuleVersion(
+      desiredFeePool,
+      'contracts/v2/interfaces/IFeePool.sol:IFeePool',
+      'FeePool'
+    );
+    const currentFeePoolAddress =
+      currentFeePool === ethers.ZeroAddress
+        ? ethers.ZeroAddress
+        : ethers.getAddress(currentFeePool);
+    if (!sameAddress(desiredFeePool, currentFeePoolAddress)) {
+      actions.push({
+        label: `Update FeePool to ${desiredFeePool}`,
+        method: 'setFeePool',
+        args: [desiredFeePool],
+        current: currentFeePoolAddress,
+        desired: desiredFeePool,
+        notes: ['FeePool must expose version() == 2.'],
+      });
+    }
+  }
+
+  const currentMinStakeValue = currentMinStake as bigint;
+  let minStakeHandledByRecommendations = false;
+
+  const currentMaxStakeValue = currentMaxStakePerAddress as bigint;
+  const recConfigured =
+    desiredRecMin !== undefined || desiredRecMax !== undefined;
+  if (recConfigured) {
+    const targetMin = desiredRecMin ?? currentMinStakeValue;
+    const targetMax = desiredRecMax ?? currentMaxStakeValue;
+    if (targetMin <= 0n) {
+      throw new Error('stakeRecommendations.min must be greater than zero');
+    }
+    if (targetMax !== 0n && targetMax < targetMin) {
+      throw new Error('stakeRecommendations.max cannot be below min');
+    }
+    if (
+      targetMin !== currentMinStakeValue ||
+      targetMax !== currentMaxStakeValue
+    ) {
+      actions.push({
+        label: `Set stake recommendations to min ${formatToken(
+          targetMin,
+          decimals,
+          symbol
+        )}, max ${
+          targetMax === 0n
+            ? 'disabled'
+            : formatToken(targetMax, decimals, symbol)
+        }`,
+        method: 'setStakeRecommendations',
+        args: [targetMin, targetMax],
+        current: `min ${formatToken(
+          currentMinStakeValue,
+          decimals,
+          symbol
+        )}, max ${
+          currentMaxStakeValue === 0n
+            ? 'disabled'
+            : formatToken(currentMaxStakeValue, decimals, symbol)
+        }`,
+        desired: `min ${formatToken(targetMin, decimals, symbol)}, max ${
+          targetMax === 0n
+            ? 'disabled'
+            : formatToken(targetMax, decimals, symbol)
+        }`,
+      });
+      if (desiredRecMin !== undefined) {
+        minStakeHandledByRecommendations = true;
+      }
+    }
+  }
+
+  if (
+    desiredMinStake !== undefined &&
+    !minStakeHandledByRecommendations &&
+    desiredMinStake !== currentMinStakeValue
+  ) {
+    if (desiredMinStake <= 0n) {
+      throw new Error('minStake must be greater than zero');
+    }
+    actions.push({
+      label: `Update minimum stake to ${formatToken(
+        desiredMinStake,
+        decimals,
+        symbol
+      )}`,
+      method: 'setMinStake',
+      args: [desiredMinStake],
+      current: formatToken(currentMinStakeValue, decimals, symbol),
+      desired: formatToken(desiredMinStake, decimals, symbol),
+    });
+  }
+
+  if (
+    desiredMaxStake !== undefined &&
+    desiredMaxStake !== currentMaxStakeValue
+  ) {
+    if (desiredMaxStake !== 0n && desiredMaxStake < currentMinStakeValue) {
+      throw new Error(
+        'maxStakePerAddress cannot be below the current minimum stake'
+      );
+    }
+    actions.push({
+      label: `Update max stake per address to ${
+        desiredMaxStake === 0n
+          ? 'disabled'
+          : formatToken(desiredMaxStake, decimals, symbol)
+      }`,
+      method: 'setMaxStakePerAddress',
+      args: [desiredMaxStake],
+      current:
+        currentMaxStakeValue === 0n
+          ? 'disabled'
+          : formatToken(currentMaxStakeValue, decimals, symbol),
+      desired:
+        desiredMaxStake === 0n
+          ? 'disabled'
+          : formatToken(desiredMaxStake, decimals, symbol),
+    });
+  }
+
+  const currentFee = Number(currentFeePct);
+  const currentBurn = Number(currentBurnPct);
+  const currentValidator = Number(currentValidatorRewardPct);
+
+  const targetFee = desiredFeePct ?? currentFee;
+  const targetBurn = desiredBurnPct ?? currentBurn;
+  const targetValidator = desiredValidatorPct ?? currentValidator;
+
+  if (targetFee + targetBurn + targetValidator > 100) {
+    throw new Error('feePct + burnPct + validatorRewardPct cannot exceed 100');
+  }
+
+  if (desiredFeePct !== undefined && desiredFeePct !== currentFee) {
+    percentageActions.push({
+      label: `Update protocol fee percentage to ${desiredFeePct}%`,
+      method: 'setFeePct',
+      args: [desiredFeePct],
+      current: `${currentFee}%`,
+      desired: `${desiredFeePct}%`,
+      delta: desiredFeePct - currentFee,
+    });
+  }
+
+  if (desiredBurnPct !== undefined && desiredBurnPct !== currentBurn) {
+    percentageActions.push({
+      label: `Update burn percentage to ${desiredBurnPct}%`,
+      method: 'setBurnPct',
+      args: [desiredBurnPct],
+      current: `${currentBurn}%`,
+      desired: `${desiredBurnPct}%`,
+      delta: desiredBurnPct - currentBurn,
+    });
+  }
+
+  if (
+    desiredValidatorPct !== undefined &&
+    desiredValidatorPct !== currentValidator
+  ) {
+    percentageActions.push({
+      label: `Update validator reward percentage to ${desiredValidatorPct}%`,
+      method: 'setValidatorRewardPct',
+      args: [desiredValidatorPct],
+      current: `${currentValidator}%`,
+      desired: `${desiredValidatorPct}%`,
+      delta: desiredValidatorPct - currentValidator,
+    });
+  }
+
+  percentageActions.sort((a, b) => a.delta - b.delta);
+  actions.push(...percentageActions);
+
+  if (
+    desiredEmployerSlashPct !== undefined ||
+    desiredTreasurySlashPct !== undefined
+  ) {
+    const employerTarget =
+      desiredEmployerSlashPct ?? Number(currentEmployerSlashPct);
+    const treasuryTarget =
+      desiredTreasurySlashPct ?? Number(currentTreasurySlashPct);
+    if (employerTarget + treasuryTarget > 100) {
+      throw new Error('employerSlashPct + treasurySlashPct cannot exceed 100');
+    }
+    const currentEmployer = Number(currentEmployerSlashPct);
+    const currentTreasuryPct = Number(currentTreasurySlashPct);
+    if (
+      employerTarget !== currentEmployer ||
+      treasuryTarget !== currentTreasuryPct
+    ) {
+      actions.push({
+        label: `Update slashing percentages (employer ${employerTarget}%, treasury ${treasuryTarget}%)`,
+        method: 'setSlashingPercentages',
+        args: [employerTarget, treasuryTarget],
+        current: `employer ${currentEmployer}%, treasury ${currentTreasuryPct}%`,
+        desired: `employer ${employerTarget}%, treasury ${treasuryTarget}%`,
+        notes: ['Employer + treasury percentages must not exceed 100%.'],
+      });
+    }
+  }
+
+  if (
+    desiredUnbondingPeriod !== undefined &&
+    desiredUnbondingPeriod !== (currentUnbondingPeriod as bigint)
+  ) {
+    if (desiredUnbondingPeriod <= 0n) {
+      throw new Error('unbondingPeriodSeconds must be greater than zero');
+    }
+    actions.push({
+      label: `Update unbonding period to ${desiredUnbondingPeriod.toString()} seconds`,
+      method: 'setUnbondingPeriod',
+      args: [desiredUnbondingPeriod],
+      current: `${(currentUnbondingPeriod as bigint).toString()} seconds`,
+      desired: `${desiredUnbondingPeriod.toString()} seconds`,
+    });
+  }
+
+  const currentAutoEnabled = Boolean(currentAutoStakeEnabled);
+  if (
+    desiredAutoEnabled !== undefined &&
+    desiredAutoEnabled !== currentAutoEnabled
+  ) {
+    actions.push({
+      label: `${
+        desiredAutoEnabled ? 'Enable' : 'Disable'
+      } automatic stake tuning`,
+      method: 'autoTuneStakes',
+      args: [desiredAutoEnabled],
+      current: currentAutoEnabled ? 'enabled' : 'disabled',
+      desired: desiredAutoEnabled ? 'enabled' : 'disabled',
+    });
+  }
+
+  const autoTargets = {
+    threshold: desiredAutoThreshold ?? (currentDisputeThreshold as bigint),
+    increase: desiredAutoIncrease ?? Number(currentIncreasePct),
+    decrease: desiredAutoDecrease ?? Number(currentDecreasePct),
+    window: desiredAutoWindow ?? (currentWindow as bigint),
+    floor: desiredAutoFloor ?? (currentFloor as bigint),
+    ceil: desiredAutoCeil ?? (currentMaxMinStake as bigint),
+    tempThreshold: desiredTempThreshold ?? (currentTempThreshold as bigint),
+    hamThreshold: desiredHamThreshold ?? (currentHamThreshold as bigint),
+    disputeWeight: desiredDisputeWeight ?? (currentDisputeWeight as bigint),
+    tempWeight: desiredTempWeight ?? (currentTempWeight as bigint),
+    hamWeight: desiredHamWeight ?? (currentHamWeight as bigint),
+  };
+
+  if (autoTargets.increase < 0 || autoTargets.increase > 100) {
+    throw new Error('autoStake.increasePct must be between 0 and 100');
+  }
+  if (autoTargets.decrease < 0 || autoTargets.decrease > 100) {
+    throw new Error('autoStake.decreasePct must be between 0 and 100');
+  }
+
+  const autoChanged =
+    (desiredAutoThreshold !== undefined &&
+      desiredAutoThreshold !== (currentDisputeThreshold as bigint)) ||
+    (desiredAutoIncrease !== undefined &&
+      desiredAutoIncrease !== Number(currentIncreasePct)) ||
+    (desiredAutoDecrease !== undefined &&
+      desiredAutoDecrease !== Number(currentDecreasePct)) ||
+    (desiredAutoWindow !== undefined &&
+      desiredAutoWindow !== (currentWindow as bigint)) ||
+    (desiredAutoFloor !== undefined &&
+      desiredAutoFloor !== (currentFloor as bigint)) ||
+    (desiredAutoCeil !== undefined &&
+      desiredAutoCeil !== (currentMaxMinStake as bigint)) ||
+    (desiredTempThreshold !== undefined &&
+      desiredTempThreshold !== (currentTempThreshold as bigint)) ||
+    (desiredHamThreshold !== undefined &&
+      desiredHamThreshold !== (currentHamThreshold as bigint)) ||
+    (desiredDisputeWeight !== undefined &&
+      desiredDisputeWeight !== (currentDisputeWeight as bigint)) ||
+    (desiredTempWeight !== undefined &&
+      desiredTempWeight !== (currentTempWeight as bigint)) ||
+    (desiredHamWeight !== undefined &&
+      desiredHamWeight !== (currentHamWeight as bigint));
+
+  if (autoChanged) {
+    actions.push({
+      label: 'Update automatic stake tuning parameters',
+      method: 'configureAutoStake',
+      args: [
+        autoTargets.threshold,
+        autoTargets.increase,
+        autoTargets.decrease,
+        autoTargets.window,
+        autoTargets.floor,
+        autoTargets.ceil,
+        autoTargets.tempThreshold,
+        autoTargets.hamThreshold,
+        autoTargets.disputeWeight,
+        autoTargets.tempWeight,
+        autoTargets.hamWeight,
+      ],
+      notes: [
+        'Floor values of 0 keep the current minimum stake floor.',
+        'Ceiling of 0 disables the cap.',
+      ],
+    });
+  }
+
+  if (desiredMaxAGITypes !== undefined) {
+    if (!Number.isInteger(desiredMaxAGITypes) || desiredMaxAGITypes <= 0) {
+      throw new Error('maxAGITypes must be a positive integer');
+    }
+    if (desiredMaxAGITypes > MAX_AGI_TYPES_CAP) {
+      throw new Error(`maxAGITypes cannot exceed ${MAX_AGI_TYPES_CAP}`);
+    }
+    if (desiredMaxAGITypes < currentAgiTypeCount) {
+      throw new Error(
+        `maxAGITypes cannot be below the current AGI type count (${currentAgiTypeCount})`
+      );
+    }
+    const currentMaxAgi = Number(currentMaxAGITypes);
+    if (desiredMaxAGITypes !== currentMaxAgi) {
+      actions.push({
+        label: `Update max AGI types to ${desiredMaxAGITypes}`,
+        method: 'setMaxAGITypes',
+        args: [desiredMaxAGITypes],
+        current: currentMaxAgi.toString(),
+        desired: desiredMaxAGITypes.toString(),
+      });
+    }
+  }
+
+  if (desiredMaxTotalPayoutPct !== undefined) {
+    if (!Number.isInteger(desiredMaxTotalPayoutPct)) {
+      throw new Error('maxTotalPayoutPct must be an integer');
+    }
+    if (
+      desiredMaxTotalPayoutPct < 100 ||
+      desiredMaxTotalPayoutPct > MAX_PAYOUT_PCT
+    ) {
+      throw new Error(
+        `maxTotalPayoutPct must be between 100 and ${MAX_PAYOUT_PCT}`
+      );
+    }
+    const currentMaxTotal = Number(currentMaxTotalPayoutPct);
+    if (desiredMaxTotalPayoutPct !== currentMaxTotal) {
+      actions.push({
+        label: `Update max total payout percentage to ${desiredMaxTotalPayoutPct}%`,
+        method: 'setMaxTotalPayoutPct',
+        args: [desiredMaxTotalPayoutPct],
+        current: `${currentMaxTotal}%`,
+        desired: `${desiredMaxTotalPayoutPct}%`,
+      });
+    }
+  }
+
+  console.log('StakeManager:', stakeManagerAddress);
+  console.log('Configuration file:', stakeConfigPath);
+
+  if (actions.length === 0) {
+    console.log('All tracked parameters already match the configuration.');
+    return;
+  }
+
+  console.log(`Planned actions (${actions.length}):`);
+  const iface = stakeManager.interface;
+  actions.forEach((action, index) => {
+    const data = iface.encodeFunctionData(action.method, action.args);
+    console.log(`\n${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      console.log(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      console.log(`   Desired: ${action.desired}`);
+    }
+    if (action.notes) {
+      for (const note of action.notes) {
+        console.log(`   Note: ${note}`);
+      }
+    }
+    console.log(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    console.log(`   Calldata: ${data}`);
+  });
+
+  if (!cli.execute || !sameAddress(ownerAddress, signerAddress)) {
+    console.log(
+      '\nDry run complete. Re-run with --execute once ready to submit transactions.'
+    );
+    return;
+  }
+
+  console.log('\nSubmitting transactions...');
+  for (const action of actions) {
+    console.log(`Executing ${action.method}...`);
+    const tx = await (stakeManager as any)[action.method](...action.args);
+    console.log(`   Tx hash: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (receipt?.status !== 1n) {
+      throw new Error(`Transaction for ${action.method} failed`);
+    }
+    console.log('   Confirmed');
+  }
+  console.log('All transactions confirmed.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add stake-manager config loader alongside a hardhat helper for governance-controlled updates
- document the workflow and provide a default stake-manager configuration file
- link the new guide from the main documentation index

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a2cb984c83339eb9bd5c6527b281