### PR TITLE
Add status board and demo mode to One-Box UI

### DIFF
--- a/apps/onebox/app.js
+++ b/apps/onebox/app.js
@@ -1,125 +1,710 @@
 // apps/onebox/app.js
-const $ = s=>document.querySelector(s), chat=$('#chat'), box=$('#box'), mode=$('#mode');
-const sendBtn=$('#send'), expertBtn=$('#expert'), saveBtn=$('#save'), orchInput=$('#orch'), tokInput=$('#tok'), connectBtn=$('#connect');
-document.querySelectorAll('.pill').forEach(p=>p.onclick=()=>box.value=p.dataset.example);
+const $ = (selector) => document.querySelector(selector);
+const chat = $('#chat');
+const box = $('#box');
+const modeBadge = $('#mode');
+const statusList = $('#status-list');
+const statusEmpty = $('#status-empty');
+const statusNote = $('#status-note');
+const statusRefresh = $('#status-refresh');
+const sendBtn = $('#send');
+const expertBtn = $('#expert');
+const saveBtn = $('#save');
+const orchInput = $('#orch');
+const tokInput = $('#tok');
+const connectBtn = $('#connect');
 
-const COPY={
-  planning:"Let me prepare this…",
-  executing:"Publishing to the network… this usually takes a few seconds.",
-  posted:(id,url)=>`✅ Job <b>#${id??'?'}</b> is live. ${url?`<a target="_blank" rel="noopener" href="${url}">Verify on chain</a>`:''}`,
-  finalized:(id,url)=>`✅ Job <b>#${id}</b> finalized. ${url?`<a target="_blank" rel="noopener" href="${url}">Receipt</a>`:''}`,
-  cancelled:"Okay, cancelled.",
-  status:(s)=>`Job <b>#${s.jobId}</b> is <b>${s.state}</b>${s.reward?`. Reward ${s.reward}`:''}${s.token?` ${s.token}`:''}.`
+const STORAGE_KEYS = {
+  ORCH: 'ORCH_URL',
+  TOKEN: 'ORCH_TOKEN',
+  STATUS_INTERVAL: 'ONEBOX_STATUS_INTERVAL',
+  EXPERT_MODE: 'ONEBOX_EXPERT_MODE',
 };
-const ERRORS={
-  INSUFFICIENT_BALANCE:"You don’t have enough AGIALPHA to fund this job. Reduce the reward or top up.",
-  INSUFFICIENT_ALLOWANCE:"Your wallet needs permission to use AGIALPHA. I can prepare an approval transaction.",
-  IPFS_FAILED:"I couldn’t package your job details. Remove broken links and try again.",
-  DEADLINE_INVALID:"That deadline is in the past. Pick at least 24 hours from now.",
-  NETWORK_CONGESTED:"The network is busy; I’ll keep retrying for a moment.",
-  RELAYER_NOT_CONFIGURED:"The orchestrator isn’t configured to relay transactions yet. Ask the operator to set ONEBOX_RELAYER_PRIVATE_KEY.",
-  JOB_ID_REQUIRED:"I need a job ID to continue. Include the job number in your request.",
-  REQUEST_EMPTY:"Please describe what you need before sending.",
-  UNSUPPORTED_ACTION:"That action isn’t available yet. Try posting, checking status, or finalizing jobs.",
-  UNKNOWN:"Something went wrong. Try rephrasing your request or adjust the reward/deadline."
+const DEFAULT_STATUS_INTERVAL = 30_000;
+
+const COPY = {
+  planning: 'Let me prepare this…',
+  executing: 'Publishing to the network… this usually takes a few seconds.',
+  posted: (id, url) =>
+    `✅ Job <b>#${id ?? '?'}</b> is live. ${
+      url ? `<a target="_blank" rel="noopener" href="${url}">Verify on chain</a>` : ''
+    }`,
+  finalized: (id, url) =>
+    `✅ Job <b>#${id}</b> finalized. ${
+      url ? `<a target="_blank" rel="noopener" href="${url}">Receipt</a>` : ''
+    }`,
+  cancelled: 'Okay, cancelled.',
+  status: (s) =>
+    `Job <b>#${s.jobId}</b> is <b>${s.state}</b>${
+      s.reward ? `. Reward ${s.reward}` : ''
+    }${s.token ? ` ${s.token}` : ''}.`,
 };
 
-let EXPERT=false, ETH=null;
-let ORCH=localStorage.getItem('ORCH_URL')||'', TOK=localStorage.getItem('ORCH_TOKEN')||'';
-orchInput.value=ORCH; tokInput.value=TOK;
+const ERRORS = {
+  INSUFFICIENT_BALANCE: 'You don’t have enough AGIALPHA to fund this job. Reduce the reward or top up.',
+  INSUFFICIENT_ALLOWANCE: 'Your wallet needs permission to use AGIALPHA. I can prepare an approval transaction.',
+  IPFS_FAILED: 'I couldn’t package your job details. Remove broken links and try again.',
+  DEADLINE_INVALID: 'That deadline is in the past. Pick at least 24 hours from now.',
+  NETWORK_CONGESTED: 'The network is busy; I’ll keep retrying for a moment.',
+  RELAYER_NOT_CONFIGURED: 'The orchestrator isn’t configured to relay transactions yet. Ask the operator to set ONEBOX_RELAYER_PRIVATE_KEY.',
+  JOB_ID_REQUIRED: 'I need a job ID to continue. Include the job number in your request.',
+  REQUEST_EMPTY: 'Please describe what you need before sending.',
+  UNSUPPORTED_ACTION: 'That action isn’t available yet. Try posting, checking status, or finalizing jobs.',
+  NO_WALLET: 'Connect an EIP-1193 wallet before using Expert Mode.',
+  NETWORK_FAILURE: 'I couldn’t reach the orchestrator. Check the URL or try again in a moment.',
+  UNKNOWN: 'Something went wrong. Try rephrasing your request or adjust the reward/deadline.',
+};
 
-function add(role,html){const d=document.createElement('div');d.className='msg '+(role==='user'?'m-user':'m-assist');d.innerHTML=html;chat.appendChild(d);chat.scrollTop=chat.scrollHeight}
-function note(t){add('assist',`<div class="note">${t}</div>`)}
-function setMode(){mode.textContent='Mode: '+(EXPERT?'Expert (wallet)':'Guest (walletless)')}
+const DEMO_STATE = {
+  nextJobId: 301,
+  jobs: [],
+};
 
-async function api(path, body){
-  if(!ORCH){throw new Error('Set your Orchestrator URL in Advanced')}
-  const headers={'Content-Type':'application/json'}; if(TOK) headers['Authorization']='Bearer '+TOK;
-  const r=await fetch(ORCH+path,{method: body? 'POST':'GET',headers,body: body? JSON.stringify(body):undefined});
-  if(!r.ok){
-    let code='UNKNOWN';
-    try{
-      const raw=await r.text();
-      if(raw){
-        try{
-          const parsed=JSON.parse(raw);
-          if(typeof parsed==='string') code=parsed;
-          else if(parsed && typeof parsed==='object'){
-            if(typeof parsed.error==='string') code=parsed.error;
-            else if(typeof parsed.detail==='string') code=parsed.detail;
-            else if(parsed.detail && typeof parsed.detail==='object' && typeof parsed.detail.error==='string') code=parsed.detail.error;
-          }
-        }catch{
-          code=raw.trim()||'UNKNOWN';
+const trackedJobs = new Map();
+
+let expertMode = localStorage.getItem(STORAGE_KEYS.EXPERT_MODE) === '1';
+let ethProvider = null;
+let orchestratorUrl = (localStorage.getItem(STORAGE_KEYS.ORCH) || '').trim();
+let bearerToken = (localStorage.getItem(STORAGE_KEYS.TOKEN) || '').trim();
+let statusInterval = readStatusInterval();
+let statusTimer = null;
+let demoMode = false;
+
+hydrateFromQueryParams();
+
+orchInput.value = orchestratorUrl;
+tokInput.value = bearerToken;
+
+document.querySelectorAll('.pill').forEach((pill) => {
+  pill.onclick = () => {
+    box.value = pill.dataset.example;
+    box.focus();
+  };
+});
+
+const EXPERT_TOOLTIP = {
+  true: 'Expert Mode enabled — transactions return calldata for signing.',
+  false: 'Guest Mode — requests execute via the orchestrator relayer.',
+};
+
+updateModeBadge();
+
+if (!orchestratorUrl) {
+  demoMode = true;
+  note('Demo mode active. Save an orchestrator URL in Advanced to go live.');
+  renderStatuses(Array.from(trackedJobs.values()));
+}
+
+scheduleStatusPoll();
+
+async function api(path, body) {
+  if (!orchestratorUrl) {
+    return demoApi(path, body);
+  }
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (bearerToken) {
+    headers.Authorization = `Bearer ${bearerToken}`;
+  }
+
+  const url = path.startsWith('http') ? path : `${orchestratorUrl.replace(/\/$/, '')}${path}`;
+
+  try {
+    const response = await fetch(url, {
+      method: body ? 'POST' : 'GET',
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!response.ok) {
+      const code = await extractErrorCode(response);
+      throw new Error(code.toUpperCase());
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      return await response.json();
+    }
+    return null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '';
+    if (message) {
+      if (message.toLowerCase().includes('fetch') || message.toLowerCase().includes('network')) {
+        throw new Error('NETWORK_FAILURE');
+      }
+      throw new Error(message);
+    }
+    throw new Error('NETWORK_FAILURE');
+  }
+}
+
+async function extractErrorCode(response) {
+  try {
+    const raw = await response.text();
+    if (!raw) {
+      return 'UNKNOWN';
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === 'string') {
+        return parsed || 'UNKNOWN';
+      }
+      if (parsed && typeof parsed === 'object') {
+        if (typeof parsed.error === 'string') return parsed.error;
+        if (typeof parsed.detail === 'string') return parsed.detail;
+        if (parsed.detail && typeof parsed.detail === 'object' && typeof parsed.detail.error === 'string') {
+          return parsed.detail.error;
         }
       }
-    }catch{}
-    throw new Error(code.toUpperCase());
+    } catch (jsonErr) {
+      if (jsonErr) {
+        return raw.trim() || 'UNKNOWN';
+      }
+    }
+    return raw.trim() || 'UNKNOWN';
+  } catch (err) {
+    return 'UNKNOWN';
   }
-  return await r.json();
 }
 
-function confirmUI(summary,intent){
-  add('assist', summary + `<div class="row" style="margin-top:10px">
-    <button class="pill ok" id="yes">Yes</button><button class="pill" id="no">Cancel</button></div>`);
-  setTimeout(()=>{
-    document.getElementById('yes').onclick=()=>execute(intent);
-    document.getElementById('no').onclick=()=>add('assist', COPY.cancelled);
-  },0);
+function addMessage(role, html) {
+  const div = document.createElement('div');
+  div.className = `msg ${role === 'user' ? 'm-user' : 'm-assist'}`;
+  if (typeof html === 'string') {
+    div.innerHTML = html;
+  } else if (html instanceof Node) {
+    div.appendChild(html);
+  }
+  chat.appendChild(div);
+  chat.scrollTop = chat.scrollHeight;
+  return div;
 }
 
-async function plan(text){
-  add('assist', COPY.planning);
-  const j=await api('/onebox/plan',{text,expert:EXPERT});
-  return j;
+function note(text) {
+  addMessage('assist', `<div class="note">${text}</div>`);
 }
 
-async function execute(intent){
-  add('assist', COPY.executing);
-  const mode = EXPERT ? 'wallet' : 'relayer';
-  const j=await api('/onebox/execute',{intent,mode});
+function updateModeBadge() {
+  if (modeBadge) {
+    modeBadge.textContent = `Mode: ${expertMode ? 'Expert (wallet)' : 'Guest (walletless)'}`;
+    modeBadge.title = EXPERT_TOOLTIP[expertMode ? 'true' : 'false'];
+  }
+}
 
-  // Expert: sign via EIP-1193
-  if(EXPERT && j.to && j.data){
-    if(!ETH) throw new Error('NO_WALLET');
-    const from=(await ETH.request({method:'eth_requestAccounts'}))[0];
-    const txHash=await ETH.request({method:'eth_sendTransaction',params:[{from,to:j.to,data:j.data,value:j.value||'0x0'}]});
-    // The server's receiptUrl likely has a {tx} pattern; we replace tail if provided
-    const url=(j.receiptUrl||'').replace(/0x[0-9a-fA-F]{64}.?$/, txHash);
-    if(intent.action==='finalize_job') add('assist', COPY.finalized(j.jobId||'?', url||''));
-    else add('assist', COPY.posted(j.jobId||'?', url||''));
+function confirmUI(summary, intent) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'msg m-assist';
+  wrapper.innerHTML = `${summary}<div class="row" style="margin-top:10px">
+    <button class="pill ok" id="confirm-yes">Yes</button>
+    <button class="pill" id="confirm-no">Cancel</button>
+  </div>`;
+  chat.appendChild(wrapper);
+  chat.scrollTop = chat.scrollHeight;
+
+  setTimeout(() => {
+    const yesBtn = document.getElementById('confirm-yes');
+    const noBtn = document.getElementById('confirm-no');
+    if (yesBtn) {
+      yesBtn.onclick = () => execute(intent);
+    }
+    if (noBtn) {
+      noBtn.onclick = () => addMessage('assist', COPY.cancelled);
+    }
+  }, 0);
+}
+
+async function plan(text) {
+  addMessage('assist', COPY.planning);
+  return api('/onebox/plan', { text, expert: expertMode });
+}
+
+async function execute(intent) {
+  addMessage('assist', COPY.executing);
+  const mode = expertMode ? 'wallet' : 'relayer';
+  const response = await api('/onebox/execute', { intent, mode });
+
+  if (expertMode && response && response.to && response.data) {
+    if (!ethProvider) {
+      throw new Error('NO_WALLET');
+    }
+    const [from] = await ethProvider.request({ method: 'eth_requestAccounts' });
+    const txHash = await ethProvider.request({
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from,
+          to: response.to,
+          data: response.data,
+          value: response.value || '0x0',
+        },
+      ],
+    });
+    const receiptUrl = (response.receiptUrl || '').replace(/0x[0-9a-fA-F]{64}.?$/, txHash);
+    if (intent.action === 'finalize_job') {
+      addMessage('assist', COPY.finalized(response.jobId || '?', receiptUrl || ''));
+      rememberJob({ jobId: response.jobId, state: 'finalized', receiptUrl });
+    } else {
+      addMessage('assist', COPY.posted(response.jobId || '?', receiptUrl || ''));
+      rememberJob({ jobId: response.jobId, state: 'open', receiptUrl });
+    }
+    renderTrackedJobs();
     return;
   }
-  if(intent.action==='finalize_job') add('assist', COPY.finalized(j.jobId, j.receiptUrl||''));
-  else add('assist', COPY.posted(j.jobId, j.receiptUrl||''));
+
+  const receiptUrl = response?.receiptUrl || '';
+  if (intent.action === 'finalize_job') {
+    addMessage('assist', COPY.finalized(response?.jobId ?? '?', receiptUrl));
+    rememberJob({ jobId: response?.jobId, state: 'finalized', receiptUrl });
+  } else {
+    addMessage('assist', COPY.posted(response?.jobId ?? '?', receiptUrl));
+    rememberJob({ jobId: response?.jobId, state: 'open', receiptUrl });
+  }
+  if (intent.action === 'post_job' && intent.payload) {
+    rememberJob({
+      jobId: response?.jobId,
+      state: 'open',
+      reward: formatReward(intent.payload.reward),
+      token: intent.payload.rewardToken || 'AGIALPHA',
+      deadline: intent.payload.deadlineDays ? humanDeadline(intent.payload.deadlineDays) : undefined,
+    });
+  }
+  renderTrackedJobs();
+  pollTrackedJobs();
 }
 
-async function go(){
-  const text=box.value.trim(); if(!text) return;
-  add('user', text); box.value='';
-  try{
-    const {summary,intent} = await plan(text);
-    // status shortcut
-    if(intent.action==='check_status'){
-      const idMatch = text.match(/\d+/); const jobId = intent.payload.jobId || (idMatch? parseInt(idMatch[0],10):0);
-      const s = await api(`/onebox/status?jobId=${jobId}`);
-      add('assist', COPY.status(s)); return;
+async function go() {
+  const text = box.value.trim();
+  if (!text) {
+    return;
+  }
+  addMessage('user', text);
+  box.value = '';
+
+  try {
+    const { summary, intent } = await plan(text);
+
+    if (intent.action === 'check_status') {
+      const jobId = resolveJobId(text, intent.payload?.jobId);
+      const status = await api(`/onebox/status?jobId=${jobId}`);
+      addMessage('assist', COPY.status(status));
+      rememberJob(status);
+      renderTrackedJobs();
+      return;
     }
-    confirmUI(summary,intent);
-  }catch(e){handleError(e)}
+
+    confirmUI(summary, intent);
+  } catch (error) {
+    handleError(error);
+  }
 }
 
-function handleError(e){
-  const upper=(e.message||'').toUpperCase();
-  const key = Object.keys(ERRORS).find(k=> upper.includes(k)) || 'UNKNOWN';
-  add('assist','⚠️ '+ERRORS[key]);
+function handleError(error) {
+  const message = (error && error.message) || '';
+  const upper = message.toUpperCase();
+  const key = Object.keys(ERRORS).find((code) => upper.includes(code)) || 'UNKNOWN';
+  addMessage('assist', `⚠️ ${ERRORS[key]}`);
 }
 
-sendBtn.onclick=go; box.onkeydown=e=>{if(e.key==='Enter') go()};
-expertBtn.onclick=()=>{EXPERT=!EXPERT; setMode()};
-saveBtn.onclick=()=>{ORCH=orchInput.value.trim(); TOK=tokInput.value.trim(); localStorage.setItem('ORCH_URL',ORCH); localStorage.setItem('ORCH_TOKEN',TOK); note('Saved.')};
-connectBtn.onclick=async()=>{
-  if(window.ethereum){ETH=window.ethereum; try{await ETH.request({method:'eth_requestAccounts'}); note('Wallet connected.');}catch{}}
-  else{note('No EIP‑1193 provider found.')}
+function resolveJobId(text, fallback) {
+  if (fallback) {
+    return fallback;
+  }
+  const match = text.match(/\d+/);
+  if (match) {
+    return parseInt(match[0], 10);
+  }
+  const keys = Array.from(trackedJobs.keys());
+  if (keys.length > 0) {
+    return keys[0];
+  }
+  return 0;
+}
+
+function rememberJob(entry) {
+  if (!entry || !entry.jobId) {
+    return;
+  }
+  const existing = trackedJobs.get(entry.jobId) || {};
+  trackedJobs.set(entry.jobId, {
+    ...existing,
+    ...entry,
+    updatedAt: Date.now(),
+  });
+}
+
+function renderTrackedJobs() {
+  renderStatuses(Array.from(trackedJobs.values()).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0)));
+}
+
+function renderStatuses(list) {
+  if (!statusList || !statusEmpty) {
+    return;
+  }
+  if (!list || list.length === 0) {
+    statusEmpty.hidden = false;
+    statusList.innerHTML = '';
+    if (statusNote) {
+      statusNote.hidden = true;
+    }
+    return;
+  }
+  statusEmpty.hidden = true;
+  statusList.innerHTML = '';
+  list.forEach((item) => {
+    if (!item || !item.jobId) {
+      return;
+    }
+    const li = document.createElement('li');
+    li.className = 'status-item';
+    const state = (item.state || 'unknown').toLowerCase();
+    const rewardText = item.reward ? `${item.reward}${item.token ? ` ${item.token}` : ''}` : '—';
+    const deadlineText = item.deadline ? describeDeadline(item.deadline) : '—';
+    li.innerHTML = `
+      <div class="status-top">
+        <span class="status-id">#${item.jobId}</span>
+        <span class="status-chip ${state}">${state}</span>
+      </div>
+      <div class="status-meta">Reward ${rewardText} · Deadline ${deadlineText}</div>
+    `;
+    if (item.receiptUrl || item.explorerUrl) {
+      const links = document.createElement('div');
+      links.className = 'status-links';
+      const href = item.receiptUrl || item.explorerUrl;
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.target = '_blank';
+      anchor.rel = 'noopener';
+      anchor.textContent = 'Verify on chain';
+      links.appendChild(anchor);
+      li.appendChild(links);
+    }
+    statusList.appendChild(li);
+  });
+  if (statusNote) {
+    statusNote.hidden = true;
+  }
+}
+
+function describeDeadline(deadline) {
+  if (typeof deadline === 'number') {
+    const now = Math.floor(Date.now() / 1000);
+    const diff = deadline - now;
+    if (diff <= 0) return 'elapsed';
+    const days = Math.floor(diff / 86400);
+    if (days > 0) return `${days} day${days === 1 ? '' : 's'} left`;
+    const hours = Math.floor(diff / 3600);
+    if (hours > 0) return `${hours} hour${hours === 1 ? '' : 's'} left`;
+    const minutes = Math.floor(diff / 60);
+    if (minutes > 0) return `${minutes} min left`;
+    return `${diff} sec left`;
+  }
+  if (typeof deadline === 'string') {
+    return deadline;
+  }
+  return '—';
+}
+
+function formatReward(value) {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === 'number') {
+    return value.toString();
+  }
+  return String(value);
+}
+
+function humanDeadline(days) {
+  const dayCount = Number(days);
+  if (!Number.isFinite(dayCount) || dayCount <= 0) {
+    return undefined;
+  }
+  return `${dayCount} day${dayCount === 1 ? '' : 's'}`;
+}
+
+async function pollTrackedJobs() {
+  if (!orchestratorUrl || trackedJobs.size === 0) {
+    return;
+  }
+  const ids = Array.from(trackedJobs.keys());
+  const requests = await Promise.allSettled(
+    ids.map((id) => api(`/onebox/status?jobId=${id}`))
+  );
+  let changed = false;
+  requests.forEach((result) => {
+    if (result.status === 'fulfilled' && result.value && result.value.jobId) {
+      rememberJob(result.value);
+      changed = true;
+    }
+  });
+  if (changed) {
+    renderTrackedJobs();
+  }
+}
+
+function scheduleStatusPoll() {
+  if (statusTimer) {
+    clearInterval(statusTimer);
+    statusTimer = null;
+  }
+  if (statusInterval <= 0) {
+    return;
+  }
+  statusTimer = setInterval(() => {
+    pollTrackedJobs().catch(() => {
+      if (statusNote) {
+        statusNote.hidden = false;
+        statusNote.textContent = 'Unable to refresh status right now. Retrying shortly…';
+      }
+    });
+  }, statusInterval);
+}
+
+function readStatusInterval() {
+  const raw = localStorage.getItem(STORAGE_KEYS.STATUS_INTERVAL);
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_STATUS_INTERVAL;
+  }
+  return parsed;
+}
+
+function hydrateFromQueryParams() {
+  const params = new URLSearchParams(window.location.search);
+  const urlOverride = (params.get('orchestrator') || params.get('orch') || '').trim();
+  if (urlOverride) {
+    orchestratorUrl = urlOverride;
+    localStorage.setItem(STORAGE_KEYS.ORCH, orchestratorUrl);
+  }
+  const tokenOverride = (params.get('token') || params.get('bearer') || '').trim();
+  if (tokenOverride) {
+    bearerToken = tokenOverride;
+    localStorage.setItem(STORAGE_KEYS.TOKEN, bearerToken);
+  }
+  const intervalOverride = params.get('statusInterval');
+  if (intervalOverride) {
+    const parsed = Number(intervalOverride);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      statusInterval = parsed;
+      localStorage.setItem(STORAGE_KEYS.STATUS_INTERVAL, String(parsed));
+    }
+  }
+}
+
+async function demoApi(path, body) {
+  if (path.startsWith('/onebox/plan')) {
+    return demoPlan(body?.text || '');
+  }
+  if (path.startsWith('/onebox/execute')) {
+    return demoExecute(body?.intent || {});
+  }
+  if (path.startsWith('/onebox/status')) {
+    const url = new URL(path, window.location.origin);
+    const jobIdParam = Number(url.searchParams.get('jobId') || '0');
+    return demoStatus(jobIdParam);
+  }
+  throw new Error('UNSUPPORTED_ACTION');
+}
+
+function demoPlan(text) {
+  const clean = text.trim();
+  if (!clean) {
+    throw new Error('REQUEST_EMPTY');
+  }
+  const lower = clean.toLowerCase();
+  if (lower.includes('status')) {
+    const jobId = extractJobId(clean) || (DEMO_STATE.jobs[0]?.jobId ?? 300);
+    return {
+      summary: `I’ll fetch the latest updates for job #${jobId}.`,
+      intent: { action: 'check_status', payload: { jobId } },
+      warnings: [],
+    };
+  }
+  if (lower.includes('final')) {
+    const jobId = extractJobId(clean) || (DEMO_STATE.jobs[0]?.jobId ?? DEMO_STATE.nextJobId - 1);
+    return {
+      summary: `I’ll finalize job #${jobId}. Ready?`,
+      intent: { action: 'finalize_job', payload: { jobId } },
+      warnings: [],
+    };
+  }
+  const reward = extractReward(clean);
+  const deadlineDays = extractDeadline(clean);
+  const title = clean.length > 64 ? `${clean.slice(0, 61)}…` : clean;
+  return {
+    summary: `I’ll post “${title}” with reward ${reward} AGIALPHA and deadline ${deadlineDays} day${deadlineDays === 1 ? '' : 's'}. Proceed?`,
+    intent: {
+      action: 'post_job',
+      payload: {
+        title,
+        description: clean,
+        reward,
+        rewardToken: 'AGIALPHA',
+        deadlineDays,
+      },
+    },
+    warnings: [],
+  };
+}
+
+function demoExecute(intent) {
+  if (!intent || !intent.action) {
+    throw new Error('UNSUPPORTED_ACTION');
+  }
+  if (intent.action === 'post_job') {
+    const jobId = DEMO_STATE.nextJobId++;
+    const reward = formatReward(intent.payload?.reward) || '5.0';
+    const token = intent.payload?.rewardToken || 'AGIALPHA';
+    const deadlineDays = intent.payload?.deadlineDays || 7;
+    const explorerUrl = `https://demo.explorer/tx/${jobId.toString(16).padStart(8, '0')}`;
+    const job = {
+      jobId,
+      state: 'open',
+      reward,
+      token,
+      deadline: humanDeadline(deadlineDays),
+      explorerUrl,
+      updatedAt: Date.now(),
+    };
+    DEMO_STATE.jobs.unshift(job);
+    rememberJob(job);
+    return { jobId, receiptUrl: explorerUrl };
+  }
+  if (intent.action === 'finalize_job') {
+    const jobId = intent.payload?.jobId || DEMO_STATE.jobs[0]?.jobId || DEMO_STATE.nextJobId - 1;
+    const job = DEMO_STATE.jobs.find((j) => j.jobId === jobId);
+    if (job) {
+      job.state = 'finalized';
+      job.updatedAt = Date.now();
+    } else {
+      DEMO_STATE.jobs.unshift({
+        jobId,
+        state: 'finalized',
+        reward: '5.0',
+        token: 'AGIALPHA',
+        deadline: '—',
+        explorerUrl: '#',
+        updatedAt: Date.now(),
+      });
+    }
+    rememberJob({ jobId, state: 'finalized', receiptUrl: '#', updatedAt: Date.now() });
+    return { jobId, receiptUrl: '#' };
+  }
+  if (intent.action === 'check_status') {
+    const jobId = intent.payload?.jobId || DEMO_STATE.jobs[0]?.jobId || DEMO_STATE.nextJobId - 1;
+    return demoStatus(jobId);
+  }
+  throw new Error('UNSUPPORTED_ACTION');
+}
+
+function demoStatus(jobId) {
+  if (!jobId) {
+    return { jobId: 0, state: 'unknown' };
+  }
+  const job = DEMO_STATE.jobs.find((j) => j.jobId === jobId);
+  if (job) {
+    rememberJob(job);
+    renderTrackedJobs();
+    return job;
+  }
+  const fallback = {
+    jobId,
+    state: 'open',
+    reward: '5.0',
+    token: 'AGIALPHA',
+    deadline: '7 days',
+    explorerUrl: '#',
+    updatedAt: Date.now(),
+  };
+  rememberJob(fallback);
+  renderTrackedJobs();
+  return fallback;
+}
+
+function extractJobId(text) {
+  const match = text.match(/\b(\d{1,10})\b/);
+  return match ? Number(match[1]) : null;
+}
+
+function extractReward(text) {
+  const rewardMatch = text.match(/(\d+(?:\.\d+)?)\s*(?:agialpha|agi|token)/i);
+  if (rewardMatch) {
+    return rewardMatch[1];
+  }
+  const genericMatch = text.match(/\b(\d+(?:\.\d+)?)\b/);
+  return genericMatch ? genericMatch[1] : '5.0';
+}
+
+function extractDeadline(text) {
+  const deadlineMatch = text.match(/(\d+)\s*(?:day|days|d)\b/i);
+  if (deadlineMatch) {
+    return Number(deadlineMatch[1]);
+  }
+  const weekMatch = text.match(/week/i);
+  if (weekMatch) {
+    return 7;
+  }
+  return 7;
+}
+
+sendBtn.onclick = go;
+box.onkeydown = (event) => {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    go();
+  }
 };
-setMode();
+
+expertBtn.onclick = () => {
+  expertMode = !expertMode;
+  localStorage.setItem(STORAGE_KEYS.EXPERT_MODE, expertMode ? '1' : '0');
+  updateModeBadge();
+  note(expertMode ? 'Expert Mode on. I’ll return calldata for signing.' : 'Guest Mode on. I’ll use the relayer when possible.');
+};
+
+saveBtn.onclick = () => {
+  orchestratorUrl = orchInput.value.trim();
+  bearerToken = tokInput.value.trim();
+  localStorage.setItem(STORAGE_KEYS.ORCH, orchestratorUrl);
+  localStorage.setItem(STORAGE_KEYS.TOKEN, bearerToken);
+  demoMode = !orchestratorUrl;
+  note('Saved.');
+  if (demoMode) {
+    note('Demo mode active. Requests will be simulated until an orchestrator URL is provided.');
+  }
+  scheduleStatusPoll();
+  if (!demoMode) {
+    pollTrackedJobs();
+  }
+};
+
+if (statusRefresh) {
+  statusRefresh.onclick = () => {
+    pollTrackedJobs()
+      .then(() => {
+        renderTrackedJobs();
+      })
+      .catch(() => {
+        if (statusNote) {
+          statusNote.hidden = false;
+          statusNote.textContent = 'Unable to refresh status right now. Retrying shortly…';
+        }
+      });
+  };
+}
+
+if (connectBtn) {
+  connectBtn.onclick = async () => {
+    if (window.ethereum) {
+      try {
+        ethProvider = window.ethereum;
+        await ethProvider.request({ method: 'eth_requestAccounts' });
+        note('Wallet connected.');
+      } catch (error) {
+        handleError(error);
+      }
+    } else {
+      note('No EIP-1193 provider found.');
+    }
+  };
+}
+

--- a/apps/onebox/index.html
+++ b/apps/onebox/index.html
@@ -3,7 +3,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>AGI Jobs — One‑Box</title>
 <style>
-:root{--bg:#0b0f14;--fg:#f5f7fb;--muted:#a7b0be;--soft:#121923;--line:#1c2531;--acc:#7c5cff;--ok:#1bbf6b}
+:root{--bg:#0b0f14;--fg:#f5f7fb;--muted:#a7b0be;--soft:#121923;--line:#1c2531;--acc:#7c5cff;--ok:#1bbf6b;--warn:#ffb020}
 *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--fg);font:16px/1.45 system-ui}
 .wrap{max-width:880px;margin:auto;padding:24px}
 .header{display:flex;gap:10px;align-items:center}
@@ -21,6 +21,24 @@ input[type=text]{flex:1;padding:14px 16px;border-radius:12px;border:1px solid va
 button{padding:12px 16px;border-radius:12px;border:0;background:var(--acc);color:#fff;font-weight:600;cursor:pointer}
 button.secondary{background:#1a2330;color:var(--fg);border:1px solid #273245}
 .small{font-size:13px;color:var(--muted)}
+.status{margin-top:18px;padding:16px;border:1px solid var(--line);border-radius:12px;background:#0e141c;display:flex;flex-direction:column;gap:10px}
+.status-header{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.status-title{font-weight:600;font-size:15px}
+.status-refresh{padding:8px 12px;border-radius:999px;background:#182131;border:1px solid #273245;color:var(--fg);cursor:pointer;font-size:13px}
+.status-refresh:hover{border-color:#36445a}
+.status-note{font-size:12px;color:var(--muted)}
+.status-empty{font-size:13px;color:var(--muted)}
+.status-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px}
+.status-item{border:1px solid #1c2531;border-radius:10px;padding:10px 12px;background:#111925;display:flex;flex-direction:column;gap:4px}
+.status-top{display:flex;align-items:center;justify-content:space-between;gap:10px;font-size:14px}
+.status-id{font-weight:600}
+.status-chip{padding:4px 10px;border-radius:999px;font-size:12px;text-transform:capitalize;background:#182131;border:1px solid #253349;color:var(--fg)}
+.status-chip.open{color:#8ad8ff;border-color:#274760}
+.status-chip.finalized{color:#7de6b2;border-color:#214b38;background:#0e2a1c}
+.status-chip.disputed{color:#ffddb0;border-color:#5a3a0f;background:#26170a}
+.status-meta{font-size:12px;color:var(--muted)}
+.status-links{display:flex;gap:10px;font-size:12px}
+.status-links a{color:#b7a8ff}
 .sec{margin-top:18px;padding:12px;border:1px dashed #263142;border-radius:10px;background:#0c131c}
 .kbd{padding:2px 6px;border-radius:6px;background:#1a2330;border:1px solid #283446;color:#c8d0da;font-size:12px}
 a{color:#b7a8ff}
@@ -59,6 +77,16 @@ a{color:#b7a8ff}
   </div>
 
   <div class="small" style="margin-top:12px">No hashes, no gas prompts by default. A “Verify on chain” link appears after success.</div>
+
+  <section class="status" aria-live="polite">
+    <div class="status-header">
+      <span class="status-title">Recent jobs</span>
+      <button id="status-refresh" class="status-refresh" type="button">Refresh</button>
+    </div>
+    <div id="status-note" class="status-note" hidden></div>
+    <div id="status-empty" class="status-empty">Jobs you post (or request) will appear here.</div>
+    <ul id="status-list" class="status-list" aria-label="Recent job statuses"></ul>
+  </section>
 </div>
 <script type="module" src="./app.js"></script>
 </html>


### PR DESCRIPTION
## Summary
- add a recent jobs panel to the static One-Box page with refresh controls and styles
- expand the One-Box front-end logic with tracked status polling, query parameter hydration, and friendlier error handling
- provide a demo planner/executor/status pipeline so the UI works without an orchestrator URL

## Testing
- node --check apps/onebox/app.js

------
https://chatgpt.com/codex/tasks/task_e_68d74050aa5c83338f8e077c9b19d757