### PR TITLE
Add unified owner update orchestration CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,27 @@ npm run owner:rotate -- --network <network> \
 
 The script validates deployed bytecode, highlights modules missing configuration, and warns if any `Ownable2Step` contract still requires `acceptOwnership()` by the new controller. Safe bundles include typed inputs for inspection inside the transaction builder UI.
 
+### Unified owner parameter updates
+
+For day-to-day parameter maintenance run the consolidated helper, which loads every module configuration and builds a single execution plan:
+
+```bash
+# Preview all module changes defined in config/*.json
+npm run owner:update-all -- --network <network>
+
+# Limit the run to a subset or skip noisy modules
+npm run owner:update-all -- --network <network> --only=stakeManager,feePool
+npm run owner:update-all -- --network <network> --skip=energyOracle
+
+# Emit machine-readable output for Gnosis Safe or change-control pipelines
+npm run owner:update-all -- --network <network> --json > owner-plan.json
+
+# Submit transactions once the dry run looks correct
+npm run owner:update-all -- --network <network> --execute
+```
+
+The script resolves contract addresses from `config/*.json`, `.env` overrides and `config/agialpha.json`, verifies signer ownership and prints calldata for every proposed change. When invoked with `--execute`, each module action is submitted sequentially so a non-technical operator can review the dry-run output and immediately replay it against production. Optional `--only`/`--skip` filters make it easy to scope updates to specific subsystems without editing configuration files.
+
 ### Mainnet Deployment
 
 For a step-by-step mainnet deployment using Truffle, see the [Deploying AGIJobs v2 to Ethereum Mainnet (CLI Guide)](docs/deploying-agijobs-v2-truffle-cli.md). Operators who prefer an automated checklist can launch the guided wizard:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "owner:wizard": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/owner-config-wizard.ts",
     "owner:dashboard": "npx hardhat run --no-compile scripts/v2/owner-dashboard.ts",
     "owner:rotate": "npx hardhat run --no-compile scripts/v2/rotateGovernance.ts",
+    "owner:update-all": "npx hardhat run --no-compile scripts/v2/updateAllModules.ts",
     "test": "hardhat test --no-compile",
     "e2e:local": "hardhat test --no-compile test/e2e/localnet.gateway.e2e.test.ts",
     "echidna:commit-reveal": "docker run --rm -v \"$PWD\":/src -v \"$PWD/tools/forge-shim\":/usr/local/bin/forge:ro -w /src ghcr.io/crytic/echidna/echidna:v2.2.7 echidna-test ./contracts/test/CommitRevealEchidna.sol --contract CommitRevealEchidnaHarness --config echidna/commit-reveal.yaml",

--- a/scripts/v2/updateAllModules.ts
+++ b/scripts/v2/updateAllModules.ts
@@ -1,0 +1,788 @@
+import { ethers, network } from 'hardhat';
+import type { Contract } from 'ethers';
+import {
+  loadTokenConfig,
+  loadStakeManagerConfig,
+  loadFeePoolConfig,
+  loadJobRegistryConfig,
+  loadPlatformRegistryConfig,
+  loadPlatformIncentivesConfig,
+  loadRewardEngineConfig,
+  loadThermostatConfig,
+  loadRandaoCoordinatorConfig,
+  loadEnergyOracleConfig,
+  loadTaxPolicyConfig,
+  loadIdentityRegistryConfig,
+  type TokenConfigResult,
+  type StakeManagerConfigResult,
+  type FeePoolConfigResult,
+  type JobRegistryConfigResult,
+  type PlatformRegistryConfigResult,
+  type PlatformIncentivesConfigResult,
+  type RewardEngineConfigResult,
+  type ThermostatConfigResult,
+  type RandaoCoordinatorConfigResult,
+  type EnergyOracleConfigResult,
+  type TaxPolicyConfigResult,
+  type IdentityRegistryConfigResult,
+} from '../config';
+import { buildStakeManagerPlan } from './lib/stakeManagerPlan';
+import { buildFeePoolPlan } from './lib/feePoolPlan';
+import { buildJobRegistryPlan } from './lib/jobRegistryPlan';
+import { buildPlatformRegistryPlan } from './lib/platformRegistryPlan';
+import { buildPlatformIncentivesPlan } from './lib/platformIncentivesPlan';
+import { buildRewardEnginePlan } from './lib/rewardEnginePlan';
+import { buildThermostatPlan } from './lib/thermostatPlan';
+import { buildRandaoCoordinatorPlan } from './lib/randaoCoordinatorPlan';
+import { buildEnergyOraclePlan } from './lib/energyOraclePlan';
+import { buildTaxPolicyPlan } from './lib/taxPolicyPlan';
+import { buildIdentityRegistryPlan } from './lib/identityRegistryPlan';
+import type { ModulePlan, PlannedAction } from './lib/types';
+import { describeArgs, sameAddress } from './lib/utils';
+
+interface CliOptions {
+  execute: boolean;
+  json: boolean;
+  only?: Set<ModuleKey>;
+  skip: Set<ModuleKey>;
+}
+
+type ModuleKey =
+  | 'stakeManager'
+  | 'feePool'
+  | 'jobRegistry'
+  | 'platformRegistry'
+  | 'platformIncentives'
+  | 'rewardEngine'
+  | 'thermostat'
+  | 'randaoCoordinator'
+  | 'energyOracle'
+  | 'taxPolicy'
+  | 'identityRegistry';
+
+const MODULE_ORDER: ModuleKey[] = [
+  'stakeManager',
+  'feePool',
+  'jobRegistry',
+  'platformRegistry',
+  'platformIncentives',
+  'rewardEngine',
+  'thermostat',
+  'randaoCoordinator',
+  'energyOracle',
+  'taxPolicy',
+  'identityRegistry',
+];
+
+const MODULE_ALIASES: Record<string, ModuleKey> = {
+  stake: 'stakeManager',
+  'stake-manager': 'stakeManager',
+  stakemanager: 'stakeManager',
+  fee: 'feePool',
+  'fee-pool': 'feePool',
+  feepool: 'feePool',
+  job: 'jobRegistry',
+  'job-registry': 'jobRegistry',
+  jobregistry: 'jobRegistry',
+  platform: 'platformRegistry',
+  registry: 'platformRegistry',
+  'platform-registry': 'platformRegistry',
+  platformregistry: 'platformRegistry',
+  incentives: 'platformIncentives',
+  'platform-incentives': 'platformIncentives',
+  reward: 'rewardEngine',
+  'reward-engine': 'rewardEngine',
+  thermostat: 'thermostat',
+  randao: 'randaoCoordinator',
+  'randao-coordinator': 'randaoCoordinator',
+  oracle: 'energyOracle',
+  'energy-oracle': 'energyOracle',
+  energy: 'energyOracle',
+  tax: 'taxPolicy',
+  'tax-policy': 'taxPolicy',
+  identity: 'identityRegistry',
+  'identity-registry': 'identityRegistry',
+};
+
+type AnyConfigResult =
+  | StakeManagerConfigResult
+  | FeePoolConfigResult
+  | JobRegistryConfigResult
+  | PlatformRegistryConfigResult
+  | PlatformIncentivesConfigResult
+  | RewardEngineConfigResult
+  | ThermostatConfigResult
+  | RandaoCoordinatorConfigResult
+  | EnergyOracleConfigResult
+  | TaxPolicyConfigResult
+  | IdentityRegistryConfigResult;
+
+interface ModuleDefinition<TConfig extends AnyConfigResult> {
+  key: ModuleKey;
+  label: string;
+  artifact: string;
+  loadConfig: (opts: LoadContext) => TConfig;
+  resolveAddress: (ctx: {
+    moduleConfig: TConfig;
+    tokenConfig: TokenConfigResult;
+  }) => string | undefined;
+  buildPlan: (ctx: ModuleBuildContext<TConfig>) => Promise<ModulePlan>;
+}
+
+interface LoadContext {
+  network: string;
+  chainId?: number;
+}
+
+interface ModuleBuildContext<TConfig extends AnyConfigResult> {
+  contract: Contract;
+  moduleConfig: TConfig;
+  tokenConfig: TokenConfigResult;
+  ownerAddress: string;
+  signerAddress: string;
+}
+
+interface ModuleExecutionPlan<TConfig extends AnyConfigResult> {
+  definition: ModuleDefinition<TConfig>;
+  moduleConfig: TConfig;
+  plan: ModulePlan;
+  ownerAddress: string;
+  signerAddress: string;
+}
+
+function parseModuleKey(value: string): ModuleKey {
+  const normalised = value.trim().toLowerCase();
+  if (!normalised) {
+    throw new Error('Module name cannot be empty');
+  }
+  if ((MODULE_ALIASES as Record<string, ModuleKey>)[normalised]) {
+    return MODULE_ALIASES[normalised];
+  }
+  const exact = MODULE_ORDER.find((key) => key.toLowerCase() === normalised);
+  if (exact) {
+    return exact;
+  }
+  throw new Error(`Unknown module "${value}"`);
+}
+
+function parseCliOptions(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false, json: false, skip: new Set() };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--execute') {
+      options.execute = true;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg.startsWith('--only=')) {
+      const [, raw] = arg.split('=');
+      if (!raw) {
+        throw new Error('--only requires a comma-separated module list');
+      }
+      const parts = raw.split(',').map(parseModuleKey);
+      options.only = new Set(parts);
+    } else if (arg === '--only') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--only requires a comma-separated module list');
+      }
+      const parts = value.split(',').map(parseModuleKey);
+      options.only = new Set(parts);
+      i += 1;
+    } else if (arg.startsWith('--skip=')) {
+      const [, raw] = arg.split('=');
+      if (!raw) {
+        throw new Error('--skip requires a comma-separated module list');
+      }
+      raw
+        .split(',')
+        .forEach((entry) => options.skip.add(parseModuleKey(entry)));
+    } else if (arg === '--skip') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--skip requires a comma-separated module list');
+      }
+      value
+        .split(',')
+        .forEach((entry) => options.skip.add(parseModuleKey(entry)));
+      i += 1;
+    }
+  }
+  return options;
+}
+
+async function fetchOwnerAddress(contract: Contract): Promise<string> {
+  if (typeof (contract as any).owner === 'function') {
+    const owner = await (contract as any).owner();
+    return ethers.getAddress(owner);
+  }
+  if (typeof (contract as any).governance === 'function') {
+    const governance = await (contract as any).governance();
+    return ethers.getAddress(governance);
+  }
+  throw new Error('Target contract does not expose owner() or governance()');
+}
+
+async function ensurePlanContract(
+  plan: ModulePlan,
+  contract: Contract
+): Promise<void> {
+  if (!plan.contract) {
+    plan.contract = contract;
+  }
+  if (!plan.iface) {
+    plan.iface = contract.interface;
+  }
+}
+
+function addMetadata(
+  plan: ModulePlan,
+  metadata: Record<string, unknown>
+): void {
+  plan.metadata = { ...(plan.metadata ?? {}), ...metadata };
+}
+
+const MODULE_DEFINITIONS: Record<ModuleKey, ModuleDefinition<any>> = {
+  stakeManager: {
+    key: 'stakeManager',
+    label: 'StakeManager',
+    artifact: 'contracts/v2/StakeManager.sol:StakeManager',
+    loadConfig: (ctx: LoadContext) =>
+      loadStakeManagerConfig({ network: ctx.network, chainId: ctx.chainId }),
+    resolveAddress: ({ moduleConfig, tokenConfig }) => {
+      const configAddress = (moduleConfig.config as any).address;
+      return (
+        configAddress ||
+        tokenConfig.config.modules?.stakeManager ||
+        tokenConfig.config.contracts?.stakeManager
+      );
+    },
+    buildPlan: async ({
+      contract,
+      moduleConfig,
+      tokenConfig,
+      ownerAddress,
+    }) => {
+      const decimals = Number(tokenConfig.config.decimals ?? 18);
+      const symbol = tokenConfig.config.symbol || 'AGIALPHA';
+      const plan = await buildStakeManagerPlan({
+        stakeManager: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+        decimals,
+        symbol,
+        ownerAddress,
+      });
+      return plan;
+    },
+  },
+  feePool: {
+    key: 'feePool',
+    label: 'FeePool',
+    artifact: 'contracts/v2/FeePool.sol:FeePool',
+    loadConfig: (ctx: LoadContext) =>
+      loadFeePoolConfig({ network: ctx.network, chainId: ctx.chainId }),
+    resolveAddress: ({ moduleConfig, tokenConfig }) => {
+      const configAddress = (moduleConfig.config as any).address;
+      return (
+        configAddress ||
+        tokenConfig.config.modules?.feePool ||
+        tokenConfig.config.contracts?.feePool
+      );
+    },
+    buildPlan: async ({ contract, moduleConfig, ownerAddress }) =>
+      buildFeePoolPlan({
+        feePool: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+        ownerAddress,
+      }),
+  },
+  jobRegistry: {
+    key: 'jobRegistry',
+    label: 'JobRegistry',
+    artifact: 'contracts/v2/JobRegistry.sol:JobRegistry',
+    loadConfig: (ctx: LoadContext) =>
+      loadJobRegistryConfig({ network: ctx.network, chainId: ctx.chainId }),
+    resolveAddress: ({ moduleConfig, tokenConfig }) => {
+      const configAddress = (moduleConfig.config as any).address;
+      return (
+        configAddress ||
+        tokenConfig.config.modules?.jobRegistry ||
+        tokenConfig.config.contracts?.jobRegistry
+      );
+    },
+    buildPlan: async ({ contract, moduleConfig, tokenConfig }) => {
+      const decimals = Number(tokenConfig.config.decimals ?? 18);
+      const symbol = tokenConfig.config.symbol || 'AGIALPHA';
+      return buildJobRegistryPlan({
+        registry: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+        decimals,
+        symbol,
+      });
+    },
+  },
+  platformRegistry: {
+    key: 'platformRegistry',
+    label: 'PlatformRegistry',
+    artifact: 'contracts/v2/PlatformRegistry.sol:PlatformRegistry',
+    loadConfig: (ctx: LoadContext) =>
+      loadPlatformRegistryConfig({
+        network: ctx.network,
+        chainId: ctx.chainId,
+      }),
+    resolveAddress: ({ moduleConfig, tokenConfig }) => {
+      const configAddress = (moduleConfig.config as any).address;
+      return (
+        configAddress ||
+        tokenConfig.config.modules?.platformRegistry ||
+        tokenConfig.config.contracts?.platformRegistry
+      );
+    },
+    buildPlan: async ({
+      contract,
+      moduleConfig,
+      tokenConfig,
+      ownerAddress,
+    }) => {
+      const decimals = Number(tokenConfig.config.decimals ?? 18);
+      const symbol = tokenConfig.config.symbol || 'AGIALPHA';
+      return buildPlatformRegistryPlan({
+        platformRegistry: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+        decimals,
+        symbol,
+        ownerAddress,
+      });
+    },
+  },
+  platformIncentives: {
+    key: 'platformIncentives',
+    label: 'PlatformIncentives',
+    artifact: 'contracts/v2/PlatformIncentives.sol:PlatformIncentives',
+    loadConfig: (ctx: LoadContext) =>
+      loadPlatformIncentivesConfig({
+        network: ctx.network,
+        chainId: ctx.chainId,
+      }),
+    resolveAddress: ({ moduleConfig, tokenConfig }) => {
+      const configAddress = (moduleConfig.config as any).address;
+      return (
+        configAddress ||
+        tokenConfig.config.modules?.platformIncentives ||
+        tokenConfig.config.contracts?.platformIncentives
+      );
+    },
+    buildPlan: async ({ contract, moduleConfig, ownerAddress }) => {
+      const plan = await buildPlatformIncentivesPlan({
+        platformIncentives: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+        ownerAddress,
+      });
+      return plan;
+    },
+  },
+  rewardEngine: {
+    key: 'rewardEngine',
+    label: 'RewardEngine',
+    artifact: 'contracts/v2/RewardEngineMB.sol:RewardEngineMB',
+    loadConfig: (ctx: LoadContext) =>
+      loadRewardEngineConfig({ network: ctx.network, chainId: ctx.chainId }),
+    resolveAddress: ({ moduleConfig, tokenConfig }) => {
+      const configAddress = (moduleConfig.config as any).address;
+      return (
+        configAddress ||
+        tokenConfig.config.modules?.rewardEngine ||
+        tokenConfig.config.contracts?.rewardEngine
+      );
+    },
+    buildPlan: async ({ contract, moduleConfig }) =>
+      buildRewardEnginePlan({
+        rewardEngine: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+      }),
+  },
+  thermostat: {
+    key: 'thermostat',
+    label: 'Thermostat',
+    artifact: 'contracts/v2/Thermostat.sol:Thermostat',
+    loadConfig: (ctx: LoadContext) =>
+      loadThermostatConfig({ network: ctx.network, chainId: ctx.chainId }),
+    resolveAddress: ({ moduleConfig }) =>
+      (moduleConfig.config as any).address ||
+      moduleConfig.rewardEngineThermostat,
+    buildPlan: async ({ contract, moduleConfig }) =>
+      buildThermostatPlan({
+        thermostat: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+      }),
+  },
+  randaoCoordinator: {
+    key: 'randaoCoordinator',
+    label: 'RandaoCoordinator',
+    artifact: 'contracts/v2/RandaoCoordinator.sol:RandaoCoordinator',
+    loadConfig: (ctx: LoadContext) =>
+      loadRandaoCoordinatorConfig({
+        network: ctx.network,
+        chainId: ctx.chainId,
+      }),
+    resolveAddress: ({ moduleConfig, tokenConfig }) => {
+      const configAddress = (moduleConfig.config as any).address;
+      return (
+        configAddress ||
+        tokenConfig.config.modules?.randaoCoordinator ||
+        tokenConfig.config.contracts?.randaoCoordinator
+      );
+    },
+    buildPlan: async ({ contract, moduleConfig }) =>
+      buildRandaoCoordinatorPlan({
+        randao: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+      }),
+  },
+  energyOracle: {
+    key: 'energyOracle',
+    label: 'EnergyOracle',
+    artifact: 'contracts/v2/EnergyOracle.sol:EnergyOracle',
+    loadConfig: (ctx: LoadContext) =>
+      loadEnergyOracleConfig({ network: ctx.network, chainId: ctx.chainId }),
+    resolveAddress: ({ tokenConfig }) => {
+      const modules = tokenConfig.config.modules ?? {};
+      const contracts = tokenConfig.config.contracts ?? {};
+      const envCandidate = readEnvCandidate([
+        'ENERGY_ORACLE_ADDRESS',
+        'ENERGY_ORACLE',
+        'AGI_ENERGY_ORACLE',
+        'AGJ_ENERGY_ORACLE',
+        'AGIALPHA_ENERGY_ORACLE',
+        'AGIALPHA_ORACLE',
+      ]);
+      return (
+        envCandidate ||
+        modules.energyOracle ||
+        contracts.energyOracle ||
+        modules.oracle ||
+        contracts.oracle
+      );
+    },
+    buildPlan: async ({ contract, moduleConfig, ownerAddress }) =>
+      buildEnergyOraclePlan({
+        oracle: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+        ownerAddress,
+        retainUnknown: moduleConfig.config.retainUnknown,
+      }),
+  },
+  taxPolicy: {
+    key: 'taxPolicy',
+    label: 'TaxPolicy',
+    artifact: 'contracts/v2/TaxPolicy.sol:TaxPolicy',
+    loadConfig: (ctx: LoadContext) =>
+      loadTaxPolicyConfig({ network: ctx.network, chainId: ctx.chainId }),
+    resolveAddress: ({ moduleConfig, tokenConfig }) => {
+      const configAddress = (moduleConfig.config as any).address;
+      return (
+        configAddress ||
+        tokenConfig.config.modules?.taxPolicy ||
+        tokenConfig.config.contracts?.taxPolicy
+      );
+    },
+    buildPlan: async ({ contract, moduleConfig }) =>
+      buildTaxPolicyPlan({
+        taxPolicy: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+      }),
+  },
+  identityRegistry: {
+    key: 'identityRegistry',
+    label: 'IdentityRegistry',
+    artifact: 'contracts/v2/IdentityRegistry.sol:IdentityRegistry',
+    loadConfig: (ctx: LoadContext) =>
+      loadIdentityRegistryConfig({
+        network: ctx.network,
+        chainId: ctx.chainId,
+      }),
+    resolveAddress: ({ moduleConfig, tokenConfig }) => {
+      const configAddress = (moduleConfig.config as any).address;
+      return (
+        configAddress ||
+        tokenConfig.config.modules?.identityRegistry ||
+        tokenConfig.config.contracts?.identityRegistry
+      );
+    },
+    buildPlan: async ({ contract, moduleConfig, ownerAddress }) =>
+      buildIdentityRegistryPlan({
+        identity: contract,
+        config: moduleConfig.config,
+        configPath: moduleConfig.path,
+        ownerAddress,
+      }),
+  },
+};
+
+function readEnvCandidate(keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (value !== undefined && value !== null) {
+      const trimmed = String(value).trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function selectModules(options: CliOptions): ModuleKey[] {
+  const base = options.only ? Array.from(options.only) : MODULE_ORDER.slice();
+  return base.filter((key) => !options.skip.has(key));
+}
+
+function summariseAction(
+  action: PlannedAction,
+  index: number,
+  iface?: { encodeFunctionData(method: string, values?: unknown[]): string }
+): void {
+  const callDescription = action.method
+    ? `${action.method}(${describeArgs(action.args ?? [])})`
+    : 'unknown()';
+  console.log(`  ${index + 1}. ${action.label}`);
+  if (action.current !== undefined) {
+    console.log(`     Current: ${action.current}`);
+  }
+  if (action.desired !== undefined) {
+    console.log(`     Desired: ${action.desired}`);
+  }
+  if (action.notes?.length) {
+    action.notes.forEach((note) => console.log(`     Note: ${note}`));
+  }
+  console.log(`     Call: ${callDescription}`);
+  if (iface && action.method) {
+    try {
+      const encoded = iface.encodeFunctionData(
+        action.method,
+        action.args ?? []
+      );
+      console.log(`     Calldata: ${encoded}`);
+    } catch (_) {
+      // iface may not expose the function; ignore silently
+    }
+  }
+}
+
+async function buildModulePlan<TConfig extends AnyConfigResult>(
+  definition: ModuleDefinition<TConfig>,
+  tokenConfig: TokenConfigResult,
+  cli: CliOptions
+): Promise<ModuleExecutionPlan<TConfig> | undefined> {
+  const loadCtx: LoadContext = {
+    network: network.name,
+    chainId: network.config?.chainId,
+  };
+  let moduleConfig: TConfig;
+  try {
+    moduleConfig = definition.loadConfig(loadCtx);
+  } catch (err) {
+    console.warn(
+      `${definition.label}: skipping (failed to load configuration: ${
+        (err as Error).message
+      })`
+    );
+    return undefined;
+  }
+
+  const addressCandidate = definition.resolveAddress({
+    moduleConfig,
+    tokenConfig,
+  });
+  if (!addressCandidate) {
+    console.warn(
+      `${definition.label}: skipping (no address configured in token or module configuration)`
+    );
+    return undefined;
+  }
+
+  const address = ethers.getAddress(addressCandidate);
+  if (address === ethers.ZeroAddress) {
+    console.warn(
+      `${definition.label}: skipping (address resolves to zero address)`
+    );
+    return undefined;
+  }
+
+  const contract = await ethers.getContractAt(definition.artifact, address);
+  const signer = await ethers.getSigner();
+  const signerAddress = await signer.getAddress();
+  const ownerAddress = await fetchOwnerAddress(contract);
+
+  if (cli.execute && !sameAddress(ownerAddress, signerAddress)) {
+    throw new Error(
+      `${definition.label}: signer ${signerAddress} is not the contract owner ${ownerAddress}`
+    );
+  }
+
+  const connected = contract.connect(signer);
+  const plan = await definition.buildPlan({
+    contract: connected,
+    moduleConfig,
+    tokenConfig,
+    ownerAddress,
+    signerAddress,
+  });
+  await ensurePlanContract(plan, connected);
+  addMetadata(plan, {
+    ownerAddress,
+    signerAddress,
+    configPath: moduleConfig.path,
+    configSource: (moduleConfig as any).source,
+  });
+  return {
+    definition,
+    moduleConfig,
+    plan,
+    ownerAddress,
+    signerAddress,
+  };
+}
+
+async function executePlan(plan: ModuleExecutionPlan<any>): Promise<void> {
+  if (!plan.plan.actions.length) {
+    return;
+  }
+  console.log(
+    `\nExecuting ${plan.definition.label} updates (${plan.plan.actions.length} actions)...`
+  );
+  for (const action of plan.plan.actions) {
+    const contract = plan.plan.contract as any;
+    if (!contract || typeof contract[action.method] !== 'function') {
+      throw new Error(
+        `${plan.definition.label}: contract does not expose method ${action.method}`
+      );
+    }
+    console.log(`  Calling ${action.method}...`);
+    const tx = await contract[action.method](...action.args);
+    console.log(`    Tx hash: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (receipt?.status !== 1n) {
+      throw new Error(
+        `${plan.definition.label}: transaction ${tx.hash} for ${action.method} failed`
+      );
+    }
+    console.log('    Confirmed');
+  }
+}
+
+function printPlan(plan: ModuleExecutionPlan<any>): void {
+  const {
+    definition,
+    moduleConfig,
+    plan: modulePlan,
+    ownerAddress,
+    signerAddress,
+  } = plan;
+  console.log(`\n=== ${definition.label} ===`);
+  console.log(`Address:         ${modulePlan.address}`);
+  console.log(`Owner/Governance: ${ownerAddress}`);
+  console.log(`Connected signer: ${signerAddress}`);
+  console.log(`Config file:      ${moduleConfig.path}`);
+  if ((moduleConfig as any).source) {
+    console.log(`Config source:    ${(moduleConfig as any).source}`);
+  }
+  if (modulePlan.warnings?.length) {
+    console.log('Warnings:');
+    modulePlan.warnings.forEach((warning) => console.log(`  - ${warning}`));
+  }
+  if (modulePlan.actions.length === 0) {
+    console.log('No changes required.');
+    return;
+  }
+  console.log(`Planned actions (${modulePlan.actions.length}):`);
+  modulePlan.actions.forEach((action, index) =>
+    summariseAction(action, index, modulePlan.iface as any)
+  );
+}
+
+async function main(): Promise<void> {
+  const cli = parseCliOptions(process.argv.slice(2));
+  const tokenConfig = loadTokenConfig({
+    network: network.name,
+    chainId: network.config?.chainId,
+  });
+
+  const modules = selectModules(cli);
+  if (!modules.length) {
+    console.log('No modules selected after applying filters.');
+    return;
+  }
+
+  const plans: ModuleExecutionPlan<any>[] = [];
+  for (const key of modules) {
+    const definition = MODULE_DEFINITIONS[key];
+    if (!definition) {
+      continue;
+    }
+    const plan = await buildModulePlan(definition, tokenConfig, cli);
+    if (plan) {
+      plans.push(plan);
+    }
+  }
+
+  if (!plans.length) {
+    console.log('No actionable modules discovered.');
+    return;
+  }
+
+  if (cli.json) {
+    const output = {
+      network: network.name,
+      chainId: network.config?.chainId,
+      modules: plans.map((entry) => ({
+        key: entry.definition.key,
+        label: entry.definition.label,
+        address: entry.plan.address,
+        owner: entry.ownerAddress,
+        signer: entry.signerAddress,
+        configPath: entry.moduleConfig.path,
+        configSource: (entry.moduleConfig as any).source,
+        actions: entry.plan.actions,
+        warnings: entry.plan.warnings,
+        metadata: entry.plan.metadata,
+      })),
+    };
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  plans.forEach(printPlan);
+
+  const totalActions = plans.reduce(
+    (sum, entry) => sum + entry.plan.actions.length,
+    0
+  );
+  console.log(`\nTotal planned actions: ${totalActions}`);
+
+  if (cli.execute) {
+    console.log('\nSubmitting transactions...');
+    for (const plan of plans) {
+      await executePlan(plan);
+    }
+    console.log('\nAll transactions confirmed.');
+  } else {
+    console.log(
+      '\nDry run complete. Re-run with --execute to submit transactions.'
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `scripts/v2/updateAllModules.ts` to orchestrate contract parameter updates across all owner-governed modules
- expose the helper via `npm run owner:update-all` and document the workflow for operators in the README

## Testing
- npx eslint scripts/v2/updateAllModules.ts
- npx hardhat run --no-compile scripts/v2/updateAllModules.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9982dbeac8333b24de260d04ac3c4