### PR TITLE
Extend onebox planner intent detection for job management actions

### DIFF
--- a/test/routes/test_onebox.py
+++ b/test/routes/test_onebox.py
@@ -297,6 +297,27 @@ class PlannerIntentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.intent.payload.jobId, 42)
         self.assertIn("detected job finalization request", response.summary.lower())
 
+    async def test_stake_keyword_maps_to_stake_intent(self) -> None:
+        response = await plan(PlanRequest(text="Stake on job 555"))
+        self.assertEqual(response.intent.action, "stake")
+        self.assertEqual(response.intent.payload.jobId, 555)
+        self.assertIn("detected staking request", response.summary.lower())
+        self.assertIn("stake on job 555", response.summary.lower())
+
+    async def test_validate_keyword_maps_to_validate_intent(self) -> None:
+        response = await plan(PlanRequest(text="Please validate job 777"))
+        self.assertEqual(response.intent.action, "validate")
+        self.assertEqual(response.intent.payload.jobId, 777)
+        self.assertIn("detected validation request", response.summary.lower())
+        self.assertIn("validate job 777", response.summary.lower())
+
+    async def test_dispute_keyword_maps_to_dispute_intent(self) -> None:
+        response = await plan(PlanRequest(text="Dispute job 888 immediately"))
+        self.assertEqual(response.intent.action, "dispute")
+        self.assertEqual(response.intent.payload.jobId, 888)
+        self.assertIn("detected dispute request", response.summary.lower())
+        self.assertIn("dispute job 888", response.summary.lower())
+
 
 class DeadlineComputationTests(unittest.TestCase):
     def test_calculate_deadline_uses_epoch_seconds(self) -> None:


### PR DESCRIPTION
## Summary
- extend the naive planner parser with staking, validation, and dispute keyword detection while preserving post job fallback
- update plan summaries to describe the inferred non-posting actions and ensure job IDs propagate to the payload
- add unit tests covering the new finalize/status/stake/validate/dispute parsing behaviours

## Testing
- pytest test/routes/test_onebox.py

------
https://chatgpt.com/codex/tasks/task_e_68d700b8ff4c8333bb0b1c3596376fa6