### PR TITLE
Implement ERC-4337 walletless policy enforcement and fallbacks

### DIFF
--- a/config/paymaster.yaml
+++ b/config/paymaster.yaml
@@ -1,8 +1,9 @@
-chain_id: 11155111
-paymaster_address: "0x000000000000000000000000000000000000dead"
-balance_threshold_wei: 500000000000000000
-max_user_operation_gas: 2500000
-default_daily_cap_wei: 100000000000000000
+chainId: 11155111
+paymasterAddr: "0x000000000000000000000000000000000000dead"
+balanceThresholdWei: 500000000000000000
+maxUserOperationGas: 2500000
+maxFeePerGasWei: 150000000000
+defaultDailyCapWei: 100000000000000000
 reload_interval_seconds: 2
 orgs:
   engineering:

--- a/paymaster/supervisor/process.py
+++ b/paymaster/supervisor/process.py
@@ -77,7 +77,7 @@ def create_app(
         try:
             result = await supervisor.sponsor(user_operation, context=context)
         except PermissionError as exc:
-            raise HTTPException(status_code=403, detail=str(exc)) from exc
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
         return JSONResponse(result)
 
     return app


### PR DESCRIPTION
## Summary
- track total gas and estimated spend when building user operations so sponsorship context carries selector, target, and max fee data to the paymaster
- expand the paymaster supervisor configuration and enforcement to honor fee caps, parse camelCase YAML, expose 422 errors, and disable sponsorship on low balances
- fall back to wallet signing on paymaster rejections, harden receipt hashing for environments without full web3 helpers, and add a regression test for the new fallback path

## Testing
- pytest test/routes/test_onebox.py

------
https://chatgpt.com/codex/tasks/task_e_68dbcdcf85e88333bc936ab2f9c27e52