### PR TITLE
feat: harden helm stack and runbooks

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -9,7 +9,45 @@ on:
   workflow_dispatch:
 
 jobs:
+  enforce-digests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PyYAML
+        run: pip install --disable-pip-version-check pyyaml
+
+      - name: Validate Helm image digests
+        run: |
+          python - <<'PY'
+          import sys
+          import yaml
+
+          required_components = [
+              "orchestrator",
+              "bundler",
+              "paymaster-supervisor",
+              "attester",
+          ]
+
+          with open("deploy/helm/values.yaml", "r", encoding="utf-8") as handle:
+              values = yaml.safe_load(handle)
+
+          missing = []
+          for component in required_components:
+              image_cfg = values.get(component, {}).get("image", {})
+              digest = image_cfg.get("digest") or values.get("global", {}).get("image", {}).get("digestOverrides", {}).get(component)
+              tag = image_cfg.get("tag") or values.get("global", {}).get("image", {}).get("tag")
+
+              if not digest and (not tag or tag == "latest"):
+                  missing.append(component)
+
+          if missing:
+              sys.exit(f"Missing immutable image digests or pinned tags for: {', '.join(missing)}")
+          PY
+
   build-attest:
+    needs: enforce-digests
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/deploy/helm/charts/attester/templates/deployment.yaml
+++ b/deploy/helm/charts/attester/templates/deployment.yaml
@@ -22,7 +22,11 @@ spec:
     spec:
       containers:
         - name: attester
-          image: {{ .Values.image.repository }}{{- if .Values.image.digest -}}@{{ .Values.image.digest }}{{- else -}}:{{ .Values.image.tag }}{{- end }}
+          {{- $repoPrefix := default "" (dig "image" "repositoryPrefix" .Values.global) }}
+          {{- $repository := default (printf "%s/attester" $repoPrefix | trimPrefix "/") .Values.image.repository }}
+          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "attester" .Values.global) }}
+          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
+          image: {{ $repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for attester" $tag }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: RPC_URL
@@ -30,9 +34,9 @@ spec:
             - name: EAS_SCHEMA_UID
               value: {{ default (dig "eas" "schemaUID" .Values.global) .Values.config.easSchemaUid | required "config.easSchemaUid or global.eas.schemaUID must be set" | quote }}
             - name: KMS_KEY_URI
-              value: {{ default (dig "secrets" "attester" "kmsKey" .Values.global) .Values.config.kmsKey | required "config.kmsKey or global.secrets.attester.kmsKey must be set" | quote }}
+              value: {{ default (dig "secrets" "attester" "kmsKeyUri" .Values.global) .Values.config.kmsKey | required "config.kmsKey or global.secrets.attester.kmsKeyUri must be set" | quote }}
             - name: CORS_ALLOWED_ORIGINS
-              value: {{ join "," (.Values.config.corsOrigins | default (list "*")) | quote }}
+              value: {{ join "," (default (.Values.global.cors.allowedOrigins | default (list)) .Values.config.corsOrigins) | quote }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: http

--- a/deploy/helm/charts/attester/templates/env-secret.yaml
+++ b/deploy/helm/charts/attester/templates/env-secret.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "attester.fullname" . }}-secrets
+  name: {{ default (printf "%s-secrets" (include "attester.fullname" .)) (dig "secrets" "attester" "secretName" .Values.global) }}
   labels:
     {{- include "attester.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  KMS_KEYRING: "{{ .Values.global.secrets.kmsKeyring }}"
-  ATTESTER_KMS_KEY_URI: "{{ .Values.global.secrets.attesterKeyUri }}"
+  KMS_KEYRING: "{{ required "global.secrets.kmsKeyring is required" (dig "secrets" "kmsKeyring" .Values.global) }}"
+  ATTESTER_KMS_KEY_URI: "{{ required "global.secrets.attester.kmsKeyUri is required" (dig "secrets" "attester" "kmsKeyUri" .Values.global) }}"
 {{- range $key, $value := .Values.secrets }}
   {{ $key }}: "{{ $value }}"
 {{- end }}

--- a/deploy/helm/charts/bundler/templates/deployment.yaml
+++ b/deploy/helm/charts/bundler/templates/deployment.yaml
@@ -22,7 +22,11 @@ spec:
     spec:
       containers:
         - name: bundler
-          image: {{ .Values.image.repository }}{{- if .Values.image.digest -}}@{{ .Values.image.digest }}{{- else -}}:{{ .Values.image.tag }}{{- end }}
+          {{- $repoPrefix := default "" (dig "image" "repositoryPrefix" .Values.global) }}
+          {{- $repository := default (printf "%s/bundler" $repoPrefix | trimPrefix "/") .Values.image.repository }}
+          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "bundler" .Values.global) }}
+          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
+          image: {{ $repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for bundler" $tag }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: RPC_URL

--- a/deploy/helm/charts/bundler/templates/env-secret.yaml
+++ b/deploy/helm/charts/bundler/templates/env-secret.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "bundler.fullname" . }}-secrets
+  name: {{ default (printf "%s-secrets" (include "bundler.fullname" .)) (dig "secrets" "bundler" "secretName" .Values.global) }}
   labels:
     {{- include "bundler.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  KMS_KEYRING: "{{ .Values.global.secrets.kmsKeyring }}"
-{{- range ,  := .Values.secrets }}
-  {{  }}: "{{  }}"
+  KMS_KEYRING: "{{ required "global.secrets.kmsKeyring is required" (dig "secrets" "kmsKeyring" .Values.global) }}"
+{{- range $key, $value := .Values.secrets }}
+  {{ $key }}: "{{ $value }}"
 {{- end }}

--- a/deploy/helm/charts/graph-node/templates/deployment.yaml
+++ b/deploy/helm/charts/graph-node/templates/deployment.yaml
@@ -21,7 +21,9 @@ spec:
     spec:
       containers:
         - name: graph-node
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "graph-node" .Values.global) }}
+          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
+          image: {{ .Values.image.repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for graph-node" $tag }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: GRAPH_LOG

--- a/deploy/helm/charts/ingress/templates/ingress.yaml
+++ b/deploy/helm/charts/ingress/templates/ingress.yaml
@@ -13,6 +13,12 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rpm: "{{ default 300 .Values.rateLimitRpm }}"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "1"
     nginx.ingress.kubernetes.io/enable-modsecurity: {{ .Values.security.wafAnnotation | quote }}
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "{{ .Values.security.corsAllowOrigin }}"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "{{ join "," (.Values.security.corsAllowHeaders | default (list "Authorization" "Content-Type")) }}"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "{{ join "," (.Values.security.corsAllowMethods | default (list "GET" "POST")) }}"
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ default "1m" .Values.security.proxyBodySize }}"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ default "60s" .Values.security.requestTimeout }}"
 spec:
   ingressClassName: {{ .Values.ingressClassName }}
   tls:

--- a/deploy/helm/charts/ipfs/templates/statefulset.yaml
+++ b/deploy/helm/charts/ipfs/templates/statefulset.yaml
@@ -20,7 +20,9 @@ spec:
     spec:
       containers:
         - name: ipfs
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "ipfs" .Values.global) }}
+          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
+          image: {{ .Values.image.repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for ipfs" $tag }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - daemon

--- a/deploy/helm/charts/orchestrator/templates/deployment.yaml
+++ b/deploy/helm/charts/orchestrator/templates/deployment.yaml
@@ -22,13 +22,19 @@ spec:
     spec:
       containers:
         - name: orchestrator
-          image: {{ .Values.image.repository }}{{- if .Values.image.digest -}}@{{ .Values.image.digest }}{{- else -}}:{{ default .Chart.AppVersion .Values.image.tag }}{{- end }}
+          {{- $repoPrefix := default "" (dig "image" "repositoryPrefix" .Values.global) }}
+          {{- $repository := default (printf "%s/orchestrator" $repoPrefix | trimPrefix "/") .Values.image.repository }}
+          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "orchestrator" .Values.global) }}
+          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
+          image: {{ $repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for orchestrator" $tag }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: LOG_LEVEL
               value: {{ .Values.env.logLevel | quote }}
             - name: CORS_ALLOWED_ORIGINS
-              value: {{ join "," .Values.env.corsOrigins | quote }}
+              value: {{ join "," (default (.Values.global.cors.allowedOrigins | default (list)) .Values.env.corsOrigins) | quote }}
+            - name: CORS_ALLOWED_HEADERS
+              value: {{ join "," (default (.Values.global.cors.allowedHeaders | default (list)) .Values.env.corsHeaders) | quote }}
             - name: KMS_KEY_URI
               value: {{ .Values.env.kmsKey | quote }}
             - name: ENTRY_POINT_ADDRESS

--- a/deploy/helm/charts/orchestrator/templates/env-secret.yaml
+++ b/deploy/helm/charts/orchestrator/templates/env-secret.yaml
@@ -1,13 +1,14 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "orchestrator.fullname" . }}-secrets
+  name: {{ default (printf "%s-secrets" (include "orchestrator.fullname" .)) (dig "secrets" "orchestrator" "secretName" .Values.global) }}
   labels:
     {{- include "orchestrator.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  KMS_KEYRING: "{{ .Values.global.secrets.kmsKeyring }}"
-  ORCHESTRATOR_ENV: "{{ .Values.global.secrets.orchestratorEnv }}"
+  KMS_KEYRING: "{{ required "global.secrets.kmsKeyring is required" (dig "secrets" "kmsKeyring" .Values.global) }}"
+  ORCHESTRATOR_ENV: "{{ default "production" (dig "secrets" "orchestrator" "environment" .Values.global) }}"
+  ORCHESTRATOR_KMS_KEY_URI: "{{ required "global.secrets.orchestrator.kmsKeyUri is required" (dig "secrets" "orchestrator" "kmsKeyUri" .Values.global) }}"
 {{- range $key, $value := .Values.secrets }}
   {{ $key }}: "{{ $value }}"
 {{- end }}

--- a/deploy/helm/charts/paymaster-supervisor/templates/deployment.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/templates/deployment.yaml
@@ -22,7 +22,11 @@ spec:
     spec:
       containers:
         - name: paymaster-supervisor
-          image: {{ .Values.image.repository }}{{- if .Values.image.digest -}}@{{ .Values.image.digest }}{{- else -}}:{{ .Values.image.tag }}{{- end }}
+          {{- $repoPrefix := default "" (dig "image" "repositoryPrefix" .Values.global) }}
+          {{- $repository := default (printf "%s/paymaster-supervisor" $repoPrefix | trimPrefix "/") .Values.image.repository }}
+          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "paymaster-supervisor" .Values.global) }}
+          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
+          image: {{ $repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for paymaster-supervisor" $tag }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: RPC_URL
@@ -30,11 +34,11 @@ spec:
             - name: PAYMASTER_ADDRESS
               value: {{ default (dig "contracts" "paymaster" .Values.global) .Values.config.paymasterAddress | required "config.paymasterAddress or global.contracts.paymaster must be set" | quote }}
             - name: TREASURY_ADDRESS
-              value: {{ required "config.treasuryAddress is required" .Values.config.treasuryAddress | quote }}
+              value: {{ default (dig "secrets" "paymaster" "treasuryAddress" .Values.global) .Values.config.treasuryAddress | required "config.treasuryAddress or global.secrets.paymaster.treasuryAddress must be set" | quote }}
             - name: SPONSORSHIP_BUDGET_USD
               value: {{ default 100.0 .Values.config.sponsorshipBudgetUsd | quote }}
             - name: KMS_KEY_URI
-              value: {{ default (dig "secrets" "paymaster" "kmsKey" .Values.global) .Values.config.kmsKey | required "config.kmsKey or global.secrets.paymaster.kmsKey must be set" | quote }}
+              value: {{ default (dig "secrets" "paymaster" "kmsKeyUri" .Values.global) .Values.config.kmsKey | required "config.kmsKey or global.secrets.paymaster.kmsKeyUri must be set" | quote }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: http

--- a/deploy/helm/charts/paymaster-supervisor/templates/env-secret.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/templates/env-secret.yaml
@@ -1,13 +1,16 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "paymaster-supervisor.fullname" . }}-secrets
+  name: {{ default (printf "%s-secrets" (include "paymaster-supervisor.fullname" .)) (dig "secrets" "paymaster" "secretName" .Values.global) }}
   labels:
     {{- include "paymaster-supervisor.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  KMS_KEYRING: "{{ .Values.global.secrets.kmsKeyring }}"
-  PAYMASTER_KMS_KEY_URI: "{{ .Values.global.secrets.paymasterKeyUri }}"
+  KMS_KEYRING: "{{ required "global.secrets.kmsKeyring is required" (dig "secrets" "kmsKeyring" .Values.global) }}"
+  PAYMASTER_KMS_KEY_URI: "{{ required "global.secrets.paymaster.kmsKeyUri is required" (dig "secrets" "paymaster" "kmsKeyUri" .Values.global) }}"
+{{- with (dig "secrets" "paymaster" "treasuryAddress" .Values.global) }}
+  TREASURY_ADDRESS: "{{ . }}"
+{{- end }}
 {{- range $key, $value := .Values.secrets }}
   {{ $key }}: "{{ $value }}"
 {{- end }}

--- a/deploy/helm/templates/tests/pause-switch.yaml
+++ b/deploy/helm/templates/tests/pause-switch.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ printf "%s-pause-switch" .Release.Name }}
+  labels:
+    app.kubernetes.io/name: agi-stack
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: pause-switch-check
+      image: busybox:1.36
+      command:
+        - sh
+        - -c
+        - |
+          set -eu
+          if [ ! -f "/pause/{{ .Values.global.pauseSwitch.key }}" ]; then
+            echo "pause switch key missing"
+            exit 1
+          fi
+          value=$(cat /pause/{{ .Values.global.pauseSwitch.key }})
+          echo "pause switch value: $value"
+      volumeMounts:
+        - name: pause-switch
+          mountPath: /pause
+  volumes:
+    - name: pause-switch
+      configMap:
+        name: {{ .Values.global.pauseSwitch.configMap }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -29,20 +29,22 @@ global:
       requestsPerMinute: 60
       burst: 15
   secrets:
-    kmsKeyRing: projects/example/locations/global/keyRings/agi
+    kmsKeyring: projects/example/locations/global/keyRings/agi
     orchestrator:
       secretName: orchestrator-secrets
-      kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/orchestrator
+      kmsKeyUri: projects/example/locations/global/keyRings/agi/cryptoKeys/orchestrator
+      environment: production
     paymaster:
       secretName: paymaster-secrets
-      kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/paymaster
+      kmsKeyUri: projects/example/locations/global/keyRings/agi/cryptoKeys/paymaster
+      treasuryAddress: "0x0000000000000000000000000000000000000000"
     attester:
       secretName: attester-secrets
-      kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/attester
+      kmsKeyUri: projects/example/locations/global/keyRings/agi/cryptoKeys/attester
   image:
     pullPolicy: IfNotPresent
     repositoryPrefix: ghcr.io/agi/jobs
-    tag: latest
+    tag: ""
     digestOverrides: {}
   autoscaling:
     enabled: true
@@ -66,13 +68,16 @@ global:
 orchestrator:
   image:
     repository: ghcr.io/agi/jobs/orchestrator
-    tag: latest
-    digest: ""
+    tag: ""
+    digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
     pullPolicy: IfNotPresent
   env:
     logLevel: info
     corsOrigins:
       - https://operator.example.com
+    corsHeaders:
+      - Authorization
+      - Content-Type
     kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/orchestrator
     maxRequestBytes: 1048576
   service:
@@ -90,8 +95,8 @@ orchestrator:
 bundler:
   image:
     repository: ghcr.io/agi/jobs/bundler
-    tag: latest
-    digest: ""
+    tag: ""
+    digest: sha256:2222222222222222222222222222222222222222222222222222222222222222
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -104,8 +109,8 @@ bundler:
 paymaster-supervisor:
   image:
     repository: ghcr.io/agi/jobs/paymaster-supervisor
-    tag: latest
-    digest: ""
+    tag: ""
+    digest: sha256:3333333333333333333333333333333333333333333333333333333333333333
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -120,8 +125,8 @@ paymaster-supervisor:
 attester:
   image:
     repository: ghcr.io/agi/jobs/attester
-    tag: latest
-    digest: ""
+    tag: ""
+    digest: sha256:4444444444444444444444444444444444444444444444444444444444444444
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -198,3 +203,12 @@ ingress:
     includeSubdomains: true
     preload: true
     wafAnnotation: "true"
+    corsAllowOrigin: https://operator.example.com
+    corsAllowHeaders:
+      - Authorization
+      - Content-Type
+    corsAllowMethods:
+      - GET
+      - POST
+    proxyBodySize: 1m
+    requestTimeout: 60s

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -18,9 +18,10 @@
 1. **Provision Cluster** – Create new Kubernetes cluster in standby region with identical node pools.
 2. **Restore Postgres** – Apply latest snapshot and promote replica.
 3. **Rehydrate IPFS** – Restore pinset via `ipfs pin add --recursive` from backup.
-4. **Deploy Stack** – Run `helm install agi-stack deploy/helm -f bootstrap-values.yaml` and pin image digests using `images-<component>-<network>` artifacts from CI.
-5. **Rebuild Subgraph** – Trigger Graph Node resync, monitor lag panel until under 20 blocks.
-6. **Validation** – Execute synthetic sponsored operation and verify receipt via portal.
+4. **Rehydrate Secrets** – Re-create KMS backed secrets by binding the workload identity to the restored namespace and confirming the SecretProviderClass synchronises attester/paymaster materials (no private keys on disk).
+5. **Deploy Stack** – Run `helm install agi-stack deploy/helm -f bootstrap-values.yaml` and pin image digests using `images-<component>-<network>` artifacts from CI.
+6. **Rebuild Subgraph** – Trigger Graph Node resync, monitor lag panel until under 20 blocks.
+7. **Validation** – Execute synthetic sponsored operation and verify receipt via portal.
 
 ## Communication Plan
 

--- a/docs/node-operator-runbook.md
+++ b/docs/node-operator-runbook.md
@@ -17,6 +17,7 @@ This runbook is designed for non-technical operators. Every workflow is achievab
 2. Select **Fee Schedule** and choose the target chain (Testnet/Mainnet).
 3. Use the slider to set the base sponsorship fee in gwei. Tooltips show the resulting USD equivalent (sourced from the cpvo_usd metric).
 4. Click **Preview** to confirm the change and **Submit**. The portal creates a signed policy update via the Paymaster Supervisor API. No CLI steps are required.
+5. Review the confirmation banner which links to the [Sponsorship Policy Playbook](policy-playbook.md) for post-change validation.
 
 ## Top Up Gas Treasury
 

--- a/docs/sre-runbooks.md
+++ b/docs/sre-runbooks.md
@@ -4,12 +4,12 @@
 
 | Scenario | Trigger | Runbook Link |
 | -------- | ------- | ------------ |
-| Paymaster gas low | `LowGasBalance` alert | https://docs.example.com/runbooks/paymaster-gas |
-| Sponsorship rejection spike | `SponsorshipRejectionSpike` alert | https://docs.example.com/runbooks/rejection-spike |
-| Bundler reverts spike | `BundlerRevertSpike` alert | https://docs.example.com/runbooks/revert-spike |
-| IPFS backlog | Dashboard panel "IPFS Pinning p95" > 60s | https://docs.example.com/runbooks/ipfs-backlog |
-| Subgraph lag | `service:subgraph_lag_blocks` > 40 | https://docs.example.com/runbooks/subgraph-lag |
-| RPC outage | `orchestrator_rpc_requests_failed_total` increase | https://docs.example.com/runbooks/rpc-outage |
+| Paymaster gas low | `LowGasBalance` alert | https://docs.agijobsv0.dev/runbooks/paymaster-gas |
+| Sponsorship rejection spike | `SponsorshipRejectionSpike` alert | https://docs.agijobsv0.dev/runbooks/rejection-spike |
+| Bundler reverts spike | `BundlerRevertSpike` alert | https://docs.agijobsv0.dev/runbooks/revert-spike |
+| IPFS backlog | Dashboard panel "IPFS Pinning p95" > 60s | https://docs.agijobsv0.dev/runbooks/ipfs-backlog |
+| Subgraph lag | `service:subgraph_lag_blocks` > 40 | https://docs.agijobsv0.dev/runbooks/subgraph-lag |
+| RPC outage | `orchestrator_rpc_requests_failed_total` increase | https://docs.agijobsv0.dev/runbooks/rpc-outage |
 
 ## CI Artifact Reference
 

--- a/monitoring/grafana/dashboard-agi-ops.json
+++ b/monitoring/grafana/dashboard-agi-ops.json
@@ -2,6 +2,17 @@
   "title": "AGI Stack SLOs",
   "uid": "agi-slos",
   "version": 2,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "targetBlank": true,
+      "title": "SRE Runbooks",
+      "type": "link",
+      "url": "https://docs.agijobsv0.dev/runbooks"
+    }
+  ],
   "panels": [
     {
       "type": "timeseries",

--- a/monitoring/prometheus/rules.yaml
+++ b/monitoring/prometheus/rules.yaml
@@ -23,28 +23,28 @@ groups:
         for: 5m
         labels:
           severity: critical
-          runbook: https://docs.agistack.dev/runbooks/paymaster-gas
+          runbook: https://docs.agijobsv0.dev/runbooks/paymaster-gas
         annotations:
           summary: Paymaster gas wallet below 0.05 ETH
           description: Top up the configured treasury wallet before sponsorship halts.
-          runbook: https://docs.agistack.dev/runbooks/paymaster-gas
+          runbook: https://docs.agijobsv0.dev/runbooks/paymaster-gas
       - alert: SponsorshipRejectionSpike
         expr: service:sponsored_ops_rejections:rate5m > 5
         for: 10m
         labels:
           severity: warning
-          runbook: https://docs.agistack.dev/runbooks/rejection-spike
+          runbook: https://docs.agijobsv0.dev/runbooks/rejection-spike
         annotations:
           summary: Sponsored operation rejections increasing
           description: Investigate upstream AA flow or contract configuration issues.
-          runbook: https://docs.agistack.dev/runbooks/rejection-spike
+          runbook: https://docs.agijobsv0.dev/runbooks/rejection-spike
       - alert: BundlerRevertSpike
         expr: rate(bundler_operations_total{status="reverted"}[5m]) > 2
         for: 5m
         labels:
           severity: warning
-          runbook: https://docs.agistack.dev/runbooks/revert-spike
+          runbook: https://docs.agijobsv0.dev/runbooks/revert-spike
         annotations:
           summary: Bundler revert spike detected
           description: Review recent deployments and mempool conditions.
-          runbook: https://docs.agistack.dev/runbooks/revert-spike
+          runbook: https://docs.agijobsv0.dev/runbooks/revert-spike


### PR DESCRIPTION
## Summary
- add a digest-enforcement gate to the supply-chain workflow so releases always use immutable images
- harden Helm charts with KMS-aware secrets, strict ingress controls, digest rendering, and a pause-switch helm test hook
- refresh observability assets and runbooks with updated SLO rules, dashboard links, and disaster-recovery guidance

## Testing
- helm lint deploy/helm *(fails in CI runner: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0dc0d6488333bba7045369ce6060