### PR TITLE
Allow governance to retarget reward engine modules

### DIFF
--- a/contracts/v2/RewardEngineMB.sol
+++ b/contracts/v2/RewardEngineMB.sol
@@ -56,6 +56,10 @@ contract RewardEngineMB is Governable, ReentrancyGuard {
     uint256 public maxProofs = 100;
     mapping(uint256 => bool) public epochSettled;
 
+    error InvalidFeePool();
+    error InvalidReputationEngine();
+    error InvalidEnergyOracle();
+
     /// @notice Fallback temperature when Thermostat is unset.
     int256 public temperature;
 
@@ -79,6 +83,9 @@ contract RewardEngineMB is Governable, ReentrancyGuard {
     event RewardBudget(
         uint256 indexed epoch, uint256 minted, uint256 dust, uint256 redistributed, uint256 distributionRatio
     );
+    event FeePoolUpdated(address indexed feePool);
+    event ReputationEngineUpdated(address indexed reputationEngine);
+    event EnergyOracleUpdated(address indexed energyOracle);
 
     constructor(
         Thermostat _thermostat,
@@ -197,6 +204,30 @@ contract RewardEngineMB is Governable, ReentrancyGuard {
     function setTemperature(int256 temp) external onlyGovernance {
         require(temp > 0, "temp");
         temperature = temp;
+    }
+
+    /// @notice Update the fee pool contract receiving freshly minted rewards.
+    /// @param _feePool Address of the replacement fee pool contract.
+    function setFeePool(IFeePool _feePool) external onlyGovernance {
+        if (address(_feePool) == address(0)) revert InvalidFeePool();
+        feePool = _feePool;
+        emit FeePoolUpdated(address(_feePool));
+    }
+
+    /// @notice Update the reputation engine used to adjust agent credibility.
+    /// @param _reputation Address of the replacement reputation engine.
+    function setReputationEngine(IReputationEngineV2 _reputation) external onlyGovernance {
+        if (address(_reputation) == address(0)) revert InvalidReputationEngine();
+        reputation = _reputation;
+        emit ReputationEngineUpdated(address(_reputation));
+    }
+
+    /// @notice Update the energy oracle verifying epoch attestations.
+    /// @param _energyOracle Address of the replacement energy oracle.
+    function setEnergyOracle(IEnergyOracle _energyOracle) external onlyGovernance {
+        if (address(_energyOracle) == address(0)) revert InvalidEnergyOracle();
+        energyOracle = _energyOracle;
+        emit EnergyOracleUpdated(address(_energyOracle));
     }
 
     /// @notice Distribute rewards for an epoch based on energy attestations.

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -254,6 +254,9 @@ export interface RewardEngineThermoConfig {
   address?: string;
   treasury?: string | null;
   thermostat?: string | null;
+  feePool?: string | null;
+  reputation?: string | null;
+  energyOracle?: string | null;
   roleShares?: Record<string, RoleShareInput>;
   mu?: Record<string, number | string>;
   baselineEnergy?: Record<string, number | string>;

--- a/scripts/config/index.js
+++ b/scripts/config/index.js
@@ -1325,6 +1325,42 @@ function normaliseRewardEngineConfig(config = {}) {
         });
   }
 
+  if (reward.feePool !== undefined) {
+    if (reward.feePool === null || reward.feePool === '') {
+      delete reward.feePool;
+    } else {
+      reward.feePool = ensureAddress(
+        reward.feePool,
+        'RewardEngine feePool',
+        { allowZero: false }
+      );
+    }
+  }
+
+  if (reward.reputation !== undefined) {
+    if (reward.reputation === null || reward.reputation === '') {
+      delete reward.reputation;
+    } else {
+      reward.reputation = ensureAddress(
+        reward.reputation,
+        'RewardEngine reputation engine',
+        { allowZero: false }
+      );
+    }
+  }
+
+  if (reward.energyOracle !== undefined) {
+    if (reward.energyOracle === null || reward.energyOracle === '') {
+      delete reward.energyOracle;
+    } else {
+      reward.energyOracle = ensureAddress(
+        reward.energyOracle,
+        'RewardEngine energy oracle',
+        { allowZero: false }
+      );
+    }
+  }
+
   if (reward.settlers && typeof reward.settlers === 'object') {
     const mapped = {};
     for (const [key, value] of Object.entries(reward.settlers)) {

--- a/scripts/v2/lib/rewardEnginePlan.ts
+++ b/scripts/v2/lib/rewardEnginePlan.ts
@@ -119,12 +119,18 @@ export async function buildRewardEnginePlan(
   const [
     currentTreasury,
     currentThermostat,
+    currentFeePool,
+    currentReputation,
+    currentEnergyOracle,
     currentKappa,
     currentMaxProofs,
     currentTemperature,
   ] = await Promise.all([
     rewardEngine.treasury(),
     rewardEngine.thermostat(),
+    rewardEngine.feePool(),
+    rewardEngine.reputation(),
+    rewardEngine.energyOracle(),
     rewardEngine.kappa(),
     rewardEngine.maxProofs(),
     rewardEngine.temperature(),
@@ -175,6 +181,52 @@ export async function buildRewardEnginePlan(
       args: [desiredThermostat],
       current: currentThermostatAddr,
       desired: desiredThermostat,
+    });
+  }
+
+  const desiredFeePool = normaliseAddress(config.feePool, { allowZero: false });
+  if (
+    desiredFeePool &&
+    !sameAddress(desiredFeePool, ethers.getAddress(currentFeePool))
+  ) {
+    actions.push({
+      label: `Update fee pool to ${desiredFeePool}`,
+      method: 'setFeePool',
+      args: [desiredFeePool],
+      current: ethers.getAddress(currentFeePool),
+      desired: desiredFeePool,
+    });
+  }
+
+  const desiredReputation = normaliseAddress(config.reputation, {
+    allowZero: false,
+  });
+  if (
+    desiredReputation &&
+    !sameAddress(desiredReputation, ethers.getAddress(currentReputation))
+  ) {
+    actions.push({
+      label: `Update reputation engine to ${desiredReputation}`,
+      method: 'setReputationEngine',
+      args: [desiredReputation],
+      current: ethers.getAddress(currentReputation),
+      desired: desiredReputation,
+    });
+  }
+
+  const desiredEnergyOracle = normaliseAddress(config.energyOracle, {
+    allowZero: false,
+  });
+  if (
+    desiredEnergyOracle &&
+    !sameAddress(desiredEnergyOracle, ethers.getAddress(currentEnergyOracle))
+  ) {
+    actions.push({
+      label: `Update energy oracle to ${desiredEnergyOracle}`,
+      method: 'setEnergyOracle',
+      args: [desiredEnergyOracle],
+      current: ethers.getAddress(currentEnergyOracle),
+      desired: desiredEnergyOracle,
     });
   }
 


### PR DESCRIPTION
## Summary
- add governance-controlled setters on RewardEngineMB so the owner can retarget the fee pool, reputation engine, and energy oracle without redeploying
- extend reward engine configuration schemas and normalisation to track the new module addresses
- update the reward engine owner tooling to include the new configuration knobs when generating execution plans

## Testing
- npm run compile -- --network hardhat
- npx eslint scripts/v2/lib/rewardEnginePlan.ts


------
https://chatgpt.com/codex/tasks/task_e_68d9aa1afff48333b767889ef4744acd