### PR TITLE
feat: add helm stack, supply chain ci, and ops runbooks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,155 @@
+name: CI/CD Supply Chain
+
+on:
+  push:
+    branches:
+      - main
+      - release/**
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  actions: read
+
+env:
+  REGISTRY: ghcr.io/${{ github.repository }}
+  CACHE_VERSION: v1
+
+jobs:
+  build:
+    name: Build & Sign
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [orchestrator, bundler, paymaster-supervisor, attester]
+        network: [testnet, mainnet]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ env.CACHE_VERSION }}-${{ matrix.target }}-${{ matrix.network }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ env.CACHE_VERSION }}-${{ matrix.target }}-${{ matrix.network }}-
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ matrix.target }}
+          tags: |
+            type=raw,value=${{ matrix.network }}-${{ github.sha }}
+            type=raw,value=${{ matrix.network }}-latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=${{ matrix.network }}-${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/docker/${{ matrix.target }}.Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          provenance: false
+          sbom: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      - name: Move cache
+        if: always()
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Generate SBOM
+        id: sbom
+        uses: anchore/syft-action@v1
+        with:
+          image: ${{ env.REGISTRY }}/${{ matrix.target }}@${{ steps.build.outputs.digest }}
+          output-file: sbom-${{ matrix.target }}-${{ matrix.network }}.spdx.json
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ matrix.target }}-${{ matrix.network }}
+          path: ${{ steps.sbom.outputs.output-file }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.3.0
+      - name: Sign image
+        if: github.event_name != 'pull_request'
+        env:
+          COSIGN_YES: 'true'
+          COSIGN_EXPERIMENTAL: 'true'
+          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          if [ -n "$COSIGN_KEY" ]; then
+            echo "$COSIGN_KEY" | base64 -d > cosign.key
+            cosign sign --key cosign.key ${{ env.REGISTRY }}/${{ matrix.target }}@${{ steps.build.outputs.digest }}
+          else
+            echo "COSIGN_KEY not configured, skipping signature";
+          fi
+      - name: Generate provenance predicate
+        if: github.event_name != 'pull_request'
+        run: |
+          cat <<'JSON' > predicate.json
+          {
+            "buildType": "https://slsa.dev/container/v1",
+            "invocation": {
+              "parameters": {
+                "target": "${{ matrix.target }}",
+                "network": "${{ matrix.network }}"
+              }
+            },
+            "metadata": {
+              "buildInvocationId": "${{ github.run_id }}",
+              "completeness": {
+                "parameters": true
+              }
+            }
+          }
+JSON
+      - name: Attest provenance
+        if: github.event_name != 'pull_request'
+        env:
+          COSIGN_YES: 'true'
+        run: |
+          cosign attest --predicate predicate.json --type slsaprovenance ${{ env.REGISTRY }}/${{ matrix.target }}@${{ steps.build.outputs.digest }}
+      - name: Publish image digest summary
+        run: |
+          echo "${{ matrix.target }} (${{ matrix.network }}): ${{ steps.build.outputs.digest }}" >> image-digests.txt
+      - name: Upload digest summary
+        if: matrix.network == 'mainnet' && matrix.target == 'orchestrator'
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-digests
+          path: image-digests.txt
+
+  helm-test:
+    name: Helm Lint
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+      - name: Helm dependency build
+        run: |
+          helm dependency build deploy/helm/agi-stack
+      - name: Helm lint
+        run: |
+          helm lint deploy/helm/agi-stack

--- a/deploy/docker/attester.Dockerfile
+++ b/deploy/docker/attester.Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /srv/app
+RUN apk add --no-cache python3 make g++
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY deploy/docker/entrypoints/attester.mjs ./entrypoint.mjs
+EXPOSE 7000
+CMD ["node", "entrypoint.mjs"]

--- a/deploy/docker/bundler.Dockerfile
+++ b/deploy/docker/bundler.Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /srv/app
+RUN apk add --no-cache python3 make g++
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY deploy/docker/entrypoints/bundler.mjs ./entrypoint.mjs
+EXPOSE 3000
+CMD ["node", "entrypoint.mjs"]

--- a/deploy/docker/entrypoints/attester.mjs
+++ b/deploy/docker/entrypoints/attester.mjs
@@ -1,0 +1,17 @@
+import express from 'express';
+
+const app = express();
+app.use(express.json({ limit: process.env.MAX_REQUEST_BYTES || '256kb' }));
+
+app.get('/healthz', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/attest', (req, res) => {
+  res.json({ schemaUID: process.env.EAS_SCHEMA_UID || '0x0', receipt: req.body });
+});
+
+const port = Number(process.env.PORT || 7000);
+app.listen(port, '0.0.0.0', () => {
+  console.log(`Attester mock on ${port}`);
+});

--- a/deploy/docker/entrypoints/bundler.mjs
+++ b/deploy/docker/entrypoints/bundler.mjs
@@ -1,0 +1,17 @@
+import express from 'express';
+
+const app = express();
+app.use(express.json({ limit: process.env.MAX_REQUEST_BYTES || '1mb' }));
+
+app.get('/healthz', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/rpc', (req, res) => {
+  res.json({ id: req.body?.id ?? null, result: 'ok' });
+});
+
+const port = Number(process.env.PORT || 3000);
+app.listen(port, '0.0.0.0', () => {
+  console.log(`Bundler mock listening on ${port}`);
+});

--- a/deploy/docker/entrypoints/paymaster-supervisor.mjs
+++ b/deploy/docker/entrypoints/paymaster-supervisor.mjs
@@ -1,0 +1,18 @@
+import express from 'express';
+
+const app = express();
+app.use(express.json({ limit: process.env.MAX_REQUEST_BYTES || '512kb' }));
+
+app.get('/healthz', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/policy', (req, res) => {
+  console.log('Received policy update', req.body);
+  res.status(202).json({ accepted: true });
+});
+
+const port = Number(process.env.PORT || 4000);
+app.listen(port, '0.0.0.0', () => {
+  console.log(`Paymaster supervisor mock on ${port}`);
+});

--- a/deploy/docker/orchestrator.Dockerfile
+++ b/deploy/docker/orchestrator.Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine AS build
+WORKDIR /srv/app
+RUN apk add --no-cache python3 make g++
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npx tsc -p apps/orchestrator/tsconfig.json
+
+FROM node:20-alpine
+WORKDIR /srv/app
+ENV NODE_ENV=production
+RUN apk add --no-cache python3 make g++
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=build /srv/app/apps/orchestrator/dist ./apps/orchestrator/dist
+COPY --from=build /srv/app/apps/orchestrator/*.json ./apps/orchestrator/
+CMD ["node", "apps/orchestrator/dist/main.js"]

--- a/deploy/docker/paymaster-supervisor.Dockerfile
+++ b/deploy/docker/paymaster-supervisor.Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /srv/app
+RUN apk add --no-cache python3 make g++
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY deploy/docker/entrypoints/paymaster-supervisor.mjs ./entrypoint.mjs
+EXPOSE 4000
+CMD ["node", "entrypoint.mjs"]

--- a/deploy/helm/agi-stack/Chart.yaml
+++ b/deploy/helm/agi-stack/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: agi-stack
+version: 0.1.0
+description: Full AGI stack umbrella chart
+appVersion: "0.1.0"
+type: application
+dependencies:
+  - name: orchestrator
+    version: 0.1.0
+    repository: "file://../orchestrator"
+  - name: bundler
+    version: 0.1.0
+    repository: "file://../bundler"
+  - name: paymaster-supervisor
+    version: 0.1.0
+    repository: "file://../paymaster-supervisor"
+  - name: ipfs
+    version: 0.1.0
+    repository: "file://../ipfs"
+  - name: graph-node
+    version: 0.1.0
+    repository: "file://../graph-node"
+  - name: postgres
+    version: 0.1.0
+    repository: "file://../postgres"
+  - name: attester
+    version: 0.1.0
+    repository: "file://../attester"
+  - name: ingress
+    version: 0.1.0
+    repository: "file://../ingress"

--- a/deploy/helm/agi-stack/templates/NOTES.txt
+++ b/deploy/helm/agi-stack/templates/NOTES.txt
@@ -1,0 +1,4 @@
+The AGI stack is now deploying.
+
+To verify the installation run:
+  kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }}

--- a/deploy/helm/agi-stack/values.yaml
+++ b/deploy/helm/agi-stack/values.yaml
@@ -1,0 +1,129 @@
+global:
+  environment: testnet
+  chain:
+    id: 1
+    rpcURLs: []
+    fallbackRPCURLs: []
+  contracts:
+    bundler: "0x"
+    paymaster: "0x"
+    easRegistry: "0x"
+    easSchemaUID: "0x"
+  cors:
+    allowedOrigins:
+      - "https://example.com"
+    allowedMethods:
+      - GET
+      - POST
+    allowedHeaders:
+      - Authorization
+      - Content-Type
+    allowCredentials: false
+  ratelimits:
+    requestsPerSecond: 20
+    burst: 40
+  secrets:
+    kmsKeys:
+      attester: projects/sample/locations/global/keyRings/app/cryptoKeys/attester
+      paymaster: projects/sample/locations/global/keyRings/app/cryptoKeys/paymaster
+    externalSecretStore: aws
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+  imagePullSecrets: []
+  tls:
+    enabled: true
+    secretName: agi-tls
+  ingress:
+    host: agi.example.com
+    className: nginx
+    tls:
+      enabled: true
+      secretName: agi-tls
+
+orchestrator:
+  image:
+    repository: ghcr.io/example/orchestrator
+    tag: "0.1.0"
+    digest: ""
+  service:
+    port: 8000
+  env:
+    logLevel: info
+    cors: {}
+    ratelimits: {}
+  resources: {}
+
+bundler:
+  image:
+    repository: ghcr.io/example/bundler
+    tag: "0.1.0"
+    digest: ""
+  service:
+    port: 3000
+  resources: {}
+
+paymaster-supervisor:
+  image:
+    repository: ghcr.io/example/paymaster-supervisor
+    tag: "0.1.0"
+    digest: ""
+  service:
+    port: 4000
+  resources: {}
+
+ipfs:
+  image:
+    repository: ipfs/kubo
+    tag: v0.22.0
+    digest: ""
+  service:
+    port: 5001
+  config:
+    swarmPort: 4001
+  resources: {}
+
+graph-node:
+  image:
+    repository: graphprotocol/graph-node
+    tag: v0.33.0
+    digest: ""
+  service:
+    queryPort: 8000
+    statusPort: 8020
+    rpcPort: 8030
+  resources: {}
+
+postgres:
+  image:
+    repository: postgres
+    tag: 15
+    digest: ""
+  service:
+    port: 5432
+  persistence:
+    enabled: true
+    size: 20Gi
+  resources: {}
+
+attester:
+  image:
+    repository: ghcr.io/example/attester
+    tag: "0.1.0"
+    digest: ""
+  service:
+    port: 7000
+  resources: {}
+
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "63072000"
+    nginx.ingress.kubernetes.io/hsts-include-subdomains: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "1m"
+  rateLimit:
+    enabled: true
+    requestsPerMinute: 120
+    burst: 60

--- a/deploy/helm/attester/Chart.yaml
+++ b/deploy/helm/attester/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: attester
+version: 0.1.0
+description: attester service chart
+appVersion: "0.1.0"
+type: application

--- a/deploy/helm/attester/templates/_helpers.tpl
+++ b/deploy/helm/attester/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "attester.fullname" -}}
+{{- printf "%s-%s" .Release.Name "attester" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "attester.labels" -}}
+helm.sh/chart: {{ include "attester.chart" . }}
+app.kubernetes.io/name: attester
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{- define "attester.selectorLabels" -}}
+app.kubernetes.io/name: attester
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "attester.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "attester.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/attester/templates/deployment.yaml
+++ b/deploy/helm/attester/templates/deployment.yaml
@@ -1,0 +1,58 @@
+{{- $global := .Values.global | default (dict) -}}
+{{- $secrets := (index $global "secrets") | default (dict) -}}
+{{- $kms := (index $secrets "kmsKeys") | default (dict) -}}
+{{- $contracts := (index $global "contracts") | default (dict) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "attester.fullname" . }}
+  labels:
+    {{- include "attester.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "attester.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "attester.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ default (include "attester.fullname" .) .Values.serviceAccount.name }}
+      {{- end }}
+      containers:
+        - name: attester
+          image: {{ include "attester.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.env.logLevel | quote }}
+            - name: KMS_KEY_URI
+              value: {{ default (index $kms "attester") .Values.env.kmsKey | quote }}
+            - name: EAS_SCHEMA_UID
+              value: {{ default (index $contracts "easSchemaUID") .Values.env.schemaUID | quote }}
+          envFrom:
+            {{- range .Values.secretRefs }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.probe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probe.path }}
+              port: {{ .Values.probe.port }}
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probe.path }}
+              port: {{ .Values.probe.port }}
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.periodSeconds }}
+          {{- end }}

--- a/deploy/helm/attester/templates/hpa.yaml
+++ b/deploy/helm/attester/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "attester.fullname" . }}
+  labels:
+    {{- include "attester.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "attester.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/attester/templates/service.yaml
+++ b/deploy/helm/attester/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "attester.fullname" . }}
+  labels:
+    {{- include "attester.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "attester.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/attester/templates/serviceaccount.yaml
+++ b/deploy/helm/attester/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default (include "attester.fullname" .) .Values.serviceAccount.name }}
+  labels:
+    {{- include "attester.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/attester/values.yaml
+++ b/deploy/helm/attester/values.yaml
@@ -1,0 +1,32 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/example/attester
+  tag: "0.1.0"
+  digest: ""
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+service:
+  type: ClusterIP
+  port: 7000
+resources: {}
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+env:
+  logLevel: info
+  kmsKey: ""
+  schemaUID: ""
+  extra: {}
+secretRefs: []
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+probe:
+  enabled: true
+  path: /healthz
+  port: http
+  initialDelaySeconds: 10
+  periodSeconds: 30

--- a/deploy/helm/bundler/Chart.yaml
+++ b/deploy/helm/bundler/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: bundler
+version: 0.1.0
+description: bundler service chart
+appVersion: "0.1.0"
+type: application

--- a/deploy/helm/bundler/templates/_helpers.tpl
+++ b/deploy/helm/bundler/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "bundler.fullname" -}}
+{{- printf "%s-%s" .Release.Name "bundler" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "bundler.labels" -}}
+helm.sh/chart: {{ include "bundler.chart" . }}
+app.kubernetes.io/name: bundler
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{- define "bundler.selectorLabels" -}}
+app.kubernetes.io/name: bundler
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "bundler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "bundler.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/bundler/templates/deployment.yaml
+++ b/deploy/helm/bundler/templates/deployment.yaml
@@ -1,0 +1,64 @@
+{{- $global := .Values.global | default (dict) -}}
+{{- $chain := (index $global "chain") | default (dict) -}}
+{{- $contracts := (index $global "contracts") | default (dict) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bundler.fullname" . }}
+  labels:
+    {{- include "bundler.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "bundler.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "bundler.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ default (include "bundler.fullname" .) .Values.serviceAccount.name }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: bundler
+          image: {{ include "bundler.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.env.logLevel | quote }}
+            - name: CHAIN_ID
+              value: {{ default (index $chain "id") .Values.env.extra.chainId | quote }}
+            - name: PAYMASTER_ADDRESS
+              value: {{ default (index $contracts "paymaster") .Values.env.extra.paymaster | quote }}
+            - name: RELAYER_URL
+              value: {{ .Values.env.relayerURL | default "" | quote }}
+          envFrom:
+            {{- range .Values.secretRefs }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.probe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probe.path }}
+              port: {{ .Values.probe.port }}
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probe.path }}
+              port: {{ .Values.probe.port }}
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.periodSeconds }}
+          {{- end }}

--- a/deploy/helm/bundler/templates/hpa.yaml
+++ b/deploy/helm/bundler/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bundler.fullname" . }}
+  labels:
+    {{- include "bundler.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bundler.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/bundler/templates/service.yaml
+++ b/deploy/helm/bundler/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bundler.fullname" . }}
+  labels:
+    {{- include "bundler.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "bundler.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/bundler/templates/serviceaccount.yaml
+++ b/deploy/helm/bundler/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default (include "bundler.fullname" .) .Values.serviceAccount.name }}
+  labels:
+    {{- include "bundler.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/bundler/values.yaml
+++ b/deploy/helm/bundler/values.yaml
@@ -1,0 +1,31 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/example/bundler
+  tag: "0.1.0"
+  digest: ""
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+service:
+  type: ClusterIP
+  port: 3000
+resources: {}
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+env:
+  logLevel: info
+  relayerURL: ""
+  extra: {}
+secretRefs: []
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+probe:
+  enabled: true
+  path: /healthz
+  port: http
+  initialDelaySeconds: 10
+  periodSeconds: 30

--- a/deploy/helm/graph-node/Chart.yaml
+++ b/deploy/helm/graph-node/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: graph-node
+version: 0.1.0
+description: graph-node service chart
+appVersion: "0.1.0"
+type: application

--- a/deploy/helm/graph-node/templates/_helpers.tpl
+++ b/deploy/helm/graph-node/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "graph-node.fullname" -}}
+{{- printf "%s-%s" .Release.Name "graph-node" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "graph-node.labels" -}}
+helm.sh/chart: {{ include "graph-node.chart" . }}
+app.kubernetes.io/name: graph-node
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{- define "graph-node.selectorLabels" -}}
+app.kubernetes.io/name: graph-node
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "graph-node.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "graph-node.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/graph-node/templates/deployment.yaml
+++ b/deploy/helm/graph-node/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "graph-node.fullname" . }}
+  labels:
+    {{- include "graph-node.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "graph-node.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "graph-node.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: graph-node
+          image: {{ include "graph-node.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: query
+              containerPort: {{ .Values.service.queryPort }}
+            - name: status
+              containerPort: {{ .Values.service.statusPort }}
+            - name: rpc
+              containerPort: {{ .Values.service.rpcPort }}
+          env:
+            - name: postgres_host
+              value: {{ .Values.env.postgresHost | quote }}
+            - name: postgres_user
+              value: {{ .Values.env.postgresUser | quote }}
+            - name: postgres_pass
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.env.postgresPasswordSecret }}
+                  key: password
+            - name: ipfs
+              value: {{ .Values.env.ipfsURL | quote }}
+            - name: ethereum
+              value: {{ join "," .Values.env.ethereumRPC | quote }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/graph-node/templates/service.yaml
+++ b/deploy/helm/graph-node/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "graph-node.fullname" . }}
+  labels:
+    {{- include "graph-node.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "graph-node.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: query
+      port: {{ .Values.service.queryPort }}
+      targetPort: query
+    - name: status
+      port: {{ .Values.service.statusPort }}
+      targetPort: status
+    - name: rpc
+      port: {{ .Values.service.rpcPort }}
+      targetPort: rpc

--- a/deploy/helm/graph-node/values.yaml
+++ b/deploy/helm/graph-node/values.yaml
@@ -1,0 +1,23 @@
+replicaCount: 1
+image:
+  repository: graphprotocol/graph-node
+  tag: v0.33.0
+  digest: ""
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  queryPort: 8000
+  statusPort: 8020
+  rpcPort: 8030
+resources: {}
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+env:
+  postgresHost: postgres
+  postgresUser: graph
+  postgresPasswordSecret: graph-node-db
+  ipfsURL: http://ipfs:5001
+  ethereumRPC: []

--- a/deploy/helm/ingress/Chart.yaml
+++ b/deploy/helm/ingress/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ingress
+version: 0.1.0
+description: ingress service chart
+appVersion: "0.1.0"
+type: application

--- a/deploy/helm/ingress/templates/_helpers.tpl
+++ b/deploy/helm/ingress/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{- define "ingress.fullname" -}}
+{{- printf "%s-%s" .Release.Name "ingress" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ingress.labels" -}}
+helm.sh/chart: {{ include "ingress.chart" . }}
+app.kubernetes.io/name: ingress
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{- define "ingress.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}

--- a/deploy/helm/ingress/templates/ingress.yaml
+++ b/deploy/helm/ingress/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- $global := .Values.global | default (dict) -}}
+{{- $ingress := (index $global "ingress") | default (dict) -}}
+{{- $annotations := deepCopy (.Values.annotations | default (dict)) -}}
+{{- $host := .Values.host | default (index $ingress "host") -}}
+{{- $className := .Values.className | default (index $ingress "className") -}}
+{{- $tls := .Values.tls | default (index $ingress "tls") | default (dict) -}}
+{{- if and .Values.rateLimit.enabled (not (hasKey $annotations "nginx.ingress.kubernetes.io/limit-rps")) -}}
+{{- $_ := set $annotations "nginx.ingress.kubernetes.io/limit-rps" (toString (div .Values.rateLimit.requestsPerMinute 60)) -}}
+{{- end -}}
+{{- if and .Values.rateLimit.enabled (not (hasKey $annotations "nginx.ingress.kubernetes.io/limit-burst")) -}}
+{{- $_ := set $annotations "nginx.ingress.kubernetes.io/limit-burst" (toString .Values.rateLimit.burst) -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ingress.fullname" . }}
+  labels:
+    {{- include "ingress.labels" . | nindent 4 }}
+  {{- if $annotations }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ $className | quote }}
+  {{- if (and ($tls.enabled | default false) $host) }}
+  tls:
+    - hosts:
+        - {{ $host | quote }}
+      secretName: {{ $tls.secretName | quote }}
+  {{- end }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          {{- range .Values.serviceTargets }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ printf "%s-%s" $.Release.Name .name }}
+                port:
+                  number: {{ .port }}
+          {{- end }}

--- a/deploy/helm/ingress/values.yaml
+++ b/deploy/helm/ingress/values.yaml
@@ -1,0 +1,15 @@
+className: nginx
+annotations: {}
+host: agi.example.com
+tls:
+  enabled: true
+  secretName: agi-tls
+rateLimit:
+  enabled: true
+  requestsPerMinute: 120
+  burst: 60
+serviceTargets:
+  - name: orchestrator
+    port: 8000
+    path: /
+    pathType: Prefix

--- a/deploy/helm/ipfs/Chart.yaml
+++ b/deploy/helm/ipfs/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ipfs
+version: 0.1.0
+description: ipfs service chart
+appVersion: "0.1.0"
+type: application

--- a/deploy/helm/ipfs/templates/_helpers.tpl
+++ b/deploy/helm/ipfs/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "ipfs.fullname" -}}
+{{- printf "%s-%s" .Release.Name "ipfs" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ipfs.labels" -}}
+helm.sh/chart: {{ include "ipfs.chart" . }}
+app.kubernetes.io/name: ipfs
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{- define "ipfs.selectorLabels" -}}
+app.kubernetes.io/name: ipfs
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "ipfs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "ipfs.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/ipfs/templates/service.yaml
+++ b/deploy/helm/ipfs/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ipfs.fullname" . }}
+  labels:
+    {{- include "ipfs.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - name: api
+      port: {{ .Values.service.port }}
+      targetPort: api
+    - name: swarm
+      port: {{ .Values.service.swarmPort }}
+      targetPort: swarm
+    - name: gateway
+      port: {{ .Values.service.gatewayPort }}
+      targetPort: gateway
+  selector:
+    {{- include "ipfs.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/ipfs/templates/statefulset.yaml
+++ b/deploy/helm/ipfs/templates/statefulset.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "ipfs.fullname" . }}
+  labels:
+    {{- include "ipfs.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "ipfs.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ipfs.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ipfs.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: ipfs
+          image: {{ include "ipfs.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: api
+              containerPort: {{ .Values.service.port }}
+            - name: swarm
+              containerPort: {{ .Values.service.swarmPort }}
+            - name: gateway
+              containerPort: {{ .Values.service.gatewayPort }}
+          volumeMounts:
+            - name: data
+              mountPath: /data/ipfs
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+  volumeClaimTemplates:
+    {{- if .Values.persistence.enabled }}
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass }}
+        {{- end }}
+    {{- else }}
+    []
+    {{- end }}

--- a/deploy/helm/ipfs/values.yaml
+++ b/deploy/helm/ipfs/values.yaml
@@ -1,0 +1,16 @@
+replicaCount: 1
+image:
+  repository: ipfs/kubo
+  tag: v0.22.0
+  digest: ""
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 5001
+  swarmPort: 4001
+  gatewayPort: 8080
+persistence:
+  enabled: true
+  size: 50Gi
+  storageClass: ""
+resources: {}

--- a/deploy/helm/orchestrator/Chart.yaml
+++ b/deploy/helm/orchestrator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: orchestrator
+version: 0.1.0
+description: Orchestrator FastAPI service
+appVersion: "0.1.0"
+type: application

--- a/deploy/helm/orchestrator/templates/_helpers.tpl
+++ b/deploy/helm/orchestrator/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{- define "orchestrator.fullname" -}}
+{{- printf "%s-%s" .Release.Name "orchestrator" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "orchestrator.labels" -}}
+helm.sh/chart: {{ include "orchestrator.chart" . }}
+app.kubernetes.io/name: orchestrator
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{- define "orchestrator.selectorLabels" -}}
+app.kubernetes.io/name: orchestrator
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "orchestrator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "orchestrator.image" -}}
+{{- $image := printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- $image -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/orchestrator/templates/configmap.yaml
+++ b/deploy/helm/orchestrator/templates/configmap.yaml
@@ -1,0 +1,19 @@
+{{- $global := .Values.global | default (dict) -}}
+{{- $cors := (index $global "cors") | default (dict) -}}
+{{- $ratelimits := (index $global "ratelimits") | default (dict) -}}
+{{- $allowedOrigins := (default (index $cors "allowedOrigins") .Values.env.cors.allowedOrigins) | default (list) -}}
+{{- $allowedMethods := (default (index $cors "allowedMethods") .Values.env.cors.allowedMethods) | default (list) -}}
+{{- $allowedHeaders := (default (index $cors "allowedHeaders") .Values.env.cors.allowedHeaders) | default (list) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "orchestrator.fullname" . }}-config
+  labels:
+    {{- include "orchestrator.labels" . | nindent 4 }}
+data:
+  cors.allowedOrigins: {{ join "," $allowedOrigins | quote }}
+  cors.allowedMethods: {{ join "," $allowedMethods | quote }}
+  cors.allowedHeaders: {{ join "," $allowedHeaders | quote }}
+  cors.allowCredentials: {{ default (index $cors "allowCredentials") .Values.env.cors.allowCredentials | quote }}
+  rateLimit.requestsPerSecond: {{ default (index $ratelimits "requestsPerSecond") .Values.env.ratelimits.requestsPerSecond | quote }}
+  rateLimit.burst: {{ default (index $ratelimits "burst") .Values.env.ratelimits.burst | quote }}

--- a/deploy/helm/orchestrator/templates/deployment.yaml
+++ b/deploy/helm/orchestrator/templates/deployment.yaml
@@ -1,0 +1,93 @@
+{{- $global := .Values.global | default (dict) -}}
+{{- $chain := (index $global "chain") | default (dict) -}}
+{{- $contracts := (index $global "contracts") | default (dict) -}}
+{{- $cors := (index $global "cors") | default (dict) -}}
+{{- $ratelimits := (index $global "ratelimits") | default (dict) -}}
+{{- $rpc := (default (index $chain "rpcURLs") .Values.env.extra.rpcURLs) | default (list) -}}
+{{- $fallbackRpc := (default (index $chain "fallbackRPCURLs") .Values.env.extra.fallbackRPCURLs) | default (list) -}}
+{{- $allowedOrigins := (default (index $cors "allowedOrigins") .Values.env.cors.allowedOrigins) | default (list) -}}
+{{- $allowedMethods := (default (index $cors "allowedMethods") .Values.env.cors.allowedMethods) | default (list) -}}
+{{- $allowedHeaders := (default (index $cors "allowedHeaders") .Values.env.cors.allowedHeaders) | default (list) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "orchestrator.fullname" . }}
+  labels:
+    {{- include "orchestrator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "orchestrator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "orchestrator.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ default (include "orchestrator.fullname" .) .Values.serviceAccount.name }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: orchestrator
+          image: {{ include "orchestrator.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.env.logLevel | quote }}
+            - name: CHAIN_ID
+              value: {{ default (index $chain "id") .Values.env.extra.chainId | quote }}
+            - name: RPC_URLS
+              value: {{ join "," $rpc | quote }}
+            - name: FALLBACK_RPC_URLS
+              value: {{ join "," $fallbackRpc | quote }}
+            - name: BUNDLER_ADDRESS
+              value: {{ default (index $contracts "bundler") .Values.env.extra.bundler | quote }}
+            - name: PAYMASTER_ADDRESS
+              value: {{ default (index $contracts "paymaster") .Values.env.extra.paymaster | quote }}
+            - name: EAS_REGISTRY
+              value: {{ default (index $contracts "easRegistry") .Values.env.extra.easRegistry | quote }}
+            - name: EAS_SCHEMA_UID
+              value: {{ default (index $contracts "easSchemaUID") .Values.env.extra.easSchemaUID | quote }}
+            - name: ALLOWED_ORIGINS
+              value: {{ join "," $allowedOrigins | quote }}
+            - name: ALLOWED_METHODS
+              value: {{ join "," $allowedMethods | quote }}
+            - name: ALLOWED_HEADERS
+              value: {{ join "," $allowedHeaders | quote }}
+            - name: MAX_REQUEST_BYTES
+              value: {{ .Values.env.maxRequestBytes | quote }}
+            - name: RATE_LIMIT_RPS
+              value: {{ default (index $ratelimits "requestsPerSecond") .Values.env.ratelimits.requestsPerSecond | quote }}
+            - name: RATE_LIMIT_BURST
+              value: {{ default (index $ratelimits "burst") .Values.env.ratelimits.burst | quote }}
+          envFrom:
+            {{- range .Values.secretRefs }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.probe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probe.path }}
+              port: {{ .Values.probe.port }}
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probe.path }}
+              port: {{ .Values.probe.port }}
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.periodSeconds }}
+          {{- end }}

--- a/deploy/helm/orchestrator/templates/hpa.yaml
+++ b/deploy/helm/orchestrator/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "orchestrator.fullname" . }}
+  labels:
+    {{- include "orchestrator.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "orchestrator.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/orchestrator/templates/service.yaml
+++ b/deploy/helm/orchestrator/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "orchestrator.fullname" . }}
+  labels:
+    {{- include "orchestrator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "orchestrator.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/orchestrator/templates/serviceaccount.yaml
+++ b/deploy/helm/orchestrator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default (include "orchestrator.fullname" .) .Values.serviceAccount.name }}
+  labels:
+    {{- include "orchestrator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/orchestrator/values.yaml
+++ b/deploy/helm/orchestrator/values.yaml
@@ -1,0 +1,33 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/example/orchestrator
+  tag: "0.1.0"
+  digest: ""
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+service:
+  type: ClusterIP
+  port: 8000
+resources: {}
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+env:
+  logLevel: info
+  maxRequestBytes: 1048576
+  cors: {}
+  ratelimits: {}
+  extra: {}
+secretRefs: []
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+probe:
+  enabled: true
+  path: /healthz
+  port: http
+  initialDelaySeconds: 10
+  periodSeconds: 30

--- a/deploy/helm/paymaster-supervisor/Chart.yaml
+++ b/deploy/helm/paymaster-supervisor/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: paymaster-supervisor
+version: 0.1.0
+description: paymaster-supervisor service chart
+appVersion: "0.1.0"
+type: application

--- a/deploy/helm/paymaster-supervisor/templates/_helpers.tpl
+++ b/deploy/helm/paymaster-supervisor/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "paymaster-supervisor.fullname" -}}
+{{- printf "%s-%s" .Release.Name "paymaster-supervisor" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "paymaster-supervisor.labels" -}}
+helm.sh/chart: {{ include "paymaster-supervisor.chart" . }}
+app.kubernetes.io/name: paymaster-supervisor
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{- define "paymaster-supervisor.selectorLabels" -}}
+app.kubernetes.io/name: paymaster-supervisor
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "paymaster-supervisor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "paymaster-supervisor.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/paymaster-supervisor/templates/deployment.yaml
+++ b/deploy/helm/paymaster-supervisor/templates/deployment.yaml
@@ -1,0 +1,58 @@
+{{- $global := .Values.global | default (dict) -}}
+{{- $ratelimits := (index $global "ratelimits") | default (dict) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "paymaster-supervisor.fullname" . }}
+  labels:
+    {{- include "paymaster-supervisor.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "paymaster-supervisor.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "paymaster-supervisor.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ default (include "paymaster-supervisor.fullname" .) .Values.serviceAccount.name }}
+      {{- end }}
+      containers:
+        - name: paymaster-supervisor
+          image: {{ include "paymaster-supervisor.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.env.logLevel | quote }}
+            - name: ALLOWLIST
+              value: {{ join "," .Values.env.allowlist | quote }}
+            - name: RATE_LIMIT_RPS
+              value: {{ default (index $ratelimits "requestsPerSecond") .Values.env.extra.requestsPerSecond | quote }}
+            - name: RATE_LIMIT_BURST
+              value: {{ default (index $ratelimits "burst") .Values.env.extra.burst | quote }}
+          envFrom:
+            {{- range .Values.secretRefs }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.probe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probe.path }}
+              port: {{ .Values.probe.port }}
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probe.path }}
+              port: {{ .Values.probe.port }}
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.periodSeconds }}
+          {{- end }}

--- a/deploy/helm/paymaster-supervisor/templates/hpa.yaml
+++ b/deploy/helm/paymaster-supervisor/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "paymaster-supervisor.fullname" . }}
+  labels:
+    {{- include "paymaster-supervisor.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "paymaster-supervisor.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/paymaster-supervisor/templates/service.yaml
+++ b/deploy/helm/paymaster-supervisor/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "paymaster-supervisor.fullname" . }}
+  labels:
+    {{- include "paymaster-supervisor.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "paymaster-supervisor.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/paymaster-supervisor/templates/serviceaccount.yaml
+++ b/deploy/helm/paymaster-supervisor/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default (include "paymaster-supervisor.fullname" .) .Values.serviceAccount.name }}
+  labels:
+    {{- include "paymaster-supervisor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/paymaster-supervisor/values.yaml
+++ b/deploy/helm/paymaster-supervisor/values.yaml
@@ -1,0 +1,31 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/example/paymaster-supervisor
+  tag: "0.1.0"
+  digest: ""
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+service:
+  type: ClusterIP
+  port: 4000
+resources: {}
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+env:
+  logLevel: info
+  allowlist: []
+  extra: {}
+secretRefs: []
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+probe:
+  enabled: true
+  path: /healthz
+  port: http
+  initialDelaySeconds: 10
+  periodSeconds: 30

--- a/deploy/helm/postgres/Chart.yaml
+++ b/deploy/helm/postgres/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: postgres
+version: 0.1.0
+description: postgres service chart
+appVersion: "0.1.0"
+type: application

--- a/deploy/helm/postgres/templates/_helpers.tpl
+++ b/deploy/helm/postgres/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "postgres.fullname" -}}
+{{- printf "%s-%s" .Release.Name "postgres" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "postgres.labels" -}}
+helm.sh/chart: {{ include "postgres.chart" . }}
+app.kubernetes.io/name: postgres
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{- define "postgres.selectorLabels" -}}
+app.kubernetes.io/name: postgres
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "postgres.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "postgres.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/postgres/templates/secret.yaml
+++ b/deploy/helm/postgres/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "postgres.fullname" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+stringData:
+  postgres-user: {{ .Values.postgresUser | quote }}
+  postgres-password: {{ .Values.postgresPassword | quote }}
+  postgres-database: {{ .Values.postgresDatabase | quote }}

--- a/deploy/helm/postgres/templates/service.yaml
+++ b/deploy/helm/postgres/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postgres.fullname" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "postgres.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: postgres
+      name: postgres

--- a/deploy/helm/postgres/templates/statefulset.yaml
+++ b/deploy/helm/postgres/templates/statefulset.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "postgres.fullname" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "postgres.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "postgres.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "postgres.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: postgres
+          image: {{ include "postgres.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.fullname" . }}
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.fullname" . }}
+                  key: postgres-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.fullname" . }}
+                  key: postgres-database
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+  volumeClaimTemplates:
+    {{- if .Values.persistence.enabled }}
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass }}
+        {{- end }}
+    {{- else }}
+    []
+    {{- end }}

--- a/deploy/helm/postgres/values.yaml
+++ b/deploy/helm/postgres/values.yaml
@@ -1,0 +1,16 @@
+image:
+  repository: postgres
+  tag: "15"
+  digest: ""
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 5432
+postgresUser: graph
+postgresPassword: changeme
+postgresDatabase: graph
+persistence:
+  enabled: true
+  size: 20Gi
+  storageClass: ""
+resources: {}

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,34 @@
+# Disaster Recovery Plan
+
+## Objectives
+
+- **RPO**: 15 minutes for critical databases (Postgres, Graph Node).
+- **RTO**: 60 minutes for full stack restoration.
+
+## Backups
+
+| Component | Backup Method | Frequency | Retention |
+| --------- | ------------- | --------- | --------- |
+| Postgres | Managed snapshot via cloud storage | Hourly | 7 days rolling |
+| IPFS Data | Gateway pinset export to S3 | Daily | 30 days |
+| Helm Values | Encrypted copy in secrets manager | On change | 90 days |
+
+## Restoration Steps
+
+1. **Provision Cluster** – Create new Kubernetes cluster in standby region with identical node pools.
+2. **Restore Postgres** – Apply latest snapshot and promote replica.
+3. **Rehydrate IPFS** – Restore pinset via `ipfs pin add --recursive` from backup.
+4. **Deploy Stack** – Run `helm install` using stored `bootstrap-values.yaml` and image digests from CI artifacts.
+5. **Rebuild Subgraph** – Trigger Graph Node resync, monitor lag panel until under 20 blocks.
+6. **Validation** – Execute synthetic sponsored operation and verify receipt via portal.
+
+## Communication Plan
+
+- Incident commander opens bridge within 5 minutes.
+- Hourly updates posted to #agi-status Slack channel.
+- Post-mortem completed within 72 hours using blameless format.
+
+## Testing Cadence
+
+- Quarterly DR drill rotating between standby regions.
+- After every major infra change, run tabletop exercise covering reorg and RPC outage scenarios.

--- a/docs/node-operator-runbook.md
+++ b/docs/node-operator-runbook.md
@@ -1,0 +1,48 @@
+# Node Operator Runbook (Browser-Only)
+
+This runbook is designed for non-technical operators. Every workflow is achievable with a browser-based console such as Grafana, the stack dashboard, or a managed blockchain explorer.
+
+## Prerequisites
+
+- Access to the AGI Stack Operator Portal with multi-factor authentication.
+- Access to the treasury wallet view-only dashboard.
+- PagerDuty or Slack mobile app for receiving alerts.
+
+## Adjust Sponsored Fee Rates
+
+1. Navigate to **Operator Portal → Paymaster Controls**.
+2. Select **Fee Schedule** and choose the target chain (Testnet/Mainnet).
+3. Use the slider to set the base sponsorship fee in gwei. Tooltips show the resulting USD equivalent (sourced from the cpvo_usd metric).
+4. Click **Preview** to confirm the change and **Submit**. The portal creates a signed policy update via the Paymaster Supervisor API. No CLI steps are required.
+
+## Top Up Gas Treasury
+
+1. On the same portal, open **Treasury → Gas Wallet**.
+2. Review current balance and projected runway (based on 6h moving average of paymaster_sponsored_operations_total).
+3. If below the runbook threshold (0.05 ETH), click **Request Top-Up**.
+4. Approve the transaction in the connected custodial wallet UI (Fireblocks, Anchorage, etc.).
+5. The portal confirms the broadcast and records the transaction hash for auditing.
+
+## Flip Emergency Pause
+
+1. Open **Safety → Circuit Breaker**.
+2. Review live status of orchestrator success rates and current alerts.
+3. Click **Pause Sponsored Operations**. The portal performs a KMS-backed signature to toggle the on-chain pause switch.
+4. Confirm the dialog. The UI displays the resulting transaction hash and expected block confirmation time.
+5. To resume, use **Resume Operations** with the same confirmation flow.
+
+## View Receipts & EAS Proofs
+
+1. Navigate to **Receipts → Search**.
+2. Filter by wallet address, session ID, or attestation UID.
+3. The portal queries the subgraph and IPFS gateway to render:
+   - Sponsored operation metadata.
+   - EAS attestation details.
+   - Download link for receipt bundle.
+4. Click **Export** to save a PDF summary for compliance teams.
+
+## Respond to Alerts
+
+- Alerts contain direct runbook links. Tap the link to open the corresponding SRE action plan.
+- Acknowledge the alert in PagerDuty to avoid duplication.
+- For critical alerts, follow the escalation policy in the SRE runbook.

--- a/docs/one-pass-bootstrap.md
+++ b/docs/one-pass-bootstrap.md
@@ -1,0 +1,78 @@
+# One-Pass Bootstrap with Helm
+
+This document describes how to deploy the entire AGI stack in a single Helm install, covering chart dependencies, secrets, and validation.
+
+## Prerequisites
+
+- Kubernetes cluster (1.25+) with storage class for StatefulSets.
+- kubectl configured and authenticated.
+- Helm 3.12+.
+- Access to the secrets manager providing KMS URIs (AWS KMS, GCP KMS, or Hashicorp Vault).
+- DNS entry for the public ingress host.
+
+## 1. Prepare Values
+
+Create `bootstrap-values.yaml` by copying the sample below and updating the placeholders with production values.
+
+```yaml
+global:
+  environment: mainnet
+  chain:
+    id: 8453
+    rpcURLs:
+      - https://mainnet.example.rpc
+    fallbackRPCURLs:
+      - https://backup.rpc
+  contracts:
+    bundler: "0x..."
+    paymaster: "0x..."
+    easRegistry: "0x..."
+    easSchemaUID: "0x..."
+  cors:
+    allowedOrigins:
+      - https://portal.example.com
+  secrets:
+    kmsKeys:
+      attester: projects/app/locations/global/keyRings/prod/cryptoKeys/attester
+      paymaster: projects/app/locations/global/keyRings/prod/cryptoKeys/paymaster
+  ingress:
+    host: agi.example.com
+    className: nginx
+```
+
+## 2. Fetch Dependencies
+
+```bash
+helm dependency build deploy/helm/agi-stack
+```
+
+## 3. Install the Stack
+
+```bash
+helm install agi-stack deploy/helm/agi-stack -f bootstrap-values.yaml
+```
+
+The dependencies include orchestrator, bundler, paymaster supervisor, IPFS, graph-node, postgres, attester, and ingress. Helm renders pinned image digests by default when `.Values.*.image.digest` is provided, guaranteeing immutability.
+
+## 4. Validate Install
+
+- `kubectl get pods -l app.kubernetes.io/instance=agi-stack` should show all pods running.
+- `kubectl get ingress agi-stack-ingress` should expose the configured host with TLS.
+- Use the Grafana dashboard from `monitoring/grafana/dashboard-agi-ops.json` to confirm metrics emit within 15 minutes.
+
+## 5. Uninstall Cleanly
+
+```bash
+helm uninstall agi-stack
+```
+
+- All Deployments, StatefulSets, Services, and ConfigMaps are removed.
+- PersistentVolumeClaims remain only if `persistence.enabled` is set; otherwise the release is fully cleaned.
+- Use `kubectl get pvc` to confirm there are no orphaned volumes.
+
+## 6. Post-Install Hardening Checklist
+
+- Configure WAF rules on the ingress controller for IP throttling.
+- Enable HSTS by adding `nginx.ingress.kubernetes.io/hsts: "true"` to the ingress annotations.
+- Configure Kubernetes NetworkPolicies to restrict namespace traffic.
+- Sync SBOM artifacts from the CI workflow to your compliance store.

--- a/docs/policy-playbook.md
+++ b/docs/policy-playbook.md
@@ -1,0 +1,40 @@
+# Sponsorship Policy Playbook
+
+This playbook defines the guardrails for paymaster sponsorship and on-chain policies managed by the Paymaster Supervisor.
+
+## Governance Roles
+
+| Role | Responsibility | Approval Threshold |
+| ---- | -------------- | ------------------ |
+| Policy Admin | Draft and submit rule changes | 1 of 2 | 
+| Security Steward | Reviews changes for abuse vectors | 1 of 1 | 
+| Treasury | Confirms fee schedules | 1 of 1 |
+
+All changes are executed through the Operator Portal with KMS-backed signatures. Manual keys are prohibited.
+
+## Policy Types
+
+1. **Fee Schedule** – Sets base gas markup and USD equivalency thresholds.
+2. **Allowlist** – Defines dApps or AA accounts allowed to request sponsorship.
+3. **Velocity Controls** – Caps sponsored operations per minute per dApp.
+4. **Chain Failover** – Toggles fallback RPCs or disables chains after reorg events.
+
+## Change Workflow
+
+1. Draft policy in the portal and attach Jira ticket reference.
+2. Portal routes change to Security Steward for approval.
+3. Upon dual approval, the Paymaster Supervisor API executes an update transaction using a dedicated KMS key.
+4. CI/CD pipeline records the change hash in the provenance log artifact.
+5. Grafana annotation is created for visibility.
+
+## Emergency Controls
+
+- **Pause Switch** – Immediately halts sponsorship. Only Security Stewards can activate.
+- **Rate-Limit Override** – Temporarily increases rate limits to absorb legitimate traffic surges; auto expires in 60 minutes.
+- **RPC Failover** – Switches orchestrator RPC URLs to fallback set.
+
+## Review Cadence
+
+- Weekly review of cpvo_usd trend vs. treasury forecasts.
+- Monthly table-top validation of policy enforcement paths.
+- Quarterly red-team simulation for sponsorship abuse patterns.

--- a/docs/receipts-eas-guide.md
+++ b/docs/receipts-eas-guide.md
@@ -1,0 +1,40 @@
+# Receipts & EAS Verification Guide
+
+This guide shows auditors how to validate sponsored operation receipts and EAS attestations.
+
+## 1. Locate the Receipt Bundle
+
+1. Open the Operator Portal and navigate to **Receipts**.
+2. Search by wallet address or attestation UID.
+3. Download the bundle (ZIP) which contains:
+   - `receipt.json` – metadata and transaction hash.
+   - `eas.json` – attestation payload.
+   - `ipfs.cid` – root CID for attachments.
+
+## 2. Verify On-Chain Transaction
+
+1. Use the embedded link to open the transaction on a block explorer.
+2. Confirm the paymaster address matches the configured contract in `global.contracts.paymaster`.
+3. Ensure the `sponsorUserOperation` event includes the expected session identifier.
+
+## 3. Validate Attestation
+
+1. Copy the `schemaUID` from `eas.json`.
+2. Visit the EAS explorer and search by UID.
+3. Confirm the schema matches the documented `global.contracts.easSchemaUID`.
+4. Verify the attester address equals the Attester service’s KMS-backed signer.
+
+## 4. Rehydrate IPFS Assets
+
+1. Use `ipfs cid get <CID>` via the managed gateway URL from the portal.
+2. Confirm file hashes match those in `receipt.json`.
+3. Retain the downloaded evidence for 7 years per compliance policy.
+
+## 5. Offline Verification (Optional)
+
+1. Run the `tools/verify_receipt.ts` script with the downloaded bundle.
+2. The script checks:
+   - Merkle proofs for the receipt bundle.
+   - Attestation signature validity.
+   - Subgraph confirmation that the attestation is indexed.
+3. Record the success output in the compliance log.

--- a/docs/sre-runbooks.md
+++ b/docs/sre-runbooks.md
@@ -1,0 +1,47 @@
+# SRE Runbooks
+
+## Runbook Index
+
+| Scenario | Trigger | Runbook Link |
+| -------- | ------- | ------------ |
+| Paymaster gas low | `LowGasBalance` alert | https://docs.example.com/runbooks/paymaster-gas |
+| Sponsorship rejection spike | `SponsorshipRejectionSpike` alert | https://docs.example.com/runbooks/rejection-spike |
+| Bundler reverts spike | `BundlerRevertSpike` alert | https://docs.example.com/runbooks/revert-spike |
+| IPFS backlog | Dashboard panel "IPFS Pinning p95" > 60s | https://docs.example.com/runbooks/ipfs-backlog |
+| Subgraph lag | `service:subgraph_lag_blocks` > 40 | https://docs.example.com/runbooks/subgraph-lag |
+
+## Paymaster Gas Low
+
+1. Acknowledge alert in PagerDuty.
+2. Confirm gas balance in Operator Portal.
+3. Request treasury to top up via custodial wallet.
+4. Update incident ticket with transaction hash.
+5. Monitor cpvo_usd to ensure sponsorship pricing covers new cost basis.
+
+## Sponsorship Rejection Spike
+
+1. Inspect Grafana panel for rejection breakdown by dApp.
+2. Review Paymaster Supervisor logs for policy enforcement messages.
+3. If due to contract upgrades, coordinate rollback or whitelist update via Policy Playbook.
+4. If due to chain reorg, switch orchestrator to fallback RPC using Portal failover control.
+
+## Bundler Revert Spike
+
+1. Check mempool health and base fee using RPC diagnostics.
+2. Validate bundler image digest matches latest signed artifact from CI (see `image-digests` artifact).
+3. Pause sponsorship if revert rate > 20% for 15 minutes.
+4. Resume once reverts fall below 2/min and on-chain transactions confirm normally.
+
+## IPFS Pin Backlog
+
+1. Compare `service:ipfs_pin_latency_seconds:p95` to baseline (under 10s).
+2. Increase IPFS StatefulSet replicas temporarily via `helm upgrade --set ipfs.replicaCount=3`.
+3. Flush queue by retriggering pin workers in the Operator Portal.
+4. Scale down once backlog clears to avoid excess cost.
+
+## Subgraph Lag
+
+1. Inspect Graph Node logs for `head block behind` messages.
+2. Verify Postgres IOPS not saturated; scale volume or CPU if necessary.
+3. Trigger resync for affected subgraphs.
+4. If lag persists > 100 blocks, escalate to Indexing vendor support.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,52 @@
+# Threat Model & Tabletop Runbook
+
+## Assets & Trust Boundaries
+
+- **KMS-backed Keys** – Stored in cloud HSM, never written to disk. Used by Attester and Paymaster Supervisor pods via workload identity.
+- **Sponsored Funds** – Paymaster treasury wallet and bundler hot wallet.
+- **Attestations** – EAS schema data stored on-chain and pinned to IPFS.
+- **RPC Connectivity** – Primary and fallback RPC endpoints for orchestrator and bundler.
+
+Trust boundaries exist between the Kubernetes cluster, external RPC providers, IPFS gateways, and operator portal users.
+
+## Threat Scenarios
+
+| ID | Scenario | Control |
+| -- | -------- | ------- |
+| TM-1 | Chain reorg invalidates sponsored ops | Use fallback RPC, replay pending ops, alert via BundlerRevertSpike |
+| TM-2 | RPC outage causes downtime | Fallback RPC URLs, health probes, portal failover control |
+| TM-3 | IPFS pin backlog delays receipts | Autoscaling IPFS, monitoring `service:ipfs_pin_latency_seconds:p95` |
+| TM-4 | Account abstraction abuse (spam ops) | Rate limits, allowlists, WAF on ingress |
+| TM-5 | Key compromise | Workload identity, KMS HSM, strict pod security |
+
+## Tabletop Exercise Playbook
+
+### Chain Reorg (TM-1)
+1. Simulate reorg alert with sample Grafana annotation.
+2. Operator triggers orchestrator failover to fallback RPC.
+3. Bundler replays pending mempool and verifies receipts via portal.
+4. Post-incident review ensures cpvo_usd stays within budget.
+
+### RPC Outage (TM-2)
+1. Disable primary RPC endpoint in staging.
+2. Confirm alerts fire and portal failover toggled.
+3. Observe orchestrator pods using fallback endpoints from ConfigMap.
+4. Validate success rate recovers to >95% within 10 minutes.
+
+### IPFS Pin Backlog (TM-3)
+1. Flood pin queue in staging.
+2. Autoscale IPFS chart to 3 replicas via Helm upgrade.
+3. Monitor latency metric drop below 15s.
+4. Document actions in incident ticket.
+
+### AA Sponsorship Abuse (TM-4)
+1. Generate synthetic burst above configured rate limit.
+2. Confirm ingress WAF and paymaster supervisor rejections increase.
+3. Apply policy update using Policy Playbook.
+4. Resume normal operations and verify `SponsorshipRejectionSpike` alert clears.
+
+## Residual Risks
+
+- Dependence on third-party RPC SLA.
+- Operator portal availability (mitigated via multi-region hosting).
+- IPFS gateway rate limiting (mitigated by maintaining local pinning cluster).

--- a/monitoring/alertmanager/alerts.yaml
+++ b/monitoring/alertmanager/alerts.yaml
@@ -1,0 +1,20 @@
+route:
+  receiver: pagerduty
+  group_by: ['alertname']
+  routes:
+    - match:
+        severity: critical
+      receiver: pagerduty
+    - match:
+        severity: warning
+      receiver: slack
+receivers:
+  - name: pagerduty
+    pagerduty_configs:
+      - routing_key: '{{ pagerduty_routing_key }}'
+        description: '{{ .CommonAnnotations.summary }}'
+  - name: slack
+    slack_configs:
+      - channel: '#agi-ops'
+        text: '{{ template "slack.default.text" . }}'
+templates: []

--- a/monitoring/grafana/dashboard-agi-ops.json
+++ b/monitoring/grafana/dashboard-agi-ops.json
@@ -1,0 +1,88 @@
+{
+  "title": "AGI Stack SLOs",
+  "uid": "agi-slos",
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Time to Onboard p95",
+      "targets": [
+        {
+          "expr": "service:tto_seconds:rate5m",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Cost per Verified Operation (USD)",
+      "targets": [
+        {
+          "expr": "service:cpvo_usd:rate5m",
+          "legendFormat": "USD"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Bundler Success Rate",
+      "targets": [
+        {
+          "expr": "service:bundler_success_rate:ratio5m",
+          "legendFormat": "success rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "IPFS Pinning p95",
+      "targets": [
+        {
+          "expr": "service:ipfs_pin_latency_seconds:p95",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Subgraph Lag",
+      "targets": [
+        {
+          "expr": "service:subgraph_lag_blocks",
+          "legendFormat": "lag"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        }
+      }
+    }
+  ],
+  "templating": {
+    "list": []
+  },
+  "links": [
+    {
+      "title": "Runbooks",
+      "url": "https://docs.example.com/runbooks"
+    }
+  ]
+}

--- a/monitoring/prometheus/rules.yaml
+++ b/monitoring/prometheus/rules.yaml
@@ -1,0 +1,47 @@
+groups:
+  - name: orchestrator.slo
+    interval: 30s
+    rules:
+      - record: service:tto_seconds:rate5m
+        expr: histogram_quantile(0.95, sum(rate(orchestrator_time_to_onboard_seconds_bucket[5m])) by (le))
+      - record: service:cpvo_usd:rate5m
+        expr: sum(rate(paymaster_cost_per_verified_operation_usd[5m]))
+      - record: service:bundler_success_rate:ratio5m
+        expr: sum(rate(bundler_operations_total{status="success"}[5m])) / clamp_min(sum(rate(bundler_operations_total[5m])), 1)
+      - record: service:sponsored_ops_total:rate5m
+        expr: sum(rate(paymaster_sponsored_operations_total[5m]))
+      - record: service:sponsored_ops_rejections:rate5m
+        expr: sum(rate(paymaster_sponsored_operations_total{result="rejected"}[5m]))
+      - record: service:ipfs_pin_latency_seconds:p95
+        expr: histogram_quantile(0.95, sum(rate(ipfs_pin_duration_seconds_bucket[5m])) by (le))
+      - record: service:subgraph_lag_blocks
+        expr: max(max_over_time(graph_subgraph_head_block{deployment=~".*"}[5m]) - max_over_time(graph_chain_head_block{network=~".*"}[5m]))
+  - name: orchestrator.alerts
+    rules:
+      - alert: LowGasBalance
+        expr: min(eth_wallet_balance_wei{wallet="paymaster"}) < 5e16
+        for: 5m
+        labels:
+          severity: critical
+          runbook: https://docs.example.com/runbooks/paymaster-gas
+        annotations:
+          summary: Paymaster gas wallet below 0.05 ETH
+          description: Top up the configured treasury wallet before sponsorship halts.
+      - alert: SponsorshipRejectionSpike
+        expr: service:sponsored_ops_rejections:rate5m > 5
+        for: 10m
+        labels:
+          severity: warning
+          runbook: https://docs.example.com/runbooks/rejection-spike
+        annotations:
+          summary: Sponsored operation rejections increasing
+          description: Investigate upstream AA flow or contract configuration issues.
+      - alert: BundlerRevertSpike
+        expr: rate(bundler_operations_total{status="reverted"}[5m]) > 2
+        for: 5m
+        labels:
+          severity: warning
+          runbook: https://docs.example.com/runbooks/revert-spike
+        annotations:
+          summary: Bundler revert spike detected
+          description: Review recent deployments and mempool conditions.


### PR DESCRIPTION
## Summary
- add a one-pass umbrella Helm chart and component charts for the orchestrator, bundler, paymaster supervisor, attester, IPFS, graph node, Postgres, and ingress
- introduce docker build recipes and a CI/CD workflow that builds multi-environment images, signs artifacts, and emits SBOMs and provenance
- deliver observability rules, Grafana dashboards, and operations documentation covering bootstrap, policy, runbooks, and threat modelling

## Testing
- helm dependency build deploy/helm/agi-stack *(fails: helm not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbefa2b9408333be19894ad38f90be