### PR TITLE
Add deterministic local/testnet e2e coverage and fixtures

### DIFF
--- a/packages/orchestrator/test/e2e/accountAbstraction.e2e.test.ts
+++ b/packages/orchestrator/test/e2e/accountAbstraction.e2e.test.ts
@@ -1,0 +1,412 @@
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { ethers } from 'ethers';
+
+import {
+  AccountAbstractionSigner,
+  type AccountAbstractionConfig,
+} from '../../src/chain/providers/aa.js';
+import {
+  MetaTxSigner,
+  __resetForwarderConfigForTests,
+} from '../../src/chain/providers/metaTx.js';
+import type { UserOperationStruct } from '../../src/chain/providers/userOperation.js';
+
+const FIXTURE_PATH = path.resolve(process.cwd(), 'test/fixtures/aa-e2e.json');
+
+interface SepoliaScenario {
+  chainId: number;
+  entryPoint: string;
+  session: { privateKey: string; address?: string };
+  tx: { to: string; data: string; value: string };
+  policy: { userId: string; jobId: string; jobBudgetWei: string };
+  provider: { estimateGas: string };
+  feeData: { maxFeePerGas: string; maxPriorityFeePerGas: string };
+  config: {
+    verificationGasLimit: string;
+    preVerificationGas: string;
+    callGasBuffer: string;
+    paymasterContext?: Record<string, unknown>;
+  };
+  nonce: string;
+  paymaster: {
+    paymasterAndData: string;
+    preVerificationGas: string;
+    verificationGasLimit: string;
+    callGasLimit: string;
+  };
+  bundler: {
+    userOpHash: string;
+    actualGasCost: string;
+    actualGasUsed: string;
+  };
+  expected: {
+    transactionHash: string;
+    blockNumber: number;
+    blockHash: string;
+    gasUsed: string;
+    status: number;
+    paymasterContext: Record<string, unknown>;
+  };
+}
+
+interface OptimismScenario {
+  chainId: number;
+  forwarder: { address: string; nonce: string };
+  user: { privateKey: string; address?: string };
+  relayer: { privateKey: string };
+  provider: { estimateGas: string };
+  feeData: { maxFeePerGas: string; maxPriorityFeePerGas: string };
+  metaTx: {
+    policy: { userId: string; jobId: string; jobBudgetWei: string };
+    request: { to: string; data: string; value: string };
+    execute: { data: string; gasLimit: string | null };
+    response: { hash: string; status: number };
+  };
+  expected: {
+    forwardRequest: { gas: string; nonce: string };
+    signature: string;
+    relayerGasLimit: string;
+  };
+}
+
+const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8')) as {
+  sepolia: SepoliaScenario;
+  optimismSepolia: OptimismScenario;
+};
+
+function toBigIntHex(value: string): bigint {
+  return BigInt(value);
+}
+
+class MockAAProvider extends ethers.AbstractProvider {
+  public readonly estimateGasCalls: ethers.TransactionRequest[] = [];
+
+  public readonly waitedFor: string[] = [];
+
+  constructor(private readonly scenario: SepoliaScenario & { sessionAddress: string }) {
+    super({ name: 'mock', chainId: scenario.chainId });
+  }
+
+  async estimateGas(tx: ethers.TransactionRequest): Promise<bigint> {
+    this.estimateGasCalls.push(tx);
+    return BigInt(this.scenario.provider.estimateGas);
+  }
+
+  async getFeeData(): Promise<ethers.FeeData> {
+    const maxFee = BigInt(this.scenario.feeData.maxFeePerGas);
+    const maxPriority = BigInt(this.scenario.feeData.maxPriorityFeePerGas);
+    return {
+      gasPrice: maxFee,
+      maxFeePerGas: maxFee,
+      maxPriorityFeePerGas: maxPriority,
+      toJSON: () => ({
+        gasPrice: ethers.toQuantity(maxFee),
+        maxFeePerGas: ethers.toQuantity(maxFee),
+        maxPriorityFeePerGas: ethers.toQuantity(maxPriority),
+      }),
+    } as ethers.FeeData;
+  }
+
+  async getNetwork(): Promise<ethers.Network> {
+    return new ethers.Network('mock', this.scenario.chainId);
+  }
+
+  async waitForTransaction(hash: string): Promise<ethers.TransactionReceipt> {
+    this.waitedFor.push(hash);
+    return {
+      hash: this.scenario.expected.transactionHash,
+      transactionHash: this.scenario.expected.transactionHash,
+      blockNumber: this.scenario.expected.blockNumber,
+      blockHash: this.scenario.expected.blockHash,
+      from: this.scenario.sessionAddress,
+      to: this.scenario.tx.to,
+      gasUsed: BigInt(this.scenario.expected.gasUsed),
+      cumulativeGasUsed: BigInt(this.scenario.expected.gasUsed),
+      effectiveGasPrice: BigInt(this.scenario.feeData.maxFeePerGas),
+      status: this.scenario.expected.status,
+      logs: [],
+      logsBloom: `0x${'00'.repeat(256)}`,
+      type: 2,
+      confirmations: 1,
+    } as unknown as ethers.TransactionReceipt;
+  }
+
+  async _perform(): Promise<never> {
+    throw new Error('MockAAProvider does not support RPC operations');
+  }
+}
+
+class MockBundler {
+  public lastUserOperation: UserOperationStruct | null = null;
+
+  public estimateInvocations = 0;
+
+  constructor(private readonly scenario: SepoliaScenario & { sessionAddress: string }) {}
+
+  async estimateUserOperationGas(userOp: UserOperationStruct) {
+    this.estimateInvocations += 1;
+    this.lastUserOperation = userOp;
+    return {
+      callGasLimit: BigInt(this.scenario.paymaster.callGasLimit),
+      preVerificationGas: BigInt(this.scenario.paymaster.preVerificationGas),
+      verificationGasLimit: BigInt(this.scenario.paymaster.verificationGasLimit),
+    };
+  }
+
+  async sendUserOperation(userOp: UserOperationStruct): Promise<string> {
+    this.lastUserOperation = userOp;
+    return this.scenario.bundler.userOpHash;
+  }
+
+  async waitForUserOperation(hash: string) {
+    if (hash !== this.scenario.bundler.userOpHash) {
+      throw new Error('unexpected user operation hash');
+    }
+    return {
+      userOpHash: hash,
+      entryPoint: this.scenario.entryPoint,
+      sender: this.lastUserOperation?.sender ?? this.scenario.sessionAddress,
+      nonce: this.scenario.nonce,
+      actualGasCost: this.scenario.bundler.actualGasCost,
+      actualGasUsed: this.scenario.bundler.actualGasUsed,
+      success: true,
+      logs: [],
+      receipt: { hash: this.scenario.expected.transactionHash },
+    };
+  }
+}
+
+class MockPaymaster {
+  public readonly contexts: Array<Record<string, unknown> | undefined> = [];
+
+  public readonly sponsored: UserOperationStruct[] = [];
+
+  constructor(private readonly scenario: SepoliaScenario & { sessionAddress: string }) {}
+
+  async sponsorUserOperation(params: {
+    userOperation: UserOperationStruct;
+    entryPoint: string;
+    chainId: bigint;
+    context?: Record<string, unknown>;
+  }) {
+    this.contexts.push(params.context);
+    this.sponsored.push(params.userOperation);
+    return {
+      paymasterAndData: this.scenario.paymaster.paymasterAndData,
+      preVerificationGas: this.scenario.paymaster.preVerificationGas,
+      verificationGasLimit: this.scenario.paymaster.verificationGasLimit,
+      callGasLimit: this.scenario.paymaster.callGasLimit,
+    };
+  }
+}
+
+class MockMetaProvider extends ethers.AbstractProvider {
+  public readonly estimateGasCalls: ethers.TransactionRequest[] = [];
+
+  constructor(private readonly scenario: OptimismScenario & { userAddress: string }) {
+    super({ name: 'mock', chainId: scenario.chainId });
+  }
+
+  async estimateGas(tx: ethers.TransactionRequest): Promise<bigint> {
+    this.estimateGasCalls.push(tx);
+    return BigInt(this.scenario.provider.estimateGas);
+  }
+
+  async getFeeData(): Promise<ethers.FeeData> {
+    const maxFee = BigInt(this.scenario.feeData.maxFeePerGas);
+    const maxPriority = BigInt(this.scenario.feeData.maxPriorityFeePerGas);
+    return {
+      gasPrice: maxFee,
+      maxFeePerGas: maxFee,
+      maxPriorityFeePerGas: maxPriority,
+      toJSON: () => ({
+        gasPrice: ethers.toQuantity(maxFee),
+        maxFeePerGas: ethers.toQuantity(maxFee),
+        maxPriorityFeePerGas: ethers.toQuantity(maxPriority),
+      }),
+    } as ethers.FeeData;
+  }
+
+  async getNetwork(): Promise<ethers.Network> {
+    return new ethers.Network('mock', this.scenario.chainId);
+  }
+
+  async _perform(): Promise<never> {
+    throw new Error('MockMetaProvider does not support RPC operations');
+  }
+}
+
+class MockForwarder {
+  public readonly requests: Array<{ request: any; signature: string }> = [];
+
+  constructor(private readonly scenario: OptimismScenario & { userAddress: string }) {}
+
+  async getNonce(): Promise<bigint> {
+    return BigInt(this.scenario.forwarder.nonce);
+  }
+
+  getFunction(name: string) {
+    if (name !== 'execute') {
+      throw new Error(`Unexpected forwarder function ${name}`);
+    }
+    return {
+      populateTransaction: async (request: unknown, signature: string) => {
+        this.requests.push({ request, signature });
+        return {
+          to: this.scenario.forwarder.address,
+          data: this.scenario.metaTx.execute.data,
+          gasLimit: this.scenario.metaTx.execute.gasLimit
+            ? BigInt(this.scenario.metaTx.execute.gasLimit)
+            : undefined,
+        } satisfies ethers.TransactionRequest;
+      },
+    };
+  }
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+test('sepolia AA signer produces deterministic user operation with paymaster', async () => {
+  const scenario = clone(fixture.sepolia);
+  const sessionWallet = new ethers.Wallet(scenario.session.privateKey);
+  scenario.session.address = sessionWallet.address;
+  const provider = new MockAAProvider({ ...scenario, sessionAddress: sessionWallet.address });
+  const wallet = sessionWallet.connect(provider);
+
+  const config: AccountAbstractionConfig = {
+    entryPoint: scenario.entryPoint,
+    bundlerUrl: 'mock://bundler',
+    bundlerHeaders: {},
+    accountSalt: 0n,
+    verificationGasLimit: toBigIntHex(scenario.config.verificationGasLimit),
+    preVerificationGas: toBigIntHex(scenario.config.preVerificationGas),
+    callGasBuffer: toBigIntHex(scenario.config.callGasBuffer),
+    paymasterContext: scenario.config.paymasterContext,
+  };
+
+  const signer = new AccountAbstractionSigner(wallet, config);
+  const bundler = new MockBundler({ ...scenario, sessionAddress: sessionWallet.address });
+  const paymaster = new MockPaymaster({ ...scenario, sessionAddress: sessionWallet.address });
+  Reflect.set(signer, 'bundler', bundler);
+  Reflect.set(signer, 'entryPointContract', {
+    getNonce: async () => BigInt(scenario.nonce),
+  });
+  const signerConfig = Reflect.get(signer, 'config') as AccountAbstractionConfig;
+  signerConfig.paymaster = paymaster as unknown as AccountAbstractionConfig['paymaster'];
+
+  const tx: ethers.TransactionRequest = {
+    to: scenario.tx.to,
+    data: scenario.tx.data,
+    value: BigInt(scenario.tx.value),
+    customData: {
+      policy: {
+        userId: scenario.policy.userId,
+        jobId: scenario.policy.jobId,
+        jobBudgetWei: BigInt(scenario.policy.jobBudgetWei),
+      },
+    },
+  };
+
+  const response = await signer.sendTransaction(tx);
+  assert.equal(response.hash, scenario.bundler.userOpHash);
+
+  assert.ok(bundler.lastUserOperation, 'user operation should be recorded');
+  const userOp = bundler.lastUserOperation!;
+  assert.equal(userOp.paymasterAndData, scenario.paymaster.paymasterAndData);
+  assert.equal(userOp.callGasLimit, BigInt(scenario.paymaster.callGasLimit));
+  assert.equal(userOp.verificationGasLimit, BigInt(scenario.paymaster.verificationGasLimit));
+  assert.equal(userOp.preVerificationGas, BigInt(scenario.paymaster.preVerificationGas));
+
+  assert.equal(paymaster.contexts.length, 1);
+  assert.deepEqual(paymaster.contexts[0], scenario.expected.paymasterContext);
+
+  const receipt = await response.wait();
+  assert.ok(receipt);
+  assert.equal(receipt.hash, scenario.expected.transactionHash);
+  assert.equal(provider.waitedFor[0], scenario.expected.transactionHash);
+});
+
+test('optimism sepolia fallback meta-tx request is deterministic', async () => {
+  const scenario = clone(fixture.optimismSepolia);
+  const userWallet = new ethers.Wallet(scenario.user.privateKey);
+  scenario.user.address = userWallet.address;
+  const provider = new MockMetaProvider({ ...scenario, userAddress: userWallet.address });
+  const user = userWallet.connect(provider);
+  const relayer = new ethers.Wallet(scenario.relayer.privateKey, provider);
+
+  const forwarder = new MockForwarder({ ...scenario, userAddress: userWallet.address });
+  const relayerTxs: ethers.TransactionRequest[] = [];
+  const relayerResponse = {
+    hash: scenario.metaTx.response.hash,
+    wait: async () => ({
+      transactionHash: scenario.metaTx.response.hash,
+      status: scenario.metaTx.response.status,
+    }),
+  } as unknown as ethers.TransactionResponse;
+
+  __resetForwarderConfigForTests();
+  process.env.EIP2771_TRUSTED_FORWARDER = scenario.forwarder.address;
+  process.env.EIP2771_GAS_BUFFER = '25000';
+  process.env.EIP2771_GAS_CEILING = '900000';
+
+  const signer = new MetaTxSigner(user, relayer);
+  Reflect.set(signer, 'forwarder', forwarder);
+  const relayerWallet = Reflect.get(signer, 'relayerWallet') as ethers.Wallet;
+  relayerWallet.sendTransaction = async (tx: ethers.TransactionRequest) => {
+    relayerTxs.push(tx);
+    return relayerResponse;
+  };
+
+  const response = await signer.sendTransaction({
+    to: scenario.metaTx.request.to,
+    data: scenario.metaTx.request.data,
+    value: BigInt(scenario.metaTx.request.value),
+    customData: {
+      policy: {
+        userId: scenario.metaTx.policy.userId,
+        jobId: scenario.metaTx.policy.jobId,
+        jobBudgetWei: BigInt(scenario.metaTx.policy.jobBudgetWei),
+      },
+    },
+  });
+
+  assert.equal(response.hash, scenario.metaTx.response.hash);
+  assert.equal(forwarder.requests.length, 1);
+  const forwarded = forwarder.requests[0];
+  const request = forwarded.request as {
+    gas: bigint | string;
+    nonce: bigint | string;
+  };
+  const normalizedGas = BigInt(request.gas).toString(16);
+  assert.equal(`0x${normalizedGas}`, scenario.expected.forwardRequest.gas.toLowerCase());
+  assert.equal(
+    BigInt(request.nonce).toString(),
+    BigInt(scenario.expected.forwardRequest.nonce).toString()
+  );
+  const actualSignature = forwarder.requests[0].signature;
+  assert.equal(actualSignature, scenario.expected.signature);
+
+  assert.equal(provider.estimateGasCalls.length, 1);
+  const gasCall = provider.estimateGasCalls[0];
+  assert.equal(
+    (gasCall.from as string).toLowerCase(),
+    scenario.forwarder.address.toLowerCase()
+  );
+
+  assert.equal(relayerTxs.length, 1);
+  assert.equal(
+    BigInt(relayerTxs[0].gasLimit ?? 0n).toString(),
+    BigInt(scenario.expected.relayerGasLimit).toString()
+  );
+
+  __resetForwarderConfigForTests();
+  delete process.env.EIP2771_TRUSTED_FORWARDER;
+  delete process.env.EIP2771_GAS_BUFFER;
+  delete process.env.EIP2771_GAS_CEILING;
+});

--- a/packages/orchestrator/test/fixtures/aa-e2e.json
+++ b/packages/orchestrator/test/fixtures/aa-e2e.json
@@ -1,0 +1,107 @@
+{
+  "sepolia": {
+    "chainId": 11155111,
+    "entryPoint": "0x0000000000000000000000000000000000004337",
+    "session": {
+      "privateKey": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "tx": {
+      "to": "0x0000000000000000000000000000000000000005",
+      "data": "0x1234",
+      "value": "0x0"
+    },
+    "policy": {
+      "userId": "analyst.sepolia",
+      "jobId": "42",
+      "jobBudgetWei": "1000000000000000000"
+    },
+    "provider": {
+      "estimateGas": "0x2bf20"
+    },
+    "feeData": {
+      "maxFeePerGas": "0x2540be400",
+      "maxPriorityFeePerGas": "0x3b9aca00"
+    },
+    "config": {
+      "verificationGasLimit": "0x16e360",
+      "preVerificationGas": "0xea60",
+      "callGasBuffer": "0x61a8",
+      "paymasterContext": {
+        "network": "sepolia"
+      }
+    },
+    "nonce": "0x07",
+    "paymaster": {
+      "paymasterAndData": "0xdeadbeef",
+      "preVerificationGas": "0x1adb0",
+      "verificationGasLimit": "0x1c9c0",
+      "callGasLimit": "0x3a980"
+    },
+    "bundler": {
+      "userOpHash": "0x9f5f7c4f5c3ab1c4734b9ffdf6b903e5bb5a5e4c50bba1a52ecd822b1c4d9051",
+      "actualGasCost": "0x0",
+      "actualGasUsed": "0x0"
+    },
+    "expected": {
+      "transactionHash": "0xf47fcb2f12c8b12cc00cf78a0985e05d39a5927e1a5c1d22222d0331c5c0ffee",
+      "blockNumber": 12345678,
+      "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "gasUsed": "0x3d090",
+      "status": 1,
+      "paymasterContext": {
+        "network": "sepolia",
+        "userId": "analyst.sepolia",
+        "jobId": "42",
+        "jobBudgetWei": "1000000000000000000"
+      }
+    }
+  },
+  "optimismSepolia": {
+    "chainId": 11155420,
+    "forwarder": {
+      "address": "0x0000000000000000000000000000000000000001",
+      "nonce": "0x02"
+    },
+    "user": {
+      "privateKey": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "relayer": {
+      "privateKey": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "provider": {
+      "estimateGas": "0x249f0"
+    },
+    "feeData": {
+      "maxFeePerGas": "0x165a0bc00",
+      "maxPriorityFeePerGas": "0x59682f00"
+    },
+    "metaTx": {
+      "policy": {
+        "userId": "analyst.optimism",
+        "jobId": "84",
+        "jobBudgetWei": "500000000000000000"
+      },
+      "request": {
+        "to": "0x0000000000000000000000000000000000000009",
+        "data": "0xdeadbeef",
+        "value": "0x0"
+      },
+      "execute": {
+        "data": "0xabcdef",
+        "gasLimit": null
+      },
+      "response": {
+        "hash": "0xfeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface",
+        "status": 1
+      }
+    },
+    "expected": {
+      "forwardRequest": {
+        "gas": "0x2ab98",
+        "nonce": "0x02"
+      },
+      "signature": "0x4d375a21d29d25326cc9c0cbdad5f2d33fb6031c9c86d05abf918b75f59e5a870e71e1386d943a095dbbd15ccccf9ca1c196b993117de8c76f12db3b5794b6011b",
+      "relayerGasLimit": "200000"
+    }
+  }
+}

--- a/test/e2e/fixtures/localnet-artifacts.json
+++ b/test/e2e/fixtures/localnet-artifacts.json
@@ -1,0 +1,27 @@
+{
+  "token": {
+    "initialMint": "1000",
+    "decimals": 18
+  },
+  "job": {
+    "subdomain": "local-agent",
+    "specHash": "0x518e448d72cef12acd9f1e4deba0930235c2e29bafc79c2526975d8c3b3d9785",
+    "uri": "ipfs://local-job",
+    "reward": "25",
+    "deadlineOffsetSeconds": 7200,
+    "analysisDescription": "Localnet pipeline"
+  },
+  "agent": {
+    "ensRoot": "agent.agi.eth",
+    "summary": "deterministic-output",
+    "resultCid": "bafy-local-cid-1",
+    "deterministicSalt": "0x1111111111111111111111111111111111111111111111111111111111111111"
+  },
+  "timestamps": {
+    "base": 1700000000
+  },
+  "expected": {
+    "resultURI": "ipfs://bafy-local-cid-1",
+    "submissionMethod": "submit"
+  }
+}


### PR DESCRIPTION
## Summary
- seed the local gateway e2e with fixture data, clean generated artifacts, and rely on deterministic mocks
- add orchestrator account abstraction e2e coverage with pinned Sepolia and Optimism-Sepolia scenarios
- store reusable fixture data for both local and testnet flows to ensure reproducible runs

## Testing
- npm run e2e:local
- npm test (packages/orchestrator)


------
https://chatgpt.com/codex/tasks/task_e_68d8b344a35c8333a4fb14be00a37bb6