### PR TITLE
Align graph-node Postgres defaults with postgres subchart

### DIFF
--- a/deploy/helm/agi-stack/values.yaml
+++ b/deploy/helm/agi-stack/values.yaml
@@ -98,6 +98,10 @@ graph-node:
     statusPort: 8020
     rpcPort: 8030
   resources: {}
+  # Override to point graph-node at an external Postgres instance if required
+  env:
+    postgresHost: ""
+    postgresPasswordSecret: ""
 
 postgres:
   image:

--- a/deploy/helm/graph-node/templates/_helpers.tpl
+++ b/deploy/helm/graph-node/templates/_helpers.tpl
@@ -26,3 +26,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "graph-node.postgresFullname" -}}
+{{- printf "%s-%s" .Release.Name "postgres" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/helm/graph-node/templates/deployment.yaml
+++ b/deploy/helm/graph-node/templates/deployment.yaml
@@ -27,14 +27,14 @@ spec:
               containerPort: {{ .Values.service.rpcPort }}
           env:
             - name: postgres_host
-              value: {{ .Values.env.postgresHost | quote }}
+              value: {{ default (include "graph-node.postgresFullname" .) .Values.env.postgresHost | quote }}
             - name: postgres_user
               value: {{ .Values.env.postgresUser | quote }}
             - name: postgres_pass
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.env.postgresPasswordSecret }}
-                  key: password
+                  name: {{ default (include "graph-node.postgresFullname" .) .Values.env.postgresPasswordSecret }}
+                  key: postgres-password
             - name: ipfs
               value: {{ .Values.env.ipfsURL | quote }}
             - name: ethereum

--- a/deploy/helm/graph-node/values.yaml
+++ b/deploy/helm/graph-node/values.yaml
@@ -16,8 +16,9 @@ autoscaling:
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80
 env:
-  postgresHost: postgres
+  # Defaults derive from the postgres subchart fullname when unset
+  postgresHost: ""
   postgresUser: graph
-  postgresPasswordSecret: graph-node-db
+  postgresPasswordSecret: ""
   ipfsURL: http://ipfs:5001
   ethereumRPC: []


### PR DESCRIPTION
## Summary
- default the graph-node chart Postgres host and password secret to the release's postgres fullname helper
- document how to override those values from the agi-stack umbrella chart
- ensure the deployment references the postgres chart secret key name

## Testing
- helm template graph deploy/helm/graph-node

------
https://chatgpt.com/codex/tasks/task_e_68dbfc14029483338d94ff8df4f595dd