### PR TITLE
Add PlatformRegistry inspection tooling

### DIFF
--- a/docs/platform-registry-operations.md
+++ b/docs/platform-registry-operations.md
@@ -71,6 +71,27 @@ npm run platform:registry:update -- --network <network> [--execute]
 This wrapper simply forwards arguments to the Hardhat script and behaves
 identically to the raw `npx hardhat run` invocation.
 
+## Inspect on-chain state
+
+Before executing changes, you can generate a high-signal snapshot of the
+current PlatformRegistry configuration, active registrars and blacklist entries.
+
+```bash
+npm run platform:registry:inspect -- --network <network> [--json] \
+  [--from-block <number>] [--to-block <number>] [--batch-size <number>]
+```
+
+- Collects registrar/blacklist history directly from `RegistrarUpdated` and
+  `Blacklisted` events, highlighting any addresses missing from the JSON
+  configuration file.
+- Outputs a human-readable table by default and supports `--json` for pipelines
+  or change-management tooling.
+- Accepts optional block range arguments for RPC providers with limited log
+  windows. By default the helper scans from block 0 to the latest block.
+
+This inspection tool complements `updatePlatformRegistry.ts` by confirming the
+live state before submitting governance transactions.
+
 ## Operational tips
 
 - Keep `config/platform-registry.json` under version control so governance

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "thermostat:update": "npx hardhat run scripts/v2/updateThermostat.ts",
     "hamiltonian:update": "npx hardhat run scripts/v2/updateHamiltonianMonitor.ts",
     "platform:registry:update": "npx hardhat run scripts/v2/updatePlatformRegistry.ts",
+    "platform:registry:inspect": "npx hardhat run scripts/v2/inspectPlatformRegistry.ts",
     "namehash:mainnet": "node scripts/compute-namehash.js deployment-config/mainnet.json",
     "namehash:sepolia": "node scripts/compute-namehash.js deployment-config/sepolia.json",
     "deploy:protocol": "npx hardhat run scripts/deploy/providerAgnosticDeploy.ts",

--- a/scripts/v2/inspectPlatformRegistry.ts
+++ b/scripts/v2/inspectPlatformRegistry.ts
@@ -1,0 +1,384 @@
+import { ethers, network } from 'hardhat';
+import type { Contract } from 'ethers';
+import {
+  loadPlatformRegistryConfig,
+  loadTokenConfig,
+  type PlatformRegistryConfig,
+} from '../config';
+import { collectPlatformRegistryState } from './lib/platformRegistryInspector';
+import { formatToken, normaliseAddress } from './lib/utils';
+
+interface CliOptions {
+  json: boolean;
+  configPath?: string;
+  platformRegistryAddress?: string;
+  fromBlock?: number;
+  toBlock?: number;
+  batchSize?: number;
+  noLogs?: boolean;
+}
+
+function parseInteger(value: string | undefined, label: string): number {
+  if (value === undefined) {
+    throw new Error(`${label} requires a numeric value`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--json':
+        options.json = true;
+        break;
+      case '--config': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--config requires a path');
+        }
+        options.configPath = value;
+        i += 1;
+        break;
+      }
+      case '--platform-registry':
+      case '--platformRegistry': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--platform-registry requires an address');
+        }
+        options.platformRegistryAddress = value;
+        i += 1;
+        break;
+      }
+      case '--from-block':
+      case '--fromBlock':
+        options.fromBlock = parseInteger(argv[i + 1], arg);
+        i += 1;
+        break;
+      case '--to-block':
+      case '--toBlock':
+        options.toBlock = parseInteger(argv[i + 1], arg);
+        i += 1;
+        break;
+      case '--batch-size':
+      case '--batchSize':
+        options.batchSize = parseInteger(argv[i + 1], arg);
+        i += 1;
+        break;
+      case '--no-logs':
+      case '--skip-logs':
+        options.noLogs = true;
+        break;
+      default:
+        if (arg.startsWith('--')) {
+          throw new Error(`Unrecognised flag: ${arg}`);
+        }
+        break;
+    }
+  }
+  return options;
+}
+
+function normaliseMap(map?: Record<string, boolean>): Map<string, boolean> {
+  const result = new Map<string, boolean>();
+  if (!map) {
+    return result;
+  }
+  for (const [key, value] of Object.entries(map)) {
+    try {
+      result.set(ethers.getAddress(key), Boolean(value));
+    } catch (_) {
+      // ignore invalid addresses; config loader should already sanitise
+    }
+  }
+  return result;
+}
+
+function ensurePlatformRegistryAddress(
+  config: PlatformRegistryConfig,
+  override?: string,
+  fallback?: string
+): string {
+  const candidate = override || config.address || fallback;
+  if (!candidate) {
+    throw new Error('Platform registry address is not configured');
+  }
+  const address = ethers.getAddress(candidate);
+  if (address === ethers.ZeroAddress) {
+    throw new Error('Platform registry address cannot be the zero address');
+  }
+  return address;
+}
+
+function printDivider(): void {
+  console.log(''.padEnd(72, '-'));
+}
+
+function formatBlockInfo(
+  blockNumber: number | null,
+  txHash: string | null
+): string {
+  if (blockNumber === null) {
+    return 'unknown';
+  }
+  const tx = txHash ? `, tx ${txHash}` : '';
+  return `block ${blockNumber}${tx}`;
+}
+
+async function main(): Promise<void> {
+  const cli = parseArgs(process.argv.slice(2));
+
+  const { config: tokenConfig } = loadTokenConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
+
+  const { config: registryConfig, path: configPath } = loadPlatformRegistryConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+    path: cli.configPath,
+  });
+
+  const fallbackAddress = normaliseAddress(tokenConfig.modules?.platformRegistry, {
+    allowZero: false,
+  });
+
+  const platformRegistryAddress = ensurePlatformRegistryAddress(
+    registryConfig,
+    cli.platformRegistryAddress,
+    fallbackAddress
+  );
+
+  const platformRegistry = (await ethers.getContractAt(
+    'contracts/v2/PlatformRegistry.sol:PlatformRegistry',
+    platformRegistryAddress
+  )) as Contract;
+
+  const provider = ethers.provider;
+  const latestBlock = await provider.getBlockNumber();
+
+  const toBlock = cli.toBlock !== undefined ? cli.toBlock : latestBlock;
+  const fromBlock = cli.fromBlock !== undefined ? cli.fromBlock : 0;
+  if (fromBlock > toBlock) {
+    throw new Error('--from-block cannot be greater than --to-block');
+  }
+
+  const configRegistrars = normaliseMap(registryConfig.registrars);
+  const configBlacklist = normaliseMap(registryConfig.blacklist);
+
+  const state = await collectPlatformRegistryState({
+    platformRegistry,
+    fromBlock,
+    toBlock,
+    batchSize: cli.batchSize,
+    skipLogs: cli.noLogs ?? false,
+    registrarAddressesToProbe: configRegistrars.keys(),
+    blacklistAddressesToProbe: configBlacklist.keys(),
+  });
+
+  const decimals =
+    typeof tokenConfig.decimals === 'number' ? tokenConfig.decimals : 18;
+  const symbol =
+    typeof tokenConfig.symbol === 'string' && tokenConfig.symbol
+      ? tokenConfig.symbol
+      : 'tokens';
+
+  const registrarSummaries = Array.from(state.registrars.entries()).map(
+    ([address, snapshot]) => ({
+      address,
+      allowed: snapshot.value,
+      lastUpdatedBlock: snapshot.lastUpdatedBlock,
+      transactionHash: snapshot.transactionHash,
+      config: configRegistrars.get(address),
+    })
+  );
+  registrarSummaries.sort((a, b) => a.address.localeCompare(b.address));
+
+  const blacklistSummaries = Array.from(state.blacklist.entries()).map(
+    ([address, snapshot]) => ({
+      address,
+      blacklisted: snapshot.value,
+      lastUpdatedBlock: snapshot.lastUpdatedBlock,
+      transactionHash: snapshot.transactionHash,
+      config: configBlacklist.get(address),
+    })
+  );
+  blacklistSummaries.sort((a, b) => a.address.localeCompare(b.address));
+
+  const configRegistrarSet = new Set(configRegistrars.keys());
+  registrarSummaries.forEach((entry) => configRegistrarSet.delete(entry.address));
+  const missingRegistrarConfigs = Array.from(configRegistrarSet);
+
+  const configBlacklistSet = new Set(configBlacklist.keys());
+  blacklistSummaries.forEach((entry) => configBlacklistSet.delete(entry.address));
+  const missingBlacklistConfigs = Array.from(configBlacklistSet);
+
+  const output = {
+    network: network.name,
+    configPath,
+    platformRegistry: platformRegistryAddress,
+    core: {
+      owner: state.owner,
+      stakeManager: state.stakeManager,
+      reputationEngine: state.reputationEngine,
+      pauser: state.pauser,
+      minPlatformStake: state.minPlatformStake.toString(),
+      minPlatformStakeFormatted: formatToken(
+        state.minPlatformStake,
+        decimals,
+        symbol
+      ),
+    },
+    events: state.metadata,
+    registrars: {
+      entries: registrarSummaries,
+      missingConfigEntries: missingRegistrarConfigs,
+    },
+    blacklist: {
+      entries: blacklistSummaries,
+      missingConfigEntries: missingBlacklistConfigs,
+    },
+  };
+
+  if (cli.json) {
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  console.log(`PlatformRegistry inspection on network: ${network.name}`);
+  console.log(`Configuration file: ${configPath}`);
+  console.log(`PlatformRegistry address: ${platformRegistryAddress}`);
+  printDivider();
+  console.log('Core configuration:');
+  console.log(`  Owner:            ${state.owner}`);
+  console.log(`  StakeManager:     ${state.stakeManager}`);
+  console.log(`  ReputationEngine: ${state.reputationEngine}`);
+  console.log(
+    `  Pauser:           ${state.pauser ?? 'not configured (owner-only pause)'}`
+  );
+  console.log(
+    `  Min platform stake: ${formatToken(
+      state.minPlatformStake,
+      decimals,
+      symbol
+    )} (${state.minPlatformStake.toString()} base units)`
+  );
+  printDivider();
+  console.log(
+    `Events scanned from block ${state.metadata.fromBlock} to ${state.metadata.toBlock} ` +
+      `(registrar events: ${state.metadata.registrarEvents}, blacklist events: ${state.metadata.blacklistEvents})`
+  );
+  printDivider();
+
+  const activeRegistrars = registrarSummaries.filter((entry) => entry.allowed);
+  const inactiveRegistrars = registrarSummaries.filter((entry) => !entry.allowed);
+
+  console.log(`Active registrars (${activeRegistrars.length}):`);
+  if (activeRegistrars.length === 0) {
+    console.log('  • none');
+  } else {
+    activeRegistrars.forEach((entry) => {
+      const configNote =
+        entry.config === undefined
+          ? 'not in config'
+          : entry.config
+          ? 'configured ✅'
+          : 'configured as revoked ⚠️';
+      console.log(
+        `  • ${entry.address} — ${formatBlockInfo(
+          entry.lastUpdatedBlock,
+          entry.transactionHash
+        )} (${configNote})`
+      );
+    });
+  }
+
+  console.log(`\nRevoked registrars (${inactiveRegistrars.length}):`);
+  if (inactiveRegistrars.length === 0) {
+    console.log('  • none');
+  } else {
+    inactiveRegistrars.forEach((entry) => {
+      const configNote =
+        entry.config === undefined
+          ? 'not in config'
+          : entry.config
+          ? 'configured as active ⚠️'
+          : 'configured ✅';
+      console.log(
+        `  • ${entry.address} — ${formatBlockInfo(
+          entry.lastUpdatedBlock,
+          entry.transactionHash
+        )} (${configNote})`
+      );
+    });
+  }
+
+  if (missingRegistrarConfigs.length > 0) {
+    console.log('\nWarning: configuration file is missing registrar entries for:');
+    missingRegistrarConfigs.forEach((address) => console.log(`  • ${address}`));
+  }
+
+  printDivider();
+
+  const activeBlacklist = blacklistSummaries.filter((entry) => entry.blacklisted);
+  const clearedBlacklist = blacklistSummaries.filter((entry) => !entry.blacklisted);
+
+  console.log(`Blacklisted operators (${activeBlacklist.length}):`);
+  if (activeBlacklist.length === 0) {
+    console.log('  • none');
+  } else {
+    activeBlacklist.forEach((entry) => {
+      const configNote =
+        entry.config === undefined
+          ? 'not in config'
+          : entry.config
+          ? 'configured ✅'
+          : 'configured as cleared ⚠️';
+      console.log(
+        `  • ${entry.address} — ${formatBlockInfo(
+          entry.lastUpdatedBlock,
+          entry.transactionHash
+        )} (${configNote})`
+      );
+    });
+  }
+
+  console.log(`\nCleared blacklist entries (${clearedBlacklist.length}):`);
+  if (clearedBlacklist.length === 0) {
+    console.log('  • none');
+  } else {
+    clearedBlacklist.forEach((entry) => {
+      const configNote =
+        entry.config === undefined
+          ? 'not in config'
+          : entry.config
+          ? 'configured as blacklisted ⚠️'
+          : 'configured ✅';
+      console.log(
+        `  • ${entry.address} — ${formatBlockInfo(
+          entry.lastUpdatedBlock,
+          entry.transactionHash
+        )} (${configNote})`
+      );
+    });
+  }
+
+  if (missingBlacklistConfigs.length > 0) {
+    console.log('\nWarning: configuration file is missing blacklist entries for:');
+    missingBlacklistConfigs.forEach((address) => console.log(`  • ${address}`));
+  }
+
+  printDivider();
+  console.log('Inspection complete. Re-run with --json for machine-readable output.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/v2/lib/platformRegistryInspector.ts
+++ b/scripts/v2/lib/platformRegistryInspector.ts
@@ -1,0 +1,321 @@
+import { ethers } from 'ethers';
+import type { Contract, ContractRunner, Log, Provider } from 'ethers';
+
+export interface AddressSnapshot {
+  value: boolean;
+  lastUpdatedBlock: number | null;
+  transactionHash: string | null;
+}
+
+export interface PlatformRegistryState {
+  owner: string;
+  stakeManager: string;
+  reputationEngine: string;
+  pauser: string | null;
+  minPlatformStake: bigint;
+  registrars: Map<string, AddressSnapshot>;
+  blacklist: Map<string, AddressSnapshot>;
+  metadata: {
+    fromBlock: number;
+    toBlock: number;
+    batchSize: number;
+    registrarEvents: number;
+    blacklistEvents: number;
+  };
+}
+
+export interface CollectPlatformRegistryStateOptions {
+  platformRegistry: Contract;
+  fromBlock?: number;
+  toBlock?: number;
+  batchSize?: number;
+  skipLogs?: boolean;
+  addressesToProbe?: Iterable<string>;
+  registrarAddressesToProbe?: Iterable<string>;
+  blacklistAddressesToProbe?: Iterable<string>;
+  provider?: Provider;
+}
+
+type AddressEvent = {
+  address: string;
+  value: boolean;
+  blockNumber: number;
+  transactionHash: string;
+};
+
+type AddressEventInfo = {
+  blockNumber: number;
+  transactionHash: string;
+  value: boolean;
+};
+
+function resolveProvider(
+  contract: Contract,
+  explicit?: Provider
+): Provider {
+  if (explicit) {
+    return explicit;
+  }
+
+  const runner: ContractRunner | null | undefined = contract.runner;
+  if (runner && typeof (runner as any).provider === 'object') {
+    const provider = (runner as any).provider as Provider;
+    if (provider) {
+      return provider;
+    }
+  }
+
+  if ((contract as any).provider) {
+    return (contract as any).provider as Provider;
+  }
+
+  if (ethers.getDefaultProvider) {
+    try {
+      const defaultProvider = ethers.getDefaultProvider();
+      if (defaultProvider) {
+        return defaultProvider;
+      }
+    } catch (_) {
+      // ignore default provider errors
+    }
+  }
+
+  if (ethers.provider) {
+    return ethers.provider;
+  }
+
+  throw new Error('Unable to resolve a provider for PlatformRegistry introspection');
+}
+
+function coerceBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'bigint') {
+    return value !== 0n;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed === '0' || trimmed === 'false') {
+      return false;
+    }
+    if (trimmed === '1' || trimmed === 'true') {
+      return true;
+    }
+  }
+  return Boolean(value);
+}
+
+function normaliseAddresses(values?: Iterable<string>): string[] {
+  if (!values) {
+    return [];
+  }
+  const unique = new Set<string>();
+  for (const value of values) {
+    if (!value) continue;
+    try {
+      unique.add(ethers.getAddress(value));
+    } catch (_) {
+      // ignore malformed addresses
+    }
+  }
+  return Array.from(unique);
+}
+
+async function fetchAddressEvents(
+  provider: Provider,
+  iface: ethers.Interface,
+  address: string,
+  eventName: string,
+  addressIndex: number,
+  statusIndex: number | null,
+  fromBlock: number,
+  toBlock: number,
+  batchSize: number
+): Promise<AddressEvent[]> {
+  const fragment = iface.getEvent(eventName);
+  const topic = fragment.topicHash;
+  const inputNames = fragment.inputs.map((input) => input.name || '');
+  const events: AddressEvent[] = [];
+  let start = fromBlock;
+  while (start <= toBlock) {
+    const end = Math.min(start + batchSize - 1, toBlock);
+    const logs: Log[] = await provider.getLogs({
+      address,
+      topics: [topic],
+      fromBlock: start,
+      toBlock: end,
+    });
+    for (const log of logs) {
+      try {
+        const parsed = iface.parseLog(log);
+        const args = parsed.args as any;
+        const addressValue =
+          args[addressIndex] ?? args[inputNames[addressIndex] || addressIndex];
+        const statusValue =
+          statusIndex === null
+            ? undefined
+            : args[statusIndex] ?? args[inputNames[statusIndex] || statusIndex];
+        const parsedAddress = ethers.getAddress(String(addressValue));
+        const parsedValue =
+          statusIndex === null ? false : coerceBoolean(statusValue);
+        events.push({
+          address: parsedAddress,
+          value: parsedValue,
+          blockNumber: log.blockNumber ?? 0,
+          transactionHash: log.transactionHash,
+        });
+      } catch (_) {
+        // ignore logs that fail to parse
+      }
+    }
+    start = end + 1;
+  }
+  return events;
+}
+
+function latestEventInfo(events: AddressEvent[]): Map<string, AddressEventInfo> {
+  const map = new Map<string, AddressEventInfo>();
+  events.forEach((event) => {
+    map.set(event.address, {
+      blockNumber: event.blockNumber,
+      transactionHash: event.transactionHash,
+      value: event.value,
+    });
+  });
+  return map;
+}
+
+export async function collectPlatformRegistryState(
+  options: CollectPlatformRegistryStateOptions
+): Promise<PlatformRegistryState> {
+  const contract = options.platformRegistry;
+  const provider = resolveProvider(contract, options.provider);
+
+  const batchSize = Math.max(1, options.batchSize ?? 50_000);
+  const toBlock = options.toBlock ?? (await provider.getBlockNumber());
+  const requestedFrom = options.fromBlock ?? 0;
+  if (requestedFrom > toBlock) {
+    throw new Error('fromBlock cannot be greater than toBlock');
+  }
+  const fromBlock = Math.max(0, requestedFrom);
+
+  const [
+    owner,
+    stakeManager,
+    reputationEngine,
+    minPlatformStake,
+    pauser,
+    contractAddress,
+  ] = await Promise.all([
+    contract.owner(),
+    contract.stakeManager(),
+    contract.reputationEngine(),
+    contract.minPlatformStake(),
+    contract.pauser(),
+    contract.getAddress(),
+  ]);
+
+  const registrars = new Map<string, AddressSnapshot>();
+  const blacklist = new Map<string, AddressSnapshot>();
+
+  let registrarEvents: AddressEvent[] = [];
+  let blacklistEvents: AddressEvent[] = [];
+
+  if (!options.skipLogs) {
+    const iface = contract.interface;
+    registrarEvents = await fetchAddressEvents(
+      provider,
+      iface,
+      contractAddress,
+      'RegistrarUpdated',
+      0,
+      1,
+      fromBlock,
+      toBlock,
+      batchSize
+    );
+    blacklistEvents = await fetchAddressEvents(
+      provider,
+      iface,
+      contractAddress,
+      'Blacklisted',
+      0,
+      1,
+      fromBlock,
+      toBlock,
+      batchSize
+    );
+  }
+
+  const registrarEventInfo = latestEventInfo(registrarEvents);
+  const blacklistEventInfo = latestEventInfo(blacklistEvents);
+
+  const registrarAddresses = new Set<string>(
+    normaliseAddresses(options.registrarAddressesToProbe)
+  );
+  const blacklistAddresses = new Set<string>(
+    normaliseAddresses(options.blacklistAddressesToProbe)
+  );
+
+  const generalProbeAddresses = normaliseAddresses(options.addressesToProbe);
+  generalProbeAddresses.forEach((address) => {
+    registrarAddresses.add(address);
+    blacklistAddresses.add(address);
+  });
+
+  registrarEventInfo.forEach((_, address) => registrarAddresses.add(address));
+  blacklistEventInfo.forEach((_, address) => blacklistAddresses.add(address));
+
+  const registrarStatuses = await Promise.all(
+    Array.from(registrarAddresses).map(async (address) => {
+      const value = await contract.registrars(address);
+      return { address, value: coerceBoolean(value) };
+    })
+  );
+
+  registrarStatuses.forEach(({ address, value }) => {
+    const info = registrarEventInfo.get(address);
+    registrars.set(address, {
+      value,
+      lastUpdatedBlock: info?.blockNumber ?? null,
+      transactionHash: info?.transactionHash ?? null,
+    });
+  });
+
+  const blacklistStatuses = await Promise.all(
+    Array.from(blacklistAddresses).map(async (address) => {
+      const value = await contract.blacklist(address);
+      return { address, value: coerceBoolean(value) };
+    })
+  );
+
+  blacklistStatuses.forEach(({ address, value }) => {
+    const info = blacklistEventInfo.get(address);
+    blacklist.set(address, {
+      value,
+      lastUpdatedBlock: info?.blockNumber ?? null,
+      transactionHash: info?.transactionHash ?? null,
+    });
+  });
+
+  return {
+    owner: ethers.getAddress(owner),
+    stakeManager: ethers.getAddress(stakeManager),
+    reputationEngine: ethers.getAddress(reputationEngine),
+    pauser: pauser === ethers.ZeroAddress ? null : ethers.getAddress(pauser),
+    minPlatformStake: BigInt(minPlatformStake),
+    registrars,
+    blacklist,
+    metadata: {
+      fromBlock,
+      toBlock,
+      batchSize,
+      registrarEvents: registrarEvents.length,
+      blacklistEvents: blacklistEvents.length,
+    },
+  };
+}

--- a/test/v2/platformRegistryInspector.test.ts
+++ b/test/v2/platformRegistryInspector.test.ts
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { collectPlatformRegistryState } from '../../scripts/v2/lib/platformRegistryInspector';
+
+describe('PlatformRegistry inspector', function () {
+  it('collects registrar and blacklist state with event metadata', async function () {
+    const [owner, registrarA, registrarB, operator] = await ethers.getSigners();
+
+    const PlatformRegistry = await ethers.getContractFactory(
+      'contracts/v2/PlatformRegistry.sol:PlatformRegistry'
+    );
+    const registry = await PlatformRegistry.connect(owner).deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0
+    );
+    await registry.waitForDeployment();
+
+    const registrarAAddress = await registrarA.getAddress();
+    const registrarBAddress = await registrarB.getAddress();
+    const operatorAddress = await operator.getAddress();
+
+    const regATx = await registry.connect(owner).setRegistrar(registrarAAddress, true);
+    const regATxReceipt = await regATx.wait();
+
+    const regBTx = await registry.connect(owner).setRegistrar(registrarBAddress, true);
+    await regBTx.wait();
+    const regBTxRevoke = await registry
+      .connect(owner)
+      .setRegistrar(registrarBAddress, false);
+    const regBTxRevokeReceipt = await regBTxRevoke.wait();
+
+    const blacklistAddTx = await registry
+      .connect(owner)
+      .setBlacklist(operatorAddress, true);
+    await blacklistAddTx.wait();
+    const blacklistClearTx = await registry
+      .connect(owner)
+      .setBlacklist(operatorAddress, false);
+    const blacklistClearReceipt = await blacklistClearTx.wait();
+
+    const topic = registry.interface.getEvent('RegistrarUpdated').topicHash;
+    const logs = await ethers.provider.getLogs({
+      address: await registry.getAddress(),
+      topics: [topic],
+      fromBlock: 0,
+      toBlock: 'latest',
+    });
+    expect(logs.length).to.be.greaterThan(0);
+
+    const state = await collectPlatformRegistryState({
+      platformRegistry: registry,
+    });
+
+    expect(state.owner).to.equal(await owner.getAddress());
+    expect(state.stakeManager).to.equal(ethers.ZeroAddress);
+    expect(state.reputationEngine).to.equal(ethers.ZeroAddress);
+    expect(state.pauser).to.equal(null);
+    expect(state.minPlatformStake).to.equal(ethers.parseUnits('1', 18));
+
+    const registrarAEntry = state.registrars.get(registrarAAddress);
+    expect(registrarAEntry).to.not.be.undefined;
+    expect(registrarAEntry?.value).to.equal(true);
+    expect(registrarAEntry?.lastUpdatedBlock).to.equal(
+      regATxReceipt?.blockNumber ?? null
+    );
+    expect(registrarAEntry?.transactionHash).to.equal(regATx.hash);
+
+    const registrarBEntry = state.registrars.get(registrarBAddress);
+    expect(registrarBEntry).to.not.be.undefined;
+    expect(registrarBEntry?.value).to.equal(false);
+    expect(registrarBEntry?.lastUpdatedBlock).to.equal(
+      regBTxRevokeReceipt?.blockNumber ?? null
+    );
+    expect(registrarBEntry?.transactionHash).to.equal(regBTxRevoke.hash);
+
+    const operatorEntry = state.blacklist.get(operatorAddress);
+    expect(operatorEntry).to.not.be.undefined;
+    expect(operatorEntry?.value).to.equal(false);
+    expect(operatorEntry?.lastUpdatedBlock).to.equal(
+      blacklistClearReceipt?.blockNumber ?? null
+    );
+    expect(operatorEntry?.transactionHash).to.equal(blacklistClearTx.hash);
+
+    expect(state.metadata.registrarEvents).to.equal(3);
+    expect(state.metadata.blacklistEvents).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable PlatformRegistry state collector that aggregates registrar and blacklist metadata from logs
- create a CLI helper to inspect PlatformRegistry configuration with JSON output and config diffing hints
- document the inspection workflow, expose an npm script, and add targeted tests to validate the collector

## Testing
- `npx hardhat test --no-compile test/v2/platformRegistryInspector.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d8739249488333937783dc020d68a1