### PR TITLE
Ensure planner reports missing reward and deadline fields

### DIFF
--- a/orchestrator/planner.py
+++ b/orchestrator/planner.py
@@ -151,6 +151,11 @@ def make_plan(req: PlanIn) -> PlanOut:
     warnings: List[str] = []
     missing: List[str] = []
 
+    if _missing_reward:
+        missing.extend(_missing_reward)
+    if _missing_deadline:
+        missing.extend(_missing_deadline)
+
     reward_decimal = Decimal("0")
 
     if intent_kind == "post_job":
@@ -217,8 +222,19 @@ def make_plan(req: PlanIn) -> PlanOut:
     summary_parts = []
     if intent.kind == "post_job":
         summary_parts.append(f"Post job '{intent.title}'")
-        summary_parts.append(f"escrowing {reward} AGIALPHA")
-        summary_parts.append(f"duration {intent.deadline_days} day(s)")
+        if reward is None:
+            summary_parts.append("escrowing ??? AGIALPHA")
+        elif intent_kind == "post_job" and "DEFAULT_REWARD_APPLIED" in warnings:
+            summary_parts.append(f"escrowing {reward} AGIALPHA (default)")
+        else:
+            summary_parts.append(f"escrowing {reward} AGIALPHA")
+
+        if deadline is None:
+            summary_parts.append("duration ??? day(s)")
+        elif intent_kind == "post_job" and "DEFAULT_DEADLINE_APPLIED" in warnings:
+            summary_parts.append(f"duration {intent.deadline_days} day(s) (default)")
+        else:
+            summary_parts.append(f"duration {intent.deadline_days} day(s)")
         summary_parts.append(
             (
                 f"total escrow {format(total_budget, 'f')} AGIALPHA "

--- a/test/orchestrator/test_planner.py
+++ b/test/orchestrator/test_planner.py
@@ -17,6 +17,7 @@ def test_make_plan_defaults_and_summary():
     assert plan.intent.kind == "post_job"
     assert plan.intent.reward_agialpha == "50.00"
     assert plan.intent.deadline_days == 7
+    assert plan.missing_fields == ["reward_agialpha", "deadline_days"]
     assert plan.simulation is not None
     assert plan.simulation.est_budget == plan.plan.budget.max
     assert plan.preview_summary.endswith("Proceed?")
@@ -24,7 +25,7 @@ def test_make_plan_defaults_and_summary():
     assert "DEFAULT_DEADLINE_APPLIED" in plan.warnings
     assert plan.requires_confirmation is True
     assert plan.plan.budget.max == "53.50"
-    assert "escrowing 50.00 AGIALPHA" in plan.preview_summary
+    assert "escrowing 50.00 AGIALPHA (default)" in plan.preview_summary
     assert "total escrow 53.50 AGIALPHA" in plan.preview_summary
 
 
@@ -80,3 +81,25 @@ def test_default_plan_is_within_budget():
     assert plan_out.simulation is not None
     assert "OVER_BUDGET" not in plan_out.simulation.risks
     assert plan_out.simulation.est_budget == plan_out.plan.budget.max
+
+
+def test_missing_reward_is_reported():
+    plan = make_plan(PlanIn(input_text="Post a job with deadline in 5 days"))
+
+    assert plan.intent.kind == "post_job"
+    assert plan.intent.reward_agialpha == "50.00"
+    assert plan.intent.deadline_days == 5
+    assert plan.missing_fields == ["reward_agialpha"]
+    assert "duration 5 day(s)" in plan.preview_summary
+    assert "escrowing 50.00 AGIALPHA (default)" in plan.preview_summary
+
+
+def test_missing_deadline_is_reported():
+    plan = make_plan(PlanIn(input_text="Post a 200 AGI job"))
+
+    assert plan.intent.kind == "post_job"
+    assert plan.intent.reward_agialpha == "200.00"
+    assert plan.intent.deadline_days == 7
+    assert plan.missing_fields == ["deadline_days"]
+    assert "escrowing 200.00 AGIALPHA" in plan.preview_summary
+    assert "duration 7 day(s) (default)" in plan.preview_summary


### PR DESCRIPTION
## Summary
- propagate missing reward and deadline hints from the natural language parser into the final plan output
- adjust the post-job summary so default reward/deadline values are clearly marked when they are assumed
- extend the planner tests to cover missing reward and deadline scenarios

## Testing
- pytest test/orchestrator/test_planner.py *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68d975bf1c24833399ecc38993558243