### PR TITLE
Validate reward conversion in onebox execute

### DIFF
--- a/routes/onebox.py
+++ b/routes/onebox.py
@@ -731,7 +731,10 @@ def _get_fee_policy() -> Tuple[Decimal, Decimal]:
 
 
 def _to_wei(amount: str) -> int:
-    return int(Decimal(amount) * Decimal(10**AGIALPHA_DECIMALS))
+    value = Decimal(amount)
+    if value <= 0:
+        raise ValueError("amount must be positive")
+    return int(value * Decimal(10**AGIALPHA_DECIMALS))
 
 
 def _format_reward(value: int) -> str:
@@ -2151,7 +2154,10 @@ async def execute(request: Request, req: ExecuteRequest):
             if payload.deadlineDays is None:
                 raise _http_error(400, "DEADLINE_INVALID")
 
-            reward_wei = _to_wei(str(payload.reward))
+            try:
+                reward_wei = _to_wei(str(payload.reward))
+            except (InvalidOperation, ValueError, TypeError) as exc:
+                raise _http_error(400, "REWARD_INVALID") from exc
             deadline_days = int(payload.deadlineDays)
             org_identifier = _resolve_org_identifier(intent)
             try:


### PR DESCRIPTION
## Summary
- guard reward conversion in /onebox/execute so malformed rewards return REWARD_INVALID
- reject non-positive rewards during wei conversion to prevent bypassing validation
- add a POST /onebox/execute test that verifies the new REWARD_INVALID response for non-numeric rewards

## Testing
- pytest test/routes/test_onebox.py -k non_numeric_reward

------
https://chatgpt.com/codex/tasks/task_e_68da97bd0bdc8333ada605de67fa4a0c