### PR TITLE
Add owner dashboard tooling and mainnet deployment playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ For a step-by-step mainnet deployment using Truffle, see the [Deploying AGIJobs 
 
 - **Non-technical operators:** follow the [Non-Technical Mainnet Deployment Runbook (Truffle)](docs/production/nontechnical-mainnet-deployment.md) for an operations-friendly checklist powered by `npm run deploy:checklist`.
 - **Institutional change-control teams:** use the [Institutional Truffle Mainnet Playbook](docs/production/institutional-truffle-mainnet-playbook.md) for staged approvals, migration summaries, and sign-off artefact tracking.
+- **Command-line launch coordinators:** the [AGIJobs v0 Institutional Truffle Mainnet Playbook](docs/truffle-mainnet-playbook.md) packages the full CLI workflow with diagrams, rehearsals and owner-control checkpoints suitable for non-technical operators.
 
 - [docs/deployment-production-guide.md](docs/deployment-production-guide.md) – step-by-step walkthrough for deploying AGI Jobs v2 using only a web browser and Etherscan.
 - [docs/deployment-guide-production.md](docs/deployment-guide-production.md) – production deployment checklist.
@@ -156,15 +157,17 @@ The wiring verifier doubles as a continuous identity/wiring guardrail for the α
 
 ### Governance change sets
 
-`npm run owner:plan` (optionally with `OWNER_PLAN_JSON=1` or
-`OWNER_PLAN_EXECUTE=1`) generates a consolidated governance plan for
-`JobRegistry`, `StakeManager`, and `FeePool`, comparing the live parameters
-against the committed config JSON files. The helper prints human-readable diffs,
-exposes the raw calldata for multisig execution, optionally writes a
-machine-readable JSON artifact and, when `OWNER_PLAN_EXECUTE=1` is provided,
-submits the transactions using the connected signer. See
-[docs/owner-control-playbook.md](docs/owner-control-playbook.md) for
-step-by-step usage guidance.
+`npm run owner:dashboard` surfaces a live snapshot of governance ownership,
+treasury destinations and module wiring in both human-readable and JSON
+formats. Combine it with `npm run owner:plan` (optionally with
+`OWNER_PLAN_JSON=1` or `OWNER_PLAN_EXECUTE=1`) to generate a consolidated
+governance plan for `JobRegistry`, `StakeManager`, and `FeePool`, comparing the
+live parameters against the committed config JSON files. The helper prints
+human-readable diffs, exposes the raw calldata for multisig execution,
+optionally writes a machine-readable JSON artifact and, when
+`OWNER_PLAN_EXECUTE=1` is provided, submits the transactions using the
+connected signer. See [docs/owner-control-playbook.md](docs/owner-control-playbook.md)
+for step-by-step usage guidance.
 
 ## Quick Start
 

--- a/docs/truffle-mainnet-playbook.md
+++ b/docs/truffle-mainnet-playbook.md
@@ -1,0 +1,228 @@
+# AGIJobs v0 – Institutional Truffle Mainnet Playbook
+
+> **Purpose**: give a non-technical launch coordinator a safe, repeatable and audit-friendly recipe to deploy the AGIJobs protocol to Ethereum Mainnet using Truffle, with built-in owner controls, validation tooling and governance hand-off guardrails.
+
+## 1. Mission Control Overview
+
+```mermaid
+flowchart TD
+    A[Preflight & Tooling] --> B[Configuration Review]
+    B --> C[Dry-Run Simulation]
+    C --> D[Truffle Migrations]
+    D --> E[Post-Deploy Wiring]
+    E --> F[Operational Handover]
+    F --> G[Ongoing Owner Controls]
+    classDef focus fill:#0a1626,stroke:#2ec4ff,stroke-width:2px,color:#f4faff;
+    class A,B,C,D,E,F,G focus;
+```
+
+## 2. Preflight Checklist
+
+| Item                | Command / Action                 | Notes                                            |
+| ------------------- | -------------------------------- | ------------------------------------------------ |
+| Node.js 20.x        | `node -v`                        | CI and scripts expect ≥ 20.12.0                  |
+| NPM clean install   | `npm ci`                         | Must be run from repo root                       |
+| Environment secrets | `.env`                           | See §3.1 for template                            |
+| RPC connectivity    | `curl $MAINNET_RPC_URL`          | Ensure 200 OK JSON-RPC response                  |
+| Etherscan API       | `ETHERSCAN_API_KEY`              | Needed for automatic verification                |
+| Address book        | `docs/deployment-addresses.json` | Populate with final module addresses post-deploy |
+| Governance signer   | multisig / timelock              | Confirm hardware wallet + Safe access            |
+
+```mermaid
+mindmap
+  root((Launch Readiness))
+    Tooling
+      Node 20.x
+      NPM ci
+      Hardhat cache cleaned
+    Secrets
+      Private key (hardware backed)
+      RPC URLs
+      Etherscan API key
+      .env stored in password manager
+    Dry Run
+      Local fork smoke test
+      `npm run owner:dashboard -- --json`
+    Governance
+      Timelock configured
+      Owner control plan exported
+```
+
+## 3. Configuration for Mainnet
+
+### 3.1. Environment variables (`.env`)
+
+Create `./.env` (never commit it):
+
+```ini
+MAINNET_PRIVATE_KEY=0xYOUR_PRODUCTION_SIGNER_PRIVATE_KEY
+MAINNET_RPC_URL=https://mainnet.infura.io/v3/YOUR_PROJECT_ID
+ETHERSCAN_API_KEY=your_etherscan_key
+AGIALPHA_TOKEN=0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA
+# Optional governance overrides
+GOVERNANCE_ADDRESS=0xYourTimelockOrSafe
+FEE_PCT=5
+BURN_PCT=5
+```
+
+For Sepolia rehearsals, also set `SEPOLIA_PRIVATE_KEY` and `SEPOLIA_RPC_URL`.
+
+### 3.2. Canonical configuration files
+
+1. Review `config/agialpha.mainnet.json`, `config/ens.mainnet.json`, `config/stake-manager.json`, `config/fee-pool.json`, `config/job-registry.json`, `config/platform-registry.json`, `config/platform-incentives.json`, `config/tax-policy.json`, and `deployment-config/mainnet.json`.
+2. Run the interactive owner wizard to confirm thresholds:
+   ```bash
+   npm run owner:wizard -- --network mainnet
+   ```
+3. Capture a governance plan for review:
+   ```bash
+   npm run owner:plan -- --network mainnet --json --out owner-plan.mainnet.json
+   ```
+4. If the plan must be executed via Safe, pre-generate the bundle:
+   ```bash
+   npm run owner:plan:safe
+   ```
+
+## 4. Dry-run Simulation (strongly recommended)
+
+```bash
+# Reset local artifacts
+rm -rf cache artifacts
+
+# Spin up a fork (Anvil or Ganache)
+npx hardhat node --fork $MAINNET_RPC_URL --no-deploy &
+sleep 5
+
+# Deploy against the fork
+TRUFFLE_NETWORK=mainnet MAINNET_RPC_URL=http://127.0.0.1:8545 \
+  MAINNET_PRIVATE_KEY=0x.... npm run migrate:mainnet
+
+# Inspect resulting state
+npm run owner:dashboard -- --config-network mainnet --json > fork-dashboard.json
+```
+
+Review `fork-dashboard.json` to confirm every module points to the expected governance, treasury and cross-module wiring.
+
+## 5. Production Deployment Steps
+
+```mermaid
+sequenceDiagram
+    participant O as Owner (Signer)
+    participant T as Truffle CLI
+    participant D as Deployer Contract
+    participant M as Modules
+    O->>T: npm run migrate:mainnet
+    T->>D: Deploy Deployer + modules
+    D->>M: Deterministic install & wiring
+    M-->>D: Emit Deployed events
+    D-->>T: Return final addresses
+    T-->>O: Migration summary
+```
+
+1. **Install dependencies (fresh machine each run):**
+   ```bash
+   npm ci
+   ```
+2. **Compile with deterministic constants:**
+   ```bash
+   npm run compile:mainnet
+   ```
+3. **Execute the full migration bundle:**
+   ```bash
+   npm run migrate:mainnet
+   ```
+   Internally this performs:
+   - `1_initial_migration.js`
+   - `2_deploy_protocol.js` (deploys `Deployer`)
+   - `3_wire_protocol.js` (installs modules + economic parameters)
+   - `4_configure_ens.js`
+   - `5_transfer_ownership.js`
+4. **Record addresses:** after the run, update `docs/deployment-addresses.json` with the emitted addresses (the script auto-writes; verify contents then commit in a secure PR).
+5. **Verify wiring + owner controls on-chain:**
+   ```bash
+   npm run owner:dashboard -- --config-network mainnet
+   npm run wire:verify
+   npm run owner:health
+   ```
+6. **Publish Safe execution bundle (if applicable):** review `owner-safe-bundle.json` (generated by `owner:plan:safe`) and upload to the Safe transaction service.
+
+## 6. Post-Deployment Tasks
+
+| Task                   | Command                                                                                   | Purpose                            |
+| ---------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------- |
+| Etherscan verification | `npm run wire:verify`                                                                     | Confirms ABI metadata + ENS wiring |
+| Coverage regression    | `npm run coverage:report`                                                                 | Optional attestation for auditors  |
+| Slither & Echidna      | GitHub CI                                                                                 | Ensure badges remain green         |
+| Update runbook         | Commit updated `docs/deployment-addresses.json` + `CHANGELOG.md`                          | Institutional traceability         |
+| Archive artifacts      | Securely store `owner-plan.mainnet.json`, `owner-safe-bundle.json`, `fork-dashboard.json` | Future audits                      |
+
+## 7. Owner Control Toolkit
+
+The following scripts give the owner full operational control post-launch:
+
+| Script                            | Description                                                                                                |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `npm run owner:dashboard`         | Human-readable module status (governance, treasury, thresholds) + JSON export via `--json`.                |
+| `npm run owner:wizard`            | Guided CLI to adjust economic parameters and regenerate configs.                                           |
+| `npm run owner:plan`              | Generates a governance execution plan; add `--execute` to apply instantly (use only with extreme caution). |
+| `npm run owner:plan:safe`         | Produces a Safe Transaction Service bundle (`owner-safe-bundle.json`).                                     |
+| `npm run updateStakeManager` etc. | Fine-grained module updaters located in `scripts/v2/`.                                                     |
+
+```mermaid
+flowchart LR
+    subgraph OwnerControl
+      A[owner:dashboard]
+      B[owner:wizard]
+      C[owner:plan]
+      D[owner:plan:safe]
+      E[update* scripts]
+    end
+    A --> B --> C --> D
+    B --> E
+    classDef control fill:#102a43,stroke:#2ec4ff,stroke-width:2px,color:#e0fbfc;
+    class A,B,C,D,E control;
+```
+
+### 7.1. Example owner healthcheck procedure
+
+```bash
+# 1. Snapshot live state
+npm run owner:dashboard -- --config-network mainnet --json > live-dashboard.json
+
+# 2. Generate recommended actions
+npm run owner:plan -- --network mainnet --out live-owner-plan.json
+
+# 3. Execute adjustments (Safe-first)
+npm run owner:plan:safe
+# Review & execute in Safe UI with required signers
+```
+
+## 8. Troubleshooting Matrix
+
+| Symptom                                | Diagnosis                          | Resolution                                                                      |
+| -------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------- |
+| `Missing private key` during migration | `.env` not loaded                  | Confirm `.env` is present and `MAINNET_PRIVATE_KEY` is non-zero hex             |
+| `AGIALPHA token mismatch`              | Config vs deployment plan mismatch | Align `config/agialpha.mainnet.json` and `deployment-config/mainnet.json`       |
+| `Governance contract missing`          | `GOVERNANCE_ADDRESS` not provided  | Export Safe/Timelock address and rerun `npm run migrate:mainnet`                |
+| `wire:verify` failure                  | RPC 404 or wrong chain             | Ensure `WIRE_VERIFY_RPC_URL` points to a synced node (default Ganache on :8545) |
+| Owner dashboard errors                 | Module artifacts missing           | Run `npm run compile` to refresh ABIs                                           |
+
+## 9. Institutional Governance Commitments
+
+- Always run the Sepolia rehearsal (`npm run migrate:sepolia`) before mainnet.
+- Require dual-control (at least two reviewers) for config changes and address book updates.
+- Store signed JSON artifacts (`owner-plan*.json`, `owner-safe-bundle.json`) in an encrypted vault.
+- Keep GitHub Actions CI green; re-run `CI` workflow whenever dependencies change.
+
+## 10. Quick Reference Commands
+
+```bash
+npm ci                                   # clean install
+npm run compile:mainnet                  # compile + generate constants
+npm run migrate:mainnet                  # full mainnet deployment via Truffle
+npm run wire:verify                      # ENS + wiring validation
+npm run owner:dashboard -- --json        # governance status snapshot
+npm run owner:plan:safe                  # Safe bundle for governance updates
+```
+
+Stay disciplined: execute the checklist, store artifacts securely, and never skip rehearsals. This playbook keeps mainnet launches deterministic, reviewable and owner-friendly.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "owner:plan": "node scripts/v2/run-owner-plan.js",
     "owner:plan:safe": "node scripts/v2/run-owner-plan.js --safe owner-safe-bundle.json --safe-name \"AGIJobs Owner Control Plan\"",
     "owner:wizard": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/owner-config-wizard.ts",
+    "owner:dashboard": "npx hardhat run --no-compile scripts/v2/owner-dashboard.ts",
     "test": "hardhat test --no-compile",
     "echidna:commit-reveal": "docker run --rm -v \"$PWD\":/src -v \"$PWD/tools/forge-shim\":/usr/local/bin/forge:ro -w /src ghcr.io/crytic/echidna/echidna:v2.2.7 echidna-test ./contracts/test/CommitRevealEchidna.sol --contract CommitRevealEchidnaHarness --config echidna/commit-reveal.yaml",
     "echidna": "npm run echidna:commit-reveal",

--- a/scripts/v2/owner-dashboard.ts
+++ b/scripts/v2/owner-dashboard.ts
@@ -1,0 +1,529 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { ethers, network } from 'hardhat';
+import {
+  loadStakeManagerConfig,
+  loadFeePoolConfig,
+  loadJobRegistryConfig,
+  loadPlatformRegistryConfig,
+  loadPlatformIncentivesConfig,
+  loadTaxPolicyConfig,
+  loadDeploymentPlan,
+  inferNetworkKey,
+} from '../config';
+import type { Contract } from 'ethers';
+
+type CliOptions = {
+  json: boolean;
+  configNetwork?: string;
+};
+
+type ModuleMetric = {
+  label: string;
+  value: string | number | boolean | null;
+};
+
+type ModuleSummary = {
+  key: string;
+  name: string;
+  address: string | null;
+  metrics: ModuleMetric[];
+};
+
+const ADDRESS_BOOK = path.join(
+  __dirname,
+  '..',
+  '..',
+  'docs',
+  'deployment-addresses.json'
+);
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--config-network' || arg === '--network-config') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a value`);
+      }
+      options.configNetwork = value;
+      i += 1;
+    }
+  }
+  return options;
+}
+
+async function readAddressBook(): Promise<Record<string, string>> {
+  try {
+    const raw = await fs.readFile(ADDRESS_BOOK, 'utf8');
+    return JSON.parse(raw);
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
+}
+
+function normaliseAddress(value: string | undefined | null): string | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    const address = ethers.getAddress(value);
+    return address === ethers.ZeroAddress ? null : address;
+  } catch (_) {
+    return null;
+  }
+}
+
+async function resolveOwner(contract: Contract): Promise<string | null> {
+  for (const method of ['owner', 'governance']) {
+    try {
+      const value = await contract[method]();
+      if (typeof value === 'string') {
+        return ethers.getAddress(value);
+      }
+    } catch (_) {
+      // ignore missing methods
+    }
+  }
+  return null;
+}
+
+async function callBigInt(
+  contract: Contract,
+  method: string
+): Promise<bigint | null> {
+  try {
+    const value = await contract[method]();
+    if (typeof value === 'bigint') {
+      return value;
+    }
+    if (value && typeof value === 'object' && 'toBigInt' in value) {
+      return (value as { toBigInt: () => bigint }).toBigInt();
+    }
+    if (typeof value === 'number') {
+      return BigInt(value);
+    }
+    if (typeof value === 'string') {
+      return BigInt(value);
+    }
+  } catch (_) {
+    // ignore
+  }
+  return null;
+}
+
+async function callString(
+  contract: Contract,
+  method: string
+): Promise<string | null> {
+  try {
+    const value = await contract[method]();
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed ? trimmed : null;
+    }
+  } catch (_) {
+    // ignore
+  }
+  return null;
+}
+
+async function collectStakeManagerSummary(
+  address: string
+): Promise<ModuleSummary> {
+  const stakeManager = await ethers.getContractAt('StakeManager', address);
+  const [
+    ownerAddress,
+    feePctRaw,
+    burnPctRaw,
+    minStakeRaw,
+    treasury,
+    jobRegistry,
+    validationModule,
+    disputeModule,
+    autoStakeTuning,
+    pauser,
+  ] = await Promise.all([
+    resolveOwner(stakeManager),
+    callBigInt(stakeManager, 'feePct'),
+    callBigInt(stakeManager, 'burnPct'),
+    callBigInt(stakeManager, 'minStake'),
+    callString(stakeManager, 'treasury'),
+    callString(stakeManager, 'jobRegistry'),
+    callString(stakeManager, 'validationModule'),
+    callString(stakeManager, 'disputeModule'),
+    (async () => {
+      try {
+        return Boolean(await stakeManager.autoStakeTuning());
+      } catch (_) {
+        return false;
+      }
+    })(),
+    callString(stakeManager, 'pauser'),
+  ]);
+
+  return {
+    key: 'stakeManager',
+    name: 'StakeManager',
+    address,
+    metrics: [
+      { label: 'Governance', value: ownerAddress },
+      { label: 'Fee %', value: feePctRaw !== null ? Number(feePctRaw) : null },
+      {
+        label: 'Burn %',
+        value: burnPctRaw !== null ? Number(burnPctRaw) : null,
+      },
+      {
+        label: 'Minimum Stake',
+        value:
+          minStakeRaw !== null
+            ? `${ethers.formatUnits(minStakeRaw, 18)} AGIALPHA`
+            : null,
+      },
+      { label: 'Treasury', value: normaliseAddress(treasury) },
+      { label: 'JobRegistry', value: normaliseAddress(jobRegistry) },
+      {
+        label: 'ValidationModule',
+        value: normaliseAddress(validationModule),
+      },
+      { label: 'DisputeModule', value: normaliseAddress(disputeModule) },
+      { label: 'Auto Stake Tuning', value: autoStakeTuning },
+      { label: 'Pauser', value: normaliseAddress(pauser) },
+    ],
+  };
+}
+
+async function collectFeePoolSummary(address: string): Promise<ModuleSummary> {
+  const feePool = await ethers.getContractAt('FeePool', address);
+  const [
+    ownerAddress,
+    governance,
+    burnPctRaw,
+    treasury,
+    stakeManager,
+    taxPolicy,
+    pauser,
+  ] = await Promise.all([
+    resolveOwner(feePool),
+    callString(feePool, 'governance'),
+    callBigInt(feePool, 'burnPct'),
+    callString(feePool, 'treasury'),
+    callString(feePool, 'stakeManager'),
+    callString(feePool, 'taxPolicy'),
+    callString(feePool, 'pauser'),
+  ]);
+
+  return {
+    key: 'feePool',
+    name: 'FeePool',
+    address,
+    metrics: [
+      { label: 'Owner', value: ownerAddress },
+      { label: 'Governance', value: normaliseAddress(governance) },
+      {
+        label: 'Burn %',
+        value: burnPctRaw !== null ? Number(burnPctRaw) : null,
+      },
+      { label: 'Treasury', value: normaliseAddress(treasury) },
+      { label: 'StakeManager', value: normaliseAddress(stakeManager) },
+      { label: 'TaxPolicy', value: normaliseAddress(taxPolicy) },
+      { label: 'Pauser', value: normaliseAddress(pauser) },
+    ],
+  };
+}
+
+async function collectTaxPolicySummary(
+  address: string
+): Promise<ModuleSummary> {
+  const taxPolicy = await ethers.getContractAt('TaxPolicy', address);
+  const [ownerAddress, treasury, burnAddress] = await Promise.all([
+    resolveOwner(taxPolicy),
+    callString(taxPolicy, 'treasury'),
+    callString(taxPolicy, 'burnAddress'),
+  ]);
+
+  return {
+    key: 'taxPolicy',
+    name: 'TaxPolicy',
+    address,
+    metrics: [
+      { label: 'Governance', value: ownerAddress },
+      { label: 'Treasury', value: normaliseAddress(treasury) },
+      { label: 'Burn Address', value: normaliseAddress(burnAddress) },
+    ],
+  };
+}
+
+async function collectJobRegistrySummary(
+  address: string
+): Promise<ModuleSummary> {
+  const jobRegistry = await ethers.getContractAt('JobRegistry', address);
+  const [ownerAddress, feePool, stakeManager, validationModule, taxPolicy] =
+    await Promise.all([
+      resolveOwner(jobRegistry),
+      callString(jobRegistry, 'feePool'),
+      callString(jobRegistry, 'stakeManager'),
+      callString(jobRegistry, 'validationModule'),
+      callString(jobRegistry, 'taxPolicy'),
+    ]);
+
+  return {
+    key: 'jobRegistry',
+    name: 'JobRegistry',
+    address,
+    metrics: [
+      { label: 'Governance', value: ownerAddress },
+      { label: 'FeePool', value: normaliseAddress(feePool) },
+      { label: 'StakeManager', value: normaliseAddress(stakeManager) },
+      { label: 'ValidationModule', value: normaliseAddress(validationModule) },
+      { label: 'TaxPolicy', value: normaliseAddress(taxPolicy) },
+    ],
+  };
+}
+
+async function collectValidationModuleSummary(
+  address: string
+): Promise<ModuleSummary> {
+  const validationModule = await ethers.getContractAt(
+    'ValidationModule',
+    address
+  );
+  const [ownerAddress, reputationEngine, committee] = await Promise.all([
+    resolveOwner(validationModule),
+    callString(validationModule, 'reputationEngine'),
+    callString(validationModule, 'committee'),
+  ]);
+
+  return {
+    key: 'validationModule',
+    name: 'ValidationModule',
+    address,
+    metrics: [
+      { label: 'Governance', value: ownerAddress },
+      {
+        label: 'ReputationEngine',
+        value: normaliseAddress(reputationEngine),
+      },
+      { label: 'Committee', value: normaliseAddress(committee) },
+    ],
+  };
+}
+
+async function collectPlatformRegistrySummary(
+  address: string
+): Promise<ModuleSummary> {
+  const platformRegistry = await ethers.getContractAt(
+    'PlatformRegistry',
+    address
+  );
+  const [ownerAddress, incentives, feePool] = await Promise.all([
+    resolveOwner(platformRegistry),
+    callString(platformRegistry, 'platformIncentives'),
+    callString(platformRegistry, 'feePool'),
+  ]);
+
+  return {
+    key: 'platformRegistry',
+    name: 'PlatformRegistry',
+    address,
+    metrics: [
+      { label: 'Governance', value: ownerAddress },
+      {
+        label: 'PlatformIncentives',
+        value: normaliseAddress(incentives),
+      },
+      { label: 'FeePool', value: normaliseAddress(feePool) },
+    ],
+  };
+}
+
+async function collectSystemPauseSummary(
+  address: string
+): Promise<ModuleSummary> {
+  const systemPause = await ethers.getContractAt('SystemPause', address);
+  const [ownerAddress, paused] = await Promise.all([
+    resolveOwner(systemPause),
+    (async () => {
+      try {
+        return Boolean(await systemPause.paused());
+      } catch (_) {
+        return false;
+      }
+    })(),
+  ]);
+
+  return {
+    key: 'systemPause',
+    name: 'SystemPause',
+    address,
+    metrics: [
+      { label: 'Governance', value: ownerAddress },
+      { label: 'Paused', value: paused },
+    ],
+  };
+}
+
+const COLLECTORS: Record<string, (address: string) => Promise<ModuleSummary>> =
+  {
+    stakeManager: collectStakeManagerSummary,
+    feePool: collectFeePoolSummary,
+    taxPolicy: collectTaxPolicySummary,
+    jobRegistry: collectJobRegistrySummary,
+    validationModule: collectValidationModuleSummary,
+    platformRegistry: collectPlatformRegistrySummary,
+    systemPause: collectSystemPauseSummary,
+  };
+
+function printModule(summary: ModuleSummary): void {
+  if (!summary.address) {
+    console.log(`\n${summary.name}\n  address: (not configured)`);
+    return;
+  }
+  console.log(`\n${summary.name}\n  address: ${summary.address}`);
+  for (const metric of summary.metrics) {
+    let value: string;
+    if (metric.value === null) {
+      value = 'unknown';
+    } else if (typeof metric.value === 'boolean') {
+      value = metric.value ? 'true' : 'false';
+    } else {
+      value = String(metric.value);
+    }
+    console.log(`  ${metric.label}: ${value}`);
+  }
+}
+
+async function loadConfigSummary(configNetwork: string) {
+  const result: Record<string, any> = {};
+
+  try {
+    const { plan } = loadDeploymentPlan({
+      network: configNetwork,
+      optional: true,
+    });
+    if (plan && Object.keys(plan).length > 0) {
+      result.deploymentPlan = plan;
+    }
+  } catch (_) {
+    // ignore missing
+  }
+
+  try {
+    const { config } = loadStakeManagerConfig({ network: configNetwork });
+    result.stakeManager = config;
+  } catch (_) {}
+
+  try {
+    const { config } = loadFeePoolConfig({ network: configNetwork });
+    result.feePool = config;
+  } catch (_) {}
+
+  try {
+    const { config } = loadJobRegistryConfig({ network: configNetwork });
+    result.jobRegistry = config;
+  } catch (_) {}
+
+  try {
+    const { config } = loadPlatformRegistryConfig({ network: configNetwork });
+    result.platformRegistry = config;
+  } catch (_) {}
+
+  try {
+    const { config } = loadPlatformIncentivesConfig({ network: configNetwork });
+    result.platformIncentives = config;
+  } catch (_) {}
+
+  try {
+    const { config } = loadTaxPolicyConfig({ network: configNetwork });
+    result.taxPolicy = config;
+  } catch (_) {}
+
+  return result;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const networkInfo = await ethers.provider.getNetwork();
+  const addressBook = await readAddressBook();
+  const configNetwork =
+    inferNetworkKey(
+      options.configNetwork || network.name || networkInfo.name
+    ) || networkInfo.name;
+
+  const summaries: ModuleSummary[] = [];
+
+  for (const [key, collector] of Object.entries(COLLECTORS)) {
+    const rawAddress = addressBook[key];
+    const address = normaliseAddress(rawAddress);
+    if (!address) {
+      summaries.push({ key, name: key, address: null, metrics: [] });
+      continue;
+    }
+    try {
+      const summary = await collector(address);
+      summaries.push(summary);
+    } catch (error) {
+      summaries.push({
+        key,
+        name: key,
+        address,
+        metrics: [
+          {
+            label: 'error',
+            value:
+              error instanceof Error
+                ? error.message
+                : 'Failed to load module state',
+          },
+        ],
+      });
+    }
+  }
+
+  const configSummary = await loadConfigSummary(configNetwork || '');
+
+  if (options.json) {
+    const output = {
+      network: {
+        chainId: Number(networkInfo.chainId),
+        name: networkInfo.name,
+        configNetwork,
+      },
+      modules: summaries,
+      config: configSummary,
+    };
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  console.log('AGIJobs Owner Control Dashboard');
+  console.log('================================');
+  console.log(`Network: ${networkInfo.name} (chainId: ${networkInfo.chainId})`);
+  if (configNetwork) {
+    console.log(`Config network: ${configNetwork}`);
+  }
+
+  for (const summary of summaries) {
+    printModule(summary);
+  }
+
+  if (Object.keys(configSummary).length > 0) {
+    console.log('\nConfiguration Snapshots');
+    console.log('-----------------------');
+    for (const [key, value] of Object.entries(configSummary)) {
+      console.log(`\n${key}`);
+      console.log(JSON.stringify(value, null, 2));
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('Owner dashboard failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add an interactive `owner:dashboard` Hardhat script that surfaces governance ownership, wiring, and config snapshots from `docs/deployment-addresses.json`
- publish an institutional Truffle mainnet playbook with mermaid diagrams, preflight checklists, and post-deployment owner procedures
- wire the new tooling into `package.json` and surface the documentation and dashboard workflow in the README

## Testing
- npm run lint:check *(fails: repository already contains numerous Prettier formatting violations unrelated to this change)*
- npm run compile
- npm test
- npx hardhat run --no-compile scripts/v2/owner-dashboard.ts

------
https://chatgpt.com/codex/tasks/task_e_68d565e39f948333a7a2c58769a6cbbe