### PR TITLE
Document meta orchestrator contract and governance inventory

### DIFF
--- a/docs/adr/0001-python-ics-interoperability.md
+++ b/docs/adr/0001-python-ics-interoperability.md
@@ -1,0 +1,38 @@
+# ADR 0001: Python ↔ ICS Interoperability
+
+- Status: Accepted
+- Date: 2024-10-19
+- Authors: Meta-Orchestrator Team
+- Supersedes: None
+
+## Context
+
+The FastAPI meta-orchestrator exposes a `plan → simulate → execute → status` pipeline implemented in Python. Plans consist of DAG steps, policy guards and budgets that ultimately have to be executed by the Intent Canonical Schema (ICS) handlers implemented in `packages/orchestrator`. The TypeScript layer owns the canonical ICS schema, streaming UX and transaction choreography, while the Python layer owns natural-language planning, risk simulation and run-state persistence.【F:routes/meta_orchestrator.py†L1-L60】【F:orchestrator/models.py†L42-L113】【F:packages/orchestrator/src/ics.ts†L1-L163】【F:packages/orchestrator/src/llm.ts†L6-L80】
+
+Without an explicit contract the two halves can drift: planners may emit step identifiers or tool names that the ICS router cannot execute, ICS handlers may assume metadata fields (such as `meta.userId`) that planners fail to populate, or simulators may estimate fees with different percentages than the ICS settlement logic. The resulting misalignment would surface as failed confirmations, incorrect validator policies, or unexpected fee drains when governance-approved plans hit production.
+
+## Decision
+
+We codify the following interoperability expectations:
+
+1. **Shared step vocabulary** – Python planners must continue to emit `Step.tool` identifiers that map directly onto ICS router intents (`job.post`, `job.apply`, `validator.quorum`, etc.), preserving the implicit binding between the DAG and the async generators exposed in `packages/orchestrator/src/tools`. Any new step kind or tool name requires a coordinated change to the ICS router switch-case and handler modules.【F:orchestrator/planner.py†L85-L146】【F:packages/orchestrator/src/router.ts†L21-L39】【F:packages/orchestrator/src/tools/job.ts†L15-L151】
+2. **Metadata propagation** – Execution requests must preserve `meta.userId`, `meta.traceId` and (when present) `meta.txMode` so the TypeScript layer can select the correct signer, surface confirmations and replay pending intents. The Python runner therefore treats these metadata fields as immutable once a plan is approved and never strips them when marshalling to ICS payloads or storing run state.【F:packages/orchestrator/src/ics.ts†L14-L40】【F:packages/orchestrator/src/llm.ts†L65-L126】【F:orchestrator/models.py†L96-L113】
+3. **Policy and budget parity** – Both layers source tool allow/deny lists and daily budget caps from the same JSON configuration so that simulation guarantees match runtime enforcement. Python planners already hydrate `OrchestrationPlan.policies` from `config/policies.default.json`; ICS handlers must treat those values as authoritative when building policy overrides or enforcing spend limits.【F:orchestrator/models.py†L90-L113】【F:config/policies.default.json†L1-L7】【F:packages/orchestrator/src/tools/job.ts†L22-L50】
+4. **Fee schedule alignment** – The simulator’s fee and burn percentages come from `orchestrator/config.get_fee_fraction()`/`get_burn_fraction()` which read JSON and environment overrides. ICS handlers that escrow rewards or validate budgets rely on the same percentages via policy helpers; any change to fee sourcing must update both layers together.【F:orchestrator/simulator.py†L1-L58】【F:orchestrator/config.py†L60-L85】【F:packages/orchestrator/src/tools/job.ts†L22-L50】
+5. **Streaming contract** – Python runners consume the ICS handler output as streaming text logs and must tolerate multi-phase confirmations (pending intent cache, human confirmation, final execution). The ADR therefore locks in the expectation that ICS handlers remain async generators of newline-delimited status messages, and that Python-side status logs surface them verbatim without truncation.【F:packages/orchestrator/src/llm.ts†L25-L125】【F:packages/orchestrator/src/router.ts†L21-L39】【F:orchestrator/runner.py†L1-L78】
+
+## Consequences
+
+- Coordinated schema evolution becomes part of the change-management checklist: planners cannot ship new step kinds without a matching ICS handler PR and vice versa.
+- Run metadata becomes a compatibility surface; observability tooling can rely on `traceId` and `userId` fields surviving the entire orchestration lifecycle.
+- Governance sign-off on fee or tool policy changes requires verifying both Python (`config/*.json`) and TypeScript (`policyManager`) consumption, preventing silent drift.
+- Testing must cover end-to-end plan execution, asserting that a Python-generated plan yields successful ICS handler output for each supported intent.
+
+## Alternatives considered
+
+- **Duplication of ICS schema in Python** – Rejected to avoid divergence. We instead treat the TypeScript definition as source of truth and keep Python focused on plan synthesis and simulation.
+- **Synchronising via generated gRPC interfaces** – Deferred; current HTTP/JSON contract is sufficient given the streaming model and the desire to keep the LLM planner decoupled from blockchain dependencies.
+
+## Status
+
+Accepted. Future ADRs should amend this decision if we migrate the runner into the TypeScript layer or adopt a unified codebase for ICS execution.

--- a/docs/meta-orchestrator-contract.md
+++ b/docs/meta-orchestrator-contract.md
@@ -1,0 +1,79 @@
+# Planner → Simulator → Runner Contract
+
+This document captures the interaction contract enforced by the FastAPI meta-orchestrator router exposed in [`routes/meta_orchestrator.py`](../routes/meta_orchestrator.py).
+
+## Overview
+
+The orchestrator exposes four core endpoints that implement the `plan → simulate → execute → status` lifecycle for automation jobs:
+
+- `POST /onebox/plan` validates operator intent and emits a typed plan (`PlanOut`).
+- `POST /onebox/simulate` replays the plan against risk and policy checks, raising a 422 with blockers when the run cannot proceed.
+- `POST /onebox/execute` hands the approved plan to the runner, which starts a tracked run and returns the `run_id` and timestamps.
+- `GET /onebox/status` retrieves the runner state machine, updating success/failure counters.
+
+The following sections describe the request/response choreography and metrics emitted during each step.
+
+## Sequence diagrams
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Planner as meta_orchestrator.plan
+    participant Simulator as meta_orchestrator.simulate
+    participant Runner as meta_orchestrator.execute
+
+    Client->>Planner: POST /onebox/plan (PlanIn)
+    activate Planner
+    Planner->>Planner: make_plan(req)
+    Planner-->>Client: PlanOut
+    deactivate Planner
+
+    Client->>Simulator: POST /onebox/simulate (SimIn.plan)
+    activate Simulator
+    Simulator->>Simulator: simulate_plan(plan)
+    alt blockers returned
+        Simulator-->>Client: HTTP 422 {"code": "BLOCKED", ...}
+    else success
+        Simulator-->>Client: SimOut
+    end
+    deactivate Simulator
+```
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Runner as meta_orchestrator.execute
+    participant Status as meta_orchestrator.status
+
+    Client->>Runner: POST /onebox/execute (ExecIn)
+    activate Runner
+    Runner->>Runner: start_run(plan, approvals)
+    Runner-->>Client: { run_id, started_at, plan_id }
+    deactivate Runner
+
+    loop poll until terminal
+        Client->>Status: GET /onebox/status?run_id=…
+        activate Status
+        Status->>Status: get_status(run_id)
+        alt run state succeeded
+            Status->>Status: _RUN_SUCCESS++
+        else run state failed
+            Status->>Status: _RUN_FAIL++
+        end
+        Status-->>Client: StatusOut
+        deactivate Status
+    end
+```
+
+## Contract guarantees
+
+- **Latency metrics** – The router measures planning, simulation and execution latency with Prometheus histograms, providing guardrails for SLO dashboards (`plan_latency_seconds`, `simulate_latency_seconds`, `execute_step_latency_seconds`).
+- **Run accounting** – Every terminal status update increments the `run_success_total` or `run_fail_total` counter, ensuring downstream telemetry is consistent with client-observed results.
+- **Error semantics** – Simulation blockers are always communicated via a structured 422 error payload so that clients can surface actionable messages before attempting execution.
+- **Traceability** – Each endpoint logs the `plan_id` (and `run_id` for execution/status) to the shared logger, enabling distributed traces to correlate planner/simulator/runner calls.
+
+## Implementation pointers
+
+- The router is mounted under the `/onebox` prefix and protects endpoints with the `require_api` dependency when available.
+- `PlanIn`, `SimIn`, `ExecIn` and `StatusOut` share the same Pydantic models as the internal planner, simulator and runner modules, guaranteeing schema parity between services.
+- The metrics and logging helpers are defined inside `routes/meta_orchestrator.py` so any refactor must keep their module-level lifetimes intact.

--- a/docs/orchestrator-config-governance.md
+++ b/docs/orchestrator-config-governance.md
@@ -1,0 +1,51 @@
+# Orchestrator Configuration Inventory
+
+This inventory links every orchestrator configuration knob to the governance workflows described in the root [`README.md`](../README.md). Use it as a checklist when reviewing proposals or preparing change-control bundles.
+
+## Environment-driven percentages
+
+| Helper | Sources | Governance linkage |
+| --- | --- | --- |
+| `get_fee_fraction()` | `ONEBOX_DEFAULT_FEE_PCT` → `ONEBOX_FEE_PCT` → `config/job-registry.json:feePct` | Feed the same protocol fee used by `JobRegistry.setFeePool` into planner cost projections so governance can keep on/off-chain math aligned when tuning fee policy.【F:orchestrator/config.py†L64-L69】【F:config/job-registry.json†L2-L12】【F:README.md†L327-L345】 |
+| `get_burn_fraction()` | `ONEBOX_DEFAULT_BURN_PCT` → `ONEBOX_BURN_PCT` | Mirrors the burn schedule that `FeePool.setBurnPct` enforces during the fee-handling workflow, keeping simulated runs faithful to governance decisions.【F:orchestrator/config.py†L72-L85】【F:README.md†L48-L57】 |
+
+## Core protocol modules
+
+| Config file | Key knobs | Governance workflow |
+| --- | --- | --- |
+| `config/job-registry.json` | Stake requirements, reward caps, lifecycle windows, fee and treasury wiring knobs, tax policy binding, acknowledger allowlist | Updated when governance runs the Job Registry wiring sequence (`setModules`, `setTaxPolicy`, `setTreasury`, etc.) during deployment or parameter changes.【F:config/job-registry.json†L2-L12】【F:README.md†L323-L345】 |
+| `config/stake-manager.json` | Minimum stake, slashing splits, treasury/burn/validator percentages, unbonding window, auto-staking heuristics, wiring to other modules | Inputs for the StakeManager governance bundle that tunes stake levels, slashing and dispute connectivity before handing control to the multisig/timelock.【F:config/stake-manager.json†L2-L35】【F:README.md†L326-L343】【F:README.md†L361-L368】 |
+| `config/fee-pool.json` | Stake manager binding, reward role, burn percentage, treasury allowlist, governance/pauser targets, downstream rewarders | Referenced when executing the fee-handling workflow to align `FeePool` with treasury policy and pauser governance expectations.【F:config/fee-pool.json†L2-L10】【F:README.md†L48-L57】【F:README.md†L361-L368】 |
+| `config/reward-engine.json` | Thermodynamic role shares, chemical potentials (`mu`), baseline energy, settlement cap, thermostat feed, settlers allowlist | Governs the reward rebalancing playbook that directs updates via `scripts/v2/updateThermodynamics.ts` and related governance proposals.【F:config/reward-engine.json†L2-L21】【F:README.md†L52-L58】 |
+| `config/thermodynamics.json` | RewardEngine mirror plus thermostat PID weights, bounds and role temperatures | Drives the thermodynamic incentive retuning workflow, ensuring on-chain controller updates match the documented operations guide.【F:config/thermodynamics.json†L2-L39】【F:README.md†L52-L58】 |
+| `config/platform-registry.json` | Minimum platform stake, module addresses, pauser and registrar lists | Supports governance routines that onboard/blacklist platforms while maintaining pause coverage before ownership transfer.【F:config/platform-registry.json†L2-L8】【F:README.md†L361-L368】 |
+| `config/platform-incentives.json` | Stake manager, platform registry and job router bindings | Couples platform incentive scripts to the deployment wiring workflow highlighted in the step-by-step deployment section.【F:config/platform-incentives.json†L2-L4】【F:README.md†L337-L345】 |
+| `config/randao-coordinator.json` | Commit/reveal windows and stake deposit sizing | Aligns with dispute and validation governance that defines randomness windows for validator coordination prior to enabling modules.【F:config/randao-coordinator.json†L2-L8】【F:README.md†L327-L343】 |
+
+## Identity and address books
+
+| Config file | Key knobs | Governance workflow |
+| --- | --- | --- |
+| `config/identity-registry*.json` | ENS roots, Merkle overrides, reputation/attestation bindings, emergency allowlists | Maintains the ENS identity workflow (`npm run identity:update`) and emergency allowlists governed by Identity policy procedures.【F:config/identity-registry.json†L2-L20】【F:README.md†L32-L38】【F:README.md†L344-L346】 |
+| `config/ens*.json` | Registry/NameWrapper/ReverseRegistrar addresses plus per-root metadata, hashes and alias mapping | Mirrors the ENS registration duties that governance verifies against deployments when wiring the IdentityRegistry.【F:config/ens.json†L2-L34】【F:README.md†L344-L346】 |
+| `config/agialpha*.json` | Canonical token metadata, burn address, governance addresses, module wiring | Used during `$AGIALPHA` compile/verify workflows and during wiring verification to keep deployment addresses aligned.【F:config/agialpha.json†L2-L22】【F:README.md†L40-L47】【F:README.md†L347-L352】 |
+
+## Telemetry, energy and safety rails
+
+| Config file | Key knobs | Governance workflow |
+| --- | --- | --- |
+| `config/hamiltonian-monitor.json` | Observation window, reset controls, seeded records | Supports the Hamiltonian monitor upkeep process executed via `updateHamiltonianMonitor.ts` to keep economic telemetry tuned.【F:config/hamiltonian-monitor.json†L2-L5】【F:README.md†L89-L97】 |
+| `config/energy-oracle.json` | Authorised signer roster, retention policy | Drives the energy oracle signer management workflow that reviews diffs before execution.【F:config/energy-oracle.json†L2-L3】【F:README.md†L99-L107】 |
+| `config/thermodynamics.json` (thermostat block) | Temperature bounds, PID gains, KPI weights | Directly informs thermostat adjustments executed under the thermodynamic governance runbook.【F:config/thermodynamics.json†L21-L39】【F:README.md†L52-L58】 |
+| `config/sandbox-tests.json` | Quality guardrail definitions (success-rate windows, reward floors) | Used by sandbox smoke-test workflows that governance monitors before enabling production changes.【F:config/sandbox-tests.json†L1-L13】【F:README.md†L190-L200】 |
+
+## Policy and tooling controls
+
+| Config file | Key knobs | Governance workflow |
+| --- | --- | --- |
+| `config/tax-policy.json` | Tax policy URI, acknowledgement text, allowlist management | Part of the tax-policy deployment workflow and multisig approvals when refreshing acknowledgements.【F:config/tax-policy.json†L1-L5】【F:README.md†L337-L345】【F:README.md†L117-L118】 |
+| `config/policies.default.json` | Tool allow/deny lists, validator requirement, spend budget | Feeds governance reviews of orchestrator automation privileges before executing plans via the planner/simulator contract.【F:config/policies.default.json†L1-L7】【F:routes/meta_orchestrator.py†L34-L60】 |
+| `config/tools.registry.json` | Tool catalog with budgets and enablement flags | Checked during One-Box UX governance reviews to ensure only approved automation tools are active.【F:config/tools.registry.json†L1-L8】【F:README.md†L30-L31】 |
+| `config/agents.json` | Curated agent cohorts with energy weights | Audited alongside reward distribution governance to keep offline planner heuristics aligned with identity policy outcomes.【F:config/agents.json†L1-L16】【F:README.md†L32-L38】【F:README.md†L52-L66】 |
+| `config/owner-control.json` | Default governance/owner targets and module-specific ownership models | Powers the owner-control playbook that ensures each module transfers to multisig/timelock governance with the right interface (governable/ownable/ownable2step).【F:config/owner-control.json†L1-L30】【F:README.md†L361-L377】 |
+


### PR DESCRIPTION
## Summary
- add a planner→simulator→runner contract doc with sequence diagrams for the meta orchestrator endpoints
- inventory orchestrator configuration knobs and map them to the governance workflows highlighted in the README
- capture an ADR describing the interoperability contract between Python services and the packages/orchestrator ICS handlers

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d9b29838cc8333976c4a8f7d40bc03