### PR TITLE
Avoid duplicate pending bubble in chat

### DIFF
--- a/apps/onebox/src/app/page.tsx
+++ b/apps/onebox/src/app/page.tsx
@@ -45,12 +45,13 @@ export default function OneBox() {
 
     const appendPending = () =>
       setMessages((prev) => {
+        if (pendingInserted) return prev;
         pendingInserted = true;
         return [...prev, { role: 'assistant_pending', text: '' }];
       });
 
     const removeTrailingPending = (list: ChatMessage[]) => {
-      if (!pendingInserted) return list;
+      if (!pendingInserted || list.length === 0) return list;
       if (list[list.length - 1]?.role !== 'assistant_pending') {
         return list;
       }


### PR DESCRIPTION
## Summary
- avoid adding multiple pending assistant bubbles when streaming responses
- guard pending-removal helper against empty histories before trimming state

## Testing
- npm run lint *(fails: existing solhint and prettier violations outside onebox app)*

------
https://chatgpt.com/codex/tasks/task_e_68d59ab8ee248333ba47e5727eca3294