### PR TITLE
Add static one-box Web3 interface

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -1,83 +1,25 @@
-# AGI Jobs One-Box (Static UI)
+# AGI Jobs One-Box (Static)
 
-A single-textbox, gasless, walletless interface for AGI Jobs v2 that runs entirely from static hosting (e.g. IPFS). The page talks to the AGI-Alpha Orchestrator for natural-language planning and streams execution receipts through either an Account Abstraction (ERC-4337) path or a Defender relayer fallback.
-
-## Features
-
-- **One input box** with streaming responses and an advanced details toggle for receipts and diagnostics.
-- **ICS guardrails** – planner responses are validated client-side (intent allowlist, confirmation summaries ≤140 chars, trace IDs).
-- **Gasless execution** – delegates to the orchestrator for AA-sponsored user operations or relayer fallbacks.
-- **IPFS integration** – job specs, submissions, and dispute evidence are pinned via `web3.storage` straight from the browser.
-- **ENS awareness** – dedicated event type for orchestrator hints to walk users through identity requirements.
+This directory hosts a standalone, standards-based HTML/JS bundle that can be pinned to IPFS and served from any public gateway.
 
 ## Files
 
-| File | Purpose |
-| --- | --- |
-| `index.html` | Minimal shell (HTML/CSS) for the chat surface, advanced panel, and accessibility hooks. |
-| `app.mjs` | Main ES module orchestrating user interactions, planner calls, confirmations, IPFS uploads, and execution streaming. |
-| `config.mjs` | Environment-specific endpoints and AA toggle. |
-| `lib.mjs` | Shared helpers: ICS validation, event formatting, AA summary helpers, IPFS utilities. |
+- `index.html` – single-page chat surface optimised for mobile and desktop.
+- `app.js` – client logic for planner/executor orchestration, confirmations, receipts, and local IPFS pinning.
+- `config.js` – endpoints and AA configuration that operators customise per deployment.
+- `lib.js` – lightweight helpers for ICS validation, token math, and IPFS pinning.
 
-## Quick start (local)
+## Local preview
 
-1. Serve the directory with any static server, e.g. `npx serve apps/onebox-static`.
-2. Update `config.mjs` with your orchestrator endpoints (and optional AA configuration).
-3. In the UI’s **Advanced** panel set a `web3.storage` token (stored locally) if you plan to upload attachments.
-4. Type natural-language requests. When value moves, you will be prompted for a `YES/NO` confirmation capped at 140 characters.
+Open `index.html` in any modern browser or run a simple static file server, e.g.:
 
-## Publishing to IPFS
+```bash
+npx serve .
+```
 
-1. Ensure `config.mjs` points at publicly reachable orchestrator endpoints with CORS enabled for the gateway you plan to use.
-2. From the project root run:
-   ```bash
-   npx web3.storage upload apps/onebox-static
-   ```
-   or upload the folder manually via the [web3.storage dashboard](https://web3.storage/).
-3. Pin the returned CID and share `https://w3s.link/ipfs/<CID>/index.html` (or configure DNSLink for a custom domain).
-4. Optional: pre-populate `config.mjs` with production endpoints, then pin the folder for an immutable deployment.
+## Deploying to IPFS
 
-## User guide (walletless UX)
-
-- **Plan** – describe the action (“Post a labeling job for 500 images, 50 AGIALPHA, 7 days”). The orchestrator returns an Intent-Constraint Schema (ICS) payload which is validated in-browser.
-- **Confirm** – if the action moves AGIALPHA or affects stake, you’ll see a ≤140 character summary. Reply `YES` to proceed or anything else to cancel.
-- **Execute** – receipts stream back with plain-language updates. Enable the **Advanced** toggle to view tx hashes, block numbers, or ENS guidance supplied by the orchestrator.
-- **Attachments** – drag/drop or browse a file. The UI pins it to IPFS (requires a `web3.storage` token) and injects the resulting CID into the ICS before execution.
-
-## Operator runbook
-
-1. **Meta-agent (planner)** – run the AGI-Alpha orchestrator and expose `/plan` + `/execute`. Ensure responses include `meta.traceId` and confirmations for value-moving intents.
-2. **Account Abstraction (primary path)**
-   - Configure a bundler & paymaster (e.g. Alchemy Account Kit) with spend limits per origin.
-   - Set `AA_MODE = { enabled: true, bundler: "alchemy", chainId: <chain> }` in `config.mjs`.
-   - Simulator/guardrails live server-side: every user operation must be simulated before broadcast.
-3. **Relayer fallback**
-   - Provision an OpenZeppelin Defender Relayer (or equivalent) with function allowlists and daily spend caps.
-   - In `/execute`, switch to relayer mode when AA sponsorship is unavailable, while keeping receipts consistent.
-4. **ENS enforcement**
-   - When the Identity Registry requires `*.agent.agi.eth` or `*.club.agi.eth`, emit `type:"ens_requirement"` events with human guidance. The UI surfaces these as 🔐 notices.
-5. **Monitoring**
-   - Use the `meta.traceId` echoed back from the UI to correlate planner decisions, simulations, and final receipts.
-
-## Security notes
-
-- The static bundle contains **no private keys**. Paymaster / relayer credentials must live in the orchestrator environment.
-- ICS validation prevents unsupported intents from reaching the executor. Owner-only commands should be gated server-side as well.
-- The `web3.storage` token is stored in `localStorage` under `AGIJOBS_W3S_TOKEN`; clearing the token from the Advanced panel prevents further uploads.
-- Always pin specs and evidence before execution to avoid missing metadata.
-
-## Safe governance handover (optional)
-
-If operators delegate control to a Safe (multisig), ensure:
-
-- Owner-only intents in the planner map to Safe module calls with explicit confirmations.
-- The orchestrator simulates both the Safe transaction and underlying module calls before prompting the user.
-- Receipts include Safe tx hashes in the advanced panel so signers can reconcile approvals.
-
-## Troubleshooting
-
-- **Planner unavailable** – the UI shows `Planner unavailable (<status>)`; verify orchestrator URL/CORS and retry.
-- **Missing IPFS token** – set the `web3.storage` token from the Advanced panel; uploads resume automatically.
-- **ENS blocked** – follow the 🔐 instructions (claim the required subdomain or associate an address) before re-sending the intent.
-- **Slow receipts** – check bundler/relayer health; the SSE stream stays open until the orchestrator completes execution.
-
+1. Generate a Web3.Storage API token and store it in the browser via the Advanced panel (the token is persisted in `localStorage.W3S_TOKEN`).
+2. Update `config.js` with your orchestrator and executor endpoints.
+3. Upload the contents of this folder to IPFS (e.g. using `web3.storage` CLI or dashboard).
+4. Share the resulting gateway URL, such as `https://w3s.link/ipfs/<CID>/index.html`.

--- a/apps/onebox-static/app.js
+++ b/apps/onebox-static/app.js
@@ -1,0 +1,311 @@
+import { PLAN_URL, EXEC_URL, IPFS_GATEWAY, AA_MODE } from "./config.js";
+import { validateICS, pinJSON, pinFile } from "./lib.js";
+
+const feed = document.getElementById("feed");
+const advLog = document.getElementById("adv-log");
+const promptForm = document.getElementById("prompt-form");
+const promptInput = document.getElementById("prompt-input");
+const promptSubmit = document.getElementById("prompt-submit");
+const toggleAdvanced = document.getElementById("toggle-advanced");
+const w3sForm = document.getElementById("w3s-form");
+const w3sTokenInput = document.getElementById("w3s-token");
+const w3sStatus = document.getElementById("w3s-status");
+const attachButton = document.getElementById("attach-button");
+const fileInput = document.getElementById("prompt-file");
+const attachmentName = document.getElementById("attachment-name");
+
+const history = [];
+let pendingAttachment = null;
+
+function deepClone(value) {
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function addMessage(role, text) {
+  const node = document.createElement("div");
+  node.className = `msg${role === "user" ? " me" : ""}`;
+  node.textContent = text;
+  node.setAttribute("data-role", role);
+  feed.appendChild(node);
+  feed.scrollTop = feed.scrollHeight;
+}
+
+function setAdvanced(text) {
+  if (!text) {
+    advLog.textContent = "";
+    return;
+  }
+  advLog.textContent = advLog.textContent
+    ? `${advLog.textContent}\n${text}`
+    : text;
+}
+
+toggleAdvanced.addEventListener("click", (event) => {
+  event.preventDefault();
+  document.body.classList.toggle("adv-show");
+});
+
+async function callPlanner(message) {
+  const response = await fetch(PLAN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message, history }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Planner unavailable (try again in a few moments)");
+  }
+
+  const payload = await response.json();
+  return validateICS(payload);
+}
+
+async function runExecution(ics, attachments) {
+  const enriched = await maybePinPayload(ics, attachments);
+  setAdvanced("");
+  if (enriched.meta?.clientPinned) {
+    const pinned = enriched.meta.clientPinned;
+    const sizeKb = pinned.size ? `${Math.round(pinned.size / 1024)} KB` : "unknown size";
+    setAdvanced(`📦 Pinned ${pinned.name ?? "attachment"} → ${pinned.cid} (${sizeKb})`);
+  }
+
+  const response = await fetch(EXEC_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ics: enriched, aa: AA_MODE }),
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error("Executor unavailable (no response body)");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+
+    const segments = buffer.split("\n\n");
+    while (segments.length > 1) {
+      const raw = segments.shift();
+      if (!raw) continue;
+      try {
+        const evt = JSON.parse(raw);
+        dispatchEvent(evt);
+      } catch (err) {
+        console.warn("Malformed execution event", err, raw);
+      }
+    }
+    buffer = segments[0] ?? "";
+  }
+}
+
+async function maybePinPayload(ics, attachments) {
+  const copy = deepClone(ics);
+  const intent = copy.intent;
+  let pinnedFile;
+
+  async function ensureFileCid() {
+    if (!attachments?.length) return undefined;
+    if (!pinnedFile) {
+      const file = attachments[0];
+      const { cid } = await pinFile(file);
+      pinnedFile = {
+        cid,
+        uri: `ipfs://${cid}`,
+        gateway: `${IPFS_GATEWAY}${cid}`,
+        name: file.name,
+        size: file.size,
+      };
+    }
+    return pinnedFile;
+  }
+
+  if (intent === "create_job" && copy.params?.job) {
+    const job = copy.params.job;
+    if (!job.uri) {
+      const payload = {
+        title: job.title ?? "Untitled job",
+        description: job.description ?? "",
+        deadlineDays: job.deadlineDays ?? null,
+        rewardAGIA: job.rewardAGIA ?? null,
+        attachments: [],
+      };
+
+      const file = await ensureFileCid();
+      if (file) {
+        payload.attachments.push(file.uri);
+      }
+
+      const { cid } = await pinJSON(payload);
+      job.uri = `ipfs://${cid}`;
+      job.gatewayUri = `${IPFS_GATEWAY}${cid}`;
+      if (file) {
+        job.attachments = payload.attachments;
+      }
+    }
+  }
+
+  if (intent === "submit_work") {
+    const file = await ensureFileCid();
+    if (file) {
+      if (!copy.params.uri && !copy.params.resultUri) {
+        copy.params.uri = file.uri;
+      }
+      copy.params.gatewayUri = copy.params.gatewayUri ?? file.gateway;
+      copy.params.attachments = copy.params.attachments ?? [file.uri];
+    }
+  }
+
+  if (intent === "dispute") {
+    const file = await ensureFileCid();
+    if (file) {
+      copy.params.evidenceUri = copy.params.evidenceUri ?? file.uri;
+      copy.params.attachments = copy.params.attachments ?? [file.uri];
+    }
+  }
+
+  if (pinnedFile) {
+    copy.meta = {
+      ...(copy.meta ?? {}),
+      clientPinned: {
+        cid: pinnedFile.cid,
+        uri: pinnedFile.uri,
+        gateway: pinnedFile.gateway,
+        name: pinnedFile.name,
+        size: pinnedFile.size,
+      },
+    };
+  }
+
+  return copy;
+}
+
+function dispatchEvent(evt) {
+  if (!evt || typeof evt !== "object") return;
+
+  switch (evt.type) {
+    case "confirm":
+      addMessage("assistant", evt.text);
+      setAdvanced(evt.advanced ?? "");
+      break;
+    case "status":
+      addMessage("assistant", evt.text);
+      break;
+    case "receipt":
+      addMessage("assistant", evt.text);
+      setAdvanced(evt.advanced ?? "");
+      break;
+    case "error":
+      addMessage("assistant", `❌ ${evt.text}`);
+      setAdvanced(evt.advanced ?? "");
+      break;
+    default:
+      console.debug("Unknown event", evt);
+  }
+}
+
+function waitForConfirmation() {
+  return new Promise((resolve) => {
+    addMessage("assistant", "Type YES to confirm or NO to cancel.");
+
+    function handler(event) {
+      event.preventDefault();
+      const value = promptInput.value.trim();
+      if (!value) return;
+
+      addMessage("user", value);
+      promptInput.value = "";
+      promptForm.removeEventListener("submit", handler);
+      resolve(value);
+    }
+
+    promptForm.addEventListener("submit", handler);
+  });
+}
+
+promptForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const value = promptInput.value.trim();
+  if (!value) return;
+
+  promptInput.value = "";
+  addMessage("user", value);
+  promptSubmit.disabled = true;
+
+  try {
+    const ics = await callPlanner(value);
+
+    if (ics.confirm) {
+      addMessage("assistant", ics.summary || "Please confirm to continue.");
+      const confirmation = await waitForConfirmation();
+      if (!/^y(?:es)?$/i.test(confirmation)) {
+        addMessage("assistant", "Cancelled.");
+        return;
+      }
+    }
+
+    const attachments = pendingAttachment ? [pendingAttachment] : [];
+    await runExecution(ics, attachments);
+    history.push({ role: "user", content: value });
+    history.push({ role: "assistant", content: JSON.stringify(ics) });
+  } catch (err) {
+    console.error(err);
+    addMessage("assistant", `❌ ${err.message ?? "Unexpected error"}`);
+  } finally {
+    promptSubmit.disabled = false;
+    promptInput.focus();
+    if (pendingAttachment) {
+      attachmentName.textContent = "";
+      pendingAttachment = null;
+      fileInput.value = "";
+    }
+  }
+});
+
+addMessage(
+  "assistant",
+  "Welcome to AGI Jobs One-Box. Describe what you want to do and I will handle the chain-side steps for you."
+);
+
+// Advanced token persistence
+const storedToken = localStorage.getItem("W3S_TOKEN");
+if (storedToken) {
+  w3sTokenInput.value = storedToken;
+  w3sStatus.textContent = "Token loaded from previous session.";
+}
+
+w3sForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const token = w3sTokenInput.value.trim();
+  if (!token) {
+    localStorage.removeItem("W3S_TOKEN");
+    w3sStatus.textContent = "Token cleared.";
+    return;
+  }
+  localStorage.setItem("W3S_TOKEN", token);
+  w3sStatus.textContent = "Token saved in this browser.";
+});
+
+attachButton.addEventListener("click", (event) => {
+  event.preventDefault();
+  fileInput.click();
+});
+
+fileInput.addEventListener("change", () => {
+  const file = fileInput.files?.[0];
+  if (file) {
+    pendingAttachment = file;
+    attachmentName.textContent = `Attached: ${file.name} (${Math.round(file.size / 1024)} KB)`;
+  } else {
+    attachmentName.textContent = "";
+    pendingAttachment = null;
+  }
+});

--- a/apps/onebox-static/config.js
+++ b/apps/onebox-static/config.js
@@ -1,0 +1,4 @@
+export const PLAN_URL = "https://alpha-orchestrator.example.com/plan";
+export const EXEC_URL = "https://alpha-orchestrator.example.com/execute";
+export const IPFS_GATEWAY = "https://w3s.link/ipfs/";
+export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };

--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -7,201 +7,229 @@
   <style>
     :root {
       color-scheme: light dark;
-      --bg: #f5f7fb;
-      --fg: #0b1b3f;
-      --accent: #0f4cdd;
-      --accent-fg: #ffffff;
-      --border: rgba(15, 76, 221, 0.12);
     }
-    * { box-sizing: border-box; }
     body {
       margin: 0;
+      font: 16px/1.5 "Inter", "Segoe UI", system-ui, sans-serif;
+      background: #f5f7fb;
+      color: #141c2f;
       min-height: 100vh;
-      font: 16px/1.5 "Inter", system-ui, -apple-system, Segoe UI, sans-serif;
-      background: var(--bg);
-      color: var(--fg);
       display: flex;
       flex-direction: column;
     }
-    header, footer {
-      padding: 12px 18px;
-      border-bottom: 1px solid var(--border);
-      background: rgba(255, 255, 255, 0.82);
-      backdrop-filter: blur(12px);
-      position: sticky;
-      top: 0;
-      z-index: 2;
+    header,
+    footer {
+      padding: 12px 16px;
+      background: rgba(255, 255, 255, 0.85);
+      backdrop-filter: blur(6px);
+      border-bottom: 1px solid rgba(20, 28, 47, 0.08);
     }
     footer {
-      border-top: 1px solid var(--border);
+      border-top: 1px solid rgba(20, 28, 47, 0.08);
       border-bottom: none;
-      bottom: 0;
-      top: auto;
     }
-    header h1 {
-      margin: 0;
-      font-size: 1.05rem;
+    header b {
       font-weight: 600;
-    }
-    header p {
-      margin: 4px 0 0;
-      font-size: 0.9rem;
-      color: rgba(11, 27, 63, 0.7);
     }
     #feed {
       flex: 1;
       overflow-y: auto;
-      padding: 12px clamp(12px, 4vw, 24px);
+      padding: 16px;
       display: flex;
       flex-direction: column;
-      gap: 10px;
+      gap: 12px;
     }
     .msg {
-      max-width: min(76ch, 92%);
+      max-width: 72ch;
       padding: 12px 14px;
-      border-radius: 14px;
-      background: #ffffff;
-      border: 1px solid var(--border);
-      box-shadow: 0 4px 16px rgba(15, 76, 221, 0.08);
-      transition: transform 120ms ease;
-      white-space: pre-wrap;
+      border-radius: 16px;
+      box-shadow: 0 4px 12px rgba(20, 28, 47, 0.08);
+      background: #fff;
+      align-self: flex-start;
       word-break: break-word;
     }
     .msg.me {
       margin-left: auto;
-      background: var(--accent);
-      color: var(--accent-fg);
-      border-color: transparent;
+      background: linear-gradient(120deg, #1052d6, #4b8aff);
+      color: #fff;
+      box-shadow: 0 6px 16px rgba(16, 82, 214, 0.25);
     }
     form {
       display: flex;
-      gap: 8px;
-      padding: 12px clamp(12px, 4vw, 24px) 16px;
-      border-top: 1px solid var(--border);
+      gap: 10px;
+      padding: 12px 16px 20px;
       background: rgba(255, 255, 255, 0.9);
-      backdrop-filter: blur(12px);
+      border-top: 1px solid rgba(20, 28, 47, 0.08);
     }
-    input[type="text"], input[type="file"] {
+    #attachment-name {
+      font-size: 13px;
+      color: rgba(20, 28, 47, 0.7);
+      padding: 0 16px 8px;
+      min-height: 1.4em;
+    }
+    input[type="text"] {
       flex: 1;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 12px 14px;
-      font-size: 1rem;
-      background: #fff;
-      color: inherit;
+      padding: 14px 16px;
+      border-radius: 14px;
+      border: 1px solid rgba(20, 28, 47, 0.12);
+      font-size: 16px;
+      background: rgba(255, 255, 255, 0.9);
+      transition: border 0.2s ease;
     }
-    input[type="file"] {
-      flex: unset;
-      max-width: 200px;
+    input[type="text"]:focus {
+      outline: none;
+      border-color: #1052d6;
+      box-shadow: 0 0 0 3px rgba(16, 82, 214, 0.15);
     }
     button {
-      padding: 12px 18px;
-      border-radius: 12px;
+      padding: 14px 20px;
+      border-radius: 14px;
       border: none;
-      background: var(--accent);
-      color: var(--accent-fg);
+      background: #1052d6;
+      color: #fff;
       font-weight: 600;
       cursor: pointer;
-      transition: transform 120ms ease, box-shadow 120ms ease;
-      box-shadow: 0 8px 20px rgba(15, 76, 221, 0.22);
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+    #attach-button {
+      width: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 18px;
+      background: rgba(16, 82, 214, 0.12);
+      color: #1052d6;
+      box-shadow: none;
+    }
+    #attach-button:hover:not(:disabled) {
+      transform: none;
+      box-shadow: none;
+      background: rgba(16, 82, 214, 0.2);
     }
     button:disabled {
-      opacity: 0.6;
-      cursor: wait;
-      box-shadow: none;
+      cursor: progress;
+      opacity: 0.7;
     }
-    button:focus-visible {
-      outline: 2px solid var(--accent);
-      outline-offset: 2px;
+    button:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 16px rgba(16, 82, 214, 0.25);
     }
-    #advanced-panel {
+    #adv {
+      font-size: 13px;
+      color: rgba(20, 28, 47, 0.75);
+      padding: 0 16px 12px;
       display: none;
+      white-space: pre-line;
     }
-    body.advanced #advanced-panel {
-      display: flex;
-      font-size: 0.85rem;
-      padding: 0 clamp(12px, 4vw, 24px) 12px;
-      color: rgba(11, 27, 63, 0.75);
-      flex-direction: column;
-      gap: 12px;
+    .adv-show #adv {
+      display: block;
     }
-    body.advanced #advanced-panel .card {
-      background: rgba(255, 255, 255, 0.92);
-      border: 1px solid var(--border);
+    #adv h2 {
+      margin: 0 0 8px;
+      font-size: 14px;
+      font-weight: 600;
+      color: #0b2b5a;
+    }
+    #adv pre {
+      background: rgba(16, 82, 214, 0.08);
       border-radius: 12px;
-      padding: 12px 14px;
-      box-shadow: 0 8px 24px rgba(15, 76, 221, 0.12);
+      padding: 12px;
+      font-family: "SFMono-Regular", ui-monospace, Menlo, Monaco, Consolas, monospace;
+      max-height: 200px;
+      overflow: auto;
+      white-space: pre-wrap;
     }
-    body.advanced #advanced-panel .status {
-      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-      font-size: 0.75rem;
-      word-break: break-all;
-      color: rgba(11, 27, 63, 0.7);
+    .adv-grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
-    body.advanced #advanced-panel button.inline {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 8px 12px;
-      font-size: 0.8rem;
-      box-shadow: none;
+    #w3s-form {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
     }
-    body.advanced #advanced-panel ul {
-      margin: 8px 0 0;
-      padding-left: 18px;
+    #w3s-form input {
+      padding: 10px 12px;
+      border-radius: 10px;
+      border: 1px solid rgba(20, 28, 47, 0.2);
+      font-size: 14px;
     }
-    body.advanced #advanced-panel li {
-      margin-bottom: 4px;
+    #w3s-form button {
+      align-self: flex-start;
+      padding: 10px 16px;
+      font-size: 14px;
+    }
+    #w3s-status {
+      margin: 0;
+      min-height: 1.4em;
     }
     footer a {
-      color: var(--accent);
+      color: #1052d6;
       text-decoration: none;
-      font-weight: 600;
+      font-weight: 500;
       cursor: pointer;
     }
-    .chip {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 4px 8px;
-      border-radius: 999px;
-      background: rgba(15, 76, 221, 0.08);
-      font-size: 0.75rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
-    @media (max-width: 600px) {
-      header, footer {
-        padding: 10px 14px;
-      }
+    @media (max-width: 640px) {
+      header,
+      footer,
       form {
-        flex-direction: column;
-        padding: 10px 14px 14px;
+        padding-left: 12px;
+        padding-right: 12px;
       }
-      input[type="file"] {
-        max-width: 100%;
+      input[type="text"] {
+        font-size: 15px;
       }
       button {
-        width: 100%;
+        padding: 12px 18px;
       }
     }
   </style>
 </head>
 <body>
   <header>
-    <h1>AGI Jobs — One-Box <span class="chip">Gasless</span></h1>
-    <p aria-live="polite">Natural language planning with Meta-Agentic orchestration.</p>
+    <b>AGI Jobs</b> — One-Box (gasless, walletless)
   </header>
-  <main id="feed" role="log" aria-live="polite"></main>
-  <form id="composer" aria-label="Chat input">
-    <input id="question" type="text" placeholder="Post a job for 500 images rewarded 50 AGIALPHA" aria-label="Enter your request" required />
-    <input id="attachment" type="file" aria-label="Attach supporting file" />
-    <button id="send" type="submit">Send</button>
+  <div id="feed" role="log" aria-live="polite"></div>
+  <form id="prompt-form">
+    <input id="prompt-file" type="file" hidden />
+    <label class="sr-only" for="prompt-input">Request</label>
+    <button id="attach-button" type="button" aria-label="Attach a file">📎</button>
+    <input id="prompt-input" type="text" placeholder='e.g., "Post a job: 500 images, 50 AGIALPHA, 7 days"' aria-label="Type your request" autocomplete="off" />
+    <button id="prompt-submit" type="submit">Send</button>
   </form>
-  <section id="advanced-panel" aria-live="polite"></section>
+  <div id="attachment-name" aria-live="polite"></div>
+  <div id="adv" aria-live="polite">
+    <div class="adv-grid">
+      <section>
+        <h2>Execution details</h2>
+        <pre id="adv-log" aria-live="polite"></pre>
+      </section>
+      <section>
+        <h2>web3.storage token</h2>
+        <form id="w3s-form">
+          <label class="sr-only" for="w3s-token">web3.storage API token</label>
+          <input id="w3s-token" type="text" placeholder="Paste token" autocomplete="off" />
+          <button type="submit">Save token</button>
+          <p id="w3s-status" role="status"></p>
+        </form>
+      </section>
+    </div>
+  </div>
   <footer>
-    <a id="advanced-toggle" href="#">Toggle advanced details</a>
+    <a href="#" id="toggle-advanced">Advanced</a>
   </footer>
-  <script type="module" src="./app.mjs"></script>
+  <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/apps/onebox-static/lib.js
+++ b/apps/onebox-static/lib.js
@@ -1,0 +1,78 @@
+const INTENTS = [
+  "create_job",
+  "apply_job",
+  "submit_work",
+  "validate",
+  "finalize",
+  "dispute",
+  "stake",
+  "withdraw",
+  "admin_set",
+];
+
+export function validateICS(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Planner returned invalid payload");
+  }
+
+  if (!INTENTS.includes(value.intent)) {
+    throw new Error(`Unsupported intent: ${String(value.intent)}`);
+  }
+
+  if (value.confirm && value.summary && value.summary.length > 140) {
+    throw new Error("Confirmation summary is too long");
+  }
+
+  value.params = value.params ?? {};
+  return value;
+}
+
+const DECIMALS = 18n;
+const TEN = 10n;
+
+export function toWei(amount) {
+  const [wholeRaw, fracRaw = ""] = String(amount).split(".");
+  const whole = BigInt(wholeRaw || "0");
+  const frac = fracRaw.padEnd(18, "0").slice(0, 18);
+  return whole * TEN ** DECIMALS + BigInt(frac || "0");
+}
+
+export function fmtAGIA(wei) {
+  const asString = BigInt(wei).toString().padStart(19, "0");
+  const head = asString.slice(0, -18) || "0";
+  const tail = asString.slice(-18).replace(/0+$/, "");
+  return tail ? `${head}.${tail}` : head;
+}
+
+async function postToW3S(body, contentType) {
+  const token = localStorage.getItem("W3S_TOKEN");
+  if (!token) {
+    throw new Error("Missing web3.storage token. Add it in Advanced settings.");
+  }
+
+  const response = await fetch("https://api.web3.storage/upload", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(contentType ? { "Content-Type": contentType } : {}),
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`IPFS pin failed: ${text}`);
+  }
+
+  const { cid } = await response.json();
+  return { cid };
+}
+
+export async function pinJSON(data) {
+  return postToW3S(JSON.stringify(data), "application/json");
+}
+
+export async function pinFile(file) {
+  const bytes = await file.arrayBuffer();
+  return postToW3S(new Blob([bytes]));
+}


### PR DESCRIPTION
## Summary
- add an IPFS-ready one-box chat surface with attachment support and advanced execution telemetry
- wire client logic for planner/executor calls, IPFS pinning, and gasless meta-data handling
- document configuration, deployment, and token management for the static bundle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6027416cc833390ef34d92c87d581