### PR TITLE
Align onebox static bundle with modern helpers

### DIFF
--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -114,23 +114,23 @@
       transform: translateY(-1px);
       box-shadow: 0 8px 16px rgba(16, 82, 214, 0.25);
     }
-    #adv {
+    #advanced-panel {
       font-size: 13px;
       color: rgba(20, 28, 47, 0.75);
       padding: 0 16px 12px;
       display: none;
       white-space: pre-line;
     }
-    .adv-show #adv {
+    body.advanced #advanced-panel {
       display: block;
     }
-    #adv h2 {
+    #advanced-panel h2 {
       margin: 0 0 8px;
       font-size: 14px;
       font-weight: 600;
       color: #0b2b5a;
     }
-    #adv pre {
+    #advanced-panel pre {
       background: rgba(16, 82, 214, 0.08);
       border-radius: 12px;
       padding: 12px;
@@ -202,15 +202,21 @@
     <b>AGI Jobs</b> — One-Box (gasless, walletless)
   </header>
   <div id="feed" role="log" aria-live="polite"></div>
-  <form id="prompt-form">
-    <input id="prompt-file" type="file" hidden />
-    <label class="sr-only" for="prompt-input">Request</label>
+  <form id="composer">
+    <input id="attachment" type="file" hidden />
+    <label class="sr-only" for="question">Request</label>
     <button id="attach-button" type="button" aria-label="Attach a file">📎</button>
-    <input id="prompt-input" type="text" placeholder='e.g., "Post a job: 500 images, 50 AGIALPHA, 7 days"' aria-label="Type your request" autocomplete="off" />
-    <button id="prompt-submit" type="submit">Send</button>
+    <input
+      id="question"
+      type="text"
+      placeholder='e.g., "Post a job: 500 images, 50 AGIALPHA, 7 days"'
+      aria-label="Type your request"
+      autocomplete="off"
+    />
+    <button id="send" type="submit">Send</button>
   </form>
   <div id="attachment-name" aria-live="polite"></div>
-  <div id="adv" aria-live="polite">
+  <div id="advanced-panel" aria-live="polite">
     <div class="adv-grid">
       <section>
         <h2>Execution details</h2>
@@ -228,7 +234,7 @@
     </div>
   </div>
   <footer>
-    <a href="#" id="toggle-advanced">Advanced</a>
+    <a href="#" id="advanced-toggle">Advanced</a>
   </footer>
   <script type="module" src="./app.mjs"></script>
 </body>

--- a/apps/onebox-static/test/validateICS-static.test.mjs
+++ b/apps/onebox-static/test/validateICS-static.test.mjs
@@ -37,7 +37,6 @@ test('trims confirmationText and stores it as summary', () => {
   const normalized = validateICS(payload);
 
   assert.equal(normalized.summary, 'Send 5 AGIALPHA');
-  assert.equal(payload.summary, 'Send 5 AGIALPHA');
 });
 
 test('rejects confirm payloads missing a usable summary', () => {
@@ -57,7 +56,24 @@ test('rejects confirm payloads with summaries longer than 140 characters', () =>
     confirmationText: 'x'.repeat(141),
   };
 
-  assert.throws(() => validateICS(payload), /Confirmation summary is too long/);
+  assert.throws(
+    () => validateICS(payload),
+    /Confirmation summary must be 140 characters or fewer/,
+  );
+});
+
+test('generates a fallback traceId when none provided', () => {
+  const payload = {
+    ...BASE_INTENT,
+    confirm: true,
+    summary: 'Needs trace',
+  };
+
+  const normalized = validateICS(payload);
+
+  assert.ok(normalized.meta?.traceId);
+  assert.equal(typeof normalized.meta.traceId, 'string');
+  assert.ok(normalized.meta.traceId.trim().length > 0);
 });
 
 test('uses summary fallback when confirmationText missing', () => {


### PR DESCRIPTION
## Summary
- update the static HTML shell to use the maintained module entry and DOM identifiers expected by app.mjs
- port the modern validateICS logic (confirmation normalization and trace IDs) into the legacy lib.js helper
- refresh the static test expectations to cover the new guardrails

## Testing
- node --test apps/onebox-static/test/*.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d60b918a5083338ec8e55d6e99a2db