### PR TITLE
Ensure OrgPolicyStore loads defaults without config file

### DIFF
--- a/test/routes/test_org_policy_store_load.py
+++ b/test/routes/test_org_policy_store_load.py
@@ -41,3 +41,17 @@ def test_load_respects_overrides_from_file(temp_policy_file):
     record = store._policies["acme"]
     assert record.max_budget_wei == 3 * 10**18
     assert record.max_duration_days == 4
+
+
+def test_load_without_file_uses_defaults(tmp_path):
+    policy_path = tmp_path / "missing.json"
+
+    store = OrgPolicyStore(
+        policy_path=str(policy_path),
+        default_max_budget_wei=5 * 10**17,
+        default_max_duration_days=3,
+    )
+
+    record = store._policies["__default__"]
+    assert record.max_budget_wei == 5 * 10**17
+    assert record.max_duration_days == 3


### PR DESCRIPTION
## Summary
- populate the default policy record when no persisted configuration exists
- add coverage to confirm OrgPolicyStore returns the provided defaults when the policy file is absent
- add a compatibility shim for importing `geth_poa_middleware` from newer web3 versions

## Testing
- `pytest test/routes/test_org_policy_store_load.py`


------
https://chatgpt.com/codex/tasks/task_e_68daab9d256c83338a047a13c989d88e