### PR TITLE
docs: refresh one-box ui readme

### DIFF
--- a/apps/onebox/README.md
+++ b/apps/onebox/README.md
@@ -1,26 +1,26 @@
 # AGI Jobs One-Box UI
 
-A static, IPFS-friendly front-end that wraps the AGI Jobs v2 workflow behind a single natural-language input. It calls the AGI-Alpha Orchestrator meta-agent (`/onebox/*`) to translate human requests into actionable job intents and execute them via the relayer (guest mode) or wallet signing (expert mode).
+A static, IPFS-friendly front-end that wraps the AGI Jobs workflow behind a single natural-language input. It calls the AGI-Alpha orchestrator (`/onebox/*`) to translate human requests into actionable job intents and execute them via the relayer (guest mode) or wallet signing (expert mode).
 
 ## Features
 
 - **Single text box UX**: type what you need, receive a plan, confirm, execute.
 - **Walletless by default**: guest mode uses the orchestrator relayer; expert mode exposes wallet signing flows.
-- **Status board**: lightweight polling of `/onebox/status` for recent jobs.
-- **Demo mode**: if no orchestrator URL is configured, the UI simulates responses for offline demos.
-- **Persistent settings**: orchestrator URL, API token, and status refresh cadence are stored in `localStorage`.
+- **Expert Mode toggle**: enables EIP-1193 wallets (MetaMask, Rabby, etc.) for self-signing.
+- **Local persistence**: orchestrator URL and API token are stored in `localStorage` for quick reconnects.
 - **Humanised errors**: maps common on-chain failures to plain-language hints.
+- **Pure static assets**: ships as `index.html` + `app.js` without build tooling so it can be pinned straight to IPFS.
 
 ## Getting started
 
-1. Serve the folder locally (any static web server works). Example using `http-server`:
+1. Serve the folder locally (any static web server works). Example using Python:
    ```sh
-   npx http-server apps/onebox -p 4173 -c-1
+   cd apps/onebox
+   python -m http.server 4173
    ```
-2. Open the page in your browser and open the **Settings** dialog.
-3. Set the Orchestrator URL (e.g. `https://alpha-agent.example`) and optional API token.
-4. Submit a request such as “Post a labeling job for 500 images; pay 5 AGIALPHA; 7 days.”
-5. Confirm the plan and watch the execution receipt. Recent jobs appear in the status board.
+2. Open the page in your browser and fill out the **Advanced** section with your orchestrator URL and optional API token.
+3. Submit a request such as “Post a labeling job for 500 images; pay 5 AGIALPHA; 7 days.”
+4. Confirm the plan and watch for the on-chain receipt link.
 
 ### Hosting on IPFS
 
@@ -35,18 +35,13 @@ Take the returned CID and publish through your preferred gateway or ENS content 
 - The chat log is marked `aria-live="polite"` to announce updates.
 - Confirmation prompts expose explicit buttons for yes/no decisions.
 
-## Development notes
-
-- `app.js` is written as an ES module without build tooling to keep the site hostable on IPFS.
-- Update the error dictionary in `app.js` if the orchestrator introduces new error codes/messages.
-- When `/onebox/status` gains pagination, extend `renderStatuses` to handle `nextToken` / paging metadata.
-
 ## Directory structure
 
 ```
 apps/onebox/
-├── app.js       # UI logic, planner/executor calls, demo mode
-├── index.html   # Markup and settings modal
+├── app.js       # UI logic, planner/executor calls
+├── index.html   # Markup, inline styling, advanced settings
 ├── README.md    # This file
-└── styles.css   # Visual design tokens and layout
+├── styles.css   # Legacy theme tokens (optional)
+└── ...          # Next.js scaffold kept for future iterations
 ```


### PR DESCRIPTION
## Summary
- update the One-Box UI README to describe the walletless-by-default flow and expert mode toggle
- refresh hosting instructions to highlight simple static hosting and IPFS pinning

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d75fbbe0548333ad1384df3e9460a3