### PR TITLE
Add Node setup to Echidna workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,11 @@ jobs:
     container: ghcr.io/crytic/echidna:2.2.3
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install JS dependencies
+        run: npm ci
       - name: Smoke fuzz (bounded & deterministic)
         env:
           MALLOC_ARENA_MAX: 2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,8 @@
 name: Nightly Security
 
+env:
+  NODE_VERSION: '20.12.2'
+
 on:
   schedule:
     - cron: '0 3 * * *'
@@ -12,6 +15,11 @@ jobs:
     container: ghcr.io/crytic/echidna:2.2.3
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install JS dependencies
+        run: npm ci
       - name: Long fuzz (more tests, more runs)
         env:
           MALLOC_ARENA_MAX: 2


### PR DESCRIPTION
## Summary
- provision Node.js inside the Echidna smoke workflow job so npm tooling is available
- mirror the Node setup and dependency install in the nightly Echidna job

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d21be46bb883338afc869db7a5c33a