### PR TITLE
Enable configurable deposit token for Randao coordinator

### DIFF
--- a/contracts/test/MockERC20NoMetadata.sol
+++ b/contracts/test/MockERC20NoMetadata.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev Mock ERC20 token whose metadata accessors revert.
+contract MockERC20NoMetadata is ERC20 {
+    constructor() ERC20("MockNoMetadata", "MNM") {
+        _mint(msg.sender, 1e24);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        revert("MockERC20NoMetadata: decimals unavailable");
+    }
+}

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -233,6 +233,7 @@ export interface RandaoCoordinatorConfig {
   commitWindow?: number;
   revealWindow?: number;
   deposit?: string;
+  token?: string;
   treasury?: string | null;
   [key: string]: unknown;
 }

--- a/scripts/config/index.js
+++ b/scripts/config/index.js
@@ -1272,6 +1272,14 @@ function normaliseRandaoCoordinatorConfig(config = {}) {
     delete result.depositTokens;
   }
 
+  if (result.token !== undefined) {
+    if (result.token === null || result.token === '') {
+      delete result.token;
+    } else {
+      result.token = ensureAddress(result.token, 'RandaoCoordinator token');
+    }
+  }
+
   if (result.treasury !== undefined) {
     if (result.treasury === null || result.treasury === '') {
       result.treasury = ethers.ZeroAddress;

--- a/scripts/v2/lib/randaoCoordinatorPlan.ts
+++ b/scripts/v2/lib/randaoCoordinatorPlan.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import type { Contract } from 'ethers';
+import type { Contract, ContractRunner } from 'ethers';
 import { type RandaoCoordinatorConfig } from '../../config';
 import { type ModulePlan, type PlannedAction } from './types';
 
@@ -8,11 +8,23 @@ const ABI = [
   'function revealWindow() view returns (uint256)',
   'function deposit() view returns (uint256)',
   'function treasury() view returns (address)',
+  'function token() view returns (address)',
   'function setCommitWindow(uint256)',
   'function setRevealWindow(uint256)',
   'function setDeposit(uint256)',
-  'function setTreasury(address)'
+  'function setTreasury(address)',
+  'function setToken(address)'
 ];
+
+const TOKEN_METADATA_ABI = [
+  'function symbol() view returns (string)',
+  'function decimals() view returns (uint8)'
+];
+
+type TokenMetadata = {
+  symbol: string;
+  decimals: number;
+};
 
 export interface RandaoCoordinatorPlanInput {
   randao: Contract;
@@ -42,6 +54,55 @@ function formatSeconds(value: bigint | number | undefined): string {
   return `${seconds} seconds`;
 }
 
+async function fetchTokenMetadata(
+  randao: Contract,
+  tokenAddress: string
+): Promise<TokenMetadata> {
+  const defaultMetadata: TokenMetadata = { symbol: 'AGIALPHA', decimals: 18 };
+  if (!tokenAddress || tokenAddress === ethers.ZeroAddress) {
+    return defaultMetadata;
+  }
+
+  const runner: ContractRunner | null =
+    (randao.runner as ContractRunner | null) ?? randao.provider ?? null;
+  if (!runner) {
+    return defaultMetadata;
+  }
+
+  const contract = new ethers.Contract(tokenAddress, TOKEN_METADATA_ABI, runner);
+  let symbol = defaultMetadata.symbol;
+  let decimals = defaultMetadata.decimals;
+
+  try {
+    const resolved = await contract.symbol();
+    if (typeof resolved === 'string' && resolved.length > 0) {
+      symbol = resolved;
+    }
+  } catch (_) {
+    // ignore symbol failures
+  }
+
+  try {
+    const resolved = await contract.decimals();
+    const parsed = Number(resolved);
+    if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 255) {
+      decimals = parsed;
+    }
+  } catch (_) {
+    // ignore decimals failures
+  }
+
+  return { symbol, decimals };
+}
+
+function formatTokenAmount(amount: bigint, metadata: TokenMetadata): string {
+  const decimals = Number.isFinite(metadata.decimals)
+    ? Number(metadata.decimals)
+    : 18;
+  const symbol = metadata.symbol ?? 'TOKEN';
+  return `${ethers.formatUnits(amount, decimals)} ${symbol}`;
+}
+
 export async function buildRandaoCoordinatorPlan(
   input: RandaoCoordinatorPlanInput
 ): Promise<ModulePlan> {
@@ -49,16 +110,44 @@ export async function buildRandaoCoordinatorPlan(
   const address = await randao.getAddress();
   const iface = new ethers.Interface(ABI);
 
-  const [currentCommitWindow, currentRevealWindow, currentDeposit, currentTreasury] =
-    await Promise.all([
-      randao.commitWindow(),
-      randao.revealWindow(),
-      randao.deposit(),
-      randao.treasury()
-    ]);
+  const [
+    currentCommitWindow,
+    currentRevealWindow,
+    currentDeposit,
+    currentTreasury,
+    currentToken
+  ] = await Promise.all([
+    randao.commitWindow(),
+    randao.revealWindow(),
+    randao.deposit(),
+    randao.treasury(),
+    randao.token()
+  ]);
+
+  const currentTokenAddress = ethers.getAddress(currentToken);
+  const currentTokenMetadata = await fetchTokenMetadata(randao, currentTokenAddress);
+  let desiredTokenAddress = currentTokenAddress;
+  let desiredTokenMetadata = currentTokenMetadata;
 
   const actions: PlannedAction[] = [];
   const warnings: string[] = [];
+
+  if (config.token !== undefined) {
+    const desired = ethers.getAddress(config.token);
+    desiredTokenAddress = desired;
+    if (desired !== currentTokenAddress) {
+      desiredTokenMetadata = await fetchTokenMetadata(randao, desired);
+      actions.push({
+        label: 'Update deposit token',
+        method: 'setToken',
+        args: [desired],
+        current: currentTokenAddress,
+        desired
+      });
+    }
+  } else {
+    warnings.push('token missing from configuration; leaving current value.');
+  }
 
   if (config.commitWindow !== undefined) {
     const desired = BigInt(config.commitWindow);
@@ -97,8 +186,8 @@ export async function buildRandaoCoordinatorPlan(
         label: 'Update deposit requirement',
         method: 'setDeposit',
         args: [desired],
-        current: `${ethers.formatUnits(currentDeposit, 18)} AGIALPHA`,
-        desired: `${ethers.formatUnits(desired, 18)} AGIALPHA`
+        current: formatTokenAmount(currentDeposit, currentTokenMetadata),
+        desired: formatTokenAmount(desired, desiredTokenMetadata)
       });
     }
   } else {


### PR DESCRIPTION
## Summary
- allow the Randao coordinator owner to retarget the deposit token safely while validating metadata and guarding outstanding stakes
- expose the coordinator token in configuration tooling and the owner dashboard so governance can plan and review token updates
- extend the Randao coordinator test suite with token-update cases and supporting mocks

## Testing
- npx hardhat test test/v2/RandaoCoordinator.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9d97a138c8333becce132c2da1957