### PR TITLE
Fix static confirmation summary validation

### DIFF
--- a/apps/onebox-static/lib.js
+++ b/apps/onebox-static/lib.js
@@ -10,6 +10,8 @@ const INTENTS = [
   "admin_set",
 ];
 
+const CONFIRMATION_SUMMARY_LIMIT = 140;
+
 export function validateICS(value) {
   if (!value || typeof value !== "object") {
     throw new Error("Planner returned invalid payload");
@@ -19,8 +21,25 @@ export function validateICS(value) {
     throw new Error(`Unsupported intent: ${String(value.intent)}`);
   }
 
-  if (value.confirm && value.summary && value.summary.length > 140) {
-    throw new Error("Confirmation summary is too long");
+  const confirmationText =
+    typeof value.confirmationText === "string"
+      ? value.confirmationText.trim()
+      : "";
+  const fallbackSummary =
+    typeof value.summary === "string" ? value.summary.trim() : "";
+  const summary = confirmationText || fallbackSummary;
+
+  if (value.confirm) {
+    if (!summary) {
+      throw new Error("Planner confirmation summary missing");
+    }
+    if (summary.length > CONFIRMATION_SUMMARY_LIMIT) {
+      throw new Error("Confirmation summary is too long");
+    }
+  }
+
+  if (summary) {
+    value.summary = summary;
   }
 
   value.params = value.params ?? {};

--- a/apps/onebox-static/test/validateICS-static.test.mjs
+++ b/apps/onebox-static/test/validateICS-static.test.mjs
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+async function loadStaticLib() {
+  const url = new URL('../lib.js', import.meta.url);
+  const source = await readFile(url, 'utf8');
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(source, 'utf8').toString('base64')}`;
+  return import(dataUrl);
+}
+
+const { validateICS } = await loadStaticLib();
+
+const BASE_INTENT = {
+  intent: 'submit_work',
+  params: {},
+};
+
+function renderConfirmPrompt(payload) {
+  const normalized = validateICS(payload);
+  const messages = [];
+  if (normalized.confirm) {
+    const summary = normalized.summary || 'Please confirm to continue.';
+    messages.push(summary);
+    messages.push('Type YES to confirm or NO to cancel.');
+  }
+  return messages;
+}
+
+test('trims confirmationText and stores it as summary', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    confirmationText: '   Send 5 AGIALPHA   ',
+  };
+
+  const normalized = validateICS(payload);
+
+  assert.equal(normalized.summary, 'Send 5 AGIALPHA');
+  assert.equal(payload.summary, 'Send 5 AGIALPHA');
+});
+
+test('rejects confirm payloads missing a usable summary', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    confirmationText: '   ',
+  };
+
+  assert.throws(() => validateICS(payload), /Planner confirmation summary missing/);
+});
+
+test('rejects confirm payloads with summaries longer than 140 characters', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    confirmationText: 'x'.repeat(141),
+  };
+
+  assert.throws(() => validateICS(payload), /Confirmation summary is too long/);
+});
+
+test('uses summary fallback when confirmationText missing', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    summary: 'Legacy summary',
+  };
+
+  const normalized = validateICS(payload);
+
+  assert.equal(normalized.summary, 'Legacy summary');
+});
+
+test('confirmation prompt shows trimmed summary before instructions', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    confirmationText: 'Pay validator',
+  };
+
+  const messages = renderConfirmPrompt(payload);
+
+  assert.deepEqual(messages, [
+    'Pay validator',
+    'Type YES to confirm or NO to cancel.',
+  ]);
+});


### PR DESCRIPTION
## Summary
- trim and reuse confirmation text for static ICS payloads, enforcing the 140 character limit when confirmation is required
- add static bundle tests to ensure confirmation prompts surface the trimmed summary

## Testing
- node --test apps/onebox-static/test/validateICS-static.test.mjs
- node --test apps/onebox-static/test/validateICS.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d6095eca148333952cd63ea9356a2c