### PR TITLE
Expand owner control coverage and add institutional deployment blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The wizard validates `.env` secrets, highlights ENS configuration drift, prints 
 
 - **Non-technical operators:** follow the [Non-Technical Mainnet Deployment Runbook (Truffle)](docs/production/nontechnical-mainnet-deployment.md) for an operations-friendly checklist powered by `npm run deploy:checklist`.
 - **Institutional change-control teams:** use the [Institutional Truffle Mainnet Playbook](docs/production/institutional-truffle-mainnet-playbook.md) for staged approvals, migration summaries, and sign-off artefact tracking.
+- **Blueprint view:** hand non-technical coordinators the [Truffle Mainnet Blueprint](docs/production/truffle-mainnet-blueprint.md) for a storyboarded deployment plus the enhanced owner-control matrix introduced in this release.
 - **Visual learners:** review the updated [Mermaid-driven workflow and owner control maps](docs/production/institutional-truffle-mainnet-playbook.md#10-owner-control-matrix-visual) to preview the entire migration pipeline and governance levers at a glance.
 - **Command-line launch coordinators:** the [AGIJobs v0 Institutional Truffle Mainnet Playbook](docs/truffle-mainnet-playbook.md) packages the full CLI workflow with diagrams, rehearsals and owner-control checkpoints suitable for non-technical operators.
 

--- a/docs/production/truffle-mainnet-blueprint.md
+++ b/docs/production/truffle-mainnet-blueprint.md
@@ -1,0 +1,205 @@
+# AGIJobs v2 Truffle Mainnet Blueprint (Non-Technical Edition)
+
+> **Purpose:** Provide an operations-ready, zero-assumption deployment and owner-control playbook for launching AGIJobs v2 on Ethereum mainnet using Truffle, including interactive scripts and visual checklists that a non-technical coordinator can follow without improvisation.
+>
+> **Companion tooling:** `npm run migrate:wizard`, `npm run owner:plan`, `npm run owner:dashboard`, and the owner configuration plans enhanced in this release.
+
+---
+
+## 1. Deployment storyboard (at a glance)
+
+```mermaid
+flowchart TD
+    subgraph Prep[Preparation]
+        A[Clone repo \n & install deps]
+        B[Populate .env \n (RPC, key, governance)]
+        C[Review deployment-config/mainnet.json]
+    end
+    subgraph DryRun[Dry-run & Checklist]
+        D[npm run deploy:checklist]
+        E[npm run migrate:wizard -- --network mainnet]
+    end
+    subgraph Execute[Execute & Verify]
+        F[npm run migrate:wizard -- --network mainnet --execute]
+        G[npm run wire:verify]
+        H[npm run owner:dashboard]
+    end
+    subgraph Control[Owner Control]
+        I[npm run owner:plan -- --out plan.json]
+        J[Review Safe bundle / CSV]
+        K[Execute via Safe or Timelock]
+    end
+
+    A --> B --> C --> D --> E --> F --> G --> H --> I --> J --> K
+```
+
+Keep this storyboard near the console. Every command is idempotent and prints a status banner before doing anything potentially irreversible.
+
+---
+
+## 2. Zero-assumption prerequisites
+
+| Item | Why it matters | How to confirm |
+| --- | --- | --- |
+| Hardware signer with ≥0.5 ETH | Funds deployment and emergency pause ops | Unlock device, verify balance on Etherscan |
+| `.env` populated with `MAINNET_RPC_URL`, `MAINNET_PRIVATE_KEY`, `GOVERNANCE_ADDRESS`, `ETHERSCAN_API_KEY` | Feeds Truffle, verification, and owner tooling | Run `grep -v '^#' .env` and ensure no blanks |
+| `deployment-config/mainnet.json` reviewed | Aligns ENS roots, economic overrides, governance owner | Open file in editor; ensure addresses match change ticket |
+| `config/agialpha.json` modules blank/known | Guarantees migrations write deterministic addresses | Confirm each module entry is `0x000…` before deploying |
+| Secondary reviewer on-call | Required for institutional change-control | Book a video bridge before starting |
+
+---
+
+## 3. Launch procedure (non-technical walkthrough)
+
+1. **Dry-run the entire pipeline.**
+   ```bash
+   env DOTENV_PATH=.env npm run deploy:checklist
+   npm run migrate:wizard -- --network mainnet
+   ```
+   - ✅ Expect a green table summarising RPC reachability, config diffs, ENS hashes, and migration availability.
+   - ⚠️ Any `WARN` row indicates an optional improvement (e.g., ENS aliases missing). `FAIL` means stop and remediate.
+
+2. **Execute the mainnet deployment when reviewers approve.**
+   ```bash
+   npm run migrate:wizard -- --network mainnet --execute
+   ```
+   The wizard handles: Hardhat compilation (`viaIR`), Truffle migrations 1–5, wiring verification, and Etherscan submission (if the API key is present).
+
+3. **Capture artefacts immediately.**
+   - `docs/deployment-addresses.json` – generated automatically by migration 3; upload to the change ticket.
+   - Console output – copy/paste into the deployment log (contains tx hashes and final module map).
+
+4. **Validate post-deployment health.**
+   ```bash
+   npm run owner:dashboard
+   ```
+   The dashboard prints the governance owner and key parameters for StakeManager, FeePool, JobRegistry, ValidationModule, PlatformRegistry, TaxPolicy, and SystemPause.
+
+---
+
+## 4. Owner control plan – now covering every governance-critical module
+
+The improved owner plan generator inspects and proposes transactions for:
+
+- `JobRegistry`
+- `StakeManager`
+- `FeePool`
+- `PlatformRegistry`
+- `PlatformIncentives`
+- `TaxPolicy`
+- `IdentityRegistry`
+
+### 4.1 Generate the change set
+
+```bash
+npm run owner:plan -- --json --out owner-plan.json --safe owner-safe-bundle.json
+```
+
+- `owner-plan.json` – machine-readable summary for audits and offline review.
+- `owner-safe-bundle.json` – ready to import into Safe Transaction Builder for multisig execution.
+- The JSON now includes alias updates, tax acknowledger permissions, and identity allowlists derived directly from the config files under `config/`.
+
+### 4.2 Visualising the owner actions
+
+```mermaid
+sequenceDiagram
+    participant Gov as Governance signer
+    participant OPC as owner:plan script
+    participant MOD as Modules (StakeManager, JobRegistry,...)
+    participant Safe as Safe / Timelock
+
+    Gov->>OPC: npm run owner:plan -- --json
+    OPC->>MOD: Read configuration & on-chain state
+    OPC-->>Gov: owner-plan.json + Safe bundle
+    Gov->>Safe: Upload bundle / review CSV
+    Safe->>MOD: Execute batched transactions
+    MOD-->>Gov: Emit events confirming new parameters
+```
+
+Use the generated CSV to brief compliance teams; every row includes the module, function, previous value, and new value.
+
+---
+
+## 5. Identity Registry checklist (new in this release)
+
+The plan generator now inspects ENS roots, aliases, Merkle roots, agent allowlists, agent types, and profile URIs. Keep the following table handy when reviewing:
+
+| Config file key | On-chain setter | Notes |
+| --- | --- | --- |
+| `config/identity-registry.json → ens.registry` | `setENS(address)` | Must be the canonical ENS registry; zero address is rejected |
+| `ens.agentRoot.node` | `setAgentRootNode(bytes32)` | Provide the ENS namehash (e.g., `agent.agi.eth`) |
+| `ens.agentRoot.aliases` & `ens.agentAliases` | `add/removeAgentRootNodeAlias(bytes32)` | The plan adds/removes entries to match config |
+| `merkle.agent` / `merkle.validator` | `setAgentMerkleRoot(bytes32)` / `setValidatorMerkleRoot(bytes32)` | Accepts 32-byte hex strings |
+| `additionalAgents` & `additionalValidators` | `add/removeAdditionalAgent`, `add/removeAdditionalValidator` | Boolean map: `true` grants allowlist, `false` revokes |
+| `agentTypes` | `setAgentType(address,uint8)` | Values: `0` Human, `1` AI |
+| `agentProfiles` | `setAgentProfileURI(address,string)` | Empty string clears metadata |
+
+Before executing the plan, open `config/identity-registry.json` to ensure every override is deliberate. The script will highlight additions and removals in the console.
+
+---
+
+## 6. Hand-off artefact bundle
+
+After execution, archive the following in your change ticket:
+
+1. `docs/deployment-addresses.json`
+2. `owner-plan.json`
+3. `owner-safe-bundle.json`
+4. Console transcript from `npm run owner:dashboard`
+5. Signed approvals from reviewers (screenshots or exported Safe transaction)
+
+Store the bundle in your institution’s vault alongside emergency pause instructions.
+
+---
+
+## 7. Emergency response playbook (condensed)
+
+```mermaid
+gantt
+    title First 15 minutes after discovering a misconfiguration
+    dateFormat  mm-dd HH:MM
+    axisFormat  %H:%M
+    section Detection
+    Alert raised           :active, 00-00 00:00, 5m
+    section Containment
+    Pause SystemPause      :crit, 00-00 00:05, 2m
+    Notify operators       :after Pause SystemPause, 3m
+    section Remediation
+    Execute owner-plan fix :after Notify operators, 5m
+    Verify with dashboard  :after Execute owner-plan fix, 5m
+```
+
+Commands to keep on a sticky note:
+
+```bash
+# Freeze all modules via SystemPause
+eval "$(npx hardhat run scripts/v2/updateSystemPause.ts --network mainnet --pause)"
+
+# Re-apply governance-approved configuration
+npm run owner:plan -- --execute --out executed-plan.json
+```
+
+Document the block number at which the pause happened and share it with stakeholders.
+
+---
+
+## 8. Cross-check matrix
+
+| Step | Tooling | Evidence |
+| --- | --- | --- |
+| Deployment dry-run | `npm run migrate:wizard -- --network mainnet` | Wizard transcript saved |
+| Production deploy | `npm run migrate:wizard -- --network mainnet --execute` | Tx hashes + addresses JSON |
+| Wiring verification | `npm run wire:verify` | Console output captured |
+| Owner authority | `npm run owner:dashboard` | Screenshot or console log |
+| Owner plan | `npm run owner:plan -- --json` | `owner-plan.json` + CSV |
+| Safe bundle import | Safe Transaction Builder | Screenshot of queued batch |
+
+---
+
+## 9. Support and escalation
+
+- **Security issues:** Follow the disclosure process in [`SECURITY.md`](../../SECURITY.md).
+- **Operational questions:** Start with `docs/production/institutional-truffle-mainnet-playbook.md` and `docs/production/nontechnical-mainnet-deployment.md`.
+- **Change management:** Attach this blueprint and the generated artefacts to every production change request.
+
+Stay disciplined, collect artefacts, and treat every parameter change as a regulated event.

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,38 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
@@ -192,6 +224,25 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
@@ -228,6 +279,21 @@
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1307,6 +1373,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1917,6 +2007,133 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@nomicfoundation/hardhat-chai-matchers": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.1.0.tgz",
+      "integrity": "sha512-GPhBNafh1fCnVD9Y7BYvoLnblnvfcq3j8YDbO1gGe/1nOFWzGmV7gFu5DkwFXF+IpYsS+t96o9qc/mPu3V3Vfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/chai-as-promised": "^7.1.3",
+        "chai-as-promised": "^7.1.1",
+        "deep-eql": "^4.0.1",
+        "ordinal": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.1.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.14.0",
+        "hardhat": "^2.26.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.1.0.tgz",
+      "integrity": "sha512-jx6fw3Ms7QBwFGT2MU6ICG292z0P81u6g54JjSV105+FbTZOF4FJqPksLfDybxkkOeq28eDxbqq7vpxRYyIlxA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "ethers": "^6.14.0",
+        "hardhat": "^2.26.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.13.tgz",
+      "integrity": "sha512-G4XGPWvxs9DJhZ6PE1wdvKjHkjErWbsETf4c7YxO6GUz+MJGlw+PtgbnCwhL3tQzSq3oD4MB0LGi+sK0polpUA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/ignition-core": "^0.15.13",
+        "@nomicfoundation/ignition-ui": "^0.15.12",
+        "chalk": "^4.0.0",
+        "debug": "^4.3.2",
+        "fs-extra": "^10.0.0",
+        "json5": "^2.2.3",
+        "prompts": "^2.4.2"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-verify": "^2.1.0",
+        "hardhat": "^2.26.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
+      "version": "0.15.14",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.14.tgz",
+      "integrity": "sha512-eq+5n+c1DW18/Xp8/QrHBBvG5QaKUxYF/byol4f1jrnZ1zAy0OrqEa/oaNFWchhpLalX7d7suk/2EL0PbT0CDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.1.0",
+        "@nomicfoundation/hardhat-ignition": "^0.15.13",
+        "@nomicfoundation/ignition-core": "^0.15.13",
+        "ethers": "^6.14.0",
+        "hardhat": "^2.26.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-network-helpers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.1.0.tgz",
+      "integrity": "sha512-ZS+NulZuR99NUHt2VwcgZvgeD6Y63qrbORNRuKO+lTowJxNVsrJ0zbRx1j5De6G3dOno5pVGvuYSq2QVG0qCYg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ethereumjs-util": "^7.1.4"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.26.0"
+      }
+    },
     "node_modules/@nomicfoundation/hardhat-toolbox": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-6.1.0.tgz",
@@ -1943,6 +2160,134 @@
         "typechain": "^8.3.0",
         "typescript": ">=4.5.0"
       }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.1.1.tgz",
+      "integrity": "sha512-K1plXIS42xSHDJZRkrE2TZikqxp9T4y6jUMUNI/imLgN5uCcEQokmfU0DlyP9zzHncYK92HlT5IWP35UVCLrPw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^8.1.0",
+        "debug": "^4.1.1",
+        "lodash.clonedeep": "^4.5.0",
+        "picocolors": "^1.1.0",
+        "semver": "^6.3.0",
+        "table": "^6.8.0",
+        "undici": "^5.14.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.26.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.13.tgz",
+      "integrity": "sha512-Z4T1WIbw0EqdsN9RxtnHeQXBi7P/piAmCu8bZmReIdDo/2h06qgKWxjDoNfc9VBFZJ0+Dx79tkgQR3ewxMDcpA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/address": "5.6.1",
+        "@nomicfoundation/solidity-analyzer": "^0.1.1",
+        "cbor": "^9.0.0",
+        "debug": "^4.3.2",
+        "ethers": "^6.14.0",
+        "fs-extra": "^10.0.0",
+        "immer": "10.0.2",
+        "lodash": "4.17.21",
+        "ndjson": "2.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/@ethersproject/address": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
+      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.6.2",
+        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/keccak256": "^5.6.1",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/rlp": "^5.6.1"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/cbor": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
+      "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-ui": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.12.tgz",
+      "integrity": "sha512-nQl8tusvmt1ANoyIj5RQl9tVSEmG0FnNbtwnWbTim+F8JLm4YLHWS0yEgYUZC+BEO3oS0D8r6V8a02JGZJgqiQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
       "version": "0.1.2",
@@ -2602,6 +2947,82 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typechain/ethers-v6": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.5.1.tgz",
+      "integrity": "sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.2",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "node_modules/@typechain/hardhat": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-9.1.0.tgz",
+      "integrity": "sha512-mtaUlzLlkqTlfPwB3FORdejqBskSnh+Jl8AIJGjXNAQfRQ4ofHADPl1+oU7Z3pAJzmZbUXII8MhOLQltcHgKnA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fs-extra": "^9.1.0"
+      },
+      "peerDependencies": {
+        "@typechain/ethers-v6": "^0.5.1",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.9",
+        "typechain": "^8.3.2"
+      }
+    },
+    "node_modules/@typechain/hardhat/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typechain/hardhat/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@typechain/hardhat/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@types/bn.js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
@@ -2632,6 +3053,25 @@
         "@types/keyv": "^3.1.4",
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.8",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz",
+      "integrity": "sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/chai": "*"
       }
     },
     "node_modules/@types/connect": {
@@ -2741,6 +3181,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/node": {
       "version": "20.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
@@ -2758,6 +3206,14 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",
@@ -3410,6 +3866,17 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -3449,6 +3916,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ast-parents": {
@@ -3523,6 +4001,17 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/audit-ci": {
       "version": "7.1.0",
@@ -4222,6 +4711,20 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "license": "Apache-2.0"
     },
+    "node_modules/cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
     "node_modules/cborg": {
       "version": "4.2.15",
       "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.15.tgz",
@@ -4229,6 +4732,40 @@
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
+      "integrity": "sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==",
+      "dev": true,
+      "license": "WTFPL",
+      "peer": true,
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 6"
       }
     },
     "node_modules/chalk": {
@@ -4254,6 +4791,20 @@
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
       "engines": {
         "node": "*"
       }
@@ -4499,6 +5050,147 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -4567,6 +5259,14 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cookie": {
       "version": "1.0.2",
@@ -4837,6 +5537,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -6860,6 +7574,20 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -7129,6 +7857,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -7137,6 +7876,17 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -8040,6 +8790,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/immer": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
+      "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/immutable": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
@@ -8897,6 +9659,20 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -9010,6 +9786,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/latest-version": {
@@ -9215,12 +10002,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -9258,6 +10070,17 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
     },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
@@ -10085,6 +10908,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ndjson": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
+      "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.5",
+        "readable-stream": "^3.6.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "ndjson": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -10160,6 +11004,17 @@
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.19"
+      }
     },
     "node_modules/nopt": {
       "version": "3.0.6",
@@ -10311,6 +11166,14 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/ordinal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ordinal/-/ordinal-1.0.3.tgz",
+      "integrity": "sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
@@ -10693,6 +11556,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -10889,6 +11763,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/proto-list": {
@@ -11195,6 +12084,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/registry-auth-token": {
@@ -12018,6 +12918,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12313,6 +13221,17 @@
         "node": "*"
       }
     },
+    "node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -12420,6 +13339,14 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
+      "dev": true,
+      "license": "WTFPL OR MIT",
+      "peer": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -12796,6 +13723,45 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/table/node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -13015,6 +13981,34 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-command-line-args": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz",
+      "integrity": "sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^6.1.0",
+        "string-format": "^2.0.0"
+      },
+      "bin": {
+        "write-markdown": "dist/write-markdown.js"
+      }
+    },
+    "node_modules/ts-essentials": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": ">=3.7.0"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -13128,6 +14122,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
@@ -13152,6 +14157,69 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typechain": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.3.2.tgz",
+      "integrity": "sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prettier": "^2.1.1",
+        "debug": "^4.3.1",
+        "fs-extra": "^7.0.0",
+        "glob": "7.1.7",
+        "js-sha3": "^0.8.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^1.0.4",
+        "prettier": "^2.3.1",
+        "ts-command-line-args": "^2.2.0",
+        "ts-essentials": "^7.0.1"
+      },
+      "bin": {
+        "typechain": "dist/cli/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.3.0"
+      }
+    },
+    "node_modules/typechain/node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typechain/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -13189,6 +14257,17 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/uglify-js": {
@@ -14732,6 +15811,32 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/workerpool": {
       "version": "6.5.1",

--- a/scripts/v2/lib/identityRegistryPlan.ts
+++ b/scripts/v2/lib/identityRegistryPlan.ts
@@ -1,0 +1,389 @@
+import type { Contract } from 'ethers';
+import { ethers } from 'ethers';
+import type { IdentityRegistryConfig } from '../../config';
+import { ModulePlan, PlannedAction } from './types';
+import {
+  formatBytes32List,
+  normaliseAddress,
+  normaliseBytes32,
+  sameAddress,
+  sameBytes32,
+} from './utils';
+
+interface AliasPlan {
+  desired: Set<string>;
+  enforce: boolean;
+}
+
+function collectAliasPlan(
+  config: IdentityRegistryConfig,
+  kind: 'agent' | 'club'
+): AliasPlan {
+  const ensConfig = config.ens || {};
+  const root = kind === 'agent' ? ensConfig.agentRoot : ensConfig.clubRoot;
+  const explicitAliasesKey = kind === 'agent' ? 'agentAliases' : 'clubAliases';
+  const explicitAliases = (ensConfig as any)[explicitAliasesKey] as
+    | { node?: string }[]
+    | undefined;
+
+  const set = new Set<string>();
+  const push = (value: any) => {
+    if (!value) return;
+    const node = value.node ?? value;
+    try {
+      const hex = normaliseBytes32(node);
+      if (hex) {
+        set.add(hex);
+      }
+    } catch (error) {
+      throw new Error(
+        `Invalid ${kind} alias value ${String(node)}: ${
+          (error as Error).message
+        }`
+      );
+    }
+  };
+
+  if (root && Array.isArray((root as any).aliases)) {
+    for (const alias of (root as any).aliases) {
+      push(alias);
+    }
+  }
+
+  if (explicitAliases && Array.isArray(explicitAliases)) {
+    for (const alias of explicitAliases) {
+      push(alias);
+    }
+  }
+
+  const enforce =
+    (root && Object.prototype.hasOwnProperty.call(root, 'aliases')) ||
+    Object.prototype.hasOwnProperty.call(ensConfig, explicitAliasesKey);
+
+  return { desired: set, enforce };
+}
+
+function toLowerHex(value: any): string {
+  return ethers.hexlify(value).toLowerCase();
+}
+
+export interface IdentityRegistryPlanInput {
+  identityRegistry: Contract;
+  config: IdentityRegistryConfig;
+  configPath?: string;
+}
+
+export async function buildIdentityRegistryPlan(
+  input: IdentityRegistryPlanInput
+): Promise<ModulePlan> {
+  const { identityRegistry, config, configPath } = input;
+  const address = await identityRegistry.getAddress();
+  const iface = identityRegistry.interface;
+
+  const [
+    currentEns,
+    currentWrapper,
+    currentReputation,
+    currentAttestation,
+    currentAgentRoot,
+    currentClubRoot,
+    currentAgentMerkle,
+    currentValidatorMerkle,
+    currentAgentAliases,
+    currentClubAliases,
+  ] = await Promise.all([
+    identityRegistry.ens(),
+    identityRegistry.nameWrapper(),
+    identityRegistry.reputationEngine(),
+    identityRegistry.attestationRegistry(),
+    identityRegistry.agentRootNode(),
+    identityRegistry.clubRootNode(),
+    identityRegistry.agentMerkleRoot(),
+    identityRegistry.validatorMerkleRoot(),
+    identityRegistry.getAgentRootNodeAliases(),
+    identityRegistry.getClubRootNodeAliases(),
+  ]);
+
+  const actions: PlannedAction[] = [];
+
+  const desiredEns = normaliseAddress(config.ens?.registry);
+  if (desiredEns && !sameAddress(currentEns, desiredEns)) {
+    actions.push({
+      label: 'Update ENS registry address',
+      method: 'setENS',
+      args: [desiredEns],
+      current: currentEns,
+      desired: desiredEns,
+    });
+  }
+
+  const desiredWrapper = normaliseAddress(config.ens?.nameWrapper);
+  if (
+    desiredWrapper !== undefined &&
+    !sameAddress(currentWrapper, desiredWrapper)
+  ) {
+    actions.push({
+      label: 'Update ENS NameWrapper',
+      method: 'setNameWrapper',
+      args: [desiredWrapper ?? ethers.ZeroAddress],
+      current: currentWrapper,
+      desired: desiredWrapper ?? ethers.ZeroAddress,
+    });
+  }
+
+  const desiredReputation = normaliseAddress(config.reputationEngine);
+  if (
+    desiredReputation !== undefined &&
+    !sameAddress(currentReputation, desiredReputation)
+  ) {
+    actions.push({
+      label: 'Update ReputationEngine reference',
+      method: 'setReputationEngine',
+      args: [desiredReputation ?? ethers.ZeroAddress],
+      current: currentReputation,
+      desired: desiredReputation ?? ethers.ZeroAddress,
+    });
+  }
+
+  const desiredAttestation = normaliseAddress(config.attestationRegistry);
+  if (
+    desiredAttestation !== undefined &&
+    !sameAddress(currentAttestation, desiredAttestation)
+  ) {
+    actions.push({
+      label: 'Update AttestationRegistry reference',
+      method: 'setAttestationRegistry',
+      args: [desiredAttestation ?? ethers.ZeroAddress],
+      current: currentAttestation,
+      desired: desiredAttestation ?? ethers.ZeroAddress,
+    });
+  }
+
+  const desiredAgentRoot =
+    config.ens?.agentRoot &&
+    Object.prototype.hasOwnProperty.call(config.ens.agentRoot, 'node')
+      ? normaliseBytes32(config.ens.agentRoot.node)
+      : undefined;
+  if (
+    desiredAgentRoot !== undefined &&
+    !sameBytes32(currentAgentRoot, desiredAgentRoot)
+  ) {
+    actions.push({
+      label: 'Set agent ENS root node',
+      method: 'setAgentRootNode',
+      args: [desiredAgentRoot],
+      current: toLowerHex(currentAgentRoot),
+      desired: desiredAgentRoot,
+    });
+  }
+
+  const desiredClubRoot =
+    config.ens?.clubRoot &&
+    Object.prototype.hasOwnProperty.call(config.ens.clubRoot, 'node')
+      ? normaliseBytes32(config.ens.clubRoot.node)
+      : undefined;
+  if (
+    desiredClubRoot !== undefined &&
+    !sameBytes32(currentClubRoot, desiredClubRoot)
+  ) {
+    actions.push({
+      label: 'Set club ENS root node',
+      method: 'setClubRootNode',
+      args: [desiredClubRoot],
+      current: toLowerHex(currentClubRoot),
+      desired: desiredClubRoot,
+    });
+  }
+
+  const desiredAgentMerkle =
+    config.merkle &&
+    Object.prototype.hasOwnProperty.call(config.merkle, 'agent')
+      ? normaliseBytes32(config.merkle.agent)
+      : undefined;
+  if (
+    desiredAgentMerkle !== undefined &&
+    !sameBytes32(currentAgentMerkle, desiredAgentMerkle)
+  ) {
+    actions.push({
+      label: 'Update agent Merkle root',
+      method: 'setAgentMerkleRoot',
+      args: [desiredAgentMerkle],
+      current: toLowerHex(currentAgentMerkle),
+      desired: desiredAgentMerkle,
+    });
+  }
+
+  const desiredValidatorMerkle =
+    config.merkle &&
+    Object.prototype.hasOwnProperty.call(config.merkle, 'validator')
+      ? normaliseBytes32(config.merkle.validator)
+      : undefined;
+  if (
+    desiredValidatorMerkle !== undefined &&
+    !sameBytes32(currentValidatorMerkle, desiredValidatorMerkle)
+  ) {
+    actions.push({
+      label: 'Update validator Merkle root',
+      method: 'setValidatorMerkleRoot',
+      args: [desiredValidatorMerkle],
+      current: toLowerHex(currentValidatorMerkle),
+      desired: desiredValidatorMerkle,
+    });
+  }
+
+  const agentAliasPlan = collectAliasPlan(config, 'agent');
+  const currentAgentAliasSet = new Set(
+    currentAgentAliases.map((value: any) => toLowerHex(value))
+  );
+  if (agentAliasPlan.enforce) {
+    for (const alias of agentAliasPlan.desired) {
+      if (!currentAgentAliasSet.has(alias)) {
+        actions.push({
+          label: `Add agent alias ${alias}`,
+          method: 'addAgentRootNodeAlias',
+          args: [alias],
+        });
+      }
+    }
+    for (const alias of currentAgentAliasSet) {
+      if (!agentAliasPlan.desired.has(alias)) {
+        actions.push({
+          label: `Remove agent alias ${alias}`,
+          method: 'removeAgentRootNodeAlias',
+          args: [alias],
+        });
+      }
+    }
+  } else {
+    for (const alias of agentAliasPlan.desired) {
+      if (!currentAgentAliasSet.has(alias)) {
+        actions.push({
+          label: `Add agent alias ${alias}`,
+          method: 'addAgentRootNodeAlias',
+          args: [alias],
+          notes: [
+            'Removal not planned because aliases are not enforced by config',
+          ],
+        });
+      }
+    }
+  }
+
+  const clubAliasPlan = collectAliasPlan(config, 'club');
+  const currentClubAliasSet = new Set(
+    currentClubAliases.map((value: any) => toLowerHex(value))
+  );
+  if (clubAliasPlan.enforce) {
+    for (const alias of clubAliasPlan.desired) {
+      if (!currentClubAliasSet.has(alias)) {
+        actions.push({
+          label: `Add club alias ${alias}`,
+          method: 'addClubRootNodeAlias',
+          args: [alias],
+        });
+      }
+    }
+    for (const alias of currentClubAliasSet) {
+      if (!clubAliasPlan.desired.has(alias)) {
+        actions.push({
+          label: `Remove club alias ${alias}`,
+          method: 'removeClubRootNodeAlias',
+          args: [alias],
+        });
+      }
+    }
+  } else {
+    for (const alias of clubAliasPlan.desired) {
+      if (!currentClubAliasSet.has(alias)) {
+        actions.push({
+          label: `Add club alias ${alias}`,
+          method: 'addClubRootNodeAlias',
+          args: [alias],
+          notes: [
+            'Removal not planned because aliases are not enforced by config',
+          ],
+        });
+      }
+    }
+  }
+
+  for (const [address, allowed] of Object.entries(
+    config.additionalAgents || {}
+  )) {
+    const addr = ethers.getAddress(address);
+    const currentlyAllowed = await identityRegistry.additionalAgents(addr);
+    if (Boolean(currentlyAllowed) === Boolean(allowed)) {
+      continue;
+    }
+    actions.push({
+      label: `${allowed ? 'Allow' : 'Remove'} additional agent ${addr}`,
+      method: allowed ? 'addAdditionalAgent' : 'removeAdditionalAgent',
+      args: [addr],
+      current: currentlyAllowed ? 'allowed' : 'blocked',
+      desired: allowed ? 'allowed' : 'blocked',
+    });
+  }
+
+  for (const [address, allowed] of Object.entries(
+    config.additionalValidators || {}
+  )) {
+    const addr = ethers.getAddress(address);
+    const currentlyAllowed = await identityRegistry.additionalValidators(addr);
+    if (Boolean(currentlyAllowed) === Boolean(allowed)) {
+      continue;
+    }
+    actions.push({
+      label: `${allowed ? 'Allow' : 'Remove'} additional validator ${addr}`,
+      method: allowed ? 'addAdditionalValidator' : 'removeAdditionalValidator',
+      args: [addr],
+      current: currentlyAllowed ? 'allowed' : 'blocked',
+      desired: allowed ? 'allowed' : 'blocked',
+    });
+  }
+
+  for (const [address, typeConfig] of Object.entries(config.agentTypes || {})) {
+    if (!typeConfig) continue;
+    const addr = ethers.getAddress(address);
+    const desiredType = Number(typeConfig.value);
+    const currentType = Number(await identityRegistry.agentTypes(addr));
+    if (currentType === desiredType) {
+      continue;
+    }
+    actions.push({
+      label: `Set agent type for ${addr} to ${desiredType} (${typeConfig.label})`,
+      method: 'setAgentType',
+      args: [addr, desiredType],
+      current: `${currentType}`,
+      desired: `${desiredType}`,
+    });
+  }
+
+  for (const [address, uri] of Object.entries(config.agentProfiles || {})) {
+    const addr = ethers.getAddress(address);
+    const desiredUri = uri ?? '';
+    const currentUri = await identityRegistry.agentProfileURI(addr);
+    if ((currentUri || '') === desiredUri) {
+      continue;
+    }
+    actions.push({
+      label: `Set agent profile URI for ${addr}`,
+      method: 'setAgentProfileURI',
+      args: [addr, desiredUri],
+      current: currentUri || '<unset>',
+      desired: desiredUri || '<unset>',
+    });
+  }
+
+  return {
+    module: 'IdentityRegistry',
+    address,
+    actions,
+    configPath,
+    iface,
+    contract: identityRegistry,
+    metadata: {
+      desiredAgentAliases: formatBytes32List(agentAliasPlan.desired),
+      desiredClubAliases: formatBytes32List(clubAliasPlan.desired),
+    },
+  };
+}

--- a/scripts/v2/lib/platformIncentivesPlan.ts
+++ b/scripts/v2/lib/platformIncentivesPlan.ts
@@ -1,0 +1,74 @@
+import type { Contract } from 'ethers';
+import { ethers } from 'ethers';
+import type { PlatformIncentivesConfig } from '../../config';
+import { ModulePlan, PlannedAction } from './types';
+import { normaliseAddress, sameAddress } from './utils';
+
+export interface PlatformIncentivesPlanInput {
+  platformIncentives: Contract;
+  config: PlatformIncentivesConfig;
+  configPath?: string;
+  ownerAddress: string;
+}
+
+export async function buildPlatformIncentivesPlan(
+  input: PlatformIncentivesPlanInput
+): Promise<ModulePlan> {
+  const { platformIncentives, config, configPath } = input;
+  const address = await platformIncentives.getAddress();
+  const iface = platformIncentives.interface;
+
+  const [currentStakeManager, currentPlatformRegistry, currentJobRouter] =
+    await Promise.all([
+      platformIncentives.stakeManager(),
+      platformIncentives.platformRegistry(),
+      platformIncentives.jobRouter(),
+    ]);
+
+  const desiredStakeManager = normaliseAddress(config.stakeManager);
+  const desiredPlatformRegistry = normaliseAddress(config.platformRegistry);
+  const desiredJobRouter = normaliseAddress(config.jobRouter);
+
+  const stakeManagerAddress =
+    desiredStakeManager ??
+    (currentStakeManager
+      ? ethers.getAddress(currentStakeManager)
+      : undefined) ??
+    ethers.ZeroAddress;
+  const platformRegistryAddress =
+    desiredPlatformRegistry ??
+    (currentPlatformRegistry
+      ? ethers.getAddress(currentPlatformRegistry)
+      : undefined) ??
+    ethers.ZeroAddress;
+  const jobRouterAddress =
+    desiredJobRouter ??
+    (currentJobRouter ? ethers.getAddress(currentJobRouter) : undefined) ??
+    ethers.ZeroAddress;
+
+  const actions: PlannedAction[] = [];
+
+  if (
+    !sameAddress(currentStakeManager, stakeManagerAddress) ||
+    !sameAddress(currentPlatformRegistry, platformRegistryAddress) ||
+    !sameAddress(currentJobRouter, jobRouterAddress)
+  ) {
+    actions.push({
+      label:
+        'Update linked modules (StakeManager, PlatformRegistry, JobRouter)',
+      method: 'setModules',
+      args: [stakeManagerAddress, platformRegistryAddress, jobRouterAddress],
+      current: `${currentStakeManager}, ${currentPlatformRegistry}, ${currentJobRouter}`,
+      desired: `${stakeManagerAddress}, ${platformRegistryAddress}, ${jobRouterAddress}`,
+    });
+  }
+
+  return {
+    module: 'PlatformIncentives',
+    address,
+    actions,
+    configPath,
+    iface,
+    contract: platformIncentives,
+  };
+}

--- a/scripts/v2/lib/taxPolicyPlan.ts
+++ b/scripts/v2/lib/taxPolicyPlan.ts
@@ -1,0 +1,86 @@
+import type { Contract } from 'ethers';
+import type { TaxPolicyConfig } from '../../config';
+import { ModulePlan, PlannedAction } from './types';
+
+function trimOrUndefined(value?: string | null): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : '';
+}
+
+export interface TaxPolicyPlanInput {
+  taxPolicy: Contract;
+  config: TaxPolicyConfig;
+  configPath?: string;
+}
+
+export async function buildTaxPolicyPlan(
+  input: TaxPolicyPlanInput
+): Promise<ModulePlan> {
+  const { taxPolicy, config, configPath } = input;
+  const address = await taxPolicy.getAddress();
+  const iface = taxPolicy.interface;
+
+  const [currentUri, currentAcknowledgement] = await Promise.all([
+    taxPolicy.policyURI(),
+    taxPolicy.acknowledgement(),
+  ]);
+
+  const desiredUri = trimOrUndefined(config.policyURI);
+  const desiredAcknowledgement = trimOrUndefined(config.acknowledgement);
+
+  const actions: PlannedAction[] = [];
+
+  const uriChanged =
+    desiredUri !== undefined && desiredUri !== (currentUri || '').trim();
+  const ackChanged =
+    desiredAcknowledgement !== undefined &&
+    desiredAcknowledgement !== (currentAcknowledgement || '').trim();
+
+  if (uriChanged && ackChanged) {
+    actions.push({
+      label: 'Update tax policy URI and acknowledgement',
+      method: 'setPolicy',
+      args: [desiredUri, desiredAcknowledgement],
+      current: `URI=${currentUri}; ACK=${currentAcknowledgement}`,
+      desired: `URI=${desiredUri}; ACK=${desiredAcknowledgement}`,
+    });
+  } else if (uriChanged) {
+    actions.push({
+      label: 'Update tax policy URI',
+      method: 'setPolicyURI',
+      args: [desiredUri],
+      current: currentUri || '<unset>',
+      desired: desiredUri,
+    });
+  } else if (ackChanged) {
+    actions.push({
+      label: 'Update tax acknowledgement text',
+      method: 'setAcknowledgement',
+      args: [desiredAcknowledgement],
+      current: currentAcknowledgement || '<unset>',
+      desired: desiredAcknowledgement,
+    });
+  }
+
+  for (const [address, allowed] of Object.entries(config.acknowledgers || {})) {
+    actions.push({
+      label: `${allowed ? 'Authorize' : 'Revoke'} acknowledger ${address}`,
+      method: 'setAcknowledger',
+      args: [address, Boolean(allowed)],
+      current: '-',
+      desired: allowed ? 'allowed' : 'revoked',
+    });
+  }
+
+  return {
+    module: 'TaxPolicy',
+    address,
+    actions,
+    configPath,
+    iface,
+    contract: taxPolicy,
+  };
+}

--- a/scripts/v2/lib/utils.ts
+++ b/scripts/v2/lib/utils.ts
@@ -99,7 +99,10 @@ export function parsePercentage(
   return numberValue;
 }
 
-export function parseBoolean(value: unknown, label: string): boolean | undefined {
+export function parseBoolean(
+  value: unknown,
+  label: string
+): boolean | undefined {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -113,7 +116,9 @@ export function parseBoolean(value: unknown, label: string): boolean | undefined
   if (['true', '1', 'yes', 'y', 'on', 'enable', 'enabled'].includes(asString)) {
     return true;
   }
-  if (['false', '0', 'no', 'n', 'off', 'disable', 'disabled'].includes(asString)) {
+  if (
+    ['false', '0', 'no', 'n', 'off', 'disable', 'disabled'].includes(asString)
+  ) {
     return false;
   }
   throw new Error(`${label} must be a boolean value`);
@@ -142,4 +147,42 @@ export function parseTokenAmount(
     throw new Error(`${label}Tokens cannot be negative`);
   }
   return parsed;
+}
+
+export function normaliseBytes32(
+  value: string | Uint8Array | null | undefined,
+  { allowZero = true }: { allowZero?: boolean } = {}
+): string | undefined {
+  if (value === undefined || value === null) {
+    return allowZero ? ethers.ZeroHash : undefined;
+  }
+  const bytes = ethers.getBytes(value);
+  if (bytes.length !== 32) {
+    throw new Error(`Expected 32-byte value, received ${bytes.length}`);
+  }
+  const hex = ethers.hexlify(bytes).toLowerCase();
+  if (!allowZero && hex === ethers.ZeroHash) {
+    return undefined;
+  }
+  return hex;
+}
+
+export function sameBytes32(a?: string | null, b?: string | null): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  try {
+    return (
+      ethers.hexlify(ethers.getBytes(a)).toLowerCase() ===
+      ethers.hexlify(ethers.getBytes(b)).toLowerCase()
+    );
+  } catch (_) {
+    return false;
+  }
+}
+
+export function formatBytes32List(values: Iterable<string>): string {
+  return Array.from(values)
+    .map((value) => value.toLowerCase())
+    .join(', ');
 }

--- a/scripts/v2/truffle-preflight.ts
+++ b/scripts/v2/truffle-preflight.ts
@@ -583,7 +583,7 @@ function checkTruffleScripts(): CheckResult[] {
 function checkTruffleConfig(network: SupportedNetwork): CheckResult[] {
   const results: CheckResult[] = [];
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
     const truffleConfig = require('../../truffle-config');
     const entry = truffleConfig?.networks?.[network];
     if (!entry) {


### PR DESCRIPTION
## Summary
- add planning helpers for IdentityRegistry, PlatformIncentives, and TaxPolicy so `owner:plan` spans every governance-critical module
- extend shared owner-control utilities and CLI to aggregate the new module plans while keeping truffle preflight logic lint-clean
- document an institutional Truffle deployment blueprint for non-technical operators and surface it from the README

## Testing
- `npm test` *(passes but suite currently reports 0 cases)*
- `npm run lint:check` *(fails: repository has numerous pre-existing Prettier/solhint warnings that exceed the lint gate)*

------
https://chatgpt.com/codex/tasks/task_e_68d5733f5a448333b4ef21754b28674c