### PR TITLE
Allowlist treasury during StakeManager deployment

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -280,6 +280,9 @@ contract Deployer is Ownable {
             address(0),
             address(this)
         );
+        if (governance != address(0)) {
+            stake.setTreasuryAllowlist(governance, true);
+        }
         address[] memory ackInit = new address[](1);
         ackInit[0] = address(stake);
         JobRegistry registry = new JobRegistry(


### PR DESCRIPTION
## Summary
- allowlist the configured treasury when StakeManager is deployed through the v2 Deployer
- add an integration test that deploys via the Deployer and verifies slashing routes funds to the treasury

## Testing
- npx hardhat test test/v2/StakeManagerSlashing.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc1a3541e083339d5a62e80463e4ea