### PR TITLE
Add bundler gas fallback for AA signer

### DIFF
--- a/packages/orchestrator/src/chain/providers/bundler.ts
+++ b/packages/orchestrator/src/chain/providers/bundler.ts
@@ -79,6 +79,27 @@ export class BundlerClient {
     return this.rpcRequest<string>("eth_sendUserOperation", [payload, entryPoint]);
   }
 
+  async estimateUserOperationGas(
+    userOp: UserOperationStruct,
+    entryPoint: string
+  ): Promise<{
+    callGasLimit: bigint;
+    preVerificationGas: bigint;
+    verificationGasLimit: bigint;
+  }> {
+    const payload = userOperationToJson(userOp);
+    const result = await this.rpcRequest<{
+      callGasLimit: string;
+      preVerificationGas: string;
+      verificationGasLimit: string;
+    }>("eth_estimateUserOperationGas", [payload, entryPoint]);
+    return {
+      callGasLimit: ethers.toBigInt(result.callGasLimit),
+      preVerificationGas: ethers.toBigInt(result.preVerificationGas),
+      verificationGasLimit: ethers.toBigInt(result.verificationGasLimit),
+    };
+  }
+
   async getUserOperationReceipt(userOpHash: string): Promise<UserOperationReceipt | null> {
     const receipt = await this.rpcRequest<UserOperationReceipt | null>("eth_getUserOperationReceipt", [userOpHash]);
     return receipt;


### PR DESCRIPTION
## Summary
- add a bundler helper for `eth_estimateUserOperationGas` that returns bigint gas limits
- update the AA signer to fall back to bundler-provided gas limits (with the configured buffer) when RPC estimation fails
- add a regression test covering bundler gas estimation for undeployed accounts

## Testing
- npx tsc -p packages/orchestrator/tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d8152fda348333b61535264bdfd979