### PR TITLE
Fix coverage workflow compatibility with latest plugin

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,5 +1,10 @@
 module.exports = {
   istanbulReporter: ['json-summary', 'lcov', 'text'],
   skipFiles: ['contracts/test', 'contracts/mocks'],
-  mocha: { grep: '@coverage-skip', invert: true },
+  mocha: {
+    require: ['ts-node/register/transpile-only', './test/setup.js'],
+    grep: '@coverage-skip',
+    invert: true,
+    timeout: 300000,
+  },
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "hardhat test --no-compile",
     "echidna:commit-reveal": "docker run --rm -v \"$PWD\":/src -v \"$PWD/tools/forge-shim\":/usr/local/bin/forge:ro -w /src ghcr.io/crytic/echidna/echidna:v2.2.7 echidna-test ./contracts/test/CommitRevealEchidna.sol --contract CommitRevealEchidnaHarness --config echidna/commit-reveal.yaml",
     "echidna": "npm run echidna:commit-reveal",
-    "coverage:report": "COVERAGE_ONLY=1 hardhat coverage --network coverage --temp build-coverage --testfiles 'test/**/*.ts'",
+    "coverage:report": "COVERAGE_ONLY=1 hardhat coverage --temp build-coverage",
     "coverage:check": "node scripts/check-coverage.js",
     "coverage:full": "npm run coverage:report",
     "check:coverage": "npm run coverage:check",


### PR DESCRIPTION
## Summary
- update the coverage npm script to rely on the built-in Hardhat coverage network support added in recent solidity-coverage releases
- configure the solidity coverage harness to register ts-node in transpile-only mode and extend Mocha timeouts so the instrumented suite completes reliably

## Testing
- npm test
- COVERAGE_ONLY=1 hardhat coverage --temp build-coverage --testfiles 'test/v2/RoutingModule.test.js test/v2/ValidatorSelectionReservoir.test.js'
- node scripts/ci/check-coverage-threshold.mjs 90

------
https://chatgpt.com/codex/tasks/task_e_68d2d05292b483339d3cb2748ffac770