### PR TITLE
Support wallet calldata responses for one-box orchestrator

### DIFF
--- a/apps/orchestrator/execution.ts
+++ b/apps/orchestrator/execution.ts
@@ -246,7 +246,14 @@ function ensureBlob(
     type = type ?? 'text/plain';
     suggestedFileName = 'payload.txt';
   } else if (content instanceof ArrayBuffer || ArrayBuffer.isView(content)) {
-    data = content instanceof ArrayBuffer ? new Uint8Array(content) : content;
+    const buffer =
+      content instanceof ArrayBuffer
+        ? content
+        : ((content as ArrayBufferView).buffer.slice(
+            (content as ArrayBufferView).byteOffset,
+            (content as ArrayBufferView).byteOffset + (content as ArrayBufferView).byteLength
+          ) as ArrayBuffer);
+    data = new Uint8Array(buffer);
     type = type ?? 'application/octet-stream';
   } else if (content && typeof content === 'object') {
     data = JSON.stringify(content);

--- a/packages/onebox-sdk/src/index.ts
+++ b/packages/onebox-sdk/src/index.ts
@@ -38,6 +38,7 @@ export interface JobIntent {
     rewardToken?: string;
     deadlineDays?: number;
     attachments?: JobAttachment[];
+    agentTypes?: number;
   };
   constraints?: Record<string, unknown> & {
     maxFee?: string;
@@ -63,6 +64,14 @@ export interface ExecuteResponse {
   jobId?: number;
   txHash?: string;
   receiptUrl?: string;
+  /** Target address for wallet execution flows. */
+  to?: string;
+  /** ABI-encoded calldata for wallet execution flows. */
+  data?: string;
+  /** Hex-encoded value (in wei) to send with the transaction. */
+  value?: string;
+  /** Target chain id for the prepared transaction. */
+  chainId?: number;
   error?: string;
 }
 


### PR DESCRIPTION
## Summary
- expose reusable job artifact pinning so the orchestrator can prepare calldata without duplicating IPFS logic
- teach the one-box orchestrator to return wallet-ready calldata for job posting and finalization, plus tighten supporting utilities
- extend the shared SDK types and add coverage to confirm wallet mode responses are shaped as expected

## Testing
- npx tsc -p apps/orchestrator/tsconfig.json

------
https://chatgpt.com/codex/tasks/task_e_68d7438791d08333ba087ab789ffde08