### PR TITLE
Implement validation commit/reveal and dispute flows

### DIFF
--- a/packages/orchestrator/src/chain/contracts.ts
+++ b/packages/orchestrator/src/chain/contracts.ts
@@ -18,9 +18,16 @@ const JOB_REGISTRY_ABI = [
   "function applyForJob(uint256 jobId, string subdomain, bytes32[] proof)",
   "function submit(uint256 jobId, bytes32 resultHash, string resultURI, string subdomain, bytes32[] proof)",
   "function finalizeAfterValidation(uint256 jobId, bool success)",
+  "function getSpecHash(uint256 jobId) view returns (bytes32)",
 ];
 
-const VALIDATION_MODULE_ABI = ["function finalize(uint256 jobId)"];
+const VALIDATION_MODULE_ABI = [
+  "function finalize(uint256 jobId)",
+  "function jobNonce(uint256 jobId) view returns (uint256)",
+  "function DOMAIN_SEPARATOR() view returns (bytes32)",
+  "function commitValidation(uint256 jobId, bytes32 commitHash, string subdomain, bytes32[] proof)",
+  "function revealValidation(uint256 jobId, bool approve, bytes32 burnTxHash, bytes32 salt, string subdomain, bytes32[] proof)",
+];
 
 const DISPUTE_MODULE_ABI = ["function raiseDispute(uint256 jobId, string reason)"];
 

--- a/packages/orchestrator/src/chain/deps.ts
+++ b/packages/orchestrator/src/chain/deps.ts
@@ -1,0 +1,26 @@
+import { loadContracts as baseLoadContracts } from "./contracts.js";
+import { getSignerForUser as baseGetSignerForUser } from "./provider.js";
+
+type LoadContractsFn = typeof baseLoadContracts;
+type GetSignerFn = typeof baseGetSignerForUser;
+
+let loadContractsOverride: LoadContractsFn | null = null;
+let getSignerOverride: GetSignerFn | null = null;
+
+export function loadContracts(...args: Parameters<LoadContractsFn>) {
+  const fn = loadContractsOverride ?? baseLoadContracts;
+  return fn(...args);
+}
+
+export function getSignerForUser(...args: Parameters<GetSignerFn>) {
+  const fn = getSignerOverride ?? baseGetSignerForUser;
+  return fn(...args);
+}
+
+export function __setLoadContracts(fn: LoadContractsFn | null) {
+  loadContractsOverride = fn;
+}
+
+export function __setGetSignerForUser(fn: GetSignerFn | null) {
+  getSignerOverride = fn;
+}

--- a/packages/orchestrator/src/providers/openai.ts
+++ b/packages/orchestrator/src/providers/openai.ts
@@ -43,6 +43,41 @@ export async function streamLLM(
     });
   }
 
+  if (text.includes("validate")) {
+    const jobId = extractJobId(last);
+    const ens = buildEns(last);
+    const approve = inferSuccess(last);
+    return JSON.stringify({
+      intent: "validate",
+      params: {
+        jobId: jobId ?? 0,
+        validation: {
+          vote: approve ? "approve" : "reject",
+          salt: "orchestrator-salt",
+        },
+        ens,
+      },
+      confirm: false,
+      meta,
+    });
+  }
+
+  if (text.includes("dispute")) {
+    const jobId = extractJobId(last);
+    return JSON.stringify({
+      intent: "dispute",
+      params: {
+        jobId: jobId ?? 0,
+        dispute: {
+          reason: { summary: last },
+          evidence: { note: "auto-generated" },
+        },
+      },
+      confirm: false,
+      meta,
+    });
+  }
+
   if (text.includes("finalize")) {
     const jobId = extractJobId(last);
     const success = inferSuccess(last);

--- a/packages/orchestrator/src/tools/dispute.ts
+++ b/packages/orchestrator/src/tools/dispute.ts
@@ -1,17 +1,112 @@
 import type { ICSType } from "../router.js";
+import { loadContracts, getSignerForUser } from "../chain/deps.js";
+import { formatError, pinToIpfs } from "./common.js";
 
 export async function* raise(ics: ICSType) {
-  const jobId = (ics.params as any)?.jobId;
-  const dispute = (ics.params as any)?.dispute ?? {};
-  if (!jobId) {
+  const jobIdInput = (ics.params as any)?.jobId;
+  const dispute = ((ics.params as any)?.dispute ?? {}) as Record<string, unknown>;
+  const userId = ics.meta?.userId;
+
+  if (!jobIdInput) {
     yield "Missing jobId.\n";
     return;
   }
-  if (!dispute.reason) {
+  if (dispute.reason === undefined) {
     yield "Missing dispute reason.\n";
     return;
   }
+  if (!userId) {
+    yield "Missing meta.userId for signing.\n";
+    return;
+  }
 
-  yield "⚖️ Raising dispute (stub).\n";
-  yield `✅ Dispute submitted for job #${jobId} (scaffolding stub).\n`;
+  try {
+    const jobId = normalizeJobId(jobIdInput);
+    const signer = await getSignerForUser(userId);
+    const { disputeModule } = loadContracts(signer);
+
+    const { reasonUri, packaged } = await prepareReason(dispute);
+    if (!reasonUri) {
+      throw new Error("Unable to resolve dispute reason");
+    }
+
+    if (packaged) {
+      yield "📦 Packaging dispute evidence…\n";
+      yield `📨 Evidence pinned: ${reasonUri}\n`;
+    }
+
+    yield "⚖️ Raising dispute…\n";
+    const tx = await disputeModule.raiseDispute(jobId, reasonUri);
+    yield `⛓️ Dispute tx submitted: ${tx.hash}\n`;
+    await tx.wait();
+
+    yield `✅ Dispute submitted for job #${jobId.toString()}.\n`;
+  } catch (error: unknown) {
+    yield formatError(error);
+  }
+}
+
+function normalizeJobId(input: unknown): bigint {
+  if (typeof input === "bigint") {
+    return input;
+  }
+  if (typeof input === "number") {
+    if (!Number.isFinite(input)) throw new Error("Invalid jobId");
+    return BigInt(Math.floor(input));
+  }
+  if (typeof input === "string") {
+    const trimmed = input.trim().replace(/^#/, "");
+    if (!trimmed) throw new Error("Invalid jobId");
+    return BigInt(trimmed);
+  }
+  throw new Error("Invalid jobId");
+}
+
+async function prepareReason(
+  dispute: Record<string, unknown>
+): Promise<{ reasonUri: string | null; packaged: boolean }> {
+  const rawReason = dispute.reason;
+  const reasonText = typeof rawReason === "string" ? rawReason.trim() : "";
+  const reasonObject =
+    rawReason && typeof rawReason === "object" ? (rawReason as Record<string, unknown>) : undefined;
+  const uri = typeof dispute.uri === "string" ? dispute.uri.trim() : "";
+  const evidence = dispute.evidence;
+  const attachments = dispute.attachments;
+  const payload = dispute.payload;
+
+  if (uri) {
+    return { reasonUri: uri, packaged: false };
+  }
+
+  const needsPackaging =
+    reasonObject !== undefined ||
+    !reasonText ||
+    evidence !== undefined ||
+    attachments !== undefined ||
+    payload !== undefined;
+
+  if (needsPackaging) {
+    const bundle: Record<string, unknown> = {};
+    if (reasonObject !== undefined) {
+      bundle.reason = reasonObject;
+    } else if (reasonText) {
+      bundle.reason = reasonText;
+    }
+    if (payload !== undefined) {
+      bundle.payload = payload;
+    }
+    if (evidence !== undefined) {
+      bundle.evidence = evidence;
+    }
+    if (attachments !== undefined) {
+      bundle.attachments = attachments;
+    }
+    const uriValue = await pinToIpfs(bundle);
+    return { reasonUri: uriValue, packaged: true };
+  }
+
+  if (!reasonText) {
+    return { reasonUri: null, packaged: false };
+  }
+  return { reasonUri: reasonText, packaged: false };
 }

--- a/packages/orchestrator/src/tools/validation.ts
+++ b/packages/orchestrator/src/tools/validation.ts
@@ -1,9 +1,15 @@
+import { ethers } from "ethers";
 import type { ICSType } from "../router.js";
+import { loadContracts, getSignerForUser } from "../chain/deps.js";
+import { formatError } from "./common.js";
 
 export async function* commitReveal(ics: ICSType) {
-  const jobId = (ics.params as any)?.jobId;
-  const validation = (ics.params as any)?.validation ?? {};
-  if (!jobId) {
+  const jobIdInput = (ics.params as any)?.jobId;
+  const validation = ((ics.params as any)?.validation ?? {}) as Record<string, unknown>;
+  const ens = ((ics.params as any)?.ens ?? {}) as Record<string, unknown>;
+  const userId = ics.meta?.userId;
+
+  if (!jobIdInput) {
     yield "Missing jobId.\n";
     return;
   }
@@ -11,8 +17,212 @@ export async function* commitReveal(ics: ICSType) {
     yield "Missing validation vote.\n";
     return;
   }
+  if (!validation.salt) {
+    yield "Missing validation salt.\n";
+    return;
+  }
+  if (!userId) {
+    yield "Missing meta.userId for signing.\n";
+    return;
+  }
 
-  yield "🗳️ Committing validation vote (stub).\n";
-  yield "🔓 Revealing validation vote (stub).\n";
-  yield `✅ Validation recorded for job #${jobId} (scaffolding stub).\n`;
+  try {
+    const jobId = normalizeJobId(jobIdInput);
+    const approve = parseVote(validation.vote);
+    const salt = deriveSalt(validation.salt);
+    const burnTxHash = normalizeBytes32(validation.burnTxHash);
+    const subdomain = normalizeSubdomain(validation.subdomain ?? ens.subdomain);
+    const proof = normalizeProof(validation.proof ?? ens.proof);
+
+    const signer = await getSignerForUser(userId);
+    const { jobRegistry, validationModule } = loadContracts(signer);
+    const validatorAddress = await signer.getAddress();
+
+    const [nonce, specHash, domainSeparator, chainId] = await Promise.all([
+      validationModule.jobNonce(jobId),
+      jobRegistry.getSpecHash(jobId),
+      validationModule.DOMAIN_SEPARATOR(),
+      resolveChainId(signer),
+    ]);
+
+    const commitHash = computeCommitHash({
+      jobId,
+      nonce,
+      approve,
+      burnTxHash,
+      salt,
+      specHash,
+      domainSeparator,
+      chainId,
+      validator: validatorAddress,
+    });
+
+    yield "🗳️ Committing validation vote…\n";
+    const commitTx = await validationModule.commitValidation(
+      jobId,
+      commitHash,
+      subdomain,
+      proof
+    );
+    yield `⛓️ Commit tx submitted: ${commitTx.hash}\n`;
+    await commitTx.wait();
+
+    yield "🔓 Revealing validation vote…\n";
+    const revealTx = await validationModule.revealValidation(
+      jobId,
+      approve,
+      burnTxHash,
+      salt,
+      subdomain,
+      proof
+    );
+    yield `⛓️ Reveal tx submitted: ${revealTx.hash}\n`;
+    await revealTx.wait();
+
+    yield `✅ Validation recorded for job #${jobId.toString()}.\n`;
+  } catch (error: unknown) {
+    yield formatError(error);
+  }
+}
+
+function normalizeJobId(input: unknown): bigint {
+  if (typeof input === "bigint") {
+    return input;
+  }
+  if (typeof input === "number") {
+    if (!Number.isFinite(input)) throw new Error("Invalid jobId");
+    return BigInt(Math.floor(input));
+  }
+  if (typeof input === "string") {
+    const trimmed = input.trim().replace(/^#/, "");
+    if (!trimmed) throw new Error("Invalid jobId");
+    return BigInt(trimmed);
+  }
+  throw new Error("Invalid jobId");
+}
+
+function parseVote(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "yes", "approve", "approved", "accept", "success"].includes(normalized)) {
+      return true;
+    }
+    if (["false", "no", "reject", "rejected", "deny", "fail", "failed"].includes(normalized)) {
+      return false;
+    }
+  }
+  throw new Error("Unsupported validation vote");
+}
+
+function deriveSalt(value: unknown): string {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) throw new Error("Validation salt cannot be empty");
+    try {
+      const bytes = ethers.getBytes(trimmed);
+      if (bytes.length !== 32) {
+        throw new Error("Invalid length");
+      }
+      return ethers.hexlify(bytes);
+    } catch (error) {
+      if (error instanceof Error && /offset out of bounds|invalid hex/i.test(error.message)) {
+        // Fallback to hashing arbitrary input into bytes32
+        return ethers.keccak256(ethers.toUtf8Bytes(trimmed));
+      }
+      if (error instanceof Error && /invalid length/i.test(error.message)) {
+        throw new Error("Validation salt must be 32 bytes");
+      }
+      return ethers.keccak256(ethers.toUtf8Bytes(trimmed));
+    }
+  }
+  if (value instanceof Uint8Array) {
+    if (value.length !== 32) throw new Error("Validation salt must be 32 bytes");
+    return ethers.hexlify(value);
+  }
+  throw new Error("Validation salt must be provided as a string or bytes");
+}
+
+function normalizeBytes32(value: unknown): string {
+  if (!value) {
+    return ethers.ZeroHash;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return ethers.ZeroHash;
+    const bytes = ethers.getBytes(trimmed.startsWith("0x") ? trimmed : `0x${trimmed}`);
+    if (bytes.length !== 32) {
+      throw new Error("Burn receipt hash must be 32 bytes");
+    }
+    return ethers.hexlify(bytes);
+  }
+  if (value instanceof Uint8Array) {
+    if (value.length !== 32) throw new Error("Burn receipt hash must be 32 bytes");
+    return ethers.hexlify(value);
+  }
+  throw new Error("Burn receipt hash must be a bytes32 value");
+}
+
+function normalizeSubdomain(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  return "";
+}
+
+function normalizeProof(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((entry) => {
+    if (typeof entry !== "string") {
+      throw new Error("ENS proof entries must be hex strings");
+    }
+    const bytes = ethers.getBytes(entry);
+    if (bytes.length !== 32) {
+      throw new Error("ENS proof entries must be 32-byte values");
+    }
+    return ethers.hexlify(bytes);
+  });
+}
+
+function computeCommitHash(params: {
+  jobId: bigint;
+  nonce: bigint;
+  approve: boolean;
+  burnTxHash: string;
+  salt: string;
+  specHash: string;
+  domainSeparator: string;
+  chainId: bigint;
+  validator: string;
+}): string {
+  const coder = ethers.AbiCoder.defaultAbiCoder();
+  const outcomeHash = ethers.keccak256(
+    coder.encode(
+      ["uint256", "bytes32", "bool", "bytes32"],
+      [params.nonce, params.specHash, params.approve, params.burnTxHash]
+    )
+  );
+  return ethers.keccak256(
+    coder.encode(
+      ["uint256", "bytes32", "bytes32", "address", "uint256", "bytes32"],
+      [params.jobId, outcomeHash, params.salt, params.validator, params.chainId, params.domainSeparator]
+    )
+  );
+}
+
+async function resolveChainId(signer: ethers.Signer): Promise<bigint> {
+  if (typeof (signer as ethers.Signer & { getChainId?: () => Promise<number | bigint> }).getChainId === "function") {
+    const raw = await (signer as ethers.Signer & { getChainId?: () => Promise<number | bigint> }).getChainId!();
+    return typeof raw === "bigint" ? raw : BigInt(raw);
+  }
+  const provider = signer.provider;
+  if (!provider) {
+    throw new Error("Signer is missing provider for chain id resolution");
+  }
+  const network = await provider.getNetwork();
+  return typeof network.chainId === "bigint" ? network.chainId : BigInt(network.chainId);
 }

--- a/packages/orchestrator/test/planAndExecute.test.ts
+++ b/packages/orchestrator/test/planAndExecute.test.ts
@@ -1,7 +1,12 @@
 import { strict as assert } from "node:assert";
 import test from "node:test";
+import { ethers } from "ethers";
 
 import { planAndExecute } from "../src/llm.js";
+import {
+  __setGetSignerForUser,
+  __setLoadContracts,
+} from "../src/chain/deps.js";
 
 test("create_job confirmation routes with user meta", async () => {
   const userId = "session-test-123";
@@ -33,4 +38,159 @@ test("create_job confirmation routes with user meta", async () => {
   assert.ok(!jobStep.value?.includes("Missing meta.userId"));
 
   await iterator.return?.();
+});
+
+test("validate intent commits and reveals vote", async (t) => {
+  const userId = "validator-001";
+  const message = "Please validate job #77 as approved with validator.agijobs.eth.";
+
+  const nonce = 5n;
+  const specHash = "0x" + "11".repeat(32);
+  const domain = "0x" + "22".repeat(32);
+  const chainId = 31337n;
+  const validator = "0x1111111111111111111111111111111111111111";
+  const commitTxHash = "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+  const revealTxHash = "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+
+  const commitCalls: unknown[][] = [];
+  const revealCalls: unknown[][] = [];
+
+  t.after(() => {
+    __setLoadContracts(null);
+    __setGetSignerForUser(null);
+  });
+
+  __setLoadContracts(() =>
+    ({
+      erc20: {} as unknown,
+      stakeManager: {} as unknown,
+      jobRegistry: {
+        getSpecHash: async () => specHash,
+      } as unknown,
+      validationModule: {
+        jobNonce: async () => nonce,
+        DOMAIN_SEPARATOR: async () => domain,
+        commitValidation: async (...args: unknown[]) => {
+          commitCalls.push(args);
+          return { hash: commitTxHash, wait: async () => ({}) };
+        },
+        revealValidation: async (...args: unknown[]) => {
+          revealCalls.push(args);
+          return { hash: revealTxHash, wait: async () => ({}) };
+        },
+      } as unknown,
+      disputeModule: {} as unknown,
+    }) as any
+  );
+
+  __setGetSignerForUser(async () =>
+    ({
+      address: validator,
+      getAddress: async () => validator,
+      provider: {
+        getNetwork: async () => ({ chainId, name: "anvil" }),
+      },
+    }) as any
+  );
+
+  const chunks: string[] = [];
+  for await (const chunk of planAndExecute({ message, meta: { userId } })) {
+    chunks.push(chunk);
+  }
+
+  assert.ok(chunks.includes("🗳️ Committing validation vote…\n"));
+  assert.ok(chunks.includes("🔓 Revealing validation vote…\n"));
+  assert.ok(chunks.includes("✅ Validation recorded for job #77.\n"));
+
+  assert.equal(commitCalls.length, 1);
+  assert.equal(revealCalls.length, 1);
+
+  const [commitJobId, commitHash, commitSubdomain, commitProof] = commitCalls[0];
+  assert.equal(commitJobId, 77n);
+  assert.equal(commitSubdomain, "validator");
+  assert.deepEqual(commitProof, []);
+
+  const [revealJobId, approve, burnTxHash, salt, subdomain, proof] = revealCalls[0];
+  assert.equal(revealJobId, 77n);
+  assert.equal(approve, true);
+  assert.equal(burnTxHash, ethers.ZeroHash);
+  assert.equal(subdomain, "validator");
+  assert.deepEqual(proof, []);
+
+  const expectedSalt = ethers.keccak256(ethers.toUtf8Bytes("orchestrator-salt"));
+  assert.equal(salt, expectedSalt);
+
+  const outcomeHash = ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["uint256", "bytes32", "bool", "bytes32"],
+      [nonce, specHash, true, ethers.ZeroHash]
+    )
+  );
+  const expectedCommitHash = ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["uint256", "bytes32", "bytes32", "address", "uint256", "bytes32"],
+      [77n, outcomeHash, expectedSalt, validator, chainId, domain]
+    )
+  );
+  assert.equal(commitHash, expectedCommitHash);
+});
+
+test("dispute intent packages evidence and raises", async (t) => {
+  const userId = "disputer-002";
+  const message = "I need to dispute job #88 due to incorrect output.";
+
+  const disputeCalls: unknown[][] = [];
+  const disputeTxHash = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+  t.after(() => {
+    __setLoadContracts(null);
+    __setGetSignerForUser(null);
+  });
+
+  __setLoadContracts(() =>
+    ({
+      erc20: {} as unknown,
+      stakeManager: {} as unknown,
+      jobRegistry: {} as unknown,
+      validationModule: {} as unknown,
+      disputeModule: {
+        raiseDispute: async (...args: unknown[]) => {
+          disputeCalls.push(args);
+          return { hash: disputeTxHash, wait: async () => ({}) };
+        },
+      } as unknown,
+    }) as any
+  );
+
+  __setGetSignerForUser(async () =>
+    ({
+      address: "0x2222222222222222222222222222222222222222",
+      getAddress: async () => "0x2222222222222222222222222222222222222222",
+      provider: {
+        getNetwork: async () => ({ chainId: 1n, name: "mainnet" }),
+      },
+    }) as any
+  );
+
+  const outputs: string[] = [];
+  for await (const chunk of planAndExecute({ message, meta: { userId } })) {
+    outputs.push(chunk);
+  }
+
+  assert.ok(outputs.includes("📦 Packaging dispute evidence…\n"));
+  assert.ok(outputs.some((line) => line.startsWith("📨 Evidence pinned:")));
+  assert.ok(outputs.includes("⚖️ Raising dispute…\n"));
+  assert.ok(outputs.includes("✅ Dispute submitted for job #88.\n"));
+
+  assert.equal(disputeCalls.length, 1);
+  const [jobId, reasonUri] = disputeCalls[0];
+  assert.equal(jobId, 88n);
+
+  const payload = {
+    reason: { summary: message },
+    evidence: { note: "auto-generated" },
+  } as const;
+  const digest = ethers.id(JSON.stringify(payload)).slice(2, 10);
+  const expectedUri = `ipfs://stub-${digest}`;
+  assert.equal(reasonUri, expectedUri);
 });


### PR DESCRIPTION
## Summary
- extend the orchestrator contract bindings with validation commit/reveal accessors and add an overrideable dependency shim for tests
- implement validation commit/reveal tooling with salt normalization, commit hash computation, and ENS proof handling, plus dispute evidence packaging
- update the OpenAI planner stub and tests to drive end-to-end commit/reveal and dispute scenarios

## Testing
- npm --prefix packages/orchestrator test

------
https://chatgpt.com/codex/tasks/task_e_68d5b7c9e1508333b2578824f8b0d6b8