### PR TITLE
Tighten job ID parsing to require explicit identifiers

### DIFF
--- a/routes/onebox.py
+++ b/routes/onebox.py
@@ -906,12 +906,25 @@ def _normalize_title(text: str) -> str:
     return s[:160] if s else "New Job"
 
 
+_JOB_ID_PATTERN = re.compile(
+    r"""
+    \bjob
+    (?:
+        \s*(?:\#|id(?:entifier)?|number|no\.?|num\.?)?
+    )
+    \s*[:#-]?
+    \s*(\d+)
+    \b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
 def _extract_job_id(text: str) -> Optional[int]:
-    match = re.search(r"job\s*#?\s*(\d+)", text, re.IGNORECASE)
+    match = _JOB_ID_PATTERN.search(text)
     if match:
         return int(match.group(1))
-    digits = re.search(r"\b(\d{1,8})\b", text)
-    return int(digits.group(1)) if digits else None
+    return None
 
 
 def _format_job_id(job_id: Optional[int]) -> str:

--- a/test/routes/test_onebox.py
+++ b/test/routes/test_onebox.py
@@ -458,6 +458,15 @@ class PlannerValidationTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("jobId", response.missingFields)
         self.assertFalse(response.requiresConfirmation)
 
+    async def test_plan_ignores_numbers_without_job_identifier(self) -> None:
+        response = await plan(
+            _make_request(), PlanRequest(text="Finalize the job in 2 days")
+        )
+        self.assertEqual(response.intent.action, "finalize_job")
+        self.assertIsNone(response.intent.payload.jobId)
+        self.assertIn("jobId", response.missingFields)
+        self.assertFalse(response.requiresConfirmation)
+
 
 class SimulatorTests(unittest.IsolatedAsyncioTestCase):
     async def test_simulate_post_job_success(self) -> None:


### PR DESCRIPTION
## Summary
- require explicit job references before extracting job IDs in the onebox parser
- ensure finalize requests with unrelated numbers leave jobId missing via new unit test

## Testing
- python -m unittest test.routes.test_onebox

------
https://chatgpt.com/codex/tasks/task_e_68d97ca1399c8333853ec255250f54a3