### PR TITLE
Update digest artifact publishing and runbook references

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -132,13 +132,12 @@ JSON
           cosign attest --predicate predicate.json --type slsaprovenance ${{ env.REGISTRY }}/${{ matrix.target }}@${{ steps.build.outputs.digest }}
       - name: Publish image digest summary
         run: |
-          echo "${{ matrix.target }} (${{ matrix.network }}): ${{ steps.build.outputs.digest }}" >> image-digests.txt
+          echo "${{ matrix.target }} (${{ matrix.network }}): ${{ steps.build.outputs.digest }}" > image-digest-${{ matrix.target }}-${{ matrix.network }}.txt
       - name: Upload digest summary
-        if: matrix.network == 'mainnet' && matrix.target == 'orchestrator'
         uses: actions/upload-artifact@v4
         with:
-          name: image-digests
-          path: image-digests.txt
+          name: image-digest-${{ matrix.target }}-${{ matrix.network }}
+          path: image-digest-${{ matrix.target }}-${{ matrix.network }}.txt
 
   helm-test:
     name: Helm Lint

--- a/docs/sre-runbooks.md
+++ b/docs/sre-runbooks.md
@@ -10,6 +10,12 @@
 | IPFS backlog | Dashboard panel "IPFS Pinning p95" > 60s | https://docs.example.com/runbooks/ipfs-backlog |
 | Subgraph lag | `service:subgraph_lag_blocks` > 40 | https://docs.example.com/runbooks/subgraph-lag |
 
+## CI Artifact Reference
+
+- Container image digests are published per target/network combination as CI artifacts named `image-digest-${target}-${network}`.
+- Bundler releases: download `image-digest-bundler-mainnet` for mainnet or `image-digest-bundler-testnet` for testnet validation.
+- Paymaster supervisor releases: download `image-digest-paymaster-supervisor-mainnet` (or `...-testnet`) when preparing a rollout or comparing against running deployments.
+
 ## Paymaster Gas Low
 
 1. Acknowledge alert in PagerDuty.
@@ -17,6 +23,7 @@
 3. Request treasury to top up via custodial wallet.
 4. Update incident ticket with transaction hash.
 5. Monitor cpvo_usd to ensure sponsorship pricing covers new cost basis.
+6. If a redeploy is necessary, retrieve the latest paymaster image digest from the `image-digest-paymaster-supervisor-${network}` artifact before rolling out.
 
 ## Sponsorship Rejection Spike
 
@@ -30,7 +37,7 @@
 ## Bundler Revert Spike
 
 1. Check mempool health and base fee using RPC diagnostics.
-2. Validate bundler image digest matches latest signed artifact from CI (see `image-digests` artifact).
+2. Validate the bundler image digest matches the latest signed artifact from CI by downloading the `image-digest-bundler-${network}` artifact (mainnet uses `image-digest-bundler-mainnet`).
 3. Pause sponsorship if revert rate > 20% for 15 minutes.
 4. Resume once reverts fall below 2/min and on-chain transactions confirm normally.
 


### PR DESCRIPTION
## Summary
- update the CI workflow to publish per-target image digest artifacts
- refresh the SRE runbook with instructions for retrieving bundler and paymaster digests

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dbffc70d148333b171a319bc2312b8