### PR TITLE
Attach user identity to orchestrator confirmations

### DIFF
--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rm -rf dist",
-    "test": "tsc -p tsconfig.test.json && node --test dist-test/test/openai.test.js"
+    "test": "tsc -p tsconfig.test.json && node --test --experimental-specifier-resolution=node dist-test/test"
   },
   "dependencies": {
     "ethers": "6.15.0",

--- a/packages/orchestrator/src/chain/contracts.ts
+++ b/packages/orchestrator/src/chain/contracts.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
-import { CONTRACT_ADDRESSES } from "./addresses";
-import { rpc } from "./provider";
+import { CONTRACT_ADDRESSES } from "./addresses.js";
+import { rpc } from "./provider.js";
 
 const ERC20_ABI = [
   "function allowance(address owner, address spender) view returns (uint256)",

--- a/packages/orchestrator/src/chain/provider.ts
+++ b/packages/orchestrator/src/chain/provider.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
-import { getAAProvider } from "./providers/aa";
-import { getRelayerWallet } from "./providers/relayer";
+import { getAAProvider } from "./providers/aa.js";
+import { getRelayerWallet } from "./providers/relayer.js";
 
 const MODE = process.env.TX_MODE ?? "relayer";
 

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./llm";
-export * from "./router";
+export * from "./llm.js";
+export * from "./router.js";

--- a/packages/orchestrator/src/tools/dispute.ts
+++ b/packages/orchestrator/src/tools/dispute.ts
@@ -1,4 +1,4 @@
-import type { ICSType } from "../router";
+import type { ICSType } from "../router.js";
 
 export async function* raise(ics: ICSType) {
   const jobId = (ics.params as any)?.jobId;

--- a/packages/orchestrator/src/tools/job.ts
+++ b/packages/orchestrator/src/tools/job.ts
@@ -4,10 +4,10 @@ import type {
   CreateJobIntent,
   FinalizeIntent,
   SubmitWorkIntent,
-} from "../router";
-import { loadContracts } from "../chain/contracts";
-import { getSignerForUser } from "../chain/provider";
-import { formatError, pinToIpfs, toWei } from "./common";
+} from "../router.js";
+import { loadContracts } from "../chain/contracts.js";
+import { getSignerForUser } from "../chain/provider.js";
+import { formatError, pinToIpfs, toWei } from "./common.js";
 
 export async function* createJob(ics: CreateJobIntent) {
   const userId = ics.meta?.userId;

--- a/packages/orchestrator/src/tools/stake.ts
+++ b/packages/orchestrator/src/tools/stake.ts
@@ -1,7 +1,7 @@
-import type { StakeIntent, WithdrawIntent } from "../router";
-import { loadContracts } from "../chain/contracts";
-import { getSignerForUser } from "../chain/provider";
-import { formatError, toWei } from "./common";
+import type { StakeIntent, WithdrawIntent } from "../router.js";
+import { loadContracts } from "../chain/contracts.js";
+import { getSignerForUser } from "../chain/provider.js";
+import { formatError, toWei } from "./common.js";
 
 export async function* deposit(ics: StakeIntent) {
   const userId = ics.meta?.userId;

--- a/packages/orchestrator/src/tools/validation.ts
+++ b/packages/orchestrator/src/tools/validation.ts
@@ -1,4 +1,4 @@
-import type { ICSType } from "../router";
+import type { ICSType } from "../router.js";
 
 export async function* commitReveal(ics: ICSType) {
   const jobId = (ics.params as any)?.jobId;

--- a/packages/orchestrator/test/planAndExecute.test.ts
+++ b/packages/orchestrator/test/planAndExecute.test.ts
@@ -1,0 +1,36 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import { planAndExecute } from "../src/llm.js";
+
+test("create_job confirmation routes with user meta", async () => {
+  const userId = "session-test-123";
+  const message =
+    "Create a job to label 500 images, paying 500 AGIA, deadline in 7 days with a detailed spec.";
+
+  const history: { role: string; text: string; meta?: Record<string, unknown> }[] = [];
+
+  let firstResponse = "";
+  for await (const chunk of planAndExecute({ message, history, meta: { userId } })) {
+    firstResponse += chunk;
+  }
+
+  assert.match(firstResponse, /trace:/, "confirmation response includes trace id");
+
+  history.push({ role: "user", text: message, meta: { userId } });
+  history.push({ role: "assistant", text: firstResponse, meta: { userId } });
+
+  const iterator = planAndExecute({ message: "yes", history, meta: { userId } });
+
+  const planning = await iterator.next();
+  assert.equal(planning.value, "🤖 Planning…\n");
+
+  const confirmation = await iterator.next();
+  assert.ok(confirmation.value?.includes("Confirmation received"));
+
+  const jobStep = await iterator.next();
+  assert.ok(jobStep.value?.includes("📦 Packaging job spec"));
+  assert.ok(!jobStep.value?.includes("Missing meta.userId"));
+
+  await iterator.return?.();
+});


### PR DESCRIPTION
## Summary
- resolve the One-Box caller’s identity and include it in chat history when delegating to the orchestrator
- teach the orchestrator planner to propagate meta.userId through confirmations and align internal imports with ESM expectations
- add a regression test and test runner update to prove create_job confirmations reach job.createJob without missing-user errors

## Testing
- npm run test --prefix packages/orchestrator

------
https://chatgpt.com/codex/tasks/task_e_68d5b25c7f1c8333b0ee6bf3518aef4a