### PR TITLE
Guard pending fees during FeePool rewards

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -120,6 +120,7 @@ Stores platform fees and distributes rewards.
 
 - `depositFee(amount)` – `StakeManager` deposits collected fees.
 - `claimRewards()` – stakers withdraw accumulated rewards.
+- `reward(to, amount)` – authorised rewarders may transfer surplus tokens, but the pool guarantees that `pendingFees` remain reserved for automated fee distribution and will revert with `InsufficientRewardBalance` if a transfer would reduce that balance.
 
 ```javascript
 await feePool.depositFee(feeAmount);


### PR DESCRIPTION
## Summary
- add an `InsufficientRewardBalance` guard so FeePool reward payouts cannot consume pending fees
- document the separation between automated fee accrual and manual rewards in the FeePool docs
- cover the new invariant with a Hardhat test that attempts a reward withdrawal before distributing fees

## Testing
- npm test -- --grep "FeePool"


------
https://chatgpt.com/codex/tasks/task_e_68d83a8e49e48333a88464aec1ed0e9f