### PR TITLE
Update one-box static client for /onebox orchestration

### DIFF
--- a/apps/onebox-static/config.js
+++ b/apps/onebox-static/config.js
@@ -1,5 +1,8 @@
-export const PLAN_URL = "https://alpha-orchestrator.example.com/plan";
-export const EXEC_URL = "https://alpha-orchestrator.example.com/execute";
+export const ORCHESTRATOR_BASE_URL = "https://alpha-orchestrator.example.com";
+export const ORCHESTRATOR_ONEBOX_PREFIX = "/onebox";
+export const PLAN_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/plan`;
+export const EXEC_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/execute`;
+export const STATUS_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/status`;
 export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };
 export const HISTORY_LENGTH = 6;
 export const IPFS_ENDPOINT = "https://api.web3.storage/upload";

--- a/apps/onebox-static/config.mjs
+++ b/apps/onebox-static/config.mjs
@@ -1,5 +1,8 @@
-export const PLAN_URL = "https://alpha-orchestrator.example.com/plan";
-export const EXEC_URL = "https://alpha-orchestrator.example.com/execute"; // SSE stream (JSON per line)
+export const ORCHESTRATOR_BASE_URL = "https://alpha-orchestrator.example.com";
+export const ORCHESTRATOR_ONEBOX_PREFIX = "/onebox";
+export const PLAN_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/plan`;
+export const EXEC_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/execute`;
+export const STATUS_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/status`;
 export const IPFS_ENDPOINT = "https://api.web3.storage/upload";
 export const IPFS_TOKEN_STORAGE_KEY = "AGIJOBS_W3S_TOKEN";
 export const IPFS_GATEWAYS = [

--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -106,10 +106,14 @@
     body.advanced main.layout {
       display: grid;
       grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+      grid-template-areas:
+        "feed advanced"
+        "status advanced";
       align-items: start;
     }
 
     #feed {
+      grid-area: feed;
       min-height: 0;
       max-height: 100%;
       overflow-y: auto;
@@ -120,6 +124,59 @@
       display: flex;
       flex-direction: column;
       gap: 12px;
+    }
+
+    .status-board {
+      grid-area: status;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 0;
+    }
+
+    .status-card {
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.7);
+      padding: 16px 18px;
+      box-shadow: var(--shadow);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .status-card h3 {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 700;
+    }
+
+    .status-meta {
+      font-size: 12px;
+      opacity: 0.8;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 8px;
+      border-radius: 999px;
+      border: 1px solid var(--border-strong);
+      background: rgba(16, 82, 214, 0.08);
+      font-size: 12px;
+    }
+
+    .status-empty {
+      border-radius: var(--radius);
+      border: 1px dashed var(--border);
+      padding: 18px;
+      text-align: center;
+      font-size: 14px;
+      opacity: 0.75;
     }
 
     .msg {
@@ -283,6 +340,12 @@
 
   <main class="layout">
     <section id="feed" role="log" aria-live="polite"></section>
+    <section
+      id="status-board"
+      class="status-board"
+      aria-live="polite"
+      aria-label="Job status updates"
+    ></section>
     <aside id="advanced-panel" aria-live="polite" aria-label="Advanced details"></aside>
   </main>
 

--- a/docs/onebox-static.md
+++ b/docs/onebox-static.md
@@ -10,8 +10,9 @@ This guide explains how to run, configure, and operate the **AGI Jobs v0 One-Box
 User ↔ Static UI (IPFS) ↔ AGI-Alpha Orchestrator ↔ Execution Bridge (AA or Relayer) ↔ Ethereum (AGIJobsv0 v2)
 ```
 
-- **Planner (`/plan`)**: accepts free-form text and returns an **Intent-Constraint Schema (ICS)**.
-- **Executor (`/execute`)**: consumes the ICS, simulates, and submits transactions via sponsored Account Abstraction (primary) or a relayer (fallback). Responses stream back as Server-Sent Events.
+- **Planner (`/onebox/plan`)**: accepts free-form text and returns either an **Intent-Constraint Schema (ICS)** or a higher-level JobIntent envelope.
+- **Executor (`/onebox/execute`)**: consumes the ICS or JobIntent, simulates, and submits transactions via sponsored Account Abstraction (primary) or a relayer (fallback). Responses may stream back as Server-Sent Events (ICS flow) or return a JSON receipt (JobIntent flow).
+- **Status (`/onebox/status`)**: provides a compact JSON feed of recent jobs that the UI renders in the live status board.
 - **Static UI**: validates ICS, prompts the user for confirmations, uploads payloads to IPFS, and renders human-readable receipts.
 
 ---
@@ -47,6 +48,7 @@ User ↔ Static UI (IPFS) ↔ AGI-Alpha Orchestrator ↔ Execution Bridge (AA or
 4. When the ICS would move tokens or stake, the UI shows a ≤140-character confirmation line (“Post job 50 AGIALPHA, 7 days, fee 5%, burn 2%?”). Respond with **YES** to continue or **NO** to cancel.
 5. For jobs or submissions requiring attachments, the UI triggers a file picker and uploads the file to IPFS via web3.storage. The CID is inserted into the ICS before execution.
 6. Execution status and receipts stream into the chat. Advanced details (tx hash, block number, AA/relayer metadata) appear under the **Advanced** toggle.
+7. A live status board underneath the chat polls `/onebox/status` for recent jobs so users can rejoin ongoing workflows without refreshing.
 
 ### ENS enforcement
 
@@ -90,7 +92,7 @@ web3 storage upload apps/onebox-static
 | Symptom | Possible cause | Resolution |
 | ------- | -------------- | ---------- |
 | “Planner unavailable” | Incorrect `PLAN_URL`, orchestrator offline, or CORS blocked. | Verify URL, check orchestrator logs, adjust CORS origins. |
-| “Executor error” | `/execute` rejected the ICS or SSE stream failed. | Inspect orchestrator logs; ensure AA Paymaster funded and ICS passes validation. |
+| “Executor error” | `/onebox/execute` rejected the request or the SSE stream failed. | Inspect orchestrator logs; ensure AA Paymaster funded and ICS passes validation. |
 | “web3.storage token required” | Token not set in browser. | Obtain token from operator, paste when prompted, or clear via `localStorage.removeItem("W3S_TOKEN")`. |
 | ENS requirement message | Identity registry enforced. | Follow the provided claim/associate instructions before retrying. |
 


### PR DESCRIPTION
## Summary
- point the static one-box UI at the new /onebox/plan, /onebox/execute, and /onebox/status orchestrator routes
- add a live status board with polling and humanised formatting for recent jobs
- expand the configuration/docs to cover the new endpoints and status feed behaviour

## Testing
- `node --test AGIJobsv0/apps/onebox-static/test`


------
https://chatgpt.com/codex/tasks/task_e_68d6b52eaee08333b49ca2922d35252b