### PR TITLE
Add owner control mermaid dashboard generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 - [Owner control quick reference CLI](#owner-control-quick-reference-cli)
 - [Owner control handbook](#owner-control-handbook)
 - [Owner mission control](#owner-mission-control)
+- [Owner control visual guide](#owner-control-visual-guide)
 
 ### Identity policy
 
@@ -254,6 +255,26 @@ environment overrides (`OWNER_UPDATE_ALL_JSON`, `OWNER_VERIFY_JSON`,
 dry-runs, Safe reviews and production verification. The full playbook lives in
 [docs/owner-mission-control.md](docs/owner-mission-control.md) with journey maps,
 step tables and troubleshooting guidance.
+
+### Owner control visual guide
+
+Need a single command that renders an **owner authority map** for auditors or
+ops reviews? Run the visual generator to produce a ready-to-share Markdown
+report with Mermaid diagrams and a control matrix:
+
+```bash
+OWNER_MERMAID_OUTPUT=storage/owner-dashboards/<network>-$(date +%F).md \
+  npm run owner:diagram -- --network <network>
+```
+
+The helper powers the new [Owner Control Visual Guide](docs/owner-control-visual-guide.md),
+highlighting missing addresses, mismatched controllers, and pending ownership
+acceptances. Supply overrides via environment variables such as
+`OWNER_MERMAID_ADDRESS_OVERRIDES="stakeManager=0x..."` or
+`AGJ_STAKE_MANAGER_ADDRESS=0x...` so the contract owner retains full control without
+editing source files. Pair the generated diagram with
+`npm run owner:verify-control` to close the loop between visualization and
+transaction execution.
 
 ### Mainnet Deployment
 

--- a/docs/owner-control-visual-guide.md
+++ b/docs/owner-control-visual-guide.md
@@ -1,0 +1,132 @@
+# Owner Control Visual Guide
+
+This guide packages the **AGIJobs owner command surface** into a visual-first workflow
+that non-technical operators can run in a few minutes. It pairs a richly annotated
+Mermaid diagram with a tabular control matrix so the contract owner can instantly see
+which addresses hold authority, what needs attention, and which follow-up scripts to run.
+
+## Why this matters
+
+- **Production assurance** – Governance, owner, and pending controllers are surfaced in
+  a single place, making it obvious when a module is miswired or an ownership transfer is
+  still pending.
+- **Instant documentation** – Generate Markdown that drops directly into incident logs,
+  quarterly reports, or Confluence pages with zero manual formatting.
+- **Owner-first controls** – Address overrides, network selection, and pending owner
+  highlights ensure the contract owner can retune the system without editing source code.
+
+## Quick start (non-technical operator)
+
+1. Ensure you have the repository checked out and Hardhat configured with the target RPC.
+2. Run the diagram generator:
+
+   ```bash
+   npm run owner:diagram -- --network <network>
+   ```
+
+   Replace `<network>` with `mainnet`, `sepolia`, or any configured alias. The command
+   prints a Markdown report containing a Mermaid diagram and an ownership matrix.
+
+3. Paste the Markdown into any viewer that supports Mermaid (GitHub, Notion, VS Code,
+   Obsidian, GitBook, etc.).
+4. If any module shows a **Missing Address** or **Mismatch** status, follow the action
+   checklist below to remediate.
+
+> **Pro tip:** Store the rendered Markdown in `storage/owner-dashboards/` to create a
+> dated audit trail. Use `OWNER_MERMAID_OUTPUT=storage/owner-dashboards/<date>.md`
+> when invoking the script to automate this.
+
+## Diagram anatomy
+
+```mermaid
+%% Sample visualisation
+flowchart LR
+  classDef module fill:#eef2ff,stroke:#312e81,stroke-width:1px;
+  classDef owner fill:#ecfdf5,stroke:#065f46,stroke-width:1px;
+  classDef pending fill:#fff7ed,stroke:#b45309,stroke-width:1px;
+  classDef mismatch fill:#fee2e2,stroke:#b91c1c,stroke-width:1px;
+  classDef unknown fill:#f3f4f6,stroke:#6b7280,stroke-width:1px;
+
+  module_jobRegistry["Job Registry\n0xABCD…1234"]
+  class module_jobRegistry module;
+  owner_governance["Governor Safe\n0xDEAD…BEEF"]
+  class owner_governance owner;
+  pending_owner["Pending 0xFACE…CAFE"]
+  class pending_owner pending;
+
+  module_jobRegistry -->|expected| owner_governance
+  module_jobRegistry -.pending.-> pending_owner
+```
+
+- **Blue modules** – On-chain contracts the owner steers.
+- **Green controllers** – Addresses expected to own or govern modules.
+- **Orange pending nodes** – `Ownable2Step` transfers that still require `acceptOwnership()`
+  (or `acceptGovernance()` for governable contracts).
+- **Red outlines** – Mismatches between the expected controller and the on-chain controller.
+- **Grey nodes** – Missing configuration data; supply overrides to complete the picture.
+
+## Owner response checklist
+
+| Signal | What it means | Immediate action |
+| --- | --- | --- |
+| **Missing Address** | The system could not locate a deployed address for that module. | Supply an override via CLI/env, or update `docs/deployment-addresses.json`. |
+| **Mismatch** | The expected controller does not match the on-chain owner/governance. | Use `npm run owner:verify-control` to inspect the discrepancy, then run the appropriate rotation script (e.g. `npm run owner:rotate`). |
+| **Pending node present** | Ownership transfer initiated but not finalised. | Call `acceptOwnership()` / `acceptGovernance()` from the pending controller. |
+| **Warnings about missing controllers** | The global config lacks `owner`/`governance`. | Update `config/owner-control.json` and re-run the generator. |
+
+## Customising the output
+
+| Goal | Command | Notes |
+| --- | --- | --- |
+| Export Markdown to a file | `OWNER_MERMAID_OUTPUT=storage/owner-dashboards/$(date +%F).md npm run owner:diagram -- --network <network>` | Directory is auto-created. |
+| Generate Mermaid only | `OWNER_MERMAID_FORMAT=mermaid npm run owner:diagram -- --network <network>` | Ideal for embedding in dashboards. |
+| Supply ad-hoc addresses | `OWNER_MERMAID_ADDRESS_OVERRIDES="stakeManager=0x123...,jobRegistry=0x456..." npm run owner:diagram` | Highest priority source. |
+| Use environment overrides | `export AGJ_STAKE_MANAGER_ADDRESS=0x123...` | Takes precedence over config/address book. |
+| Load alternate config network | `OWNER_MERMAID_CONFIG_NETWORK=sepolia npm run owner:diagram` | Useful for cross-network comparisons. |
+| Suppress pending edges | `OWNER_MERMAID_INCLUDE_PENDING=0 npm run owner:diagram` | Focus on settled ownership only. |
+
+All overrides accept comma-separated lists. You can also set
+`OWNER_MERMAID_ADDRESS_OVERRIDES="stakeManager=0x...,jobRegistry=0x..."` for persistent
+CI/CD runs.
+
+## Action workflow for the contract owner
+
+```mermaid
+flowchart TD
+  subgraph Discover
+    A[Run owner diagram] --> B{Any warnings?}
+  end
+  B -- No --> H[Archive report]
+  B -- Yes --> subgraph Triaging
+    C[Identify affected modules]
+    D[Cross-check with owner:verify-control]
+    E[Decide fix: rotate / update config / accept pending]
+  end
+  E --> F[Execute remediation script]
+  F --> G[Confirm on-chain state]
+  G --> A
+```
+
+1. **Generate** – Run the diagram generator for the active network.
+2. **Diagnose** – If a module is highlighted, inspect it with `npm run owner:verify-control`.
+3. **Remediate** – Execute the targeted helper (`owner:rotate`, `owner:update-all`,
+   or `owner:mission-control`) to restore the expected controller.
+4. **Verify** – Re-run the diagram. Once all modules are green and pending edges vanish,
+   commit the Markdown report.
+
+## Embedding into governance reports
+
+- Add the generated Markdown to `docs/production/` or your internal wiki for auditors.
+- Store multiple snapshots per quarter to show governance continuity.
+- Combine with `npm run owner:dashboard -- --json` to keep machine-readable artefacts
+  alongside the visual summary.
+
+## Related playbooks
+
+- [Owner Control Handbook](owner-control-handbook.md) – Deep-dive operations for every module.
+- [Owner Mission Control](owner-mission-control.md) – Multi-module execution plans.
+- [Owner Control Surface](owner-control-surface.md) – Formal interface definitions.
+- [Verify Owner Control script](../scripts/v2/verifyOwnerControl.ts) – Low-level verification helper.
+
+By integrating the visual diagram into regular operations you ensure the platform owner
+always has authoritative insight—and control—over every deployed module.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "owner:guide": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlGuide.ts",
     "owner:wizard": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/owner-config-wizard.ts",
     "owner:dashboard": "npx hardhat run --no-compile scripts/v2/owner-dashboard.ts",
+    "owner:diagram": "npx hardhat run --no-compile scripts/v2/renderOwnerMermaid.ts",
     "owner:mission-control": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerMissionControl.ts",
     "owner:verify-control": "npx hardhat run --no-compile scripts/v2/verifyOwnerControl.ts",
     "owner:rotate": "npx hardhat run --no-compile scripts/v2/rotateGovernance.ts",

--- a/scripts/v2/renderOwnerMermaid.ts
+++ b/scripts/v2/renderOwnerMermaid.ts
@@ -1,0 +1,656 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { ethers, network } from 'hardhat';
+import {
+  loadOwnerControlConfig,
+  inferNetworkKey,
+} from '../config';
+import type {
+  OwnerControlConfigResult,
+  OwnerControlModuleConfig,
+  OwnerControlModuleType,
+} from '../config';
+
+const ADDRESS_BOOK_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'docs',
+  'deployment-addresses.json'
+);
+
+const DEFAULT_TITLE = 'AGIJobs Owner Control Map';
+
+const SUPPORTED_FORMATS = new Set(['markdown', 'mermaid'] as const);
+
+type OutputFormat = 'markdown' | 'mermaid';
+
+type CliOptions = {
+  format: OutputFormat;
+  outputPath?: string;
+  configNetwork?: string;
+  title?: string;
+  includePending: boolean;
+  addressOverrides: Record<string, string>;
+};
+
+type ModuleInsight = {
+  key: string;
+  label: string;
+  address: string | null;
+  type: OwnerControlModuleType;
+  expectedController?: string;
+  expectedSource?: string;
+  onChainController?: string | null;
+  pendingController?: string | null;
+  status: 'ok' | 'missing-address' | 'mismatch' | 'skipped';
+  notes: string[];
+};
+
+type AddressBook = Record<string, string>;
+
+type MermaidBuildResult = {
+  mermaid: string;
+  warnings: string[];
+};
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    format: 'markdown',
+    includePending: true,
+    addressOverrides: {},
+  };
+
+  const envFormat = process.env.OWNER_MERMAID_FORMAT?.trim().toLowerCase();
+  if (envFormat && SUPPORTED_FORMATS.has(envFormat as OutputFormat)) {
+    options.format = envFormat as OutputFormat;
+  }
+
+  if (process.env.OWNER_MERMAID_OUTPUT?.trim()) {
+    options.outputPath = process.env.OWNER_MERMAID_OUTPUT.trim();
+  }
+
+  if (process.env.OWNER_MERMAID_TITLE?.trim()) {
+    options.title = process.env.OWNER_MERMAID_TITLE.trim();
+  }
+
+  if (process.env.OWNER_MERMAID_INCLUDE_PENDING) {
+    const flag = process.env.OWNER_MERMAID_INCLUDE_PENDING.trim().toLowerCase();
+    options.includePending = !['0', 'false', 'no', 'off'].includes(flag);
+  }
+
+  if (process.env.OWNER_MERMAID_CONFIG_NETWORK?.trim()) {
+    options.configNetwork = process.env.OWNER_MERMAID_CONFIG_NETWORK.trim();
+  }
+
+  if (process.env.OWNER_MERMAID_ADDRESS_OVERRIDES?.trim()) {
+    Object.assign(
+      options.addressOverrides,
+      parseOverrides(process.env.OWNER_MERMAID_ADDRESS_OVERRIDES.trim())
+    );
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--format': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--format requires a value (markdown|mermaid)');
+        }
+        const normalised = value.trim().toLowerCase();
+        if (!SUPPORTED_FORMATS.has(normalised as OutputFormat)) {
+          throw new Error(`Unsupported format: ${value}`);
+        }
+        options.format = normalised as OutputFormat;
+        i += 1;
+        break;
+      }
+      case '--output':
+      case '--out': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a file path`);
+        }
+        options.outputPath = value;
+        i += 1;
+        break;
+      }
+      case '--config-network':
+      case '--network-config': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a value`);
+        }
+        options.configNetwork = value;
+        i += 1;
+        break;
+      }
+      case '--title': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--title requires a value');
+        }
+        options.title = value;
+        i += 1;
+        break;
+      }
+      case '--no-pending':
+      case '--omit-pending': {
+        options.includePending = false;
+        break;
+      }
+      case '--include-pending': {
+        options.includePending = true;
+        break;
+      }
+      case '--address':
+      case '--address-override':
+      case '--address-overrides': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires entries in the form module=address`);
+        }
+        Object.assign(options.addressOverrides, parseOverrides(value));
+        i += 1;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return options;
+}
+
+function normaliseModuleLookupKey(key: string): string {
+  return key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+}
+
+function envAddressKey(moduleKey: string): string {
+  const upper = moduleKey.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase();
+  return `AGJ_${upper}_ADDRESS`;
+}
+
+function parseOverrides(value: string): Record<string, string> {
+  const overrides: Record<string, string> = {};
+  const entries = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  for (const entry of entries) {
+    const [key, address] = entry.split('=');
+    if (!key || !address) {
+      throw new Error(`Invalid address override entry: ${entry}`);
+    }
+    overrides[normaliseModuleLookupKey(key)] = address.trim();
+  }
+  return overrides;
+}
+
+function lookupAddress(addressBook: AddressBook, key: string): string | undefined {
+  if (addressBook[key]) {
+    return addressBook[key];
+  }
+  const target = normaliseModuleLookupKey(key);
+  for (const [bookKey, value] of Object.entries(addressBook)) {
+    if (normaliseModuleLookupKey(bookKey) === target) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+async function readAddressBook(): Promise<AddressBook> {
+  try {
+    const raw = await fs.readFile(ADDRESS_BOOK_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as AddressBook;
+    return parsed;
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
+}
+
+function normaliseModuleType(value?: string): OwnerControlModuleType {
+  if (!value) return 'governable';
+  const lower = value.toLowerCase();
+  if (lower === 'governable' || lower === 'ownable' || lower === 'ownable2step') {
+    return lower;
+  }
+  throw new Error(`Unsupported module type: ${value}`);
+}
+
+function safeAddress(value?: string | null): string | null {
+  if (!value) return null;
+  try {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const prefixed = trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`;
+    const address = ethers.getAddress(prefixed);
+    return address === ethers.ZeroAddress ? null : address;
+  } catch (_) {
+    return null;
+  }
+}
+
+function determineExpectedController(
+  moduleKey: string,
+  module: OwnerControlModuleConfig,
+  config: OwnerControlConfigResult
+): { address?: string; source?: string } {
+  if (module.skip) {
+    return {};
+  }
+  if (module.owner) {
+    return { address: safeAddress(module.owner) ?? undefined, source: `${moduleKey}.owner` };
+  }
+  if (module.governance) {
+    return { address: safeAddress(module.governance) ?? undefined, source: `${moduleKey}.governance` };
+  }
+  if (config.config.owner) {
+    return { address: safeAddress(config.config.owner) ?? undefined, source: 'config.owner' };
+  }
+  if (config.config.governance) {
+    return {
+      address: safeAddress(config.config.governance) ?? undefined,
+      source: 'config.governance',
+    };
+  }
+  return {};
+}
+
+function labelFromKey(key: string): string {
+  const withSpaces = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!withSpaces) return key;
+  return withSpaces
+    .split(' ')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function shortAddress(address: string | null | undefined): string {
+  if (!address) return '–';
+  const normalised = safeAddress(address);
+  if (!normalised) return '–';
+  return `${normalised.slice(0, 6)}…${normalised.slice(-4)}`;
+}
+
+function addressesEqual(a?: string | null, b?: string | null): boolean {
+  const first = safeAddress(a);
+  const second = safeAddress(b);
+  if (!first || !second) {
+    return false;
+  }
+  return first.toLowerCase() === second.toLowerCase();
+}
+
+async function fetchOnChainController(
+  address: string,
+  type: OwnerControlModuleType,
+  includePending: boolean
+): Promise<{ current?: string | null; pending?: string | null; errors: string[] }> {
+  const abi = [
+    'function owner() view returns (address)',
+    'function governance() view returns (address)',
+    'function pendingOwner() view returns (address)',
+    'function pendingGovernance() view returns (address)',
+  ];
+  const contract = new ethers.Contract(address, abi, ethers.provider);
+  const errors: string[] = [];
+
+  async function tryCall(method: string): Promise<string | null | undefined> {
+    try {
+      const result = await contract[method]();
+      if (typeof result === 'string') {
+        return safeAddress(result);
+      }
+    } catch (error: any) {
+      if (error?.code !== 'CALL_EXCEPTION') {
+        errors.push(`${method} failed: ${String(error?.message ?? error)}`);
+      }
+    }
+    return undefined;
+  }
+
+  let current: string | null | undefined;
+  if (type === 'governable') {
+    current = await tryCall('governance');
+    if (current === undefined) {
+      current = await tryCall('owner');
+    }
+  } else {
+    current = await tryCall('owner');
+    if (current === undefined && type === 'ownable2step') {
+      current = await tryCall('governance');
+    }
+  }
+
+  let pending: string | null | undefined;
+  if (includePending) {
+    if (type === 'governable') {
+      pending = await tryCall('pendingGovernance');
+    } else {
+      pending = await tryCall('pendingOwner');
+    }
+  }
+
+  return {
+    current: current ?? null,
+    pending: pending ?? null,
+    errors,
+  };
+}
+
+async function collectModuleInsights(
+  configResult: OwnerControlConfigResult,
+  addressBook: AddressBook,
+  includePending: boolean,
+  overrides: Record<string, string>
+): Promise<ModuleInsight[]> {
+  const entries: ModuleInsight[] = [];
+  const modules: Record<string, OwnerControlModuleConfig> = configResult.config.modules ?? {};
+  for (const [key, moduleConfig] of Object.entries(modules)) {
+    const moduleType = normaliseModuleType(moduleConfig.type as string | undefined);
+    const canonicalKey = normaliseModuleLookupKey(key);
+    const overrideAddress = overrides[canonicalKey];
+    const envOverrideRaw = process.env[envAddressKey(key)];
+    const envOverride = envOverrideRaw ? envOverrideRaw.trim() : undefined;
+    const addressCandidate =
+      overrideAddress ??
+      (envOverride && envOverride.length > 0 ? envOverride : undefined) ??
+      moduleConfig.address ??
+      lookupAddress(addressBook, key);
+    const moduleAddress = safeAddress(addressCandidate);
+    const notes: string[] = [];
+
+    if (moduleConfig.notes && Array.isArray(moduleConfig.notes)) {
+      notes.push(...moduleConfig.notes.map((value) => String(value)));
+    }
+
+    if (moduleConfig.skip) {
+      entries.push({
+        key,
+        label: moduleConfig.label ?? labelFromKey(key),
+        address: moduleAddress,
+        type: moduleType,
+        status: 'skipped',
+        notes,
+      });
+      continue;
+    }
+
+    const expected = determineExpectedController(key, moduleConfig, configResult);
+    if (expected.source) {
+      if (expected.address) {
+        notes.push(`Expected controller source: ${expected.source}`);
+      } else {
+        notes.push(`Expected controller source ${expected.source} is configured but missing`);
+      }
+    }
+
+    if (!moduleAddress) {
+      entries.push({
+        key,
+        label: moduleConfig.label ?? labelFromKey(key),
+        address: moduleAddress,
+        type: moduleType,
+        expectedController: expected.address,
+        expectedSource: expected.source,
+        status: 'missing-address',
+        notes,
+      });
+      continue;
+    }
+
+    const { current, pending, errors } = await fetchOnChainController(
+      moduleAddress,
+      moduleType,
+      includePending
+    );
+    if (errors.length > 0) {
+      notes.push(...errors);
+    }
+
+    let status: ModuleInsight['status'] = 'ok';
+    if (expected.address && current) {
+      if (!addressesEqual(expected.address, current)) {
+        status = 'mismatch';
+        notes.push(
+          `On-chain controller ${current ?? 'unknown'} differs from expected ${
+            expected.address ?? 'unknown'
+          }`
+        );
+      }
+    } else if (expected.address && !current) {
+      status = 'mismatch';
+      notes.push(`On-chain controller is unset but expected ${expected.address}`);
+    }
+
+    entries.push({
+      key,
+      label: moduleConfig.label ?? labelFromKey(key),
+      address: moduleAddress,
+      type: moduleType,
+      expectedController: expected.address,
+      expectedSource: expected.source,
+      onChainController: current ?? null,
+      pendingController: pending ?? null,
+      status,
+      notes,
+    });
+  }
+  return entries;
+}
+
+function renderMermaid(
+  title: string,
+  modules: ModuleInsight[],
+  includePending: boolean
+): MermaidBuildResult {
+  const lines: string[] = [];
+  const warnings: string[] = [];
+  lines.push(`%% ${title}`);
+  lines.push('flowchart LR');
+  lines.push('  classDef module fill:#eef2ff,stroke:#312e81,stroke-width:1px;');
+  lines.push('  classDef owner fill:#ecfdf5,stroke:#065f46,stroke-width:1px;');
+  lines.push('  classDef pending fill:#fff7ed,stroke:#b45309,stroke-width:1px;');
+  lines.push('  classDef mismatch fill:#fee2e2,stroke:#b91c1c,stroke-width:1px;');
+  lines.push('  classDef unknown fill:#f3f4f6,stroke:#6b7280,stroke-width:1px;');
+
+  const moduleNodeIds = new Map<string, string>();
+  const ownerNodeIds = new Map<string, string>();
+  const pendingNodeIds = new Map<string, string>();
+  let moduleIndex = 0;
+  let ownerIndex = 0;
+  let pendingIndex = 0;
+
+  function escapeLabel(value: string): string {
+    return value.replace(/"/g, '\\"');
+  }
+
+  function ensureOwnerNode(address: string | null | undefined, label?: string): string {
+    const key = address ?? 'unknown';
+    if (ownerNodeIds.has(key)) {
+      return ownerNodeIds.get(key)!;
+    }
+    const nodeId = `owner_${ownerIndex += 1}`;
+    const nodeLabel = label ?? (address ? `${shortAddress(address)}` : 'Unassigned');
+    lines.push(`  ${nodeId}["${escapeLabel(nodeLabel)}"]`);
+    if (address) {
+      lines.push(`  class ${nodeId} owner;`);
+    } else {
+      lines.push(`  class ${nodeId} unknown;`);
+      warnings.push('Some modules are missing controller addresses.');
+    }
+    ownerNodeIds.set(key, nodeId);
+    return nodeId;
+  }
+
+  function ensurePendingNode(address: string | null | undefined): string {
+    const key = address ?? 'pending';
+    if (pendingNodeIds.has(key)) {
+      return pendingNodeIds.get(key)!;
+    }
+    const nodeId = `pending_${pendingIndex += 1}`;
+    const label = address ? `Pending ${shortAddress(address)}` : 'Pending Unassigned';
+    lines.push(`  ${nodeId}["${escapeLabel(label)}"]`);
+    lines.push(`  class ${nodeId} pending;`);
+    pendingNodeIds.set(key, nodeId);
+    return nodeId;
+  }
+
+  for (const module of modules) {
+    const moduleId = `module_${moduleIndex += 1}`;
+    moduleNodeIds.set(module.key, moduleId);
+    const moduleAddressLabel = module.address ? `\n${shortAddress(module.address)}` : '';
+    lines.push(`  ${moduleId}["${escapeLabel(module.label + moduleAddressLabel)}"]`);
+    lines.push(`  class ${moduleId} module;`);
+    if (module.status === 'mismatch') {
+      lines.push(`  class ${moduleId} mismatch;`);
+    }
+    if (module.status === 'missing-address') {
+      lines.push(`  class ${moduleId} unknown;`);
+    }
+
+    const expectedNode = ensureOwnerNode(module.expectedController ?? null);
+    if (module.expectedController) {
+      lines.push(`  ${moduleId} -->|expected| ${expectedNode}`);
+    } else {
+      lines.push(`  ${moduleId} -.-> ${expectedNode}`);
+    }
+
+    if (
+      module.onChainController &&
+      module.expectedController &&
+      !addressesEqual(module.onChainController, module.expectedController)
+    ) {
+      const actualNode = ensureOwnerNode(module.onChainController, `On-chain ${shortAddress(module.onChainController)}`);
+      lines.push(`  ${moduleId} -.actual.-> ${actualNode}`);
+      lines.push(`  class ${actualNode} mismatch;`);
+      warnings.push(
+        `${module.label} controller ${module.onChainController} differs from expected ${module.expectedController}`
+      );
+    }
+
+    if (
+      module.onChainController &&
+      (!module.expectedController ||
+        addressesEqual(module.onChainController, module.expectedController))
+    ) {
+      const actualNode = ensureOwnerNode(
+        module.onChainController,
+        `On-chain ${shortAddress(module.onChainController)}`
+      );
+      lines.push(`  ${moduleId} -.onchain.-> ${actualNode}`);
+    }
+
+    if (includePending && module.pendingController) {
+      const pendingNode = ensurePendingNode(module.pendingController);
+      lines.push(`  ${moduleId} -.pending.-> ${pendingNode}`);
+    }
+  }
+
+  return { mermaid: lines.join('\n'), warnings };
+}
+
+function renderMarkdown(
+  title: string,
+  modules: ModuleInsight[],
+  mermaid: string,
+  warnings: string[],
+  includePending: boolean
+): string {
+  const parts: string[] = [];
+  parts.push(`# ${title}`);
+  parts.push('');
+  parts.push(
+    `Generated ${new Date().toISOString()} on network **${network.name ?? 'unknown'}** with Hardhat.`
+  );
+  parts.push('');
+  parts.push('```mermaid');
+  parts.push(mermaid);
+  parts.push('```');
+  parts.push('');
+  if (warnings.length > 0) {
+    parts.push('> **Warnings**');
+    for (const warning of warnings) {
+      parts.push(`> - ${warning}`);
+    }
+    parts.push('');
+  }
+
+  parts.push('## Module Ownership Matrix');
+  parts.push('');
+  parts.push(
+    '| Module | Address | Type | Expected Controller | On-chain Controller | Pending | Status | Notes |'
+  );
+  parts.push('| --- | --- | --- | --- | --- | --- | --- | --- |');
+
+  for (const module of modules) {
+    const pending = includePending
+      ? shortAddress(module.pendingController) || '–'
+      : '–';
+    const notes = module.notes.length > 0 ? module.notes.join('; ').replace(/\n/g, ' ') : '';
+    const status = module.status
+      .replace('-', ' ')
+      .replace(/\b([a-z])/g, (match) => match.toUpperCase());
+    parts.push(
+      `| ${module.label} | ${shortAddress(module.address)} | ${module.type} | ${shortAddress(
+        module.expectedController
+      )} | ${shortAddress(module.onChainController)} | ${pending} | ${status} | ${notes || '–'} |`
+    );
+  }
+
+  return parts.join('\n');
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const addressBook = await readAddressBook();
+  const detectedNetwork = inferNetworkKey(network) ?? undefined;
+  const configResult = loadOwnerControlConfig({
+    network: options.configNetwork ?? detectedNetwork,
+  });
+
+  const insights = await collectModuleInsights(
+    configResult,
+    addressBook,
+    options.includePending,
+    options.addressOverrides
+  );
+
+  const title = options.title ?? DEFAULT_TITLE;
+  const { mermaid, warnings } = renderMermaid(title, insights, options.includePending);
+
+  const output =
+    options.format === 'mermaid'
+      ? mermaid
+      : renderMarkdown(title, insights, mermaid, warnings, options.includePending);
+
+  if (options.outputPath) {
+    const resolved = path.resolve(options.outputPath);
+    await fs.mkdir(path.dirname(resolved), { recursive: true });
+    await fs.writeFile(resolved, output, 'utf8');
+    console.log(`Owner control diagram written to ${resolved}`);
+  } else {
+    console.log(output);
+  }
+
+  if (warnings.length > 0) {
+    for (const warning of warnings) {
+      console.warn(`Warning: ${warning}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a Hardhat-powered script that renders owner control Mermaid diagrams and Markdown summaries with address overrides and on-chain validation
- document the workflow in a new Owner Control Visual Guide with diagrams and operational checklists
- expose the new helper in README and package scripts for easy access by non-technical owners

## Testing
- npm run owner:diagram -- --network hardhat

------
https://chatgpt.com/codex/tasks/task_e_68db1940ee208333a44fec01b1733d45