### PR TITLE
feat: add mission control bundle export and documentation

### DIFF
--- a/docs/owner-control-handbook.md
+++ b/docs/owner-control-handbook.md
@@ -6,6 +6,10 @@
 > **Goal:** Provide a production-ready, copy/paste friendly guide for inspecting,
 > updating and validating every owner-editable parameter without writing code.
 
+> **Bundle Exports:** Need tamper-evident artefacts for auditors? Pair the commands
+> below with the bundle workflow in
+> [`docs/owner-mission-bundle.md`](./owner-mission-bundle.md).
+
 ---
 
 ## Command Quick Reference
@@ -90,12 +94,14 @@ control without direct Solidity interaction.
 ## Step-by-Step Owner Workflow
 
 1. **Inspect the current state**
+
    - Run `npm run owner:surface -- --network <network>`.
    - Review highlighted warnings (yellow) and errors (red). Hovering text in the
      terminal shows missing configuration files or mismatched addresses.
    - For audit trails, rerun with `--format markdown --out reports/<network>-owner-surface.md`.
 
 2. **Plan configuration edits**
+
    - Edit the relevant JSON file under `config/` (for example,
      `config/thermodynamics.json`). Every key is documented inline within the
      files and mirrors the Solidity setter signature.
@@ -103,6 +109,7 @@ control without direct Solidity interaction.
      reference the network and expected on-chain impact.
 
 3. **Validate against live contracts**
+
    - Execute `npm run owner:update-all -- --network <network>`.
    - The script loads every config module, compares against on-chain state and
      prints a transaction plan without sending transactions.
@@ -110,6 +117,7 @@ control without direct Solidity interaction.
      RPC traces before proceeding.
 
 4. **Execute the plan**
+
    - Once the dry run is correct, append `--execute` to broadcast the batched
      transactions from the configured signer.
    - Hardware wallets and multisigs are supported: specify
@@ -126,17 +134,17 @@ control without direct Solidity interaction.
 
 ## Parameter Inventory
 
-| Module | Key Controls | Setter Commands |
-| ------ | ------------ | --------------- |
-| `JobRegistry` | Job fee rates, treasury address, per-role caps | `npm run owner:update-all` (reads `config/job-registry.json`) |
-| `StakeManager` | Minimum/maximum stake, cooldown windows, treasury | `npm run owner:update-all` (reads `config/stake-manager.json`) |
-| `FeePool` | Burn percentage, treasury allowlist | `npm run owner:update-all` (reads `config/fee-pool.json`) |
-| `RewardEngineMB` | Free-energy budget split, chemical potentials | `npm run owner:update-all` (reads `config/thermodynamics.json`) |
-| `Thermostat` | PID gains, target entropy, max adjustments | `npm run owner:update-all` (reads `config/thermostat.json`) |
-| `HamiltonianMonitor` | Observation window, reset flag | `npm run owner:update-all` (reads `config/hamiltonian-monitor.json`) |
-| `EnergyOracle` | Authorised signers, quorum requirements | `npm run owner:update-all` (reads `config/energy-oracle.json`) |
-| `TaxPolicy` | Tax brackets, exemptions, treasury routing | `npm run owner:update-all` (reads `config/tax-policy.json`) |
-| `SystemPause` | Module wiring, pause guardians | `npm run owner:update-all` (reads `config/system-pause.json`) |
+| Module               | Key Controls                                      | Setter Commands                                                      |
+| -------------------- | ------------------------------------------------- | -------------------------------------------------------------------- |
+| `JobRegistry`        | Job fee rates, treasury address, per-role caps    | `npm run owner:update-all` (reads `config/job-registry.json`)        |
+| `StakeManager`       | Minimum/maximum stake, cooldown windows, treasury | `npm run owner:update-all` (reads `config/stake-manager.json`)       |
+| `FeePool`            | Burn percentage, treasury allowlist               | `npm run owner:update-all` (reads `config/fee-pool.json`)            |
+| `RewardEngineMB`     | Free-energy budget split, chemical potentials     | `npm run owner:update-all` (reads `config/thermodynamics.json`)      |
+| `Thermostat`         | PID gains, target entropy, max adjustments        | `npm run owner:update-all` (reads `config/thermostat.json`)          |
+| `HamiltonianMonitor` | Observation window, reset flag                    | `npm run owner:update-all` (reads `config/hamiltonian-monitor.json`) |
+| `EnergyOracle`       | Authorised signers, quorum requirements           | `npm run owner:update-all` (reads `config/energy-oracle.json`)       |
+| `TaxPolicy`          | Tax brackets, exemptions, treasury routing        | `npm run owner:update-all` (reads `config/tax-policy.json`)          |
+| `SystemPause`        | Module wiring, pause guardians                    | `npm run owner:update-all` (reads `config/system-pause.json`)        |
 
 Every configuration file supports per-network overrides. Place a file named
 `config/<module>.<network>.json` next to the default to specialise a deployment
@@ -161,12 +169,12 @@ without forking the repository.
 
 ## Troubleshooting Matrix
 
-| Symptom | Diagnosis Steps | Resolution |
-| ------- | --------------- | ---------- |
-| `owner:surface` throws `Unknown argument` | Ensure extra flags are placed after `--` so `npm` passes them through. | `npm run owner:surface -- --network sepolia --format markdown` |
-| Update scripts fail with `CALL_EXCEPTION` | The executing signer lacks the required role (owner/governance). | Re-run `owner:verify-control` and rotate ownership if necessary. |
-| Markdown export missing sections | One or more config files are absent. | Copy the template from `config/templates` and adjust values. |
-| Multisig bundle rejected | Safe transaction nonce mismatch. | Pull the latest Safe state and increment `--safe-nonce` accordingly. |
+| Symptom                                   | Diagnosis Steps                                                        | Resolution                                                           |
+| ----------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `owner:surface` throws `Unknown argument` | Ensure extra flags are placed after `--` so `npm` passes them through. | `npm run owner:surface -- --network sepolia --format markdown`       |
+| Update scripts fail with `CALL_EXCEPTION` | The executing signer lacks the required role (owner/governance).       | Re-run `owner:verify-control` and rotate ownership if necessary.     |
+| Markdown export missing sections          | One or more config files are absent.                                   | Copy the template from `config/templates` and adjust values.         |
+| Multisig bundle rejected                  | Safe transaction nonce mismatch.                                       | Pull the latest Safe state and increment `--safe-nonce` accordingly. |
 
 ---
 
@@ -216,4 +224,3 @@ sign-off from the Emergency Council.
 - **2025-01-12:** Initial publication of the Owner Control Handbook. Aligns with
   repository scripts `owner:surface`, `owner:update-all`, `owner:verify-control`,
   and `owner:rotate`.
-

--- a/docs/owner-mission-bundle.md
+++ b/docs/owner-mission-bundle.md
@@ -1,0 +1,127 @@
+# Owner Mission Control Bundle Playbook
+
+> **Audience:** Contract owners, governance leads, and auditors who require a
+> tamper-evident packet of every mission-control run. Suitable for ticketing,
+> audit archives, and non-technical reviewers.
+>
+> **Goal:** Produce a single directory containing Markdown, JSON, human-friendly
+> text, a manifest, and cryptographic checksums so stakeholders can review and
+> re-verify governance actions without accessing developer tooling.
+
+---
+
+## Command Cheat Sheet
+
+```bash
+npm run owner:mission-control -- \
+  --network <network> \
+  --bundle runtime/bundles \
+  --bundle-name mission-control-<stamp>
+```
+
+- `--bundle` points at the folder that should receive the artefacts (it will be
+  created if it does not exist).
+- `--bundle-name` controls the filename stem. Use incident/ticket IDs or
+  calendar stamps such as `mission-control-2025-03-14`. Unsafe characters are
+  automatically sanitised.
+- Combine with `--format`/`--out` if you still want a standalone file in
+  addition to the bundle.
+
+---
+
+## Artefact Layout
+
+```mermaid
+flowchart LR
+    subgraph Bundle[mission-control bundle]
+        direction TB
+        MD[*.md\n(visual briefing)]
+        JSON[*.json\n(machine payload)]
+        TXT[*.txt\n(human console)]
+        MAN[*.manifest.json\n(step+metric index)]
+        SHA[*.checksums.txt\n(SHA-256 ledger)]
+    end
+    OPS[Operators] --> MD
+    Pipelines --> JSON
+    Auditors --> MAN
+    Compliance --> SHA
+    IncidentResponders --> TXT
+    classDef node fill:#f4f9ff,stroke:#2c82c9;
+    classDef actor fill:#fef5e7,stroke:#f39c12;
+    class MD,JSON,TXT,MAN,SHA node;
+    class OPS,Pipelines,Auditors,Compliance,IncidentResponders actor;
+```
+
+Each file contains trailing newlines for compatibility with UNIX tooling.
+Hashes use lowercase hex-encoded SHA-256 digests that match `sha256sum` and
+`shasum -a 256` output formats.
+
+---
+
+## Review Workflow
+
+1. **Generate the bundle** on a dry-run network (Hardhat, staging RPC).
+2. **Attach the directory** (or a zipped copy) to the governance ticket.
+3. **Run checksum verification** before approval:
+   ```bash
+   cd runtime/bundles
+   sha256sum --check mission-control-<stamp>.checksums.txt
+   ```
+4. **Review the manifest** (`*.manifest.json`) for a structured overview of
+   step status, metrics, runtime, and exact CLI/env pairs that produced the
+   artefact.
+5. **Forward Markdown/JSON** files to stakeholders:
+   - Markdown → executive summaries with Mermaid diagrams.
+   - JSON → automation, regression diffing, compliance archives.
+   - TXT → non-technical operator logs or mobile readers.
+6. **Re-run** mission control against production RPC once governance signs off.
+   The new bundle should produce matching hashes except for live network
+   differences.
+
+---
+
+## Manifest Fields
+
+| Field            | Description                                                                                     |
+| ---------------- | ----------------------------------------------------------------------------------------------- |
+| `network`        | Hardhat network supplied to mission control.                                                    |
+| `baseName`       | Sanitised bundle stem used for filenames.                                                       |
+| `generatedAt`    | ISO timestamp (UTC) when the bundle was produced.                                               |
+| `overallStatus`  | Aggregated step status (`success`, `warning`, `error`, `skipped`).                              |
+| `includeMermaid` | Indicates whether Mermaid diagrams were enabled.                                                |
+| `steps[]`        | Array of step summaries, metrics, commands, environment overrides, and runtime in milliseconds. |
+| `files[]`        | Records every exported file with byte length and SHA-256 digest.                                |
+
+The manifest deliberately excludes private keys, RPC URLs, and secrets. Only
+surface-level environment overrides (e.g., `OWNER_DASHBOARD_JSON=1`) are
+captured.
+
+---
+
+## Frequently Asked Questions
+
+**Can I store bundles in version control?** Yes. Each file ends with a newline
+and uses deterministic ordering, so Git diffs remain stable across runs.
+
+**How do I change the output directory per network?** Combine shell variables
+and the bundle CLI:
+
+```bash
+STAMP=$(date -u +%Y%m%dT%H%MZ)
+OUTDIR=runtime/bundles/$STAMP
+npm run owner:mission-control -- \
+  --network mainnet \
+  --bundle "$OUTDIR" \
+  --bundle-name "mission-control-mainnet-$STAMP"
+```
+
+**Can the manifest be ingested by dashboards?** Absolutely. Point any JSON
+consumer at `*.manifest.json` to hydrate dashboards with per-step metrics and
+links to source files. The manifest intentionally mirrors the JSON payload so
+pipelines can diff or alert on configuration drift.
+
+---
+
+With the bundle playbook, non-technical owners gain a push-button mechanism to
+collect audit-grade governance artefacts, while engineers retain a reproducible
+trail for every production parameter change.

--- a/docs/owner-mission-control.md
+++ b/docs/owner-mission-control.md
@@ -32,17 +32,24 @@ The helper executes four guardrail-heavy stages, merges JSON outputs, then rende
      --network hardhat \
      --out runtime/mission-control.md
    ```
-4. Open `runtime/mission-control.md` for the aggregated status report.
-5. Repeat with production RPC once the dry run is clean.
+4. Export a full evidence bundle for ticketing systems:
+   ```bash
+   npm run owner:mission-control -- \
+     --network hardhat \
+     --bundle runtime/bundles \
+     --bundle-name mission-control-dryrun
+   ```
+5. Open `runtime/mission-control.md` or the bundle artefacts for the aggregated status report.
+6. Repeat with production RPC once the dry run is clean.
 
 ## Step Reference Matrix
 
-| Step | Purpose | Underlying Command | Output Signals | Retry Command |
-| --- | --- | --- | --- | --- |
-| Control Surface Snapshot | Hashes configuration files, flags owner drift, and records parameter summaries. | `npx ts-node --compiler-options '{"module":"commonjs"}' scripts/v2/ownerControlSurface.ts --network <net> --json` | Warns on missing owners, absent configs, or invalid constants. | `npm run owner:surface -- --network <net>` |
-| Owner Update Plan | Builds a multi-module execution plan and optional Safe bundle. | `node scripts/v2/run-owner-plan.js --json` (with `HARDHAT_NETWORK=<net>`) | Counts pending actions; warns when no module addresses resolve. | `npm run owner:plan -- --network <net> --json` |
-| Owner Control Verification | Confirms owners, governance, and pending acceptances on live contracts. | `npx hardhat run --no-compile scripts/v2/verifyOwnerControl.ts --network <net>` (`OWNER_VERIFY_JSON=1`) | Emits mismatch/missing-address counts and affected modules. | `OWNER_VERIFY_JSON=1 npm run owner:verify-control -- --network <net>` |
-| Owner Command Dashboard | Pulls live module metrics (balances, cooldowns, PID coefficients). | `npx hardhat run --no-compile scripts/v2/owner-dashboard.ts --network <net>` (`OWNER_DASHBOARD_JSON=1`) | Highlights telemetry gaps or module RPC errors. | `OWNER_DASHBOARD_JSON=1 npm run owner:dashboard -- --network <net>` |
+| Step                       | Purpose                                                                         | Underlying Command                                                                                                | Output Signals                                                  | Retry Command                                                         |
+| -------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Control Surface Snapshot   | Hashes configuration files, flags owner drift, and records parameter summaries. | `npx ts-node --compiler-options '{"module":"commonjs"}' scripts/v2/ownerControlSurface.ts --network <net> --json` | Warns on missing owners, absent configs, or invalid constants.  | `npm run owner:surface -- --network <net>`                            |
+| Owner Update Plan          | Builds a multi-module execution plan and optional Safe bundle.                  | `node scripts/v2/run-owner-plan.js --json` (with `HARDHAT_NETWORK=<net>`)                                         | Counts pending actions; warns when no module addresses resolve. | `npm run owner:plan -- --network <net> --json`                        |
+| Owner Control Verification | Confirms owners, governance, and pending acceptances on live contracts.         | `npx hardhat run --no-compile scripts/v2/verifyOwnerControl.ts --network <net>` (`OWNER_VERIFY_JSON=1`)           | Emits mismatch/missing-address counts and affected modules.     | `OWNER_VERIFY_JSON=1 npm run owner:verify-control -- --network <net>` |
+| Owner Command Dashboard    | Pulls live module metrics (balances, cooldowns, PID coefficients).              | `npx hardhat run --no-compile scripts/v2/owner-dashboard.ts --network <net>` (`OWNER_DASHBOARD_JSON=1`)           | Highlights telemetry gaps or module RPC errors.                 | `OWNER_DASHBOARD_JSON=1 npm run owner:dashboard -- --network <net>`   |
 
 ## Output Modes
 
@@ -51,15 +58,46 @@ The helper executes four guardrail-heavy stages, merges JSON outputs, then rende
 - `--format human` – Console-friendly plaintext with emoji statuses.
 - `--no-mermaid` – Disable diagrams when rendering for terminals without Mermaid support.
 
+## Mission Bundle Export
+
+```mermaid
+flowchart TD
+    MC[owner:mission-control] -->|--bundle| DIR[Bundle Directory]
+    DIR --> MD[mission-control-<net>.md]
+    DIR --> JSON[mission-control-<net>.json]
+    DIR --> TXT[mission-control-<net>.txt]
+    DIR --> MANIFEST[mission-control-<net>.manifest.json]
+    DIR --> SHA[mission-control-<net>.checksums.txt]
+    classDef file fill:#eef5ff,stroke:#2980b9;
+    classDef dir fill:#fef9e7,stroke:#f39c12;
+    classDef root fill:#e8f9e9,stroke:#27ae60;
+    class MC root;
+    class DIR dir;
+    class MD,JSON,TXT,MANIFEST,SHA file;
+```
+
+- `--bundle <dir>` writes a complete evidence pack containing Markdown, JSON, and human-readable text alongside a manifest and SHA-256 checksum ledger.
+- `--bundle-name <label>` controls the base filename (defaults to `mission-control-<network>`). The helper strips unsafe characters automatically.
+- Each bundle file ends with a newline and is hash-signed so auditors can confirm provenance with `sha256sum mission-control-<net>.checksums.txt`.
+
+### Verifying a Bundle
+
+```bash
+cd runtime/bundles
+sha256sum --check mission-control-dryrun.checksums.txt
+```
+
+The checksum file validates every artefact, including the manifest. The manifest records step-by-step statuses, metrics, commands, and environment overrides so approvers can trace exactly how governance decisions were generated.
+
 ## Environment Variable Overrides
 
 Mission control leans on new environment hooks so each sub-command stays automation-friendly:
 
-| Variable | Applies To | Description |
-| --- | --- | --- |
-| `OWNER_UPDATE_ALL_JSON` / `OWNER_UPDATE_ALL_EXECUTE` / `OWNER_UPDATE_ALL_ONLY` / `OWNER_UPDATE_ALL_SKIP` | `owner:update-all` | Force JSON output, toggle execution, or select modules when Hardhat CLI flags are unavailable (e.g., Gnosis Safe automation). |
-| `OWNER_VERIFY_JSON`, `OWNER_VERIFY_STRICT`, `OWNER_VERIFY_MODULES`, `OWNER_VERIFY_SKIP`, `OWNER_VERIFY_ADDRESS_BOOK`, `OWNER_VERIFY_ADDRESS_OVERRIDES` | `owner:verify-control` | Enable structured output, tighten failure modes, scope modules, or inject ad-hoc address maps without editing config files. |
-| `OWNER_DASHBOARD_JSON`, `OWNER_DASHBOARD_CONFIG_NETWORK` | `owner:dashboard` | Emit JSON telemetry and override the configuration network key. |
+| Variable                                                                                                                                               | Applies To             | Description                                                                                                                   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `OWNER_UPDATE_ALL_JSON` / `OWNER_UPDATE_ALL_EXECUTE` / `OWNER_UPDATE_ALL_ONLY` / `OWNER_UPDATE_ALL_SKIP`                                               | `owner:update-all`     | Force JSON output, toggle execution, or select modules when Hardhat CLI flags are unavailable (e.g., Gnosis Safe automation). |
+| `OWNER_VERIFY_JSON`, `OWNER_VERIFY_STRICT`, `OWNER_VERIFY_MODULES`, `OWNER_VERIFY_SKIP`, `OWNER_VERIFY_ADDRESS_BOOK`, `OWNER_VERIFY_ADDRESS_OVERRIDES` | `owner:verify-control` | Enable structured output, tighten failure modes, scope modules, or inject ad-hoc address maps without editing config files.   |
+| `OWNER_DASHBOARD_JSON`, `OWNER_DASHBOARD_CONFIG_NETWORK`                                                                                               | `owner:dashboard`      | Emit JSON telemetry and override the configuration network key.                                                               |
 
 All overrides accept truthy strings (`1`, `true`, `yes`, `on`) and falsy strings (`0`, `false`, `no`, `off`). List-style variables use comma-separated values.
 
@@ -93,10 +131,10 @@ journey
 
 ## Troubleshooting Signals
 
-| Symptom | Likely Cause | Resolution |
-| --- | --- | --- |
+| Symptom                                          | Likely Cause                                       | Resolution                                                                                                                              |
+| ------------------------------------------------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `Command exited with code 1` during verification | RPC misconfiguration or contract bytecode mismatch | Confirm RPC URL, ensure `HARDHAT_NETWORK`/`--network` points at the intended chain, re-run with `DEBUG_OWNER_GUIDE=1` for verbose logs. |
-| Dashboard marks modules as missing | `docs/deployment-addresses.json` lacks addresses | Update the address book or pass `OWNER_VERIFY_ADDRESS_OVERRIDES`/`OWNER_DASHBOARD_CONFIG_NETWORK`. |
-| Plan reports “No module addresses resolved” | Token or module configs missing `address` fields | Populate `config/*` JSON files or set `HARDHAT_NETWORK` to a deployment with known addresses. |
+| Dashboard marks modules as missing               | `docs/deployment-addresses.json` lacks addresses   | Update the address book or pass `OWNER_VERIFY_ADDRESS_OVERRIDES`/`OWNER_DASHBOARD_CONFIG_NETWORK`.                                      |
+| Plan reports “No module addresses resolved”      | Token or module configs missing `address` fields   | Populate `config/*` JSON files or set `HARDHAT_NETWORK` to a deployment with known addresses.                                           |
 
 Mission control turns four governance guardrails into a one-click briefing. Pair the Markdown artefact with existing playbooks (`docs/owner-control-playbook.md`, `docs/owner-control-command-center.md`) to keep the contract owner in full, auditable control of every production parameter.


### PR DESCRIPTION
## Summary
- extend `ownerMissionControl.ts` with `--bundle`/`--bundle-name` to generate multi-format mission-control bundles complete with manifest and checksum ledger
- document the bundle workflow in `docs/owner-mission-control.md` and cross-link it from the owner control handbook
- add `docs/owner-mission-bundle.md` detailing the tamper-evident export procedure with diagrams and operator guidance

## Testing
- npm run lint:check *(fails: existing solhint/prettier findings in unrelated files)*
- npx ts-node --compiler-options '{"module":"commonjs"}' scripts/v2/ownerMissionControl.ts --help
- npx ts-node --compiler-options '{"module":"commonjs"}' scripts/v2/ownerMissionControl.ts --only surface --skip-surface --bundle runtime/test-bundle --format json


------
https://chatgpt.com/codex/tasks/task_e_68db20409a3c8333aec6f5cd11de094f