### PR TITLE
feat: enhance meta orchestrator pipeline

### DIFF
--- a/orchestrator/planner.py
+++ b/orchestrator/planner.py
@@ -11,9 +11,15 @@ from fastapi import HTTPException, status
 from .models import Attachment, JobIntent, OrchestrationPlan, PlanIn, PlanOut, Step
 
 
-_REWARD_PATTERN = re.compile(r"(?P<amount>\d+(?:\.\d+)?)\s*(?:agi|agialpha)", re.IGNORECASE)
+_REWARD_PATTERN = re.compile(r"(?P<amount>-?\d+(?:\.\d+)?)\s*(?:agi|agialpha)", re.IGNORECASE)
 _DEADLINE_PATTERN = re.compile(r"(?P<days>\d+)\s*(?:day|days)", re.IGNORECASE)
 _TITLE_PATTERN = re.compile(r"^(?P<title>[^.!?]{3,80})")
+_JOB_ID_PATTERN = re.compile(r"job\s*(?:#|id\s*)?(?P<job_id>\d+)", re.IGNORECASE)
+
+DEFAULT_REWARD = Decimal("50")
+DEFAULT_DEADLINE_DAYS = 7
+FEE_PCT = Decimal("0.05")
+BURN_PCT = Decimal("0.02")
 
 
 def _infer_reward(text: str) -> Tuple[str | None, List[str]]:
@@ -43,6 +49,27 @@ def _infer_title(text: str) -> str:
     if not match:
         return text.strip()[:80] or "Untitled job"
     return match.group("title").strip().capitalize()
+
+
+def _infer_job_id(text: str) -> int | None:
+    match = _JOB_ID_PATTERN.search(text)
+    if not match:
+        return None
+    try:
+        return int(match.group("job_id"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _detect_intent_kind(text: str) -> str:
+    lowered = text.lower()
+    if any(keyword in lowered for keyword in ("finalize", "payout", "close job")):
+        return "finalize"
+    if any(keyword in lowered for keyword in ("submit", "deliver", "turn in")):
+        return "submit"
+    if any(keyword in lowered for keyword in ("apply", "claim", "work on")):
+        return "apply"
+    return "post_job"
 
 
 def _build_steps(intent: JobIntent) -> List[Step]:
@@ -84,6 +111,15 @@ def _build_steps(intent: JobIntent) -> List[Step]:
         return steps[-1:]
     if intent.kind == "submit":
         return steps[2:]
+    if intent.kind == "apply":
+        return [
+            Step(
+                id="apply_job",
+                name="Submit agent application",
+                kind="chain",
+                tool="job.apply",
+            )
+        ]
     return steps
 
 
@@ -95,37 +131,93 @@ def make_plan(req: PlanIn) -> PlanOut:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="INPUT_TEXT_REQUIRED")
 
     attachments = list(req.attachments)
-    reward, missing_reward = _infer_reward(text)
-    deadline, missing_deadline = _infer_deadline(text)
-    missing = [*missing_reward, *missing_deadline]
+    intent_kind = _detect_intent_kind(text)
+    reward_raw, missing_reward = _infer_reward(text)
+    deadline_raw, missing_deadline = _infer_deadline(text)
+    reward = reward_raw
+    deadline = deadline_raw
+    job_id = _infer_job_id(text) if intent_kind != "post_job" else None
+
+    warnings: List[str] = []
+    missing: List[str] = []
+
+    reward_decimal = Decimal("0")
+
+    if intent_kind == "post_job":
+        if reward is None:
+            reward_decimal = DEFAULT_REWARD.quantize(Decimal("0.01"))
+            reward = format(reward_decimal, "f")
+            warnings.append("DEFAULT_REWARD_APPLIED")
+        else:
+            try:
+                reward_decimal = Decimal(reward)
+                if reward_decimal <= 0:
+                    raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="INVALID_REWARD")
+                reward_decimal = reward_decimal.quantize(Decimal("0.01"))
+                reward = format(reward_decimal, "f")
+            except InvalidOperation as exc:
+                raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="INVALID_REWARD") from exc
+
+        if deadline is None:
+            deadline = DEFAULT_DEADLINE_DAYS
+            warnings.append("DEFAULT_DEADLINE_APPLIED")
+        elif deadline <= 0:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="DEADLINE_INVALID")
+    elif intent_kind == "apply":
+        missing.extend(field for field in missing_reward if field not in missing)
+        missing.extend(field for field in missing_deadline if field not in missing)
+
+    if intent_kind in {"apply", "submit", "finalize"} and job_id is None:
+        missing.append("job_id")
+
     title = _infer_title(text)
 
     intent = JobIntent(
-        kind="post_job",
+        kind=intent_kind,  # type: ignore[arg-type]
         title=title,
         description=text,
         reward_agialpha=reward,
         deadline_days=deadline,
+        job_id=job_id,
         attachments=attachments,
     )
 
-    plan = OrchestrationPlan.from_intent(intent, _build_steps(intent), reward or "0")
-    summary_parts = [f"Post job '{intent.title}'"]
-    if intent.reward_agialpha:
+    if reward and intent_kind != "post_job":
         try:
-            reward_amount = Decimal(intent.reward_agialpha)
-        except InvalidOperation:
-            reward_amount = Decimal("0")
-        if reward_amount > 0:
-            summary_parts.append(f"escrowing {intent.reward_agialpha} AGIALPHA")
-    if intent.deadline_days:
-        summary_parts.append(f"running for {intent.deadline_days} day(s)")
-    preview_summary = ", ".join(summary_parts) + "."
+            reward_decimal = Decimal(reward).quantize(Decimal("0.01"))
+        except (InvalidOperation, TypeError):
+            reward_decimal = Decimal("0")
+
+    total_budget = reward_decimal
+    budget_value = reward_decimal
+    if intent_kind == "post_job":
+        total_budget = (reward_decimal * (Decimal("1") + FEE_PCT + BURN_PCT)).quantize(Decimal("0.01"))
+        budget_value = reward_decimal
+
+    plan = OrchestrationPlan.from_intent(intent, _build_steps(intent), format(budget_value, "f"))
+
+    summary_parts = []
+    if intent.kind == "post_job":
+        summary_parts.append(f"Post job '{intent.title}'")
+        summary_parts.append(f"escrowing {reward} AGIALPHA")
+        summary_parts.append(f"duration {intent.deadline_days} day(s)")
+        summary_parts.append(f"total escrow {format(total_budget, 'f')} AGIALPHA (fee 5%, burn 2%)")
+    elif intent.kind == "apply":
+        summary_parts.append(f"Apply to job {intent.job_id or '???'}")
+    elif intent.kind == "submit":
+        summary_parts.append(f"Submit deliverable for job {intent.job_id or '???'}")
+    elif intent.kind == "finalize":
+        summary_parts.append(f"Finalize payout for job {intent.job_id or '???'}")
+    else:
+        summary_parts.append("Custom workflow ready")
+    preview_summary = ", ".join(summary_parts) + ". Proceed?"
 
     return PlanOut(
         intent=intent,
         plan=plan,
         missing_fields=missing,
         preview_summary=preview_summary,
+        warnings=warnings,
+        requiresConfirmation=True,
     )
 

--- a/orchestrator/simulator.py
+++ b/orchestrator/simulator.py
@@ -32,15 +32,17 @@ def simulate_plan(plan: OrchestrationPlan) -> SimOut:
 
     total_budget, total_fees = _estimate_budget(plan)
     confirmations = [
-        f"You’ll escrow {plan.budget.max} AGIALPHA (fee 5%, burn 2%).",
-        "This plan requires 3 validators; est duration ~48h.",
+        f"You’ll escrow {format(total_budget, 'f')} {plan.budget.token} (fee 5%, burn 2%).",
     ]
+    if plan.policies.requireValidator:
+        confirmations.append("This plan requires validator quorum (3 validators).")
 
     risks: list[str] = []
     blockers: list[str] = []
-    if _safe_decimal(plan.budget.max) <= 0:
+    budget_cap = _safe_decimal(plan.budget.max)
+    if budget_cap <= 0:
         blockers.append("BUDGET_REQUIRED")
-    if total_budget > _safe_decimal(plan.budget.max):
+    if total_budget > budget_cap:
         risks.append("OVER_BUDGET")
 
     return SimOut(

--- a/packages/onebox-sdk/src/types.ts
+++ b/packages/onebox-sdk/src/types.ts
@@ -56,6 +56,8 @@ export const PlanResponseSchema = z.object({
   plan: OrchestrationPlanSchema,
   missing_fields: z.array(z.string()).default([]),
   preview_summary: z.string(),
+  warnings: z.array(z.string()).default([]),
+  requiresConfirmation: z.boolean().default(true),
 });
 
 export const SimulationResponseSchema = z.object({

--- a/routes/meta_orchestrator.py
+++ b/routes/meta_orchestrator.py
@@ -15,7 +15,7 @@ from orchestrator.simulator import simulate_plan
 try:  # pragma: no cover - import guard for test environments
     from .onebox import require_api  # type: ignore
 except (RuntimeError, ImportError):  # pragma: no cover - fallback when core router not configured
-    def require_api(*_args, **_kwargs):  # type: ignore
+    def require_api() -> None:  # type: ignore
         return None
 
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/test/orchestrator/test_planner.py
+++ b/test/orchestrator/test_planner.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from orchestrator.models import PlanIn
+from orchestrator.planner import make_plan
+
+
+def test_make_plan_defaults_and_summary():
+    plan = make_plan(PlanIn(input_text="Post a job for image labeling"))
+
+    assert plan.intent.kind == "post_job"
+    assert plan.intent.reward_agialpha == "50.00"
+    assert plan.intent.deadline_days == 7
+    assert plan.preview_summary.endswith("Proceed?")
+    assert "DEFAULT_REWARD_APPLIED" in plan.warnings
+    assert "DEFAULT_DEADLINE_APPLIED" in plan.warnings
+    assert plan.requires_confirmation is True
+    assert plan.plan.budget.max == "50.00"
+
+
+def test_make_plan_non_post_job_marks_missing_fields():
+    plan = make_plan(PlanIn(input_text="Please finalize payout for job 42"))
+
+    assert plan.intent.kind == "finalize"
+    assert plan.intent.job_id == 42
+    assert plan.missing_fields == []
+    assert plan.preview_summary.startswith("Finalize payout")
+    assert plan.requires_confirmation is True
+
+
+def test_make_plan_requires_job_id_for_apply():
+    plan = make_plan(PlanIn(input_text="Apply to the newest job"))
+
+    assert plan.intent.kind == "apply"
+    assert "job_id" in plan.missing_fields
+    assert plan.intent.job_id is None
+    assert plan.preview_summary.startswith("Apply to job")
+    assert plan.requires_confirmation is True
+
+
+def test_make_plan_invalid_reward_raises():
+    with pytest.raises(Exception):
+        make_plan(PlanIn(input_text="Post a job with 0 AGI reward"))
+    with pytest.raises(Exception):
+        make_plan(PlanIn(input_text="Post a job with -5 AGI reward"))

--- a/test/routes/test_meta_orchestrator.py
+++ b/test/routes/test_meta_orchestrator.py
@@ -29,6 +29,9 @@ def test_plan_simulate_execute_flow():
     plan_data = plan_resp.json()
     assert plan_data["intent"]["kind"] == "post_job"
     assert plan_data["plan"]["steps"], "expected at least one step"
+    assert plan_data["requiresConfirmation"] is True
+    assert isinstance(plan_data["warnings"], list)
+    assert plan_data["preview_summary"].endswith("Proceed?")
 
     simulate_resp = client.post("/onebox/simulate", json={"plan": plan_data["plan"]})
     assert simulate_resp.status_code == 200


### PR DESCRIPTION
## Summary
- port the meta-orchestrator data models to Pydantic v2 and surface policy defaults plus confirmation metadata on plans
- expand the planner, simulator, and runner stubs so plans derive richer defaults, budgets, and deterministic status updates
- add TypeScript schema updates and focused FastAPI tests that exercise the planner, simulator, and execute flow

## Testing
- pytest test/orchestrator test/routes/test_meta_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68d9463653f48333a44b84e36f042f82