### PR TITLE
Enhance job registry owner configuration support

### DIFF
--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -65,6 +65,20 @@ export interface JobRegistryConfig {
   validatorRewardPct?: number | string;
   treasury?: string | null;
   taxPolicy?: string | null;
+  pauser?: string | null;
+  identityRegistry?: string | null;
+  disputeModule?: string | null;
+  validationModule?: string | null;
+  stakeManager?: string | null;
+  reputationModule?: string | null;
+  certificateNFT?: string | null;
+  feePool?: string | null;
+  agentRootNode?: string | null;
+  agentMerkleRoot?: string | null;
+  validatorRootNode?: string | null;
+  validatorMerkleRoot?: string | null;
+  agentAuthCacheDurationSeconds?: number | string;
+  bumpAgentAuthCacheVersion?: boolean | string;
   acknowledgers?: Record<string, boolean>;
   [key: string]: unknown;
 }

--- a/scripts/v2/lib/jobRegistryPlan.ts
+++ b/scripts/v2/lib/jobRegistryPlan.ts
@@ -6,9 +6,13 @@ import {
   describeArgs,
   formatToken,
   normaliseAddress,
+  normaliseBytes32,
   parseBigInt,
+  parseBoolean,
   parsePercentage,
   parseTokenAmount,
+  sameAddress,
+  sameBytes32,
 } from './utils';
 
 const MAX_UINT96 = (1n << 96n) - 1n;
@@ -49,6 +53,16 @@ export async function buildJobRegistryPlan(
     currentExpirationGrace,
     currentTreasury,
     currentTaxPolicy,
+    currentPauser,
+    currentValidationModule,
+    currentStakeManager,
+    currentReputationModule,
+    currentDisputeModule,
+    currentCertificateNFT,
+    currentFeePool,
+    currentIdentityRegistry,
+    currentAgentAuthCacheDuration,
+    currentAgentAuthCacheVersion,
   ] = await Promise.all([
     registry.jobStake(),
     registry.maxJobReward(),
@@ -60,7 +74,73 @@ export async function buildJobRegistryPlan(
     registry.expirationGracePeriod(),
     registry.treasury(),
     registry.taxPolicy(),
+    registry.pauser(),
+    registry.validationModule(),
+    registry.stakeManager(),
+    registry.reputationEngine(),
+    registry.disputeModule(),
+    registry.certificateNFT(),
+    registry.feePool(),
+    registry.identityRegistry(),
+    registry.agentAuthCacheDuration(),
+    registry.agentAuthCacheVersion(),
   ]);
+
+  const currentPauserAddress = ethers.getAddress(currentPauser);
+  const currentValidationModuleAddress = ethers.getAddress(
+    currentValidationModule
+  );
+  const currentStakeManagerAddress = ethers.getAddress(currentStakeManager);
+  const currentReputationModuleAddress = ethers.getAddress(
+    currentReputationModule
+  );
+  const currentDisputeModuleAddress = ethers.getAddress(currentDisputeModule);
+  const currentCertificateNFTAddress = ethers.getAddress(currentCertificateNFT);
+  const currentFeePoolAddress = ethers.getAddress(currentFeePool);
+  const currentIdentityRegistryAddress = ethers.getAddress(
+    currentIdentityRegistry
+  );
+
+  const toBytes32String = (value: string): string =>
+    ethers.hexlify(ethers.getBytes(value)).toLowerCase();
+
+  let currentAgentRootNode: string | undefined;
+  let currentAgentMerkleRoot: string | undefined;
+  let currentValidatorRootNode: string | undefined;
+  let currentValidatorMerkleRoot: string | undefined;
+
+  if (currentIdentityRegistryAddress !== ethers.ZeroAddress) {
+    if (!registry.runner) {
+      throw new Error('JobRegistry contract runner is not configured');
+    }
+    const identity = new ethers.Contract(
+      currentIdentityRegistryAddress,
+      [
+        'function agentRootNode() view returns (bytes32)',
+        'function agentMerkleRoot() view returns (bytes32)',
+        'function clubRootNode() view returns (bytes32)',
+        'function validatorMerkleRoot() view returns (bytes32)',
+      ],
+      registry.runner
+    );
+    const [
+      identityAgentRoot,
+      identityAgentMerkle,
+      identityClubRoot,
+      identityValidatorMerkle,
+    ] = await Promise.all([
+      identity.agentRootNode(),
+      identity.agentMerkleRoot(),
+      identity.clubRootNode(),
+      identity.validatorMerkleRoot(),
+    ]);
+    currentAgentRootNode = toBytes32String(identityAgentRoot as string);
+    currentAgentMerkleRoot = toBytes32String(identityAgentMerkle as string);
+    currentValidatorRootNode = toBytes32String(identityClubRoot as string);
+    currentValidatorMerkleRoot = toBytes32String(
+      identityValidatorMerkle as string
+    );
+  }
 
   const desiredJobStake = parseTokenAmount(
     config.jobStake,
@@ -103,8 +183,283 @@ export async function buildJobRegistryPlan(
   const desiredTaxPolicy = normaliseAddress(config.taxPolicy, {
     allowZero: false,
   });
+  const desiredPauser = normaliseAddress(config.pauser, { allowZero: true });
+  const desiredIdentityRegistry = normaliseAddress(config.identityRegistry, {
+    allowZero: false,
+  });
+  const desiredDisputeModule = normaliseAddress(config.disputeModule, {
+    allowZero: false,
+  });
+  const desiredValidationModule = normaliseAddress(config.validationModule, {
+    allowZero: false,
+  });
+  const desiredStakeManager = normaliseAddress(config.stakeManager, {
+    allowZero: false,
+  });
+  const desiredReputationModule = normaliseAddress(config.reputationModule, {
+    allowZero: false,
+  });
+  const desiredCertificateNFT = normaliseAddress(config.certificateNFT, {
+    allowZero: false,
+  });
+  const desiredFeePool = normaliseAddress(config.feePool, { allowZero: false });
+  const desiredAgentRootNode =
+    config.agentRootNode !== undefined
+      ? normaliseBytes32(config.agentRootNode, { allowZero: true })
+      : undefined;
+  const desiredAgentMerkleRoot =
+    config.agentMerkleRoot !== undefined
+      ? normaliseBytes32(config.agentMerkleRoot, { allowZero: true })
+      : undefined;
+  const desiredValidatorRootNode =
+    config.validatorRootNode !== undefined
+      ? normaliseBytes32(config.validatorRootNode, { allowZero: true })
+      : undefined;
+  const desiredValidatorMerkleRoot =
+    config.validatorMerkleRoot !== undefined
+      ? normaliseBytes32(config.validatorMerkleRoot, { allowZero: true })
+      : undefined;
+  const desiredAgentAuthCacheDuration = parseBigInt(
+    config.agentAuthCacheDurationSeconds,
+    'agentAuthCacheDurationSeconds'
+  );
+  const desiredBumpCacheVersion = parseBoolean(
+    config.bumpAgentAuthCacheVersion,
+    'bumpAgentAuthCacheVersion'
+  );
 
   const actions: PlannedAction[] = [];
+
+  const formatAddressWithStatus = (value?: string): string => {
+    if (!value) {
+      return 'not set';
+    }
+    const normalised = ethers.getAddress(value);
+    if (normalised === ethers.ZeroAddress) {
+      return `${ethers.ZeroAddress} (disabled)`;
+    }
+    return normalised;
+  };
+
+  const formatBytes32Value = (value?: string): string => {
+    if (!value) {
+      return 'not set';
+    }
+    return value.toLowerCase();
+  };
+
+  if (
+    desiredPauser !== undefined &&
+    !sameAddress(desiredPauser, currentPauserAddress)
+  ) {
+    const notes =
+      desiredPauser === ethers.ZeroAddress
+        ? [
+            'Setting the pauser to the zero address restricts pause/unpause to governance only.',
+          ]
+        : undefined;
+    actions.push({
+      label:
+        desiredPauser === ethers.ZeroAddress
+          ? 'Clear dedicated pauser (governance retains control)'
+          : `Update pauser to ${desiredPauser}`,
+      method: 'setPauser',
+      args: [desiredPauser],
+      current: formatAddressWithStatus(currentPauserAddress),
+      desired: formatAddressWithStatus(desiredPauser),
+      ...(notes ? { notes } : {}),
+    });
+  }
+
+  const enqueueModuleUpdate = (
+    desired: string | undefined,
+    current: string,
+    method: string,
+    label: string,
+    extraNotes: string[] = []
+  ) => {
+    if (!desired || sameAddress(desired, current)) {
+      return;
+    }
+    const entry: PlannedAction = {
+      label: `Update ${label} to ${desired}`,
+      method,
+      args: [desired],
+      current: formatAddressWithStatus(current),
+      desired: formatAddressWithStatus(desired),
+    };
+    if (extraNotes.length > 0) {
+      entry.notes = extraNotes;
+    }
+    actions.push(entry);
+  };
+
+  enqueueModuleUpdate(
+    desiredIdentityRegistry,
+    currentIdentityRegistryAddress,
+    'setIdentityRegistry',
+    'identity registry',
+    ['Ensure the target identity registry reports version() == 2.']
+  );
+  enqueueModuleUpdate(
+    desiredDisputeModule,
+    currentDisputeModuleAddress,
+    'setDisputeModule',
+    'dispute module',
+    ['Ensure the dispute module reports version() == 2.']
+  );
+  enqueueModuleUpdate(
+    desiredValidationModule,
+    currentValidationModuleAddress,
+    'setValidationModule',
+    'validation module',
+    ['Ensure the validation module reports version() == 2.']
+  );
+  enqueueModuleUpdate(
+    desiredStakeManager,
+    currentStakeManagerAddress,
+    'setStakeManager',
+    'stake manager',
+    ['Ensure the stake manager reports version() == 2.']
+  );
+  enqueueModuleUpdate(
+    desiredReputationModule,
+    currentReputationModuleAddress,
+    'setReputationEngine',
+    'reputation engine',
+    ['Ensure the reputation engine reports version() == 2.']
+  );
+  enqueueModuleUpdate(
+    desiredCertificateNFT,
+    currentCertificateNFTAddress,
+    'setCertificateNFT',
+    'certificate NFT',
+    ['Ensure the certificate NFT reports version() == 2.']
+  );
+  enqueueModuleUpdate(
+    desiredFeePool,
+    currentFeePoolAddress,
+    'setFeePool',
+    'fee pool',
+    ['Ensure the fee pool reports version() == 2.']
+  );
+
+  const identityNotesBase: string[] = [];
+  if (currentIdentityRegistryAddress === ethers.ZeroAddress) {
+    identityNotesBase.push(
+      'Configure the identity registry before applying this change.'
+    );
+  }
+  if (
+    desiredIdentityRegistry &&
+    !sameAddress(desiredIdentityRegistry, currentIdentityRegistryAddress)
+  ) {
+    identityNotesBase.push(
+      'Execute after updating the identity registry address.'
+    );
+  }
+
+  if (
+    desiredAgentRootNode !== undefined &&
+    !sameBytes32(desiredAgentRootNode, currentAgentRootNode)
+  ) {
+    actions.push({
+      label: `Update agent root node to ${desiredAgentRootNode}`,
+      method: 'setAgentRootNode',
+      args: [desiredAgentRootNode],
+      current: formatBytes32Value(currentAgentRootNode),
+      desired: formatBytes32Value(desiredAgentRootNode),
+      ...(identityNotesBase.length > 0
+        ? { notes: [...identityNotesBase] }
+        : {}),
+    });
+  }
+
+  if (
+    desiredAgentMerkleRoot !== undefined &&
+    !sameBytes32(desiredAgentMerkleRoot, currentAgentMerkleRoot)
+  ) {
+    actions.push({
+      label: `Update agent Merkle root to ${desiredAgentMerkleRoot}`,
+      method: 'setAgentMerkleRoot',
+      args: [desiredAgentMerkleRoot],
+      current: formatBytes32Value(currentAgentMerkleRoot),
+      desired: formatBytes32Value(desiredAgentMerkleRoot),
+      ...(identityNotesBase.length > 0
+        ? { notes: [...identityNotesBase] }
+        : {}),
+    });
+  }
+
+  const validatorNotes: string[] = [...identityNotesBase];
+  if (currentValidationModuleAddress === ethers.ZeroAddress) {
+    validatorNotes.push(
+      'Configure the validation module before applying validator updates.'
+    );
+  }
+  if (
+    desiredValidationModule &&
+    !sameAddress(desiredValidationModule, currentValidationModuleAddress)
+  ) {
+    validatorNotes.push(
+      'Execute after updating the validation module address.'
+    );
+  }
+
+  if (
+    desiredValidatorRootNode !== undefined &&
+    !sameBytes32(desiredValidatorRootNode, currentValidatorRootNode)
+  ) {
+    actions.push({
+      label: `Update validator root node to ${desiredValidatorRootNode}`,
+      method: 'setValidatorRootNode',
+      args: [desiredValidatorRootNode],
+      current: formatBytes32Value(currentValidatorRootNode),
+      desired: formatBytes32Value(desiredValidatorRootNode),
+      ...(validatorNotes.length > 0 ? { notes: [...validatorNotes] } : {}),
+    });
+  }
+
+  if (
+    desiredValidatorMerkleRoot !== undefined &&
+    !sameBytes32(desiredValidatorMerkleRoot, currentValidatorMerkleRoot)
+  ) {
+    actions.push({
+      label: `Update validator Merkle root to ${desiredValidatorMerkleRoot}`,
+      method: 'setValidatorMerkleRoot',
+      args: [desiredValidatorMerkleRoot],
+      current: formatBytes32Value(currentValidatorMerkleRoot),
+      desired: formatBytes32Value(desiredValidatorMerkleRoot),
+      ...(validatorNotes.length > 0 ? { notes: [...validatorNotes] } : {}),
+    });
+  }
+
+  if (
+    desiredAgentAuthCacheDuration !== undefined &&
+    desiredAgentAuthCacheDuration !== currentAgentAuthCacheDuration
+  ) {
+    actions.push({
+      label: `Update agent auth cache duration to ${desiredAgentAuthCacheDuration} seconds`,
+      method: 'setAgentAuthCacheDuration',
+      args: [desiredAgentAuthCacheDuration],
+      current: `${currentAgentAuthCacheDuration.toString()} seconds`,
+      desired: `${desiredAgentAuthCacheDuration.toString()} seconds`,
+    });
+  }
+
+  if (desiredBumpCacheVersion) {
+    const nextVersion = currentAgentAuthCacheVersion + 1n;
+    actions.push({
+      label: 'Bump agent auth cache version',
+      method: 'bumpAgentAuthCacheVersion',
+      args: [],
+      current: `v${currentAgentAuthCacheVersion.toString()}`,
+      desired: `v${nextVersion.toString()}`,
+      notes: [
+        'Forces all agent identity cache entries to refresh after ENS or Merkle updates.',
+      ],
+    });
+  }
 
   if (desiredJobStake !== undefined && desiredJobStake !== currentJobStake) {
     if (desiredJobStake > MAX_UINT96) {
@@ -200,7 +555,10 @@ export async function buildJobRegistryPlan(
   const currentValidator = Number(currentValidatorRewardPct);
 
   if (desiredFeePct !== undefined && desiredFeePct !== currentFee) {
-    ensureFeeBudgetValid(desiredFeePct, desiredValidatorPct ?? currentValidator);
+    ensureFeeBudgetValid(
+      desiredFeePct,
+      desiredValidatorPct ?? currentValidator
+    );
     actions.push({
       label: `Update protocol fee percentage to ${desiredFeePct}%`,
       method: 'setFeePct',
@@ -224,13 +582,10 @@ export async function buildJobRegistryPlan(
     });
   }
 
-  const currentTreasuryAddress =
-    currentTreasury === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentTreasury);
+  const currentTreasuryAddress = ethers.getAddress(currentTreasury);
   if (
     desiredTreasury !== undefined &&
-    desiredTreasury !== currentTreasuryAddress
+    !sameAddress(desiredTreasury, currentTreasuryAddress)
   ) {
     actions.push({
       label: `Update treasury to ${desiredTreasury}`,
@@ -242,14 +597,11 @@ export async function buildJobRegistryPlan(
     });
   }
 
-  const currentTaxPolicyAddress =
-    currentTaxPolicy === ethers.ZeroAddress
-      ? ethers.ZeroAddress
-      : ethers.getAddress(currentTaxPolicy);
+  const currentTaxPolicyAddress = ethers.getAddress(currentTaxPolicy);
   if (
     desiredTaxPolicy &&
     desiredTaxPolicy !== ethers.ZeroAddress &&
-    desiredTaxPolicy !== currentTaxPolicyAddress
+    !sameAddress(desiredTaxPolicy, currentTaxPolicyAddress)
   ) {
     actions.push({
       label: `Update tax policy to ${desiredTaxPolicy}`,
@@ -305,9 +657,7 @@ export function renderJobRegistryPlan(plan: ModulePlan): string {
     action.notes?.forEach((note) => {
       lines.push(`   Note: ${note}`);
     });
-    lines.push(
-      `   Method: ${action.method}(${describeArgs(action.args)})`
-    );
+    lines.push(`   Method: ${action.method}(${describeArgs(action.args)})`);
     if (data) {
       lines.push(`   Calldata: ${data}`);
     }


### PR DESCRIPTION
## Summary
- extend the JobRegistry config schema so owners can describe module, root, and cache preferences
- normalise and validate the new configuration fields for safer owner updates
- teach the owner plan builder to diff module wiring, ENS/Merkle roots, and cache parameters so changes become actionable

## Testing
- npx eslint scripts/v2/lib/jobRegistryPlan.ts scripts/config/index.js

------
https://chatgpt.com/codex/tasks/task_e_68d99f2a4b8c8333a29ffc7a97880a93