### PR TITLE
feat: humanize one-box orchestrator errors

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -11,6 +11,7 @@ A single-input, gasless, walletless interface that talks to the AGI-Alpha Meta-A
 - Advanced receipts toggle exposing transaction hashes, gas sponsorship info, and raw ICS payloads.
 - Drag-and-drop attachment support (plus orchestrator prompts) with client-side IPFS pinning backed by `web3.storage`.
 - Live job status board that polls `/onebox/status` for recent updates and renders walletless receipts.
+- Human-readable error dictionary that turns common revert strings and HTTP failures into actionable guidance.
 - Neutral static hosting footprint suited for IPFS pinning.
 
 ## Quick start

--- a/apps/onebox-static/test/error-formatting.test.mjs
+++ b/apps/onebox-static/test/error-formatting.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatError, FRIENDLY_ERROR_RULES } from '../lib.mjs';
+
+test('friendly error catalogue exposes at least 20 rules', () => {
+  assert.ok(
+    FRIENDLY_ERROR_RULES.length >= 20,
+    `expected 20+ error rules, received ${FRIENDLY_ERROR_RULES.length}`
+  );
+});
+
+test('insufficient allowance errors are mapped to actionable guidance', () => {
+  const err = new Error('execution reverted: InsufficientAllowance');
+  const message = formatError(err);
+  assert.match(message, /allowance/i);
+  assert.match(message, /Tip:/);
+});
+
+test('network failures are detected and translated', () => {
+  const err = new Error('TypeError: Failed to fetch');
+  const message = formatError(err);
+  assert.match(message, /network/i);
+  assert.match(message, /Tip:/);
+});
+
+test('429 responses surface rate limiting guidance', () => {
+  const err = new Error('Too Many Requests');
+  err.status = 429;
+  const message = formatError(err);
+  assert.match(message, /too quickly/i);
+  assert.match(message, /Tip:/);
+});
+
+test('fallback preserves original message when no rule matches', () => {
+  const err = new Error('Subtle custom orchestrator error');
+  const message = formatError(err);
+  assert.equal(message, 'Subtle custom orchestrator error');
+});

--- a/docs/onebox-static.md
+++ b/docs/onebox-static.md
@@ -13,6 +13,10 @@ User ↔ Static UI (IPFS) ↔ AGI-Alpha Orchestrator ↔ Execution Bridge (AA or
 - **Planner (`/onebox/plan`)**: accepts free-form text and returns either an **Intent-Constraint Schema (ICS)** or a higher-level JobIntent envelope.
 - **Executor (`/onebox/execute`)**: consumes the ICS or JobIntent, simulates, and submits transactions via sponsored Account Abstraction (primary) or a relayer (fallback). Responses may stream back as Server-Sent Events (ICS flow) or return a JSON receipt (JobIntent flow).
 - **Status (`/onebox/status`)**: provides a compact JSON feed of recent jobs that the UI renders in the live status board.
+
+### Human-readable error handling
+
+The static client ships with a **friendly error dictionary** (`FRIENDLY_ERROR_RULES` in [`lib.mjs`](../apps/onebox-static/lib.mjs)) that translates more than twenty common revert strings, HTTP responses, and wallet errors into actionable guidance (“**You don’t have enough AGIALPHA to fund this job. Tip: Lower the reward or top up your balance before trying again.**”). Keep the catalogue current whenever new orchestrator failure modes appear so end-users never see raw stack traces.
 - **Static UI**: validates ICS, prompts the user for confirmations, uploads payloads to IPFS, and renders human-readable receipts.
 
 ---


### PR DESCRIPTION
## Summary
- add a friendly error dictionary to the one-box static client so common revert strings and HTTP failures return actionable guidance
- document the new humanized messaging in the static UI README and operator guide
- cover the error mapper with unit tests to ensure key pathways stay readable

## Testing
- node --test apps/onebox-static/test

------
https://chatgpt.com/codex/tasks/task_e_68d6b8c337588333b184d67cd33256f1