### PR TITLE
feat(onebox): add execution receipt history

### DIFF
--- a/apps/onebox/src/components/ChatWindow.tsx
+++ b/apps/onebox/src/components/ChatWindow.tsx
@@ -9,6 +9,8 @@ import type {
 } from '@agijobs/onebox-sdk';
 import deploymentAddresses from '../../../../docs/deployment-addresses.json';
 import { defaultMessages } from '../lib/defaultMessages';
+import { ReceiptsPanel } from './ReceiptsPanel';
+import type { ExecutionReceipt } from './receiptTypes';
 
 const ORCHESTRATOR_BASE_URL = (
   process.env.NEXT_PUBLIC_ONEBOX_ORCHESTRATOR_URL ??
@@ -20,16 +22,6 @@ const ORCHESTRATOR_TOKEN =
   process.env.NEXT_PUBLIC_ONEBOX_ORCHESTRATOR_TOKEN ??
   process.env.NEXT_PUBLIC_ALPHA_ORCHESTRATOR_TOKEN ??
   '';
-
-type ExecutionReceipt = {
-  id: string;
-  jobId?: number;
-  specCid?: string;
-  reward?: string;
-  token?: string;
-  receiptUrl?: string;
-  createdAt: number;
-};
 
 type TextMessage = {
   id: string;
@@ -100,9 +92,6 @@ export function ChatWindow() {
     messageId: string;
     plan: PlanResponse;
   } | null>(null);
-  const [latestReceipt, setLatestReceipt] = useState<ExecutionReceipt | null>(
-    null
-  );
   const [receipts, setReceipts] = useState<ExecutionReceipt[]>([]);
   const [isExpertMode, setIsExpertMode] = useState(false);
   const [isExpertPanelOpen, setIsExpertPanelOpen] = useState(true);
@@ -152,6 +141,40 @@ export function ChatWindow() {
           return acc;
         }
 
+        const legacyReward =
+          typeof (candidate as { reward?: string }).reward === 'string' &&
+          (candidate as { reward?: string }).reward
+            ? (candidate as { reward?: string }).reward
+            : undefined;
+        const legacyToken =
+          typeof (candidate as { token?: string }).token === 'string' &&
+          (candidate as { token?: string }).token
+            ? (candidate as { token?: string }).token
+            : undefined;
+        const storedNetPayout =
+          typeof candidate.netPayout === 'string' &&
+          candidate.netPayout.length > 0
+            ? candidate.netPayout
+            : undefined;
+        const derivedNetPayout = legacyReward
+          ? legacyToken
+            ? `${legacyReward} ${legacyToken}`
+            : legacyReward
+          : undefined;
+        const { receiptUrl: receiptUrlCandidate } = candidate as {
+          receiptUrl?: unknown;
+        };
+        const legacyExplorerUrl =
+          typeof receiptUrlCandidate === 'string' &&
+          receiptUrlCandidate.length > 0
+            ? receiptUrlCandidate
+            : undefined;
+        const resolvedExplorerUrl =
+          typeof candidate.explorerUrl === 'string' &&
+          candidate.explorerUrl.length > 0
+            ? candidate.explorerUrl
+            : legacyExplorerUrl;
+
         const record: ExecutionReceipt = {
           id: candidate.id,
           jobId:
@@ -161,19 +184,8 @@ export function ChatWindow() {
             candidate.specCid.length > 0
               ? candidate.specCid
               : undefined,
-          reward:
-            typeof candidate.reward === 'string' && candidate.reward.length > 0
-              ? candidate.reward
-              : undefined,
-          token:
-            typeof candidate.token === 'string' && candidate.token.length > 0
-              ? candidate.token
-              : undefined,
-          receiptUrl:
-            typeof candidate.receiptUrl === 'string' &&
-            candidate.receiptUrl.length > 0
-              ? candidate.receiptUrl
-              : undefined,
+          netPayout: storedNetPayout ?? derivedNetPayout,
+          explorerUrl: resolvedExplorerUrl,
           createdAt:
             typeof candidate.createdAt === 'number'
               ? candidate.createdAt
@@ -188,7 +200,6 @@ export function ChatWindow() {
         valid.sort((a, b) => b.createdAt - a.createdAt);
         const limited = valid.slice(0, RECEIPT_HISTORY_LIMIT);
         setReceipts(limited);
-        setLatestReceipt(limited[0] ?? null);
       }
     } catch (error) {
       console.error('Failed to restore receipts from storage.', error);
@@ -206,20 +217,6 @@ export function ChatWindow() {
       JSON.stringify(receipts.slice(0, RECEIPT_HISTORY_LIMIT))
     );
   }, [receipts]);
-
-  useEffect(() => {
-    if (receipts.length === 0) {
-      if (latestReceipt !== null) {
-        setLatestReceipt(null);
-      }
-      return;
-    }
-
-    const [first] = receipts;
-    if (!latestReceipt || latestReceipt.id !== first.id) {
-      setLatestReceipt(first);
-    }
-  }, [latestReceipt, receipts]);
 
   const submitMessage = useCallback(
     async (prompt: string) => {
@@ -438,13 +435,16 @@ export function ChatWindow() {
         throw new Error(reason);
       }
 
+      const netPayout = [payload.reward, payload.token]
+        .filter((value): value is string => typeof value === 'string' && value)
+        .join(' ');
+
       const receipt: ExecutionReceipt = {
         id: createReceiptId(),
         jobId: payload.jobId,
         specCid: payload.specCid,
-        reward: payload.reward,
-        token: payload.token,
-        receiptUrl: payload.receiptUrl,
+        netPayout: netPayout.length > 0 ? netPayout : undefined,
+        explorerUrl: payload.receiptUrl,
         createdAt: Date.now(),
       };
 
@@ -455,17 +455,13 @@ export function ChatWindow() {
       if (receipt.specCid) {
         successLines.push(`CID: ${receipt.specCid}`);
       }
-      if (receipt.reward) {
-        const payoutLabel = receipt.token
-          ? `${receipt.reward} ${receipt.token}`
-          : receipt.reward;
-        successLines.push(`Payout: ${payoutLabel}`);
+      if (receipt.netPayout) {
+        successLines.push(`Payout: ${receipt.netPayout}`);
       }
-      if (receipt.receiptUrl) {
-        successLines.push(`Receipt: ${receipt.receiptUrl}`);
+      if (receipt.explorerUrl) {
+        successLines.push(`Receipt: ${receipt.explorerUrl}`);
       }
 
-      setLatestReceipt(receipt);
       setReceipts((current) => {
         const next = [receipt, ...current];
         return next.slice(0, RECEIPT_HISTORY_LIMIT);
@@ -485,13 +481,6 @@ export function ChatWindow() {
       setIsExecuting(false);
     }
   }, [isExpertMode, pendingPlan, updateMessageContent]);
-
-  const formatPayout = (receipt: ExecutionReceipt) => {
-    if (receipt.reward && receipt.token) {
-      return `${receipt.reward} ${receipt.token}`;
-    }
-    return receipt.reward ?? null;
-  };
 
   const contractEntries = useMemo(
     () =>
@@ -690,60 +679,7 @@ export function ChatWindow() {
           </div>
         </form>
       </div>
-      <aside
-        className="chat-receipts"
-        aria-live="polite"
-        aria-label="Recent receipts"
-      >
-        <h2 className="chat-receipts-title">Recent jobs</h2>
-        {latestReceipt ? (
-          <ul className="chat-receipts-list">
-            {receipts.map((receipt) => {
-              const payout = formatPayout(receipt);
-              return (
-                <li key={receipt.id} className="chat-receipts-item">
-                  {receipt.jobId !== undefined ? (
-                    <div className="chat-receipt-field">
-                      <span className="chat-receipt-label">Job ID</span>
-                      <span className="chat-receipt-value">
-                        #{receipt.jobId}
-                      </span>
-                    </div>
-                  ) : null}
-                  {receipt.specCid ? (
-                    <div className="chat-receipt-field">
-                      <span className="chat-receipt-label">CID</span>
-                      <span className="chat-receipt-value chat-receipt-monospace">
-                        {receipt.specCid}
-                      </span>
-                    </div>
-                  ) : null}
-                  {payout ? (
-                    <div className="chat-receipt-field">
-                      <span className="chat-receipt-label">Payout</span>
-                      <span className="chat-receipt-value">{payout}</span>
-                    </div>
-                  ) : null}
-                  {receipt.receiptUrl ? (
-                    <a
-                      className="chat-receipt-link"
-                      href={receipt.receiptUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      View on explorer
-                    </a>
-                  ) : null}
-                </li>
-              );
-            })}
-          </ul>
-        ) : (
-          <p className="chat-receipts-empty">
-            Execute a plan to see job details here.
-          </p>
-        )}
-      </aside>
+      <ReceiptsPanel receipts={receipts} />
     </div>
   );
 }

--- a/apps/onebox/src/components/ReceiptsPanel.tsx
+++ b/apps/onebox/src/components/ReceiptsPanel.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import type { ExecutionReceipt } from './receiptTypes';
+
+type ReceiptsPanelProps = {
+  receipts: ExecutionReceipt[];
+};
+
+const formatCid = (cid: string) => cid.trim();
+
+export function ReceiptsPanel({ receipts }: ReceiptsPanelProps) {
+  if (receipts.length === 0) {
+    return (
+      <aside
+        className="chat-receipts"
+        aria-live="polite"
+        aria-label="Recent receipts"
+      >
+        <h2 className="chat-receipts-title">Recent jobs</h2>
+        <p className="chat-receipts-empty">
+          Execute a plan to see job details here.
+        </p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      className="chat-receipts"
+      aria-live="polite"
+      aria-label="Recent receipts"
+    >
+      <h2 className="chat-receipts-title">Recent jobs</h2>
+      <ul className="chat-receipts-list">
+        {receipts.map((receipt) => (
+          <li key={receipt.id} className="chat-receipts-item">
+            {receipt.jobId !== undefined ? (
+              <div className="chat-receipt-field">
+                <span className="chat-receipt-label">Job ID</span>
+                <span className="chat-receipt-value">#{receipt.jobId}</span>
+              </div>
+            ) : null}
+            {receipt.specCid ? (
+              <div className="chat-receipt-field">
+                <span className="chat-receipt-label">CID</span>
+                <span className="chat-receipt-value chat-receipt-monospace">
+                  {formatCid(receipt.specCid)}
+                </span>
+              </div>
+            ) : null}
+            {receipt.netPayout ? (
+              <div className="chat-receipt-field">
+                <span className="chat-receipt-label">Net payout</span>
+                <span className="chat-receipt-value">{receipt.netPayout}</span>
+              </div>
+            ) : null}
+            {receipt.explorerUrl ? (
+              <a
+                className="chat-receipt-link"
+                href={receipt.explorerUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                View on explorer
+              </a>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/apps/onebox/src/components/receiptTypes.ts
+++ b/apps/onebox/src/components/receiptTypes.ts
@@ -1,0 +1,8 @@
+export type ExecutionReceipt = {
+  id: string;
+  jobId?: number;
+  specCid?: string;
+  netPayout?: string;
+  explorerUrl?: string;
+  createdAt: number;
+};


### PR DESCRIPTION
## Summary
- persist execution receipts with job metadata and hydrate on load in the chat window
- surface a reusable receipts panel component that renders job id, CID, net payout, and explorer links
- feed successful execute responses into the receipts list and store the latest history locally

## Testing
- npx eslint apps/onebox/src/components/ChatWindow.tsx apps/onebox/src/components/ReceiptsPanel.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7f15ad1c88333bb752f8ecb44a716