### PR TITLE
feat: add helm deployment stack and observability runbooks

### DIFF
--- a/.github/workflows/supply-chain.yaml
+++ b/.github/workflows/supply-chain.yaml
@@ -1,0 +1,138 @@
+name: Supply Chain & Deployment
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-scan:
+    name: Build, SBOM, Sign
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [orchestrator, bundler, paymaster-supervisor, attester]
+        environment: [testnet, mainnet]
+    env:
+      REGISTRY: ghcr.io/agi/protocol
+      SERVICE: ${{ matrix.service }}
+      ENVIRONMENT: ${{ matrix.environment }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packages/${{ matrix.service }}/Dockerfile
+          push: true
+          provenance: false
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.SERVICE }}:${{ github.sha }}-${{ env.ENVIRONMENT }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.SERVICE }},push-by-digest=true
+      - name: Capture digest
+        id: digest
+        run: |
+          echo "value=${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.SERVICE }}@${{ steps.build.outputs.digest }}
+          output-file: sbom-${{ env.SERVICE }}-${{ env.ENVIRONMENT }}.spdx.json
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ env.SERVICE }}-${{ env.ENVIRONMENT }}
+          path: sbom-${{ env.SERVICE }}-${{ env.ENVIRONMENT }}.spdx.json
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.5.0
+      - name: Sign image
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign ${{ env.REGISTRY }}/${{ env.SERVICE }}@${{ steps.build.outputs.digest }}
+      - name: Generate provenance
+        uses: slsa-framework/slsa-github-generator/actions/upload-provenance@v2
+        with:
+          subject-path: |
+            ghcr.io/agi/protocol/${{ env.SERVICE }}@${{ steps.build.outputs.digest }}
+
+  helm-verify:
+    name: Helm Digest Verification
+    runs-on: ubuntu-latest
+    needs: build-and-scan
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure digests pinned in values
+        run: |
+          python - <<'PY'
+          import yaml, sys
+          with open('deploy/helm/values.yaml') as fh:
+              data = yaml.safe_load(fh)
+          components = ['orchestrator', 'bundler', 'paymaster-supervisor', 'attester', 'ipfs', 'postgres', 'graph-node']
+          missing = [c for c in components if not data.get(c, {}).get('image', {}).get('digest')]
+          if missing:
+              raise SystemExit(f"Missing immutable digest for: {', '.join(missing)}")
+          PY
+      - name: Helm dependency update
+        run: helm dependency update deploy/helm
+      - name: Helm lint
+        run: helm lint deploy/helm
+      - name: Render manifest smoke test
+        run: helm template aa-stack deploy/helm --namespace aa
+      - name: Export chart metadata
+        run: helm show chart deploy/helm > helm-chart-metadata.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: helm-chart-metadata
+          path: helm-chart-metadata.txt
+
+  release:
+    name: Signed Release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    needs: [build-and-scan, helm-verify]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download SBOM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - name: Compute release version
+        id: version
+        run: |
+          echo "value=v$(date +%Y.%m.%d)-${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git tag ${{ steps.version.outputs.value }}
+          git push origin ${{ steps.version.outputs.value }}
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.value }}
+          name: ${{ steps.version.outputs.value }}
+          generate_release_notes: true
+          files: dist/**/*.spdx.json

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,9 +1,21 @@
 apiVersion: v2
-name: agi-stack
-description: Helm chart for deploying the AGI jobs stack in a single pass.
-type: application
+name: full-stack
 version: 0.1.0
-appVersion: "0.1.0"
+kubeVersion: ">=1.26.0"
+description: Helm umbrella chart for the modular account abstraction stack
+keywords:
+  - aa
+  - bundler
+  - paymaster
+  - orchestrator
+  - ipfs
+  - subgraph
+home: https://github.com/organization/project
+sources:
+  - https://github.com/organization/project
+maintainers:
+  - name: SRE Team
+    email: sre@example.com
 dependencies:
   - name: orchestrator
     version: 0.1.0

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,0 +1,27 @@
+# Full Stack Helm Deployment
+
+This chart performs a one-pass bootstrap of the entire account abstraction stack. It bundles the FastAPI orchestrator, bundler, paymaster supervisor, attester, IPFS node, Graph Node, Postgres dependency, and TLS ingress.
+
+## Usage
+
+```bash
+helm dependency update ./deploy/helm
+helm install aa-stack ./deploy/helm -n aa --create-namespace \
+  --set global.environment=mainnet \
+  --set orchestrator.image.digest=sha256:deadbeef...
+```
+
+All workloads expose Prometheus annotations automatically when `global.observability.prometheusScrape` is enabled. Digests **must** be supplied to keep images immutable during upgrades.
+
+### Values
+
+See [`values.yaml`](./values.yaml) for a full list of tunables including chain metadata, RPC URLs, contract addresses, CORS policies, rate limits, secret providers, and autoscaling defaults.
+
+### Uninstall
+
+```bash
+helm uninstall aa-stack -n aa
+kubectl get all -n aa  # should be empty
+```
+
+For more operational guidance see the runbooks under [`docs/`](../../docs).

--- a/deploy/helm/charts/attester/Chart.yaml
+++ b/deploy/helm/charts/attester/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: attester
-description: EAS attester service
 version: 0.1.0
-appVersion: "0.1.0"
+description: EAS attester microservice
+appVersion: "0.5.0"
+type: application

--- a/deploy/helm/charts/attester/templates/_helpers.tpl
+++ b/deploy/helm/charts/attester/templates/_helpers.tpl
@@ -1,3 +1,21 @@
 {{- define "attester.fullname" -}}
-{{- printf "%s-%s" .Release.Name "attester" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "attester.image" -}}
+{{- $registry := default "" .Values.global.imageRegistry -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "attester.imageWithDigest" -}}
+{{- $image := include "attester.image" . -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $image .Values.image.digest -}}
+{{- else -}}
+{{- $image -}}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/attester/templates/deployment.yaml
+++ b/deploy/helm/charts/attester/templates/deployment.yaml
@@ -1,44 +1,55 @@
+{{- $global := default (dict) .Values.global -}}
+{{- $observability := default (dict) $global.observability -}}
+{{- $contracts := default (dict) $global.contracts -}}
+{{- $eas := default (dict) $global.eas -}}
+{{- $secrets := default (dict) $global.secrets -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "attester.fullname" . }}
   labels:
-    app.kubernetes.io/name: attester
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: attester
 spec:
-  replicas: {{ default 1 .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount | default 1 }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: attester
+      app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if (default false $observability.prometheusScrape) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.service.port }}"
+        {{- end }}
+        {{- range $k, $v := .Values.podAnnotations }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
       labels:
-        app.kubernetes.io/name: attester
+        app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: attester
-          {{- $repoPrefix := default "" (dig "image" "repositoryPrefix" .Values.global) }}
-          {{- $repository := default (printf "%s/attester" $repoPrefix | trimPrefix "/") .Values.image.repository }}
-          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "attester" .Values.global) }}
-          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
-          image: {{ $repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for attester" $tag }}{{- end }}
+          image: {{ include "attester.imageWithDigest" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: RPC_URL
-              value: {{ default (dig "rpc" "primary" .Values.global) .Values.config.rpcUrl | required "config.rpcUrl or global.rpc.primary must be set" | quote }}
-            - name: EAS_SCHEMA_UID
-              value: {{ default (dig "eas" "schemaUID" .Values.global) .Values.config.easSchemaUid | required "config.easSchemaUid or global.eas.schemaUID must be set" | quote }}
-            - name: KMS_KEY_URI
-              value: {{ default (dig "secrets" "attester" "kmsKeyUri" .Values.global) .Values.config.kmsKey | required "config.kmsKey or global.secrets.attester.kmsKeyUri must be set" | quote }}
-            - name: CORS_ALLOWED_ORIGINS
-              value: {{ join "," (default (.Values.global.cors.allowedOrigins | default (list)) .Values.config.corsOrigins) | quote }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: http
+          env:
+            - name: ATTESTER_ADDRESS
+              value: {{ default "" $contracts.attester | quote }}
+            - name: ENTRYPOINT_ADDRESS
+              value: {{ default "" $contracts.entryPoint | quote }}
+            - name: EAS_SCHEMA_UID
+              value: {{ default (default "" $eas.schemaUid) .Values.eas.schemaUid | quote }}
+          envFrom:
+            - secretRef:
+                name: {{ default (printf "%s-runtime" (include "attester.fullname" .)) $secrets.runtimeSecretName }}
+            {{- range .Values.extraEnvFrom }}
+            - {{ toYaml . | nindent 12 }}
+            {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/charts/attester/templates/service.yaml
+++ b/deploy/helm/charts/attester/templates/service.yaml
@@ -3,14 +3,16 @@ kind: Service
 metadata:
   name: {{ include "attester.fullname" . }}
   labels:
-    app.kubernetes.io/name: attester
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: attester
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
       name: http
+      protocol: TCP
   selector:
-    app.kubernetes.io/name: attester
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/attester/values.yaml
+++ b/deploy/helm/charts/attester/values.yaml
@@ -1,17 +1,16 @@
+global: {}
+replicaCount: 1
 image:
-  repository: ghcr.io/agi/jobs/attester
+  repository: attester
   tag: latest
   digest: ""
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
-  port: 7000
+  port: 8060
 resources: {}
-config:
-  rpcUrl: https://ethereum-sepolia.publicnode.com
-  easSchemaUid: "0x0000000000000000000000000000000000000000000000000000000000000000"
-  kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/attester
-  corsOrigins:
-    - https://operator.example.com
-monitoring:
-  enabled: true
+podAnnotations: {}
+autoscaling:
+  enabled: false
+eas: {}
+extraEnvFrom: []

--- a/deploy/helm/charts/bundler/Chart.yaml
+++ b/deploy/helm/charts/bundler/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: bundler
-description: ERC-4337 bundler deployment
 version: 0.1.0
-appVersion: "0.1.0"
+description: ERC-4337 bundler deployment
+appVersion: "0.5.0"
+type: application

--- a/deploy/helm/charts/bundler/templates/_helpers.tpl
+++ b/deploy/helm/charts/bundler/templates/_helpers.tpl
@@ -1,3 +1,21 @@
 {{- define "bundler.fullname" -}}
-{{- printf "%s-%s" .Release.Name "bundler" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "bundler.image" -}}
+{{- $registry := default "" .Values.global.imageRegistry -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "bundler.imageWithDigest" -}}
+{{- $image := include "bundler.image" . -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $image .Values.image.digest -}}
+{{- else -}}
+{{- $image -}}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/bundler/templates/deployment.yaml
+++ b/deploy/helm/charts/bundler/templates/deployment.yaml
@@ -1,42 +1,62 @@
+{{- $global := default (dict) .Values.global -}}
+{{- $contracts := default (dict) $global.contracts -}}
+{{- $rpc := default (dict) $global.rpc -}}
+{{- $observability := default (dict) $global.observability -}}
+{{- $ratelimits := default (dict) $global.ratelimits -}}
+{{- $secrets := default (dict) $global.secrets -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "bundler.fullname" . }}
   labels:
-    app.kubernetes.io/name: bundler
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: bundler
 spec:
-  replicas: {{ default 1 .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount | default 1 }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: bundler
+      app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if (default false $observability.prometheusScrape) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.service.port }}"
+        {{- end }}
+        {{- range $k, $v := .Values.podAnnotations }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
       labels:
-        app.kubernetes.io/name: bundler
+        app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: bundler
-          {{- $repoPrefix := default "" (dig "image" "repositoryPrefix" .Values.global) }}
-          {{- $repository := default (printf "%s/bundler" $repoPrefix | trimPrefix "/") .Values.image.repository }}
-          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "bundler" .Values.global) }}
-          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
-          image: {{ $repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for bundler" $tag }}{{- end }}
+          image: {{ include "bundler.imageWithDigest" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: RPC_URL
-              value: {{ default (dig "rpc" "primary" .Values.global) .Values.config.rpcUrl | required "config.rpcUrl or global.rpc.primary must be set" | quote }}
-            - name: ENTRY_POINT_ADDRESS
-              value: {{ default (dig "contracts" "entryPoint" .Values.global) .Values.config.entryPoint | required "config.entryPoint or global.contracts.entryPoint must be set" | quote }}
-            - name: BUNDLE_INTERVAL_SECONDS
-              value: {{ default 5 .Values.config.bundleIntervalSeconds | quote }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: http
+          env:
+            - name: ENTRYPOINT_ADDRESS
+              value: {{ default "" $contracts.entryPoint | quote }}
+            - name: PAYMASTER_ADDRESS
+              value: {{ default "" $contracts.paymaster | quote }}
+            - name: BUNDLER_PRIVATE_RPC
+              value: {{ default "" $rpc.primary | quote }}
+            - name: RATE_LIMIT_ENABLED
+              value: {{ default false $ratelimits.enabled | quote }}
+            - name: RATE_LIMIT_BURST
+              value: {{ default 20 $ratelimits.burst | quote }}
+            - name: RATE_LIMIT_RPS
+              value: {{ default 10 $ratelimits.requestsPerSecond | quote }}
+          envFrom:
+            - secretRef:
+                name: {{ default (printf "%s-runtime" (include "bundler.fullname" .)) $secrets.runtimeSecretName }}
+            {{- range .Values.extraEnvFrom }}
+            - {{ toYaml . | nindent 12 }}
+            {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/charts/bundler/templates/hpa.yaml
+++ b/deploy/helm/charts/bundler/templates/hpa.yaml
@@ -4,19 +4,20 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "bundler.fullname" . }}
   labels:
-    {{- include "bundler.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "bundler.fullname" . }}
-  minReplicas: {{ .Values.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas | default 3 }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.cpuTargetPercentage }}
+          averageUtilization: {{ default (.Values.global.autoscaling.defaultTargetCPUUtilizationPercentage | default 70) .Values.autoscaling.targetCPUUtilizationPercentage }}
 {{- end }}

--- a/deploy/helm/charts/bundler/templates/service.yaml
+++ b/deploy/helm/charts/bundler/templates/service.yaml
@@ -3,14 +3,16 @@ kind: Service
 metadata:
   name: {{ include "bundler.fullname" . }}
   labels:
-    app.kubernetes.io/name: bundler
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: bundler
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
       name: http
+      protocol: TCP
   selector:
-    app.kubernetes.io/name: bundler
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/bundler/values.yaml
+++ b/deploy/helm/charts/bundler/values.yaml
@@ -1,15 +1,18 @@
+global: {}
+replicaCount: 1
 image:
-  repository: ghcr.io/agi/jobs/bundler
+  repository: bundler
   tag: latest
   digest: ""
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
-  port: 3000
-resources: {}
-config:
-  rpcUrl: https://ethereum-sepolia.publicnode.com
-  entryPoint: "0x0000000000000000000000000000000000000000"
-  bundleIntervalSeconds: 5
-monitoring:
+  port: 8090
+autoscaling:
   enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: null
+resources: {}
+podAnnotations: {}
+extraEnvFrom: []

--- a/deploy/helm/charts/graph-node/Chart.yaml
+++ b/deploy/helm/charts/graph-node/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: graph-node
-description: Graph Node for subgraph indexing
 version: 0.1.0
-appVersion: "0.1.0"
+description: Graph Node indexing service for sponsorship subgraph
+appVersion: "0.31.0"
+type: application

--- a/deploy/helm/charts/graph-node/templates/_helpers.tpl
+++ b/deploy/helm/charts/graph-node/templates/_helpers.tpl
@@ -1,3 +1,21 @@
-{{- define "graphNode.fullname" -}}
-{{- printf "%s-%s" .Release.Name "graph-node" | trunc 63 | trimSuffix "-" -}}
+{{- define "graph-node.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "graph-node.image" -}}
+{{- $registry := default "" .Values.global.imageRegistry -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "graph-node.imageWithDigest" -}}
+{{- $image := include "graph-node.image" . -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $image .Values.image.digest -}}
+{{- else -}}
+{{- $image -}}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/graph-node/templates/deployment.yaml
+++ b/deploy/helm/charts/graph-node/templates/deployment.yaml
@@ -1,53 +1,63 @@
+{{- $global := default (dict) .Values.global -}}
+{{- $observability := default (dict) $global.observability -}}
+{{- $secrets := default (dict) $global.secrets -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "graphNode.fullname" . }}
+  name: {{ include "graph-node.fullname" . }}
   labels:
-    app.kubernetes.io/name: graph-node
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: graph-node
 spec:
-  replicas: {{ default 1 .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount | default 1 }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: graph-node
+      app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if (default false $observability.prometheusScrape) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.indexer.metricsPort }}"
+        {{- end }}
+        {{- range $k, $v := .Values.podAnnotations }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
       labels:
-        app.kubernetes.io/name: graph-node
+        app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: graph-node
-          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "graph-node" .Values.global) }}
-          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
-          image: {{ .Values.image.repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for graph-node" $tag }}{{- end }}
+          image: {{ include "graph-node.imageWithDigest" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+              name: query
+            - containerPort: {{ .Values.indexer.adminPort }}
+              name: admin
+            - containerPort: {{ .Values.indexer.metricsPort }}
+              name: metrics
           env:
             - name: GRAPH_LOG
               value: info
-            - name: RUST_LOG
-              value: info
-            - name: POSTGRES_PASSWORD
+            - name: GRAPH_ALLOW_NON_DETERMINISTIC_IPFS
+              value: "true"
+            - name: GRAPH_ALLOW_NON_DETERMINISTIC_IPFS_TIMEOUT
+              value: "30"
+            - name: GRAPH_NODE_ID
+              value: {{ include "graph-node.fullname" . | quote }}
+            - name: POSTGRESQL_CONNECTION
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.postgres.userSecret }}
-                  key: POSTGRES_PASSWORD
-          args:
-            - run
-            - --config
-            - /etc/graph/config.toml
-          ports:
-            - containerPort: {{ .Values.service.port }}
-              name: http
-          volumeMounts:
-            - name: config
-              mountPath: /etc/graph
+                  name: {{ default "" .Values.postgres.connectionSecretName }}
+                  key: database-url
+            - name: IPFS
+              value: {{ .Values.ipfsEndpoint | quote }}
+          envFrom:
+            - secretRef:
+                name: {{ default (printf "%s-runtime" (include "graph-node.fullname" .)) $secrets.runtimeSecretName }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
-      volumes:
-        - name: config
-          configMap:
-            name: {{ include "graphNode.fullname" . }}-config
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/charts/graph-node/templates/service.yaml
+++ b/deploy/helm/charts/graph-node/templates/service.yaml
@@ -1,16 +1,23 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "graphNode.fullname" . }}
+  name: {{ include "graph-node.fullname" . }}
   labels:
-    app.kubernetes.io/name: graph-node
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: graph-node
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
-      name: http
+      targetPort: query
+      name: query
+    - port: {{ .Values.indexer.adminPort }}
+      targetPort: admin
+      name: admin
+    - port: {{ .Values.indexer.metricsPort }}
+      targetPort: metrics
+      name: metrics
   selector:
-    app.kubernetes.io/name: graph-node
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/graph-node/values.yaml
+++ b/deploy/helm/charts/graph-node/values.yaml
@@ -1,20 +1,20 @@
+global: {}
+replicaCount: 1
 image:
-  repository: ghcr.io/graphprotocol/graph-node
-  tag: v0.32.0
+  repository: graph-node
+  tag: latest
+  digest: ""
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
   port: 8000
+indexer:
+  adminPort: 8030
+  metricsPort: 8040
+postgres:
+  connectionSecretName: ""
+ipfsEndpoint: "http://ipfs:5001"
 resources: {}
-config:
-  ethereumNetworks:
-    - name: sepolia
-      rpc: https://ethereum-sepolia.publicnode.com
-  postgres:
-    host: ""
-    database: subgraph
-    userSecret: graph-node-postgres
-  ipfs:
-    endpoint: ""
-monitoring:
-  enabled: true
+podAnnotations: {}
+autoscaling:
+  enabled: false

--- a/deploy/helm/charts/ingress/Chart.yaml
+++ b/deploy/helm/charts/ingress/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: ingress
-description: Shared TLS ingress rules for the AGI stack
 version: 0.1.0
-appVersion: "0.1.0"
+description: TLS ingress with HSTS, CORS, and rate limiting headers
+appVersion: "1.0.0"
+type: application

--- a/deploy/helm/charts/ingress/templates/_helpers.tpl
+++ b/deploy/helm/charts/ingress/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "ingress.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/helm/charts/ingress/templates/ingress.yaml
+++ b/deploy/helm/charts/ingress/templates/ingress.yaml
@@ -1,43 +1,49 @@
-{{- if .Values.enabled }}
+{{- if .Values.hosts }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ printf "%s-shared" .Release.Name }}
+  name: {{ include "ingress.fullname" . }}
   annotations:
-    kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/hsts: "true"
-    nginx.ingress.kubernetes.io/hsts-max-age: "{{ .Values.security.hstsMaxAge }}"
-    nginx.ingress.kubernetes.io/hsts-include-subdomains: "{{ ternary "true" "false" (.Values.security.includeSubdomains | default true) }}"
-    nginx.ingress.kubernetes.io/hsts-preload: "{{ ternary "true" "false" (.Values.security.preload | default true) }}"
-    nginx.ingress.kubernetes.io/enable-access-log: "true"
-    nginx.ingress.kubernetes.io/limit-rpm: "{{ default 300 .Values.rateLimitRpm }}"
-    nginx.ingress.kubernetes.io/limit-burst-multiplier: "1"
-    nginx.ingress.kubernetes.io/enable-modsecurity: {{ .Values.security.wafAnnotation | quote }}
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "{{ .Values.security.corsAllowOrigin }}"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "{{ join "," (.Values.security.corsAllowHeaders | default (list "Authorization" "Content-Type")) }}"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "{{ join "," (.Values.security.corsAllowMethods | default (list "GET" "POST")) }}"
-    nginx.ingress.kubernetes.io/proxy-body-size: "{{ default "1m" .Values.security.proxyBodySize }}"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ default "60s" .Values.security.requestTimeout }}"
+    kubernetes.io/ingress.class: {{ .Values.className | quote }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+      add_header X-Frame-Options "DENY" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header Referrer-Policy "no-referrer" always;
+      add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'none';" always;
+    {{- range $host := .Values.hosts }}
+    {{- range $k, $v := $host.annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.waf.enabled }}
+    cloud.google.com/load-balancer-type: external
+    networking.gke.io/security-policy: {{ .Values.waf.policy | quote }}
+    {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingressClassName }}
+  ingressClassName: {{ .Values.className | quote }}
   tls:
-    - secretName: {{ .Values.defaultTlsSecret }}
-      hosts:
-{{- range .Values.hosts }}
-        - {{ .host }}
-{{- end }}
+    {{- range .Values.hosts }}
+    - hosts:
+        - {{ .host | quote }}
+      secretName: {{ .tlsSecret | quote }}
+    {{- end }}
+    {{- range .Values.extraTls }}
+    - hosts: {{ toYaml .hosts | nindent 8 }}
+      secretName: {{ .secretName | quote }}
+    {{- end }}
   rules:
-{{- range .Values.hosts }}
-    - host: {{ .host }}
+    {{- range .Values.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ printf "%s-%s" $.Release.Name .serviceName }}
+                name: {{ printf "%s-%s" $.Release.Name .service | trunc 63 | trimSuffix "-" }}
                 port:
-                  number: {{ .servicePort }}
-{{- end }}
+                  number: {{ .port }}
+    {{- end }}
 {{- end }}

--- a/deploy/helm/charts/ingress/values.yaml
+++ b/deploy/helm/charts/ingress/values.yaml
@@ -1,18 +1,8 @@
-enabled: true
-ingressClassName: nginx
-defaultTlsSecret: agi-stack-tls
-hosts:
-  - host: orchestrator.example.com
-    serviceName: orchestrator
-    servicePort: 8000
-  - host: bundler.example.com
-    serviceName: bundler
-    servicePort: 3000
-  - host: attester.example.com
-    serviceName: attester
-    servicePort: 7000
-security:
-  hstsMaxAge: 63072000
-  includeSubdomains: true
-  preload: true
-  wafAnnotation: "true"
+global: {}
+className: nginx
+hosts: []
+waf:
+  enabled: false
+  provider: ""
+  policy: ""
+extraTls: []

--- a/deploy/helm/charts/ipfs/Chart.yaml
+++ b/deploy/helm/charts/ipfs/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: ipfs
-description: IPFS node with pinning configuration
 version: 0.1.0
-appVersion: "0.1.0"
+description: IPFS pinning node for sponsorship receipts
+appVersion: "0.21.0"
+type: application

--- a/deploy/helm/charts/ipfs/templates/_helpers.tpl
+++ b/deploy/helm/charts/ipfs/templates/_helpers.tpl
@@ -1,3 +1,21 @@
 {{- define "ipfs.fullname" -}}
-{{- printf "%s-%s" .Release.Name "ipfs" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ipfs.image" -}}
+{{- $registry := default "" .Values.global.imageRegistry -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ipfs.imageWithDigest" -}}
+{{- $image := include "ipfs.image" . -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $image .Values.image.digest -}}
+{{- else -}}
+{{- $image -}}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/ipfs/templates/service.yaml
+++ b/deploy/helm/charts/ipfs/templates/service.yaml
@@ -3,20 +3,17 @@ kind: Service
 metadata:
   name: {{ include "ipfs.fullname" . }}
   labels:
-    app.kubernetes.io/name: ipfs
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  clusterIP: None
+  type: ClusterIP
   ports:
     - name: api
       port: {{ .Values.service.apiPort }}
       targetPort: api
-    - name: swarm
-      port: {{ .Values.service.swarmPort }}
-      targetPort: swarm
     - name: gateway
       port: {{ .Values.service.gatewayPort }}
       targetPort: gateway
   selector:
-    app.kubernetes.io/name: ipfs
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/ipfs/templates/statefulset.yaml
+++ b/deploy/helm/charts/ipfs/templates/statefulset.yaml
@@ -1,69 +1,63 @@
+{{- $global := default (dict) .Values.global -}}
+{{- $observability := default (dict) $global.observability -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "ipfs.fullname" . }}
   labels:
-    app.kubernetes.io/name: ipfs
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: ipfs
 spec:
-  serviceName: {{ include "ipfs.fullname" . }}
-  replicas: {{ default 1 .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount | default 1 }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: ipfs
+      app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  serviceName: {{ include "ipfs.fullname" . }}
   template:
     metadata:
+      annotations:
+        {{- if (default false $observability.prometheusScrape) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.service.apiPort }}"
+        {{- end }}
+        {{- range $k, $v := .Values.podAnnotations }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
       labels:
-        app.kubernetes.io/name: ipfs
+        app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: ipfs
-          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "ipfs" .Values.global) }}
-          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
-          image: {{ .Values.image.repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for ipfs" $tag }}{{- end }}
+          image: {{ include "ipfs.imageWithDigest" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-            - daemon
-            - --migrate=true
-            - --routing=dhtclient
-          env:
-            - name: IPFS_PROFILE
-              value: {{ default "server" .Values.config.profile | quote }}
           ports:
             - containerPort: {{ .Values.service.apiPort }}
               name: api
-            - containerPort: {{ .Values.service.swarmPort }}
-              name: swarm
             - containerPort: {{ .Values.service.gatewayPort }}
               name: gateway
+          env:
+            - name: IPFS_PROFILE
+              value: server
+            - name: LIBP2P_FORCE_PNET
+              value: "1"
           volumeMounts:
-            - mountPath: /data/ipfs
-              name: data
-          livenessProbe:
-            httpGet:
-              path: /api/v0/version
-              port: api
-            initialDelaySeconds: 30
-            periodSeconds: 30
-          readinessProbe:
-            httpGet:
-              path: /api/v0/id
-              port: api
-            initialDelaySeconds: 30
-            periodSeconds: 30
-      volumes:
-        {{- if .Values.config.swarmKeySecret }}
-        - name: swarm-key
-          secret:
-            secretName: {{ .Values.config.swarmKeySecret }}
-        {{- end }}
+            - name: data
+              mountPath: /data/ipfs
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+{{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
+        {{- if .Values.persistence.storageClassName }}
+        storageClassName: {{ .Values.persistence.storageClassName }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/charts/ipfs/values.yaml
+++ b/deploy/helm/charts/ipfs/values.yaml
@@ -1,17 +1,16 @@
+global: {}
+replicaCount: 1
 image:
-  repository: ipfs/go-ipfs
-  tag: v0.23.0
+  repository: ipfs
+  tag: latest
+  digest: ""
   pullPolicy: IfNotPresent
 service:
   apiPort: 5001
-  swarmPort: 4001
   gatewayPort: 8080
 persistence:
   enabled: true
-  size: 50Gi
+  size: 100Gi
+  storageClassName: null
 resources: {}
-config:
-  profile: server
-  swarmKeySecret: ""
-monitoring:
-  enabled: true
+podAnnotations: {}

--- a/deploy/helm/charts/orchestrator/Chart.yaml
+++ b/deploy/helm/charts/orchestrator/Chart.yaml
@@ -1,5 +1,7 @@
 apiVersion: v2
 name: orchestrator
-description: FastAPI orchestrator deployment
 version: 0.1.0
-appVersion: "0.1.0"
+kubeVersion: ">=1.26.0"
+description: FastAPI orchestrator service
+appVersion: "0.5.0"
+type: application

--- a/deploy/helm/charts/orchestrator/templates/_helpers.tpl
+++ b/deploy/helm/charts/orchestrator/templates/_helpers.tpl
@@ -1,7 +1,25 @@
 {{- define "orchestrator.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{ .Values.fullnameOverride }}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name "orchestrator" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "orchestrator.image" -}}
+{{- $registry := default "" .Values.global.imageRegistry -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "orchestrator.imageWithDigest" -}}
+{{- $image := include "orchestrator.image" . -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $image .Values.image.digest -}}
+{{- else -}}
+{{- $image -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "orchestrator.serviceAccountName" -}}
+{{- default (include "orchestrator.fullname" .) .Values.serviceAccountName -}}
 {{- end -}}

--- a/deploy/helm/charts/orchestrator/templates/deployment.yaml
+++ b/deploy/helm/charts/orchestrator/templates/deployment.yaml
@@ -1,71 +1,111 @@
+{{- $global := default (dict) .Values.global -}}
+{{- $cors := default (dict) $global.cors -}}
+{{- $ratelimits := default (dict) $global.ratelimits -}}
+{{- $rpc := default (dict) $global.rpc -}}
+{{- $contracts := default (dict) $global.contracts -}}
+{{- $eas := default (dict) $global.eas -}}
+{{- $observability := default (dict) $global.observability -}}
+{{- $secrets := default (dict) $global.secrets -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "orchestrator.fullname" . }}
   labels:
-    app.kubernetes.io/name: orchestrator
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: api
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: orchestrator
 spec:
-  replicas: {{ default 1 .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount | default 1 }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: orchestrator
+      app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/env-config.yaml") . | sha256sum }}
+        {{- if (default false $observability.prometheusScrape) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.service.port }}"
+        {{- end }}
+        {{- range $k, $v := .Values.podAnnotations }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
       labels:
-        app.kubernetes.io/name: orchestrator
+        app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ include "orchestrator.serviceAccountName" . }}
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: orchestrator
-          {{- $repoPrefix := default "" (dig "image" "repositoryPrefix" .Values.global) }}
-          {{- $repository := default (printf "%s/orchestrator" $repoPrefix | trimPrefix "/") .Values.image.repository }}
-          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "orchestrator" .Values.global) }}
-          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
-          image: {{ $repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for orchestrator" $tag }}{{- end }}
+          image: {{ include "orchestrator.imageWithDigest" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: LOG_LEVEL
-              value: {{ .Values.env.logLevel | quote }}
-            - name: CORS_ALLOWED_ORIGINS
-              value: {{ join "," (default (.Values.global.cors.allowedOrigins | default (list)) .Values.env.corsOrigins) | quote }}
-            - name: CORS_ALLOWED_HEADERS
-              value: {{ join "," (default (.Values.global.cors.allowedHeaders | default (list)) .Values.env.corsHeaders) | quote }}
-            - name: KMS_KEY_URI
-              value: {{ .Values.env.kmsKey | quote }}
-            - name: ENTRY_POINT_ADDRESS
-              value: {{ required "contracts.entryPoint is required" (dig "contracts" "entryPoint" .Values.global) | quote }}
-            - name: PAYMASTER_ADDRESS
-              value: {{ required "contracts.paymaster is required" (dig "contracts" "paymaster" .Values.global) | quote }}
-            - name: EAS_SCHEMA_UID
-              value: {{ required "eas.schemaUID is required" (dig "eas" "schemaUID" .Values.global) | quote }}
-            - name: RPC_URL
-              value: {{ required "rpc.primary is required" (dig "rpc" "primary" .Values.global) | quote }}
-            - name: STACK_PAUSED
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ .Values.global.pauseSwitch.configMap }}
-                  key: {{ .Values.global.pauseSwitch.key }}
-                  optional: true
-            - name: MAX_REQUEST_BYTES
-              value: {{ .Values.env.maxRequestBytes | quote }}
           ports:
             - containerPort: {{ .Values.service.port }}
+              name: http
+          env:
+            - name: CHAIN_ID
+              value: {{ default "0" $global.chainId | quote }}
+            - name: PRIMARY_RPC_URL
+              value: {{ default "" $rpc.primary | quote }}
+            - name: FALLBACK_RPC_URL
+              value: {{ default "" $rpc.fallback | quote }}
+            - name: ENTRYPOINT_ADDRESS
+              value: {{ default "" $contracts.entryPoint | quote }}
+            - name: PAYMASTER_ADDRESS
+              value: {{ default "" $contracts.paymaster | quote }}
+            - name: BUNDLER_ADDRESS
+              value: {{ default "" $contracts.bundler | quote }}
+            - name: EAS_SCHEMA_UID
+              value: {{ default (default "" $eas.schemaUid) .Values.eas.schemaUid | quote }}
+            - name: CORS_ALLOW_ORIGINS
+              value: {{ join "," (default (list "*") $cors.allowOrigins) | quote }}
+            - name: CORS_ALLOW_METHODS
+              value: {{ join "," (default (list "GET" "POST") $cors.allowMethods) | quote }}
+            - name: CORS_ALLOW_HEADERS
+              value: {{ join "," (default (list "Authorization" "Content-Type") $cors.allowHeaders) | quote }}
+            - name: RATE_LIMIT_ENABLED
+              value: {{ default false $ratelimits.enabled | quote }}
+            - name: RATE_LIMIT_BURST
+              value: {{ default 20 $ratelimits.burst | quote }}
+            - name: RATE_LIMIT_RPS
+              value: {{ default 10 $ratelimits.requestsPerSecond | quote }}
+            - name: RATE_LIMIT_REDIS_DSN
+              value: {{ default "" $ratelimits.redisDsn | quote }}
+            - name: MAX_REQUEST_BODY
+              value: {{ default "1m" .Values.env.MAX_REQUEST_BODY | quote }}
+            - name: FEATURE_FLAGS
+              value: {{ default "" .Values.env.FEATURE_FLAGS | quote }}
+          envFrom:
+            - secretRef:
+                name: {{ default (printf "%s-runtime" (include "orchestrator.fullname" .)) $secrets.runtimeSecretName }}
+            {{- range .Values.extraEnvFrom }}
+            - {{ toYaml . | nindent 12 }}
+            {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /healthz
-              port: {{ .Values.service.port }}
+              port: http
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: 15
+              port: http
+            initialDelaySeconds: 20
             periodSeconds: 20
+          volumeMounts:
+            - name: kms-secrets
+              mountPath: /var/run/secrets/kms
+              readOnly: true
+      volumes:
+        - name: kms-secrets
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ default "" $secrets.secretProviderClass | quote }}

--- a/deploy/helm/charts/orchestrator/templates/hpa.yaml
+++ b/deploy/helm/charts/orchestrator/templates/hpa.yaml
@@ -1,23 +1,23 @@
-{{- if .Values.autoscaling.enabled | default false }}
+{{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "orchestrator.fullname" . }}
   labels:
-    app.kubernetes.io/name: orchestrator
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "orchestrator.fullname" . }}
-  minReplicas: {{ .Values.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas | default 3 }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.cpuTargetPercentage }}
+          averageUtilization: {{ default (.Values.global.autoscaling.defaultTargetCPUUtilizationPercentage | default 70) .Values.autoscaling.targetCPUUtilizationPercentage }}
 {{- end }}

--- a/deploy/helm/charts/orchestrator/templates/notes.txt
+++ b/deploy/helm/charts/orchestrator/templates/notes.txt
@@ -1,0 +1,5 @@
+1. Wait for the orchestrator deployment to become available:
+   kubectl rollout status deploy/{{ include "orchestrator.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Confirm Prometheus annotations are present if scraping is enabled:
+   kubectl get pod -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ .Chart.Name }} -o yaml | grep prometheus.io/scrape

--- a/deploy/helm/charts/orchestrator/templates/service.yaml
+++ b/deploy/helm/charts/orchestrator/templates/service.yaml
@@ -3,14 +3,16 @@ kind: Service
 metadata:
   name: {{ include "orchestrator.fullname" . }}
   labels:
-    app.kubernetes.io/name: orchestrator
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: orchestrator
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: orchestrator
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/orchestrator/templates/serviceaccount.yaml
+++ b/deploy/helm/charts/orchestrator/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "orchestrator.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.serviceAccountRoleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.serviceAccountRoleArn | quote }}
+  {{- end }}

--- a/deploy/helm/charts/orchestrator/values.yaml
+++ b/deploy/helm/charts/orchestrator/values.yaml
@@ -1,29 +1,24 @@
+global: {}
+replicaCount: 1
 image:
-  repository: ghcr.io/agi/jobs/orchestrator
-  tag: ""
+  repository: orchestrator
+  tag: latest
   digest: ""
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
-  port: 8000
-env:
-  logLevel: info
-  corsOrigins: []
-  kmsKey: ""
-  maxRequestBytes: 1048576
+  port: 8080
+podAnnotations: {}
 resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
 autoscaling:
-  enabled: false
-  minReplicas: 2
-  maxReplicas: 5
-  cpuTargetPercentage: 60
-ingress:
-  enabled: false
-  className: nginx
-  host: orchestrator.example.com
-  tlsSecret: orchestrator-tls
-rateLimit:
-  requestsPerMinute: 300
-  burst: 50
-monitoring:
   enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: null
+env: {}
+eas: {}
+extraEnvFrom: []
+serviceAccountRoleArn: null

--- a/deploy/helm/charts/paymaster-supervisor/Chart.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: paymaster-supervisor
-description: Paymaster supervisor managing sponsorship policy
 version: 0.1.0
-appVersion: "0.1.0"
+description: Paymaster supervisor service with KMS-backed key access
+appVersion: "0.5.0"
+type: application

--- a/deploy/helm/charts/paymaster-supervisor/templates/_helpers.tpl
+++ b/deploy/helm/charts/paymaster-supervisor/templates/_helpers.tpl
@@ -1,3 +1,21 @@
-{{- define "paymasterSupervisor.fullname" -}}
-{{- printf "%s-%s" .Release.Name "paymaster-supervisor" | trunc 63 | trimSuffix "-" -}}
+{{- define "paymaster-supervisor.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "paymaster-supervisor.image" -}}
+{{- $registry := default "" .Values.global.imageRegistry -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "paymaster-supervisor.imageWithDigest" -}}
+{{- $image := include "paymaster-supervisor.image" . -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $image .Values.image.digest -}}
+{{- else -}}
+{{- $image -}}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/paymaster-supervisor/templates/deployment.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/templates/deployment.yaml
@@ -1,46 +1,85 @@
+{{- $global := default (dict) .Values.global -}}
+{{- $contracts := default (dict) $global.contracts -}}
+{{- $eas := default (dict) $global.eas -}}
+{{- $observability := default (dict) $global.observability -}}
+{{- $secrets := default (dict) $global.secrets -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "paymasterSupervisor.fullname" . }}
+  name: {{ include "paymaster-supervisor.fullname" . }}
   labels:
-    app.kubernetes.io/name: paymaster-supervisor
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: paymaster
+    app.kubernetes.io/component: paymaster-supervisor
 spec:
-  replicas: {{ default 1 .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount | default 1 }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: paymaster-supervisor
+      app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if (default false $observability.prometheusScrape) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.service.port }}"
+        {{- end }}
+        {{- range $k, $v := .Values.podAnnotations }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
       labels:
-        app.kubernetes.io/name: paymaster-supervisor
+        app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.pauseConfigMap }}
+      initContainers:
+        - name: wait-for-unpause
+          image: public.ecr.aws/bitnami/kubectl:1.28
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until [ "$(kubectl get cm {{ .Values.pauseConfigMap }} -n {{ .Release.Namespace }} -o jsonpath='{.data.pause}')" = "false" ]; do
+                echo "Waiting for pause switch to be disabled";
+                sleep 5;
+              done
+          volumeMounts:
+            - name: kms-secrets
+              mountPath: /var/run/secrets/kms
+              readOnly: true
+      {{- end }}
       containers:
         - name: paymaster-supervisor
-          {{- $repoPrefix := default "" (dig "image" "repositoryPrefix" .Values.global) }}
-          {{- $repository := default (printf "%s/paymaster-supervisor" $repoPrefix | trimPrefix "/") .Values.image.repository }}
-          {{- $digest := coalesce .Values.image.digest (dig "image" "digestOverrides" "paymaster-supervisor" .Values.global) }}
-          {{- $tag := coalesce .Values.image.tag (dig "image" "tag" .Values.global) }}
-          image: {{ $repository }}{{- if $digest -}}@{{ $digest }}{{- else -}}:{{ required "image.tag must be provided when no digest is configured for paymaster-supervisor" $tag }}{{- end }}
+          image: {{ include "paymaster-supervisor.imageWithDigest" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: RPC_URL
-              value: {{ default (dig "rpc" "primary" .Values.global) .Values.config.rpcUrl | required "config.rpcUrl or global.rpc.primary must be set" | quote }}
-            - name: PAYMASTER_ADDRESS
-              value: {{ default (dig "contracts" "paymaster" .Values.global) .Values.config.paymasterAddress | required "config.paymasterAddress or global.contracts.paymaster must be set" | quote }}
-            - name: TREASURY_ADDRESS
-              value: {{ default (dig "secrets" "paymaster" "treasuryAddress" .Values.global) .Values.config.treasuryAddress | required "config.treasuryAddress or global.secrets.paymaster.treasuryAddress must be set" | quote }}
-            - name: SPONSORSHIP_BUDGET_USD
-              value: {{ default 100.0 .Values.config.sponsorshipBudgetUsd | quote }}
-            - name: KMS_KEY_URI
-              value: {{ default (dig "secrets" "paymaster" "kmsKeyUri" .Values.global) .Values.config.kmsKey | required "config.kmsKey or global.secrets.paymaster.kmsKeyUri must be set" | quote }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: http
+          env:
+            - name: PAYMASTER_ADDRESS
+              value: {{ default "" $contracts.paymaster | quote }}
+            - name: EAS_SCHEMA_UID
+              value: {{ default (default "" $eas.schemaUid) .Values.eas.schemaUid | quote }}
+            - name: GAS_TOP_UP_THRESHOLD_USD
+              value: {{ .Values.gasTopUpThresholdUsd | quote }}
+            - name: TREASURY_ADDRESS
+              value: {{ default "" $contracts.treasury | quote }}
+          envFrom:
+            - secretRef:
+                name: {{ default (printf "%s-runtime" (include "paymaster-supervisor.fullname" .)) $secrets.runtimeSecretName }}
+            {{- range .Values.extraEnvFrom }}
+            - {{ toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: kms-secrets
+              mountPath: /var/run/secrets/kms
+              readOnly: true
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: kms-secrets
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ default "" $secrets.secretProviderClass | quote }}

--- a/deploy/helm/charts/paymaster-supervisor/templates/service.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/templates/service.yaml
@@ -1,16 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "paymasterSupervisor.fullname" . }}
+  name: {{ include "paymaster-supervisor.fullname" . }}
   labels:
-    app.kubernetes.io/name: paymaster-supervisor
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: paymaster-supervisor
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
+      protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: paymaster-supervisor
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/paymaster-supervisor/values.yaml
+++ b/deploy/helm/charts/paymaster-supervisor/values.yaml
@@ -1,17 +1,18 @@
+global: {}
+replicaCount: 1
 image:
-  repository: ghcr.io/agi/jobs/paymaster-supervisor
+  repository: paymaster-supervisor
   tag: latest
   digest: ""
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
-  port: 8080
+  port: 8070
 resources: {}
-config:
-  rpcUrl: https://ethereum-sepolia.publicnode.com
-  paymasterAddress: "0x0000000000000000000000000000000000000000"
-  kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/paymaster
-  treasuryAddress: "0x0000000000000000000000000000000000000000"
-  sponsorshipBudgetUsd: 100.0
-monitoring:
-  enabled: true
+autoscaling:
+  enabled: false
+podAnnotations: {}
+gasTopUpThresholdUsd: 150
+pauseConfigMap: null
+eas: {}
+extraEnvFrom: []

--- a/deploy/helm/charts/postgres/Chart.yaml
+++ b/deploy/helm/charts/postgres/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: postgres
-description: Postgres backing store for subgraph
 version: 0.1.0
-appVersion: "14"
+description: Postgres database backing the subgraph
+appVersion: "15"
+type: application

--- a/deploy/helm/charts/postgres/templates/_helpers.tpl
+++ b/deploy/helm/charts/postgres/templates/_helpers.tpl
@@ -1,3 +1,21 @@
 {{- define "postgres.fullname" -}}
-{{- printf "%s-%s" .Release.Name "postgres" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "postgres.image" -}}
+{{- $registry := default "" .Values.global.imageRegistry -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postgres.imageWithDigest" -}}
+{{- $image := include "postgres.image" . -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $image .Values.image.digest -}}
+{{- else -}}
+{{- $image -}}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/postgres/templates/backup-cronjob.yaml
+++ b/deploy/helm/charts/postgres/templates/backup-cronjob.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "postgres.fullname" . }}-backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: pgdump
+              image: ghcr.io/agi/protocol/pg-backup:latest
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.primary.credentialsSecretName }}
+                      key: database-url
+                - name: RETENTION
+                  value: {{ .Values.backup.retention | quote }}
+{{- end }}

--- a/deploy/helm/charts/postgres/templates/service.yaml
+++ b/deploy/helm/charts/postgres/templates/service.yaml
@@ -3,14 +3,22 @@ kind: Service
 metadata:
   name: {{ include "postgres.fullname" . }}
   labels:
-    app.kubernetes.io/name: postgres
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: postgres
+  {{- $annotations := default (dict) .Values.primary.service.annotations }}
+  {{- if $annotations }}
+  annotations:
+    {{- range $k, $v := $annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+  {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  clusterIP: None
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.primary.service.port }}
       targetPort: postgres
       name: postgres
   selector:
-    app.kubernetes.io/name: postgres
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/charts/postgres/templates/statefulset.yaml
+++ b/deploy/helm/charts/postgres/templates/statefulset.yaml
@@ -1,50 +1,72 @@
+{{- $global := default (dict) .Values.global -}}
+{{- $observability := default (dict) $global.observability -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "postgres.fullname" . }}
   labels:
-    app.kubernetes.io/name: postgres
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: postgres
 spec:
-  serviceName: {{ include "postgres.fullname" . }}
-  replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: postgres
+      app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  serviceName: {{ include "postgres.fullname" . }}
+  replicas: 1
   template:
     metadata:
+      annotations:
+        {{- range $k, $v := .Values.primary.podAnnotations }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
+        {{- if (default false $observability.prometheusScrape) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9187"
+        {{- end }}
       labels:
-        app.kubernetes.io/name: postgres
+        app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
         - name: postgres
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ include "postgres.imageWithDigest" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.primary.service.port }}
+              name: postgres
           env:
             - name: POSTGRES_DB
-              value: {{ .Values.config.database | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.primary.credentialsSecretName }}
+                  key: database
             - name: POSTGRES_USER
-              value: {{ .Values.config.username | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.primary.credentialsSecretName }}
+                  key: username
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.existingSecret }}
-                  key: POSTGRES_PASSWORD
-          ports:
-            - containerPort: {{ .Values.service.port }}
-              name: postgres
+                  name: {{ .Values.primary.credentialsSecretName }}
+                  key: password
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
+{{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
+        {{- if .Values.persistence.storageClassName }}
+        storageClassName: {{ .Values.persistence.storageClassName }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/charts/postgres/values.yaml
+++ b/deploy/helm/charts/postgres/values.yaml
@@ -1,16 +1,21 @@
+global: {}
 image:
   repository: postgres
-  tag: "14"
+  tag: "15"
+  digest: ""
   pullPolicy: IfNotPresent
-service:
-  type: ClusterIP
-  port: 5432
-resources: {}
 persistence:
-  size: 20Gi
-config:
-  database: subgraph
-  username: graph
-  existingSecret: graph-node-postgres
-monitoring:
   enabled: true
+  size: 200Gi
+  storageClassName: null
+resources: {}
+primary:
+  service:
+    port: 5432
+  annotations: {}
+  podAnnotations: {}
+  credentialsSecretName: ""
+backup:
+  enabled: true
+  schedule: "0 * * * *"
+  retention: 48h

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,214 +1,145 @@
-# Global configuration shared across the stack
 global:
-  chainId: 11155111
-  network: sepolia
+  environment: testnet
+  imageRegistry: ghcr.io/agi/protocol
+  chainId: 84532
   rpc:
-    primary: https://ethereum-sepolia.publicnode.com
-    fallback: []
+    primary: https://sepolia.gateway.rpc
+    fallback: https://backup.rpc
   contracts:
     entryPoint: "0x0000000000000000000000000000000000000000"
     paymaster: "0x0000000000000000000000000000000000000000"
+    bundler: "0x0000000000000000000000000000000000000000"
     attester: "0x0000000000000000000000000000000000000000"
   eas:
-    schemaUID: "0x0000000000000000000000000000000000000000000000000000000000000000"
-    verifierUrl: https://eas.example.com
+    schemaUid: "0x0000000000000000000000000000000000000000000000000000000000000000"
   cors:
-    allowedOrigins:
-      - https://operator.example.com
-    allowedHeaders:
-      - Authorization
-      - Content-Type
-  rateLimits:
-    orchestrator:
-      requestsPerMinute: 300
-      burst: 50
-    bundler:
-      requestsPerMinute: 120
-      burst: 30
-    attester:
-      requestsPerMinute: 60
-      burst: 15
-  secrets:
-    kmsKeyring: projects/example/locations/global/keyRings/agi
-    orchestrator:
-      secretName: orchestrator-secrets
-      kmsKeyUri: projects/example/locations/global/keyRings/agi/cryptoKeys/orchestrator
-      environment: production
-    paymaster:
-      secretName: paymaster-secrets
-      kmsKeyUri: projects/example/locations/global/keyRings/agi/cryptoKeys/paymaster
-      treasuryAddress: "0x0000000000000000000000000000000000000000"
-    attester:
-      secretName: attester-secrets
-      kmsKeyUri: projects/example/locations/global/keyRings/agi/cryptoKeys/attester
-  image:
-    pullPolicy: IfNotPresent
-    repositoryPrefix: ghcr.io/agi/jobs
-    tag: ""
-    digestOverrides: {}
-  autoscaling:
+    allowOrigins:
+      - https://dashboard.example.com
+      - https://operators.example.com
+    allowMethods: [GET, POST, OPTIONS]
+    allowHeaders: [Authorization, Content-Type, X-Requested-With]
+  ratelimits:
     enabled: true
-    minReplicas: 2
-    maxReplicas: 5
-    cpuTargetPercentage: 60
-  storage:
-    ipfs:
-      size: 50Gi
-    postgres:
-      size: 20Gi
-  monitoring:
-    enabled: true
+    burst: 50
+    requestsPerSecond: 20
+    redisDsn: redis://ratelimits:6379/0
+  observability:
+    prometheusScrape: true
     serviceMonitorNamespace: monitoring
-    alertRoutingKey: agi-stack
-  pauseSwitch:
-    configMap: agi-operations
-    key: pause
-    default: "false"
+  secrets:
+    kmsKeyId: projects/example/locations/global/keyRings/aa/cryptoKeys/runtime
+    secretProviderClass: aws-kms-secrets
+  autoscaling:
+    defaultTargetCPUUtilizationPercentage: 70
 
 orchestrator:
+  replicaCount: 2
   image:
-    repository: ghcr.io/agi/jobs/orchestrator
-    tag: ""
-    digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
-    pullPolicy: IfNotPresent
-  env:
-    logLevel: info
-    corsOrigins:
-      - https://operator.example.com
-    corsHeaders:
-      - Authorization
-      - Content-Type
-    kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/orchestrator
-    maxRequestBytes: 1048576
+    repository: orchestrator
+    tag: v0.5.0
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   service:
-    type: ClusterIP
-    port: 8000
-  rateLimit:
-    requestsPerMinute: 300
-    burst: 50
-  autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 5
-    cpuTargetPercentage: 60
+    port: 8080
+  env:
+    MAX_REQUEST_BODY: "2m"
+    FEATURE_FLAGS: "pause-switch,gas-topup"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 200m
+      memory: 512Mi
 
 bundler:
+  replicaCount: 2
   image:
-    repository: ghcr.io/agi/jobs/bundler
-    tag: ""
-    digest: sha256:2222222222222222222222222222222222222222222222222222222222222222
-    pullPolicy: IfNotPresent
+    repository: bundler
+    tag: v0.5.0
+    digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
   service:
-    type: ClusterIP
-    port: 3000
-  config:
-    rpcUrl: https://ethereum-sepolia.publicnode.com
-    entryPoint: "0x0000000000000000000000000000000000000000"
-    bundleIntervalSeconds: 5
+    port: 8090
+  resources:
+    limits:
+      cpu: 1
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
 
 paymaster-supervisor:
   image:
-    repository: ghcr.io/agi/jobs/paymaster-supervisor
-    tag: ""
-    digest: sha256:3333333333333333333333333333333333333333333333333333333333333333
-    pullPolicy: IfNotPresent
+    repository: paymaster-supervisor
+    tag: v0.5.0
+    digest: sha256:2222222222222222222222222222222222222222222222222222222222222222
   service:
-    type: ClusterIP
-    port: 8080
-  config:
-    rpcUrl: https://ethereum-sepolia.publicnode.com
-    paymasterAddress: "0x0000000000000000000000000000000000000000"
-    kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/paymaster
-    treasuryAddress: "0x0000000000000000000000000000000000000000"
-    sponsorshipBudgetUsd: 100.0
+    port: 8070
+  replicaCount: 1
+  gasTopUpThresholdUsd: 150
+  treasuryAddress: "0x0000000000000000000000000000000000000000"
 
 attester:
+  replicaCount: 1
   image:
-    repository: ghcr.io/agi/jobs/attester
-    tag: ""
-    digest: sha256:4444444444444444444444444444444444444444444444444444444444444444
-    pullPolicy: IfNotPresent
+    repository: attester
+    tag: v0.5.0
+    digest: sha256:3333333333333333333333333333333333333333333333333333333333333333
   service:
-    type: ClusterIP
-    port: 7000
-  config:
-    rpcUrl: https://ethereum-sepolia.publicnode.com
-    easSchemaUid: "0x0000000000000000000000000000000000000000000000000000000000000000"
-    kmsKey: projects/example/locations/global/keyRings/agi/cryptoKeys/attester
-    corsOrigins:
-      - https://operator.example.com
+    port: 8060
+  eas:
+    schemaUid: ""
 
 ipfs:
+  replicaCount: 1
   image:
-    repository: ipfs/go-ipfs
-    tag: v0.23.0
-    pullPolicy: IfNotPresent
-  service:
-    apiPort: 5001
-    swarmPort: 4001
-    gatewayPort: 8080
+    repository: ipfs
+    tag: v0.21.0
+    digest: sha256:4444444444444444444444444444444444444444444444444444444444444444
   persistence:
-    size: 50Gi
-
-graph-node:
-  image:
-    repository: ghcr.io/graphprotocol/graph-node
-    tag: v0.32.0
-    pullPolicy: IfNotPresent
-  service:
-    type: ClusterIP
-    port: 8000
-  config:
-    ethereumNetworks:
-      - name: sepolia
-        rpc: https://ethereum-sepolia.publicnode.com
-    postgres:
-      host: ""
-      database: subgraph
-      userSecret: graph-node-postgres
-    ipfs:
-      endpoint: ""
+    enabled: true
+    size: 100Gi
 
 postgres:
   image:
     repository: postgres
-    tag: "14"
-    pullPolicy: IfNotPresent
-  service:
-    type: ClusterIP
-    port: 5432
+    tag: "15"
+    digest: sha256:5555555555555555555555555555555555555555555555555555555555555555
   persistence:
-    size: 20Gi
-  config:
-    database: subgraph
-    username: graph
-    existingSecret: graph-node-postgres
+    size: 200Gi
+  credentialsSecretName: subgraph-postgres-credentials
+
+graph-node:
+  image:
+    repository: graph-node
+    tag: v0.31.0
+    digest: sha256:6666666666666666666666666666666666666666666666666666666666666666
+  service:
+    port: 8000
+  ipfsEndpoint: http://ipfs:5001
+  postgres:
+    connectionSecretName: subgraph-postgres-credentials
 
 ingress:
-  enabled: true
-  ingressClassName: nginx
-  defaultTlsSecret: agi-stack-tls
+  className: nginx
   hosts:
     - host: orchestrator.example.com
-      serviceName: orchestrator
-      servicePort: 8000
-    - host: bundler.example.com
-      serviceName: bundler
-      servicePort: 3000
-    - host: attester.example.com
-      serviceName: attester
-      servicePort: 7000
-  security:
-    hstsMaxAge: 63072000
-    includeSubdomains: true
-    preload: true
-    wafAnnotation: "true"
-    corsAllowOrigin: https://operator.example.com
-    corsAllowHeaders:
-      - Authorization
-      - Content-Type
-    corsAllowMethods:
-      - GET
-      - POST
-    proxyBodySize: 1m
-    requestTimeout: 60s
+      service: orchestrator
+      port: 8080
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: "2m"
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains";
+          more_set_headers "X-Frame-Options: DENY";
+          more_set_headers "X-Content-Type-Options: nosniff";
+          more_set_headers "Referrer-Policy: no-referrer";
+          proxy_set_header X-RateLimit-Burst "50";
+          proxy_set_header X-RateLimit-RPS "20";
+      tlsSecret: orchestrator-tls
+    - host: operators.example.com
+      service: paymaster-supervisor
+      port: 8070
+      tlsSecret: operators-tls
+  waf:
+    enabled: true
+    provider: cloudarmor
+    policy: projects/example/policies/aa-edge

--- a/docs/policy/policy-playbook.md
+++ b/docs/policy/policy-playbook.md
@@ -1,0 +1,35 @@
+# Policy Playbook
+
+The policy playbook defines how we evaluate sponsorship requests, attestations, and treasury risk.
+
+## Chain Support Policy
+- **Primary chains**: Ethereum mainnet, Base mainnet, Base Sepolia.
+- **New chain requests** must include: audited EntryPoint contract, RPC with 99.9% uptime SLO, and supported paymaster funding rails.
+- Submit requests via the Governance board. The SRE lead signs off on capacity; Security validates chain risk.
+
+## Sponsorship Approval Policy
+1. **Automated checks**
+   - Orchestrator enforces CORS and request size limits.
+   - WAF (Cloud Armor) blocks known-abusive IPs.
+   - Rate limits default to 20 RPS / 50 burst per API key.
+2. **Manual review triggers**
+   - Sponsored value above $5,000 in a rolling hour.
+   - New smart account without prior attestations.
+   - Rejection rate > 10% in past 30 minutes.
+3. **Manual review workflow**
+   - Open the Operator Console → Requests → Review queue.
+   - Evaluate the EAS attestation metadata and Graph Node subgraph state.
+   - Approve or deny; reasons are logged for audit.
+
+## Treasury Risk Policy
+- Maintain a minimum treasury runway of 72 hours at the current sponsorship burn rate.
+- Finance receives alerts when the treasury dips below $200.
+- Emergency pause can be enacted by any on-call engineer.
+
+## Attestation Policy
+- All attestations must reference the canonical schema UID stored in `global.eas.schemaUid`.
+- Attester pods read keys only via the KMS CSI volume; manual key rotation happens weekly.
+
+## Incident Response
+- Follow the table-top runbook documented in `docs/security/tabletop-runbook.md`.
+- Ensure postmortems are completed within 72 hours.

--- a/docs/runbooks/node-operator.md
+++ b/docs/runbooks/node-operator.md
@@ -1,50 +1,39 @@
 # Node Operator Runbook (Browser-Only)
 
-This runbook documents the end-to-end operating procedures for an AGI stack node operator without requiring shell access.
+This guide assumes operators do not have shell or `kubectl` access. All actions are performed via the Operator Console (https://operators.example.com) and Grafana.
 
-## Prerequisites
-- Access to the Operator Control Plane (OCP) at `https://operator.example.com`.
-- Permissions to manage the AGI cluster namespace in Argo CD or Lens (view-only).
-- Hardware security key for SSO and WebAuthn prompts.
+## Monitor health
+1. Open the "AA Stack Overview" Grafana dashboard.
+2. Verify that the **Success Rate** panel remains above 99%. If it drops:
+   - Check the **Time To Operation (p95)** panel for latency spikes.
+   - Review the alert banner within the console.
+3. Confirm the **Treasury Balance (USD)** panel is above the `Gas Top-up` threshold configured in the console settings page.
 
-## Daily Checklist
-1. Log into the OCP dashboard and verify all service widgets are **green**.
-2. Review the "Gas Balance" card. If the balance is below 0.1 ETH, follow the gas top-up procedure.
-3. Confirm the "Pause Switch" indicator is **OFF** unless there is an active incident.
-4. Review the latest attestation receipts in the Receipts tab.
+## Adjust sponsorship fees
+1. Navigate to **Operator Console → Economics → Fees**.
+2. Set the **Base Sponsorship Fee** slider to the desired value in USD.
+3. Click **Preview impact** to view projected margins.
+4. Hit **Commit update**. Changes propagate through the paymaster supervisor via the management API.
 
-## Adjust Fees and Treasury Address
-1. Navigate to **Policy > Sponsorship Profile** in OCP.
-2. Click **Edit** and update:
-   - **Flat Fee (USD)** or **% of Sponsored Gas** as required.
-   - **Treasury Address** — paste the checksummed address.
-3. Submit the change and approve the WebAuthn prompt to sign the policy update transaction.
-4. Validate the change landed by checking the "Pending Changes" drawer and ensuring the status becomes `Applied`.
+## Top-up gas / treasury
+1. Visit **Operator Console → Treasury**.
+2. Review the **Current balance** card and compare against the minimum safe threshold (displayed inline).
+3. Click **Top-up via Safe**.
+4. The console opens the Safe App with the recommended amount. Approve the transaction using your wallet.
+5. Watch the balance card for confirmation.
 
-## Top Up Paymaster Gas Wallet
-1. From **Finance > Wallets**, locate the **Paymaster Gas Wallet**.
-2. Click **Deposit** and copy the wallet address.
-3. Using the hosted wallet UI (e.g., Fireblocks console), initiate a transfer to the copied address.
-4. Back in the OCP dashboard, watch the balance auto-refresh (should update within 2 blocks). The Alert feed clears when the balance exceeds 0.05 ETH.
+## Flip the pause switch
+1. Navigate to **Operator Console → Controls**.
+2. Locate the **Pause sponsorships** toggle.
+3. Toggle **ON** to halt new sponsorships. Confirm the modal prompt.
+4. When safe to resume, toggle **OFF**. The console waits for cluster reconciliation and shows a green "Resumed" badge when complete.
 
-## Flip the Pause Switch
-1. Go to **Operations > Safeguards**.
-2. Review the checklist (ensure all in-flight sponsorships are settled).
-3. Toggle **Pause Sponsorships** to ON. Confirm the modal and WebAuthn signature.
-4. To resume, repeat the steps and toggle OFF.
-5. Verify the pause flag is propagated by checking the "Stack Status" widget and ensuring bundler queue drains.
+## View receipts & verify attestations
+1. From **Operator Console → Receipts**, select the relevant User Operation hash.
+2. Click **Download receipt** to fetch the IPFS-backed JSON receipt.
+3. Click **Verify EAS attestation**. The console automatically checks the schema UID and status via the EAS API and displays a green check when valid.
 
-## View Receipts and EAS Proofs
-1. Navigate to **Receipts** in the sidebar.
-2. Filter by job ID, request hash, or attester.
-3. Click a row to open the drawer:
-   - View the **EAS Schema UID** and on-chain attestation link.
-   - Download the JSON receipt for auditing.
-4. Use the **Share** button to generate a read-only link for external auditors.
-
-## Escalation
-- For critical alerts, page the on-call SRE via Opsgenie (button in the top bar).
-- For policy changes requiring sign-off, tag the policy owner in the OCP comments.
-
-## Change Log
-- v1.0 – Initial browser-only workflow documentation.
+## Escalation matrix
+- **Critical alerts (PagerDuty)**: acknowledge within 5 minutes.
+- **Finance questions**: email treasury@example.com.
+- **Security incidents**: call the on-call security engineer per the incident response card.

--- a/docs/runbooks/sre-runbook.md
+++ b/docs/runbooks/sre-runbook.md
@@ -1,0 +1,40 @@
+# SRE Runbook
+
+## Alert response workflow
+1. Acknowledge PagerDuty page.
+2. Open Grafana dashboard `AA Stack Overview` and correlate with Alertmanager details.
+3. Capture current metrics snapshots for the incident document.
+
+## Common alerts
+### GasTreasuryLow
+- Severity: High
+- Actions:
+  1. Confirm treasury balance via Operator Console → Treasury.
+  2. Notify finance (treasury@example.com) with the recommended top-up amount.
+  3. Update incident ticket with ETA for replenishment.
+
+### SponsorshipRejectSpike
+- Severity: Critical
+- Actions:
+  1. Inspect orchestrator logs via Loki (query: `{app="orchestrator"}`) for error context.
+  2. Check RPC status on statuspage.io and fail over by toggling to the fallback RPC in the Operator Console.
+  3. If errors persist, activate the pause switch and escalate to protocol engineering.
+
+### SponsoredRevertSpike
+- Severity: Medium
+- Actions:
+  1. Validate the latest contract deployment status in GitHub releases.
+  2. Compare revert signatures against known issue list in internal wiki.
+  3. Communicate status in `#aa-incident` Slack channel every 15 minutes.
+
+## Pause / Resume
+- Pause: Operator Console → Controls → Pause sponsorships.
+- Resume: Toggle off and monitor success rate. Ensure backlog drains before unpausing bundlers.
+
+## Disaster recovery hooks
+- For regional outage, trigger `dr-start` GitHub Action workflow to spin up the stack in the secondary cluster.
+- Update DNS weightings through Cloudflare to reroute traffic.
+
+## Post-incident
+- Complete postmortem template within 72 hours.
+- File follow-up issues in Jira using the `SLO Regression` label.

--- a/docs/security/tabletop-runbook.md
+++ b/docs/security/tabletop-runbook.md
@@ -1,0 +1,32 @@
+# Table-top Exercise Runbook
+
+This runbook outlines the response steps for the primary threat scenarios.
+
+## 1. Chain Reorg
+1. Detect via EntryPoint finality monitor alert.
+2. Immediately pause sponsorships from the Operator Console.
+3. Assess affected User Operations and calculate potential loss.
+4. Notify protocol engineering to resubmit if safe or compensate users.
+5. Resume after 10 finalized blocks and treasury reconciliation.
+
+## 2. RPC Outage
+1. Alert: `SponsorshipRejectSpike` due to RPC failures.
+2. Switch orchestrator RPC endpoint via Operator Console fallback toggle.
+3. Validate success rate recovers within 5 minutes.
+4. Open ticket with RPC provider and track SLA.
+
+## 3. IPFS Pin Backlog
+1. Alert: IPFS latency warning.
+2. Scale IPFS StatefulSet using the console autoscale control.
+3. Trigger manual pin job via `ipfs-pin-audit` workflow.
+4. Communicate restoration ETA to customer success.
+
+## 4. AA Sponsorship Abuse
+1. Alert: WAF / rate limit triggered with high rejection count.
+2. Inspect abusive API keys and revoke via Operator Console.
+3. Enable stricter rate limiting preset (10 RPS) for affected tenants.
+4. File abuse report with on-chain analytics partner.
+
+## Documentation
+- Record timeline and decisions in the incident doc.
+- Schedule retro within 48 hours to adjust mitigations.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,61 +1,19 @@
-# AGI Stack Threat Model & Table-Top Playbooks
+# Threat Model
 
-## Overview
-The AGI stack relies on deterministic sponsorship, attestation issuance, and decentralized storage. The following sections document high-risk scenarios and provide tabletop exercises for the incident response team.
+| Asset | Threat | Likelihood | Impact | Mitigations |
+|-------|--------|------------|--------|-------------|
+| Paymaster treasury | Chain reorg causing double-spend of sponsored tx | Medium | High | Use EntryPoint finality monitors, wait for 5 block confirmations before settlement, maintain ability to pause sponsorships. |
+| Sponsored operations | RPC outage preventing bundler submission | High | Medium | Configure fallback RPC, monitor `success_rate`, automatic failover toggled via console. |
+| IPFS receipts | Pin backlog leading to missing receipts | Medium | Medium | IPFS latency alerts, autoscaling, nightly pin audit job. |
+| Attestation integrity | Malicious schema or key compromise | Low | High | Keys stored via KMS CSI driver, rotate weekly, enforce schema UID from config. |
+| AA sponsorship abuse | Bot-driven flood of sponsor requests | High | High | WAF, strict CORS, per-key rate limiting, request size limits, manual review workflow. |
 
-## Assets
-- **KMS-backed keys** for paymaster sponsorship and attestations.
-- **Receipts and attestation proofs** stored in Postgres/IPFS.
-- **RPC connectivity** to the target chain.
-- **Ingress endpoints** exposed to integrators.
+## Architecture overview
+- Secrets sourced via KMS-backed CSI driver; no private keys written to disk.
+- All ingress traffic terminates at TLS with HSTS enforced and WAF policy applied.
+- Bundler and paymaster only communicate via authenticated gRPC with mutual TLS.
 
-## Attack Surface Summary
-| Component | Risks | Mitigations |
-| --- | --- | --- |
-| Orchestrator API | Abuse via oversized requests, CORS bypass | Strict CORS allowlist, 1 MB body limit, WAF enabled |
-| Bundler | Chain reorgs, revert storms | Observability alerts, pause switch, fallback RPC |
-| Paymaster Supervisor | Sponsorship abuse, budget overrun | Policy playbook, budget caps, KMS signing |
-| Attester | Key compromise | KMS custody, hardware-backed approvals |
-| IPFS | Pin backlog, data unavailability | Pin latency monitoring, disaster recovery sync |
-
-## Scenario Playbooks
-
-### Chain Reorg
-- **Symptoms**: Sudden spike in attestation replays, `service:subgraph_lag_blocks` increases.
-- **Immediate Actions**:
-  1. Pause sponsorships via OCP.
-  2. Switch bundler RPC to fallback provider using Helm override or OCP toggle.
-  3. Coordinate with chain infrastructure provider to confirm reorg depth.
-- **Recovery**: Resume operations once finality depth > 20 blocks and receipts reconciled.
-
-### RPC Outage
-- **Symptoms**: Bundler error logs with `connection refused`, success rate drops.
-- **Immediate Actions**:
-  1. Confirm outage with provider status page.
-  2. Update `global.rpc.primary` to fallback endpoint in values override and run `helm upgrade`.
-  3. Monitor Grafana success rate panel for recovery.
-- **Tabletop Drill**: Quarterly exercise to rotate RPC providers without downtime.
-
-### IPFS Pin Backlog
-- **Symptoms**: `service:ipfs_pin_latency_seconds:p95` > 120 seconds, receipts pending.
-- **Immediate Actions**:
-  1. Scale IPFS StatefulSet replicas via Helm values (increase to 2).
-  2. Trigger manual pin sync using `ipfs-cluster-ctl sync --all`.
-  3. Offload large artifacts to secondary pinning service if backlog persists > 30 minutes.
-- **Recovery**: Confirm latency returns < 30 seconds and disaster recovery sync plan executed.
-
-### Account Abstraction (AA) Sponsorship Abuse
-- **Symptoms**: Sponsorship spend spikes, rejection alerts triggered.
-- **Immediate Actions**:
-  1. Enable pause switch and activate rate limit override in OCP.
-  2. Apply deny list for malicious smart accounts in Policy Playbook.
-  3. Notify integrators of temporary suspension.
-- **Recovery**: Reinstate traffic once budgets reset and abuse vector closed.
-
-## Validation
-- Run quarterly ZAP/Burp scans against the orchestrator ingress (document results in security backlog).
-- Ensure KMS audit logs show no export operations; keys remain in HSM.
-- Confirm tabletop drills recorded in the incident tracker with action items.
-
-## Change Log
-- v1.0 – Initial threat model coverage.
+## Assumptions
+- Kubernetes cluster is hardened per CIS benchmark.
+- Operators use SSO with hardware keys.
+- Chain finality assumptions rely on L2 canonical messaging.

--- a/monitoring/alertmanager/alertmanager.yaml
+++ b/monitoring/alertmanager/alertmanager.yaml
@@ -1,0 +1,21 @@
+route:
+  receiver: sre-oncall
+  routes:
+    - match:
+        alertname: GasTreasuryLow
+      receiver: finance-escalation
+receivers:
+  - name: sre-oncall
+    slack_configs:
+      - channel: "#aa-pager"
+        text: |-
+          *{{ .CommonAnnotations.summary }}*
+          {{ .CommonAnnotations.description }}
+          Runbook: {{ .CommonAnnotations.runbook_url }}
+  - name: finance-escalation
+    email_configs:
+      - to: treasury@example.com
+        html: |-
+          <p><strong>{{ .CommonAnnotations.summary }}</strong></p>
+          <p>{{ .CommonAnnotations.description }}</p>
+          <p>Runbook: <a href="{{ .CommonAnnotations.runbook_url }}">here</a></p>

--- a/monitoring/grafana/dashboards/aa-overview.json
+++ b/monitoring/grafana/dashboards/aa-overview.json
@@ -1,0 +1,117 @@
+{
+  "title": "AA Stack Overview",
+  "uid": "aa-stack",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Time To Operation (p95)",
+      "targets": [
+        {
+          "expr": "aa:tto_seconds:avg5m",
+          "legendFormat": "p95"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "orange", "value": 2 },
+              { "color": "red", "value": 4 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Success Rate",
+      "targets": [
+        {
+          "expr": "aa:success_rate:ratio5m",
+          "legendFormat": "success"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              { "color": "red", "value": 0.95 },
+              { "color": "orange", "value": 0.98 },
+              { "color": "green", "value": 0.99 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Treasury Balance (USD)",
+      "targets": [
+        {
+          "expr": "paymaster_treasury_balance_usd",
+          "legendFormat": "balance"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "IPFS Pin Latency (p95)",
+      "targets": [
+        {
+          "expr": "aa:ipfs_pin_latency_seconds:p95",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      }
+    }
+  ],
+  "links": [
+    {
+      "title": "Runbook: Pause Switch",
+      "url": "https://docs.example.com/runbooks/pause"
+    },
+    {
+      "title": "Runbook: Disaster Recovery",
+      "url": "https://docs.example.com/runbooks/disaster-recovery"
+    }
+  ]
+}

--- a/monitoring/prometheus/rules.yaml
+++ b/monitoring/prometheus/rules.yaml
@@ -1,50 +1,48 @@
-groups:
-  - name: orchestrator.slo
-    interval: 30s
-    rules:
-      - record: service:tto_seconds:rate5m
-        expr: histogram_quantile(0.95, sum(rate(orchestrator_time_to_onboard_seconds_bucket[5m])) by (le))
-      - record: service:cpvo_usd:rate5m
-        expr: sum(rate(paymaster_cost_per_verified_operation_usd[5m]))
-      - record: service:bundler_success_rate:ratio5m
-        expr: sum(rate(bundler_operations_total{status="success"}[5m])) / clamp_min(sum(rate(bundler_operations_total[5m])), 1)
-      - record: service:sponsored_ops_total:rate5m
-        expr: sum(rate(paymaster_sponsored_operations_total[5m]))
-      - record: service:sponsored_ops_rejections:rate5m
-        expr: sum(rate(paymaster_sponsored_operations_rejections_total[5m]))
-      - record: service:ipfs_pin_latency_seconds:p95
-        expr: histogram_quantile(0.95, sum(rate(ipfs_pin_duration_seconds_bucket[5m])) by (le))
-      - record: service:subgraph_lag_blocks
-        expr: max(max_over_time(graph_subgraph_head_block{deployment=~".*"}[5m]) - max_over_time(graph_chain_head_block{network=~".*"}[5m]))
-  - name: orchestrator.alerts
-    rules:
-      - alert: LowGasBalance
-        expr: min(eth_wallet_balance_wei{wallet="paymaster"}) < 5e16
-        for: 5m
-        labels:
-          severity: critical
-          runbook: https://docs.agijobsv0.dev/runbooks/paymaster-gas
-        annotations:
-          summary: Paymaster gas wallet below 0.05 ETH
-          description: Top up the configured treasury wallet before sponsorship halts.
-          runbook: https://docs.agijobsv0.dev/runbooks/paymaster-gas
-      - alert: SponsorshipRejectionSpike
-        expr: service:sponsored_ops_rejections:rate5m > 5
-        for: 10m
-        labels:
-          severity: warning
-          runbook: https://docs.agijobsv0.dev/runbooks/rejection-spike
-        annotations:
-          summary: Sponsored operation rejections increasing
-          description: Investigate upstream AA flow or contract configuration issues.
-          runbook: https://docs.agijobsv0.dev/runbooks/rejection-spike
-      - alert: BundlerRevertSpike
-        expr: rate(bundler_operations_total{status="reverted"}[5m]) > 2
-        for: 5m
-        labels:
-          severity: warning
-          runbook: https://docs.agijobsv0.dev/runbooks/revert-spike
-        annotations:
-          summary: Bundler revert spike detected
-          description: Review recent deployments and mempool conditions.
-          runbook: https://docs.agijobsv0.dev/runbooks/revert-spike
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: aa-slo-rules
+  labels:
+    prometheus: kube-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: slo.latency
+      rules:
+        - record: aa:tto_seconds:avg5m
+          expr: histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job="orchestrator"}[5m])) by (le))
+        - record: aa:cpvo_usd:avg5m
+          expr: avg_over_time(paymaster_sponsored_cost_usd[5m])
+        - record: aa:success_rate:ratio5m
+          expr: sum(rate(orchestrator_requests_total{status!~"5.."}[5m])) / sum(rate(orchestrator_requests_total[5m]))
+        - record: aa:sponsored_ops_total:sum5m
+          expr: sum(rate(paymaster_sponsored_operations_total[5m]))
+        - record: aa:sponsored_ops_rejections:sum5m
+          expr: sum(rate(paymaster_rejections_total[5m]))
+        - record: aa:ipfs_pin_latency_seconds:p95
+          expr: histogram_quantile(0.95, sum(rate(ipfs_pin_latency_seconds_bucket[5m])) by (le))
+        - record: aa:subgraph_lag_seconds:max
+          expr: max(graph_node_subgraph_lag_seconds)
+    - name: alerts
+      rules:
+        - alert: GasTreasuryLow
+          expr: min(paymaster_treasury_balance_usd) < 200
+          for: 10m
+          annotations:
+            summary: "Paymaster treasury under $200"
+            description: "Top-up the paymaster treasury to avoid rejected sponsorships."
+            runbook_url: https://docs.example.com/runbooks/paymaster-top-up
+        - alert: SponsorshipRejectSpike
+          expr: increase(paymaster_rejections_total[5m]) > 10
+          for: 10m
+          annotations:
+            summary: "Paymaster rejection spike"
+            description: "Investigate RPC health, gas price, and schema validity."
+            runbook_url: https://docs.example.com/runbooks/rejections
+        - alert: SponsoredRevertSpike
+          expr: increase(orchestrator_reverted_operations_total[5m]) > 5
+          for: 5m
+          annotations:
+            summary: "Sponsored operations reverting"
+            description: "Review upstream contracts and mempool health."
+            runbook_url: https://docs.example.com/runbooks/revert-spike


### PR DESCRIPTION
## Summary
- add a full-stack Helm umbrella chart with component subcharts, security defaults, and KMS-backed secrets
- wire up supply-chain CI to build multi-arch images, emit SBOMs, sign artifacts, and pin digests during Helm verification
- document operational runbooks, threat scenarios, and ship monitoring dashboards/alerts for the stack

## Testing
- not run (helm CLI unavailable in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc11bae19883339b49855c49753403