### PR TITLE
Document observability stack wiring

### DIFF
--- a/monitoring/alertmanager/alerts.yaml
+++ b/monitoring/alertmanager/alerts.yaml
@@ -13,8 +13,10 @@ receivers:
     pagerduty_configs:
       - routing_key: '{{ pagerduty_routing_key }}'
         description: '{{ .CommonAnnotations.summary }}'
+        details:
+          runbook: '{{ .CommonAnnotations.runbook }}'
   - name: slack
     slack_configs:
       - channel: '#agi-ops'
-        text: '{{ template "slack.default.text" . }}'
+        text: '{{ template "slack.default.text" . }}\nRunbook: {{ .CommonAnnotations.runbook }}'
 templates: []

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,75 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+  scrape_timeout: 10s
+
+rule_files:
+  - rules.yaml
+
+scrape_configs:
+  - job_name: orchestrator
+    metrics_path: /metrics
+    kubernetes_sd_configs:
+      - role: endpoints
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+        action: keep
+        regex: orchestrator
+      - source_labels: [__meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: http
+  - job_name: bundler
+    metrics_path: /metrics
+    kubernetes_sd_configs:
+      - role: endpoints
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+        action: keep
+        regex: bundler
+      - source_labels: [__meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: http
+  - job_name: paymaster-supervisor
+    metrics_path: /metrics
+    kubernetes_sd_configs:
+      - role: endpoints
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+        action: keep
+        regex: paymaster-supervisor
+      - source_labels: [__meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: http
+  - job_name: attester
+    metrics_path: /metrics
+    kubernetes_sd_configs:
+      - role: endpoints
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+        action: keep
+        regex: attester
+      - source_labels: [__meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: http
+  - job_name: ipfs
+    metrics_path: /metrics
+    kubernetes_sd_configs:
+      - role: endpoints
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+        action: keep
+        regex: ipfs
+      - source_labels: [__meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: api
+  - job_name: graph-node
+    metrics_path: /metrics
+    kubernetes_sd_configs:
+      - role: endpoints
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+        action: keep
+        regex: graph-node
+      - source_labels: [__meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: status

--- a/monitoring/prometheus/rules.yaml
+++ b/monitoring/prometheus/rules.yaml
@@ -27,6 +27,7 @@ groups:
         annotations:
           summary: Paymaster gas wallet below 0.05 ETH
           description: Top up the configured treasury wallet before sponsorship halts.
+          runbook: https://docs.example.com/runbooks/paymaster-gas
       - alert: SponsorshipRejectionSpike
         expr: service:sponsored_ops_rejections:rate5m > 5
         for: 10m
@@ -36,6 +37,7 @@ groups:
         annotations:
           summary: Sponsored operation rejections increasing
           description: Investigate upstream AA flow or contract configuration issues.
+          runbook: https://docs.example.com/runbooks/rejection-spike
       - alert: BundlerRevertSpike
         expr: rate(bundler_operations_total{status="reverted"}[5m]) > 2
         for: 5m
@@ -45,3 +47,4 @@ groups:
         annotations:
           summary: Bundler revert spike detected
           description: Review recent deployments and mempool conditions.
+          runbook: https://docs.example.com/runbooks/revert-spike


### PR DESCRIPTION
## Summary
- add Prometheus configuration that auto-discovers Helm services and loads SLO rules
- enrich alertmanager templates with runbook pointers and document the observability workflow

## Testing
- not run (documentation and configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68dc00d936ac83339e0c296cf5452289