### PR TITLE
Fix org policy store default fallbacks

### DIFF
--- a/routes/onebox.py
+++ b/routes/onebox.py
@@ -486,6 +486,9 @@ class OrgPolicyStore:
                     "maxBudgetWei": self._default_max_budget_wei,
                     "maxDurationDays": self._default_max_duration_days,
                 }
+        default_budget = self._default_max_budget_wei
+        default_duration = self._default_max_duration_days
+
         for key, value in data.items():
             if not isinstance(value, dict):
                 logging.warning("Invalid policy entry for %s: expected dict, got %r", key, value)
@@ -495,33 +498,33 @@ class OrgPolicyStore:
 
             stored_budget = value.get("maxBudgetWei")
             if stored_budget is None or stored_budget == "":
-                record.max_budget_wei = self._default_max_budget_wei
+                record.max_budget_wei = default_budget
             elif isinstance(stored_budget, str):
                 try:
                     record.max_budget_wei = int(stored_budget)
                 except ValueError:
                     logging.warning("Invalid maxBudgetWei for %s: %r", key, stored_budget)
-                    record.max_budget_wei = self._default_max_budget_wei
+                    record.max_budget_wei = default_budget
             elif isinstance(stored_budget, (int, float)):
                 record.max_budget_wei = int(stored_budget)
             else:
                 logging.warning("Unsupported maxBudgetWei type for %s: %r", key, type(stored_budget))
-                record.max_budget_wei = self._default_max_budget_wei
+                record.max_budget_wei = default_budget
 
             stored_duration = value.get("maxDurationDays")
             if stored_duration is None or stored_duration == "":
-                record.max_duration_days = self._default_max_duration_days
+                record.max_duration_days = default_duration
             elif isinstance(stored_duration, (int, float, str)):
                 try:
                     record.max_duration_days = int(stored_duration)
                 except (TypeError, ValueError):
                     logging.warning("Invalid maxDurationDays for %s: %r", key, stored_duration)
-                    record.max_duration_days = self._default_max_duration_days
+                    record.max_duration_days = default_duration
             else:
                 logging.warning(
                     "Unsupported maxDurationDays type for %s: %r", key, type(stored_duration)
                 )
-                record.max_duration_days = self._default_max_duration_days
+                record.max_duration_days = default_duration
 
             self._policies[key] = record
 

--- a/test/routes/test_org_policy_store_load.py
+++ b/test/routes/test_org_policy_store_load.py
@@ -43,6 +43,16 @@ def test_load_respects_overrides_from_file(temp_policy_file):
     assert record.max_duration_days == 4
 
 
+def test_load_with_missing_values_and_no_defaults(temp_policy_file):
+    temp_policy_file.write_text(json.dumps({"acme": {}}))
+
+    store = OrgPolicyStore(policy_path=str(temp_policy_file))
+
+    record = store._policies["acme"]
+    assert record.max_budget_wei is None
+    assert record.max_duration_days is None
+
+
 def test_load_without_file_uses_defaults(tmp_path):
     policy_path = tmp_path / "missing.json"
 


### PR DESCRIPTION
## Summary
- ensure OrgPolicyStore uses its configured defaults when normalizing stored policy values
- add a regression test covering initialization with missing record fields and no configured defaults

## Testing
- pytest test/routes/test_org_policy_store_load.py

------
https://chatgpt.com/codex/tasks/task_e_68dab3b790b88333984b7ed1e42e1529