### PR TITLE
Fix advanced panel default visibility

### DIFF
--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -119,7 +119,6 @@
       font-size: 0.85rem;
       padding: 0 clamp(12px, 4vw, 24px) 12px;
       color: rgba(11, 27, 63, 0.75);
-      display: flex;
       flex-direction: column;
       gap: 12px;
     }


### PR DESCRIPTION
## Summary
- remove the stray `display: flex` declaration from the base `#advanced-panel` styles so the panel stays hidden until toggled

## Testing
- python - <<'PY'
import asyncio
from playwright.async_api import async_playwright

async def main():
    async with async_playwright() as p:
        browser = await p.chromium.launch()
        page = await browser.new_page()
        await page.goto('http://127.0.0.1:8000/index.html', wait_until='networkidle')
        display_initial = await page.eval_on_selector('#advanced-panel', 'el => getComputedStyle(el).display')
        await page.click('#advanced-toggle')
        await page.wait_for_timeout(200)
        display_toggled = await page.eval_on_selector('#advanced-panel', 'el => getComputedStyle(el).display')
        print('initial display:', display_initial)
        print('toggled display:', display_toggled)
        await browser.close()

asyncio.run(main())
PY

------
https://chatgpt.com/codex/tasks/task_e_68d5f7fe1ff483338af8d5aea692b986