### PR TITLE
Add static one-box UI bundle for IPFS deployment

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -1,0 +1,33 @@
+# AGI Jobs One-Box (Static UI)
+
+A single-textbox, gasless, walletless interface for AGI Jobs v2 that runs entirely from static hosting (e.g. IPFS). The page talks to the AGI-Alpha Orchestrator for natural-language planning and streams execution receipts through either an Account Abstraction (ERC-4337) path or a Defender relayer fallback.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `index.html` | Minimal shell (HTML/CSS) for the chat surface, advanced panel, and accessibility hooks. |
+| `app.mjs` | Main ES module orchestrating user interactions, planner calls, confirmations, IPFS uploads, and execution streaming. |
+| `config.mjs` | Environment-specific endpoints and AA toggle. |
+| `lib.mjs` | Shared helpers: ICS validation, event formatting, IPFS utilities. |
+
+## Running locally
+
+1. Serve the directory with any static server (`npx serve apps/onebox-static`).
+2. Update `config.mjs` to point at your AGI-Alpha Orchestrator endpoints.
+3. In the browser console, set your web3.storage token if you plan to attach files:
+   ```js
+   localStorage.setItem('AGIJOBS_W3S_TOKEN', '<token>');
+   ```
+4. Interact via the single input box. Value-moving intents ask for `YES/NO` confirmation, then stream receipts to the conversation.
+
+## Publishing to IPFS
+
+* Zip or upload the folder via [web3.storage](https://web3.storage/).
+* Pin the resulting CID and share `https://w3s.link/ipfs/<CID>/index.html`.
+* Optionally configure DNSLink for a custom domain.
+
+## Notes
+
+* The UI never stores private keys. Account Abstraction sponsorship configuration lives server-side in the orchestrator or paymaster.
+* ENS requirements must be handled in the orchestrator response; the UI surfaces the human-readable guidance via planner messages.

--- a/apps/onebox-static/app.mjs
+++ b/apps/onebox-static/app.mjs
@@ -1,0 +1,183 @@
+import { PLAN_URL, EXEC_URL, IPFS_ENDPOINT, IPFS_TOKEN_STORAGE_KEY, AA_MODE } from "./config.mjs";
+import { validateICS, needsAttachmentPin, prepareJobPayload, formatEvent, pinBlob, pinJSON, formatError } from "./lib.mjs";
+
+const feed = document.getElementById("feed");
+const composer = document.getElementById("composer");
+const questionInput = document.getElementById("question");
+const attachmentInput = document.getElementById("attachment");
+const sendButton = document.getElementById("send");
+const advancedToggle = document.getElementById("advanced-toggle");
+const advancedPanel = document.getElementById("advanced-panel");
+
+let busy = false;
+let history = [];
+let confirmCallback = null;
+
+function toggleAdvanced(e) {
+  e?.preventDefault();
+  document.body.classList.toggle("advanced");
+}
+advancedToggle.addEventListener("click", toggleAdvanced);
+
+function scrollFeed() {
+  feed.scrollTo({ top: feed.scrollHeight, behavior: "smooth" });
+}
+
+function pushMessage(role, text) {
+  if (!text) return;
+  const bubble = document.createElement("div");
+  bubble.className = role === "user" ? "msg me" : "msg";
+  bubble.textContent = text;
+  feed.appendChild(bubble);
+  scrollFeed();
+}
+
+function setBusy(state) {
+  busy = state;
+  sendButton.disabled = state;
+  questionInput.disabled = state;
+  attachmentInput.disabled = state;
+}
+
+async function plannerRequest(prompt) {
+  const body = JSON.stringify({ message: prompt, history });
+  const response = await fetch(PLAN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+  if (!response.ok) {
+    throw new Error(`Planner unavailable (${response.status})`);
+  }
+  const payload = await response.json();
+  return validateICS(payload);
+}
+
+async function confirmFlow(ics) {
+  if (!ics.confirm) return true;
+  const summary = ics.summary || "Please confirm to continue.";
+  pushMessage("assistant", summary);
+  pushMessage("assistant", "Type YES to confirm or NO to cancel.");
+  setBusy(false);
+
+  return new Promise((resolve) => {
+    confirmCallback = (value) => {
+      const ok = /^(y|yes)$/i.test(value);
+      if (!ok) {
+        pushMessage("assistant", "Cancelled.");
+      }
+      confirmCallback = null;
+      setBusy(true);
+      resolve(ok);
+    };
+  });
+}
+
+async function maybePinAttachments(ics, file) {
+  if (!file) return ics;
+  if (!needsAttachmentPin(ics)) return ics;
+  const token = localStorage.getItem(IPFS_TOKEN_STORAGE_KEY);
+  if (!token) {
+    throw new Error("IPFS token missing. Provide a web3.storage token via Advanced panel.");
+  }
+  const { cid } = await pinBlob(IPFS_ENDPOINT, token, file);
+  const prepared = prepareJobPayload(ics, cid);
+  const { cid: metaCid } = await pinJSON(IPFS_ENDPOINT, token, prepared.payload);
+  prepared.assign(metaCid);
+  return ics;
+}
+
+async function executeICS(ics) {
+  const response = await fetch(EXEC_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ics, aa: AA_MODE }),
+  });
+  if (!response.ok || !response.body) {
+    throw new Error(`Executor error (${response.status})`);
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let boundary = buffer.indexOf("\n\n");
+    while (boundary !== -1) {
+      const chunk = buffer.slice(0, boundary).trim();
+      buffer = buffer.slice(boundary + 2);
+      if (chunk) {
+        try {
+          const normalized = chunk.startsWith("data:") ? chunk.slice(5).trim() : chunk;
+          if (!normalized) {
+            continue;
+          }
+          const event = JSON.parse(normalized);
+          const { text, advanced } = formatEvent(event);
+          pushMessage("assistant", text);
+          if (advanced) {
+            advancedPanel.textContent = advanced;
+          }
+        } catch (err) {
+          console.error("Bad event", err, chunk);
+        }
+      }
+      boundary = buffer.indexOf("\n\n");
+    }
+  }
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+
+  if (confirmCallback) {
+    const value = questionInput.value.trim();
+    if (!value) return;
+    pushMessage("user", value);
+    questionInput.value = "";
+    const callback = confirmCallback;
+    confirmCallback = null;
+    callback(value);
+    return;
+  }
+
+  if (busy) return;
+
+  const text = questionInput.value.trim();
+  const file = attachmentInput.files?.[0];
+  if (!text) return;
+
+  pushMessage("user", text);
+  questionInput.value = "";
+  attachmentInput.value = "";
+
+  setBusy(true);
+
+  try {
+    const ics = await plannerRequest(text);
+    const confirmed = await confirmFlow(ics);
+    if (!confirmed) {
+      setBusy(false);
+      return;
+    }
+
+    await maybePinAttachments(ics, file);
+    history = history.concat(
+      { role: "user", text },
+      { role: "assistant", text: JSON.stringify(ics) }
+    ).slice(-10);
+
+    await executeICS(ics);
+  } catch (err) {
+    const friendly = formatError(err);
+    pushMessage("assistant", `❌ ${friendly}`);
+  } finally {
+    setBusy(false);
+  }
+}
+
+composer.addEventListener("submit", handleSubmit);
+
+// Surface helpers for Advanced panel token setup
+advancedPanel.textContent = "Set your web3.storage token via localStorage: localStorage.setItem('AGIJOBS_W3S_TOKEN', '<token>')";

--- a/apps/onebox-static/config.mjs
+++ b/apps/onebox-static/config.mjs
@@ -1,0 +1,5 @@
+export const PLAN_URL = "https://alpha-orchestrator.example.com/plan";
+export const EXEC_URL = "https://alpha-orchestrator.example.com/execute"; // SSE stream (JSON per line)
+export const IPFS_ENDPOINT = "https://api.web3.storage/upload";
+export const IPFS_TOKEN_STORAGE_KEY = "AGIJOBS_W3S_TOKEN";
+export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };

--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>AGI Jobs — One-Box</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f5f7fb;
+      --fg: #0b1b3f;
+      --accent: #0f4cdd;
+      --accent-fg: #ffffff;
+      --border: rgba(15, 76, 221, 0.12);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font: 16px/1.5 "Inter", system-ui, -apple-system, Segoe UI, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      display: flex;
+      flex-direction: column;
+    }
+    header, footer {
+      padding: 12px 18px;
+      border-bottom: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.82);
+      backdrop-filter: blur(12px);
+      position: sticky;
+      top: 0;
+      z-index: 2;
+    }
+    footer {
+      border-top: 1px solid var(--border);
+      border-bottom: none;
+      bottom: 0;
+      top: auto;
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.05rem;
+      font-weight: 600;
+    }
+    #feed {
+      flex: 1;
+      overflow-y: auto;
+      padding: 12px clamp(12px, 4vw, 24px);
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .msg {
+      max-width: min(76ch, 92%);
+      padding: 12px 14px;
+      border-radius: 14px;
+      background: #ffffff;
+      border: 1px solid var(--border);
+      box-shadow: 0 4px 16px rgba(15, 76, 221, 0.08);
+      transition: transform 120ms ease;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .msg.me {
+      margin-left: auto;
+      background: var(--accent);
+      color: var(--accent-fg);
+      border-color: transparent;
+    }
+    form {
+      display: flex;
+      gap: 8px;
+      padding: 12px clamp(12px, 4vw, 24px) 16px;
+      border-top: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.9);
+      backdrop-filter: blur(12px);
+    }
+    input[type="text"], input[type="file"] {
+      flex: 1;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 12px 14px;
+      font-size: 1rem;
+      background: #fff;
+      color: inherit;
+    }
+    input[type="file"] {
+      flex: unset;
+      max-width: 200px;
+    }
+    button {
+      padding: 12px 18px;
+      border-radius: 12px;
+      border: none;
+      background: var(--accent);
+      color: var(--accent-fg);
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 120ms ease, box-shadow 120ms ease;
+      box-shadow: 0 8px 20px rgba(15, 76, 221, 0.22);
+    }
+    button:disabled {
+      opacity: 0.6;
+      cursor: wait;
+      box-shadow: none;
+    }
+    button:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+    #advanced-panel {
+      display: none;
+      font-size: 0.85rem;
+      padding: 0 clamp(12px, 4vw, 24px) 12px;
+      color: rgba(11, 27, 63, 0.75);
+    }
+    body.advanced #advanced-panel {
+      display: block;
+    }
+    footer a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 8px;
+      border-radius: 999px;
+      background: rgba(15, 76, 221, 0.08);
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    @media (max-width: 600px) {
+      header, footer {
+        padding: 10px 14px;
+      }
+      form {
+        flex-direction: column;
+        padding: 10px 14px 14px;
+      }
+      button {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>AGI Jobs — One-Box <span class="chip">Gasless</span></h1>
+    <p aria-live="polite">Natural language planning with Meta-Agentic orchestration.</p>
+  </header>
+  <main id="feed" role="log" aria-live="polite"></main>
+  <form id="composer" aria-label="Chat input">
+    <input id="question" type="text" placeholder="Post a job for 500 images rewarded 50 AGIALPHA" aria-label="Enter your request" required />
+    <input id="attachment" type="file" aria-label="Attach supporting file" />
+    <button id="send" type="submit">Send</button>
+  </form>
+  <section id="advanced-panel" aria-live="polite"></section>
+  <footer>
+    <a id="advanced-toggle" href="#">Toggle advanced details</a>
+  </footer>
+  <script type="module" src="./app.mjs"></script>
+</body>
+</html>

--- a/apps/onebox-static/lib.mjs
+++ b/apps/onebox-static/lib.mjs
@@ -1,0 +1,145 @@
+const SUPPORTED_INTENTS = [
+  "create_job",
+  "apply_job",
+  "submit_work",
+  "validate",
+  "finalize",
+  "dispute",
+  "stake",
+  "withdraw",
+  "admin_set",
+];
+
+export function validateICS(payload) {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Planner returned an invalid response");
+  }
+  const { intent, params = {}, confirm = false, summary } = payload;
+  if (!SUPPORTED_INTENTS.includes(intent)) {
+    throw new Error(`Unsupported intent: ${intent}`);
+  }
+  if (confirm && summary && summary.length > 140) {
+    console.warn("Summary exceeds 140 chars", summary);
+  }
+  return { ...payload, intent, params, confirm };
+}
+
+export function needsAttachmentPin(ics) {
+  if (ics.intent === "create_job") {
+    const uri = ics?.params?.job?.uri;
+    return !uri;
+  }
+  if (ics.intent === "submit_work") {
+    return !ics?.params?.resultUri;
+  }
+  return false;
+}
+
+export function prepareJobPayload(ics, attachmentCid) {
+  const { intent, params = {} } = ics;
+  const payload = { attachments: [] };
+  if (intent === "create_job") {
+    const job = params.job || {};
+    const existingAttachments = Array.isArray(job.attachments)
+      ? job.attachments.filter(Boolean)
+      : [];
+    payload.attachments.push(...existingAttachments);
+    if (attachmentCid) {
+      payload.attachments.push(`ipfs://${attachmentCid}`);
+    }
+    payload.title = job.title || "";
+    payload.description = job.description || "";
+    payload.deadlineDays = job.deadlineDays ?? null;
+    payload.rewardAGIA = job.rewardAGIA ?? job.reward ?? null;
+    return {
+      payload,
+      assign(cid) {
+        if (!ics.params.job) ics.params.job = {};
+        ics.params.job.uri = `ipfs://${cid}`;
+      },
+    };
+  }
+  if (intent === "submit_work") {
+    if (!ics.params) ics.params = {};
+    payload.note = "AGI Jobs work submission";
+    const existing = Array.isArray(params?.attachments)
+      ? params.attachments.filter(Boolean)
+      : [];
+    payload.attachments.push(...existing);
+    if (attachmentCid) {
+      payload.attachments.push(`ipfs://${attachmentCid}`);
+    }
+    return {
+      payload,
+      assign(cid) {
+        ics.params.resultUri = `ipfs://${cid}`;
+      },
+    };
+  }
+  return {
+    payload,
+    assign() {},
+  };
+}
+
+export function formatEvent(event) {
+  if (!event || typeof event !== "object") {
+    return { text: "(malformed event)", advanced: "" };
+  }
+  const { type = "status", text = "", advanced = "" } = event;
+  if (type === "error") {
+    return { text: `❌ ${text || "Unknown error"}`, advanced };
+  }
+  if (type === "receipt") {
+    return { text: `✅ ${text}`, advanced };
+  }
+  return { text: text || "…", advanced };
+}
+
+export async function pinBlob(endpoint, token, file) {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: file,
+  });
+  if (!response.ok) {
+    throw new Error(`IPFS upload failed (${response.status})`);
+  }
+  const body = await response.json();
+  if (!body.cid) {
+    throw new Error("IPFS response missing CID");
+  }
+  return { cid: body.cid };
+}
+
+export async function pinJSON(endpoint, token, json) {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(json),
+  });
+  if (!response.ok) {
+    throw new Error(`IPFS upload failed (${response.status})`);
+  }
+  const body = await response.json();
+  if (!body.cid) {
+    throw new Error("IPFS response missing CID");
+  }
+  return { cid: body.cid };
+}
+
+export function formatError(err) {
+  if (!err) return "Unknown error";
+  if (typeof err === "string") return err;
+  if (err.message) return err.message;
+  try {
+    return JSON.stringify(err);
+  } catch (e) {
+    return "Unexpected error";
+  }
+}


### PR DESCRIPTION
## Summary
- add an IPFS-ready static chat UI with single-input experience under apps/onebox-static
- wire client logic for planner calls, confirmation flow, streaming execution events, and IPFS pinning helpers
- document configuration and publishing steps for the static one-box app

## Testing
- npm run lint *(fails: repository has existing solhint and prettier findings outside the new static app)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e2022e9483339a207a0a64250eab