### PR TITLE
Improve validator vote tracking in subgraph

### DIFF
--- a/subgraph/generated/schema.ts
+++ b/subgraph/generated/schema.ts
@@ -993,6 +993,32 @@ export class ValidatorVote extends Entity {
     }
   }
 
+  get txHash(): Bytes {
+    let value = this.get("txHash");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set txHash(value: Bytes) {
+    this.set("txHash", Value.fromBytes(value));
+  }
+
+  get logIndex(): BigInt {
+    let value = this.get("logIndex");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set logIndex(value: BigInt) {
+    this.set("logIndex", Value.fromBigInt(value));
+  }
+
   get revealedAtBlock(): BigInt {
     let value = this.get("revealedAtBlock");
     if (!value || value.kind == ValueKind.NULL) {

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -75,6 +75,8 @@ type ValidatorVote @entity {
   validator: Validator!
   approved: Boolean!
   burnTxHash: Bytes
+  txHash: Bytes!
+  logIndex: BigInt!
   revealedAtBlock: BigInt!
   revealedAtTimestamp: BigInt!
 }

--- a/subgraph/tests/mapping.test.ts
+++ b/subgraph/tests/mapping.test.ts
@@ -369,9 +369,33 @@ describe("mapping handlers", () => {
 
     assert.fieldEquals("Job", "2", "validatorQuorum", "1");
     assert.fieldEquals("Job", "2", "approvals", "1");
+    assert.fieldEquals("Job", "2", "state", "Validating");
     assert.fieldEquals("Validator", voter.toHexString(), "totalVotes", "1");
-    const voteId =
-      reveal.transaction.hash.toHexString() + ":" + reveal.logIndex.toString();
+    const voteId = "2:" + voter.toHexString();
     assert.fieldEquals("ValidatorVote", voteId, "approved", "true");
+    assert.fieldEquals(
+      "ValidatorVote",
+      voteId,
+      "txHash",
+      reveal.transaction.hash.toHexString(),
+    );
+
+    const changeVote = createValidationRevealedEvent(
+      2,
+      voter,
+      false,
+      Bytes.fromHexString(
+        "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      ) as Bytes,
+      7,
+    );
+    handleValidatorVoted(changeVote);
+
+    assert.fieldEquals("Job", "2", "validatorQuorum", "1");
+    assert.fieldEquals("Job", "2", "approvals", "0");
+    assert.fieldEquals("Job", "2", "rejections", "1");
+    assert.fieldEquals("Validator", voter.toHexString(), "totalVotes", "1");
+    assert.fieldEquals("ProtocolStats", "agi-jobs", "totalValidatorVotes", "1");
+    assert.fieldEquals("ValidatorVote", voteId, "approved", "false");
   });
 });


### PR DESCRIPTION
## Summary
- capture transaction metadata on validator votes in the schema for easier referencing from console clients
- deduplicate validator vote handling so job/validator counters stay accurate and mark active jobs as validating when votes arrive
- expand matchstick tests to cover vote replacement and the refined state transitions

## Testing
- npm --prefix subgraph run test *(fails: Graph CLI attempted to reach GitHub to resolve latest version tag and the sandbox has no egress)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe8e22e848333821e6ff0ae3d7611