### PR TITLE
Flag long deadlines as simulation risks

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -11,7 +11,7 @@ This sprint introduces a planner → simulator → runner pipeline that powers t
 ## Simulator
 
 * `POST /onebox/simulate` checks the plan against budget caps, deadline limits, and intent-specific requirements before any transaction is prepared.
-* Returns human readable confirmations plus machine readable `risks` (soft warnings) and `blockers` (fatal issues). Planner warnings are echoed as risks so the UI can display them inline.
+* Returns human readable confirmations plus machine readable `risks` (soft warnings) and `blockers` (fatal issues). Planner warnings are echoed as risks so the UI can display them inline. Examples include `LOW_REWARD` for small budgets and `LONG_DEADLINE` when a job keeps funds locked for extended periods.
 * If any blockers are present the API responds with HTTP 422 and includes the `blockers` list in the response body. The client should gather additional input and retry planning.
 
 ## Runner

--- a/routes/onebox.py
+++ b/routes/onebox.py
@@ -1820,6 +1820,8 @@ async def simulate(request: Request, req: SimulateRequest):
                         blockers.append("DEADLINE_INVALID")
                     elif deadline_days <= 2:
                         risks.append("SHORT_DEADLINE")
+                    elif deadline_days >= 45:
+                        risks.append("LONG_DEADLINE")
 
             if not blockers and reward_wei is not None and deadline_days is not None:
                 org_identifier = _resolve_org_identifier(intent)

--- a/test/routes/test_onebox.py
+++ b/test/routes/test_onebox.py
@@ -517,6 +517,19 @@ class SimulatorTests(unittest.IsolatedAsyncioTestCase):
         detail = exc.exception.detail
         self.assertIn("INSUFFICIENT_BALANCE", detail["blockers"])  # type: ignore[index]
 
+    async def test_simulate_flags_long_deadline_as_risk(self) -> None:
+        intent = JobIntent(
+            action="post_job",
+            payload=Payload(title="Map terrain", reward="5", deadlineDays=60),
+        )
+        plan_hash = _compute_plan_hash(intent)
+        response = await simulate(
+            _make_request(),
+            SimulateRequest(intent=intent, planHash=plan_hash),
+        )
+        self.assertEqual(response.blockers, [])
+        self.assertIn("LONG_DEADLINE", response.risks)
+
     async def test_simulate_policy_violation_returns_blocker(self) -> None:
         intent = JobIntent(action="post_job", payload=Payload(title="Label data", reward="25", deadlineDays=7))
         violation = OrgPolicyViolation(


### PR DESCRIPTION
## Summary
- flag very long job deadlines as a non-blocking LONG_DEADLINE risk during simulation
- document common simulator risk codes in the orchestration overview
- add regression test ensuring long deadlines are surfaced as risks without blocking execution

## Testing
- pytest test/routes/test_onebox.py

------
https://chatgpt.com/codex/tasks/task_e_68d9788d04548333b53e33fa8d624ea0