### PR TITLE
Enforce SystemPause module ownership before rewiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ npx hardhat run scripts/v2/deployDefaults.ts --network <network> --governance <a
 
 Provide `--governance` to assign a multisig or timelock owner. Include `--no-tax` to skip deploying `TaxPolicy`.
 
+### System pause maintenance
+
+`SystemPause.setModules` now validates that every module has already transferred ownership or governance to the pause contract before it rewires addresses. This prevents accidentally wiring in contracts that cannot be paused during an emergency. When swapping modules, transfer ownership to the deployed `SystemPause` address first, then run the helper script:
+
+```bash
+npx hardhat run scripts/v2/updateSystemPause.ts --network <network>
+```
+
+The script performs a dry run by default, reporting any address, ownership or pauser mismatches. Re-run with `--execute` once all modules report `owner == SystemPause` to apply the wiring transaction safely.
+
 ### Mainnet Deployment
 
 For a step-by-step mainnet deployment using Truffle, see the [Deploying AGIJobs v2 to Ethereum Mainnet (CLI Guide)](docs/deploying-agijobs-v2-truffle-cli.md).

--- a/contracts/v2/SystemPause.sol
+++ b/contracts/v2/SystemPause.sol
@@ -33,6 +33,7 @@ contract SystemPause is Governable, ReentrancyGuard {
     error InvalidFeePool(address module);
     error InvalidReputationEngine(address module);
     error InvalidArbitratorCommittee(address module);
+    error ModuleNotOwned(address module, address owner);
 
     event ModulesUpdated(
         address jobRegistry,
@@ -138,6 +139,17 @@ contract SystemPause is Governable, ReentrancyGuard {
             address(_arbitratorCommittee).code.length == 0
         ) revert InvalidArbitratorCommittee(address(_arbitratorCommittee));
 
+        _requireModuleOwnership(
+            _jobRegistry,
+            _stakeManager,
+            _validationModule,
+            _disputeModule,
+            _platformRegistry,
+            _feePool,
+            _reputationEngine,
+            _arbitratorCommittee
+        );
+
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
         validationModule = _validationModule;
@@ -192,6 +204,51 @@ contract SystemPause is Governable, ReentrancyGuard {
         feePool.setPauser(address(this));
         reputationEngine.setPauser(address(this));
         arbitratorCommittee.setPauser(address(this));
+    }
+
+    function _requireModuleOwnership(
+        JobRegistry _jobRegistry,
+        StakeManager _stakeManager,
+        ValidationModule _validationModule,
+        DisputeModule _disputeModule,
+        PlatformRegistry _platformRegistry,
+        FeePool _feePool,
+        ReputationEngine _reputationEngine,
+        ArbitratorCommittee _arbitratorCommittee
+    ) internal view {
+        if (_jobRegistry.owner() != address(this)) {
+            revert ModuleNotOwned(address(_jobRegistry), _jobRegistry.owner());
+        }
+        if (_stakeManager.owner() != address(this)) {
+            revert ModuleNotOwned(address(_stakeManager), _stakeManager.owner());
+        }
+        if (_validationModule.owner() != address(this)) {
+            revert ModuleNotOwned(address(_validationModule), _validationModule.owner());
+        }
+        if (_disputeModule.owner() != address(this)) {
+            revert ModuleNotOwned(address(_disputeModule), _disputeModule.owner());
+        }
+        if (_platformRegistry.owner() != address(this)) {
+            revert ModuleNotOwned(
+                address(_platformRegistry),
+                _platformRegistry.owner()
+            );
+        }
+        if (_feePool.owner() != address(this)) {
+            revert ModuleNotOwned(address(_feePool), _feePool.owner());
+        }
+        if (_reputationEngine.owner() != address(this)) {
+            revert ModuleNotOwned(
+                address(_reputationEngine),
+                _reputationEngine.owner()
+            );
+        }
+        if (_arbitratorCommittee.owner() != address(this)) {
+            revert ModuleNotOwned(
+                address(_arbitratorCommittee),
+                _arbitratorCommittee.owner()
+            );
+        }
     }
 }
 

--- a/scripts/v2/updateSystemPause.ts
+++ b/scripts/v2/updateSystemPause.ts
@@ -1,0 +1,354 @@
+import fs from 'fs';
+import path from 'path';
+import { ethers, network } from 'hardhat';
+import type { Contract } from 'ethers';
+import { loadTokenConfig } from '../config';
+
+type ModuleKey =
+  | 'jobRegistry'
+  | 'stakeManager'
+  | 'validationModule'
+  | 'disputeModule'
+  | 'platformRegistry'
+  | 'feePool'
+  | 'reputationEngine'
+  | 'arbitratorCommittee';
+
+type ModuleAddresses = Record<ModuleKey, string>;
+
+type ModuleConfig = Partial<Record<ModuleKey, string>> & {
+  systemPause?: string;
+};
+
+interface CliOptions {
+  execute: boolean;
+  configPath?: string;
+  pauseAddress?: string;
+  overrides: Partial<Record<ModuleKey, string>>;
+  forceRefresh: boolean;
+  skipRefresh: boolean;
+}
+
+interface PlannedAction {
+  label: string;
+  method: string;
+  args: any[];
+  contract: Contract;
+  notes?: string[];
+}
+
+const MODULE_KEYS: ModuleKey[] = [
+  'jobRegistry',
+  'stakeManager',
+  'validationModule',
+  'disputeModule',
+  'platformRegistry',
+  'feePool',
+  'reputationEngine',
+  'arbitratorCommittee',
+];
+
+const FLAG_TO_KEY = new Map<string, ModuleKey>([
+  ['--job-registry', 'jobRegistry'],
+  ['--jobRegistry', 'jobRegistry'],
+  ['--stake-manager', 'stakeManager'],
+  ['--stakeManager', 'stakeManager'],
+  ['--validation-module', 'validationModule'],
+  ['--validationModule', 'validationModule'],
+  ['--dispute-module', 'disputeModule'],
+  ['--disputeModule', 'disputeModule'],
+  ['--platform-registry', 'platformRegistry'],
+  ['--platformRegistry', 'platformRegistry'],
+  ['--fee-pool', 'feePool'],
+  ['--feePool', 'feePool'],
+  ['--reputation-engine', 'reputationEngine'],
+  ['--reputationEngine', 'reputationEngine'],
+  ['--arbitrator-committee', 'arbitratorCommittee'],
+  ['--arbitratorCommittee', 'arbitratorCommittee'],
+]);
+
+const OWNER_AND_PAUSER_ABI = [
+  'function owner() view returns (address)',
+  'function pauser() view returns (address)',
+];
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    execute: false,
+    overrides: {},
+    forceRefresh: false,
+    skipRefresh: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--execute') {
+      options.execute = true;
+      continue;
+    }
+    if (arg === '--config') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--config requires a file path');
+      }
+      options.configPath = value;
+      i += 1;
+      continue;
+    }
+    if (arg === '--pause' || arg === '--system-pause' || arg === '--systemPause') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--pause requires an address');
+      }
+      options.pauseAddress = value;
+      i += 1;
+      continue;
+    }
+    if (arg === '--refresh') {
+      options.forceRefresh = true;
+      continue;
+    }
+    if (arg === '--no-refresh') {
+      options.skipRefresh = true;
+      continue;
+    }
+    const key = FLAG_TO_KEY.get(arg);
+    if (key) {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error(`${arg} requires an address`);
+      }
+      options.overrides[key] = value;
+      i += 1;
+    }
+  }
+
+  if (options.forceRefresh && options.skipRefresh) {
+    throw new Error('Cannot use --refresh and --no-refresh together');
+  }
+
+  return options;
+}
+
+function ensureAddress(value: string | undefined, label: string): string {
+  if (!value) {
+    throw new Error(`${label} is not configured`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${label} is not configured`);
+  }
+  const prefixed = trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`;
+  const address = ethers.getAddress(prefixed);
+  if (address === ethers.ZeroAddress) {
+    throw new Error(`${label} cannot be the zero address`);
+  }
+  return address;
+}
+
+function sameAddress(a?: string, b?: string): boolean {
+  if (!a || !b) return false;
+  return ethers.getAddress(a) === ethers.getAddress(b);
+}
+
+function readModuleConfig(filePath: string): ModuleConfig {
+  const resolved = path.resolve(filePath);
+  const raw = JSON.parse(fs.readFileSync(resolved, 'utf8')) as Record<string, any>;
+  const modules = (raw.modules && typeof raw.modules === 'object') ? raw.modules : {};
+  const result: ModuleConfig = {};
+
+  for (const key of MODULE_KEYS) {
+    const value = raw[key] ?? modules[key];
+    if (typeof value === 'string' && value.trim()) {
+      result[key] = value;
+    }
+  }
+
+  const pauseValue = raw.systemPause ?? modules.systemPause ?? raw.system_pause;
+  if (typeof pauseValue === 'string' && pauseValue.trim()) {
+    result.systemPause = pauseValue;
+  }
+
+  return result;
+}
+
+function describeArgs(args: any[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'bigint') return arg.toString();
+      if (typeof arg === 'string') return arg;
+      if (typeof arg === 'boolean') return arg ? 'true' : 'false';
+      return JSON.stringify(arg);
+    })
+    .join(', ');
+}
+
+async function executeActions(actions: PlannedAction[], execute: boolean): Promise<void> {
+  if (!actions.length) {
+    console.log('No changes required.');
+    return;
+  }
+
+  console.log('\nPlanned actions:');
+  for (const action of actions) {
+    const lines = [`- ${action.label}: ${action.method}(${describeArgs(action.args)})`];
+    if (action.notes && action.notes.length) {
+      for (const note of action.notes) {
+        lines.push(`    note: ${note}`);
+      }
+    }
+    console.log(lines.join('\n'));
+  }
+
+  if (!execute) {
+    console.log('\nDry run complete. Re-run with --execute to apply changes.');
+    return;
+  }
+
+  for (const action of actions) {
+    console.log(`\nExecuting ${action.label}...`);
+    const tx = await (action.contract as any)[action.method](...action.args);
+    console.log(`  tx: ${tx.hash}`);
+    await tx.wait();
+    console.log('  confirmed');
+  }
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const { config: tokenConfig } = loadTokenConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
+
+  const configModules: ModuleConfig = cli.configPath
+    ? readModuleConfig(cli.configPath)
+    : {};
+
+  const modules: ModuleAddresses = {} as ModuleAddresses;
+  for (const key of MODULE_KEYS) {
+    const candidate =
+      cli.overrides[key] ??
+      configModules[key] ??
+      (tokenConfig.modules && typeof tokenConfig.modules[key] === 'string'
+        ? (tokenConfig.modules[key] as string)
+        : undefined);
+    modules[key] = ensureAddress(candidate, `${key} address`);
+  }
+
+  const pauseAddressCandidate =
+    cli.pauseAddress ??
+    configModules.systemPause ??
+    (tokenConfig.modules && typeof tokenConfig.modules.systemPause === 'string'
+      ? (tokenConfig.modules.systemPause as string)
+      : undefined);
+  const pauseAddress = ensureAddress(pauseAddressCandidate, 'SystemPause address');
+
+  const pause = await ethers.getContractAt(
+    'contracts/v2/SystemPause.sol:SystemPause',
+    pauseAddress
+  );
+  const signer = await ethers.getSigner();
+  const signerAddress = await signer.getAddress();
+  const ownerAddress = await pause.owner();
+  if (cli.execute && !sameAddress(ownerAddress, signerAddress)) {
+    throw new Error(
+      `Signer ${signerAddress} is not the governance owner (${ownerAddress}) of SystemPause`
+    );
+  }
+
+  const current: ModuleAddresses = {
+    jobRegistry: await pause.jobRegistry(),
+    stakeManager: await pause.stakeManager(),
+    validationModule: await pause.validationModule(),
+    disputeModule: await pause.disputeModule(),
+    platformRegistry: await pause.platformRegistry(),
+    feePool: await pause.feePool(),
+    reputationEngine: await pause.reputationEngine(),
+    arbitratorCommittee: await pause.arbitratorCommittee(),
+  };
+
+  const differences: ModuleKey[] = [];
+  for (const key of MODULE_KEYS) {
+    if (!sameAddress(current[key], modules[key])) {
+      differences.push(key);
+    }
+  }
+
+  const ownershipIssues: string[] = [];
+  const pauserIssues: string[] = [];
+
+  for (const key of MODULE_KEYS) {
+    const target = modules[key];
+    const inspection = new ethers.Contract(target, OWNER_AND_PAUSER_ABI, ethers.provider);
+    let owner: string;
+    try {
+      owner = await inspection.owner();
+    } catch (error) {
+      ownershipIssues.push(`${key}: owner() not available`);
+      continue;
+    }
+    if (!sameAddress(owner, pauseAddress)) {
+      ownershipIssues.push(`${key}: owner is ${owner}`);
+    }
+
+    try {
+      const pauser = await inspection.pauser();
+      if (!sameAddress(pauser, pauseAddress)) {
+        pauserIssues.push(`${key}: pauser is ${pauser}`);
+      }
+    } catch (error) {
+      pauserIssues.push(`${key}: pauser() not available`);
+    }
+  }
+
+  if (ownershipIssues.length) {
+    console.warn('\nOwnership mismatches detected:');
+    for (const note of ownershipIssues) {
+      console.warn(` - ${note}`);
+    }
+    if (cli.execute) {
+      throw new Error('Resolve ownership mismatches before executing wiring updates.');
+    }
+  }
+
+  if (pauserIssues.length) {
+    console.warn('\nPauser mismatches detected:');
+    for (const note of pauserIssues) {
+      console.warn(` - ${note}`);
+    }
+  }
+
+  const actions: PlannedAction[] = [];
+  const shouldUpdateModules =
+    differences.length > 0 || (!cli.skipRefresh && (cli.forceRefresh || pauserIssues.length > 0));
+
+  if (shouldUpdateModules) {
+    const notes: string[] = [];
+    if (differences.length) {
+      for (const key of differences) {
+        notes.push(`${key}: ${current[key]} -> ${modules[key]}`);
+      }
+    }
+    if (!differences.length && pauserIssues.length) {
+      notes.push('No address changes detected; reapplying pauser roles to SystemPause.');
+    }
+    if (ownershipIssues.length) {
+      notes.push('Action will revert until ownership is transferred to SystemPause.');
+    }
+    actions.push({
+      label: 'Update SystemPause module wiring',
+      method: 'setModules',
+      args: MODULE_KEYS.map((key) => modules[key]),
+      contract: pause,
+      notes,
+    });
+  }
+
+  await executeActions(actions, cli.execute);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/v2/SystemPause.test.js
+++ b/test/v2/SystemPause.test.js
@@ -2,125 +2,164 @@ const { expect } = require('chai');
 const { ethers, artifacts, network } = require('hardhat');
 const { AGIALPHA } = require('../../scripts/constants');
 
+async function deploySystem(governanceAddress) {
+  const Deployer = await ethers.getContractFactory(
+    'contracts/v2/Deployer.sol:Deployer'
+  );
+  const deployer = await Deployer.deploy();
+  const econ = {
+    token: ethers.ZeroAddress,
+    feePct: 0,
+    burnPct: 0,
+    employerSlashPct: 0,
+    treasurySlashPct: 0,
+    commitWindow: 0,
+    revealWindow: 0,
+    minStake: 0,
+    jobStake: 0,
+  };
+  const ids = {
+    ens: ethers.ZeroAddress,
+    nameWrapper: ethers.ZeroAddress,
+    clubRootNode: ethers.ZeroHash,
+    agentRootNode: ethers.ZeroHash,
+    validatorMerkleRoot: ethers.ZeroHash,
+    agentMerkleRoot: ethers.ZeroHash,
+  };
+  const artifact = await artifacts.readArtifact(
+    'contracts/test/MockERC20.sol:MockERC20'
+  );
+  await network.provider.send('hardhat_setCode', [
+    AGIALPHA,
+    artifact.deployedBytecode,
+  ]);
+  const tx = await deployer.deploy(econ, ids, governanceAddress);
+  const receipt = await tx.wait();
+  const deployerAddress = await deployer.getAddress();
+  const log = receipt.logs.find((l) => l.address === deployerAddress);
+  const decoded = deployer.interface.decodeEventLog(
+    'Deployed',
+    log.data,
+    log.topics
+  );
+  const [
+    stakeAddr,
+    registryAddr,
+    validationAddr,
+    reputationAddr,
+    disputeAddr,
+    ,
+    platformRegistryAddr,
+    ,
+    ,
+    feePoolAddr,
+    ,
+    ,
+    systemPauseAddr,
+  ] = decoded;
+  const StakeManager = await ethers.getContractFactory(
+    'contracts/v2/StakeManager.sol:StakeManager'
+  );
+  const JobRegistry = await ethers.getContractFactory(
+    'contracts/v2/JobRegistry.sol:JobRegistry'
+  );
+  const ValidationModule = await ethers.getContractFactory(
+    'contracts/v2/ValidationModule.sol:ValidationModule'
+  );
+  const DisputeModule = await ethers.getContractFactory(
+    'contracts/v2/modules/DisputeModule.sol:DisputeModule'
+  );
+  const ReputationEngine = await ethers.getContractFactory(
+    'contracts/v2/ReputationEngine.sol:ReputationEngine'
+  );
+  const PlatformRegistry = await ethers.getContractFactory(
+    'contracts/v2/PlatformRegistry.sol:PlatformRegistry'
+  );
+  const FeePool = await ethers.getContractFactory(
+    'contracts/v2/FeePool.sol:FeePool'
+  );
+  const Committee = await ethers.getContractFactory(
+    'contracts/v2/ArbitratorCommittee.sol:ArbitratorCommittee'
+  );
+  const SystemPause = await ethers.getContractFactory(
+    'contracts/v2/SystemPause.sol:SystemPause'
+  );
+
+  const stake = StakeManager.attach(stakeAddr);
+  const registry = JobRegistry.attach(registryAddr);
+  const validation = ValidationModule.attach(validationAddr);
+  const dispute = DisputeModule.attach(disputeAddr);
+  const reputation = ReputationEngine.attach(reputationAddr);
+  const platformRegistry = PlatformRegistry.attach(platformRegistryAddr);
+  const feePool = FeePool.attach(feePoolAddr);
+  const committeeAddr = await dispute.committee();
+  const committee = Committee.attach(committeeAddr);
+  const pause = SystemPause.attach(systemPauseAddr);
+
+  return {
+    pause,
+    stake,
+    registry,
+    validation,
+    dispute,
+    reputation,
+    platformRegistry,
+    feePool,
+    committee,
+    addresses: {
+      stake: stakeAddr,
+      jobRegistry: registryAddr,
+      validationModule: validationAddr,
+      disputeModule: disputeAddr,
+      platformRegistry: platformRegistryAddr,
+      feePool: feePoolAddr,
+      reputationEngine: reputationAddr,
+      arbitratorCommittee: committeeAddr,
+      systemPause: systemPauseAddr,
+    },
+  };
+}
+
 describe('SystemPause', function () {
   it('pauses and unpauses all modules', async function () {
     const [owner, other] = await ethers.getSigners();
-    const Deployer = await ethers.getContractFactory(
-      'contracts/v2/Deployer.sol:Deployer'
-    );
-    const deployer = await Deployer.deploy();
-    const econ = {
-      token: ethers.ZeroAddress,
-      feePct: 0,
-      burnPct: 0,
-      employerSlashPct: 0,
-      treasurySlashPct: 0,
-      commitWindow: 0,
-      revealWindow: 0,
-      minStake: 0,
-      jobStake: 0,
-    };
-    const ids = {
-      ens: ethers.ZeroAddress,
-      nameWrapper: ethers.ZeroAddress,
-      clubRootNode: ethers.ZeroHash,
-      agentRootNode: ethers.ZeroHash,
-      validatorMerkleRoot: ethers.ZeroHash,
-      agentMerkleRoot: ethers.ZeroHash,
-    };
-    const artifact = await artifacts.readArtifact(
-      'contracts/test/MockERC20.sol:MockERC20'
-    );
-    await network.provider.send('hardhat_setCode', [
-      AGIALPHA,
-      artifact.deployedBytecode,
-    ]);
-    const tx = await deployer.deploy(econ, ids, owner.address);
-    const receipt = await tx.wait();
-    const deployerAddress = await deployer.getAddress();
-    const log = receipt.logs.find((l) => l.address === deployerAddress);
-    const decoded = deployer.interface.decodeEventLog(
-      'Deployed',
-      log.data,
-      log.topics
-    );
-    const [
-      stakeAddr,
-      registryAddr,
-      validationAddr,
-      reputationAddr,
-      disputeAddr,
-      ,
-      platformRegistryAddr,
-      ,
-      ,
-      feePoolAddr,
-      ,
-      ,
-      systemPauseAddr,
-    ] = decoded;
-    const StakeManager = await ethers.getContractFactory(
-      'contracts/v2/StakeManager.sol:StakeManager'
-    );
-    const JobRegistry = await ethers.getContractFactory(
-      'contracts/v2/JobRegistry.sol:JobRegistry'
-    );
-    const ValidationModule = await ethers.getContractFactory(
-      'contracts/v2/ValidationModule.sol:ValidationModule'
-    );
-    const DisputeModule = await ethers.getContractFactory(
-      'contracts/v2/modules/DisputeModule.sol:DisputeModule'
-    );
-    const ReputationEngine = await ethers.getContractFactory(
-      'contracts/v2/ReputationEngine.sol:ReputationEngine'
-    );
-    const PlatformRegistry = await ethers.getContractFactory(
-      'contracts/v2/PlatformRegistry.sol:PlatformRegistry'
-    );
-    const FeePool = await ethers.getContractFactory(
-      'contracts/v2/FeePool.sol:FeePool'
-    );
-    const Committee = await ethers.getContractFactory(
-      'contracts/v2/ArbitratorCommittee.sol:ArbitratorCommittee'
-    );
-    const SystemPause = await ethers.getContractFactory(
-      'contracts/v2/SystemPause.sol:SystemPause'
-    );
-    const stake = StakeManager.attach(stakeAddr);
-    const registry = JobRegistry.attach(registryAddr);
-    const validation = ValidationModule.attach(validationAddr);
-    const dispute = DisputeModule.attach(disputeAddr);
-    const reputation = ReputationEngine.attach(reputationAddr);
-    const platformRegistry = PlatformRegistry.attach(platformRegistryAddr);
-    const feePool = FeePool.attach(feePoolAddr);
-    const committeeAddr = await dispute.committee();
-    const committee = Committee.attach(committeeAddr);
-    const pause = SystemPause.attach(systemPauseAddr);
+    const {
+      pause,
+      stake,
+      registry,
+      validation,
+      dispute,
+      reputation,
+      platformRegistry,
+      feePool,
+      committee,
+      addresses,
+    } = await deploySystem(owner.address);
 
     await expect(
       pause
         .connect(owner)
         .setModules(
-          registryAddr,
-          stakeAddr,
-          validationAddr,
-          disputeAddr,
-          platformRegistryAddr,
-          feePoolAddr,
-          reputationAddr,
-          committeeAddr
+          addresses.jobRegistry,
+          addresses.stake,
+          addresses.validationModule,
+          addresses.disputeModule,
+          addresses.platformRegistry,
+          addresses.feePool,
+          addresses.reputationEngine,
+          addresses.arbitratorCommittee
         )
     )
       .to.emit(pause, 'ModulesUpdated')
       .withArgs(
-        registryAddr,
-        stakeAddr,
-        validationAddr,
-        disputeAddr,
-        platformRegistryAddr,
-        feePoolAddr,
-        reputationAddr,
-        committeeAddr
+        addresses.jobRegistry,
+        addresses.stake,
+        addresses.validationModule,
+        addresses.disputeModule,
+        addresses.platformRegistry,
+        addresses.feePool,
+        addresses.reputationEngine,
+        addresses.arbitratorCommittee
       );
 
     await expect(pause.connect(other).pauseAll()).to.be.revertedWithCustomError(
@@ -162,5 +201,40 @@ describe('SystemPause', function () {
     expect(await feePool.paused()).to.equal(false);
     expect(await reputation.paused()).to.equal(false);
     expect(await committee.paused()).to.equal(false);
+  });
+
+  it('rejects module wiring when ownership is not transferred', async function () {
+    const [owner, other] = await ethers.getSigners();
+    const { pause, validation, addresses } = await deploySystem(owner.address);
+
+    const pauseAddress = await pause.getAddress();
+    await network.provider.send('hardhat_impersonateAccount', [pauseAddress]);
+    await network.provider.send('hardhat_setBalance', [
+      pauseAddress,
+      '0xde0b6b3a7640000',
+    ]);
+    const pauseSigner = await ethers.getSigner(pauseAddress);
+    await validation.connect(pauseSigner).transferOwnership(other.address);
+    await network.provider.send('hardhat_stopImpersonatingAccount', [pauseAddress]);
+
+    expect(await validation.owner()).to.equal(other.address);
+
+    await expect(
+      pause
+        .connect(owner)
+        .setModules
+        .staticCall(
+          addresses.jobRegistry,
+          addresses.stake,
+          addresses.validationModule,
+          addresses.disputeModule,
+          addresses.platformRegistry,
+          addresses.feePool,
+          addresses.reputationEngine,
+          addresses.arbitratorCommittee
+        )
+    )
+      .to.be.revertedWithCustomError(pause, 'ModuleNotOwned')
+      .withArgs(addresses.validationModule, other.address);
   });
 });


### PR DESCRIPTION
## Summary
- add a CLI helper that validates module ownership and pauser roles before updating `SystemPause`
- document the new governance workflow and the requirement to transfer ownership ahead of rewiring
- require all target modules to be owned by `SystemPause` during `setModules` and cover the revert path in tests

## Testing
- `npx hardhat test test/v2/SystemPause.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d1da2f0f488333b16840dd1a77cb6f