### PR TITLE
Add energy oracle signer tooling and config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ npx hardhat run scripts/v2/updateHamiltonianMonitor.ts --network <network>
 
 Pass `--execute` once the dry run looks correct to submit the queued actions. Use `resetHistory: true` in the config to wipe accumulated observations and start fresh—either on its own or combined with a window change. The helper automatically skips recording duplicate observations if they already match the most recent on-chain history.
 
+### Energy oracle signer management
+
+Governance controls which off-chain measurement nodes can sign energy attestations. Update [`config/energy-oracle.json`](config/energy-oracle.json) (or its per-network override) with the authorised signer list. Run the helper to review the planned changes and, once satisfied, apply them on-chain:
+
+```bash
+npx hardhat run scripts/v2/updateEnergyOracle.ts --network <network>
+```
+
+Pass `--execute` to submit the transactions from the governance signer or timelock. The helper prints the existing signer set, highlights additions and removals, and supports `--json` for automation workflows. By default it keeps currently authorised signers that are not listed in the configuration; add `"retainUnknown": false` to prune any stale entries automatically.
+
 ### Deploy defaults
 
 Spin up the full stack with a single helper script:

--- a/config/energy-oracle.json
+++ b/config/energy-oracle.json
@@ -1,0 +1,4 @@
+{
+  "signers": [],
+  "retainUnknown": true
+}

--- a/contracts/v2/EnergyOracle.sol
+++ b/contracts/v2/EnergyOracle.sol
@@ -5,14 +5,19 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import {IEnergyOracle} from "./interfaces/IEnergyOracle.sol";
 import {Governable} from "./Governable.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /// @title EnergyOracle
 /// @notice Verifies signed energy attestations used for reward settlement.
 contract EnergyOracle is EIP712, Governable, IEnergyOracle {
     using ECDSA for bytes32;
+    using EnumerableSet for EnumerableSet.AddressSet;
 
     /// @dev Thrown when batched signer updates receive mismatched array lengths.
     error LengthMismatch();
+
+    /// @dev Thrown when attempting to manage the zero address as a signer.
+    error ZeroSigner();
 
     /// @notice Emitted when a signer is added or removed from the oracle.
     /// @param signer The address of the signer that was updated.
@@ -25,6 +30,7 @@ contract EnergyOracle is EIP712, Governable, IEnergyOracle {
 
     mapping(address => bool) public signers;
     mapping(address => uint256) public nonces;
+    EnumerableSet.AddressSet private signerSet;
 
     constructor(address _governance) EIP712("EnergyOracle", "1") Governable(_governance) {}
 
@@ -32,7 +38,13 @@ contract EnergyOracle is EIP712, Governable, IEnergyOracle {
     /// @param signer The address of the signer to update.
     /// @param allowed Whether the signer is allowed to sign attestations.
     function setSigner(address signer, bool allowed) external onlyGovernance {
+        if (signer == address(0)) revert ZeroSigner();
         signers[signer] = allowed;
+        if (allowed) {
+            signerSet.add(signer);
+        } else {
+            signerSet.remove(signer);
+        }
         emit SignerUpdated(signer, allowed);
     }
 
@@ -48,10 +60,32 @@ contract EnergyOracle is EIP712, Governable, IEnergyOracle {
 
         for (uint256 i = 0; i < length; ++i) {
             address signer = signers_[i];
+            if (signer == address(0)) revert ZeroSigner();
             bool status = allowed[i];
             signers[signer] = status;
+            if (status) {
+                signerSet.add(signer);
+            } else {
+                signerSet.remove(signer);
+            }
             emit SignerUpdated(signer, status);
         }
+    }
+
+    /// @notice Returns true if the given account is authorised to sign attestations.
+    /// @param account The address to query.
+    function isSigner(address account) external view returns (bool) {
+        return signers[account];
+    }
+
+    /// @notice Returns the total number of authorised signers.
+    function signerCount() external view returns (uint256) {
+        return signerSet.length();
+    }
+
+    /// @notice Returns the full list of authorised signers.
+    function getSigners() external view returns (address[] memory) {
+        return signerSet.values();
     }
 
     /// @inheritdoc IEnergyOracle

--- a/contracts/v2/interfaces/IEnergyOracle.sol
+++ b/contracts/v2/interfaces/IEnergyOracle.sol
@@ -18,5 +18,14 @@ interface IEnergyOracle {
 
     /// @return signer Address of oracle signer if signature valid, zero address otherwise
     function verify(Attestation calldata att, bytes calldata sig) external returns (address signer);
+
+    /// @notice Returns whether `account` is authorised to sign attestations.
+    function isSigner(address account) external view returns (bool);
+
+    /// @notice Returns the total number of authorised signers.
+    function signerCount() external view returns (uint256);
+
+    /// @notice Returns the list of all authorised signers.
+    function getSigners() external view returns (address[] memory);
 }
 

--- a/contracts/v2/mocks/RewardEngineMBMocks.sol
+++ b/contracts/v2/mocks/RewardEngineMBMocks.sol
@@ -46,4 +46,16 @@ contract MockEnergyOracle is IEnergyOracle {
     function verify(Attestation calldata att, bytes calldata) external pure override returns (address) {
         return att.user;
     }
+
+    function isSigner(address) external pure override returns (bool) {
+        return true;
+    }
+
+    function signerCount() external pure override returns (uint256) {
+        return 0;
+    }
+
+    function getSigners() external pure override returns (address[] memory) {
+        return new address[](0);
+    }
 }

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -153,6 +153,18 @@ export interface FeePoolConfigResult {
   network?: SupportedNetwork;
 }
 
+export interface EnergyOracleConfig {
+  signers: string[];
+  retainUnknown?: boolean;
+  [key: string]: unknown;
+}
+
+export interface EnergyOracleConfigResult {
+  config: EnergyOracleConfig;
+  path: string;
+  network?: SupportedNetwork;
+}
+
 export interface PlatformIncentivesConfig {
   address?: string;
   stakeManager?: string | null;
@@ -438,6 +450,9 @@ export function loadStakeManagerConfig(
   options?: LoadOptions
 ): StakeManagerConfigResult;
 export function loadFeePoolConfig(options?: LoadOptions): FeePoolConfigResult;
+export function loadEnergyOracleConfig(
+  options?: LoadOptions
+): EnergyOracleConfigResult;
 export function loadPlatformIncentivesConfig(
   options?: LoadOptions
 ): PlatformIncentivesConfigResult;

--- a/scripts/v2/lib/energyOraclePlan.ts
+++ b/scripts/v2/lib/energyOraclePlan.ts
@@ -1,0 +1,96 @@
+import type { Contract } from 'ethers';
+import { ethers } from 'ethers';
+import type { EnergyOracleConfig } from '../../config';
+import { ModulePlan, PlannedAction } from './types';
+
+export interface EnergyOraclePlanInput {
+  oracle: Contract;
+  config: EnergyOracleConfig;
+  configPath?: string;
+  ownerAddress: string;
+  retainUnknown?: boolean;
+}
+
+function dedupeSorted(addresses: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  addresses.forEach((addr) => {
+    const normalised = ethers.getAddress(addr);
+    if (!seen.has(normalised)) {
+      seen.add(normalised);
+      result.push(normalised);
+    }
+  });
+  result.sort((a, b) => a.localeCompare(b));
+  return result;
+}
+
+export async function buildEnergyOraclePlan(
+  input: EnergyOraclePlanInput
+): Promise<ModulePlan> {
+  const { oracle, config, configPath, ownerAddress } = input;
+  const retainUnknown =
+    input.retainUnknown ?? config.retainUnknown ?? false;
+
+  const [oracleAddress, currentSignersRaw] = await Promise.all([
+    oracle.getAddress(),
+    oracle.getSigners(),
+  ]);
+
+  const currentSigners = dedupeSorted(currentSignersRaw);
+  const desiredSigners = dedupeSorted(config.signers ?? []);
+
+  const currentSet = new Set(currentSigners);
+  const desiredSet = new Set(desiredSigners);
+
+  const actions: PlannedAction[] = [];
+  const warnings: string[] = [];
+
+  desiredSigners.forEach((addr) => {
+    if (!currentSet.has(addr)) {
+      actions.push({
+        label: `Authorize signer ${addr}`,
+        method: 'setSigner',
+        args: [addr, true],
+        current: 'unauthorised',
+        desired: 'authorised',
+      });
+    }
+  });
+
+  if (!retainUnknown) {
+    currentSigners.forEach((addr) => {
+      if (!desiredSet.has(addr)) {
+        actions.push({
+          label: `Revoke signer ${addr}`,
+          method: 'setSigner',
+          args: [addr, false],
+          current: 'authorised',
+          desired: 'revoked',
+        });
+      }
+    });
+  } else if (desiredSigners.length === 0 && currentSigners.length > 0) {
+    warnings.push(
+      'retainUnknown is enabled and no desired signers are specified; existing signers will be left unchanged.'
+    );
+  }
+
+  const plan: ModulePlan = {
+    module: 'EnergyOracle',
+    address: ethers.getAddress(oracleAddress),
+    actions,
+    configPath,
+    warnings: warnings.length ? warnings : undefined,
+    metadata: {
+      ownerAddress: ethers.getAddress(ownerAddress),
+      retainUnknown,
+      currentSigners,
+      desiredSigners,
+    },
+    iface: oracle.interface,
+    contract: oracle,
+  };
+
+  return plan;
+}

--- a/scripts/v2/updateEnergyOracle.ts
+++ b/scripts/v2/updateEnergyOracle.ts
@@ -1,0 +1,248 @@
+import { ethers, network } from 'hardhat';
+import type { Contract } from 'ethers';
+import {
+  loadTokenConfig,
+  loadEnergyOracleConfig,
+  type EnergyOracleConfig,
+} from '../config';
+import { buildEnergyOraclePlan } from './lib/energyOraclePlan';
+import { describeArgs, sameAddress } from './lib/utils';
+
+interface CliOptions {
+  execute: boolean;
+  configPath?: string;
+  oracleAddress?: string;
+  json?: boolean;
+  keepExtras?: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--execute') {
+      options.execute = true;
+    } else if (arg === '--config') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--config requires a file path');
+      }
+      options.configPath = value;
+      i += 1;
+    } else if (arg === '--oracle' || arg === '--energy-oracle') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--oracle requires an address');
+      }
+      options.oracleAddress = value;
+      i += 1;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--keep-extras') {
+      options.keepExtras = true;
+    } else if (arg === '--prune-extras' || arg === '--no-keep-extras') {
+      options.keepExtras = false;
+    }
+  }
+  return options;
+}
+
+const ENV_ORACLE_KEYS = [
+  'ENERGY_ORACLE_ADDRESS',
+  'ENERGY_ORACLE',
+  'AGI_ENERGY_ORACLE',
+  'AGJ_ENERGY_ORACLE',
+  'AGIALPHA_ENERGY_ORACLE',
+  'AGIALPHA_ORACLE',
+];
+
+function readEnvOracleCandidate(): string | undefined {
+  for (const key of ENV_ORACLE_KEYS) {
+    const value = process.env[key];
+    if (value !== undefined && value !== null) {
+      const trimmed = String(value).trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function resolveOracleAddress(
+  tokenConfigModules: Record<string, string> | undefined,
+  tokenConfigContracts: Record<string, string> | undefined,
+  cliCandidate?: string,
+  envCandidate?: string
+): string | undefined {
+  if (cliCandidate) {
+    return cliCandidate;
+  }
+  if (envCandidate) {
+    return envCandidate;
+  }
+  if (tokenConfigModules?.energyOracle) {
+    return tokenConfigModules.energyOracle;
+  }
+  if (tokenConfigContracts?.energyOracle) {
+    return tokenConfigContracts.energyOracle;
+  }
+  if (tokenConfigModules?.oracle) {
+    return tokenConfigModules.oracle;
+  }
+  if (tokenConfigContracts?.oracle) {
+    return tokenConfigContracts.oracle;
+  }
+  return undefined;
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+
+  const { config: tokenConfig } = loadTokenConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
+
+  const {
+    config: energyConfig,
+    path: energyConfigPath,
+  }: { config: EnergyOracleConfig; path: string } = loadEnergyOracleConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+    path: cli.configPath,
+  });
+
+  const envOracle = readEnvOracleCandidate();
+  const oracleCandidate = resolveOracleAddress(
+    tokenConfig.modules,
+    tokenConfig.contracts,
+    cli.oracleAddress,
+    envOracle
+  );
+  if (!oracleCandidate) {
+    throw new Error('Energy oracle address is not configured');
+  }
+
+  const energyOracleAddress = ethers.getAddress(oracleCandidate);
+  if (energyOracleAddress === ethers.ZeroAddress) {
+    throw new Error('Energy oracle address cannot be the zero address');
+  }
+
+  const energyOracle = (await ethers.getContractAt(
+    'contracts/v2/EnergyOracle.sol:EnergyOracle',
+    energyOracleAddress
+  )) as Contract;
+
+  const signers = await ethers.getSigners();
+  const signer = signers[0];
+  if (!signer) {
+    throw new Error('No signer accounts available on the selected network');
+  }
+  const signerAddress = await signer.getAddress();
+  const ownerAddress = await energyOracle.owner();
+
+  if (cli.execute && !sameAddress(ownerAddress, signerAddress)) {
+    throw new Error(
+      `Signer ${signerAddress} is not the contract owner ${ownerAddress}`
+    );
+  }
+
+  if (!sameAddress(ownerAddress, signerAddress)) {
+    console.warn(
+      `Warning: connected signer ${signerAddress} is not the contract owner ${ownerAddress}. ` +
+        'Running in dry-run mode.'
+    );
+  }
+
+  const plan = await buildEnergyOraclePlan({
+    oracle: energyOracle,
+    config: energyConfig,
+    configPath: energyConfigPath,
+    ownerAddress,
+    retainUnknown: cli.keepExtras,
+  });
+
+  if (cli.json) {
+    console.log(JSON.stringify(plan, null, 2));
+    return;
+  }
+
+  console.log('EnergyOracle:', energyOracleAddress);
+  console.log('Configuration file:', energyConfigPath);
+  console.log('Governance (owner):', ownerAddress);
+  console.log('Connected signer:', signerAddress);
+
+  if (plan.metadata) {
+    const metadata = plan.metadata as Record<string, unknown>;
+    if (Array.isArray(metadata.currentSigners)) {
+      console.log(
+        `Current signers (${metadata.currentSigners.length}): ${metadata.currentSigners.join(', ')}`
+      );
+    }
+    if (Array.isArray(metadata.desiredSigners)) {
+      console.log(
+        `Desired signers (${metadata.desiredSigners.length}): ${metadata.desiredSigners.join(', ')}`
+      );
+    }
+    if (metadata.retainUnknown !== undefined) {
+      console.log(
+        `Retain unknown signers: ${metadata.retainUnknown ? 'yes' : 'no'}`
+      );
+    }
+  }
+
+  if (plan.warnings?.length) {
+    console.log('\nWarnings:');
+    plan.warnings.forEach((warning) => console.log(` - ${warning}`));
+  }
+
+  if (plan.actions.length === 0) {
+    console.log('All tracked parameters already match the configuration.');
+    return;
+  }
+
+  console.log(`\nPlanned actions (${plan.actions.length}):`);
+  plan.actions.forEach((action, index) => {
+    const data = plan.iface?.encodeFunctionData(action.method, action.args);
+    console.log(`\n${index + 1}. ${action.label}`);
+    if (action.current !== undefined) {
+      console.log(`   Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      console.log(`   Desired: ${action.desired}`);
+    }
+    action.notes?.forEach((note) => {
+      console.log(`   Note: ${note}`);
+    });
+    console.log(`   Method: ${action.method}(${describeArgs(action.args)})`);
+    if (data) {
+      console.log(`   Calldata: ${data}`);
+    }
+  });
+
+  if (!cli.execute || !sameAddress(ownerAddress, signerAddress)) {
+    console.log(
+      '\nDry run complete. Re-run with --execute once ready to submit transactions.'
+    );
+    return;
+  }
+
+  console.log('\nSubmitting transactions...');
+  for (const action of plan.actions) {
+    console.log(`Executing ${action.method}...`);
+    const tx = await (energyOracle as any)[action.method](...action.args);
+    console.log(`   Tx hash: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (receipt?.status !== 1n) {
+      throw new Error(`Transaction for ${action.method} failed`);
+    }
+    console.log('   Confirmed');
+  }
+  console.log('All transactions confirmed.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -69,6 +69,18 @@ contract MockEnergyOracle is IEnergyOracle {
     function verify(Attestation calldata att, bytes calldata) external pure override returns (address) {
         return att.user; // treat user's address as signer for testing
     }
+
+    function isSigner(address) external pure override returns (bool) {
+        return true;
+    }
+
+    function signerCount() external pure override returns (uint256) {
+        return 0;
+    }
+
+    function getSigners() external pure override returns (address[] memory) {
+        return new address[](0);
+    }
 }
 
 contract RewardEngineMBHarness is RewardEngineMB {


### PR DESCRIPTION
## Summary
- extend the EnergyOracle contract with signer enumeration helpers and zero-address guards
- expose the new view helpers in the interface and tighten tests/mocks
- add a configurable energy-oracle JSON schema, Hardhat helper plan, and documentation for signer operations

## Testing
- npx hardhat compile --force

------
https://chatgpt.com/codex/tasks/task_e_68d85ad00594833393608145ac69b8b3