### PR TITLE
feat(onebox): add expert mode insights panel

### DIFF
--- a/apps/onebox/src/app/globals.css
+++ b/apps/onebox/src/app/globals.css
@@ -166,6 +166,37 @@ button {
   background: rgba(15, 23, 42, 0.7);
 }
 
+.chat-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 1rem 1.5rem 0;
+}
+
+.expert-toggle {
+  border-radius: 999px;
+  border: 1px solid #1e293b;
+  background: rgba(15, 23, 42, 0.6);
+  color: #e2e8f0;
+  font-weight: 600;
+  padding: 0.35rem 0.9rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, filter 0.15s ease;
+}
+
+.expert-toggle:hover {
+  transform: translateY(-1px);
+}
+
+.expert-toggle:active {
+  transform: translateY(1px);
+}
+
+.expert-toggle.is-active {
+  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  color: #0f172a;
+  border-color: transparent;
+}
+
 .chat-history {
   flex: 1;
   padding: 1.5rem;
@@ -318,4 +349,145 @@ button {
 
 .chat-send-button:not(:disabled):active {
   transform: translateY(1px);
+}
+
+.expert-panel {
+  margin: 0 1.5rem 1rem;
+  border: 1px solid #1e293b;
+  border-radius: 0.75rem;
+  background: rgba(2, 6, 23, 0.7);
+  display: flex;
+  flex-direction: column;
+}
+
+.expert-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1rem;
+  gap: 0.75rem;
+}
+
+.expert-panel-title {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.expert-panel-toggle {
+  border: none;
+  background: none;
+  color: #38bdf8;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.expert-panel-toggle:hover {
+  text-decoration: underline;
+}
+
+.expert-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 0 1rem 1.2rem;
+}
+
+.expert-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.expert-meta-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.expert-meta-label {
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.14em;
+  color: #94a3b8;
+}
+
+.expert-meta-value {
+  font-weight: 600;
+  color: #f8fafc;
+  word-break: break-word;
+}
+
+.expert-section-title {
+  display: block;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  color: #94a3b8;
+  margin-bottom: 0.5rem;
+}
+
+.expert-contracts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.expert-contract-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.expert-contract-name {
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.expert-contract-address {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Consolas,
+    'Liberation Mono', Menlo, monospace;
+  font-size: 0.8rem;
+  word-break: break-all;
+  color: #38bdf8;
+}
+
+.expert-json-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 900px) {
+  .expert-json-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.expert-json-block {
+  margin: 0;
+  padding: 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(15, 23, 42, 0.85);
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Consolas,
+    'Liberation Mono', Menlo, monospace;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  max-height: 220px;
+  overflow: auto;
+  white-space: pre;
 }


### PR DESCRIPTION
## Summary
- add an expert mode toggle with a collapsible insights panel surfacing network info and contract metadata
- capture the latest planner and executor request/response payloads so the expert view stays in sync
- style the expert controls and panel to match the existing chat experience

## Testing
- npx eslint apps/onebox/src/components/ChatWindow.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7eaa146f4833392e51f503c768d24