### PR TITLE
Update confirmation summary limit to 140 characters

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -5,7 +5,7 @@ A single-textbox, gasless, walletless interface for AGI Jobs v2 that runs entire
 ## Features
 
 - **One input box** with streaming responses and an advanced details toggle for receipts and diagnostics.
-- **ICS guardrails** – planner responses are validated client-side (intent allowlist, confirmation summaries ≤160 chars, trace IDs).
+- **ICS guardrails** – planner responses are validated client-side (intent allowlist, confirmation summaries ≤140 chars, trace IDs).
 - **Gasless execution** – delegates to the orchestrator for AA-sponsored user operations or relayer fallbacks.
 - **IPFS integration** – job specs, submissions, and dispute evidence are pinned via `web3.storage` straight from the browser.
 - **ENS awareness** – dedicated event type for orchestrator hints to walk users through identity requirements.
@@ -24,7 +24,7 @@ A single-textbox, gasless, walletless interface for AGI Jobs v2 that runs entire
 1. Serve the directory with any static server, e.g. `npx serve apps/onebox-static`.
 2. Update `config.mjs` with your orchestrator endpoints (and optional AA configuration).
 3. In the UI’s **Advanced** panel set a `web3.storage` token (stored locally) if you plan to upload attachments.
-4. Type natural-language requests. When value moves, you will be prompted for a `YES/NO` confirmation capped at 160 characters.
+4. Type natural-language requests. When value moves, you will be prompted for a `YES/NO` confirmation capped at 140 characters.
 
 ## Publishing to IPFS
 
@@ -40,7 +40,7 @@ A single-textbox, gasless, walletless interface for AGI Jobs v2 that runs entire
 ## User guide (walletless UX)
 
 - **Plan** – describe the action (“Post a labeling job for 500 images, 50 AGIALPHA, 7 days”). The orchestrator returns an Intent-Constraint Schema (ICS) payload which is validated in-browser.
-- **Confirm** – if the action moves AGIALPHA or affects stake, you’ll see a ≤160 character summary. Reply `YES` to proceed or anything else to cancel.
+- **Confirm** – if the action moves AGIALPHA or affects stake, you’ll see a ≤140 character summary. Reply `YES` to proceed or anything else to cancel.
 - **Execute** – receipts stream back with plain-language updates. Enable the **Advanced** toggle to view tx hashes, block numbers, or ENS guidance supplied by the orchestrator.
 - **Attachments** – drag/drop or browse a file. The UI pins it to IPFS (requires a `web3.storage` token) and injects the resulting CID into the ICS before execution.
 

--- a/apps/onebox-static/app.mjs
+++ b/apps/onebox-static/app.mjs
@@ -56,7 +56,7 @@ function renderAdvancedPanel() {
       <h2>Runbook</h2>
       <ul>
         <li>Planner responses must comply with the Intent-Constraint Schema (ICS).</li>
-        <li>Value-moving intents require human confirmation (≤160 chars summary).</li>
+        <li>Value-moving intents require human confirmation (≤140 chars summary).</li>
         <li>Simulations, paymaster sponsorship, and relayer limits run server-side.</li>
         <li>ENS enforcement notices appear inline when required.</li>
       </ul>

--- a/apps/onebox-static/lib.mjs
+++ b/apps/onebox-static/lib.mjs
@@ -10,7 +10,7 @@ const SUPPORTED_INTENTS = [
   "admin_set",
 ];
 
-const CONFIRMATION_SUMMARY_LIMIT = 160;
+const CONFIRMATION_SUMMARY_LIMIT = 140;
 const META_VERSION = "agijobs.onebox/1.0.0";
 
 function isObject(value) {

--- a/apps/onebox-static/test/validateICS.test.mjs
+++ b/apps/onebox-static/test/validateICS.test.mjs
@@ -28,13 +28,13 @@ test('accepts legacy summary field when confirmationText missing', () => {
   assert.equal(normalized.summary, 'Legacy summary');
 });
 
-test('enforces 160 character limit when confirmation is required', () => {
+test('enforces 140 character limit when confirmation is required', () => {
   const payload = {
     ...BASE_INTENT,
     confirm: true,
-    confirmationText: 'x'.repeat(161),
+    confirmationText: 'x'.repeat(141),
   };
-  assert.throws(() => validateICS(payload), /160/);
+  assert.throws(() => validateICS(payload), /140/);
 });
 
 test('generates a fallback traceId when missing', () => {


### PR DESCRIPTION
## Summary
- lower the confirmation summary limit to 140 characters in the ICS validator and UI messaging
- refresh documentation to reflect the new confirmation summary cap
- update validation unit test expectations for the 140-character threshold

## Testing
- node --test apps/onebox-static/test/validateICS.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d5fff715b88333883625711e33c6a2