### PR TITLE
Normalize submit_work result URIs in Onebox pinning

### DIFF
--- a/apps/onebox-static/lib.mjs
+++ b/apps/onebox-static/lib.mjs
@@ -87,7 +87,8 @@ export function needsAttachmentPin(ics) {
     return !(ics?.params?.job && ics.params.job.uri);
   }
   if (intent === "submit_work") {
-    return !ics?.params?.resultUri;
+    const uri = ics?.params?.result?.uri ?? ics?.params?.resultUri;
+    return !(typeof uri === "string" && uri.trim());
   }
   if (intent === "dispute") {
     const dispute = ics?.params?.dispute;
@@ -151,7 +152,12 @@ export function prepareJobPayload(ics, attachmentCid) {
       payload,
       assign(cid) {
         if (!ics.params) ics.params = {};
-        ics.params.resultUri = `ipfs://${cid}`;
+        const existing = isObject(ics.params.result) ? ics.params.result : {};
+        const uri = `ipfs://${cid}`;
+        ics.params.result = { ...existing, uri };
+        if ("resultUri" in ics.params) {
+          delete ics.params.resultUri;
+        }
       },
     };
   }

--- a/apps/onebox-static/test/pinning.test.mjs
+++ b/apps/onebox-static/test/pinning.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { needsAttachmentPin, prepareJobPayload } from '../lib.mjs';
+
+const CID = 'bafyreigdyrnucsac53examplecid0000000000000000000000000000000';
+
+function assignCid(ics, cid) {
+  const result = prepareJobPayload(ics, null);
+  assert.ok(result.payload, 'expected a payload for submission intents');
+  result.assign(cid);
+  return ics;
+}
+
+test('submit_work ICS without result uri pins and normalises result field', () => {
+  const ics = {
+    intent: 'submit_work',
+    params: {
+      note: 'Hello world',
+      attachments: ['ipfs://existing-cid'],
+    },
+  };
+
+  assert.equal(needsAttachmentPin(ics), true);
+
+  assignCid(ics, CID);
+
+  assert.deepEqual(ics.params.result, {
+    uri: `ipfs://${CID}`,
+  });
+  assert.equal('resultUri' in ics.params, false);
+});
+
+test('submit_work ICS with result uri keeps other result metadata', () => {
+  const ics = {
+    intent: 'submit_work',
+    params: {
+      result: {
+        uri: 'ipfs://preexisting',
+        status: 'draft',
+      },
+    },
+  };
+
+  assert.equal(needsAttachmentPin(ics), false);
+
+  assignCid(ics, CID);
+
+  assert.deepEqual(ics.params.result, {
+    status: 'draft',
+    uri: `ipfs://${CID}`,
+  });
+});


### PR DESCRIPTION
## Summary
- update Onebox pinning helpers to read `params.result.uri`, remove the legacy field, and keep existing metadata intact
- ensure submit_work payload preparation merges new CIDs into the nested result object
- add node:test coverage that exercises pinning both with and without a pre-existing result URI

## Testing
- node --test apps/onebox-static/test

------
https://chatgpt.com/codex/tasks/task_e_68d5f58af8348333b03bbdba0b401a35