### PR TITLE
feat: polish one-box ui and server orchestration

### DIFF
--- a/apps/onebox/app.js
+++ b/apps/onebox/app.js
@@ -1,105 +1,440 @@
 // apps/onebox/app.js
-const $ = s=>document.querySelector(s), chat=$('#chat'), box=$('#box'), mode=$('#mode');
-const sendBtn=$('#send'), expertBtn=$('#expert'), saveBtn=$('#save'), orchInput=$('#orch'), tokInput=$('#tok'), connectBtn=$('#connect');
-document.querySelectorAll('.pill').forEach(p=>p.onclick=()=>box.value=p.dataset.example);
+const $ = (selector) => document.querySelector(selector);
+const chat = $('#chat');
+const box = $('#onebox-input');
+const form = $('#onebox-form');
+const sendBtn = $('#send');
+const expertBtn = $('#expert');
+const orchInput = $('#orch');
+const tokenInput = $('#tok');
+const saveBtn = $('#save');
+const connectBtn = $('#connect');
+const modeBadge = $('#mode');
+const receiptList = $('#receipts-list');
+const receiptsEmpty = $('#receipts-empty');
+const clearReceiptsBtn = $('#clear-receipts');
 
-const COPY={
-  planning:"Let me prepare this…",
-  executing:"Publishing to the network… this usually takes a few seconds.",
-  posted:(id,url)=>`✅ Job <b>#${id??'?'}</b> is live. ${url?`<a target="_blank" rel="noopener" href="${url}">Verify on chain</a>`:''}`,
-  finalized:(id,url)=>`✅ Job <b>#${id}</b> finalized. ${url?`<a target="_blank" rel="noopener" href="${url}">Receipt</a>`:''}`,
-  cancelled:"Okay, cancelled.",
-  status:(s)=>`Job <b>#${s.jobId}</b> is <b>${s.state}</b>${s.reward?`. Reward ${s.reward}`:''}${s.token?` ${s.token}`:''}.`
+const COPY = {
+  planning: 'Planning your workflow…',
+  confirm: (summary) =>
+    `${summary}<div class="pill-row" style="margin-top:12px"><button class="primary-btn" id="confirm-yes" type="button">Yes, do it</button><button class="ghost-btn" id="confirm-no" type="button">Cancel</button></div>`,
+  cancelled: 'Okay, cancelled. Adjust the details and try again.',
+  progressSteps: [
+    'Creating job specification…',
+    'Securing escrow and sponsorship…',
+    'Posting spec to IPFS…',
+    'Inviting validators and agents…',
+  ],
+  posted: (receipt) =>
+    `✅ Posted. <strong>Job #${receipt.jobId ?? '?'}.</strong><br>Reward: ${receipt.reward ?? '—'} ${
+      receipt.token ?? 'AGIALPHA'
+    }${receipt.cid ? `<br>CID: <code>${receipt.cid}</code>` : ''}${
+      receipt.url
+        ? `<br><a href="${receipt.url}" target="_blank" rel="noopener">View on explorer</a>`
+        : receipt.tx
+        ? `<br>Tx: ${receipt.tx}`
+        : ''
+    }`,
+  finalized: (receipt) =>
+    `✅ Finalized. <strong>Job #${receipt.jobId ?? '?'}.</strong>${
+      receipt.url
+        ? `<br><a href="${receipt.url}" target="_blank" rel="noopener">Receipt</a>`
+        : receipt.tx
+        ? `<br>Tx: ${receipt.tx}`
+        : ''
+    }`,
+  status: (status) => {
+    const parts = [`Job <strong>#${status.jobId}</strong> is <strong>${status.state}</strong>.`];
+    if (status.reward) {
+      parts.push(`Reward ${status.reward} ${status.token ?? 'AGIALPHA'}`);
+    }
+    if (status.deadline) {
+      parts.push(`Deadline ${new Date(status.deadline * 1000).toLocaleString()}`);
+    }
+    if (status.assignee) {
+      parts.push(`Assignee ${status.assignee}`);
+    }
+    return parts.join('<br>');
+  },
 };
-const ERRORS={
-  INSUFFICIENT_BALANCE:"You don’t have enough AGIALPHA to fund this job. Reduce the reward or top up.",
-  INSUFFICIENT_ALLOWANCE:"Your wallet needs permission to use AGIALPHA. I can prepare an approval transaction.",
-  IPFS_FAILED:"I couldn’t package your job details. Remove broken links and try again.",
-  DEADLINE_INVALID:"That deadline is in the past. Pick at least 24 hours from now.",
-  NETWORK_CONGESTED:"The network is busy; I’ll keep retrying for a moment.",
-  UNKNOWN:"Something went wrong. Try rephrasing your request or adjust the reward/deadline."
+
+const ERRORS = {
+  ORCH_NOT_SET: 'Set your orchestrator URL in Advanced before running jobs.',
+  AUTH_MISSING: 'Add your API token in Advanced to continue.',
+  AUTH_INVALID: 'The API token looks incorrect. Double-check and try again.',
+  INSUFFICIENT_BALANCE: 'Not enough AGIALPHA. Lower the reward or top up and retry.',
+  INSUFFICIENT_ALLOWANCE: 'We need allowance to use AGIALPHA. Enable approvals in Expert mode.',
+  IPFS_FAILED: 'IPFS pinning failed. Remove broken attachments or retry in a moment.',
+  DEADLINE_INVALID: 'Deadline must be at least 1 day and within protocol limits.',
+  RELAY_UNAVAILABLE: 'Relayer unavailable. Retry in a moment or switch to Expert mode.',
+  JOB_ID_REQUIRED: 'I need a job ID for that action. Try “Finalize job 123”.',
+  UNSUPPORTED_ACTION: 'That action is not supported yet. Try posting, finalizing, or checking status.',
+  UNKNOWN: 'Something went wrong. I logged the details so we can retry safely.',
 };
 
-let EXPERT=false, ETH=null;
-let ORCH=localStorage.getItem('ORCH_URL')||'', TOK=localStorage.getItem('ORCH_TOKEN')||'';
-orchInput.value=ORCH; tokInput.value=TOK;
+const STORAGE_KEYS = {
+  orch: 'ONEBOX_ORCH_URL',
+  token: 'ONEBOX_ORCH_TOKEN',
+  receipts: 'ONEBOX_RECEIPTS_V1',
+};
 
-function add(role,html){const d=document.createElement('div');d.className='msg '+(role==='user'?'m-user':'m-assist');d.innerHTML=html;chat.appendChild(d);chat.scrollTop=chat.scrollHeight}
-function note(t){add('assist',`<div class="note">${t}</div>`)}
-function setMode(){mode.textContent='Mode: '+(EXPERT?'Expert (wallet)':'Guest (walletless)')}
+let expertMode = false;
+let ethereum = null;
+let orchestrator = localStorage.getItem(STORAGE_KEYS.orch) || '';
+let apiToken = localStorage.getItem(STORAGE_KEYS.token) || '';
+let receipts = loadReceipts();
+let isSubmitting = false;
 
-async function api(path, body){
-  if(!ORCH){throw new Error('Set your Orchestrator URL in Advanced')}
-  const headers={'Content-Type':'application/json'}; if(TOK) headers['Authorization']='Bearer '+TOK;
-  const r=await fetch(ORCH+path,{method: body? 'POST':'GET',headers,body: body? JSON.stringify(body):undefined});
-  if(!r.ok){
-    let msg='UNKNOWN'; try{msg=(await r.text())||'UNKNOWN'}catch{}
-    throw new Error(msg.toUpperCase());
+orchInput.value = orchestrator;
+tokenInput.value = apiToken;
+renderReceipts();
+setModeLabel();
+
+function addMessage(role, html) {
+  const node = document.createElement('div');
+  node.className = `msg ${role === 'user' ? 'm-user' : 'm-assist'}`;
+  node.innerHTML = html;
+  chat.appendChild(node);
+  chat.scrollTop = chat.scrollHeight;
+  return node;
+}
+
+function startProgress() {
+  const node = document.createElement('div');
+  node.className = 'msg m-assist';
+  node.innerHTML = `<ul class="progress">${COPY.progressSteps
+    .map((step) => `<li>${step}</li>`)
+    .join('')}</ul>`;
+  chat.appendChild(node);
+  chat.scrollTop = chat.scrollHeight;
+  const items = Array.from(node.querySelectorAll('li'));
+  let index = 0;
+  const timer = setInterval(() => {
+    if (index < items.length) {
+      const current = items[index];
+      current.classList.add('is-active');
+      if (index > 0) {
+        items[index - 1].classList.remove('is-active');
+        items[index - 1].classList.add('is-done');
+      }
+      index += 1;
+    } else {
+      clearInterval(timer);
+      items.forEach((li) => li.classList.add('is-done'));
+    }
+  }, 1100);
+  return {
+    complete() {
+      clearInterval(timer);
+      items.forEach((li) => li.classList.add('is-done'));
+    },
+    fail() {
+      clearInterval(timer);
+      items.forEach((li) => li.classList.remove('is-active'));
+    },
+  };
+}
+
+function loadReceipts() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.receipts);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error('Failed to parse receipts', error);
+    return [];
   }
-  return await r.json();
 }
 
-function confirmUI(summary,intent){
-  add('assist', summary + `<div class="row" style="margin-top:10px">
-    <button class="pill ok" id="yes">Yes</button><button class="pill" id="no">Cancel</button></div>`);
-  setTimeout(()=>{
-    document.getElementById('yes').onclick=()=>execute(intent);
-    document.getElementById('no').onclick=()=>add('assist', COPY.cancelled);
-  },0);
+function saveReceipts() {
+  localStorage.setItem(STORAGE_KEYS.receipts, JSON.stringify(receipts.slice(0, 10)));
 }
 
-async function plan(text){
-  add('assist', COPY.planning);
-  const j=await api('/onebox/plan',{text,expert:EXPERT});
-  return j;
-}
-
-async function execute(intent){
-  add('assist', COPY.executing);
-  const mode = EXPERT ? 'wallet' : 'relayer';
-  const j=await api('/onebox/execute',{intent,mode});
-
-  // Expert: sign via EIP-1193
-  if(EXPERT && j.to && j.data){
-    if(!ETH) throw new Error('NO_WALLET');
-    const from=(await ETH.request({method:'eth_requestAccounts'}))[0];
-    const txHash=await ETH.request({method:'eth_sendTransaction',params:[{from,to:j.to,data:j.data,value:j.value||'0x0'}]});
-    // The server's receiptUrl likely has a {tx} pattern; we replace tail if provided
-    const url=(j.receiptUrl||'').replace(/0x[0-9a-fA-F]{64}.?$/, txHash);
-    if(intent.action==='finalize_job') add('assist', COPY.finalized(j.jobId||'?', url||''));
-    else add('assist', COPY.posted(j.jobId||'?', url||''));
+function renderReceipts() {
+  receiptList.innerHTML = '';
+  if (!receipts.length) {
+    receiptsEmpty.style.display = 'block';
     return;
   }
-  if(intent.action==='finalize_job') add('assist', COPY.finalized(j.jobId, j.receiptUrl||''));
-  else add('assist', COPY.posted(j.jobId, j.receiptUrl||''));
+  receiptsEmpty.style.display = 'none';
+  receipts.forEach((receipt) => {
+    const item = document.createElement('li');
+    item.className = 'receipt-card';
+    const ts = new Date(receipt.timestamp).toLocaleString();
+    const txLabel = receipt.url
+      ? `<a href="${receipt.url}" target="_blank" rel="noopener">${truncate(receipt.tx || 'View')}</a>`
+      : receipt.tx
+      ? truncate(receipt.tx)
+      : '—';
+    item.innerHTML = `
+      <strong>Job #${receipt.jobId ?? '?'} · ${receipt.status ?? 'posted'}</strong>
+      <div class="receipt-meta">
+        <span>${ts}</span>
+        <span>Reward: ${receipt.reward ?? '—'} ${receipt.token ?? 'AGIALPHA'}</span>
+      </div>
+      <div>Tx: ${txLabel}</div>
+      ${receipt.cid ? `<div>CID: <code>${receipt.cid}</code></div>` : ''}
+    `;
+    receiptList.appendChild(item);
+  });
 }
 
-async function go(){
-  const text=box.value.trim(); if(!text) return;
-  add('user', text); box.value='';
-  try{
-    const {summary,intent} = await plan(text);
-    // status shortcut
-    if(intent.action==='check_status'){
-      const idMatch = text.match(/\d+/); const jobId = intent.payload.jobId || (idMatch? parseInt(idMatch[0],10):0);
-      const s = await api(`/onebox/status?jobId=${jobId}`);
-      add('assist', COPY.status(s)); return;
+function truncate(value) {
+  if (!value) return '';
+  return value.length > 18 ? `${value.slice(0, 8)}…${value.slice(-6)}` : value;
+}
+
+function storeReceipt(data) {
+  receipts = [data, ...receipts].slice(0, 10);
+  saveReceipts();
+  renderReceipts();
+}
+
+async function api(path, body) {
+  const base = orchestrator.trim();
+  if (!base) {
+    throw new Error('ORCH_NOT_SET');
+  }
+  const url = `${base ? base.replace(/\/$/, '') : ''}${path}`;
+  const headers = {};
+  if (body) {
+    headers['Content-Type'] = 'application/json';
+  }
+  if (apiToken) {
+    headers['Authorization'] = `Bearer ${apiToken}`;
+  }
+  const response = await fetch(url, {
+    method: body ? 'POST' : 'GET',
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!response.ok) {
+    let code = 'UNKNOWN';
+    try {
+      const payload = await response.json();
+      if (typeof payload === 'string') {
+        code = payload;
+      } else if (payload && typeof payload.detail === 'string') {
+        code = payload.detail;
+      } else if (payload?.detail?.code) {
+        code = payload.detail.code;
+      }
+    } catch (_) {
+      try {
+        code = (await response.text()) || 'UNKNOWN';
+      } catch (__) {
+        code = 'UNKNOWN';
+      }
     }
-    confirmUI(summary,intent);
-  }catch(e){handleError(e)}
+    throw new Error((code || '').toUpperCase());
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return await response.json();
+  }
+  return await response.json();
 }
 
-function handleError(e){
-  const upper=(e.message||'').toUpperCase();
-  const key = Object.keys(ERRORS).find(k=> upper.includes(k)) || 'UNKNOWN';
-  add('assist','⚠️ '+ERRORS[key]);
+async function planRequest(text) {
+  addMessage('assist', COPY.planning);
+  return api('/onebox/plan', { text, expert: expertMode });
 }
 
-sendBtn.onclick=go; box.onkeydown=e=>{if(e.key==='Enter') go()};
-expertBtn.onclick=()=>{EXPERT=!EXPERT; setMode()};
-saveBtn.onclick=()=>{ORCH=orchInput.value.trim(); TOK=tokInput.value.trim(); localStorage.setItem('ORCH_URL',ORCH); localStorage.setItem('ORCH_TOKEN',TOK); note('Saved.')};
-connectBtn.onclick=async()=>{
-  if(window.ethereum){ETH=window.ethereum; try{await ETH.request({method:'eth_requestAccounts'}); note('Wallet connected.');}catch{}}
-  else{note('No EIP‑1193 provider found.')}
-};
-setMode();
+async function executeIntent(intent) {
+  const progress = startProgress();
+  try {
+    const mode = expertMode ? 'wallet' : 'relayer';
+    const result = await api('/onebox/execute', { intent, mode });
+
+    if (intent.action === 'check_status') {
+      progress.complete();
+      addMessage('assist', COPY.status(result));
+      return;
+    }
+
+    if (mode === 'wallet' && result && result.to && result.data) {
+      if (!ethereum) {
+        throw new Error('RELAY_UNAVAILABLE');
+      }
+      const [from] = await ethereum.request({ method: 'eth_requestAccounts' });
+      const txHash = await ethereum.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from,
+            to: result.to,
+            data: result.data,
+            value: result.value || '0x0',
+          },
+        ],
+      });
+      progress.complete();
+      const receipt = buildReceipt({
+        jobId: intent.payload.jobId,
+        txHash,
+        reward: intent.payload.reward,
+        token: intent.payload.rewardToken,
+        specCid: result.specCid,
+        status: intent.action === 'finalize_job' ? 'finalized' : 'submitted',
+      });
+      storeReceipt(receipt);
+      const url = result.receiptUrl ? result.receiptUrl.replace(/0x[a-fA-F0-9]{64}/, txHash) : null;
+      receipt.url = url;
+      if (intent.action === 'finalize_job') {
+        addMessage('assist', COPY.finalized(receipt));
+      } else {
+        addMessage('assist', COPY.posted(receipt));
+      }
+      return;
+    }
+
+    progress.complete();
+    const receipt = buildReceipt({
+      jobId: result.jobId,
+      txHash: result.txHash,
+      reward: result.reward || intent.payload.reward,
+      token: result.token || intent.payload.rewardToken,
+      specCid: result.specCid,
+      url: result.receiptUrl,
+      status: result.status || (intent.action === 'finalize_job' ? 'finalized' : 'submitted'),
+    });
+    storeReceipt(receipt);
+    if (intent.action === 'finalize_job') {
+      addMessage('assist', COPY.finalized(receipt));
+    } else {
+      addMessage('assist', COPY.posted(receipt));
+    }
+  } catch (error) {
+    progress.fail();
+    handleError(error);
+  }
+}
+
+function buildReceipt(data) {
+  return {
+    jobId: data.jobId ?? null,
+    tx: data.txHash ?? null,
+    url: data.url ?? null,
+    cid: data.specCid ?? null,
+    reward: data.reward ?? null,
+    token: data.token ?? null,
+    status: data.status ?? 'submitted',
+    timestamp: Date.now(),
+  };
+}
+
+async function fetchStatus(jobId) {
+  try {
+    const status = await api(`/onebox/status?jobId=${jobId}`);
+    addMessage('assist', COPY.status(status));
+  } catch (error) {
+    handleError(error);
+  }
+}
+
+function handleError(error) {
+  const message = (error && error.message ? error.message : 'UNKNOWN').toUpperCase();
+  const key = Object.keys(ERRORS).find((code) => message.includes(code)) || 'UNKNOWN';
+  console.error('One-box error', error);
+  addMessage('assist', `<span class="error-text">⚠️ ${ERRORS[key]}</span>`);
+}
+
+function setModeLabel() {
+  modeBadge.textContent = `Mode: ${expertMode ? 'Expert (wallet)' : 'Guest (walletless)'}`;
+  expertBtn.textContent = expertMode ? 'Switch to Guest' : 'Expert Mode';
+}
+
+function disableForm(disabled) {
+  isSubmitting = disabled;
+  sendBtn.disabled = disabled;
+  box.disabled = disabled;
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  if (isSubmitting) return;
+  const text = box.value.trim();
+  if (!text) return;
+  addMessage('user', text);
+  box.value = '';
+  disableForm(true);
+
+  try {
+    const plan = await planRequest(text);
+    disableForm(false);
+    if (!plan) {
+      handleError(new Error('UNKNOWN'));
+      return;
+    }
+    const { summary, intent } = plan;
+    if (intent.action === 'check_status' && intent.payload.jobId) {
+      await fetchStatus(intent.payload.jobId);
+      return;
+    }
+    const confirmation = addMessage('assist', COPY.confirm(summary));
+    const yesBtn = confirmation.querySelector('#confirm-yes');
+    const noBtn = confirmation.querySelector('#confirm-no');
+    yesBtn?.addEventListener('click', () => {
+      yesBtn.disabled = true;
+      noBtn.disabled = true;
+      void executeIntent(intent);
+    });
+    noBtn?.addEventListener('click', () => {
+      yesBtn.disabled = true;
+      noBtn.disabled = true;
+      addMessage('assist', COPY.cancelled);
+    });
+  } catch (error) {
+    disableForm(false);
+    handleError(error);
+  }
+});
+
+expertBtn.addEventListener('click', () => {
+  expertMode = !expertMode;
+  setModeLabel();
+});
+
+saveBtn.addEventListener('click', () => {
+  orchestrator = orchInput.value.trim();
+  apiToken = tokenInput.value.trim();
+  localStorage.setItem(STORAGE_KEYS.orch, orchestrator);
+  localStorage.setItem(STORAGE_KEYS.token, apiToken);
+  addMessage('assist', '✅ Saved advanced settings.');
+});
+
+connectBtn.addEventListener('click', async () => {
+  if (!window.ethereum) {
+    addMessage('assist', '⚠️ No EIP‑1193 wallet detected.');
+    return;
+  }
+  try {
+    ethereum = window.ethereum;
+    await ethereum.request({ method: 'eth_requestAccounts' });
+    addMessage('assist', '✅ Wallet connected. Expert mode ready.');
+  } catch (error) {
+    handleError(error);
+  }
+});
+
+clearReceiptsBtn.addEventListener('click', () => {
+  receipts = [];
+  saveReceipts();
+  renderReceipts();
+});
+
+Array.from(document.querySelectorAll('.pill')).forEach((pill) => {
+  pill.addEventListener('click', () => {
+    const example = pill.dataset.example || '';
+    box.value = example;
+    box.focus();
+  });
+});
+
+if (window.ethereum) {
+  ethereum = window.ethereum;
+}

--- a/apps/onebox/index.html
+++ b/apps/onebox/index.html
@@ -1,64 +1,430 @@
 <!doctype html>
 <html lang="en">
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>AGI Jobs — One‑Box</title>
-<style>
-:root{--bg:#0b0f14;--fg:#f5f7fb;--muted:#a7b0be;--soft:#121923;--line:#1c2531;--acc:#7c5cff;--ok:#1bbf6b}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--fg);font:16px/1.45 system-ui}
-.wrap{max-width:880px;margin:auto;padding:24px}
-.header{display:flex;gap:10px;align-items:center}
-.badge{padding:4px 8px;border-radius:999px;background:var(--soft);color:var(--muted);font-size:12px}
-.chat{display:flex;flex-direction:column;gap:12px;min-height:52vh;padding:12px;border:1px solid var(--line);border-radius:12px;background:#0e141c}
-.msg{max-width:75%;padding:12px 14px;border-radius:12px}
-.m-user{background:#1a2330;margin-left:auto}
-.m-assist{background:#121925;border:1px solid #1e2836}
-.note{font-size:13px;color:var(--muted)}
-.row{display:flex;gap:8px;flex-wrap:wrap}
-.pill{padding:8px 12px;border-radius:999px;background:#182131;border:1px solid #273245;cursor:pointer}
-.pill.ok{background:#0e2a1c;border-color:#214b38;color:#7de6b2}
-.input{display:flex;gap:8px;margin-top:12px}
-input[type=text]{flex:1;padding:14px 16px;border-radius:12px;border:1px solid var(--line);background:#0e141c;color:var(--fg)}
-button{padding:12px 16px;border-radius:12px;border:0;background:var(--acc);color:#fff;font-weight:600;cursor:pointer}
-button.secondary{background:#1a2330;color:var(--fg);border:1px solid #273245}
-.small{font-size:13px;color:var(--muted)}
-.sec{margin-top:18px;padding:12px;border:1px dashed #263142;border-radius:10px;background:#0c131c}
-.kbd{padding:2px 6px;border-radius:6px;background:#1a2330;border:1px solid #283446;color:#c8d0da;font-size:12px}
-a{color:#b7a8ff}
-</style>
-<div class="wrap">
-  <div class="header">
-    <h1 style="margin:0;font-size:20px">AGI Jobs — One‑Box</h1>
-    <span class="badge" id="mode">Mode: Guest (walletless)</span>
-    <span class="badge">Web3‑native • IPFS‑hosted</span>
-  </div>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>AGI Jobs — One‑Box</title>
+  <style>
+    :root {
+      --bg: #060b12;
+      --fg: #f8fafc;
+      --muted: #94a3b8;
+      --soft: rgba(15, 23, 42, 0.7);
+      --line: #1e293b;
+      --accent: linear-gradient(135deg, #6366f1, #0ea5e9);
+      --success: #10b981;
+      --warning: #f59e0b;
+      color-scheme: dark;
+    }
 
-  <div id="chat" class="chat" role="log" aria-live="polite">
-    <div class="msg m-assist">Hi! Tell me what you need and I’ll handle it.<div class="note">Try: <em>Post a labeling job for 500 images, pay 5 AGIALPHA, 7 days.</em></div></div>
-  </div>
+    * {
+      box-sizing: border-box;
+    }
 
-  <div class="input">
-    <input id="box" type="text" placeholder="Type here… Press Enter to send" aria-label="Your request">
-    <button id="send">Send</button>
-    <button id="expert" class="secondary" title="Toggle Expert Mode (EIP‑1193 wallet)">Expert</button>
-  </div>
-  <div class="row small" style="margin-top:8px">
-    <div class="pill" data-example="Create a research task, 2 AGIALPHA, 48 days">Create a research task…</div>
-    <div class="pill" data-example="Finalize job 123">Finalize job…</div>
-    <div class="pill" data-example="Status of job 123">Status of job…</div>
-  </div>
+    body {
+      margin: 0;
+      font: 16px/1.5 "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+        sans-serif;
+      background: radial-gradient(circle at top, rgba(37, 99, 235, 0.08), transparent 60%),
+        var(--bg);
+      color: var(--fg);
+      min-height: 100vh;
+    }
 
-  <div class="sec small">
-    <b>Advanced</b>
-    <div class="row" style="margin-top:8px;gap:8px">
-      <label>Orchestrator URL <input id="orch" type="text" placeholder="https://your‑orchestrator.example" style="width:340px;margin-left:6px"></label>
-      <label>API Token <input id="tok" type="text" placeholder="(Bearer token)" style="width:220px;margin-left:6px"></label>
-      <button id="save" class="secondary">Save</button>
-      <button id="connect" class="secondary">Connect Wallet</button>
+    a {
+      color: #c7d2fe;
+    }
+
+    button {
+      font-family: inherit;
+    }
+
+    .wrap {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 32px 20px 72px;
+      display: grid;
+      gap: 24px;
+    }
+
+    @media (min-width: 980px) {
+      .wrap {
+        grid-template-columns: 1fr 320px;
+        align-items: flex-start;
+      }
+    }
+
+    .header {
+      grid-column: 1 / -1;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .header h1 {
+      margin: 0;
+      font-size: 1.5rem;
+      letter-spacing: -0.01em;
+    }
+
+    .badge {
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: rgba(148, 163, 184, 0.12);
+      color: var(--muted);
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.15em;
+    }
+
+    .chat-shell {
+      background: rgba(15, 23, 42, 0.8);
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      display: flex;
+      flex-direction: column;
+      min-height: 540px;
+      box-shadow: 0 20px 45px rgba(8, 47, 73, 0.25);
+    }
+
+    .chat-history {
+      flex: 1;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      overflow-y: auto;
+    }
+
+    .msg {
+      max-width: 82%;
+      padding: 16px 18px;
+      border-radius: 16px;
+      line-height: 1.6;
+      font-size: 0.96rem;
+      background: rgba(15, 23, 42, 0.95);
+      border: 1px solid rgba(148, 163, 184, 0.1);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    }
+
+    .m-user {
+      margin-left: auto;
+      background: rgba(79, 70, 229, 0.25);
+      border-color: rgba(129, 140, 248, 0.4);
+    }
+
+    .m-assist {
+      background: rgba(15, 23, 42, 0.85);
+    }
+
+    .leadline {
+      display: block;
+      color: var(--muted);
+      font-size: 0.85rem;
+      margin-top: 6px;
+    }
+
+    .chat-form {
+      border-top: 1px solid var(--line);
+      padding: 20px 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      background: rgba(2, 6, 23, 0.85);
+      border-radius: 0 0 18px 18px;
+    }
+
+    .chat-form label {
+      text-transform: uppercase;
+      font-size: 0.7rem;
+      letter-spacing: 0.18em;
+      color: var(--muted);
+    }
+
+    .chat-input-row {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    textarea {
+      flex: 1;
+      min-height: 4.5rem;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: rgba(15, 23, 42, 0.92);
+      color: var(--fg);
+      padding: 14px 16px;
+      font-size: 1rem;
+      resize: none;
+    }
+
+    textarea:focus {
+      outline: 2px solid #38bdf8;
+      outline-offset: 2px;
+    }
+
+    .primary-btn {
+      padding: 0 22px;
+      min-height: 44px;
+      border-radius: 12px;
+      border: none;
+      background-image: var(--accent);
+      color: #fff;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .primary-btn:disabled {
+      cursor: not-allowed;
+      filter: grayscale(45%);
+      opacity: 0.65;
+    }
+
+    .primary-btn:not(:disabled):hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 18px rgba(79, 70, 229, 0.35);
+    }
+
+    .ghost-btn {
+      padding: 0 18px;
+      min-height: 44px;
+      border-radius: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.65);
+      color: var(--fg);
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    .pill-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 8px;
+    }
+
+    .pill {
+      padding: 8px 12px;
+      border-radius: 999px;
+      background: rgba(30, 41, 59, 0.75);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      cursor: pointer;
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    .note {
+      display: block;
+      color: var(--muted);
+      font-size: 0.85rem;
+      margin-top: 8px;
+    }
+
+    .sec {
+      padding: 20px;
+      border-radius: 14px;
+      border: 1px dashed rgba(148, 163, 184, 0.28);
+      background: rgba(15, 23, 42, 0.6);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .sec h2 {
+      margin: 0;
+      font-size: 0.95rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .sec label {
+      font-size: 0.85rem;
+      color: var(--muted);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .sec input[type='text'] {
+      border-radius: 10px;
+      border: 1px solid var(--line);
+      background: rgba(15, 23, 42, 0.85);
+      color: var(--fg);
+      padding: 10px 12px;
+      min-width: 0;
+    }
+
+    .sec-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .kbd {
+      padding: 2px 6px;
+      border-radius: 6px;
+      background: rgba(30, 41, 59, 0.85);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      font-size: 0.75rem;
+      color: #cbd5f5;
+    }
+
+    .sidebar {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+
+    .receipt-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .receipt-card {
+      border: 1px solid rgba(148, 163, 184, 0.28);
+      border-radius: 12px;
+      padding: 14px;
+      background: rgba(15, 23, 42, 0.7);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 0.85rem;
+    }
+
+    .receipt-card strong {
+      font-size: 0.95rem;
+    }
+
+    .receipt-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 12px;
+      color: var(--muted);
+    }
+
+    .receipt-empty {
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .progress {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .progress li {
+      position: relative;
+      padding-left: 22px;
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+
+    .progress li::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0.4em;
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      border: 2px solid rgba(148, 163, 184, 0.35);
+      background: transparent;
+      transition: all 0.25s ease;
+    }
+
+    .progress li.is-active::before {
+      border-color: rgba(129, 140, 248, 0.9);
+      background: rgba(129, 140, 248, 0.7);
+    }
+
+    .progress li.is-done::before {
+      border-color: var(--success);
+      background: var(--success);
+    }
+
+    .error-text {
+      color: #fca5a5;
+      font-weight: 600;
+    }
+  </style>
+  <body>
+    <div class="wrap">
+      <div class="header">
+        <h1>AGI Jobs — One‑Box</h1>
+        <span class="badge" id="mode">Mode: Guest (walletless)</span>
+        <span class="badge">Ask → Confirm → Done + Receipt</span>
+      </div>
+
+      <div class="chat-shell">
+        <div id="chat" class="chat-history" role="log" aria-live="polite">
+          <div class="msg m-assist">
+            Hi! I can plan, run, and finalize your job.
+            <span class="leadline">Try: <em>Label 500 images, budget 5 AGIALPHA, 7 days.</em></span>
+          </div>
+        </div>
+        <form id="onebox-form" class="chat-form">
+          <label for="onebox-input">Describe what you need done</label>
+          <div class="chat-input-row">
+            <textarea
+              id="onebox-input"
+              placeholder="Describe what you need done… e.g. Label 500 images, 5 AGIALPHA, 7 days"
+            ></textarea>
+            <button type="submit" class="primary-btn" id="send">Send</button>
+            <button type="button" class="ghost-btn" id="expert" title="Toggle Expert Mode (wallet signing)">
+              Expert Mode
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <div class="sec">
+        <h2>Shortcuts</h2>
+        <div class="pill-row">
+          <div class="pill" data-example="Post a research job, 3 AGIALPHA, 5 days">Research job</div>
+          <div class="pill" data-example="Finalize job 123">Finalize job</div>
+          <div class="pill" data-example="Status of job 123">Status check</div>
+        </div>
+        <span class="note">Walletless by default. Expert mode prepares calldata for your wallet via <span class="kbd">eth_sendTransaction</span>.</span>
+      </div>
+
+      <div class="sidebar">
+        <div class="sec">
+          <h2>Advanced</h2>
+          <label>
+            Orchestrator URL
+            <input id="orch" type="text" placeholder="https://your-orchestrator.example" />
+          </label>
+          <label>
+            API Token
+            <input id="tok" type="text" placeholder="(Bearer token)" />
+          </label>
+          <div class="sec-actions">
+            <button type="button" class="ghost-btn" id="save">Save</button>
+            <button type="button" class="ghost-btn" id="connect">Connect Wallet</button>
+            <button type="button" class="ghost-btn" id="clear-receipts">Clear Receipts</button>
+          </div>
+          <span class="note">No hashes or gas pop-ups for end users. Confirmations stay under 140 characters.</span>
+        </div>
+
+        <div class="sec">
+          <h2>Receipts</h2>
+          <div id="receipts-empty" class="receipt-empty">No receipts yet — run a job to see the audit trail.</div>
+          <ul id="receipts-list" class="receipt-list"></ul>
+        </div>
+      </div>
     </div>
-    <div class="small">Walletless by default. In Expert Mode, transactions are returned for you to sign via <span class="kbd">eth_sendTransaction</span>.</div>
-  </div>
 
-  <div class="small" style="margin-top:12px">No hashes, no gas prompts by default. A “Verify on chain” link appears after success.</div>
-</div>
-<script type="module" src="./app.js"></script>
+    <script type="module" src="./app.js"></script>
+  </body>
 </html>

--- a/apps/onebox/src/lib/defaultMessages.ts
+++ b/apps/onebox/src/lib/defaultMessages.ts
@@ -3,7 +3,7 @@ export const defaultMessages = [
     id: 'intro-1',
     role: 'assistant' as const,
     content:
-      'Hi! I am the AGI Jobs orchestrator. Describe what you want and I will prepare the intent. Configure AGI-Alpha or paste a JSON intent to proceed.',
+      'Hi! I can plan, run, and finalize your job. Ask → Confirm → Done + Receipt. Configure the orchestrator URL in Advanced or paste a JSON intent to proceed.',
   },
 ];
 


### PR DESCRIPTION
## Summary
- redesign the IPFS-ready one-box shell with receipts, expert-mode controls, and improved microcopy
- harden the FastAPI router with structured planner parsing, IPFS pinning, metrics, and health checks
- refresh shared defaults to align with the new “Ask → Confirm → Done + Receipt” narrative

## Testing
- pytest test/routes/test_onebox.py test/routes/test_onebox_intents.py


------
https://chatgpt.com/codex/tasks/task_e_68d760d551c88333a88284d48eadc1b9