### PR TITLE
Support multi-attachment pinning and summary messaging

### DIFF
--- a/apps/onebox-static/lib.mjs
+++ b/apps/onebox-static/lib.mjs
@@ -238,16 +238,25 @@ export function prepareJobPayload(ics, pinnedFiles = []) {
       rewardAGIA: job?.rewardAGIA ?? job?.reward ?? null,
       attachments,
     };
+    const applyAttachments = () => {
+      if (!ics.params) ics.params = {};
+      if (!isObject(ics.params.job)) ics.params.job = {};
+      if (attachments.length) {
+        ics.params.job.attachments = attachments;
+      }
+    };
     return {
       payload,
+      applyAttachments,
       assign({ cid, gateways }) {
         if (!ics.params) ics.params = {};
         if (!isObject(ics.params.job)) ics.params.job = {};
         ics.params.job.uri = `ipfs://${cid}`;
-        if (attachments.length) {
-          ics.params.job.attachments = attachments;
-        }
+        applyAttachments();
         mergeMeta(cid, gateways);
+      },
+      mergeClientPins(payloadCid, gateways) {
+        mergeMeta(payloadCid, gateways);
       },
     };
   }
@@ -260,8 +269,15 @@ export function prepareJobPayload(ics, pinnedFiles = []) {
       note: ics.params?.note || "AGI Jobs work submission",
       attachments,
     };
+    const applyAttachments = () => {
+      if (!ics.params) ics.params = {};
+      if (attachments.length) {
+        ics.params.attachments = attachments;
+      }
+    };
     return {
       payload,
+      applyAttachments,
       assign({ cid, gateways }) {
         if (!ics.params) ics.params = {};
         const existing = isObject(ics.params.result) ? ics.params.result : {};
@@ -273,10 +289,11 @@ export function prepareJobPayload(ics, pinnedFiles = []) {
         if ("uri" in ics.params) {
           delete ics.params.uri;
         }
-        if (attachments.length) {
-          ics.params.attachments = attachments;
-        }
+        applyAttachments();
         mergeMeta(cid, gateways);
+      },
+      mergeClientPins(payloadCid, gateways) {
+        mergeMeta(payloadCid, gateways);
       },
     };
   }
@@ -290,8 +307,15 @@ export function prepareJobPayload(ics, pinnedFiles = []) {
       reason,
       attachments,
     };
+    const applyAttachments = () => {
+      if (!ics.params) ics.params = {};
+      if (attachments.length) {
+        ics.params.attachments = attachments;
+      }
+    };
     return {
       payload,
+      applyAttachments,
       assign({ cid, gateways }) {
         const uri = `ipfs://${cid}`;
         if (!ics.params) ics.params = {};
@@ -299,17 +323,22 @@ export function prepareJobPayload(ics, pinnedFiles = []) {
         if (isObject(ics.params.dispute)) {
           ics.params.dispute.evidenceUri = uri;
         }
-        if (attachments.length) {
-          ics.params.attachments = attachments;
-        }
+        applyAttachments();
         mergeMeta(cid, gateways);
+      },
+      mergeClientPins(payloadCid, gateways) {
+        mergeMeta(payloadCid, gateways);
       },
     };
   }
 
   return {
     payload: null,
+    applyAttachments() {},
     assign() {},
+    mergeClientPins(payloadCid, gateways) {
+      mergeMeta(payloadCid, gateways);
+    },
   };
 }
 

--- a/apps/onebox-static/test/ui-messages.test.mjs
+++ b/apps/onebox-static/test/ui-messages.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatPinnedSummaryMessage } from '../app.mjs';
+
+test('formatPinnedSummaryMessage lists all pinned CIDs in summary', () => {
+  const summary = formatPinnedSummaryMessage([
+    { label: 'Attachment (scope.pdf)', cid: 'bafy-att-0001' },
+    { label: 'Attachment (examples.csv)', cid: 'bafy-att-0002' },
+    { label: 'Job JSON', cid: 'bafy-payload-0003' },
+  ]);
+
+  assert.match(summary, /Pinned 3 items?/);
+  assert.match(summary, /scope\.pdf/);
+  assert.match(summary, /bafy-att-0001/);
+  assert.match(summary, /bafy-payload-0003/);
+  const bulletCount = summary.split('\n').filter((line) => line.trim().startsWith('•')).length;
+  assert.equal(bulletCount, 3);
+});


### PR DESCRIPTION
## Summary
- ensure the UI forwards every file selected in the attachment control and pins each uploaded blob before executing a plan
- extend the payload helpers so pinned attachment URIs are merged into job, submission, and dispute metadata even when no new payload is created
- add tests for multi-attachment metadata handling and UI summaries that enumerate every pinned CID

## Testing
- node --test apps/onebox-static/test/*.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d6a659dd3883339e1da3d2749c7dbf