### PR TITLE
Adjust advanced panel display toggle

### DIFF
--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -116,26 +116,29 @@
     }
     #advanced-panel {
       display: none;
+    }
+    body.advanced #advanced-panel {
+      display: flex;
       font-size: 0.85rem;
       padding: 0 clamp(12px, 4vw, 24px) 12px;
       color: rgba(11, 27, 63, 0.75);
       flex-direction: column;
       gap: 12px;
     }
-    #advanced-panel .card {
+    body.advanced #advanced-panel .card {
       background: rgba(255, 255, 255, 0.92);
       border: 1px solid var(--border);
       border-radius: 12px;
       padding: 12px 14px;
       box-shadow: 0 8px 24px rgba(15, 76, 221, 0.12);
     }
-    #advanced-panel .status {
+    body.advanced #advanced-panel .status {
       font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
       font-size: 0.75rem;
       word-break: break-all;
       color: rgba(11, 27, 63, 0.7);
     }
-    #advanced-panel button.inline {
+    body.advanced #advanced-panel button.inline {
       display: inline-flex;
       align-items: center;
       gap: 6px;
@@ -143,15 +146,12 @@
       font-size: 0.8rem;
       box-shadow: none;
     }
-    #advanced-panel ul {
+    body.advanced #advanced-panel ul {
       margin: 8px 0 0;
       padding-left: 18px;
     }
-    #advanced-panel li {
+    body.advanced #advanced-panel li {
       margin-bottom: 4px;
-    }
-    body.advanced #advanced-panel {
-      display: flex;
     }
     footer a {
       color: var(--accent);


### PR DESCRIPTION
## Summary
- ensure the advanced panel stays hidden until the body receives the `advanced` class by moving layout styles into the toggled selector

## Testing
- browser_container.run_playwright_script to verify default hidden state and toggle behavior on desktop and mobile viewports

------
https://chatgpt.com/codex/tasks/task_e_68d5fdb9aa7c83338cbd1bceffdcc7cf