### PR TITLE
Add Safe bundle export for owner control tooling

### DIFF
--- a/docs/owner-control-playbook.md
+++ b/docs/owner-control-playbook.md
@@ -20,6 +20,13 @@ OWNER_PLAN_JSON=1 npm run owner:plan
 # Persist the plan for a multisig (Gnosis Safe, Zodiac, etc.)
 OWNER_PLAN_OUT=call-plan/mainnet-$(date +%Y%m%d).json npm run owner:plan
 
+# Generate a Safe Transaction Builder bundle alongside the plan
+npm run owner:plan:safe
+
+# Custom Safe bundle location/metadata (works cross-platform)
+npm run owner:plan -- --safe ops/mainnet-safe.json --safe-name "AGIJobs Mainnet Controls" \
+  --safe-description "Owner updates generated $(date +%Y-%m-%d)"
+
 # Apply all outstanding updates using the connected signer
 OWNER_PLAN_EXECUTE=1 npm run owner:plan
 ```
@@ -44,6 +51,31 @@ For each module the plan lists:
 The JSON output mirrors the console plan and is structured so downstream
 automation can submit calls without reimplementing the diff logic. Each action
 exposes `to`, `value`, `method`, `args`, and `calldata` fields.
+
+### Safe transaction bundles
+
+Operations teams that rely on [Safe](https://safe.global) multisigs can export a
+ready-to-import transaction bundle using the new `--safe` switches. The helper
+produces a JSON document compatible with the Safe Transaction Builder, complete
+with function signatures, argument metadata, and human-readable descriptions.
+
+- `OWNER_PLAN_SAFE_OUT` – absolute or relative file path for the Safe bundle.
+- `OWNER_PLAN_SAFE_NAME` – overrides the bundle name (defaults to “AGIJobs
+  Owner Control Plan”).
+- `OWNER_PLAN_SAFE_DESCRIPTION` – optional descriptive text embedded in the
+  bundle metadata.
+
+Example:
+
+```bash
+OWNER_PLAN_SAFE_OUT=ops/2025-guardrail-safe.json \
+OWNER_PLAN_SAFE_NAME="AGIJobs v2 Ops" \
+OWNER_PLAN_SAFE_DESCRIPTION="Treasury + fee update for March 2025" \
+  npm run owner:plan
+```
+
+Upload the resulting JSON at <https://app.safe.global/transactions/builder>,
+review each step, and submit it through your usual governance approval flow.
 
 ### Execution safeguards
 

--- a/docs/production/nontechnical-mainnet-deployment.md
+++ b/docs/production/nontechnical-mainnet-deployment.md
@@ -99,11 +99,17 @@ npm run owner:health
 # Generate a governance change plan (CSV) that can be executed via Safe or OZ timelock
 npm run owner:plan > owner-plan.csv
 
+# Export a Safe Transaction Builder bundle for multisig execution
+npm run owner:plan:safe
+
 # Optional guided wizard to enact common changes (stake floor, fee %, ENS registrars)
 npm run owner:wizard
 ```
 
 Review the CSV with your governance team and store it in the same vault as the deployment report.
+
+Upload the generated `owner-safe-bundle.json` to the [Safe Transaction Builder](https://app.safe.global/transactions/builder)
+interface when your multisig needs to batch the updates without writing calldata manually.
 
 ---
 
@@ -141,6 +147,7 @@ Review the CSV with your governance team and store it in the same vault as the d
 | Verify wiring post-upgrade | `npm run wire:verify` |
 | Inspect module ownership | `npm run owner:health` |
 | Update economics | `npm run owner:wizard` |
+| Produce Safe bundle for multisig | `npm run owner:plan:safe` |
 | Pause the system | `npx hardhat run scripts/v2/updateSystemPause.ts --network mainnet --pause` |
 
 Keep this cheat-sheet near the operations console. Every command is safe to run multiple times and produces deterministic output when the environment is configured correctly.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "verify:wiring": "npm run wire:verify",
     "owner:health": "npx hardhat run --no-compile scripts/owner-healthcheck.js",
     "owner:plan": "node scripts/v2/run-owner-plan.js",
+    "owner:plan:safe": "node scripts/v2/run-owner-plan.js --safe owner-safe-bundle.json --safe-name \"AGIJobs Owner Control Plan\"",
     "owner:wizard": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/owner-config-wizard.ts",
     "test": "hardhat test --no-compile",
     "echidna:commit-reveal": "docker run --rm -v \"$PWD\":/src -v \"$PWD/tools/forge-shim\":/usr/local/bin/forge:ro -w /src ghcr.io/crytic/echidna/echidna:v2.2.7 echidna-test ./contracts/test/CommitRevealEchidna.sol --contract CommitRevealEchidnaHarness --config echidna/commit-reveal.yaml",

--- a/scripts/v2/run-owner-plan.js
+++ b/scripts/v2/run-owner-plan.js
@@ -3,11 +3,70 @@ const { spawn } = require('child_process');
 
 const userArgs = process.argv.slice(2);
 const hardhatArgs = ['hardhat', 'run', '--no-compile', 'scripts/v2/ownerControlPlan.ts'];
-if (userArgs.length > 0) {
-  hardhatArgs.push('--', ...userArgs);
+
+const forwardedEnv = { ...process.env };
+
+for (let i = 0; i < userArgs.length; i += 1) {
+  const arg = userArgs[i];
+  switch (arg) {
+    case '--execute':
+      forwardedEnv.OWNER_PLAN_EXECUTE = '1';
+      break;
+    case '--json':
+      forwardedEnv.OWNER_PLAN_JSON = '1';
+      break;
+    case '--no-json':
+      forwardedEnv.OWNER_PLAN_JSON = '0';
+      break;
+    case '--out':
+    case '--output': {
+      const value = userArgs[i + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a file path`);
+      }
+      forwardedEnv.OWNER_PLAN_OUT = value;
+      i += 1;
+      break;
+    }
+    case '--safe':
+    case '--safe-out': {
+      const value = userArgs[i + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a file path`);
+      }
+      forwardedEnv.OWNER_PLAN_SAFE_OUT = value;
+      i += 1;
+      break;
+    }
+    case '--safe-name': {
+      const value = userArgs[i + 1];
+      if (!value) {
+        throw new Error('--safe-name requires a value');
+      }
+      forwardedEnv.OWNER_PLAN_SAFE_NAME = value;
+      i += 1;
+      break;
+    }
+    case '--safe-desc':
+    case '--safe-description': {
+      const value = userArgs[i + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a value`);
+      }
+      forwardedEnv.OWNER_PLAN_SAFE_DESCRIPTION = value;
+      i += 1;
+      break;
+    }
+    default:
+      throw new Error(`Unknown owner:plan argument ${arg}`);
+  }
 }
 
-const child = spawn('npx', hardhatArgs, { stdio: 'inherit', shell: process.platform === 'win32' });
+const child = spawn('npx', hardhatArgs, {
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+  env: forwardedEnv,
+});
 child.on('exit', (code) => {
   process.exit(code ?? 0);
 });


### PR DESCRIPTION
## Summary
- capture ABI metadata in the owner control planner and emit Safe Transaction Builder bundles for multisig execution
- translate CLI flags into environment variables in the runner and add a convenience npm script for Safe bundle generation
- document the Safe export workflow for operators in the owner control playbook and non-technical deployment runbook

## Testing
- npm run owner:plan:safe
- npm test *(fails: compiler artifacts unavailable because the solc download hangs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d541314ebc8333bd433e3edae5febf