### PR TITLE
Handle pending assistant bubble on errors

### DIFF
--- a/apps/onebox/src/app/page.tsx
+++ b/apps/onebox/src/app/page.tsx
@@ -43,11 +43,15 @@ export default function OneBox() {
 
     let pendingInserted = false;
 
+    const appendPending = () =>
+      setMessages((prev) => {
+        pendingInserted = true;
+        return [...prev, { role: 'assistant_pending', text: '' }];
+      });
+
     const removeTrailingPending = (list: ChatMessage[]) => {
       if (!pendingInserted) return list;
-      const last = list[list.length - 1];
-      if (!last || last.role !== 'assistant_pending') {
-        pendingInserted = false;
+      if (list[list.length - 1]?.role !== 'assistant_pending') {
         return list;
       }
       pendingInserted = false;
@@ -80,8 +84,7 @@ export default function OneBox() {
       const decoder = new TextDecoder();
       let assistantText = '';
 
-      setMessages((prev) => [...prev, { role: 'assistant_pending', text: '' }]);
-      pendingInserted = true;
+      appendPending();
 
       while (true) {
         const { value, done } = await reader.read();
@@ -117,10 +120,10 @@ export default function OneBox() {
         const last = next[next.length - 1];
         if (last && last.role === 'assistant_pending') {
           next[next.length - 1] = { role: 'assistant', text: assistantText };
+          pendingInserted = false;
         }
         return next;
       });
-      pendingInserted = false;
     } catch (error: unknown) {
       const message =
         error instanceof Error


### PR DESCRIPTION
## Summary
- add helpers to track when the assistant pending message is queued
- remove the trailing pending bubble before showing an error or finishing the request
- ensure successful responses promote the pending bubble and clear the tracking flag

## Testing
- npx eslint apps/onebox/src/app/page.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d597e27df48333b1d0656f1991951d