### PR TITLE
Add emergency pause toggles to StakeManager applyConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ The contract owner can retune live systems from block‑explorer **Write** tabs:
 - **Merkle roots** – `IdentityRegistry.setAgentMerkleRoot` / `setValidatorMerkleRoot`.
 - **Timing & fees** – `ValidationModule.setCommitWindow`, `setRevealWindow`, `setValidatorBounds`, and `DisputeModule.setDisputeFee`.
 - **Routing & policies** – `JobRegistry.setModules`, `setFeePool`, `setTaxPolicy`, then `DisputeModule.setTaxPolicy`.
-- **Aggregated updates** – `StakeManager.applyConfiguration(ConfigUpdate, TreasuryAllowlistUpdate[])` and `JobRegistry.applyConfiguration(ConfigUpdate, AcknowledgerUpdate[], address[])` bundle multi-parameter governance changes with the same guards as the individual setters. Review the [institutional playbook](docs/production/institutional-truffle-mainnet-playbook.md#7a-one-transaction-owner-bundles) for step-by-step Safe instructions.
+- **Aggregated updates** – `StakeManager.applyConfiguration(ConfigUpdate, TreasuryAllowlistUpdate[])` (now with built-in pause/unpause toggles) and `JobRegistry.applyConfiguration(ConfigUpdate, AcknowledgerUpdate[], address[])` bundle multi-parameter governance changes with the same guards as the individual setters. Review the [institutional playbook](docs/production/institutional-truffle-mainnet-playbook.md#7a-one-transaction-owner-bundles) for step-by-step Safe instructions.
 
 Use `npm run owner:wizard` for an interactive, non-destructive configuration walkthrough. The wizard:
 

--- a/docs/production/institutional-truffle-mainnet-playbook.md
+++ b/docs/production/institutional-truffle-mainnet-playbook.md
@@ -168,7 +168,7 @@ flowchart LR
         SMCFG[ConfigUpdate
         • treasury & allowlist
         • fee/burn/validator %
-        • pauser & auto-tuning
+        • pauser, pause/unpause & auto-tuning
         • job/dispute modules]
         AL[AllowlistUpdate[]]
         SMCFG -->|1.| StakeManager
@@ -192,7 +192,7 @@ flowchart LR
     JRCFG -.via Safe bundle .-> GOV
 ```
 
-**StakeManager** – call `applyConfiguration(ConfigUpdate, TreasuryAllowlistUpdate[])` when you need to adjust protocol fees, pauser keys, dispute modules, or auto-stake tuning thresholds. Populate the `allowlistUpdates` array first so new treasury addresses are authorised before being set.
+**StakeManager** – call `applyConfiguration(ConfigUpdate, TreasuryAllowlistUpdate[])` when you need to adjust protocol fees, pauser keys, pause/unpause the system, dispute modules, or auto-stake tuning thresholds. Populate the `allowlistUpdates` array first so new treasury addresses are authorised before being set.
 
 **JobRegistry** – call `applyConfiguration(ConfigUpdate, AcknowledgerUpdate[], address[] ackModules)` to refresh ENS roots, rotate modules, update fee splits, or bump the agent authorisation cache. Passing `setModuleBundle=true` rewires the entire module graph and validates every version atomically.
 


### PR DESCRIPTION
## Summary
- extend StakeManager ConfigUpdate with pause and unpause flags that can be bundled with other governance actions
- emit pause/unpause status in the ConfigurationApplied event and document the new capability in the README and operational playbook

## Testing
- npx hardhat compile

------
https://chatgpt.com/codex/tasks/task_e_68d8463ed3888333a75d66c980e05fcd