### PR TITLE
Make JobEscrow timeout configurable by owner

### DIFF
--- a/contracts/v2/interfaces/IJobEscrow.sol
+++ b/contracts/v2/interfaces/IJobEscrow.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.25;
 /// @notice Minimal interface for job escrow helpers
 interface IJobEscrow {
     event RewardPaid(uint256 indexed jobId, address indexed operator, uint256 amount);
+    event ResultTimeoutUpdated(uint256 timeout);
     /// @notice Post a new job and escrow the reward
     function postJob(uint256 reward, string calldata data, bytes32 seed) external returns (uint256);
 
@@ -19,4 +20,7 @@ interface IJobEscrow {
 
     /// @notice Acknowledge the tax policy and accept the job result
     function acknowledgeAndAcceptResult(uint256 jobId) external;
+
+    /// @notice Update the result acceptance timeout window.
+    function setResultTimeout(uint256 timeout) external;
 }


### PR DESCRIPTION
## Summary
- allow JobEscrow owners to tune the result acceptance window through a configurable timeout and dedicated event
- surface the timeout setter and event on the public IJobEscrow interface for downstream tooling
- harden the JobEscrow tests to reset token balances and cover the new governance flow

## Testing
- npx hardhat test test/v2/JobEscrow.test.js --no-compile

------
https://chatgpt.com/codex/tasks/task_e_68d85803818c83339bb8c027e6e5d207