### PR TITLE
Add structured observability and metrics for onebox endpoints

### DIFF
--- a/apps/orchestrator/__tests__/oneboxRouter.test.ts
+++ b/apps/orchestrator/__tests__/oneboxRouter.test.ts
@@ -120,10 +120,10 @@ test('metrics endpoint exposes Prometheus counters', async () => {
   assert.equal(metricsResponse.status, 200);
   assert.equal(metricsResponse.headers['content-type'], 'text/plain; version=0.0.4; charset=utf-8');
   const body = metricsResponse.text;
-  assert.match(body, /onebox_plan_requests_total 1/);
-  assert.match(body, /onebox_execute_requests_total 1/);
-  assert.match(body, /onebox_execute_action_total\{action="post_job"\} 1/);
-  assert.match(body, /onebox_status_requests_total 1/);
+  assert.match(body, /plan_total\{intent_type="post_job",http_status="200"\} 1/);
+  assert.match(body, /execute_total\{intent_type="post_job",http_status="200"\} 1/);
+  assert.match(body, /status_total\{intent_type="status",http_status="200"\} 1/);
+  assert.match(body, /time_to_outcome_seconds_bucket\{endpoint="plan",le="\+Inf"\} 1/);
 });
 
 test('DefaultOneboxService produces calldata for wallet mode', async () => {


### PR DESCRIPTION
## Summary
- instrument the FastAPI onebox router with Prometheus counters/histogram, correlation IDs, and structured logs
- replace the orchestrator metrics helper with labeled counters plus a TTO histogram and emit structured logs/correlation IDs from the Express router
- adjust API tests to build request stubs, assert minimal health output, and validate the new metrics surface

## Testing
- python -m pytest test/routes/test_onebox.py
- TS_NODE_PROJECT=apps/orchestrator/tsconfig.json node --test --loader ts-node/esm apps/orchestrator/__tests__/oneboxRouter.test.ts *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_68d800d7351483338ba157bf1e92437c