### PR TITLE
feat(orchestrator): add deterministic tool dry-runs and contract metadata

### DIFF
--- a/config/contracts.orchestrator.json
+++ b/config/contracts.orchestrator.json
@@ -1,0 +1,63 @@
+{
+  "agialphaToken": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "abi": [
+      "function allowance(address owner, address spender) view returns (uint256)",
+      "function approve(address spender, uint256 amount) returns (bool)",
+      "function balanceOf(address account) view returns (uint256)",
+      "function decimals() view returns (uint8)",
+      "function symbol() view returns (string)"
+    ]
+  },
+  "jobRegistry": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "abi": [
+      "event JobCreated(uint256 indexed jobId, address indexed employer, address indexed agent, uint256 reward, uint256 stake, uint256 fee, bytes32 specHash, string uri)",
+      "function createJob(uint256 reward, uint64 deadline, bytes32 specHash, string uri) returns (uint256)",
+      "function applyForJob(uint256 jobId, string subdomain, bytes32[] proof)",
+      "function submit(uint256 jobId, bytes32 resultHash, string resultURI, string subdomain, bytes32[] proof)",
+      "function finalizeAfterValidation(uint256 jobId, bool success)",
+      "function raiseDispute(uint256 jobId, string reason)",
+      "function feePct() view returns (uint256)",
+      "function validatorRewardPct() view returns (uint256)",
+      "function jobs(uint256 jobId) view returns (address employer,address agent,uint128 reward,uint96 stake,uint32 feePct,uint8 state,bool success,uint8 agentTypes,uint64 deadline,uint64 assignedAt,bytes32 uriHash,bytes32 resultHash)"
+    ]
+  },
+  "stakeManager": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "abi": [
+      "function depositStake(uint8 role, uint256 amount)",
+      "function withdrawStake(uint8 role, uint256 amount)",
+      "function feePct() view returns (uint256)",
+      "function burnPct() view returns (uint256)",
+      "function validatorRewardPct() view returns (uint256)"
+    ]
+  },
+  "validationModule": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "abi": [
+      "function commitVote(uint256 jobId, bytes32 commitHash, string subdomain, bytes32[] proof)",
+      "function revealVote(uint256 jobId, bool approve, bytes32 burnTxHash, bytes32 salt, string subdomain, bytes32[] proof)",
+      "function finalize(uint256 jobId) returns (bool)",
+      "function forceFinalize(uint256 jobId) returns (bool)",
+      "function validatorsPerJob() view returns (uint256)",
+      "function maxValidatorsPerJob() view returns (uint256)",
+      "function revealDeadline(uint256 jobId) view returns (uint64)",
+      "function earlyFinalizeDelay() view returns (uint64)"
+    ]
+  },
+  "disputeModule": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "abi": [
+      "function raiseDispute(uint256 jobId, address claimant, bytes32 evidenceHash, string reason)",
+      "function disputeFee() view returns (uint256)"
+    ]
+  },
+  "feePool": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "abi": [
+      "function burnPct() view returns (uint256)",
+      "function treasury() view returns (address)"
+    ]
+  }
+}

--- a/packages/orchestrator/src/chain/addresses.ts
+++ b/packages/orchestrator/src/chain/addresses.ts
@@ -1,7 +1,14 @@
+import { getAllContractMetadata } from "./metadata.js";
+
+const metadata = getAllContractMetadata();
+
 export const CONTRACT_ADDRESSES = {
-  AGIALPHA_TOKEN: process.env.AGIALPHA_TOKEN ?? "0x0000000000000000000000000000000000000000",
-  STAKE_MANAGER: process.env.STAKE_MANAGER ?? "0x0000000000000000000000000000000000000000",
-  JOB_REGISTRY: process.env.JOB_REGISTRY ?? "0x0000000000000000000000000000000000000000",
-  VALIDATION_MODULE: process.env.VALIDATION_MODULE ?? "0x0000000000000000000000000000000000000000",
-  DISPUTE_MODULE: process.env.DISPUTE_MODULE ?? "0x0000000000000000000000000000000000000000",
+  AGIALPHA_TOKEN: metadata.agialphaToken.address,
+  STAKE_MANAGER: metadata.stakeManager.address,
+  JOB_REGISTRY: metadata.jobRegistry.address,
+  VALIDATION_MODULE: metadata.validationModule.address,
+  DISPUTE_MODULE: metadata.disputeModule.address,
+  FEE_POOL: metadata.feePool.address,
 };
+
+export const CONTRACT_METADATA = metadata;

--- a/packages/orchestrator/src/chain/contracts.ts
+++ b/packages/orchestrator/src/chain/contracts.ts
@@ -1,61 +1,34 @@
 import { ethers } from "ethers";
-import { CONTRACT_ADDRESSES } from "./addresses.js";
+import { CONTRACT_METADATA } from "./addresses.js";
 import { rpc } from "./provider.js";
 
-const ERC20_ABI = [
-  "function allowance(address owner, address spender) view returns (uint256)",
-  "function approve(address spender, uint256 amount) returns (bool)",
-];
+type ContractInstances = {
+  erc20: ethers.Contract;
+  stakeManager: ethers.Contract;
+  jobRegistry: ethers.Contract;
+  validationModule: ethers.Contract;
+  disputeModule: ethers.Contract;
+  feePool: ethers.Contract;
+};
 
-const STAKE_MANAGER_ABI = [
-  "function depositStake(uint8 role, uint256 amount)",
-  "function withdrawStake(uint8 role, uint256 amount)",
-];
-
-const JOB_REGISTRY_ABI = [
-  "event JobCreated(uint256 indexed jobId, address indexed employer, address indexed agent, uint256 reward, uint256 stake, uint256 fee, bytes32 specHash, string uri)",
-  "function createJob(uint256 reward, uint64 deadline, bytes32 specHash, string uri) returns (uint256 jobId)",
-  "function applyForJob(uint256 jobId, string subdomain, bytes32[] proof)",
-  "function submit(uint256 jobId, bytes32 resultHash, string resultURI, string subdomain, bytes32[] proof)",
-  "function finalizeAfterValidation(uint256 jobId, bool success)",
-];
-
-const VALIDATION_MODULE_ABI = ["function finalize(uint256 jobId)"];
-
-const DISPUTE_MODULE_ABI = ["function raiseDispute(uint256 jobId, string reason)"];
-
-export function loadContracts(signerOrProvider?: ethers.Signer | ethers.Provider) {
+function instantiate(
+  key: keyof typeof CONTRACT_METADATA,
+  signerOrProvider?: ethers.Signer | ethers.Provider
+): ethers.Contract {
   const connection = signerOrProvider ?? rpc();
+  const { address, abi } = CONTRACT_METADATA[key];
+  return new ethers.Contract(address, abi, connection);
+}
 
-  const erc20 = new ethers.Contract(
-    CONTRACT_ADDRESSES.AGIALPHA_TOKEN,
-    ERC20_ABI,
-    connection
-  );
-
-  const stakeManager = new ethers.Contract(
-    CONTRACT_ADDRESSES.STAKE_MANAGER,
-    STAKE_MANAGER_ABI,
-    connection
-  );
-
-  const jobRegistry = new ethers.Contract(
-    CONTRACT_ADDRESSES.JOB_REGISTRY,
-    JOB_REGISTRY_ABI,
-    connection
-  );
-
-  const validationModule = new ethers.Contract(
-    CONTRACT_ADDRESSES.VALIDATION_MODULE,
-    VALIDATION_MODULE_ABI,
-    connection
-  );
-
-  const disputeModule = new ethers.Contract(
-    CONTRACT_ADDRESSES.DISPUTE_MODULE,
-    DISPUTE_MODULE_ABI,
-    connection
-  );
-
-  return { erc20, stakeManager, jobRegistry, validationModule, disputeModule };
+export function loadContracts(
+  signerOrProvider?: ethers.Signer | ethers.Provider
+): ContractInstances {
+  return {
+    erc20: instantiate("agialphaToken", signerOrProvider),
+    stakeManager: instantiate("stakeManager", signerOrProvider),
+    jobRegistry: instantiate("jobRegistry", signerOrProvider),
+    validationModule: instantiate("validationModule", signerOrProvider),
+    disputeModule: instantiate("disputeModule", signerOrProvider),
+    feePool: instantiate("feePool", signerOrProvider),
+  };
 }

--- a/packages/orchestrator/src/chain/metadata.ts
+++ b/packages/orchestrator/src/chain/metadata.ts
@@ -1,0 +1,90 @@
+import { createRequire } from "node:module";
+import { ethers } from "ethers";
+
+const requireJson = createRequire(import.meta.url);
+
+type RawContractEntry = {
+  address?: string;
+  abi?: readonly unknown[];
+};
+
+type RawContracts = {
+  agialphaToken: RawContractEntry;
+  jobRegistry: RawContractEntry;
+  stakeManager: RawContractEntry;
+  validationModule: RawContractEntry;
+  disputeModule: RawContractEntry;
+  feePool: RawContractEntry;
+};
+
+const rawContracts = requireJson("../../../config/contracts.orchestrator.json") as RawContracts;
+
+export type ContractKey = keyof typeof rawContracts;
+
+export interface ContractMetadata {
+  address: string;
+  abi: readonly string[];
+}
+
+const ENV_OVERRIDES: Record<ContractKey, readonly string[]> = {
+  agialphaToken: ["AGIALPHA_TOKEN", "AGIALPHA_TOKEN_ADDRESS", "TOKEN_ADDRESS"],
+  jobRegistry: ["JOB_REGISTRY", "JOB_REGISTRY_ADDRESS"],
+  stakeManager: ["STAKE_MANAGER", "STAKE_MANAGER_ADDRESS"],
+  validationModule: ["VALIDATION_MODULE", "VALIDATION_MODULE_ADDRESS"],
+  disputeModule: ["DISPUTE_MODULE", "DISPUTE_MODULE_ADDRESS"],
+  feePool: ["FEE_POOL", "FEE_POOL_ADDRESS"],
+};
+
+function normalizeAddress(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    return ethers.getAddress(trimmed);
+  } catch (error) {
+    console.warn(`Invalid address override '${value}':`, error);
+    return undefined;
+  }
+}
+
+function resolveAddress(key: ContractKey): string {
+  const envCandidates = ENV_OVERRIDES[key] ?? [];
+  for (const name of envCandidates) {
+    const override = normalizeAddress(process.env[name]);
+    if (override) {
+      return override;
+    }
+  }
+  const configured = normalizeAddress(rawContracts[key]?.address);
+  return configured ?? ethers.ZeroAddress;
+}
+
+function resolveAbi(key: ContractKey): readonly string[] {
+  const abi = rawContracts[key]?.abi;
+  if (!Array.isArray(abi)) {
+    return [];
+  }
+  return abi.map((entry) => String(entry));
+}
+
+export function getContractMetadata(key: ContractKey): ContractMetadata {
+  return {
+    address: resolveAddress(key),
+    abi: resolveAbi(key),
+  };
+}
+
+export function getAllContractMetadata(): Record<ContractKey, ContractMetadata> {
+  return {
+    agialphaToken: getContractMetadata("agialphaToken"),
+    jobRegistry: getContractMetadata("jobRegistry"),
+    stakeManager: getContractMetadata("stakeManager"),
+    validationModule: getContractMetadata("validationModule"),
+    disputeModule: getContractMetadata("disputeModule"),
+    feePool: getContractMetadata("feePool"),
+  };
+}

--- a/packages/orchestrator/src/chain/provider.ts
+++ b/packages/orchestrator/src/chain/provider.ts
@@ -3,9 +3,9 @@ import { getAAProvider as getAAProviderImpl } from "./providers/aa.js";
 import { getMetaTxSigner } from "./providers/metaTx.js";
 import { getRelayerWallet } from "./providers/relayer.js";
 
-type NormalizedTxMode = "relayer" | "aa" | "direct";
+export type NormalizedTxMode = "relayer" | "aa" | "direct";
 
-function normalizeTxMode(value: string | undefined): NormalizedTxMode {
+export function resolveTxMode(value?: string): NormalizedTxMode {
   const raw = (value ?? process.env.TX_MODE ?? "relayer").trim().toLowerCase();
   if (!raw) {
     return "relayer";
@@ -87,7 +87,7 @@ export function __setAAProviderFactoryForTests(factory?: AAProviderFactory) {
 }
 
 export async function getSignerForUser(userId: string, overrideMode?: string) {
-  const mode = normalizeTxMode(overrideMode);
+  const mode = resolveTxMode(overrideMode);
   if (mode === "aa") {
     try {
       return await aaProviderFactory(userId);

--- a/packages/orchestrator/src/router.ts
+++ b/packages/orchestrator/src/router.ts
@@ -23,6 +23,28 @@ export type {
   WithdrawIntent,
 } from "./ics.js";
 
+export {
+  createJobDryRun,
+  createJobExecute,
+  applyJobDryRun,
+  applyJobExecute,
+  submitWorkDryRun,
+  submitWorkExecute,
+  finalizeDryRun,
+  finalizeExecute,
+} from "./tools/job.js";
+
+export {
+  depositDryRun,
+  depositExecute,
+  withdrawDryRun,
+  withdrawExecute,
+} from "./tools/stake.js";
+
+export { validateDryRun, validateExecute } from "./tools/validation.js";
+
+export { disputeDryRun, disputeExecute } from "./tools/dispute.js";
+
 type AsyncGeneratorString = AsyncGenerator<string, void, unknown>;
 
 export function route(ics: ICSType): AsyncGeneratorString {

--- a/packages/orchestrator/src/tools/dispute.ts
+++ b/packages/orchestrator/src/tools/dispute.ts
@@ -1,17 +1,148 @@
+import { ethers } from "ethers";
 import type { ICSType } from "../router.js";
+import { loadContracts } from "../chain/contracts.js";
+import { getSignerForUser } from "../chain/provider.js";
+import {
+  buildDryRunResult,
+  buildPolicyOverrides,
+  formatError,
+  hexlify,
+  simulateContractCall,
+  type DryRunResult,
+  type ExecutionStepResult,
+} from "./common.js";
+
+interface DisputeParams {
+  jobId: bigint;
+  reason: string;
+}
+
+function requireUserId(meta?: { userId?: string | null }): string {
+  const candidate = meta?.userId?.trim();
+  if (!candidate) {
+    throw new Error("Missing meta.userId for signing.");
+  }
+  return candidate;
+}
+
+function normalizeJobId(value: unknown): bigint {
+  if (typeof value === "bigint") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return BigInt(Math.floor(value));
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim().replace(/^#/, "");
+    if (!trimmed) {
+      throw new Error("Job ID cannot be empty");
+    }
+    return BigInt(trimmed);
+  }
+  throw new Error("Missing jobId for dispute intent");
+}
+
+function parseDisputeParams(ics: ICSType): DisputeParams {
+  const jobId = normalizeJobId((ics.params as Record<string, unknown>).jobId);
+  const reasonRaw = (ics.params as Record<string, unknown>).reason ?? (ics.params as Record<string, unknown>).evidence;
+  if (!reasonRaw) {
+    throw new Error("Dispute intent requires reason or evidence");
+  }
+  const reason = typeof reasonRaw === "string" ? reasonRaw : JSON.stringify(reasonRaw);
+  return { jobId, reason };
+}
+
+export async function disputeDryRun(ics: ICSType): Promise<DryRunResult> {
+  const userId = requireUserId(ics.meta);
+  const params = parseDisputeParams(ics);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { jobRegistry } = loadContracts(signer);
+  const from = await signer.getAddress();
+
+  const tx = await jobRegistry.raiseDispute.populateTransaction(
+    params.jobId,
+    params.reason,
+    buildPolicyOverrides(ics.meta, { jobId: params.jobId })
+  );
+  tx.from = from;
+  const simulation = await simulateContractCall(signer, tx);
+
+  return buildDryRunResult(from, ics.meta?.txMode, [
+    {
+      label: "JobRegistry.raiseDispute",
+      to: (tx.to ?? (jobRegistry.target as string)) as string,
+      data: tx.data ?? "0x",
+      value: hexlify(tx.value ?? 0),
+      gasEstimate: hexlify(simulation.gasEstimate),
+      result: {
+        jobId: params.jobId.toString(),
+      },
+    },
+  ], {
+    jobId: params.jobId.toString(),
+    reason: params.reason,
+  });
+}
+
+export async function disputeExecute(ics: ICSType): Promise<ExecutionStepResult[]> {
+  const userId = requireUserId(ics.meta);
+  const params = parseDisputeParams(ics);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { jobRegistry } = loadContracts(signer);
+
+  const tx = await jobRegistry.raiseDispute(
+    params.jobId,
+    params.reason,
+    buildPolicyOverrides(ics.meta, { jobId: params.jobId })
+  );
+  const receipt = await tx.wait();
+
+  return [
+    {
+      label: "JobRegistry.raiseDispute",
+      txHash: tx.hash,
+      receipt,
+      metadata: {
+        jobId: params.jobId.toString(),
+        reason: params.reason,
+      },
+    },
+  ];
+}
 
 export async function* raise(ics: ICSType) {
-  const jobId = (ics.params as any)?.jobId;
-  const dispute = (ics.params as any)?.dispute ?? {};
-  if (!jobId) {
-    yield "Missing jobId.\n";
-    return;
+  try {
+    const dryRun = await disputeDryRun(ics);
+    yield renderDisputeDryRun(dryRun);
+    if (ics.confirm === false) {
+      yield "🧪 Dry-run completed. Set confirm=true to execute.\n";
+      return;
+    }
+    const [execution] = await disputeExecute(ics);
+    yield `⛓️ Tx submitted: ${execution.txHash}\n`;
+    yield `✅ Dispute submitted for job #${execution.metadata?.jobId ?? dryRun.metadata?.jobId}.\n`;
+  } catch (error: unknown) {
+    yield formatError(error);
   }
-  if (!dispute.reason) {
-    yield "Missing dispute reason.\n";
-    return;
-  }
+}
 
-  yield "⚖️ Raising dispute (stub).\n";
-  yield `✅ Dispute submitted for job #${jobId} (scaffolding stub).\n`;
+function renderDisputeDryRun(result: DryRunResult): string {
+  const lines: string[] = [];
+  lines.push(`🔍 Dispute dry-run (${result.txMode})\n`);
+  if (result.metadata?.jobId) {
+    lines.push(`• Job ID: ${result.metadata.jobId}\n`);
+  }
+  if (result.metadata?.reason) {
+    lines.push(`• Reason: ${result.metadata.reason}\n`);
+  }
+  const primary = result.calls[0];
+  if (primary?.gasEstimate) {
+    try {
+      const gas = BigInt(primary.gasEstimate);
+      lines.push(`• Estimated gas: ${gas.toString()}\n`);
+    } catch (error) {
+      console.warn("Failed to parse gas estimate", error);
+    }
+  }
+  return lines.join("");
 }

--- a/packages/orchestrator/src/tools/job.ts
+++ b/packages/orchestrator/src/tools/job.ts
@@ -7,46 +7,451 @@ import type {
 } from "../router.js";
 import { loadContracts } from "../chain/contracts.js";
 import { getSignerForUser } from "../chain/provider.js";
-import { formatError, pinToIpfs, toWei, buildPolicyOverrides } from "./common.js";
+import {
+  buildDryRunResult,
+  buildPolicyOverrides,
+  formatError,
+  hexlify,
+  pinToIpfs,
+  simulateContractCall,
+  toWei,
+  type DryRunResult,
+  type ExecutionStepResult,
+  type PreparedCallStep,
+} from "./common.js";
 import { policyManager } from "../policy/index.js";
+import { CONTRACT_ADDRESSES } from "../chain/addresses.js";
 
 const policy = policyManager();
 
-export async function* createJob(ics: CreateJobIntent) {
-  const userId = ics.meta?.userId;
-  if (!userId) {
-    yield "Missing meta.userId for signing.\n";
-    return;
+type PreparedCreateJobParams = {
+  rewardWei: bigint;
+  deadline: bigint;
+  specPayload: unknown;
+  specHash: string;
+  specUri: string;
+  overrides: Record<string, unknown>;
+  title?: string;
+};
+
+type FeeSettings = {
+  feePct?: bigint;
+  burnPct?: bigint;
+  validatorRewardPct?: bigint;
+};
+
+function requireUserId(meta?: { userId?: string | null }): string {
+  const candidate = meta?.userId?.trim();
+  if (!candidate) {
+    throw new Error("Missing meta.userId for signing.");
+  }
+  return candidate;
+}
+
+function isDeployed(address: string): boolean {
+  return address !== ethers.ZeroAddress;
+}
+
+async function safeReadBigInt(
+  contract: ethers.Contract,
+  fn: string
+): Promise<bigint | undefined> {
+  try {
+    const callable = contract.getFunction(fn);
+    const value = await callable.staticCall();
+    if (typeof value === "bigint") {
+      return value;
+    }
+    if (typeof value === "number") {
+      return BigInt(value);
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return undefined;
+      }
+      if (trimmed.startsWith("0x")) {
+        return BigInt(trimmed);
+      }
+      return BigInt(trimmed);
+    }
+    return undefined;
+  } catch (error) {
+    console.warn(`Failed to read ${fn} from contract`, error);
+    return undefined;
+  }
+}
+
+async function gatherFeeSettings(
+  jobRegistry: ethers.Contract,
+  stakeManager: ethers.Contract,
+  feePool: ethers.Contract
+): Promise<FeeSettings> {
+  const [registryFee, stakeBurn, stakeFee, registryValidator, feePoolBurn] = await Promise.all([
+    safeReadBigInt(jobRegistry, "feePct"),
+    isDeployed(CONTRACT_ADDRESSES.STAKE_MANAGER)
+      ? safeReadBigInt(stakeManager, "burnPct")
+      : Promise.resolve(undefined),
+    isDeployed(CONTRACT_ADDRESSES.STAKE_MANAGER)
+      ? safeReadBigInt(stakeManager, "feePct")
+      : Promise.resolve(undefined),
+    safeReadBigInt(jobRegistry, "validatorRewardPct"),
+    isDeployed(CONTRACT_ADDRESSES.FEE_POOL)
+      ? safeReadBigInt(feePool, "burnPct")
+      : Promise.resolve(undefined),
+  ]);
+
+  const burnPct = stakeBurn ?? feePoolBurn;
+
+  return {
+    feePct: registryFee ?? stakeFee,
+    burnPct: burnPct ?? undefined,
+    validatorRewardPct: registryValidator,
+  };
+}
+
+function serializeFeeSettings(settings: FeeSettings): Record<string, unknown> {
+  const entries: Record<string, unknown> = {};
+  if (settings.feePct !== undefined) {
+    entries.feePct = settings.feePct.toString();
+  }
+  if (settings.burnPct !== undefined) {
+    entries.burnPct = settings.burnPct.toString();
+  }
+  if (settings.validatorRewardPct !== undefined) {
+    entries.validatorRewardPct = settings.validatorRewardPct.toString();
+  }
+  return entries;
+}
+
+function buildCallStep(
+  label: string,
+  contract: ethers.Contract,
+  tx: ethers.TransactionRequest,
+  gasEstimate: bigint,
+  result?: unknown
+): PreparedCallStep {
+  return {
+    label,
+    to: (tx.to ?? (contract.target as string)) as string,
+    data: tx.data ?? "0x",
+    value: hexlify(tx.value ?? 0),
+    gasEstimate: hexlify(gasEstimate),
+    result,
+  };
+}
+
+async function prepareCreateJobParams(
+  ics: CreateJobIntent
+): Promise<PreparedCreateJobParams> {
+  const job = ics.params.job;
+  const rewardWei = toWei(job.rewardAGIA);
+  policy.validateJobCreationBudget(rewardWei);
+  const deadline = normalizeDeadline(job.deadline);
+  const specPayload = job.spec;
+  const serializedSpec = JSON.stringify(specPayload);
+  const specHash = ethers.id(serializedSpec);
+  const specUri = await pinToIpfs(specPayload);
+  const overrides = buildPolicyOverrides(ics.meta, { jobBudgetWei: rewardWei });
+  return {
+    rewardWei,
+    deadline,
+    specPayload,
+    specHash,
+    specUri,
+    overrides,
+    title: job.title,
+  };
+}
+
+export async function createJobDryRun(ics: CreateJobIntent): Promise<DryRunResult> {
+  const userId = requireUserId(ics.meta);
+  const prepared = await prepareCreateJobParams(ics);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { jobRegistry, stakeManager, feePool } = loadContracts(signer);
+
+  const tx = await jobRegistry.createJob.populateTransaction(
+    prepared.rewardWei,
+    prepared.deadline,
+    prepared.specHash,
+    prepared.specUri,
+    prepared.overrides
+  );
+  tx.from = await signer.getAddress();
+
+  const simulation = await simulateContractCall(signer, tx, (raw) => {
+    const decoded = jobRegistry.interface.decodeFunctionResult("createJob", raw);
+    return decoded[0];
+  });
+
+  const jobPreview = simulation.decoded !== undefined ? BigInt(simulation.decoded as bigint).toString() : undefined;
+  const call = buildCallStep(
+    "JobRegistry.createJob",
+    jobRegistry,
+    tx,
+    simulation.gasEstimate,
+    jobPreview ? { jobIdPreview: jobPreview } : undefined
+  );
+
+  const feeSettings = await gatherFeeSettings(jobRegistry, stakeManager, feePool);
+  const metadata: Record<string, unknown> = {
+    rewardWei: prepared.rewardWei.toString(),
+    rewardAGIA: ethers.formatEther(prepared.rewardWei),
+    deadline: prepared.deadline.toString(),
+    specHash: prepared.specHash,
+    specUri: prepared.specUri,
+    title: prepared.title,
+    ...serializeFeeSettings(feeSettings),
+  };
+
+  return buildDryRunResult(tx.from as string, ics.meta?.txMode, [call], metadata);
+}
+
+export async function createJobExecute(
+  ics: CreateJobIntent
+): Promise<ExecutionStepResult[]> {
+  const userId = requireUserId(ics.meta);
+  const prepared = await prepareCreateJobParams(ics);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { jobRegistry, stakeManager, feePool } = loadContracts(signer);
+
+  const tx = await jobRegistry.createJob(
+    prepared.rewardWei,
+    prepared.deadline,
+    prepared.specHash,
+    prepared.specUri,
+    prepared.overrides
+  );
+  const receipt = await tx.wait();
+  const jobId = extractJobId(jobRegistry, receipt);
+  if (jobId) {
+    policy.registerJobBudget(jobId, prepared.rewardWei);
   }
 
-  try {
-    const job = ics.params.job;
-    const reward = toWei(job.rewardAGIA);
-    policy.validateJobCreationBudget(reward);
-    const deadline = normalizeDeadline(job.deadline);
-    yield "📦 Packaging job spec…\n";
-    const specPayload = job.spec;
-    const serializedSpec = JSON.stringify(specPayload);
-    const specHash = ethers.id(serializedSpec);
-    const uri = await pinToIpfs(specPayload);
-    yield `📨 Spec pinned: ${uri}\n`;
-    yield `🧾 specHash: ${specHash}\n`;
+  const feeSettings = await gatherFeeSettings(jobRegistry, stakeManager, feePool);
+  const metadata: Record<string, unknown> = {
+    rewardWei: prepared.rewardWei.toString(),
+    rewardAGIA: ethers.formatEther(prepared.rewardWei),
+    deadline: prepared.deadline.toString(),
+    specHash: prepared.specHash,
+    specUri: prepared.specUri,
+    title: prepared.title,
+    jobId,
+    ...serializeFeeSettings(feeSettings),
+  };
 
-    const signer = await getSignerForUser(userId, ics.meta?.txMode);
-    const { jobRegistry } = loadContracts(signer);
-    const tx = await jobRegistry.createJob(
-      reward,
-      deadline,
-      specHash,
-      uri,
-      buildPolicyOverrides(ics.meta, { jobBudgetWei: reward })
-    );
-    yield `⛓️ Tx submitted: ${tx.hash}\n`;
-    const receipt = await tx.wait();
-    const jobId = extractJobId(jobRegistry, receipt);
-    if (jobId) {
-      policy.registerJobBudget(jobId, reward);
+  return [
+    {
+      label: "JobRegistry.createJob",
+      txHash: tx.hash,
+      receipt,
+      metadata,
+    },
+  ];
+}
+
+export async function applyJobDryRun(ics: ApplyJobIntent): Promise<DryRunResult> {
+  const userId = requireUserId(ics.meta);
+  const jobId = normalizeJobId(ics.params.jobId);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { jobRegistry, stakeManager, feePool } = loadContracts(signer);
+  const proof = ics.params.ens.proof ?? [];
+
+  const tx = await jobRegistry.applyForJob.populateTransaction(
+    jobId,
+    ics.params.ens.subdomain,
+    proof,
+    buildPolicyOverrides(ics.meta, { jobId })
+  );
+  tx.from = await signer.getAddress();
+
+  const simulation = await simulateContractCall(signer, tx);
+  const call = buildCallStep("JobRegistry.applyForJob", jobRegistry, tx, simulation.gasEstimate, {
+    jobId: jobId.toString(),
+    subdomain: ics.params.ens.subdomain,
+  });
+
+  const feeSettings = await gatherFeeSettings(jobRegistry, stakeManager, feePool);
+  const metadata: Record<string, unknown> = {
+    jobId: jobId.toString(),
+    subdomain: ics.params.ens.subdomain,
+    ...serializeFeeSettings(feeSettings),
+  };
+
+  return buildDryRunResult(tx.from as string, ics.meta?.txMode, [call], metadata);
+}
+
+export async function applyJobExecute(
+  ics: ApplyJobIntent
+): Promise<ExecutionStepResult[]> {
+  const userId = requireUserId(ics.meta);
+  const jobId = normalizeJobId(ics.params.jobId);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { jobRegistry, stakeManager, feePool } = loadContracts(signer);
+  const proof = ics.params.ens.proof ?? [];
+
+  const tx = await jobRegistry.applyForJob(
+    jobId,
+    ics.params.ens.subdomain,
+    proof,
+    buildPolicyOverrides(ics.meta, { jobId })
+  );
+  const receipt = await tx.wait();
+  const feeSettings = await gatherFeeSettings(jobRegistry, stakeManager, feePool);
+
+  return [
+    {
+      label: "JobRegistry.applyForJob",
+      txHash: tx.hash,
+      receipt,
+      metadata: {
+        jobId: jobId.toString(),
+        subdomain: ics.params.ens.subdomain,
+        ...serializeFeeSettings(feeSettings),
+      },
+    },
+  ];
+}
+
+export async function submitWorkDryRun(ics: SubmitWorkIntent): Promise<DryRunResult> {
+  const userId = requireUserId(ics.meta);
+  const prepared = await prepareSubmitWorkParams(ics);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { jobRegistry, stakeManager, feePool } = loadContracts(signer);
+
+  const tx = await jobRegistry.submit.populateTransaction(
+    prepared.jobId,
+    prepared.resultHash,
+    prepared.resultUri,
+    prepared.subdomain,
+    prepared.proof,
+    buildPolicyOverrides(ics.meta, { jobId: prepared.jobId })
+  );
+  tx.from = await signer.getAddress();
+
+  const simulation = await simulateContractCall(signer, tx);
+  const call = buildCallStep("JobRegistry.submit", jobRegistry, tx, simulation.gasEstimate, {
+    jobId: prepared.jobId.toString(),
+    resultUri: prepared.resultUri,
+  });
+
+  const feeSettings = await gatherFeeSettings(jobRegistry, stakeManager, feePool);
+  const metadata: Record<string, unknown> = {
+    jobId: prepared.jobId.toString(),
+    resultHash: prepared.resultHash,
+    resultUri: prepared.resultUri,
+    subdomain: prepared.subdomain,
+    ...serializeFeeSettings(feeSettings),
+  };
+
+  return buildDryRunResult(tx.from as string, ics.meta?.txMode, [call], metadata);
+}
+
+export async function submitWorkExecute(
+  ics: SubmitWorkIntent
+): Promise<ExecutionStepResult[]> {
+  const userId = requireUserId(ics.meta);
+  const prepared = await prepareSubmitWorkParams(ics);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { jobRegistry, stakeManager, feePool } = loadContracts(signer);
+
+  const tx = await jobRegistry.submit(
+    prepared.jobId,
+    prepared.resultHash,
+    prepared.resultUri,
+    prepared.subdomain,
+    prepared.proof,
+    buildPolicyOverrides(ics.meta, { jobId: prepared.jobId })
+  );
+  const receipt = await tx.wait();
+  const feeSettings = await gatherFeeSettings(jobRegistry, stakeManager, feePool);
+
+  return [
+    {
+      label: "JobRegistry.submit",
+      txHash: tx.hash,
+      receipt,
+      metadata: {
+        jobId: prepared.jobId.toString(),
+        resultHash: prepared.resultHash,
+        resultUri: prepared.resultUri,
+        subdomain: prepared.subdomain,
+        ...serializeFeeSettings(feeSettings),
+      },
+    },
+  ];
+}
+
+export async function finalizeDryRun(ics: FinalizeIntent): Promise<DryRunResult> {
+  const userId = requireUserId(ics.meta);
+  const jobId = normalizeJobId(ics.params.jobId);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { jobRegistry, stakeManager, feePool } = loadContracts(signer);
+
+  const tx = await jobRegistry.finalizeAfterValidation.populateTransaction(
+    jobId,
+    ics.params.success,
+    buildPolicyOverrides(ics.meta, { jobId })
+  );
+  tx.from = await signer.getAddress();
+
+  const simulation = await simulateContractCall(signer, tx);
+  const call = buildCallStep("JobRegistry.finalizeAfterValidation", jobRegistry, tx, simulation.gasEstimate, {
+    jobId: jobId.toString(),
+    success: ics.params.success,
+  });
+
+  const feeSettings = await gatherFeeSettings(jobRegistry, stakeManager, feePool);
+  const metadata: Record<string, unknown> = {
+    jobId: jobId.toString(),
+    success: ics.params.success,
+    ...serializeFeeSettings(feeSettings),
+  };
+
+  return buildDryRunResult(tx.from as string, ics.meta?.txMode, [call], metadata);
+}
+
+export async function finalizeExecute(
+  ics: FinalizeIntent
+): Promise<ExecutionStepResult[]> {
+  const userId = requireUserId(ics.meta);
+  const jobId = normalizeJobId(ics.params.jobId);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { jobRegistry, stakeManager, feePool } = loadContracts(signer);
+
+  const tx = await jobRegistry.finalizeAfterValidation(
+    jobId,
+    ics.params.success,
+    buildPolicyOverrides(ics.meta, { jobId })
+  );
+  const receipt = await tx.wait();
+  const feeSettings = await gatherFeeSettings(jobRegistry, stakeManager, feePool);
+
+  return [
+    {
+      label: "JobRegistry.finalizeAfterValidation",
+      txHash: tx.hash,
+      receipt,
+      metadata: {
+        jobId: jobId.toString(),
+        success: ics.params.success,
+        ...serializeFeeSettings(feeSettings),
+      },
+    },
+  ];
+}
+
+export async function* createJob(ics: CreateJobIntent) {
+  try {
+    const dryRun = await createJobDryRun(ics);
+    yield renderDryRunSummary("Create job", dryRun);
+    if (ics.confirm === false) {
+      yield "🧪 Dry-run completed. Set confirm=true to execute.\n";
+      return;
     }
+    const [execution] = await createJobExecute(ics);
+    const jobId = execution.metadata?.jobId as string | undefined;
+    yield `⛓️ Tx submitted: ${execution.txHash}\n`;
     yield `✅ Job posted${jobId ? ` with ID ${jobId}` : ""}.\n`;
   } catch (error: unknown) {
     yield formatError(error);
@@ -54,100 +459,85 @@ export async function* createJob(ics: CreateJobIntent) {
 }
 
 export async function* applyJob(ics: ApplyJobIntent) {
-  const userId = ics.meta?.userId;
-  if (!userId) {
-    yield "Missing meta.userId for signing.\n";
-    return;
-  }
-
   try {
-    const jobId = normalizeJobId(ics.params.jobId);
-    const signer = await getSignerForUser(userId, ics.meta?.txMode);
-    const { jobRegistry } = loadContracts(signer);
-    const proof = ics.params.ens.proof ?? [];
-    const tx = await jobRegistry.applyForJob(
-      jobId,
-      ics.params.ens.subdomain,
-      proof,
-      buildPolicyOverrides(ics.meta, { jobId })
-    );
-    yield `⛓️ Tx submitted: ${tx.hash}\n`;
-    await tx.wait();
-    yield `✅ Application submitted for job #${jobId.toString()}.\n`;
+    const dryRun = await applyJobDryRun(ics);
+    yield renderDryRunSummary("Apply for job", dryRun);
+    if (ics.confirm === false) {
+      yield "🧪 Dry-run completed. Set confirm=true to execute.\n";
+      return;
+    }
+    const [execution] = await applyJobExecute(ics);
+    yield `⛓️ Tx submitted: ${execution.txHash}\n`;
+    yield `✅ Application submitted for job #${execution.metadata?.jobId ?? "?"}.\n`;
   } catch (error: unknown) {
     yield formatError(error);
   }
 }
 
 export async function* submitWork(ics: SubmitWorkIntent) {
-  const userId = ics.meta?.userId;
-  if (!userId) {
-    yield "Missing meta.userId for signing.\n";
-    return;
-  }
-
   try {
-    const { jobId: rawJobId, result, ens } = ics.params;
-    const jobId = normalizeJobId(rawJobId);
-
-    let resultURI = result.uri;
-    let hashSource: string | undefined;
-    if (result.payload !== undefined) {
-      yield "📦 Uploading result payload…\n";
-      resultURI = await pinToIpfs(result.payload);
-      hashSource = JSON.stringify(result.payload);
-      yield `📡 Result pinned at ${resultURI}.\n`;
-    } else if (resultURI) {
-      hashSource = resultURI;
-    }
-
-    if (!resultURI) {
-      yield "Missing result URI.\n";
+    const dryRun = await submitWorkDryRun(ics);
+    yield renderDryRunSummary("Submit work", dryRun);
+    if (ics.confirm === false) {
+      yield "🧪 Dry-run completed. Set confirm=true to execute.\n";
       return;
     }
-
-    const resultHash = result.hash ?? ethers.id(hashSource ?? resultURI);
-    const signer = await getSignerForUser(userId, ics.meta?.txMode);
-    const { jobRegistry } = loadContracts(signer);
-    const proof = ens.proof ?? [];
-    const tx = await jobRegistry.submit(
-      jobId,
-      resultHash,
-      resultURI,
-      ens.subdomain,
-      proof,
-      buildPolicyOverrides(ics.meta, { jobId })
-    );
-    yield `⛓️ Tx submitted: ${tx.hash}\n`;
-    await tx.wait();
-    yield `✅ Submission broadcast for job #${jobId.toString()}.\n`;
+    const [execution] = await submitWorkExecute(ics);
+    yield `⛓️ Tx submitted: ${execution.txHash}\n`;
+    yield `✅ Submission broadcast for job #${execution.metadata?.jobId ?? "?"}.\n`;
   } catch (error: unknown) {
     yield formatError(error);
   }
 }
 
 export async function* finalize(ics: FinalizeIntent) {
-  const userId = ics.meta?.userId;
-  if (!userId) {
-    yield "Missing meta.userId for signing.\n";
-    return;
-  }
-
   try {
-    const jobId = normalizeJobId(ics.params.jobId);
-    const signer = await getSignerForUser(userId, ics.meta?.txMode);
-    const { jobRegistry } = loadContracts(signer);
-    const tx = await jobRegistry.finalizeAfterValidation(
-      jobId,
-      ics.params.success,
-      buildPolicyOverrides(ics.meta, { jobId })
-    );
-    yield `⛓️ Tx submitted: ${tx.hash}\n`;
-    await tx.wait();
-    yield `✅ Job #${jobId.toString()} finalized.\n`;
+    const dryRun = await finalizeDryRun(ics);
+    yield renderDryRunSummary("Finalize job", dryRun);
+    if (ics.confirm === false) {
+      yield "🧪 Dry-run completed. Set confirm=true to execute.\n";
+      return;
+    }
+    const [execution] = await finalizeExecute(ics);
+    yield `⛓️ Tx submitted: ${execution.txHash}\n`;
+    yield `✅ Job #${execution.metadata?.jobId ?? "?"} finalized.\n`;
   } catch (error: unknown) {
     yield formatError(error);
   }
+}
+
+function renderDryRunSummary(title: string, result: DryRunResult): string {
+  const lines: string[] = [];
+  lines.push(`🔍 ${title} dry-run (${result.txMode})\n`);
+  const primary = result.calls[0];
+  if (primary?.gasEstimate) {
+    try {
+      const gas = BigInt(primary.gasEstimate);
+      lines.push(`• Estimated gas: ${gas.toString()}\n`);
+    } catch (error) {
+      console.warn("Failed to parse gas estimate", error);
+    }
+  }
+  const metadata = result.metadata ?? {};
+  if (metadata.rewardAGIA) {
+    lines.push(`• Reward: ${metadata.rewardAGIA} AGIA\n`);
+  }
+  if (metadata.feePct !== undefined) {
+    lines.push(`• Fee pct: ${metadata.feePct}%\n`);
+  }
+  if (metadata.burnPct !== undefined) {
+    lines.push(`• Burn pct: ${metadata.burnPct}%\n`);
+  }
+  if (metadata.specUri) {
+    lines.push(`• Spec URI: ${metadata.specUri}\n`);
+  }
+  if (metadata.jobId) {
+    lines.push(`• Job ID: ${metadata.jobId}\n`);
+  }
+  if (metadata.subdomain) {
+    lines.push(`• ENS subdomain: ${metadata.subdomain}\n`);
+  }
+  return lines.join("");
 }
 
 function normalizeDeadline(input: CreateJobIntent["params"]["job"]["deadline"]): bigint {
@@ -165,7 +555,7 @@ function normalizeDeadline(input: CreateJobIntent["params"]["job"]["deadline"]):
     if (!trimmed) {
       throw new Error("Deadline string cannot be empty");
     }
-    if (/^\d+$/.test(trimmed)) {
+    if (/^\d+$/u.test(trimmed)) {
       return BigInt(trimmed);
     }
     const parsed = Date.parse(trimmed);
@@ -191,6 +581,31 @@ function normalizeJobId(jobId: SubmitWorkIntent["params"]["jobId"]): bigint {
   return BigInt(trimmed);
 }
 
+async function prepareSubmitWorkParams(ics: SubmitWorkIntent) {
+  const jobId = normalizeJobId(ics.params.jobId);
+  const { result, ens } = ics.params;
+  let resultURI = result.uri;
+  let hashSource: string | undefined;
+  if (result.payload !== undefined) {
+    resultURI = await pinToIpfs(result.payload);
+    hashSource = JSON.stringify(result.payload);
+  } else if (resultURI) {
+    hashSource = resultURI;
+  }
+  if (!resultURI) {
+    throw new Error("Missing result URI.");
+  }
+  const resultHash = result.hash ?? ethers.id(hashSource ?? resultURI);
+  const proof = ens.proof ?? [];
+  return {
+    jobId,
+    resultUri: resultURI,
+    resultHash,
+    subdomain: ens.subdomain,
+    proof,
+  };
+}
+
 function extractJobId(contract: ethers.Contract, receipt: ethers.TransactionReceipt) {
   for (const log of receipt.logs ?? []) {
     try {
@@ -210,4 +625,3 @@ function extractJobId(contract: ethers.Contract, receipt: ethers.TransactionRece
   }
   return undefined;
 }
-

--- a/packages/orchestrator/src/tools/stake.ts
+++ b/packages/orchestrator/src/tools/stake.ts
@@ -1,70 +1,25 @@
+import { ethers } from "ethers";
 import type { StakeIntent, WithdrawIntent } from "../router.js";
 import { loadContracts } from "../chain/contracts.js";
 import { getSignerForUser } from "../chain/provider.js";
-import { formatError, toWei, buildPolicyOverrides } from "./common.js";
+import {
+  buildDryRunResult,
+  buildPolicyOverrides,
+  formatError,
+  hexlify,
+  simulateContractCall,
+  toWei,
+  type DryRunResult,
+  type ExecutionStepResult,
+  type PreparedCallStep,
+} from "./common.js";
 
-export async function* deposit(ics: StakeIntent) {
-  const userId = ics.meta?.userId;
-  if (!userId) {
-    yield "Missing meta.userId for signing.\n";
-    return;
+function requireUserId(meta?: { userId?: string | null }): string {
+  const candidate = meta?.userId?.trim();
+  if (!candidate) {
+    throw new Error("Missing meta.userId for signing.");
   }
-
-  try {
-    const { amountAGIA, role } = ics.params.stake;
-    const normalized = normalizeRole(role);
-    const amountWei = toWei(amountAGIA);
-    const signer = await getSignerForUser(userId, ics.meta?.txMode);
-    const { erc20, stakeManager } = loadContracts(signer);
-    const owner = await signer.getAddress();
-    const spender = stakeManager.target as string;
-    const allowance = await erc20.allowance(owner, spender);
-    if (allowance < amountWei) {
-      const approveTx = await erc20.approve(
-        spender,
-        amountWei,
-        buildPolicyOverrides(ics.meta)
-      );
-      yield `🪙 Approving ${spender} to spend ${amountAGIA} AGIALPHA…\n`;
-      await approveTx.wait();
-    }
-    const tx = await stakeManager.depositStake(
-      normalized.index,
-      amountWei,
-      buildPolicyOverrides(ics.meta)
-    );
-    yield `⛓️ Tx submitted: ${tx.hash}\n`;
-    await tx.wait();
-    yield `✅ Deposited ${amountAGIA} AGIALPHA for ${normalized.label} staking.\n`;
-  } catch (error: unknown) {
-    yield formatError(error);
-  }
-}
-
-export async function* withdraw(ics: WithdrawIntent) {
-  const userId = ics.meta?.userId;
-  if (!userId) {
-    yield "Missing meta.userId for signing.\n";
-    return;
-  }
-
-  try {
-    const { amountAGIA, role } = ics.params.stake;
-    const normalized = normalizeRole(role);
-    const amountWei = toWei(amountAGIA);
-    const signer = await getSignerForUser(userId, ics.meta?.txMode);
-    const { stakeManager } = loadContracts(signer);
-    const tx = await stakeManager.withdrawStake(
-      normalized.index,
-      amountWei,
-      buildPolicyOverrides(ics.meta)
-    );
-    yield `⛓️ Tx submitted: ${tx.hash}\n`;
-    await tx.wait();
-    yield `✅ Withdrawn ${amountAGIA} AGIALPHA from ${normalized.label} stake.\n`;
-  } catch (error: unknown) {
-    yield formatError(error);
-  }
+  return candidate;
 }
 
 function normalizeRole(role: string) {
@@ -79,4 +34,238 @@ function normalizeRole(role: string) {
     default:
       throw new Error(`Unsupported staking role: ${role}`);
   }
+}
+
+function buildCall(label: string, tx: ethers.TransactionRequest, gasEstimate: bigint, extra?: Record<string, unknown>): PreparedCallStep {
+  return {
+    label,
+    to: (tx.to ?? ethers.ZeroAddress) as string,
+    data: tx.data ?? "0x",
+    value: hexlify(tx.value ?? 0),
+    gasEstimate: hexlify(gasEstimate),
+    result: extra,
+  };
+}
+
+export async function depositDryRun(ics: StakeIntent): Promise<DryRunResult> {
+  const userId = requireUserId(ics.meta);
+  const normalizedRole = normalizeRole(ics.params.stake.role);
+  const amountWei = toWei(ics.params.stake.amountAGIA);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { erc20, stakeManager } = loadContracts(signer);
+
+  const owner = await signer.getAddress();
+  const spender = stakeManager.target as string;
+  const allowance = await erc20.allowance(owner, spender);
+
+  const calls: PreparedCallStep[] = [];
+  let approvalNeeded = allowance < amountWei;
+  if (approvalNeeded) {
+    const approveTx = await erc20.approve.populateTransaction(
+      spender,
+      amountWei,
+      buildPolicyOverrides(ics.meta)
+    );
+    approveTx.from = owner;
+    const approvalSimulation = await simulateContractCall(signer, approveTx);
+    calls.push(
+      buildCall("ERC20.approve", approveTx, approvalSimulation.gasEstimate, {
+        spender,
+        amountWei: amountWei.toString(),
+      })
+    );
+  }
+
+  const depositTx = await stakeManager.depositStake.populateTransaction(
+    normalizedRole.index,
+    amountWei,
+    buildPolicyOverrides(ics.meta)
+  );
+  depositTx.from = owner;
+  const depositSimulation = await simulateContractCall(signer, depositTx);
+  calls.push(
+    buildCall("StakeManager.depositStake", depositTx, depositSimulation.gasEstimate, {
+      role: normalizedRole.label,
+      amountWei: amountWei.toString(),
+    })
+  );
+
+  const metadata: Record<string, unknown> = {
+    role: normalizedRole.label,
+    amountWei: amountWei.toString(),
+    amountAGIA: ethers.formatEther(amountWei),
+    approvalRequired: approvalNeeded,
+  };
+
+  return buildDryRunResult(owner, ics.meta?.txMode, calls, metadata);
+}
+
+export async function depositExecute(
+  ics: StakeIntent
+): Promise<ExecutionStepResult[]> {
+  const userId = requireUserId(ics.meta);
+  const normalizedRole = normalizeRole(ics.params.stake.role);
+  const amountWei = toWei(ics.params.stake.amountAGIA);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { erc20, stakeManager } = loadContracts(signer);
+  const owner = await signer.getAddress();
+  const spender = stakeManager.target as string;
+  const allowance = await erc20.allowance(owner, spender);
+
+  const results: ExecutionStepResult[] = [];
+  if (allowance < amountWei) {
+    const approveTx = await erc20.approve(
+      spender,
+      amountWei,
+      buildPolicyOverrides(ics.meta)
+    );
+    const approvalReceipt = await approveTx.wait();
+    results.push({
+      label: "ERC20.approve",
+      txHash: approveTx.hash,
+      receipt: approvalReceipt,
+      metadata: {
+        spender,
+        amountWei: amountWei.toString(),
+      },
+    });
+  }
+
+  const depositTx = await stakeManager.depositStake(
+    normalizedRole.index,
+    amountWei,
+    buildPolicyOverrides(ics.meta)
+  );
+  const depositReceipt = await depositTx.wait();
+  results.push({
+    label: "StakeManager.depositStake",
+    txHash: depositTx.hash,
+    receipt: depositReceipt,
+    metadata: {
+      role: normalizedRole.label,
+      amountWei: amountWei.toString(),
+      amountAGIA: ethers.formatEther(amountWei),
+    },
+  });
+
+  return results;
+}
+
+export async function withdrawDryRun(ics: WithdrawIntent): Promise<DryRunResult> {
+  const userId = requireUserId(ics.meta);
+  const normalizedRole = normalizeRole(ics.params.stake.role);
+  const amountWei = toWei(ics.params.stake.amountAGIA);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { stakeManager } = loadContracts(signer);
+  const owner = await signer.getAddress();
+
+  const tx = await stakeManager.withdrawStake.populateTransaction(
+    normalizedRole.index,
+    amountWei,
+    buildPolicyOverrides(ics.meta)
+  );
+  tx.from = owner;
+  const simulation = await simulateContractCall(signer, tx);
+  const call = buildCall("StakeManager.withdrawStake", tx, simulation.gasEstimate, {
+    role: normalizedRole.label,
+    amountWei: amountWei.toString(),
+  });
+
+  const metadata: Record<string, unknown> = {
+    role: normalizedRole.label,
+    amountWei: amountWei.toString(),
+    amountAGIA: ethers.formatEther(amountWei),
+  };
+
+  return buildDryRunResult(owner, ics.meta?.txMode, [call], metadata);
+}
+
+export async function withdrawExecute(
+  ics: WithdrawIntent
+): Promise<ExecutionStepResult[]> {
+  const userId = requireUserId(ics.meta);
+  const normalizedRole = normalizeRole(ics.params.stake.role);
+  const amountWei = toWei(ics.params.stake.amountAGIA);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { stakeManager } = loadContracts(signer);
+
+  const tx = await stakeManager.withdrawStake(
+    normalizedRole.index,
+    amountWei,
+    buildPolicyOverrides(ics.meta)
+  );
+  const receipt = await tx.wait();
+
+  return [
+    {
+      label: "StakeManager.withdrawStake",
+      txHash: tx.hash,
+      receipt,
+      metadata: {
+        role: normalizedRole.label,
+        amountWei: amountWei.toString(),
+        amountAGIA: ethers.formatEther(amountWei),
+      },
+    },
+  ];
+}
+
+export async function* deposit(ics: StakeIntent) {
+  try {
+    const dryRun = await depositDryRun(ics);
+    yield renderStakeDryRun("Deposit stake", dryRun);
+    if (ics.confirm === false) {
+      yield "🧪 Dry-run completed. Set confirm=true to execute.\n";
+      return;
+    }
+    const executions = await depositExecute(ics);
+    for (const step of executions) {
+      yield `⛓️ Tx submitted: ${step.txHash}\n`;
+    }
+    const last = executions[executions.length - 1];
+    yield `✅ Deposited ${last.metadata?.amountAGIA ?? ics.params.stake.amountAGIA} AGIALPHA for ${last.metadata?.role ?? "stake"}.\n`;
+  } catch (error: unknown) {
+    yield formatError(error);
+  }
+}
+
+export async function* withdraw(ics: WithdrawIntent) {
+  try {
+    const dryRun = await withdrawDryRun(ics);
+    yield renderStakeDryRun("Withdraw stake", dryRun);
+    if (ics.confirm === false) {
+      yield "🧪 Dry-run completed. Set confirm=true to execute.\n";
+      return;
+    }
+    const [execution] = await withdrawExecute(ics);
+    yield `⛓️ Tx submitted: ${execution.txHash}\n`;
+    yield `✅ Withdrawn ${execution.metadata?.amountAGIA ?? ics.params.stake.amountAGIA} AGIALPHA from ${execution.metadata?.role ?? "stake"}.\n`;
+  } catch (error: unknown) {
+    yield formatError(error);
+  }
+}
+
+function renderStakeDryRun(title: string, result: DryRunResult): string {
+  const lines: string[] = [];
+  lines.push(`🔍 ${title} dry-run (${result.txMode})\n`);
+  const metadata = result.metadata ?? {};
+  if (metadata.amountAGIA) {
+    lines.push(`• Amount: ${metadata.amountAGIA} AGIA\n`);
+  }
+  if (metadata.role) {
+    lines.push(`• Role: ${metadata.role}\n`);
+  }
+  if (metadata.approvalRequired) {
+    lines.push(`• Approval required before deposit\n`);
+  }
+  const primary = result.calls[0];
+  if (primary?.gasEstimate) {
+    try {
+      const gas = BigInt(primary.gasEstimate);
+      lines.push(`• Estimated gas (first step): ${gas.toString()}\n`);
+    } catch (error) {
+      console.warn("Failed to parse gas estimate", error);
+    }
+  }
+  return lines.join("");
 }

--- a/packages/orchestrator/src/tools/validation.ts
+++ b/packages/orchestrator/src/tools/validation.ts
@@ -1,18 +1,320 @@
+import { ethers } from "ethers";
 import type { ICSType } from "../router.js";
+import { loadContracts } from "../chain/contracts.js";
+import { getSignerForUser } from "../chain/provider.js";
+import {
+  buildDryRunResult,
+  buildPolicyOverrides,
+  formatError,
+  hexlify,
+  simulateContractCall,
+  type DryRunResult,
+  type ExecutionStepResult,
+  type PreparedCallStep,
+} from "./common.js";
+
+interface ValidationParams {
+  jobId: bigint;
+  commit?: {
+    hash: string;
+    subdomain: string;
+    proof: string[];
+  };
+  reveal?: {
+    approve: boolean;
+    burnTxHash: string;
+    salt: string;
+    subdomain: string;
+    proof: string[];
+  };
+  finalize?: {
+    force: boolean;
+  };
+}
+
+function requireUserId(meta?: { userId?: string | null }): string {
+  const candidate = meta?.userId?.trim();
+  if (!candidate) {
+    throw new Error("Missing meta.userId for signing.");
+  }
+  return candidate;
+}
+
+function normalizeJobId(value: unknown): bigint {
+  if (typeof value === "bigint") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return BigInt(Math.floor(value));
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim().replace(/^#/, "");
+    if (!trimmed) {
+      throw new Error("Job ID cannot be empty");
+    }
+    return BigInt(trimmed);
+  }
+  throw new Error("Missing jobId for validation intent");
+}
+
+function ensureBytes32(value: string | undefined, fallback = ethers.ZeroHash): string {
+  if (!value) {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  if (!/^0x[0-9a-fA-F]{64}$/u.test(trimmed)) {
+    throw new Error(`Invalid bytes32 value: ${value}`);
+  }
+  return trimmed;
+}
+
+function parseProof(value: unknown): string[] {
+  if (!value) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("Proof must be an array");
+  }
+  return value.map((entry) => ensureBytes32(String(entry)));
+}
+
+function parseValidationParams(ics: ICSType): ValidationParams {
+  const jobId = normalizeJobId((ics.params as Record<string, unknown>).jobId);
+  const params: ValidationParams = { jobId };
+  const rawCommit = (ics.params as Record<string, unknown>).commit as Record<string, unknown> | undefined;
+  if (rawCommit) {
+    if (!rawCommit.hash || !rawCommit.subdomain) {
+      throw new Error("Validation commit requires hash and subdomain");
+    }
+    params.commit = {
+      hash: ensureBytes32(String(rawCommit.hash)),
+      subdomain: String(rawCommit.subdomain),
+      proof: parseProof(rawCommit.proof),
+    };
+  }
+  const rawReveal = (ics.params as Record<string, unknown>).reveal as Record<string, unknown> | undefined;
+  if (rawReveal) {
+    if (rawReveal.approve === undefined || rawReveal.salt === undefined || rawReveal.subdomain === undefined) {
+      throw new Error("Validation reveal requires approve, salt, and subdomain");
+    }
+    params.reveal = {
+      approve: Boolean(rawReveal.approve),
+      burnTxHash: ensureBytes32(rawReveal.burnTxHash as string | undefined, ethers.ZeroHash),
+      salt: ensureBytes32(String(rawReveal.salt)),
+      subdomain: String(rawReveal.subdomain),
+      proof: parseProof(rawReveal.proof),
+    };
+  }
+  const rawFinalize = (ics.params as Record<string, unknown>).finalize as Record<string, unknown> | undefined;
+  if (rawFinalize) {
+    params.finalize = {
+      force: Boolean(rawFinalize.force),
+    };
+  }
+  if (!params.commit && !params.reveal && !params.finalize) {
+    throw new Error("Validation intent must include commit, reveal, or finalize step");
+  }
+  return params;
+}
+
+function buildCall(
+  label: string,
+  tx: ethers.TransactionRequest,
+  gasEstimate: bigint,
+  result?: Record<string, unknown>
+): PreparedCallStep {
+  return {
+    label,
+    to: (tx.to ?? ethers.ZeroAddress) as string,
+    data: tx.data ?? "0x",
+    value: hexlify(tx.value ?? 0),
+    gasEstimate: hexlify(gasEstimate),
+    result,
+  };
+}
+
+export async function validateDryRun(ics: ICSType): Promise<DryRunResult> {
+  const userId = requireUserId(ics.meta);
+  const params = parseValidationParams(ics);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { validationModule } = loadContracts(signer);
+  const from = await signer.getAddress();
+
+  const calls: PreparedCallStep[] = [];
+  const stages: string[] = [];
+
+  if (params.commit) {
+    const tx = await validationModule.commitVote.populateTransaction(
+      params.jobId,
+      params.commit.hash,
+      params.commit.subdomain,
+      params.commit.proof,
+      buildPolicyOverrides(ics.meta, { jobId: params.jobId })
+    );
+    tx.from = from;
+    const simulation = await simulateContractCall(signer, tx);
+    calls.push(
+      buildCall("ValidationModule.commitVote", tx, simulation.gasEstimate, {
+        stage: "commit",
+      })
+    );
+    stages.push("commit");
+  }
+
+  if (params.reveal) {
+    const tx = await validationModule.revealVote.populateTransaction(
+      params.jobId,
+      params.reveal.approve,
+      params.reveal.burnTxHash,
+      params.reveal.salt,
+      params.reveal.subdomain,
+      params.reveal.proof,
+      buildPolicyOverrides(ics.meta, { jobId: params.jobId })
+    );
+    tx.from = from;
+    const simulation = await simulateContractCall(signer, tx);
+    calls.push(
+      buildCall("ValidationModule.revealVote", tx, simulation.gasEstimate, {
+        stage: "reveal",
+        approve: params.reveal.approve,
+      })
+    );
+    stages.push("reveal");
+  }
+
+  if (params.finalize) {
+    const method = params.finalize.force ? "forceFinalize" : "finalize";
+    const fn = validationModule.getFunction(method);
+    const tx = await fn.populateTransaction(
+      params.jobId,
+      buildPolicyOverrides(ics.meta, { jobId: params.jobId })
+    );
+    tx.from = from;
+    const simulation = await simulateContractCall(signer, tx);
+    calls.push(
+      buildCall(`ValidationModule.${method}`, tx, simulation.gasEstimate, {
+        stage: params.finalize.force ? "forceFinalize" : "finalize",
+      })
+    );
+    stages.push(params.finalize.force ? "forceFinalize" : "finalize");
+  }
+
+  const metadata: Record<string, unknown> = {
+    jobId: params.jobId.toString(),
+    stages,
+  };
+
+  return buildDryRunResult(from, ics.meta?.txMode, calls, metadata);
+}
+
+export async function validateExecute(ics: ICSType): Promise<ExecutionStepResult[]> {
+  const userId = requireUserId(ics.meta);
+  const params = parseValidationParams(ics);
+  const signer = await getSignerForUser(userId, ics.meta?.txMode);
+  const { validationModule } = loadContracts(signer);
+
+  const results: ExecutionStepResult[] = [];
+
+  if (params.commit) {
+    const tx = await validationModule.commitVote(
+      params.jobId,
+      params.commit.hash,
+      params.commit.subdomain,
+      params.commit.proof,
+      buildPolicyOverrides(ics.meta, { jobId: params.jobId })
+    );
+    const receipt = await tx.wait();
+    results.push({
+      label: "ValidationModule.commitVote",
+      txHash: tx.hash,
+      receipt,
+      metadata: {
+        jobId: params.jobId.toString(),
+        stage: "commit",
+      },
+    });
+  }
+
+  if (params.reveal) {
+    const tx = await validationModule.revealVote(
+      params.jobId,
+      params.reveal.approve,
+      params.reveal.burnTxHash,
+      params.reveal.salt,
+      params.reveal.subdomain,
+      params.reveal.proof,
+      buildPolicyOverrides(ics.meta, { jobId: params.jobId })
+    );
+    const receipt = await tx.wait();
+    results.push({
+      label: "ValidationModule.revealVote",
+      txHash: tx.hash,
+      receipt,
+      metadata: {
+        jobId: params.jobId.toString(),
+        stage: "reveal",
+        approve: params.reveal.approve,
+      },
+    });
+  }
+
+  if (params.finalize) {
+    const method = params.finalize.force ? "forceFinalize" : "finalize";
+    const fn = validationModule.getFunction(method);
+    const tx = await fn(
+      params.jobId,
+      buildPolicyOverrides(ics.meta, { jobId: params.jobId })
+    );
+    const receipt = await tx.wait();
+    results.push({
+      label: `ValidationModule.${method}`,
+      txHash: tx.hash,
+      receipt,
+      metadata: {
+        jobId: params.jobId.toString(),
+        stage: params.finalize.force ? "forceFinalize" : "finalize",
+      },
+    });
+  }
+
+  return results;
+}
 
 export async function* commitReveal(ics: ICSType) {
-  const jobId = (ics.params as any)?.jobId;
-  const validation = (ics.params as any)?.validation ?? {};
-  if (!jobId) {
-    yield "Missing jobId.\n";
-    return;
+  try {
+    const dryRun = await validateDryRun(ics);
+    yield renderValidationDryRun(dryRun);
+    if (ics.confirm === false) {
+      yield "🧪 Dry-run completed. Set confirm=true to execute.\n";
+      return;
+    }
+    const executions = await validateExecute(ics);
+    for (const step of executions) {
+      yield `⛓️ Tx submitted: ${step.txHash}\n`;
+    }
+    yield `✅ Validation steps completed for job #${executions[executions.length - 1]?.metadata?.jobId ?? dryRun.metadata?.jobId}.\n`;
+  } catch (error: unknown) {
+    yield formatError(error);
   }
-  if (!validation.vote) {
-    yield "Missing validation vote.\n";
-    return;
-  }
+}
 
-  yield "🗳️ Committing validation vote (stub).\n";
-  yield "🔓 Revealing validation vote (stub).\n";
-  yield `✅ Validation recorded for job #${jobId} (scaffolding stub).\n`;
+function renderValidationDryRun(result: DryRunResult): string {
+  const lines: string[] = [];
+  lines.push(`🔍 Validation dry-run (${result.txMode})\n`);
+  if (result.metadata?.jobId) {
+    lines.push(`• Job ID: ${result.metadata.jobId}\n`);
+  }
+  if (Array.isArray(result.metadata?.stages)) {
+    lines.push(`• Stages: ${(result.metadata?.stages as string[]).join(", ")}\n`);
+  }
+  const primary = result.calls[0];
+  if (primary?.gasEstimate) {
+    try {
+      const gas = BigInt(primary.gasEstimate);
+      lines.push(`• Estimated gas (first step): ${gas.toString()}\n`);
+    } catch (error) {
+      console.warn("Failed to parse gas estimate", error);
+    }
+  }
+  return lines.join("");
 }


### PR DESCRIPTION
## Summary
- load contract addresses and ABIs from config/contracts.orchestrator.json and expose a metadata helper that honors environment overrides
- extend the common tool helpers with structured dry-run/execute result types and a reusable simulation wrapper
- implement dry-run plus execute flows for job, stake, validation, and dispute intents and re-export them for downstream orchestrators

## Testing
- npx tsc -p packages/orchestrator/tsconfig.json

------
https://chatgpt.com/codex/tasks/task_e_68d9e479d26483338b9297e1209e2987