### PR TITLE
Improve one-box confirmation flow

### DIFF
--- a/apps/onebox/src/app/page.tsx
+++ b/apps/onebox/src/app/page.tsx
@@ -42,12 +42,18 @@ export default function OneBox() {
     setBusy(true);
 
     try {
+      const historyPayload = messages.slice(-12).map(({ role, text, meta }) => ({
+        role,
+        text,
+        meta,
+      }));
+
       const response = await fetch("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           message: mine.text,
-          history: messages.slice(-12),
+          history: historyPayload,
         }),
       });
 

--- a/packages/orchestrator/src/llm.ts
+++ b/packages/orchestrator/src/llm.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { validateICS, type ICSType, route } from "./router";
 import { streamLLM } from "./providers/openai";
 
@@ -15,6 +16,17 @@ export type PlanAndExecuteArgs = {
 
 export async function* planAndExecute({ message, history = [] }: PlanAndExecuteArgs) {
   yield "🤖 Planning…\n";
+
+  const confirmation = resolvePendingConfirmation(message, history);
+  if (confirmation?.type === "confirm" && confirmation.ics) {
+    yield "🔐 Confirmation received.\n";
+    yield* route(confirmation.ics);
+    return;
+  }
+  if (confirmation?.type === "decline") {
+    yield "👍 Okay, I’ve cancelled that request.\n";
+    return;
+  }
 
   const normalizedHistory = normalizeHistory(history);
 
@@ -41,25 +53,110 @@ export async function* planAndExecute({ message, history = [] }: PlanAndExecuteA
   }
 
   if (requiresUserConsent(ics)) {
-    yield `${nlConfirm(ics)}\n`;
+    const decorated = ensureTraceId(ics);
+    cachePendingIntent(decorated);
+    yield `${nlConfirm(decorated)}\n`;
     return;
   }
 
   yield* route(ics);
 }
 
+type HistoryMessage = {
+  role?: string;
+  text?: string;
+  content?: string;
+};
+
 function normalizeHistory(history: unknown[]): { role: string; content: string }[] {
-  if (!Array.isArray(history)) return [];
-  return history
-    .filter((item): item is { role: string; content: string } => {
-      return (
-        typeof item === "object" &&
-        item !== null &&
-        typeof (item as any).role === "string" &&
-        typeof (item as any).content === "string"
-      );
+  const entries = coerceHistory(history);
+  return entries
+    .map((item) => {
+      const role = (item.role ?? "user").replace("assistant_pending", "assistant");
+      const content = typeof item.content === "string" ? item.content : item.text ?? "";
+      return { role, content };
     })
-    .map((item) => ({ role: item.role, content: item.content }));
+    .filter((item) => Boolean(item.content));
+}
+
+const pendingIntents = new Map<string, ICSType>();
+
+type ConfirmationResolution =
+  | { type: "confirm"; ics: ICSType }
+  | { type: "decline" }
+  | null;
+
+function resolvePendingConfirmation(
+  message: string,
+  history: unknown[]
+): ConfirmationResolution {
+  const decision = parseConfirmationDecision(message);
+  if (!decision) return null;
+
+  const traceId = findTraceId(history);
+  if (!traceId) return null;
+
+  const pending = pendingIntents.get(traceId);
+  if (!pending) return null;
+
+  pendingIntents.delete(traceId);
+  if (decision === "decline") {
+    return { type: "decline" };
+  }
+
+  return { type: "confirm", ics: pending };
+}
+
+function parseConfirmationDecision(message: string): "confirm" | "decline" | null {
+  const normalized = message.trim().toLowerCase();
+  if (!normalized) return null;
+  if (/^(yes|y|confirm|sure|do it|go ahead|please proceed)\b/.test(normalized)) {
+    return "confirm";
+  }
+  if (/^(no|n|cancel|stop|abort|never mind)\b/.test(normalized)) {
+    return "decline";
+  }
+  return null;
+}
+
+function findTraceId(history: unknown[]): string | null {
+  const entries = coerceHistory(history);
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    const role = (entry.role ?? "").replace("assistant_pending", "assistant");
+    if (!role.startsWith("assistant")) continue;
+    const text = typeof entry.content === "string" ? entry.content : entry.text ?? "";
+    if (!text) continue;
+    const match = text.match(/trace[:\s-]*([0-9a-fA-F-]{6,})/);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+function coerceHistory(history: unknown[]): HistoryMessage[] {
+  if (!Array.isArray(history)) return [];
+  return history.filter((item): item is HistoryMessage => typeof item === "object" && item !== null);
+}
+
+function ensureTraceId(ics: ICSType): ICSType {
+  const traceId = ics.meta?.traceId ?? randomUUID();
+  return {
+    ...ics,
+    meta: { ...(ics.meta ?? {}), traceId },
+  };
+}
+
+function cachePendingIntent(ics: ICSType) {
+  const traceId = ics.meta?.traceId;
+  if (!traceId) return;
+  const sanitized: ICSType = {
+    ...ics,
+    confirm: false,
+    meta: { ...(ics.meta ?? {}), traceId },
+  };
+  pendingIntents.set(traceId, sanitized);
 }
 
 function needsInfo(ics: ICSType): boolean {
@@ -75,8 +172,10 @@ function needsInfo(ics: ICSType): boolean {
     case "dispute":
       return typeof ics.params?.jobId !== "number" && typeof ics.params?.jobId !== "string";
     case "stake":
-    case "withdraw":
-      return !ics.params?.stake || !ics.params?.stake?.amountAGIA;
+    case "withdraw": {
+      const stake = ics.params?.stake ?? {};
+      return !stake.amountAGIA || !stake.role;
+    }
     default:
       return false;
   }
@@ -88,7 +187,8 @@ function requiresUserConsent(ics: ICSType): boolean {
 
 function nlConfirm(ics: ICSType): string {
   const serialized = JSON.stringify(ics.params, null, 2);
-  return `I’m ready to ${ics.intent}. Reply \"yes\" to confirm these details:\n${serialized}`;
+  const traceId = ics.meta?.traceId ? ` (trace:${ics.meta.traceId})` : "";
+  return `I’m ready to ${ics.intent}. Reply \"yes\" to confirm these details${traceId}, or \"no\" to cancel.\n${serialized}`;
 }
 
 function askFollowUp(ics: ICSType): string {
@@ -117,11 +217,16 @@ function missingFields(ics: ICSType): string[] {
     case "dispute":
       return ["a jobId"].filter(() => !ics.params?.jobId);
     case "stake":
-    case "withdraw":
+    case "withdraw": {
+      const missing: string[] = [];
       if (!ics.params?.stake?.amountAGIA) {
-        return ["a stake amount"];
+        missing.push("a stake amount");
       }
-      return [];
+      if (!ics.params?.stake?.role) {
+        missing.push("a stake role");
+      }
+      return missing;
+    }
     default:
       return [];
   }


### PR DESCRIPTION
## Summary
- send structured chat history metadata from the one-box UI so the orchestrator can recover confirmations
- add pending-intent tracking with trace IDs to the orchestrator planner so "yes"/"no" replies resolve confirmations without re-planning
- tighten validation prompts for stake actions and produce clearer confirmation messages with trace identifiers

## Testing
- npm run build --prefix packages/orchestrator

------
https://chatgpt.com/codex/tasks/task_e_68d591632eac83338a78aca5bd61cf32