### PR TITLE
Tighten ICS confirmation summary to 140 characters

### DIFF
--- a/apps/onebox-static/lib.mjs
+++ b/apps/onebox-static/lib.mjs
@@ -64,7 +64,9 @@ export function validateICS(payload) {
       throw new Error("Planner confirmation summary missing");
     }
     if (confirmation.length > CONFIRMATION_SUMMARY_LIMIT) {
-      throw new Error(`Confirmation summary exceeds ${CONFIRMATION_SUMMARY_LIMIT} characters`);
+      throw new Error(
+        `Confirmation summary must be ${CONFIRMATION_SUMMARY_LIMIT} characters or fewer`,
+      );
     }
     normalized.summary = confirmation;
   } else if (confirmation) {

--- a/apps/onebox-static/test/validateICS.test.mjs
+++ b/apps/onebox-static/test/validateICS.test.mjs
@@ -34,7 +34,10 @@ test('enforces 140 character limit when confirmation is required', () => {
     confirm: true,
     confirmationText: 'x'.repeat(141),
   };
-  assert.throws(() => validateICS(payload), /140/);
+  assert.throws(
+    () => validateICS(payload),
+    /Confirmation summary must be 140 characters or fewer/,
+  );
 });
 
 test('generates a fallback traceId when missing', () => {

--- a/packages/onebox-orchestrator/src/ics/schema.ts
+++ b/packages/onebox-orchestrator/src/ics/schema.ts
@@ -85,7 +85,7 @@ const baseIntentSchema = z.object({
   confirmationText: z
     .string()
     .trim()
-    .max(160, 'Confirmation text should be 160 characters or fewer')
+    .max(140, 'Confirmation text should be 140 characters or fewer')
     .optional(),
 });
 


### PR DESCRIPTION
## Summary
- enforce a 140-character cap when validating confirmation summaries in the static UI
- update the guardrail test to match the stricter error messaging
- align the orchestrator schema with the new 140-character confirmation ceiling

## Testing
- node --test apps/onebox-static/test/validateICS.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d600d9c5fc8333a527ea985cb89a75