### PR TITLE
Add dedicated thermostat update helper

### DIFF
--- a/docs/thermodynamics-operations.md
+++ b/docs/thermodynamics-operations.md
@@ -13,6 +13,21 @@ only submits transactions when `--execute` is supplied. It covers the
 `RewardEngineMB` distribution, settlers, thermodynamic constants and the
 `Thermostat` PID loop.
 
+### Thermostat-only adjustments
+
+Governance teams that only need to retune the `Thermostat` can use the focused
+helper instead of running the full thermodynamics pipeline:
+
+```
+AGIALPHA_NETWORK=mainnet npx hardhat run scripts/v2/updateThermostat.ts --network mainnet
+```
+
+The script reads either `config/thermostat.json` or the thermostat section of
+`config/thermodynamics.json`, prints the planned changes and supports `--execute`
+and `--json` just like the broader helper. It automatically falls back to the
+thermostat address recorded in `config/agialpha.json` or the reward-engine
+section when the thermostat config omits an explicit address.
+
 ## Configuration file
 
 Populate `config/thermodynamics.json` (or the

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "identity:register": "npx ts-node scripts/identity/manageEnsKeys.ts",
     "identity:update": "npx hardhat run scripts/v2/updateIdentityRegistry.ts",
     "reward-engine:update": "npx hardhat run scripts/v2/updateRewardEngine.ts",
+    "thermostat:update": "npx hardhat run scripts/v2/updateThermostat.ts",
     "hamiltonian:update": "npx hardhat run scripts/v2/updateHamiltonianMonitor.ts",
     "platform:registry:update": "npx hardhat run scripts/v2/updatePlatformRegistry.ts",
     "namehash:mainnet": "node scripts/compute-namehash.js deployment-config/mainnet.json",

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -288,6 +288,14 @@ export interface ThermodynamicsConfigResult {
   network?: SupportedNetwork;
 }
 
+export interface ThermostatConfigResult {
+  config: ThermostatConfigInput;
+  path: string;
+  network?: SupportedNetwork;
+  source?: 'thermostat' | 'thermodynamics';
+  rewardEngineThermostat?: string;
+}
+
 export interface EnsRootConfig {
   label: string;
   name: string;
@@ -445,6 +453,9 @@ export function loadOwnerControlConfig(
 export function loadThermodynamicsConfig(
   options?: LoadOptions
 ): ThermodynamicsConfigResult;
+export function loadThermostatConfig(
+  options?: LoadOptions & { path?: string }
+): ThermostatConfigResult;
 export function loadRewardEngineConfig(
   options?: LoadOptions
 ): RewardEngineConfigResult;

--- a/scripts/v2/updateThermostat.ts
+++ b/scripts/v2/updateThermostat.ts
@@ -1,0 +1,193 @@
+import { ethers, network } from 'hardhat';
+import type { Contract } from 'ethers';
+import { loadThermostatConfig, loadTokenConfig } from '../config';
+import { buildThermostatPlan } from './lib/thermostatPlan';
+import { describeArgs, sameAddress } from './lib/utils';
+
+type ThermostatConfig = ReturnType<typeof loadThermostatConfig>['config'];
+
+interface CliOptions {
+  execute: boolean;
+  configPath?: string;
+  thermostatAddress?: string;
+  json?: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false, json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--execute') {
+      options.execute = true;
+    } else if (arg === '--config') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--config requires a file path');
+      }
+      options.configPath = value;
+      i += 1;
+    } else if (arg === '--thermostat') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--thermostat requires an address');
+      }
+      options.thermostatAddress = value;
+      i += 1;
+    } else if (arg === '--json') {
+      options.json = true;
+    }
+  }
+  return options;
+}
+
+function resolveThermostatAddress(
+  cli: CliOptions,
+  thermostatConfig: ThermostatConfig,
+  linkedRewardEngineThermostat: string | undefined,
+  tokenModules?: Record<string, string | undefined>
+): string {
+  const candidate =
+    cli.thermostatAddress ||
+    thermostatConfig.address ||
+    linkedRewardEngineThermostat ||
+    tokenModules?.thermostat;
+
+  if (!candidate) {
+    throw new Error('Thermostat address is not configured');
+  }
+
+  const address = ethers.getAddress(candidate);
+  if (address === ethers.ZeroAddress) {
+    throw new Error('Thermostat address cannot be the zero address');
+  }
+  return address;
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+
+  const { config: tokenConfig } = loadTokenConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
+
+  const {
+    config: thermostatConfig,
+    path: thermostatConfigPath,
+    source: configSource,
+    rewardEngineThermostat,
+  } = loadThermostatConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+    path: cli.configPath,
+  });
+
+  const thermostatAddress = resolveThermostatAddress(
+    cli,
+    thermostatConfig,
+    rewardEngineThermostat,
+    tokenConfig.modules
+  );
+
+  const thermostatRead = (await ethers.getContractAt(
+    'contracts/v2/Thermostat.sol:Thermostat',
+    thermostatAddress
+  )) as Contract;
+
+  const signer = await ethers.getSigner();
+  const signerAddress = await signer.getAddress();
+  const governanceAddress = await thermostatRead.owner();
+
+  if (cli.execute && !sameAddress(governanceAddress, signerAddress)) {
+    throw new Error(
+      `Signer ${signerAddress} is not the governance owner ${governanceAddress}`
+    );
+  }
+
+  if (!sameAddress(governanceAddress, signerAddress)) {
+    console.warn(
+      `Warning: connected signer ${signerAddress} is not the governance owner ${governanceAddress}. Running in dry-run mode.`
+    );
+  }
+
+  const thermostat = thermostatRead.connect(signer);
+
+  const plan = await buildThermostatPlan({
+    thermostat,
+    config: thermostatConfig,
+    configPath: thermostatConfigPath,
+  });
+
+  if (cli.json) {
+    const { contract: _contract, iface: _iface, ...serialisable } = plan;
+    console.log(
+      JSON.stringify(
+        {
+          ...serialisable,
+          source: configSource,
+          governance: governanceAddress,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log('Thermostat:', thermostatAddress);
+  console.log('Configuration file:', thermostatConfigPath);
+  if (configSource === 'thermodynamics') {
+    console.log('Configuration source: thermodynamics (thermostat section)');
+  } else {
+    console.log('Configuration source: thermostat');
+  }
+
+  if (plan.actions.length === 0) {
+    console.log('All tracked parameters already match the configuration.');
+    return;
+  }
+
+  console.log(`Planned actions (${plan.actions.length}):`);
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
+    console.log(`\n${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      console.log(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      console.log(`   Desired: ${action.desired}`);
+    }
+    action.notes?.forEach((note) => {
+      console.log(`   Note: ${note}`);
+    });
+    console.log(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    if (data) {
+      console.log(`   Calldata: ${data}`);
+    }
+  });
+
+  if (!cli.execute || !sameAddress(governanceAddress, signerAddress)) {
+    console.log(
+      '\nDry run complete. Re-run with --execute once governance is ready to submit transactions.'
+    );
+    return;
+  }
+
+  console.log('\nSubmitting transactions...');
+  for (const action of plan.actions) {
+    console.log(`Executing ${action.method}...`);
+    const tx = await (thermostat as any)[action.method](...action.args);
+    console.log(`   Tx hash: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (receipt?.status !== 1n) {
+      throw new Error(`Transaction for ${action.method} failed`);
+    }
+    console.log('   Confirmed');
+  }
+  console.log('All transactions confirmed.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add reusable thermostat config normalisation and loader utilities
- introduce a focused Hardhat script for applying thermostat updates and expose it via npm
- document the lighter-weight governance workflow for thermostat-only changes

## Testing
- `npx tsc --noEmit` *(fails: pre-existing type errors across unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d84a70ec448333a3876e6f07764f91