### PR TITLE
Remove redundant onlyGovernor modifier alias

### DIFF
--- a/contracts/v2/Governable.sol
+++ b/contracts/v2/Governable.sol
@@ -43,11 +43,6 @@ abstract contract Governable {
         _;
     }
 
-    modifier onlyGovernor() {
-        _checkGovernor();
-        _;
-    }
-
     function setGovernance(address _governance) public onlyGovernance {
         _setGovernance(_governance);
     }

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -32,7 +32,7 @@ executed.
    );
    ```
 3. After deployment the timelock or multisig becomes the only account
-   capable of invoking functions marked `onlyGovernor`.
+   capable of invoking functions marked `onlyGovernance`.
 
 ## Upgrading through the timelock
 


### PR DESCRIPTION
## Summary
- remove the unused `onlyGovernor` modifier from `Governable` so there is a single authoritative access control modifier
- update the governance documentation to reference the surviving `onlyGovernance` modifier

## Testing
- npx hardhat test test/v2/GovernanceHandover.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d85006e2ac8333a69ce428e3a55494