### PR TITLE
Allow zero-budget finalize plans in simulator

### DIFF
--- a/test/orchestrator/test_simulator.py
+++ b/test/orchestrator/test_simulator.py
@@ -2,9 +2,13 @@ import os
 import sys
 from decimal import Decimal
 
+import pytest
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
+
+pytest.importorskip("pydantic")
 
 from orchestrator.config import get_burn_fraction, get_fee_fraction
 from orchestrator.models import JobIntent, OrchestrationPlan, Step
@@ -18,13 +22,21 @@ def _build_plan(reward: str = "50.00") -> OrchestrationPlan:
     intent = JobIntent(kind="post_job", title="Test", reward_agialpha=reward, deadline_days=7)
     steps = [
         Step(id="pin", name="Pin", kind="pin"),
-        Step(id="post", name="Post", kind="chain"),
+        Step(id="post", name="Post", kind="chain", tool="job.post"),
     ]
     reward_decimal = Decimal(reward)
     total_budget = (
         reward_decimal * (Decimal("1") + FEE_FRACTION + BURN_FRACTION)
     ).quantize(Decimal("0.01"))
     return OrchestrationPlan.from_intent(intent, steps, format(total_budget, "f"))
+
+
+def _build_finalize_plan() -> OrchestrationPlan:
+    intent = JobIntent(kind="finalize", job_id=123)
+    steps = [
+        Step(id="finalize", name="Finalize", kind="finalize", tool="job.finalize"),
+    ]
+    return OrchestrationPlan.from_intent(intent, steps, "0")
 
 
 def test_simulator_returns_budget_and_confirmation():
@@ -52,3 +64,11 @@ def test_simulator_detects_over_budget():
 
     assert "OVER_BUDGET" in result.risks
     assert "OVER_BUDGET" in result.blockers
+
+
+def test_simulator_allows_zero_budget_for_finalize_plan():
+    plan = _build_finalize_plan()
+    result = simulate_plan(plan)
+
+    assert "BUDGET_REQUIRED" not in result.blockers
+    assert result.confirmations[0] == "No escrow required for this plan."


### PR DESCRIPTION
## Summary
- teach the simulator to detect escrow/posting steps and allow zero-budget plans without them
- cover zero-budget finalize plans in the simulator unit tests
- add route-level tests that accept finalize simulations while still blocking missing budgets for post-job plans

## Testing
- pytest test/orchestrator/test_simulator.py test/routes/test_meta_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68d98064a29083338eaaf6a19715e021