### PR TITLE
Fix planner budget totals and adjust simulator

### DIFF
--- a/orchestrator/planner.py
+++ b/orchestrator/planner.py
@@ -189,12 +189,16 @@ def make_plan(req: PlanIn) -> PlanOut:
             reward_decimal = Decimal("0")
 
     total_budget = reward_decimal
-    budget_value = reward_decimal
     if intent_kind == "post_job":
-        total_budget = (reward_decimal * (Decimal("1") + FEE_PCT + BURN_PCT)).quantize(Decimal("0.01"))
-        budget_value = reward_decimal
+        total_budget = (reward_decimal * (Decimal("1") + FEE_PCT + BURN_PCT)).quantize(
+            Decimal("0.01")
+        )
 
-    plan = OrchestrationPlan.from_intent(intent, _build_steps(intent), format(budget_value, "f"))
+    plan = OrchestrationPlan.from_intent(
+        intent,
+        _build_steps(intent),
+        format(total_budget, "f"),
+    )
 
     summary_parts = []
     if intent.kind == "post_job":


### PR DESCRIPTION
## Summary
- ensure planner passes the full escrow amount into orchestration plans so the budget matches on-chain totals
- update simulator math to derive rewards and fees from the total escrow while keeping confirmations accurate
- extend planner and simulator tests to cover the new totals and confirm the default post job flow is within budget

## Testing
- pytest test/orchestrator -q

------
https://chatgpt.com/codex/tasks/task_e_68d951f08ce883339db94799ee8a7698