### PR TITLE
Ensure trimmed plans keep valid dependencies

### DIFF
--- a/test/orchestrator/test_planner.py
+++ b/test/orchestrator/test_planner.py
@@ -58,6 +58,11 @@ def test_make_plan_requires_job_id_for_submit():
     assert plan.preview_summary.startswith("Submit deliverable for job")
     assert plan.requires_confirmation is False
 
+    step_ids = {step.id for step in plan.plan.steps}
+    for step in plan.plan.steps:
+        for dependency in step.needs:
+            assert dependency in step_ids
+
 
 def test_make_plan_requires_job_id_for_finalize():
     plan = make_plan(PlanIn(input_text="Finalize the payout now"))
@@ -67,6 +72,11 @@ def test_make_plan_requires_job_id_for_finalize():
     assert plan.intent.job_id is None
     assert plan.preview_summary.startswith("Finalize payout for job")
     assert plan.requires_confirmation is False
+
+    step_ids = {step.id for step in plan.plan.steps}
+    for step in plan.plan.steps:
+        for dependency in step.needs:
+            assert dependency in step_ids
 
 
 def test_make_plan_invalid_reward_raises():


### PR DESCRIPTION
## Summary
- adjust submit/finalize plan trimming to filter out dependencies on removed steps
- add unit tests confirming submit/finalize plans only reference retained steps

## Testing
- pytest test/orchestrator/test_planner.py

------
https://chatgpt.com/codex/tasks/task_e_68d97fab75dc8333bce3d04bc8566933