### PR TITLE
feat(onebox): add fingerprinted build and IPFS publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ packages/orchestrator/dist/
 packages/orchestrator/dist-test/
 packages/onebox-orchestrator/dist/
 apps/onebox-static/dist/
+apps/onebox/dist/
 examples/agentic/runtime-agentic.jsonl
 !scripts/v2/run-owner-plan.js
 !scripts/v2/lib/

--- a/apps/onebox/README.md
+++ b/apps/onebox/README.md
@@ -2,6 +2,8 @@
 
 A static, IPFS-friendly front-end that wraps the AGI Jobs workflow behind a single natural-language input. It calls the AGI-Alpha orchestrator (`/onebox/*`) to translate human requests into actionable job intents and execute them via the relayer (guest mode) or wallet signing (expert mode).
 
+The build now fingerprints assets, injects Subresource Integrity (SRI) hashes, and emits a hardened Content Security Policy (CSP) so releases can be safely pinned to IPFS and surfaced through ENS gateways.
+
 ## Features
 
 - **Single text box UX**: type what you need, receive a plan, confirm, execute.
@@ -13,21 +15,36 @@ A static, IPFS-friendly front-end that wraps the AGI Jobs workflow behind a sing
 
 ## Getting started
 
-1. Serve the folder locally (any static web server works). Example using Python:
+1. Build the static bundle (fingerprinted assets land in `apps/onebox/dist`):
    ```sh
-   cd apps/onebox
+   npm run onebox:build
+   ```
+2. Serve the `dist/` directory locally (any static web server works). Example using Python:
+   ```sh
+   cd apps/onebox/dist
    python -m http.server 4173
    ```
-2. Open the page in your browser and fill out the **Advanced** section with your orchestrator URL and optional API token.
-3. Submit a request such as “Post a labeling job for 500 images; pay 5 AGIALPHA; 7 days.”
-4. Confirm the plan and watch for the on-chain receipt link.
+3. Open the page in your browser and fill out the **Advanced** section with your orchestrator URL and optional API token.
+4. Submit a request such as “Post a labeling job for 500 images; pay 5 AGIALPHA; 7 days.”
+5. Confirm the plan and watch for the on-chain receipt link.
 
-### Hosting on IPFS
+### Hosting on IPFS & ENS
+
+Use the automated publisher to package the build into a CAR file, upload to web3.storage, pin with Pinata, probe gateway health, and (optionally) update an ENS contenthash:
 
 ```sh
-ipfs add -r apps/onebox
+npm run onebox:publish
 ```
-Take the returned CID and publish through your preferred gateway or ENS content hash. No environment secrets are embedded in the client.
+
+Environment variables control optional steps:
+
+| Purpose | Variables |
+| --- | --- |
+| web3.storage upload | `WEB3_STORAGE_TOKEN` or `W3S_TOKEN` |
+| Pinata pin | `PINATA_JWT` (or `PINATA_API_KEY` + `PINATA_SECRET_API_KEY`) |
+| ENS contenthash | `ENS_NAME`, `ENS_PRIVATE_KEY`, `ENS_RPC_URL` *(and optionally `ENS_RESOLVER`/`ENS_REGISTRY`)* |
+
+Add `--dry-run` to inspect the flow without writing anything on-chain or uploading to the pinning services.
 
 ## Accessibility & UX
 
@@ -39,9 +56,11 @@ Take the returned CID and publish through your preferred gateway or ENS content 
 
 ```
 apps/onebox/
-├── app.js       # UI logic, planner/executor calls
-├── index.html   # Markup, inline styling, advanced settings
-├── README.md    # This file
-├── styles.css   # Legacy theme tokens (optional)
-└── ...          # Next.js scaffold kept for future iterations
+├── app.js          # UI logic, planner/executor calls
+├── config.mjs      # CSP connect-src allow list & gateway probes
+├── dist/           # Build artefacts (fingerprinted assets + release metadata)
+├── index.html      # Build template (placeholders resolved by scripts/build.mjs)
+├── README.md       # This file
+├── scripts/        # Build, integrity verification, and publish workflows
+└── styles.css      # Theme tokens (extracted from the original inline styles)
 ```

--- a/apps/onebox/app.js
+++ b/apps/onebox/app.js
@@ -23,7 +23,7 @@ const expertExecuteResponseJson = $('#expert-execute-response');
 const COPY = {
   planning: 'Planning your workflow…',
   confirm: (summary) =>
-    `${summary}<div class="pill-row" style="margin-top:12px"><button class="primary-btn" id="confirm-yes" type="button">Yes, do it</button><button class="ghost-btn" id="confirm-no" type="button">Cancel</button></div>`,
+    `${summary}<div class="pill-row pill-row-confirm"><button class="primary-btn" id="confirm-yes" type="button">Yes, do it</button><button class="ghost-btn" id="confirm-no" type="button">Cancel</button></div>`,
   cancelled: 'Okay, cancelled. Adjust the details and try again.',
   progressSteps: [
     'Creating job specification…',

--- a/apps/onebox/config.mjs
+++ b/apps/onebox/config.mjs
@@ -1,0 +1,12 @@
+const DEFAULT_CONNECT_SRC = [
+  "https:",
+  "http:",
+  "wss:",
+];
+
+export const CONNECT_SRC_ORIGINS = DEFAULT_CONNECT_SRC;
+
+export const IPFS_GATEWAYS = [
+  "https://w3s.link/ipfs/",
+  "https://ipfs.io/ipfs/",
+];

--- a/apps/onebox/index.html
+++ b/apps/onebox/index.html
@@ -1,442 +1,34 @@
 <!doctype html>
 <html lang="en">
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>AGI Jobs — One‑Box</title>
-  <style>
-    :root {
-      --bg: #060b12;
-      --fg: #f8fafc;
-      --muted: #94a3b8;
-      --soft: rgba(15, 23, 42, 0.7);
-      --line: #1e293b;
-      --accent: linear-gradient(135deg, #6366f1, #0ea5e9);
-      --success: #10b981;
-      --warning: #f59e0b;
-      color-scheme: dark;
-    }
-
-    * {
-      box-sizing: border-box;
-    }
-
-    body {
-      margin: 0;
-      font: 16px/1.5 "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-        sans-serif;
-      background: radial-gradient(circle at top, rgba(37, 99, 235, 0.08), transparent 60%),
-        var(--bg);
-      color: var(--fg);
-      min-height: 100vh;
-    }
-
-    a {
-      color: #c7d2fe;
-    }
-
-    button {
-      font-family: inherit;
-    }
-
-    .wrap {
-      max-width: 1080px;
-      margin: 0 auto;
-      padding: 32px 20px 72px;
-      display: grid;
-      gap: 24px;
-    }
-
-    @media (min-width: 980px) {
-      .wrap {
-        grid-template-columns: 1fr 320px;
-        align-items: flex-start;
-      }
-    }
-
-    .header {
-      grid-column: 1 / -1;
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 12px;
-    }
-
-    .header h1 {
-      margin: 0;
-      font-size: 1.5rem;
-      letter-spacing: -0.01em;
-    }
-
-    .badge {
-      padding: 6px 12px;
-      border-radius: 999px;
-      background: rgba(148, 163, 184, 0.12);
-      color: var(--muted);
-      font-size: 0.75rem;
-      text-transform: uppercase;
-      letter-spacing: 0.15em;
-    }
-
-    .chat-shell {
-      background: rgba(15, 23, 42, 0.8);
-      border: 1px solid var(--line);
-      border-radius: 18px;
-      display: flex;
-      flex-direction: column;
-      min-height: 540px;
-      box-shadow: 0 20px 45px rgba(8, 47, 73, 0.25);
-    }
-
-    .chat-history {
-      flex: 1;
-      padding: 24px;
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-      overflow-y: auto;
-    }
-
-    .msg {
-      max-width: 82%;
-      padding: 16px 18px;
-      border-radius: 16px;
-      line-height: 1.6;
-      font-size: 0.96rem;
-      background: rgba(15, 23, 42, 0.95);
-      border: 1px solid rgba(148, 163, 184, 0.1);
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-    }
-
-    .m-user {
-      margin-left: auto;
-      background: rgba(79, 70, 229, 0.25);
-      border-color: rgba(129, 140, 248, 0.4);
-    }
-
-    .m-assist {
-      background: rgba(15, 23, 42, 0.85);
-    }
-
-    .leadline {
-      display: block;
-      color: var(--muted);
-      font-size: 0.85rem;
-      margin-top: 6px;
-    }
-
-    .chat-form {
-      border-top: 1px solid var(--line);
-      padding: 20px 24px;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      background: rgba(2, 6, 23, 0.85);
-      border-radius: 0 0 18px 18px;
-    }
-
-    .chat-form label {
-      text-transform: uppercase;
-      font-size: 0.7rem;
-      letter-spacing: 0.18em;
-      color: var(--muted);
-    }
-
-    .chat-input-row {
-      display: flex;
-      gap: 12px;
-      flex-wrap: wrap;
-    }
-
-    textarea {
-      flex: 1;
-      min-height: 4.5rem;
-      border-radius: 12px;
-      border: 1px solid var(--line);
-      background: rgba(15, 23, 42, 0.92);
-      color: var(--fg);
-      padding: 14px 16px;
-      font-size: 1rem;
-      resize: none;
-    }
-
-    textarea:focus {
-      outline: 2px solid #38bdf8;
-      outline-offset: 2px;
-    }
-
-    .primary-btn {
-      padding: 0 22px;
-      min-height: 44px;
-      border-radius: 12px;
-      border: none;
-      background-image: var(--accent);
-      color: #fff;
-      font-weight: 600;
-      cursor: pointer;
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
-    }
-
-    .primary-btn:disabled {
-      cursor: not-allowed;
-      filter: grayscale(45%);
-      opacity: 0.65;
-    }
-
-    .primary-btn:not(:disabled):hover {
-      transform: translateY(-1px);
-      box-shadow: 0 12px 18px rgba(79, 70, 229, 0.35);
-    }
-
-    .ghost-btn {
-      padding: 0 18px;
-      min-height: 44px;
-      border-radius: 12px;
-      border: 1px solid rgba(148, 163, 184, 0.35);
-      background: rgba(15, 23, 42, 0.65);
-      color: var(--fg);
-      font-weight: 600;
-      cursor: pointer;
-    }
-
-    .pill-row {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-      margin-top: 8px;
-    }
-
-    .pill {
-      padding: 8px 12px;
-      border-radius: 999px;
-      background: rgba(30, 41, 59, 0.75);
-      border: 1px solid rgba(148, 163, 184, 0.25);
-      cursor: pointer;
-      font-size: 0.85rem;
-      color: var(--muted);
-    }
-
-    .note {
-      display: block;
-      color: var(--muted);
-      font-size: 0.85rem;
-      margin-top: 8px;
-    }
-
-    .sec {
-      padding: 20px;
-      border-radius: 14px;
-      border: 1px dashed rgba(148, 163, 184, 0.28);
-      background: rgba(15, 23, 42, 0.6);
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-
-    .expert-panel {
-      display: block;
-      gap: 12px;
-    }
-
-    .expert-panel[hidden] {
-      display: none;
-    }
-
-    .expert-panel summary {
-      margin: 0;
-      font-size: 0.95rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: var(--muted);
-      cursor: pointer;
-      list-style: none;
-      outline: none;
-    }
-
-    .expert-panel summary::-webkit-details-marker {
-      display: none;
-    }
-
-    .expert-meta {
-      display: grid;
-      gap: 10px;
-    }
-
-    .expert-panel-content {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      margin-top: 12px;
-    }
-
-    .expert-label {
-      font-size: 0.7rem;
-      text-transform: uppercase;
-      letter-spacing: 0.14em;
-      color: var(--muted);
-    }
-
-    .expert-value {
-      font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas,
-        'Liberation Mono', 'Courier New', monospace;
-      font-size: 0.85rem;
-      word-break: break-all;
-    }
-
-    .expert-json-block {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-
-    .expert-json {
-      margin: 0;
-      background: rgba(15, 23, 42, 0.85);
-      border: 1px solid var(--line);
-      border-radius: 10px;
-      padding: 12px;
-      font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas,
-        'Liberation Mono', 'Courier New', monospace;
-      font-size: 0.8rem;
-      line-height: 1.5;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-
-    .sec h2 {
-      margin: 0;
-      font-size: 0.95rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: var(--muted);
-    }
-
-    .sec label {
-      font-size: 0.85rem;
-      color: var(--muted);
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-
-    .sec input[type='text'] {
-      border-radius: 10px;
-      border: 1px solid var(--line);
-      background: rgba(15, 23, 42, 0.85);
-      color: var(--fg);
-      padding: 10px 12px;
-      min-width: 0;
-    }
-
-    .sec-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-    }
-
-    .kbd {
-      padding: 2px 6px;
-      border-radius: 6px;
-      background: rgba(30, 41, 59, 0.85);
-      border: 1px solid rgba(148, 163, 184, 0.2);
-      font-size: 0.75rem;
-      color: #cbd5f5;
-    }
-
-    .sidebar {
-      display: flex;
-      flex-direction: column;
-      gap: 18px;
-    }
-
-    .receipt-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-
-    .receipt-card {
-      border: 1px solid rgba(148, 163, 184, 0.28);
-      border-radius: 12px;
-      padding: 14px;
-      background: rgba(15, 23, 42, 0.7);
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-      font-size: 0.85rem;
-    }
-
-    .receipt-card strong {
-      font-size: 0.95rem;
-    }
-
-    .receipt-meta {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 6px 12px;
-      color: var(--muted);
-    }
-
-    .receipt-empty {
-      color: var(--muted);
-      font-size: 0.9rem;
-    }
-
-    .progress {
-      margin: 0;
-      padding: 0;
-      list-style: none;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-
-    .progress li {
-      position: relative;
-      padding-left: 22px;
-      color: var(--muted);
-      font-size: 0.88rem;
-    }
-
-    .progress li::before {
-      content: '';
-      position: absolute;
-      left: 0;
-      top: 0.4em;
-      width: 10px;
-      height: 10px;
-      border-radius: 999px;
-      border: 2px solid rgba(148, 163, 184, 0.35);
-      background: transparent;
-      transition: all 0.25s ease;
-    }
-
-    .progress li.is-active::before {
-      border-color: rgba(129, 140, 248, 0.9);
-      background: rgba(129, 140, 248, 0.7);
-    }
-
-    .progress li.is-done::before {
-      border-color: var(--success);
-      background: var(--success);
-    }
-
-    .error-text {
-      color: #fca5a5;
-      font-weight: 600;
-    }
-  </style>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>AGI Jobs — One‑Box</title>
+    <meta
+      name="description"
+      content="Single-box interface for orchestrating AGI Jobs workflows with walletless and expert modes."
+    />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; base-uri 'none'; connect-src {{ connect_src }}; font-src 'self'; form-action 'self'; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; style-src 'self'; upgrade-insecure-requests"
+    />
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='24' fill='%2308121f'/%3E%3Ctext x='50' y='64' font-family='Inter,Arial,sans-serif' font-size='52' fill='%23f8fafc' text-anchor='middle'%3EA%3C/text%3E%3C/svg%3E" />
+    <link
+      rel="stylesheet"
+      href="{{ styles_css_href }}"
+      integrity="{{ styles_css_integrity }}"
+      crossorigin="anonymous"
+    />
+  </head>
   <body>
     <div class="wrap">
-      <div class="header">
+      <header class="header">
         <h1>AGI Jobs — One‑Box</h1>
         <span class="badge" id="mode">Mode: Guest (walletless)</span>
         <span class="badge">Ask → Confirm → Done + Receipt</span>
-      </div>
+      </header>
 
-      <div class="chat-shell">
+      <section class="chat-shell">
         <div id="chat" class="chat-history" role="log" aria-live="polite">
           <div class="msg m-assist">Ask → Confirm → Done + Receipt.</div>
         </div>
@@ -453,19 +45,21 @@
             </button>
           </div>
         </form>
-      </div>
+      </section>
 
-      <div class="sec">
+      <section class="sec">
         <h2>Shortcuts</h2>
         <div class="pill-row">
-          <div class="pill" data-example="Post a research job, 3 AGIALPHA, 5 days">Research job</div>
-          <div class="pill" data-example="Finalize job 123">Finalize job</div>
-          <div class="pill" data-example="Status of job 123">Status check</div>
+          <button class="pill" type="button" data-example="Post a research job, 3 AGIALPHA, 5 days">Research job</button>
+          <button class="pill" type="button" data-example="Finalize job 123">Finalize job</button>
+          <button class="pill" type="button" data-example="Status of job 123">Status check</button>
         </div>
-        <span class="note">Walletless by default. Expert mode prepares calldata for your wallet via <span class="kbd">eth_sendTransaction</span>.</span>
-      </div>
+        <span class="note"
+          >Walletless by default. Expert mode prepares calldata for your wallet via <span class="kbd">eth_sendTransaction</span>.
+        </span>
+      </section>
 
-      <div class="sidebar">
+      <aside class="sidebar">
         <details id="expert-panel" class="sec expert-panel" hidden>
           <summary>Expert Details</summary>
           <div class="expert-panel-content">
@@ -493,7 +87,8 @@
             </div>
           </div>
         </details>
-        <div class="sec">
+
+        <section class="sec">
           <h2>Advanced</h2>
           <label>
             Orchestrator URL
@@ -509,16 +104,25 @@
             <button type="button" class="ghost-btn" id="clear-receipts">Clear Receipts</button>
           </div>
           <span class="note">No hashes or gas pop-ups for end users. Confirmations stay under 140 characters.</span>
-        </div>
+        </section>
 
-        <div class="sec">
+        <section class="sec">
           <h2>Receipts</h2>
           <div id="receipts-empty" class="receipt-empty">No receipts yet — run a job to see the audit trail.</div>
           <ul id="receipts-list" class="receipt-list"></ul>
-        </div>
-      </div>
+        </section>
+      </aside>
     </div>
 
-    <script type="module" src="./app.js"></script>
+    <noscript>
+      <p class="note">JavaScript is required for the AGI Jobs one-box interface.</p>
+    </noscript>
+
+    <script
+      type="module"
+      src="{{ app_js_src }}"
+      integrity="{{ app_js_integrity }}"
+      crossorigin="anonymous"
+    ></script>
   </body>
 </html>

--- a/apps/onebox/scripts/build.mjs
+++ b/apps/onebox/scripts/build.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(__dirname, "..");
+const distDir = path.join(appDir, "dist");
+const templatePath = path.join(appDir, "index.html");
+const configModuleUrl = pathToFileURL(path.join(appDir, "config.mjs"));
+
+const assets = ["app.js", "styles.css"];
+
+const fingerprint = (buffer) =>
+  createHash("sha256").update(buffer).digest("hex").slice(0, 16);
+
+const computeIntegrity = (buffer) => ({
+  sha384: `sha384-${createHash("sha384").update(buffer).digest("base64")}`,
+  sha512: `sha512-${createHash("sha512").update(buffer).digest("base64")}`,
+});
+
+await fs.rm(distDir, { recursive: true, force: true });
+await fs.mkdir(distDir, { recursive: true });
+
+const manifest = {};
+
+for (const asset of assets) {
+  const sourcePath = path.join(appDir, asset);
+  const buffer = await fs.readFile(sourcePath);
+  const ext = path.extname(asset);
+  const base = path.basename(asset, ext);
+  const hashedName = `${base}.${fingerprint(buffer)}${ext}`;
+  await fs.writeFile(path.join(distDir, hashedName), buffer);
+  manifest[asset] = {
+    file: hashedName,
+    integrity: computeIntegrity(buffer),
+  };
+}
+
+const manifestPath = path.join(distDir, "manifest.json");
+await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+const template = await fs.readFile(templatePath, "utf8");
+const { CONNECT_SRC_ORIGINS = [] } = await import(configModuleUrl.href);
+
+const connectEntries = new Set(["'self'"]);
+for (const origin of CONNECT_SRC_ORIGINS) {
+  if (typeof origin === "string" && origin.trim()) {
+    connectEntries.add(origin.trim());
+  }
+}
+
+const scriptEntry = manifest["app.js"];
+const stylesEntry = manifest["styles.css"];
+
+if (!scriptEntry || !stylesEntry) {
+  throw new Error("Manifest missing required entries for app.js or styles.css");
+}
+
+const formatIntegrity = (entry) => `${entry.integrity.sha384} ${entry.integrity.sha512}`;
+
+const html = template
+  .replace(/\{\{\s*app_js_src\s*\}\}/g, `./${scriptEntry.file}`)
+  .replace(/\{\{\s*app_js_integrity\s*\}\}/g, formatIntegrity(scriptEntry))
+  .replace(/\{\{\s*styles_css_href\s*\}\}/g, `./${stylesEntry.file}`)
+  .replace(/\{\{\s*styles_css_integrity\s*\}\}/g, formatIntegrity(stylesEntry))
+  .replace(/\{\{\s*connect_src\s*\}\}/g, Array.from(connectEntries).join(" "));
+
+await fs.writeFile(path.join(distDir, "index.html"), html);
+
+console.log(`Built onebox static bundle -> ${path.relative(process.cwd(), distDir)}`);
+console.log(`Manifest written to ${path.relative(process.cwd(), manifestPath)}`);

--- a/apps/onebox/scripts/publish.mjs
+++ b/apps/onebox/scripts/publish.mjs
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { CarReader } from "@ipld/car";
+import namehashModule from "eth-ens-namehash";
+import { ethers } from "ethers";
+import contentHash from "content-hash";
+import { packToFs } from "ipfs-car/pack/fs";
+import PinataClientModule from "@pinata/sdk";
+import { Web3Storage } from "web3.storage";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(__dirname, "..");
+const distDir = path.join(appDir, "dist");
+const manifestPath = path.join(distDir, "manifest.json");
+const configModuleUrl = pathToFileURL(path.join(appDir, "config.mjs"));
+const carOutputPath = path.join(distDir, "onebox.car");
+
+const args = new Set(process.argv.slice(2));
+const skipBuild = args.has("--skip-build");
+const skipWeb3 = args.has("--skip-web3");
+const skipPinata = args.has("--skip-pinata");
+const skipEns = args.has("--skip-ens");
+const dryRun = args.has("--dry-run");
+const skipHealth = args.has("--skip-health");
+
+const log = (...messages) => console.log("[onebox:publish]", ...messages);
+
+function formatError(message) {
+  return new Error(`[onebox:publish] ${message}`);
+}
+
+async function runNodeScript(scriptName) {
+  const scriptPath = path.join(__dirname, scriptName);
+  await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: appDir,
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          formatError(`${scriptName} failed with exit code ${code ?? "unknown"}`),
+        );
+      }
+    });
+  });
+}
+
+function deriveReleaseLabel() {
+  if (process.env.ONEBOX_RELEASE_LABEL) return process.env.ONEBOX_RELEASE_LABEL;
+  if (process.env.GITHUB_REF_NAME) return process.env.GITHUB_REF_NAME;
+  if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA.slice(0, 12);
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function resolvePinataConfig() {
+  const jwt = process.env.PINATA_JWT || process.env.PINATA_JWT_KEY;
+  if (jwt) {
+    return { pinataJWTKey: jwt };
+  }
+  const apiKey = process.env.PINATA_API_KEY;
+  const secret = process.env.PINATA_SECRET_API_KEY;
+  if (apiKey && secret) {
+    return { pinataApiKey: apiKey, pinataSecretApiKey: secret };
+  }
+  return null;
+}
+
+function sanitizeHostNodes(raw) {
+  if (!raw) return undefined;
+  const nodes = raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return nodes.length ? nodes : undefined;
+}
+
+async function ensureBuildArtifacts() {
+  if (!skipBuild && !dryRun) {
+    log("Running static build...");
+    await runNodeScript("build.mjs");
+    log("Verifying subresource integrity...");
+    await runNodeScript("verify-sri.mjs");
+  }
+  try {
+    await fs.access(manifestPath);
+  } catch {
+    throw formatError(
+      "Static manifest missing. Run the build step or pass --skip-build only after generating dist/.",
+    );
+  }
+}
+
+async function createCarArchive() {
+  log("Packing dist/ directory into CAR archive...");
+  await fs.rm(carOutputPath, { force: true });
+  const { root } = await packToFs({
+    input: distDir,
+    output: carOutputPath,
+    wrapWithDirectory: true,
+  });
+  const rootCid = root.toString();
+  log(`CAR archive ready: ${path.relative(appDir, carOutputPath)} (cid=${rootCid})`);
+  return rootCid;
+}
+
+async function uploadToWeb3Storage(rootCid, releaseName) {
+  if (dryRun || skipWeb3) {
+    log("Skipping web3.storage upload (dry run or --skip-web3)");
+    return null;
+  }
+  const token = process.env.WEB3_STORAGE_TOKEN || process.env.W3S_TOKEN;
+  if (!token) {
+    throw formatError(
+      "WEB3_STORAGE_TOKEN (or W3S_TOKEN) must be set to upload to web3.storage",
+    );
+  }
+  log("Uploading CAR to web3.storage...");
+  const client = new Web3Storage({ token });
+  const carBytes = await fs.readFile(carOutputPath);
+  const carReader = await CarReader.fromBytes(carBytes);
+  const uploadCid = await client.putCar(carReader, { name: releaseName });
+  if (uploadCid !== rootCid) {
+    throw formatError(
+      `CID mismatch from web3.storage upload (expected ${rootCid}, received ${uploadCid})`,
+    );
+  }
+  const status = await client.status(rootCid).catch((err) => {
+    log("Warning: unable to fetch web3.storage status", err.message ?? err);
+    return null;
+  });
+  log("web3.storage upload complete.");
+  return {
+    cid: uploadCid,
+    status: status
+      ? {
+          cid: status.cid,
+          dagSize: status.dagSize,
+          pins: status.pins?.map(({ region, status: pinStatus }) => ({
+            region,
+            status: pinStatus,
+          })),
+        }
+      : null,
+  };
+}
+
+function normalizeGateway(base) {
+  if (typeof base !== "string") return "";
+  return base.endsWith("/") ? base : `${base}/`;
+}
+
+async function probeGateway(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  const startedAt = performance.now();
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      redirect: "follow",
+      cache: "no-store",
+      signal: controller.signal,
+      headers: { Accept: "text/html,application/xhtml+xml" },
+    });
+    const duration = performance.now() - startedAt;
+    return {
+      url,
+      ok: response.ok,
+      status: response.status,
+      durationMs: Math.round(duration),
+      error: response.ok ? null : response.statusText || null,
+    };
+  } catch (err) {
+    const duration = performance.now() - startedAt;
+    return {
+      url,
+      ok: false,
+      status: null,
+      durationMs: Math.round(duration),
+      error: err?.message ?? String(err),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function checkGatewayAvailability(rootCid, gateways, ensGateway) {
+  if (dryRun || skipHealth) {
+    log("Skipping gateway availability checks (dry run or --skip-health)");
+    return { skipped: true, results: [] };
+  }
+
+  const checks = [];
+  const targets = [];
+
+  for (const gateway of gateways ?? []) {
+    if (typeof gateway !== "string" || !gateway.trim()) continue;
+    const normalized = normalizeGateway(gateway.trim());
+    targets.push(`${normalized}${rootCid}/index.html`);
+  }
+
+  if (ensGateway) {
+    targets.push(`${normalizeGateway(ensGateway)}index.html`);
+  }
+
+  if (!targets.length) {
+    return { skipped: true, results: [] };
+  }
+
+  log("Checking gateway availability...");
+  for (const targetUrl of targets) {
+    const result = await probeGateway(targetUrl);
+    checks.push(result);
+    if (result.ok) {
+      log(`Gateway OK (${result.status}) -> ${targetUrl}`);
+    } else {
+      log(
+        `Gateway FAILED${result.status ? ` (${result.status})` : ""} -> ${targetUrl} (${result.error ?? "unknown error"})`,
+      );
+    }
+  }
+
+  const successCount = checks.filter((entry) => entry.ok).length;
+  return {
+    skipped: false,
+    successCount,
+    total: checks.length,
+    sloTarget: "99.9% availability across two pinning providers",
+    results: checks,
+  };
+}
+
+async function pinWithPinata(rootCid, releaseName) {
+  if (dryRun || skipPinata) {
+    log("Skipping Pinata pin (dry run or --skip-pinata)");
+    return null;
+  }
+  const config = resolvePinataConfig();
+  if (!config) {
+    throw formatError(
+      "Pinata credentials missing. Provide PINATA_JWT or PINATA_API_KEY/PINATA_SECRET_API_KEY",
+    );
+  }
+  const PinataClient = PinataClientModule.default || PinataClientModule;
+  const pinata = new PinataClient(config);
+  log("Requesting Pinata to pin existing CID...");
+  const hostNodes = sanitizeHostNodes(process.env.PINATA_HOST_NODES);
+  const result = await pinata.pinByHash(rootCid, {
+    pinataMetadata: { name: releaseName },
+    ...(hostNodes ? { pinataOptions: { hostNodes } } : {}),
+  });
+  let jobs = null;
+  try {
+    jobs = await pinata.pinJobs({
+      sort: "ASC",
+      ipfs_pin_hash: rootCid,
+    });
+  } catch (err) {
+    log("Warning: unable to query Pinata pin jobs", err.message ?? err);
+  }
+  log("Pinata pin requested.");
+  return {
+    requestId: result?.id ?? null,
+    status: result?.status ?? null,
+    hostNodes: hostNodes ?? null,
+    jobs: jobs?.rows ?? null,
+  };
+}
+
+const { hash: namehash } = namehashModule;
+
+async function updateEnsContenthash(rootCid) {
+  if (dryRun || skipEns) {
+    log("Skipping ENS contenthash update (dry run or --skip-ens)");
+    return null;
+  }
+  const ensName = process.env.ENS_NAME || process.env.ONEBOX_ENS_NAME;
+  if (!ensName) {
+    log("No ENS_NAME provided; skipping contenthash update.");
+    return null;
+  }
+  const privateKey = process.env.ENS_PRIVATE_KEY || process.env.ONEBOX_ENS_PRIVATE_KEY;
+  const rpcUrl = process.env.ENS_RPC_URL || process.env.ONEBOX_ENS_RPC_URL;
+  if (!privateKey || !rpcUrl) {
+    throw formatError("ENS_PRIVATE_KEY and ENS_RPC_URL are required to update contenthash");
+  }
+  const registryAddress =
+    process.env.ENS_REGISTRY || "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const wallet = new ethers.Wallet(privateKey, provider);
+  const registry = new ethers.Contract(
+    registryAddress,
+    ["function resolver(bytes32 node) view returns (address)"],
+    wallet,
+  );
+  const node = namehash(ensName);
+  const resolverAddress =
+    process.env.ENS_RESOLVER || (await registry.resolver(node));
+  if (!resolverAddress || resolverAddress === ethers.ZeroAddress) {
+    throw formatError(
+      `Resolver not configured for ${ensName}. Provide ENS_RESOLVER or set one on-chain.`,
+    );
+  }
+  const resolver = new ethers.Contract(
+    resolverAddress,
+    [
+      "function contenthash(bytes32 node) view returns (bytes)",
+      "function setContenthash(bytes32 node, bytes hash) external",
+    ],
+    wallet,
+  );
+  const encoded = `0x${contentHash.fromIpfs(rootCid)}`;
+  const current = await resolver
+    .contenthash(node)
+    .catch(() => "0x");
+  if (current === encoded) {
+    log(`ENS contenthash already set for ${ensName}.`);
+    return {
+      name: ensName,
+      resolver: resolverAddress,
+      txHash: null,
+      contenthash: encoded,
+      gateway: `https://${ensName}.limo`,
+    };
+  }
+  log(`Updating ENS contenthash for ${ensName} -> ${rootCid}...`);
+  const tx = await resolver.setContenthash(node, encoded);
+  const receipt = await tx.wait();
+  log("ENS contenthash update transaction mined.");
+  return {
+    name: ensName,
+    resolver: resolverAddress,
+    txHash: receipt?.hash || tx.hash,
+    contenthash: encoded,
+    gateway: `https://${ensName}.limo`,
+  };
+}
+
+async function main() {
+  const releaseLabel = deriveReleaseLabel();
+  const releaseName = `agi-onebox-${releaseLabel}`;
+  await ensureBuildArtifacts();
+  const manifestRaw = await fs.readFile(manifestPath, "utf8");
+  const manifest = JSON.parse(manifestRaw);
+  const rootCid = await createCarArchive();
+  const web3Result = await uploadToWeb3Storage(rootCid, releaseName);
+  const pinataResult = await pinWithPinata(rootCid, releaseName);
+  const ensResult = await updateEnsContenthash(rootCid);
+  const { IPFS_GATEWAYS = [] } = await import(configModuleUrl.href);
+  const gatewayChecks = await checkGatewayAvailability(
+    rootCid,
+    IPFS_GATEWAYS,
+    ensResult?.gateway,
+  );
+  const releaseMetadata = {
+    createdAt: new Date().toISOString(),
+    release: releaseName,
+    cid: rootCid,
+    car: path.relative(appDir, carOutputPath),
+    manifest,
+    ipfsGateways: IPFS_GATEWAYS,
+    web3Storage: web3Result,
+    pinata: pinataResult,
+    ens: ensResult,
+    availability: gatewayChecks,
+    skipped: {
+      build: skipBuild,
+      web3: skipWeb3 || dryRun,
+      pinata: skipPinata || dryRun,
+      ens: skipEns || dryRun || !ensResult,
+      health: skipHealth || dryRun || gatewayChecks?.skipped,
+    },
+  };
+  await fs.writeFile(
+    path.join(distDir, "release.json"),
+    `${JSON.stringify(releaseMetadata, null, 2)}\n`,
+  );
+  log("Release metadata written to dist/release.json");
+  log(`Root CID: ${rootCid}`);
+  if (ensResult?.gateway) {
+    log(`Gateway preview: ${ensResult.gateway}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/apps/onebox/scripts/verify-sri.mjs
+++ b/apps/onebox/scripts/verify-sri.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(__dirname, "..");
+const distDir = path.join(appDir, "dist");
+const manifestPath = path.join(distDir, "manifest.json");
+const indexPath = path.join(distDir, "index.html");
+
+const requiredEntries = ["app.js", "styles.css"];
+
+async function exists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!(await exists(manifestPath))) {
+  throw new Error("Manifest not found. Run the static build before verifying SRI.");
+}
+
+if (!(await exists(indexPath))) {
+  throw new Error("Built index.html not found. Run the static build before verifying SRI.");
+}
+
+const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+
+const computeIntegrity = (buffer) => ({
+  sha384: `sha384-${createHash("sha384").update(buffer).digest("base64")}`,
+  sha512: `sha512-${createHash("sha512").update(buffer).digest("base64")}`,
+});
+
+for (const entryKey of requiredEntries) {
+  const entry = manifest[entryKey];
+  if (!entry || !entry.file || !entry.integrity) {
+    throw new Error(`Manifest entry for ${entryKey} is incomplete.`);
+  }
+
+  const filePath = path.join(distDir, entry.file);
+  if (!(await exists(filePath))) {
+    throw new Error(`Manifest entry for ${entryKey} points to missing file ${entry.file}`);
+  }
+
+  const buffer = await fs.readFile(filePath);
+  const actual = computeIntegrity(buffer);
+
+  for (const algo of ["sha384", "sha512"]) {
+    if (entry.integrity[algo] !== actual[algo]) {
+      throw new Error(
+        `Integrity mismatch for ${entryKey} (${algo}): manifest ${entry.integrity[algo]}, actual ${actual[algo]}`,
+      );
+    }
+  }
+}
+
+const html = await fs.readFile(indexPath, "utf8");
+
+const expectScriptSrc = `./${manifest["app.js"].file}`;
+const expectScriptIntegrity = `${manifest["app.js"].integrity.sha384} ${manifest["app.js"].integrity.sha512}`;
+const expectStylesHref = `./${manifest["styles.css"].file}`;
+const expectStylesIntegrity = `${manifest["styles.css"].integrity.sha384} ${manifest["styles.css"].integrity.sha512}`;
+
+const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const scriptPattern = new RegExp(
+  `<script[^>]*type="module"[^>]*src="${escape(expectScriptSrc)}"[^>]*integrity="${escape(expectScriptIntegrity)}"[^>]*crossorigin="anonymous"`,
+);
+
+if (!scriptPattern.test(html)) {
+  throw new Error("Built index.html is missing the expected <script> tag with integrity and crossorigin attributes.");
+}
+
+const linkPattern = new RegExp(
+  `<link[^>]*rel="stylesheet"[^>]*href="${escape(expectStylesHref)}"[^>]*integrity="${escape(expectStylesIntegrity)}"[^>]*crossorigin="anonymous"`,
+);
+
+if (!linkPattern.test(html)) {
+  throw new Error("Built index.html is missing the expected stylesheet link with integrity and crossorigin attributes.");
+}
+
+console.log("Static asset integrity verified successfully.");

--- a/apps/onebox/styles.css
+++ b/apps/onebox/styles.css
@@ -1,14 +1,13 @@
 :root {
+  --bg: #060b12;
+  --fg: #f8fafc;
+  --muted: #94a3b8;
+  --soft: rgba(15, 23, 42, 0.7);
+  --line: #1e293b;
+  --accent: linear-gradient(135deg, #6366f1, #0ea5e9);
+  --success: #10b981;
+  --warning: #f59e0b;
   color-scheme: dark;
-  --bg: #070c11;
-  --panel: #0f1620;
-  --border: #1c2430;
-  --accent: #7c5cff;
-  --accent-soft: rgba(124, 92, 255, 0.2);
-  --fg: #f5f7fb;
-  --muted: #9aa4b2;
-  --success: #1bbf6b;
-  --warning: #ffb020;
 }
 
 * {
@@ -17,444 +16,416 @@
 
 body {
   margin: 0;
-  min-height: 100vh;
-  font: 16px/1.5 "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
-  background: radial-gradient(circle at top left, rgba(124, 92, 255, 0.12), transparent 50%),
-    radial-gradient(circle at bottom right, rgba(17, 220, 148, 0.08), transparent 45%),
+  font: 16px/1.5 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  background: radial-gradient(
+      circle at top,
+      rgba(37, 99, 235, 0.08),
+      transparent 60%
+    ),
     var(--bg);
   color: var(--fg);
+  min-height: 100vh;
+}
+
+a {
+  color: #c7d2fe;
+}
+
+button {
+  font-family: inherit;
 }
 
 .wrap {
-  max-width: 920px;
+  max-width: 1080px;
   margin: 0 auto;
-  padding: 32px 18px 48px;
-  display: flex;
-  flex-direction: column;
+  padding: 32px 20px 72px;
+  display: grid;
   gap: 24px;
 }
 
+@media (min-width: 980px) {
+  .wrap {
+    grid-template-columns: 1fr 320px;
+    align-items: flex-start;
+  }
+}
+
 .header {
+  grid-column: 1 / -1;
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
+  align-items: center;
+  gap: 12px;
 }
 
 .header h1 {
   margin: 0;
-  font-size: clamp(1.6rem, 2vw + 1rem, 2.2rem);
-}
-
-.tagline {
-  margin: 4px 0 0;
-  color: var(--muted);
-  max-width: 32ch;
-}
-
-.badges {
-  display: flex;
-  gap: 8px;
+  font-size: 1.5rem;
+  letter-spacing: -0.01em;
 }
 
 .badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
   padding: 6px 12px;
-  background: var(--panel);
-  border: 1px solid var(--border);
   border-radius: 999px;
-  font-size: 12px;
+  background: rgba(148, 163, 184, 0.12);
   color: var(--muted);
+  font-size: 0.75rem;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.15em;
 }
 
-.badge-soft {
-  background: var(--accent-soft);
-  border-color: transparent;
-  color: #c2b7ff;
-}
-
-.chat {
-  background: var(--panel);
-  border: 1px solid var(--border);
+.chat-shell {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid var(--line);
   border-radius: 18px;
-  padding: 20px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  min-height: 45vh;
-  max-height: 60vh;
-  overflow-y: auto;
-  scroll-behavior: smooth;
+  min-height: 540px;
+  box-shadow: 0 20px 45px rgba(8, 47, 73, 0.25);
 }
 
-.msg {
-  background: #101927;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 16px;
-  padding: 14px 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  max-width: min(560px, 78%);
-  box-shadow: 0 8px 18px rgba(5, 10, 20, 0.4);
-}
-
-.msg.user {
-  margin-left: auto;
-  background: rgba(124, 92, 255, 0.16);
-  border-color: rgba(124, 92, 255, 0.4);
-}
-
-.msg.assistant {
-  background: rgba(13, 19, 30, 0.78);
-}
-
-.msg.confirm {
-  border: 1px solid rgba(17, 220, 148, 0.35);
-}
-
-.msg-note {
-  font-size: 13px;
-  color: var(--muted);
-}
-
-.msg-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 6px;
-}
-
-.composer {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-}
-
-.composer input {
+.chat-history {
   flex: 1;
-  padding: 14px 18px;
-  border-radius: 14px;
-  border: 1px solid var(--border);
-  background: rgba(10, 15, 24, 0.9);
-  color: var(--fg);
-  font-size: 1rem;
-}
-
-.composer input:focus {
-  outline: 2px solid rgba(124, 92, 255, 0.6);
-  outline-offset: 0;
-}
-
-.btn {
-  border: 1px solid var(--border);
-  background: rgba(16, 23, 34, 0.9);
-  color: var(--fg);
-  padding: 12px 16px;
-  border-radius: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.15s ease, background 0.2s ease, border 0.2s ease;
-}
-
-.btn.ghost {
-  background: transparent;
-  color: var(--muted);
-  border-color: rgba(255, 255, 255, 0.08);
-}
-
-.btn.ghost:hover,
-.btn.ghost:focus-visible {
-  color: var(--fg);
-  border-color: rgba(255, 255, 255, 0.18);
-  background: rgba(15, 22, 32, 0.6);
-}
-
-.btn:hover {
-  transform: translateY(-1px);
-}
-
-.btn.primary {
-  background: var(--accent);
-  border-color: transparent;
-  color: #fff;
-}
-
-.btn[aria-pressed="true"],
-.btn.active {
-  background: rgba(124, 92, 255, 0.25);
-  border-color: rgba(124, 92, 255, 0.6);
-  color: #d0c6ff;
-}
-
-.quick-prompts {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.pill {
-  border: 1px solid var(--border);
-  background: rgba(13, 21, 33, 0.8);
-  padding: 10px 14px;
-  border-radius: 999px;
-  color: var(--muted);
-  cursor: pointer;
-  transition: background 0.2s ease;
-}
-
-.pill:hover {
-  background: rgba(124, 92, 255, 0.18);
-  color: var(--fg);
-}
-
-.status-board {
-  background: rgba(10, 15, 24, 0.65);
-  border: 1px solid var(--border);
-  border-radius: 18px;
-  padding: 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.status-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.status-cards {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.status-card {
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  background: rgba(15, 22, 34, 0.9);
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-height: 120px;
-}
-
-.status-card .status-line {
-  display: flex;
-  justify-content: space-between;
-  font-size: 14px;
-  color: var(--muted);
-}
-
-.status-card .status-title {
-  font-weight: 600;
-  font-size: 15px;
-}
-
-.status-card .status-meta {
-  font-size: 13px;
-  color: var(--muted);
-}
-
-.status-card .status-ok {
-  color: var(--success);
-}
-
-.status-empty {
-  font-size: 14px;
-  color: var(--muted);
-}
-
-.footnotes {
-  font-size: 13px;
-  color: var(--muted);
-  line-height: 1.6;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.footnotes .btn {
-  align-self: flex-start;
-}
-
-.advanced {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 18px;
-  padding: 20px;
+  padding: 24px;
   display: flex;
   flex-direction: column;
   gap: 16px;
+  overflow-y: auto;
 }
 
-.advanced[hidden] {
+.msg {
+  max-width: 82%;
+  padding: 16px 18px;
+  border-radius: 16px;
+  line-height: 1.6;
+  font-size: 0.96rem;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.m-user {
+  margin-left: auto;
+  background: rgba(79, 70, 229, 0.25);
+  border-color: rgba(129, 140, 248, 0.4);
+}
+
+.m-assist {
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.leadline {
+  display: block;
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-top: 6px;
+}
+
+.chat-form {
+  border-top: 1px solid var(--line);
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(2, 6, 23, 0.85);
+  border-radius: 0 0 18px 18px;
+}
+
+.chat-form label {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+textarea {
+  flex: 1;
+  min-height: 4.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: rgba(15, 23, 42, 0.92);
+  color: var(--fg);
+  padding: 14px 16px;
+  font-size: 1rem;
+  resize: none;
+}
+
+textarea:focus {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
+.primary-btn {
+  padding: 0 22px;
+  min-height: 44px;
+  border-radius: 12px;
+  border: none;
+  background-image: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-btn:disabled {
+  cursor: not-allowed;
+  filter: grayscale(45%);
+  opacity: 0.65;
+}
+
+.primary-btn:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 18px rgba(79, 70, 229, 0.35);
+}
+
+.ghost-btn {
+  padding: 0 18px;
+  min-height: 44px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--fg);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.pill-row-confirm {
+  margin-top: 12px;
+}
+
+.pill {
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.note {
+  display: block;
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-top: 8px;
+}
+
+.sec {
+  padding: 20px;
+  border-radius: 14px;
+  border: 1px dashed rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.expert-panel {
+  display: block;
+  gap: 12px;
+}
+
+.expert-panel[hidden] {
   display: none;
 }
 
-.advanced-head {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.advanced-note {
+.expert-panel summary {
   margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   color: var(--muted);
-  font-size: 13px;
-}
-
-.advanced-receipts {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.advanced-empty {
-  margin: 0;
-  font-size: 13px;
-  color: var(--muted);
-}
-
-.advanced-receipt {
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 14px;
-  padding: 14px 16px;
-  background: rgba(11, 17, 27, 0.8);
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.advanced-receipt header {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.advanced-title {
-  font-weight: 600;
-}
-
-.advanced-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  font-size: 12px;
-  color: var(--muted);
-}
-
-.advanced-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  font-size: 13px;
-}
-
-.advanced-links a {
-  color: #c2b7ff;
-}
-
-.advanced-json {
-  font-family: "SFMono-Regular", "Roboto Mono", "Fira Code", monospace;
-  font-size: 12px;
-  background: rgba(0, 0, 0, 0.35);
-  border-radius: 12px;
-  padding: 12px;
-  overflow-x: auto;
-}
-
-.advanced details summary {
   cursor: pointer;
-  color: #c2b7ff;
-  font-size: 13px;
+  list-style: none;
+  outline: none;
 }
 
-.advanced details summary:focus-visible {
-  outline: 2px solid rgba(124, 92, 255, 0.6);
-  outline-offset: 4px;
+.expert-panel summary::-webkit-details-marker {
+  display: none;
 }
 
-.advanced time {
-  font-variant-numeric: tabular-nums;
+.expert-meta {
+  display: grid;
+  gap: 10px;
 }
 
-.modal {
-  border: none;
-  border-radius: 14px;
-  padding: 20px;
-  background: rgba(11, 17, 27, 0.96);
-  color: var(--fg);
-  max-width: 480px;
-}
-
-.modal::backdrop {
-  background: rgba(4, 8, 14, 0.6);
-}
-
-.field {
+.expert-panel-content {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin-bottom: 14px;
+  gap: 12px;
+  margin-top: 12px;
 }
 
-.field input,
-.field select {
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: rgba(10, 15, 24, 0.85);
-  color: var(--fg);
-}
-
-.field input:focus,
-.field select:focus {
-  outline: 2px solid rgba(124, 92, 255, 0.5);
-}
-
-.hint {
-  font-size: 12px;
+.expert-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
   color: var(--muted);
 }
 
-menu {
+.expert-value {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco,
+    Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+.expert-json-block {
   display: flex;
-  justify-content: flex-end;
-  gap: 10px;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.expert-json {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco,
+    Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.sec h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.sec label {
+  font-size: 0.85rem;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sec input[type='text'] {
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--fg);
+  padding: 10px 12px;
+  min-width: 0;
+}
+
+.sec-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.kbd {
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(30, 41, 59, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.75rem;
+  color: #cbd5f5;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.receipt-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.receipt-card {
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 12px;
+  padding: 14px;
+  background: rgba(15, 23, 42, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+}
+
+.receipt-card strong {
+  font-size: 0.95rem;
+}
+
+.receipt-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  color: var(--muted);
+}
+
+.receipt-empty {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.progress {
   margin: 0;
   padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.sr-only {
+.progress li {
+  position: relative;
+  padding-left: 22px;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.progress li::before {
+  content: '';
   position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
+  left: 0;
+  top: 0.4em;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  border: 2px solid rgba(148, 163, 184, 0.35);
+  background: transparent;
+  transition: all 0.25s ease;
 }
 
-@media (max-width: 640px) {
-  .composer {
-    flex-wrap: wrap;
-  }
+.progress li.is-active::before {
+  border-color: rgba(129, 140, 248, 0.9);
+  background: rgba(129, 140, 248, 0.7);
+}
 
-  .composer input {
-    flex-basis: 100%;
-  }
+.progress li.is-done::before {
+  border-color: var(--success);
+  background: var(--success);
+}
 
-  .chat {
-    max-height: none;
-    min-height: 40vh;
-  }
+.error-text {
+  color: #fca5a5;
+  font-weight: 600;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@ipld/car": "^3.2.4",
         "@pinata/sdk": "^2.1.0",
         "@prb/math": "^4.0.1",
         "content-hash": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "lint:check": "solhint 'contracts/**/*.sol' && eslint . --ext .js,.ts,.tsx --max-warnings=0",
     "lint:fix": "solhint --fix 'contracts/**/*.sol' && eslint . --ext .js,.ts,.tsx --fix",
     "format:fix": "prettier --write \".github/workflows/**/*.yml\" \"scripts/ci/**/*.{js,mjs}\" \"hardhat.config.js\" \"package.json\" \".solcover.js\"",
+    "onebox:build": "node apps/onebox/scripts/build.mjs",
+    "onebox:publish": "node apps/onebox/scripts/publish.mjs",
+    "onebox:verify-sri": "node apps/onebox/scripts/verify-sri.mjs",
     "onebox:static:build": "node apps/onebox-static/scripts/build.mjs",
     "onebox:static:publish": "node apps/onebox-static/scripts/publish.mjs",
     "verify:sri": "node apps/onebox-static/scripts/verify-sri.mjs"
@@ -80,15 +83,16 @@
     "eslint-plugin-prettier": "^4.2.5",
     "hardhat": "^2.26.1",
     "hardhat-gas-reporter": "^2.3.0",
+    "ipfs-car": "^0.9.2",
     "prettier": "^2.8.8",
     "solhint": "^6.0.0",
     "solidity-coverage": "^0.8.14",
     "supertest": "^7.1.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2",
-    "ipfs-car": "^0.9.2"
+    "typescript": "^5.9.2"
   },
   "dependencies": {
+    "@ipld/car": "^3.2.4",
     "@pinata/sdk": "^2.1.0",
     "@prb/math": "^4.0.1",
     "content-hash": "^2.5.2",
@@ -97,8 +101,8 @@
     "express": "^4.21.2",
     "ipfs-http-client": "^60.0.0",
     "parse-duration": "^2.1.4",
-    "web3.storage": "^4.5.5",
     "web3": "^1.10.0",
+    "web3.storage": "^4.5.5",
     "ws": "^8.18.3",
     "zod": "^3.25.76"
   },


### PR DESCRIPTION
## Summary
- refactor the One-Box static assets into a build template with CSP placeholders, hashed filenames, and SRI injection
- add config-driven build, integrity verification, and publish scripts that package releases, pin to IPFS providers, and update ENS
- document the new workflow, ignore generated artifacts, and declare the @ipld/car dependency used by the publisher

## Testing
- npm run onebox:build
- npm run onebox:verify-sri
- npm run onebox:publish -- --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d9362d1d1083338ee106258390fc45