### PR TITLE
Add configurable validator reveal quorum

### DIFF
--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -144,6 +144,9 @@ interface IValidationModule {
     /// @notice Configure the penalty applied when validators fail to reveal.
     function setNonRevealPenalty(uint256 penaltyBps, uint256 banBlocks) external;
 
+    /// @notice Update quorum requirements for validator reveals.
+    function setRevealQuorum(uint256 pct, uint256 minValidators) external;
+
     /// @notice Update the cool-off delay before early finalization is permitted.
     function setEarlyFinalizeDelay(uint256 delay) external;
 

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -94,6 +94,8 @@ contract ValidationStub is IValidationModule {
 
     function setNonRevealPenalty(uint256, uint256) external override {}
 
+    function setRevealQuorum(uint256, uint256) external override {}
+
     function setEarlyFinalizeDelay(uint256) external override {}
 
     function setForceFinalizeGrace(uint256) external override {}

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -132,6 +132,9 @@ contract NoValidationModule is IValidationModule, Ownable {
     function setNonRevealPenalty(uint256, uint256) external pure override {}
 
     /// @inheritdoc IValidationModule
+    function setRevealQuorum(uint256, uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
     function setEarlyFinalizeDelay(uint256) external pure override {}
 
     function setForceFinalizeGrace(uint256) external pure override {}

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -155,6 +155,9 @@ contract OracleValidationModule is IValidationModule, Ownable {
     function setNonRevealPenalty(uint256, uint256) external pure override {}
 
     /// @inheritdoc IValidationModule
+    function setRevealQuorum(uint256, uint256) external pure override {}
+
+    /// @inheritdoc IValidationModule
     function setEarlyFinalizeDelay(uint256) external pure override {}
 
     function setForceFinalizeGrace(uint256) external pure override {}


### PR DESCRIPTION
## Summary
- add configurable reveal quorum parameters and governance setter to ValidationModule
- update finalize logic to enforce quorum targets and adjust early finalization behaviour
- expose quorum setter in the validation interface and stub implementations for compatibility

## Testing
- `npx hardhat compile --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68dc1f68bde483338e9dbe337a0833b8