### PR TITLE
Enhance one-box static UI with settings dialog

### DIFF
--- a/apps/onebox-static/v2/README.md
+++ b/apps/onebox-static/v2/README.md
@@ -13,18 +13,9 @@ A static, IPFS-friendly single-input interface for AGI Jobs v2. The page works i
 ## Usage
 
 1. Open `index.html` locally or via static hosting.
-2. Configure the orchestrator endpoint in the browser console:
-   ```js
-   localStorage.ORCH_URL = "https://your-orchestrator.example";
-   ```
-   You can also run `oneboxSetOrchestrator("https://your-orchestrator.example")` for a helper that saves the URL and reloads the page.
-   When targeting a token-protected orchestrator, store your API credential alongside the URL:
-   ```js
-   localStorage.ONEBOX_API_TOKEN = "replace-with-your-token";
-   ```
-   The UI automatically attaches `Authorization: Bearer …` to planner, execution, and status calls when a token is present. Clear the key to fall back to anonymous mode.
+2. Click **Settings** and enter the orchestrator URL. Leave it blank to stay in Demo Mode. Optionally paste an API token (stored securely in `localStorage`) and choose how frequently the status board should refresh.
 3. Send a natural-language instruction such as "Post a labeling job for 500 images; pay 5 AGIALPHA; 7 days".
-4. Confirm the plan and wait for the orchestrator to execute.
+4. Confirm the plan and wait for the orchestrator to execute. Expert Mode can be toggled at any time if you want calldata for a connected wallet.
 5. Monitor the recent activity panel at the bottom of the page or press **Refresh** to force a status update on demand.
 
 When no orchestrator URL is configured the UI remains interactive using built-in demo responses, making it safe to embed in documentation or marketing materials before backend integration is ready.

--- a/apps/onebox-static/v2/index.html
+++ b/apps/onebox-static/v2/index.html
@@ -9,9 +9,17 @@
   <body>
     <div class="wrap">
       <header class="header">
-        <h1>AGI Jobs — One-Box</h1>
-        <span class="badge">Walletless by default</span>
-        <span id="mode" class="badge">Mode: Guest</span>
+        <div class="header-titles">
+          <h1>AGI Jobs — One-Box</h1>
+          <p class="tagline">Plan → confirm → execute. No blockchain jargon.</p>
+        </div>
+        <div class="header-actions">
+          <span class="badge">Walletless by default</span>
+          <span id="mode" class="badge">Mode: Guest</span>
+          <button id="settings" type="button" class="secondary small" aria-haspopup="dialog" aria-controls="settings-dialog">
+            Settings
+          </button>
+        </div>
       </header>
 
       <main>
@@ -38,8 +46,8 @@
         <hr />
         <p class="small">
           This static client talks to the AGI-Alpha Orchestrator (<span class="kbd">/onebox/plan</span>,
-          <span class="kbd">/onebox/execute</span>, <span class="kbd">/onebox/status</span>). Configure the endpoint via the
-          browser console: <span class="kbd">localStorage.ORCH_URL = "https://your-orchestrator.example"</span>.
+          <span class="kbd">/onebox/execute</span>, <span class="kbd">/onebox/status</span>). Use
+          <strong>Settings</strong> to configure the endpoint and API token. Leave the fields blank for Demo Mode.
         </p>
 
         <section class="status" aria-live="polite">
@@ -52,6 +60,34 @@
         </section>
       </main>
     </div>
+
+    <dialog id="settings-dialog" class="modal" aria-modal="true">
+      <form method="dialog" id="settings-form">
+        <h2>Settings</h2>
+        <label class="field">
+          <span>Orchestrator URL</span>
+          <input type="url" id="settings-orch" placeholder="https://orchestrator.example" autocomplete="off" />
+          <span class="hint">Blank uses Demo Mode (no network calls).</span>
+        </label>
+        <label class="field">
+          <span>API token (optional)</span>
+          <input type="password" id="settings-token" placeholder="Bearer token" autocomplete="off" />
+        </label>
+        <label class="field">
+          <span>Status auto-refresh</span>
+          <select id="settings-interval">
+            <option value="0">Manual only</option>
+            <option value="15000">Every 15 seconds</option>
+            <option value="30000">Every 30 seconds</option>
+            <option value="60000">Every minute</option>
+          </select>
+        </label>
+        <menu>
+          <button value="cancel" class="secondary">Cancel</button>
+          <button value="confirm">Save</button>
+        </menu>
+      </form>
+    </dialog>
 
     <script src="app.js" type="module"></script>
   </body>

--- a/apps/onebox-static/v2/styles.css
+++ b/apps/onebox-static/v2/styles.css
@@ -27,14 +27,29 @@ body {
 
 .header {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
   gap: 12px;
   margin-bottom: 16px;
 }
 
-.header h1 {
+.header-titles h1 {
   margin: 0;
-  font-size: 20px;
+  font-size: 22px;
+}
+
+.tagline {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .badge {
@@ -126,6 +141,11 @@ button.secondary {
   border: 1px solid #273245;
 }
 
+button.small {
+  padding: 8px 12px;
+  font-size: 13px;
+}
+
 .row {
   display: flex;
   gap: 8px;
@@ -147,6 +167,62 @@ button.secondary {
   background: #0e2a1c;
   border-color: #214b38;
   color: #7de6b2;
+}
+
+.modal {
+  border: none;
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 440px;
+  width: min(440px, 90vw);
+  background: #0f1622;
+  color: var(--fg);
+  box-shadow: 0 24px 60px rgba(4, 8, 15, 0.45);
+}
+
+.modal::backdrop {
+  background: rgba(3, 6, 12, 0.65);
+}
+
+.modal h2 {
+  margin: 0 0 16px;
+  font-size: 18px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.field input,
+.field select {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #273245;
+  background: #111b29;
+  color: var(--fg);
+}
+
+.field input:focus,
+.field select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.field .hint {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.modal menu {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
 }
 
 hr {


### PR DESCRIPTION
## Summary
- add an in-page settings dialog to the static one-box UI for configuring the orchestrator URL, API token, and status refresh cadence
- persist expert mode and orchestrator settings in localStorage, update status polling to honour manual mode, and surface demo-mode guidance in the chat
- refresh the static UI README to reflect the new workflow and Expert Mode guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e08773f08333805609f4df6e5cd1