### PR TITLE
feat(orchestrator): derive deterministic user signers

### DIFF
--- a/packages/orchestrator/README.md
+++ b/packages/orchestrator/README.md
@@ -1,6 +1,7 @@
 # @agi/orchestrator
 
-A TypeScript toolkit that implements the intent-constrained schema (ICS) planner, tool routing, and blockchain adapters for the AGI Jobs "one-box" experience. The package is designed to be imported by UI surfaces or service workers that need to translate natural language into deterministic protocol actions.
+A TypeScript toolkit that implements the intent-constrained schema (ICS) planner, tool routing, and blockchain adapters for the
+AGI Jobs "one-box" experience. The package is designed to be imported by UI surfaces or service workers that need to translate natural language into deterministic protocol actions.
 
 ## Scripts
 
@@ -15,3 +16,20 @@ A TypeScript toolkit that implements the intent-constrained schema (ICS) planner
 - `src/chain/` – lightweight provider abstractions and contract factories.
 
 Replace the placeholder logic in each tool as you connect to production smart contracts, relayers, and paymasters.
+
+## Environment variables
+
+The orchestrator reads its blockchain configuration from environment variables. When a global relayer key is not provided, the
+orchestrator deterministically derives per-user wallets from the configured mnemonic so that each user session reuses the same
+account and funding source.
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `RPC_URL` | Optional | JSON-RPC endpoint for chain access. Defaults to `http://127.0.0.1:8545`. |
+| `TX_MODE` | Optional | Set to `relayer` (default) or `aa` to choose between direct relaying or account abstraction session keys. |
+| `RELAYER_PRIVATE_KEY` | Optional | Hex-encoded private key for a single relayer account. Overrides mnemonic derivation. |
+| `RELAYER_MNEMONIC` | When `RELAYER_PRIVATE_KEY` is unset | BIP-39 mnemonic used to deterministically derive relayer wallets per `userId`. |
+| `AA_SESSION_PRIVATE_KEY` | Optional | Hex-encoded private key for a single AA session signer. Overrides mnemonic derivation. |
+| `AA_SESSION_MNEMONIC` | When `AA_SESSION_PRIVATE_KEY` is unset in `aa` mode | BIP-39 mnemonic used to deterministically derive AA session wallets per `userId`. Falls back to `RELAYER_MNEMONIC` when set. |
+
+Ensure these secrets are provisioned in the deployment environment so user requests always resolve to a stable signer.

--- a/packages/orchestrator/src/chain/provider.ts
+++ b/packages/orchestrator/src/chain/provider.ts
@@ -2,10 +2,12 @@ import { ethers } from "ethers";
 import { getAAProvider } from "./providers/aa.js";
 import { getRelayerWallet } from "./providers/relayer.js";
 
-const MODE = process.env.TX_MODE ?? "relayer";
+function txMode() {
+  return process.env.TX_MODE ?? "relayer";
+}
 
 export async function getSignerForUser(userId: string) {
-  if (MODE === "aa") {
+  if (txMode() === "aa") {
     return getAAProvider(userId);
   }
   return getRelayerWallet(userId);

--- a/packages/orchestrator/src/chain/providers/aa.ts
+++ b/packages/orchestrator/src/chain/providers/aa.ts
@@ -1,9 +1,48 @@
 import { ethers } from "ethers";
+import { deterministicWalletFromMnemonic } from "./signer.js";
 
 const rpcUrl = process.env.RPC_URL ?? "http://127.0.0.1:8545";
 const provider = new ethers.JsonRpcProvider(rpcUrl);
 
-export async function getAAProvider(_userId: string) {
-  // Placeholder AA signer – replace with smart account SDK.
-  return ethers.Wallet.createRandom().connect(provider);
+type CachedSession = { fingerprint: string; wallet: ethers.Wallet };
+
+const aaWalletCache = new Map<string, CachedSession>();
+
+function fingerprintFromEnv() {
+  const key = process.env.AA_SESSION_PRIVATE_KEY;
+  if (key) {
+    return `pk:${key}`;
+  }
+  const mnemonic = process.env.AA_SESSION_MNEMONIC ?? process.env.RELAYER_MNEMONIC;
+  if (!mnemonic) {
+    throw new Error(
+      "AA_SESSION_MNEMONIC (or RELAYER_MNEMONIC) must be configured when AA_SESSION_PRIVATE_KEY is not provided.",
+    );
+  }
+  return `mnemonic:${ethers.id(mnemonic)}`;
+}
+
+function deriveSessionKey(userId: string) {
+  const key = process.env.AA_SESSION_PRIVATE_KEY;
+  if (key) {
+    return new ethers.Wallet(key, provider);
+  }
+  const mnemonic = process.env.AA_SESSION_MNEMONIC ?? process.env.RELAYER_MNEMONIC;
+  if (!mnemonic) {
+    throw new Error(
+      "AA_SESSION_MNEMONIC (or RELAYER_MNEMONIC) must be configured when AA_SESSION_PRIVATE_KEY is not provided.",
+    );
+  }
+  return deterministicWalletFromMnemonic(mnemonic, userId, provider);
+}
+
+export async function getAAProvider(userId: string) {
+  const fingerprint = fingerprintFromEnv();
+  const cached = aaWalletCache.get(userId);
+  if (cached && cached.fingerprint === fingerprint) {
+    return cached.wallet;
+  }
+  const wallet = deriveSessionKey(userId);
+  aaWalletCache.set(userId, { fingerprint, wallet });
+  return wallet;
 }

--- a/packages/orchestrator/src/chain/providers/relayer.ts
+++ b/packages/orchestrator/src/chain/providers/relayer.ts
@@ -1,13 +1,53 @@
 import { ethers } from "ethers";
+import { deterministicWalletFromMnemonic } from "./signer.js";
 
 const rpcUrl = process.env.RPC_URL ?? "http://127.0.0.1:8545";
 const provider = new ethers.JsonRpcProvider(rpcUrl);
 
-export async function getRelayerWallet(_userId: string) {
+type CachedWallet = { fingerprint: string; wallet: ethers.Wallet };
+
+const relayerWalletCache = new Map<string, CachedWallet>();
+
+function cacheKey(userId: string) {
+  return userId;
+}
+
+function getFingerprint() {
+  const key = process.env.RELAYER_PRIVATE_KEY;
+  if (key) {
+    return `pk:${key}`;
+  }
+  const mnemonic = process.env.RELAYER_MNEMONIC;
+  if (!mnemonic) {
+    throw new Error(
+      "RELAYER_MNEMONIC must be configured when RELAYER_PRIVATE_KEY is not provided.",
+    );
+  }
+  return `mnemonic:${ethers.id(mnemonic)}`;
+}
+
+function deriveWallet(userId: string) {
   const key = process.env.RELAYER_PRIVATE_KEY;
   if (key) {
     return new ethers.Wallet(key, provider);
   }
-  // For scaffolding we fallback to an ephemeral key so local development works.
-  return ethers.Wallet.createRandom().connect(provider);
+  const mnemonic = process.env.RELAYER_MNEMONIC;
+  if (!mnemonic) {
+    throw new Error(
+      "RELAYER_MNEMONIC must be configured when RELAYER_PRIVATE_KEY is not provided.",
+    );
+  }
+  return deterministicWalletFromMnemonic(mnemonic, userId, provider);
+}
+
+export async function getRelayerWallet(userId: string) {
+  const key = cacheKey(userId);
+  const fingerprint = getFingerprint();
+  const cached = relayerWalletCache.get(key);
+  if (cached && cached.fingerprint === fingerprint) {
+    return cached.wallet;
+  }
+  const wallet = deriveWallet(userId);
+  relayerWalletCache.set(key, { fingerprint, wallet });
+  return wallet;
 }

--- a/packages/orchestrator/src/chain/providers/signer.ts
+++ b/packages/orchestrator/src/chain/providers/signer.ts
@@ -1,0 +1,20 @@
+import { ethers } from "ethers";
+
+const derivationBasePath = "m/44'/60'/0'/0";
+
+function getAccountIndex(userId: string) {
+  const hash = BigInt(ethers.id(userId));
+  const maxIndex = BigInt(0x80000000); // 2**31
+  return Number(hash % maxIndex);
+}
+
+export function deterministicWalletFromMnemonic(
+  mnemonic: string,
+  userId: string,
+  provider: ethers.Provider,
+) {
+  const index = getAccountIndex(userId);
+  const path = `${derivationBasePath}/${index}`;
+  const derived = ethers.HDNodeWallet.fromPhrase(mnemonic, undefined, path);
+  return new ethers.Wallet(derived.privateKey, provider);
+}

--- a/packages/orchestrator/test/chainProviders.test.ts
+++ b/packages/orchestrator/test/chainProviders.test.ts
@@ -1,0 +1,69 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import { getSignerForUser } from "../src/chain/provider.js";
+
+const relayerMnemonic = "test test test test test test test test test test test junk";
+const aaMnemonic = "test walk nut penalty hip pave soap entry language right filter choice";
+
+function snapshotEnv(keys: string[]) {
+  return keys.map((key) => ({ key, value: process.env[key] }));
+}
+
+function restoreEnv(entries: { key: string; value: string | undefined }[]) {
+  for (const { key, value } of entries) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+test("relayer mode reuses deterministic wallets per user", async () => {
+  const backup = snapshotEnv([
+    "TX_MODE",
+    "RELAYER_PRIVATE_KEY",
+    "RELAYER_MNEMONIC",
+  ]);
+
+  try {
+    process.env.TX_MODE = "relayer";
+    delete process.env.RELAYER_PRIVATE_KEY;
+    process.env.RELAYER_MNEMONIC = relayerMnemonic;
+
+    const aliceFirst = await getSignerForUser("alice");
+    const aliceSecond = await getSignerForUser("alice");
+    const bob = await getSignerForUser("bob");
+
+    assert.equal(aliceFirst.address, aliceSecond.address);
+    assert.notEqual(aliceFirst.address, bob.address);
+  } finally {
+    restoreEnv(backup);
+  }
+});
+
+test("aa mode derives deterministic session keys per user", async () => {
+  const backup = snapshotEnv([
+    "TX_MODE",
+    "AA_SESSION_PRIVATE_KEY",
+    "AA_SESSION_MNEMONIC",
+    "RELAYER_MNEMONIC",
+  ]);
+
+  try {
+    process.env.TX_MODE = "aa";
+    delete process.env.AA_SESSION_PRIVATE_KEY;
+    process.env.AA_SESSION_MNEMONIC = aaMnemonic;
+    delete process.env.RELAYER_MNEMONIC;
+
+    const aliceFirst = await getSignerForUser("alice");
+    const aliceSecond = await getSignerForUser("alice");
+    const bob = await getSignerForUser("bob");
+
+    assert.equal(aliceFirst.address, aliceSecond.address);
+    assert.notEqual(aliceFirst.address, bob.address);
+  } finally {
+    restoreEnv(backup);
+  }
+});


### PR DESCRIPTION
## Summary
- derive deterministic relayer and AA wallets from configured secrets instead of random fallbacks
- cache per-user wallets keyed by userId and secret fingerprint so repeated calls reuse the same signer
- document required environment variables for relayer and AA modes and add integration tests that cover both flows

## Testing
- npm test --workspace @agi/orchestrator

------
https://chatgpt.com/codex/tasks/task_e_68d5b5c88ea48333b0848be9a30490a4