### PR TITLE
Add plan hash receipts to onebox execution responses

### DIFF
--- a/apps/onebox/src/components/receiptTypes.ts
+++ b/apps/onebox/src/components/receiptTypes.ts
@@ -8,6 +8,9 @@ export type ExecutionReceipt = {
   specUrl?: string | null;
   deliverableCid?: string | null;
   deliverableUrl?: string | null;
+  receiptCid?: string | null;
+  receiptUri?: string | null;
+  receiptGatewayUrls?: string[];
   netPayout?: string;
   explorerUrl?: string;
   createdAt: number;

--- a/packages/onebox-sdk/src/index.ts
+++ b/packages/onebox-sdk/src/index.ts
@@ -64,6 +64,7 @@ export interface ExecuteResponse {
   ok: boolean;
   jobId?: number;
   txHash?: string;
+  txHashes?: string[];
   receiptUrl?: string;
   specCid?: string;
   specUri?: string;
@@ -78,6 +79,17 @@ export interface ExecuteResponse {
   reward?: string;
   token?: string;
   status?: string;
+  planHash?: string;
+  createdAt?: string;
+  receiptCid?: string;
+  receiptUri?: string;
+  receiptGatewayUrl?: string;
+  receiptGatewayUrls?: string[];
+  receipt?: Record<string, unknown>;
+  feePct?: number;
+  burnPct?: number;
+  feeAmount?: string;
+  burnAmount?: string;
   /** Target address for wallet execution flows. */
   to?: string;
   /** ABI-encoded calldata for wallet execution flows. */
@@ -120,4 +132,7 @@ export interface PlanRequest {
 export interface ExecuteRequest {
   intent: JobIntent;
   mode: 'relayer' | 'wallet';
+  planHash?: string;
+  createdAt?: string;
+  receiptCid?: string;
 }


### PR DESCRIPTION
## Summary
- require execute callers to echo the planner hash, propagate it through orchestrator responses, and publish a consolidated receipt artifact
- extend the shared onebox SDK response contract with plan, timestamp, transaction, fee, and receipt metadata
- update the onebox UI clients to send the new execution metadata and surface the enriched receipt details locally

## Testing
- npm run lint *(fails: repository contains pre-existing solhint/eslint formatting violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d8962c3a2c83339ec75b3ee0484a9a