### PR TITLE
Handle settings dialog close event consistently

### DIFF
--- a/apps/onebox/app.js
+++ b/apps/onebox/app.js
@@ -459,7 +459,7 @@ function registerListeners() {
     dom.input.focus();
   }));
   dom.settingsBtn.addEventListener('click', openSettings);
-  dom.settingsForm.addEventListener('close', applySettings);
+  dom.settingsDialog.addEventListener('close', applySettings);
   dom.refreshStatus.addEventListener('click', refreshStatuses);
 
   dom.settingsForm.addEventListener('submit', (event) => {


### PR DESCRIPTION
## Summary
- rebind the settings apply handler to the dialog's close event so changes persist regardless of how the dialog is dismissed

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6ddbec878833388209864edce27e5