### PR TITLE
Refine OpenAI job id extraction

### DIFF
--- a/packages/orchestrator/src/providers/openai.test.mjs
+++ b/packages/orchestrator/src/providers/openai.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { extractJobId } = await import("./openai.ts");
+
+test("parses straightforward job references", () => {
+  assert.equal(extractJobId("apply to job 45"), 45);
+});
+
+test("ignores unrelated numbers while capturing explicit job references", () => {
+  assert.equal(
+    extractJobId("Apply to the job about labeling 500 images (#123)"),
+    123
+  );
+});
+
+test("recognizes job id phrasing", () => {
+  assert.equal(
+    extractJobId("please finalize job id 789 once you're ready"),
+    789
+  );
+});
+
+test("returns null when no job id is present", () => {
+  assert.equal(
+    extractJobId("the job requires labeling 500 images today"),
+    null
+  );
+});


### PR DESCRIPTION
## Summary
- tighten the OpenAI job id parsing logic so it only accepts ids tied to job or id references
- add automated coverage to guard the new parsing scenarios, including ignoring unrelated numbers

## Testing
- TS_NODE_PROJECT=packages/orchestrator/tsconfig.json node --test --loader ts-node/esm packages/orchestrator/src/providers/openai.test.mjs
- TS_NODE_PROJECT=packages/orchestrator/tsconfig.json node --loader ts-node/esm -e "import('./packages/orchestrator/src/providers/openai.ts').then(async (m) => { const res = await m.streamLLM([{ role: 'user', content: 'apply to job 45' }], { expect: 'json' }); console.log(res); });"
- TS_NODE_PROJECT=packages/orchestrator/tsconfig.json node --loader ts-node/esm -e "import('./packages/orchestrator/src/providers/openai.ts').then(async (m) => { const res = await m.streamLLM([{ role: 'user', content: 'submit job 45 results are attached' }], { expect: 'json' }); console.log(res); });"
- TS_NODE_PROJECT=packages/orchestrator/tsconfig.json node --loader ts-node/esm -e "import('./packages/orchestrator/src/providers/openai.ts').then(async (m) => { const res = await m.streamLLM([{ role: 'user', content: 'please finalize job 45 now' }], { expect: 'json' }); console.log(res); });"
- TS_NODE_PROJECT=packages/orchestrator/tsconfig.json node --loader ts-node/esm -e "import('./packages/orchestrator/src/providers/openai.ts').then(async (m) => { const res = await m.streamLLM([{ role: 'user', content: 'create a job to label 500 images in 3 days for 150 agia' }], { expect: 'json' }); console.log(res); });"

------
https://chatgpt.com/codex/tasks/task_e_68d5a32566f48333a70a5d25ea979c02