### PR TITLE
Normalize onebox SSE parsing for CRLF-delimited responses

### DIFF
--- a/apps/onebox-static/test/sse-parser.test.mjs
+++ b/apps/onebox-static/test/sse-parser.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { drainSSEBuffer } from '../app.mjs';
+
+function collectEvents() {
+  const events = [];
+  return {
+    events,
+    drain(buffer) {
+      return drainSSEBuffer(buffer, (chunk) => {
+        const normalized = chunk.startsWith('data:') ? chunk.slice(5).trim() : chunk;
+        if (!normalized) {
+          return;
+        }
+        events.push(JSON.parse(normalized));
+      });
+    },
+  };
+}
+
+test('drainSSEBuffer parses CRLF-delimited events', () => {
+  const { events, drain } = collectEvents();
+  let buffer = '';
+
+  buffer += 'data: {"text":"hello"}\r\n';
+  buffer = drain(buffer);
+  assert.equal(events.length, 0);
+
+  buffer += '\r\n';
+  buffer = drain(buffer);
+  assert.equal(buffer, '');
+
+  assert.deepEqual(events, [{ text: 'hello' }]);
+});
+
+test('drainSSEBuffer handles mixed line endings across multiple events', () => {
+  const { events, drain } = collectEvents();
+  let buffer = '';
+
+  buffer += 'data: {"text":"first"}\r\n\r\n';
+  buffer = drain(buffer);
+
+  buffer += 'data: {"text":"second"}\n\n';
+  buffer = drain(buffer);
+
+  assert.equal(buffer, '');
+  assert.deepEqual(events, [{ text: 'first' }, { text: 'second' }]);
+});


### PR DESCRIPTION
## Summary
- normalize the onebox SSE buffer handling to accept CRLF and reuse a shared drain helper
- guard DOM-dependent setup so the module can be imported in Node-based tests
- add a regression test that feeds CRLF-delimited SSE payloads through the new helper

## Testing
- node --test apps/onebox-static/test/*.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d5f9a712d88333a2f324d299ade9c9