### PR TITLE
feat: add static one-box UI for AGI Jobs

### DIFF
--- a/apps/onebox-static/app.js
+++ b/apps/onebox-static/app.js
@@ -1,389 +1,171 @@
-import { PLAN_URL, EXEC_URL, IPFS_API_URL, IPFS_GATEWAY, AA_MODE } from "./config.js";
-import { validateICS, ensureSummary, pinJSON, pinFile } from "./lib.js";
+import { PLAN_URL, EXEC_URL, AA_MODE, HISTORY_LENGTH } from "./config.js";
+import { buildHistoryEnvelope, confirmSummary, ensureAttachmentCIDs, formatError, validateICS } from "./lib.js";
 
 const feed = document.getElementById("feed");
-const advancedPanel = document.getElementById("advanced-panel");
-const form = document.getElementById("composer");
-const input = document.getElementById("question");
-const send = document.getElementById("send");
-const toggleAdvanced = document.getElementById("advanced-toggle");
-const attachmentInput = document.getElementById("attachment");
+const form = document.getElementById("chat-form");
+const input = document.getElementById("chat-input");
+const sendBtn = document.getElementById("send-btn");
+const adv = document.getElementById("adv");
+const toggleAdvanced = document.getElementById("toggle-advanced");
 
 const history = [];
-let pendingConfirmation = null;
-const queuedAttachments = [];
-
-const advancedState = {
-  latest: "",
-};
-
-function maskToken(token) {
-  if (!token) return "Not set";
-  if (token.length <= 6) return "••••";
-  return `••••${token.slice(-4)}`;
-}
-
-function aaSummary() {
-  if (!AA_MODE || !AA_MODE.enabled) {
-    return "Account Abstraction disabled.";
-  }
-  const { bundler = "custom", chainId = "unknown" } = AA_MODE;
-  return `Account Abstraction enabled (bundler: ${bundler}, chainId: ${chainId}).`;
-}
-
-function renderAdvancedPanel() {
-  if (!advancedPanel) return;
-  const token = (localStorage.getItem("W3S_TOKEN") || "").trim();
-  const masked = maskToken(token);
-  const latest = advancedState.latest || "No advanced details yet.";
-  const aaDetail = JSON.stringify(AA_MODE, null, 2);
-  advancedPanel.innerHTML = `
-    <div class="card">
-      <h2>Meta-agent endpoints</h2>
-      <p class="status">Planner: ${PLAN_URL}</p>
-      <p class="status">Executor: ${EXEC_URL}</p>
-      <p class="status">IPFS Gateway: ${IPFS_GATEWAY}</p>
-    </div>
-    <div class="card">
-      <h2>Execution mode</h2>
-      <p>${aaSummary()}</p>
-      <pre class="status">${aaDetail}</pre>
-    </div>
-    <div class="card">
-      <h2>web3.storage token</h2>
-      <p>Token is stored locally in this browser and used only for client-side pinning.</p>
-      <p class="status">${masked}</p>
-      <div style="display:flex; gap:8px; flex-wrap:wrap;">
-        <button type="button" class="inline" data-action="set-token">Set token</button>
-        ${token ? '<button type="button" class="inline" data-action="clear-token">Clear token</button>' : ""}
-      </div>
-    </div>
-    <div class="card">
-      <h2>Latest advanced details</h2>
-      <p class="status">${latest}</p>
-    </div>
-  `;
-}
-
-function setAdvanced(text) {
-  advancedState.latest = text || "";
-  renderAdvancedPanel();
-}
+let awaitingFollowUp = null;
 
 function push(role, text) {
-  if (!text) return;
-  const bubble = document.createElement("div");
-  bubble.className = role === "user" ? "msg me" : "msg";
-  bubble.textContent = text;
-  feed.appendChild(bubble);
-  feed.scrollTop = feed.scrollHeight;
+  const node = document.createElement("article");
+  node.className = `msg${role === "user" ? " me" : ""}`;
+  node.textContent = text;
+  feed.appendChild(node);
+  feed.scrollTo({ top: feed.scrollHeight, behavior: "smooth" });
 }
 
-function trimHistory() {
-  if (history.length > 10) {
-    history.splice(0, history.length - 10);
+function setBusy(busy) {
+  sendBtn.disabled = busy;
+  input.disabled = busy;
+  if (busy) {
+    sendBtn.dataset.prev = sendBtn.textContent;
+    sendBtn.textContent = "…";
+  } else {
+    sendBtn.textContent = sendBtn.dataset.prev || "Send";
   }
 }
 
-function recordHistory(entry) {
-  history.push(entry);
-  trimHistory();
-}
+toggleAdvanced.addEventListener("click", (event) => {
+  event.preventDefault();
+  document.body.classList.toggle("adv-show");
+});
 
-function plannerBody(message) {
-  return JSON.stringify({ message, history });
-}
-
-async function callPlanner(message) {
+async function requestPlan(message) {
+  const envelope = buildHistoryEnvelope(history.slice(-HISTORY_LENGTH));
   const response = await fetch(PLAN_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: plannerBody(message),
+    body: JSON.stringify({ message, history: envelope })
   });
   if (!response.ok) {
-    throw new Error(`Planner error (${response.status})`);
+    throw new Error(`Planner unavailable (${response.status})`);
   }
-  const plan = await response.json();
-  return validateICS(plan);
+  const json = await response.json();
+  return validateICS(json);
 }
 
-async function ensureStorageToken() {
-  let token = (localStorage.getItem("W3S_TOKEN") || "").trim();
-  if (token) {
-    renderAdvancedPanel();
-    return token;
-  }
-  const supplied = window.prompt(
-    "Enter your web3.storage API token to enable IPFS uploads (stored locally)."
-  );
-  if (!supplied) {
-    throw new Error("IPFS upload cancelled. Set a web3.storage token to continue.");
-  }
-  token = supplied.trim();
-  localStorage.setItem("W3S_TOKEN", token);
-  renderAdvancedPanel();
-  push("bot", "Stored web3.storage token.");
-  return token;
-}
-
-async function callExecutor(ics, attachments) {
-  const needsIpfs =
-    (ics.intent === "create_job" && ics.params?.job && !ics.params.job.uri) ||
-    Boolean(attachments?.length);
-  if (needsIpfs) {
-    await ensureStorageToken();
-  }
-
-  const pinnedAttachments = [];
-  if (attachments?.length) {
-    for (const file of attachments) {
-      const { cid } = await pinFile(file, IPFS_API_URL);
-      pinnedAttachments.push(`ipfs://${cid}`);
-    }
-    push("bot", `📎 Pinned attachments: ${pinnedAttachments.join(", ")}`);
-  }
-
-  if (ics.intent === "create_job" && ics.params?.job && !ics.params.job.uri) {
-    const payload = { ...ics.params.job };
-    if (pinnedAttachments.length) {
-      payload.attachments = [...new Set([...(payload.attachments ?? []), ...pinnedAttachments])];
-    }
-    const { cid } = await pinJSON(payload, IPFS_API_URL);
-    ics.params.job.uri = `ipfs://${cid}`;
-    if (pinnedAttachments.length && !ics.params.job.attachments) {
-      ics.params.job.attachments = payload.attachments;
-    }
-    setAdvanced(JSON.stringify({ jobUri: ics.params.job.uri, attachments: payload.attachments ?? [] }, null, 2));
-  } else if (pinnedAttachments.length) {
-    ics.params = ics.params ?? {};
-    ics.params.attachments = [...new Set([...(ics.params.attachments ?? []), ...pinnedAttachments])];
-    setAdvanced(JSON.stringify({ attachments: ics.params.attachments }, null, 2));
-  }
-
+async function requestExecute(ics) {
   const response = await fetch(EXEC_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ ics, aa: AA_MODE }),
+    body: JSON.stringify({ ics, aa: AA_MODE })
   });
-
   if (!response.ok || !response.body) {
-    throw new Error("Executor unavailable");
+    throw new Error(`Executor error (${response.status})`);
   }
-
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
-
   while (true) {
     const { value, done } = await reader.read();
     if (done) break;
     buffer += decoder.decode(value, { stream: true });
-
-    const segments = buffer.split("\n\n");
-    while (segments.length > 1) {
-      const segment = segments.shift();
-      if (!segment) continue;
-      processExecutorSegment(segment);
+    const chunks = buffer.split("\n\n");
+    buffer = chunks.pop() ?? "";
+    for (const chunk of chunks) {
+      if (!chunk.trim()) continue;
+      try {
+        onEvent(JSON.parse(chunk));
+      } catch (error) {
+        console.error("Bad event", error, chunk);
+      }
     }
-    buffer = segments[0] ?? "";
   }
-
   if (buffer.trim()) {
-    processExecutorSegment(buffer);
+    try { onEvent(JSON.parse(buffer)); } catch (error) { console.error("Bad tail", error, buffer); }
   }
 }
 
-function processExecutorSegment(segment) {
-  try {
-    const dataLines = [];
-    for (const line of segment.split("\n")) {
-      if (line.startsWith("data:")) {
-        dataLines.push(line.slice(5).trimStart());
-      }
-    }
-    const payload = dataLines.length ? dataLines.join("\n") : segment;
-    if (!payload) return;
-    const event = JSON.parse(payload);
-    handleExecutorEvent(event);
-  } catch (err) {
-    console.warn("Bad executor segment", segment, err);
+function onEvent(evt) {
+  if (evt.advanced) {
+    adv.textContent = evt.advanced;
   }
-}
-
-function handleExecutorEvent(evt) {
   switch (evt.type) {
-    case "confirm":
-      {
-        const previous = pendingConfirmation;
-        pendingConfirmation = {
-          ics: evt.ics ?? previous?.ics ?? null,
-          attachments: evt.attachments ?? previous?.attachments ?? null,
-        };
-      }
-      push("bot", evt.text ?? "Confirm action?");
-      setAdvanced(evt.advanced ?? "");
-      break;
     case "status":
+    case "info":
+      push("bot", evt.text);
+      break;
+    case "confirm":
+      awaitingFollowUp = evt.followUp || null;
       push("bot", evt.text);
       break;
     case "receipt":
       push("bot", evt.text);
-      setAdvanced(evt.advanced ?? "");
       break;
     case "error":
-      push("bot", `❌ ${evt.text ?? "Unknown executor error"}`);
+      push("bot", `❌ ${evt.text}`);
       break;
     default:
-      console.warn("Unhandled executor event", evt);
+      console.warn("Unknown event", evt);
   }
 }
 
-async function handleSubmit(event) {
+async function handleSubmission(message) {
+  setBusy(true);
+  push("user", message);
+  try {
+    const ics = await requestPlan(message);
+    if (ics.followUp) {
+      push("bot", ics.followUp);
+      history.push({ role: "user", content: message }, { role: "assistant", content: ics.followUp });
+      return;
+    }
+    const enriched = await ensureAttachmentCIDs(ics);
+    const summary = confirmSummary(enriched);
+    if (summary) {
+      setBusy(false);
+      const accepted = await promptConfirmation(summary);
+      if (!accepted) {
+        push("bot", "Cancelled.");
+        return;
+      }
+      setBusy(true);
+    }
+    await requestExecute(enriched);
+    history.push({ role: "user", content: message }, { role: "assistant", content: JSON.stringify(enriched) });
+  } catch (error) {
+    push("bot", formatError(error));
+  } finally {
+    setBusy(false);
+  }
+}
+
+function promptConfirmation(summary) {
+  return new Promise((resolve) => {
+    awaitingFollowUp = { summary, resolve };
+    push("bot", summary);
+    push("bot", "Type YES to confirm or NO to cancel.");
+  });
+}
+
+form.addEventListener("submit", async (event) => {
   event.preventDefault();
   const text = input.value.trim();
   if (!text) return;
-
   input.value = "";
-  push("user", text);
 
-  if (pendingConfirmation) {
-    const confirmed = /^(y|yes)$/i.test(text);
-    if (!confirmed) {
+  if (awaitingFollowUp?.resolve) {
+    push("user", text);
+    const accepted = /^y(es)?$/i.test(text);
+    awaitingFollowUp.resolve(accepted);
+    awaitingFollowUp = null;
+    if (!accepted) {
       push("bot", "Cancelled.");
-      if (pendingConfirmation.attachments?.length) {
-        queuedAttachments.unshift(...pendingConfirmation.attachments);
-        queuedAttachments.splice(3);
-      }
-      pendingConfirmation = null;
-      return;
-    }
-    const { ics, attachments } = pendingConfirmation;
-    send.disabled = true;
-    pendingConfirmation = null;
-    if (!ics) {
-      push("bot", "No actionable request to execute.");
-      send.disabled = false;
-      return;
-    }
-    push("bot", "Confirmed. Executing...");
-    try {
-      await callExecutor(ics, attachments);
-    } catch (err) {
-      push("bot", `❌ ${err.message}`);
-      if (attachments?.length) {
-        queuedAttachments.unshift(...attachments);
-        queuedAttachments.splice(3);
-      }
-    } finally {
-      send.disabled = false;
     }
     return;
   }
 
-  send.disabled = true;
-  const attachments = queuedAttachments.splice(0, queuedAttachments.length);
-  try {
-    const ics = await callPlanner(text);
-    ensureSummary(ics);
-
-    recordHistory({ role: "user", content: text });
-    recordHistory({ role: "assistant", content: JSON.stringify(ics) });
-
-    if (ics.confirm) {
-      pendingConfirmation = { ics, attachments };
-      push("bot", ics.summary);
-      push("bot", "Type YES to confirm or NO to cancel.");
-      return;
-    }
-
-    await callExecutor(ics, attachments);
-  } catch (err) {
-    push("bot", `❌ ${err.message}`);
-    if (attachments.length) {
-      queuedAttachments.unshift(...attachments);
-      queuedAttachments.splice(3);
-    }
-  } finally {
-    send.disabled = false;
-  }
-}
-
-function formatBytes(size) {
-  if (!Number.isFinite(size)) return "unknown size";
-  if (size < 1024) return `${size} B`;
-  const units = ["KB", "MB", "GB", "TB"];
-  let value = size;
-  let unitIndex = -1;
-  do {
-    value /= 1024;
-    unitIndex += 1;
-  } while (value >= 1024 && unitIndex < units.length - 1);
-  return `${value.toFixed(1)} ${units[unitIndex]}`;
-}
-
-function queueAttachments(files) {
-  const limited = files.slice(0, 3);
-  queuedAttachments.splice(0, queuedAttachments.length, ...limited);
-  if (!limited.length) return;
-  const summary = limited.map((file) => `${file.name} (${formatBytes(file.size)})`).join(", ");
-  push("bot", `Attached for next request: ${summary}`);
-}
-
-if (attachmentInput) {
-  attachmentInput.addEventListener("change", () => {
-    const files = Array.from(attachmentInput.files ?? []);
-    queueAttachments(files);
-    attachmentInput.value = "";
-  });
-}
-
-document.addEventListener("dragover", (event) => {
-  if (event.dataTransfer?.types?.includes("Files")) {
-    event.preventDefault();
-  }
+  await handleSubmission(text);
 });
 
-document.addEventListener("drop", (event) => {
-  if (!event.dataTransfer?.files?.length) return;
+window.addEventListener("unhandledrejection", (event) => {
   event.preventDefault();
-  queueAttachments(Array.from(event.dataTransfer.files));
+  push("bot", formatError(event.reason));
 });
 
-document.addEventListener("paste", (event) => {
-  const files = Array.from(event.clipboardData?.files ?? []);
-  if (!files.length) return;
-  queueAttachments(files);
-});
-
-if (advancedPanel) {
-  advancedPanel.addEventListener("click", (event) => {
-    const button = event.target.closest("button[data-action]");
-    if (!button) return;
-    const action = button.dataset.action;
-    if (action === "set-token") {
-      ensureStorageToken().catch((err) => {
-        push("bot", `❌ ${err.message}`);
-      });
-    } else if (action === "clear-token") {
-      localStorage.removeItem("W3S_TOKEN");
-      renderAdvancedPanel();
-      push("bot", "Cleared stored web3.storage token.");
-    }
-  });
-}
-
-if (toggleAdvanced) {
-  toggleAdvanced.addEventListener("click", (event) => {
-    event.preventDefault();
-    renderAdvancedPanel();
-    document.body.classList.toggle("advanced");
-  });
-}
-
-if (form) {
-  form.addEventListener("submit", handleSubmit);
-}
-
-push("bot", "Hi! I'm the AGI Jobs one-box. Describe what you need (e.g., \"Post a job for 500 images\").");
-setAdvanced(`Planner: ${PLAN_URL}\nExecutor: ${EXEC_URL}\nIPFS Gateway: ${IPFS_GATEWAY}`);
-renderAdvancedPanel();
+push("bot", "👋 Welcome to AGI Jobs v0. Describe what you need in plain language.");

--- a/apps/onebox-static/config.js
+++ b/apps/onebox-static/config.js
@@ -1,5 +1,5 @@
 export const PLAN_URL = "https://alpha-orchestrator.example.com/plan";
-export const EXEC_URL = "https://alpha-orchestrator.example.com/execute"; // SSE stream expected
-export const IPFS_API_URL = "https://api.web3.storage/upload";
-export const IPFS_GATEWAY = "https://w3s.link/ipfs/";
+export const EXEC_URL = "https://alpha-orchestrator.example.com/execute";
 export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };
+export const HISTORY_LENGTH = 6;
+export const WEB3_STORAGE_API = "https://api.web3.storage/upload";

--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -2,76 +2,144 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>AGI Jobs — One‑Box</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>AGI Jobs — One-Box</title>
+  <meta name="description" content="Gasless, walletless one-box interface for AGI Jobs v0" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='48' fill='%231052d6'/%3E%3Ctext x='50' y='62' font-family='Arial' font-size='52' fill='white' text-anchor='middle'%3EA%3C/text%3E%3C/svg%3E" />
   <style>
     :root {
       color-scheme: light dark;
-      --bg: #f5f7fb;
-      --surface: #ffffff;
-      --surface-alt: #edf1ff;
-      --text: #1a2333;
-      --muted: #5a6577;
-      --primary: #1052d6;
-      --danger: #c62828;
-      --radius: 14px;
-      font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+      --bg: #fafafa;
+      --bg-card: #ffffff;
+      --bg-card-me: #1052d6;
+      --bg-header: rgba(255,255,255,0.85);
+      --border: #e6e6e6;
+      --text: #1f1f1f;
+      --text-inverse: #ffffff;
+      --accent: #1052d6;
+      --radius: 12px;
+      --shadow: 0 12px 32px rgba(16,82,214,0.15);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a;
+        --bg-card: rgba(15,23,42,0.75);
+        --bg-card-me: rgba(37,99,235,0.85);
+        --bg-header: rgba(15,23,42,0.9);
+        --border: rgba(148,163,184,0.35);
+        --text: #e2e8f0;
+        --text-inverse: #f8fafc;
+        --accent: #60a5fa;
+        --shadow: 0 20px 45px rgba(37,99,235,0.25);
+      }
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       min-height: 100vh;
+      font: 16px/1.45 "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
       background: var(--bg);
       color: var(--text);
       display: flex;
       flex-direction: column;
     }
     header, footer {
-      padding: 12px 20px;
-      background: var(--surface);
-      box-shadow: 0 1px 0 rgba(16, 82, 214, 0.06);
-      z-index: 1;
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(10px);
+      background: var(--bg-header);
+      position: sticky;
+      top: 0;
+      z-index: 10;
     }
-    header strong { font-weight: 600; }
+    footer {
+      border-top: 1px solid var(--border);
+      border-bottom: none;
+      top: auto;
+      bottom: 0;
+    }
+    header h1 {
+      margin: 0;
+      font-size: 18px;
+    }
+    header span {
+      display: block;
+      font-size: 13px;
+      opacity: 0.75;
+    }
     #feed {
       flex: 1;
       overflow-y: auto;
-      padding: 18px 20px 96px;
+      padding: 18px;
       display: flex;
       flex-direction: column;
       gap: 12px;
     }
     .msg {
-      max-width: min(720px, 92%);
-      padding: 14px 16px;
-      background: var(--surface);
+      max-width: min(72ch, 100%);
+      padding: 12px 16px;
+      background: var(--bg-card);
       border-radius: var(--radius);
-      box-shadow: 0 8px 24px rgba(13, 32, 82, 0.08);
-      border: 1px solid rgba(16, 82, 214, 0.08);
-      line-height: 1.5;
-      white-space: pre-line;
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow);
+      align-self: flex-start;
+      white-space: pre-wrap;
     }
     .msg.me {
-      margin-left: auto;
-      background: var(--primary);
-      color: #fff;
-      box-shadow: 0 8px 24px rgba(16, 82, 214, 0.16);
-      border-color: transparent;
+      background: var(--bg-card-me);
+      color: var(--text-inverse);
+      border: none;
+      align-self: flex-end;
     }
     form {
-      position: sticky;
-      bottom: 0;
-      background: linear-gradient(180deg, rgba(245,247,251,0) 0%, var(--bg) 60%);
-      padding: 16px 20px 20px;
-      display: grid;
-      grid-template-columns: 1fr auto;
-      gap: 12px;
-      align-items: end;
+      display: flex;
+      gap: 10px;
+      padding: 12px 18px 20px;
+      background: var(--bg);
     }
-    label { font-size: 12px; color: var(--muted); }
+    form input[type="text"], form textarea {
+      flex: 1;
+      padding: 14px 16px;
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+      font: inherit;
+      background: var(--bg-card);
+      color: inherit;
+      transition: border 0.2s ease, box-shadow 0.2s ease;
+    }
+    form input:focus, form textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(16,82,214,0.25);
+    }
+    button {
+      padding: 14px 22px;
+      border-radius: var(--radius);
+      border: none;
+      background: var(--accent);
+      color: var(--text-inverse);
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+    button:active {
+      transform: scale(0.98);
+      box-shadow: 0 4px 18px rgba(16,82,214,0.25);
+    }
+    button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: none;
+    }
+    #adv {
+      font-size: 13px;
+      color: rgba(15,23,42,0.7);
+      padding: 0 18px 18px;
+      display: none;
+      word-break: break-word;
+    }
+    body.adv-show #adv { display: block; }
     .sr-only {
       position: absolute;
       width: 1px;
@@ -79,210 +147,31 @@
       padding: 0;
       margin: -1px;
       overflow: hidden;
-      clip: rect(0, 0, 0, 0);
+      clip: rect(0,0,0,0);
       border: 0;
     }
-    textarea, input[type="file"] {
-      width: 100%;
-      font: inherit;
-      padding: 12px 14px;
-      border-radius: var(--radius);
-      border: 1px solid rgba(16, 82, 214, 0.25);
-      background: var(--surface);
-      resize: vertical;
-      min-height: 68px;
-    }
-    textarea:focus, input[type="file"]:focus-visible {
-      outline: 2px solid rgba(16,82,214,0.45);
-      outline-offset: 2px;
-    }
-    button {
-      padding: 14px 22px;
-      border-radius: var(--radius);
-      border: none;
-      font-weight: 600;
-      background: var(--primary);
-      color: #fff;
-      cursor: pointer;
-      transition: transform 0.12s ease, box-shadow 0.12s ease;
-    }
-    button:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-      box-shadow: none;
-    }
-    button:hover:not(:disabled) {
-      transform: translateY(-1px);
-      box-shadow: 0 8px 18px rgba(16, 82, 214, 0.26);
-    }
-    .hint {
-      font-size: 13px;
-      color: var(--muted);
-      margin-top: 6px;
-    }
-    #advanced-panel {
-      display: none;
-      border-top: 1px solid rgba(16, 82, 214, 0.12);
-      padding: 14px 20px;
-      background: var(--surface);
-      font-size: 13px;
-      color: var(--muted);
-      white-space: pre-wrap;
-      overflow-wrap: anywhere;
-    }
-    #advanced-panel .card {
-      border: 1px solid rgba(16, 82, 214, 0.12);
-      border-radius: var(--radius);
-      padding: 14px 16px;
-      margin-bottom: 12px;
-      background: var(--surface-alt);
-    }
-    #advanced-panel .card h2 {
-      margin: 0 0 8px;
-      font-size: 14px;
-      font-weight: 600;
-      color: var(--text);
-    }
-    #advanced-panel .status {
-      display: block;
-      font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-      font-size: 12px;
-      color: var(--muted);
-      background: rgba(16,82,214,0.08);
-      padding: 8px 10px;
-      border-radius: 10px;
-      word-break: break-word;
-      margin-top: 6px;
-    }
-    #advanced-panel .pin-summary {
-      font-weight: 600;
-      color: var(--text);
-      margin-bottom: 6px;
-    }
-    #advanced-panel .pin-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-    #advanced-panel .pin-list li {
-      border: 1px solid rgba(16,82,214,0.16);
-      border-radius: 10px;
-      padding: 8px 10px;
-      background: rgba(16,82,214,0.05);
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-    #advanced-panel .pin-label {
-      font-weight: 500;
-      color: var(--text);
-    }
-    #advanced-panel .pin-cid code {
-      background: rgba(16,82,214,0.08);
-      padding: 4px 6px;
-      border-radius: 6px;
-      font-size: 12px;
-    }
-    #advanced-panel .pin-gateways {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 4px;
-    }
-    #advanced-panel .pin-gateways a {
-      font-size: 12px;
-      color: var(--primary);
-    }
-    #advanced-panel .advanced-kv {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-    #advanced-panel .advanced-kv-row {
-      display: flex;
-      justify-content: space-between;
-      gap: 12px;
-      align-items: flex-start;
-      font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-      font-size: 12px;
-    }
-    #advanced-panel .advanced-kv-key {
-      font-weight: 600;
-      color: var(--text);
-      min-width: 96px;
-    }
-    #advanced-panel .advanced-kv-value {
-      flex: 1;
-    }
-    #advanced-panel .advanced-kv-value code {
-      background: rgba(16,82,214,0.08);
-      padding: 4px 6px;
-      border-radius: 6px;
-      display: inline-block;
-    }
-    #advanced-panel .advanced-kv-value pre {
-      margin: 0;
-      padding: 6px 8px;
-      border-radius: 8px;
-      background: rgba(16,82,214,0.08);
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-    #advanced-panel button.inline {
-      padding: 8px 12px;
-      font-size: 12px;
-      border-radius: 10px;
-      background: transparent;
-      border: 1px solid rgba(16,82,214,0.45);
-      color: var(--primary);
-      box-shadow: none;
-    }
-    #advanced-panel button.inline:hover {
-      background: rgba(16, 82, 214, 0.08);
-    }
-    body.advanced #advanced-panel { display: block; }
-    footer {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      font-size: 13px;
-    }
-    footer a {
-      color: var(--primary);
-      text-decoration: none;
-      font-weight: 500;
-      cursor: pointer;
-    }
-    @media (max-width: 640px) {
-      form {
-        grid-template-columns: 1fr;
-      }
+    @media (max-width: 600px) {
+      header, footer { padding: 12px 14px; }
+      form { flex-direction: column; }
       button { width: 100%; }
     }
   </style>
 </head>
 <body>
   <header>
-    <strong>AGI Jobs — One‑Box</strong>
-    <div class="hint">Natural language control • Gasless • ENS aware • Powered by AGI‑Alpha</div>
+    <h1>AGI Jobs — One-Box</h1>
+    <span>Gasless, walletless Web3 interface powered by the AGI-Alpha orchestrator.</span>
   </header>
-  <main id="feed" role="log" aria-live="polite" aria-label="Conversation feed"></main>
-  <form id="composer">
-    <label for="question" class="sr-only">Describe what you want to do</label>
-    <textarea id="question" placeholder='Ex: "Post a labeling job for 500 images, reward 50 AGIALPHA, due in 7 days"' aria-label="Describe what you want to do" required></textarea>
-    <div>
-      <label for="attachment">Attach (optional)</label>
-      <input id="attachment" type="file" aria-label="Attachment" multiple />
-      <button type="submit" id="send">Send</button>
-    </div>
+  <main id="feed" role="log" aria-live="polite"></main>
+  <form id="chat-form">
+    <label class="sr-only" for="chat-input">Request</label>
+    <input id="chat-input" type="text" placeholder='e.g., "Post a job: 500 images, 50 AGIALPHA, 7 days"' autocomplete="off" />
+    <button id="send-btn" type="submit">Send</button>
   </form>
-  <section id="advanced-panel" aria-live="polite"></section>
+  <section id="adv" aria-live="polite"></section>
   <footer>
-    <span>Need a web3.storage token? Paste it in Advanced.</span>
-    <a id="advanced-toggle" href="#">Advanced</a>
+    <a id="toggle-advanced" href="#">Advanced</a>
   </footer>
-  <script type="module" src="./app.mjs"></script>
+  <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/docs/onebox-static.md
+++ b/docs/onebox-static.md
@@ -1,0 +1,112 @@
+# One-Box Static Interface — Operator & User Guide
+
+This guide explains how to run, configure, and operate the **AGI Jobs v0 One-Box** interface located at [`apps/onebox-static`](../apps/onebox-static/). The UI is intentionally static so it can be pinned to IPFS and delivered from any gateway while delegating planning and execution to the AGI-Alpha orchestrator.
+
+---
+
+## 1. Architecture recap
+
+```
+User ↔ Static UI (IPFS) ↔ AGI-Alpha Orchestrator ↔ Execution Bridge (AA or Relayer) ↔ Ethereum (AGIJobsv0 v2)
+```
+
+- **Planner (`/plan`)**: accepts free-form text and returns an **Intent-Constraint Schema (ICS)**.
+- **Executor (`/execute`)**: consumes the ICS, simulates, and submits transactions via sponsored Account Abstraction (primary) or a relayer (fallback). Responses stream back as Server-Sent Events.
+- **Static UI**: validates ICS, prompts the user for confirmations, uploads payloads to IPFS, and renders human-readable receipts.
+
+---
+
+## 2. Operator checklist
+
+| Step | Action | Notes |
+| ---- | ------ | ----- |
+| 1 | Deploy or configure the AGI-Alpha orchestrator | Ensure the AGI Jobs toolchain is enabled and populated with v2 contract addresses, ENS policy, and `$AGIALPHA` metadata. |
+| 2 | Configure CORS | Allow origins where the IPFS gateway will serve the UI, e.g. `https://w3s.link` or custom gateways. |
+| 3 | Set Account Abstraction credentials | Provision a bundler and sponsored Paymaster (Alchemy Account Kit or equivalent). Stake and fund them according to ERC-4337 requirements. |
+| 4 | Configure relayer fallback | If AA is unavailable, create an OpenZeppelin Defender Relayer with contract/function allowlists and daily spend caps. |
+| 5 | Populate [`apps/onebox-static/config.js`](../apps/onebox-static/config.js) | Update planner/executor URLs, AA chainId, and bundler label. |
+| 6 | Generate web3.storage tokens | Issue per-origin tokens to team members; tokens stay in-browser. Consider revocation schedules. |
+| 7 | Pin the static bundle to IPFS | `web3 storage upload apps/onebox-static` or your preferred pinning workflow. |
+| 8 | Share gateway URL & monitor | Provide the gateway link to users, monitor orchestrator logs, and top-up the Paymaster balance. |
+
+### Safe & governance handover (optional)
+
+- If operators prefer a multi-signature Safe to manage Paymaster deposits and relayer keys, rotate Paymaster ownership to the Safe and share runbooks for replenishment and revocation.
+- Document admin-only intents (e.g., `admin_set`) and confirm orchestrator-side checks align with Safe signer policies.
+
+---
+
+## 3. User flow (walletless UX)
+
+1. Navigate to the published gateway URL (e.g., `https://w3s.link/ipfs/<CID>/index.html`).
+2. Describe your request in the single input box. Examples:
+   - “Post a labeling job for 500 images, reward 50 AGIALPHA, due in 7 days.”
+   - “Apply for job #123.”
+   - “Finalize job #123.”
+3. The orchestrator responds with clarifying questions if required fields are missing. The UI echoes them in the chat feed.
+4. When the ICS would move tokens or stake, the UI shows a ≤140-character confirmation line (“Post job 50 AGIALPHA, 7 days, fee 5%, burn 2%?”). Respond with **YES** to continue or **NO** to cancel.
+5. For jobs or submissions requiring attachments, the UI triggers a file picker and uploads the file to IPFS via web3.storage. The CID is inserted into the ICS before execution.
+6. Execution status and receipts stream into the chat. Advanced details (tx hash, block number, AA/relayer metadata) appear under the **Advanced** toggle.
+
+### ENS enforcement
+
+- If the orchestrator indicates that ENS identity is mandatory (`*.agent.agi.eth` or `*.club.agi.eth`), the confirmation summary explains the requirement and suggests the appropriate claim/associate flow before continuing.
+
+---
+
+## 4. Account Abstraction (AA) configuration
+
+1. Create an ERC-4337 smart account + Paymaster setup using Alchemy’s Account Kit or similar.
+2. Fund the Paymaster and ensure `sponsorUserOperation` is gated by:
+   - Allowed target contract addresses (AGIJobsv0 v2 modules only).
+   - Spend caps per intent (`create_job`, `stake`, etc.).
+   - Rate limiting keyed by `meta.traceId` or end-user fingerprinting headers.
+3. Point [`AA_MODE`](../apps/onebox-static/config.js) to the desired chainId (e.g., 8453 for Base).
+4. The orchestrator should simulate every `UserOperation` before submit and surface errors back through SSE.
+
+### Relayer fallback
+
+- Configure an OpenZeppelin Defender Relayer with scoped API keys. The orchestrator should call the relayer only when `AA_MODE.enabled` is `false`.
+- Defender allows function-specific policies; restrict to the v2 contract selectors.
+- Include replay protection (trace id + nonce) and log correlation to the ICS meta trace.
+
+---
+
+## 5. Publishing to IPFS
+
+```bash
+# From repository root
+web3 storage upload apps/onebox-static
+```
+
+- Store the resulting CID in deployment notes.
+- Optionally pin via multiple providers for resiliency.
+- Configure DNSLink (`_dnslink.example.com` TXT record) for custom domains.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Possible cause | Resolution |
+| ------- | -------------- | ---------- |
+| “Planner unavailable” | Incorrect `PLAN_URL`, orchestrator offline, or CORS blocked. | Verify URL, check orchestrator logs, adjust CORS origins. |
+| “Executor error” | `/execute` rejected the ICS or SSE stream failed. | Inspect orchestrator logs; ensure AA Paymaster funded and ICS passes validation. |
+| “web3.storage token required” | Token not set in browser. | Obtain token from operator, paste when prompted, or clear via `localStorage.removeItem("W3S_TOKEN")`. |
+| ENS requirement message | Identity registry enforced. | Follow the provided claim/associate instructions before retrying. |
+
+---
+
+## 7. Extensibility
+
+- ICS schema and guardrails live entirely in the orchestrator + [`lib.js`](../apps/onebox-static/lib.js); add new intents by updating both ends while preserving backwards compatibility.
+- Additional tool metadata can flow via `ics.meta` without UI changes; the Advanced panel renders raw strings supplied in SSE events.
+- If future versions require analytics, add privacy-preserving hooks that batch events server-side instead of embedding trackers in the static bundle.
+
+---
+
+## 8. Support contacts
+
+- **Orchestrator Ops:** maintainers of the AGI-Alpha deployment.
+- **Protocol Ops:** AGI Jobs core team (contract upgrades, fee knob changes).
+- **Security:** rotate Paymaster & relayer credentials via Safe signers; maintain alerting on unusual spend or repeated denials.
+


### PR DESCRIPTION
## Summary
- build a single-input, IPFS-ready chat surface that talks to the AGI-Alpha orchestrator and renders confirmations/receipts
- add lightweight ICS guardrails, IPFS upload helpers, and Account Abstraction configuration defaults for the static bundle
- document operator and user flows for deploying and running the gasless one-box UI

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d6acb076e48333b930495f803edbe4