### PR TITLE
Expose fee projections in onebox simulate responses

### DIFF
--- a/apps/onebox/app.js
+++ b/apps/onebox/app.js
@@ -29,7 +29,28 @@ const COPY = {
   simulating: 'Running safety checks and estimating budget…',
   simulationPreview: (sim) => {
     const risks = sim.risks && sim.risks.length ? `<br><strong>Risks:</strong> ${sim.risks.join(', ')}` : '';
-    return `Est. budget <strong>${sim.est_budget} AGIALPHA</strong> (fees ${sim.est_fees}).${
+    const budget = sim.estimatedBudget ? `${sim.estimatedBudget} AGIALPHA` : '—';
+    const feeSegments = [];
+    if (sim.feeAmount) {
+      feeSegments.push(
+        `protocol fee ${sim.feeAmount} AGIALPHA${
+          sim.feePct !== undefined && sim.feePct !== null ? ` (${sim.feePct}%)` : ''
+        }`
+      );
+    } else if (sim.feePct !== undefined && sim.feePct !== null) {
+      feeSegments.push(`protocol fee ${sim.feePct}%`);
+    }
+    if (sim.burnAmount) {
+      feeSegments.push(
+        `burn ${sim.burnAmount} AGIALPHA${
+          sim.burnPct !== undefined && sim.burnPct !== null ? ` (${sim.burnPct}%)` : ''
+        }`
+      );
+    } else if (sim.burnPct !== undefined && sim.burnPct !== null) {
+      feeSegments.push(`burn ${sim.burnPct}%`);
+    }
+    const feeSummary = feeSegments.length ? ` Fee projections: ${feeSegments.join('; ')}.` : '';
+    return `Est. budget <strong>${budget}</strong>.${feeSummary ? feeSummary : ''}${
       risks
     }<div class="pill-row pill-row-confirm"><button class="primary-btn" id="sim-approve" type="button">Proceed to execute</button><button class="ghost-btn" id="sim-cancel" type="button">Cancel</button></div>`;
   },

--- a/apps/onebox/src/components/ChatWindow.tsx
+++ b/apps/onebox/src/components/ChatWindow.tsx
@@ -108,10 +108,37 @@ const mapStatusToReceipt = (status: StatusResponse): ExecutionReceipt | null => 
 };
 
 const formatSimulationSummary = (simulation: SimulationResponse) => {
-  const lines = [
-    `Est. budget: ${simulation.est_budget} (fees ${simulation.est_fees}).`,
-    `Est. duration: ${simulation.est_duration} hour(s).`,
-  ];
+  const budgetParts: string[] = [`Est. budget: ${simulation.estimatedBudget ?? '—'}`];
+  const feeSegments: string[] = [];
+  if (simulation.feeAmount) {
+    feeSegments.push(
+      `protocol fee ${simulation.feeAmount} AGIALPHA${
+        simulation.feePct !== undefined && simulation.feePct !== null
+          ? ` (${simulation.feePct}%)`
+          : ''
+      }`
+    );
+  } else if (simulation.feePct !== undefined && simulation.feePct !== null) {
+    feeSegments.push(`protocol fee ${simulation.feePct}%`);
+  }
+  if (simulation.burnAmount) {
+    feeSegments.push(
+      `burn ${simulation.burnAmount} AGIALPHA${
+        simulation.burnPct !== undefined && simulation.burnPct !== null
+          ? ` (${simulation.burnPct}%)`
+          : ''
+      }`
+    );
+  } else if (simulation.burnPct !== undefined && simulation.burnPct !== null) {
+    feeSegments.push(`burn ${simulation.burnPct}%`);
+  }
+  if (feeSegments.length > 0) {
+    budgetParts.push(`Fee projections: ${feeSegments.join('; ')}`);
+  }
+  const lines = [`${budgetParts.join('. ')}.`];
+  if (typeof simulation.est_duration === 'number') {
+    lines.push(`Est. duration: ${simulation.est_duration} hour(s).`);
+  }
   if (simulation.risks.length > 0) {
     lines.push(`Risks: ${simulation.risks.join(', ')}.`);
   }

--- a/packages/onebox-sdk/src/types.ts
+++ b/packages/onebox-sdk/src/types.ts
@@ -61,9 +61,18 @@ export const PlanResponseSchema = z.object({
 });
 
 export const SimulationResponseSchema = z.object({
-  est_budget: z.string(),
-  est_fees: z.string(),
-  est_duration: z.number().int(),
+  summary: z.string().optional(),
+  intent: JobIntentSchema.optional(),
+  planHash: z.string().optional(),
+  createdAt: z.string().optional(),
+  estimatedBudget: z.string().optional(),
+  feePct: z.number().optional(),
+  feeAmount: z.string().optional(),
+  burnPct: z.number().optional(),
+  burnAmount: z.string().optional(),
+  est_budget: z.string().optional(),
+  est_fees: z.string().optional(),
+  est_duration: z.number().int().optional(),
   risks: z.array(z.string()).default([]),
   confirmations: z.array(z.string()).default([]),
   blockers: z.array(z.string()).default([]),
@@ -149,7 +158,12 @@ export function parsePlanResponse(value: unknown): PlanResponse {
 }
 
 export function parseSimulationResponse(value: unknown): SimulationResponse {
-  return SimulationResponseSchema.parse(value);
+  const parsed = SimulationResponseSchema.parse(value);
+  return {
+    ...parsed,
+    estimatedBudget: parsed.estimatedBudget ?? parsed.est_budget,
+    feeAmount: parsed.feeAmount ?? parsed.est_fees,
+  };
 }
 
 export function parseStatusResponse(value: unknown): StatusResponse {

--- a/test/routes/test_onebox.py
+++ b/test/routes/test_onebox.py
@@ -548,6 +548,11 @@ class SimulatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.blockers, [])
         self.assertTrue(response.planHash.startswith("0x"))
         self.assertIsNotNone(response.createdAt)
+        self.assertEqual(response.estimatedBudget, "5.15")
+        self.assertEqual(response.feePct, 2.0)
+        self.assertEqual(response.feeAmount, "0.1")
+        self.assertEqual(response.burnPct, 1.0)
+        self.assertEqual(response.burnAmount, "0.05")
 
     async def test_simulate_rejects_missing_plan_hash(self) -> None:
         intent = JobIntent(action="post_job", payload=Payload(title="Label data", reward="5", deadlineDays=7))
@@ -639,6 +644,11 @@ class SimulatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(exc.exception.status_code, 422)
         detail = exc.exception.detail
         self.assertIn("JOB_BUDGET_CAP_EXCEEDED", detail["blockers"])  # type: ignore[index]
+        self.assertEqual(detail["estimatedBudget"], "25.75")  # type: ignore[index]
+        self.assertEqual(detail["feePct"], 2.0)  # type: ignore[index]
+        self.assertEqual(detail["feeAmount"], "0.5")  # type: ignore[index]
+        self.assertEqual(detail["burnPct"], 1.0)  # type: ignore[index]
+        self.assertEqual(detail["burnAmount"], "0.25")  # type: ignore[index]
 
     async def test_simulate_rejects_runner_unsupported_actions(self) -> None:
         intent = JobIntent(action="stake", payload=Payload(jobId=123))


### PR DESCRIPTION
## Summary
- compute estimated budget plus fee and burn projections during /onebox/simulate, normalizing plan hashes and honoring org defaults
- surface the new projections in the Onebox web UI and chat summary while keeping the SDK schema aligned
- extend simulation unit tests to assert the new response fields

## Testing
- pytest test/routes/test_onebox.py::SimulatorTests::test_simulate_post_job_success
- pytest test/routes/test_onebox.py::SimulatorTests::test_simulate_policy_violation_returns_blocker

------
https://chatgpt.com/codex/tasks/task_e_68dae9a42ee0833399a4e3075921ce19