### PR TITLE
Handle final decoder flush for assistant messages

### DIFF
--- a/apps/onebox/src/app/page.tsx
+++ b/apps/onebox/src/app/page.tsx
@@ -82,11 +82,25 @@ export default function OneBox() {
         });
       }
 
+      const flushedText = decoder.decode();
+      if (flushedText) {
+        assistantText += flushedText;
+        const partial = assistantText;
+        setMessages((prev) => {
+          const next = [...prev];
+          const last = next[next.length - 1];
+          if (last && last.role === "assistant_pending") {
+            next[next.length - 1] = { ...last, text: partial };
+          }
+          return next;
+        });
+      }
+
       setMessages((prev) => {
         const next = [...prev];
         const last = next[next.length - 1];
         if (last && last.role === "assistant_pending") {
-          next[next.length - 1] = { role: "assistant", text: last.text };
+          next[next.length - 1] = { role: "assistant", text: assistantText };
         }
         return next;
       });


### PR DESCRIPTION
## Summary
- append any remaining decoded text after the streaming loop completes
- ensure the pending assistant bubble reflects the flushed text
- convert the assistant_pending message to assistant using the full accumulated text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59680fb40833396ece04e773cc1d1