### PR TITLE
Enhance tax policy administration tooling

### DIFF
--- a/config/tax-policy.json
+++ b/config/tax-policy.json
@@ -1,5 +1,6 @@
 {
   "policyURI": "ipfs://example-tax-policy",
   "acknowledgement": "Employers, agents, and validators accept full responsibility for all applicable taxes.",
-  "acknowledgers": {}
+  "acknowledgers": {},
+  "revokeAcknowledgements": []
 }

--- a/contracts/legacy/BadTaxPolicy.sol
+++ b/contracts/legacy/BadTaxPolicy.sol
@@ -26,6 +26,22 @@ contract BadTaxPolicy is ITaxPolicy {
 
     function setAcknowledger(address, bool) external {}
 
+    function setAcknowledgers(address[] calldata, bool[] calldata) external {}
+
+    function revokeAcknowledgement(address user) external {
+        acknowledgedVersion[user] = 0;
+    }
+
+    function revokeAcknowledgements(address[] calldata users) external {
+        for (uint256 i = 0; i < users.length; i++) {
+            acknowledgedVersion[users[i]] = 0;
+        }
+    }
+
+    function acknowledgerAllowed(address) external pure returns (bool) {
+        return false;
+    }
+
     function hasAcknowledged(address user) external view returns (bool) {
         return acknowledgedVersion[user] != 0;
     }

--- a/contracts/v2/interfaces/ITaxPolicy.sol
+++ b/contracts/v2/interfaces/ITaxPolicy.sol
@@ -19,9 +19,26 @@ interface ITaxPolicy {
     /// @param allowed True to allow the address, false to revoke.
     function setAcknowledger(address acknowledger, bool allowed) external;
 
+    /// @notice Batch update acknowledger permissions with per-address flags.
+    /// @param acknowledgers Array of addresses to update.
+    /// @param allowed Boolean flags matching `acknowledgers` by index.
+    function setAcknowledgers(address[] calldata acknowledgers, bool[] calldata allowed) external;
+
+    /// @notice Clears the acknowledgement record for a user.
+    /// @param user Address whose acknowledgement should be revoked.
+    function revokeAcknowledgement(address user) external;
+
+    /// @notice Clears acknowledgement records for multiple users.
+    /// @param users Addresses whose acknowledgements should be revoked.
+    function revokeAcknowledgements(address[] calldata users) external;
+
     /// @notice Check if a user has acknowledged the policy.
     /// @param user Address of the participant.
     function hasAcknowledged(address user) external view returns (bool);
+
+    /// @notice Check if an address is authorised to call {acknowledgeFor}.
+    /// @param acknowledger Address of the delegate.
+    function acknowledgerAllowed(address acknowledger) external view returns (bool);
 
     /// @notice Returns the policy version a user has acknowledged.
     /// @param user Address of the participant.

--- a/docs/v2-deployment-and-operations.md
+++ b/docs/v2-deployment-and-operations.md
@@ -291,7 +291,12 @@ To generate proofs:
   `npx hardhat run scripts/v2/updatePlatformIncentives.ts --network <network>`
   (rewires module addresses) and
   `npx hardhat run scripts/v2/updateTaxPolicy.ts --network <network>`
-  (updates policy URI, acknowledgement text, acknowledger allowlist, or bumps
-  the version). Both scripts read defaults from `config/*.json`, ensure the
-  connected signer controls the target contract, and print a human-readable
-  plan before executing.
+  (updates policy URI, acknowledgement text, acknowledger allowlist, clears
+  stale acknowledgements, or bumps the version). Both scripts read defaults from
+  `config/*.json`, ensure the connected signer controls the target contract, and
+  print a human-readable plan before executing.
+
+  Populate `config/tax-policy.json` with `acknowledgers` (address-to-boolean map)
+  and `revokeAcknowledgements` (array of addresses to reset). The helper now
+  fetches current allowlist status and acknowledgement versions so the plan only
+  includes the deltas that require on-chain transactions.

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -203,6 +203,7 @@ export interface TaxPolicyConfig {
   acknowledgement?: string;
   bumpVersion?: boolean;
   acknowledgers?: Record<string, boolean>;
+  revokeAcknowledgements?: string[];
   [key: string]: unknown;
 }
 

--- a/scripts/config/index.js
+++ b/scripts/config/index.js
@@ -1110,6 +1110,20 @@ function normaliseTaxPolicyConfig(config = {}) {
     result.acknowledgers = mapped;
   }
 
+  if (Array.isArray(result.revokeAcknowledgements)) {
+    const cleaned = [];
+    for (let i = 0; i < result.revokeAcknowledgements.length; i += 1) {
+      const value = result.revokeAcknowledgements[i];
+      if (value === undefined || value === null || value === '') continue;
+      cleaned.push(
+        ensureAddress(value, `TaxPolicy revokeAcknowledgements[${i}]`, {
+          allowZero: false,
+        })
+      );
+    }
+    result.revokeAcknowledgements = cleaned;
+  }
+
   return result;
 }
 


### PR DESCRIPTION
## Summary
- extend the TaxPolicy contract with batch acknowledger management, acknowledgement revocation, and a readable allowlist for stronger owner control
- update the tax-policy configuration loader and maintenance script to diff on-chain state, support acknowledgement revocations, and document the workflow
- expand tests and legacy stubs to cover the new admin capabilities

## Testing
- `npx hardhat test test/v2/TaxPolicyIntegration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d85e78ad748333b308d6c95d2f9a6a