### PR TITLE
Add governance controls and tooling for Hamiltonian monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ flowchart LR
 - **Employers** – Design jobs with clear requirements so agents expend minimal energy on speculation or rework, improving overall budget share.
 - **Operators** – Maintain energy‑efficient, highly available infrastructure and publish transparent metrics so the oracle can measure consumption accurately.
 
+### Hamiltonian monitor upkeep
+
+Governance can now retune the `HamiltonianMonitor` without redeploying. Update [`config/hamiltonian-monitor.json`](config/hamiltonian-monitor.json) with the desired window size and any observations to append, then preview the required transactions:
+
+```bash
+npx hardhat run scripts/v2/updateHamiltonianMonitor.ts --network <network>
+```
+
+Pass `--execute` once the dry run looks correct to submit the queued actions. Use `resetHistory: true` in the config to wipe accumulated observations and start fresh—either on its own or combined with a window change. The helper automatically skips recording duplicate observations if they already match the most recent on-chain history.
+
 ### Deploy defaults
 
 Spin up the full stack with a single helper script:

--- a/config/hamiltonian-monitor.json
+++ b/config/hamiltonian-monitor.json
@@ -1,0 +1,6 @@
+{
+  "address": "0x0000000000000000000000000000000000000000",
+  "window": "5",
+  "resetHistory": false,
+  "records": []
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "identity:register": "npx ts-node scripts/identity/manageEnsKeys.ts",
     "identity:update": "npx hardhat run scripts/v2/updateIdentityRegistry.ts",
     "reward-engine:update": "npx hardhat run scripts/v2/updateRewardEngine.ts",
+    "hamiltonian:update": "npx hardhat run scripts/v2/updateHamiltonianMonitor.ts",
     "platform:registry:update": "npx hardhat run scripts/v2/updatePlatformRegistry.ts",
     "namehash:mainnet": "node scripts/compute-namehash.js deployment-config/mainnet.json",
     "namehash:sepolia": "node scripts/compute-namehash.js deployment-config/sepolia.json",

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -203,6 +203,28 @@ export interface RewardEngineConfigResult {
   source?: 'reward-engine' | 'thermodynamics';
 }
 
+export interface HamiltonianMonitorRecordConfig {
+  d: string;
+  u: string;
+  timestamp?: string;
+  note?: string;
+  [key: string]: unknown;
+}
+
+export interface HamiltonianMonitorConfig {
+  address?: string;
+  window?: string;
+  resetHistory?: boolean;
+  records?: HamiltonianMonitorRecordConfig[];
+  [key: string]: unknown;
+}
+
+export interface HamiltonianMonitorConfigResult {
+  config: HamiltonianMonitorConfig;
+  path: string;
+  network?: SupportedNetwork;
+}
+
 export interface ThermostatConfigInput {
   address?: string | null;
   systemTemperature?: number | string;
@@ -397,6 +419,9 @@ export function loadThermodynamicsConfig(
 export function loadRewardEngineConfig(
   options?: LoadOptions
 ): RewardEngineConfigResult;
+export function loadHamiltonianMonitorConfig(
+  options?: LoadOptions
+): HamiltonianMonitorConfigResult;
 export function loadDeploymentPlan(
   options?: DeploymentPlanOptions
 ): DeploymentPlanResult;

--- a/scripts/v2/updateHamiltonianMonitor.ts
+++ b/scripts/v2/updateHamiltonianMonitor.ts
@@ -1,0 +1,286 @@
+import { ethers, network } from 'hardhat';
+import type { Contract } from 'ethers';
+import { loadHamiltonianMonitorConfig } from '../config';
+import { describeArgs, sameAddress } from './lib/utils';
+
+interface CliOptions {
+  execute: boolean;
+  configPath?: string;
+  monitorAddress?: string;
+  json?: boolean;
+}
+
+interface PlannedAction {
+  label: string;
+  method: 'setWindow' | 'resetHistory' | 'record';
+  args: Array<string | bigint | boolean>;
+  contract: Contract;
+  notes?: string[];
+}
+
+interface SerialisedAction
+  extends Omit<PlannedAction, 'contract' | 'args'> {
+  args: Array<string | boolean>;
+}
+
+interface RecordEntry {
+  d: bigint;
+  u: bigint;
+  note?: string;
+  timestamp?: string;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false, json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--execute') {
+      options.execute = true;
+    } else if (arg === '--config') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--config requires a file path');
+      }
+      options.configPath = value;
+      i += 1;
+    } else if (arg === '--monitor' || arg === '--address') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--monitor requires an address');
+      }
+      options.monitorAddress = value;
+      i += 1;
+    } else if (arg === '--json') {
+      options.json = true;
+    }
+  }
+  return options;
+}
+
+function bigintToString(value: bigint): string {
+  return value.toString();
+}
+
+function mapRecord(entry: {
+  d: string;
+  u: string;
+  note?: string;
+  timestamp?: string;
+}): RecordEntry {
+  return {
+    d: BigInt(entry.d),
+    u: BigInt(entry.u),
+    note: entry.note,
+    timestamp: entry.timestamp,
+  };
+}
+
+function serialiseActions(actions: PlannedAction[]): SerialisedAction[] {
+  return actions.map(({ contract: _contract, args, ...rest }) => ({
+    ...rest,
+    args: args.map((value) =>
+      typeof value === 'bigint' ? value.toString() : String(value)
+    ),
+  }));
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+
+  const { config, path: configPath } = loadHamiltonianMonitorConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+    path: cli.configPath,
+  });
+
+  const monitorCandidate = cli.monitorAddress || config.address;
+  if (!monitorCandidate) {
+    throw new Error('Hamiltonian monitor address is not configured');
+  }
+
+  const monitorAddress = ethers.getAddress(monitorCandidate);
+  if (monitorAddress === ethers.ZeroAddress) {
+    throw new Error('Hamiltonian monitor address cannot be the zero address');
+  }
+
+  const monitorRead = await ethers.getContractAt(
+    'contracts/v2/HamiltonianMonitor.sol:HamiltonianMonitor',
+    monitorAddress
+  );
+
+  const signer = await ethers.getSigner();
+  const signerAddress = await signer.getAddress();
+  const ownerAddress = await monitorRead.owner();
+  const isOwner = sameAddress(ownerAddress, signerAddress);
+
+  if (cli.execute && !isOwner) {
+    throw new Error(
+      `Signer ${signerAddress} is not the governance owner ${ownerAddress}`
+    );
+  }
+
+  if (!isOwner) {
+    console.warn(
+      `Warning: connected signer ${signerAddress} is not the governance owner ${ownerAddress}. Running in dry-run mode.`
+    );
+  }
+
+  const monitor = monitorRead.connect(signer);
+
+  const currentWindow = BigInt((await monitorRead.window()).toString());
+  const [dHistoryRaw, uHistoryRaw] = await monitorRead.history();
+  const dHistory = dHistoryRaw.map((value: bigint | number | string) =>
+    BigInt(value.toString())
+  );
+  const uHistory = uHistoryRaw.map((value: bigint | number | string) =>
+    BigInt(value.toString())
+  );
+
+  const desiredWindow = config.window ? BigInt(config.window) : undefined;
+  const resetRequested = Boolean(config.resetHistory);
+  const configuredRecords = Array.isArray(config.records)
+    ? config.records.map(mapRecord)
+    : [];
+
+  const actions: PlannedAction[] = [];
+  let resetsHistory = false;
+
+  if (resetRequested && desiredWindow !== undefined) {
+    resetsHistory = true;
+    actions.push({
+      label: `Set window to ${desiredWindow} and reset history`,
+      method: 'setWindow',
+      args: [desiredWindow, true],
+      contract: monitor,
+      notes: [
+        `previous window: ${currentWindow}`,
+        `clearing ${dHistory.length} stored observations`,
+      ],
+    });
+  } else {
+    if (desiredWindow !== undefined && desiredWindow !== currentWindow) {
+      actions.push({
+        label: `Set window to ${desiredWindow}`,
+        method: 'setWindow',
+        args: [desiredWindow, false],
+        contract: monitor,
+        notes: [`previous window: ${currentWindow}`],
+      });
+    }
+
+    if (resetRequested) {
+      resetsHistory = true;
+      actions.push({
+        label: 'Reset dissipation/utility history',
+        method: 'resetHistory',
+        args: [],
+        contract: monitor,
+        notes: [`clearing ${dHistory.length} stored observations`],
+      });
+    }
+  }
+
+  let recordMatchesTail = false;
+  if (!resetsHistory && configuredRecords.length > 0) {
+    if (dHistory.length >= configuredRecords.length) {
+      const start = dHistory.length - configuredRecords.length;
+      recordMatchesTail = configuredRecords.every((entry, index) => {
+        return (
+          dHistory[start + index] === entry.d &&
+          uHistory[start + index] === entry.u
+        );
+      });
+    }
+  }
+
+  if (configuredRecords.length > 0 && !recordMatchesTail) {
+    configuredRecords.forEach((entry, index) => {
+      const notes: string[] = [];
+      if (entry.timestamp) {
+        notes.push(`timestamp: ${entry.timestamp}`);
+      }
+      if (entry.note) {
+        notes.push(`note: ${entry.note}`);
+      }
+      actions.push({
+        label: `Record observation #${index + 1}`,
+        method: 'record',
+        args: [entry.d, entry.u],
+        contract: monitor,
+        notes,
+      });
+    });
+  }
+
+  const summary = {
+    address: monitorAddress,
+    configPath,
+    currentWindow: bigintToString(currentWindow),
+    desiredWindow: desiredWindow ? bigintToString(desiredWindow) : undefined,
+    resetRequested,
+    existingObservations: dHistory.length,
+    recordCount: configuredRecords.length,
+    actions: serialiseActions(actions),
+    recordsAlreadyApplied: recordMatchesTail,
+  };
+
+  if (cli.json) {
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  console.log('HamiltonianMonitor:', monitorAddress);
+  console.log('Configuration file:', configPath);
+  console.log(`Current window: ${summary.currentWindow}`);
+  if (summary.desiredWindow) {
+    console.log(`Desired window: ${summary.desiredWindow}`);
+  }
+  console.log(`Stored observations: ${summary.existingObservations}`);
+  if (configuredRecords.length > 0) {
+    console.log(`Configured records: ${configuredRecords.length}`);
+  }
+  if (recordMatchesTail && configuredRecords.length > 0) {
+    console.log(
+      'Configured records match the most recent on-chain observations; no record transactions are required.'
+    );
+  }
+
+  if (actions.length === 0) {
+    console.log('No changes required.');
+    return;
+  }
+
+  console.log(`Planned actions (${actions.length}):`);
+  actions.forEach((action, index) => {
+    console.log(`\n${index + 1}. ${action.label}`);
+    console.log(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    action.notes?.forEach((note) => {
+      console.log(`   Note: ${note}`);
+    });
+  });
+
+  if (!cli.execute || !isOwner) {
+    console.log(
+      '\nDry run complete. Re-run with --execute once governance is ready to submit transactions.'
+    );
+    return;
+  }
+
+  console.log('\nSubmitting transactions...');
+  for (const action of actions) {
+    console.log(`Executing ${action.method}...`);
+    const tx = await (action.contract as any)[action.method](...action.args);
+    console.log(`   Tx hash: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (receipt?.status !== 1n) {
+      throw new Error(`Transaction for ${action.method} failed`);
+    }
+    console.log('   Confirmed');
+  }
+  console.log('All transactions confirmed.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/v2/HamiltonianMonitor.test.js
+++ b/test/v2/HamiltonianMonitor.test.js
@@ -1,0 +1,138 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('HamiltonianMonitor', function () {
+  let owner;
+  let stranger;
+  let monitor;
+
+  beforeEach(async () => {
+    [owner, stranger] = await ethers.getSigners();
+    const Factory = await ethers.getContractFactory(
+      'contracts/v2/HamiltonianMonitor.sol:HamiltonianMonitor'
+    );
+    monitor = await Factory.deploy(5, owner.address);
+  });
+
+  async function recordSeries(series) {
+    for (const entry of series) {
+      await monitor.connect(owner).record(entry.d, entry.u);
+    }
+  }
+
+  it('restricts window updates to governance', async () => {
+    await expect(
+      monitor.connect(stranger).setWindow(10, false)
+    ).to.be.revertedWithCustomError(monitor, 'NotGovernance');
+
+    await expect(
+      monitor.connect(stranger).resetHistory()
+    ).to.be.revertedWithCustomError(monitor, 'NotGovernance');
+  });
+
+  it('drops the oldest observations when the window shrinks', async () => {
+    await recordSeries([
+      { d: 10n, u: 1n },
+      { d: 20n, u: 2n },
+      { d: 30n, u: 3n },
+      { d: 40n, u: 4n },
+      { d: 50n, u: 5n },
+      { d: 60n, u: 6n },
+    ]);
+
+    expect(await monitor.averageD()).to.equal(40n);
+    expect(await monitor.averageU()).to.equal(4n);
+
+    await expect(monitor.connect(owner).setWindow(3, false))
+      .to.emit(monitor, 'WindowUpdated')
+      .withArgs(5n, 3n, false);
+
+    expect(await monitor.window()).to.equal(3n);
+    expect(await monitor.averageD()).to.equal(50n);
+    expect(await monitor.averageU()).to.equal(5n);
+
+    const history = await monitor.history();
+    expect(history[0].map((value) => value.toString())).to.deep.equal([
+      '40',
+      '50',
+      '60',
+    ]);
+    expect(history[1].map((value) => value.toString())).to.deep.equal([
+      '4',
+      '5',
+      '6',
+    ]);
+  });
+
+  it('allows expanding the window without losing existing data', async () => {
+    await recordSeries([
+      { d: 10n, u: 1n },
+      { d: 20n, u: 2n },
+      { d: 30n, u: 3n },
+      { d: 40n, u: 4n },
+      { d: 50n, u: 5n },
+    ]);
+
+    await monitor.connect(owner).setWindow(3, false);
+
+    await expect(monitor.connect(owner).setWindow(6, false))
+      .to.emit(monitor, 'WindowUpdated')
+      .withArgs(3n, 6n, false);
+
+    await monitor.connect(owner).record(60n, 6n);
+    await monitor.connect(owner).record(70n, 7n);
+
+    const [dHistory, uHistory] = await monitor.history();
+    expect(dHistory.map((value) => value.toString())).to.deep.equal([
+      '30',
+      '40',
+      '50',
+      '60',
+      '70',
+    ]);
+    expect(uHistory.map((value) => value.toString())).to.deep.equal([
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+    ]);
+    expect(await monitor.window()).to.equal(6n);
+  });
+
+  it('supports resetting history independently of window size', async () => {
+    await recordSeries([
+      { d: 100n, u: 10n },
+      { d: 200n, u: 20n },
+    ]);
+
+    await expect(monitor.connect(owner).resetHistory())
+      .to.emit(monitor, 'HistoryReset')
+      .withArgs(2n);
+
+    const [dHistory, uHistory] = await monitor.history();
+    expect(dHistory).to.be.empty;
+    expect(uHistory).to.be.empty;
+    expect(await monitor.averageD()).to.equal(0n);
+    expect(await monitor.currentHamiltonian()).to.equal(0);
+  });
+
+  it('resets history when requested during a window update', async () => {
+    await recordSeries([
+      { d: 5n, u: 2n },
+      { d: 6n, u: 3n },
+      { d: 7n, u: 4n },
+    ]);
+
+    await expect(monitor.connect(owner).setWindow(8, true))
+      .to.emit(monitor, 'HistoryReset')
+      .withArgs(3n)
+      .and.to.emit(monitor, 'WindowUpdated')
+      .withArgs(5n, 8n, true);
+
+    const [dHistory, uHistory] = await monitor.history();
+    expect(dHistory).to.be.empty;
+    expect(uHistory).to.be.empty;
+    expect(await monitor.window()).to.equal(8n);
+  });
+});


### PR DESCRIPTION
## Summary
- allow the HamiltonianMonitor governance owner to resize the rolling window, reset history and emit explicit lifecycle events
- add a Hardhat helper, config loader and sample config file so operators can plan and execute Hamiltonian monitor updates safely
- document the workflow and cover new behaviours with targeted Hardhat tests

## Testing
- npx hardhat compile
- npx hardhat test --no-compile test/v2/HamiltonianMonitor.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d83ef767b08333a78ae3428a915ba7