### PR TITLE
Update one-box plan summary to surface fee policy

### DIFF
--- a/routes/onebox.py
+++ b/routes/onebox.py
@@ -733,14 +733,19 @@ def _summary_for_intent(intent: JobIntent, request_text: str) -> Tuple[str, bool
 
     payload = intent.payload
     reward = payload.reward or _parse_reward(request_text) or "1.0"
-    days = payload.deadlineDays if payload.deadlineDays is not None else (_parse_deadline_days(request_text) or 7)
-    title = payload.title or _normalize_title(request_text)
+    days = (
+        payload.deadlineDays
+        if payload.deadlineDays is not None
+        else (_parse_deadline_days(request_text) or 7)
+    )
     token = (payload.rewardToken or "AGIALPHA").strip() or "AGIALPHA"
     fee_pct, burn_pct = _get_fee_policy()
+    reward_text = str(reward).strip() or "0"
+    fee_text = _format_percentage(fee_pct)
+    burn_text = _format_percentage(burn_pct)
     summary = (
-        f'Post job "{title}" with reward {reward} {token} '
-        f"and a {days}-day deadline. Fee {_format_percentage(fee_pct)}%, "
-        f"burn {_format_percentage(burn_pct)}%. Proceed?"
+        f"Post job {reward_text} {token}, {days} days. "
+        f"Fee {fee_text}%, burn {burn_text}%. Proceed?"
     )
     return _ensure_summary_limit(summary), True, warnings
 


### PR DESCRIPTION
## Summary
- update the one-box plan summary to surface the cached or fetched fee and burn percentages with default fallbacks when unavailable
- extend the plan tests to expect the new confirmation text and enhance the pydantic shims so plan hashing works during tests

## Testing
- pytest test/routes/test_onebox.py test/routes/test_onebox_intents.py

------
https://chatgpt.com/codex/tasks/task_e_68d8a0e226f4833387a20f93d9ae1f9e