### PR TITLE
Add static one-box demo bundle and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ For detailed behaviour and additional modules such as `FeePool`, `TaxPolicy` and
 - [Production deployment guide](docs/deployment-guide-production.md)
 - [AGIJobs v2 sprint plan and deployment guide](docs/agi-jobs-v2-production-deployment-guide.md)
 - [API reference and SDK snippets](docs/api-reference.md)
+- [One-box UX overview](docs/onebox-ux.md)
 - [Job registry configuration guide](docs/job-registry-configuration.md)
 - [FeePool configuration guide](docs/fee-pool-configuration.md)
 - [StakeManager configuration guide](docs/stake-manager-configuration.md)

--- a/apps/onebox/README.md
+++ b/apps/onebox/README.md
@@ -2,6 +2,10 @@
 
 A minimal Next.js application that delivers the ChatGPT-style "one input box" user experience for AGI Jobs. It streams responses from the meta-orchestrator backend while abstracting blockchain complexity behind natural language confirmations.
 
+## Static build
+
+Need an IPFS-hostable version without the Next.js runtime? Use the self-contained bundle in [`static/`](./static/). Pin the entire folder to IPFS and point the page at your orchestrator by setting `localStorage.ORCH_URL` or appending `#orch=<encoded-url>` to the gateway URL. The bundle supports a demo mode when no orchestrator URL is provided, making it safe to preview offline.
+
 ## Getting started
 
 ```bash

--- a/apps/onebox/static/app.js
+++ b/apps/onebox/static/app.js
@@ -1,0 +1,170 @@
+const chat = document.getElementById("chat");
+const input = document.getElementById("box");
+const sendButton = document.getElementById("send");
+const expertButton = document.getElementById("expert");
+const modeBadge = document.getElementById("mode");
+const exampleButtons = document.querySelectorAll("[data-example]");
+
+const orchUrl = window.localStorage.getItem("ORCH_URL") ?? "";
+let expertMode = false;
+
+function createMessageElement(role, html) {
+  const div = document.createElement("div");
+  div.classList.add("msg");
+  div.classList.add(role === "user" ? "m-user" : "m-assistant");
+  div.innerHTML = html;
+  return div;
+}
+
+function appendMessage(role, html) {
+  const node = createMessageElement(role, html);
+  chat.appendChild(node);
+  chat.scrollTop = chat.scrollHeight;
+  return node;
+}
+
+function appendNote(text) {
+  appendMessage("assistant", `<p class="m-note">${text}</p>`);
+}
+
+async function plan(text) {
+  if (!orchUrl) {
+    const normalized = text.replace(/^i\s*/i, "");
+    const action = normalized.toLowerCase().includes("finalize")
+      ? "finalize_job"
+      : normalized.toLowerCase().includes("status")
+      ? "check_status"
+      : "post_job";
+
+    return {
+      summary: `I will ${normalized}. Proceed?`,
+      intent: {
+        action,
+        payload: {
+          title: normalized,
+          rewardToken: "AGIALPHA",
+          reward: "5.0",
+          deadlineDays: 7,
+        },
+      },
+    };
+  }
+
+  const response = await fetch(`${orchUrl}/onebox/plan`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text, expert: expertMode }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Planner error");
+  }
+
+  return response.json();
+}
+
+async function execute(intent) {
+  appendMessage("assistant", "Working on it…");
+
+  if (!orchUrl) {
+    window.setTimeout(() => {
+      appendMessage("assistant", "✅ Done. Job ID is <strong>#123</strong>.");
+    }, 800);
+    return;
+  }
+
+  const response = await fetch(`${orchUrl}/onebox/execute`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ intent, mode: expertMode ? "wallet" : "relayer" }),
+  });
+
+  const payload = await response.json();
+  if (!response.ok || !payload.ok) {
+    const message = payload?.error ?? "Execution failed";
+    throw new Error(message);
+  }
+
+  const { jobId, receiptUrl } = payload;
+  let text = `✅ Success. Job ID <strong>#${jobId}</strong>.`;
+  if (receiptUrl) {
+    text += ` <a href="${receiptUrl}" target="_blank" rel="noopener">Receipt</a>`;
+  }
+  appendMessage("assistant", text);
+}
+
+function renderConfirmation(summary, intent) {
+  const wrapper = appendMessage(
+    "assistant",
+    `${summary}<div class="row row-confirm"><button class="pill ok" data-yes>Yes</button><button class="pill" data-no>Cancel</button></div>`
+  );
+
+  const yesButton = wrapper.querySelector("[data-yes]");
+  const noButton = wrapper.querySelector("[data-no]");
+
+  yesButton.addEventListener("click", async () => {
+    try {
+      await execute(intent);
+    } catch (error) {
+      appendMessage("assistant", `⚠️ ${error.message}`);
+      appendNote("Try rephrasing in one sentence (e.g. “Create…, pay X AGIALPHA, deadline”).");
+    }
+  });
+
+  noButton.addEventListener("click", () => {
+    appendMessage("assistant", "Okay, cancelled.");
+  });
+}
+
+async function handleSubmit() {
+  const text = input.value.trim();
+  if (!text) {
+    input.focus();
+    return;
+  }
+
+  appendMessage("user", text);
+  input.value = "";
+
+  try {
+    const { summary, intent } = await plan(text);
+    renderConfirmation(summary, intent);
+  } catch (error) {
+    appendMessage("assistant", `⚠️ ${error.message ?? "Something went wrong."}`);
+    appendNote("The orchestrator planner is unavailable. Please try again or contact support.");
+  }
+}
+
+sendButton.addEventListener("click", handleSubmit);
+input.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    event.preventDefault();
+    handleSubmit();
+  }
+});
+
+exampleButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    input.value = button.dataset.example;
+    input.focus();
+  });
+});
+
+expertButton.addEventListener("click", () => {
+  expertMode = !expertMode;
+  modeBadge.textContent = `Mode: ${expertMode ? "Expert" : "Guest"}`;
+});
+
+// Allow deep-linking to a preset orchestrator URL via hash: #orch=https://...
+if (!orchUrl && window.location.hash.startsWith("#orch=")) {
+  const [, value] = window.location.hash.split("#orch=");
+  if (value) {
+    window.localStorage.setItem("ORCH_URL", decodeURIComponent(value));
+    window.location.href = window.location.pathname;
+  }
+}
+
+// Maintain focus on load for faster demos.
+window.addEventListener("DOMContentLoaded", () => {
+  input.focus();
+});

--- a/apps/onebox/static/index.html
+++ b/apps/onebox/static/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AGI Jobs — One-Box</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="wrap">
+      <header class="header">
+        <h1>AGI Jobs — One-Box</h1>
+        <span class="badge">Walletless by default</span>
+        <span id="mode" class="badge">Mode: Guest</span>
+      </header>
+
+      <section id="chat" class="chat" role="log" aria-live="polite">
+        <div class="msg m-assistant">
+          Hi! Tell me what you need and I’ll handle the rest.
+          <p class="m-note">Try: Post a labeling job for 500 images, pay 5 AGIALPHA, 7 days.</p>
+        </div>
+      </section>
+
+      <section class="input" aria-label="Interaction controls">
+        <label class="sr-only" for="box">Your request</label>
+        <input id="box" type="text" placeholder="Type here… Press Enter to send" autocomplete="off" />
+        <button id="send" type="button">Send</button>
+        <button id="expert" type="button" class="secondary" title="Toggle Expert Mode (wallet signing)">
+          Expert
+        </button>
+      </section>
+
+      <section class="row small" aria-label="Example prompts">
+        <button class="pill" type="button" data-example="Create a research task, 2 AGIALPHA, 48h">
+          Create a research task, 2 AGIALPHA, 48h
+        </button>
+        <button class="pill" type="button" data-example="Finalize my last job">Finalize my last job</button>
+        <button class="pill" type="button" data-example="What’s the status of job 123?">What’s the status of job 123?</button>
+      </section>
+
+      <hr />
+      <p class="small">
+        This demo can run without a backend. When connected, it talks to the AGI-Alpha Orchestrator
+        (<span class="kbd">/onebox/plan</span>, <span class="kbd">/onebox/execute</span>, <span class="kbd">/onebox/status</span>).
+      </p>
+    </div>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/apps/onebox/static/styles.css
+++ b/apps/onebox/static/styles.css
@@ -1,0 +1,188 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b0f14;
+  --fg: #f5f7fb;
+  --muted: #9aa4b2;
+  --acc: #7c5cff;
+  --soft: #151b24;
+  --ok: #1bbf6b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: "Inter", "SF Pro Text", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+.wrap {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.badge {
+  padding: 4px 8px;
+  background: var(--soft);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 50vh;
+  padding: 12px;
+  background: #0e141c;
+  border: 1px solid #1c2531;
+  border-radius: 12px;
+  overflow-y: auto;
+}
+
+.msg {
+  max-width: 75%;
+  padding: 12px 14px;
+  border-radius: 12px;
+}
+
+.m-user {
+  background: #1a2330;
+  margin-left: auto;
+}
+
+.m-assistant {
+  background: #121925;
+  border: 1px solid #1e2836;
+}
+
+.m-note {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 8px 0 0;
+}
+
+.input {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+input[type="text"] {
+  flex: 1;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid #1e2836;
+  background: #0e141c;
+  color: var(--fg);
+}
+
+button {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 0;
+  background: var(--acc);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button.secondary {
+  background: #1a2330;
+  color: var(--fg);
+  border: 1px solid #273245;
+}
+
+button:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--acc);
+  outline-offset: 2px;
+}
+
+.row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.pill {
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: #182131;
+  border: 1px solid #273245;
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.pill.ok {
+  background: #0e2a1c;
+  border-color: #214b38;
+  color: #7de6b2;
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid #1e2836;
+  margin: 24px 0 16px;
+}
+
+.small {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.kbd {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: #1a2330;
+  border: 1px solid #283446;
+  color: #c8d0da;
+  font-size: 0.75rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .wrap {
+    padding: 16px;
+  }
+
+  .chat {
+    min-height: 60vh;
+  }
+
+  .msg {
+    max-width: 100%;
+  }
+}

--- a/docs/onebox-ux.md
+++ b/docs/onebox-ux.md
@@ -1,0 +1,35 @@
+# AGI Jobs v2 – One-Box UX
+
+This document describes the single-input “one-box” experience that layers on top of the existing AGI Jobs v2 stack. The goal is to let non-crypto native employers describe work in natural language, confirm a human-readable plan, and rely on the orchestrator to post and manage jobs on-chain without surfacing blockchain abstractions by default.
+
+## Overview
+
+- **Front-end**: static bundle under [`apps/onebox/static/`](../apps/onebox/static/) that can be served from IPFS or any static host. It renders a chat-style timeline with a single input box, contextual prompt chips, and an optional expert mode for wallet signing.
+- **Orchestrator**: AGI-Alpha-Agent-v0 exposes `/onebox/plan`, `/onebox/execute`, and `/onebox/status` routes. The planner turns natural language into a structured intent; the executor performs relayed transactions or returns typed calldata for expert mode clients; the status endpoint merges on-chain reads with the agent-gateway event cache.
+- **Identity & token policy**: unchanged. Agents and validators still rely on the ENS subdomain registry (`*.agent.agi.eth`, `*.club.agi.eth`) and $AGIALPHA remains the canonical reward token defined in [`config/agialpha.json`](../config/agialpha.json).
+
+## Front-end behaviour
+
+1. **Planning** – Text is POSTed to `/onebox/plan`. The response contains a human-readable summary and a `JobIntent` payload. In demo mode (no orchestrator URL configured) the page synthesises intents locally so the UI can be previewed offline.
+2. **Confirmation** – Users accept or cancel the proposed plan. Acceptance triggers `/onebox/execute` with either `mode="relayer"` (default walletless flow) or `mode="wallet"` (expert mode, where the API can reply with calldata for the connected signer).
+3. **Execution feedback** – Successful responses surface the resulting job identifier and an optional transaction receipt URL. Failures are mapped to humanised error messages so users never see raw revert strings.
+
+### Expert mode
+
+- Disabled by default and clearly labelled in the header badge.
+- When toggled, the UI swaps execution mode to `wallet` while retaining every other orchestration step, enabling advanced users to review and sign transactions locally via Web3Modal/viem integrations added in future iterations.
+
+## Configuration
+
+- Set `localStorage.ORCH_URL` to the orchestrator base URL (for example `https://alpha-orchestrator.example`) or append `#orch=<encoded-url>` to the IPFS gateway link once, which persists the value in local storage.
+- The orchestrator must enable CORS for the IPFS gateway origins and protect the routes with the existing `API_TOKEN` and rate limiting described in the AGI-Alpha-Agent-v0 documentation.
+
+## Hosting
+
+The contents of `apps/onebox/` are self-contained and require no build step. Pin the folder to IPFS and publish the resulting CID through your preferred gateway. Because the front-end is static, no secrets are exposed and the same bundle can be reused across environments by pointing it at different orchestrator URLs.
+
+## Next steps
+
+- Extend the orchestrator to expose typed error codes so the front-end can show tailored remediation messages for common failure states (insufficient balance, invalid deadline, etc.).
+- Integrate the agent-gateway job stream into a right-rail status card for live updates without polling.
+- Add Cypress smoke tests that cover confirmation flows, demo mode, and expert mode toggling.


### PR DESCRIPTION
## Summary
- add an IPFS-hostable static one-box interface bundle with demo mode and expert toggle
- document the intended one-box workflow and reference it from the root README
- highlight the static bundle option in the existing one-box app README

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d6b52eaee08333b49ca2922d35252b