### PR TITLE
Add automated IPFS publish workflow for onebox static bundle

### DIFF
--- a/apps/onebox-static/index.html
+++ b/apps/onebox-static/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Gasless, walletless one-box interface for AGI Jobs v0" />
   <meta
     http-equiv="Content-Security-Policy"
-    content="default-src 'self'; style-src 'self'; script-src 'self'; connect-src 'self' https://alpha-orchestrator.example.com https://api.web3.storage https://w3s.link https://ipfs.io; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'self';"
+    content="default-src 'self'; style-src 'self'; script-src 'self'; connect-src {{ connect_src }}; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'self';"
   />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='48' fill='%231052d6'/%3E%3Ctext x='50' y='62' font-family='Arial' font-size='52' fill='white' text-anchor='middle'%3EA%3C/text%3E%3C/svg%3E" />
   <!-- Build template: assets injected by scripts/build.mjs -->

--- a/apps/onebox-static/scripts/publish.mjs
+++ b/apps/onebox-static/scripts/publish.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { CarReader } from "@ipld/car";
+import namehashModule from "eth-ens-namehash";
+import { ethers } from "ethers";
+import contentHash from "content-hash";
+import { packToFs } from "ipfs-car/pack/fs";
+import PinataClientModule from "@pinata/sdk";
+import { Web3Storage } from "web3.storage";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(__dirname, "..");
+const distDir = path.join(appDir, "dist");
+const manifestPath = path.join(distDir, "manifest.json");
+const configModuleUrl = pathToFileURL(path.join(appDir, "config.mjs"));
+const carOutputPath = path.join(distDir, "onebox.car");
+
+const args = new Set(process.argv.slice(2));
+const skipBuild = args.has("--skip-build");
+const skipWeb3 = args.has("--skip-web3");
+const skipPinata = args.has("--skip-pinata");
+const skipEns = args.has("--skip-ens");
+const dryRun = args.has("--dry-run");
+
+const log = (...messages) => console.log("[onebox:publish]", ...messages);
+
+function formatError(message) {
+  return new Error(`[onebox:publish] ${message}`);
+}
+
+async function runNodeScript(scriptName) {
+  const scriptPath = path.join(__dirname, scriptName);
+  await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: appDir,
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          formatError(`${scriptName} failed with exit code ${code ?? "unknown"}`),
+        );
+      }
+    });
+  });
+}
+
+function deriveReleaseLabel() {
+  if (process.env.ONEBOX_RELEASE_LABEL) return process.env.ONEBOX_RELEASE_LABEL;
+  if (process.env.GITHUB_REF_NAME) return process.env.GITHUB_REF_NAME;
+  if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA.slice(0, 12);
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function resolvePinataConfig() {
+  const jwt = process.env.PINATA_JWT || process.env.PINATA_JWT_KEY;
+  if (jwt) {
+    return { pinataJWTKey: jwt };
+  }
+  const apiKey = process.env.PINATA_API_KEY;
+  const secret = process.env.PINATA_SECRET_API_KEY;
+  if (apiKey && secret) {
+    return { pinataApiKey: apiKey, pinataSecretApiKey: secret };
+  }
+  return null;
+}
+
+function sanitizeHostNodes(raw) {
+  if (!raw) return undefined;
+  const nodes = raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return nodes.length ? nodes : undefined;
+}
+
+async function ensureBuildArtifacts() {
+  if (!skipBuild && !dryRun) {
+    log("Running static build...");
+    await runNodeScript("build.mjs");
+    log("Verifying subresource integrity...");
+    await runNodeScript("verify-sri.mjs");
+  }
+  try {
+    await fs.access(manifestPath);
+  } catch {
+    throw formatError(
+      "Static manifest missing. Run the build step or pass --skip-build only after generating dist/.",
+    );
+  }
+}
+
+async function createCarArchive() {
+  log("Packing dist/ directory into CAR archive...");
+  await fs.rm(carOutputPath, { force: true });
+  const { root } = await packToFs({
+    input: distDir,
+    output: carOutputPath,
+    wrapWithDirectory: true,
+  });
+  const rootCid = root.toString();
+  log(`CAR archive ready: ${path.relative(appDir, carOutputPath)} (cid=${rootCid})`);
+  return rootCid;
+}
+
+async function uploadToWeb3Storage(rootCid, releaseName) {
+  if (dryRun || skipWeb3) {
+    log("Skipping web3.storage upload (dry run or --skip-web3)");
+    return null;
+  }
+  const token = process.env.WEB3_STORAGE_TOKEN || process.env.W3S_TOKEN;
+  if (!token) {
+    throw formatError(
+      "WEB3_STORAGE_TOKEN (or W3S_TOKEN) must be set to upload to web3.storage",
+    );
+  }
+  log("Uploading CAR to web3.storage...");
+  const client = new Web3Storage({ token });
+  const carBytes = await fs.readFile(carOutputPath);
+  const carReader = await CarReader.fromBytes(carBytes);
+  const uploadCid = await client.putCar(carReader, { name: releaseName });
+  if (uploadCid !== rootCid) {
+    throw formatError(
+      `CID mismatch from web3.storage upload (expected ${rootCid}, received ${uploadCid})`,
+    );
+  }
+  const status = await client.status(rootCid).catch((err) => {
+    log("Warning: unable to fetch web3.storage status", err.message ?? err);
+    return null;
+  });
+  log("web3.storage upload complete.");
+  return {
+    cid: uploadCid,
+    status: status
+      ? {
+          cid: status.cid,
+          dagSize: status.dagSize,
+          pins: status.pins?.map(({ region, status: pinStatus }) => ({
+            region,
+            status: pinStatus,
+          })),
+        }
+      : null,
+  };
+}
+
+async function pinWithPinata(rootCid, releaseName) {
+  if (dryRun || skipPinata) {
+    log("Skipping Pinata pin (dry run or --skip-pinata)");
+    return null;
+  }
+  const config = resolvePinataConfig();
+  if (!config) {
+    throw formatError(
+      "Pinata credentials missing. Provide PINATA_JWT or PINATA_API_KEY/PINATA_SECRET_API_KEY",
+    );
+  }
+  const PinataClient = PinataClientModule.default || PinataClientModule;
+  const pinata = new PinataClient(config);
+  log("Requesting Pinata to pin existing CID...");
+  const hostNodes = sanitizeHostNodes(process.env.PINATA_HOST_NODES);
+  const result = await pinata.pinByHash(rootCid, {
+    pinataMetadata: { name: releaseName },
+    ...(hostNodes ? { pinataOptions: { hostNodes } } : {}),
+  });
+  let jobs = null;
+  try {
+    jobs = await pinata.pinJobs({
+      sort: "ASC",
+      ipfs_pin_hash: rootCid,
+    });
+  } catch (err) {
+    log("Warning: unable to query Pinata pin jobs", err.message ?? err);
+  }
+  log("Pinata pin requested.");
+  return {
+    requestId: result?.id ?? null,
+    status: result?.status ?? null,
+    hostNodes: hostNodes ?? null,
+    jobs: jobs?.rows ?? null,
+  };
+}
+
+const { hash: namehash } = namehashModule;
+
+async function updateEnsContenthash(rootCid) {
+  if (dryRun || skipEns) {
+    log("Skipping ENS contenthash update (dry run or --skip-ens)");
+    return null;
+  }
+  const ensName = process.env.ENS_NAME || process.env.ONEBOX_ENS_NAME;
+  if (!ensName) {
+    log("No ENS_NAME provided; skipping contenthash update.");
+    return null;
+  }
+  const privateKey = process.env.ENS_PRIVATE_KEY || process.env.ONEBOX_ENS_PRIVATE_KEY;
+  const rpcUrl = process.env.ENS_RPC_URL || process.env.ONEBOX_ENS_RPC_URL;
+  if (!privateKey || !rpcUrl) {
+    throw formatError("ENS_PRIVATE_KEY and ENS_RPC_URL are required to update contenthash");
+  }
+  const registryAddress =
+    process.env.ENS_REGISTRY || "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const wallet = new ethers.Wallet(privateKey, provider);
+  const registry = new ethers.Contract(
+    registryAddress,
+    ["function resolver(bytes32 node) view returns (address)"],
+    wallet,
+  );
+  const node = namehash(ensName);
+  const resolverAddress =
+    process.env.ENS_RESOLVER || (await registry.resolver(node));
+  if (!resolverAddress || resolverAddress === ethers.ZeroAddress) {
+    throw formatError(
+      `Resolver not configured for ${ensName}. Provide ENS_RESOLVER or set one on-chain.`,
+    );
+  }
+  const resolver = new ethers.Contract(
+    resolverAddress,
+    [
+      "function contenthash(bytes32 node) view returns (bytes)",
+      "function setContenthash(bytes32 node, bytes hash) external",
+    ],
+    wallet,
+  );
+  const encoded = `0x${contentHash.fromIpfs(rootCid)}`;
+  const current = await resolver
+    .contenthash(node)
+    .catch(() => "0x");
+  if (current === encoded) {
+    log(`ENS contenthash already set for ${ensName}.`);
+    return {
+      name: ensName,
+      resolver: resolverAddress,
+      txHash: null,
+      contenthash: encoded,
+      gateway: `https://${ensName}.limo`,
+    };
+  }
+  log(`Updating ENS contenthash for ${ensName} -> ${rootCid}...`);
+  const tx = await resolver.setContenthash(node, encoded);
+  const receipt = await tx.wait();
+  log("ENS contenthash update transaction mined.");
+  return {
+    name: ensName,
+    resolver: resolverAddress,
+    txHash: receipt?.hash || tx.hash,
+    contenthash: encoded,
+    gateway: `https://${ensName}.limo`,
+  };
+}
+
+async function main() {
+  const releaseLabel = deriveReleaseLabel();
+  const releaseName = `agi-onebox-${releaseLabel}`;
+  await ensureBuildArtifacts();
+  const manifestRaw = await fs.readFile(manifestPath, "utf8");
+  const manifest = JSON.parse(manifestRaw);
+  const rootCid = await createCarArchive();
+  const web3Result = await uploadToWeb3Storage(rootCid, releaseName);
+  const pinataResult = await pinWithPinata(rootCid, releaseName);
+  const ensResult = await updateEnsContenthash(rootCid);
+  const { IPFS_GATEWAYS = [] } = await import(configModuleUrl.href);
+  const releaseMetadata = {
+    createdAt: new Date().toISOString(),
+    release: releaseName,
+    cid: rootCid,
+    car: path.relative(appDir, carOutputPath),
+    manifest,
+    ipfsGateways: IPFS_GATEWAYS,
+    web3Storage: web3Result,
+    pinata: pinataResult,
+    ens: ensResult,
+    skipped: {
+      build: skipBuild,
+      web3: skipWeb3 || dryRun,
+      pinata: skipPinata || dryRun,
+      ens: skipEns || dryRun || !ensResult,
+    },
+  };
+  await fs.writeFile(
+    path.join(distDir, "release.json"),
+    `${JSON.stringify(releaseMetadata, null, 2)}\n`,
+  );
+  log("Release metadata written to dist/release.json");
+  log(`Root CID: ${rootCid}`);
+  if (ensResult?.gateway) {
+    log(`Gateway preview: ${ensResult.gateway}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-plugin-prettier": "^4.2.5",
         "hardhat": "^2.26.1",
         "hardhat-gas-reporter": "^2.3.0",
+        "ipfs-car": "^0.9.2",
         "prettier": "^2.8.8",
         "solhint": "^6.0.0",
         "solidity-coverage": "^0.8.14",
@@ -5115,6 +5116,12 @@
       "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
       "license": "ISC"
     },
+    "node_modules/blockstore-core/node_modules/it-filter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.3.tgz",
+      "integrity": "sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w==",
+      "license": "ISC"
+    },
     "node_modules/blockstore-core/node_modules/multiformats": {
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
@@ -10099,9 +10106,10 @@
       }
     },
     "node_modules/ipfs-car": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.7.0.tgz",
-      "integrity": "sha512-9ser6WWZ1ZMTCGbcVkRXUzOrpQ4SIiLfzIEnk+3LQsXbV09yeZg3ijhRuEXozEIYE68Go9JmOFshamsK9iKlNQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.9.2.tgz",
+      "integrity": "sha512-OUKgQqCN9C16eyu9OSOXe2CyRUL/jemWDODfALihvwRHfLLU6tKQVb8rhjhheWhQ1InlFBMgfIiLNxGpUSqOXA==",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^3.2.3",
@@ -10135,6 +10143,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
       "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -10145,6 +10154,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
       "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "browser-readablestream-to-it": "^1.0.3"
@@ -10154,12 +10164,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
       "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ipfs-car/node_modules/dns-over-http-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
       "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.1",
@@ -10171,6 +10183,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
       "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "interface-store": "^2.0.2",
@@ -10182,6 +10195,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
       "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg==",
+      "dev": true,
       "license": "(Apache-2.0 OR MIT)"
     },
     "node_modules/ipfs-car/node_modules/ipfs-core-types": {
@@ -10189,6 +10203,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.8.4.tgz",
       "integrity": "sha512-sbRZA1QX3xJ6ywTiVQZMOxhlhp4osAZX2SXx3azOLxAtxmGWDMkHYt722VV4nZ2GyJy8qyk5GHQIZ0uvQnpaTg==",
       "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "interface-datastore": "^6.0.2",
@@ -10201,6 +10216,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.12.2.tgz",
       "integrity": "sha512-RfxP3rPhXuqKIUmTAUhmee6fmaV3A7LMnjOUikRKpSyqESz/DR7aGK7tbttMxkZdkSEr0rFXlqbyb0vVwmn0wQ==",
       "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-signal": "^2.1.2",
@@ -10229,6 +10245,7 @@
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
       "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "err-code": "^3.0.1",
@@ -10243,30 +10260,35 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
       "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ipfs-car/node_modules/it-last": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
       "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ipfs-car/node_modules/it-map": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
       "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ipfs-car/node_modules/it-peekable": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
       "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ipfs-car/node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/ipfs-car/node_modules/multiaddr": {
@@ -10274,6 +10296,7 @@
       "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
       "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
       "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dns-over-http-resolver": "^1.2.3",
@@ -10288,12 +10311,14 @@
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/ipfs-car/node_modules/native-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
       "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "node-fetch": "*"
@@ -10303,6 +10328,7 @@
       "version": "6.11.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
       "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10329,12 +10355,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/retimer/-/retimer-2.0.0.tgz",
       "integrity": "sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ipfs-car/node_modules/timeout-abort-controller": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-1.1.1.tgz",
       "integrity": "sha512-BsF9i3NAJag6T0ZEjki9j654zoafI2X6ayuNd6Tp8+Ul6Tr5s4jo973qFeiWrRSweqvskC+AHDKUmIW4b7pdhQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -10345,6 +10373,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
       "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
@@ -11147,12 +11176,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.5.tgz",
       "integrity": "sha512-r/GjkiW1bZswC04TNmUnLxa6uovme7KKwPhc+cb1hHU65E3AByypHH6Pm91WHuvqfFsm+9ws0kPtDBV3/8vmIg==",
-      "license": "ISC"
-    },
-    "node_modules/it-filter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.3.tgz",
-      "integrity": "sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w==",
       "license": "ISC"
     },
     "node_modules/it-first": {
@@ -18303,6 +18326,25 @@
         "w3name": "^1.0.6"
       }
     },
+    "node_modules/web3.storage/node_modules/any-signal": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
+      "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.3"
+      }
+    },
+    "node_modules/web3.storage/node_modules/blob-to-it": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
+      "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
+      "license": "ISC",
+      "dependencies": {
+        "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
     "node_modules/web3.storage/node_modules/browser-readablestream-to-it": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
@@ -18318,11 +18360,223 @@
         "cborg": "cli.js"
       }
     },
+    "node_modules/web3.storage/node_modules/dns-over-http-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^3.0.0",
+        "receptacle": "^1.3.2"
+      }
+    },
+    "node_modules/web3.storage/node_modules/interface-datastore": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
+      "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "interface-store": "^2.0.2",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/web3.storage/node_modules/interface-store": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg==",
+      "license": "(Apache-2.0 OR MIT)"
+    },
+    "node_modules/web3.storage/node_modules/ipfs-car": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.7.0.tgz",
+      "integrity": "sha512-9ser6WWZ1ZMTCGbcVkRXUzOrpQ4SIiLfzIEnk+3LQsXbV09yeZg3ijhRuEXozEIYE68Go9JmOFshamsK9iKlNQ==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@ipld/car": "^3.2.3",
+        "@web-std/blob": "^3.0.1",
+        "bl": "^5.0.0",
+        "blockstore-core": "^1.0.2",
+        "browser-readablestream-to-it": "^1.0.2",
+        "idb-keyval": "^6.0.3",
+        "interface-blockstore": "^2.0.2",
+        "ipfs-core-types": "^0.8.3",
+        "ipfs-core-utils": "^0.12.1",
+        "ipfs-unixfs-exporter": "^7.0.4",
+        "ipfs-unixfs-importer": "^9.0.4",
+        "ipfs-utils": "^9.0.2",
+        "it-all": "^1.0.5",
+        "it-last": "^1.0.5",
+        "it-pipe": "^1.1.0",
+        "meow": "^9.0.0",
+        "move-file": "^2.1.0",
+        "multiformats": "^9.6.3",
+        "stream-to-it": "^0.2.3",
+        "streaming-iterables": "^6.0.0",
+        "uint8arrays": "^3.0.0"
+      },
+      "bin": {
+        "🚘": "dist/cjs/cli/cli.js",
+        "ipfs-car": "dist/cjs/cli/cli.js"
+      }
+    },
+    "node_modules/web3.storage/node_modules/ipfs-core-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.8.4.tgz",
+      "integrity": "sha512-sbRZA1QX3xJ6ywTiVQZMOxhlhp4osAZX2SXx3azOLxAtxmGWDMkHYt722VV4nZ2GyJy8qyk5GHQIZ0uvQnpaTg==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "interface-datastore": "^6.0.2",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13"
+      }
+    },
+    "node_modules/web3.storage/node_modules/ipfs-core-utils": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.12.2.tgz",
+      "integrity": "sha512-RfxP3rPhXuqKIUmTAUhmee6fmaV3A7LMnjOUikRKpSyqESz/DR7aGK7tbttMxkZdkSEr0rFXlqbyb0vVwmn0wQ==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "license": "MIT",
+      "dependencies": {
+        "any-signal": "^2.1.2",
+        "blob-to-it": "^1.0.1",
+        "browser-readablestream-to-it": "^1.0.1",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.8.4",
+        "ipfs-unixfs": "^6.0.3",
+        "ipfs-utils": "^9.0.2",
+        "it-all": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-peekable": "^1.0.2",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "multiformats": "^9.4.13",
+        "nanoid": "^3.1.23",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^1.1.1",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/web3.storage/node_modules/ipfs-unixfs": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
+      "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "protobufjs": "^6.10.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/web3.storage/node_modules/it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+      "license": "ISC"
+    },
+    "node_modules/web3.storage/node_modules/it-last": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
+      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q==",
+      "license": "ISC"
+    },
+    "node_modules/web3.storage/node_modules/it-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ==",
+      "license": "ISC"
+    },
+    "node_modules/web3.storage/node_modules/it-peekable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
+      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ==",
+      "license": "ISC"
+    },
+    "node_modules/web3.storage/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/web3.storage/node_modules/multiaddr": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
+      "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
+      "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr",
+      "license": "MIT",
+      "dependencies": {
+        "dns-over-http-resolver": "^1.2.3",
+        "err-code": "^3.0.1",
+        "is-ip": "^3.1.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
+      }
+    },
     "node_modules/web3.storage/node_modules/multiformats": {
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
       "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/web3.storage/node_modules/native-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-fetch": "*"
+      }
+    },
+    "node_modules/web3.storage/node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/web3.storage/node_modules/retimer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-2.0.0.tgz",
+      "integrity": "sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg==",
+      "license": "MIT"
+    },
+    "node_modules/web3.storage/node_modules/timeout-abort-controller": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-1.1.1.tgz",
+      "integrity": "sha512-BsF9i3NAJag6T0ZEjki9j654zoafI2X6ayuNd6Tp8+Ul6Tr5s4jo973qFeiWrRSweqvskC+AHDKUmIW4b7pdhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "retimer": "^2.0.0"
+      }
     },
     "node_modules/web3.storage/node_modules/uint8arrays": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lint:fix": "solhint --fix 'contracts/**/*.sol' && eslint . --ext .js,.ts,.tsx --fix",
     "format:fix": "prettier --write \".github/workflows/**/*.yml\" \"scripts/ci/**/*.{js,mjs}\" \"hardhat.config.js\" \"package.json\" \".solcover.js\"",
     "onebox:static:build": "node apps/onebox-static/scripts/build.mjs",
+    "onebox:static:publish": "node apps/onebox-static/scripts/publish.mjs",
     "verify:sri": "node apps/onebox-static/scripts/verify-sri.mjs"
   },
   "keywords": [],
@@ -84,7 +85,8 @@
     "solidity-coverage": "^0.8.14",
     "supertest": "^7.1.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "ipfs-car": "^0.9.2"
   },
   "dependencies": {
     "@pinata/sdk": "^2.1.0",


### PR DESCRIPTION
## Summary
- derive the onebox static CSP connect-src directive from the config manifest during the build
- add an npm publish helper that builds, CAR-packs, pins via web3.storage & Pinata, and updates ENS contenthash
- document the release workflow, availability SLO, and wire the new publish command and ipfs-car dependency

## Testing
- npm run onebox:static:build
- npm run onebox:static:publish -- --dry-run --skip-build
- npm run verify:sri

------
https://chatgpt.com/codex/tasks/task_e_68d92f2ac2a483338f3760bf749b9618