### PR TITLE
Hold quadratic voting funds on contract

### DIFF
--- a/test/v2/QuadraticVotingReentrancy.test.js
+++ b/test/v2/QuadraticVotingReentrancy.test.js
@@ -71,8 +71,6 @@ describe('QuadraticVoting reentrancy', function () {
     // perform normal vote to accrue cost
     await attack.vote();
     await qv.connect(executor).execute(1);
-    await token.connect(deployer).approve(await qv.getAddress(), 10n);
-
     await expect(attack.attackReward()).to.be.revertedWithCustomError(
       qv,
       'ReentrancyGuardReentrantCall'


### PR DESCRIPTION
## Summary
- hold quadratic voting payments on the contract, allowing sweeps after rewards settle
- transfer rewards directly from the voting contract and require a non-zero treasury target
- cover reward claims without treasury approvals and treasury sweeping in the Hardhat tests

## Testing
- npx hardhat test test/v2/QuadraticVoting.test.js test/v2/QuadraticVotingReentrancy.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d2c23a5e3c833393b9f3c9dce7543a