### PR TITLE
Add CSP guidance and externalize One-Box inline styling

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -43,6 +43,12 @@ A single-input, gasless, walletless interface that talks to the AGI-Alpha Meta-A
 
 The build emits a `manifest.json` inside `dist/` that records the hashed filenames used by `index.html`.
 
+## Content Security Policy
+
+- The production HTML template embeds a restrictive CSP meta tag: `default-src 'self'; style-src 'self'; script-src 'self'; connect-src 'self' https://alpha-orchestrator.example.com https://api.web3.storage https://w3s.link https://ipfs.io; …`.
+- Update the `connect-src` directive when pointing the client at different orchestrator, pinning, or gateway infrastructure. The helper export `CONNECT_SRC_ORIGINS` in [`config.mjs`](./config.mjs) / [`config.js`](./config.js) enumerates the origins that must be permitted.
+- Keep orchestrator, pinning, and gateway hosts aligned between your configuration files and the CSP meta tag before pinning to IPFS to avoid runtime fetch failures.
+
 ## Runtime configuration & demo mode
 
 - **Advanced panel overrides**: Click the new **Orchestrator** controls to set the base URL (e.g. `https://alpha.example.com`) and prefix (default `/onebox`). Values are stored in `localStorage` under `AGIJOBS_ONEBOX_ORCHESTRATOR_BASE` / `_PREFIX`.

--- a/apps/onebox-static/config.js
+++ b/apps/onebox-static/config.js
@@ -1,17 +1,73 @@
-export const ORCHESTRATOR_BASE_URL = "https://alpha-orchestrator.example.com";
-export const ORCHESTRATOR_ONEBOX_PREFIX = "/onebox";
-export const PLAN_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/plan`;
-export const EXEC_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/execute`;
-export const STATUS_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/status`;
-export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };
-export const HISTORY_LENGTH = 6;
-export const IPFS_ENDPOINT = "https://api.web3.storage/upload";
-export const IPFS_TOKEN_STORAGE_KEY = "AGIJOBS_W3S_TOKEN";
-export const IPFS_GATEWAYS = [
+const RAW_ORCHESTRATOR_BASE_URL = "https://alpha-orchestrator.example.com";
+const RAW_ORCHESTRATOR_ONEBOX_PREFIX = "/onebox";
+const RAW_IPFS_ENDPOINT = "https://api.web3.storage/upload";
+const RAW_IPFS_GATEWAYS = [
   "https://w3s.link/ipfs/",
   "https://ipfs.io/ipfs/",
 ];
+
+function trimTrailingSlash(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/\/+$/, "");
+}
+
+function trimSlashes(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^\/+|\/+$/g, "");
+}
+
+function joinUrlSegments(base, ...segments) {
+  if (!base) return "";
+  let normalized = trimTrailingSlash(base);
+  for (const segment of segments) {
+    if (!segment) continue;
+    const trimmed = trimSlashes(segment);
+    if (!trimmed) continue;
+    normalized += `/${trimmed}`;
+  }
+  return normalized;
+}
+
+function toOrigin(value) {
+  try {
+    if (typeof value !== "string" || !value.trim()) return null;
+    return new URL(value).origin;
+  } catch (err) {
+    return null;
+  }
+}
+
+function unique(list) {
+  return Array.from(new Set(list));
+}
+
+export const ORCHESTRATOR_BASE_URL = trimTrailingSlash(RAW_ORCHESTRATOR_BASE_URL);
+export const ORCHESTRATOR_ONEBOX_PREFIX = RAW_ORCHESTRATOR_ONEBOX_PREFIX;
+export const ORCHESTRATOR_ROOT = joinUrlSegments(
+  ORCHESTRATOR_BASE_URL,
+  trimSlashes(ORCHESTRATOR_ONEBOX_PREFIX),
+);
+export const PLAN_URL = joinUrlSegments(ORCHESTRATOR_ROOT, "plan");
+export const EXEC_URL = joinUrlSegments(ORCHESTRATOR_ROOT, "execute");
+export const STATUS_URL = joinUrlSegments(ORCHESTRATOR_ROOT, "status");
+export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };
+export const HISTORY_LENGTH = 6;
+export const IPFS_ENDPOINT = RAW_IPFS_ENDPOINT;
+export const IPFS_TOKEN_STORAGE_KEY = "AGIJOBS_W3S_TOKEN";
+export const IPFS_GATEWAYS = RAW_IPFS_GATEWAYS.map((url) => url.trim()).filter(Boolean);
 export const WEB3_STORAGE_API = IPFS_ENDPOINT;
+export const CONNECT_SRC_ORIGINS = unique(
+  [
+    ORCHESTRATOR_BASE_URL,
+    PLAN_URL,
+    EXEC_URL,
+    STATUS_URL,
+    IPFS_ENDPOINT,
+    ...IPFS_GATEWAYS,
+  ]
+    .map(toOrigin)
+    .filter(Boolean),
+);
 export const ORCHESTRATOR_STORAGE_KEYS = {
   base: "AGIJOBS_ONEBOX_ORCHESTRATOR_BASE",
   prefix: "AGIJOBS_ONEBOX_ORCHESTRATOR_PREFIX",

--- a/apps/onebox-static/config.mjs
+++ b/apps/onebox-static/config.mjs
@@ -1,14 +1,70 @@
-export const ORCHESTRATOR_BASE_URL = "https://alpha-orchestrator.example.com";
-export const ORCHESTRATOR_ONEBOX_PREFIX = "/onebox";
-export const PLAN_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/plan`;
-export const EXEC_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/execute`;
-export const STATUS_URL = `${ORCHESTRATOR_BASE_URL}${ORCHESTRATOR_ONEBOX_PREFIX}/status`;
-export const IPFS_ENDPOINT = "https://api.web3.storage/upload";
-export const IPFS_TOKEN_STORAGE_KEY = "AGIJOBS_W3S_TOKEN";
-export const IPFS_GATEWAYS = [
+const RAW_ORCHESTRATOR_BASE_URL = "https://alpha-orchestrator.example.com";
+const RAW_ORCHESTRATOR_ONEBOX_PREFIX = "/onebox";
+const RAW_IPFS_ENDPOINT = "https://api.web3.storage/upload";
+const RAW_IPFS_GATEWAYS = [
   "https://w3s.link/ipfs/",
   "https://ipfs.io/ipfs/",
 ];
+
+function trimTrailingSlash(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/\/+$/, "");
+}
+
+function trimSlashes(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^\/+|\/+$/g, "");
+}
+
+function joinUrlSegments(base, ...segments) {
+  if (!base) return "";
+  let normalized = trimTrailingSlash(base);
+  for (const segment of segments) {
+    if (!segment) continue;
+    const trimmed = trimSlashes(segment);
+    if (!trimmed) continue;
+    normalized += `/${trimmed}`;
+  }
+  return normalized;
+}
+
+function toOrigin(value) {
+  try {
+    if (typeof value !== "string" || !value.trim()) return null;
+    return new URL(value).origin;
+  } catch (err) {
+    return null;
+  }
+}
+
+function unique(list) {
+  return Array.from(new Set(list));
+}
+
+export const ORCHESTRATOR_BASE_URL = trimTrailingSlash(RAW_ORCHESTRATOR_BASE_URL);
+export const ORCHESTRATOR_ONEBOX_PREFIX = RAW_ORCHESTRATOR_ONEBOX_PREFIX;
+export const ORCHESTRATOR_ROOT = joinUrlSegments(
+  ORCHESTRATOR_BASE_URL,
+  trimSlashes(ORCHESTRATOR_ONEBOX_PREFIX),
+);
+export const PLAN_URL = joinUrlSegments(ORCHESTRATOR_ROOT, "plan");
+export const EXEC_URL = joinUrlSegments(ORCHESTRATOR_ROOT, "execute");
+export const STATUS_URL = joinUrlSegments(ORCHESTRATOR_ROOT, "status");
+export const IPFS_ENDPOINT = RAW_IPFS_ENDPOINT;
+export const IPFS_TOKEN_STORAGE_KEY = "AGIJOBS_W3S_TOKEN";
+export const IPFS_GATEWAYS = RAW_IPFS_GATEWAYS.map((url) => url.trim()).filter(Boolean);
+export const CONNECT_SRC_ORIGINS = unique(
+  [
+    ORCHESTRATOR_BASE_URL,
+    PLAN_URL,
+    EXEC_URL,
+    STATUS_URL,
+    IPFS_ENDPOINT,
+    ...IPFS_GATEWAYS,
+  ]
+    .map(toOrigin)
+    .filter(Boolean),
+);
 export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };
 export const ORCHESTRATOR_STORAGE_KEYS = {
   base: "AGIJOBS_ONEBOX_ORCHESTRATOR_BASE",

--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>AGI Jobs — One-Box</title>
   <meta name="description" content="Gasless, walletless one-box interface for AGI Jobs v0" />
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="default-src 'self'; style-src 'self'; script-src 'self'; connect-src 'self' https://alpha-orchestrator.example.com https://api.web3.storage https://w3s.link https://ipfs.io; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'self';"
+  />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='48' fill='%231052d6'/%3E%3Ctext x='50' y='62' font-family='Arial' font-size='52' fill='white' text-anchor='middle'%3EA%3C/text%3E%3C/svg%3E" />
   <!-- Build template: assets injected by scripts/build.mjs -->
   <link rel="stylesheet" href="{{ styles_css }}" />
@@ -53,7 +57,7 @@
   </form>
 
   <noscript>
-    <p style="padding:16px; text-align:center;">JavaScript is required for the AGI Jobs one-box interface.</p>
+    <p class="noscript-message">JavaScript is required for the AGI Jobs one-box interface.</p>
   </noscript>
 
   <script type="module" src="{{ app_js }}"></script>

--- a/apps/onebox-static/styles.css
+++ b/apps/onebox-static/styles.css
@@ -42,6 +42,11 @@ body {
   color: var(--text);
 }
 
+.noscript-message {
+  padding: 16px;
+  text-align: center;
+}
+
 header {
   position: sticky;
   top: 0;


### PR DESCRIPTION
## Summary
- move the noscript warning styles into the hashed stylesheet and add the CSP meta tag to the One-Box template
- normalize orchestrator and IPFS endpoints in the shared config modules and expose the derived connect-src origins
- document the CSP expectations for operators in the One-Box README

## Testing
- npm run onebox:static:build *(fails locally: missing esbuild dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9292c50f4833397a66173bc066aa5