### PR TITLE
Align Python planner ICS output with TypeScript schema

### DIFF
--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -122,10 +122,16 @@ class PlanOut(BaseModel):
 
     intent: JobIntent
     plan: OrchestrationPlan
+    ics: Dict[str, Any] | None = None
     missing_fields: List[str] = Field(default_factory=list)
     preview_summary: str
     warnings: List[str] = Field(default_factory=list)
     simulation: "SimOut | None" = None
+    clarification_prompt: str | None = Field(
+        default=None,
+        alias="clarificationPrompt",
+        serialization_alias="clarificationPrompt",
+    )
     requires_confirmation: bool = Field(
         default=True,
         alias="requiresConfirmation",

--- a/test/orchestrator/fixtures/create_job_complete.json
+++ b/test/orchestrator/fixtures/create_job_complete.json
@@ -1,0 +1,18 @@
+{
+  "intent": "create_job",
+  "params": {
+    "job": {
+      "rewardAGIA": "50.00",
+      "deadline": 5,
+      "spec": {
+        "description": "Post a 50 AGI job with deadline 5 days",
+        "title": "Post a 50 agi job with deadline 5 days"
+      },
+      "title": "Post a 50 agi job with deadline 5 days"
+    }
+  },
+  "confirm": true,
+  "meta": {
+    "traceId": "11111111-1111-1111-1111-111111111111"
+  }
+}

--- a/test/orchestrator/test_ics_golden.py
+++ b/test/orchestrator/test_ics_golden.py
@@ -1,0 +1,50 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from orchestrator import planner
+from orchestrator.models import PlanIn
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_create_job_ics_matches_fixture(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        planner,
+        "_generate_trace_id",
+        lambda: "11111111-1111-1111-1111-111111111111",
+    )
+
+    plan = planner.make_plan(PlanIn(input_text="Post a 50 AGI job with deadline 5 days"))
+
+    assert plan.ics is not None, "Planner should emit an ICS payload for complete jobs"
+
+    fixture_path = FIXTURE_DIR / "create_job_complete.json"
+    expected = json.loads(fixture_path.read_text())
+
+    assert plan.ics == expected
+
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text(json.dumps(plan.ics))
+
+    script = (
+        "import { readFileSync } from 'node:fs';"
+        "(async () => {"
+        "const mod = await import('./packages/orchestrator/src/ics.ts');"
+        "const validate = mod.validateICS ?? (mod.default && mod.default.validateICS);"
+        "if (!validate) { throw new Error('validateICS not available'); }"
+        "const data = readFileSync(process.argv[1], 'utf8');"
+        "validate(data);"
+        "})();"
+    )
+
+    env = {**os.environ, "TS_NODE_COMPILER_OPTIONS": "{\"module\":\"esnext\",\"moduleResolution\":\"node\"}"}
+
+    subprocess.run(
+        ["node", "--loader", "ts-node/esm", "-e", script, str(payload_path)],
+        cwd=ROOT,
+        check=True,
+        env=env,
+    )


### PR DESCRIPTION
## Summary
- expose ICS payloads and clarification prompts on `PlanOut` for downstream consumers
- build ICS payloads in the Python planner that match the TypeScript schema, including confirm flags and meta trace IDs, while reusing shared missing-field prompts
- add cross-language fixtures and pytest coverage that validate the Python ICS against the TypeScript `validateICS`

## Testing
- pytest test/orchestrator/test_planner.py test/orchestrator/test_ics_golden.py

------
https://chatgpt.com/codex/tasks/task_e_68d9c613745883338d545c040ca2c9be