### PR TITLE
chore: extend owner plan to thermodynamics modules

### DIFF
--- a/scripts/v2/lib/rewardEnginePlan.ts
+++ b/scripts/v2/lib/rewardEnginePlan.ts
@@ -1,0 +1,360 @@
+import type { Contract } from 'ethers';
+import { ethers } from 'ethers';
+import type { RewardEngineThermoConfig, RoleShareInput } from '../../config';
+import { ModulePlan, PlannedAction } from './types';
+import {
+  describeArgs,
+  normaliseAddress,
+  parseBigInt,
+  sameAddress,
+} from './utils';
+
+const ROLE_KEYS = ['agent', 'validator', 'operator', 'employer'] as const;
+
+const ROLE_INDEX: Record<(typeof ROLE_KEYS)[number], number> = {
+  agent: 0,
+  validator: 1,
+  operator: 2,
+  employer: 3,
+};
+
+const WAD = 1000000000000000000n;
+
+function parseRoleShare(
+  value: RoleShareInput | undefined,
+  role: (typeof ROLE_KEYS)[number]
+): bigint | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    if (value.wad !== undefined && value.wad !== null && value.wad !== '') {
+      const wad = parseBigInt(value.wad, `rewardEngine.roleShares.${role}.wad`);
+      if (wad === undefined) {
+        return undefined;
+      }
+      if (wad < 0n) {
+        throw new Error(
+          `rewardEngine.roleShares.${role}.wad cannot be negative`
+        );
+      }
+      return wad;
+    }
+    if (
+      value.percent !== undefined &&
+      value.percent !== null &&
+      value.percent !== ''
+    ) {
+      return parseRoleShare(value.percent, role);
+    }
+  }
+
+  const asString =
+    typeof value === 'string' ? value.trim() : value.toString().trim();
+  if (!asString) {
+    return undefined;
+  }
+  const percent = Number(asString);
+  if (!Number.isFinite(percent)) {
+    throw new Error(
+      `rewardEngine.roleShares.${role} must be a finite percentage or wad`
+    );
+  }
+  if (percent < 0 || percent > 100) {
+    throw new Error(
+      `rewardEngine.roleShares.${role} must be between 0 and 100 percent`
+    );
+  }
+  return ethers.parseUnits(percent.toString(), 16);
+}
+
+function formatBigint(value: bigint): string {
+  return value.toString();
+}
+
+function parseUnsigned(value: unknown, label: string): bigint | undefined {
+  const parsed = parseBigInt(value, label);
+  if (parsed === undefined) {
+    return undefined;
+  }
+  if (parsed < 0n) {
+    throw new Error(`${label} cannot be negative`);
+  }
+  return parsed;
+}
+
+function parseBoolean(value: unknown): boolean | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  const normalised = value.toString().trim().toLowerCase();
+  if (!normalised) {
+    return undefined;
+  }
+  if (['true', '1', 'yes', 'y', 'on'].includes(normalised)) {
+    return true;
+  }
+  if (['false', '0', 'no', 'n', 'off'].includes(normalised)) {
+    return false;
+  }
+  throw new Error(`Unable to parse boolean value for ${value}`);
+}
+
+export interface RewardEnginePlanInput {
+  rewardEngine: Contract;
+  config: RewardEngineThermoConfig;
+  configPath?: string;
+}
+
+export async function buildRewardEnginePlan(
+  input: RewardEnginePlanInput
+): Promise<ModulePlan> {
+  const { rewardEngine, config, configPath } = input;
+  const iface = rewardEngine.interface;
+
+  const [
+    currentTreasury,
+    currentThermostat,
+    currentKappa,
+    currentMaxProofs,
+    currentTemperature,
+  ] = await Promise.all([
+    rewardEngine.treasury(),
+    rewardEngine.thermostat(),
+    rewardEngine.kappa(),
+    rewardEngine.maxProofs(),
+    rewardEngine.temperature(),
+  ]);
+
+  const currentRoleShares = await Promise.all(
+    ROLE_KEYS.map((_, index) => rewardEngine.roleShare(index))
+  );
+  const currentMu = await Promise.all(
+    ROLE_KEYS.map((_, index) => rewardEngine.mu(index))
+  );
+  const currentBaseline = await Promise.all(
+    ROLE_KEYS.map((_, index) => rewardEngine.baselineEnergy(index))
+  );
+
+  const actions: PlannedAction[] = [];
+
+  const desiredTreasury = normaliseAddress(config.treasury, {
+    allowZero: false,
+  });
+  if (
+    desiredTreasury &&
+    !sameAddress(desiredTreasury, ethers.getAddress(currentTreasury))
+  ) {
+    actions.push({
+      label: `Update treasury to ${desiredTreasury}`,
+      method: 'setTreasury',
+      args: [desiredTreasury],
+      current: ethers.getAddress(currentTreasury),
+      desired: desiredTreasury,
+    });
+  }
+
+  const desiredThermostat = normaliseAddress(config.thermostat);
+  const currentThermostatAddr = ethers.getAddress(currentThermostat);
+  if (
+    desiredThermostat !== undefined &&
+    !sameAddress(
+      desiredThermostat,
+      currentThermostatAddr === ethers.ZeroAddress
+        ? ethers.ZeroAddress
+        : currentThermostatAddr
+    )
+  ) {
+    actions.push({
+      label: `Point to thermostat ${desiredThermostat}`,
+      method: 'setThermostat',
+      args: [desiredThermostat],
+      current: currentThermostatAddr,
+      desired: desiredThermostat,
+    });
+  }
+
+  const desiredShares: Record<(typeof ROLE_KEYS)[number], bigint> = {
+    agent: currentRoleShares[0],
+    validator: currentRoleShares[1],
+    operator: currentRoleShares[2],
+    employer: currentRoleShares[3],
+  };
+  let sharesChanged = false;
+  for (const role of ROLE_KEYS) {
+    const desired = parseRoleShare(config.roleShares?.[role], role);
+    if (desired !== undefined) {
+      desiredShares[role] = desired;
+      const index = ROLE_INDEX[role];
+      if (desired !== currentRoleShares[index]) {
+        sharesChanged = true;
+      }
+    }
+  }
+
+  if (sharesChanged) {
+    const total = ROLE_KEYS.reduce<bigint>(
+      (acc, role) => acc + desiredShares[role],
+      0n
+    );
+    if (total !== WAD) {
+      throw new Error(
+        `Role share totals must equal 100%. Provided sum: ${total.toString()}`
+      );
+    }
+    actions.push({
+      label: 'Rebalance role shares',
+      method: 'setRoleShares',
+      args: ROLE_KEYS.map((role) => desiredShares[role]),
+      notes: ROLE_KEYS.map(
+        (role, index) =>
+          `${role}: ${formatBigint(currentRoleShares[index])} -> ${formatBigint(
+            desiredShares[role]
+          )}`
+      ),
+    });
+  }
+
+  for (const role of ROLE_KEYS) {
+    const desiredMu = parseBigInt(
+      config.mu?.[role],
+      `rewardEngine.mu.${role}`,
+      { allowNegative: true }
+    );
+    const index = ROLE_INDEX[role];
+    if (desiredMu !== undefined && desiredMu !== currentMu[index]) {
+      actions.push({
+        label: `Update mu for ${role}`,
+        method: 'setMu',
+        args: [index, desiredMu],
+        current: formatBigint(currentMu[index]),
+        desired: formatBigint(desiredMu),
+      });
+    }
+  }
+
+  for (const role of ROLE_KEYS) {
+    const desiredBaseline = parseBigInt(
+      config.baselineEnergy?.[role],
+      `rewardEngine.baselineEnergy.${role}`,
+      { allowNegative: true }
+    );
+    const index = ROLE_INDEX[role];
+    if (
+      desiredBaseline !== undefined &&
+      desiredBaseline !== currentBaseline[index]
+    ) {
+      actions.push({
+        label: `Update baseline energy for ${role}`,
+        method: 'setBaselineEnergy',
+        args: [index, desiredBaseline],
+        current: formatBigint(currentBaseline[index]),
+        desired: formatBigint(desiredBaseline),
+      });
+    }
+  }
+
+  const desiredKappa = parseUnsigned(config.kappa, 'rewardEngine.kappa');
+  if (desiredKappa !== undefined && desiredKappa !== currentKappa) {
+    actions.push({
+      label: `Set kappa to ${desiredKappa.toString()}`,
+      method: 'setKappa',
+      args: [desiredKappa],
+      current: currentKappa.toString(),
+      desired: desiredKappa.toString(),
+    });
+  }
+
+  const desiredMaxProofs = parseUnsigned(
+    config.maxProofs,
+    'rewardEngine.maxProofs'
+  );
+  if (desiredMaxProofs !== undefined && desiredMaxProofs !== currentMaxProofs) {
+    actions.push({
+      label: `Update max proofs to ${desiredMaxProofs.toString()}`,
+      method: 'setMaxProofs',
+      args: [desiredMaxProofs],
+      current: currentMaxProofs.toString(),
+      desired: desiredMaxProofs.toString(),
+    });
+  }
+
+  const desiredTemperature = parseBigInt(
+    config.temperature,
+    'rewardEngine.temperature',
+    { allowNegative: false }
+  );
+  if (
+    desiredTemperature !== undefined &&
+    desiredTemperature !== currentTemperature
+  ) {
+    actions.push({
+      label: `Set fallback temperature to ${desiredTemperature.toString()}`,
+      method: 'setTemperature',
+      args: [desiredTemperature],
+      current: currentTemperature.toString(),
+      desired: desiredTemperature.toString(),
+    });
+  }
+
+  if (config.settlers && Object.keys(config.settlers).length) {
+    const entries = Object.entries(config.settlers);
+    const currentStates = await Promise.all(
+      entries.map(([address]) => rewardEngine.settlers(address))
+    );
+    entries.forEach(([address, desired], index) => {
+      const desiredBool = parseBoolean(desired);
+      if (desiredBool === undefined) {
+        return;
+      }
+      if (currentStates[index] !== desiredBool) {
+        actions.push({
+          label: `${
+            desiredBool ? 'Authorize' : 'Revoke'
+          } settler ${ethers.getAddress(address)}`,
+          method: 'setSettler',
+          args: [ethers.getAddress(address), desiredBool],
+          current: currentStates[index] ? 'true' : 'false',
+          desired: desiredBool ? 'true' : 'false',
+        });
+      }
+    });
+  }
+
+  return {
+    module: 'RewardEngineMB',
+    address: rewardEngine.target as string,
+    actions,
+    configPath,
+    iface,
+    contract: rewardEngine,
+  };
+}
+
+export function renderRewardEnginePlan(plan: ModulePlan): string {
+  if (plan.actions.length === 0) {
+    return 'All tracked parameters already match the configuration.';
+  }
+  const lines: string[] = [];
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
+    lines.push(`${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      lines.push(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      lines.push(`   Desired: ${action.desired}`);
+    }
+    action.notes?.forEach((note) => lines.push(`   Note: ${note}`));
+    lines.push(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    if (data) {
+      lines.push(`   Calldata: ${data}`);
+    }
+    lines.push('');
+  });
+  return lines.join('\n');
+}

--- a/scripts/v2/lib/thermostatPlan.ts
+++ b/scripts/v2/lib/thermostatPlan.ts
@@ -1,0 +1,276 @@
+import type { Contract } from 'ethers';
+import type { ThermostatConfigInput } from '../../config';
+import { ModulePlan, PlannedAction } from './types';
+import { describeArgs, parseBigInt } from './utils';
+
+const ROLE_KEYS = ['agent', 'validator', 'operator', 'employer'] as const;
+const ROLE_INDEX: Record<(typeof ROLE_KEYS)[number], number> = {
+  agent: 0,
+  validator: 1,
+  operator: 2,
+  employer: 3,
+};
+
+function parseSigned(
+  value: unknown,
+  label: string,
+  { allowZero = false }: { allowZero?: boolean } = {}
+): bigint | undefined {
+  const parsed = parseBigInt(value, label, { allowNegative: true });
+  if (parsed === undefined) {
+    return undefined;
+  }
+  if (!allowZero && parsed === 0n) {
+    throw new Error(`${label} cannot be zero`);
+  }
+  return parsed;
+}
+
+function parsePositive(value: unknown, label: string): bigint | undefined {
+  const parsed = parseBigInt(value, label, { allowNegative: false });
+  if (parsed === undefined) {
+    return undefined;
+  }
+  if (parsed <= 0n) {
+    throw new Error(`${label} must be greater than zero`);
+  }
+  return parsed;
+}
+
+export interface ThermostatPlanInput {
+  thermostat: Contract;
+  config: ThermostatConfigInput;
+  configPath?: string;
+}
+
+export async function buildThermostatPlan(
+  input: ThermostatPlanInput
+): Promise<ModulePlan> {
+  const { thermostat, config, configPath } = input;
+  const iface = thermostat.interface;
+
+  const [
+    currentSystemTemp,
+    currentMinTemp,
+    currentMaxTemp,
+    currentIntegralMin,
+    currentIntegralMax,
+    currentKp,
+    currentKi,
+    currentKd,
+    currentWEmission,
+    currentWBacklog,
+    currentWSla,
+  ] = await Promise.all([
+    thermostat.systemTemperature(),
+    thermostat.minTemp(),
+    thermostat.maxTemp(),
+    thermostat.integralMin(),
+    thermostat.integralMax(),
+    thermostat.kp(),
+    thermostat.ki(),
+    thermostat.kd(),
+    thermostat.wEmission(),
+    thermostat.wBacklog(),
+    thermostat.wSla(),
+  ]);
+
+  const actions: PlannedAction[] = [];
+
+  const desiredSystemTemp = parsePositive(
+    config.systemTemperature,
+    'thermostat.systemTemperature'
+  );
+  if (
+    desiredSystemTemp !== undefined &&
+    desiredSystemTemp !== currentSystemTemp
+  ) {
+    actions.push({
+      label: `Set system temperature to ${desiredSystemTemp.toString()}`,
+      method: 'setSystemTemperature',
+      args: [desiredSystemTemp],
+      current: currentSystemTemp.toString(),
+      desired: desiredSystemTemp.toString(),
+    });
+  }
+
+  const desiredMin = parsePositive(config.bounds?.min, 'thermostat.bounds.min');
+  const desiredMax = parsePositive(config.bounds?.max, 'thermostat.bounds.max');
+  const boundsMin = desiredMin ?? currentMinTemp;
+  const boundsMax = desiredMax ?? currentMaxTemp;
+  if (desiredMin !== undefined || desiredMax !== undefined) {
+    if (boundsMax <= boundsMin) {
+      throw new Error('thermostat bounds must satisfy max > min > 0');
+    }
+  }
+  if (boundsMin !== currentMinTemp || boundsMax !== currentMaxTemp) {
+    actions.push({
+      label: `Update temperature bounds (${boundsMin.toString()} - ${boundsMax.toString()})`,
+      method: 'setTemperatureBounds',
+      args: [boundsMin, boundsMax],
+      current: `${currentMinTemp.toString()} - ${currentMaxTemp.toString()}`,
+      desired: `${boundsMin.toString()} - ${boundsMax.toString()}`,
+    });
+  }
+
+  const desiredIntegralMin = parseSigned(
+    config.integralBounds?.min,
+    'thermostat.integralBounds.min',
+    { allowZero: true }
+  );
+  const desiredIntegralMax = parseSigned(
+    config.integralBounds?.max,
+    'thermostat.integralBounds.max',
+    { allowZero: true }
+  );
+  const integralMin = desiredIntegralMin ?? currentIntegralMin;
+  const integralMax = desiredIntegralMax ?? currentIntegralMax;
+  if (desiredIntegralMin !== undefined || desiredIntegralMax !== undefined) {
+    if (integralMax <= integralMin) {
+      throw new Error(
+        'thermostat integral bounds must satisfy max > min when both provided'
+      );
+    }
+  }
+  if (
+    integralMin !== currentIntegralMin ||
+    integralMax !== currentIntegralMax
+  ) {
+    actions.push({
+      label: `Update integral bounds (${integralMin.toString()} - ${integralMax.toString()})`,
+      method: 'setIntegralBounds',
+      args: [integralMin, integralMax],
+      current: `${currentIntegralMin.toString()} - ${currentIntegralMax.toString()}`,
+      desired: `${integralMin.toString()} - ${integralMax.toString()}`,
+    });
+  }
+
+  const desiredKp = parseSigned(config.pid?.kp, 'thermostat.pid.kp', {
+    allowZero: true,
+  });
+  const desiredKi = parseSigned(config.pid?.ki, 'thermostat.pid.ki', {
+    allowZero: true,
+  });
+  const desiredKd = parseSigned(config.pid?.kd, 'thermostat.pid.kd', {
+    allowZero: true,
+  });
+  const kp = desiredKp ?? currentKp;
+  const ki = desiredKi ?? currentKi;
+  const kd = desiredKd ?? currentKd;
+  if (kp !== currentKp || ki !== currentKi || kd !== currentKd) {
+    actions.push({
+      label: 'Update PID gains',
+      method: 'setPID',
+      args: [kp, ki, kd],
+      current: `kp=${currentKp.toString()}, ki=${currentKi.toString()}, kd=${currentKd.toString()}`,
+      desired: `kp=${kp.toString()}, ki=${ki.toString()}, kd=${kd.toString()}`,
+    });
+  }
+
+  const desiredWEmission = parseSigned(
+    config.kpiWeights?.emission,
+    'thermostat.kpiWeights.emission',
+    { allowZero: true }
+  );
+  const desiredWBacklog = parseSigned(
+    config.kpiWeights?.backlog,
+    'thermostat.kpiWeights.backlog',
+    { allowZero: true }
+  );
+  const desiredWSla = parseSigned(
+    config.kpiWeights?.sla,
+    'thermostat.kpiWeights.sla',
+    { allowZero: true }
+  );
+  const wEmission = desiredWEmission ?? currentWEmission;
+  const wBacklog = desiredWBacklog ?? currentWBacklog;
+  const wSla = desiredWSla ?? currentWSla;
+  if (
+    wEmission !== currentWEmission ||
+    wBacklog !== currentWBacklog ||
+    wSla !== currentWSla
+  ) {
+    actions.push({
+      label: 'Update KPI weights',
+      method: 'setKPIWeights',
+      args: [wEmission, wBacklog, wSla],
+      current: `emission=${currentWEmission.toString()}, backlog=${currentWBacklog.toString()}, sla=${currentWSla.toString()}`,
+      desired: `emission=${wEmission.toString()}, backlog=${wBacklog.toString()}, sla=${wSla.toString()}`,
+    });
+  }
+
+  const targetSystemTemp = desiredSystemTemp ?? currentSystemTemp;
+
+  if (config.roleTemperatures) {
+    const entries = Object.entries(config.roleTemperatures);
+    for (const [roleKey, value] of entries) {
+      if (!ROLE_KEYS.includes(roleKey as (typeof ROLE_KEYS)[number])) {
+        continue;
+      }
+      const role = roleKey as (typeof ROLE_KEYS)[number];
+      const index = ROLE_INDEX[role];
+      if (value === null) {
+        const current = await thermostat.getRoleTemperature(index);
+        if (current !== targetSystemTemp) {
+          actions.push({
+            label: `Clear role temperature override for ${role}`,
+            method: 'unsetRoleTemperature',
+            args: [index],
+            current: current.toString(),
+            desired: targetSystemTemp.toString(),
+          });
+        }
+        continue;
+      }
+      const desiredRoleTemp = parsePositive(
+        value,
+        `thermostat.roleTemperatures.${role}`
+      );
+      if (desiredRoleTemp === undefined) {
+        continue;
+      }
+      const current = await thermostat.getRoleTemperature(index);
+      if (desiredRoleTemp !== current) {
+        actions.push({
+          label: `Set ${role} role temperature to ${desiredRoleTemp.toString()}`,
+          method: 'setRoleTemperature',
+          args: [index, desiredRoleTemp],
+          current: current.toString(),
+          desired: desiredRoleTemp.toString(),
+        });
+      }
+    }
+  }
+
+  return {
+    module: 'Thermostat',
+    address: thermostat.target as string,
+    actions,
+    configPath,
+    iface,
+    contract: thermostat,
+  };
+}
+
+export function renderThermostatPlan(plan: ModulePlan): string {
+  if (plan.actions.length === 0) {
+    return 'All tracked parameters already match the configuration.';
+  }
+  const lines: string[] = [];
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
+    lines.push(`${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      lines.push(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      lines.push(`   Desired: ${action.desired}`);
+    }
+    lines.push(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    if (data) {
+      lines.push(`   Calldata: ${data}`);
+    }
+    lines.push('');
+  });
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- add RewardEngineMB and Thermostat planners so owner:plan covers thermodynamics levers
- load thermodynamics config in the owner control generator and surface the new modules in documentation

## Testing
- npm run lint *(fails: existing prettier/solhint issues in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d5875dc7dc8333b78100d68890f89b