### PR TITLE
Add reward engine config tooling and CLI update helper

### DIFF
--- a/config/reward-engine.json
+++ b/config/reward-engine.json
@@ -1,0 +1,27 @@
+{
+  "address": "0x0000000000000000000000000000000000000000",
+  "treasury": "0x0000000000000000000000000000000000000000",
+  "thermostat": "0x0000000000000000000000000000000000000000",
+  "roleShares": {
+    "agent": 65,
+    "validator": 15,
+    "operator": 15,
+    "employer": 5
+  },
+  "mu": {
+    "agent": "0",
+    "validator": "0",
+    "operator": "0",
+    "employer": "0"
+  },
+  "baselineEnergy": {
+    "agent": "0",
+    "validator": "0",
+    "operator": "0",
+    "employer": "0"
+  },
+  "kappa": "1000000000000000000",
+  "maxProofs": 100,
+  "temperature": "1000000000000000000",
+  "settlers": {}
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "format:check": "prettier --check \".github/workflows/**/*.yml\" \"scripts/ci/**/*.{js,mjs}\" \"hardhat.config.js\" \"package.json\" \".solcover.js\"",
     "identity:register": "npx ts-node scripts/identity/manageEnsKeys.ts",
     "identity:update": "npx hardhat run scripts/v2/updateIdentityRegistry.ts",
+    "reward-engine:update": "npx hardhat run scripts/v2/updateRewardEngine.ts",
     "platform:registry:update": "npx hardhat run scripts/v2/updatePlatformRegistry.ts",
     "namehash:mainnet": "node scripts/compute-namehash.js deployment-config/mainnet.json",
     "namehash:sepolia": "node scripts/compute-namehash.js deployment-config/sepolia.json",

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -196,6 +196,13 @@ export interface RewardEngineThermoConfig {
   [key: string]: unknown;
 }
 
+export interface RewardEngineConfigResult {
+  config: RewardEngineThermoConfig;
+  path: string;
+  network?: SupportedNetwork;
+  source?: 'reward-engine' | 'thermodynamics';
+}
+
 export interface ThermostatConfigInput {
   address?: string | null;
   systemTemperature?: number | string;
@@ -387,6 +394,9 @@ export function loadTaxPolicyConfig(
 export function loadThermodynamicsConfig(
   options?: LoadOptions
 ): ThermodynamicsConfigResult;
+export function loadRewardEngineConfig(
+  options?: LoadOptions
+): RewardEngineConfigResult;
 export function loadDeploymentPlan(
   options?: DeploymentPlanOptions
 ): DeploymentPlanResult;

--- a/scripts/v2/updateRewardEngine.ts
+++ b/scripts/v2/updateRewardEngine.ts
@@ -1,0 +1,172 @@
+import { ethers, network } from 'hardhat';
+import type { Contract } from 'ethers';
+import { loadTokenConfig, loadRewardEngineConfig } from '../config';
+import { buildRewardEnginePlan } from './lib/rewardEnginePlan';
+import { describeArgs, sameAddress } from './lib/utils';
+
+interface CliOptions {
+  execute: boolean;
+  configPath?: string;
+  rewardEngineAddress?: string;
+  json?: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false, json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--execute') {
+      options.execute = true;
+    } else if (arg === '--config') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--config requires a file path');
+      }
+      options.configPath = value;
+      i += 1;
+    } else if (arg === '--reward-engine' || arg === '--rewardEngine') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--reward-engine requires an address');
+      }
+      options.rewardEngineAddress = value;
+      i += 1;
+    } else if (arg === '--json') {
+      options.json = true;
+    }
+  }
+  return options;
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+
+  const { config: tokenConfig } = loadTokenConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
+
+  const {
+    config: rewardConfig,
+    path: rewardConfigPath,
+    source: configSource,
+  } = loadRewardEngineConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+    path: cli.configPath,
+  });
+
+  const rewardEngineCandidate =
+    cli.rewardEngineAddress ||
+    rewardConfig.address ||
+    tokenConfig.modules?.rewardEngine;
+  if (!rewardEngineCandidate) {
+    throw new Error('Reward engine address is not configured');
+  }
+
+  const rewardEngineAddress = ethers.getAddress(rewardEngineCandidate);
+  if (rewardEngineAddress === ethers.ZeroAddress) {
+    throw new Error('Reward engine address cannot be the zero address');
+  }
+
+  const rewardEngineRead = (await ethers.getContractAt(
+    'contracts/v2/RewardEngineMB.sol:RewardEngineMB',
+    rewardEngineAddress
+  )) as Contract;
+
+  const signer = await ethers.getSigner();
+  const signerAddress = await signer.getAddress();
+  const ownerAddress = await rewardEngineRead.owner();
+
+  if (cli.execute && !sameAddress(ownerAddress, signerAddress)) {
+    throw new Error(
+      `Signer ${signerAddress} is not the governance owner ${ownerAddress}`
+    );
+  }
+
+  if (!sameAddress(ownerAddress, signerAddress)) {
+    console.warn(
+      `Warning: connected signer ${signerAddress} is not the governance owner ${ownerAddress}. Running in dry-run mode.`
+    );
+  }
+
+  const rewardEngine = rewardEngineRead.connect(signer);
+
+  const plan = await buildRewardEnginePlan({
+    rewardEngine,
+    config: rewardConfig,
+    configPath: rewardConfigPath,
+  });
+
+  if (cli.json) {
+    const { contract: _contract, ...serialisable } = plan;
+    console.log(
+      JSON.stringify(
+        {
+          ...serialisable,
+          source: configSource,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log('RewardEngineMB:', rewardEngineAddress);
+  console.log('Configuration file:', rewardConfigPath);
+  if (configSource === 'thermodynamics') {
+    console.log('Configuration source: thermodynamics (rewardEngine section)');
+  } else {
+    console.log('Configuration source: reward-engine');
+  }
+
+  if (plan.actions.length === 0) {
+    console.log('All tracked parameters already match the configuration.');
+    return;
+  }
+
+  console.log(`Planned actions (${plan.actions.length}):`);
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
+    console.log(`\n${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      console.log(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      console.log(`   Desired: ${action.desired}`);
+    }
+    action.notes?.forEach((note) => {
+      console.log(`   Note: ${note}`);
+    });
+    console.log(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    if (data) {
+      console.log(`   Calldata: ${data}`);
+    }
+  });
+
+  if (!cli.execute || !sameAddress(ownerAddress, signerAddress)) {
+    console.log(
+      '\nDry run complete. Re-run with --execute once governance is ready to submit transactions.'
+    );
+    return;
+  }
+
+  console.log('\nSubmitting transactions...');
+  for (const action of plan.actions) {
+    console.log(`Executing ${action.method}...`);
+    const tx = await (rewardEngine as any)[action.method](...action.args);
+    console.log(`   Tx hash: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (receipt?.status !== 1n) {
+      throw new Error(`Transaction for ${action.method} failed`);
+    }
+    console.log('   Confirmed');
+  }
+  console.log('All transactions confirmed.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a dedicated reward engine configuration file and loader that fall back to thermodynamics settings when needed
- expose typed accessors for the reward engine config and ship a focused Hardhat script for planning/applying governance updates
- register an npm shortcut so operators can invoke the new reward engine updater with a single command

## Testing
- npm run lint:check *(fails: repository already has extensive Solhint/Prettier violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d83c6ed25c8333b132bb1b794fc817