### PR TITLE
Handle execute errors in confirmation flow

### DIFF
--- a/apps/onebox/app.js
+++ b/apps/onebox/app.js
@@ -90,7 +90,13 @@ function confirmUI(summary,intent){
   const confirmBtn=message.querySelector('[data-role="confirm"]');
   const cancelBtn=message.querySelector('[data-role="cancel"]');
 
-  if(confirmBtn) confirmBtn.onclick=()=>execute(intent);
+  if(confirmBtn) confirmBtn.onclick=async()=>{
+    try{
+      await execute(intent);
+    }catch(e){
+      handleError(e);
+    }
+  };
   if(cancelBtn) cancelBtn.onclick=()=>add('assist', COPY.cancelled);
 }
 


### PR DESCRIPTION
## Summary
- wrap the confirmation handler so `execute` errors are routed through `handleError`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d75c214c908333969c271e1d27ebe8