### PR TITLE
feat(onebox-static): expose AGIA math helpers and gateway config

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -15,7 +15,7 @@ A single-input, gasless, walletless interface that talks to the AGI-Alpha Meta-A
 ## Quick start
 
 1. Run or obtain an AGI-Alpha orchestrator endpoint (see [AGI-Alpha-Agent-v0](https://github.com/MontrealAI/AGI-Alpha-Agent-v0)). Ensure CORS allows the origin the static page will be served from.
-2. Update [`config.js`](./config.js) with your orchestrator URLs and desired Account Abstraction settings.
+2. Update [`config.js`](./config.js) with your orchestrator URLs, desired Account Abstraction settings, and any alternate IPFS gateways you want the Advanced receipts panel to surface.
 3. (Optional) Prepare web3.storage API tokens for team members. Tokens are stored client-side in `localStorage`.
 4. Serve the directory locally for development, e.g.:
 
@@ -56,6 +56,11 @@ When the orchestrator returns ICS metadata indicating that an ENS identity is re
 - `web3.storage` tokens are retained in the user’s browser only. Encourage operators to issue per-origin scoped tokens.
 - The UI enforces a maximum history window (`HISTORY_LENGTH`) to limit prompt size; the orchestrator should also cap history depth.
 - Validate all ICS payloads server-side even if the client performs its own checks.
+
+## Utility helpers
+
+- [`toWei`](./lib.mjs) converts human-readable AGIALPHA amounts into 18-decimal `BigInt` values for simulations and spend-cap checks.
+- [`formatAGIA`](./lib.mjs) renders on-chain balances back into concise human units, trimming trailing decimals by default.
 
 ## Testing suggestions
 

--- a/apps/onebox-static/config.js
+++ b/apps/onebox-static/config.js
@@ -2,4 +2,10 @@ export const PLAN_URL = "https://alpha-orchestrator.example.com/plan";
 export const EXEC_URL = "https://alpha-orchestrator.example.com/execute";
 export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };
 export const HISTORY_LENGTH = 6;
-export const WEB3_STORAGE_API = "https://api.web3.storage/upload";
+export const IPFS_ENDPOINT = "https://api.web3.storage/upload";
+export const IPFS_TOKEN_STORAGE_KEY = "AGIJOBS_W3S_TOKEN";
+export const IPFS_GATEWAYS = [
+  "https://w3s.link/ipfs/",
+  "https://ipfs.io/ipfs/",
+];
+export const WEB3_STORAGE_API = IPFS_ENDPOINT;

--- a/apps/onebox-static/config.mjs
+++ b/apps/onebox-static/config.mjs
@@ -2,4 +2,8 @@ export const PLAN_URL = "https://alpha-orchestrator.example.com/plan";
 export const EXEC_URL = "https://alpha-orchestrator.example.com/execute"; // SSE stream (JSON per line)
 export const IPFS_ENDPOINT = "https://api.web3.storage/upload";
 export const IPFS_TOKEN_STORAGE_KEY = "AGIJOBS_W3S_TOKEN";
+export const IPFS_GATEWAYS = [
+  "https://w3s.link/ipfs/",
+  "https://ipfs.io/ipfs/",
+];
 export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };

--- a/apps/onebox-static/test/agia-math.test.mjs
+++ b/apps/onebox-static/test/agia-math.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+async function loadLib() {
+  const url = new URL('../lib.mjs', import.meta.url);
+  return import(url);
+}
+
+const { toWei, formatAGIA } = await loadLib();
+
+test('toWei converts decimal strings into 18-decimal BigInt values', () => {
+  assert.equal(toWei('0'), 0n);
+  assert.equal(toWei('1.5'), 1500000000000000000n);
+  assert.equal(toWei('42.125'), 42125000000000000000n);
+});
+
+test('toWei accepts bigint and number inputs', () => {
+  assert.equal(toWei(2n), 2n);
+  assert.equal(toWei(3), 3000000000000000000n);
+});
+
+test('toWei rejects malformed inputs', () => {
+  assert.throws(() => toWei('abc'), /Invalid AGIA amount/);
+  assert.throws(() => toWei('1,23'), /Invalid AGIA amount/);
+});
+
+test('formatAGIA trims trailing zeros by default', () => {
+  const value = 1500000000000000000n;
+  assert.equal(formatAGIA(value), '1.5');
+});
+
+test('formatAGIA supports maximum and minimum fraction digit hints', () => {
+  const value = toWei('1.234567890123456789');
+  assert.equal(formatAGIA(value), '1.234567');
+  assert.equal(formatAGIA(value, { maximumFractionDigits: 9 }), '1.23456789');
+  assert.equal(formatAGIA(value, { maximumFractionDigits: 4, minimumFractionDigits: 4 }), '1.2345');
+});
+
+test('formatAGIA preserves sign information', () => {
+  const negative = toWei('-2.75');
+  assert.equal(formatAGIA(negative), '-2.75');
+});


### PR DESCRIPTION
## Summary
- add optional IPFS gateway list to the static one-box configuration files
- expose AGIALPHA helper utilities for human↔on-chain amount conversions and document their use
- cover the conversion helpers with node-based unit tests

## Testing
- node --test apps/onebox-static/test/*.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d6b348acfc8333a6c416aa4d3caad2