### PR TITLE
Update agent flow documentation for v2 JobRegistry

### DIFF
--- a/docs/chat-interface-architecture.md
+++ b/docs/chat-interface-architecture.md
@@ -55,7 +55,7 @@ flowchart LR
 - **Safety Guard** – enforces policy checks so the orchestrator never executes actions outside the user’s permissions, and scores plan confidence before proceeding with irreversible operations.
 
 ### Backend Services Layer
-- **Job Service** – wraps JobRegistry calls (create, apply, complete, cancel) and ensures job specifications and artifacts are written to IPFS or another decentralized storage.
+- **Job Service** – wraps JobRegistry calls (`createJob`, `applyForJob`/`stakeAndApply`, `submit`, `finalize`, `cancel`) and ensures job specifications and artifacts are written to IPFS or another decentralized storage.
 - **Stake Service** – manages role-specific stake deposits, withdrawals, reward claims, and slashing hooks through StakeManager.
 - **Validation Service** – handles commit–reveal flows, validator assignments, tally aggregation from ValidationModule events, and validator reward distribution messaging.
 - **Dispute Service** – abstracts DisputeModule operations including bond management, evidence submission, arbitrator messaging, and post-resolution fund movement summaries.
@@ -80,10 +80,10 @@ flowchart LR
 ### 2. Agent: Application & Completion
 1. Agent queries for jobs (“List available image labeling work”).
 2. Planner composes response from indexed job data, offers quick actions, and surfaces stake requirements upfront.
-3. Upon acceptance, Stake Service ensures collateral via `StakeManager.depositStake` and registers participation (`JobRegistry.apply` / role assignment). If insufficient stake exists, the assistant guides the user through topping up.
+3. Upon acceptance, Stake Service ensures collateral via `StakeManager.depositStake` and registers participation with `JobRegistry.applyForJob(jobId, subdomain, proof)` or the combined `JobRegistry.stakeAndApply(jobId, amount, subdomain, proof)` when topping up stake. If insufficient stake exists, the assistant guides the user through funding requirements.
 4. Task assets delivered via chat (download links, instructions). If the worker is an AI microservice, the Orchestrator can spawn specialized agents using the AGI-Alpha toolchain and supervise progress checkpoints.
-5. Completion triggers result upload, IPFS hashing, and `JobRegistry.completeJob(jobId, resultHash)` call. The Orchestrator keeps the agent informed of pending validation steps and expected payout timing.
-6. Chat informs the agent about validation status, stake locks, payout timeline, and reputation updates once finalized.
+5. Completion triggers result upload, IPFS hashing, and a `JobRegistry.submit(jobId, resultHash, resultURI, subdomain, proof)` call. The Orchestrator keeps the agent informed of pending validation or dispute steps, noting that finalization occurs later via `JobRegistry.finalize(jobId)` once outcomes are confirmed.
+6. Chat informs the agent about validation status, stake locks, payout timeline, and reputation updates after `JobRegistry.finalize(jobId)` (or `JobRegistry.finalizeAfterValidation(jobId, success)` when triggered by the validation module) completes the flow.
 
 ### 3. Validator: Quality Assurance
 1. Validation Service subscribes to `JobCompleted` events and invites staked validators through chat with reward breakdowns and deadlines.


### PR DESCRIPTION
## Summary
- align chat interface agent flow with current JobRegistry v2 function names
- document usage of applyForJob/stakeAndApply for applications and submit/finalize for completion
- update backend service description to list the correct JobRegistry entry points

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ad81becc8333a64a023a9e4d40b4