### PR TITLE
feat(orchestrator): allow per-request tx mode overrides

### DIFF
--- a/packages/orchestrator/README.md
+++ b/packages/orchestrator/README.md
@@ -54,3 +54,9 @@ budget when they are created, and repeated API calls are throttled via a sliding
 th your paymaster allowances and per-job burn caps.
 
 Ensure these secrets are provisioned in the deployment environment so user requests always resolve to a stable signer.
+
+### Per-request overrides
+
+The orchestrator defaults to the transport specified by `TX_MODE`, but callers can override the signer on a per-request basis by
+including a `meta.txMode` field in the ICS payload. Supported values are `aa`, `relayer`/`2771`, and `direct`, which map to the
+ERC-4337 paymaster path, the EIP-2771 relayer, and raw key-based signing respectively.

--- a/packages/orchestrator/src/chain/provider.ts
+++ b/packages/orchestrator/src/chain/provider.ts
@@ -3,13 +3,25 @@ import { getAAProvider } from "./providers/aa.js";
 import { getMetaTxSigner } from "./providers/metaTx.js";
 import { getRelayerWallet } from "./providers/relayer.js";
 
-function txMode() {
-  return (process.env.TX_MODE ?? "relayer").toLowerCase();
+type NormalizedTxMode = "relayer" | "aa" | "direct";
+
+function normalizeTxMode(value: string | undefined): NormalizedTxMode {
+  const raw = (value ?? process.env.TX_MODE ?? "relayer").trim().toLowerCase();
+  if (!raw) {
+    return "relayer";
+  }
+  if (["aa", "account-abstraction", "account_abstraction", "4337"].includes(raw)) {
+    return "aa";
+  }
+  if (["direct", "raw"].includes(raw)) {
+    return "direct";
+  }
+  return "relayer";
 }
 
-export async function getSignerForUser(userId: string) {
-  const mode = txMode();
-  if (mode === "aa" || mode === "account-abstraction") {
+export async function getSignerForUser(userId: string, overrideMode?: string) {
+  const mode = normalizeTxMode(overrideMode);
+  if (mode === "aa") {
     return getAAProvider(userId);
   }
   if (mode === "direct") {

--- a/packages/orchestrator/src/chain/providers/aa.ts
+++ b/packages/orchestrator/src/chain/providers/aa.ts
@@ -586,3 +586,8 @@ export async function getAAProvider(userId: string) {
   return signer;
 }
 
+export function __resetAAConfigForTests() {
+  aaConfigCache = null;
+  aaSignerCache.clear();
+}
+

--- a/packages/orchestrator/src/ics.ts
+++ b/packages/orchestrator/src/ics.ts
@@ -11,10 +11,26 @@ const ensSchema = z.object({
   proof: z.array(bytes32Schema).optional(),
 });
 
+const txModeSchema = z
+  .enum([
+    "aa",
+    "account-abstraction",
+    "account_abstraction",
+    "4337",
+    "relayer",
+    "2771",
+    "meta-tx",
+    "meta_tx",
+    "direct",
+    "raw",
+  ])
+  .optional();
+
 const metaSchema = z
   .object({
     traceId: z.string().uuid().optional(),
     userId: z.string().min(1).optional(),
+    txMode: txModeSchema,
   })
   .optional();
 

--- a/packages/orchestrator/src/llm.ts
+++ b/packages/orchestrator/src/llm.ts
@@ -19,6 +19,7 @@ export type PlanAndExecuteArgs = {
 type PlanMeta = {
   traceId?: string;
   userId?: string;
+  txMode?: string;
 };
 
 export async function* planAndExecute({

--- a/packages/orchestrator/src/providers/openai.ts
+++ b/packages/orchestrator/src/providers/openai.ts
@@ -7,6 +7,7 @@ export type StreamOptions = {
 type MetaOptions = {
   traceId?: string;
   userId?: string;
+  txMode?: string;
 };
 
 export async function streamLLM(
@@ -77,10 +78,15 @@ export async function streamLLM(
 }
 
 function resolveMeta(meta?: MetaOptions) {
-  return {
+  const resolved: Required<Omit<MetaOptions, "txMode">> &
+    Partial<Pick<MetaOptions, "txMode">> = {
     traceId: meta?.traceId ?? "00000000-0000-4000-8000-000000000000",
     userId: meta?.userId ?? "user-sandbox",
-  } satisfies Required<MetaOptions>;
+  };
+  if (meta?.txMode) {
+    resolved.txMode = meta.txMode;
+  }
+  return resolved;
 }
 
 export function extractJobId(text: string): number | null {

--- a/packages/orchestrator/src/tools/job.ts
+++ b/packages/orchestrator/src/tools/job.ts
@@ -32,7 +32,7 @@ export async function* createJob(ics: CreateJobIntent) {
     yield `📨 Spec pinned: ${uri}\n`;
     yield `🧾 specHash: ${specHash}\n`;
 
-    const signer = await getSignerForUser(userId);
+    const signer = await getSignerForUser(userId, ics.meta?.txMode);
     const { jobRegistry } = loadContracts(signer);
     const tx = await jobRegistry.createJob(
       reward,
@@ -62,7 +62,7 @@ export async function* applyJob(ics: ApplyJobIntent) {
 
   try {
     const jobId = normalizeJobId(ics.params.jobId);
-    const signer = await getSignerForUser(userId);
+    const signer = await getSignerForUser(userId, ics.meta?.txMode);
     const { jobRegistry } = loadContracts(signer);
     const proof = ics.params.ens.proof ?? [];
     const tx = await jobRegistry.applyForJob(
@@ -107,7 +107,7 @@ export async function* submitWork(ics: SubmitWorkIntent) {
     }
 
     const resultHash = result.hash ?? ethers.id(hashSource ?? resultURI);
-    const signer = await getSignerForUser(userId);
+    const signer = await getSignerForUser(userId, ics.meta?.txMode);
     const { jobRegistry } = loadContracts(signer);
     const proof = ens.proof ?? [];
     const tx = await jobRegistry.submit(
@@ -135,7 +135,7 @@ export async function* finalize(ics: FinalizeIntent) {
 
   try {
     const jobId = normalizeJobId(ics.params.jobId);
-    const signer = await getSignerForUser(userId);
+    const signer = await getSignerForUser(userId, ics.meta?.txMode);
     const { jobRegistry } = loadContracts(signer);
     const tx = await jobRegistry.finalizeAfterValidation(
       jobId,

--- a/packages/orchestrator/src/tools/stake.ts
+++ b/packages/orchestrator/src/tools/stake.ts
@@ -14,7 +14,7 @@ export async function* deposit(ics: StakeIntent) {
     const { amountAGIA, role } = ics.params.stake;
     const normalized = normalizeRole(role);
     const amountWei = toWei(amountAGIA);
-    const signer = await getSignerForUser(userId);
+    const signer = await getSignerForUser(userId, ics.meta?.txMode);
     const { erc20, stakeManager } = loadContracts(signer);
     const owner = await signer.getAddress();
     const spender = stakeManager.target as string;
@@ -52,7 +52,7 @@ export async function* withdraw(ics: WithdrawIntent) {
     const { amountAGIA, role } = ics.params.stake;
     const normalized = normalizeRole(role);
     const amountWei = toWei(amountAGIA);
-    const signer = await getSignerForUser(userId);
+    const signer = await getSignerForUser(userId, ics.meta?.txMode);
     const { stakeManager } = loadContracts(signer);
     const tx = await stakeManager.withdrawStake(
       normalized.index,

--- a/packages/orchestrator/test/openai.test.ts
+++ b/packages/orchestrator/test/openai.test.ts
@@ -7,6 +7,7 @@ import { validateICS } from "../src/ics.js";
 const meta = {
   traceId: "11111111-2222-4333-8444-555555555555",
   userId: "user-123",
+  txMode: "aa" as const,
 };
 
 test("create_job prompt yields valid ICS", async () => {
@@ -27,6 +28,7 @@ test("create_job prompt yields valid ICS", async () => {
   assert.equal(ics.params.job.deadline, 14);
   assert.equal(ics.meta?.traceId, meta.traceId);
   assert.equal(ics.meta?.userId, meta.userId);
+  assert.equal(ics.meta?.txMode, meta.txMode);
   assert.ok(ics.params.job.spec);
 });
 
@@ -45,6 +47,7 @@ test("apply_job prompt yields valid ICS", async () => {
   assert.equal(ics.params.jobId, 42);
   assert.equal(ics.params.ens.subdomain, "alice");
   assert.equal(ics.meta?.traceId, meta.traceId);
+  assert.equal(ics.meta?.txMode, meta.txMode);
 });
 
 test("submit_work prompt yields valid ICS", async () => {
@@ -63,6 +66,7 @@ test("submit_work prompt yields valid ICS", async () => {
   assert.equal(ics.params.jobId, 87);
   assert.equal(ics.params.ens.subdomain, "bob");
   assert.ok(ics.params.result.payload);
+  assert.equal(ics.meta?.txMode, meta.txMode);
 });
 
 test("finalize prompt yields valid ICS", async () => {
@@ -79,4 +83,5 @@ test("finalize prompt yields valid ICS", async () => {
   assert.equal(ics.intent, "finalize");
   assert.equal(ics.params.jobId, 73);
   assert.equal(ics.params.success, true);
+  assert.equal(ics.meta?.txMode, meta.txMode);
 });


### PR DESCRIPTION
## Summary
- allow ICS payloads to carry a `meta.txMode` hint that selects the AA paymaster, 2771 relayer, or direct signer on demand
- propagate the override through the job and stake toolchain and keep generated ICS metadata in sync
- document the runtime override capability and add targeted tests plus helpers to reset cached AA config during testing

## Testing
- npm test (packages/orchestrator)


------
https://chatgpt.com/codex/tasks/task_e_68d8225b4f588333b55878513b322bf7