### PR TITLE
Add token authentication middleware to onebox router

### DIFF
--- a/apps/orchestrator/__tests__/oneboxRouter.test.ts
+++ b/apps/orchestrator/__tests__/oneboxRouter.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
 import test, { mock } from 'node:test';
 import { ethers } from 'ethers';
 import type { Wallet } from 'ethers';
@@ -57,6 +58,37 @@ test('mapJobStateToStatus returns sensible defaults', () => {
   assert.equal(mapJobStateToStatus(99).code, 'none');
 });
 
+const TEST_TOKEN = 'test-token';
+
+function withRouter<T>(
+  service: Parameters<typeof createOneboxRouter>[0],
+  callback: (router: express.Router) => Promise<T> | T
+): Promise<T> | T {
+  const previousOnebox = process.env.ONEBOX_API_TOKEN;
+  const previousApiToken = process.env.API_TOKEN;
+  process.env.ONEBOX_API_TOKEN = TEST_TOKEN;
+  delete process.env.API_TOKEN;
+  try {
+    const router = createOneboxRouter(service);
+    return callback(router);
+  } finally {
+    if (previousOnebox === undefined) {
+      delete process.env.ONEBOX_API_TOKEN;
+    } else {
+      process.env.ONEBOX_API_TOKEN = previousOnebox;
+    }
+    if (previousApiToken === undefined) {
+      delete process.env.API_TOKEN;
+    } else {
+      process.env.API_TOKEN = previousApiToken;
+    }
+  }
+}
+
+function authorised(requestBuilder: request.Test): request.Test {
+  return requestBuilder.set('Authorization', `Bearer ${TEST_TOKEN}`);
+}
+
 test('onebox router plan route delegates to service', async () => {
   const planResponse: PlanResponse = {
     summary: 'Summary',
@@ -65,65 +97,181 @@ test('onebox router plan route delegates to service', async () => {
     warnings: [],
   };
 
-  const router = createOneboxRouter({
-    async plan() {
-      return planResponse;
+  await withRouter(
+    {
+      async plan() {
+        return planResponse;
+      },
+      async execute() {
+        return { ok: true };
+      },
+      async status(): Promise<StatusResponse> {
+        return { jobs: [] };
+      },
     },
-    async execute() {
-      return { ok: true };
-    },
-    async status(): Promise<StatusResponse> {
-      return { jobs: [] };
-    },
-  });
+    async (router) => {
+      const app = express();
+      app.use(express.json());
+      app.use('/onebox', router);
 
-  const app = express();
-  app.use(express.json());
-  app.use('/onebox', router);
+      const response = await authorised(request(app).post('/onebox/plan')).send({ text: 'Create a job' });
+      assert.equal(response.status, 200);
+      assert.deepEqual(response.body.summary, planResponse.summary);
+    }
+  );
+});
 
-  const response = await request(app).post('/onebox/plan').send({ text: 'Create a job' });
-  assert.equal(response.status, 200);
-  assert.deepEqual(response.body.summary, planResponse.summary);
+test('plan route responds with 401 when token missing', async () => {
+  const previousOnebox = process.env.ONEBOX_API_TOKEN;
+  const previousApiToken = process.env.API_TOKEN;
+  delete process.env.ONEBOX_API_TOKEN;
+  delete process.env.API_TOKEN;
+  try {
+    const router = createOneboxRouter({
+      async plan() {
+        return {
+          summary: 'Summary',
+          intent: { action: 'post_job', payload: {} },
+          requiresConfirmation: true,
+          warnings: [],
+        } satisfies PlanResponse;
+      },
+      async execute() {
+        return { ok: true };
+      },
+      async status(): Promise<StatusResponse> {
+        return { jobs: [] };
+      },
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use('/onebox', router);
+
+    const response = await request(app).post('/onebox/plan').send({ text: 'Create a job' });
+    assert.equal(response.status, 401);
+    assert.match(response.body.error, /not configured/i);
+  } finally {
+    if (previousOnebox === undefined) {
+      delete process.env.ONEBOX_API_TOKEN;
+    } else {
+      process.env.ONEBOX_API_TOKEN = previousOnebox;
+    }
+    if (previousApiToken === undefined) {
+      delete process.env.API_TOKEN;
+    } else {
+      process.env.API_TOKEN = previousApiToken;
+    }
+  }
+});
+
+test('plan route responds with 403 for invalid token', async () => {
+  await withRouter(
+    {
+      async plan() {
+        return {
+          summary: 'Summary',
+          intent: { action: 'post_job', payload: {} },
+          requiresConfirmation: true,
+          warnings: [],
+        } satisfies PlanResponse;
+      },
+      async execute() {
+        return { ok: true };
+      },
+      async status(): Promise<StatusResponse> {
+        return { jobs: [] };
+      },
+    },
+    async (router) => {
+      const app = express();
+      app.use(express.json());
+      app.use('/onebox', router);
+
+      const response = await request(app)
+        .post('/onebox/plan')
+        .set('Authorization', 'Bearer wrong-token')
+        .send({ text: 'Create a job' });
+      assert.equal(response.status, 403);
+    }
+  );
+});
+
+test('plan route accepts valid HMAC authorization', async () => {
+  await withRouter(
+    {
+      async plan() {
+        return {
+          summary: 'Summary',
+          intent: { action: 'post_job', payload: {} },
+          requiresConfirmation: true,
+          warnings: [],
+        } satisfies PlanResponse;
+      },
+      async execute() {
+        return { ok: true };
+      },
+      async status(): Promise<StatusResponse> {
+        return { jobs: [] };
+      },
+    },
+    async (router) => {
+      const app = express();
+      app.use(express.json());
+      app.use('/onebox', router);
+
+      const timestamp = Math.floor(Date.now() / 1000);
+      const canonical = `POST /onebox/plan ${timestamp}`;
+      const signature = createHmac('sha256', TEST_TOKEN).update(canonical).digest('hex');
+      const response = await request(app)
+        .post('/onebox/plan')
+        .set('Authorization', `HMAC ${timestamp}:${signature}`)
+        .send({ text: 'Create a job' });
+
+      assert.equal(response.status, 200);
+    }
+  );
 });
 
 test('metrics endpoint exposes Prometheus counters', async () => {
   resetMetrics();
 
-  const router = createOneboxRouter({
-    async plan() {
-      return {
-        summary: 'Summary',
-        intent: { action: 'post_job', payload: {} },
-        requiresConfirmation: true,
-        warnings: [],
-      } satisfies PlanResponse;
+  await withRouter(
+    {
+      async plan() {
+        return {
+          summary: 'Summary',
+          intent: { action: 'post_job', payload: {} },
+          requiresConfirmation: true,
+          warnings: [],
+        } satisfies PlanResponse;
+      },
+      async execute() {
+        return { ok: true };
+      },
+      async status(): Promise<StatusResponse> {
+        return { jobs: [] };
+      },
     },
-    async execute() {
-      return { ok: true };
-    },
-    async status(): Promise<StatusResponse> {
-      return { jobs: [] };
-    },
-  });
+    async (router) => {
+      const app = express();
+      app.use(express.json());
+      app.use('/onebox', router);
 
-  const app = express();
-  app.use(express.json());
-  app.use('/onebox', router);
+      await authorised(request(app).post('/onebox/plan')).send({ text: 'Create a job' });
+      await authorised(request(app).post('/onebox/execute')).send({ intent: { action: 'post_job', payload: {} }, mode: 'relayer' });
+      await authorised(request(app).get('/onebox/status'));
 
-  await request(app).post('/onebox/plan').send({ text: 'Create a job' });
-  await request(app)
-    .post('/onebox/execute')
-    .send({ intent: { action: 'post_job', payload: {} }, mode: 'relayer' });
-  await request(app).get('/onebox/status');
-
-  const metricsResponse = await request(app).get('/onebox/metrics');
-  assert.equal(metricsResponse.status, 200);
-  assert.equal(metricsResponse.headers['content-type'], 'text/plain; version=0.0.4; charset=utf-8');
-  const body = metricsResponse.text;
-  assert.match(body, /plan_total\{intent_type="post_job",http_status="200"\} 1/);
-  assert.match(body, /execute_total\{intent_type="post_job",http_status="200"\} 1/);
-  assert.match(body, /status_total\{intent_type="status",http_status="200"\} 1/);
-  assert.match(body, /time_to_outcome_seconds_bucket\{endpoint="plan",le="\+Inf"\} 1/);
+      const metricsResponse = await authorised(request(app).get('/onebox/metrics'));
+      assert.equal(metricsResponse.status, 200);
+      assert.equal(metricsResponse.headers['content-type'], 'text/plain; charset=utf-8; version=0.0.4');
+      const body = metricsResponse.text;
+      assert.match(body, /plan_total\{intent_type="post_job",http_status="200"\} 1/);
+      assert.match(body, /execute_total\{intent_type="post_job",http_status="200"\} 1/);
+      assert.match(body, /status_total\{intent_type="status",http_status="200"\} 1/);
+      assert.match(body, /time_to_outcome_seconds_bucket\{endpoint="plan",le="\+Inf"\} 1/);
+    }
+  );
 });
 
 test('DefaultOneboxService produces calldata for wallet mode', async () => {
@@ -170,13 +318,14 @@ test('DefaultOneboxService produces calldata for wallet mode', async () => {
 
 test('finalizeJob invokes registry finalize function', async () => {
   const finalizeCall = mock.fn(async () => ({ wait: async () => undefined }));
-  const contractMock = mock.method(
-    ethers as unknown as { Contract: new (...args: any[]) => unknown },
-    'Contract',
-    function () {
+  const ethersModule = require('ethers') as { ethers: { Contract: new (...args: any[]) => unknown } };
+  const originalDescriptor = Object.getOwnPropertyDescriptor(ethersModule.ethers, 'Contract');
+  Object.defineProperty(ethersModule.ethers, 'Contract', {
+    configurable: true,
+    value: function () {
       return { finalize: finalizeCall };
-    } as unknown as new (...args: any[]) => unknown
-  );
+    } as unknown as new (...args: any[]) => unknown,
+  });
 
   const loadStateMock = mock.method(execution, 'loadState', () => ({}));
   const saveStateMock = mock.method(execution, 'saveState', () => undefined);
@@ -193,7 +342,9 @@ test('finalizeJob invokes registry finalize function', async () => {
     assert.equal(finalizeCall.mock.calls.length, 1);
     assert.deepEqual(finalizeCall.mock.calls[0].arguments, ['42']);
   } finally {
-    contractMock.mock.restore();
+    if (originalDescriptor) {
+      Object.defineProperty(ethersModule.ethers, 'Contract', originalDescriptor);
+    }
     loadStateMock.mock.restore();
     saveStateMock.mock.restore();
   }


### PR DESCRIPTION
## Summary
- load the configured API token during onebox router creation and validate incoming authorization headers
- add support for both bearer tokens and HMAC-based credentials via a reusable middleware
- update onebox router tests to cover authorized, unauthorized, and metrics access flows

## Testing
- TS_NODE_COMPILER_OPTIONS='{"module":"commonjs","esModuleInterop":true}' node --require ts-node/register --test apps/orchestrator/__tests__/oneboxRouter.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d80ae800348333bcde1076be4c7275