### PR TITLE
Ensure OpenAI mock returns schema-compliant ICS and add validation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build/
 lib/
 agent-gateway/dist/
 packages/orchestrator/dist/
+packages/orchestrator/dist-test/
 examples/agentic/runtime-agentic.jsonl
 !scripts/v2/run-owner-plan.js
 !scripts/v2/lib/

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -7,7 +7,8 @@
   "private": true,
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "tsc -p tsconfig.test.json && node --test dist-test/test/openai.test.js"
   },
   "dependencies": {
     "ethers": "6.15.0",

--- a/packages/orchestrator/src/ics.ts
+++ b/packages/orchestrator/src/ics.ts
@@ -1,0 +1,147 @@
+import { z } from "zod";
+
+const amountSchema = z.union([z.string(), z.number()]);
+const deadlineSchema = z.union([z.number().int().nonnegative(), z.string(), z.date()]);
+const bytes32Schema = z
+  .string()
+  .regex(/^0x[0-9a-fA-F]{64}$/u, "Invalid bytes32 value");
+const jobIdSchema = z.union([z.string(), z.number().int().nonnegative(), z.bigint()]);
+const ensSchema = z.object({
+  subdomain: z.string().min(1),
+  proof: z.array(bytes32Schema).optional(),
+});
+
+const metaSchema = z
+  .object({
+    traceId: z.string().uuid().optional(),
+    userId: z.string().min(1).optional(),
+  })
+  .optional();
+
+const baseFields = {
+  confirm: z.boolean().optional(),
+  meta: metaSchema,
+};
+
+const CreateJobIntentSchema = z
+  .object({
+    intent: z.literal("create_job"),
+    params: z.object({
+      job: z.object({
+        rewardAGIA: amountSchema,
+        deadline: deadlineSchema,
+        spec: z.record(z.any()),
+        title: z.string().optional(),
+      }),
+    }),
+  })
+  .extend(baseFields);
+
+const ApplyJobIntentSchema = z
+  .object({
+    intent: z.literal("apply_job"),
+    params: z.object({
+      jobId: jobIdSchema,
+      ens: ensSchema,
+    }),
+  })
+  .extend(baseFields);
+
+const SubmitWorkIntentSchema = z
+  .object({
+    intent: z.literal("submit_work"),
+    params: z.object({
+      jobId: jobIdSchema,
+      result: z
+        .object({
+          payload: z.record(z.any()).optional(),
+          uri: z.string().optional(),
+          hash: bytes32Schema.optional(),
+        })
+        .refine(
+          (value) => value.payload !== undefined || value.uri !== undefined,
+          "Provide either a result payload or URI"
+        ),
+      ens: ensSchema,
+    }),
+  })
+  .extend(baseFields);
+
+const FinalizeIntentSchema = z
+  .object({
+    intent: z.literal("finalize"),
+    params: z.object({
+      jobId: jobIdSchema,
+      success: z.boolean(),
+    }),
+  })
+  .extend(baseFields);
+
+const StakeIntentSchema = z
+  .object({
+    intent: z.literal("stake"),
+    params: z.object({
+      stake: z.object({
+        amountAGIA: amountSchema,
+        role: z.string().min(1),
+      }),
+    }),
+  })
+  .extend(baseFields);
+
+const WithdrawIntentSchema = z
+  .object({
+    intent: z.literal("withdraw"),
+    params: z.object({
+      stake: z.object({
+        amountAGIA: amountSchema,
+        role: z.string().min(1),
+      }),
+    }),
+  })
+  .extend(baseFields);
+
+const ValidateIntentSchema = z
+  .object({
+    intent: z.literal("validate"),
+    params: z.record(z.any()).default({}),
+  })
+  .extend(baseFields);
+
+const DisputeIntentSchema = z
+  .object({
+    intent: z.literal("dispute"),
+    params: z.record(z.any()).default({}),
+  })
+  .extend(baseFields);
+
+const AdminSetIntentSchema = z
+  .object({
+    intent: z.literal("admin_set"),
+    params: z.record(z.any()).default({}),
+  })
+  .extend(baseFields);
+
+export const ICSSchema = z.discriminatedUnion("intent", [
+  CreateJobIntentSchema,
+  ApplyJobIntentSchema,
+  SubmitWorkIntentSchema,
+  FinalizeIntentSchema,
+  ValidateIntentSchema,
+  DisputeIntentSchema,
+  StakeIntentSchema,
+  WithdrawIntentSchema,
+  AdminSetIntentSchema,
+]);
+
+export type ICSType = z.infer<typeof ICSSchema>;
+export type CreateJobIntent = z.infer<typeof CreateJobIntentSchema>;
+export type ApplyJobIntent = z.infer<typeof ApplyJobIntentSchema>;
+export type SubmitWorkIntent = z.infer<typeof SubmitWorkIntentSchema>;
+export type FinalizeIntent = z.infer<typeof FinalizeIntentSchema>;
+export type StakeIntent = z.infer<typeof StakeIntentSchema>;
+export type WithdrawIntent = z.infer<typeof WithdrawIntentSchema>;
+
+export function validateICS(payload: string): ICSType {
+  return ICSSchema.parse(JSON.parse(payload));
+}

--- a/packages/orchestrator/src/llm.ts
+++ b/packages/orchestrator/src/llm.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
-import { validateICS, type ICSType, route } from "./router";
+import { route } from "./router.js";
+import { validateICS, type ICSType } from "./ics.js";
 import { streamLLM } from "./providers/openai";
 
 const SYSTEM_PROMPT = `

--- a/packages/orchestrator/src/router.ts
+++ b/packages/orchestrator/src/router.ts
@@ -1,156 +1,29 @@
-import { z } from "zod";
-import * as job from "./tools/job";
-import * as stake from "./tools/stake";
-import * as validation from "./tools/validation";
-import * as dispute from "./tools/dispute";
+import * as job from "./tools/job.js";
+import * as stake from "./tools/stake.js";
+import * as validation from "./tools/validation.js";
+import * as dispute from "./tools/dispute.js";
+import type {
+  ApplyJobIntent,
+  CreateJobIntent,
+  FinalizeIntent,
+  ICSType,
+  StakeIntent,
+  SubmitWorkIntent,
+  WithdrawIntent,
+} from "./ics.js";
+
+export { validateICS, ICSSchema } from "./ics.js";
+export type {
+  ApplyJobIntent,
+  CreateJobIntent,
+  FinalizeIntent,
+  ICSType,
+  StakeIntent,
+  SubmitWorkIntent,
+  WithdrawIntent,
+} from "./ics.js";
 
 type AsyncGeneratorString = AsyncGenerator<string, void, unknown>;
-
-const amountSchema = z.union([z.string(), z.number()]);
-const deadlineSchema = z.union([z.number().int().nonnegative(), z.string(), z.date()]);
-const bytes32Schema = z
-  .string()
-  .regex(/^0x[0-9a-fA-F]{64}$/u, "Invalid bytes32 value");
-const jobIdSchema = z.union([z.string(), z.number().int().nonnegative(), z.bigint()]);
-const ensSchema = z.object({
-  subdomain: z.string().min(1),
-  proof: z.array(bytes32Schema).optional(),
-});
-
-const metaSchema = z
-  .object({
-    traceId: z.string().uuid().optional(),
-    userId: z.string().min(1).optional(),
-  })
-  .optional();
-
-const baseFields = {
-  confirm: z.boolean().optional(),
-  meta: metaSchema,
-};
-
-const CreateJobIntentSchema = z
-  .object({
-    intent: z.literal("create_job"),
-    params: z.object({
-      job: z.object({
-        rewardAGIA: amountSchema,
-        deadline: deadlineSchema,
-        spec: z.record(z.any()),
-        title: z.string().optional(),
-      }),
-    }),
-  })
-  .extend(baseFields);
-
-const ApplyJobIntentSchema = z
-  .object({
-    intent: z.literal("apply_job"),
-    params: z.object({
-      jobId: jobIdSchema,
-      ens: ensSchema,
-    }),
-  })
-  .extend(baseFields);
-
-const SubmitWorkIntentSchema = z
-  .object({
-    intent: z.literal("submit_work"),
-    params: z.object({
-      jobId: jobIdSchema,
-      result: z
-        .object({
-          payload: z.record(z.any()).optional(),
-          uri: z.string().optional(),
-          hash: bytes32Schema.optional(),
-        })
-        .refine(
-          (value) => value.payload !== undefined || value.uri !== undefined,
-          "Provide either a result payload or URI"
-        ),
-      ens: ensSchema,
-    }),
-  })
-  .extend(baseFields);
-
-const FinalizeIntentSchema = z
-  .object({
-    intent: z.literal("finalize"),
-    params: z.object({
-      jobId: jobIdSchema,
-      success: z.boolean(),
-    }),
-  })
-  .extend(baseFields);
-
-const StakeIntentSchema = z
-  .object({
-    intent: z.literal("stake"),
-    params: z.object({
-      stake: z.object({
-        amountAGIA: amountSchema,
-        role: z.string().min(1),
-      }),
-    }),
-  })
-  .extend(baseFields);
-
-const WithdrawIntentSchema = z
-  .object({
-    intent: z.literal("withdraw"),
-    params: z.object({
-      stake: z.object({
-        amountAGIA: amountSchema,
-        role: z.string().min(1),
-      }),
-    }),
-  })
-  .extend(baseFields);
-
-const ValidateIntentSchema = z
-  .object({
-    intent: z.literal("validate"),
-    params: z.record(z.any()).default({}),
-  })
-  .extend(baseFields);
-
-const DisputeIntentSchema = z
-  .object({
-    intent: z.literal("dispute"),
-    params: z.record(z.any()).default({}),
-  })
-  .extend(baseFields);
-
-const AdminSetIntentSchema = z
-  .object({
-    intent: z.literal("admin_set"),
-    params: z.record(z.any()).default({}),
-  })
-  .extend(baseFields);
-
-export const ICSSchema = z.discriminatedUnion("intent", [
-  CreateJobIntentSchema,
-  ApplyJobIntentSchema,
-  SubmitWorkIntentSchema,
-  FinalizeIntentSchema,
-  ValidateIntentSchema,
-  DisputeIntentSchema,
-  StakeIntentSchema,
-  WithdrawIntentSchema,
-  AdminSetIntentSchema,
-]);
-
-export type ICSType = z.infer<typeof ICSSchema>;
-export type CreateJobIntent = z.infer<typeof CreateJobIntentSchema>;
-export type ApplyJobIntent = z.infer<typeof ApplyJobIntentSchema>;
-export type SubmitWorkIntent = z.infer<typeof SubmitWorkIntentSchema>;
-export type FinalizeIntent = z.infer<typeof FinalizeIntentSchema>;
-export type StakeIntent = z.infer<typeof StakeIntentSchema>;
-export type WithdrawIntent = z.infer<typeof WithdrawIntentSchema>;
-
-export function validateICS(payload: string): ICSType {
-  return ICSSchema.parse(JSON.parse(payload));
-}
 
 export function route(ics: ICSType): AsyncGeneratorString {
   switch (ics.intent) {

--- a/packages/orchestrator/test/openai.test.ts
+++ b/packages/orchestrator/test/openai.test.ts
@@ -1,0 +1,82 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import { streamLLM } from "../src/providers/openai.js";
+import { validateICS } from "../src/ics.js";
+
+const meta = {
+  traceId: "11111111-2222-4333-8444-555555555555",
+  userId: "user-123",
+};
+
+test("create_job prompt yields valid ICS", async () => {
+  const prompt = [
+    { role: "system", content: "system" },
+    {
+      role: "user",
+      content:
+        "Create a job for a marketing plan paying 500 AGIA, deadline in 14 days, include market analysis and outreach steps.",
+    },
+  ];
+
+  const icsText = await streamLLM(prompt, { expect: "json", meta });
+  const ics = validateICS(icsText);
+
+  assert.equal(ics.intent, "create_job");
+  assert.equal(ics.params.job.rewardAGIA, "500");
+  assert.equal(ics.params.job.deadline, 14);
+  assert.equal(ics.meta?.traceId, meta.traceId);
+  assert.equal(ics.meta?.userId, meta.userId);
+  assert.ok(ics.params.job.spec);
+});
+
+test("apply_job prompt yields valid ICS", async () => {
+  const prompt = [
+    {
+      role: "user",
+      content: "I want to apply to job #42 using alice.agijobs.eth as my ENS.",
+    },
+  ];
+
+  const icsText = await streamLLM(prompt, { expect: "json", meta });
+  const ics = validateICS(icsText);
+
+  assert.equal(ics.intent, "apply_job");
+  assert.equal(ics.params.jobId, 42);
+  assert.equal(ics.params.ens.subdomain, "alice");
+  assert.equal(ics.meta?.traceId, meta.traceId);
+});
+
+test("submit_work prompt yields valid ICS", async () => {
+  const prompt = [
+    {
+      role: "user",
+      content:
+        "Submit work for job 87 with final files, referencing report link and signed by bob.agijobs.eth.",
+    },
+  ];
+
+  const icsText = await streamLLM(prompt, { expect: "json", meta });
+  const ics = validateICS(icsText);
+
+  assert.equal(ics.intent, "submit_work");
+  assert.equal(ics.params.jobId, 87);
+  assert.equal(ics.params.ens.subdomain, "bob");
+  assert.ok(ics.params.result.payload);
+});
+
+test("finalize prompt yields valid ICS", async () => {
+  const prompt = [
+    {
+      role: "user",
+      content: "Finalize job 73 as successful completion, release payment.",
+    },
+  ];
+
+  const icsText = await streamLLM(prompt, { expect: "json", meta });
+  const ics = validateICS(icsText);
+
+  assert.equal(ics.intent, "finalize");
+  assert.equal(ics.params.jobId, 73);
+  assert.equal(ics.params.success, true);
+});

--- a/packages/orchestrator/tsconfig.test.json
+++ b/packages/orchestrator/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-test",
+    "rootDir": ".",
+    "declaration": false,
+    "noEmit": false
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- ensure the OpenAI provider returns schema-compliant ICS payloads with meta, job spec, and ENS details
- extract the ICS schema/validation into a shared module and update router exports
- add tests that validate streamLLM outputs against the ICS schema

## Testing
- npm --prefix packages/orchestrator test

------
https://chatgpt.com/codex/tasks/task_e_68d5ae7063bc8333945cfa64c1d39cff