### PR TITLE
Expose static onebox polling config for IPFS build

### DIFF
--- a/apps/onebox-static/app.mjs
+++ b/apps/onebox-static/app.mjs
@@ -56,7 +56,11 @@ const IPFS_GATEWAYS = Array.isArray(Config.IPFS_GATEWAYS) && Config.IPFS_GATEWAY
   ? Config.IPFS_GATEWAYS
   : ["https://w3s.link/ipfs/"];
 
-const MAX_HISTORY = 10;
+const MAX_HISTORY = (() => {
+  const raw = Config.HISTORY_LENGTH;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : 10;
+})();
 const STATUS_REFRESH_MS = (() => {
   const raw =
     Config.STATUS_REFRESH_MS ?? Config.STATUS_REFRESH_INTERVAL_MS ?? Config.STATUS_POLL_INTERVAL_MS;

--- a/apps/onebox-static/config.js
+++ b/apps/onebox-static/config.js
@@ -5,6 +5,8 @@ const RAW_IPFS_GATEWAYS = [
   "https://w3s.link/ipfs/",
   "https://ipfs.io/ipfs/",
 ];
+const RAW_STATUS_REFRESH_MS = 15_000;
+const RAW_STATUS_MAX_ITEMS = 4;
 
 function trimTrailingSlash(value) {
   if (typeof value !== "string") return "";
@@ -51,11 +53,15 @@ export const PLAN_URL = joinUrlSegments(ORCHESTRATOR_ROOT, "plan");
 export const EXEC_URL = joinUrlSegments(ORCHESTRATOR_ROOT, "execute");
 export const STATUS_URL = joinUrlSegments(ORCHESTRATOR_ROOT, "status");
 export const AA_MODE = { enabled: true, bundler: "alchemy", chainId: 1 };
-export const HISTORY_LENGTH = 6;
+export const HISTORY_LENGTH = 10;
 export const IPFS_ENDPOINT = RAW_IPFS_ENDPOINT;
 export const IPFS_TOKEN_STORAGE_KEY = "AGIJOBS_W3S_TOKEN";
 export const IPFS_GATEWAYS = RAW_IPFS_GATEWAYS.map((url) => url.trim()).filter(Boolean);
 export const WEB3_STORAGE_API = IPFS_ENDPOINT;
+export const STATUS_REFRESH_MS = RAW_STATUS_REFRESH_MS;
+export const STATUS_REFRESH_INTERVAL_MS = RAW_STATUS_REFRESH_MS;
+export const STATUS_POLL_INTERVAL_MS = RAW_STATUS_REFRESH_MS;
+export const STATUS_MAX_ITEMS = RAW_STATUS_MAX_ITEMS;
 export const CONNECT_SRC_ORIGINS = unique(
   [
     ORCHESTRATOR_BASE_URL,

--- a/apps/onebox-static/config.mjs
+++ b/apps/onebox-static/config.mjs
@@ -5,6 +5,9 @@ const RAW_IPFS_GATEWAYS = [
   "https://w3s.link/ipfs/",
   "https://ipfs.io/ipfs/",
 ];
+const RAW_HISTORY_LENGTH = 10;
+const RAW_STATUS_REFRESH_MS = 15_000;
+const RAW_STATUS_MAX_ITEMS = 4;
 
 function trimTrailingSlash(value) {
   if (typeof value !== "string") return "";
@@ -53,6 +56,11 @@ export const STATUS_URL = joinUrlSegments(ORCHESTRATOR_ROOT, "status");
 export const IPFS_ENDPOINT = RAW_IPFS_ENDPOINT;
 export const IPFS_TOKEN_STORAGE_KEY = "AGIJOBS_W3S_TOKEN";
 export const IPFS_GATEWAYS = RAW_IPFS_GATEWAYS.map((url) => url.trim()).filter(Boolean);
+export const HISTORY_LENGTH = RAW_HISTORY_LENGTH;
+export const STATUS_REFRESH_MS = RAW_STATUS_REFRESH_MS;
+export const STATUS_REFRESH_INTERVAL_MS = RAW_STATUS_REFRESH_MS;
+export const STATUS_POLL_INTERVAL_MS = RAW_STATUS_REFRESH_MS;
+export const STATUS_MAX_ITEMS = RAW_STATUS_MAX_ITEMS;
 export const CONNECT_SRC_ORIGINS = unique(
   [
     ORCHESTRATOR_BASE_URL,


### PR DESCRIPTION
## Summary
- export history length and status polling defaults from the static onebox config so integrity scripts can import them cleanly
- derive the runtime chat history cap from the shared configuration rather than a hard-coded value

## Testing
- npm run onebox:static:build
- npm run verify:sri

------
https://chatgpt.com/codex/tasks/task_e_68d931ada6108333976c538095a62487