### PR TITLE
Add simulation endpoint and planner safeguards

### DIFF
--- a/docs/onebox-ux.md
+++ b/docs/onebox-ux.md
@@ -6,7 +6,7 @@ This document covers how the single-input One-Box interface interacts with the A
 
 - **Front-end**: `apps/onebox/` — static HTML/CSS/JS that can be pinned to IPFS. It consumes the orchestrator over HTTPS.
 - **Shared types**: `packages/onebox-sdk/` — TypeScript definitions for the planner/executor/status payloads.
-- **Server**: extend the FastAPI app with `/onebox/plan`, `/onebox/execute`, `/onebox/status`.
+- **Server**: extend the FastAPI app with `/onebox/plan`, `/onebox/simulate`, `/onebox/execute`, `/onebox/status`.
 
 Guest mode routes execution through the orchestrator relayer. Expert mode surfaces calldata so power users can sign with their own wallets (e.g. through viem/Web3Modal).
 
@@ -15,7 +15,7 @@ The static bundle also exposes runtime configuration controls: operators can cha
 ## API surface (FastAPI stubs)
 
 Add the following endpoints to `AGI-Alpha-Agent-v0` (or reuse the ready-made Express router in `apps/orchestrator/oneboxRouter.ts`).
-A production-ready FastAPI router now ships in [`routes/onebox.py`](../routes/onebox.py); mount it directly on the existing API server to gain `/onebox/plan`, `/onebox/execute`, `/onebox/status`, `/onebox/healthz`, and `/onebox/metrics` with Prometheus instrumentation:
+A production-ready FastAPI router now ships in [`routes/onebox.py`](../routes/onebox.py); mount it directly on the existing API server to gain `/onebox/plan`, `/onebox/simulate`, `/onebox/execute`, `/onebox/status`, `/onebox/healthz`, and `/onebox/metrics` with Prometheus instrumentation:
 
 ```py
 from fastapi import APIRouter, Depends, HTTPException
@@ -96,7 +96,7 @@ The planner must output a `JobIntent` structure:
 }
 ```
 
-`packages/onebox-sdk` exports matching TypeScript interfaces, which keeps UI, orchestrator, and tooling aligned.
+`packages/onebox-sdk` exports matching TypeScript interfaces, which keeps UI, orchestrator, and tooling aligned. The Python router mirrors those shapes: `PlanResponse` includes a `missingFields` array so the UI can gather required values before moving to simulation, and `SimulateResponse` returns `risks` and `blockers` to differentiate warnings from fatal blockers (422 responses).
 
 ## Error handling
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -4,27 +4,24 @@ This sprint introduces a planner → simulator → runner pipeline that powers t
 
 ## Planner
 
-* `POST /onebox/plan` accepts natural language and produces a `JobIntent` + `OrchestrationPlan`.
-* Missing fields are echoed back via `missing_fields` so the chat UI can ask clarifying questions.
-* Plans are hashed (`plan_id`) to provide a stable correlation identifier.
+* `POST /onebox/plan` accepts natural language and produces a `JobIntent` and summary.
+* Missing parameters are surfaced via the `missingFields` array so the chat UI can request clarifications before execution. When `missingFields` is non-empty the backend also flips `requiresConfirmation` to `false`.
+* Plans are hashed (`planHash`) to provide a stable correlation identifier that carries through simulate and execute responses.
 
 ## Simulator
 
-* `POST /onebox/simulate` checks the plan against budget and tool policies.
-* Returns human readable confirmations plus machine readable `risks` and `blockers`.
-* If any blockers are present the API responds with HTTP 422 and the caller should re-plan.
+* `POST /onebox/simulate` checks the plan against budget caps, deadline limits, and intent-specific requirements before any transaction is prepared.
+* Returns human readable confirmations plus machine readable `risks` (soft warnings) and `blockers` (fatal issues). Planner warnings are echoed as risks so the UI can display them inline.
+* If any blockers are present the API responds with HTTP 422 and includes the `blockers` list in the response body. The client should gather additional input and retry planning.
 
 ## Runner
 
 * `POST /onebox/execute` kicks off the in-memory runner which executes each step sequentially.
 * `GET /onebox/status?run_id=…` streams back step state, logs, and a final receipt.
-* Receipts capture plan hash, placeholder tx hashes, and pinned CID references.
+* Receipts capture the originating plan hash, all transaction hashes, and pinned CID references for downstream auditing.
 
 ## Metrics
 
-* `plan_latency_seconds`
-* `simulate_latency_seconds`
-* `execute_step_latency_seconds`
-* `run_success_total`
-* `run_fail_total`
+* `plan_total` / `simulate_total` / `execute_total` / `status_total`
+* `time_to_outcome_seconds` histogram tagged with `endpoint`
 


### PR DESCRIPTION
## Summary
- surface missingFields in planner responses and reject empty plan requests
- implement POST /onebox/simulate with policy enforcement, risk reporting, and new metrics
- document the simulator flow and add unit coverage for planning and simulation changes

## Testing
- pytest test/routes/test_onebox.py

------
https://chatgpt.com/codex/tasks/task_e_68d96270333c8333a245d9bf09a1f2bc