### PR TITLE
feat: bootstrap helm stack and ops runbooks

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,13 +1,9 @@
 apiVersion: v2
-name: aa-stack
+name: agi-stack
+description: Helm chart for deploying the AGI jobs stack in a single pass.
+type: application
 version: 0.1.0
-description: Unified chart for account abstraction stack components.
-icon: https://example.com/icon.png
-home: https://github.com/example/agi-stack
-keywords:
-  - account-abstraction
-  - bundler
-  - attestations
+appVersion: "0.1.0"
 dependencies:
   - name: orchestrator
     version: 0.1.0

--- a/deploy/helm/charts/attester/Chart.yaml
+++ b/deploy/helm/charts/attester/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: attester
+description: EAS attester service
 version: 0.1.0
-type: application
-description: Placeholder
+appVersion: "0.1.0"

--- a/deploy/helm/charts/attester/templates/_helpers.tpl
+++ b/deploy/helm/charts/attester/templates/_helpers.tpl
@@ -1,10 +1,3 @@
 {{- define "attester.fullname" -}}
-{{- printf "%s-attester" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "attester.labels" -}}
-app.kubernetes.io/name: attester
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: attester
-app.kubernetes.io/managed-by: Helm
+{{- printf "%s-%s" .Release.Name "attester" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/deploy/helm/charts/attester/templates/configmap.yaml
+++ b/deploy/helm/charts/attester/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "attester.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: attester
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  config.json: |
+    {
+      "corsAllowedOrigins": {{ toJson (.Values.config.corsOrigins | default .Values.global.cors.allowedOrigins | default (list "*")) }},
+      "schemaUid": "{{ required "config.easSchemaUid is required" .Values.config.easSchemaUid }}"
+    }

--- a/deploy/helm/charts/attester/templates/deployment.yaml
+++ b/deploy/helm/charts/attester/templates/deployment.yaml
@@ -3,31 +3,38 @@ kind: Deployment
 metadata:
   name: {{ include "attester.fullname" . }}
   labels:
-    {{- include "attester.labels" . | nindent 4 }}
+    app.kubernetes.io/name: attester
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: attester
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.autoscaling.minReplicas }}
-  {{- end }}
+  replicas: {{ default 1 .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "attester.labels" . | nindent 6 }}
+      app.kubernetes.io/name: attester
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      labels:
-        {{- include "attester.labels" . | nindent 8 }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/env-configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        app.kubernetes.io/name: attester
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: attester
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- end }}"
+          image: {{ .Values.image.repository }}{{- if .Values.image.digest -}}@{{ .Values.image.digest }}{{- else -}}:{{ .Values.image.tag }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: RPC_URL
+              value: {{ default (dig "rpc" "primary" .Values.global) .Values.config.rpcUrl | required "config.rpcUrl or global.rpc.primary must be set" | quote }}
+            - name: EAS_SCHEMA_UID
+              value: {{ default (dig "eas" "schemaUID" .Values.global) .Values.config.easSchemaUid | required "config.easSchemaUid or global.eas.schemaUID must be set" | quote }}
+            - name: KMS_KEY_URI
+              value: {{ default (dig "secrets" "attester" "kmsKey" .Values.global) .Values.config.kmsKey | required "config.kmsKey or global.secrets.attester.kmsKey must be set" | quote }}
+            - name: CORS_ALLOWED_ORIGINS
+              value: {{ join "," (.Values.config.corsOrigins | default (list "*")) | quote }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: http
-          envFrom:
-            - configMapRef:
-                name: {{ include "attester.fullname" . }}-env
-            - secretRef:
-                name: {{ include "attester.fullname" . }}-secrets
-          resources: {{- toYaml .Values.resources | nindent 12 }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/deploy/helm/charts/attester/templates/service.yaml
+++ b/deploy/helm/charts/attester/templates/service.yaml
@@ -3,13 +3,14 @@ kind: Service
 metadata:
   name: {{ include "attester.fullname" . }}
   labels:
-    {{- include "attester.labels" . | nindent 4 }}
+    app.kubernetes.io/name: attester
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   type: {{ .Values.service.type }}
-  selector:
-    {{- include "attester.labels" . | nindent 4 }}
   ports:
-    - name: http
-      port: {{ .Values.service.port }}
+    - port: {{ .Values.service.port }}
       targetPort: http
-      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: attester
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/attester/templates/servicemonitor.yaml
+++ b/deploy/helm/charts/attester/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.monitoring.enabled | default false) (.Values.global.monitoring.enabled | default false) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "attester.fullname" . }}
+  labels:
+    release: prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.global.monitoring.serviceMonitorNamespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: attester
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+{{- end }}

--- a/deploy/helm/charts/attester/values.yaml
+++ b/deploy/helm/charts/attester/values.yaml
@@ -1,16 +1,17 @@
 image:
-  repository: ghcr.io/example/attester
+  repository: ghcr.io/agi/jobs/attester
   tag: latest
   digest: ""
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
-  port: 8787
+  port: 7000
 resources: {}
-autoscaling:
+config:
+  rpcUrl: https://ethereum-sepolia.publicnode.com
+  easSchemaUid: "0x0000000000000000000000000000000000000000000000000000000000000000"
+  kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/attester
+  corsOrigins:
+    - https://operator.example.com
+monitoring:
   enabled: true
-  minReplicas: 1
-  maxReplicas: 3
-  cpuTargetPercentage: 75
-env: {}
-secrets: {}

--- a/deploy/helm/charts/bundler/Chart.yaml
+++ b/deploy/helm/charts/bundler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: bundler
+description: ERC-4337 bundler deployment
 version: 0.1.0
-type: application
-description: Placeholder
+appVersion: "0.1.0"

--- a/deploy/helm/charts/bundler/templates/_helpers.tpl
+++ b/deploy/helm/charts/bundler/templates/_helpers.tpl
@@ -1,10 +1,3 @@
 {{- define "bundler.fullname" -}}
-{{- printf "%s-bundler" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "bundler.labels" -}}
-app.kubernetes.io/name: bundler
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: bundler
-app.kubernetes.io/managed-by: Helm
+{{- printf "%s-%s" .Release.Name "bundler" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/deploy/helm/charts/bundler/templates/configmap.yaml
+++ b/deploy/helm/charts/bundler/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bundler.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: bundler
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  config.json: |
+    {
+      "bundleIntervalSeconds": {{ default 5 .Values.config.bundleIntervalSeconds }}
+    }

--- a/deploy/helm/charts/bundler/templates/deployment.yaml
+++ b/deploy/helm/charts/bundler/templates/deployment.yaml
@@ -3,31 +3,36 @@ kind: Deployment
 metadata:
   name: {{ include "bundler.fullname" . }}
   labels:
-    {{- include "bundler.labels" . | nindent 4 }}
+    app.kubernetes.io/name: bundler
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: bundler
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.autoscaling.minReplicas }}
-  {{- end }}
+  replicas: {{ default 1 .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "bundler.labels" . | nindent 6 }}
+      app.kubernetes.io/name: bundler
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      labels:
-        {{- include "bundler.labels" . | nindent 8 }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/env-configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        app.kubernetes.io/name: bundler
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: bundler
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- end }}"
+          image: {{ .Values.image.repository }}{{- if .Values.image.digest -}}@{{ .Values.image.digest }}{{- else -}}:{{ .Values.image.tag }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: RPC_URL
+              value: {{ default (dig "rpc" "primary" .Values.global) .Values.config.rpcUrl | required "config.rpcUrl or global.rpc.primary must be set" | quote }}
+            - name: ENTRY_POINT_ADDRESS
+              value: {{ default (dig "contracts" "entryPoint" .Values.global) .Values.config.entryPoint | required "config.entryPoint or global.contracts.entryPoint must be set" | quote }}
+            - name: BUNDLE_INTERVAL_SECONDS
+              value: {{ default 5 .Values.config.bundleIntervalSeconds | quote }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: http
-          envFrom:
-            - configMapRef:
-                name: {{ include "bundler.fullname" . }}-env
-            - secretRef:
-                name: {{ include "bundler.fullname" . }}-secrets
-          resources: {{- toYaml .Values.resources | nindent 12 }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/deploy/helm/charts/bundler/templates/service.yaml
+++ b/deploy/helm/charts/bundler/templates/service.yaml
@@ -3,13 +3,14 @@ kind: Service
 metadata:
   name: {{ include "bundler.fullname" . }}
   labels:
-    {{- include "bundler.labels" . | nindent 4 }}
+    app.kubernetes.io/name: bundler
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   type: {{ .Values.service.type }}
-  selector:
-    {{- include "bundler.labels" . | nindent 4 }}
   ports:
-    - name: http
-      port: {{ .Values.service.port }}
+    - port: {{ .Values.service.port }}
       targetPort: http
-      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: bundler
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/bundler/templates/servicemonitor.yaml
+++ b/deploy/helm/charts/bundler/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.monitoring.enabled | default false) (.Values.global.monitoring.enabled | default false) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "bundler.fullname" . }}
+  labels:
+    release: prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.global.monitoring.serviceMonitorNamespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bundler
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+{{- end }}

--- a/deploy/helm/charts/bundler/values.yaml
+++ b/deploy/helm/charts/bundler/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/example/bundler
+  repository: ghcr.io/agi/jobs/bundler
   tag: latest
   digest: ""
   pullPolicy: IfNotPresent
@@ -7,10 +7,9 @@ service:
   type: ClusterIP
   port: 3000
 resources: {}
-autoscaling:
+config:
+  rpcUrl: https://ethereum-sepolia.publicnode.com
+  entryPoint: "0x0000000000000000000000000000000000000000"
+  bundleIntervalSeconds: 5
+monitoring:
   enabled: true
-  minReplicas: 1
-  maxReplicas: 3
-  cpuTargetPercentage: 75
-env: {}
-secrets: {}

--- a/deploy/helm/charts/graph-node/Chart.yaml
+++ b/deploy/helm/charts/graph-node/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: graph-node
+description: Graph Node for subgraph indexing
 version: 0.1.0
-type: application
-description: Graph node for indexing contracts.
+appVersion: "0.1.0"

--- a/deploy/helm/charts/graph-node/templates/_helpers.tpl
+++ b/deploy/helm/charts/graph-node/templates/_helpers.tpl
@@ -1,10 +1,3 @@
-{{- define "graph-node.fullname" -}}
-{{- printf "%s-graph-node" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "graph-node.labels" -}}
-app.kubernetes.io/name: graph-node
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: graph-node
-app.kubernetes.io/managed-by: Helm
+{{- define "graphNode.fullname" -}}
+{{- printf "%s-%s" .Release.Name "graph-node" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/deploy/helm/charts/graph-node/templates/configmap.yaml
+++ b/deploy/helm/charts/graph-node/templates/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "graphNode.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: graph-node
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  config.toml: |
+    [store]
+    connection = "postgresql://{{ default "graph" .Values.config.postgres.username | urlquery }}:{{ "${POSTGRES_PASSWORD}" }}@{{ default (printf "%s-postgres" .Release.Name) .Values.config.postgres.host }}:5432/{{ .Values.config.postgres.database }}"
+
+    [chains]
+{{- range .Values.config.ethereumNetworks }}
+    [[chains.networks]]
+    name = "{{ .name }}"
+    label = "{{ .name }}"
+    provider = "{{ .rpc }}"
+{{- end }}
+
+    [ipfs]
+    address = "{{ default (printf "http://%s-ipfs:5001" .Release.Name) .Values.config.ipfs.endpoint }}"

--- a/deploy/helm/charts/graph-node/templates/deployment.yaml
+++ b/deploy/helm/charts/graph-node/templates/deployment.yaml
@@ -1,58 +1,51 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "graph-node.fullname" . }}
+  name: {{ include "graphNode.fullname" . }}
   labels:
-    {{- include "graph-node.labels" . | nindent 4 }}
+    app.kubernetes.io/name: graph-node
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: 1
+  replicas: {{ default 1 .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "graph-node.labels" . | nindent 6 }}
+      app.kubernetes.io/name: graph-node
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
-        {{- include "graph-node.labels" . | nindent 8 }}
+        app.kubernetes.io/name: graph-node
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: graph-node
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- end }}"
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: GRAPH_LOG
+              value: info
+            - name: RUST_LOG
+              value: info
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.postgres.userSecret }}
+                  key: POSTGRES_PASSWORD
+          args:
+            - run
+            - --config
+            - /etc/graph/config.toml
           ports:
             - containerPort: {{ .Values.service.port }}
               name: http
-          env:
-            {{- if (index .Values.env "ETHEREUM_RPC") }}
-            - name: ETHEREUM_RPC
-              value: "{{ index .Values.env "ETHEREUM_RPC" }}"
-            {{- else if .Values.ethereum.rpc }}
-            - name: ETHEREUM_RPC
-              value: "{{ join "," .Values.ethereum.rpc }}"
-            {{- end }}
-            - name: POSTGRES_HOST
-              value: {{ .Values.postgres.host | quote }}
-            - name: POSTGRES_PORT
-              value: "{{ .Values.postgres.port }}"
-            - name: POSTGRES_USER
-              value: {{ .Values.postgres.user | quote }}
-            - name: POSTGRES_DB
-              value: {{ .Values.postgres.database | quote }}
-            {{- range $key, $value := .Values.env }}
-            {{- if ne $key "ETHEREUM_RPC" }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
-            {{- end }}
-            {{- end }}
-          envFrom:
-            {{- if .Values.postgres.passwordSecret }}
-            - secretRef:
-                name: {{ .Values.postgres.passwordSecret }}
-            {{- end }}
-          readinessProbe:
-            httpGet:
-              path: /
-              port: http
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/graph
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "graphNode.fullname" . }}-config

--- a/deploy/helm/charts/graph-node/templates/secret.yaml
+++ b/deploy/helm/charts/graph-node/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: graph-node-postgres
+  labels:
+    app.kubernetes.io/name: graph-node
+    app.kubernetes.io/instance: {{ .Release.Name }}
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: change-me

--- a/deploy/helm/charts/graph-node/templates/service.yaml
+++ b/deploy/helm/charts/graph-node/templates/service.yaml
@@ -1,14 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "graph-node.fullname" . }}
+  name: {{ include "graphNode.fullname" . }}
   labels:
-    {{- include "graph-node.labels" . | nindent 4 }}
+    app.kubernetes.io/name: graph-node
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   type: {{ .Values.service.type }}
-  selector:
-    {{- include "graph-node.labels" . | nindent 4 }}
   ports:
-    - name: http
-      port: {{ .Values.service.port }}
+    - port: {{ .Values.service.port }}
       targetPort: http
+      name: http
+  selector:
+    app.kubernetes.io/name: graph-node
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/graph-node/templates/servicemonitor.yaml
+++ b/deploy/helm/charts/graph-node/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.monitoring.enabled | default false) (.Values.global.monitoring.enabled | default false) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "graphNode.fullname" . }}
+  labels:
+    release: prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.global.monitoring.serviceMonitorNamespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: graph-node
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+{{- end }}

--- a/deploy/helm/charts/graph-node/values.yaml
+++ b/deploy/helm/charts/graph-node/values.yaml
@@ -1,19 +1,20 @@
 image:
-  repository: graphprotocol/graph-node
-  tag: latest
-  digest: ""
+  repository: ghcr.io/graphprotocol/graph-node
+  tag: v0.32.0
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
   port: 8000
-postgres:
-  host: postgres
-  port: 5432
-  database: subgraph
-  user: subgraph
-  passwordSecret: ""
-  passwordSecretKey: password
-ethereum:
-  rpc: []
-env: {}
 resources: {}
+config:
+  ethereumNetworks:
+    - name: sepolia
+      rpc: https://ethereum-sepolia.publicnode.com
+  postgres:
+    host: ""
+    database: subgraph
+    userSecret: graph-node-postgres
+  ipfs:
+    endpoint: ""
+monitoring:
+  enabled: true

--- a/deploy/helm/charts/ingress/Chart.yaml
+++ b/deploy/helm/charts/ingress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: ingress
+description: Shared TLS ingress rules for the AGI stack
 version: 0.1.0
-type: application
-description: TLS ingress resources for external APIs.
+appVersion: "0.1.0"

--- a/deploy/helm/charts/ingress/templates/ingress.yaml
+++ b/deploy/helm/charts/ingress/templates/ingress.yaml
@@ -2,31 +2,36 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ printf "%s-gateway" .Release.Name | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-shared" .Release.Name }}
   annotations:
-{{- range $key, $value := .Values.annotations }}
-    {{ $key }}: {{ $value | quote }}
-{{- end }}
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "{{ .Values.security.hstsMaxAge }}"
+    nginx.ingress.kubernetes.io/hsts-include-subdomains: "{{ ternary "true" "false" (.Values.security.includeSubdomains | default true) }}"
+    nginx.ingress.kubernetes.io/hsts-preload: "{{ ternary "true" "false" (.Values.security.preload | default true) }}"
+    nginx.ingress.kubernetes.io/enable-access-log: "true"
+    nginx.ingress.kubernetes.io/limit-rpm: "{{ default 300 .Values.rateLimitRpm }}"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "1"
+    nginx.ingress.kubernetes.io/enable-modsecurity: {{ .Values.security.wafAnnotation | quote }}
 spec:
-  ingressClassName: {{ .Values.className }}
-  {{- if and .Values.tls.enabled .Values.tls.secretName }}
+  ingressClassName: {{ .Values.ingressClassName }}
   tls:
-    - hosts:
-        - {{ .Values.host }}
-      secretName: {{ .Values.tls.secretName }}
-  {{- end }}
+    - secretName: {{ .Values.defaultTlsSecret }}
+      hosts:
+{{- range .Values.hosts }}
+        - {{ .host }}
+{{- end }}
   rules:
-    - host: {{ .Values.host }}
+{{- range .Values.hosts }}
+    - host: {{ .host }}
       http:
         paths:
-{{- range $name, $service := .Values.services }}
-          {{- $svcName := default (printf "%s-%s" $.Release.Name $name) $service.serviceName }}
-          - path: /{{ $name }}
+          - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ $svcName }}
+                name: {{ printf "%s-%s" $.Release.Name .serviceName }}
                 port:
-                  number: {{ default 80 $service.servicePort }}
+                  number: {{ .servicePort }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/charts/ingress/values.yaml
+++ b/deploy/helm/charts/ingress/values.yaml
@@ -1,14 +1,18 @@
 enabled: true
-className: nginx
-host: example.org
-tls:
-  enabled: true
-  secretName: example-tls
-annotations: {}
-services:
-  orchestrator:
+ingressClassName: nginx
+defaultTlsSecret: agi-stack-tls
+hosts:
+  - host: orchestrator.example.com
     serviceName: orchestrator
-    servicePort: 80
-  bundler:
+    servicePort: 8000
+  - host: bundler.example.com
     serviceName: bundler
-    servicePort: 80
+    servicePort: 3000
+  - host: attester.example.com
+    serviceName: attester
+    servicePort: 7000
+security:
+  hstsMaxAge: 63072000
+  includeSubdomains: true
+  preload: true
+  wafAnnotation: "true"

--- a/deploy/helm/charts/ipfs/Chart.yaml
+++ b/deploy/helm/charts/ipfs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: ipfs
+description: IPFS node with pinning configuration
 version: 0.1.0
-type: application
-description: IPFS pinning service for receipts.
+appVersion: "0.1.0"

--- a/deploy/helm/charts/ipfs/templates/_helpers.tpl
+++ b/deploy/helm/charts/ipfs/templates/_helpers.tpl
@@ -1,10 +1,3 @@
 {{- define "ipfs.fullname" -}}
-{{- printf "%s-ipfs" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "ipfs.labels" -}}
-app.kubernetes.io/name: ipfs
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: ipfs
-app.kubernetes.io/managed-by: Helm
+{{- printf "%s-%s" .Release.Name "ipfs" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/deploy/helm/charts/ipfs/templates/service.yaml
+++ b/deploy/helm/charts/ipfs/templates/service.yaml
@@ -3,11 +3,10 @@ kind: Service
 metadata:
   name: {{ include "ipfs.fullname" . }}
   labels:
-    {{- include "ipfs.labels" . | nindent 4 }}
+    app.kubernetes.io/name: ipfs
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  type: {{ .Values.service.type }}
-  selector:
-    {{- include "ipfs.labels" . | nindent 4 }}
+  clusterIP: None
   ports:
     - name: api
       port: {{ .Values.service.apiPort }}
@@ -15,18 +14,9 @@ spec:
     - name: swarm
       port: {{ .Values.service.swarmPort }}
       targetPort: swarm
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "ipfs.fullname" . }}-headless
-  labels:
-    {{- include "ipfs.labels" . | nindent 4 }}
-spec:
-  clusterIP: None
+    - name: gateway
+      port: {{ .Values.service.gatewayPort }}
+      targetPort: gateway
   selector:
-    {{- include "ipfs.labels" . | nindent 4 }}
-  ports:
-    - name: api
-      port: {{ .Values.service.apiPort }}
-      targetPort: api
+    app.kubernetes.io/name: ipfs
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/ipfs/templates/servicemonitor.yaml
+++ b/deploy/helm/charts/ipfs/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.monitoring.enabled | default false) (.Values.global.monitoring.enabled | default false) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ipfs.fullname" . }}
+  labels:
+    release: prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.global.monitoring.serviceMonitorNamespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ipfs
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: api
+      path: /debug/metrics/prometheus
+      interval: 30s
+{{- end }}

--- a/deploy/helm/charts/ipfs/templates/statefulset.yaml
+++ b/deploy/helm/charts/ipfs/templates/statefulset.yaml
@@ -3,39 +3,65 @@ kind: StatefulSet
 metadata:
   name: {{ include "ipfs.fullname" . }}
   labels:
-    {{- include "ipfs.labels" . | nindent 4 }}
+    app.kubernetes.io/name: ipfs
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  serviceName: {{ include "ipfs.fullname" . }}-headless
-  replicas: 1
+  serviceName: {{ include "ipfs.fullname" . }}
+  replicas: {{ default 1 .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "ipfs.labels" . | nindent 6 }}
+      app.kubernetes.io/name: ipfs
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        {{- include "ipfs.labels" . | nindent 8 }}
+        app.kubernetes.io/name: ipfs
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: ipfs
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- end }}"
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: api
-              containerPort: {{ .Values.service.apiPort }}
-            - name: swarm
-              containerPort: {{ .Values.service.swarmPort }}
-          volumeMounts:
-            - name: data
-              mountPath: /data/ipfs
+          args:
+            - daemon
+            - --migrate=true
+            - --routing=dhtclient
           env:
-            - name: LIBP2P_FORCE_PNET
-              value: "1"
+            - name: IPFS_PROFILE
+              value: {{ default "server" .Values.config.profile | quote }}
+          ports:
+            - containerPort: {{ .Values.service.apiPort }}
+              name: api
+            - containerPort: {{ .Values.service.swarmPort }}
+              name: swarm
+            - containerPort: {{ .Values.service.gatewayPort }}
+              name: gateway
+          volumeMounts:
+            - mountPath: /data/ipfs
+              name: data
+          livenessProbe:
+            httpGet:
+              path: /api/v0/version
+              port: api
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/v0/id
+              port: api
+            initialDelaySeconds: 30
+            periodSeconds: 30
+      volumes:
+        {{- if .Values.config.swarmKeySecret }}
+        - name: swarm-key
+          secret:
+            secretName: {{ .Values.config.swarmKeySecret }}
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
-        storageClassName: {{ .Values.persistence.storageClass | quote }}
         resources:
           requests:
             storage: {{ .Values.persistence.size }}

--- a/deploy/helm/charts/ipfs/values.yaml
+++ b/deploy/helm/charts/ipfs/values.yaml
@@ -1,14 +1,17 @@
 image:
-  repository: ipfs/kubo
-  tag: latest
-  digest: ""
+  repository: ipfs/go-ipfs
+  tag: v0.23.0
   pullPolicy: IfNotPresent
 service:
-  type: ClusterIP
   apiPort: 5001
   swarmPort: 4001
+  gatewayPort: 8080
 persistence:
   enabled: true
-  storageClass: standard
-  size: 100Gi
+  size: 50Gi
 resources: {}
+config:
+  profile: server
+  swarmKeySecret: ""
+monitoring:
+  enabled: true

--- a/deploy/helm/charts/orchestrator/Chart.yaml
+++ b/deploy/helm/charts/orchestrator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: orchestrator
+description: FastAPI orchestrator deployment
 version: 0.1.0
-description: FastAPI orchestrator for sponsored AA flows.
-type: application
+appVersion: "0.1.0"

--- a/deploy/helm/charts/orchestrator/templates/_helpers.tpl
+++ b/deploy/helm/charts/orchestrator/templates/_helpers.tpl
@@ -1,10 +1,7 @@
 {{- define "orchestrator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{ .Values.fullnameOverride }}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name "orchestrator" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{- define "orchestrator.labels" -}}
-app.kubernetes.io/name: orchestrator
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: orchestrator
-app.kubernetes.io/managed-by: Helm
 {{- end -}}

--- a/deploy/helm/charts/orchestrator/templates/deployment.yaml
+++ b/deploy/helm/charts/orchestrator/templates/deployment.yaml
@@ -3,39 +3,63 @@ kind: Deployment
 metadata:
   name: {{ include "orchestrator.fullname" . }}
   labels:
-    {{- include "orchestrator.labels" . | nindent 4 }}
+    app.kubernetes.io/name: orchestrator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: api
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.autoscaling.minReplicas }}
-  {{- end }}
+  replicas: {{ default 1 .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "orchestrator.labels" . | nindent 6 }}
+      app.kubernetes.io/name: orchestrator
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      labels:
-        {{- include "orchestrator.labels" . | nindent 8 }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/env-configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/env-config.yaml") . | sha256sum }}
+      labels:
+        app.kubernetes.io/name: orchestrator
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: orchestrator
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- end }}"
+          image: {{ .Values.image.repository }}{{- if .Values.image.digest -}}@{{ .Values.image.digest }}{{- else -}}:{{ default .Chart.AppVersion .Values.image.tag }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.env.logLevel | quote }}
+            - name: CORS_ALLOWED_ORIGINS
+              value: {{ join "," .Values.env.corsOrigins | quote }}
+            - name: KMS_KEY_URI
+              value: {{ .Values.env.kmsKey | quote }}
+            - name: ENTRY_POINT_ADDRESS
+              value: {{ required "contracts.entryPoint is required" (dig "contracts" "entryPoint" .Values.global) | quote }}
+            - name: PAYMASTER_ADDRESS
+              value: {{ required "contracts.paymaster is required" (dig "contracts" "paymaster" .Values.global) | quote }}
+            - name: EAS_SCHEMA_UID
+              value: {{ required "eas.schemaUID is required" (dig "eas" "schemaUID" .Values.global) | quote }}
+            - name: RPC_URL
+              value: {{ required "rpc.primary is required" (dig "rpc" "primary" .Values.global) | quote }}
+            - name: STACK_PAUSED
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.global.pauseSwitch.configMap }}
+                  key: {{ .Values.global.pauseSwitch.key }}
+                  optional: true
+            - name: MAX_REQUEST_BYTES
+              value: {{ .Values.env.maxRequestBytes | quote }}
           ports:
-            - containerPort: 8000
-              name: http
-          envFrom:
-            - configMapRef:
-                name: {{ include "orchestrator.fullname" . }}-env
-            - secretRef:
-                name: {{ include "orchestrator.fullname" . }}-secrets
-          resources: {{- toYaml .Values.resources | nindent 12 }}
+            - containerPort: {{ .Values.service.port }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 15
+            periodSeconds: 20

--- a/deploy/helm/charts/orchestrator/templates/env-config.yaml
+++ b/deploy/helm/charts/orchestrator/templates/env-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "orchestrator.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: orchestrator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  config.json: |
+    {
+      "rateLimit": {
+        "requestsPerMinute": {{ .Values.rateLimit.requestsPerMinute }},
+        "burst": {{ .Values.rateLimit.burst }}
+      }
+    }

--- a/deploy/helm/charts/orchestrator/templates/hpa.yaml
+++ b/deploy/helm/charts/orchestrator/templates/hpa.yaml
@@ -1,10 +1,11 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if .Values.autoscaling.enabled | default false }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "orchestrator.fullname" . }}
   labels:
-    {{- include "orchestrator.labels" . | nindent 4 }}
+    app.kubernetes.io/name: orchestrator
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deploy/helm/charts/orchestrator/templates/ingress.yaml
+++ b/deploy/helm/charts/orchestrator/templates/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "orchestrator.fullname" . }}
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: {{ join "," (.Values.env.corsOrigins | default (list "*")) | quote }}
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET,POST,OPTIONS"
+    nginx.ingress.kubernetes.io/limit-rpm: "{{ .Values.rateLimit.requestsPerMinute }}"
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ div .Values.env.maxRequestBytes 1024 }}k"
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  tls:
+    - secretName: {{ .Values.ingress.tlsSecret }}
+      hosts:
+        - {{ .Values.ingress.host }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "orchestrator.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/deploy/helm/charts/orchestrator/templates/service.yaml
+++ b/deploy/helm/charts/orchestrator/templates/service.yaml
@@ -3,13 +3,14 @@ kind: Service
 metadata:
   name: {{ include "orchestrator.fullname" . }}
   labels:
-    {{- include "orchestrator.labels" . | nindent 4 }}
+    app.kubernetes.io/name: orchestrator
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   type: {{ .Values.service.type }}
-  selector:
-    {{- include "orchestrator.labels" . | nindent 4 }}
   ports:
-    - name: http
-      port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      name: http
+  selector:
+    app.kubernetes.io/name: orchestrator
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/orchestrator/templates/servicemonitor.yaml
+++ b/deploy/helm/charts/orchestrator/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.monitoring.enabled | default false) (.Values.global.monitoring.enabled | default false) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "orchestrator.fullname" . }}
+  labels:
+    release: prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.global.monitoring.serviceMonitorNamespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: orchestrator
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+{{- end }}

--- a/deploy/helm/charts/orchestrator/values.yaml
+++ b/deploy/helm/charts/orchestrator/values.yaml
@@ -1,16 +1,29 @@
 image:
-  repository: ghcr.io/example/orchestrator
-  tag: latest
+  repository: ghcr.io/agi/jobs/orchestrator
+  tag: ""
   digest: ""
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
-  port: 80
+  port: 8000
+env:
+  logLevel: info
+  corsOrigins: []
+  kmsKey: ""
+  maxRequestBytes: 1048576
 resources: {}
 autoscaling:
-  enabled: true
+  enabled: false
   minReplicas: 2
   maxReplicas: 5
-  cpuTargetPercentage: 70
-env: {}
-secrets: {}
+  cpuTargetPercentage: 60
+ingress:
+  enabled: false
+  className: nginx
+  host: orchestrator.example.com
+  tlsSecret: orchestrator-tls
+rateLimit:
+  requestsPerMinute: 300
+  burst: 50
+monitoring:
+  enabled: true

--- a/deploy/helm/charts/paymaster-supervisor/Chart.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: paymaster-supervisor
+description: Paymaster supervisor managing sponsorship policy
 version: 0.1.0
-type: application
-description: Placeholder
+appVersion: "0.1.0"

--- a/deploy/helm/charts/paymaster-supervisor/templates/_helpers.tpl
+++ b/deploy/helm/charts/paymaster-supervisor/templates/_helpers.tpl
@@ -1,10 +1,3 @@
-{{- define "paymaster-supervisor.fullname" -}}
-{{- printf "%s-paymaster-supervisor" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "paymaster-supervisor.labels" -}}
-app.kubernetes.io/name: paymaster-supervisor
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: paymaster-supervisor
-app.kubernetes.io/managed-by: Helm
+{{- define "paymasterSupervisor.fullname" -}}
+{{- printf "%s-%s" .Release.Name "paymaster-supervisor" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/deploy/helm/charts/paymaster-supervisor/templates/configmap.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "paymasterSupervisor.fullname" . }}-policy
+  labels:
+    app.kubernetes.io/name: paymaster-supervisor
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  policy.yaml: |
+    treasury: {{ required "config.treasuryAddress is required" .Values.config.treasuryAddress }}
+    sponsorshipBudgetUsd: {{ default 100.0 .Values.config.sponsorshipBudgetUsd }}

--- a/deploy/helm/charts/paymaster-supervisor/templates/deployment.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/templates/deployment.yaml
@@ -1,33 +1,42 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "paymaster-supervisor.fullname" . }}
+  name: {{ include "paymasterSupervisor.fullname" . }}
   labels:
-    {{- include "paymaster-supervisor.labels" . | nindent 4 }}
+    app.kubernetes.io/name: paymaster-supervisor
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: paymaster
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.autoscaling.minReplicas }}
-  {{- end }}
+  replicas: {{ default 1 .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "paymaster-supervisor.labels" . | nindent 6 }}
+      app.kubernetes.io/name: paymaster-supervisor
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      labels:
-        {{- include "paymaster-supervisor.labels" . | nindent 8 }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/env-configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        app.kubernetes.io/name: paymaster-supervisor
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: paymaster-supervisor
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- end }}"
+          image: {{ .Values.image.repository }}{{- if .Values.image.digest -}}@{{ .Values.image.digest }}{{- else -}}:{{ .Values.image.tag }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: RPC_URL
+              value: {{ default (dig "rpc" "primary" .Values.global) .Values.config.rpcUrl | required "config.rpcUrl or global.rpc.primary must be set" | quote }}
+            - name: PAYMASTER_ADDRESS
+              value: {{ default (dig "contracts" "paymaster" .Values.global) .Values.config.paymasterAddress | required "config.paymasterAddress or global.contracts.paymaster must be set" | quote }}
+            - name: TREASURY_ADDRESS
+              value: {{ required "config.treasuryAddress is required" .Values.config.treasuryAddress | quote }}
+            - name: SPONSORSHIP_BUDGET_USD
+              value: {{ default 100.0 .Values.config.sponsorshipBudgetUsd | quote }}
+            - name: KMS_KEY_URI
+              value: {{ default (dig "secrets" "paymaster" "kmsKey" .Values.global) .Values.config.kmsKey | required "config.kmsKey or global.secrets.paymaster.kmsKey must be set" | quote }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: http
-          envFrom:
-            - configMapRef:
-                name: {{ include "paymaster-supervisor.fullname" . }}-env
-            - secretRef:
-                name: {{ include "paymaster-supervisor.fullname" . }}-secrets
-          resources: {{- toYaml .Values.resources | nindent 12 }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/deploy/helm/charts/paymaster-supervisor/templates/service.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/templates/service.yaml
@@ -1,15 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "paymaster-supervisor.fullname" . }}
+  name: {{ include "paymasterSupervisor.fullname" . }}
   labels:
-    {{- include "paymaster-supervisor.labels" . | nindent 4 }}
+    app.kubernetes.io/name: paymaster-supervisor
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   type: {{ .Values.service.type }}
-  selector:
-    {{- include "paymaster-supervisor.labels" . | nindent 4 }}
   ports:
-    - name: http
-      port: {{ .Values.service.port }}
+    - port: {{ .Values.service.port }}
       targetPort: http
-      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: paymaster-supervisor
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/paymaster-supervisor/templates/servicemonitor.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.monitoring.enabled | default false) (.Values.global.monitoring.enabled | default false) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "paymasterSupervisor.fullname" . }}
+  labels:
+    release: prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.global.monitoring.serviceMonitorNamespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: paymaster-supervisor
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+{{- end }}

--- a/deploy/helm/charts/paymaster-supervisor/values.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/example/paymaster-supervisor
+  repository: ghcr.io/agi/jobs/paymaster-supervisor
   tag: latest
   digest: ""
   pullPolicy: IfNotPresent
@@ -7,10 +7,11 @@ service:
   type: ClusterIP
   port: 8080
 resources: {}
-autoscaling:
+config:
+  rpcUrl: https://ethereum-sepolia.publicnode.com
+  paymasterAddress: "0x0000000000000000000000000000000000000000"
+  kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/paymaster
+  treasuryAddress: "0x0000000000000000000000000000000000000000"
+  sponsorshipBudgetUsd: 100.0
+monitoring:
   enabled: true
-  minReplicas: 1
-  maxReplicas: 3
-  cpuTargetPercentage: 75
-env: {}
-secrets: {}

--- a/deploy/helm/charts/postgres/Chart.yaml
+++ b/deploy/helm/charts/postgres/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: postgres
+description: Postgres backing store for subgraph
 version: 0.1.0
-type: application
-description: Postgres backing store for subgraph data.
+appVersion: "14"

--- a/deploy/helm/charts/postgres/templates/_helpers.tpl
+++ b/deploy/helm/charts/postgres/templates/_helpers.tpl
@@ -1,10 +1,3 @@
 {{- define "postgres.fullname" -}}
-{{- printf "%s-postgres" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "postgres.labels" -}}
-app.kubernetes.io/name: postgres
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: postgres
-app.kubernetes.io/managed-by: Helm
+{{- printf "%s-%s" .Release.Name "postgres" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/deploy/helm/charts/postgres/templates/service.yaml
+++ b/deploy/helm/charts/postgres/templates/service.yaml
@@ -3,26 +3,14 @@ kind: Service
 metadata:
   name: {{ include "postgres.fullname" . }}
   labels:
-    {{- include "postgres.labels" . | nindent 4 }}
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  selector:
-    {{- include "postgres.labels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
   ports:
-    - name: postgres
-      port: {{ .Values.service.port }}
+    - port: {{ .Values.service.port }}
       targetPort: postgres
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "postgres.fullname" . }}-headless
-  labels:
-    {{- include "postgres.labels" . | nindent 4 }}
-spec:
-  clusterIP: None
+      name: postgres
   selector:
-    {{- include "postgres.labels" . | nindent 4 }}
-  ports:
-    - name: postgres
-      port: {{ .Values.service.port }}
-      targetPort: postgres
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/postgres/templates/servicemonitor.yaml
+++ b/deploy/helm/charts/postgres/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and (.Values.monitoring.enabled | default false) (.Values.global.monitoring.enabled | default false) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "postgres.fullname" . }}
+  labels:
+    release: prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.global.monitoring.serviceMonitorNamespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: postgres
+      interval: 30s
+      scrapeTimeout: 10s
+      metricRelabelings: []
+{{- end }}

--- a/deploy/helm/charts/postgres/templates/statefulset.yaml
+++ b/deploy/helm/charts/postgres/templates/statefulset.yaml
@@ -3,44 +3,48 @@ kind: StatefulSet
 metadata:
   name: {{ include "postgres.fullname" . }}
   labels:
-    {{- include "postgres.labels" . | nindent 4 }}
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  serviceName: {{ include "postgres.fullname" . }}-headless
+  serviceName: {{ include "postgres.fullname" . }}
   replicas: 1
   selector:
     matchLabels:
-      {{- include "postgres.labels" . | nindent 6 }}
+      app.kubernetes.io/name: postgres
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        {{- include "postgres.labels" . | nindent 8 }}
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: postgres
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- end }}"
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.config.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.config.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.existingSecret }}
+                  key: POSTGRES_PASSWORD
           ports:
             - containerPort: {{ .Values.service.port }}
               name: postgres
-          env:
-            - name: POSTGRES_DB
-              value: {{ .Values.auth.database | quote }}
-            - name: POSTGRES_USER
-              value: {{ .Values.auth.username | quote }}
-          envFrom:
-            {{- if .Values.auth.existingSecret }}
-            - secretRef:
-                name: {{ .Values.auth.existingSecret }}
-            {{- end }}
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
   volumeClaimTemplates:
     - metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
-        storageClassName: {{ .Values.persistence.storageClass | quote }}
         resources:
           requests:
             storage: {{ .Values.persistence.size }}

--- a/deploy/helm/charts/postgres/values.yaml
+++ b/deploy/helm/charts/postgres/values.yaml
@@ -1,15 +1,16 @@
 image:
   repository: postgres
-  tag: "15"
-  digest: ""
+  tag: "14"
   pullPolicy: IfNotPresent
-auth:
-  username: subgraph
-  database: subgraph
-  existingSecret: ""
-persistence:
-  storageClass: standard
-  size: 100Gi
 service:
+  type: ClusterIP
   port: 5432
 resources: {}
+persistence:
+  size: 20Gi
+config:
+  database: subgraph
+  username: graph
+  existingSecret: graph-node-postgres
+monitoring:
+  enabled: true

--- a/deploy/helm/templates/pause-switch.yaml
+++ b/deploy/helm/templates/pause-switch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.global.pauseSwitch.configMap }}
+  labels:
+    app.kubernetes.io/name: agi-stack
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  {{ .Values.global.pauseSwitch.key }}: {{ default "false" .Values.global.pauseSwitch.default | quote }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,137 +1,200 @@
+# Global configuration shared across the stack
 global:
   chainId: 11155111
+  network: sepolia
   rpc:
-    primary: https://sepolia.example.org
-    fallback: https://rpc-backup.example.org
+    primary: https://ethereum-sepolia.publicnode.com
+    fallback: []
   contracts:
     entryPoint: "0x0000000000000000000000000000000000000000"
     paymaster: "0x0000000000000000000000000000000000000000"
-    aaRegistry: "0x0000000000000000000000000000000000000000"
-    eas:
-      schemaUID: "0x0000000000000000000000000000000000000000000000000000000000000000"
+    attester: "0x0000000000000000000000000000000000000000"
+  eas:
+    schemaUID: "0x0000000000000000000000000000000000000000000000000000000000000000"
+    verifierUrl: https://eas.example.com
   cors:
-    allowOrigins:
-      - https://operator.example.org
-    allowMethods: [GET, POST]
-    allowHeaders: [Content-Type, Authorization]
+    allowedOrigins:
+      - https://operator.example.com
+    allowedHeaders:
+      - Authorization
+      - Content-Type
   rateLimits:
     orchestrator:
-      rps: 20
+      requestsPerMinute: 300
       burst: 50
     bundler:
-      rps: 50
-      burst: 200
+      requestsPerMinute: 120
+      burst: 30
+    attester:
+      requestsPerMinute: 60
+      burst: 15
   secrets:
-    kmsKeyring: projects/sample/locations/global/keyRings/aa-stack
-    orchestratorEnv: ""
-    attesterKeyUri: projects/sample/locations/global/keyRings/aa-stack/cryptoKeys/attester
-    paymasterKeyUri: projects/sample/locations/global/keyRings/aa-stack/cryptoKeys/paymaster
+    kmsKeyRing: projects/example/locations/global/keyRings/agi
+    orchestrator:
+      secretName: orchestrator-secrets
+      kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/orchestrator
+    paymaster:
+      secretName: paymaster-secrets
+      kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/paymaster
+    attester:
+      secretName: attester-secrets
+      kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/attester
+  image:
+    pullPolicy: IfNotPresent
+    repositoryPrefix: ghcr.io/agi/jobs
+    tag: latest
+    digestOverrides: {}
   autoscaling:
+    enabled: true
     minReplicas: 2
-    maxReplicas: 6
-    cpuTargetPercentage: 70
+    maxReplicas: 5
+    cpuTargetPercentage: 60
+  storage:
+    ipfs:
+      size: 50Gi
+    postgres:
+      size: 20Gi
+  monitoring:
+    enabled: true
+    serviceMonitorNamespace: monitoring
+    alertRoutingKey: agi-stack
+  pauseSwitch:
+    configMap: agi-operations
+    key: pause
+    default: "false"
 
 orchestrator:
   image:
-    repository: ghcr.io/example/orchestrator
-    tag: "v1.2.3"
-    digest: "sha256:example"
+    repository: ghcr.io/agi/jobs/orchestrator
+    tag: latest
+    digest: ""
+    pullPolicy: IfNotPresent
+  env:
+    logLevel: info
+    corsOrigins:
+      - https://operator.example.com
+    kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/orchestrator
+    maxRequestBytes: 1048576
   service:
     type: ClusterIP
-    port: 80
-  env:
-    LOG_LEVEL: info
-    ENABLE_CORS: true
+    port: 8000
+  rateLimit:
+    requestsPerMinute: 300
+    burst: 50
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 5
+    cpuTargetPercentage: 60
 
 bundler:
   image:
-    repository: ghcr.io/example/bundler
-    tag: "v1.2.3"
-    digest: "sha256:example"
+    repository: ghcr.io/agi/jobs/bundler
+    tag: latest
+    digest: ""
+    pullPolicy: IfNotPresent
   service:
     type: ClusterIP
     port: 3000
-  env:
-    RELAY_URL: https://relay.example.org
+  config:
+    rpcUrl: https://ethereum-sepolia.publicnode.com
+    entryPoint: "0x0000000000000000000000000000000000000000"
+    bundleIntervalSeconds: 5
 
 paymaster-supervisor:
   image:
-    repository: ghcr.io/example/paymaster-supervisor
-    tag: "v1.2.3"
-    digest: "sha256:example"
+    repository: ghcr.io/agi/jobs/paymaster-supervisor
+    tag: latest
+    digest: ""
+    pullPolicy: IfNotPresent
   service:
     type: ClusterIP
     port: 8080
-  env:
-    TREASURY_ADDRESS: "0x1111111111111111111111111111111111111111"
+  config:
+    rpcUrl: https://ethereum-sepolia.publicnode.com
+    paymasterAddress: "0x0000000000000000000000000000000000000000"
+    kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/paymaster
+    treasuryAddress: "0x0000000000000000000000000000000000000000"
+    sponsorshipBudgetUsd: 100.0
+
+attester:
+  image:
+    repository: ghcr.io/agi/jobs/attester
+    tag: latest
+    digest: ""
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 7000
+  config:
+    rpcUrl: https://ethereum-sepolia.publicnode.com
+    easSchemaUid: "0x0000000000000000000000000000000000000000000000000000000000000000"
+    kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/attester
+    corsOrigins:
+      - https://operator.example.com
 
 ipfs:
   image:
-    repository: ipfs/kubo
-    tag: v0.24.0
-    digest: "sha256:example"
+    repository: ipfs/go-ipfs
+    tag: v0.23.0
+    pullPolicy: IfNotPresent
+  service:
+    apiPort: 5001
+    swarmPort: 4001
+    gatewayPort: 8080
+  persistence:
+    size: 50Gi
+
+graph-node:
+  image:
+    repository: ghcr.io/graphprotocol/graph-node
+    tag: v0.32.0
+    pullPolicy: IfNotPresent
   service:
     type: ClusterIP
-    port: 5001
-  persistence:
-    enabled: true
-    size: 200Gi
+    port: 8000
+  config:
+    ethereumNetworks:
+      - name: sepolia
+        rpc: https://ethereum-sepolia.publicnode.com
+    postgres:
+      host: ""
+      database: subgraph
+      userSecret: graph-node-postgres
+    ipfs:
+      endpoint: ""
 
 postgres:
   image:
     repository: postgres
-    tag: "15"
-    digest: "sha256:example"
+    tag: "14"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 5432
   persistence:
-    storageClass: fast
-    size: 200Gi
-  auth:
-    username: subgraph
+    size: 20Gi
+  config:
     database: subgraph
-    existingSecret: "subgraph-postgres"
-
-graph-node:
-  image:
-    repository: graphprotocol/graph-node
-    tag: v0.33.0
-    digest: "sha256:example"
-  service:
-    type: ClusterIP
-    port: 8000
-  env:
-    ETHEREUM_RPC: https://eth.example.org
-
-attester:
-  image:
-    repository: ghcr.io/example/attester
-    tag: "v1.2.3"
-    digest: "sha256:example"
-  service:
-    type: ClusterIP
-    port: 8787
-  env:
-    ATTESTER_ADDRESS: "0x2222222222222222222222222222222222222222"
+    username: graph
+    existingSecret: graph-node-postgres
 
 ingress:
   enabled: true
-  className: nginx
-  host: api.example.org
-  tls:
-    enabled: true
-    secretName: aa-stack-tls
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/hsts: "true"
-    nginx.ingress.kubernetes.io/hsts-max-age: "63072000"
-    nginx.ingress.kubernetes.io/hsts-include-subdomains: "true"
-    nginx.ingress.kubernetes.io/proxy-body-size: "2m"
-    nginx.ingress.kubernetes.io/limit-rps: "20"
-    nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
-  services:
-    orchestrator:
-      serviceName: ""
-      servicePort: 80
-    bundler:
-      serviceName: ""
+  ingressClassName: nginx
+  defaultTlsSecret: agi-stack-tls
+  hosts:
+    - host: orchestrator.example.com
+      serviceName: orchestrator
+      servicePort: 8000
+    - host: bundler.example.com
+      serviceName: bundler
       servicePort: 3000
+    - host: attester.example.com
+      serviceName: attester
+      servicePort: 7000
+  security:
+    hstsMaxAge: 63072000
+    includeSubdomains: true
+    preload: true
+    wafAnnotation: "true"

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -1,0 +1,30 @@
+# Disaster Recovery Runbook
+
+## Objectives
+- Restore AGI stack functionality within 60 minutes of a regional outage.
+- Recover receipts and attestation state with < 5 minutes of data loss.
+
+## Recovery Sites
+- **Primary**: GKE `us-central1`
+- **Secondary**: GKE `europe-west1`
+
+## DR Checklist
+1. Declare incident and page DR lead.
+2. Snapshot current Helm values artifact from Git (`deploy/helm/values.yaml`).
+3. In secondary region, run the One-Pass Bootstrap guide with the latest pinned image digests.
+4. Restore Postgres from the most recent `pg_basebackup` stored in GCS (`gs://agi-backups/subgraph`).
+5. Sync IPFS pins using the `ipfs-cluster-ctl sync` command against the backup cluster.
+6. Update DNS records (Cloudflare) to point ingress hosts to the secondary load balancer.
+7. Validate health via Grafana and synthetic checks.
+
+## Failback
+1. Once primary region is restored, resync database replication.
+2. Cut traffic back to primary using Cloudflare load balancing.
+3. Scale down secondary cluster to warm standby.
+
+## Data Validation
+- Run attestation receipt reconciliation script (`tools/reconcile-receipts.ts`).
+- Confirm `service:subgraph_lag_blocks` returns to < 5.
+
+## Change Log
+- v1.0 – Initial DR plan.

--- a/docs/runbooks/node-operator.md
+++ b/docs/runbooks/node-operator.md
@@ -1,0 +1,50 @@
+# Node Operator Runbook (Browser-Only)
+
+This runbook documents the end-to-end operating procedures for an AGI stack node operator without requiring shell access.
+
+## Prerequisites
+- Access to the Operator Control Plane (OCP) at `https://operator.example.com`.
+- Permissions to manage the AGI cluster namespace in Argo CD or Lens (view-only).
+- Hardware security key for SSO and WebAuthn prompts.
+
+## Daily Checklist
+1. Log into the OCP dashboard and verify all service widgets are **green**.
+2. Review the "Gas Balance" card. If the balance is below 0.1 ETH, follow the gas top-up procedure.
+3. Confirm the "Pause Switch" indicator is **OFF** unless there is an active incident.
+4. Review the latest attestation receipts in the Receipts tab.
+
+## Adjust Fees and Treasury Address
+1. Navigate to **Policy > Sponsorship Profile** in OCP.
+2. Click **Edit** and update:
+   - **Flat Fee (USD)** or **% of Sponsored Gas** as required.
+   - **Treasury Address** — paste the checksummed address.
+3. Submit the change and approve the WebAuthn prompt to sign the policy update transaction.
+4. Validate the change landed by checking the "Pending Changes" drawer and ensuring the status becomes `Applied`.
+
+## Top Up Paymaster Gas Wallet
+1. From **Finance > Wallets**, locate the **Paymaster Gas Wallet**.
+2. Click **Deposit** and copy the wallet address.
+3. Using the hosted wallet UI (e.g., Fireblocks console), initiate a transfer to the copied address.
+4. Back in the OCP dashboard, watch the balance auto-refresh (should update within 2 blocks). The Alert feed clears when the balance exceeds 0.05 ETH.
+
+## Flip the Pause Switch
+1. Go to **Operations > Safeguards**.
+2. Review the checklist (ensure all in-flight sponsorships are settled).
+3. Toggle **Pause Sponsorships** to ON. Confirm the modal and WebAuthn signature.
+4. To resume, repeat the steps and toggle OFF.
+5. Verify the pause flag is propagated by checking the "Stack Status" widget and ensuring bundler queue drains.
+
+## View Receipts and EAS Proofs
+1. Navigate to **Receipts** in the sidebar.
+2. Filter by job ID, request hash, or attester.
+3. Click a row to open the drawer:
+   - View the **EAS Schema UID** and on-chain attestation link.
+   - Download the JSON receipt for auditing.
+4. Use the **Share** button to generate a read-only link for external auditors.
+
+## Escalation
+- For critical alerts, page the on-call SRE via Opsgenie (button in the top bar).
+- For policy changes requiring sign-off, tag the policy owner in the OCP comments.
+
+## Change Log
+- v1.0 – Initial browser-only workflow documentation.

--- a/docs/runbooks/one-pass-bootstrap.md
+++ b/docs/runbooks/one-pass-bootstrap.md
@@ -1,0 +1,52 @@
+# One-Pass Bootstrap with Helm
+
+This guide bootstraps the entire AGI stack using the aggregated Helm chart located in `deploy/helm`.
+
+## Prerequisites
+- Kubernetes cluster >= v1.26 with cert-manager and nginx ingress controller installed.
+- `helm` >= v3.12.
+- Access to the secrets referenced in `values.yaml` (KMS-backed secrets delivered via your secret manager).
+- Docker registry credentials for GHCR images.
+
+## Steps
+1. **Clone and configure values**
+   ```bash
+   git clone https://github.com/agi/jobs.git
+   cd AGIJobsv0/deploy/helm
+   cp values.yaml override.yaml
+   ```
+   Update `override.yaml` with:
+   - Correct RPC URLs and contract addresses.
+   - KMS key resource IDs for orchestrator, attester, and paymaster.
+   - TLS secret name if using an existing certificate.
+
+2. **Install dependencies**
+   ```bash
+   helm dependency update
+   ```
+
+3. **Install the stack**
+   ```bash
+   helm install agi-stack . -f override.yaml --create-namespace --namespace agi
+   ```
+   Within ~2 minutes all Deployments should report `AVAILABLE=1`. Validate with `kubectl get pods -n agi`.
+
+4. **Post-install checks**
+   - Confirm ingress routes issue valid certificates (`curl -I https://orchestrator.example.com/healthz`).
+   - Verify `ServiceMonitor` objects exist in the monitoring namespace.
+   - Ensure the pause switch ConfigMap is created: `kubectl get cm agi-operations -n agi`.
+
+5. **Uninstall**
+   ```bash
+   helm uninstall agi-stack -n agi
+   kubectl delete namespace agi --wait
+   ```
+   This removes all workloads and volumes. Persistent volumes are deleted because the chart provisions them as part of the release.
+
+## Troubleshooting
+- If cosigned images fail to pull, ensure the cluster trusts Sigstore fulcio roots.
+- When RPC endpoints rate-limit, set `global.rpc.fallback` to a list of additional providers before reinstalling.
+- To pause sponsorships during bootstrap, edit the `agi-operations` ConfigMap and set `pause=true`.
+
+## Change Log
+- v1.0 – Initial bootstrap guide.

--- a/docs/runbooks/paymaster-gas.md
+++ b/docs/runbooks/paymaster-gas.md
@@ -1,0 +1,20 @@
+# Paymaster Gas Top-Up Runbook
+
+## Trigger
+- Alert: **LowGasBalance** (critical)
+- Metric: `eth_wallet_balance_wei{wallet="paymaster"}` < 0.05 ETH equivalent.
+
+## Response Steps
+1. Acknowledge the Alertmanager notification.
+2. Confirm the balance in OCP (**Finance > Wallets**).
+3. Initiate a transfer from the treasury hot wallet to the paymaster gas wallet.
+4. Verify the transaction on Etherscan (target confirmations: 6).
+5. Update the incident ticket with tx hash and new balance.
+6. Close the alert once the metric recovers above the threshold.
+
+## Preventative Actions
+- Schedule weekly automated top-ups through Fireblocks.
+- Review sponsorship usage trends in Grafana.
+
+## Escalation
+If the wallet cannot receive funds (e.g., account frozen), escalate to Finance leadership and pause sponsorships.

--- a/docs/runbooks/policy-playbook.md
+++ b/docs/runbooks/policy-playbook.md
@@ -1,0 +1,42 @@
+# Sponsorship Policy Playbook
+
+Use this playbook to design, approve, and roll out paymaster sponsorship policy changes.
+
+## Stakeholders
+- **Policy Owner** – defines eligibility rules and fee schedules.
+- **Security Lead** – reviews abuse vectors.
+- **Node Operator** – executes the change via the Operator Control Plane (OCP).
+
+## Change Types
+1. **Fee Adjustment** – Update flat and percentage fees.
+2. **Eligibility Rule Change** – Modify allow/deny lists, schema requirements, or rate caps.
+3. **Emergency Block** – Immediately stop a bad actor from consuming sponsorships.
+
+## Workflow
+1. **Proposal**
+   - Document the change in Notion with expected impact metrics.
+   - Capture baseline values for `service:sponsored_ops_total:rate5m` and rejection rate.
+2. **Risk Review**
+   - Security Lead validates against the threat model (see `docs/security/threat-model.md`).
+   - Ensure KMS policies permit any new signers.
+3. **Approval**
+   - Gather sign-off from Policy Owner + Security Lead in OCP comments.
+4. **Execution**
+   - Node Operator applies the change in OCP under **Policy > Sponsorship Profile**.
+   - Require WebAuthn + policy change multi-sig to complete.
+5. **Verification**
+   - Monitor Grafana dashboard (panels "Sponsored Operations Rate" and "Sponsorship Rejections by Result").
+   - Acknowledge/close any Alertmanager notifications triggered during rollout.
+
+## Emergency Block Procedure
+1. Toggle the **Pause Sponsorships** switch (see Node Operator Runbook).
+2. In OCP, add the offending smart wallet or schema UID to the deny list.
+3. Resume sponsorships once metrics return to baseline.
+4. File an incident review within 24 hours.
+
+## Audit
+- Export receipts for the affected period using the Receipts tab.
+- Store audit logs in the compliance bucket for 7 years.
+
+## Change Log
+- v1.0 – Initial policy change workflow.

--- a/docs/runbooks/receipts-eas-verification.md
+++ b/docs/runbooks/receipts-eas-verification.md
@@ -1,0 +1,43 @@
+# Receipts & EAS Verification Guide
+
+This guide helps auditors and integrators validate that attestation receipts emitted by the AGI stack correspond to on-chain EAS attestations.
+
+## Retrieve a Receipt
+1. Log into the Operator Control Plane (OCP).
+2. Navigate to **Receipts** and locate the desired job.
+3. Download the JSON payload via **Download Receipt**.
+
+## Receipt Structure
+```json
+{
+  "jobId": "uuid",
+  "requestHash": "0x...",
+  "attester": "0x...",
+  "schemaUID": "0x...",
+  "attestationUID": "0x...",
+  "timestamp": 1700000000,
+  "signature": "0x..."
+}
+```
+
+## Verify the EAS Attestation
+1. Open the EAS Explorer at `https://easscan.org/attestation/<attestationUID>`.
+2. Confirm the attester matches the receipt and the schema UID equals `receipt.schemaUID`.
+3. Ensure the attestation payload hash equals `receipt.requestHash`.
+
+## Validate the Signature
+1. Use the browser-based verifier at `https://docs.agistack.dev/tools/receipt-verify`.
+2. Upload the JSON receipt.
+3. The tool checks the signature against the configured attester public key and displays a green check.
+4. Alternatively, use the CLI:
+   ```bash
+   npx @eas-project/verify --attestation <attestationUID>
+   ```
+
+## Troubleshooting
+- **Mismatch attester** – Confirm the attestation originated from the correct network (see `receipt.chainId`).
+- **Signature invalid** – Rotate the attester key using the KMS playbook and re-issue the attestation.
+- **No attestation found** – Wait for the subgraph to catch up (monitor "Subgraph Lag" panel).
+
+## Change Log
+- v1.0 – Initial receipts verification workflow.

--- a/docs/runbooks/rejection-spike.md
+++ b/docs/runbooks/rejection-spike.md
@@ -1,0 +1,21 @@
+# Sponsorship Rejection Spike Runbook
+
+## Trigger
+- Alert: **SponsorshipRejectionSpike** (warning).
+- Metric: `service:sponsored_ops_rejections:rate5m` > 5.
+
+## Response Steps
+1. Confirm the alert in Grafana by inspecting the "Sponsorship Rejections by Result" panel.
+2. Identify the top offending result label (e.g., `rate_limit`, `policy_denied`, `reorg`).
+3. In OCP, filter the Receipts tab by the current hour to inspect failed requests.
+4. If abuse is detected, use the Policy Playbook to block the offending wallet or schema.
+5. Review bundler logs via Loki for accompanying errors.
+6. Document mitigation actions in the incident ticket.
+
+## Escalation
+- If rejection rate exceeds 50% for more than 30 minutes, escalate to the Policy Owner and Security Lead.
+- Consider pausing sponsorships if legitimate users are impacted.
+
+## Post-Mortem Checklist
+- Capture the timeline and root cause.
+- Update policy automation tests if a rule misfired.

--- a/docs/runbooks/revert-spike.md
+++ b/docs/runbooks/revert-spike.md
@@ -1,0 +1,21 @@
+# Bundler Revert Spike Runbook
+
+## Trigger
+- Alert: **BundlerRevertSpike** (warning).
+- Metric: `rate(bundler_operations_total{status="reverted"}[5m])` > 2.
+
+## Response Steps
+1. Inspect the Bundler dashboard in Grafana for correlating latency or mempool anomalies.
+2. Pull recent transaction hashes from the Bundler UI and review them on Etherscan.
+3. Validate entry point configuration and ensure the latest contract addresses match Helm values.
+4. Check L2 sequencer status (for rollups) and RPC health dashboards.
+5. If reverts stem from user operations, notify affected integrators via the status page.
+6. Reduce the bundler submission rate via the OCP toggle if mempool congestion persists.
+
+## Escalation
+- Escalate to the smart contract engineering team if contract-level reverts persist beyond 15 minutes.
+- Consider pausing sponsorships if reverts are due to upstream chain instability.
+
+## Post-Mortem Checklist
+- Capture failing calldata samples.
+- Update integration guides with mitigation steps.

--- a/docs/runbooks/sre.md
+++ b/docs/runbooks/sre.md
@@ -1,0 +1,31 @@
+# SRE Operations Runbook
+
+This runbook covers alert response procedures for the AGI stack.
+
+## Tooling
+- **Grafana** (`https://grafana.agistack.dev`) – Dashboard `AGI Stack SLOs`.
+- **Alertmanager** (`https://alerts.agistack.dev`) – Triage alerts, ensure runbook links resolve.
+- **Opsgenie** – Paging integration for `sev1` and `sev2` alerts.
+
+## Key Alerts
+| Alert | Severity | Runbook |
+| --- | --- | --- |
+| LowGasBalance | Critical | `docs/runbooks/paymaster-gas.md` |
+| SponsorshipRejectionSpike | Warning | `docs/runbooks/rejection-spike.md` |
+| BundlerRevertSpike | Warning | `docs/runbooks/revert-spike.md` |
+
+## Standard Response Flow
+1. **Acknowledge** the Alertmanager notification.
+2. **Inspect** the Grafana dashboard to confirm metric deviation.
+3. **Execute** the linked runbook. Escalate to the on-call engineer if remediation exceeds 30 minutes.
+4. **Post-Incident** – File a retrospective in the incident tracker within 48 hours.
+
+## Manual Tests
+- **Pause Switch** – Toggle to ON via OCP, confirm the ConfigMap updates and bundler queue drains.
+- **RPC Fallback** – Simulate outage by blocking the primary RPC host in Cloudflare; ensure fallback metrics show traffic shift.
+
+## Disaster Recovery Hooks
+See `docs/runbooks/disaster-recovery.md` for detailed steps.
+
+## Change Log
+- v1.0 – Initial SRE incident response doc.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,61 @@
+# AGI Stack Threat Model & Table-Top Playbooks
+
+## Overview
+The AGI stack relies on deterministic sponsorship, attestation issuance, and decentralized storage. The following sections document high-risk scenarios and provide tabletop exercises for the incident response team.
+
+## Assets
+- **KMS-backed keys** for paymaster sponsorship and attestations.
+- **Receipts and attestation proofs** stored in Postgres/IPFS.
+- **RPC connectivity** to the target chain.
+- **Ingress endpoints** exposed to integrators.
+
+## Attack Surface Summary
+| Component | Risks | Mitigations |
+| --- | --- | --- |
+| Orchestrator API | Abuse via oversized requests, CORS bypass | Strict CORS allowlist, 1 MB body limit, WAF enabled |
+| Bundler | Chain reorgs, revert storms | Observability alerts, pause switch, fallback RPC |
+| Paymaster Supervisor | Sponsorship abuse, budget overrun | Policy playbook, budget caps, KMS signing |
+| Attester | Key compromise | KMS custody, hardware-backed approvals |
+| IPFS | Pin backlog, data unavailability | Pin latency monitoring, disaster recovery sync |
+
+## Scenario Playbooks
+
+### Chain Reorg
+- **Symptoms**: Sudden spike in attestation replays, `service:subgraph_lag_blocks` increases.
+- **Immediate Actions**:
+  1. Pause sponsorships via OCP.
+  2. Switch bundler RPC to fallback provider using Helm override or OCP toggle.
+  3. Coordinate with chain infrastructure provider to confirm reorg depth.
+- **Recovery**: Resume operations once finality depth > 20 blocks and receipts reconciled.
+
+### RPC Outage
+- **Symptoms**: Bundler error logs with `connection refused`, success rate drops.
+- **Immediate Actions**:
+  1. Confirm outage with provider status page.
+  2. Update `global.rpc.primary` to fallback endpoint in values override and run `helm upgrade`.
+  3. Monitor Grafana success rate panel for recovery.
+- **Tabletop Drill**: Quarterly exercise to rotate RPC providers without downtime.
+
+### IPFS Pin Backlog
+- **Symptoms**: `service:ipfs_pin_latency_seconds:p95` > 120 seconds, receipts pending.
+- **Immediate Actions**:
+  1. Scale IPFS StatefulSet replicas via Helm values (increase to 2).
+  2. Trigger manual pin sync using `ipfs-cluster-ctl sync --all`.
+  3. Offload large artifacts to secondary pinning service if backlog persists > 30 minutes.
+- **Recovery**: Confirm latency returns < 30 seconds and disaster recovery sync plan executed.
+
+### Account Abstraction (AA) Sponsorship Abuse
+- **Symptoms**: Sponsorship spend spikes, rejection alerts triggered.
+- **Immediate Actions**:
+  1. Enable pause switch and activate rate limit override in OCP.
+  2. Apply deny list for malicious smart accounts in Policy Playbook.
+  3. Notify integrators of temporary suspension.
+- **Recovery**: Reinstate traffic once budgets reset and abuse vector closed.
+
+## Validation
+- Run quarterly ZAP/Burp scans against the orchestrator ingress (document results in security backlog).
+- Ensure KMS audit logs show no export operations; keys remain in HSM.
+- Confirm tabletop drills recorded in the incident tracker with action items.
+
+## Change Log
+- v1.0 – Initial threat model coverage.

--- a/monitoring/grafana/dashboard-agi-ops.json
+++ b/monitoring/grafana/dashboard-agi-ops.json
@@ -114,7 +114,7 @@
   "links": [
     {
       "title": "Runbooks",
-      "url": "https://docs.example.com/runbooks"
+      "url": "https://docs.agistack.dev/runbooks"
     }
   ]
 }

--- a/monitoring/prometheus/rules.yaml
+++ b/monitoring/prometheus/rules.yaml
@@ -23,28 +23,28 @@ groups:
         for: 5m
         labels:
           severity: critical
-          runbook: https://docs.example.com/runbooks/paymaster-gas
+          runbook: https://docs.agistack.dev/runbooks/paymaster-gas
         annotations:
           summary: Paymaster gas wallet below 0.05 ETH
           description: Top up the configured treasury wallet before sponsorship halts.
-          runbook: https://docs.example.com/runbooks/paymaster-gas
+          runbook: https://docs.agistack.dev/runbooks/paymaster-gas
       - alert: SponsorshipRejectionSpike
         expr: service:sponsored_ops_rejections:rate5m > 5
         for: 10m
         labels:
           severity: warning
-          runbook: https://docs.example.com/runbooks/rejection-spike
+          runbook: https://docs.agistack.dev/runbooks/rejection-spike
         annotations:
           summary: Sponsored operation rejections increasing
           description: Investigate upstream AA flow or contract configuration issues.
-          runbook: https://docs.example.com/runbooks/rejection-spike
+          runbook: https://docs.agistack.dev/runbooks/rejection-spike
       - alert: BundlerRevertSpike
         expr: rate(bundler_operations_total{status="reverted"}[5m]) > 2
         for: 5m
         labels:
           severity: warning
-          runbook: https://docs.example.com/runbooks/revert-spike
+          runbook: https://docs.agistack.dev/runbooks/revert-spike
         annotations:
           summary: Bundler revert spike detected
           description: Review recent deployments and mempool conditions.
-          runbook: https://docs.example.com/runbooks/revert-spike
+          runbook: https://docs.agistack.dev/runbooks/revert-spike


### PR DESCRIPTION
## Summary
- add an aggregated Helm stack with per-service charts, pause switch wiring, and hardened ingress defaults
- ship ServiceMonitor resources plus Prometheus/Grafana assets for SLO tracking with runbook links
- document the node operator bootstrap, policy, and disaster recovery guides alongside the security threat model

## Testing
- helm lint deploy/helm *(fails: helm CLI is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc084a5ce48333b5f5a00117269a55