### PR TITLE
Add anvil network configuration

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -83,6 +83,10 @@ module.exports = {
       gas: 100000000,
       blockGasLimit: 100000000,
     },
+    anvil: {
+      url: process.env.ANVIL_RPC_URL || 'http://127.0.0.1:8545',
+      chainId: 31337,
+    },
     mainnet: {
       url: process.env.MAINNET_RPC_URL || '',
       accounts: resolveAccounts('MAINNET_PRIVATE_KEY'),


### PR DESCRIPTION
## Summary
- add an anvil network configuration to point Hardhat at a local Anvil instance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1fcd7cea08333a410a13f47af65fc