### PR TITLE
feat(onebox): surface recent execution receipts

### DIFF
--- a/apps/onebox/src/app/globals.css
+++ b/apps/onebox/src/app/globals.css
@@ -53,6 +53,110 @@ button {
   font-size: 0.9rem;
 }
 
+.chat-wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.chat-receipts {
+  border: 1px solid #1e293b;
+  border-radius: 0.75rem;
+  background: rgba(2, 6, 23, 0.85);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chat-receipts-title {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.chat-receipts-empty {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.chat-receipts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.chat-receipts-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.9rem;
+  border-radius: 0.6rem;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.chat-receipt-field {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: #e2e8f0;
+}
+
+.chat-receipt-label {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  color: #94a3b8;
+}
+
+.chat-receipt-value {
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.chat-receipt-monospace {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Consolas,
+    'Liberation Mono', Menlo, monospace;
+  word-break: break-all;
+}
+
+.chat-receipt-link {
+  align-self: flex-start;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #38bdf8;
+  text-decoration: none;
+}
+
+.chat-receipt-link:hover {
+  text-decoration: underline;
+}
+
+@media (min-width: 1024px) {
+  .chat-wrapper {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .chat-shell {
+    flex: 1 1 auto;
+  }
+
+  .chat-receipts {
+    flex: 0 0 280px;
+  }
+}
+
 .chat-shell {
   flex: 1;
   display: flex;

--- a/apps/onebox/src/components/ChatWindow.tsx
+++ b/apps/onebox/src/components/ChatWindow.tsx
@@ -15,6 +15,16 @@ const ORCHESTRATOR_TOKEN =
   process.env.NEXT_PUBLIC_ALPHA_ORCHESTRATOR_TOKEN ??
   '';
 
+type ExecutionReceipt = {
+  id: string;
+  jobId?: number;
+  specCid?: string;
+  reward?: string;
+  token?: string;
+  receiptUrl?: string;
+  createdAt: number;
+};
+
 type TextMessage = {
   id: string;
   role: 'user' | 'assistant';
@@ -32,6 +42,9 @@ type PlanMessage = {
 type ChatMessage = TextMessage | PlanMessage;
 
 const createMessageId = () => crypto.randomUUID();
+const createReceiptId = () => crypto.randomUUID();
+const RECEIPTS_STORAGE_KEY = 'onebox:receipts';
+const RECEIPT_HISTORY_LIMIT = 5;
 
 export function ChatWindow() {
   const [messages, setMessages] = useState<ChatMessage[]>(
@@ -44,11 +57,89 @@ export function ChatWindow() {
     messageId: string;
     plan: PlanResponse;
   } | null>(null);
+  const [latestReceipt, setLatestReceipt] = useState<ExecutionReceipt | null>(
+    null
+  );
+  const [receipts, setReceipts] = useState<ExecutionReceipt[]>([]);
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(RECEIPTS_STORAGE_KEY);
+      if (!stored) {
+        return;
+      }
+
+      const parsed = JSON.parse(stored) as unknown;
+      if (!Array.isArray(parsed)) {
+        return;
+      }
+
+      const valid: ExecutionReceipt[] = parsed
+        .map((item) => {
+          if (!item || typeof item !== 'object') {
+            return null;
+          }
+
+          const candidate = item as Partial<ExecutionReceipt>;
+          if (!candidate.id || typeof candidate.id !== 'string') {
+            return null;
+          }
+
+          return {
+            id: candidate.id,
+            jobId: candidate.jobId,
+            specCid: candidate.specCid,
+            reward: candidate.reward,
+            token: candidate.token,
+            receiptUrl: candidate.receiptUrl,
+            createdAt:
+              typeof candidate.createdAt === 'number'
+                ? candidate.createdAt
+                : Date.now(),
+          } satisfies ExecutionReceipt;
+        })
+        .filter((item): item is ExecutionReceipt => item !== null)
+        .slice(0, RECEIPT_HISTORY_LIMIT);
+
+      if (valid.length > 0) {
+        setReceipts(valid);
+        setLatestReceipt(valid[0] ?? null);
+      }
+    } catch (error) {
+      console.error('Failed to restore receipts from storage.', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (receipts.length === 0) {
+      localStorage.removeItem(RECEIPTS_STORAGE_KEY);
+      return;
+    }
+
+    localStorage.setItem(
+      RECEIPTS_STORAGE_KEY,
+      JSON.stringify(receipts.slice(0, RECEIPT_HISTORY_LIMIT))
+    );
+  }, [receipts]);
+
+  useEffect(() => {
+    if (receipts.length === 0) {
+      if (latestReceipt !== null) {
+        setLatestReceipt(null);
+      }
+      return;
+    }
+
+    const [first] = receipts;
+    if (!latestReceipt || latestReceipt.id !== first.id) {
+      setLatestReceipt(first);
+    }
+  }, [latestReceipt, receipts]);
 
   const submitMessage = useCallback(async (prompt: string) => {
     const trimmed = prompt.trim();
@@ -238,13 +329,38 @@ export function ChatWindow() {
         throw new Error(reason);
       }
 
+      const receipt: ExecutionReceipt = {
+        id: createReceiptId(),
+        jobId: payload.jobId,
+        specCid: payload.specCid,
+        reward: payload.reward,
+        token: payload.token,
+        receiptUrl: payload.receiptUrl,
+        createdAt: Date.now(),
+      };
+
       const successLines = ['✅ Success.'];
-      if (payload.jobId !== undefined) {
-        successLines.push(`Job ID: ${payload.jobId}`);
+      if (receipt.jobId !== undefined) {
+        successLines.push(`Job ID: ${receipt.jobId}`);
       }
-      if (payload.receiptUrl) {
-        successLines.push(`Receipt: ${payload.receiptUrl}`);
+      if (receipt.specCid) {
+        successLines.push(`CID: ${receipt.specCid}`);
       }
+      if (receipt.reward) {
+        const payoutLabel = receipt.token
+          ? `${receipt.reward} ${receipt.token}`
+          : receipt.reward;
+        successLines.push(`Payout: ${payoutLabel}`);
+      }
+      if (receipt.receiptUrl) {
+        successLines.push(`Receipt: ${receipt.receiptUrl}`);
+      }
+
+      setLatestReceipt(receipt);
+      setReceipts((current) => {
+        const next = [receipt, ...current];
+        return next.slice(0, RECEIPT_HISTORY_LIMIT);
+      });
       updateMessageContent(progressMessageId, successLines.join('\n'));
     } catch (error) {
       const message =
@@ -257,84 +373,148 @@ export function ChatWindow() {
     }
   }, [pendingPlan, updateMessageContent]);
 
+  const formatPayout = (receipt: ExecutionReceipt) => {
+    if (receipt.reward && receipt.token) {
+      return `${receipt.reward} ${receipt.token}`;
+    }
+    return receipt.reward ?? null;
+  };
+
   return (
-    <div className="chat-shell">
-      <div className="chat-history" role="log" aria-live="polite">
-        {messages.map((message) => (
-          <div key={message.id} className="chat-message">
-            <span className="chat-message-role">{message.role}</span>
-            <div className="chat-bubble">
-              {message.kind === 'plan' ? (
-                <div className="plan-summary">
-                  <p>{message.plan.summary}</p>
-                  {message.plan.warnings && message.plan.warnings.length > 0 ? (
-                    <ul className="plan-warnings">
-                      {message.plan.warnings.map(
-                        (warning: string, warningIndex: number) => (
-                          <li key={warningIndex}>{warning}</li>
-                        )
-                      )}
-                    </ul>
-                  ) : null}
-                  {pendingPlan?.messageId === message.id ? (
-                    <div className="plan-actions">
-                      <button
-                        type="button"
-                        className="plan-button"
-                        onClick={() => {
-                          void handleExecutePlan();
-                        }}
-                        disabled={isExecuting}
-                      >
-                        Yes
-                      </button>
-                      <button
-                        type="button"
-                        className="plan-button plan-button-secondary"
-                        onClick={handleRejectPlan}
-                        disabled={isExecuting}
-                      >
-                        No
-                      </button>
+    <div className="chat-wrapper">
+      <div className="chat-shell">
+        <div className="chat-history" role="log" aria-live="polite">
+          {messages.map((message) => (
+            <div key={message.id} className="chat-message">
+              <span className="chat-message-role">{message.role}</span>
+              <div className="chat-bubble">
+                {message.kind === 'plan' ? (
+                  <div className="plan-summary">
+                    <p>{message.plan.summary}</p>
+                    {message.plan.warnings &&
+                    message.plan.warnings.length > 0 ? (
+                      <ul className="plan-warnings">
+                        {message.plan.warnings.map(
+                          (warning: string, warningIndex: number) => (
+                            <li key={warningIndex}>{warning}</li>
+                          )
+                        )}
+                      </ul>
+                    ) : null}
+                    {pendingPlan?.messageId === message.id ? (
+                      <div className="plan-actions">
+                        <button
+                          type="button"
+                          className="plan-button"
+                          onClick={() => {
+                            void handleExecutePlan();
+                          }}
+                          disabled={isExecuting}
+                        >
+                          Yes
+                        </button>
+                        <button
+                          type="button"
+                          className="plan-button plan-button-secondary"
+                          onClick={handleRejectPlan}
+                          disabled={isExecuting}
+                        >
+                          No
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : (
+                  message.content
+                )}
+              </div>
+            </div>
+          ))}
+          <div ref={bottomRef} />
+        </div>
+        <form
+          className="chat-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void submitMessage(input);
+          }}
+        >
+          <label className="chat-label" htmlFor="onebox-input">
+            Ask for anything
+          </label>
+          <div className="chat-input-row">
+            <textarea
+              id="onebox-input"
+              rows={2}
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              placeholder="Describe what you need done…"
+              className="chat-textarea"
+            />
+            <button
+              type="submit"
+              disabled={isLoading || isExecuting}
+              className="chat-send-button"
+            >
+              {isLoading ? 'Sending…' : 'Send'}
+            </button>
+          </div>
+        </form>
+      </div>
+      <aside
+        className="chat-receipts"
+        aria-live="polite"
+        aria-label="Recent receipts"
+      >
+        <h2 className="chat-receipts-title">Recent jobs</h2>
+        {latestReceipt ? (
+          <ul className="chat-receipts-list">
+            {receipts.map((receipt) => {
+              const payout = formatPayout(receipt);
+              return (
+                <li key={receipt.id} className="chat-receipts-item">
+                  {receipt.jobId !== undefined ? (
+                    <div className="chat-receipt-field">
+                      <span className="chat-receipt-label">Job ID</span>
+                      <span className="chat-receipt-value">
+                        #{receipt.jobId}
+                      </span>
                     </div>
                   ) : null}
-                </div>
-              ) : (
-                message.content
-              )}
-            </div>
-          </div>
-        ))}
-        <div ref={bottomRef} />
-      </div>
-      <form
-        className="chat-form"
-        onSubmit={(event) => {
-          event.preventDefault();
-          void submitMessage(input);
-        }}
-      >
-        <label className="chat-label" htmlFor="onebox-input">
-          Ask for anything
-        </label>
-        <div className="chat-input-row">
-          <textarea
-            id="onebox-input"
-            rows={2}
-            value={input}
-            onChange={(event) => setInput(event.target.value)}
-            placeholder="Describe what you need done…"
-            className="chat-textarea"
-          />
-          <button
-            type="submit"
-            disabled={isLoading || isExecuting}
-            className="chat-send-button"
-          >
-            {isLoading ? 'Sending…' : 'Send'}
-          </button>
-        </div>
-      </form>
+                  {receipt.specCid ? (
+                    <div className="chat-receipt-field">
+                      <span className="chat-receipt-label">CID</span>
+                      <span className="chat-receipt-value chat-receipt-monospace">
+                        {receipt.specCid}
+                      </span>
+                    </div>
+                  ) : null}
+                  {payout ? (
+                    <div className="chat-receipt-field">
+                      <span className="chat-receipt-label">Payout</span>
+                      <span className="chat-receipt-value">{payout}</span>
+                    </div>
+                  ) : null}
+                  {receipt.receiptUrl ? (
+                    <a
+                      className="chat-receipt-link"
+                      href={receipt.receiptUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      View on explorer
+                    </a>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="chat-receipts-empty">
+            Execute a plan to see job details here.
+          </p>
+        )}
+      </aside>
     </div>
   );
 }

--- a/packages/onebox-sdk/src/index.ts
+++ b/packages/onebox-sdk/src/index.ts
@@ -64,6 +64,12 @@ export interface ExecuteResponse {
   jobId?: number;
   txHash?: string;
   receiptUrl?: string;
+  specCid?: string;
+  specHash?: string;
+  deadline?: number;
+  reward?: string;
+  token?: string;
+  status?: string;
   /** Target address for wallet execution flows. */
   to?: string;
   /** ABI-encoded calldata for wallet execution flows. */


### PR DESCRIPTION
## Summary
- persist recent execution receipts in the chat window and hydrate them from local storage
- display a receipts panel with job id, CID, payout, and explorer links after successful executions
- extend the shared ExecuteResponse typing and add styles for the new receipts layout

## Testing
- npx eslint apps/onebox/src/components/ChatWindow.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d7e644ac5483338dbc805c4efa2601