### PR TITLE
Normalize onebox SSE parsing across app variants

### DIFF
--- a/apps/onebox-static/sse-parser.mjs
+++ b/apps/onebox-static/sse-parser.mjs
@@ -1,0 +1,19 @@
+export function sanitizeSSEChunk(chunk) {
+  if (!chunk) return "";
+  const withoutPrefix = chunk.startsWith("data:") ? chunk.slice(5) : chunk;
+  return withoutPrefix.trim();
+}
+
+export function drainSSEBuffer(buffer, onChunk) {
+  let normalized = buffer.replace(/\r\n/g, "\n");
+  let boundary = normalized.indexOf("\n\n");
+  while (boundary !== -1) {
+    const chunk = normalized.slice(0, boundary).trim();
+    if (chunk) {
+      onChunk(chunk);
+    }
+    normalized = normalized.slice(boundary + 2);
+    boundary = normalized.indexOf("\n\n");
+  }
+  return normalized;
+}


### PR DESCRIPTION
## Summary
- extract shared SSE parser utilities for the onebox static app
- update both browser entrypoints to normalize CRLF line endings and strip `data:` prefixes before JSON parsing
- extend the SSE parser tests to cover sanitization of streamed chunks

## Testing
- node --test apps/onebox-static/test/sse-parser.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d60688f4a4833395d85d99091346b7