### PR TITLE
Add SRI generation and verification for onebox static build

### DIFF
--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -11,7 +11,12 @@
   />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='48' fill='%231052d6'/%3E%3Ctext x='50' y='62' font-family='Arial' font-size='52' fill='white' text-anchor='middle'%3EA%3C/text%3E%3C/svg%3E" />
   <!-- Build template: assets injected by scripts/build.mjs -->
-  <link rel="stylesheet" href="{{ styles_css }}" />
+  <link
+    rel="stylesheet"
+    href="{{ styles_css_href }}"
+    integrity="{{ styles_css_integrity }}"
+    crossorigin="anonymous"
+  />
 </head>
 <body>
   <header>
@@ -60,6 +65,11 @@
     <p class="noscript-message">JavaScript is required for the AGI Jobs one-box interface.</p>
   </noscript>
 
-  <script type="module" src="{{ app_js }}"></script>
+  <script
+    type="module"
+    src="{{ app_js_src }}"
+    integrity="{{ app_js_integrity }}"
+    crossorigin="anonymous"
+  ></script>
 </body>
 </html>

--- a/apps/onebox-static/scripts/build.mjs
+++ b/apps/onebox-static/scripts/build.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { build } from "esbuild";
+import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -40,29 +41,68 @@ const result = await build({
   sourcemap: false,
 });
 
-const manifest = {};
+const manifestEntries = [];
 for (const [outfile, output] of Object.entries(result.metafile.outputs)) {
   if (!output.entryPoint) continue;
   const entryPoint = posix(output.entryPoint.replace(/^\.\//, ""));
   const entry = entryMeta.get(entryPoint);
   if (!entry) continue;
-  manifest[entry.basename] = path.basename(outfile);
+  manifestEntries.push({
+    basename: entry.basename,
+    outfile,
+  });
 }
 
-if (!manifest["app.mjs"]) {
+if (!manifestEntries.some(({ basename }) => basename === "app.mjs")) {
   throw new Error("Failed to locate bundled app.mjs output in manifest");
 }
-if (!manifest["styles.css"]) {
+if (!manifestEntries.some(({ basename }) => basename === "styles.css")) {
   throw new Error("Failed to locate bundled styles.css output in manifest");
+}
+
+const computeIntegrity = async (filePath) => {
+  const fileBuffer = await fs.readFile(filePath);
+  const sha384 = createHash("sha384").update(fileBuffer).digest("base64");
+  const sha512 = createHash("sha512").update(fileBuffer).digest("base64");
+  return {
+    sha384: `sha384-${sha384}`,
+    sha512: `sha512-${sha512}`,
+  };
+};
+
+const manifest = {};
+for (const { basename, outfile } of manifestEntries) {
+  const absoluteOutfile = path.isAbsolute(outfile)
+    ? outfile
+    : path.join(appDir, outfile);
+  const integrity = await computeIntegrity(absoluteOutfile);
+  manifest[basename] = {
+    file: path.basename(outfile),
+    integrity,
+  };
 }
 
 const manifestPath = path.join(distDir, "manifest.json");
 await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
 const template = await fs.readFile(templatePath, "utf8");
+const scriptEntry = manifest["app.mjs"];
+const stylesEntry = manifest["styles.css"];
+
+const formatIntegrityAttribute = (entry) =>
+  `${entry.integrity.sha384} ${entry.integrity.sha512}`;
+
 const html = template
-  .replace(/\{\{\s*app_js\s*\}\}/g, `./${manifest["app.mjs"]}`)
-  .replace(/\{\{\s*styles_css\s*\}\}/g, `./${manifest["styles.css"]}`);
+  .replace(/\{\{\s*app_js_src\s*\}\}/g, `./${scriptEntry.file}`)
+  .replace(
+    /\{\{\s*app_js_integrity\s*\}\}/g,
+    formatIntegrityAttribute(scriptEntry),
+  )
+  .replace(/\{\{\s*styles_css_href\s*\}\}/g, `./${stylesEntry.file}`)
+  .replace(
+    /\{\{\s*styles_css_integrity\s*\}\}/g,
+    formatIntegrityAttribute(stylesEntry),
+  );
 
 await fs.writeFile(path.join(distDir, "index.html"), html);
 

--- a/apps/onebox-static/scripts/verify-sri.mjs
+++ b/apps/onebox-static/scripts/verify-sri.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(__dirname, "..");
+const distDir = path.join(appDir, "dist");
+const manifestPath = path.join(distDir, "manifest.json");
+const indexPath = path.join(distDir, "index.html");
+
+const requiredEntries = ["app.mjs", "styles.css"];
+
+const manifestExists = async (targetPath) => {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+if (!(await manifestExists(manifestPath))) {
+  throw new Error(
+    "Manifest not found. Did you run the static build before verify:sri?",
+  );
+}
+
+if (!(await manifestExists(indexPath))) {
+  throw new Error(
+    "Built index.html not found. Did you run the static build before verify:sri?",
+  );
+}
+
+const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+
+const computeIntegrity = (buffer) => ({
+  sha384: `sha384-${createHash("sha384").update(buffer).digest("base64")}`,
+  sha512: `sha512-${createHash("sha512").update(buffer).digest("base64")}`,
+});
+
+for (const entryKey of requiredEntries) {
+  const entry = manifest[entryKey];
+  if (!entry) {
+    throw new Error(`Manifest missing required entry for ${entryKey}`);
+  }
+  if (!entry.file || !entry.integrity) {
+    throw new Error(
+      `Manifest entry for ${entryKey} must include file and integrity data`,
+    );
+  }
+
+  const filePath = path.join(distDir, entry.file);
+  if (!(await manifestExists(filePath))) {
+    throw new Error(
+      `Manifest entry for ${entryKey} points to missing file ${entry.file}`,
+    );
+  }
+
+  const buffer = await fs.readFile(filePath);
+  const actualIntegrity = computeIntegrity(buffer);
+
+  for (const algo of ["sha384", "sha512"]) {
+    if (entry.integrity[algo] !== actualIntegrity[algo]) {
+      throw new Error(
+        `Integrity mismatch for ${entryKey} (${algo}): manifest has ${entry.integrity[algo]}, actual is ${actualIntegrity[algo]}`,
+      );
+    }
+  }
+}
+
+const html = await fs.readFile(indexPath, "utf8");
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const expectScriptSrc = `./${manifest["app.mjs"].file}`;
+const expectScriptIntegrity = `${manifest["app.mjs"].integrity.sha384} ${manifest["app.mjs"].integrity.sha512}`;
+const expectStylesHref = `./${manifest["styles.css"].file}`;
+const expectStylesIntegrity = `${manifest["styles.css"].integrity.sha384} ${manifest["styles.css"].integrity.sha512}`;
+
+const scriptPattern = new RegExp(
+  `<script[^>]*type="module"[^>]*src="${escapeRegExp(expectScriptSrc)}"[^>]*integrity="${escapeRegExp(expectScriptIntegrity)}"[^>]*crossorigin="anonymous"`,
+);
+
+if (!scriptPattern.test(html)) {
+  throw new Error(
+    "Built index.html is missing the expected <script> tag with integrity and crossorigin attributes",
+  );
+}
+
+const linkPattern = new RegExp(
+  `<link[^>]*rel="stylesheet"[^>]*href="${escapeRegExp(expectStylesHref)}"[^>]*integrity="${escapeRegExp(expectStylesIntegrity)}"[^>]*crossorigin="anonymous"`,
+);
+
+if (!linkPattern.test(html)) {
+  throw new Error(
+    "Built index.html is missing the expected <link> tag with integrity and crossorigin attributes",
+  );
+}
+
+console.log("Static asset integrity verified successfully.");

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "lint:check": "solhint 'contracts/**/*.sol' && eslint . --ext .js,.ts,.tsx --max-warnings=0",
     "lint:fix": "solhint --fix 'contracts/**/*.sol' && eslint . --ext .js,.ts,.tsx --fix",
     "format:fix": "prettier --write \".github/workflows/**/*.yml\" \"scripts/ci/**/*.{js,mjs}\" \"hardhat.config.js\" \"package.json\" \".solcover.js\"",
-    "onebox:static:build": "node apps/onebox-static/scripts/build.mjs"
+    "onebox:static:build": "node apps/onebox-static/scripts/build.mjs",
+    "verify:sri": "node apps/onebox-static/scripts/verify-sri.mjs"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- extend the onebox static build pipeline to compute SHA-384 and SHA-512 integrity values for hashed JS/CSS assets and expose them in the manifest
- update the HTML template injection to emit integrity and crossorigin attributes sourced from the manifest
- add a verify:sri script that recalculates hashes and validates the built HTML stays aligned with the manifest

## Testing
- npm run onebox:static:build
- npm run verify:sri

------
https://chatgpt.com/codex/tasks/task_e_68d92c754b4083338d4e61333b3f5700