### PR TITLE
Improve gas regression parser granularity

### DIFF
--- a/scripts/ci/check-gas-regressions.sh
+++ b/scripts/ci/check-gas-regressions.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <baseline-snapshot> <new-snapshot>" >&2
+  exit 1
+fi
+
+baseline_snapshot_path=$1
+new_snapshot_path=$2
+
+declare -A baseline_snapshot
+declare -A new_snapshot
+
+parse_snapshot() {
+  local snapshot_path=$1
+  local -n snapshot_map=$2
+
+  while IFS= read -r line || [[ -n $line ]]; do
+    [[ -z ${line//[[:space:]]/} ]] && continue
+
+    if [[ $line =~ ^(.+)\ \(gas:\ ([0-9]+)\)$ ]]; then
+      local identifier=${BASH_REMATCH[1]}
+      local gas_value=${BASH_REMATCH[2]}
+      snapshot_map["$identifier"]=$gas_value
+    else
+      echo "Unrecognized snapshot line: $line" >&2
+      exit 1
+    fi
+  done < "$snapshot_path"
+}
+
+parse_snapshot "$baseline_snapshot_path" baseline_snapshot
+parse_snapshot "$new_snapshot_path" new_snapshot
+
+regression_found=0
+
+for identifier in "${!baseline_snapshot[@]}"; do
+  if [[ -z ${new_snapshot[$identifier]+x} ]]; then
+    echo "Gas snapshot missing test '$identifier' in new snapshot" >&2
+    regression_found=1
+  fi
+done
+
+for identifier in "${!new_snapshot[@]}"; do
+  if [[ -z ${baseline_snapshot[$identifier]+x} ]]; then
+    echo "New gas snapshot introduced '$identifier' with gas ${new_snapshot[$identifier]}" >&2
+    continue
+  fi
+
+  old_value=${baseline_snapshot[$identifier]}
+  new_value=${new_snapshot[$identifier]}
+
+  if (( new_value > old_value )); then
+    increase=$(( new_value - old_value ))
+    echo "Gas regression for '$identifier': ${old_value} -> ${new_value} (+${increase})" >&2
+    regression_found=1
+  fi
+
+done
+
+exit $regression_found

--- a/scripts/ci/test-check-gas-regressions.sh
+++ b/scripts/ci/test-check-gas-regressions.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+baseline_snapshot="$workdir/baseline.snap"
+new_snapshot="$workdir/new.snap"
+
+cat <<'SNAP' > "$baseline_snapshot"
+ExampleContract:testOne() (gas: 100)
+ExampleContract:testTwo() (gas: 200)
+SNAP
+
+cat <<'SNAP' > "$new_snapshot"
+ExampleContract:testOne() (gas: 100)
+SNAP
+
+set +e
+output="$($repo_root/scripts/ci/check-gas-regressions.sh "$baseline_snapshot" "$new_snapshot" 2>&1)"
+status=$?
+set -e
+
+if [[ $status -eq 0 ]]; then
+  echo "check-gas-regressions.sh succeeded but should have failed" >&2
+  echo "Output was:\n$output" >&2
+  exit 1
+fi
+
+if ! grep -q "ExampleContract:testTwo()" <<< "$output"; then
+  echo "Missing identifier ExampleContract:testTwo() in error output" >&2
+  echo "Output was:\n$output" >&2
+  exit 1
+fi
+
+echo "check-gas-regressions.sh correctly detected missing entry" >&2


### PR DESCRIPTION
## Summary
- add a CI helper that parses Forge gas snapshots with a regex so each test identifier is preserved as the key
- compare baseline and new snapshots per fully qualified test name to detect missing entries and regressions
- add a shell test that exercises the parser with multiple functions from the same contract to ensure identifiers are retained

## Testing
- scripts/ci/test-check-gas-regressions.sh

------
https://chatgpt.com/codex/tasks/task_e_68d200e10fe88333b80d85f20221eb19