### PR TITLE
Align paymaster metrics schema across monitoring

### DIFF
--- a/docs/paymaster-supervisor.md
+++ b/docs/paymaster-supervisor.md
@@ -15,8 +15,9 @@ application with:
 
 - `POST /v1/sponsor` – request sponsorship for a user operation.
 - `GET /healthz` and `GET /readyz` – surface balance-aware health status.
-- `GET /metrics` – Prometheus metrics (`sponsored_ops_total` and
-  `rejections_total{reason}`) describing sponsorship outcomes.
+- `GET /metrics` – Prometheus metrics (`paymaster_sponsored_operations_total` and
+  `paymaster_sponsored_operations_rejections_total{result}`) describing sponsorship
+  outcomes.
 
 ## Configuration schema (`config/paymaster.yaml`)
 

--- a/docs/sre-runbooks.md
+++ b/docs/sre-runbooks.md
@@ -20,7 +20,9 @@
 
 ## Sponsorship Rejection Spike
 
-1. Inspect Grafana panel for rejection breakdown by dApp.
+1. Inspect the Grafana panel "Sponsorship Rejections by Result" (derived from
+   `rate(paymaster_sponsored_operations_rejections_total[5m])`) to understand
+   which policy guardrails are firing.
 2. Review Paymaster Supervisor logs for policy enforcement messages.
 3. If due to contract upgrades, coordinate rollback or whitelist update via Policy Playbook.
 4. If due to chain reorg, switch orchestrator to fallback RPC using Portal failover control.

--- a/monitoring/grafana/dashboard-agi-ops.json
+++ b/monitoring/grafana/dashboard-agi-ops.json
@@ -1,7 +1,7 @@
 {
   "title": "AGI Stack SLOs",
   "uid": "agi-slos",
-  "version": 1,
+  "version": 2,
   "panels": [
     {
       "type": "timeseries",
@@ -42,6 +42,38 @@
           "unit": "percentunit",
           "min": 0,
           "max": 1
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Sponsored Operations Rate",
+      "targets": [
+        {
+          "expr": "service:sponsored_ops_total:rate5m",
+          "legendFormat": "sponsored ops/min"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Sponsorship Rejections by Result",
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(paymaster_sponsored_operations_rejections_total[5m]))",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0
         }
       }
     },

--- a/monitoring/prometheus/rules.yaml
+++ b/monitoring/prometheus/rules.yaml
@@ -11,7 +11,7 @@ groups:
       - record: service:sponsored_ops_total:rate5m
         expr: sum(rate(paymaster_sponsored_operations_total[5m]))
       - record: service:sponsored_ops_rejections:rate5m
-        expr: sum(rate(paymaster_sponsored_operations_total{result="rejected"}[5m]))
+        expr: sum(rate(paymaster_sponsored_operations_rejections_total[5m]))
       - record: service:ipfs_pin_latency_seconds:p95
         expr: histogram_quantile(0.95, sum(rate(ipfs_pin_duration_seconds_bucket[5m])) by (le))
       - record: service:subgraph_lag_blocks

--- a/paymaster/supervisor/service.py
+++ b/paymaster/supervisor/service.py
@@ -65,14 +65,14 @@ class PaymasterSupervisor:
         self._org_spend: Dict[str, tuple[_dt.date, int]] = {}
         self._metrics_registry = CollectorRegistry()  # type: ignore[call-arg]
         self._sponsored_ops = Counter(
-            "sponsored_ops_total",
+            "paymaster_sponsored_operations_total",
             "Count of user operations sponsored",
             registry=self._metrics_registry,
         )
         self._rejections = Counter(
-            "rejections_total",
+            "paymaster_sponsored_operations_rejections_total",
             "Count of sponsorship rejections",
-            labelnames=("reason",),
+            labelnames=("result",),
             registry=self._metrics_registry,
         )
         self._reload_task: Optional[asyncio.Task[None]] = None


### PR DESCRIPTION
## Summary
- rename the paymaster supervisor counters to the paymaster_sponsored_operations_* schema
- update Prometheus recording rules and Grafana dashboard panels to consume the renamed metrics
- refresh documentation and runbooks so they reference the new metric names and panels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbfe26b8f48333a53dda97327a4d50