### PR TITLE
Add ENS alias support for AGI identity roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 
 ### Identity policy
 
-Agents and validators must own ENS subdomains under `agent.agi.eth` and `club.agi.eth`. All workflows perform on-chain verification and bypass mechanisms are reserved for emergency governance only. See [docs/ens-identity-policy.md](docs/ens-identity-policy.md) for details.
+Agents and validators must own ENS subdomains under `agent.agi.eth` and `club.agi.eth`. Owners of `*.alpha.agent.agi.eth` and `*.alpha.club.agi.eth` subdomains enjoy identical permissions—the `IdentityRegistry` treats those aliases as equivalent roots. All workflows perform on-chain verification and bypass mechanisms are reserved for emergency governance only. See [docs/ens-identity-policy.md](docs/ens-identity-policy.md) for details.
 
 > **Emergency allowlists:** The `IdentityRegistry` owner can directly whitelist addresses using `addAdditionalAgent` or `addAdditionalValidator`. These overrides bypass ENS proofs and should only be used to recover from deployment errors or other emergencies.
 


### PR DESCRIPTION
## Summary
- allow the IdentityRegistry owner to manage ENS root aliases and preload the alpha.* namehashes during mainnet configuration
- update agent/validator authorization flows to accept any configured alias alongside the primary ENS roots
- document the alias support and extend the configuration tests to cover the new management helpers

## Testing
- npx hardhat compile
- npx hardhat test --no-compile test/v2/IdentityRegistrySetters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d42896e64c83339bc0118e091df253