### PR TITLE
Handle confirmationText in ICS validation

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -5,7 +5,7 @@ A single-textbox, gasless, walletless interface for AGI Jobs v2 that runs entire
 ## Features
 
 - **One input box** with streaming responses and an advanced details toggle for receipts and diagnostics.
-- **ICS guardrails** – planner responses are validated client-side (intent allowlist, confirmation summaries ≤140 chars, trace IDs).
+- **ICS guardrails** – planner responses are validated client-side (intent allowlist, confirmation summaries ≤160 chars, trace IDs).
 - **Gasless execution** – delegates to the orchestrator for AA-sponsored user operations or relayer fallbacks.
 - **IPFS integration** – job specs, submissions, and dispute evidence are pinned via `web3.storage` straight from the browser.
 - **ENS awareness** – dedicated event type for orchestrator hints to walk users through identity requirements.
@@ -24,7 +24,7 @@ A single-textbox, gasless, walletless interface for AGI Jobs v2 that runs entire
 1. Serve the directory with any static server, e.g. `npx serve apps/onebox-static`.
 2. Update `config.mjs` with your orchestrator endpoints (and optional AA configuration).
 3. In the UI’s **Advanced** panel set a `web3.storage` token (stored locally) if you plan to upload attachments.
-4. Type natural-language requests. When value moves, you will be prompted for a `YES/NO` confirmation capped at 140 characters.
+4. Type natural-language requests. When value moves, you will be prompted for a `YES/NO` confirmation capped at 160 characters.
 
 ## Publishing to IPFS
 
@@ -40,7 +40,7 @@ A single-textbox, gasless, walletless interface for AGI Jobs v2 that runs entire
 ## User guide (walletless UX)
 
 - **Plan** – describe the action (“Post a labeling job for 500 images, 50 AGIALPHA, 7 days”). The orchestrator returns an Intent-Constraint Schema (ICS) payload which is validated in-browser.
-- **Confirm** – if the action moves AGIALPHA or affects stake, you’ll see a ≤140 character summary. Reply `YES` to proceed or anything else to cancel.
+- **Confirm** – if the action moves AGIALPHA or affects stake, you’ll see a ≤160 character summary. Reply `YES` to proceed or anything else to cancel.
 - **Execute** – receipts stream back with plain-language updates. Enable the **Advanced** toggle to view tx hashes, block numbers, or ENS guidance supplied by the orchestrator.
 - **Attachments** – drag/drop or browse a file. The UI pins it to IPFS (requires a `web3.storage` token) and injects the resulting CID into the ICS before execution.
 

--- a/apps/onebox-static/app.mjs
+++ b/apps/onebox-static/app.mjs
@@ -54,7 +54,7 @@ function renderAdvancedPanel() {
       <h2>Runbook</h2>
       <ul>
         <li>Planner responses must comply with the Intent-Constraint Schema (ICS).</li>
-        <li>Value-moving intents require human confirmation (≤140 chars summary).</li>
+        <li>Value-moving intents require human confirmation (≤160 chars summary).</li>
         <li>Simulations, paymaster sponsorship, and relayer limits run server-side.</li>
         <li>ENS enforcement notices appear inline when required.</li>
       </ul>

--- a/apps/onebox-static/test/validateICS.test.mjs
+++ b/apps/onebox-static/test/validateICS.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateICS } from '../lib.mjs';
+
+const BASE_INTENT = {
+  intent: 'submit_work',
+  params: {},
+};
+
+test('accepts confirmationText and normalises it to summary', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    confirmationText: '   Send 5 AGIALPHA   ',
+  };
+  const normalized = validateICS(payload);
+  assert.equal(normalized.summary, 'Send 5 AGIALPHA');
+  assert.equal(normalized.confirm, true);
+});
+
+test('accepts legacy summary field when confirmationText missing', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    summary: 'Legacy summary',
+  };
+  const normalized = validateICS(payload);
+  assert.equal(normalized.summary, 'Legacy summary');
+});
+
+test('enforces 160 character limit when confirmation is required', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    confirmationText: 'x'.repeat(161),
+  };
+  assert.throws(() => validateICS(payload), /160/);
+});
+
+test('generates a fallback traceId when missing', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    summary: 'Needs trace',
+  };
+  const normalized = validateICS(payload);
+  assert.ok(normalized.meta?.traceId);
+  assert.equal(typeof normalized.meta.traceId, 'string');
+  assert.ok(normalized.meta.traceId.trim().length > 0);
+});
+
+function renderConfirmPrompt(payload) {
+  const normalized = validateICS(payload);
+  const messages = [];
+  if (normalized.confirm) {
+    const summary = normalized.summary || 'Please confirm to continue.';
+    messages.push(summary);
+    messages.push('Type YES to confirm or NO to cancel.');
+  }
+  return messages;
+}
+
+test('confirmationText prompts appear before confirmation instructions', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    confirmationText: 'Pay validator',
+  };
+  const messages = renderConfirmPrompt(payload);
+  assert.deepEqual(messages, [
+    'Pay validator',
+    'Type YES to confirm or NO to cancel.',
+  ]);
+});
+
+test('legacy summary prompts still render correctly', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    summary: 'Legacy prompt',
+  };
+  const messages = renderConfirmPrompt(payload);
+  assert.deepEqual(messages, [
+    'Legacy prompt',
+    'Type YES to confirm or NO to cancel.',
+  ]);
+});


### PR DESCRIPTION
## Summary
- normalize planner confirmation payloads by accepting confirmationText or legacy summary with a 160 character cap
- refresh UI messaging to match the updated limit for confirmation prompts
- add lightweight node test coverage to verify validation and confirm prompt ordering for both fields

## Testing
- node --test apps/onebox-static/test

------
https://chatgpt.com/codex/tasks/task_e_68d5f4bb588883339732b1f7a4c8d82d