### PR TITLE
Add governance-controlled base URI rotation and locking for certificates

### DIFF
--- a/test/v2/CertificateNFT.test.js
+++ b/test/v2/CertificateNFT.test.js
@@ -38,6 +38,27 @@ describe('CertificateNFT', function () {
       .withArgs(baseURI);
     expect(await nft.tokenURI(1)).to.equal('ipfs://module/1');
 
+    expect(await nft.baseURILocked()).to.equal(false);
+
+    const updatedBaseURI = 'ipfs://module-v2/';
+    await expect(nft.updateBaseURI(updatedBaseURI))
+      .to.emit(nft, 'BaseURIUpdated')
+      .withArgs(baseURI, updatedBaseURI);
+    expect(await nft.tokenURI(1)).to.equal('ipfs://module-v2/1');
+
+    await expect(nft.lockBaseURI())
+      .to.emit(nft, 'BaseURILocked')
+      .withArgs(updatedBaseURI);
+    expect(await nft.baseURILocked()).to.equal(true);
+
+    await expect(nft.updateBaseURI('ipfs://module-v3/')).to.be.revertedWithCustomError(
+      nft,
+      'BaseURIAlreadyLocked'
+    );
+    await expect(nft.lockBaseURI()).to.be.revertedWithCustomError(
+      nft,
+      'BaseURIAlreadyLocked'
+    );
     await expect(nft.setBaseURI('ipfs://other/')).to.be.revertedWithCustomError(
       nft,
       'BaseURIAlreadySet'

--- a/test/v2/CertificateNFTMarketplace.test.js
+++ b/test/v2/CertificateNFTMarketplace.test.js
@@ -250,6 +250,24 @@ describe('CertificateNFT marketplace', function () {
 
   it('exposes deterministic metadata with an immutable base URI', async () => {
     expect(await nft.tokenURI(1)).to.equal('ipfs://certificates/1');
+
+    await expect(nft.updateBaseURI('ipfs://certificates-v2/'))
+      .to.emit(nft, 'BaseURIUpdated')
+      .withArgs('ipfs://certificates/', 'ipfs://certificates-v2/');
+    expect(await nft.tokenURI(1)).to.equal('ipfs://certificates-v2/1');
+
+    await expect(nft.lockBaseURI())
+      .to.emit(nft, 'BaseURILocked')
+      .withArgs('ipfs://certificates-v2/');
+
+    await expect(nft.updateBaseURI('ipfs://certificates-v3/')).to.be.revertedWithCustomError(
+      nft,
+      'BaseURIAlreadyLocked'
+    );
+    await expect(nft.lockBaseURI()).to.be.revertedWithCustomError(
+      nft,
+      'BaseURIAlreadyLocked'
+    );
     await expect(nft.setBaseURI('ipfs://other/')).to.be.revertedWithCustomError(
       nft,
       'BaseURIAlreadySet'

--- a/test/v2/CertificateNFTMint.test.js
+++ b/test/v2/CertificateNFTMint.test.js
@@ -39,6 +39,23 @@ describe('CertificateNFT minting', function () {
       .withArgs(baseURI);
     expect(await nft.tokenURI(1)).to.equal('ipfs://base/1');
 
+    await expect(nft.updateBaseURI('ipfs://base-v2/'))
+      .to.emit(nft, 'BaseURIUpdated')
+      .withArgs(baseURI, 'ipfs://base-v2/');
+    expect(await nft.tokenURI(1)).to.equal('ipfs://base-v2/1');
+
+    await expect(nft.lockBaseURI())
+      .to.emit(nft, 'BaseURILocked')
+      .withArgs('ipfs://base-v2/');
+
+    await expect(nft.updateBaseURI('ipfs://base-v3/')).to.be.revertedWithCustomError(
+      nft,
+      'BaseURIAlreadyLocked'
+    );
+    await expect(nft.lockBaseURI()).to.be.revertedWithCustomError(
+      nft,
+      'BaseURIAlreadyLocked'
+    );
     await expect(nft.setBaseURI('ipfs://new/')).to.be.revertedWithCustomError(
       nft,
       'BaseURIAlreadySet'


### PR DESCRIPTION
## Summary
- add governance-owned base URI rotation and irreversible locking flows to both Certificate NFT implementations
- expose a read-only lock status helper and associated events for operational transparency
- extend the Certificate NFT test suites to cover the new update and lock lifecycle in main, module, and marketplace contexts

## Testing
- `npx hardhat test test/v2/CertificateNFT.test.js test/v2/CertificateNFTMint.test.js test/v2/CertificateNFTMarketplace.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68d8786ee8f08333963114b346858bd4