### PR TITLE
Add governance update planner and reusable module plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,9 @@ scripts/**/*.js
 !scripts/run-coverage.js
 !scripts/verify-wiring.js
 !scripts/run-wire-verify.js
-
 build/
 lib/
 agent-gateway/dist/
 examples/agentic/runtime-agentic.jsonl
+!scripts/v2/run-owner-plan.js
+!scripts/v2/lib/

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ npm run compile
 npm test
 npm run owner:health
 npm run verify:agialpha -- --skip-onchain
+npm run owner:plan
 # Run the wiring verifier against a live RPC endpoint when available.
 # Example (Hardhat node running on localhost):
 #   WIRE_VERIFY_RPC_URL=http://127.0.0.1:8545 npm run wire:verify
@@ -147,6 +148,18 @@ Docker-based analyzers (Slither/Echidna) run automatically on GitHub-hosted runn
 - **Security artifacts** – Coverage reports, gas snapshots and ABIs are uploaded automatically to aid review and downstream tooling.
 
 The wiring verifier doubles as a continuous identity/wiring guardrail for the α‑AGI integration workstream. As you expose new module getters or identity requirements, extend `scripts/verify-wiring.js` so CI enforces those invariants on every build.
+
+### Governance change sets
+
+`npm run owner:plan` (optionally with `OWNER_PLAN_JSON=1` or
+`OWNER_PLAN_EXECUTE=1`) generates a consolidated governance plan for
+`JobRegistry`, `StakeManager`, and `FeePool`, comparing the live parameters
+against the committed config JSON files. The helper prints human-readable diffs,
+exposes the raw calldata for multisig execution, optionally writes a
+machine-readable JSON artifact and, when `OWNER_PLAN_EXECUTE=1` is provided,
+submits the transactions using the connected signer. See
+[docs/owner-control-playbook.md](docs/owner-control-playbook.md) for
+step-by-step usage guidance.
 
 ## Quick Start
 

--- a/docs/owner-control-playbook.md
+++ b/docs/owner-control-playbook.md
@@ -1,0 +1,58 @@
+# Owner control playbook
+
+The `owner:plan` helper generates a consolidated update plan for the
+`JobRegistry`, `StakeManager`, and `FeePool` modules using the committed
+configuration JSON files. It shows the exact calldata for each required setter,
+optionally writes a machine-readable call plan, and can execute the updates when
+run by the module owner. Behaviour is controlled via the `OWNER_PLAN_*`
+environment variables (see below); Hardhat forwards script arguments only via
+environment variables to avoid flag parsing conflicts.
+
+## Quick start
+
+```bash
+# Inspect the call plan without sending transactions
+OWNER_PLAN_JSON=false npm run owner:plan
+
+# Emit JSON (stdout) for safe execution tooling
+OWNER_PLAN_JSON=1 npm run owner:plan
+
+# Persist the plan for a multisig (Gnosis Safe, Zodiac, etc.)
+OWNER_PLAN_OUT=call-plan/mainnet-$(date +%Y%m%d).json npm run owner:plan
+
+# Apply all outstanding updates using the connected signer
+OWNER_PLAN_EXECUTE=1 npm run owner:plan
+```
+
+The script loads the target addresses from `config/agialpha*.json` for the
+active Hardhat network. Module-specific thresholds and addresses are pulled from
+`config/job-registry.json`, `config/stake-manager.json`, and
+`config/fee-pool.json` (including per-network overrides when present).
+
+### What the plan includes
+
+For each module the plan lists:
+
+- the resolved contract address and current owner
+- the config file that produced the desired state
+- every setter that needs to change, including the calldata and human-readable
+  `current → desired` values
+- treasury allowlist and rewarder toggles (FeePool) with deterministic ordering
+- safety notes (for example, when the zero address burns dust or when
+  version/owner checks are required)
+
+The JSON output mirrors the console plan and is structured so downstream
+automation can submit calls without reimplementing the diff logic. Each action
+exposes `to`, `value`, `method`, `args`, and `calldata` fields.
+
+### Execution safeguards
+
+- The helper refuses to execute a module when the connected signer is not the
+  contract owner.
+- Version checks ensure that `FeePool`, `StakeManager`, and the linked modules
+  expose the expected `version() == 2` interface before encoding transactions.
+- Treasury updates automatically stage allowlist entries to prevent accidental
+  reverts mid-execution.
+
+When `--execute` is omitted the helper acts as a dry run, enabling governance to
+review or hand the plan to a multisig for offline execution.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "wire:verify": "node scripts/run-wire-verify.js",
     "verify:wiring": "npm run wire:verify",
     "owner:health": "npx hardhat run --no-compile scripts/owner-healthcheck.js",
+    "owner:plan": "node scripts/v2/run-owner-plan.js",
     "test": "hardhat test --no-compile",
     "echidna:commit-reveal": "docker run --rm -v \"$PWD\":/src -v \"$PWD/tools/forge-shim\":/usr/local/bin/forge:ro -w /src ghcr.io/crytic/echidna/echidna:v2.2.7 echidna-test ./contracts/test/CommitRevealEchidna.sol --contract CommitRevealEchidnaHarness --config echidna/commit-reveal.yaml",
     "echidna": "npm run echidna:commit-reveal",

--- a/scripts/v2/lib/feePoolPlan.ts
+++ b/scripts/v2/lib/feePoolPlan.ts
@@ -1,0 +1,365 @@
+import type { Contract } from 'ethers';
+import { ethers } from 'ethers';
+import type { FeePoolConfig } from '../../config';
+import { ModulePlan, PlannedAction } from './types';
+import { describeArgs, normaliseAddress, parsePercentage, sameAddress } from './utils';
+
+const ROLE_LABELS = ['Agent', 'Validator', 'Platform'];
+
+function parseRewardRole(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value < 0 || value >= ROLE_LABELS.length) {
+      throw new Error('rewardRole must be 0 (Agent), 1 (Validator), or 2 (Platform)');
+    }
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    if (/^\d+$/.test(trimmed)) {
+      const parsed = Number(trimmed);
+      if (!Number.isInteger(parsed) || parsed < 0 || parsed >= ROLE_LABELS.length) {
+        throw new Error('rewardRole must be 0 (Agent), 1 (Validator), or 2 (Platform)');
+      }
+      return parsed;
+    }
+    const lower = trimmed.toLowerCase();
+    if (lower === 'agent') return 0;
+    if (lower === 'validator') return 1;
+    if (lower === 'platform' || lower === 'operator') return 2;
+    throw new Error(
+      "rewardRole must be one of 'agent', 'validator', 'platform' or the corresponding numeric value"
+    );
+  }
+  throw new Error('rewardRole must be a string or number');
+}
+
+function formatRole(value: bigint | number): string {
+  const index = Number(value);
+  return ROLE_LABELS[index] ?? `Role(${index})`;
+}
+
+export interface FeePoolPlanInput {
+  feePool: Contract;
+  config: FeePoolConfig;
+  configPath?: string;
+  ownerAddress: string;
+}
+
+export async function buildFeePoolPlan(input: FeePoolPlanInput): Promise<ModulePlan> {
+  const { feePool, config, configPath, ownerAddress } = input;
+
+  const [
+    currentStakeManager,
+    currentRewardRole,
+    currentBurnPct,
+    currentTreasury,
+    currentGovernance,
+    currentPauser,
+    currentTaxPolicy,
+  ] = await Promise.all([
+    feePool.stakeManager(),
+    feePool.rewardRole(),
+    feePool.burnPct(),
+    feePool.treasury(),
+    feePool.governance(),
+    feePool.pauser(),
+    feePool.taxPolicy(),
+  ]);
+
+  const currentStakeManagerAddress =
+    currentStakeManager === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentStakeManager);
+  const currentTreasuryAddress =
+    currentTreasury === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentTreasury);
+  const currentGovernanceAddress =
+    currentGovernance === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentGovernance);
+  const currentPauserAddress =
+    currentPauser === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentPauser);
+  const currentTaxPolicyAddress =
+    currentTaxPolicy === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentTaxPolicy);
+
+  const desiredStakeManager = normaliseAddress(config.stakeManager, {
+    allowZero: false,
+  });
+  const desiredRewardRole = parseRewardRole(config.rewardRole);
+  const desiredBurnPct = parsePercentage(config.burnPct, 'burnPct');
+  const desiredTreasury = normaliseAddress(config.treasury);
+  const desiredGovernance = normaliseAddress(config.governance, {
+    allowZero: false,
+  });
+  const desiredPauser = normaliseAddress(config.pauser);
+  const desiredTaxPolicy = normaliseAddress(config.taxPolicy, {
+    allowZero: false,
+  });
+
+  const allowlistActions: PlannedAction[] = [];
+  const mainActions: PlannedAction[] = [];
+  const rewarderActions: PlannedAction[] = [];
+
+  const allowlistState = new Map<string, boolean>();
+  async function syncAllowlistEntry(
+    addr: string,
+    desired: boolean,
+    note?: string
+  ) {
+    const normalized = ethers.getAddress(addr);
+    if (normalized === ethers.ZeroAddress) {
+      return;
+    }
+    const current = allowlistState.has(normalized)
+      ? allowlistState.get(normalized)!
+      : Boolean(await feePool.treasuryAllowlist(normalized));
+    if (current === desired) {
+      allowlistState.set(normalized, desired);
+      return;
+    }
+    const action: PlannedAction = {
+      label: `${desired ? 'Allow' : 'Block'} treasury ${normalized}`,
+      method: 'setTreasuryAllowlist',
+      args: [normalized, desired],
+      current: current ? 'allowed' : 'blocked',
+      desired: desired ? 'allowed' : 'blocked',
+    };
+    if (note) {
+      action.notes = [note];
+    }
+    allowlistActions.push(action);
+    allowlistState.set(normalized, desired);
+  }
+
+  const allowlistConfig = config.treasuryAllowlist || {};
+  const sortedAllowlist = Object.keys(allowlistConfig).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  for (const addr of sortedAllowlist) {
+    await syncAllowlistEntry(addr, Boolean(allowlistConfig[addr]));
+  }
+
+  const rewarderState = new Map<string, boolean>();
+  async function syncRewarder(addr: string, desired: boolean) {
+    const normalized = ethers.getAddress(addr);
+    if (normalized === ethers.ZeroAddress) {
+      return;
+    }
+    const current = rewarderState.has(normalized)
+      ? rewarderState.get(normalized)!
+      : Boolean(await feePool.rewarders(normalized));
+    if (current === desired) {
+      rewarderState.set(normalized, desired);
+      return;
+    }
+    rewarderActions.push({
+      label: `${desired ? 'Authorize' : 'Revoke'} rewarder ${normalized}`,
+      method: 'setRewarder',
+      args: [normalized, desired],
+      current: current ? 'authorized' : 'revoked',
+      desired: desired ? 'authorized' : 'revoked',
+    });
+    rewarderState.set(normalized, desired);
+  }
+
+  const rewarderConfig = config.rewarders || {};
+  const sortedRewarders = Object.keys(rewarderConfig).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  for (const addr of sortedRewarders) {
+    await syncRewarder(addr, Boolean(rewarderConfig[addr]));
+  }
+
+  if (
+    desiredStakeManager &&
+    !sameAddress(desiredStakeManager, currentStakeManagerAddress)
+  ) {
+    const stakeManager = await ethers.getContractAt(
+      ['function version() view returns (uint256)'],
+      desiredStakeManager
+    );
+    const stakeVersion = await stakeManager.version();
+    if (stakeVersion !== 2n) {
+      throw new Error(
+        `StakeManager at ${desiredStakeManager} reports version ${stakeVersion}, expected 2`
+      );
+    }
+    mainActions.push({
+      label: `Update StakeManager to ${desiredStakeManager}`,
+      method: 'setStakeManager',
+      args: [desiredStakeManager],
+      current: currentStakeManagerAddress,
+      desired: desiredStakeManager,
+      notes: ['StakeManager must expose version() == 2.'],
+    });
+  }
+
+  if (
+    desiredRewardRole !== undefined &&
+    desiredRewardRole !== Number(currentRewardRole)
+  ) {
+    mainActions.push({
+      label: `Update reward role to ${formatRole(desiredRewardRole)}`,
+      method: 'setRewardRole',
+      args: [desiredRewardRole],
+      current: formatRole(currentRewardRole),
+      desired: formatRole(desiredRewardRole),
+    });
+  }
+
+  if (
+    desiredBurnPct !== undefined &&
+    desiredBurnPct !== Number(currentBurnPct)
+  ) {
+    mainActions.push({
+      label: `Update burn percentage to ${desiredBurnPct}%`,
+      method: 'setBurnPct',
+      args: [desiredBurnPct],
+      current: `${Number(currentBurnPct)}%`,
+      desired: `${desiredBurnPct}%`,
+    });
+  }
+
+  if (desiredTreasury !== undefined) {
+    if (
+      desiredTreasury !== ethers.ZeroAddress &&
+      sameAddress(desiredTreasury, ownerAddress)
+    ) {
+      throw new Error('Treasury cannot be set to the contract owner');
+    }
+    const normalizedTreasury = desiredTreasury;
+    const allowlistConfigState = config.treasuryAllowlist || {};
+    if (
+      normalizedTreasury !== ethers.ZeroAddress &&
+      allowlistConfigState[normalizedTreasury] === false
+    ) {
+      throw new Error(
+        `Treasury ${normalizedTreasury} is disabled in treasuryAllowlist; set it to true before updating`
+      );
+    }
+    if (
+      normalizedTreasury !== ethers.ZeroAddress &&
+      (!allowlistState.has(normalizedTreasury) ||
+        allowlistState.get(normalizedTreasury) !== true)
+    ) {
+      await syncAllowlistEntry(
+        normalizedTreasury,
+        true,
+        'Automatically allowing treasury address before updating.'
+      );
+    }
+    if (!sameAddress(normalizedTreasury, currentTreasuryAddress)) {
+      const notes = [] as string[];
+      if (normalizedTreasury === ethers.ZeroAddress) {
+        notes.push('Zero address burns rounding dust instead of forwarding it.');
+      }
+      mainActions.push({
+        label: `Update treasury to ${normalizedTreasury}`,
+        method: 'setTreasury',
+        args: [normalizedTreasury],
+        current: currentTreasuryAddress,
+        desired: normalizedTreasury,
+        notes: notes.length ? notes : undefined,
+      });
+    }
+  }
+
+  if (
+    desiredGovernance &&
+    !sameAddress(desiredGovernance, currentGovernanceAddress)
+  ) {
+    mainActions.push({
+      label: `Update governance to ${desiredGovernance}`,
+      method: 'setGovernance',
+      args: [desiredGovernance],
+      current: currentGovernanceAddress,
+      desired: desiredGovernance,
+      notes: [
+        'Governance address must be a TimelockController capable of calling governanceWithdraw.',
+      ],
+    });
+  }
+
+  if (
+    desiredPauser !== undefined &&
+    !sameAddress(desiredPauser, currentPauserAddress)
+  ) {
+    mainActions.push({
+      label: `Update pauser to ${desiredPauser}`,
+      method: 'setPauser',
+      args: [desiredPauser],
+      current: currentPauserAddress,
+      desired: desiredPauser,
+    });
+  }
+
+  if (
+    desiredTaxPolicy &&
+    !sameAddress(desiredTaxPolicy, currentTaxPolicyAddress)
+  ) {
+    const policy = await ethers.getContractAt(
+      ['function isTaxExempt() view returns (bool)'],
+      desiredTaxPolicy
+    );
+    const exempt = await policy.isTaxExempt();
+    if (!exempt) {
+      throw new Error(
+        `Tax policy at ${desiredTaxPolicy} must return true for isTaxExempt()`
+      );
+    }
+    mainActions.push({
+      label: `Update tax policy to ${desiredTaxPolicy}`,
+      method: 'setTaxPolicy',
+      args: [desiredTaxPolicy],
+      current: currentTaxPolicyAddress,
+      desired: desiredTaxPolicy,
+      notes: ['Target policy must remain tax exempt.'],
+    });
+  }
+
+  const actions = [...allowlistActions, ...mainActions, ...rewarderActions];
+
+  return {
+    module: 'FeePool',
+    address: feePool.target as string,
+    actions,
+    configPath,
+    iface: feePool.interface,
+    contract: feePool,
+  };
+}
+
+export function renderFeePoolPlan(plan: ModulePlan): string {
+  if (plan.actions.length === 0) {
+    return 'All tracked parameters already match the configuration.';
+  }
+  const lines: string[] = [];
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
+    lines.push(`${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      lines.push(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      lines.push(`   Desired: ${action.desired}`);
+    }
+    action.notes?.forEach((note) => lines.push(`   Note: ${note}`));
+    lines.push(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    if (data) {
+      lines.push(`   Calldata: ${data}`);
+    }
+    lines.push('');
+  });
+  return lines.join('\n');
+}

--- a/scripts/v2/lib/jobRegistryPlan.ts
+++ b/scripts/v2/lib/jobRegistryPlan.ts
@@ -1,0 +1,317 @@
+import type { Contract } from 'ethers';
+import { ethers } from 'ethers';
+import type { JobRegistryConfig } from '../../config';
+import { ModulePlan, PlannedAction } from './types';
+import {
+  describeArgs,
+  formatToken,
+  normaliseAddress,
+  parseBigInt,
+  parsePercentage,
+  parseTokenAmount,
+} from './utils';
+
+const MAX_UINT96 = (1n << 96n) - 1n;
+
+export interface JobRegistryPlanInput {
+  registry: Contract;
+  config: JobRegistryConfig;
+  configPath?: string;
+  decimals: number;
+  symbol: string;
+}
+
+function ensureFeeBudgetValid(
+  fee: number | undefined,
+  validator: number | undefined
+) {
+  if (fee === undefined || validator === undefined) {
+    return;
+  }
+  if (fee + validator > 100) {
+    throw new Error('feePct + validatorRewardPct cannot exceed 100');
+  }
+}
+
+export async function buildJobRegistryPlan(
+  input: JobRegistryPlanInput
+): Promise<ModulePlan> {
+  const { registry, config, configPath, decimals, symbol } = input;
+
+  const [
+    currentJobStake,
+    currentMaxJobReward,
+    currentMinAgentStake,
+    currentFeePct,
+    currentValidatorRewardPct,
+    currentMaxDuration,
+    currentMaxActiveJobs,
+    currentExpirationGrace,
+    currentTreasury,
+    currentTaxPolicy,
+  ] = await Promise.all([
+    registry.jobStake(),
+    registry.maxJobReward(),
+    registry.minAgentStake(),
+    registry.feePct(),
+    registry.validatorRewardPct(),
+    registry.maxJobDuration(),
+    registry.maxActiveJobsPerAgent(),
+    registry.expirationGracePeriod(),
+    registry.treasury(),
+    registry.taxPolicy(),
+  ]);
+
+  const desiredJobStake = parseTokenAmount(
+    config.jobStake,
+    config.jobStakeTokens,
+    decimals,
+    'jobStake'
+  );
+  const desiredMinAgentStake = parseTokenAmount(
+    config.minAgentStake,
+    config.minAgentStakeTokens,
+    decimals,
+    'minAgentStake'
+  );
+  const desiredMaxReward = parseTokenAmount(
+    config.maxJobReward,
+    config.maxJobRewardTokens,
+    decimals,
+    'maxJobReward'
+  );
+  const desiredDuration = parseBigInt(
+    config.jobDurationLimitSeconds,
+    'jobDurationLimitSeconds'
+  );
+  const desiredMaxActive = parseBigInt(
+    config.maxActiveJobsPerAgent,
+    'maxActiveJobsPerAgent'
+  );
+  const desiredExpirationGrace = parseBigInt(
+    config.expirationGracePeriodSeconds,
+    'expirationGracePeriodSeconds'
+  );
+  const desiredFeePct = parsePercentage(config.feePct, 'feePct');
+  const desiredValidatorPct = parsePercentage(
+    config.validatorRewardPct,
+    'validatorRewardPct'
+  );
+  ensureFeeBudgetValid(desiredFeePct, desiredValidatorPct);
+
+  const desiredTreasury = normaliseAddress(config.treasury);
+  const desiredTaxPolicy = normaliseAddress(config.taxPolicy, {
+    allowZero: false,
+  });
+
+  const actions: PlannedAction[] = [];
+
+  if (desiredJobStake !== undefined && desiredJobStake !== currentJobStake) {
+    if (desiredJobStake > MAX_UINT96) {
+      throw new Error('jobStake exceeds uint96 range');
+    }
+    actions.push({
+      label: `Update job stake to ${formatToken(
+        desiredJobStake,
+        decimals,
+        symbol
+      )}`,
+      method: 'setJobStake',
+      args: [desiredJobStake],
+      current: formatToken(currentJobStake, decimals, symbol),
+      desired: formatToken(desiredJobStake, decimals, symbol),
+    });
+  }
+
+  if (
+    desiredMinAgentStake !== undefined &&
+    desiredMinAgentStake !== currentMinAgentStake
+  ) {
+    if (desiredMinAgentStake > MAX_UINT96) {
+      throw new Error('minAgentStake exceeds uint96 range');
+    }
+    actions.push({
+      label: `Update minimum agent stake to ${formatToken(
+        desiredMinAgentStake,
+        decimals,
+        symbol
+      )}`,
+      method: 'setMinAgentStake',
+      args: [desiredMinAgentStake],
+      current: formatToken(currentMinAgentStake, decimals, symbol),
+      desired: formatToken(desiredMinAgentStake, decimals, symbol),
+    });
+  }
+
+  if (
+    desiredMaxReward !== undefined &&
+    desiredMaxReward !== currentMaxJobReward
+  ) {
+    actions.push({
+      label: `Update maximum job reward to ${formatToken(
+        desiredMaxReward,
+        decimals,
+        symbol
+      )}`,
+      method: 'setMaxJobReward',
+      args: [desiredMaxReward],
+      current: formatToken(currentMaxJobReward, decimals, symbol),
+      desired: formatToken(desiredMaxReward, decimals, symbol),
+    });
+  }
+
+  if (desiredDuration !== undefined && desiredDuration !== currentMaxDuration) {
+    actions.push({
+      label: `Update job duration limit to ${desiredDuration} seconds`,
+      method: 'setJobDurationLimit',
+      args: [desiredDuration],
+      current: `${currentMaxDuration.toString()} seconds`,
+      desired: `${desiredDuration.toString()} seconds`,
+    });
+  }
+
+  if (
+    desiredMaxActive !== undefined &&
+    desiredMaxActive !== currentMaxActiveJobs
+  ) {
+    actions.push({
+      label: `Update maximum active jobs per agent to ${desiredMaxActive}`,
+      method: 'setMaxActiveJobsPerAgent',
+      args: [desiredMaxActive],
+      current: currentMaxActiveJobs.toString(),
+      desired: desiredMaxActive.toString(),
+    });
+  }
+
+  if (
+    desiredExpirationGrace !== undefined &&
+    desiredExpirationGrace !== currentExpirationGrace
+  ) {
+    actions.push({
+      label: `Update expiration grace period to ${desiredExpirationGrace} seconds`,
+      method: 'setExpirationGracePeriod',
+      args: [desiredExpirationGrace],
+      current: `${currentExpirationGrace.toString()} seconds`,
+      desired: `${desiredExpirationGrace.toString()} seconds`,
+    });
+  }
+
+  const currentFee = Number(currentFeePct);
+  const currentValidator = Number(currentValidatorRewardPct);
+
+  if (desiredFeePct !== undefined && desiredFeePct !== currentFee) {
+    ensureFeeBudgetValid(desiredFeePct, desiredValidatorPct ?? currentValidator);
+    actions.push({
+      label: `Update protocol fee percentage to ${desiredFeePct}%`,
+      method: 'setFeePct',
+      args: [desiredFeePct],
+      current: `${currentFee}%`,
+      desired: `${desiredFeePct}%`,
+    });
+  }
+
+  if (
+    desiredValidatorPct !== undefined &&
+    desiredValidatorPct !== currentValidator
+  ) {
+    ensureFeeBudgetValid(desiredFeePct ?? currentFee, desiredValidatorPct);
+    actions.push({
+      label: `Update validator reward percentage to ${desiredValidatorPct}%`,
+      method: 'setValidatorRewardPct',
+      args: [desiredValidatorPct],
+      current: `${currentValidator}%`,
+      desired: `${desiredValidatorPct}%`,
+    });
+  }
+
+  const currentTreasuryAddress =
+    currentTreasury === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentTreasury);
+  if (
+    desiredTreasury !== undefined &&
+    desiredTreasury !== currentTreasuryAddress
+  ) {
+    actions.push({
+      label: `Update treasury to ${desiredTreasury}`,
+      method: 'setTreasury',
+      args: [desiredTreasury],
+      current: currentTreasuryAddress,
+      desired: desiredTreasury,
+      notes: ['Passing the zero address burns forfeited payouts.'],
+    });
+  }
+
+  const currentTaxPolicyAddress =
+    currentTaxPolicy === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentTaxPolicy);
+  if (
+    desiredTaxPolicy &&
+    desiredTaxPolicy !== ethers.ZeroAddress &&
+    desiredTaxPolicy !== currentTaxPolicyAddress
+  ) {
+    actions.push({
+      label: `Update tax policy to ${desiredTaxPolicy}`,
+      method: 'setTaxPolicy',
+      args: [desiredTaxPolicy],
+      current: currentTaxPolicyAddress,
+      desired: desiredTaxPolicy,
+    });
+  }
+
+  const acknowledgers = config.acknowledgers || {};
+  const sortedAcks = Object.keys(acknowledgers).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  for (const ack of sortedAcks) {
+    const desired = acknowledgers[ack];
+    const current = await registry.acknowledgers(ack);
+    if (Boolean(desired) !== current) {
+      actions.push({
+        label: `${desired ? 'Enable' : 'Disable'} acknowledger ${ack}`,
+        method: 'setAcknowledger',
+        args: [ack, Boolean(desired)],
+        current: current ? 'allowed' : 'blocked',
+        desired: desired ? 'allowed' : 'blocked',
+      });
+    }
+  }
+
+  return {
+    module: 'JobRegistry',
+    address: registry.target as string,
+    actions,
+    configPath,
+    iface: registry.interface,
+    contract: registry,
+  };
+}
+
+export function renderJobRegistryPlan(plan: ModulePlan): string {
+  if (plan.actions.length === 0) {
+    return 'All tracked parameters already match the configuration.';
+  }
+  const lines: string[] = [];
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
+    lines.push(`${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      lines.push(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      lines.push(`   Desired: ${action.desired}`);
+    }
+    action.notes?.forEach((note) => {
+      lines.push(`   Note: ${note}`);
+    });
+    lines.push(
+      `   Method: ${action.method}(${describeArgs(action.args)})`
+    );
+    if (data) {
+      lines.push(`   Calldata: ${data}`);
+    }
+    lines.push('');
+  });
+  return lines.join('\n');
+}

--- a/scripts/v2/lib/stakeManagerPlan.ts
+++ b/scripts/v2/lib/stakeManagerPlan.ts
@@ -1,0 +1,754 @@
+import type { Contract } from 'ethers';
+import { ethers } from 'ethers';
+import type { StakeManagerConfig } from '../../config';
+import { ModulePlan, PlannedAction } from './types';
+import {
+  describeArgs,
+  formatToken,
+  normaliseAddress,
+  parseBigInt,
+  parseBoolean,
+  parsePercentage,
+  parseTokenAmount,
+  sameAddress,
+} from './utils';
+
+const MAX_AGI_TYPES_CAP = 50;
+const MAX_PAYOUT_PCT = 200;
+
+export interface StakeManagerPlanInput {
+  stakeManager: Contract;
+  config: StakeManagerConfig;
+  configPath?: string;
+  decimals: number;
+  symbol: string;
+  ownerAddress: string;
+}
+
+async function ensureModuleVersion(
+  address: string,
+  artifact: string,
+  label: string
+): Promise<void> {
+  const contract = await ethers.getContractAt(artifact, address);
+  const version = await contract.version();
+  if (version !== 2n) {
+    throw new Error(`${label} at ${address} reports version ${version}, expected 2`);
+  }
+}
+
+export async function buildStakeManagerPlan(
+  input: StakeManagerPlanInput
+): Promise<ModulePlan> {
+  const { stakeManager, config, configPath, decimals, symbol, ownerAddress } =
+    input;
+
+  const [
+    currentMinStake,
+    currentFeePct,
+    currentBurnPct,
+    currentValidatorRewardPct,
+    currentEmployerSlashPct,
+    currentTreasurySlashPct,
+    currentTreasury,
+    currentFeePool,
+    currentUnbondingPeriod,
+    currentMaxStakePerAddress,
+    currentAutoStakeEnabled,
+    currentDisputeThreshold,
+    currentIncreasePct,
+    currentDecreasePct,
+    currentWindow,
+    currentFloor,
+    currentMaxMinStake,
+    currentTempThreshold,
+    currentHamThreshold,
+    currentDisputeWeight,
+    currentTempWeight,
+    currentHamWeight,
+    currentThermostat,
+    currentHamiltonianFeed,
+    currentJobRegistry,
+    currentDisputeModule,
+    currentValidationModule,
+    currentPauser,
+    currentMaxAGITypes,
+    currentMaxTotalPayoutPct,
+    currentAGITypes,
+  ] = await Promise.all([
+    stakeManager.minStake(),
+    stakeManager.feePct(),
+    stakeManager.burnPct(),
+    stakeManager.validatorRewardPct(),
+    stakeManager.employerSlashPct(),
+    stakeManager.treasurySlashPct(),
+    stakeManager.treasury(),
+    stakeManager.feePool(),
+    stakeManager.unbondingPeriod(),
+    stakeManager.maxStakePerAddress(),
+    stakeManager.autoStakeTuning(),
+    stakeManager.stakeDisputeThreshold(),
+    stakeManager.stakeIncreasePct(),
+    stakeManager.stakeDecreasePct(),
+    stakeManager.stakeTuneWindow(),
+    stakeManager.minStakeFloor(),
+    stakeManager.maxMinStake(),
+    stakeManager.stakeTempThreshold(),
+    stakeManager.stakeHamiltonianThreshold(),
+    stakeManager.disputeWeight(),
+    stakeManager.temperatureWeight(),
+    stakeManager.hamiltonianWeight(),
+    stakeManager.thermostat(),
+    stakeManager.hamiltonianFeed(),
+    stakeManager.jobRegistry(),
+    stakeManager.disputeModule(),
+    stakeManager.validationModule(),
+    stakeManager.pauser(),
+    stakeManager.maxAGITypes(),
+    stakeManager.maxTotalPayoutPct(),
+    stakeManager.getAGITypes(),
+  ]);
+
+  const currentAgiTypeCount = Array.isArray(currentAGITypes)
+    ? currentAGITypes.length
+    : Number((currentAGITypes as any)?.length ?? 0);
+
+  const desiredMinStake = parseTokenAmount(
+    config.minStake,
+    config.minStakeTokens,
+    decimals,
+    'minStake'
+  );
+  const desiredMaxStake = parseTokenAmount(
+    config.maxStakePerAddress,
+    config.maxStakePerAddressTokens,
+    decimals,
+    'maxStakePerAddress'
+  );
+  const desiredFeePct = parsePercentage(config.feePct, 'feePct');
+  const desiredBurnPct = parsePercentage(config.burnPct, 'burnPct');
+  const desiredValidatorPct = parsePercentage(
+    config.validatorRewardPct,
+    'validatorRewardPct'
+  );
+  const desiredEmployerSlashPct = parsePercentage(
+    config.employerSlashPct,
+    'employerSlashPct'
+  );
+  const desiredTreasurySlashPct = parsePercentage(
+    config.treasurySlashPct,
+    'treasurySlashPct'
+  );
+  const desiredUnbondingPeriod = parseBigInt(
+    config.unbondingPeriodSeconds,
+    'unbondingPeriodSeconds'
+  );
+
+  const recommendations = config.stakeRecommendations || {};
+  const desiredRecMin = parseTokenAmount(
+    recommendations.min,
+    recommendations.minTokens,
+    decimals,
+    'stakeRecommendations.min'
+  );
+  const desiredRecMax = parseTokenAmount(
+    recommendations.max,
+    recommendations.maxTokens,
+    decimals,
+    'stakeRecommendations.max'
+  );
+
+  const autoConfig = config.autoStake || {};
+  const desiredAutoEnabled = parseBoolean(
+    autoConfig.enabled,
+    'autoStake.enabled'
+  );
+  const desiredAutoThreshold = parseBigInt(
+    autoConfig.threshold,
+    'autoStake.threshold'
+  );
+  const desiredAutoIncrease = parsePercentage(
+    autoConfig.increasePct,
+    'autoStake.increasePct'
+  );
+  const desiredAutoDecrease = parsePercentage(
+    autoConfig.decreasePct,
+    'autoStake.decreasePct'
+  );
+  const desiredAutoWindow = parseBigInt(
+    autoConfig.windowSeconds,
+    'autoStake.windowSeconds'
+  );
+  const desiredAutoFloor = parseTokenAmount(
+    autoConfig.floor,
+    autoConfig.floorTokens,
+    decimals,
+    'autoStake.floor'
+  );
+  const desiredAutoCeil = parseTokenAmount(
+    autoConfig.ceiling,
+    autoConfig.ceilingTokens,
+    decimals,
+    'autoStake.ceiling'
+  );
+  const desiredTempThreshold = parseBigInt(
+    autoConfig.temperatureThreshold,
+    'autoStake.temperatureThreshold',
+    { allowNegative: true }
+  );
+  const desiredHamThreshold = parseBigInt(
+    autoConfig.hamiltonianThreshold,
+    'autoStake.hamiltonianThreshold',
+    { allowNegative: true }
+  );
+  const desiredDisputeWeight = parseBigInt(
+    autoConfig.disputeWeight,
+    'autoStake.disputeWeight'
+  );
+  const desiredTempWeight = parseBigInt(
+    autoConfig.temperatureWeight,
+    'autoStake.temperatureWeight'
+  );
+  const desiredHamWeight = parseBigInt(
+    autoConfig.hamiltonianWeight,
+    'autoStake.hamiltonianWeight'
+  );
+
+  const desiredTreasury = normaliseAddress(config.treasury);
+  const desiredPauser = normaliseAddress(config.pauser);
+  const desiredThermostat = normaliseAddress(config.thermostat);
+  const desiredHamiltonianFeed = normaliseAddress(config.hamiltonianFeed);
+  const desiredJobRegistry = normaliseAddress(config.jobRegistry, {
+    allowZero: false,
+  });
+  const desiredDisputeModule = normaliseAddress(config.disputeModule, {
+    allowZero: false,
+  });
+  const desiredValidationModule = normaliseAddress(config.validationModule, {
+    allowZero: false,
+  });
+  const desiredFeePool = normaliseAddress(config.feePool, {
+    allowZero: false,
+  });
+  const desiredMaxAGITypes =
+    config.maxAGITypes !== undefined
+      ? Number(config.maxAGITypes)
+      : undefined;
+  const desiredMaxTotalPayoutPct =
+    config.maxTotalPayoutPct !== undefined
+      ? Number(config.maxTotalPayoutPct)
+      : undefined;
+
+  const actions: PlannedAction[] = [];
+  const percentageActions: Array<PlannedAction & { delta: number }> = [];
+
+  const currentTreasuryAddress =
+    currentTreasury === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentTreasury);
+  if (
+    desiredTreasury !== undefined &&
+    !sameAddress(desiredTreasury, currentTreasuryAddress)
+  ) {
+    if (
+      desiredTreasury !== ethers.ZeroAddress &&
+      sameAddress(desiredTreasury, ownerAddress)
+    ) {
+      throw new Error('Treasury cannot be set to the owner address');
+    }
+    actions.push({
+      label: `Update treasury to ${desiredTreasury}`,
+      method: 'setTreasury',
+      args: [desiredTreasury],
+      current: currentTreasuryAddress,
+      desired: desiredTreasury,
+      notes: [
+        'Passing the zero address burns the treasury share of slashed stake.',
+      ],
+    });
+  }
+
+  const allowlist = config.treasuryAllowlist || {};
+  const sortedAllowlist = Object.keys(allowlist).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  for (const addr of sortedAllowlist) {
+    const desired = Boolean(allowlist[addr]);
+    const current = await stakeManager.treasuryAllowlist(addr);
+    if (current !== desired) {
+      actions.push({
+        label: `${desired ? 'Allow' : 'Block'} treasury ${addr}`,
+        method: 'setTreasuryAllowlist',
+        args: [addr, desired],
+        current: current ? 'allowed' : 'blocked',
+        desired: desired ? 'allowed' : 'blocked',
+      });
+    }
+  }
+
+  const currentPauserAddress =
+    currentPauser === ethers.ZeroAddress
+      ? ethers.ZeroAddress
+      : ethers.getAddress(currentPauser);
+  if (
+    desiredPauser !== undefined &&
+    !sameAddress(desiredPauser, currentPauserAddress)
+  ) {
+    actions.push({
+      label: `Update pauser to ${desiredPauser}`,
+      method: 'setPauser',
+      args: [desiredPauser],
+      current: currentPauserAddress,
+      desired: desiredPauser,
+    });
+  }
+
+  if (
+    desiredThermostat !== undefined &&
+    !sameAddress(desiredThermostat, currentThermostat)
+  ) {
+    actions.push({
+      label: `Update thermostat to ${desiredThermostat}`,
+      method: 'setThermostat',
+      args: [desiredThermostat],
+      current: ethers.getAddress(currentThermostat),
+      desired: desiredThermostat,
+    });
+  }
+
+  if (
+    desiredHamiltonianFeed !== undefined &&
+    !sameAddress(desiredHamiltonianFeed, currentHamiltonianFeed)
+  ) {
+    actions.push({
+      label: `Update Hamiltonian feed to ${desiredHamiltonianFeed}`,
+      method: 'setHamiltonianFeed',
+      args: [desiredHamiltonianFeed],
+      current: ethers.getAddress(currentHamiltonianFeed),
+      desired: desiredHamiltonianFeed,
+    });
+  }
+
+  if (desiredJobRegistry) {
+    await ensureModuleVersion(
+      desiredJobRegistry,
+      'contracts/v2/interfaces/IJobRegistry.sol:IJobRegistry',
+      'JobRegistry'
+    );
+    const currentJobRegistryAddress =
+      currentJobRegistry === ethers.ZeroAddress
+        ? ethers.ZeroAddress
+        : ethers.getAddress(currentJobRegistry);
+    if (!sameAddress(desiredJobRegistry, currentJobRegistryAddress)) {
+      actions.push({
+        label: `Update JobRegistry to ${desiredJobRegistry}`,
+        method: 'setJobRegistry',
+        args: [desiredJobRegistry],
+        current: currentJobRegistryAddress,
+        desired: desiredJobRegistry,
+      });
+    }
+  }
+
+  if (desiredDisputeModule) {
+    await ensureModuleVersion(
+      desiredDisputeModule,
+      'contracts/v2/interfaces/IDisputeModule.sol:IDisputeModule',
+      'DisputeModule'
+    );
+    const currentDisputeModuleAddress =
+      currentDisputeModule === ethers.ZeroAddress
+        ? ethers.ZeroAddress
+        : ethers.getAddress(currentDisputeModule);
+    if (!sameAddress(desiredDisputeModule, currentDisputeModuleAddress)) {
+      actions.push({
+        label: `Update DisputeModule to ${desiredDisputeModule}`,
+        method: 'setDisputeModule',
+        args: [desiredDisputeModule],
+        current: currentDisputeModuleAddress,
+        desired: desiredDisputeModule,
+      });
+    }
+  }
+
+  if (desiredValidationModule) {
+    await ensureModuleVersion(
+      desiredValidationModule,
+      'contracts/v2/interfaces/IValidationModule.sol:IValidationModule',
+      'ValidationModule'
+    );
+    const currentValidationModuleAddress = ethers.getAddress(
+      currentValidationModule
+    );
+    if (!sameAddress(desiredValidationModule, currentValidationModuleAddress)) {
+      actions.push({
+        label: `Update ValidationModule to ${desiredValidationModule}`,
+        method: 'setValidationModule',
+        args: [desiredValidationModule],
+        current: currentValidationModuleAddress,
+        desired: desiredValidationModule,
+      });
+    }
+  }
+
+  if (desiredFeePool) {
+    await ensureModuleVersion(
+      desiredFeePool,
+      'contracts/v2/interfaces/IFeePool.sol:IFeePool',
+      'FeePool'
+    );
+    const currentFeePoolAddress =
+      currentFeePool === ethers.ZeroAddress
+        ? ethers.ZeroAddress
+        : ethers.getAddress(currentFeePool);
+    if (!sameAddress(desiredFeePool, currentFeePoolAddress)) {
+      actions.push({
+        label: `Update FeePool to ${desiredFeePool}`,
+        method: 'setFeePool',
+        args: [desiredFeePool],
+        current: currentFeePoolAddress,
+        desired: desiredFeePool,
+        notes: ['FeePool must expose version() == 2.'],
+      });
+    }
+  }
+
+  const currentMinStakeValue = currentMinStake as bigint;
+  let minStakeHandledByRecommendations = false;
+  const currentMaxStakeValue = currentMaxStakePerAddress as bigint;
+
+  const recConfigured = desiredRecMin !== undefined || desiredRecMax !== undefined;
+  if (recConfigured) {
+    const targetMin = desiredRecMin ?? currentMinStakeValue;
+    const targetMax = desiredRecMax ?? currentMaxStakeValue;
+    if (targetMin <= 0n) {
+      throw new Error('stakeRecommendations.min must be greater than zero');
+    }
+    if (targetMax !== 0n && targetMax < targetMin) {
+      throw new Error('stakeRecommendations.max cannot be below min');
+    }
+    const hasChange =
+      (desiredRecMin !== undefined && desiredRecMin !== currentMinStakeValue) ||
+      (desiredRecMax !== undefined && desiredRecMax !== currentMaxStakeValue);
+    if (hasChange) {
+      actions.push({
+        label: 'Update stake recommendations',
+        method: 'setStakeRecommendations',
+        args: [targetMin, targetMax],
+        current: `min ${formatToken(currentMinStakeValue, decimals, symbol)}, max ${
+          currentMaxStakeValue === 0n
+            ? 'disabled'
+            : formatToken(currentMaxStakeValue, decimals, symbol)
+        }`,
+        desired: `min ${formatToken(targetMin, decimals, symbol)}, max ${
+          targetMax === 0n
+            ? 'disabled'
+            : formatToken(targetMax, decimals, symbol)
+        }`,
+      });
+      if (desiredRecMin !== undefined) {
+        minStakeHandledByRecommendations = true;
+      }
+    }
+  }
+
+  if (
+    desiredMinStake !== undefined &&
+    !minStakeHandledByRecommendations &&
+    desiredMinStake !== currentMinStakeValue
+  ) {
+    if (desiredMinStake <= 0n) {
+      throw new Error('minStake must be greater than zero');
+    }
+    actions.push({
+      label: `Update minimum stake to ${formatToken(
+        desiredMinStake,
+        decimals,
+        symbol
+      )}`,
+      method: 'setMinStake',
+      args: [desiredMinStake],
+      current: formatToken(currentMinStakeValue, decimals, symbol),
+      desired: formatToken(desiredMinStake, decimals, symbol),
+    });
+  }
+
+  if (
+    desiredMaxStake !== undefined &&
+    desiredMaxStake !== currentMaxStakeValue
+  ) {
+    if (desiredMaxStake !== 0n && desiredMaxStake < currentMinStakeValue) {
+      throw new Error('maxStakePerAddress cannot be below the current minimum stake');
+    }
+    actions.push({
+      label: `Update max stake per address to ${
+        desiredMaxStake === 0n
+          ? 'disabled'
+          : formatToken(desiredMaxStake, decimals, symbol)
+      }`,
+      method: 'setMaxStakePerAddress',
+      args: [desiredMaxStake],
+      current:
+        currentMaxStakeValue === 0n
+          ? 'disabled'
+          : formatToken(currentMaxStakeValue, decimals, symbol),
+      desired:
+        desiredMaxStake === 0n
+          ? 'disabled'
+          : formatToken(desiredMaxStake, decimals, symbol),
+    });
+  }
+
+  const currentFee = Number(currentFeePct);
+  const currentBurn = Number(currentBurnPct);
+  const currentValidator = Number(currentValidatorRewardPct);
+  const targetFee = desiredFeePct ?? currentFee;
+  const targetBurn = desiredBurnPct ?? currentBurn;
+  const targetValidator = desiredValidatorPct ?? currentValidator;
+
+  if (targetFee + targetBurn + targetValidator > 100) {
+    throw new Error('feePct + burnPct + validatorRewardPct cannot exceed 100');
+  }
+
+  if (desiredFeePct !== undefined && desiredFeePct !== currentFee) {
+    percentageActions.push({
+      label: `Update protocol fee percentage to ${desiredFeePct}%`,
+      method: 'setFeePct',
+      args: [desiredFeePct],
+      current: `${currentFee}%`,
+      desired: `${desiredFeePct}%`,
+      delta: desiredFeePct - currentFee,
+    });
+  }
+
+  if (desiredBurnPct !== undefined && desiredBurnPct !== currentBurn) {
+    percentageActions.push({
+      label: `Update burn percentage to ${desiredBurnPct}%`,
+      method: 'setBurnPct',
+      args: [desiredBurnPct],
+      current: `${currentBurn}%`,
+      desired: `${desiredBurnPct}%`,
+      delta: desiredBurnPct - currentBurn,
+    });
+  }
+
+  if (
+    desiredValidatorPct !== undefined &&
+    desiredValidatorPct !== currentValidator
+  ) {
+    percentageActions.push({
+      label: `Update validator reward percentage to ${desiredValidatorPct}%`,
+      method: 'setValidatorRewardPct',
+      args: [desiredValidatorPct],
+      current: `${currentValidator}%`,
+      desired: `${desiredValidatorPct}%`,
+      delta: desiredValidatorPct - currentValidator,
+    });
+  }
+
+  percentageActions.sort((a, b) => a.delta - b.delta);
+  actions.push(...percentageActions);
+
+  if (
+    desiredEmployerSlashPct !== undefined ||
+    desiredTreasurySlashPct !== undefined
+  ) {
+    const employerTarget = desiredEmployerSlashPct ?? Number(currentEmployerSlashPct);
+    const treasuryTarget = desiredTreasurySlashPct ?? Number(currentTreasurySlashPct);
+    if (employerTarget + treasuryTarget > 100) {
+      throw new Error('employerSlashPct + treasurySlashPct cannot exceed 100');
+    }
+    const currentEmployer = Number(currentEmployerSlashPct);
+    const currentTreasuryPct = Number(currentTreasurySlashPct);
+    if (employerTarget !== currentEmployer || treasuryTarget !== currentTreasuryPct) {
+      actions.push({
+        label: `Update slashing percentages (employer ${employerTarget}%, treasury ${treasuryTarget}%)`,
+        method: 'setSlashingPercentages',
+        args: [employerTarget, treasuryTarget],
+        current: `employer ${currentEmployer}%, treasury ${currentTreasuryPct}%`,
+        desired: `employer ${employerTarget}%, treasury ${treasuryTarget}%`,
+        notes: ['Employer + treasury percentages must not exceed 100%.'],
+      });
+    }
+  }
+
+  if (
+    desiredUnbondingPeriod !== undefined &&
+    desiredUnbondingPeriod !== (currentUnbondingPeriod as bigint)
+  ) {
+    if (desiredUnbondingPeriod <= 0n) {
+      throw new Error('unbondingPeriodSeconds must be greater than zero');
+    }
+    actions.push({
+      label: `Update unbonding period to ${desiredUnbondingPeriod.toString()} seconds`,
+      method: 'setUnbondingPeriod',
+      args: [desiredUnbondingPeriod],
+      current: `${(currentUnbondingPeriod as bigint).toString()} seconds`,
+      desired: `${desiredUnbondingPeriod.toString()} seconds`,
+    });
+  }
+
+  const currentAutoEnabled = Boolean(currentAutoStakeEnabled);
+  if (
+    desiredAutoEnabled !== undefined &&
+    desiredAutoEnabled !== currentAutoEnabled
+  ) {
+    actions.push({
+      label: `${desiredAutoEnabled ? 'Enable' : 'Disable'} automatic stake tuning`,
+      method: 'autoTuneStakes',
+      args: [desiredAutoEnabled],
+      current: currentAutoEnabled ? 'enabled' : 'disabled',
+      desired: desiredAutoEnabled ? 'enabled' : 'disabled',
+    });
+  }
+
+  const autoTargets = {
+    threshold: desiredAutoThreshold ?? (currentDisputeThreshold as bigint),
+    increase: desiredAutoIncrease ?? Number(currentIncreasePct),
+    decrease: desiredAutoDecrease ?? Number(currentDecreasePct),
+    window: desiredAutoWindow ?? (currentWindow as bigint),
+    floor: desiredAutoFloor ?? (currentFloor as bigint),
+    ceil: desiredAutoCeil ?? (currentMaxMinStake as bigint),
+    tempThreshold: desiredTempThreshold ?? (currentTempThreshold as bigint),
+    hamThreshold: desiredHamThreshold ?? (currentHamThreshold as bigint),
+    disputeWeight: desiredDisputeWeight ?? (currentDisputeWeight as bigint),
+    tempWeight: desiredTempWeight ?? (currentTempWeight as bigint),
+    hamWeight: desiredHamWeight ?? (currentHamWeight as bigint),
+  };
+
+  if (autoTargets.increase < 0 || autoTargets.increase > 100) {
+    throw new Error('autoStake.increasePct must be between 0 and 100');
+  }
+  if (autoTargets.decrease < 0 || autoTargets.decrease > 100) {
+    throw new Error('autoStake.decreasePct must be between 0 and 100');
+  }
+
+  const autoChanged =
+    (desiredAutoThreshold !== undefined &&
+      desiredAutoThreshold !== (currentDisputeThreshold as bigint)) ||
+    (desiredAutoIncrease !== undefined &&
+      desiredAutoIncrease !== Number(currentIncreasePct)) ||
+    (desiredAutoDecrease !== undefined &&
+      desiredAutoDecrease !== Number(currentDecreasePct)) ||
+    (desiredAutoWindow !== undefined &&
+      desiredAutoWindow !== (currentWindow as bigint)) ||
+    (desiredAutoFloor !== undefined &&
+      desiredAutoFloor !== (currentFloor as bigint)) ||
+    (desiredAutoCeil !== undefined &&
+      desiredAutoCeil !== (currentMaxMinStake as bigint)) ||
+    (desiredTempThreshold !== undefined &&
+      desiredTempThreshold !== (currentTempThreshold as bigint)) ||
+    (desiredHamThreshold !== undefined &&
+      desiredHamThreshold !== (currentHamThreshold as bigint)) ||
+    (desiredDisputeWeight !== undefined &&
+      desiredDisputeWeight !== (currentDisputeWeight as bigint)) ||
+    (desiredTempWeight !== undefined &&
+      desiredTempWeight !== (currentTempWeight as bigint)) ||
+    (desiredHamWeight !== undefined &&
+      desiredHamWeight !== (currentHamWeight as bigint));
+
+  if (autoChanged) {
+    actions.push({
+      label: 'Update automatic stake tuning parameters',
+      method: 'configureAutoStake',
+      args: [
+        autoTargets.threshold,
+        autoTargets.increase,
+        autoTargets.decrease,
+        autoTargets.window,
+        autoTargets.floor,
+        autoTargets.ceil,
+        autoTargets.tempThreshold,
+        autoTargets.hamThreshold,
+        autoTargets.disputeWeight,
+        autoTargets.tempWeight,
+        autoTargets.hamWeight,
+      ],
+      notes: [
+        'Floor values of 0 keep the current minimum stake floor.',
+        'Ceiling of 0 disables the cap.',
+      ],
+    });
+  }
+
+  if (desiredMaxAGITypes !== undefined) {
+    if (!Number.isInteger(desiredMaxAGITypes) || desiredMaxAGITypes <= 0) {
+      throw new Error('maxAGITypes must be a positive integer');
+    }
+    if (desiredMaxAGITypes > MAX_AGI_TYPES_CAP) {
+      throw new Error(`maxAGITypes cannot exceed ${MAX_AGI_TYPES_CAP}`);
+    }
+    if (desiredMaxAGITypes < currentAgiTypeCount) {
+      throw new Error(
+        `maxAGITypes cannot be below the current AGI type count (${currentAgiTypeCount})`
+      );
+    }
+    const currentMaxAgi = Number(currentMaxAGITypes);
+    if (desiredMaxAGITypes !== currentMaxAgi) {
+      actions.push({
+        label: `Update max AGI types to ${desiredMaxAGITypes}`,
+        method: 'setMaxAGITypes',
+        args: [desiredMaxAGITypes],
+        current: currentMaxAgi.toString(),
+        desired: desiredMaxAGITypes.toString(),
+      });
+    }
+  }
+
+  if (desiredMaxTotalPayoutPct !== undefined) {
+    if (!Number.isInteger(desiredMaxTotalPayoutPct)) {
+      throw new Error('maxTotalPayoutPct must be an integer');
+    }
+    if (
+      desiredMaxTotalPayoutPct < 100 ||
+      desiredMaxTotalPayoutPct > MAX_PAYOUT_PCT
+    ) {
+      throw new Error(
+        `maxTotalPayoutPct must be between 100 and ${MAX_PAYOUT_PCT}`
+      );
+    }
+    const currentMaxTotal = Number(currentMaxTotalPayoutPct);
+    if (desiredMaxTotalPayoutPct !== currentMaxTotal) {
+      actions.push({
+        label: `Update max total payout percentage to ${desiredMaxTotalPayoutPct}%`,
+        method: 'setMaxTotalPayoutPct',
+        args: [desiredMaxTotalPayoutPct],
+        current: `${currentMaxTotal}%`,
+        desired: `${desiredMaxTotalPayoutPct}%`,
+      });
+    }
+  }
+
+  return {
+    module: 'StakeManager',
+    address: stakeManager.target as string,
+    actions,
+    configPath,
+    iface: stakeManager.interface,
+    contract: stakeManager,
+  };
+}
+
+export function renderStakeManagerPlan(plan: ModulePlan): string {
+  if (plan.actions.length === 0) {
+    return 'All tracked parameters already match the configuration.';
+  }
+  const lines: string[] = [];
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
+    lines.push(`${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      lines.push(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      lines.push(`   Desired: ${action.desired}`);
+    }
+    action.notes?.forEach((note) => lines.push(`   Note: ${note}`));
+    lines.push(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    if (data) {
+      lines.push(`   Calldata: ${data}`);
+    }
+    lines.push('');
+  });
+  return lines.join('\n');
+}

--- a/scripts/v2/lib/types.ts
+++ b/scripts/v2/lib/types.ts
@@ -1,0 +1,26 @@
+export interface PlannedAction {
+  label: string;
+  method: string;
+  args: any[];
+  current?: string;
+  desired?: string;
+  notes?: string[];
+}
+
+import type { Contract, Interface } from 'ethers';
+
+export interface ModulePlan {
+  module: string;
+  address: string;
+  actions: PlannedAction[];
+  configPath?: string;
+  warnings?: string[];
+  metadata?: Record<string, unknown>;
+  iface?: Interface;
+  contract?: Contract;
+}
+
+export interface ExecutionResult {
+  action: PlannedAction;
+  txHash: string;
+}

--- a/scripts/v2/lib/utils.ts
+++ b/scripts/v2/lib/utils.ts
@@ -1,0 +1,145 @@
+import { ethers } from 'ethers';
+
+export function describeArgs(args: any[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'bigint') {
+        return arg.toString();
+      }
+      if (typeof arg === 'string') {
+        return arg;
+      }
+      if (typeof arg === 'boolean') {
+        return arg ? 'true' : 'false';
+      }
+      if (Array.isArray(arg)) {
+        return `[${arg.map((value) => describeArgs([value])).join(', ')}]`;
+      }
+      return JSON.stringify(arg);
+    })
+    .join(', ');
+}
+
+export function sameAddress(a?: string, b?: string): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  return ethers.getAddress(a) === ethers.getAddress(b);
+}
+
+export function normaliseAddress(
+  value: string | null | undefined,
+  { allowZero = true }: { allowZero?: boolean } = {}
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return allowZero ? ethers.ZeroAddress : undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return allowZero ? ethers.ZeroAddress : undefined;
+  }
+  const address = ethers.getAddress(trimmed);
+  if (!allowZero && address === ethers.ZeroAddress) {
+    return undefined;
+  }
+  return address;
+}
+
+export function formatToken(
+  value: bigint,
+  decimals: number,
+  symbol: string
+): string {
+  return `${ethers.formatUnits(value, decimals)} ${symbol}`.trim();
+}
+
+export function parseBigInt(
+  value: unknown,
+  label: string,
+  { allowNegative = false }: { allowNegative?: boolean } = {}
+): bigint | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const asString = typeof value === 'string' ? value.trim() : String(value);
+  if (!asString) {
+    return undefined;
+  }
+  if (!/^[-+]?\d+$/.test(asString)) {
+    throw new Error(`${label} must be an integer`);
+  }
+  const parsed = BigInt(asString);
+  if (!allowNegative && parsed < 0n) {
+    throw new Error(`${label} cannot be negative`);
+  }
+  return parsed;
+}
+
+export function parsePercentage(
+  value: unknown,
+  label: string,
+  { max = 100 }: { max?: number } = {}
+): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+  if (!Number.isInteger(numberValue)) {
+    throw new Error(`${label} must be an integer between 0 and ${max}`);
+  }
+  if (numberValue < 0 || numberValue > max) {
+    throw new Error(`${label} must be between 0 and ${max}`);
+  }
+  return numberValue;
+}
+
+export function parseBoolean(value: unknown, label: string): boolean | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  const asString = String(value).trim().toLowerCase();
+  if (!asString) {
+    return undefined;
+  }
+  if (['true', '1', 'yes', 'y', 'on', 'enable', 'enabled'].includes(asString)) {
+    return true;
+  }
+  if (['false', '0', 'no', 'n', 'off', 'disable', 'disabled'].includes(asString)) {
+    return false;
+  }
+  throw new Error(`${label} must be a boolean value`);
+}
+
+export function parseTokenAmount(
+  rawValue: unknown,
+  tokensValue: unknown,
+  decimals: number,
+  label: string
+): bigint | undefined {
+  const direct = parseBigInt(rawValue, label);
+  if (direct !== undefined) {
+    return direct;
+  }
+  if (tokensValue === undefined || tokensValue === null) {
+    return undefined;
+  }
+  const asString =
+    typeof tokensValue === 'string' ? tokensValue.trim() : String(tokensValue);
+  if (!asString) {
+    return undefined;
+  }
+  const parsed = ethers.parseUnits(asString, decimals);
+  if (parsed < 0n) {
+    throw new Error(`${label}Tokens cannot be negative`);
+  }
+  return parsed;
+}

--- a/scripts/v2/ownerControlPlan.ts
+++ b/scripts/v2/ownerControlPlan.ts
@@ -1,0 +1,387 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { ethers, network } from 'hardhat';
+import {
+  loadTokenConfig,
+  loadJobRegistryConfig,
+  loadStakeManagerConfig,
+  loadFeePoolConfig,
+} from '../config';
+import { buildJobRegistryPlan } from './lib/jobRegistryPlan';
+import { buildStakeManagerPlan } from './lib/stakeManagerPlan';
+import { buildFeePoolPlan } from './lib/feePoolPlan';
+import { describeArgs, sameAddress } from './lib/utils';
+import type { ModulePlan, PlannedAction } from './lib/types';
+
+interface CliOptions {
+  execute: boolean;
+  json: boolean;
+  outPath?: string;
+}
+
+interface ActionSummary extends PlannedAction {
+  calldata?: string | null;
+  to: string;
+  value: string;
+}
+
+interface ModuleSummary {
+  module: string;
+  address: string;
+  owner?: string;
+  configPath?: string;
+  actions: ActionSummary[];
+  totalActions: number;
+}
+
+interface AggregatedPlan {
+  network: string;
+  chainId?: number;
+  signer: string;
+  generatedAt: string;
+  modules: ModuleSummary[];
+  totalActions: number;
+}
+
+function readEnvBoolean(key: string): boolean | undefined {
+  const value = process.env[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  const normalised = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalised)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalised)) {
+    return false;
+  }
+  return undefined;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false, json: false };
+  const envExecute = readEnvBoolean('OWNER_PLAN_EXECUTE');
+  const envJson = readEnvBoolean('OWNER_PLAN_JSON');
+  if (envExecute !== undefined) {
+    options.execute = envExecute;
+  }
+  if (envJson !== undefined) {
+    options.json = envJson;
+  }
+  if (process.env.OWNER_PLAN_OUT) {
+    options.outPath = process.env.OWNER_PLAN_OUT;
+  }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--execute') {
+      options.execute = true;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--out' || arg === '--output') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--out requires a file path');
+      }
+      options.outPath = value;
+      i += 1;
+    }
+  }
+  return options;
+}
+
+function serialiseArg(value: any): any {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => serialiseArg(item));
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value).map(([key, val]) => [
+      key,
+      serialiseArg(val),
+    ]);
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+function buildActionSummary(plan: ModulePlan, action: PlannedAction): ActionSummary {
+  const calldata = plan.iface?.encodeFunctionData(action.method, action.args) ?? null;
+  return {
+    ...action,
+    args: action.args.map((arg) => serialiseArg(arg)),
+    calldata,
+    to: plan.address,
+    value: '0',
+  };
+}
+
+async function ensureContractOwner(
+  label: string,
+  contract: any,
+  signerAddress: string | undefined,
+  enforce: boolean
+): Promise<string> {
+  if (!contract || typeof contract.owner !== 'function') {
+    throw new Error(`${label} does not expose owner()`);
+  }
+  const owner = await contract.owner();
+  if (enforce && (!signerAddress || !sameAddress(owner, signerAddress))) {
+    throw new Error(
+      `Signer ${signerAddress} is not the owner of ${label} (${owner}). Use --json to generate a call plan for offline execution.`
+    );
+  }
+  return owner;
+}
+
+async function writePlan(plan: AggregatedPlan, destination: string) {
+  const resolved = path.resolve(destination);
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  await fs.writeFile(resolved, `${JSON.stringify(plan, null, 2)}\n`, 'utf8');
+  console.log(`Wrote aggregated call plan to ${resolved}`);
+}
+
+function logModulePlan(module: ModuleSummary) {
+  console.log(`\n=== ${module.module} ===`);
+  console.log(`Address: ${module.address}`);
+  if (module.owner) {
+    console.log(`Owner:   ${module.owner}`);
+  }
+  if (module.configPath) {
+    console.log(`Config:  ${module.configPath}`);
+  }
+  if (module.actions.length === 0) {
+    console.log('No changes required.');
+    return;
+  }
+  console.log(`Planned actions (${module.actions.length}):`);
+  module.actions.forEach((action, index) => {
+    console.log(`\n${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      console.log(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      console.log(`   Desired: ${action.desired}`);
+    }
+    action.notes?.forEach((note) => console.log(`   Note: ${note}`));
+    console.log(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    if (action.calldata) {
+      console.log(`   Calldata: ${action.calldata}`);
+    }
+  });
+}
+
+async function executeModulePlan(plan: ModulePlan) {
+  if (!plan.contract) {
+    throw new Error(`Missing contract instance for ${plan.module}`);
+  }
+  if (plan.actions.length === 0) {
+    console.log(`No actions for ${plan.module}, skipping.`);
+    return [] as string[];
+  }
+  console.log(`\nExecuting ${plan.module} updates...`);
+  const txHashes: string[] = [];
+  for (const action of plan.actions) {
+    console.log(`→ ${action.method}`);
+    const tx = await (plan.contract as any)[action.method](...action.args);
+    console.log(`   Tx hash: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (receipt?.status !== 1n) {
+      throw new Error(`Transaction for ${action.method} failed`);
+    }
+    txHashes.push(tx.hash);
+    console.log('   Confirmed');
+  }
+  return txHashes;
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  let signerAddress: string | undefined;
+  let signer;
+  try {
+    const signers = await ethers.getSigners();
+    if (signers.length > 0) {
+      signer = signers[0];
+      signerAddress = await signers[0].getAddress();
+    } else {
+      console.warn('No signer available from Hardhat environment; running in read-only mode.');
+    }
+  } catch (error) {
+    console.warn('Unable to resolve Hardhat signer; running in read-only mode.');
+    if (process.env.DEBUG) {
+      console.warn(error);
+    }
+  }
+
+  const tokenResult = loadTokenConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
+  const tokenConfig = tokenResult.config;
+  const decimals =
+    typeof tokenConfig.decimals === 'number' ? tokenConfig.decimals : 18;
+  const symbol =
+    typeof tokenConfig.symbol === 'string' && tokenConfig.symbol
+      ? tokenConfig.symbol
+      : 'tokens';
+
+  const plans: ModulePlan[] = [];
+  const summaries: ModuleSummary[] = [];
+
+  const jobRegistryAddress = tokenConfig.modules?.jobRegistry;
+  if (jobRegistryAddress) {
+    const registryAddress = ethers.getAddress(jobRegistryAddress);
+    if (registryAddress === ethers.ZeroAddress) {
+      console.warn('JobRegistry address resolves to the zero address; skipping.');
+    } else {
+    const registry = await ethers.getContractAt(
+      'contracts/v2/JobRegistry.sol:JobRegistry',
+      registryAddress
+    );
+    const owner = await ensureContractOwner('JobRegistry', registry, signerAddress, cli.execute);
+    const jobConfig = loadJobRegistryConfig({
+      network: network.name,
+      chainId: network.config?.chainId,
+    });
+    const jobPlan = await buildJobRegistryPlan({
+      registry,
+      config: jobConfig.config,
+      configPath: jobConfig.path,
+      decimals,
+      symbol,
+    });
+    jobPlan.metadata = { ...(jobPlan.metadata || {}), owner };
+    plans.push(jobPlan);
+    }
+  } else {
+    console.warn('JobRegistry address missing from agialpha config; skipping.');
+  }
+
+  const stakeManagerAddress = tokenConfig.modules?.stakeManager;
+  if (stakeManagerAddress) {
+    const address = ethers.getAddress(stakeManagerAddress);
+    if (address === ethers.ZeroAddress) {
+      console.warn('StakeManager address resolves to the zero address; skipping.');
+    } else {
+    const stakeManager = await ethers.getContractAt(
+      'contracts/v2/StakeManager.sol:StakeManager',
+      address
+    );
+    const owner = await ensureContractOwner('StakeManager', stakeManager, signerAddress, cli.execute);
+    const stakeConfig = loadStakeManagerConfig({
+      network: network.name,
+      chainId: network.config?.chainId,
+    });
+    const stakePlan = await buildStakeManagerPlan({
+      stakeManager,
+      config: stakeConfig.config,
+      configPath: stakeConfig.path,
+      decimals,
+      symbol,
+      ownerAddress: owner,
+    });
+    stakePlan.metadata = { ...(stakePlan.metadata || {}), owner };
+    plans.push(stakePlan);
+    }
+  } else {
+    console.warn('StakeManager address missing from agialpha config; skipping.');
+  }
+
+  const feePoolAddress = tokenConfig.modules?.feePool;
+  if (feePoolAddress) {
+    const address = ethers.getAddress(feePoolAddress);
+    if (address === ethers.ZeroAddress) {
+      console.warn('FeePool address resolves to the zero address; skipping.');
+    } else {
+    const feePool = await ethers.getContractAt(
+      'contracts/v2/FeePool.sol:FeePool',
+      address
+    );
+    const version = await feePool.version();
+    if (version !== 2n) {
+      throw new Error(
+        `FeePool at ${address} reports version ${version}, expected 2`
+      );
+    }
+    const owner = await ensureContractOwner('FeePool', feePool, signerAddress, cli.execute);
+    const feeConfig = loadFeePoolConfig({
+      network: network.name,
+      chainId: network.config?.chainId,
+    });
+    const feePlan = await buildFeePoolPlan({
+      feePool,
+      config: feeConfig.config,
+      configPath: feeConfig.path,
+      ownerAddress: owner,
+    });
+    feePlan.metadata = { ...(feePlan.metadata || {}), owner };
+    plans.push(feePlan);
+    }
+  } else {
+    console.warn('FeePool address missing from agialpha config; skipping.');
+  }
+
+  if (plans.length === 0) {
+    console.warn('No module addresses resolved; nothing to plan.');
+  }
+
+  let totalActions = 0;
+  for (const plan of plans) {
+    const owner = (plan.metadata?.owner as string | undefined) ?? undefined;
+    const moduleSummary: ModuleSummary = {
+      module: plan.module,
+      address: plan.address,
+      owner,
+      configPath: plan.configPath,
+      actions: plan.actions.map((action) => buildActionSummary(plan, action)),
+      totalActions: plan.actions.length,
+    };
+    totalActions += plan.actions.length;
+    summaries.push(moduleSummary);
+  }
+
+  const aggregated: AggregatedPlan = {
+    network: tokenResult.network || network.name,
+    chainId: network.config?.chainId,
+    signer: signerAddress || '',
+    generatedAt: new Date().toISOString(),
+    modules: summaries,
+    totalActions,
+  };
+
+  if (cli.outPath) {
+    await writePlan(aggregated, cli.outPath);
+  }
+
+  if (cli.json) {
+    console.log(JSON.stringify(aggregated, null, 2));
+  } else {
+    console.log(`Signer:   ${aggregated.signer || 'n/a (read-only)'}`);
+    console.log(`Network:  ${aggregated.network}`);
+    if (aggregated.chainId) {
+      console.log(`Chain ID: ${aggregated.chainId}`);
+    }
+    console.log(`Modules planned: ${summaries.length}`);
+    console.log(`Total actions:   ${totalActions}`);
+    summaries.forEach((summary) => logModulePlan(summary));
+  }
+
+  if (!cli.execute) {
+    if (!cli.json) {
+      console.log('\nDry run complete. Use --execute to apply the plan or --json/--out for offline execution.');
+    }
+    return;
+  }
+
+  for (const plan of plans) {
+    await executeModulePlan(plan);
+  }
+  console.log('\nAll module updates confirmed.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/v2/run-owner-plan.js
+++ b/scripts/v2/run-owner-plan.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+
+const userArgs = process.argv.slice(2);
+const hardhatArgs = ['hardhat', 'run', '--no-compile', 'scripts/v2/ownerControlPlan.ts'];
+if (userArgs.length > 0) {
+  hardhatArgs.push('--', ...userArgs);
+}
+
+const child = spawn('npx', hardhatArgs, { stdio: 'inherit', shell: process.platform === 'win32' });
+child.on('exit', (code) => {
+  process.exit(code ?? 0);
+});

--- a/scripts/v2/updateFeePool.ts
+++ b/scripts/v2/updateFeePool.ts
@@ -1,26 +1,18 @@
 import { ethers, network } from 'hardhat';
 import type { Contract } from 'ethers';
 import { loadTokenConfig, loadFeePoolConfig } from '../config';
+import { buildFeePoolPlan, type FeePoolPlanInput } from './lib/feePoolPlan';
+import { describeArgs, sameAddress } from './lib/utils';
 
 interface CliOptions {
   execute: boolean;
   configPath?: string;
   feePoolAddress?: string;
+  json?: boolean;
 }
-
-interface PlannedAction {
-  label: string;
-  method: string;
-  args: any[];
-  current?: string;
-  desired?: string;
-  notes?: string[];
-}
-
-const ROLE_LABELS = ['Agent', 'Validator', 'Platform'];
 
 function parseArgs(argv: string[]): CliOptions {
-  const options: CliOptions = { execute: false };
+  const options: CliOptions = { execute: false, json: false };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--execute') {
@@ -39,94 +31,11 @@ function parseArgs(argv: string[]): CliOptions {
       }
       options.feePoolAddress = value;
       i += 1;
+    } else if (arg === '--json') {
+      options.json = true;
     }
   }
   return options;
-}
-
-function sameAddress(a?: string, b?: string): boolean {
-  if (!a || !b) return false;
-  return ethers.getAddress(a) === ethers.getAddress(b);
-}
-
-function parseRewardRole(value: unknown): number | undefined {
-  if (value === undefined || value === null || value === '') {
-    return undefined;
-  }
-  if (typeof value === 'number') {
-    if (!Number.isInteger(value) || value < 0 || value >= ROLE_LABELS.length) {
-      throw new Error(
-        'rewardRole must be 0 (Agent), 1 (Validator), or 2 (Platform)'
-      );
-    }
-    return value;
-  }
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return undefined;
-    }
-    if (/^\d+$/.test(trimmed)) {
-      const parsed = Number(trimmed);
-      if (
-        !Number.isInteger(parsed) ||
-        parsed < 0 ||
-        parsed >= ROLE_LABELS.length
-      ) {
-        throw new Error(
-          'rewardRole must be 0 (Agent), 1 (Validator), or 2 (Platform)'
-        );
-      }
-      return parsed;
-    }
-    const lower = trimmed.toLowerCase();
-    if (lower === 'agent') return 0;
-    if (lower === 'validator') return 1;
-    if (lower === 'platform' || lower === 'operator') return 2;
-    throw new Error(
-      "rewardRole must be one of 'agent', 'validator', 'platform' or the corresponding numeric value"
-    );
-  }
-  throw new Error('rewardRole must be a string or number');
-}
-
-function parsePercentage(value: unknown, label: string): number | undefined {
-  if (value === undefined || value === null || value === '') {
-    return undefined;
-  }
-  const numberValue = Number(value);
-  if (!Number.isFinite(numberValue)) {
-    throw new Error(`${label} must be a finite number`);
-  }
-  if (!Number.isInteger(numberValue)) {
-    throw new Error(`${label} must be an integer between 0 and 100`);
-  }
-  if (numberValue < 0 || numberValue > 100) {
-    throw new Error(`${label} must be between 0 and 100`);
-  }
-  return numberValue;
-}
-
-function formatRole(value: bigint | number): string {
-  const index = Number(value);
-  return ROLE_LABELS[index] ?? `Role(${index})`;
-}
-
-function describeArgs(args: any[]): string {
-  return args
-    .map((arg) => {
-      if (typeof arg === 'bigint') {
-        return arg.toString();
-      }
-      if (typeof arg === 'string') {
-        return arg;
-      }
-      if (typeof arg === 'boolean') {
-        return arg ? 'true' : 'false';
-      }
-      return JSON.stringify(arg);
-    })
-    .join(', ');
 }
 
 async function main() {
@@ -179,309 +88,30 @@ async function main() {
     );
   }
 
-  const [
-    currentStakeManager,
-    currentRewardRole,
-    currentBurnPct,
-    currentTreasury,
-    currentGovernance,
-    currentPauser,
-    currentTaxPolicy,
-  ] = await Promise.all([
-    feePool.stakeManager(),
-    feePool.rewardRole(),
-    feePool.burnPct(),
-    feePool.treasury(),
-    feePool.governance(),
-    feePool.pauser(),
-    feePool.taxPolicy(),
-  ]);
+  const planInput: FeePoolPlanInput = {
+    feePool,
+    config: feeConfig,
+    configPath: feeConfigPath,
+    ownerAddress,
+  };
+  const plan = await buildFeePoolPlan(planInput);
 
-  const currentStakeManagerAddress =
-    currentStakeManager === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentStakeManager);
-  const currentTreasuryAddress =
-    currentTreasury === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentTreasury);
-  const currentGovernanceAddress =
-    currentGovernance === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentGovernance);
-  const currentPauserAddress =
-    currentPauser === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentPauser);
-  const currentTaxPolicyAddress =
-    currentTaxPolicy === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentTaxPolicy);
-
-  const desiredStakeManager =
-    feeConfig.stakeManager && feeConfig.stakeManager !== ethers.ZeroAddress
-      ? ethers.getAddress(feeConfig.stakeManager as string)
-      : undefined;
-  const desiredRewardRole = parseRewardRole(feeConfig.rewardRole);
-  const desiredBurnPct = parsePercentage(feeConfig.burnPct, 'burnPct');
-  const desiredTreasury =
-    feeConfig.treasury !== undefined
-      ? ethers.getAddress(feeConfig.treasury as string)
-      : undefined;
-  const desiredGovernance =
-    feeConfig.governance !== undefined &&
-    feeConfig.governance !== ethers.ZeroAddress
-      ? ethers.getAddress(feeConfig.governance as string)
-      : undefined;
-  const desiredPauser =
-    feeConfig.pauser !== undefined
-      ? ethers.getAddress(feeConfig.pauser as string)
-      : undefined;
-  const desiredTaxPolicy =
-    feeConfig.taxPolicy !== undefined &&
-    feeConfig.taxPolicy !== ethers.ZeroAddress
-      ? ethers.getAddress(feeConfig.taxPolicy as string)
-      : undefined;
-
-  const allowlistActions: PlannedAction[] = [];
-  const mainActions: PlannedAction[] = [];
-  const rewarderActions: PlannedAction[] = [];
-
-  const allowlistState = new Map<string, boolean>();
-  async function syncAllowlistEntry(
-    addr: string,
-    desired: boolean,
-    note?: string
-  ) {
-    const normalized = ethers.getAddress(addr);
-    if (normalized === ethers.ZeroAddress) {
-      return;
-    }
-    const current = allowlistState.has(normalized)
-      ? allowlistState.get(normalized)!
-      : Boolean(await feePool.treasuryAllowlist(normalized));
-    if (current === desired) {
-      allowlistState.set(normalized, desired);
-      return;
-    }
-    const action: PlannedAction = {
-      label: `${desired ? 'Allow' : 'Block'} treasury ${normalized}`,
-      method: 'setTreasuryAllowlist',
-      args: [normalized, desired],
-      current: current ? 'allowed' : 'blocked',
-      desired: desired ? 'allowed' : 'blocked',
-    };
-    if (note) {
-      action.notes = [note];
-    }
-    allowlistActions.push(action);
-    allowlistState.set(normalized, desired);
+  if (cli.json) {
+    console.log(JSON.stringify(plan, null, 2));
+    return;
   }
-
-  const allowlistConfig = (feeConfig.treasuryAllowlist || {}) as Record<
-    string,
-    boolean
-  >;
-  const sortedAllowlist = Object.keys(allowlistConfig).sort((a, b) =>
-    a.localeCompare(b)
-  );
-  for (const addr of sortedAllowlist) {
-    await syncAllowlistEntry(addr, Boolean(allowlistConfig[addr]));
-  }
-
-  const rewarderState = new Map<string, boolean>();
-  async function syncRewarder(addr: string, desired: boolean) {
-    const normalized = ethers.getAddress(addr);
-    if (normalized === ethers.ZeroAddress) {
-      return;
-    }
-    const current = rewarderState.has(normalized)
-      ? rewarderState.get(normalized)!
-      : Boolean(await feePool.rewarders(normalized));
-    if (current === desired) {
-      rewarderState.set(normalized, desired);
-      return;
-    }
-    rewarderActions.push({
-      label: `${desired ? 'Authorize' : 'Revoke'} rewarder ${normalized}`,
-      method: 'setRewarder',
-      args: [normalized, desired],
-      current: current ? 'authorized' : 'revoked',
-      desired: desired ? 'authorized' : 'revoked',
-    });
-    rewarderState.set(normalized, desired);
-  }
-
-  const rewarderConfig = (feeConfig.rewarders || {}) as Record<string, boolean>;
-  const sortedRewarders = Object.keys(rewarderConfig).sort((a, b) =>
-    a.localeCompare(b)
-  );
-  for (const addr of sortedRewarders) {
-    await syncRewarder(addr, Boolean(rewarderConfig[addr]));
-  }
-
-  if (
-    desiredStakeManager &&
-    !sameAddress(desiredStakeManager, currentStakeManagerAddress)
-  ) {
-    const stakeManager = await ethers.getContractAt(
-      ['function version() view returns (uint256)'],
-      desiredStakeManager
-    );
-    const stakeVersion = await stakeManager.version();
-    if (stakeVersion !== 2n) {
-      throw new Error(
-        `StakeManager at ${desiredStakeManager} reports version ${stakeVersion}, expected 2`
-      );
-    }
-    mainActions.push({
-      label: `Update StakeManager to ${desiredStakeManager}`,
-      method: 'setStakeManager',
-      args: [desiredStakeManager],
-      current: currentStakeManagerAddress,
-      desired: desiredStakeManager,
-      notes: ['StakeManager must expose version() == 2.'],
-    });
-  }
-
-  if (
-    desiredRewardRole !== undefined &&
-    desiredRewardRole !== Number(currentRewardRole)
-  ) {
-    mainActions.push({
-      label: `Update reward role to ${formatRole(desiredRewardRole)}`,
-      method: 'setRewardRole',
-      args: [desiredRewardRole],
-      current: formatRole(currentRewardRole),
-      desired: formatRole(desiredRewardRole),
-    });
-  }
-
-  if (
-    desiredBurnPct !== undefined &&
-    desiredBurnPct !== Number(currentBurnPct)
-  ) {
-    mainActions.push({
-      label: `Update burn percentage to ${desiredBurnPct}%`,
-      method: 'setBurnPct',
-      args: [desiredBurnPct],
-      current: `${Number(currentBurnPct)}%`,
-      desired: `${desiredBurnPct}%`,
-    });
-  }
-
-  if (desiredTreasury !== undefined) {
-    if (
-      desiredTreasury !== ethers.ZeroAddress &&
-      sameAddress(desiredTreasury, ownerAddress)
-    ) {
-      throw new Error('Treasury cannot be set to the contract owner');
-    }
-    const normalizedTreasury = desiredTreasury;
-    if (
-      normalizedTreasury !== ethers.ZeroAddress &&
-      allowlistConfig[normalizedTreasury] === false
-    ) {
-      throw new Error(
-        `Treasury ${normalizedTreasury} is disabled in treasuryAllowlist; set it to true before updating`
-      );
-    }
-    if (
-      normalizedTreasury !== ethers.ZeroAddress &&
-      (!allowlistState.has(normalizedTreasury) ||
-        allowlistState.get(normalizedTreasury) !== true)
-    ) {
-      await syncAllowlistEntry(
-        normalizedTreasury,
-        true,
-        'Automatically allowing treasury address before updating.'
-      );
-    }
-    if (!sameAddress(normalizedTreasury, currentTreasuryAddress)) {
-      const notes = [] as string[];
-      if (normalizedTreasury === ethers.ZeroAddress) {
-        notes.push(
-          'Zero address burns rounding dust instead of forwarding it.'
-        );
-      }
-      mainActions.push({
-        label: `Update treasury to ${normalizedTreasury}`,
-        method: 'setTreasury',
-        args: [normalizedTreasury],
-        current: currentTreasuryAddress,
-        desired: normalizedTreasury,
-        notes: notes.length ? notes : undefined,
-      });
-    }
-  }
-
-  if (
-    desiredGovernance &&
-    !sameAddress(desiredGovernance, currentGovernanceAddress)
-  ) {
-    mainActions.push({
-      label: `Update governance to ${desiredGovernance}`,
-      method: 'setGovernance',
-      args: [desiredGovernance],
-      current: currentGovernanceAddress,
-      desired: desiredGovernance,
-      notes: [
-        'Governance address must be a TimelockController capable of calling governanceWithdraw.',
-      ],
-    });
-  }
-
-  if (
-    desiredPauser !== undefined &&
-    !sameAddress(desiredPauser, currentPauserAddress)
-  ) {
-    mainActions.push({
-      label: `Update pauser to ${desiredPauser}`,
-      method: 'setPauser',
-      args: [desiredPauser],
-      current: currentPauserAddress,
-      desired: desiredPauser,
-    });
-  }
-
-  if (
-    desiredTaxPolicy &&
-    !sameAddress(desiredTaxPolicy, currentTaxPolicyAddress)
-  ) {
-    const policy = await ethers.getContractAt(
-      ['function isTaxExempt() view returns (bool)'],
-      desiredTaxPolicy
-    );
-    const exempt = await policy.isTaxExempt();
-    if (!exempt) {
-      throw new Error(
-        `Tax policy at ${desiredTaxPolicy} must return true for isTaxExempt()`
-      );
-    }
-    mainActions.push({
-      label: `Update tax policy to ${desiredTaxPolicy}`,
-      method: 'setTaxPolicy',
-      args: [desiredTaxPolicy],
-      current: currentTaxPolicyAddress,
-      desired: desiredTaxPolicy,
-      notes: ['Target policy must remain tax exempt.'],
-    });
-  }
-
-  const actions = [...allowlistActions, ...mainActions, ...rewarderActions];
 
   console.log('FeePool:', feePoolAddress);
   console.log('Configuration file:', feeConfigPath);
 
-  if (actions.length === 0) {
+  if (plan.actions.length === 0) {
     console.log('All tracked parameters already match the configuration.');
     return;
   }
 
-  console.log(`Planned actions (${actions.length}):`);
-  const iface = feePool.interface;
-  actions.forEach((action, index) => {
-    const data = iface.encodeFunctionData(action.method, action.args);
+  console.log(`Planned actions (${plan.actions.length}):`);
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
     console.log(`\n${index + 1}. ${action.label}`);
     if (action.current !== undefined) {
       console.log(`   Current: ${action.current}`);
@@ -489,13 +119,13 @@ async function main() {
     if (action.desired !== undefined) {
       console.log(`   Desired: ${action.desired}`);
     }
-    if (action.notes) {
-      for (const note of action.notes) {
-        console.log(`   Note: ${note}`);
-      }
-    }
+    action.notes?.forEach((note) => {
+      console.log(`   Note: ${note}`);
+    });
     console.log(`   Method: ${action.method}(${describeArgs(action.args)})`);
-    console.log(`   Calldata: ${data}`);
+    if (data) {
+      console.log(`   Calldata: ${data}`);
+    }
   });
 
   if (!cli.execute || !sameAddress(ownerAddress, signerAddress)) {
@@ -506,7 +136,7 @@ async function main() {
   }
 
   console.log('\nSubmitting transactions...');
-  for (const action of actions) {
+  for (const action of plan.actions) {
     console.log(`Executing ${action.method}...`);
     const tx = await (feePool as any)[action.method](...action.args);
     console.log(`   Tx hash: ${tx.hash}`);

--- a/scripts/v2/updateJobRegistry.ts
+++ b/scripts/v2/updateJobRegistry.ts
@@ -5,26 +5,21 @@ import {
   loadJobRegistryConfig,
   type JobRegistryConfig,
 } from '../config';
+import {
+  buildJobRegistryPlan,
+  type JobRegistryPlanInput,
+} from './lib/jobRegistryPlan';
+import { describeArgs, sameAddress } from './lib/utils';
 
 interface CliOptions {
   execute: boolean;
   configPath?: string;
   registryAddress?: string;
+  json?: boolean;
 }
-
-interface PlannedAction {
-  label: string;
-  method: string;
-  args: any[];
-  current?: string;
-  desired?: string;
-  notes?: string[];
-}
-
-const MAX_UINT96 = (1n << 96n) - 1n;
 
 function parseArgs(argv: string[]): CliOptions {
-  const options: CliOptions = { execute: false };
+  const options: CliOptions = { execute: false, json: false };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--execute') {
@@ -43,120 +38,19 @@ function parseArgs(argv: string[]): CliOptions {
       }
       options.registryAddress = value;
       i += 1;
+    } else if (arg === '--json') {
+      options.json = true;
     }
   }
   return options;
 }
 
-function parseTokenAmount(
-  config: JobRegistryConfig,
-  key: string,
-  decimals: number
-): bigint | undefined {
-  const direct = config[key];
-  if (direct !== undefined && direct !== null) {
-    const asString =
-      typeof direct === 'string' ? direct.trim() : String(direct);
-    if (!asString) {
-      return undefined;
-    }
-    const value = BigInt(asString);
-    if (value < 0n) {
-      throw new Error(`${key} cannot be negative`);
-    }
+function resolveDecimals(config: JobRegistryConfig, fallback: number): number {
+  const value = (config as any)?.decimals;
+  if (typeof value === 'number' && Number.isInteger(value)) {
     return value;
   }
-  const tokensKey = `${key}Tokens`;
-  const tokenValue = config[tokensKey as keyof JobRegistryConfig];
-  if (tokenValue !== undefined && tokenValue !== null) {
-    const asString =
-      typeof tokenValue === 'string' ? tokenValue.trim() : String(tokenValue);
-    if (!asString) {
-      return undefined;
-    }
-    const parsed = ethers.parseUnits(asString, decimals);
-    if (parsed < 0n) {
-      throw new Error(`${tokensKey} cannot be negative`);
-    }
-    return parsed;
-  }
-  return undefined;
-}
-
-function parseInteger(value: unknown, label: string): bigint | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  const asString = typeof value === 'string' ? value.trim() : String(value);
-  if (!asString) {
-    return undefined;
-  }
-  if (!/^[-+]?\d+$/.test(asString)) {
-    throw new Error(`${label} must be an integer`);
-  }
-  const parsed = BigInt(asString);
-  if (parsed < 0n) {
-    throw new Error(`${label} cannot be negative`);
-  }
-  return parsed;
-}
-
-function parsePercentage(value: unknown, label: string): number | undefined {
-  if (value === undefined || value === null || value === '') {
-    return undefined;
-  }
-  const numberValue = Number(value);
-  if (!Number.isFinite(numberValue)) {
-    throw new Error(`${label} must be a finite number`);
-  }
-  if (!Number.isInteger(numberValue)) {
-    throw new Error(`${label} must be an integer between 0 and 100`);
-  }
-  if (numberValue < 0 || numberValue > 100) {
-    throw new Error(`${label} must be between 0 and 100`);
-  }
-  return numberValue;
-}
-
-function normaliseAddress(
-  value: string | null | undefined
-): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (value === null) {
-    return ethers.ZeroAddress;
-  }
-  const trimmed = value.trim();
-  if (!trimmed || trimmed === ethers.ZeroAddress) {
-    return ethers.ZeroAddress;
-  }
-  return ethers.getAddress(trimmed);
-}
-
-function sameAddress(a: string, b: string): boolean {
-  return ethers.getAddress(a) === ethers.getAddress(b);
-}
-
-function formatToken(value: bigint, decimals: number, symbol: string): string {
-  return `${ethers.formatUnits(value, decimals)} ${symbol}`.trim();
-}
-
-function describeArgs(args: any[]): string {
-  return args
-    .map((arg) => {
-      if (typeof arg === 'bigint') {
-        return arg.toString();
-      }
-      if (typeof arg === 'string') {
-        return arg;
-      }
-      if (typeof arg === 'boolean') {
-        return arg ? 'true' : 'false';
-      }
-      return JSON.stringify(arg);
-    })
-    .join(', ');
+  return fallback;
 }
 
 async function main() {
@@ -171,8 +65,7 @@ async function main() {
     path: cli.configPath,
   });
 
-  const decimals =
-    typeof tokenConfig.decimals === 'number' ? tokenConfig.decimals : 18;
+  const decimals = resolveDecimals(jobConfig, Number(tokenConfig.decimals) || 18);
   const symbol =
     typeof tokenConfig.symbol === 'string' && tokenConfig.symbol
       ? tokenConfig.symbol
@@ -210,261 +103,31 @@ async function main() {
     );
   }
 
-  const [
-    currentJobStake,
-    currentMaxJobReward,
-    currentMinAgentStake,
-    currentFeePct,
-    currentValidatorRewardPct,
-    currentMaxDuration,
-    currentMaxActiveJobs,
-    currentExpirationGrace,
-    currentTreasury,
-    currentTaxPolicy,
-  ] = await Promise.all([
-    registry.jobStake(),
-    registry.maxJobReward(),
-    registry.minAgentStake(),
-    registry.feePct(),
-    registry.validatorRewardPct(),
-    registry.maxJobDuration(),
-    registry.maxActiveJobsPerAgent(),
-    registry.expirationGracePeriod(),
-    registry.treasury(),
-    registry.taxPolicy(),
-  ]);
+  const planInput: JobRegistryPlanInput = {
+    registry,
+    config: jobConfig,
+    configPath: jobConfigPath,
+    decimals,
+    symbol,
+  };
+  const plan = await buildJobRegistryPlan(planInput);
 
-  const desiredJobStake = parseTokenAmount(jobConfig, 'jobStake', decimals);
-  const desiredMinAgentStake = parseTokenAmount(
-    jobConfig,
-    'minAgentStake',
-    decimals
-  );
-  const desiredMaxReward = parseTokenAmount(
-    jobConfig,
-    'maxJobReward',
-    decimals
-  );
-  const desiredDuration = parseInteger(
-    jobConfig.jobDurationLimitSeconds,
-    'jobDurationLimitSeconds'
-  );
-  const desiredMaxActive = parseInteger(
-    jobConfig.maxActiveJobsPerAgent,
-    'maxActiveJobsPerAgent'
-  );
-  const desiredExpirationGrace = parseInteger(
-    jobConfig.expirationGracePeriodSeconds,
-    'expirationGracePeriodSeconds'
-  );
-  const desiredFeePct = parsePercentage(jobConfig.feePct, 'feePct');
-  const desiredValidatorPct = parsePercentage(
-    jobConfig.validatorRewardPct,
-    'validatorRewardPct'
-  );
-  const desiredTreasury = normaliseAddress(
-    jobConfig.treasury as string | null | undefined
-  );
-  const desiredTaxPolicy = normaliseAddress(
-    jobConfig.taxPolicy as string | null | undefined
-  );
-
-  const actions: PlannedAction[] = [];
-
-  if (desiredJobStake !== undefined && desiredJobStake !== currentJobStake) {
-    if (desiredJobStake > MAX_UINT96) {
-      throw new Error('jobStake exceeds uint96 range');
-    }
-    actions.push({
-      label: `Update job stake to ${formatToken(
-        desiredJobStake,
-        decimals,
-        symbol
-      )}`,
-      method: 'setJobStake',
-      args: [desiredJobStake],
-      current: formatToken(currentJobStake, decimals, symbol),
-      desired: formatToken(desiredJobStake, decimals, symbol),
-    });
-  }
-
-  if (
-    desiredMinAgentStake !== undefined &&
-    desiredMinAgentStake !== currentMinAgentStake
-  ) {
-    if (desiredMinAgentStake > MAX_UINT96) {
-      throw new Error('minAgentStake exceeds uint96 range');
-    }
-    actions.push({
-      label: `Update minimum agent stake to ${formatToken(
-        desiredMinAgentStake,
-        decimals,
-        symbol
-      )}`,
-      method: 'setMinAgentStake',
-      args: [desiredMinAgentStake],
-      current: formatToken(currentMinAgentStake, decimals, symbol),
-      desired: formatToken(desiredMinAgentStake, decimals, symbol),
-    });
-  }
-
-  if (
-    desiredMaxReward !== undefined &&
-    desiredMaxReward !== currentMaxJobReward
-  ) {
-    actions.push({
-      label: `Update maximum job reward to ${formatToken(
-        desiredMaxReward,
-        decimals,
-        symbol
-      )}`,
-      method: 'setMaxJobReward',
-      args: [desiredMaxReward],
-      current: formatToken(currentMaxJobReward, decimals, symbol),
-      desired: formatToken(desiredMaxReward, decimals, symbol),
-    });
-  }
-
-  if (desiredDuration !== undefined && desiredDuration !== currentMaxDuration) {
-    actions.push({
-      label: `Update job duration limit to ${desiredDuration} seconds`,
-      method: 'setJobDurationLimit',
-      args: [desiredDuration],
-      current: `${currentMaxDuration.toString()} seconds`,
-      desired: `${desiredDuration.toString()} seconds`,
-    });
-  }
-
-  if (
-    desiredMaxActive !== undefined &&
-    desiredMaxActive !== currentMaxActiveJobs
-  ) {
-    actions.push({
-      label: `Update maximum active jobs per agent to ${desiredMaxActive}`,
-      method: 'setMaxActiveJobsPerAgent',
-      args: [desiredMaxActive],
-      current: currentMaxActiveJobs.toString(),
-      desired: desiredMaxActive.toString(),
-    });
-  }
-
-  if (
-    desiredExpirationGrace !== undefined &&
-    desiredExpirationGrace !== currentExpirationGrace
-  ) {
-    actions.push({
-      label: `Update expiration grace period to ${desiredExpirationGrace} seconds`,
-      method: 'setExpirationGracePeriod',
-      args: [desiredExpirationGrace],
-      current: `${currentExpirationGrace.toString()} seconds`,
-      desired: `${desiredExpirationGrace.toString()} seconds`,
-    });
-  }
-
-  const currentFee = Number(currentFeePct);
-  const currentValidator = Number(currentValidatorRewardPct);
-
-  if (desiredFeePct !== undefined) {
-    const validatorTarget =
-      desiredValidatorPct !== undefined
-        ? desiredValidatorPct
-        : currentValidator;
-    if (desiredFeePct + validatorTarget > 100) {
-      throw new Error('feePct + validatorRewardPct cannot exceed 100');
-    }
-    if (desiredFeePct !== currentFee) {
-      actions.push({
-        label: `Update protocol fee percentage to ${desiredFeePct}%`,
-        method: 'setFeePct',
-        args: [desiredFeePct],
-        current: `${currentFee}%`,
-        desired: `${desiredFeePct}%`,
-      });
-    }
-  }
-
-  if (desiredValidatorPct !== undefined) {
-    const feeTarget = desiredFeePct !== undefined ? desiredFeePct : currentFee;
-    if (desiredValidatorPct + feeTarget > 100) {
-      throw new Error('feePct + validatorRewardPct cannot exceed 100');
-    }
-    if (desiredValidatorPct !== currentValidator) {
-      actions.push({
-        label: `Update validator reward percentage to ${desiredValidatorPct}%`,
-        method: 'setValidatorRewardPct',
-        args: [desiredValidatorPct],
-        current: `${currentValidator}%`,
-        desired: `${desiredValidatorPct}%`,
-      });
-    }
-  }
-
-  const currentTreasuryAddress =
-    currentTreasury === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentTreasury);
-  if (
-    desiredTreasury !== undefined &&
-    desiredTreasury !== currentTreasuryAddress
-  ) {
-    actions.push({
-      label: `Update treasury to ${desiredTreasury}`,
-      method: 'setTreasury',
-      args: [desiredTreasury],
-      current: currentTreasuryAddress,
-      desired: desiredTreasury,
-      notes: ['Passing the zero address burns forfeited payouts.'],
-    });
-  }
-
-  const currentTaxPolicyAddress =
-    currentTaxPolicy === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentTaxPolicy);
-  if (
-    desiredTaxPolicy &&
-    desiredTaxPolicy !== ethers.ZeroAddress &&
-    desiredTaxPolicy !== currentTaxPolicyAddress
-  ) {
-    actions.push({
-      label: `Update tax policy to ${desiredTaxPolicy}`,
-      method: 'setTaxPolicy',
-      args: [desiredTaxPolicy],
-      current: currentTaxPolicyAddress,
-      desired: desiredTaxPolicy,
-    });
-  }
-
-  const acknowledgers = jobConfig.acknowledgers || {};
-  const sortedAcks = Object.keys(acknowledgers).sort((a, b) =>
-    a.localeCompare(b)
-  );
-  for (const ack of sortedAcks) {
-    const desired = acknowledgers[ack];
-    const current = await registry.acknowledgers(ack);
-    if (Boolean(desired) !== current) {
-      actions.push({
-        label: `${desired ? 'Enable' : 'Disable'} acknowledger ${ack}`,
-        method: 'setAcknowledger',
-        args: [ack, Boolean(desired)],
-        current: current ? 'allowed' : 'blocked',
-        desired: desired ? 'allowed' : 'blocked',
-      });
-    }
+  if (cli.json) {
+    console.log(JSON.stringify(plan, null, 2));
+    return;
   }
 
   console.log('Job Registry:', jobRegistryAddress);
   console.log('Configuration file:', jobConfigPath);
 
-  if (actions.length === 0) {
+  if (plan.actions.length === 0) {
     console.log('All tracked parameters already match the configuration.');
     return;
   }
 
-  console.log(`Planned actions (${actions.length}):`);
-  const iface = registry.interface;
-  actions.forEach((action, index) => {
-    const data = iface.encodeFunctionData(action.method, action.args);
+  console.log(`Planned actions (${plan.actions.length}):`);
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
     console.log(`\n${index + 1}. ${action.label}`);
     if (action.current !== undefined) {
       console.log(`   Current: ${action.current}`);
@@ -472,13 +135,13 @@ async function main() {
     if (action.desired !== undefined) {
       console.log(`   Desired: ${action.desired}`);
     }
-    if (action.notes) {
-      for (const note of action.notes) {
-        console.log(`   Note: ${note}`);
-      }
-    }
+    action.notes?.forEach((note) => {
+      console.log(`   Note: ${note}`);
+    });
     console.log(`   Method: ${action.method}(${describeArgs(action.args)})`);
-    console.log(`   Calldata: ${data}`);
+    if (data) {
+      console.log(`   Calldata: ${data}`);
+    }
   });
 
   if (!cli.execute || !sameAddress(ownerAddress, signerAddress)) {
@@ -489,7 +152,7 @@ async function main() {
   }
 
   console.log('\nSubmitting transactions...');
-  for (const action of actions) {
+  for (const action of plan.actions) {
     console.log(`Executing ${action.method}...`);
     const tx = await (registry as any)[action.method](...action.args);
     console.log(`   Tx hash: ${tx.hash}`);

--- a/scripts/v2/updateStakeManager.ts
+++ b/scripts/v2/updateStakeManager.ts
@@ -1,27 +1,21 @@
 import { ethers, network } from 'hardhat';
 import type { Contract } from 'ethers';
 import { loadTokenConfig, loadStakeManagerConfig } from '../config';
+import {
+  buildStakeManagerPlan,
+  type StakeManagerPlanInput,
+} from './lib/stakeManagerPlan';
+import { describeArgs, sameAddress } from './lib/utils';
 
 interface CliOptions {
   execute: boolean;
   configPath?: string;
   stakeManagerAddress?: string;
+  json?: boolean;
 }
-
-interface PlannedAction {
-  label: string;
-  method: string;
-  args: any[];
-  current?: string;
-  desired?: string;
-  notes?: string[];
-}
-
-const MAX_AGI_TYPES_CAP = 50;
-const MAX_PAYOUT_PCT = 200;
 
 function parseArgs(argv: string[]): CliOptions {
-  const options: CliOptions = { execute: false };
+  const options: CliOptions = { execute: false, json: false };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--execute') {
@@ -40,158 +34,11 @@ function parseArgs(argv: string[]): CliOptions {
       }
       options.stakeManagerAddress = value;
       i += 1;
+    } else if (arg === '--json') {
+      options.json = true;
     }
   }
   return options;
-}
-
-function parseTokenValue(
-  baseValue: unknown,
-  tokensValue: unknown,
-  decimals: number,
-  label: string
-): bigint | undefined {
-  if (baseValue !== undefined && baseValue !== null) {
-    const asString =
-      typeof baseValue === 'string' ? baseValue.trim() : String(baseValue);
-    if (!asString) {
-      return undefined;
-    }
-    if (!/^[-+]?\d+$/.test(asString)) {
-      throw new Error(`${label} must be an integer`);
-    }
-    const parsed = BigInt(asString);
-    if (parsed < 0n) {
-      throw new Error(`${label} cannot be negative`);
-    }
-    return parsed;
-  }
-  if (tokensValue !== undefined && tokensValue !== null) {
-    const asString =
-      typeof tokensValue === 'string'
-        ? tokensValue.trim()
-        : String(tokensValue);
-    if (!asString) {
-      return undefined;
-    }
-    const parsed = ethers.parseUnits(asString, decimals);
-    if (parsed < 0n) {
-      throw new Error(`${label}Tokens cannot be negative`);
-    }
-    return parsed;
-  }
-  return undefined;
-}
-
-function parseInteger(value: unknown, label: string): bigint | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  const asString = typeof value === 'string' ? value.trim() : String(value);
-  if (!asString) {
-    return undefined;
-  }
-  if (!/^[-+]?\d+$/.test(asString)) {
-    throw new Error(`${label} must be an integer`);
-  }
-  const parsed = BigInt(asString);
-  if (parsed < 0n) {
-    throw new Error(`${label} cannot be negative`);
-  }
-  return parsed;
-}
-
-function parseSignedInteger(value: unknown, label: string): bigint | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  const asString = typeof value === 'string' ? value.trim() : String(value);
-  if (!asString) {
-    return undefined;
-  }
-  if (!/^[-+]?\d+$/.test(asString)) {
-    throw new Error(`${label} must be an integer`);
-  }
-  return BigInt(asString);
-}
-
-function parsePercentage(value: unknown, label: string): number | undefined {
-  if (value === undefined || value === null || value === '') {
-    return undefined;
-  }
-  const numberValue = Number(value);
-  if (!Number.isFinite(numberValue)) {
-    throw new Error(`${label} must be a finite number`);
-  }
-  if (!Number.isInteger(numberValue)) {
-    throw new Error(`${label} must be an integer between 0 and 100`);
-  }
-  if (numberValue < 0 || numberValue > 100) {
-    throw new Error(`${label} must be between 0 and 100`);
-  }
-  return numberValue;
-}
-
-function parseBoolean(value: unknown, label: string): boolean | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value === 'boolean') {
-    return value;
-  }
-  const asString = String(value).trim().toLowerCase();
-  if (!asString) {
-    return undefined;
-  }
-  if (['true', '1', 'yes', 'y', 'on', 'enable', 'enabled'].includes(asString)) {
-    return true;
-  }
-  if (
-    ['false', '0', 'no', 'n', 'off', 'disable', 'disabled'].includes(asString)
-  ) {
-    return false;
-  }
-  throw new Error(`${label} must be a boolean value`);
-}
-
-function sameAddress(a?: string, b?: string): boolean {
-  if (!a || !b) return false;
-  return ethers.getAddress(a) === ethers.getAddress(b);
-}
-
-function formatToken(value: bigint, decimals: number, symbol: string): string {
-  return `${ethers.formatUnits(value, decimals)} ${symbol}`.trim();
-}
-
-function describeArgs(args: any[]): string {
-  return args
-    .map((arg) => {
-      if (typeof arg === 'bigint') {
-        return arg.toString();
-      }
-      if (typeof arg === 'string') {
-        return arg;
-      }
-      if (typeof arg === 'boolean') {
-        return arg ? 'true' : 'false';
-      }
-      return JSON.stringify(arg);
-    })
-    .join(', ');
-}
-
-async function ensureModuleVersion(
-  address: string,
-  artifact: string,
-  label: string
-): Promise<void> {
-  const contract = await ethers.getContractAt(artifact, address);
-  const version = await contract.version();
-  if (version !== 2n) {
-    throw new Error(
-      `${label} at ${address} reports version ${version}, expected 2`
-    );
-  }
 }
 
 async function main() {
@@ -200,13 +47,11 @@ async function main() {
     network: network.name,
     chainId: network.config?.chainId,
   });
-  const { config: stakeConfig, path: stakeConfigPath } = loadStakeManagerConfig(
-    {
-      network: network.name,
-      chainId: network.config?.chainId,
-      path: cli.configPath,
-    }
-  );
+  const { config: stakeConfig, path: stakeConfigPath } = loadStakeManagerConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+    path: cli.configPath,
+  });
 
   const decimals =
     typeof tokenConfig.decimals === 'number' ? tokenConfig.decimals : 18;
@@ -247,742 +92,32 @@ async function main() {
     );
   }
 
-  const [
-    currentMinStake,
-    currentFeePct,
-    currentBurnPct,
-    currentValidatorRewardPct,
-    currentEmployerSlashPct,
-    currentTreasurySlashPct,
-    currentTreasury,
-    currentFeePool,
-    currentUnbondingPeriod,
-    currentMaxStakePerAddress,
-    currentAutoStakeEnabled,
-    currentDisputeThreshold,
-    currentIncreasePct,
-    currentDecreasePct,
-    currentWindow,
-    currentFloor,
-    currentMaxMinStake,
-    currentTempThreshold,
-    currentHamThreshold,
-    currentDisputeWeight,
-    currentTempWeight,
-    currentHamWeight,
-    currentThermostat,
-    currentHamiltonianFeed,
-    currentJobRegistry,
-    currentDisputeModule,
-    currentValidationModule,
-    currentPauser,
-    currentMaxAGITypes,
-    currentMaxTotalPayoutPct,
-    currentAGITypes,
-  ] = await Promise.all([
-    stakeManager.minStake(),
-    stakeManager.feePct(),
-    stakeManager.burnPct(),
-    stakeManager.validatorRewardPct(),
-    stakeManager.employerSlashPct(),
-    stakeManager.treasurySlashPct(),
-    stakeManager.treasury(),
-    stakeManager.feePool(),
-    stakeManager.unbondingPeriod(),
-    stakeManager.maxStakePerAddress(),
-    stakeManager.autoStakeTuning(),
-    stakeManager.stakeDisputeThreshold(),
-    stakeManager.stakeIncreasePct(),
-    stakeManager.stakeDecreasePct(),
-    stakeManager.stakeTuneWindow(),
-    stakeManager.minStakeFloor(),
-    stakeManager.maxMinStake(),
-    stakeManager.stakeTempThreshold(),
-    stakeManager.stakeHamiltonianThreshold(),
-    stakeManager.disputeWeight(),
-    stakeManager.temperatureWeight(),
-    stakeManager.hamiltonianWeight(),
-    stakeManager.thermostat(),
-    stakeManager.hamiltonianFeed(),
-    stakeManager.jobRegistry(),
-    stakeManager.disputeModule(),
-    stakeManager.validationModule(),
-    stakeManager.pauser(),
-    stakeManager.maxAGITypes(),
-    stakeManager.maxTotalPayoutPct(),
-    stakeManager.getAGITypes(),
-  ]);
-
-  const currentAgiTypeCount = Array.isArray(currentAGITypes)
-    ? currentAGITypes.length
-    : Number((currentAGITypes as any)?.length ?? 0);
-
-  const desiredMinStake = parseTokenValue(
-    stakeConfig.minStake,
-    stakeConfig.minStakeTokens,
+  const planInput: StakeManagerPlanInput = {
+    stakeManager,
+    config: stakeConfig,
+    configPath: stakeConfigPath,
     decimals,
-    'minStake'
-  );
-  const desiredMaxStake = parseTokenValue(
-    stakeConfig.maxStakePerAddress,
-    stakeConfig.maxStakePerAddressTokens,
-    decimals,
-    'maxStakePerAddress'
-  );
-  const desiredFeePct = parsePercentage(stakeConfig.feePct, 'feePct');
-  const desiredBurnPct = parsePercentage(stakeConfig.burnPct, 'burnPct');
-  const desiredValidatorPct = parsePercentage(
-    stakeConfig.validatorRewardPct,
-    'validatorRewardPct'
-  );
-  const desiredEmployerSlashPct = parsePercentage(
-    stakeConfig.employerSlashPct,
-    'employerSlashPct'
-  );
-  const desiredTreasurySlashPct = parsePercentage(
-    stakeConfig.treasurySlashPct,
-    'treasurySlashPct'
-  );
-  const desiredUnbondingPeriod = parseInteger(
-    stakeConfig.unbondingPeriodSeconds,
-    'unbondingPeriodSeconds'
-  );
-
-  const recommendations = (stakeConfig.stakeRecommendations || {}) as Record<
-    string,
-    unknown
-  >;
-  const desiredRecMin = parseTokenValue(
-    recommendations.min,
-    recommendations.minTokens,
-    decimals,
-    'stakeRecommendations.min'
-  );
-  const desiredRecMax = parseTokenValue(
-    recommendations.max,
-    recommendations.maxTokens,
-    decimals,
-    'stakeRecommendations.max'
-  );
-
-  const autoConfig = (stakeConfig.autoStake || {}) as Record<string, unknown>;
-  const desiredAutoEnabled = parseBoolean(
-    autoConfig.enabled,
-    'autoStake.enabled'
-  );
-  const desiredAutoThreshold = parseInteger(
-    autoConfig.threshold,
-    'autoStake.threshold'
-  );
-  const desiredAutoIncrease = parsePercentage(
-    autoConfig.increasePct,
-    'autoStake.increasePct'
-  );
-  const desiredAutoDecrease = parsePercentage(
-    autoConfig.decreasePct,
-    'autoStake.decreasePct'
-  );
-  const desiredAutoWindow = parseInteger(
-    autoConfig.windowSeconds,
-    'autoStake.windowSeconds'
-  );
-  const desiredAutoFloor = parseTokenValue(
-    autoConfig.floor,
-    autoConfig.floorTokens,
-    decimals,
-    'autoStake.floor'
-  );
-  const desiredAutoCeil = parseTokenValue(
-    autoConfig.ceiling,
-    autoConfig.ceilingTokens,
-    decimals,
-    'autoStake.ceiling'
-  );
-  const desiredTempThreshold = parseSignedInteger(
-    autoConfig.temperatureThreshold,
-    'autoStake.temperatureThreshold'
-  );
-  const desiredHamThreshold = parseSignedInteger(
-    autoConfig.hamiltonianThreshold,
-    'autoStake.hamiltonianThreshold'
-  );
-  const desiredDisputeWeight = parseInteger(
-    autoConfig.disputeWeight,
-    'autoStake.disputeWeight'
-  );
-  const desiredTempWeight = parseInteger(
-    autoConfig.temperatureWeight,
-    'autoStake.temperatureWeight'
-  );
-  const desiredHamWeight = parseInteger(
-    autoConfig.hamiltonianWeight,
-    'autoStake.hamiltonianWeight'
-  );
-
-  const desiredTreasury =
-    stakeConfig.treasury !== undefined
-      ? ethers.getAddress(stakeConfig.treasury as string)
-      : undefined;
-  const desiredPauser =
-    stakeConfig.pauser !== undefined
-      ? ethers.getAddress(stakeConfig.pauser as string)
-      : undefined;
-  const desiredThermostat =
-    stakeConfig.thermostat !== undefined
-      ? ethers.getAddress(stakeConfig.thermostat as string)
-      : undefined;
-  const desiredHamiltonianFeed =
-    stakeConfig.hamiltonianFeed !== undefined
-      ? ethers.getAddress(stakeConfig.hamiltonianFeed as string)
-      : undefined;
-  const desiredJobRegistry =
-    stakeConfig.jobRegistry !== undefined &&
-    stakeConfig.jobRegistry !== ethers.ZeroAddress
-      ? ethers.getAddress(stakeConfig.jobRegistry as string)
-      : undefined;
-  const desiredDisputeModule =
-    stakeConfig.disputeModule !== undefined &&
-    stakeConfig.disputeModule !== ethers.ZeroAddress
-      ? ethers.getAddress(stakeConfig.disputeModule as string)
-      : undefined;
-  const desiredValidationModule =
-    stakeConfig.validationModule !== undefined &&
-    stakeConfig.validationModule !== ethers.ZeroAddress
-      ? ethers.getAddress(stakeConfig.validationModule as string)
-      : undefined;
-  const desiredFeePool =
-    stakeConfig.feePool !== undefined &&
-    stakeConfig.feePool !== ethers.ZeroAddress
-      ? ethers.getAddress(stakeConfig.feePool as string)
-      : undefined;
-
-  const desiredMaxAGITypes =
-    stakeConfig.maxAGITypes !== undefined
-      ? Number(stakeConfig.maxAGITypes)
-      : undefined;
-  const desiredMaxTotalPayoutPct =
-    stakeConfig.maxTotalPayoutPct !== undefined
-      ? Number(stakeConfig.maxTotalPayoutPct)
-      : undefined;
-
-  const actions: PlannedAction[] = [];
-  const percentageActions: Array<PlannedAction & { delta: number }> = [];
-
-  const currentTreasuryAddress =
-    currentTreasury === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentTreasury);
-  if (
-    desiredTreasury !== undefined &&
-    !sameAddress(desiredTreasury, currentTreasuryAddress)
-  ) {
-    if (
-      desiredTreasury !== ethers.ZeroAddress &&
-      sameAddress(desiredTreasury, ownerAddress)
-    ) {
-      throw new Error('Treasury cannot be set to the owner address');
-    }
-    actions.push({
-      label: `Update treasury to ${desiredTreasury}`,
-      method: 'setTreasury',
-      args: [desiredTreasury],
-      current: currentTreasuryAddress,
-      desired: desiredTreasury,
-      notes: [
-        'Passing the zero address burns the treasury share of slashed stake.',
-      ],
-    });
-  }
-
-  const allowlist = (stakeConfig.treasuryAllowlist || {}) as Record<
-    string,
-    boolean
-  >;
-  const sortedAllowlist = Object.keys(allowlist).sort((a, b) =>
-    a.localeCompare(b)
-  );
-  for (const addr of sortedAllowlist) {
-    const desired = Boolean(allowlist[addr]);
-    const current = await stakeManager.treasuryAllowlist(addr);
-    if (current !== desired) {
-      actions.push({
-        label: `${desired ? 'Allow' : 'Block'} treasury ${addr}`,
-        method: 'setTreasuryAllowlist',
-        args: [addr, desired],
-        current: current ? 'allowed' : 'blocked',
-        desired: desired ? 'allowed' : 'blocked',
-      });
-    }
-  }
-
-  const currentPauserAddress =
-    currentPauser === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentPauser);
-  if (
-    desiredPauser !== undefined &&
-    !sameAddress(desiredPauser, currentPauserAddress)
-  ) {
-    actions.push({
-      label: `Update pauser to ${desiredPauser}`,
-      method: 'setPauser',
-      args: [desiredPauser],
-      current: currentPauserAddress,
-      desired: desiredPauser,
-    });
-  }
-
-  if (
-    desiredThermostat !== undefined &&
-    !sameAddress(desiredThermostat, currentThermostat)
-  ) {
-    actions.push({
-      label: `Update thermostat to ${desiredThermostat}`,
-      method: 'setThermostat',
-      args: [desiredThermostat],
-      current: ethers.getAddress(currentThermostat),
-      desired: desiredThermostat,
-    });
-  }
-
-  if (
-    desiredHamiltonianFeed !== undefined &&
-    !sameAddress(desiredHamiltonianFeed, currentHamiltonianFeed)
-  ) {
-    actions.push({
-      label: `Update Hamiltonian feed to ${desiredHamiltonianFeed}`,
-      method: 'setHamiltonianFeed',
-      args: [desiredHamiltonianFeed],
-      current: ethers.getAddress(currentHamiltonianFeed),
-      desired: desiredHamiltonianFeed,
-    });
-  }
-
-  if (desiredJobRegistry) {
-    await ensureModuleVersion(
-      desiredJobRegistry,
-      'contracts/v2/interfaces/IJobRegistry.sol:IJobRegistry',
-      'JobRegistry'
-    );
-    const currentJobRegistryAddress =
-      currentJobRegistry === ethers.ZeroAddress
-        ? ethers.ZeroAddress
-        : ethers.getAddress(currentJobRegistry);
-    if (!sameAddress(desiredJobRegistry, currentJobRegistryAddress)) {
-      actions.push({
-        label: `Update JobRegistry to ${desiredJobRegistry}`,
-        method: 'setJobRegistry',
-        args: [desiredJobRegistry],
-        current: currentJobRegistryAddress,
-        desired: desiredJobRegistry,
-      });
-    }
-  }
-
-  if (desiredDisputeModule) {
-    await ensureModuleVersion(
-      desiredDisputeModule,
-      'contracts/v2/interfaces/IDisputeModule.sol:IDisputeModule',
-      'DisputeModule'
-    );
-    const currentDisputeModuleAddress =
-      currentDisputeModule === ethers.ZeroAddress
-        ? ethers.ZeroAddress
-        : ethers.getAddress(currentDisputeModule);
-    if (!sameAddress(desiredDisputeModule, currentDisputeModuleAddress)) {
-      actions.push({
-        label: `Update DisputeModule to ${desiredDisputeModule}`,
-        method: 'setDisputeModule',
-        args: [desiredDisputeModule],
-        current: currentDisputeModuleAddress,
-        desired: desiredDisputeModule,
-      });
-    }
-  }
-
-  if (desiredValidationModule) {
-    await ensureModuleVersion(
-      desiredValidationModule,
-      'contracts/v2/interfaces/IValidationModule.sol:IValidationModule',
-      'ValidationModule'
-    );
-    const currentValidationModuleAddress = ethers.getAddress(
-      currentValidationModule
-    );
-    if (!sameAddress(desiredValidationModule, currentValidationModuleAddress)) {
-      actions.push({
-        label: `Update ValidationModule to ${desiredValidationModule}`,
-        method: 'setValidationModule',
-        args: [desiredValidationModule],
-        current: currentValidationModuleAddress,
-        desired: desiredValidationModule,
-      });
-    }
-  }
-
-  if (desiredFeePool) {
-    await ensureModuleVersion(
-      desiredFeePool,
-      'contracts/v2/interfaces/IFeePool.sol:IFeePool',
-      'FeePool'
-    );
-    const currentFeePoolAddress =
-      currentFeePool === ethers.ZeroAddress
-        ? ethers.ZeroAddress
-        : ethers.getAddress(currentFeePool);
-    if (!sameAddress(desiredFeePool, currentFeePoolAddress)) {
-      actions.push({
-        label: `Update FeePool to ${desiredFeePool}`,
-        method: 'setFeePool',
-        args: [desiredFeePool],
-        current: currentFeePoolAddress,
-        desired: desiredFeePool,
-        notes: ['FeePool must expose version() == 2.'],
-      });
-    }
-  }
-
-  const currentMinStakeValue = currentMinStake as bigint;
-  let minStakeHandledByRecommendations = false;
-
-  const currentMaxStakeValue = currentMaxStakePerAddress as bigint;
-  const recConfigured =
-    desiredRecMin !== undefined || desiredRecMax !== undefined;
-  if (recConfigured) {
-    const targetMin = desiredRecMin ?? currentMinStakeValue;
-    const targetMax = desiredRecMax ?? currentMaxStakeValue;
-    if (targetMin <= 0n) {
-      throw new Error('stakeRecommendations.min must be greater than zero');
-    }
-    if (targetMax !== 0n && targetMax < targetMin) {
-      throw new Error('stakeRecommendations.max cannot be below min');
-    }
-    if (
-      targetMin !== currentMinStakeValue ||
-      targetMax !== currentMaxStakeValue
-    ) {
-      actions.push({
-        label: `Set stake recommendations to min ${formatToken(
-          targetMin,
-          decimals,
-          symbol
-        )}, max ${
-          targetMax === 0n
-            ? 'disabled'
-            : formatToken(targetMax, decimals, symbol)
-        }`,
-        method: 'setStakeRecommendations',
-        args: [targetMin, targetMax],
-        current: `min ${formatToken(
-          currentMinStakeValue,
-          decimals,
-          symbol
-        )}, max ${
-          currentMaxStakeValue === 0n
-            ? 'disabled'
-            : formatToken(currentMaxStakeValue, decimals, symbol)
-        }`,
-        desired: `min ${formatToken(targetMin, decimals, symbol)}, max ${
-          targetMax === 0n
-            ? 'disabled'
-            : formatToken(targetMax, decimals, symbol)
-        }`,
-      });
-      if (desiredRecMin !== undefined) {
-        minStakeHandledByRecommendations = true;
-      }
-    }
-  }
-
-  if (
-    desiredMinStake !== undefined &&
-    !minStakeHandledByRecommendations &&
-    desiredMinStake !== currentMinStakeValue
-  ) {
-    if (desiredMinStake <= 0n) {
-      throw new Error('minStake must be greater than zero');
-    }
-    actions.push({
-      label: `Update minimum stake to ${formatToken(
-        desiredMinStake,
-        decimals,
-        symbol
-      )}`,
-      method: 'setMinStake',
-      args: [desiredMinStake],
-      current: formatToken(currentMinStakeValue, decimals, symbol),
-      desired: formatToken(desiredMinStake, decimals, symbol),
-    });
-  }
-
-  if (
-    desiredMaxStake !== undefined &&
-    desiredMaxStake !== currentMaxStakeValue
-  ) {
-    if (desiredMaxStake !== 0n && desiredMaxStake < currentMinStakeValue) {
-      throw new Error(
-        'maxStakePerAddress cannot be below the current minimum stake'
-      );
-    }
-    actions.push({
-      label: `Update max stake per address to ${
-        desiredMaxStake === 0n
-          ? 'disabled'
-          : formatToken(desiredMaxStake, decimals, symbol)
-      }`,
-      method: 'setMaxStakePerAddress',
-      args: [desiredMaxStake],
-      current:
-        currentMaxStakeValue === 0n
-          ? 'disabled'
-          : formatToken(currentMaxStakeValue, decimals, symbol),
-      desired:
-        desiredMaxStake === 0n
-          ? 'disabled'
-          : formatToken(desiredMaxStake, decimals, symbol),
-    });
-  }
-
-  const currentFee = Number(currentFeePct);
-  const currentBurn = Number(currentBurnPct);
-  const currentValidator = Number(currentValidatorRewardPct);
-
-  const targetFee = desiredFeePct ?? currentFee;
-  const targetBurn = desiredBurnPct ?? currentBurn;
-  const targetValidator = desiredValidatorPct ?? currentValidator;
-
-  if (targetFee + targetBurn + targetValidator > 100) {
-    throw new Error('feePct + burnPct + validatorRewardPct cannot exceed 100');
-  }
-
-  if (desiredFeePct !== undefined && desiredFeePct !== currentFee) {
-    percentageActions.push({
-      label: `Update protocol fee percentage to ${desiredFeePct}%`,
-      method: 'setFeePct',
-      args: [desiredFeePct],
-      current: `${currentFee}%`,
-      desired: `${desiredFeePct}%`,
-      delta: desiredFeePct - currentFee,
-    });
-  }
-
-  if (desiredBurnPct !== undefined && desiredBurnPct !== currentBurn) {
-    percentageActions.push({
-      label: `Update burn percentage to ${desiredBurnPct}%`,
-      method: 'setBurnPct',
-      args: [desiredBurnPct],
-      current: `${currentBurn}%`,
-      desired: `${desiredBurnPct}%`,
-      delta: desiredBurnPct - currentBurn,
-    });
-  }
-
-  if (
-    desiredValidatorPct !== undefined &&
-    desiredValidatorPct !== currentValidator
-  ) {
-    percentageActions.push({
-      label: `Update validator reward percentage to ${desiredValidatorPct}%`,
-      method: 'setValidatorRewardPct',
-      args: [desiredValidatorPct],
-      current: `${currentValidator}%`,
-      desired: `${desiredValidatorPct}%`,
-      delta: desiredValidatorPct - currentValidator,
-    });
-  }
-
-  percentageActions.sort((a, b) => a.delta - b.delta);
-  actions.push(...percentageActions);
-
-  if (
-    desiredEmployerSlashPct !== undefined ||
-    desiredTreasurySlashPct !== undefined
-  ) {
-    const employerTarget =
-      desiredEmployerSlashPct ?? Number(currentEmployerSlashPct);
-    const treasuryTarget =
-      desiredTreasurySlashPct ?? Number(currentTreasurySlashPct);
-    if (employerTarget + treasuryTarget > 100) {
-      throw new Error('employerSlashPct + treasurySlashPct cannot exceed 100');
-    }
-    const currentEmployer = Number(currentEmployerSlashPct);
-    const currentTreasuryPct = Number(currentTreasurySlashPct);
-    if (
-      employerTarget !== currentEmployer ||
-      treasuryTarget !== currentTreasuryPct
-    ) {
-      actions.push({
-        label: `Update slashing percentages (employer ${employerTarget}%, treasury ${treasuryTarget}%)`,
-        method: 'setSlashingPercentages',
-        args: [employerTarget, treasuryTarget],
-        current: `employer ${currentEmployer}%, treasury ${currentTreasuryPct}%`,
-        desired: `employer ${employerTarget}%, treasury ${treasuryTarget}%`,
-        notes: ['Employer + treasury percentages must not exceed 100%.'],
-      });
-    }
-  }
-
-  if (
-    desiredUnbondingPeriod !== undefined &&
-    desiredUnbondingPeriod !== (currentUnbondingPeriod as bigint)
-  ) {
-    if (desiredUnbondingPeriod <= 0n) {
-      throw new Error('unbondingPeriodSeconds must be greater than zero');
-    }
-    actions.push({
-      label: `Update unbonding period to ${desiredUnbondingPeriod.toString()} seconds`,
-      method: 'setUnbondingPeriod',
-      args: [desiredUnbondingPeriod],
-      current: `${(currentUnbondingPeriod as bigint).toString()} seconds`,
-      desired: `${desiredUnbondingPeriod.toString()} seconds`,
-    });
-  }
-
-  const currentAutoEnabled = Boolean(currentAutoStakeEnabled);
-  if (
-    desiredAutoEnabled !== undefined &&
-    desiredAutoEnabled !== currentAutoEnabled
-  ) {
-    actions.push({
-      label: `${
-        desiredAutoEnabled ? 'Enable' : 'Disable'
-      } automatic stake tuning`,
-      method: 'autoTuneStakes',
-      args: [desiredAutoEnabled],
-      current: currentAutoEnabled ? 'enabled' : 'disabled',
-      desired: desiredAutoEnabled ? 'enabled' : 'disabled',
-    });
-  }
-
-  const autoTargets = {
-    threshold: desiredAutoThreshold ?? (currentDisputeThreshold as bigint),
-    increase: desiredAutoIncrease ?? Number(currentIncreasePct),
-    decrease: desiredAutoDecrease ?? Number(currentDecreasePct),
-    window: desiredAutoWindow ?? (currentWindow as bigint),
-    floor: desiredAutoFloor ?? (currentFloor as bigint),
-    ceil: desiredAutoCeil ?? (currentMaxMinStake as bigint),
-    tempThreshold: desiredTempThreshold ?? (currentTempThreshold as bigint),
-    hamThreshold: desiredHamThreshold ?? (currentHamThreshold as bigint),
-    disputeWeight: desiredDisputeWeight ?? (currentDisputeWeight as bigint),
-    tempWeight: desiredTempWeight ?? (currentTempWeight as bigint),
-    hamWeight: desiredHamWeight ?? (currentHamWeight as bigint),
+    symbol,
+    ownerAddress,
   };
+  const plan = await buildStakeManagerPlan(planInput);
 
-  if (autoTargets.increase < 0 || autoTargets.increase > 100) {
-    throw new Error('autoStake.increasePct must be between 0 and 100');
-  }
-  if (autoTargets.decrease < 0 || autoTargets.decrease > 100) {
-    throw new Error('autoStake.decreasePct must be between 0 and 100');
-  }
-
-  const autoChanged =
-    (desiredAutoThreshold !== undefined &&
-      desiredAutoThreshold !== (currentDisputeThreshold as bigint)) ||
-    (desiredAutoIncrease !== undefined &&
-      desiredAutoIncrease !== Number(currentIncreasePct)) ||
-    (desiredAutoDecrease !== undefined &&
-      desiredAutoDecrease !== Number(currentDecreasePct)) ||
-    (desiredAutoWindow !== undefined &&
-      desiredAutoWindow !== (currentWindow as bigint)) ||
-    (desiredAutoFloor !== undefined &&
-      desiredAutoFloor !== (currentFloor as bigint)) ||
-    (desiredAutoCeil !== undefined &&
-      desiredAutoCeil !== (currentMaxMinStake as bigint)) ||
-    (desiredTempThreshold !== undefined &&
-      desiredTempThreshold !== (currentTempThreshold as bigint)) ||
-    (desiredHamThreshold !== undefined &&
-      desiredHamThreshold !== (currentHamThreshold as bigint)) ||
-    (desiredDisputeWeight !== undefined &&
-      desiredDisputeWeight !== (currentDisputeWeight as bigint)) ||
-    (desiredTempWeight !== undefined &&
-      desiredTempWeight !== (currentTempWeight as bigint)) ||
-    (desiredHamWeight !== undefined &&
-      desiredHamWeight !== (currentHamWeight as bigint));
-
-  if (autoChanged) {
-    actions.push({
-      label: 'Update automatic stake tuning parameters',
-      method: 'configureAutoStake',
-      args: [
-        autoTargets.threshold,
-        autoTargets.increase,
-        autoTargets.decrease,
-        autoTargets.window,
-        autoTargets.floor,
-        autoTargets.ceil,
-        autoTargets.tempThreshold,
-        autoTargets.hamThreshold,
-        autoTargets.disputeWeight,
-        autoTargets.tempWeight,
-        autoTargets.hamWeight,
-      ],
-      notes: [
-        'Floor values of 0 keep the current minimum stake floor.',
-        'Ceiling of 0 disables the cap.',
-      ],
-    });
-  }
-
-  if (desiredMaxAGITypes !== undefined) {
-    if (!Number.isInteger(desiredMaxAGITypes) || desiredMaxAGITypes <= 0) {
-      throw new Error('maxAGITypes must be a positive integer');
-    }
-    if (desiredMaxAGITypes > MAX_AGI_TYPES_CAP) {
-      throw new Error(`maxAGITypes cannot exceed ${MAX_AGI_TYPES_CAP}`);
-    }
-    if (desiredMaxAGITypes < currentAgiTypeCount) {
-      throw new Error(
-        `maxAGITypes cannot be below the current AGI type count (${currentAgiTypeCount})`
-      );
-    }
-    const currentMaxAgi = Number(currentMaxAGITypes);
-    if (desiredMaxAGITypes !== currentMaxAgi) {
-      actions.push({
-        label: `Update max AGI types to ${desiredMaxAGITypes}`,
-        method: 'setMaxAGITypes',
-        args: [desiredMaxAGITypes],
-        current: currentMaxAgi.toString(),
-        desired: desiredMaxAGITypes.toString(),
-      });
-    }
-  }
-
-  if (desiredMaxTotalPayoutPct !== undefined) {
-    if (!Number.isInteger(desiredMaxTotalPayoutPct)) {
-      throw new Error('maxTotalPayoutPct must be an integer');
-    }
-    if (
-      desiredMaxTotalPayoutPct < 100 ||
-      desiredMaxTotalPayoutPct > MAX_PAYOUT_PCT
-    ) {
-      throw new Error(
-        `maxTotalPayoutPct must be between 100 and ${MAX_PAYOUT_PCT}`
-      );
-    }
-    const currentMaxTotal = Number(currentMaxTotalPayoutPct);
-    if (desiredMaxTotalPayoutPct !== currentMaxTotal) {
-      actions.push({
-        label: `Update max total payout percentage to ${desiredMaxTotalPayoutPct}%`,
-        method: 'setMaxTotalPayoutPct',
-        args: [desiredMaxTotalPayoutPct],
-        current: `${currentMaxTotal}%`,
-        desired: `${desiredMaxTotalPayoutPct}%`,
-      });
-    }
+  if (cli.json) {
+    console.log(JSON.stringify(plan, null, 2));
+    return;
   }
 
   console.log('StakeManager:', stakeManagerAddress);
   console.log('Configuration file:', stakeConfigPath);
 
-  if (actions.length === 0) {
+  if (plan.actions.length === 0) {
     console.log('All tracked parameters already match the configuration.');
     return;
   }
 
-  console.log(`Planned actions (${actions.length}):`);
-  const iface = stakeManager.interface;
-  actions.forEach((action, index) => {
-    const data = iface.encodeFunctionData(action.method, action.args);
+  console.log(`Planned actions (${plan.actions.length}):`);
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
     console.log(`\n${index + 1}. ${action.label}`);
     if (action.current !== undefined) {
       console.log(`   Current: ${action.current}`);
@@ -990,13 +125,13 @@ async function main() {
     if (action.desired !== undefined) {
       console.log(`   Desired: ${action.desired}`);
     }
-    if (action.notes) {
-      for (const note of action.notes) {
-        console.log(`   Note: ${note}`);
-      }
-    }
+    action.notes?.forEach((note) => {
+      console.log(`   Note: ${note}`);
+    });
     console.log(`   Method: ${action.method}(${describeArgs(action.args)})`);
-    console.log(`   Calldata: ${data}`);
+    if (data) {
+      console.log(`   Calldata: ${data}`);
+    }
   });
 
   if (!cli.execute || !sameAddress(ownerAddress, signerAddress)) {
@@ -1007,7 +142,7 @@ async function main() {
   }
 
   console.log('\nSubmitting transactions...');
-  for (const action of actions) {
+  for (const action of plan.actions) {
     console.log(`Executing ${action.method}...`);
     const tx = await (stakeManager as any)[action.method](...action.args);
     console.log(`   Tx hash: ${tx.hash}`);


### PR DESCRIPTION
## Summary
- factor shared planner utilities for JobRegistry, StakeManager, and FeePool updates into scripts/v2/lib
- add a consolidated owner control plan script with environment-driven JSON/output and a lightweight runner
- document the new workflow and surface the helper in README and npm scripts

## Testing
- OWNER_PLAN_JSON=1 npm run owner:plan
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68d40d448b1c8333bb5cf155b87c4c3f