### PR TITLE
feat(onebox): add staged plan confirmation flow

### DIFF
--- a/apps/onebox/src/app/globals.css
+++ b/apps/onebox/src/app/globals.css
@@ -252,6 +252,62 @@ button {
   gap: 0.5rem;
 }
 
+.chat-error {
+  margin: 0 1.5rem 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.6rem;
+  background: rgba(127, 29, 29, 0.25);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.chat-error-message {
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.chat-error-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.chat-error-button {
+  flex: 0 0 auto;
+  min-width: 72px;
+  padding: 0.4rem 0.9rem;
+  border-radius: 0.55rem;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, #f87171, #ef4444);
+  color: #0f172a;
+  transition: transform 0.15s ease, filter 0.15s ease;
+}
+
+.chat-error-button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(35%);
+  opacity: 0.7;
+}
+
+.chat-error-button:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.chat-error-button:not(:disabled):active {
+  transform: translateY(1px);
+}
+
+.chat-error-button-secondary {
+  background: rgba(15, 23, 42, 0.9);
+  color: #e2e8f0;
+  border: 1px solid #64748b;
+}
+
 .plan-button {
   flex: 0 0 auto;
   min-width: 72px;

--- a/packages/onebox-sdk/src/index.ts
+++ b/packages/onebox-sdk/src/index.ts
@@ -98,9 +98,15 @@ export interface JobStatusCard {
   assignee?: string;
 }
 
+export interface PlannerHistoryMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
 export interface PlanRequest {
   text: string;
   expert?: boolean;
+  history?: PlannerHistoryMessage[];
 }
 
 export interface ExecuteRequest {


### PR DESCRIPTION
## Summary
- send planner history to `/onebox/plan` and track plan/execution stages in the chat window
- add inline confirmation, streaming execution progress, and retry/cancel error handling in the chat UI
- style chat error alerts and extend the SDK plan request type to carry planner history

## Testing
- npm run lint *(fails: existing repository lint warnings in unrelated Solidity/TypeScript files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7faf769608333942fe514a283f448