### PR TITLE
Block unsupported runner actions during simulation

### DIFF
--- a/routes/onebox.py
+++ b/routes/onebox.py
@@ -1828,7 +1828,9 @@ async def simulate(request: Request, req: SimulateRequest):
                 except OrgPolicyViolation as violation:
                     blockers.append(violation.code)
 
-        elif intent.action in {"finalize_job", "stake", "validate", "dispute", "check_status"}:
+        elif intent.action in {"stake", "validate", "dispute"}:
+            blockers.append("UNSUPPORTED_ACTION")
+        elif intent.action in {"finalize_job", "check_status"}:
             if getattr(payload, "jobId", None) is None:
                 blockers.append("JOB_ID_REQUIRED")
         else:

--- a/test/routes/test_onebox.py
+++ b/test/routes/test_onebox.py
@@ -541,6 +541,20 @@ class SimulatorTests(unittest.IsolatedAsyncioTestCase):
         detail = exc.exception.detail
         self.assertIn("JOB_BUDGET_CAP_EXCEEDED", detail["blockers"])  # type: ignore[index]
 
+    async def test_simulate_rejects_runner_unsupported_actions(self) -> None:
+        intent = JobIntent(action="stake", payload=Payload(jobId=123))
+        plan_hash = _compute_plan_hash(intent)
+
+        with self.assertRaises(fastapi.HTTPException) as exc:
+            await simulate(
+                _make_request(),
+                SimulateRequest(intent=intent, planHash=plan_hash),
+            )
+
+        self.assertEqual(exc.exception.status_code, 422)
+        detail = exc.exception.detail
+        self.assertIn("UNSUPPORTED_ACTION", detail["blockers"])  # type: ignore[index]
+
 
 class DeadlineComputationTests(unittest.TestCase):
     def test_calculate_deadline_uses_epoch_seconds(self) -> None:


### PR DESCRIPTION
## Summary
- block stake, validate, and dispute intents in the simulator with an UNSUPPORTED_ACTION blocker to match runner capabilities
- add a regression test ensuring simulate rejects runner-unsupported intents before execution

## Testing
- pytest test/routes/test_onebox.py -k "simulate or execute"


------
https://chatgpt.com/codex/tasks/task_e_68d9747be63c8333a43c7b806839e901