### PR TITLE
Refine planner required field handling for non-post jobs

### DIFF
--- a/test/orchestrator/test_planner.py
+++ b/test/orchestrator/test_planner.py
@@ -41,9 +41,29 @@ def test_make_plan_requires_job_id_for_apply():
     plan = make_plan(PlanIn(input_text="Apply to the newest job"))
 
     assert plan.intent.kind == "apply"
-    assert "job_id" in plan.missing_fields
+    assert plan.missing_fields == ["job_id"]
     assert plan.intent.job_id is None
     assert plan.preview_summary.startswith("Apply to job")
+    assert plan.requires_confirmation is True
+
+
+def test_make_plan_requires_job_id_for_submit():
+    plan = make_plan(PlanIn(input_text="Submit my work for review"))
+
+    assert plan.intent.kind == "submit"
+    assert plan.missing_fields == ["job_id"]
+    assert plan.intent.job_id is None
+    assert plan.preview_summary.startswith("Submit deliverable for job")
+    assert plan.requires_confirmation is True
+
+
+def test_make_plan_requires_job_id_for_finalize():
+    plan = make_plan(PlanIn(input_text="Finalize the payout now"))
+
+    assert plan.intent.kind == "finalize"
+    assert plan.missing_fields == ["job_id"]
+    assert plan.intent.job_id is None
+    assert plan.preview_summary.startswith("Finalize payout for job")
     assert plan.requires_confirmation is True
 
 


### PR DESCRIPTION
## Summary
- scope planner required-field tracking per intent so non-post job flows only request job IDs
- update planner tests to cover apply, submit, and finalize prompts for missing field expectations

## Testing
- pytest test/orchestrator/test_planner.py *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68d95390e85c833399d1d4aa864f2453