### PR TITLE
Escape plan summary title and sanitize confirm UI

### DIFF
--- a/routes/onebox.py
+++ b/routes/onebox.py
@@ -3,7 +3,7 @@
 # Exposes: POST /onebox/plan, POST /onebox/execute, GET /onebox/status
 # Everything chain-related (keys, gas, ABIs, pinning) stays on the server.
 
-import os, json, time, math, re, asyncio
+import os, json, time, math, re, asyncio, html
 from decimal import Decimal
 from typing import Optional, Literal, List, Tuple, Dict, Any
 
@@ -253,7 +253,8 @@ async def plan(req: PlanRequest):
     p = intent.payload
     reward = p.reward or "1.0"
     days = p.deadlineDays if p.deadlineDays is not None else 7
-    summary = f'I will post a job “{p.title}” with reward {reward} AGIALPHA and a {days}-day deadline. Proceed?'
+    safe_title = html.escape(p.title or "")
+    summary = f'I will post a job “{safe_title}” with reward {reward} AGIALPHA and a {days}-day deadline. Proceed?'
     return PlanResponse(summary=summary, intent=intent, requiresConfirmation=True, warnings=[])
 
 @router.post("/execute", response_model=ExecuteResponse, dependencies=[Depends(require_api)])


### PR DESCRIPTION
## Summary
- escape planned job titles server-side before formatting confirmation text
- sanitize the front-end confirmation prompt by decoding the summary into text nodes before rendering the buttons
- ensure user chat messages render as escaped text to prevent HTML injection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d755f5ee1c8333beedf0ea20357df0