### PR TITLE
Update deadline wallet test pin stub

### DIFF
--- a/test/routes/test_onebox.py
+++ b/test/routes/test_onebox.py
@@ -415,9 +415,20 @@ class ExecutorDeadlineTests(unittest.IsolatedAsyncioTestCase):
     async def test_execute_wallet_with_deadline_days_succeeds(self) -> None:
         captured_metadata = {}
 
-        async def _fake_pin_json(metadata):
+        async def _fake_pin_json(metadata, file_name="payload.json"):
             captured_metadata.update(metadata)
-            return "bafkdeadline"
+            return {
+                "cid": "bafkdeadline",
+                "uri": "ipfs://bafkdeadline",
+                "gatewayUrl": "https://ipfs.io/ipfs/bafkdeadline",
+                "gatewayUrls": ["https://ipfs.io/ipfs/bafkdeadline"],
+                "provider": "test",
+                "status": "pinned",
+                "requestId": file_name,
+                "size": None,
+                "pinnedAt": None,
+                "attempts": 1,
+            }
 
         intent = JobIntent(
             action="post_job",


### PR DESCRIPTION
## Summary
- update the pinning stub used in the deadline wallet execution test to mimic the real pinning response shape

## Testing
- pytest test/routes/test_onebox.py::ExecutorDeadlineTests::test_execute_wallet_with_deadline_days_succeeds

------
https://chatgpt.com/codex/tasks/task_e_68d82bb297e083338c9286b2b1e333c1