### PR TITLE
feat: add static one-box interface and shared schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 - [Step‑by‑Step Deployment with $AGIALPHA](#step-by-step-deployment-with-agialpha)
 - [Agent/Validator Identity – ENS subdomain registration](#agentvalidator-identity--ens-subdomain-registration)
 - [Documentation](#documentation)
+- [One-Box UX](#one-box-ux)
 
 ### Identity policy
 
@@ -401,3 +402,9 @@ For detailed behaviour and additional modules such as `FeePool`, `TaxPolicy` and
 - [PlatformRegistry operations guide](docs/platform-registry-operations.md)
 - [One-Box UX overview](docs/onebox-ux.md)
 - [Agent gateway example](examples/agent-gateway.js)
+
+## One-Box UX
+
+- **Static front-end**: [`apps/onebox/`](apps/onebox/) provides an IPFS-ready, single-input UI that talks to the AGI-Alpha orchestrator (`/onebox/*`).
+- **Shared data contracts**: [`packages/onebox-sdk/`](packages/onebox-sdk/) exports TypeScript interfaces for `JobIntent`, `PlanResponse`, and `ExecuteResponse`.
+- **Integration guide**: see [`docs/onebox-ux.md`](docs/onebox-ux.md) for FastAPI stubs and deployment notes.

--- a/apps/onebox/README.md
+++ b/apps/onebox/README.md
@@ -1,18 +1,52 @@
 # AGI Jobs One-Box UI
 
-A minimal Next.js application that delivers the ChatGPT-style "one input box" user experience for AGI Jobs. It streams responses from the meta-orchestrator backend while abstracting blockchain complexity behind natural language confirmations.
+A static, IPFS-friendly front-end that wraps the AGI Jobs v2 workflow behind a single natural-language input. It calls the AGI-Alpha Orchestrator meta-agent (`/onebox/*`) to translate human requests into actionable job intents and execute them via the relayer (guest mode) or wallet signing (expert mode).
+
+## Features
+
+- **Single text box UX**: type what you need, receive a plan, confirm, execute.
+- **Walletless by default**: guest mode uses the orchestrator relayer; expert mode exposes wallet signing flows.
+- **Status board**: lightweight polling of `/onebox/status` for recent jobs.
+- **Demo mode**: if no orchestrator URL is configured, the UI simulates responses for offline demos.
+- **Persistent settings**: orchestrator URL, API token, and status refresh cadence are stored in `localStorage`.
+- **Humanised errors**: maps common on-chain failures to plain-language hints.
 
 ## Getting started
 
-```bash
-npm install --prefix apps/onebox
-npm install --prefix packages/orchestrator
-npm run build --prefix packages/orchestrator
-npm run dev --prefix apps/onebox
+1. Serve the folder locally (any static web server works). Example using `http-server`:
+   ```sh
+   npx http-server apps/onebox -p 4173 -c-1
+   ```
+2. Open the page in your browser and open the **Settings** dialog.
+3. Set the Orchestrator URL (e.g. `https://alpha-agent.example`) and optional API token.
+4. Submit a request such as “Post a labeling job for 500 images; pay 5 AGIALPHA; 7 days.”
+5. Confirm the plan and watch the execution receipt. Recent jobs appear in the status board.
+
+### Hosting on IPFS
+
+```sh
+ipfs add -r apps/onebox
 ```
+Take the returned CID and publish through your preferred gateway or ENS content hash. No environment secrets are embedded in the client.
 
-The development server runs on [http://localhost:3000](http://localhost:3000). The `/api/chat` endpoint proxies requests to the orchestrator planner implemented in `packages/orchestrator`.
+## Accessibility & UX
 
-## Environment
+- Form controls include labels and keyboard focus states.
+- The chat log is marked `aria-live="polite"` to announce updates.
+- Confirmation prompts expose explicit buttons for yes/no decisions.
 
-Create an `.env.local` file inside `apps/onebox` if you need to expose additional environment variables to the client or API routes. The orchestrator package reads from process environment variables like `RPC_URL`, `TX_MODE`, and contract addresses when executing real transactions.
+## Development notes
+
+- `app.js` is written as an ES module without build tooling to keep the site hostable on IPFS.
+- Update the error dictionary in `app.js` if the orchestrator introduces new error codes/messages.
+- When `/onebox/status` gains pagination, extend `renderStatuses` to handle `nextToken` / paging metadata.
+
+## Directory structure
+
+```
+apps/onebox/
+├── app.js       # UI logic, planner/executor calls, demo mode
+├── index.html   # Markup and settings modal
+├── README.md    # This file
+└── styles.css   # Visual design tokens and layout
+```

--- a/apps/onebox/app.js
+++ b/apps/onebox/app.js
@@ -1,0 +1,475 @@
+const STORAGE_KEY = 'agi-onebox-config-v1';
+const DEFAULT_CONFIG = {
+  orchestratorUrl: '',
+  apiToken: '',
+  statusInterval: 60,
+};
+
+const errorDictionary = new Map([
+  ['InsufficientBalance', {
+    headline: 'You do not have enough AGIALPHA to fund this job.',
+    hint: 'Lower the reward or top up your balance; I can guide you through funding.'],
+  ],
+  ['deadline', {
+    headline: 'The requested deadline is invalid.',
+    hint: 'Choose a date at least a few hours in the future.'],
+  ],
+  ['allowance', {
+    headline: 'Token approvals are missing.',
+    hint: 'In Expert mode I can prepare the approval transaction for you.'],
+  ],
+  ['network', {
+    headline: 'Unable to reach the orchestrator.',
+    hint: 'Check the configured URL or switch back to Demo Mode.'],
+  ],
+]);
+
+const state = {
+  expert: false,
+  pendingIntent: null,
+  lastSummary: null,
+  config: loadConfig(),
+  statusTimer: null,
+};
+
+const dom = {
+  chat: document.getElementById('chat-log'),
+  input: document.getElementById('onebox-input'),
+  form: document.getElementById('composer'),
+  modeLabel: document.getElementById('mode-label'),
+  expertToggle: document.getElementById('expert-toggle'),
+  pills: document.querySelectorAll('.pill'),
+  settingsBtn: document.getElementById('settings-btn'),
+  settingsDialog: document.getElementById('settings-dialog'),
+  settingsForm: document.getElementById('settings-form'),
+  orchField: document.getElementById('orch-url'),
+  tokenField: document.getElementById('api-token'),
+  statusSelect: document.getElementById('status-interval'),
+  statusCards: document.getElementById('status-cards'),
+  statusEmpty: document.getElementById('status-empty'),
+  refreshStatus: document.getElementById('refresh-status'),
+};
+
+dom.orchField.value = state.config.orchestratorUrl;
+dom.tokenField.value = state.config.apiToken;
+dom.statusSelect.value = String(state.config.statusInterval);
+updateStatusTimer();
+
+function loadConfig() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_CONFIG };
+    const parsed = JSON.parse(raw);
+    return { ...DEFAULT_CONFIG, ...parsed };
+  } catch (err) {
+    console.warn('Failed to load config', err);
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+function persistConfig() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state.config));
+}
+
+function scrollChatToBottom() {
+  dom.chat.scrollTop = dom.chat.scrollHeight;
+}
+
+function renderMessage(role, content, options = {}) {
+  const article = document.createElement('article');
+  article.classList.add('msg', role);
+  if (options.className) article.classList.add(options.className);
+  if (typeof content === 'string') {
+    article.innerHTML = `<p class="msg-body">${content}</p>`;
+  } else {
+    article.append(...content);
+  }
+  dom.chat.appendChild(article);
+  scrollChatToBottom();
+  return article;
+}
+
+function renderNote(text) {
+  const note = document.createElement('p');
+  note.className = 'msg-note';
+  note.textContent = text;
+  renderMessage('assistant', note);
+}
+
+function renderConfirm(summary, intent) {
+  state.pendingIntent = intent;
+  state.lastSummary = summary;
+  const actions = document.createElement('div');
+  actions.className = 'msg-actions';
+
+  const yes = document.createElement('button');
+  yes.type = 'button';
+  yes.className = 'btn primary';
+  yes.textContent = 'Proceed';
+  yes.addEventListener('click', () => executeIntent(intent));
+
+  const cancel = document.createElement('button');
+  cancel.type = 'button';
+  cancel.className = 'btn';
+  cancel.textContent = 'Cancel';
+  cancel.addEventListener('click', () => {
+    state.pendingIntent = null;
+    renderMessage('assistant', 'Okay, cancelled. Let me know if you want to try again.');
+  });
+
+  actions.append(yes, cancel);
+
+  const summaryPara = document.createElement('p');
+  summaryPara.className = 'msg-body';
+  summaryPara.textContent = summary;
+
+  const fragment = document.createDocumentFragment();
+  fragment.append(summaryPara, actions);
+
+  renderMessage('assistant', fragment, { className: 'confirm' });
+}
+
+async function handleFormSubmit(event) {
+  event.preventDefault();
+  const text = dom.input.value.trim();
+  if (!text) return;
+
+  renderMessage('user', escapeHtml(text));
+  dom.input.value = '';
+  await planIntent(text);
+}
+
+async function planIntent(text) {
+  try {
+    const { summary, intent, warnings } = await callPlanner(text);
+    if (warnings && warnings.length) {
+      warnings.forEach((warning) => renderNote(warning));
+    }
+    renderConfirm(summary, intent);
+  } catch (err) {
+    handleError(err);
+  }
+}
+
+async function executeIntent(intent) {
+  renderMessage('assistant', 'Working on it…');
+  try {
+    const response = await callExecutor(intent);
+    const { ok, jobId, txHash, receiptUrl } = response;
+    if (!ok) throw new Error(response.error || 'Execution failed');
+
+    const lines = [];
+    lines.push(`✅ Success. Job ID <strong>#${jobId}</strong>.`);
+    if (receiptUrl) {
+      lines.push(`<a href="${receiptUrl}" target="_blank" rel="noopener">View receipt</a>`);
+    } else if (txHash) {
+      lines.push(`<span class="msg-note">Tx hash: ${txHash}</span>`);
+    }
+    renderMessage('assistant', lines.join(' '));
+    state.pendingIntent = null;
+    refreshStatuses();
+  } catch (err) {
+    handleError(err);
+  }
+}
+
+async function callPlanner(text) {
+  if (!state.config.orchestratorUrl) {
+    return demoPlanner(text);
+  }
+
+  const body = JSON.stringify({ text, expert: state.expert });
+  const headers = { 'Content-Type': 'application/json' };
+  if (state.config.apiToken) {
+    headers['Authorization'] = `Bearer ${state.config.apiToken}`;
+  }
+
+  const res = await fetch(`${state.config.orchestratorUrl.replace(/\/$/, '')}/onebox/plan`, {
+    method: 'POST',
+    headers,
+    body,
+  });
+  if (!res.ok) {
+    throw await enrichError('Planner error', res);
+  }
+  return res.json();
+}
+
+async function callExecutor(intent) {
+  if (!state.config.orchestratorUrl) {
+    return demoExecutor(intent);
+  }
+
+  const body = JSON.stringify({ intent, mode: state.expert ? 'wallet' : 'relayer' });
+  const headers = { 'Content-Type': 'application/json' };
+  if (state.config.apiToken) {
+    headers['Authorization'] = `Bearer ${state.config.apiToken}`;
+  }
+
+  const res = await fetch(`${state.config.orchestratorUrl.replace(/\/$/, '')}/onebox/execute`, {
+    method: 'POST',
+    headers,
+    body,
+  });
+  if (!res.ok) {
+    throw await enrichError('Execution error', res);
+  }
+  return res.json();
+}
+
+async function fetchStatuses() {
+  if (!state.config.orchestratorUrl) {
+    return demoStatuses();
+  }
+  const headers = {};
+  if (state.config.apiToken) {
+    headers['Authorization'] = `Bearer ${state.config.apiToken}`;
+  }
+  const res = await fetch(`${state.config.orchestratorUrl.replace(/\/$/, '')}/onebox/status`, { headers });
+  if (!res.ok) {
+    throw await enrichError('Status error', res);
+  }
+  return res.json();
+}
+
+async function refreshStatuses() {
+  try {
+    const data = await fetchStatuses();
+    renderStatuses(Array.isArray(data?.jobs) ? data.jobs : []);
+  } catch (err) {
+    console.warn(err);
+    renderNote('Could not refresh job status right now.');
+  }
+}
+
+function renderStatuses(jobs) {
+  dom.statusCards.innerHTML = '';
+  if (!jobs.length) {
+    dom.statusCards.appendChild(dom.statusEmpty);
+    dom.statusEmpty.hidden = false;
+    return;
+  }
+  dom.statusEmpty.hidden = true;
+
+  for (const job of jobs) {
+    const card = document.createElement('article');
+    card.className = 'status-card';
+    card.setAttribute('role', 'listitem');
+
+    const title = document.createElement('div');
+    title.className = 'status-title';
+    title.textContent = job.title || `Job #${job.jobId}`;
+
+    const statusLine = document.createElement('div');
+    statusLine.className = 'status-line';
+    const statusText = document.createElement('span');
+    statusText.textContent = (job.statusLabel || job.status || 'unknown').toUpperCase();
+    if ((job.status || '').toLowerCase() === 'finalized') {
+      statusText.className = 'status-ok';
+    }
+    const reward = document.createElement('span');
+    reward.textContent = job.reward ? `${job.reward} ${job.rewardToken || 'AGIALPHA'}` : '';
+    statusLine.append(statusText, reward);
+
+    const meta = document.createElement('div');
+    meta.className = 'status-meta';
+    const parts = [];
+    if (job.deadline) parts.push(`Deadline: ${job.deadline}`);
+    if (job.assignee) parts.push(`Assigned to ${job.assignee}`);
+    meta.textContent = parts.join(' · ');
+
+    card.append(title, statusLine, meta);
+    dom.statusCards.appendChild(card);
+  }
+}
+
+function toggleExpertMode() {
+  state.expert = !state.expert;
+  dom.expertToggle.setAttribute('aria-pressed', String(state.expert));
+  dom.expertToggle.classList.toggle('active', state.expert);
+  dom.modeLabel.textContent = `Mode: ${state.expert ? 'Expert' : 'Guest'}`;
+  if (!state.expert) {
+    renderNote('Back in guest mode. I will execute through the orchestrator relayer.');
+  } else {
+    renderNote('Expert mode on. I can hand you calldata for signing if required.');
+  }
+}
+
+function openSettings() {
+  dom.orchField.value = state.config.orchestratorUrl;
+  dom.tokenField.value = state.config.apiToken;
+  dom.statusSelect.value = String(state.config.statusInterval);
+  dom.settingsDialog.showModal();
+}
+
+function applySettings(event) {
+  event.preventDefault();
+  if (dom.settingsDialog.returnValue === 'confirm') {
+    state.config.orchestratorUrl = dom.orchField.value.trim();
+    state.config.apiToken = dom.tokenField.value.trim();
+    state.config.statusInterval = Number(dom.statusSelect.value);
+    persistConfig();
+    updateStatusTimer();
+    renderNote(state.config.orchestratorUrl ? 'Connected to orchestrator.' : 'Demo Mode enabled. No network calls will be made.');
+  }
+}
+
+function updateStatusTimer() {
+  if (state.statusTimer) {
+    clearInterval(state.statusTimer);
+    state.statusTimer = null;
+  }
+  const interval = Number(state.config.statusInterval || 0);
+  if (interval > 0) {
+    state.statusTimer = setInterval(refreshStatuses, interval * 1000);
+  }
+}
+
+function escapeHtml(value) {
+  return value.replace(/[&<>"']/g, (char) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[char]);
+}
+
+async function enrichError(prefix, response) {
+  const text = await response.text();
+  const error = new Error(`${prefix}: ${response.status}`);
+  error.details = text;
+  return error;
+}
+
+function handleError(err) {
+  console.error(err);
+  const { headline, hint } = matchError(err);
+  const fragment = document.createDocumentFragment();
+  const p = document.createElement('p');
+  p.className = 'msg-body';
+  p.innerHTML = `⚠️ ${headline}`;
+  fragment.appendChild(p);
+  if (hint) {
+    const hintEl = document.createElement('p');
+    hintEl.className = 'msg-note';
+    hintEl.textContent = hint;
+    fragment.appendChild(hintEl);
+  }
+  renderMessage('assistant', fragment);
+}
+
+function matchError(err) {
+  if (err?.details) {
+    for (const [key, copy] of errorDictionary.entries()) {
+      if (err.details.includes(key)) return copy;
+    }
+    if (/429/.test(err.message)) {
+      return {
+        headline: 'You hit the rate limit.',
+        hint: 'Wait a moment before trying again. The orchestrator protects against abuse.',
+      };
+    }
+  }
+
+  if (err?.message?.includes('Failed to fetch')) {
+    return errorDictionary.get('network');
+  }
+
+  return {
+    headline: err?.message || 'Something went wrong.',
+    hint: 'Try rephrasing your request in one sentence. If the problem persists, check the orchestrator logs.',
+  };
+}
+
+function demoPlanner(text) {
+  const action = inferDemoAction(text);
+  return {
+    summary: `I understood: ${text}. Ready to ${actionLabel(action)}. Shall I proceed?`,
+    intent: {
+      action,
+      payload: buildDemoPayload(text, action),
+      constraints: { maxFee: 'auto' },
+      userContext: {},
+    },
+    warnings: [],
+  };
+}
+
+function actionLabel(action) {
+  switch (action) {
+    case 'finalize_job':
+      return 'finalize the job';
+    case 'check_status':
+      return 'check on that job';
+    default:
+      return 'post the job';
+  }
+}
+
+function inferDemoAction(text) {
+  const lc = text.toLowerCase();
+  if (lc.includes('final')) return 'finalize_job';
+  if (lc.includes('status') || lc.includes('check')) return 'check_status';
+  return 'post_job';
+}
+
+function buildDemoPayload(text, action) {
+  if (action === 'finalize_job' || action === 'check_status') {
+    const match = text.match(/(job\s*#?)(\d+)/i);
+    return { jobId: match ? Number(match[2]) : 123 };
+  }
+  return {
+    title: text,
+    description: text,
+    reward: '5.0',
+    rewardToken: 'AGIALPHA',
+    deadlineDays: 7,
+  };
+}
+
+function demoExecutor(intent) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({ ok: true, jobId: Math.floor(Math.random() * 500) + 100, txHash: null, receiptUrl: null });
+    }, 800);
+  });
+}
+
+function demoStatuses() {
+  return {
+    jobs: state.pendingIntent ? [
+      {
+        jobId: 123,
+        title: state.lastSummary || 'Demo job',
+        status: 'open',
+        reward: '5.0',
+        rewardToken: 'AGIALPHA',
+        deadline: 'in 7 days',
+      },
+    ] : [],
+  };
+}
+
+function registerListeners() {
+  dom.form.addEventListener('submit', handleFormSubmit);
+  dom.expertToggle.addEventListener('click', toggleExpertMode);
+  dom.pills.forEach((pill) => pill.addEventListener('click', () => {
+    dom.input.value = pill.dataset.fill;
+    dom.input.focus();
+  }));
+  dom.settingsBtn.addEventListener('click', openSettings);
+  dom.settingsForm.addEventListener('close', applySettings);
+  dom.refreshStatus.addEventListener('click', refreshStatuses);
+
+  dom.settingsForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    dom.settingsDialog.close('confirm');
+  });
+  dom.settingsDialog.addEventListener('cancel', () => dom.settingsDialog.close('cancel'));
+}
+
+registerListeners();
+refreshStatuses();
+
+dom.input.focus();

--- a/apps/onebox/index.html
+++ b/apps/onebox/index.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>AGI Jobs — One‑Box</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <div class="wrap">
+      <header class="header" role="banner">
+        <div>
+          <h1>AGI Jobs — One‑Box</h1>
+          <p class="tagline">Plan → Confirm → Execute. No blockchain jargon required.</p>
+        </div>
+        <div class="badges">
+          <span class="badge" id="mode-label" aria-live="polite">Mode: Guest</span>
+          <span class="badge badge-soft">Walletless by default</span>
+        </div>
+      </header>
+
+      <section class="chat" aria-live="polite" aria-label="Conversation" id="chat-log">
+        <article class="msg assistant">
+          <p class="msg-body">Hi! Tell me what you need and I’ll orchestrate the job for you.</p>
+          <p class="msg-note">Try: <span class="example-text">Post a labeling job for 500 images; pay 5 AGIALPHA; 7 days.</span></p>
+        </article>
+      </section>
+
+      <form class="composer" id="composer" autocomplete="off">
+        <label class="sr-only" for="onebox-input">Describe what you want to do</label>
+        <input id="onebox-input" type="text" required placeholder="Type here… Press Enter to send" spellcheck="true">
+        <button type="submit" class="btn primary" id="send-btn">Send</button>
+        <button type="button" class="btn" id="expert-toggle" aria-pressed="false">Expert</button>
+        <button type="button" class="btn" id="settings-btn" aria-haspopup="dialog" aria-controls="settings-dialog">Settings</button>
+      </form>
+
+      <section class="quick-prompts" aria-label="Examples">
+        <button type="button" class="pill" data-fill="Create a research task; reward 2 AGIALPHA; deadline 48 hours">Create a research task…</button>
+        <button type="button" class="pill" data-fill="Finalize my last job">Finalize my last job</button>
+        <button type="button" class="pill" data-fill="What’s the status of job 123?">Check job 123</button>
+      </section>
+
+      <section class="status-board" aria-label="Recent jobs">
+        <header class="status-header">
+          <h2>Recent jobs</h2>
+          <button type="button" class="btn" id="refresh-status">Refresh</button>
+        </header>
+        <div class="status-cards" id="status-cards" role="list">
+          <div class="status-empty" id="status-empty">No jobs yet. I’ll keep this list fresh after you run a task.</div>
+        </div>
+      </section>
+
+      <section class="footnotes">
+        <p>This static site talks to the AGI‑Alpha Orchestrator <code>/onebox/*</code> endpoints. Configure the base URL in Settings.</p>
+        <p>Expert mode reveals wallet signing flows; guest mode uses the orchestrator’s relayer.</p>
+      </section>
+    </div>
+
+    <dialog id="settings-dialog" class="modal" aria-modal="true">
+      <form method="dialog" id="settings-form">
+        <h2>Settings</h2>
+        <label class="field">
+          <span>Orchestrator URL</span>
+          <input type="url" id="orch-url" placeholder="https://orchestrator.example">
+          <span class="hint">Leave blank to use Demo Mode (no network calls).</span>
+        </label>
+        <label class="field">
+          <span>API Token (optional)</span>
+          <input type="password" id="api-token" placeholder="Bearer token">
+        </label>
+        <label class="field">
+          <span>Auto refresh status every</span>
+          <select id="status-interval">
+            <option value="0">Never</option>
+            <option value="30">30 seconds</option>
+            <option value="60" selected>60 seconds</option>
+            <option value="120">2 minutes</option>
+          </select>
+        </label>
+        <menu>
+          <button value="cancel" class="btn">Cancel</button>
+          <button value="confirm" class="btn primary">Save</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/apps/onebox/styles.css
+++ b/apps/onebox/styles.css
@@ -1,0 +1,339 @@
+:root {
+  color-scheme: dark;
+  --bg: #070c11;
+  --panel: #0f1620;
+  --border: #1c2430;
+  --accent: #7c5cff;
+  --accent-soft: rgba(124, 92, 255, 0.2);
+  --fg: #f5f7fb;
+  --muted: #9aa4b2;
+  --success: #1bbf6b;
+  --warning: #ffb020;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font: 16px/1.5 "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at top left, rgba(124, 92, 255, 0.12), transparent 50%),
+    radial-gradient(circle at bottom right, rgba(17, 220, 148, 0.08), transparent 45%),
+    var(--bg);
+  color: var(--fg);
+}
+
+.wrap {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 32px 18px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 2vw + 1rem, 2.2rem);
+}
+
+.tagline {
+  margin: 4px 0 0;
+  color: var(--muted);
+  max-width: 32ch;
+}
+
+.badges {
+  display: flex;
+  gap: 8px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.badge-soft {
+  background: var(--accent-soft);
+  border-color: transparent;
+  color: #c2b7ff;
+}
+
+.chat {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 45vh;
+  max-height: 60vh;
+  overflow-y: auto;
+  scroll-behavior: smooth;
+}
+
+.msg {
+  background: #101927;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: min(560px, 78%);
+  box-shadow: 0 8px 18px rgba(5, 10, 20, 0.4);
+}
+
+.msg.user {
+  margin-left: auto;
+  background: rgba(124, 92, 255, 0.16);
+  border-color: rgba(124, 92, 255, 0.4);
+}
+
+.msg.assistant {
+  background: rgba(13, 19, 30, 0.78);
+}
+
+.msg.confirm {
+  border: 1px solid rgba(17, 220, 148, 0.35);
+}
+
+.msg-note {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.msg-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.composer {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.composer input {
+  flex: 1;
+  padding: 14px 18px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(10, 15, 24, 0.9);
+  color: var(--fg);
+  font-size: 1rem;
+}
+
+.composer input:focus {
+  outline: 2px solid rgba(124, 92, 255, 0.6);
+  outline-offset: 0;
+}
+
+.btn {
+  border: 1px solid var(--border);
+  background: rgba(16, 23, 34, 0.9);
+  color: var(--fg);
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease, border 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn.primary {
+  background: var(--accent);
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn[aria-pressed="true"],
+.btn.active {
+  background: rgba(124, 92, 255, 0.25);
+  border-color: rgba(124, 92, 255, 0.6);
+  color: #d0c6ff;
+}
+
+.quick-prompts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pill {
+  border: 1px solid var(--border);
+  background: rgba(13, 21, 33, 0.8);
+  padding: 10px 14px;
+  border-radius: 999px;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.pill:hover {
+  background: rgba(124, 92, 255, 0.18);
+  color: var(--fg);
+}
+
+.status-board {
+  background: rgba(10, 15, 24, 0.65);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.status-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.status-cards {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.status-card {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(15, 22, 34, 0.9);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 120px;
+}
+
+.status-card .status-line {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.status-card .status-title {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.status-card .status-meta {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.status-card .status-ok {
+  color: var(--success);
+}
+
+.status-empty {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.footnotes {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.modal {
+  border: none;
+  border-radius: 14px;
+  padding: 20px;
+  background: rgba(11, 17, 27, 0.96);
+  color: var(--fg);
+  max-width: 480px;
+}
+
+.modal::backdrop {
+  background: rgba(4, 8, 14, 0.6);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.field input,
+.field select {
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(10, 15, 24, 0.85);
+  color: var(--fg);
+}
+
+.field input:focus,
+.field select:focus {
+  outline: 2px solid rgba(124, 92, 255, 0.5);
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+menu {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .composer {
+    flex-wrap: wrap;
+  }
+
+  .composer input {
+    flex-basis: 100%;
+  }
+
+  .chat {
+    max-height: none;
+    min-height: 40vh;
+  }
+}

--- a/packages/onebox-sdk/README.md
+++ b/packages/onebox-sdk/README.md
@@ -1,0 +1,41 @@
+# @agijobs/onebox-sdk
+
+TypeScript definitions shared between the AGI Jobs one-box front-end and the AGI-Alpha Orchestrator. These interfaces capture the JobIntent contract used by the planner and executor routes (`/onebox/plan`, `/onebox/execute`, `/onebox/status`).
+
+## Usage
+
+```ts
+import type { JobIntent, PlanResponse } from '@agijobs/onebox-sdk';
+
+async function submitIntent(intent: JobIntent): Promise<void> {
+  const res = await fetch('/onebox/execute', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ intent, mode: 'relayer' }),
+  });
+  const json = (await res.json()) as PlanResponse;
+  // ...
+}
+```
+
+Run `pnpm --filter @agijobs/onebox-sdk build` (or `npm run build --workspace=@agijobs/onebox-sdk`) to emit `.d.ts` files under `dist/`.
+
+## Relationship to the orchestrator
+
+The FastAPI service should export matching Pydantic models:
+
+```py
+class JobAttachment(BaseModel):
+    name: str
+    ipfs: str | None = None
+    type: str | None = None
+    url: AnyUrl | None = None
+
+class JobIntent(BaseModel):
+    action: Literal['post_job', 'finalize_job', 'check_status', 'stake', 'validate', 'dispute']
+    payload: dict[str, Any]
+    constraints: dict[str, Any] | None = None
+    userContext: dict[str, Any] | None = Field(default=None, alias='userContext')
+```
+
+Keeping the schemas in sync avoids brittle JSON parsing in the UI and enables editor autocomplete.

--- a/packages/onebox-sdk/package.json
+++ b/packages/onebox-sdk/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@agijobs/onebox-sdk",
   "version": "0.1.0",
-  "private": true,
+  "description": "Shared JobIntent and response contracts for the AGI Jobs one-box orchestrator.",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -9,5 +10,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/onebox-sdk/tsconfig.json
+++ b/packages/onebox-sdk/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist",
     "declaration": true,
-    "emitDeclarationOnly": false
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "emitDeclarationOnly": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- add an IPFS-friendly one-box UI with chat confirmations, demo mode, settings, and a status board
- document the orchestrator API surface and link the new UX from the main README
- refresh the one-box SDK types/README so the planner and executor share the same contract

## Testing
- not run (static assets and documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d6c20124ac83338704a8d5a9c41b49