### PR TITLE
feat: add governance rotation planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ npx hardhat run scripts/v2/updateSystemPause.ts --network <network>
 
 The script performs a dry run by default, reporting any address, ownership or pauser mismatches. Re-run with `--execute` once all modules report `owner == SystemPause` to apply the wiring transaction safely.
 
+### Governance & ownership rotation
+
+Keep a single source of truth for governance and ownership targets in [`config/owner-control.json`](config/owner-control.json). Populate the `governance` (timelock or multisig) and `owner` defaults, then override individual modules as required. The helper supports `governable`, `ownable` and `ownable2step` contracts and can emit a Gnosis Safe transaction bundle for non-technical operators.
+
+```bash
+# Preview pending updates
+npm run owner:rotate -- --network <network>
+
+# Emit a Safe bundle and execute changes once the plan looks correct
+npm run owner:rotate -- --network <network> \
+  --safe owner-rotation.json \
+  --safe-name "AGIJobs Governance Rotation" \
+  --execute
+```
+
+The script validates deployed bytecode, highlights modules missing configuration, and warns if any `Ownable2Step` contract still requires `acceptOwnership()` by the new controller. Safe bundles include typed inputs for inspection inside the transaction builder UI.
+
 ### Mainnet Deployment
 
 For a step-by-step mainnet deployment using Truffle, see the [Deploying AGIJobs v2 to Ethereum Mainnet (CLI Guide)](docs/deploying-agijobs-v2-truffle-cli.md). Operators who prefer an automated checklist can launch the guided wizard:

--- a/config/owner-control.json
+++ b/config/owner-control.json
@@ -1,0 +1,57 @@
+{
+  "governance": "0x0000000000000000000000000000000000000000",
+  "owner": "0x0000000000000000000000000000000000000000",
+  "modules": {
+    "stakeManager": {
+      "type": "governable"
+    },
+    "jobRegistry": {
+      "type": "governable"
+    },
+    "rewardEngine": {
+      "type": "governable"
+    },
+    "thermostat": {
+      "type": "governable"
+    },
+    "systemPause": {
+      "type": "governable"
+    },
+    "feePool": {
+      "type": "ownable"
+    },
+    "platformRegistry": {
+      "type": "ownable"
+    },
+    "platformIncentives": {
+      "type": "ownable"
+    },
+    "jobRouter": {
+      "type": "ownable"
+    },
+    "validationModule": {
+      "type": "ownable"
+    },
+    "reputationEngine": {
+      "type": "ownable"
+    },
+    "disputeModule": {
+      "type": "ownable"
+    },
+    "arbitratorCommittee": {
+      "type": "ownable"
+    },
+    "certificateNFT": {
+      "type": "ownable"
+    },
+    "taxPolicy": {
+      "type": "ownable2step"
+    },
+    "identityRegistry": {
+      "type": "ownable2step"
+    },
+    "attestationRegistry": {
+      "type": "ownable"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "owner:plan:safe": "node scripts/v2/run-owner-plan.js --safe owner-safe-bundle.json --safe-name \"AGIJobs Owner Control Plan\"",
     "owner:wizard": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/owner-config-wizard.ts",
     "owner:dashboard": "npx hardhat run --no-compile scripts/v2/owner-dashboard.ts",
+    "owner:rotate": "npx hardhat run --no-compile scripts/v2/rotateGovernance.ts",
     "test": "hardhat test --no-compile",
     "echidna:commit-reveal": "docker run --rm -v \"$PWD\":/src -v \"$PWD/tools/forge-shim\":/usr/local/bin/forge:ro -w /src ghcr.io/crytic/echidna/echidna:v2.2.7 echidna-test ./contracts/test/CommitRevealEchidna.sol --contract CommitRevealEchidnaHarness --config echidna/commit-reveal.yaml",
     "echidna": "npm run echidna:commit-reveal",

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -19,6 +19,32 @@ export interface GovernanceConfig {
   [key: string]: unknown;
 }
 
+export type OwnerControlModuleType = 'governable' | 'ownable' | 'ownable2step';
+
+export interface OwnerControlModuleConfig {
+  address?: string;
+  governance?: string;
+  owner?: string;
+  type?: OwnerControlModuleType | string;
+  label?: string;
+  skip?: boolean;
+  notes?: string[];
+  [key: string]: unknown;
+}
+
+export interface OwnerControlConfig {
+  governance?: string;
+  owner?: string;
+  modules?: Record<string, OwnerControlModuleConfig>;
+  [key: string]: unknown;
+}
+
+export interface OwnerControlConfigResult {
+  config: OwnerControlConfig;
+  path: string;
+  network?: SupportedNetwork;
+}
+
 export interface TokenConfigResult {
   config: TokenConfig;
   path: string;
@@ -413,6 +439,9 @@ export function loadPlatformRegistryConfig(
 export function loadTaxPolicyConfig(
   options?: LoadOptions
 ): TaxPolicyConfigResult;
+export function loadOwnerControlConfig(
+  options?: LoadOptions
+): OwnerControlConfigResult;
 export function loadThermodynamicsConfig(
   options?: LoadOptions
 ): ThermodynamicsConfigResult;

--- a/scripts/v2/rotateGovernance.ts
+++ b/scripts/v2/rotateGovernance.ts
@@ -1,0 +1,833 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { ethers, network } from 'hardhat';
+import type { Contract } from 'ethers';
+import {
+  loadTokenConfig,
+  loadOwnerControlConfig,
+  type OwnerControlConfig,
+  type OwnerControlModuleConfig,
+  type OwnerControlModuleType,
+} from '../config';
+import { describeArgs, sameAddress } from './lib/utils';
+
+type ModuleType = OwnerControlModuleType;
+
+interface ModuleDefinition {
+  key: string;
+  label: string;
+  type: ModuleType;
+}
+
+interface ModuleOverride extends OwnerControlModuleConfig {
+  notes?: string[];
+}
+
+interface CliOptions {
+  execute: boolean;
+  json: boolean;
+  configPath?: string;
+  governance?: string;
+  owner?: string;
+  safeOut?: string;
+  safeName?: string;
+  safeDescription?: string;
+}
+
+interface RotationAction {
+  moduleKey: string;
+  moduleName: string;
+  type: ModuleType;
+  address: string;
+  method: 'setGovernance' | 'transferOwnership';
+  args: [string];
+  currentOwner?: string;
+  desiredOwner: string;
+  pendingOwner?: string;
+  targetSource?: string;
+  notes: string[];
+  contract: Contract;
+  calldata: string;
+}
+
+interface PendingAcceptance {
+  moduleKey: string;
+  moduleName: string;
+  address: string;
+  pendingOwner: string;
+}
+
+interface MissingEntry {
+  moduleKey: string;
+  moduleName: string;
+  reason: string;
+}
+
+interface RotationPlan {
+  network: string;
+  chainId?: number;
+  signer?: string;
+  tokenConfigPath: string;
+  ownerControlPath?: string;
+  actions: RotationAction[];
+  pendingAcceptances: PendingAcceptance[];
+  missingTargets: MissingEntry[];
+  missingAddresses: MissingEntry[];
+  skipped: MissingEntry[];
+  upToDate: {
+    moduleKey: string;
+    moduleName: string;
+    address: string;
+    owner?: string;
+  }[];
+}
+
+const DEFAULT_MODULES: Record<string, ModuleDefinition> = {
+  stakeManager: {
+    key: 'stakeManager',
+    label: 'StakeManager',
+    type: 'governable',
+  },
+  jobRegistry: { key: 'jobRegistry', label: 'JobRegistry', type: 'governable' },
+  rewardEngine: {
+    key: 'rewardEngine',
+    label: 'RewardEngineMB',
+    type: 'governable',
+  },
+  thermostat: { key: 'thermostat', label: 'Thermostat', type: 'governable' },
+  systemPause: { key: 'systemPause', label: 'SystemPause', type: 'governable' },
+  validationModule: {
+    key: 'validationModule',
+    label: 'ValidationModule',
+    type: 'ownable',
+  },
+  reputationEngine: {
+    key: 'reputationEngine',
+    label: 'ReputationEngine',
+    type: 'ownable',
+  },
+  disputeModule: {
+    key: 'disputeModule',
+    label: 'DisputeModule',
+    type: 'ownable',
+  },
+  arbitratorCommittee: {
+    key: 'arbitratorCommittee',
+    label: 'ArbitratorCommittee',
+    type: 'ownable',
+  },
+  certificateNFT: {
+    key: 'certificateNFT',
+    label: 'CertificateNFT',
+    type: 'ownable',
+  },
+  feePool: { key: 'feePool', label: 'FeePool', type: 'ownable' },
+  platformRegistry: {
+    key: 'platformRegistry',
+    label: 'PlatformRegistry',
+    type: 'ownable',
+  },
+  platformIncentives: {
+    key: 'platformIncentives',
+    label: 'PlatformIncentives',
+    type: 'ownable',
+  },
+  jobRouter: { key: 'jobRouter', label: 'JobRouter', type: 'ownable' },
+  taxPolicy: { key: 'taxPolicy', label: 'TaxPolicy', type: 'ownable2step' },
+  identityRegistry: {
+    key: 'identityRegistry',
+    label: 'IdentityRegistry',
+    type: 'ownable2step',
+  },
+  attestationRegistry: {
+    key: 'attestationRegistry',
+    label: 'AttestationRegistry',
+    type: 'ownable',
+  },
+};
+
+const ABI_BY_TYPE: Record<ModuleType, string[]> = {
+  governable: [
+    'function owner() view returns (address)',
+    'function governance() view returns (address)',
+    'function setGovernance(address _governance)',
+  ],
+  ownable: [
+    'function owner() view returns (address)',
+    'function transferOwnership(address newOwner)',
+  ],
+  ownable2step: [
+    'function owner() view returns (address)',
+    'function pendingOwner() view returns (address)',
+    'function transferOwnership(address newOwner)',
+    'function acceptOwnership()',
+  ],
+};
+
+const FUNCTION_METADATA: Record<
+  RotationAction['method'],
+  { inputName: string }
+> = {
+  setGovernance: { inputName: '_governance' },
+  transferOwnership: { inputName: 'newOwner' },
+};
+
+function parseAddressOption(
+  value: string | undefined,
+  label: string
+): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const address = ethers.getAddress(value);
+    if (address === ethers.ZeroAddress) {
+      throw new Error(`${label} cannot be the zero address`);
+    }
+    return address;
+  } catch (error: any) {
+    throw new Error(
+      `${label} must be a valid address: ${error?.message || error}`
+    );
+  }
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false, json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--execute':
+        options.execute = true;
+        break;
+      case '--json':
+        options.json = true;
+        break;
+      case '--config': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--config requires a file path');
+        }
+        options.configPath = value;
+        i += 1;
+        break;
+      }
+      case '--governance': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--governance requires an address');
+        }
+        options.governance = parseAddressOption(value, '--governance');
+        i += 1;
+        break;
+      }
+      case '--owner': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--owner requires an address');
+        }
+        options.owner = parseAddressOption(value, '--owner');
+        i += 1;
+        break;
+      }
+      case '--safe':
+      case '--safe-out': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a file path`);
+        }
+        options.safeOut = value;
+        i += 1;
+        break;
+      }
+      case '--safe-name': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--safe-name requires a value');
+        }
+        options.safeName = value;
+        i += 1;
+        break;
+      }
+      case '--safe-description':
+      case '--safe-desc': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a value`);
+        }
+        options.safeDescription = value;
+        i += 1;
+        break;
+      }
+      default:
+        throw new Error(`Unknown argument ${arg}`);
+    }
+  }
+  return options;
+}
+
+function normaliseCandidate(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const address = ethers.getAddress(value);
+    return address === ethers.ZeroAddress ? undefined : address;
+  } catch (_) {
+    throw new Error(`Invalid address ${value}`);
+  }
+}
+
+function pickTarget(
+  moduleKey: string,
+  type: ModuleType,
+  override: ModuleOverride | undefined,
+  cli: CliOptions,
+  ownerConfig: OwnerControlConfig,
+  tokenConfig: ReturnType<typeof loadTokenConfig>['config']
+): { value?: string; source?: string } {
+  const candidates: { value?: string; source: string }[] = [];
+
+  if (type === 'governable') {
+    candidates.push(
+      {
+        value: override?.governance,
+        source: `owner-control.modules.${moduleKey}.governance`,
+      },
+      { value: cli.governance, source: '--governance' },
+      { value: ownerConfig.governance, source: 'owner-control.governance' },
+      {
+        value: override?.owner,
+        source: `owner-control.modules.${moduleKey}.owner`,
+      },
+      { value: cli.owner, source: '--owner' },
+      { value: ownerConfig.owner, source: 'owner-control.owner' },
+      {
+        value: tokenConfig.governance?.timelock,
+        source: 'agialpha.governance.timelock',
+      },
+      {
+        value: tokenConfig.governance?.govSafe,
+        source: 'agialpha.governance.govSafe',
+      }
+    );
+  } else {
+    candidates.push(
+      {
+        value: override?.owner,
+        source: `owner-control.modules.${moduleKey}.owner`,
+      },
+      { value: cli.owner, source: '--owner' },
+      { value: ownerConfig.owner, source: 'owner-control.owner' },
+      {
+        value: override?.governance,
+        source: `owner-control.modules.${moduleKey}.governance`,
+      },
+      { value: cli.governance, source: '--governance' },
+      { value: ownerConfig.governance, source: 'owner-control.governance' },
+      {
+        value: tokenConfig.governance?.timelock,
+        source: 'agialpha.governance.timelock',
+      },
+      {
+        value: tokenConfig.governance?.govSafe,
+        source: 'agialpha.governance.govSafe',
+      }
+    );
+  }
+
+  for (const candidate of candidates) {
+    if (!candidate.value) {
+      continue;
+    }
+    const normalised = normaliseCandidate(candidate.value);
+    if (normalised) {
+      return { value: normalised, source: candidate.source };
+    }
+  }
+  return {};
+}
+
+async function readAddress(
+  contract: Contract,
+  method: string
+): Promise<string | undefined> {
+  try {
+    const value = await (contract as any)[method]();
+    if (typeof value === 'string') {
+      return ethers.getAddress(value);
+    }
+  } catch (_) {
+    // ignore
+  }
+  return undefined;
+}
+
+function determineModuleDefinition(
+  moduleKey: string,
+  override: ModuleOverride | undefined
+): ModuleDefinition {
+  const base = DEFAULT_MODULES[moduleKey];
+  const typeCandidate =
+    (override?.type as ModuleType | undefined) || base?.type;
+  if (!typeCandidate) {
+    throw new Error(
+      `Module ${moduleKey} is unknown. Specify type in owner-control configuration.`
+    );
+  }
+  const label = override?.label || base?.label || moduleKey;
+  return { key: moduleKey, label, type: typeCandidate };
+}
+
+async function buildRotationPlan(
+  cli: CliOptions,
+  ownerConfig: OwnerControlConfig,
+  tokenConfig: ReturnType<typeof loadTokenConfig>['config']
+): Promise<RotationPlan> {
+  const plan: RotationPlan = {
+    network: network.name,
+    chainId: Number(network.config?.chainId || 0) || undefined,
+    tokenConfigPath: '',
+    ownerControlPath: '',
+    actions: [],
+    pendingAcceptances: [],
+    missingTargets: [],
+    missingAddresses: [],
+    skipped: [],
+    upToDate: [],
+  };
+
+  const ownerModules = ownerConfig.modules || {};
+  const moduleKeys = new Set([
+    ...Object.keys(DEFAULT_MODULES),
+    ...Object.keys(ownerModules),
+  ]);
+
+  for (const moduleKey of moduleKeys) {
+    const override = ownerModules[moduleKey] as ModuleOverride | undefined;
+    if (override?.skip) {
+      plan.skipped.push({
+        moduleKey,
+        moduleName: determineModuleDefinition(moduleKey, override).label,
+        reason: 'Skipped via owner-control configuration',
+      });
+      continue;
+    }
+
+    const definition = determineModuleDefinition(moduleKey, override);
+    const moduleName = definition.label;
+    const type = definition.type;
+
+    const addressCandidate =
+      override?.address ||
+      tokenConfig.modules?.[moduleKey] ||
+      tokenConfig.contracts?.[moduleKey];
+
+    const moduleAddress = normaliseCandidate(addressCandidate);
+    if (!moduleAddress) {
+      plan.missingAddresses.push({
+        moduleKey,
+        moduleName,
+        reason: 'Missing contract address in configuration',
+      });
+      continue;
+    }
+
+    const code = await ethers.provider.getCode(moduleAddress);
+    if (!code || code === '0x') {
+      plan.missingAddresses.push({
+        moduleKey,
+        moduleName,
+        reason: `No contract deployed at ${moduleAddress}`,
+      });
+      continue;
+    }
+
+    const desired = pickTarget(
+      moduleKey,
+      type,
+      override,
+      cli,
+      ownerConfig,
+      tokenConfig
+    );
+
+    if (!desired.value) {
+      plan.missingTargets.push({
+        moduleKey,
+        moduleName,
+        reason: 'No governance/owner target configured',
+      });
+      continue;
+    }
+
+    const abi = ABI_BY_TYPE[type];
+    const contract = await ethers.getContractAt(abi, moduleAddress);
+    const currentOwner = await readAddress(contract, 'owner');
+    const pendingOwner =
+      type === 'governable'
+        ? undefined
+        : await readAddress(contract, 'pendingOwner');
+
+    if (currentOwner && sameAddress(currentOwner, desired.value)) {
+      plan.upToDate.push({
+        moduleKey,
+        moduleName,
+        address: moduleAddress,
+        owner: currentOwner,
+      });
+      continue;
+    }
+
+    if (
+      type === 'ownable2step' &&
+      pendingOwner &&
+      sameAddress(pendingOwner, desired.value) &&
+      !sameAddress(currentOwner, desired.value)
+    ) {
+      plan.pendingAcceptances.push({
+        moduleKey,
+        moduleName,
+        address: moduleAddress,
+        pendingOwner,
+      });
+      continue;
+    }
+
+    const method: RotationAction['method'] =
+      type === 'governable' ? 'setGovernance' : 'transferOwnership';
+    const args: [string] = [desired.value];
+    const calldata = contract.interface.encodeFunctionData(method, args);
+
+    const notes: string[] = [];
+    if (desired.source) {
+      notes.push(`Target derived from ${desired.source}`);
+    }
+    if (override?.notes) {
+      notes.push(...override.notes.map((note) => String(note)));
+    }
+    if (type === 'ownable2step') {
+      notes.push(
+        'Transfer requires acceptOwnership() by the new owner after execution.'
+      );
+    }
+    if (!currentOwner) {
+      notes.push(
+        'Current owner() could not be read; ensure signer has control.'
+      );
+    }
+
+    plan.actions.push({
+      moduleKey,
+      moduleName,
+      type,
+      address: moduleAddress,
+      method,
+      args,
+      currentOwner,
+      desiredOwner: desired.value,
+      pendingOwner,
+      targetSource: desired.source,
+      notes,
+      contract,
+      calldata,
+    });
+  }
+
+  return plan;
+}
+
+function formatAddress(address?: string): string {
+  if (!address) {
+    return 'unknown';
+  }
+  const normalised = ethers.getAddress(address);
+  if (normalised === ethers.ZeroAddress) {
+    return `${normalised} (zero address)`;
+  }
+  return normalised;
+}
+
+function describePlan(plan: RotationPlan) {
+  console.log('Governance & Ownership Rotation Plan');
+  console.log('====================================');
+  console.log(`Network: ${plan.network}`);
+  if (plan.chainId !== undefined) {
+    console.log(`Chain ID: ${plan.chainId}`);
+  }
+  if (plan.signer) {
+    console.log(`Signer: ${plan.signer}`);
+  }
+  console.log('');
+  console.log(`Actions required: ${plan.actions.length}`);
+  if (plan.upToDate.length > 0) {
+    console.log(`Modules already aligned: ${plan.upToDate.length}`);
+  }
+  if (plan.pendingAcceptances.length > 0) {
+    console.log(
+      `Pending acceptOwnership calls: ${plan.pendingAcceptances.length}`
+    );
+  }
+  if (plan.missingTargets.length > 0) {
+    console.log(`Modules missing target owner: ${plan.missingTargets.length}`);
+  }
+  if (plan.missingAddresses.length > 0) {
+    console.log(
+      `Modules missing address deployment: ${plan.missingAddresses.length}`
+    );
+  }
+  if (plan.skipped.length > 0) {
+    console.log(`Modules skipped: ${plan.skipped.length}`);
+  }
+  console.log('');
+
+  plan.actions.forEach((action, index) => {
+    console.log(`${index + 1}. ${action.moduleName} (${action.type})`);
+    console.log(`   Address: ${action.address}`);
+    if (action.currentOwner) {
+      console.log(`   Current owner: ${formatAddress(action.currentOwner)}`);
+    } else {
+      console.log('   Current owner: unavailable');
+    }
+    console.log(`   Desired owner: ${formatAddress(action.desiredOwner)}`);
+    console.log(
+      `   Call: ${action.method}(${describeArgs(action.args as any[])})`
+    );
+    console.log(`   Calldata: ${action.calldata}`);
+    action.notes.forEach((note) => {
+      console.log(`   Note: ${note}`);
+    });
+    console.log('');
+  });
+
+  if (plan.pendingAcceptances.length > 0) {
+    console.log('Pending acceptOwnership required:');
+    plan.pendingAcceptances.forEach((entry) => {
+      console.log(
+        ` - ${entry.moduleName} (${entry.address}) waiting for ${formatAddress(
+          entry.pendingOwner
+        )} to accept`
+      );
+    });
+    console.log('');
+  }
+
+  if (plan.missingTargets.length > 0) {
+    console.log('Missing target owner configuration:');
+    plan.missingTargets.forEach((entry) => {
+      console.log(` - ${entry.moduleName}: ${entry.reason}`);
+    });
+    console.log('');
+  }
+
+  if (plan.missingAddresses.length > 0) {
+    console.log('Missing or invalid contract addresses:');
+    plan.missingAddresses.forEach((entry) => {
+      console.log(` - ${entry.moduleName}: ${entry.reason}`);
+    });
+    console.log('');
+  }
+}
+
+interface SafeTransactionEntry {
+  to: string;
+  value: string;
+  data: string;
+  description?: string;
+  contractInputsValues?: Record<string, string>;
+  contractMethod?: {
+    name: string;
+    payable: boolean;
+    stateMutability: string;
+    inputs: { name: string; type: string }[];
+  };
+}
+
+interface SafeBundle {
+  version: string;
+  chainId: number;
+  createdAt: string;
+  meta: {
+    name: string;
+    description: string;
+    txBuilderVersion: string;
+  };
+  transactions: SafeTransactionEntry[];
+}
+
+async function writeJsonFile(
+  destination: string,
+  value: unknown,
+  label: string
+) {
+  const dir = path.dirname(destination);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    destination,
+    `${JSON.stringify(value, null, 2)}\n`,
+    'utf8'
+  );
+  console.log(`${label} written to ${destination}`);
+}
+
+async function writeSafeBundle(
+  plan: RotationPlan,
+  actions: RotationAction[],
+  destination: string,
+  options: { name?: string; description?: string }
+) {
+  if (!plan.chainId) {
+    throw new Error('Chain ID required for Safe transaction bundle.');
+  }
+
+  const transactions: SafeTransactionEntry[] = actions.map((action) => {
+    const metadata = FUNCTION_METADATA[action.method];
+    const inputsValues: Record<string, string> = {};
+    inputsValues[metadata.inputName] = action.desiredOwner;
+    return {
+      to: action.address,
+      value: '0',
+      data: action.calldata,
+      description: `${action.moduleName}: ${action.method}`,
+      contractInputsValues: inputsValues,
+      contractMethod: {
+        name: action.method,
+        payable: false,
+        stateMutability: 'nonpayable',
+        inputs: [{ name: metadata.inputName, type: 'address' }],
+      },
+    };
+  });
+
+  const bundle: SafeBundle = {
+    version: '1.0',
+    chainId: plan.chainId,
+    createdAt: new Date().toISOString(),
+    meta: {
+      name: options.name || 'AGIJobs Governance Rotation',
+      description:
+        options.description ||
+        'Autogenerated multisig bundle for governance and ownership rotation.',
+      txBuilderVersion: '1.16.6',
+    },
+    transactions,
+  };
+
+  await writeJsonFile(destination, bundle, 'Safe transaction bundle');
+}
+
+async function executeActions(actions: RotationAction[]) {
+  if (actions.length === 0) {
+    console.log('No governance updates to execute.');
+    return;
+  }
+  console.log('\nSubmitting transactions...');
+  for (const action of actions) {
+    console.log(`→ ${action.moduleName}: ${action.method}`);
+    const tx = await (action.contract as any)[action.method](...action.args);
+    console.log(`   Tx hash: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (receipt?.status !== 1n) {
+      throw new Error(`Transaction for ${action.moduleName} failed`);
+    }
+    console.log('   Confirmed');
+  }
+}
+
+function serialisePlanForJson(plan: RotationPlan) {
+  return {
+    network: plan.network,
+    chainId: plan.chainId,
+    signer: plan.signer,
+    actions: plan.actions.map((action) => ({
+      moduleKey: action.moduleKey,
+      moduleName: action.moduleName,
+      type: action.type,
+      address: action.address,
+      method: action.method,
+      args: action.args,
+      currentOwner: action.currentOwner,
+      desiredOwner: action.desiredOwner,
+      pendingOwner: action.pendingOwner,
+      targetSource: action.targetSource,
+      notes: action.notes,
+      calldata: action.calldata,
+    })),
+    pendingAcceptances: plan.pendingAcceptances,
+    missingTargets: plan.missingTargets,
+    missingAddresses: plan.missingAddresses,
+    skipped: plan.skipped,
+    upToDate: plan.upToDate,
+  };
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const { config: tokenConfig, path: tokenConfigPath } = loadTokenConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
+  const { config: ownerConfig, path: ownerConfigPath } = loadOwnerControlConfig(
+    {
+      network: network.name,
+      chainId: network.config?.chainId,
+      path: cli.configPath,
+    }
+  );
+
+  const plan = await buildRotationPlan(cli, ownerConfig, tokenConfig);
+  plan.tokenConfigPath = tokenConfigPath;
+  plan.ownerControlPath = ownerConfigPath;
+
+  const signers = await ethers.getSigners();
+  if (signers.length > 0) {
+    plan.signer = await signers[0].getAddress();
+  }
+
+  if (cli.json) {
+    console.log(JSON.stringify(serialisePlanForJson(plan), null, 2));
+    return;
+  }
+
+  describePlan(plan);
+
+  if (cli.safeOut) {
+    await writeSafeBundle(plan, plan.actions, cli.safeOut, {
+      name: cli.safeName,
+      description: cli.safeDescription,
+    });
+  }
+
+  if (plan.actions.length === 0) {
+    console.log(
+      'All configured modules already target the desired governance.'
+    );
+    return;
+  }
+
+  if (!cli.execute) {
+    console.log(
+      '\nDry run complete. Re-run with --execute once ready to submit transactions.'
+    );
+    return;
+  }
+
+  if (!plan.signer) {
+    throw new Error('No signer available to execute transactions.');
+  }
+
+  for (const action of plan.actions) {
+    if (action.currentOwner && !sameAddress(action.currentOwner, plan.signer)) {
+      throw new Error(
+        `${action.moduleName}: signer ${plan.signer} does not control current owner ${action.currentOwner}`
+      );
+    }
+  }
+
+  await executeActions(plan.actions);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add an owner-control configuration template and loader support for governance rotation
- introduce a rotateGovernance Hardhat script that plans ownership updates and can emit Safe bundles
- document the new workflow and expose an npm helper for owners to preview or execute rotations

## Testing
- npm run owner:rotate -- --network hardhat
- npm run lint:check *(fails: existing solhint and prettier violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8430a206c8333bbdc4796a572e0d7