### PR TITLE
Add owner parameter matrix tooling and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 - [Owner control handbook](#owner-control-handbook)
 - [Owner mission control](#owner-mission-control)
 - [Owner control visual guide](#owner-control-visual-guide)
+- [Owner parameter matrix](#owner-parameter-matrix)
 
 ### Identity policy
 
@@ -287,6 +288,22 @@ acceptances. Supply overrides via environment variables such as
 editing source files. Pair the generated diagram with
 `npm run owner:verify-control` to close the loop between visualization and
 transaction execution.
+
+### Owner parameter matrix
+
+Generate a network-aware control sheet for every configurable module in one go:
+
+```bash
+npm run owner:parameters -- --network <network> --out reports/<network>-parameter-matrix.md
+```
+
+The script expands per-module JSON into Markdown tables, injects copy/paste update
+and verification commands, and embeds Mermaid control-loop diagrams so a
+non-technical owner can stage, execute, and audit parameter changes without
+touching Solidity. Explore the full workflow in the
+[Owner Parameter Matrix guide](docs/owner-parameter-matrix.md) and pair it with
+`npm run owner:surface` plus `npm run owner:verify-control` to archive a complete
+change-control artefact set.
 
 ### Mainnet Deployment
 

--- a/docs/owner-parameter-matrix.md
+++ b/docs/owner-parameter-matrix.md
@@ -1,0 +1,114 @@
+# Owner Parameter Matrix
+
+The owner parameter matrix gives contract owners a single command that flattens every
+production-facing configuration file into a navigable control sheet. The matrix combines
+Mermaid visualisations, subsystem summaries and ready-to-run update & verification commands
+so non-technical operators can tune the platform while preserving auditable guard rails.
+
+```mermaid
+flowchart TD
+    A[Edit config/*.json] --> B[Run npm run owner:parameters]
+    B --> C{Review matrix output}
+    C -->|Looks good| D[Execute subsystem update helper]
+    D --> E[Verify with owner:verify-control]
+    C -->|Needs change| A
+    E --> F[Archive report for compliance]
+```
+
+## Quick start
+
+1. Decide which network context you want to review (for example `mainnet` or `sepolia`).
+2. Run the CLI helper:
+
+   ```bash
+   npm run owner:parameters -- --network sepolia --out runtime/sepolia-parameter-matrix.md
+   ```
+
+3. Inspect the generated Markdown report. Each subsystem block lists:
+   - The configuration file location.
+   - Copy/paste update commands with the selected network inserted automatically.
+   - Verification steps that close the control loop.
+   - A flattened table of every configurable field so nothing is hidden.
+4. Hand the artefact to reviewers or attach it to the change-control ticket before executing
+   the matching update helper (for example `npm run owner:update-all -- --network sepolia --only=stakeManager`).
+5. After executing changes, rerun `npm run owner:parameters` and `npm run owner:verify-control`
+   to confirm production matches the desired state.
+
+> **Tip:** Omit `--out` to print the report directly to stdout, or add `--format human`
+> for a plaintext briefing that fits easily in chat applications.
+
+## Matrix anatomy
+
+The generated Markdown report is structured as follows:
+
+- **Global metadata** – Timestamp, optional network context and an embedded Mermaid
+  workflow diagram that mirrors the governance control loop.
+- **Subsystem sections** – Each configurable module appears under its own heading with
+  a narrative summary, configuration path, update & verification commands and reference
+  documentation.
+- **Flattened parameter table** – Every primitive value in the underlying JSON is rendered
+  as a `parameter → value` row so operators can review all tunables without digging through
+  nested structures.
+
+```markdown
+## StakeManager parameters
+
+Controls staking minimums, slashing weights, treasury routing, and validator incentives.
+
+- **Config file:** `config/stake-manager.json`
+- **Update with:**
+  - `npx hardhat run scripts/v2/updateStakeManager.ts --network sepolia`
+- **Verify with:**
+  - `npm run owner:verify-control -- --network sepolia --modules=stakeManager`
+- **Reference docs:**
+  - [docs/owner-control-handbook.md](docs/owner-control-handbook.md)
+  - [docs/owner-control-command-center.md](docs/owner-control-command-center.md)
+  - [docs/thermodynamics-operations.md](docs/thermodynamics-operations.md)
+
+| Parameter | Value |
+| --- | --- |
+| `minStakeTokens` | 10 |
+| `employerSlashPct` | 50 |
+| `treasury` | 0x0000000000000000000000000000000000000000 |
+| `autoStake.enabled` | false |
+| … | … |
+```
+
+## Decision companion
+
+Pair the matrix with the existing owner-control helpers to drive safe changes:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Review
+    Review --> Plan : owner:parameters
+    Plan --> DryRun : owner:update-all -- --network <n> --only=<modules>
+    DryRun --> Approve : Governance sign-off
+    Approve --> Execute : owner:update-all -- --network <n> --only=<modules> --execute
+    Execute --> Verify : owner:verify-control -- --network <n> --modules=<modules>
+    Verify --> Archive : owner:surface -- --network <n> --format markdown
+    Archive --> [*]
+```
+
+## Options reference
+
+| Flag | Description |
+| ---- | ----------- |
+| `--network <name>` | Applies per-network configuration overrides and injects the network name into commands. |
+| `--format markdown|json|human` | Choose between Markdown (default), structured JSON or a plain-text briefing. |
+| `--out <path>` | Write the matrix to disk (directories are created automatically). |
+| `--no-mermaid` | Skip Mermaid diagrams for environments that cannot render them. |
+| `--help` | Display inline documentation for the CLI tool. |
+
+## Operational playbook
+
+1. **Snapshot current state:** `npm run owner:surface -- --network <network> --format markdown --out reports/<network>-surface.md`
+2. **Generate the matrix:** `npm run owner:parameters -- --network <network> --out reports/<network>-matrix.md`
+3. **Dry-run updates:** `npm run owner:update-all -- --network <network> --only=<module>`
+4. **Execute changes:** rerun the updater with `--execute` once reviewers approve the plan.
+5. **Verify ownership:** `npm run owner:verify-control -- --network <network> --strict`
+6. **Archive artefacts:** Store the surface snapshot, matrix and verification output alongside the governance decision log.
+
+This workflow ensures the contract owner retains full, provable control over every parameter
+without touching Solidity code, while surfacing the exact JSON paths and commands needed to
+apply or roll back changes safely.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "owner:wizard": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/owner-config-wizard.ts",
     "owner:dashboard": "npx hardhat run --no-compile scripts/v2/owner-dashboard.ts",
     "owner:diagram": "npx hardhat run --no-compile scripts/v2/renderOwnerMermaid.ts",
+    "owner:parameters": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerParameterMatrix.ts",
     "owner:mission-control": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerMissionControl.ts",
     "owner:verify-control": "npx hardhat run --no-compile scripts/v2/verifyOwnerControl.ts",
     "owner:rotate": "npx hardhat run --no-compile scripts/v2/rotateGovernance.ts",

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -1,0 +1,553 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import {
+  loadTokenConfig,
+  loadStakeManagerConfig,
+  loadJobRegistryConfig,
+  loadFeePoolConfig,
+  loadThermodynamicsConfig,
+  loadHamiltonianMonitorConfig,
+  loadEnergyOracleConfig,
+  loadTaxPolicyConfig,
+  loadPlatformIncentivesConfig,
+  loadIdentityRegistryConfig,
+} from '../config';
+
+interface CliOptions {
+  network?: string;
+  outPath?: string;
+  format: OutputFormat;
+  includeMermaid: boolean;
+  help?: boolean;
+}
+
+type OutputFormat = 'markdown' | 'json' | 'human';
+
+interface HardhatContext {
+  name?: string;
+  chainId?: number;
+}
+
+interface MatrixRow {
+  path: string;
+  value: string;
+  notes?: string;
+}
+
+interface SubsystemMatrix {
+  id: string;
+  title: string;
+  summary: string;
+  configPath: string;
+  updateCommands: string[];
+  verifyCommands: string[];
+  documentation: string[];
+  rows: MatrixRow[];
+}
+
+interface SubsystemDescriptor {
+  id: string;
+  title: string;
+  summary: string;
+  documentation: string[];
+  updateCommands: string[];
+  verifyCommands: string[];
+  fallbackConfigPath: string;
+  loader: (network?: string) => { config: unknown; path: string };
+}
+
+interface MatrixPayload {
+  network?: string;
+  subsystems: SubsystemMatrix[];
+  generatedAt: string;
+}
+
+const NEWLINE = '\n';
+const DEFAULT_FORMAT: OutputFormat = 'markdown';
+
+async function resolveHardhatContext(): Promise<HardhatContext> {
+  try {
+    const hardhat = await import('hardhat');
+    const { network } = hardhat;
+    return {
+      name: network?.name,
+      chainId: network?.config?.chainId,
+    };
+  } catch (error) {
+    if (process.env.DEBUG_OWNER_MATRIX) {
+      console.warn('Failed to load hardhat context:', error);
+    }
+    return {};
+  }
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    format: DEFAULT_FORMAT,
+    includeMermaid: true,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--network': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--network requires a value');
+        }
+        options.network = value;
+        i += 1;
+        break;
+      }
+      case '--out':
+      case '--output': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a path`);
+        }
+        options.outPath = value;
+        i += 1;
+        break;
+      }
+      case '--format': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--format requires a value');
+        }
+        const normalised = value.trim().toLowerCase();
+        if (normalised !== 'markdown' && normalised !== 'json' && normalised !== 'human') {
+          throw new Error('Supported formats: markdown, json, human');
+        }
+        options.format = normalised as OutputFormat;
+        i += 1;
+        break;
+      }
+      case '--no-mermaid':
+        options.includeMermaid = false;
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new Error(`Unknown flag ${arg}`);
+        }
+    }
+  }
+
+  return options;
+}
+
+function replaceNetworkPlaceholder(command: string, network?: string): string {
+  if (!network) {
+    return command;
+  }
+  return command.replace(/<network>/g, network);
+}
+
+function toDisplayValue(input: unknown): string {
+  if (input === null || input === undefined) {
+    return '—';
+  }
+  if (typeof input === 'string') {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return '""';
+    }
+    return trimmed;
+  }
+  if (typeof input === 'number' || typeof input === 'bigint') {
+    return String(input);
+  }
+  if (typeof input === 'boolean') {
+    return input ? 'true' : 'false';
+  }
+  if (Array.isArray(input)) {
+    if (input.length === 0) {
+      return '[]';
+    }
+    return `[${input.map((item) => toDisplayValue(item)).join(', ')}]`;
+  }
+  if (typeof input === 'object') {
+    return JSON.stringify(input, null, 2);
+  }
+  return String(input);
+}
+
+function flattenConfig(value: unknown, prefix = '', rows: MatrixRow[] = [], depth = 0): MatrixRow[] {
+  if (rows.length > 256) {
+    return rows;
+  }
+
+  const pathLabel = prefix || '<root>';
+
+  if (value === null || value === undefined || typeof value !== 'object' || value instanceof Date) {
+    rows.push({ path: pathLabel, value: toDisplayValue(value) });
+    return rows;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      rows.push({ path: pathLabel, value: '[]' });
+      return rows;
+    }
+    value.forEach((item, index) => {
+      flattenConfig(item, `${pathLabel}[${index}]`, rows, depth + 1);
+    });
+    return rows;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) {
+    rows.push({ path: pathLabel, value: '{}' });
+    return rows;
+  }
+
+  for (const [key, nestedValue] of entries.sort(([a], [b]) => a.localeCompare(b))) {
+    const newPrefix = prefix ? `${prefix}.${key}` : key;
+    flattenConfig(nestedValue, newPrefix, rows, depth + 1);
+    if (rows.length > 256) {
+      break;
+    }
+  }
+
+  return rows;
+}
+
+async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix[]> {
+  const descriptors: SubsystemDescriptor[] = [
+    {
+      id: 'token',
+      title: '$AGIALPHA token constants',
+      summary:
+        'Canonical ERC-20 metadata and module addresses consumed by Solidity constants and TypeScript clients.',
+      documentation: ['docs/token-operations.md', 'docs/thermodynamics-operations.md'],
+      updateCommands: ['npm run compile'],
+      verifyCommands: ['npm run verify:agialpha -- --rpc <https-or-ws-url>'],
+      fallbackConfigPath: 'config/agialpha.json',
+      loader: (ctx) => loadTokenConfig({ network: ctx }),
+    },
+    {
+      id: 'stakeManager',
+      title: 'StakeManager parameters',
+      summary:
+        'Controls staking minimums, slashing weights, treasury routing, and validator incentives.',
+      documentation: [
+        'docs/owner-control-handbook.md',
+        'docs/owner-control-command-center.md',
+        'docs/thermodynamics-operations.md',
+      ],
+      updateCommands: ['npx hardhat run scripts/v2/updateStakeManager.ts --network <network>'],
+      verifyCommands: [
+        'npm run owner:verify-control -- --network <network> --modules=stakeManager',
+      ],
+      fallbackConfigPath: 'config/stake-manager.json',
+      loader: (ctx) => loadStakeManagerConfig({ network: ctx }),
+    },
+    {
+      id: 'jobRegistry',
+      title: 'JobRegistry policy',
+      summary: 'Job posting thresholds, fee splits, and lifecycle limits for employer contracts.',
+      documentation: [
+        'docs/owner-control-playbook.md',
+        'docs/owner-control-zero-downtime-guide.md',
+      ],
+      updateCommands: ['npx hardhat run scripts/v2/updateJobRegistry.ts --network <network>'],
+      verifyCommands: [
+        'npm run owner:verify-control -- --network <network> --modules=jobRegistry',
+      ],
+      fallbackConfigPath: 'config/job-registry.json',
+      loader: (ctx) => loadJobRegistryConfig({ network: ctx }),
+    },
+    {
+      id: 'feePool',
+      title: 'FeePool distribution',
+      summary:
+        'Treasury routing, burn percentages, and payout pacing for escrowed protocol fees.',
+      documentation: ['docs/owner-control-visual-guide.md'],
+      updateCommands: ['npx hardhat run scripts/v2/updateFeePool.ts --network <network>'],
+      verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=feePool'],
+      fallbackConfigPath: 'config/fee-pool.json',
+      loader: (ctx) => loadFeePoolConfig({ network: ctx }),
+    },
+    {
+      id: 'thermodynamics',
+      title: 'Thermodynamics & Thermostat',
+      summary:
+        'Energy budgeting, reward weights, and PID control surfaces that tune incentive gradients.',
+      documentation: [
+        'docs/thermodynamic-incentives.md',
+        'docs/thermodynamics-operations.md',
+        'docs/reward-settlement-process.md',
+      ],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updateThermodynamics.ts --network <network>',
+        'npx hardhat run scripts/v2/updateThermostat.ts --network <network>',
+      ],
+      verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=rewardEngine,thermostat'],
+      fallbackConfigPath: 'config/thermodynamics.json',
+      loader: (ctx) => loadThermodynamicsConfig({ network: ctx }),
+    },
+    {
+      id: 'hamiltonianMonitor',
+      title: 'HamiltonianMonitor windows',
+      summary:
+        'Observation window, historical energy records, and telemetry for system temperature guards.',
+      documentation: ['docs/thermodynamics-operations.md'],
+      updateCommands: ['npx hardhat run scripts/v2/updateHamiltonianMonitor.ts --network <network>'],
+      verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=rewardEngine'],
+      fallbackConfigPath: 'config/hamiltonian-monitor.json',
+      loader: (ctx) => loadHamiltonianMonitorConfig({ network: ctx }),
+    },
+    {
+      id: 'energyOracle',
+      title: 'EnergyOracle signer set',
+      summary:
+        'Authorised measurement nodes and quorum settings for the energy attestation oracle.',
+      documentation: [
+        'docs/energy-oracle-operations.md',
+        'docs/owner-control-command-center.md',
+      ],
+      updateCommands: ['npx hardhat run scripts/v2/updateEnergyOracle.ts --network <network>'],
+      verifyCommands: [
+        'npm run owner:verify-control -- --network <network> --modules=rewardEngine',
+        'npm run owner:surface -- --network <network> --only=rewardEngine',
+      ],
+      fallbackConfigPath: 'config/energy-oracle.json',
+      loader: (ctx) => loadEnergyOracleConfig({ network: ctx }),
+    },
+    {
+      id: 'taxPolicy',
+      title: 'TaxPolicy controls',
+      summary: 'Dynamic levy brackets for employer jobs and treasury burn ratios.',
+      documentation: ['docs/owner-control-command-center.md'],
+      updateCommands: ['npx hardhat run scripts/v2/updateTaxPolicy.ts --network <network>'],
+      verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=taxPolicy'],
+      fallbackConfigPath: 'config/tax-policy.json',
+      loader: (ctx) => loadTaxPolicyConfig({ network: ctx }),
+    },
+    {
+      id: 'platformIncentives',
+      title: 'PlatformIncentives weights',
+      summary: 'Bonus multipliers, vesting schedules, and autopayout tolerances for ecosystem partners.',
+      documentation: ['docs/owner-control-visual-guide.md'],
+      updateCommands: ['npx hardhat run scripts/v2/updatePlatformIncentives.ts --network <network>'],
+      verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=platformIncentives'],
+      fallbackConfigPath: 'config/platform-incentives.json',
+      loader: (ctx) => loadPlatformIncentivesConfig({ network: ctx }),
+    },
+    {
+      id: 'identityRegistry',
+      title: 'IdentityRegistry configuration',
+      summary: 'ENS registries, root nodes, and emergency allowlists for identity proofs.',
+      documentation: [
+        'docs/ens-identity-policy.md',
+        'docs/ens-identity-setup.md',
+      ],
+      updateCommands: ['npx hardhat run scripts/v2/updateIdentityRegistry.ts --network <network>'],
+      verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=identityRegistry'],
+      fallbackConfigPath: 'config/identity-registry.json',
+      loader: (ctx) => loadIdentityRegistryConfig({ network: ctx }),
+    },
+  ];
+
+  const results: SubsystemMatrix[] = [];
+  for (const descriptor of descriptors) {
+    try {
+      const loaded = descriptor.loader(network);
+      results.push({
+        id: descriptor.id,
+        title: descriptor.title,
+        summary: descriptor.summary,
+        documentation: descriptor.documentation,
+        updateCommands: descriptor.updateCommands,
+        verifyCommands: descriptor.verifyCommands,
+        configPath: path.relative(process.cwd(), loaded.path),
+        rows: flattenConfig(loaded.config),
+      });
+    } catch (error) {
+      const fallback = path.relative(process.cwd(), descriptor.fallbackConfigPath);
+      const message =
+        error instanceof Error ? error.message : 'Unknown error loading configuration';
+      results.push({
+        id: descriptor.id,
+        title: descriptor.title,
+        summary: descriptor.summary,
+        documentation: descriptor.documentation,
+        updateCommands: descriptor.updateCommands,
+        verifyCommands: descriptor.verifyCommands,
+        configPath: fallback,
+        rows: [
+          {
+            path: '<error>',
+            value: message,
+            notes: 'Fix the configuration file then rerun owner:parameters.',
+          },
+        ],
+      });
+    }
+  }
+
+  return results;
+}
+
+function renderHuman(matrix: MatrixPayload): string {
+  const lines: string[] = [];
+  lines.push(`Owner parameter matrix (${matrix.network ?? 'no network selected'})`);
+  lines.push(`Generated at: ${matrix.generatedAt}`);
+  lines.push('');
+  for (const subsystem of matrix.subsystems) {
+    lines.push(`${subsystem.title}`);
+    lines.push('-'.repeat(subsystem.title.length));
+    lines.push(subsystem.summary);
+    lines.push(`Config: ${subsystem.configPath}`);
+    if (subsystem.updateCommands.length > 0) {
+      lines.push('Update:');
+      subsystem.updateCommands.forEach((cmd) => lines.push(`  • ${cmd}`));
+    }
+    if (subsystem.verifyCommands.length > 0) {
+      lines.push('Verify:');
+      subsystem.verifyCommands.forEach((cmd) => lines.push(`  • ${cmd}`));
+    }
+    if (subsystem.documentation.length > 0) {
+      lines.push('Docs:');
+      subsystem.documentation.forEach((doc) => lines.push(`  • ${doc}`));
+    }
+    lines.push('Parameters:');
+    subsystem.rows.forEach((row) => {
+      const note = row.notes ? ` (${row.notes})` : '';
+      lines.push(`  - ${row.path}: ${row.value}${note}`);
+    });
+    lines.push('');
+  }
+  return lines.join(NEWLINE);
+}
+
+function renderMarkdown(matrix: MatrixPayload, includeMermaid: boolean): string {
+  const lines: string[] = [];
+  lines.push(`# Owner parameter matrix`);
+  lines.push('');
+  lines.push(`- Generated at: \`${matrix.generatedAt}\``);
+  if (matrix.network) {
+    lines.push(`- Network context: \`${matrix.network}\``);
+  }
+  lines.push('');
+  if (includeMermaid) {
+    lines.push('```mermaid');
+    lines.push('flowchart TD');
+    lines.push('    subgraph Owner Workflow');
+    lines.push('        A[Edit configuration JSON] --> B[Dry-run helper script]');
+    lines.push('        B --> C[Submit update transaction]');
+    lines.push('        C --> D[Verify owner control & telemetry]');
+    lines.push('    end');
+    lines.push('    E((Matrix report)) --> A');
+    lines.push('    E --> B');
+    lines.push('    E --> D');
+    lines.push('```');
+    lines.push('');
+  }
+
+  for (const subsystem of matrix.subsystems) {
+    lines.push(`## ${subsystem.title}`);
+    lines.push('');
+    lines.push(subsystem.summary);
+    lines.push('');
+    lines.push(`- **Config file:** \`${subsystem.configPath}\``);
+    if (subsystem.updateCommands.length > 0) {
+      lines.push('- **Update with:**');
+      subsystem.updateCommands.forEach((cmd) => {
+        lines.push(`  - \`${cmd}\``);
+      });
+    }
+    if (subsystem.verifyCommands.length > 0) {
+      lines.push('- **Verify with:**');
+      subsystem.verifyCommands.forEach((cmd) => {
+        lines.push(`  - \`${cmd}\``);
+      });
+    }
+    if (subsystem.documentation.length > 0) {
+      lines.push('- **Reference docs:**');
+      subsystem.documentation.forEach((doc) => {
+        lines.push(`  - [${doc}](${doc})`);
+      });
+    }
+    lines.push('');
+    lines.push('| Parameter | Value |');
+    lines.push('| --- | --- |');
+    subsystem.rows.forEach((row) => {
+      const sanitizedValue = row.value.replace(/\n/g, '<br />');
+      lines.push(`| \`${row.path}\` | ${sanitizedValue} |`);
+    });
+    lines.push('');
+  }
+
+  return lines.join(NEWLINE);
+}
+
+async function writeOutput(content: string, outPath?: string): Promise<void> {
+  if (!outPath) {
+    process.stdout.write(content);
+    if (!content.endsWith('\n')) {
+      process.stdout.write('\n');
+    }
+    return;
+  }
+  const absolute = path.resolve(outPath);
+  await fs.mkdir(path.dirname(absolute), { recursive: true });
+  await fs.writeFile(absolute, content, 'utf8');
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    const helpText = [
+      'Usage: ts-node scripts/v2/ownerParameterMatrix.ts [options]',
+      '',
+      'Options:',
+      '  --network <name>       Network alias for config overrides',
+      '  --format <format>      Output format: markdown (default), json, human',
+      '  --out <path>           Write to file instead of stdout',
+      '  --no-mermaid           Omit Mermaid diagrams in markdown mode',
+      '  -h, --help             Show this message',
+    ].join(NEWLINE);
+    process.stdout.write(`${helpText}\n`);
+    return;
+  }
+
+  const hardhat = await resolveHardhatContext();
+  const selectedNetwork = options.network ?? process.env.HARDHAT_NETWORK ?? hardhat.name;
+
+  const subsystems = await buildSubsystemMatrices(selectedNetwork);
+  const matrix: MatrixPayload = {
+    network: selectedNetwork,
+    subsystems: subsystems.map((entry) => ({
+      ...entry,
+      updateCommands: entry.updateCommands.map((cmd) => replaceNetworkPlaceholder(cmd, selectedNetwork)),
+      verifyCommands: entry.verifyCommands.map((cmd) => replaceNetworkPlaceholder(cmd, selectedNetwork)),
+    })),
+    generatedAt: new Date().toISOString(),
+  };
+
+  let output: string;
+  switch (options.format) {
+    case 'json':
+      output = JSON.stringify(matrix, null, 2);
+      break;
+    case 'human':
+      output = renderHuman(matrix);
+      break;
+    case 'markdown':
+    default:
+      output = renderMarkdown(matrix, options.includeMermaid);
+      break;
+  }
+
+  await writeOutput(output, options.outPath);
+}
+
+main().catch((error) => {
+  console.error('ownerParameterMatrix failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add an owner parameter matrix CLI that flattens configuration, includes error handling, and exports multiple output formats
- document the workflow with a dedicated Owner Parameter Matrix guide and link it from the README
- expose the helper via a new npm script for easy access by non-technical operators

## Testing
- npm run owner:parameters -- --network sepolia --format human
- npm run lint:check *(fails: existing solhint and prettier violations in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2d9b2ea88333bbdbd93f1a356db5