### PR TITLE
Add pinner-aware IPFS uploads for one-box orchestrator

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -18,6 +18,7 @@ A single-input, gasless, walletless interface that talks to the AGI-Alpha Meta-A
 ## Quick start
 
 1. Run or obtain an AGI-Alpha orchestrator endpoint (see [AGI-Alpha-Agent-v0](https://github.com/MontrealAI/AGI-Alpha-Agent-v0)). Ensure CORS allows the origin the static page will be served from.
+   - Configure orchestrator environment variables such as `PINNER_TOKEN` (and optional `PINNER_ENDPOINT`) so server-side executions can pin metadata through your chosen IPFS service.
 2. Update [`config.js`](./config.js) with your orchestrator URLs (base + `/onebox` prefix), desired Account Abstraction settings, and any alternate IPFS gateways you want the Advanced receipts panel to surface.
 3. (Optional) Prepare web3.storage API tokens for team members. Tokens are stored client-side in `localStorage`.
 4. Serve the directory locally for development, e.g.:

--- a/apps/orchestrator/__tests__/ipfs.test.ts
+++ b/apps/orchestrator/__tests__/ipfs.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  extractCidFromPinningResponse,
+  parseIpfsAddResponse,
+} from '../execution';
+
+test('extractCidFromPinningResponse handles plain cid strings', () => {
+  const cid = 'bafybeigdyrzttoexamplecid';
+  assert.equal(extractCidFromPinningResponse(cid), cid);
+});
+
+test('extractCidFromPinningResponse handles nested cid objects', () => {
+  const payload = { cid: { '/': 'bafyNestedCid' } };
+  assert.equal(extractCidFromPinningResponse(payload), 'bafyNestedCid');
+});
+
+test('extractCidFromPinningResponse handles Hash field', () => {
+  const payload = { Hash: 'QmHashExample' };
+  assert.equal(extractCidFromPinningResponse(payload), 'QmHashExample');
+});
+
+test('parseIpfsAddResponse parses multi-line responses', () => {
+  const response = '\n{"Name":"file","Hash":"bafyHash","Size":"123"}\n';
+  assert.equal(parseIpfsAddResponse(response), 'bafyHash');
+});
+
+test('parseIpfsAddResponse returns empty string for invalid payloads', () => {
+  assert.equal(parseIpfsAddResponse('not-json'), '');
+});

--- a/docs/onebox-static.md
+++ b/docs/onebox-static.md
@@ -29,10 +29,11 @@ The static client ships with a **friendly error dictionary** (`FRIENDLY_ERROR_RU
 | 2 | Configure CORS | Allow origins where the IPFS gateway will serve the UI, e.g. `https://w3s.link` or custom gateways. |
 | 3 | Set Account Abstraction credentials | Provision a bundler and sponsored Paymaster (Alchemy Account Kit or equivalent). Stake and fund them according to ERC-4337 requirements. |
 | 4 | Configure relayer fallback | If AA is unavailable, create an OpenZeppelin Defender Relayer with contract/function allowlists and daily spend caps. |
-| 5 | Populate [`apps/onebox-static/config.js`](../apps/onebox-static/config.js) | Update planner/executor URLs, AA chainId, and bundler label. |
-| 6 | Generate web3.storage tokens | Issue per-origin tokens to team members; tokens stay in-browser. Consider revocation schedules. |
-| 7 | Pin the static bundle to IPFS | `web3 storage upload apps/onebox-static` or your preferred pinning workflow. |
-| 8 | Share gateway URL & monitor | Provide the gateway link to users, monitor orchestrator logs, and top-up the Paymaster balance. |
+| 5 | Configure orchestrator IPFS pinning | Set `PINNER_TOKEN` (and optional `PINNER_ENDPOINT`) so the server can pin metadata through web3.storage or your chosen provider. |
+| 6 | Populate [`apps/onebox-static/config.js`](../apps/onebox-static/config.js) | Update planner/executor URLs, AA chainId, and bundler label. |
+| 7 | Generate web3.storage tokens | Issue per-origin tokens to team members; tokens stay in-browser. Consider revocation schedules. |
+| 8 | Pin the static bundle to IPFS | `web3 storage upload apps/onebox-static` or your preferred pinning workflow. |
+| 9 | Share gateway URL & monitor | Provide the gateway link to users, monitor orchestrator logs, and top-up the Paymaster balance. |
 
 ### Safe & governance handover (optional)
 


### PR DESCRIPTION
## Summary
- update the orchestrator IPFS helper to honour PINNER_TOKEN / PINNER_ENDPOINT and reuse a new CID parser
- add lightweight unit coverage for the CID extraction helpers
- document the new environment variables in the static UI operator guides

## Testing
- ⚠️ `node --test apps/orchestrator/__tests__/ipfs.test.ts` *(fails: Node cannot execute TypeScript test files without a loader in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d4f5fe448333a5000af01804f2a8