### PR TITLE
Add runtime orchestrator overrides and demo mode to one-box static UI

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -11,6 +11,7 @@ A single-input, gasless, walletless interface that talks to the AGI-Alpha Meta-A
 - Advanced receipts toggle exposing transaction hashes, gas sponsorship info, and raw ICS payloads.
 - Drag-and-drop attachment support (plus orchestrator prompts) with client-side IPFS pinning backed by `web3.storage`.
 - Live job status board that polls `/onebox/status` for recent updates and renders walletless receipts.
+- Runtime-configurable orchestrator endpoint with a demo-mode fallback for offline testing.
 - Human-readable error dictionary that turns common revert strings and HTTP failures into actionable guidance.
 - Neutral static hosting footprint suited for IPFS pinning.
 
@@ -32,6 +33,12 @@ A single-input, gasless, walletless interface that talks to the AGI-Alpha Meta-A
    ```
 
    Record the CID for gateway access, e.g. `https://w3s.link/ipfs/<CID>/index.html`.
+
+## Runtime configuration & demo mode
+
+- **Advanced panel overrides**: Click the new **Orchestrator** controls to set the base URL (e.g. `https://alpha.example.com`) and prefix (default `/onebox`). Values are stored in `localStorage` under `AGIJOBS_ONEBOX_ORCHESTRATOR_BASE` / `_PREFIX`.
+- **URL parameters**: Append `?orchestrator=https://alpha.example.com&oneboxPrefix=/onebox` to the page URL to preconfigure the client. Use `?orchestrator=demo` to clear overrides and return to demo mode.
+- **Demo mode**: When no orchestrator is configured the planner/executor simulate responses locally. The chat will display warnings (no blockchain calls are made) until a live endpoint is supplied. Status polling is disabled in this mode.
 
 ## Orchestrator contract configuration
 

--- a/apps/onebox-static/config.js
+++ b/apps/onebox-static/config.js
@@ -12,3 +12,12 @@ export const IPFS_GATEWAYS = [
   "https://ipfs.io/ipfs/",
 ];
 export const WEB3_STORAGE_API = IPFS_ENDPOINT;
+export const ORCHESTRATOR_STORAGE_KEYS = {
+  base: "AGIJOBS_ONEBOX_ORCHESTRATOR_BASE",
+  prefix: "AGIJOBS_ONEBOX_ORCHESTRATOR_PREFIX",
+};
+export const ORCHESTRATOR_URL_PARAMS = {
+  base: "orchestrator",
+  prefix: "oneboxPrefix",
+};
+export const ENABLE_DEMO_MODE = true;

--- a/apps/onebox-static/config.mjs
+++ b/apps/onebox-static/config.mjs
@@ -10,3 +10,12 @@ export const IPFS_GATEWAYS = [
   "https://ipfs.io/ipfs/",
 ];
 export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };
+export const ORCHESTRATOR_STORAGE_KEYS = {
+  base: "AGIJOBS_ONEBOX_ORCHESTRATOR_BASE",
+  prefix: "AGIJOBS_ONEBOX_ORCHESTRATOR_PREFIX",
+};
+export const ORCHESTRATOR_URL_PARAMS = {
+  base: "orchestrator",
+  prefix: "oneboxPrefix",
+};
+export const ENABLE_DEMO_MODE = true;

--- a/docs/onebox-static.md
+++ b/docs/onebox-static.md
@@ -96,6 +96,7 @@ web3 storage upload apps/onebox-static
 | Symptom | Possible cause | Resolution |
 | ------- | -------------- | ---------- |
 | “Planner unavailable” | Incorrect `PLAN_URL`, orchestrator offline, or CORS blocked. | Verify URL, check orchestrator logs, adjust CORS origins. |
+| “Demo mode is active” | No orchestrator base URL configured. | Open the Advanced panel, set the orchestrator base URL/prefix, or supply `?orchestrator=...` in the page URL. |
 | “Executor error” | `/onebox/execute` rejected the request or the SSE stream failed. | Inspect orchestrator logs; ensure AA Paymaster funded and ICS passes validation. |
 | “web3.storage token required” | Token not set in browser. | Obtain token from operator, paste when prompted, or clear via `localStorage.removeItem("W3S_TOKEN")`. |
 | ENS requirement message | Identity registry enforced. | Follow the provided claim/associate instructions before retrying. |

--- a/docs/onebox-ux.md
+++ b/docs/onebox-ux.md
@@ -10,6 +10,8 @@ This document covers how the single-input One-Box interface interacts with the A
 
 Guest mode routes execution through the orchestrator relayer. Expert mode surfaces calldata so power users can sign with their own wallets (e.g. through viem/Web3Modal).
 
+The static bundle also exposes runtime configuration controls: operators can change the orchestrator base URL/prefix from the **Advanced** panel or via `?orchestrator=...&oneboxPrefix=...` query parameters. When unset, the client drops into a demo mode that simulates planner/executor responses without hitting the blockchain.
+
 ## API surface (FastAPI stubs)
 
 Add the following endpoints to `AGI-Alpha-Agent-v0`:


### PR DESCRIPTION
## Summary
- Add runtime-configurable orchestrator base/prefix overrides with demo-mode fallback in the one-box static UI, including advanced panel controls, query parameter support, and simulated planner/executor responses.
- Extend configuration exports to cover storage keys, URL parameters, and demo-mode toggles.
- Refresh documentation to describe the new runtime configuration flow, demo-mode behavior, and troubleshooting guidance.

## Testing
- node --check apps/onebox-static/app.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d6cc0ab0d88333b9b8f1f02f8c9a8e