### PR TITLE
Add live status and friendly errors to one-box static UI

### DIFF
--- a/apps/onebox-static/v2/README.md
+++ b/apps/onebox-static/v2/README.md
@@ -4,8 +4,9 @@ A static, IPFS-friendly single-input interface for AGI Jobs v2. The page works i
 
 ## Features
 
-- Single request box with conversational confirmations.
+- Single request box with conversational confirmations and planner warnings.
 - Walletless default flow with optional Expert Mode toggle.
+- Live status board that polls `/onebox/status` and a friendly error dictionary for common failures.
 - Accessible keyboard shortcuts and suggestion pills for quick prompts.
 - Zero build tooling — deploy the folder to any static host or IPFS pinner.
 
@@ -16,7 +17,9 @@ A static, IPFS-friendly single-input interface for AGI Jobs v2. The page works i
    ```js
    localStorage.ORCH_URL = "https://your-orchestrator.example";
    ```
+   You can also run `oneboxSetOrchestrator("https://your-orchestrator.example")` for a helper that saves the URL and reloads the page.
 3. Send a natural-language instruction such as "Post a labeling job for 500 images; pay 5 AGIALPHA; 7 days".
 4. Confirm the plan and wait for the orchestrator to execute.
+5. Monitor the recent activity panel at the bottom of the page or press **Refresh** to force a status update on demand.
 
 When no orchestrator URL is configured the UI remains interactive using built-in demo responses, making it safe to embed in documentation or marketing materials before backend integration is ready.

--- a/apps/onebox-static/v2/app.js
+++ b/apps/onebox-static/v2/app.js
@@ -1,48 +1,167 @@
 const ORCH_URL = window.localStorage.getItem('ORCH_URL') || '';
+const STATUS_INTERVAL_MS = 20_000;
+
 let expertMode = false;
+let statusTimer = null;
+
 const chat = document.getElementById('chat');
 const input = document.getElementById('box');
 const composer = document.getElementById('composer');
 const expertBtn = document.getElementById('expert');
 const modeBadge = document.getElementById('mode');
 const suggestionButtons = document.querySelectorAll('[data-fill]');
+const statusList = document.getElementById('status-list');
+const statusNote = document.getElementById('status-note');
+const statusRefresh = document.getElementById('status-refresh');
 
 const MESSAGE_ROLE = {
   USER: 'm-user',
   ASSISTANT: 'm-assistant',
 };
 
-function appendMessage(role, html) {
+const FRIENDLY_ERROR_RULES = [
+  {
+    test: /insufficient/i,
+    message:
+      'You do not have enough AGIALPHA to cover this request. Lower the reward or top up your balance and try again.',
+  },
+  {
+    match: 'allowance',
+    message:
+      'We need to refresh the AGIALPHA allowance before proceeding. I can retry that automatically—please try again in a moment.',
+  },
+  {
+    match: 'deadline',
+    message: 'Deadlines must be at least 24 hours in the future. Try extending the timeline.',
+  },
+  {
+    match: 'ens',
+    message:
+      'I could not confirm the required ENS identity. Make sure your agent subdomain is active before retrying.',
+  },
+  {
+    match: 'unauthor',
+    message:
+      'This action needs an authorised orchestrator. Confirm you are using the official endpoint and try again.',
+  },
+  {
+    match: 'planner',
+    message: 'The planner is unavailable right now. Give me a moment and try again.',
+  },
+  {
+    match: 'timeout',
+    message: 'The orchestrator took too long to respond. Please retry shortly.',
+  },
+  {
+    match: 'network',
+    message: 'Network error. Check your connection or orchestrator URL and try again.',
+  },
+];
+
+window.oneboxSetOrchestrator = function setOrchestrator(url) {
+  window.localStorage.setItem('ORCH_URL', url || '');
+  window.location.reload();
+};
+
+function friendlyError(input) {
+  if (!input) {
+    return 'Something went wrong. Try again in a moment.';
+  }
+  const raw = typeof input === 'string' ? input : input.message || String(input);
+  const normalised = raw.toLowerCase();
+  for (const rule of FRIENDLY_ERROR_RULES) {
+    if (rule.test && rule.test.test(raw)) {
+      return rule.message;
+    }
+    if (rule.match && normalised.includes(rule.match)) {
+      return rule.message;
+    }
+  }
+  return raw;
+}
+
+function appendMessage(role, content) {
   const wrapper = document.createElement('div');
   wrapper.className = `msg ${role}`;
-  wrapper.innerHTML = html;
+  if (typeof content === 'string') {
+    wrapper.innerHTML = content;
+  } else if (content instanceof Node) {
+    wrapper.appendChild(content);
+  } else if (content !== undefined && content !== null) {
+    wrapper.textContent = String(content);
+  }
   chat.appendChild(wrapper);
   chat.scrollTop = chat.scrollHeight;
+  return wrapper;
 }
 
 function appendNote(html) {
   appendMessage(MESSAGE_ROLE.ASSISTANT, `<p class="m-note">${html}</p>`);
 }
 
-function createConfirmRow(summary, intent) {
+function appendConfirmation(plan) {
+  const container = document.createElement('div');
+  const summary = document.createElement('p');
+  summary.textContent = plan.summary || 'Ready to proceed. Shall I continue?';
   const row = document.createElement('div');
   row.className = 'row';
-  row.style.marginTop = '10px';
 
   const yes = document.createElement('button');
   yes.type = 'button';
   yes.textContent = 'Yes';
   yes.className = 'pill ok';
-  yes.addEventListener('click', () => executeIntent(intent));
 
   const no = document.createElement('button');
   no.type = 'button';
   no.textContent = 'Cancel';
   no.className = 'pill';
-  no.addEventListener('click', () => appendMessage(MESSAGE_ROLE.ASSISTANT, 'Okay, cancelled.'));
+
+  yes.addEventListener('click', () => {
+    yes.disabled = true;
+    no.disabled = true;
+    appendNote('Okay, executing now…');
+    executeIntent(plan.intent);
+  });
+
+  no.addEventListener('click', () => {
+    yes.disabled = true;
+    no.disabled = true;
+    appendMessage(MESSAGE_ROLE.ASSISTANT, 'Okay, cancelled.');
+  });
 
   row.append(yes, no);
-  return `<p>${summary}</p>${row.outerHTML}`;
+  container.append(summary, row);
+  appendMessage(MESSAGE_ROLE.ASSISTANT, container);
+}
+
+function normalizePlannerResponse(payload) {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Planner returned an invalid response.');
+  }
+  const container = payload.intent && typeof payload.intent === 'object' ? payload : payload.data || payload;
+  const intent = container.intent;
+  if (!intent || typeof intent !== 'object') {
+    throw new Error('Planner did not return a job intent.');
+  }
+  const summary =
+    typeof container.summary === 'string' && container.summary.trim()
+      ? container.summary.trim()
+      : typeof payload.summary === 'string'
+      ? payload.summary.trim()
+      : '';
+  const warnings = Array.isArray(container.warnings)
+    ? container.warnings
+    : Array.isArray(payload.warnings)
+    ? payload.warnings
+    : [];
+  const requiresConfirmation =
+    typeof container.requiresConfirmation === 'boolean'
+      ? container.requiresConfirmation
+      : typeof payload.requiresConfirmation === 'boolean'
+      ? payload.requiresConfirmation
+      : true;
+
+  return { summary, intent, warnings, requiresConfirmation };
 }
 
 async function plan(text) {
@@ -50,6 +169,8 @@ async function plan(text) {
     return {
       summary: `I will ${text.replace(/^i\s*/i, '')}. Proceed?`,
       intent: mockIntent(text),
+      warnings: [],
+      requiresConfirmation: true,
     };
   }
 
@@ -63,10 +184,11 @@ async function plan(text) {
 
   if (!response.ok) {
     const errBody = await safeJson(response);
-    throw new Error(errBody?.error || 'Planner error');
+    throw new Error(errBody?.error || `Planner error (${response.status})`);
   }
 
-  return response.json();
+  const payload = await response.json();
+  return normalizePlannerResponse(payload);
 }
 
 async function executeIntent(intent) {
@@ -90,9 +212,9 @@ async function executeIntent(intent) {
   const payload = await safeJson(response);
 
   if (!response.ok || !payload?.ok) {
-    const message = payload?.error || 'Execution failed';
+    const message = friendlyError(payload?.error || `Execution failed (${response.status})`);
     appendMessage(MESSAGE_ROLE.ASSISTANT, `⚠️ ${message}`);
-    appendNote('Try rephrasing your request or adjusting the reward/deadline.');
+    appendNote('You can adjust the request and try again, or toggle Expert Mode to review wallet signing details.');
     return;
   }
 
@@ -103,6 +225,12 @@ async function executeIntent(intent) {
     MESSAGE_ROLE.ASSISTANT,
     `✅ Success. Job ID <strong>#${payload.jobId}</strong>.${receiptLink}`,
   );
+
+  if (ORCH_URL) {
+    loadStatus(true).catch(() => {
+      /* ignore status refresh errors after success */
+    });
+  }
 }
 
 function mockIntent(text) {
@@ -144,14 +272,215 @@ function handlePlanSubmit(event) {
   input.value = '';
 
   plan(text)
-    .then(({ summary, intent }) => {
-      const html = createConfirmRow(summary, intent);
-      appendMessage(MESSAGE_ROLE.ASSISTANT, html);
+    .then((planResult) => {
+      const { warnings = [] } = planResult;
+      if (Array.isArray(warnings) && warnings.length) {
+        warnings
+          .map((warning) => (typeof warning === 'string' ? warning : null))
+          .filter(Boolean)
+          .forEach((warning) => appendNote(`⚠️ ${warning}`));
+      }
+
+      if (planResult.requiresConfirmation === false) {
+        const summary = planResult.summary || 'Executing now.';
+        appendMessage(MESSAGE_ROLE.ASSISTANT, summary);
+        executeIntent(planResult.intent);
+        return;
+      }
+
+      appendConfirmation(planResult);
     })
     .catch((err) => {
-      appendMessage(MESSAGE_ROLE.ASSISTANT, `⚠️ ${err.message}`);
+      const message = friendlyError(err);
+      appendMessage(MESSAGE_ROLE.ASSISTANT, `⚠️ ${message}`);
       appendNote('The planner could not understand that request. Try one sentence with reward and duration.');
     });
+}
+
+function renderStatusPlaceholder(message) {
+  if (!statusList) return;
+  statusList.innerHTML = '';
+  const empty = document.createElement('div');
+  empty.className = 'status-empty';
+  empty.textContent = message;
+  statusList.appendChild(empty);
+}
+
+function createStatusPill(label, variant) {
+  const pill = document.createElement('span');
+  pill.className = variant === 'ok' ? 'status-pill ok' : 'status-pill';
+  pill.textContent = label;
+  return pill;
+}
+
+function formatReward(value, token) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `${value} ${token || ''}`.trim();
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return `${numeric} ${token || ''}`.trim();
+  }
+  return `${value} ${token || ''}`.trim();
+}
+
+function formatDeadline(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value > 1e12) {
+      return new Date(value).toLocaleString();
+    }
+    if (value > 1e9) {
+      return new Date(value * 1000).toLocaleString();
+    }
+    if (value > 0) {
+      const rounded = Math.round(value);
+      return `${rounded} day${rounded === 1 ? '' : 's'}`;
+    }
+  }
+  const text = String(value).trim();
+  if (!text) return null;
+  const parsed = Date.parse(text);
+  if (!Number.isNaN(parsed)) {
+    return new Date(parsed).toLocaleString();
+  }
+  return text;
+}
+
+function normalizeStatusEntries(payload) {
+  if (!payload) return [];
+  const entries = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload.jobs)
+    ? payload.jobs
+    : Array.isArray(payload.data)
+    ? payload.data
+    : payload.job
+    ? [payload.job]
+    : [];
+
+  return entries
+    .map((entry, index) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const id = entry.id ?? entry.jobId ?? entry.jobID ?? index;
+      const state = entry.state || entry.status || entry.phase || 'Pending';
+      const reward = formatReward(entry.reward ?? entry.rewardAmount ?? entry.rewardAGIA, entry.rewardToken);
+      const deadline = formatDeadline(entry.deadline ?? entry.deadlineAt ?? entry.deadlineDays ?? entry.expiresAt);
+      const assignee = entry.assignee || entry.agent || entry.worker || entry.validator;
+      const summary = entry.summary || entry.title || entry.description || '';
+      const token = entry.rewardToken || entry.token || 'AGIALPHA';
+      return { id, state, reward, deadline, assignee, summary, token };
+    })
+    .filter(Boolean)
+    .slice(0, 5);
+}
+
+function renderStatus(entries) {
+  if (!statusList) return;
+  statusList.innerHTML = '';
+  if (!entries.length) {
+    renderStatusPlaceholder('No recent jobs yet. Your next request will appear here.');
+    return;
+  }
+
+  entries.forEach((entry) => {
+    const card = document.createElement('article');
+    card.className = 'status-card';
+
+    const heading = document.createElement('h3');
+    heading.textContent = entry.id !== undefined ? `Job #${entry.id}` : 'Job';
+    card.appendChild(heading);
+
+    const meta = document.createElement('div');
+    meta.className = 'status-meta';
+
+    const state = String(entry.state || '').toLowerCase();
+    const statePill = createStatusPill(entry.state || 'Pending',
+      state.includes('open') || state.includes('active') || state.includes('complete') ? 'ok' : undefined);
+    meta.appendChild(statePill);
+
+    if (entry.reward) {
+      meta.appendChild(createStatusPill(`${entry.reward}`));
+    }
+
+    if (entry.deadline) {
+      meta.appendChild(createStatusPill(`Deadline: ${entry.deadline}`));
+    }
+
+    if (entry.assignee) {
+      meta.appendChild(createStatusPill(`Agent: ${entry.assignee}`));
+    }
+
+    card.appendChild(meta);
+
+    if (entry.summary) {
+      const summary = document.createElement('p');
+      summary.className = 'small';
+      summary.textContent = entry.summary;
+      card.appendChild(summary);
+    }
+
+    statusList.appendChild(card);
+  });
+}
+
+async function loadStatus(manual = false) {
+  if (!statusList) return;
+  if (!ORCH_URL) {
+    renderStatusPlaceholder('Set localStorage.ORCH_URL to enable live status.');
+    if (statusNote) {
+      statusNote.textContent = 'Status feed inactive until an orchestrator URL is configured.';
+    }
+    return;
+  }
+
+  if (statusNote) {
+    statusNote.textContent = manual ? 'Refreshing…' : 'Loading status…';
+  }
+
+  try {
+    const response = await fetch(`${ORCH_URL}/onebox/status`);
+    if (!response.ok) {
+      const body = await safeJson(response);
+      throw new Error(body?.error || `Status error (${response.status})`);
+    }
+    const payload = await response.json();
+    const entries = normalizeStatusEntries(payload);
+    renderStatus(entries);
+    if (statusNote) {
+      const time = new Date().toLocaleTimeString();
+      statusNote.textContent = entries.length
+        ? `Last updated ${time}`
+        : `No recent jobs yet — last checked ${time}`;
+    }
+  } catch (error) {
+    renderStatusPlaceholder(friendlyError(error));
+    if (statusNote) {
+      statusNote.textContent = 'Unable to load status right now. Please try again later.';
+    }
+    throw error;
+  }
+}
+
+function scheduleStatusUpdates() {
+  if (!statusList) return;
+  if (statusTimer) {
+    window.clearInterval(statusTimer);
+    statusTimer = null;
+  }
+  if (!ORCH_URL) {
+    renderStatusPlaceholder('Set localStorage.ORCH_URL to enable live status.');
+    return;
+  }
+  loadStatus().catch(() => {
+    /* handled inside loadStatus */
+  });
+  statusTimer = window.setInterval(() => {
+    loadStatus().catch(() => {
+      /* handled */
+    });
+  }, STATUS_INTERVAL_MS);
 }
 
 composer.addEventListener('submit', handlePlanSubmit);
@@ -171,6 +500,23 @@ suggestionButtons.forEach((btn) => {
   });
 });
 
+statusRefresh?.addEventListener('click', () => {
+  loadStatus(true).catch(() => {
+    /* already surfaced */
+  });
+});
+
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    if (statusTimer) {
+      window.clearInterval(statusTimer);
+      statusTimer = null;
+    }
+  } else {
+    scheduleStatusUpdates();
+  }
+});
+
 window.addEventListener('keydown', (event) => {
   if (event.key === '/' && document.activeElement !== input) {
     event.preventDefault();
@@ -178,4 +524,5 @@ window.addEventListener('keydown', (event) => {
   }
 });
 
+scheduleStatusUpdates();
 input.focus();

--- a/apps/onebox-static/v2/index.html
+++ b/apps/onebox-static/v2/index.html
@@ -41,6 +41,15 @@
           <span class="kbd">/onebox/execute</span>, <span class="kbd">/onebox/status</span>). Configure the endpoint via the
           browser console: <span class="kbd">localStorage.ORCH_URL = "https://your-orchestrator.example"</span>.
         </p>
+
+        <section class="status" aria-live="polite">
+          <div class="status-header">
+            <h2>Recent activity</h2>
+            <button id="status-refresh" type="button" class="secondary">Refresh</button>
+          </div>
+          <div id="status-list" class="status-list" role="list"></div>
+          <p id="status-note" class="small"></p>
+        </section>
       </main>
     </div>
 

--- a/apps/onebox-static/v2/styles.css
+++ b/apps/onebox-static/v2/styles.css
@@ -160,6 +160,86 @@ hr {
   color: var(--muted);
 }
 
+.status {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.status-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.status-header h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.status-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 64px;
+}
+
+.status-card {
+  border: 1px solid #1e2836;
+  border-radius: 12px;
+  padding: 16px;
+  background: #0e141c;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.status-card h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.status-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid #273245;
+  background: #182131;
+  font-size: 12px;
+  color: var(--fg);
+}
+
+.status-pill.ok {
+  background: #0e2a1c;
+  border-color: #214b38;
+  color: #7de6b2;
+}
+
+.status-empty {
+  border: 1px dashed #273245;
+  border-radius: 12px;
+  padding: 16px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.status-note {
+  margin: 0;
+}
+
 .kbd {
   display: inline-block;
   padding: 2px 6px;


### PR DESCRIPTION
## Summary
- add a recent activity panel that polls `/onebox/status`, supports manual refresh, and renders accessible status cards in the static one-box demo
- improve planner and executor UX with friendly error translations, DOM-backed confirmation buttons, and warning surfacing
- document the new behaviours and helper for setting the orchestrator URL directly from the console

## Testing
- No automated tests were run (static asset update)


------
https://chatgpt.com/codex/tasks/task_e_68d6beaf13cc8333baac18f8d2bfee39