### PR TITLE
Improve meta-tx gas estimation and add coverage

### DIFF
--- a/packages/orchestrator/test/chainProviders.test.ts
+++ b/packages/orchestrator/test/chainProviders.test.ts
@@ -8,6 +8,10 @@ import {
   AccountAbstractionSigner,
   type AccountAbstractionConfig,
 } from "../src/chain/providers/aa.js";
+import {
+  MetaTxSigner,
+  __resetForwarderConfigForTests,
+} from "../src/chain/providers/metaTx.js";
 import type { ManagedPaymasterClient } from "../src/chain/providers/paymaster.js";
 
 const relayerMnemonic = "test test test test test test test test test test test junk";
@@ -34,6 +38,65 @@ function restoreEnv(entries: { key: string; value: string | undefined }[]) {
   }
 }
 
+class MockProvider extends ethers.AbstractProvider {
+  public readonly estimateGasCalls: ethers.TransactionRequest[] = [];
+
+  private readonly estimateResults: Array<{ result?: bigint; error?: Error }> = [];
+
+  private readonly feeDataResult: ethers.FeeData;
+
+  constructor() {
+    super({ name: "mock", chainId: 1 });
+    this.feeDataResult = {
+      gasPrice: ethers.parseUnits("20", "gwei"),
+      maxFeePerGas: ethers.parseUnits("20", "gwei"),
+      maxPriorityFeePerGas: ethers.parseUnits("1", "gwei"),
+      toJSON: () => ({
+        gasPrice: "0x0",
+        maxFeePerGas: "0x0",
+        maxPriorityFeePerGas: "0x0",
+      }),
+    } as ethers.FeeData;
+  }
+
+  queueEstimateGas(value: bigint | Error): void {
+    if (value instanceof Error) {
+      this.estimateResults.push({ error: value });
+    } else {
+      this.estimateResults.push({ result: value });
+    }
+  }
+
+  async estimateGas(tx: ethers.TransactionRequest): Promise<bigint> {
+    this.estimateGasCalls.push(tx);
+    const next = this.estimateResults.shift();
+    if (!next) {
+      return 100_000n;
+    }
+    if (next.error) {
+      throw next.error;
+    }
+    return next.result ?? 100_000n;
+  }
+
+  async getFeeData(): Promise<ethers.FeeData> {
+    return this.feeDataResult;
+  }
+
+  async _detectNetwork(): Promise<ethers.Network> {
+    return new ethers.Network("mock", 1);
+  }
+
+  // The tests only rely on the explicit overrides above.
+  async _perform(): Promise<never> {
+    throw new Error("MockProvider does not support direct RPC calls");
+  }
+}
+
+function resetForwarderConfig() {
+  __resetForwarderConfigForTests();
+}
+
 test("relayer mode reuses deterministic wallets per user", async () => {
   const backup = snapshotEnv([
     "TX_MODE",
@@ -42,6 +105,7 @@ test("relayer mode reuses deterministic wallets per user", async () => {
     "RELAYER_USER_MNEMONIC",
     "RELAYER_SPONSOR_MNEMONIC",
     "EIP2771_TRUSTED_FORWARDER",
+    "EIP2771_GAS_CEILING",
   ]);
 
   try {
@@ -196,4 +260,115 @@ test("aa signer forwards policy context to managed paymaster", async () => {
   assert.equal(context.traceId, policyContext.traceId);
   assert.equal(context.jobBudgetWei, policyContext.jobBudgetWei.toString());
   assert.equal(context.sponsor, staticContext.sponsor);
+});
+
+test("meta-tx signer estimates gas from the trusted forwarder context", async () => {
+  const backup = snapshotEnv([
+    "EIP2771_TRUSTED_FORWARDER",
+    "EIP2771_GAS_BUFFER",
+    "EIP2771_GAS_CEILING",
+  ]);
+
+  try {
+    process.env.EIP2771_TRUSTED_FORWARDER = forwarderAddress;
+    process.env.EIP2771_GAS_BUFFER = "25000";
+    delete process.env.EIP2771_GAS_CEILING;
+    resetForwarderConfig();
+
+    const provider = new MockProvider();
+    provider.queueEstimateGas(150_000n);
+
+    const user = randomWallet().connect(provider);
+    const relayer = randomWallet().connect(provider);
+    const signer = new MetaTxSigner(user, relayer);
+
+    const forwarderStub = {
+      getNonce: async () => 1n,
+      getFunction: () => ({
+        populateTransaction: async () => ({
+          to: forwarderAddress,
+          data: "0x",
+        }),
+      }),
+    };
+    Reflect.set(signer, "forwarder", forwarderStub);
+
+    const request = await Reflect.get(signer, "buildForwardRequest").call(signer, {
+      to: user.address,
+      data: "0x",
+    } satisfies ethers.TransactionRequest);
+
+    assert.equal(provider.estimateGasCalls.length, 1);
+    const estimateCall = provider.estimateGasCalls[0];
+    assert.equal(typeof estimateCall.from, "string");
+    const from = (estimateCall.from as string).toLowerCase();
+    assert.equal(from, forwarderAddress.toLowerCase());
+    assert.equal(
+      request.gas,
+      150_000n + BigInt(process.env.EIP2771_GAS_BUFFER ?? "25000"),
+    );
+  } finally {
+    resetForwarderConfig();
+    restoreEnv(backup);
+  }
+});
+
+test("meta-tx signer falls back to a conservative gas ceiling when estimation fails", async () => {
+  const backup = snapshotEnv([
+    "EIP2771_TRUSTED_FORWARDER",
+    "EIP2771_GAS_BUFFER",
+    "EIP2771_GAS_CEILING",
+  ]);
+
+  try {
+    process.env.EIP2771_TRUSTED_FORWARDER = forwarderAddress;
+    process.env.EIP2771_GAS_BUFFER = "25000";
+    process.env.EIP2771_GAS_CEILING = "900000";
+    resetForwarderConfig();
+
+    const provider = new MockProvider();
+    provider.queueEstimateGas(new Error("boom"));
+
+    const user = randomWallet().connect(provider);
+    const relayer = randomWallet().connect(provider);
+    const signer = new MetaTxSigner(user, relayer);
+
+    let capturedRequest: any;
+    const forwarderStub = {
+      getNonce: async () => 1n,
+      getFunction: () => ({
+        populateTransaction: async (request: unknown) => {
+          capturedRequest = request;
+          return {
+            to: forwarderAddress,
+            data: "0x",
+          };
+        },
+      }),
+    };
+    Reflect.set(signer, "forwarder", forwarderStub);
+
+    const sent: ethers.TransactionRequest[] = [];
+    const relayerWallet = Reflect.get(signer, "relayerWallet");
+    relayerWallet.sendTransaction = async (tx: ethers.TransactionRequest) => {
+      sent.push(tx);
+      return tx as unknown as ethers.TransactionResponse;
+    };
+
+    await signer.sendTransaction({
+      to: user.address,
+      data: "0x",
+    });
+
+    const fallback = BigInt(process.env.EIP2771_GAS_CEILING ?? "0");
+    const buffer = BigInt(process.env.EIP2771_GAS_BUFFER ?? "0");
+
+    assert.equal(provider.estimateGasCalls.length, 1);
+    assert.equal((capturedRequest ?? {}).gas, fallback);
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].gasLimit, fallback + buffer);
+  } finally {
+    resetForwarderConfig();
+    restoreEnv(backup);
+  }
 });


### PR DESCRIPTION
## Summary
- ensure meta-tx gas estimation runs with the trusted forwarder context and introduce a configurable fallback ceiling
- expose a test helper to reset cached forwarder configuration
- add regression tests covering forwarder-context estimation and the conservative fallback path

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d81e6962b08333876aac9ee3a8f8a7