### PR TITLE
Add alpha bridge service and document orchestrator contract

### DIFF
--- a/docs/orchestrator-call-graph.md
+++ b/docs/orchestrator-call-graph.md
@@ -1,0 +1,181 @@
+# Orchestrator ↔ One-Box Call Graph
+
+This document captures the runtime call graph between the TypeScript
+meta-orchestrator (`packages/orchestrator/src/llm.ts`), the FastAPI One-Box
+service (`routes/onebox.py`), and the new gRPC/HTTP alpha bridge. It also defines
+the JSON envelopes that flow between planner, simulator, and execution layers so
+client and server implementations can share a single contract.
+
+## 1. End-to-end sequence
+
+```mermaid
+sequenceDiagram
+  actor U as User chat
+  participant ORCH as planAndExecute()
+  participant BRIDGE as alpha-bridge (gRPC)
+  participant BOX as /onebox routes
+  participant CHAIN as Tool router
+
+  U->>ORCH: message, history
+  ORCH->>ORCH: detect confirmations & ensure userId
+  ORCH->>BRIDGE: PlanRequest (gRPC)
+  BRIDGE->>BOX: POST /plan (JSON)
+  BOX-->>BRIDGE: Plan payload (intent, planHash, requiresConfirmation)
+  BRIDGE-->>ORCH: PlanResponse (plan JSON, consent token)
+  ORCH->>ORCH: ask clarification? / prompt for consent
+  ORCH->>BRIDGE: ExecuteRequest (gRPC)
+  BRIDGE->>BOX: POST /execute (JSON)
+  BOX-->>BRIDGE: Execute payload (job status / tx receipts)
+  BRIDGE-->>ORCH: ExecuteResponse (receipt JSON)
+  ORCH-->>CHAIN: route(ICS)
+  CHAIN-->>U: streamed execution events
+```
+
+### Planner responsibilities
+
+* `planAndExecute` resolves user identity, confirmations, and pending intents
+  before emitting any network calls.【F:packages/orchestrator/src/llm.ts†L24-L111】
+* When an action requires consent, it caches the intent under a trace identifier
+  so follow-up “yes/no” answers can be correlated later.【F:packages/orchestrator/src/llm.ts†L120-L178】
+* Confirmation or decline decisions short-circuit and never hit downstream
+  services, keeping the planner responsible for user-facing guardrails.【F:packages/orchestrator/src/llm.ts†L30-L74】
+
+### One-Box API responsibilities
+
+* `/plan` converts free-form text into an intent, summary, plan hash, and missing
+  fields. It records timing metadata and emits warnings or blockers as needed.【F:routes/onebox.py†L1739-L1809】
+* `/simulate` replays the canonical hash, checks policies, and returns blockers
+  or a ready-to-execute summary; `/execute` enforces the same hash, applies
+  policy checks, and either produces wallet instructions or relayed receipts.【F:routes/onebox.py†L1813-L2130】
+* Both endpoints log correlation identifiers, emit Prometheus metrics, and reuse
+  cached plan metadata so retries remain idempotent.【F:routes/onebox.py†L1747-L1779】【F:routes/onebox.py†L2015-L2088】
+
+## 2. Shared payload contract
+
+The planner, bridge, and FastAPI service now share a stable JSON structure. All
+payloads ride inside the envelopes shown below.
+
+### 2.1 Planner → Bridge (gRPC `Plan`)
+
+```proto
+message PlanRequest {
+  string utterance = 1;           // User prompt
+  string history_json = 2;        // Optional JSON array of prior turns
+  string trace_id = 3;            // Stable correlation id
+  bool require_consent = 4;       // Planner-side expectation
+  string consent_token = 5;       // Sticky token for follow-up confirmations
+  map<string, string> metadata = 6; // Arbitrary tags (role=employer, etc)
+}
+```
+
+The bridge converts this request into:
+
+```json
+{
+  "input": { "text": "Create a job…" },
+  "history": [...],
+  "meta": {
+    "traceId": "trace-employer",
+    "consent": { "required": true, "token": "consent-create" },
+    "tags": { "flow": "employer_create_job", "stage": "plan" }
+  }
+}
+```
+
+HTTP headers carry the same metadata so legacy services that rely on header-only
+propagation continue to work:
+
+```
+x-agi-trace-id: trace-employer
+x-agi-require-consent: true
+x-agi-consent-token: consent-create
+x-agi-meta-flow: employer_create_job
+x-agi-meta-stage: plan
+```
+
+### 2.2 Bridge → Planner (gRPC `PlanResponse`)
+
+```proto
+message PlanResponse {
+  string plan_json = 1;        // Canonical intent + steps JSON string
+  string trace_id = 2;         // Echoed or upgraded trace id from upstream
+  bool requires_consent = 3;   // Server-detected consent requirement
+  string consent_token = 4;    // Sticky token to reuse during Execute
+}
+```
+
+The `plan_json` blob mirrors the One-Box payload and contains
+`intent`, `steps`, and `planHash` fields returned by `/plan`. The planner stores
+that JSON alongside the cached trace id for future confirmations.
+
+### 2.3 Planner → Bridge (gRPC `Execute`)
+
+```proto
+message ExecuteRequest {
+  string plan_json = 1;          // Exact blob returned by PlanResponse
+  string trace_id = 2;           // Same correlation id
+  bool consent_granted = 3;      // Whether the user confirmed
+  string consent_token = 4;      // Token from PlanResponse
+  map<string, string> metadata = 5; // Optional stage tags
+}
+```
+
+The bridge turns this into:
+
+```json
+{
+  "plan": { ... },
+  "meta": {
+    "traceId": "trace-employer",
+    "consent": { "granted": true, "token": "consent-create" },
+    "tags": { "flow": "employer_create_job", "stage": "execute" }
+  }
+}
+```
+
+HTTP headers now express consent decisions explicitly:
+
+```
+x-agi-trace-id: trace-employer
+x-agi-consent-granted: true
+x-agi-consent-token: consent-create
+x-agi-meta-flow: employer_create_job
+x-agi-meta-stage: execute
+```
+
+### 2.4 Bridge → Planner (gRPC `ExecuteResponse`)
+
+```proto
+message ExecuteResponse {
+  string receipt_json = 1;  // Job status, transaction receipts, etc.
+  string trace_id = 2;      // Mirrors upstream response trace id
+}
+```
+
+The receipt blob is the raw body returned by `/execute` (job id, transaction
+hashes, receipt artifacts) so the orchestrator can stream updates directly to
+clients.
+
+## 3. Canonical flows exercised in tests
+
+Integration tests replay the canonical flows from
+`docs/onebox-sprint.md`: employer job creation, agent application, and validator
+finalization. Each flow asserts that:
+
+1. Planner metadata survives the gRPC hop and lands in HTTP headers.
+2. Consent flags and tokens remain consistent across plan and execute calls.
+3. Receipts echo the upstream trace id so follow-up confirmations can be matched
+   against cached intents.
+
+See `services/alpha-bridge/test/alpha-bridge.test.js` for full coverage of these
+flows and the HTTP assertions enforced by the stub AGI-Alpha agent.【F:services/alpha-bridge/test/alpha-bridge.test.js†L1-L227】
+
+## 4. Operational notes
+
+* The bridge can bind to any address via `ALPHA_BRIDGE_BIND` and defaults to
+  `ALPHA_AGENT_URL=http://localhost:8080` when no upstream is specified.【F:services/alpha-bridge/src/server.js†L146-L210】
+* All JSON parsing failures raise gRPC `INVALID_ARGUMENT` so clients receive
+  immediate feedback before an upstream roundtrip.【F:services/alpha-bridge/src/server.js†L42-L104】【F:services/alpha-bridge/src/server.js†L213-L254】
+* Upstream HTTP status codes are mapped onto canonical gRPC errors (400 →
+  `INVALID_ARGUMENT`, 422 → `FAILED_PRECONDITION`, 5xx → `UNAVAILABLE`) to keep
+  retries and client telemetry consistent.【F:services/alpha-bridge/src/server.js†L20-L100】

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@grpc/grpc-js": "^1.14.0",
+        "@grpc/proto-loader": "^0.8.0",
         "@ipld/car": "^3.2.4",
         "@pinata/sdk": "^2.1.0",
         "@prb/math": "^4.0.1",
@@ -1549,6 +1551,78 @@
         "node": ">=14"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.0.tgz",
+      "integrity": "sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1895,6 +1969,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {
@@ -4554,7 +4638,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4564,7 +4647,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5922,7 +6004,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5935,7 +6016,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -6761,7 +6841,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -6991,7 +7070,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8943,7 +9021,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -10950,7 +11027,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11874,9 +11950,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -14639,7 +14713,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15854,7 +15927,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -15885,7 +15957,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -18765,7 +18836,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -18874,7 +18944,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
     "onebox:verify-sri": "node apps/onebox/scripts/verify-sri.mjs",
     "onebox:static:build": "node apps/onebox-static/scripts/build.mjs",
     "onebox:static:publish": "node apps/onebox-static/scripts/publish.mjs",
-    "verify:sri": "node apps/onebox-static/scripts/verify-sri.mjs"
+    "verify:sri": "node apps/onebox-static/scripts/verify-sri.mjs",
+    "alpha-bridge:start": "node services/alpha-bridge/src/server.js",
+    "alpha-bridge:test": "node --test services/alpha-bridge/test/alpha-bridge.test.js"
   },
   "keywords": [],
   "author": "",
@@ -94,6 +96,10 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
+    "@grpc/grpc-js": "^1.14.0",
+    "@grpc/proto-loader": "^0.8.0",
+    "@grpc/grpc-js": "^1.11.3",
+    "@grpc/proto-loader": "^0.7.13",
     "@ipld/car": "^3.2.4",
     "@pinata/sdk": "^2.1.0",
     "@prb/math": "^4.0.1",

--- a/services/alpha-bridge/README.md
+++ b/services/alpha-bridge/README.md
@@ -1,0 +1,34 @@
+# Alpha Bridge Service
+
+A minimal gRPC façade that forwards planner and executor calls to the HTTP-based
+AGI-Alpha-Agent-v0 API. The bridge preserves trace identifiers, consent
+handshakes, and arbitrary metadata so downstream services can correlate requests
+end-to-end.
+
+## Running locally
+
+```bash
+# ensure dependencies are installed from the repository root
+npm install
+
+# run the bridge (defaults to http://localhost:8080 for the upstream agent)
+npm run alpha-bridge:start
+```
+
+Environment variables:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `ALPHA_AGENT_URL` | Base URL for the upstream AGI-Alpha-Agent-v0 service. | `http://localhost:8080` |
+| `ALPHA_BRIDGE_BIND` | gRPC bind address (host:port). | `0.0.0.0:50052` |
+
+## Testing
+
+The bridge ships with integration tests that replay the canonical One-Box chat
+flows captured in `docs/onebox-sprint.md`. The tests stand up a stub HTTP agent
+that asserts the contract and ensures planner → simulator → runner transitions
+stay in lockstep through the gRPC hop.
+
+```bash
+npm run alpha-bridge:test
+```

--- a/services/alpha-bridge/proto/alpha_bridge.proto
+++ b/services/alpha-bridge/proto/alpha_bridge.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package agi.alpha.bridge.v1;
+
+message PlanRequest {
+  string utterance = 1;
+  string history_json = 2;
+  string trace_id = 3;
+  bool require_consent = 4;
+  string consent_token = 5;
+  map<string, string> metadata = 6;
+}
+
+message PlanResponse {
+  string plan_json = 1;
+  string trace_id = 2;
+  bool requires_consent = 3;
+  string consent_token = 4;
+}
+
+message ExecuteRequest {
+  string plan_json = 1;
+  string trace_id = 2;
+  bool consent_granted = 3;
+  string consent_token = 4;
+  map<string, string> metadata = 5;
+}
+
+message ExecuteResponse {
+  string receipt_json = 1;
+  string trace_id = 2;
+}
+
+service AlphaBridge {
+  rpc Plan(PlanRequest) returns (PlanResponse);
+  rpc Execute(ExecuteRequest) returns (ExecuteResponse);
+}

--- a/services/alpha-bridge/src/server.js
+++ b/services/alpha-bridge/src/server.js
@@ -1,0 +1,343 @@
+const path = require("node:path");
+const grpc = require("@grpc/grpc-js");
+const protoLoader = require("@grpc/proto-loader");
+
+const PROTO_PATH = path.join(__dirname, "..", "proto", "alpha_bridge.proto");
+
+const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
+
+const loaded = grpc.loadPackageDefinition(packageDefinition);
+
+const AlphaBridgeService =
+  loaded?.agi?.alpha?.bridge?.v1?.AlphaBridge?.service;
+
+if (!AlphaBridgeService) {
+  throw new Error("Failed to load AlphaBridge service definition");
+}
+
+const HTTP_TO_GRPC = new Map([
+  [400, grpc.status.INVALID_ARGUMENT],
+  [401, grpc.status.UNAUTHENTICATED],
+  [403, grpc.status.PERMISSION_DENIED],
+  [404, grpc.status.NOT_FOUND],
+  [409, grpc.status.ALREADY_EXISTS],
+  [422, grpc.status.FAILED_PRECONDITION],
+  [429, grpc.status.RESOURCE_EXHAUSTED],
+  [500, grpc.status.INTERNAL],
+  [502, grpc.status.UNAVAILABLE],
+  [503, grpc.status.UNAVAILABLE],
+]);
+
+function normalizeMetadata(metadata) {
+  if (!metadata || typeof metadata !== "object") {
+    return {};
+  }
+  const output = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value === "string" && value.trim()) {
+      output[key] = value;
+    }
+  }
+  return output;
+}
+
+function parseJsonOrThrow(label, value, { allowEmptyArray = false } = {}) {
+  if (typeof value !== "string" || !value.trim()) {
+    if (allowEmptyArray) {
+      return [];
+    }
+    const error = new Error(`${label} must be a non-empty JSON string`);
+    error.code = grpc.status.INVALID_ARGUMENT;
+    throw error;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (allowEmptyArray && parsed === undefined) {
+      return [];
+    }
+    return parsed;
+  } catch (cause) {
+    const error = new Error(`${label} is not valid JSON`);
+    error.code = grpc.status.INVALID_ARGUMENT;
+    error.cause = cause;
+    throw error;
+  }
+}
+
+async function fetchJson(url, body, headers) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  const status = response.status;
+  let parsed = null;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch (cause) {
+      const error = new Error(`AGI-Alpha responded with malformed JSON (${cause})`);
+      error.httpStatus = status;
+      error.details = text;
+      throw error;
+    }
+  }
+
+  if (!response.ok) {
+    const error = new Error(
+      `AGI-Alpha responded with HTTP ${status}${parsed?.error ? `: ${parsed.error}` : ""}`,
+    );
+    error.httpStatus = status;
+    error.details = parsed ?? text;
+    throw error;
+  }
+
+  if (parsed === null) {
+    const error = new Error("AGI-Alpha returned an empty response body");
+    error.httpStatus = status;
+    throw error;
+  }
+
+  return parsed;
+}
+
+function buildHeaders({
+  traceId,
+  requireConsent,
+  consentGranted,
+  consentToken,
+  metadata,
+}) {
+  const headers = {};
+  if (traceId) {
+    headers["x-agi-trace-id"] = traceId;
+  }
+  if (typeof requireConsent === "boolean") {
+    headers["x-agi-require-consent"] = String(requireConsent);
+  }
+  if (typeof consentGranted === "boolean") {
+    headers["x-agi-consent-granted"] = String(consentGranted);
+  }
+  if (consentToken) {
+    headers["x-agi-consent-token"] = consentToken;
+  }
+  if (metadata) {
+    for (const [key, value] of Object.entries(metadata)) {
+      headers[`x-agi-meta-${key.toLowerCase()}`] = value;
+    }
+  }
+  return headers;
+}
+
+function mapError(error) {
+  if (!error) {
+    return { code: grpc.status.UNKNOWN, message: "Unknown error" };
+  }
+  if (typeof error.code === "number") {
+    return {
+      code: error.code,
+      message: error.message || grpc.status[error.code] || "Error",
+      details: error.details,
+    };
+  }
+  const httpStatus = error.httpStatus;
+  const mapped = httpStatus ? HTTP_TO_GRPC.get(httpStatus) : null;
+  return {
+    code: mapped ?? grpc.status.UNKNOWN,
+    message: error.message || "Unexpected error",
+    details: error.details,
+  };
+}
+
+function unary(handler) {
+  return (call, callback) => {
+    Promise.resolve()
+      .then(() => handler(call))
+      .then((result) => callback(null, result))
+      .catch((error) => callback(mapError(error)));
+  };
+}
+
+function createServer(options = {}) {
+  const baseUrl = options.baseUrl || process.env.ALPHA_AGENT_URL || "http://localhost:8080";
+  const server = new grpc.Server();
+
+  server.addService(
+    AlphaBridgeService,
+    {
+      Plan: unary(async (call) => {
+        const request = call.request || {};
+        const utterance = request.utterance || "";
+        if (!utterance.trim()) {
+          const error = new Error("utterance is required");
+          error.code = grpc.status.INVALID_ARGUMENT;
+          throw error;
+        }
+
+        let history = [];
+        if (request.history_json) {
+          history = parseJsonOrThrow("history_json", request.history_json, {
+            allowEmptyArray: true,
+          });
+          if (!Array.isArray(history)) {
+            const error = new Error("history_json must encode a JSON array");
+            error.code = grpc.status.INVALID_ARGUMENT;
+            throw error;
+          }
+        }
+
+        const metadata = normalizeMetadata(request.metadata);
+        const traceId = request.trace_id || "";
+        const requireConsent = Boolean(request.require_consent);
+        const consentToken = request.consent_token || "";
+
+        const payload = {
+          input: {
+            text: utterance,
+          },
+          history,
+          meta: {
+            traceId: traceId || undefined,
+            consent: {
+              required: requireConsent,
+              token: consentToken || undefined,
+            },
+            tags: Object.keys(metadata).length ? metadata : undefined,
+          },
+        };
+
+        const headers = buildHeaders({
+          traceId,
+          requireConsent,
+          consentToken,
+          metadata,
+        });
+
+        const response = await fetchJson(`${baseUrl}/plan`, payload, headers);
+        const meta = response.meta || {};
+        const planPayload = response.plan ?? response;
+        const consent = meta.consent || {};
+        const planJson =
+          typeof planPayload === "string"
+            ? planPayload
+            : JSON.stringify(planPayload);
+
+        return {
+          plan_json: planJson,
+          trace_id: meta.traceId || traceId || "",
+          requires_consent: Boolean(
+            consent.required ?? response.requiresConsent ?? requireConsent,
+          ),
+          consent_token: consent.token || response.consentToken || consentToken || "",
+        };
+      }),
+      Execute: unary(async (call) => {
+        const request = call.request || {};
+        const traceId = request.trace_id || "";
+        const planJson = request.plan_json || "";
+        let plan;
+        try {
+          plan = JSON.parse(planJson);
+        } catch (cause) {
+          const error = new Error("plan_json is not valid JSON");
+          error.code = grpc.status.INVALID_ARGUMENT;
+          error.cause = cause;
+          throw error;
+        }
+        const consentToken = request.consent_token || "";
+        const consentGranted = Boolean(request.consent_granted);
+        const metadata = normalizeMetadata(request.metadata);
+
+        const payload = {
+          plan,
+          meta: {
+            traceId: traceId || undefined,
+            consent: {
+              granted: consentGranted,
+              token: consentToken || undefined,
+            },
+            tags: Object.keys(metadata).length ? metadata : undefined,
+          },
+        };
+
+        const headers = buildHeaders({
+          traceId,
+          consentGranted,
+          consentToken,
+          metadata,
+        });
+
+        const response = await fetchJson(`${baseUrl}/execute`, payload, headers);
+        const meta = response.meta || {};
+        const receiptPayload = response.receipt ?? response;
+        const receiptJson =
+          typeof receiptPayload === "string"
+            ? receiptPayload
+            : JSON.stringify(receiptPayload);
+
+        return {
+          receipt_json: receiptJson,
+          trace_id: meta.traceId || traceId || "",
+        };
+      }),
+    },
+  );
+
+  function listen(bindAddress = process.env.ALPHA_BRIDGE_BIND || "0.0.0.0:50052") {
+    return new Promise((resolve, reject) => {
+      server.bindAsync(
+        bindAddress,
+        grpc.ServerCredentials.createInsecure(),
+        (error, port) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve({ port });
+        },
+      );
+    });
+  }
+
+  function shutdown() {
+    return new Promise((resolve, reject) => {
+      server.tryShutdown((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  return { server, listen, shutdown };
+}
+
+module.exports = { createServer };
+
+if (require.main === module) {
+  const instance = createServer();
+  instance
+    .listen()
+    .then(({ port }) => {
+      // eslint-disable-next-line no-console
+      console.log(`alpha-bridge listening on port ${port}`);
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error("alpha-bridge failed to start", error);
+      process.exitCode = 1;
+    });
+}

--- a/services/alpha-bridge/test/alpha-bridge.test.js
+++ b/services/alpha-bridge/test/alpha-bridge.test.js
@@ -1,0 +1,320 @@
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const path = require("node:path");
+const test = require("node:test");
+const grpc = require("@grpc/grpc-js");
+const protoLoader = require("@grpc/proto-loader");
+
+const { createServer } = require("../src/server.js");
+
+const PROTO_PATH = path.join(__dirname, "..", "proto", "alpha_bridge.proto");
+const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
+const proto = grpc.loadPackageDefinition(packageDefinition);
+const AlphaBridgeClient = proto.agi.alpha.bridge.v1.AlphaBridge;
+
+const CANONICAL_FLOWS = [
+  {
+    name: "employer_create_job",
+    utterance: "Create a job to label 500 cat photos for 50 AGIALPHA by next Friday",
+    traceId: "trace-employer",
+    requiresConsent: true,
+    expectedConsent: true,
+    consentToken: "consent-create",
+    plan: {
+      intent: {
+        action: "post_job",
+        payload: {
+          title: "Label 500 cat photos",
+          reward: "50",
+          deadlineDays: 7,
+        },
+        userContext: {
+          role: "employer",
+        },
+      },
+      steps: [
+        {
+          id: "simulate",
+          tool: "simulate_job_posting",
+          summary: "Simulate escrow of 50 AGIALPHA and validate deadline",
+          needs: [],
+        },
+        {
+          id: "execute",
+          tool: "submit_job",
+          summary: "Post job via JobRegistry.postJob",
+          needs: ["simulate"],
+          consent: true,
+        },
+      ],
+    },
+    receipt: {
+      status: "submitted",
+      jobId: 101,
+      txHashes: ["0xcreate"],
+    },
+  },
+  {
+    name: "agent_apply_job",
+    utterance: "I want to apply to job 101 with my agent badge",
+    traceId: "trace-agent",
+    requiresConsent: false,
+    expectedConsent: false,
+    consentToken: "",
+    plan: {
+      intent: {
+        action: "apply_job",
+        payload: {
+          jobId: 101,
+          ens: { subdomain: "alice" },
+        },
+        userContext: {
+          role: "agent",
+        },
+      },
+      steps: [
+        {
+          id: "check",
+          tool: "check_stake",
+          summary: "Verify stake and allowlist before applying",
+          needs: [],
+        },
+        {
+          id: "submit",
+          tool: "apply_onchain",
+          summary: "Submit on-chain application",
+          needs: ["check"],
+        },
+      ],
+    },
+    receipt: {
+      status: "applied",
+      jobId: 101,
+      txHashes: ["0xapply"],
+    },
+  },
+  {
+    name: "validator_finalize_job",
+    utterance: "Finalize payout for job 101",
+    traceId: "trace-validator",
+    requiresConsent: true,
+    expectedConsent: true,
+    consentToken: "consent-finalize",
+    plan: {
+      intent: {
+        action: "finalize_job",
+        payload: {
+          jobId: 101,
+        },
+        userContext: {
+          role: "validator",
+        },
+      },
+      steps: [
+        {
+          id: "audit",
+          tool: "validate_receipts",
+          summary: "Confirm validator quorum and work receipt",
+          needs: [],
+        },
+        {
+          id: "finalize",
+          tool: "finalize_onchain",
+          summary: "Finalize payout via JobRegistry.finalize",
+          needs: ["audit"],
+          consent: true,
+        },
+      ],
+    },
+    receipt: {
+      status: "finalized",
+      jobId: 101,
+      txHashes: ["0xfinal"],
+    },
+  },
+];
+
+test("alpha-bridge proxies canonical flows via gRPC", async (t) => {
+  const receivedPlanBodies = [];
+  const receivedExecuteBodies = [];
+  const receivedPlanHeaders = [];
+  const receivedExecuteHeaders = [];
+
+  const httpServer = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      let body;
+      try {
+        body = raw ? JSON.parse(raw) : {};
+      } catch (error) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: String(error) }));
+        return;
+      }
+
+      if (req.url === "/plan") {
+        receivedPlanHeaders.push(req.headers);
+        receivedPlanBodies.push(body);
+        const traceId = body?.meta?.traceId;
+        const flow = CANONICAL_FLOWS.find((item) => item.traceId === traceId);
+        if (!flow) {
+          res.statusCode = 404;
+          res.end(JSON.stringify({ error: "unknown trace" }));
+          return;
+        }
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            plan: flow.plan,
+            meta: {
+              traceId,
+              consent: {
+                required: flow.requiresConsent,
+                token: flow.consentToken || undefined,
+              },
+            },
+          }),
+        );
+        return;
+      }
+
+      if (req.url === "/execute") {
+        receivedExecuteHeaders.push(req.headers);
+        receivedExecuteBodies.push(body);
+        const traceId = body?.meta?.traceId;
+        const flow = CANONICAL_FLOWS.find((item) => item.traceId === traceId);
+        if (!flow) {
+          res.statusCode = 404;
+          res.end(JSON.stringify({ error: "unknown trace" }));
+          return;
+        }
+        const consent = body?.meta?.consent ?? {};
+        if (Boolean(consent.granted) !== Boolean(flow.expectedConsent)) {
+          res.statusCode = 422;
+          res.end(JSON.stringify({ error: "consent mismatch" }));
+          return;
+        }
+        if ((consent.token || "") !== (flow.consentToken || "")) {
+          res.statusCode = 422;
+          res.end(JSON.stringify({ error: "consent token mismatch" }));
+          return;
+        }
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            receipt: flow.receipt,
+            meta: {
+              traceId,
+            },
+          }),
+        );
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end();
+    });
+  });
+
+  await new Promise((resolve) => httpServer.listen(0, resolve));
+  const upstreamPort = httpServer.address().port;
+  const upstreamUrl = `http://127.0.0.1:${upstreamPort}`;
+
+  const bridge = createServer({ baseUrl: upstreamUrl });
+  const { port: grpcPort } = await bridge.listen("127.0.0.1:0");
+
+  const client = new AlphaBridgeClient(
+    `127.0.0.1:${grpcPort}`,
+    grpc.credentials.createInsecure(),
+  );
+
+  for (const flow of CANONICAL_FLOWS) {
+    const planResponse = await new Promise((resolve, reject) => {
+      client.Plan(
+        {
+          utterance: flow.utterance,
+          trace_id: flow.traceId,
+          require_consent: flow.requiresConsent,
+          consent_token: flow.consentToken,
+          metadata: { flow: flow.name, stage: "plan" },
+        },
+        (error, response) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(response);
+        },
+      );
+    });
+
+    assert.equal(planResponse.trace_id, flow.traceId);
+    assert.equal(planResponse.requires_consent, flow.requiresConsent);
+    assert.equal(planResponse.consent_token, flow.consentToken || "");
+
+    const parsedPlan = JSON.parse(planResponse.plan_json);
+    assert.deepEqual(parsedPlan, flow.plan);
+
+    const executeResponse = await new Promise((resolve, reject) => {
+      client.Execute(
+        {
+          plan_json: planResponse.plan_json,
+          trace_id: planResponse.trace_id,
+          consent_granted: flow.expectedConsent,
+          consent_token: planResponse.consent_token,
+          metadata: { flow: flow.name, stage: "execute" },
+        },
+        (error, response) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(response);
+        },
+      );
+    });
+
+    assert.equal(executeResponse.trace_id, flow.traceId);
+    const parsedReceipt = JSON.parse(executeResponse.receipt_json);
+    assert.deepEqual(parsedReceipt, flow.receipt);
+  }
+
+  client.close();
+  await bridge.shutdown();
+  await new Promise((resolve) => httpServer.close(resolve));
+
+  assert.equal(receivedPlanBodies.length, CANONICAL_FLOWS.length);
+  assert.equal(receivedExecuteBodies.length, CANONICAL_FLOWS.length);
+
+  for (const [index, flow] of CANONICAL_FLOWS.entries()) {
+    const planHeaders = receivedPlanHeaders[index];
+    assert.equal(planHeaders["x-agi-trace-id"], flow.traceId);
+    assert.equal(planHeaders["x-agi-require-consent"], String(flow.requiresConsent));
+    if (flow.consentToken) {
+      assert.equal(planHeaders["x-agi-consent-token"], flow.consentToken);
+    }
+    assert.equal(planHeaders["x-agi-meta-flow"], flow.name);
+    assert.equal(planHeaders["x-agi-meta-stage"], "plan");
+
+    const executeHeaders = receivedExecuteHeaders[index];
+    assert.equal(executeHeaders["x-agi-trace-id"], flow.traceId);
+    assert.equal(
+      executeHeaders["x-agi-consent-granted"],
+      String(flow.expectedConsent),
+    );
+    if (flow.consentToken) {
+      assert.equal(executeHeaders["x-agi-consent-token"], flow.consentToken);
+    }
+    assert.equal(executeHeaders["x-agi-meta-flow"], flow.name);
+    assert.equal(executeHeaders["x-agi-meta-stage"], "execute");
+  }
+});


### PR DESCRIPTION
## Summary
- document the end-to-end planner, simulator, and executor flow between the orchestrator and FastAPI service
- add a gRPC/HTTP alpha-bridge service that proxies plan and execute calls while preserving trace and consent metadata
- cover the canonical One-Box chat flows with integration tests that validate the bridge contract

## Testing
- npm run alpha-bridge:test

------
https://chatgpt.com/codex/tasks/task_e_68d9c38a9f6c8333b9fcde1198a1ffb7