### PR TITLE
Add resilient IPFS pinning with gateway metadata

### DIFF
--- a/apps/onebox/app.js
+++ b/apps/onebox/app.js
@@ -295,6 +295,9 @@ async function executeIntent(intent) {
         reward: intent.payload.reward,
         token: intent.payload.rewardToken,
         specCid: result.specCid,
+        specGatewayUrl: result.specGatewayUrl,
+        deliverableCid: result.deliverableCid,
+        deliverableGatewayUrl: result.deliverableGatewayUrl,
         status: intent.action === 'finalize_job' ? 'finalized' : 'submitted',
       });
       storeReceipt(receipt);
@@ -315,6 +318,9 @@ async function executeIntent(intent) {
       reward: result.reward || intent.payload.reward,
       token: result.token || intent.payload.rewardToken,
       specCid: result.specCid,
+      specGatewayUrl: result.specGatewayUrl,
+      deliverableCid: result.deliverableCid,
+      deliverableGatewayUrl: result.deliverableGatewayUrl,
       url: result.receiptUrl,
       status: result.status || (intent.action === 'finalize_job' ? 'finalized' : 'submitted'),
     });
@@ -338,6 +344,9 @@ function buildReceipt(data) {
     tx: data.txHash ?? null,
     url: data.url ?? null,
     cid: data.specCid ?? null,
+    specUrl: data.specGatewayUrl ?? null,
+    deliverableCid: data.deliverableCid ?? null,
+    deliverableUrl: data.deliverableGatewayUrl ?? null,
     reward: data.reward ?? null,
     token: data.token ?? null,
     status: data.status ?? 'submitted',

--- a/apps/onebox/src/components/ChatWindow.tsx
+++ b/apps/onebox/src/components/ChatWindow.tsx
@@ -582,6 +582,9 @@ export function ChatWindow() {
         id: createReceiptId(),
         jobId: payload.jobId,
         specCid: payload.specCid,
+        specUrl: payload.specGatewayUrl ?? payload.specUri ?? undefined,
+        deliverableCid: payload.deliverableCid ?? undefined,
+        deliverableUrl: payload.deliverableGatewayUrl ?? payload.deliverableUri ?? undefined,
         netPayout: netPayout.length > 0 ? netPayout : undefined,
         explorerUrl: payload.receiptUrl,
         createdAt: Date.now(),
@@ -593,6 +596,9 @@ export function ChatWindow() {
       }
       if (receipt.specCid) {
         successLines.push(`CID: ${receipt.specCid}`);
+      }
+      if (receipt.deliverableCid) {
+        successLines.push(`Deliverable: ${receipt.deliverableCid}`);
       }
       if (receipt.netPayout) {
         successLines.push(`Payout: ${receipt.netPayout}`);

--- a/apps/onebox/src/components/ReceiptsPanel.tsx
+++ b/apps/onebox/src/components/ReceiptsPanel.tsx
@@ -42,9 +42,37 @@ export function ReceiptsPanel({ receipts }: ReceiptsPanelProps) {
             ) : null}
             {receipt.specCid ? (
               <div className="chat-receipt-field">
-                <span className="chat-receipt-label">CID</span>
+                <span className="chat-receipt-label">Spec CID</span>
                 <span className="chat-receipt-value chat-receipt-monospace">
-                  {formatCid(receipt.specCid)}
+                  {receipt.specUrl ? (
+                    <a
+                      href={receipt.specUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {formatCid(receipt.specCid)}
+                    </a>
+                  ) : (
+                    formatCid(receipt.specCid)
+                  )}
+                </span>
+              </div>
+            ) : null}
+            {receipt.deliverableCid ? (
+              <div className="chat-receipt-field">
+                <span className="chat-receipt-label">Deliverable</span>
+                <span className="chat-receipt-value chat-receipt-monospace">
+                  {receipt.deliverableUrl ? (
+                    <a
+                      href={receipt.deliverableUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {formatCid(receipt.deliverableCid)}
+                    </a>
+                  ) : (
+                    formatCid(receipt.deliverableCid)
+                  )}
                 </span>
               </div>
             ) : null}

--- a/apps/onebox/src/components/receiptTypes.ts
+++ b/apps/onebox/src/components/receiptTypes.ts
@@ -2,6 +2,9 @@ export type ExecutionReceipt = {
   id: string;
   jobId?: number;
   specCid?: string;
+  specUrl?: string | null;
+  deliverableCid?: string | null;
+  deliverableUrl?: string | null;
   netPayout?: string;
   explorerUrl?: string;
   createdAt: number;

--- a/apps/orchestrator/employer.ts
+++ b/apps/orchestrator/employer.ts
@@ -31,15 +31,17 @@ export interface JobArtifacts {
 
 export async function prepareJobArtifacts(metadata: any): Promise<JobArtifacts> {
   const jsonSpec = JSON.stringify(metadata ?? {}, null, 2);
-  const jsonCid = await uploadToIPFS(jsonSpec);
+  const jsonPin = await uploadToIPFS(jsonSpec);
+  const jsonCid = jsonPin.cid;
 
   const markdown = metadata?.markdown
     ? metadata.markdown
     : `# Job Specification\n\n\`\`\`json\n${jsonSpec}\n\`\`\`\n`;
-  const markdownCid = await uploadToIPFS(markdown);
+  const markdownPin = await uploadToIPFS(markdown);
+  const markdownCid = markdownPin.cid;
 
-  const jsonUri = `ipfs://${jsonCid}`;
-  const markdownUri = `ipfs://${markdownCid}`;
+  const jsonUri = jsonPin.uri ?? `ipfs://${jsonCid}`;
+  const markdownUri = markdownPin.uri ?? `ipfs://${markdownCid}`;
   const specWithUris = { ...metadata, json: jsonUri, markdown: markdownUri };
   const specHash = ethers.keccak256(
     ethers.toUtf8Bytes(JSON.stringify(specWithUris))

--- a/apps/orchestrator/execution.ts
+++ b/apps/orchestrator/execution.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { setTimeout as delay } from 'timers/promises';
 
 import { instrumentTask } from './metrics';
 import type { TaskMetrics } from './metrics';
@@ -29,7 +30,9 @@ export interface StageDefinition {
 interface JobStage {
   name: string;
   cid?: string;
+  url?: string;
   signatureCid?: string;
+  signatureUrl?: string;
   signature?: string;
   signer?: string;
   digest?: string;
@@ -55,7 +58,9 @@ interface JobArtifact {
   agentId?: string;
   invocationTarget?: string;
   outputCid?: string;
+  outputUrl?: string;
   signatureCid?: string;
+  signatureUrl?: string;
   signature?: string;
   signer?: string;
   digest?: string;
@@ -79,6 +84,8 @@ export interface JobRunResult {
   stageCids: string[];
   finalCid: string | null;
   manifestCid: string;
+  manifestUrl: string;
+  manifestGatewayUrls: string[];
   manifest: JobArtifactManifest;
   snapshot: WorldModelSnapshot;
 }
@@ -135,7 +142,57 @@ export async function invokeAgent(
 }
 
 const DEFAULT_IPFS_API = 'http://localhost:5001/api/v0';
-const DEFAULT_PINNER_ENDPOINT = 'https://api.web3.storage/upload';
+const DEFAULT_PINNER_ENDPOINT = 'https://api.web3.storage';
+const DEFAULT_WEB3_STORAGE_ENDPOINT = 'https://api.web3.storage';
+const DEFAULT_PINATA_ENDPOINT = 'https://api.pinata.cloud';
+const DEFAULT_GATEWAY_FALLBACKS = [
+  (cid: string) => `https://w3s.link/ipfs/${cid}`,
+  (cid: string) => `https://ipfs.io/ipfs/${cid}`,
+  (cid: string) => `https://cloudflare-ipfs.com/ipfs/${cid}`,
+];
+
+export interface PinnedContent {
+  cid: string;
+  uri: string;
+  url: string;
+  gatewayUrls: string[];
+  provider: string;
+  status?: string;
+  requestId?: string;
+  attempts: number;
+  size?: number;
+  pinnedAt?: string;
+}
+
+interface PinningCandidateConfig {
+  endpoint: string;
+  token: string;
+  provider?: string;
+  gatewayUrls?: string | string[];
+}
+
+class PinningServiceError extends Error {
+  readonly provider: string;
+  readonly status?: number;
+  readonly retryable: boolean;
+
+  constructor(
+    message: string,
+    provider: string,
+    status?: number,
+    retryable = false,
+    cause?: unknown
+  ) {
+    super(message);
+    this.name = 'PinningServiceError';
+    this.provider = provider;
+    this.status = status;
+    this.retryable = retryable;
+    if (cause !== undefined) {
+      (this as unknown as { cause?: unknown }).cause = cause;
+    }
+  }
+}
 
 export interface UploadToIPFSOptions {
   apiUrl?: string;
@@ -228,6 +285,83 @@ function normalizeUploadOptions(
   return options ?? {};
 }
 
+function buildPinnerCandidates(
+  options: UploadToIPFSOptions
+): PinningCandidateConfig[] {
+  const candidates: PinningCandidateConfig[] = [];
+  const seen = new Set<string>();
+
+  const pushCandidate = (candidate: PinningCandidateConfig | null | undefined) => {
+    if (!candidate) return;
+    const endpoint = candidate.endpoint?.trim();
+    const token = candidate.token?.trim();
+    if (!endpoint || !token) {
+      return;
+    }
+    const key = `${endpoint}|${token}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    candidates.push({
+      endpoint,
+      token,
+      provider: candidate.provider ?? detectProviderName(endpoint, candidate.provider),
+      gatewayUrls: candidate.gatewayUrls,
+    });
+  };
+
+  pushCandidate(
+    options.pinnerEndpoint && options.pinnerToken
+      ? {
+          endpoint: options.pinnerEndpoint,
+          token: options.pinnerToken,
+          provider: detectProviderName(options.pinnerEndpoint),
+        }
+      : undefined
+  );
+
+  const envEndpoint = process.env.PINNER_ENDPOINT ?? process.env.PINNER_URL;
+  const envToken = process.env.PINNER_TOKEN;
+  pushCandidate(
+    envEndpoint && envToken
+      ? {
+          endpoint: envEndpoint,
+          token: envToken,
+          provider: detectProviderName(envEndpoint),
+        }
+      : undefined
+  );
+
+  const web3Token = process.env.WEB3_STORAGE_TOKEN ?? process.env.WEB3STORAGE_TOKEN;
+  if (web3Token) {
+    const web3Endpoint =
+      process.env.WEB3_STORAGE_ENDPOINT ??
+      process.env.WEB3STORAGE_ENDPOINT ??
+      DEFAULT_WEB3_STORAGE_ENDPOINT;
+    pushCandidate({ endpoint: web3Endpoint, token: web3Token, provider: 'web3.storage' });
+  }
+
+  const pinataToken =
+    process.env.PINATA_JWT ??
+    process.env.PINATA_TOKEN ??
+    (process.env.PINATA_API_KEY && process.env.PINATA_SECRET_API_KEY
+      ? `${process.env.PINATA_API_KEY}:${process.env.PINATA_SECRET_API_KEY}`
+      : undefined);
+  if (pinataToken) {
+    const pinataEndpoint = process.env.PINATA_ENDPOINT ?? DEFAULT_PINATA_ENDPOINT;
+    const gateway = process.env.PINATA_GATEWAY ?? process.env.PINATA_PUBLIC_GATEWAY;
+    pushCandidate({
+      endpoint: pinataEndpoint,
+      token: pinataToken,
+      provider: 'pinata',
+      gatewayUrls: gateway ? [`${gateway.replace(/\/+$/, '')}/ipfs/{cid}`] : undefined,
+    });
+  }
+
+  return candidates;
+}
+
 function ensureBlob(
   content: any,
   explicitType?: string
@@ -269,10 +403,148 @@ function ensureBlob(
   return { blob, suggestedFileName };
 }
 
+function detectProviderName(endpoint?: string, explicit?: string): string {
+  if (explicit && explicit.length > 0) {
+    return explicit;
+  }
+  if (!endpoint) {
+    return 'pinning-service';
+  }
+  try {
+    const url = new URL(endpoint);
+    const host = url.hostname.toLowerCase();
+    if (host.includes('web3.storage')) {
+      return 'web3.storage';
+    }
+    if (host.includes('pinata')) {
+      return 'pinata';
+    }
+    if (host.includes('nft.storage')) {
+      return 'nft.storage';
+    }
+  } catch {
+    // ignore parsing errors and fall through
+  }
+  return 'pinning-service';
+}
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\s+$/, '').replace(/\/+$/, '');
+}
+
+function ensureUploadUrl(endpoint: string, provider: string): string {
+  const trimmed = stripTrailingSlashes(endpoint);
+  if (provider === 'pinata') {
+    if (/pinning\/pinfiletoipfs$/i.test(trimmed)) {
+      return trimmed;
+    }
+    return `${trimmed}/pinning/pinFileToIPFS`;
+  }
+  if (/\/upload$/i.test(trimmed) || /\/pins$/i.test(trimmed)) {
+    return trimmed;
+  }
+  return `${trimmed}/upload`;
+}
+
+function providerBaseUrl(endpoint: string, provider: string): string {
+  const trimmed = stripTrailingSlashes(endpoint);
+  if (provider === 'pinata') {
+    return trimmed.replace(/\/pinning\/pinfiletoipfs$/i, '');
+  }
+  return trimmed.replace(/\/(upload|pins)$/i, '');
+}
+
+function buildGatewayUrls(
+  cid: string,
+  provider: string,
+  additional?: string | string[]
+): string[] {
+  const urls = new Set<string>();
+  const extras = Array.isArray(additional)
+    ? additional
+    : additional
+    ? [additional]
+    : [];
+  for (const factory of DEFAULT_GATEWAY_FALLBACKS) {
+    urls.add(factory(cid));
+  }
+  if (provider === 'web3.storage' || provider === 'nft.storage') {
+    urls.add(`https://w3s.link/ipfs/${cid}`);
+    urls.add(`https://${cid}.ipfs.w3s.link`);
+  }
+  if (provider === 'pinata') {
+    urls.add(`https://gateway.pinata.cloud/ipfs/${cid}`);
+    urls.add(`https://ipfs.pinata.cloud/ipfs/${cid}`);
+  }
+  for (const entry of extras) {
+    if (!entry) continue;
+    urls.add(entry.replace('{cid}', cid));
+  }
+  return Array.from(urls);
+}
+
+function buildPinResult(
+  cid: string,
+  provider: string,
+  attempts: number,
+  status?: string,
+  requestId?: string,
+  size?: number,
+  pinnedAt?: string,
+  additionalGateways?: string | string[]
+): PinnedContent {
+  const gatewayUrls = buildGatewayUrls(cid, provider, additionalGateways);
+  const url = gatewayUrls[0] ?? `https://ipfs.io/ipfs/${cid}`;
+  return {
+    cid,
+    uri: `ipfs://${cid}`,
+    url,
+    gatewayUrls,
+    provider,
+    status,
+    requestId,
+    attempts,
+    size,
+    pinnedAt,
+  };
+}
+
+function buildAuthHeaders(
+  provider: string,
+  token: string
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const trimmed = token.trim();
+  if (!trimmed) {
+    return headers;
+  }
+  if (provider === 'pinata' && trimmed.includes(':')) {
+    const [apiKey, secret] = trimmed.split(':', 2);
+    if (apiKey && secret) {
+      headers['pinata_api_key'] = apiKey.trim();
+      headers['pinata_secret_api_key'] = secret.trim();
+      return headers;
+    }
+  }
+  if (trimmed.toLowerCase().startsWith('bearer ')) {
+    headers.Authorization = trimmed;
+    return headers;
+  }
+  headers.Authorization = `Bearer ${trimmed}`;
+  return headers;
+}
+
+function isRetryableStatus(status: number): boolean {
+  if (status >= 500 || status === 429 || status === 408) {
+    return true;
+  }
+  return false;
+}
+
 async function pinViaIpfsApi(
   content: any,
   options: UploadToIPFSOptions
-): Promise<string> {
+): Promise<PinnedContent> {
   const apiUrl = options.apiUrl ?? process.env.IPFS_API_URL ?? DEFAULT_IPFS_API;
   const target = `${apiUrl.replace(/\/+$/, '')}/add`;
   const { blob, suggestedFileName } = ensureBlob(content, options.contentType);
@@ -290,78 +562,307 @@ async function pinViaIpfsApi(
   if (!cid) {
     throw new Error('IPFS API response did not include a CID');
   }
-  return cid;
+  return buildPinResult(cid, 'ipfs-api', 1, 'pinned');
 }
 
 async function pinViaPinner(
   content: any,
   options: UploadToIPFSOptions,
-  token: string
-): Promise<string> {
-  const endpoint = (
-    options.pinnerEndpoint ??
-    process.env.PINNER_ENDPOINT ??
-    process.env.PINNER_URL ??
-    DEFAULT_PINNER_ENDPOINT
-  ).replace(/\/+$/, '');
-  const url = endpoint || DEFAULT_PINNER_ENDPOINT;
+  candidate: PinningCandidateConfig
+): Promise<PinnedContent> {
+  const endpoint =
+    candidate.endpoint ||
+    options.pinnerEndpoint ||
+    process.env.PINNER_ENDPOINT ||
+    process.env.PINNER_URL ||
+    DEFAULT_PINNER_ENDPOINT;
+  const token = candidate.token;
+  const provider = detectProviderName(endpoint, candidate.provider);
+  const uploadUrl = ensureUploadUrl(endpoint, provider);
+  const baseUrl = providerBaseUrl(endpoint, provider);
   const { blob, suggestedFileName } = ensureBlob(content, options.contentType);
   const buffer = Buffer.from(await blob.arrayBuffer());
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
-    'Content-Type': blob.type || options.contentType || 'application/octet-stream',
-  };
   const fileName = options.fileName ?? suggestedFileName;
-  if (fileName) {
-    headers['X-Name'] = fileName;
-  }
+  const contentType = blob.type || options.contentType || 'application/octet-stream';
+  const authHeaders = buildAuthHeaders(provider, token);
+  const maxAttempts = 3;
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers,
-    body: buffer,
-  });
-
-  const responseText = await response.text();
-  if (!response.ok) {
-    throw new Error(
-      `Pinning service responded with ${response.status}: ${responseText.slice(0, 200)}`
-    );
-  }
-
-  const contentType = response.headers.get('content-type') ?? '';
-  let payload: unknown = responseText;
-  if (contentType.includes('application/json')) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
-      payload = JSON.parse(responseText);
-    } catch {
-      // fall back to plain text parsing
+      let response: Response;
+      if (provider === 'pinata') {
+        const form = new FormData();
+        const fileBlob = new Blob([buffer], { type: contentType });
+        form.append('file', fileBlob, fileName || suggestedFileName || 'payload.bin');
+        const metadata = {
+          name: fileName || suggestedFileName || 'payload',
+          keyvalues: {
+            source: 'agi-jobs-orchestrator',
+          },
+        };
+        form.append('pinataMetadata', JSON.stringify(metadata));
+        const headers: Record<string, string> = { ...authHeaders };
+        response = await fetch(uploadUrl, {
+          method: 'POST',
+          headers,
+          body: form,
+        });
+      } else {
+        const headers: Record<string, string> = {
+          ...authHeaders,
+          'Content-Type': contentType,
+        };
+        if (fileName) {
+          headers['X-Name'] = fileName;
+        }
+        response = await fetch(uploadUrl, {
+          method: 'POST',
+          headers,
+          body: buffer,
+        });
+      }
+
+      const responseText = await response.text();
+      if (!response.ok) {
+        const retryable = isRetryableStatus(response.status);
+        throw new PinningServiceError(
+          `Pinning service responded with ${response.status}: ${responseText.slice(0, 200)}`,
+          provider,
+          response.status,
+          retryable
+        );
+      }
+
+      const contentTypeHeader = response.headers.get('content-type') ?? '';
+      let payload: unknown = responseText;
+      if (contentTypeHeader.includes('application/json')) {
+        try {
+          payload = JSON.parse(responseText);
+        } catch {
+          // fall back to plain text parsing
+        }
+      }
+
+      const cid = extractCidFromPinningResponse(payload);
+      if (!cid) {
+        throw new PinningServiceError(
+          'Pinning service response did not include a CID',
+          provider,
+          undefined,
+          false
+        );
+      }
+
+      let status: string | undefined;
+      let requestId: string | undefined;
+      let size: number | undefined;
+      let pinnedAt: string | undefined;
+
+      if (payload && typeof payload === 'object') {
+        const record = payload as Record<string, unknown>;
+        const pinRecord = record.pin as Record<string, unknown> | undefined;
+        requestId =
+          (typeof record.requestid === 'string' && record.requestid) ||
+          (typeof record.requestId === 'string' && record.requestId) ||
+          undefined;
+        status =
+          (typeof record.status === 'string' && record.status) ||
+          (pinRecord && typeof pinRecord.status === 'string' ? pinRecord.status : undefined) ||
+          undefined;
+        if (pinRecord) {
+          if (typeof pinRecord.size === 'number') {
+            size = pinRecord.size;
+          }
+          if (typeof pinRecord.created === 'string') {
+            pinnedAt = pinRecord.created;
+          }
+        }
+        if (!size && typeof record.PinSize === 'number') {
+          size = record.PinSize;
+        }
+        if (!pinnedAt && typeof record.Timestamp === 'string') {
+          pinnedAt = record.Timestamp;
+        }
+      }
+
+      try {
+        await delay(200);
+        const statusDetails = await fetchPinStatus(provider, baseUrl, token, cid);
+        status = statusDetails.status ?? status;
+        size = statusDetails.size ?? size;
+        pinnedAt = statusDetails.pinnedAt ?? pinnedAt;
+      } catch {
+        // status checks are best-effort
+      }
+
+      return buildPinResult(
+        cid,
+        provider,
+        attempt,
+        status ?? 'pinned',
+        requestId,
+        size,
+        pinnedAt,
+        candidate.gatewayUrls
+      );
+    } catch (error) {
+      const pinError =
+        error instanceof PinningServiceError
+          ? error
+          : new PinningServiceError(
+              error instanceof Error ? error.message : String(error),
+              provider,
+              undefined,
+              true,
+              error
+            );
+      if (!pinError.retryable || attempt === maxAttempts) {
+        throw pinError;
+      }
+      await delay(Math.min(1000 * attempt, 3000));
     }
   }
 
-  const cid = extractCidFromPinningResponse(payload);
-  if (!cid) {
-    throw new Error('Pinning service response did not include a CID');
+  throw new PinningServiceError(
+    'Pinning service failed after multiple retries',
+    provider,
+    undefined,
+    true
+  );
+}
+
+interface PinStatusDetails {
+  status?: string;
+  size?: number;
+  pinnedAt?: string;
+}
+
+async function fetchPinStatus(
+  provider: string,
+  baseUrl: string,
+  token: string,
+  cid: string
+): Promise<PinStatusDetails> {
+  const headers = buildAuthHeaders(provider, token);
+  if (Object.keys(headers).length === 0) {
+    return {};
   }
-  return cid;
+  const trimmedBase = stripTrailingSlashes(baseUrl || '');
+  let statusUrl: string;
+  if (provider === 'pinata') {
+    statusUrl = `${trimmedBase}/data/pinList?cid=${encodeURIComponent(cid)}`;
+  } else {
+    statusUrl = `${trimmedBase}/pins/${cid}`;
+  }
+  try {
+    const response = await fetch(statusUrl, { headers });
+    if (!response.ok) {
+      if (isRetryableStatus(response.status)) {
+        throw new PinningServiceError(
+          `Status check failed: ${response.status}`,
+          provider,
+          response.status,
+          true
+        );
+      }
+      return {};
+    }
+    const text = await response.text();
+    if (!text.trim()) {
+      return {};
+    }
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      return {};
+    }
+    if (!payload || typeof payload !== 'object') {
+      return {};
+    }
+    if (provider === 'pinata') {
+      const result = payload as { rows?: any[] };
+      const firstRow = Array.isArray(result.rows) ? result.rows[0] : undefined;
+      if (!firstRow || typeof firstRow !== 'object') {
+        return {};
+      }
+      const status = typeof firstRow.status === 'string' ? firstRow.status : undefined;
+      const size =
+        typeof firstRow.size === 'number'
+          ? firstRow.size
+          : typeof firstRow.pinSize === 'number'
+          ? firstRow.pinSize
+          : undefined;
+      const pinnedAt =
+        typeof firstRow.date_pinned === 'string'
+          ? firstRow.date_pinned
+          : typeof firstRow.timestamp === 'string'
+          ? firstRow.timestamp
+          : undefined;
+      return { status, size, pinnedAt };
+    }
+    const record = payload as Record<string, unknown>;
+    const pinRecord = record.pin as Record<string, unknown> | undefined;
+    const status =
+      (typeof record.status === 'string' && record.status) ||
+      (pinRecord && typeof pinRecord.status === 'string' ? pinRecord.status : undefined);
+    const size =
+      (pinRecord && typeof pinRecord.size === 'number' ? pinRecord.size : undefined) ??
+      (typeof record.pinSize === 'number' ? (record.pinSize as number) : undefined);
+    const pinnedAt =
+      (pinRecord && typeof pinRecord.created === 'string' ? pinRecord.created : undefined) ||
+      (typeof record.created === 'string' ? (record.created as string) : undefined);
+    return { status, size, pinnedAt };
+  } catch (error) {
+    if (error instanceof PinningServiceError) {
+      throw error;
+    }
+    throw new PinningServiceError(
+      error instanceof Error ? error.message : String(error),
+      provider,
+      undefined,
+      true,
+      error
+    );
+  }
 }
 
 export async function uploadToIPFS(
   content: any,
   options?: string | UploadToIPFSOptions
-): Promise<string> {
+): Promise<PinnedContent> {
   const resolved = normalizeUploadOptions(options);
-  const token =
-    resolved.pinnerToken ??
-    process.env.PINNER_TOKEN ??
-    process.env.WEB3_STORAGE_TOKEN ??
-    '';
+  const candidates = buildPinnerCandidates(resolved);
+  const retryableErrors: PinningServiceError[] = [];
 
-  if (token) {
-    return pinViaPinner(content, resolved, token);
+  for (const candidate of candidates) {
+    try {
+      return await pinViaPinner(content, resolved, candidate);
+    } catch (error) {
+      if (error instanceof PinningServiceError) {
+        if (!error.retryable) {
+          throw error;
+        }
+        retryableErrors.push(error);
+        continue;
+      }
+      throw error;
+    }
   }
 
-  return pinViaIpfsApi(content, resolved);
+  try {
+    return await pinViaIpfsApi(content, resolved);
+  } catch (error) {
+    if (retryableErrors.length) {
+      const last = retryableErrors[retryableErrors.length - 1];
+      const message =
+        `All configured pinning services were unavailable. ` +
+        `Try re-uploading shortly or provide a reachable IPFS API. ` +
+        `Last error (${last.provider}): ${last.message}`;
+      throw new Error(message);
+    }
+    throw error;
+  }
 }
 
 export async function runJob(
@@ -452,7 +953,8 @@ export async function runJob(
         () => invokeAgent(stage.agent, payload)
       );
       const signature = signAgentOutput(agentId, output);
-      const cid = await uploadToIPFS(output);
+      const outputPin = await uploadToIPFS(output);
+      const cid = outputPin.cid;
       const signedAt = new Date().toISOString();
       const signatureRecord = {
         jobId,
@@ -467,7 +969,8 @@ export async function runJob(
         outputCid: cid,
         signedAt,
       };
-      const signatureCid = await uploadToIPFS(signatureRecord);
+      const signaturePin = await uploadToIPFS(signatureRecord);
+      const signatureCid = signaturePin.cid;
       const observation = await recordWorldModelObservation({
         jobId,
         stage: stage.name,
@@ -480,7 +983,9 @@ export async function runJob(
         input: payload,
         output,
         outputCid: cid,
+        outputUrl: outputPin.url,
         signatureCid,
+        signatureUrl: signaturePin.url,
         signature: signature.signature,
         signer: signature.signer,
         digest: signature.digest,
@@ -490,7 +995,9 @@ export async function runJob(
       jobState.stages[i] = {
         name: stage.name,
         cid,
+        url: outputPin.url,
         signatureCid,
+        signatureUrl: signaturePin.url,
         signature: signature.signature,
         signer: signature.signer,
         digest: signature.digest,
@@ -516,7 +1023,9 @@ export async function runJob(
         details: {
           invocationTarget,
           outputCid: cid,
+          outputUrl: outputPin.url,
           signatureCid,
+          signatureUrl: signaturePin.url,
           signer: signature.signer,
           digest: signature.digest,
           metrics: metricsSummary ?? undefined,
@@ -559,7 +1068,9 @@ export async function runJob(
     agentId: obs.agentId,
     invocationTarget: obs.invocationTarget,
     outputCid: obs.outputCid,
+    outputUrl: obs.outputUrl,
     signatureCid: obs.signatureCid,
+    signatureUrl: obs.signatureUrl,
     signature: obs.signature,
     signer: obs.signer,
     digest: obs.digest,
@@ -579,15 +1090,18 @@ export async function runJob(
     artifacts,
     worldModel: snapshot,
   };
-  const manifestCid = await uploadToIPFS(manifest);
+  const manifestPin = await uploadToIPFS(manifest);
+  const manifestCid = manifestPin.cid;
   auditLog('job.complete', {
     jobId,
-    details: { outputCids: cids, manifestCid },
+    details: { outputCids: cids, manifestCid, manifestUrl: manifestPin.url },
   });
   return {
     stageCids: cids,
     finalCid: cids.length ? cids[cids.length - 1] : null,
     manifestCid,
+    manifestUrl: manifestPin.url,
+    manifestGatewayUrls: manifestPin.gatewayUrls,
     manifest,
     snapshot,
   };

--- a/apps/orchestrator/service.ts
+++ b/apps/orchestrator/service.ts
@@ -824,6 +824,7 @@ export class MetaOrchestrator {
         details: {
           resultRef,
           manifestCid: runResult.manifestCid,
+          manifestUrl: runResult.manifestUrl,
           finalStageCid: runResult.finalCid,
           stages: stages.map((s) => s.name),
           stageCount: runResult.snapshot.stageCount,

--- a/packages/onebox-sdk/src/index.ts
+++ b/packages/onebox-sdk/src/index.ts
@@ -65,6 +65,13 @@ export interface ExecuteResponse {
   txHash?: string;
   receiptUrl?: string;
   specCid?: string;
+  specUri?: string;
+  specGatewayUrl?: string;
+  specGatewayUrls?: string[];
+  deliverableCid?: string;
+  deliverableUri?: string;
+  deliverableGatewayUrl?: string;
+  deliverableGatewayUrls?: string[];
   specHash?: string;
   deadline?: number;
   reward?: string;

--- a/shared/worldModel.ts
+++ b/shared/worldModel.ts
@@ -44,7 +44,9 @@ export interface WorldModelObservation {
   inputSummary?: ContentSummary | null;
   outputSummary?: ContentSummary | null;
   outputCid?: string;
+  outputUrl?: string;
   signatureCid?: string;
+  signatureUrl?: string;
   signature?: string;
   signer?: string;
   digest?: string;
@@ -90,7 +92,9 @@ export interface RecordObservationInput {
   input?: unknown;
   output?: unknown;
   outputCid?: string;
+  outputUrl?: string;
   signatureCid?: string;
+  signatureUrl?: string;
   signature?: string;
   signer?: string;
   digest?: string;
@@ -168,7 +172,9 @@ export async function recordWorldModelObservation(
     startedAt: input.startedAt,
     completedAt: input.completedAt,
     outputCid: input.outputCid,
+    outputUrl: input.outputUrl,
     signatureCid: input.signatureCid,
+    signatureUrl: input.signatureUrl,
     signature: input.signature,
     signer: input.signer,
     digest: input.digest,


### PR DESCRIPTION
## Summary
- add a vendor-agnostic pinning client with retries, status checks, and gateway reporting for `/onebox/execute`
- propagate pin metadata through orchestrator uploads, disputes evidence, and world model artifacts
- surface spec and deliverable gateway links in the one-box UI and shared SDK types

## Testing
- npm run --silent tsc -- --project apps/orchestrator/tsconfig.json
- python -m compileall routes/onebox.py

------
https://chatgpt.com/codex/tasks/task_e_68d824e099fc833397247840172cbe7c