### PR TITLE
feat: add IPFS-ready one-box UI

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -1,25 +1,23 @@
 # AGI Jobs One-Box (Static)
 
-This directory hosts a standalone, standards-based HTML/JS bundle that can be pinned to IPFS and served from any public gateway.
+This folder hosts an unbundled, standards-based web application that can be pinned to IPFS and loaded directly from any compatible gateway. The UI exposes a single-input chat box that relays natural-language requests to the AGI-Alpha orchestrator, validates the returned Intent-Constraint Schema (ICS), and executes supported intents through the sponsored Account Abstraction or relayer bridge.
 
-## Files
+## Development quick start
 
-- `index.html` – single-page chat surface optimised for mobile and desktop.
-- `app.mjs` – client logic for planner/executor orchestration, confirmations, receipts, and local IPFS pinning.
-- `config.mjs` – endpoints and AA configuration that operators customise per deployment.
-- `lib.js` – lightweight helpers for ICS validation, token math, and IPFS pinning.
-
-## Local preview
-
-Open `index.html` in any modern browser or run a simple static file server, e.g.:
-
-```bash
-npx serve .
-```
+1. Serve the directory with any static web server (for example `npx serve apps/onebox-static`).
+2. Edit `config.js` with the orchestrator, executor, and IPFS endpoints for your environment.
+3. Paste a [web3.storage](https://web3.storage) API token into local storage under the key `W3S_TOKEN` (the UI prompts for it on demand when pinning attachments).
+4. Drop or paste files into the page before submitting a request to include them as attachments in the next interaction.
 
 ## Deploying to IPFS
 
-1. Generate a Web3.Storage API token and store it in the browser via the Advanced panel (the token is persisted in `localStorage.AGIJOBS_W3S_TOKEN`).
-2. Update `config.mjs` with your orchestrator and executor endpoints.
-3. Upload the contents of this folder to IPFS (e.g. using `web3.storage` CLI or dashboard).
-4. Share the resulting gateway URL, such as `https://w3s.link/ipfs/<CID>/index.html`.
+1. Update `config.js` with production endpoints.
+2. Upload the folder to your preferred IPFS pinning service (e.g. `web3.storage`, `nft.storage`).
+3. Share the resulting CID, or wire it to DNSLink for a custom domain.
+
+## Testing checklist
+
+- Planner requests time out after 25 seconds and surface friendly errors.
+- ICS validation enforces the supported intent allow list and 140-character confirmation summaries.
+- Attachments dropped or pasted into the page are pinned to IPFS before execution.
+- Confirmations require an explicit `YES` before value-moving intents proceed.

--- a/apps/onebox-static/app.js
+++ b/apps/onebox-static/app.js
@@ -1,0 +1,300 @@
+import { PLAN_URL, EXEC_URL, IPFS_API_URL, IPFS_GATEWAY, AA_MODE } from "./config.js";
+import { validateICS, ensureSummary, pinJSON, pinFile } from "./lib.js";
+
+const feed = document.getElementById("feed");
+const adv = document.getElementById("adv");
+const form = document.getElementById("composer");
+const input = document.getElementById("prompt");
+const send = document.getElementById("send");
+const toggleAdvanced = document.getElementById("toggle-advanced");
+
+const history = [];
+let pendingConfirmation = null;
+const queuedAttachments = [];
+
+function push(role, text) {
+  const bubble = document.createElement("div");
+  bubble.className = `msg${role === "user" ? " me" : ""}`;
+  bubble.textContent = text;
+  feed.appendChild(bubble);
+  feed.scrollTop = feed.scrollHeight;
+}
+
+function setAdvanced(text) {
+  adv.textContent = text || "";
+}
+
+toggleAdvanced.addEventListener("click", (event) => {
+  event.preventDefault();
+  document.body.classList.toggle("adv-show");
+});
+
+async function callPlanner(message) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 25_000);
+  try {
+    const response = await fetch(PLAN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message, history }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`Planner error (${response.status})`);
+    }
+    const plan = await response.json();
+    return validateICS(plan);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function callExecutor(ics, attachments) {
+  const needsIpfs =
+    (ics.intent === "create_job" && ics.params?.job && !ics.params.job.uri) ||
+    Boolean(attachments?.length);
+  if (needsIpfs) {
+    await ensureStorageToken();
+  }
+
+  const pinnedAttachments = [];
+  if (attachments?.length) {
+    for (const file of attachments) {
+      const { cid } = await pinFile(file, IPFS_API_URL);
+      pinnedAttachments.push(`ipfs://${cid}`);
+    }
+  }
+
+  if (ics.intent === "create_job" && ics.params?.job && !ics.params.job.uri) {
+    const payload = { ...ics.params.job };
+    if (pinnedAttachments.length) {
+      payload.attachments = [...new Set([...(payload.attachments ?? []), ...pinnedAttachments])];
+    }
+    const { cid } = await pinJSON(payload, IPFS_API_URL);
+    ics.params.job.uri = `ipfs://${cid}`;
+    if (pinnedAttachments.length && !ics.params.job.attachments) {
+      ics.params.job.attachments = payload.attachments;
+    }
+  } else if (pinnedAttachments.length) {
+    ics.params = ics.params ?? {};
+    ics.params.attachments = [...new Set([...(ics.params.attachments ?? []), ...pinnedAttachments])];
+  }
+
+  const response = await fetch(EXEC_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ics, aa: AA_MODE }),
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error("Executor unavailable");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    const segments = buffer.split("\n\n");
+    while (segments.length > 1) {
+      const segment = segments.shift();
+      if (!segment) continue;
+      try {
+        const dataLines = [];
+        for (const line of segment.split("\n")) {
+          if (line.startsWith("data:")) {
+            dataLines.push(line.slice(5).trimStart());
+          }
+        }
+        const payload = dataLines.length ? dataLines.join("\n") : segment;
+        if (!payload) continue;
+        const event = JSON.parse(payload);
+        handleExecutorEvent(event);
+      } catch (err) {
+        console.warn("Bad executor segment", segment, err);
+      }
+    }
+    buffer = segments[0] ?? "";
+  }
+
+  if (buffer.trim()) {
+    try {
+      const dataLines = [];
+      for (const line of buffer.split("\n")) {
+        if (line.startsWith("data:")) {
+          dataLines.push(line.slice(5).trimStart());
+        }
+      }
+      const payload = dataLines.length ? dataLines.join("\n") : buffer;
+      if (payload) {
+        handleExecutorEvent(JSON.parse(payload));
+      }
+    } catch (err) {
+      console.warn("Trailing executor payload", buffer, err);
+    }
+  }
+}
+
+function handleExecutorEvent(evt) {
+  switch (evt.type) {
+    case "confirm":
+      {
+        const previous = pendingConfirmation;
+        pendingConfirmation = {
+          ics: evt.ics ?? previous?.ics ?? null,
+          attachments: evt.attachments ?? previous?.attachments ?? null,
+        };
+      }
+      push("bot", evt.text ?? "Confirm action?");
+      setAdvanced(evt.advanced ?? "");
+      break;
+    case "status":
+      push("bot", evt.text);
+      break;
+    case "receipt":
+      push("bot", evt.text);
+      setAdvanced(evt.advanced ?? "");
+      break;
+    case "error":
+      push("bot", `❌ ${evt.text ?? "Unknown executor error"}`);
+      break;
+    default:
+      console.warn("Unhandled executor event", evt);
+  }
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+
+  input.value = "";
+  push("user", text);
+
+  if (pendingConfirmation) {
+    const confirmed = /^y(es)?$/i.test(text);
+    if (!confirmed) {
+      push("bot", "Cancelled.");
+      if (pendingConfirmation.attachments?.length) {
+        queuedAttachments.unshift(...pendingConfirmation.attachments);
+        queuedAttachments.splice(3);
+      }
+      pendingConfirmation = null;
+      return;
+    }
+    const { ics, attachments } = pendingConfirmation;
+    send.disabled = true;
+    pendingConfirmation = null;
+    if (!ics) {
+      push("bot", "No actionable request to execute.");
+      send.disabled = false;
+      return;
+    }
+    push("bot", "Confirmed. Executing...");
+    try {
+      await callExecutor(ics, attachments);
+    } catch (err) {
+      push("bot", `❌ ${err.message}`);
+      if (attachments?.length) {
+        queuedAttachments.unshift(...attachments);
+        queuedAttachments.splice(3);
+      }
+    } finally {
+      send.disabled = false;
+    }
+    return;
+  }
+
+  send.disabled = true;
+  const attachments = queuedAttachments.splice(0, queuedAttachments.length);
+  try {
+    const ics = await callPlanner(text);
+    ensureSummary(ics);
+
+    history.push({ role: "user", content: text });
+    history.push({ role: "assistant", content: JSON.stringify(ics) });
+
+    if (ics.confirm) {
+      pendingConfirmation = { ics, attachments };
+      push("bot", ics.summary);
+      push("bot", "Type YES to confirm or NO to cancel.");
+      return;
+    }
+
+    await callExecutor(ics, attachments);
+  } catch (err) {
+    push("bot", `❌ ${err.message}`);
+    if (attachments.length) {
+      queuedAttachments.unshift(...attachments);
+      queuedAttachments.splice(3);
+    }
+  } finally {
+    send.disabled = false;
+  }
+}
+
+form.addEventListener("submit", handleSubmit);
+
+// Warm welcome
+push("bot", "Hi! I'm the AGI Jobs one-box. Describe what you need (e.g., \"Post a job for 500 images\").");
+setAdvanced(`Planner: ${PLAN_URL}\nExecutor: ${EXEC_URL}\nIPFS Gateway: ${IPFS_GATEWAY}`);
+
+function formatBytes(size) {
+  if (!Number.isFinite(size)) return "unknown size";
+  if (size < 1024) return `${size} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = size;
+  let unitIndex = -1;
+  do {
+    value /= 1024;
+    unitIndex += 1;
+  } while (value >= 1024 && unitIndex < units.length - 1);
+  return `${value.toFixed(1)} ${units[unitIndex]}`;
+}
+
+async function ensureStorageToken() {
+  let token = localStorage.getItem("W3S_TOKEN");
+  if (token && token.trim()) {
+    return token.trim();
+  }
+  const supplied = window.prompt(
+    "Enter your web3.storage API token to enable IPFS uploads (stored locally)."
+  );
+  if (!supplied) {
+    throw new Error("IPFS upload cancelled. Set a web3.storage token to continue.");
+  }
+  token = supplied.trim();
+  localStorage.setItem("W3S_TOKEN", token);
+  return token;
+}
+document.addEventListener("dragover", (event) => {
+  if (event.dataTransfer?.types?.includes("Files")) {
+    event.preventDefault();
+  }
+});
+
+document.addEventListener("drop", (event) => {
+  if (!event.dataTransfer?.files?.length) return;
+  event.preventDefault();
+  queueAttachments(Array.from(event.dataTransfer.files));
+});
+
+document.addEventListener("paste", (event) => {
+  const files = Array.from(event.clipboardData?.files ?? []);
+  if (!files.length) return;
+  queueAttachments(files);
+});
+
+function queueAttachments(files) {
+  const limited = files.slice(0, 3);
+  queuedAttachments.splice(0, queuedAttachments.length, ...limited);
+  const summary = limited
+    .map((file) => `${file.name} (${formatBytes(file.size)})`)
+    .join(", ");
+  push("bot", `Attached for next request: ${summary}`);
+}
+

--- a/apps/onebox-static/config.js
+++ b/apps/onebox-static/config.js
@@ -1,0 +1,5 @@
+export const PLAN_URL = "https://alpha-orchestrator.example.com/plan";
+export const EXEC_URL = "https://alpha-orchestrator.example.com/execute";
+export const IPFS_API_URL = "https://api.web3.storage/upload";
+export const IPFS_GATEWAY = "https://w3s.link/ipfs/";
+export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };

--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -7,169 +7,28 @@
   <style>
     :root {
       color-scheme: light dark;
+      --primary: #1052d6;
+      --bg: #fafafa;
+      --card-bg: #ffffff;
+      --border: #dcdfe3;
+      --text: #111827;
+      --text-muted: #6b7280;
     }
-    body {
-      margin: 0;
-      font: 16px/1.5 "Inter", "Segoe UI", system-ui, sans-serif;
-      background: #f5f7fb;
-      color: #141c2f;
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #101828;
+        --card-bg: #111c31;
+        --border: #1f2a44;
+        --text: #f9fafb;
+        --text-muted: #9ca3af;
+      }
     }
-    header,
-    footer {
-      padding: 12px 16px;
-      background: rgba(255, 255, 255, 0.85);
-      backdrop-filter: blur(6px);
-      border-bottom: 1px solid rgba(20, 28, 47, 0.08);
+
+    * {
+      box-sizing: border-box;
     }
-    footer {
-      border-top: 1px solid rgba(20, 28, 47, 0.08);
-      border-bottom: none;
-    }
-    header b {
-      font-weight: 600;
-    }
-    #feed {
-      flex: 1;
-      overflow-y: auto;
-      padding: 16px;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-    .msg {
-      max-width: 72ch;
-      padding: 12px 14px;
-      border-radius: 16px;
-      box-shadow: 0 4px 12px rgba(20, 28, 47, 0.08);
-      background: #fff;
-      align-self: flex-start;
-      word-break: break-word;
-    }
-    .msg.me {
-      margin-left: auto;
-      background: linear-gradient(120deg, #1052d6, #4b8aff);
-      color: #fff;
-      box-shadow: 0 6px 16px rgba(16, 82, 214, 0.25);
-    }
-    form {
-      display: flex;
-      gap: 10px;
-      padding: 12px 16px 20px;
-      background: rgba(255, 255, 255, 0.9);
-      border-top: 1px solid rgba(20, 28, 47, 0.08);
-    }
-    #attachment-name {
-      font-size: 13px;
-      color: rgba(20, 28, 47, 0.7);
-      padding: 0 16px 8px;
-      min-height: 1.4em;
-    }
-    input[type="text"] {
-      flex: 1;
-      padding: 14px 16px;
-      border-radius: 14px;
-      border: 1px solid rgba(20, 28, 47, 0.12);
-      font-size: 16px;
-      background: rgba(255, 255, 255, 0.9);
-      transition: border 0.2s ease;
-    }
-    input[type="text"]:focus {
-      outline: none;
-      border-color: #1052d6;
-      box-shadow: 0 0 0 3px rgba(16, 82, 214, 0.15);
-    }
-    button {
-      padding: 14px 20px;
-      border-radius: 14px;
-      border: none;
-      background: #1052d6;
-      color: #fff;
-      font-weight: 600;
-      cursor: pointer;
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
-    }
-    #attach-button {
-      width: 44px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 18px;
-      background: rgba(16, 82, 214, 0.12);
-      color: #1052d6;
-      box-shadow: none;
-    }
-    #attach-button:hover:not(:disabled) {
-      transform: none;
-      box-shadow: none;
-      background: rgba(16, 82, 214, 0.2);
-    }
-    button:disabled {
-      cursor: progress;
-      opacity: 0.7;
-    }
-    button:hover:not(:disabled) {
-      transform: translateY(-1px);
-      box-shadow: 0 8px 16px rgba(16, 82, 214, 0.25);
-    }
-    #advanced-panel {
-      font-size: 13px;
-      color: rgba(20, 28, 47, 0.75);
-      padding: 0 16px 12px;
-      display: none;
-      white-space: pre-line;
-    }
-    body.advanced #advanced-panel {
-      display: block;
-    }
-    #advanced-panel h2 {
-      margin: 0 0 8px;
-      font-size: 14px;
-      font-weight: 600;
-      color: #0b2b5a;
-    }
-    #advanced-panel pre {
-      background: rgba(16, 82, 214, 0.08);
-      border-radius: 12px;
-      padding: 12px;
-      font-family: "SFMono-Regular", ui-monospace, Menlo, Monaco, Consolas, monospace;
-      max-height: 200px;
-      overflow: auto;
-      white-space: pre-wrap;
-    }
-    .adv-grid {
-      display: grid;
-      gap: 16px;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    }
-    #w3s-form {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-    #w3s-form input {
-      padding: 10px 12px;
-      border-radius: 10px;
-      border: 1px solid rgba(20, 28, 47, 0.2);
-      font-size: 14px;
-    }
-    #w3s-form button {
-      align-self: flex-start;
-      padding: 10px 16px;
-      font-size: 14px;
-    }
-    #w3s-status {
-      margin: 0;
-      min-height: 1.4em;
-    }
-    footer a {
-      color: #1052d6;
-      text-decoration: none;
-      font-weight: 500;
-      cursor: pointer;
-    }
+
     .sr-only {
       position: absolute;
       width: 1px;
@@ -181,61 +40,136 @@
       white-space: nowrap;
       border: 0;
     }
-    @media (max-width: 640px) {
-      header,
-      footer,
-      form {
-        padding-left: 12px;
-        padding-right: 12px;
-      }
-      input[type="text"] {
-        font-size: 15px;
-      }
-      button {
-        padding: 12px 18px;
-      }
+
+    body {
+      margin: 0;
+      font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      font-size: 16px;
+      line-height: 1.5;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+    }
+
+    header, footer {
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.65);
+      backdrop-filter: blur(6px);
+    }
+
+    footer {
+      border-top: 1px solid var(--border);
+      border-bottom: none;
+    }
+
+    main {
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+
+    #feed {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .msg {
+      max-width: 72ch;
+      padding: 12px 14px;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: var(--card-bg);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+      word-break: break-word;
+    }
+
+    .msg.me {
+      margin-left: auto;
+      background: var(--primary);
+      color: #fff;
+      border: none;
+    }
+
+    form {
+      display: flex;
+      gap: 10px;
+      padding: 12px 16px;
+      border-top: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.75);
+      backdrop-filter: blur(6px);
+    }
+
+    input[type="text"], button {
+      font: inherit;
+      padding: 12px 14px;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: var(--card-bg);
+      color: inherit;
+      width: 100%;
+    }
+
+    button {
+      width: auto;
+      background: var(--primary);
+      color: #fff;
+      border: none;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    button:active {
+      transform: scale(0.98);
+    }
+
+    button:disabled {
+      opacity: 0.7;
+      cursor: wait;
+    }
+
+    #adv {
+      font-size: 13px;
+      padding: 12px 16px;
+      border-top: 1px dashed var(--border);
+      color: var(--text-muted);
+      display: none;
+      white-space: pre-wrap;
+      background: rgba(0, 0, 0, 0.03);
+    }
+
+    .adv-show #adv {
+      display: block;
+    }
+
+    a {
+      color: var(--primary);
     }
   </style>
 </head>
 <body>
   <header>
-    <b>AGI Jobs</b> — One-Box (gasless, walletless)
+    <strong>AGI Jobs</strong> — One-Box (gasless, walletless)
   </header>
-  <div id="feed" role="log" aria-live="polite"></div>
-  <form id="composer">
-    <input id="attachment" type="file" hidden />
-    <label class="sr-only" for="question">Request</label>
-    <button id="attach-button" type="button" aria-label="Attach a file">📎</button>
-    <input
-      id="question"
-      type="text"
-      placeholder='e.g., "Post a job: 500 images, 50 AGIALPHA, 7 days"'
-      aria-label="Type your request"
-      autocomplete="off"
-    />
+  <main>
+    <section id="feed" role="log" aria-live="polite" aria-label="Conversation"></section>
+    <section id="adv" aria-live="polite" aria-label="Advanced details"></section>
+  </main>
+  <form id="composer" autocomplete="off">
+    <label class="sr-only" for="prompt">Type your request</label>
+    <input id="prompt" type="text" placeholder='e.g., "Post a job: 500 images, 50 AGIALPHA, 7 days"' aria-required="true" />
     <button id="send" type="submit">Send</button>
   </form>
-  <div id="attachment-name" aria-live="polite"></div>
-  <div id="advanced-panel" aria-live="polite">
-    <div class="adv-grid">
-      <section>
-        <h2>Execution details</h2>
-        <pre id="adv-log" aria-live="polite"></pre>
-      </section>
-      <section>
-        <h2>web3.storage token</h2>
-        <form id="w3s-form">
-          <label class="sr-only" for="w3s-token">web3.storage API token</label>
-          <input id="w3s-token" type="text" placeholder="Paste token" autocomplete="off" />
-          <button type="submit">Save token</button>
-          <p id="w3s-status" role="status"></p>
-        </form>
-      </section>
-    </div>
-  </div>
   <footer>
-    <a href="#" id="advanced-toggle">Advanced</a>
+    <a href="#" id="toggle-advanced">Advanced</a>
   </footer>
-  <script type="module" src="./app.mjs"></script>
+
+  <script type="module" src="./app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create an IPFS-hostable one-box HTML shell with accessible layout and advanced telemetry panel
- add a planner/executor bridge that validates ICS responses, manages confirmations, and pins attachments to IPFS before execution
- document configuration and deployment steps for the static bundle

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d60d5e4c1483338bcf70b79a627fc2