### PR TITLE
Add advanced receipts panel to one-box UI

### DIFF
--- a/apps/onebox/index.html
+++ b/apps/onebox/index.html
@@ -19,7 +19,7 @@
         </div>
       </header>
 
-      <section class="chat" aria-live="polite" aria-label="Conversation" id="chat-log">
+      <section class="chat" aria-live="polite" aria-label="Conversation" role="log" id="chat-log">
         <article class="msg assistant">
           <p class="msg-body">Hi! Tell me what you need and I’ll orchestrate the job for you.</p>
           <p class="msg-note">Try: <span class="example-text">Post a labeling job for 500 images; pay 5 AGIALPHA; 7 days.</span></p>
@@ -53,6 +53,18 @@
       <section class="footnotes">
         <p>This static site talks to the AGI‑Alpha Orchestrator <code>/onebox/*</code> endpoints. Configure the base URL in Settings.</p>
         <p>Expert mode reveals wallet signing flows; guest mode uses the orchestrator’s relayer.</p>
+        <button type="button" class="btn ghost" id="advanced-toggle" aria-expanded="false" aria-controls="advanced-panel">
+          Advanced receipts
+        </button>
+      </section>
+
+      <section class="advanced" id="advanced-panel" hidden aria-label="Advanced receipts" role="region">
+        <div class="advanced-head">
+          <h2>Advanced receipts</h2>
+          <p class="advanced-note">Verification links and calldata appear here after you run a task.</p>
+        </div>
+        <div class="advanced-receipts" id="advanced-receipts" role="list"></div>
+        <p class="advanced-empty" id="advanced-empty">No receipts yet. They will show up here once you run something.</p>
       </section>
     </div>
 

--- a/apps/onebox/styles.css
+++ b/apps/onebox/styles.css
@@ -162,6 +162,19 @@ body {
   transition: transform 0.15s ease, background 0.2s ease, border 0.2s ease;
 }
 
+.btn.ghost {
+  background: transparent;
+  color: var(--muted);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.btn.ghost:hover,
+.btn.ghost:focus-visible {
+  color: var(--fg);
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(15, 22, 32, 0.6);
+}
+
 .btn:hover {
   transform: translateY(-1px);
 }
@@ -263,6 +276,114 @@ body {
   font-size: 13px;
   color: var(--muted);
   line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.footnotes .btn {
+  align-self: flex-start;
+}
+
+.advanced {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.advanced[hidden] {
+  display: none;
+}
+
+.advanced-head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.advanced-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.advanced-receipts {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.advanced-empty {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.advanced-receipt {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: rgba(11, 17, 27, 0.8);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.advanced-receipt header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.advanced-title {
+  font-weight: 600;
+}
+
+.advanced-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.advanced-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 13px;
+}
+
+.advanced-links a {
+  color: #c2b7ff;
+}
+
+.advanced-json {
+  font-family: "SFMono-Regular", "Roboto Mono", "Fira Code", monospace;
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 12px;
+  padding: 12px;
+  overflow-x: auto;
+}
+
+.advanced details summary {
+  cursor: pointer;
+  color: #c2b7ff;
+  font-size: 13px;
+}
+
+.advanced details summary:focus-visible {
+  outline: 2px solid rgba(124, 92, 255, 0.6);
+  outline-offset: 4px;
+}
+
+.advanced time {
+  font-variant-numeric: tabular-nums;
 }
 
 .modal {


### PR DESCRIPTION
## Summary
- add an advanced receipts toggle and panel to the one-box static client so blockchain details stay opt-in
- track recent executions in the front-end state and render friendly success copy while routing raw calldata to the advanced view
- extend styling to support the new ghost button and verification panel layout

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6e497e1408333aa29bae25f946130