### PR TITLE
feat: scaffold one-box orchestrator schema and planner client

### DIFF
--- a/docs/onebox/overview.md
+++ b/docs/onebox/overview.md
@@ -1,0 +1,38 @@
+# One-Box Orchestrator Overview
+
+The one-box initiative wraps the AGI Jobs v2 modules behind a natural-language orchestration layer. The goal is to let an operator type a single instruction, receive clarifying questions when the request is ambiguous, and have the platform execute the full lifecycle through guarded adapters.
+
+This document captures the shared contract between the planner (LLM or meta-agent) and the execution adapters that bridge into the deployed contracts.
+
+## Intent Constraint Schema (ICS)
+
+The planner must emit a JSON object that satisfies the [`IntentConstraintSchema`](../../packages/onebox-orchestrator/src/ics/schema.ts). The schema is validated with [`zod`](https://github.com/colinhacks/zod) to guarantee:
+
+- only supported intents are produced;
+- amounts are encoded as positive decimal strings (no implicit unit conversions);
+- confirmations for token-moving actions include a ≤140 character natural-language summary;
+- optional metadata—trace identifiers, planner model versions—are propagated end-to-end for observability.
+
+If an LLM produces an object that fails validation, the orchestrator returns a structured error and the chat surface prompts the user for clarification instead of guessing.
+
+## Planner client
+
+`PlannerClient` (see [`packages/onebox-orchestrator/src/planner/client.ts`](../../packages/onebox-orchestrator/src/planner/client.ts)) calls into the Meta-Agent orchestrator exposed by `AGI-Alpha-Agent-v0`. It wraps the HTTP call with:
+
+- configurable timeouts (default 15 seconds);
+- bearer-token authentication support;
+- ICS validation before dispatching any tool.
+
+Timeouts or malformed replies surface as `PlannerClientError` instances that the UI can translate into user-friendly chat messages.
+
+## Tool registry
+
+Execution adapters are registered per intent through [`ToolRegistry`](../../packages/onebox-orchestrator/src/router/registry.ts). The registry supplies a default "not implemented" handler for any intent without a concrete adapter so we can enable the conversational surface before all blockchain integrations are in place.
+
+Each handler receives the validated ICS envelope and a `ToolExecutionContext` containing chain configuration and optional identity metadata (ENS name, address). Handlers return a `ToolResponse` that the chat surface can render to the user, including friendly error messaging if a policy gate (stake, ENS ownership, spend caps) fails.
+
+## Next steps
+
+- Wire ERC-4337 or relayer signing into the `ToolExecutionContext`.
+- Implement the concrete adapters for job creation, staking, validation, and settlement using the v2 ABIs.
+- Extend the CI workflow with forked-chain integration tests once adapters are available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "ipfs-http-client": "^60.0.0",
         "parse-duration": "^2.1.4",
         "web3": "^1.10.0",
-        "ws": "^8.18.3"
+        "ws": "^8.18.3",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "6.1.0",
@@ -16047,6 +16048,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "ipfs-http-client": "^60.0.0",
     "parse-duration": "^2.1.4",
     "web3": "^1.10.0",
-    "ws": "^8.18.3"
+    "ws": "^8.18.3",
+    "zod": "^3.23.8"
   },
   "overrides": {
     "axios": "^1.12.2",

--- a/packages/onebox-orchestrator/package.json
+++ b/packages/onebox-orchestrator/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@agijobs/onebox-orchestrator",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/onebox-orchestrator/src/ics/parser.ts
+++ b/packages/onebox-orchestrator/src/ics/parser.ts
@@ -1,0 +1,30 @@
+import { IntentConstraintSchema } from './schema';
+import type { AnyIntentEnvelope, IntentValidationResult } from './types';
+
+export function parseIntentConstraint(input: unknown): IntentValidationResult {
+  const result = IntentConstraintSchema.safeParse(input);
+  if (!result.success) {
+    const issues = result.error.issues.map((issue) => {
+      const path = issue.path.join('.');
+      return path ? `${path}: ${issue.message}` : issue.message;
+    });
+    return { ok: false, issues };
+  }
+
+  const { data } = result;
+  const envelope = {
+    intent: data.intent,
+    payload: data,
+  } as AnyIntentEnvelope;
+
+  if (data.confirmationText && data.confirm !== true) {
+    return {
+      ok: false,
+      issues: [
+        'confirmationText provided without confirm=true. The planner must request explicit confirmation when providing natural-language summaries.',
+      ],
+    };
+  }
+
+  return { ok: true, data: envelope };
+}

--- a/packages/onebox-orchestrator/src/ics/schema.ts
+++ b/packages/onebox-orchestrator/src/ics/schema.ts
@@ -1,0 +1,233 @@
+import { z } from 'zod';
+
+export const INTENT_VALUES = [
+  'create_job',
+  'apply_job',
+  'submit_work',
+  'validate',
+  'finalize',
+  'dispute',
+  'stake',
+  'withdraw',
+  'admin_set',
+] as const;
+
+export const IntentSchema = z.enum(INTENT_VALUES);
+
+const decimalString = z
+  .string()
+  .trim()
+  .min(1, 'Amount must be provided')
+  .regex(/^\d+(\.\d+)?$/, 'Amount must be a positive decimal number')
+  .transform((value) => {
+    if (value.includes('.')) {
+      const normalized = value.replace(/0+$/, '');
+      return normalized.endsWith('.')
+        ? normalized.slice(0, -1)
+        : normalized || '0';
+    }
+    return value;
+  })
+  .refine((value) => value !== '0', 'Amount must be greater than zero');
+
+const deadlineSchema = z
+  .number({ invalid_type_error: 'Deadline must be a number' })
+  .int('Deadline must be an integer number of days')
+  .min(1, 'Deadline must be at least one day')
+  .max(365, 'Deadline cannot exceed one year');
+
+const jobDefinitionSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(4, 'Title must be at least four characters long')
+    .max(120, 'Title cannot exceed 120 characters'),
+  description: z
+    .string()
+    .trim()
+    .min(12, 'Description must provide sufficient detail'),
+  rewardToken: z
+    .string()
+    .trim()
+    .min(1, 'Reward token symbol or address required')
+    .optional(),
+  rewardAmount: decimalString,
+  deadlineDays: deadlineSchema,
+  attachments: z
+    .array(z.string().url('Attachment must be a valid URL'))
+    .max(10)
+    .optional(),
+  slots: z.number().int().positive().max(25).optional(),
+  tags: z.array(z.string().trim().min(1)).max(12).optional(),
+});
+
+const jobReferenceSchema = z.object({
+  jobId: z.union([
+    z
+      .string()
+      .trim()
+      .regex(/^[0-9]+$/, 'jobId must be a numeric string'),
+    z.number().int().nonnegative(),
+  ]),
+});
+
+const stakeRoleSchema = z.enum(['agent', 'validator', 'platform', 'operator']);
+
+const confirmationSchema = z.object({
+  confirm: z.boolean().optional(),
+  confirmationText: z
+    .string()
+    .trim()
+    .max(140, 'Confirmation text must be at most 140 characters')
+    .optional(),
+});
+
+const metaSchema = z
+  .object({
+    traceId: z.string().uuid('traceId must be a valid UUID').optional(),
+    requestId: z.string().trim().min(1).optional(),
+    planner: z
+      .object({
+        model: z.string().trim().min(1).optional(),
+        version: z.string().trim().min(1).optional(),
+      })
+      .optional(),
+  })
+  .optional();
+
+const createJobSchema = z
+  .object({
+    intent: z.literal('create_job'),
+    params: z.object({ job: jobDefinitionSchema }),
+    context: z
+      .object({
+        employerEns: z.string().trim().min(1).optional(),
+        preferredValidator: z.string().trim().optional(),
+      })
+      .optional(),
+  })
+  .merge(confirmationSchema)
+  .extend({ meta: metaSchema });
+
+const applyJobSchema = z
+  .object({
+    intent: z.literal('apply_job'),
+    params: jobReferenceSchema.extend({
+      proposal: z.string().trim().max(4096).optional(),
+      stakeAmount: decimalString.optional(),
+    }),
+  })
+  .merge(confirmationSchema)
+  .extend({ meta: metaSchema });
+
+const submitWorkSchema = z
+  .object({
+    intent: z.literal('submit_work'),
+    params: jobReferenceSchema.extend({
+      deliverableUri: z
+        .string()
+        .trim()
+        .url('deliverableUri must be a valid URI'),
+      notes: z.string().trim().max(4096).optional(),
+    }),
+  })
+  .merge(confirmationSchema)
+  .extend({ meta: metaSchema });
+
+const validateSchema = z
+  .object({
+    intent: z.literal('validate'),
+    params: jobReferenceSchema.extend({
+      decision: z.enum(['approve', 'reject']),
+      justification: z.string().trim().max(4096).optional(),
+    }),
+  })
+  .merge(confirmationSchema)
+  .extend({ meta: metaSchema });
+
+const finalizeSchema = z
+  .object({
+    intent: z.literal('finalize'),
+    params: jobReferenceSchema,
+  })
+  .merge(confirmationSchema)
+  .extend({ meta: metaSchema });
+
+const disputeSchema = z
+  .object({
+    intent: z.literal('dispute'),
+    params: jobReferenceSchema.extend({
+      reason: z.string().trim().min(8, 'Dispute reason must include detail'),
+      evidenceUri: z.string().trim().url().optional(),
+    }),
+  })
+  .merge(confirmationSchema)
+  .extend({ meta: metaSchema });
+
+const stakeSchema = z
+  .object({
+    intent: z.literal('stake'),
+    params: z.object({
+      role: stakeRoleSchema,
+      amount: decimalString,
+      warmupDays: deadlineSchema.optional(),
+    }),
+  })
+  .merge(confirmationSchema)
+  .extend({ meta: metaSchema });
+
+const withdrawSchema = z
+  .object({
+    intent: z.literal('withdraw'),
+    params: z.object({
+      role: stakeRoleSchema,
+      amount: decimalString.optional(),
+      full: z.boolean().optional(),
+    }),
+  })
+  .merge(confirmationSchema)
+  .extend({ meta: metaSchema });
+
+const adminSetSchema = z
+  .object({
+    intent: z.literal('admin_set'),
+    params: z.object({
+      target: z.enum([
+        'burn_pct',
+        'fee_pct',
+        'pause_protocol',
+        'unpause_protocol',
+        'update_allowlist',
+        'set_treasury',
+      ]),
+      value: z.union([decimalString, z.boolean(), z.string().trim()]),
+    }),
+    guard: z
+      .object({
+        requesterEns: z
+          .string()
+          .trim()
+          .min(1, 'ENS name of requester required'),
+        isAuthorized: z.boolean().optional(),
+      })
+      .optional(),
+  })
+  .merge(confirmationSchema)
+  .extend({ meta: metaSchema });
+
+export const IntentConstraintSchema = z.discriminatedUnion('intent', [
+  createJobSchema,
+  applyJobSchema,
+  submitWorkSchema,
+  validateSchema,
+  finalizeSchema,
+  disputeSchema,
+  stakeSchema,
+  withdrawSchema,
+  adminSetSchema,
+]);
+
+export type IntentConstraint = z.infer<typeof IntentConstraintSchema>;
+
+export const SupportedIntentSet: ReadonlySet<IntentConstraint['intent']> =
+  new Set(INTENT_VALUES);

--- a/packages/onebox-orchestrator/src/ics/types.ts
+++ b/packages/onebox-orchestrator/src/ics/types.ts
@@ -1,0 +1,25 @@
+import type { IntentConstraint } from './schema';
+
+export type IntentName = IntentConstraint['intent'];
+
+export type ConfirmationMetadata = {
+  confirm: boolean;
+  confirmationText?: string;
+};
+
+export type IntentMeta = IntentConstraint['meta'];
+
+export interface IntentEnvelope<TIntent extends IntentName = IntentName> {
+  intent: TIntent;
+  payload: IntentConstraint & { intent: TIntent };
+}
+
+export type AnyIntentEnvelope = {
+  [K in IntentName]: IntentEnvelope<K>;
+}[IntentName];
+
+export interface IntentValidationResult {
+  ok: boolean;
+  data?: AnyIntentEnvelope;
+  issues?: string[];
+}

--- a/packages/onebox-orchestrator/src/index.ts
+++ b/packages/onebox-orchestrator/src/index.ts
@@ -1,0 +1,27 @@
+export {
+  INTENT_VALUES,
+  IntentSchema,
+  IntentConstraintSchema,
+} from './ics/schema';
+export type { IntentConstraint } from './ics/schema';
+export type {
+  IntentName,
+  ConfirmationMetadata,
+  IntentMeta,
+  IntentEnvelope,
+  AnyIntentEnvelope,
+  IntentValidationResult,
+} from './ics/types';
+export { parseIntentConstraint } from './ics/parser';
+export {
+  PlannerClient,
+  type PlannerClientOptions,
+  PlannerClientError,
+} from './planner/client';
+export {
+  ToolRegistry,
+  ToolExecutionContext,
+  ToolHandler,
+  ToolResponse,
+  registerDefaultNotImplementedHandlers,
+} from './router/registry';

--- a/packages/onebox-orchestrator/src/planner/client.ts
+++ b/packages/onebox-orchestrator/src/planner/client.ts
@@ -1,0 +1,104 @@
+import { parseIntentConstraint } from '../ics/parser';
+import type { AnyIntentEnvelope } from '../ics/types';
+
+export interface PlannerClientOptions {
+  endpoint: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export interface PlannerRequestPayload {
+  message: string;
+  conversation?: Array<{ role: 'user' | 'assistant'; content: string }>;
+  context?: Record<string, unknown>;
+}
+
+export class PlannerClientError extends Error {
+  public readonly status?: number;
+  public readonly issues?: string[];
+
+  constructor(
+    message: string,
+    options?: { status?: number; issues?: string[] }
+  ) {
+    super(message);
+    this.name = 'PlannerClientError';
+    this.status = options?.status;
+    this.issues = options?.issues;
+  }
+}
+
+export class PlannerClient {
+  private readonly endpoint: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(options: PlannerClientOptions) {
+    if (!options.endpoint) {
+      throw new PlannerClientError('Planner endpoint is required');
+    }
+    this.endpoint = options.endpoint;
+    this.apiKey = options.apiKey;
+    this.timeoutMs = options.timeoutMs ?? 15000;
+    this.fetchFn = options.fetchImpl ?? fetch;
+  }
+
+  async plan(request: PlannerRequestPayload): Promise<AnyIntentEnvelope> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await this.fetchFn(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(this.apiKey ? { authorization: `Bearer ${this.apiKey}` } : {}),
+        },
+        body: JSON.stringify(request),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new PlannerClientError(
+          `Planner responded with status ${response.status}`,
+          { status: response.status }
+        );
+      }
+
+      const contentType = response.headers.get('content-type') ?? '';
+      if (!contentType.includes('application/json')) {
+        throw new PlannerClientError(
+          'Planner response must be application/json'
+        );
+      }
+
+      const payload = (await response.json()) as unknown;
+      const validation = parseIntentConstraint(payload);
+      if (!validation.ok || !validation.data) {
+        throw new PlannerClientError('Planner response failed ICS validation', {
+          issues: validation.issues,
+        });
+      }
+
+      return validation.data;
+    } catch (error) {
+      if (error instanceof PlannerClientError) {
+        throw error;
+      }
+
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new PlannerClientError('Planner request timed out', {
+          issues: [error.message],
+        });
+      }
+
+      throw new PlannerClientError('Unexpected planner error', {
+        issues: [error instanceof Error ? error.message : String(error)],
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/packages/onebox-orchestrator/src/router/registry.ts
+++ b/packages/onebox-orchestrator/src/router/registry.ts
@@ -1,0 +1,86 @@
+import type { AnyIntentEnvelope, IntentName } from '../ics/types';
+
+export interface ToolExecutionContext {
+  chainId: number;
+  rpcUrl: string;
+  identity?: {
+    ensName?: string;
+    address?: string;
+  };
+  requestMeta?: Record<string, unknown>;
+}
+
+export interface ToolResponse {
+  status: 'success' | 'pending' | 'error';
+  messages: string[];
+  data?: Record<string, unknown>;
+  issues?: string[];
+}
+
+export type ToolHandler<TIntent extends IntentName = IntentName> = (
+  envelope: Extract<AnyIntentEnvelope, { intent: TIntent }>,
+  context: ToolExecutionContext
+) => Promise<ToolResponse>;
+
+export class ToolRegistry {
+  private readonly handlers: Map<IntentName, ToolHandler> = new Map();
+
+  register<TIntent extends IntentName>(
+    intent: TIntent,
+    handler: ToolHandler<TIntent>
+  ): void {
+    this.handlers.set(intent, handler as ToolHandler);
+  }
+
+  has(intent: IntentName): boolean {
+    return this.handlers.has(intent);
+  }
+
+  resolve(intent: IntentName): ToolHandler {
+    const handler = this.handlers.get(intent);
+    if (!handler) {
+      throw new Error(`No tool handler registered for intent: ${intent}`);
+    }
+    return handler;
+  }
+
+  async dispatch(
+    envelope: AnyIntentEnvelope,
+    context: ToolExecutionContext
+  ): Promise<ToolResponse> {
+    const handler = this.resolve(envelope.intent);
+    return handler(envelope, context);
+  }
+}
+
+export function registerDefaultNotImplementedHandlers(
+  registry: ToolRegistry
+): void {
+  const createHandler =
+    (intent: IntentName): ToolHandler =>
+    async () => ({
+      status: 'error',
+      messages: [
+        `Intent \`${intent}\` is recognised but no execution adapter has been implemented yet. Please wire the blockchain adapter before enabling this pathway.`,
+      ],
+      issues: ['not_implemented'],
+    });
+
+  const intents: IntentName[] = [
+    'create_job',
+    'apply_job',
+    'submit_work',
+    'validate',
+    'finalize',
+    'dispute',
+    'stake',
+    'withdraw',
+    'admin_set',
+  ];
+
+  intents.forEach((intent) => {
+    if (!registry.has(intent)) {
+      registry.register(intent, createHandler(intent));
+    }
+  });
+}

--- a/packages/onebox-orchestrator/test/ics-schema.test.ts
+++ b/packages/onebox-orchestrator/test/ics-schema.test.ts
@@ -1,0 +1,78 @@
+import assert from 'assert';
+import { parseIntentConstraint } from '../src/ics/parser';
+
+const validCreateJob = {
+  intent: 'create_job',
+  params: {
+    job: {
+      title: 'Label images',
+      description: 'Tag 500 images with cat vs dog',
+      rewardAmount: '42.5',
+      deadlineDays: 7,
+    },
+  },
+  confirm: true,
+  confirmationText: 'Post job paying 42.5 AGIALPHA with 7 day deadline',
+  meta: {
+    traceId: '123e4567-e89b-12d3-a456-426614174000',
+  },
+};
+
+const missingFields = {
+  intent: 'create_job',
+  params: {
+    job: {
+      title: 'Hi',
+      description: 'Too short',
+      rewardAmount: '0',
+      deadlineDays: 0,
+    },
+  },
+};
+
+function testValidCreateJob() {
+  const result = parseIntentConstraint(validCreateJob);
+  assert.strictEqual(
+    result.ok,
+    true,
+    `Expected ok=true, received issues: ${result.issues}`
+  );
+  assert.ok(result.data, 'Envelope should be defined for valid payload');
+  assert.strictEqual(result.data?.intent, 'create_job');
+  if (result.data?.intent !== 'create_job') {
+    throw new Error('Expected create_job intent');
+  }
+  const payload = result.data.payload;
+  assert.strictEqual(payload.params.job.title, 'Label images');
+  assert.strictEqual(payload.confirm, true);
+}
+
+function testInvalidJob() {
+  const result = parseIntentConstraint(missingFields);
+  assert.strictEqual(result.ok, false, 'Expected validation failure');
+  assert.ok(
+    result.issues && result.issues.length >= 2,
+    'Should report multiple issues'
+  );
+}
+
+function testConfirmationGuard() {
+  const invalid = {
+    ...validCreateJob,
+    confirmationText: 'Needs confirm',
+    confirm: false,
+  };
+  const result = parseIntentConstraint(invalid);
+  assert.strictEqual(
+    result.ok,
+    false,
+    'confirmationText requires confirm=true'
+  );
+  assert.ok(result.issues?.some((issue) => issue.includes('confirmationText')));
+}
+
+testValidCreateJob();
+testInvalidJob();
+testConfirmationGuard();
+
+console.log('ICS schema tests passed');

--- a/packages/onebox-orchestrator/tsconfig.json
+++ b/packages/onebox-orchestrator/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,12 @@
     "types": ["node", "hardhat"],
     "skipLibCheck": true
   },
-  "include": ["hardhat.config.ts", "scripts/**/*.ts", "test/**/*.ts", "docs/**/*.ts"],
+  "include": [
+    "hardhat.config.ts",
+    "scripts/**/*.ts",
+    "test/**/*.ts",
+    "docs/**/*.ts",
+    "packages/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add a dedicated one-box orchestrator package with the shared intent constraint schema and supporting types
- introduce a planner HTTP client plus a tool registry facade to plug the meta-agent into contract adapters
- document the ICS contract and provide a targeted parser test to exercise confirmation and validation flows

## Testing
- npx ts-node packages/onebox-orchestrator/test/ics-schema.test.ts
- npm run lint *(fails: pre-existing solhint and prettier findings across contracts/scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68d5da3ea33083338ce7ea5db20148f7