### PR TITLE
Update onebox chat greeting and placeholder

### DIFF
--- a/apps/onebox/src/components/ChatWindow.tsx
+++ b/apps/onebox/src/components/ChatWindow.tsx
@@ -128,7 +128,7 @@ export function ChatWindow() {
             rows={2}
             value={input}
             onChange={(event) => setInput(event.target.value)}
-            placeholder="Post a labeling job for 500 images, 50 AGIALPHA, 7 days"
+            placeholder="Describe what you need done…"
             className="chat-textarea"
           />
           <button

--- a/apps/onebox/src/lib/defaultMessages.ts
+++ b/apps/onebox/src/lib/defaultMessages.ts
@@ -2,8 +2,7 @@ export const defaultMessages = [
   {
     id: 'intro-1',
     role: 'assistant' as const,
-    content:
-      'Hi! I can plan, run, and finalize your job. Ask → Confirm → Done + Receipt. Configure the orchestrator URL in Advanced or paste a JSON intent to proceed.',
+    content: 'Ask → Confirm → Done + Receipt.',
   },
 ];
 


### PR DESCRIPTION
## Summary
- update the chat textarea placeholder to encourage describing the work request
- align the default assistant greeting with the new acceptance-criteria copy

## Testing
- TS_NODE_PROJECT=tsconfig.json TS_NODE_COMPILER_OPTIONS='{"jsx":"react-jsx"}' node --loader ts-node/esm --experimental-specifier-resolution=node <<'JS'
import React from 'react';
import { renderToStaticMarkup } from 'react-dom/server';
import { ChatWindow } from './src/components/ChatWindow.tsx';

const markup = renderToStaticMarkup(React.createElement(ChatWindow));
if (!markup.includes('Ask → Confirm → Done + Receipt.')) {
  throw new Error('Greeting not found');
}
if (!markup.includes('Describe what you need done…')) {
  throw new Error('Placeholder not found');
}
JS

------
https://chatgpt.com/codex/tasks/task_e_68d7e001fc7c83338052be0397796cf1