### PR TITLE
Add kernel staking, validation, and reward modules

### DIFF
--- a/contracts/v2/kernel/Config.sol
+++ b/contracts/v2/kernel/Config.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title KernelConfig
+/// @notice Governance owned configuration for protocol risk parameters.
+contract KernelConfig is Ownable {
+    uint256 public maxJobDuration; // seconds
+    uint256 public minAgentStake;
+    uint256 public minValidatorStake;
+    uint256 public maxConcurrentJobsPerAgent;
+
+    uint256 public minValidators;
+    uint256 public approvalThresholdBps;
+    uint256 public commitWindow;
+    uint256 public revealWindow;
+    uint256 public noRevealSlashBps;
+    uint256 public maliciousSlashBps;
+
+    event MaxJobDurationUpdated(uint256 value);
+    event MinAgentStakeUpdated(uint256 value);
+    event MinValidatorStakeUpdated(uint256 value);
+    event MaxConcurrentJobsUpdated(uint256 value);
+    event ValidatorParamsUpdated(uint256 minValidators, uint256 approvalThresholdBps);
+    event WindowsUpdated(uint256 commitWindow, uint256 revealWindow);
+    event NoRevealSlashUpdated(uint256 value);
+    event MaliciousSlashUpdated(uint256 value);
+
+    error InvalidValue();
+
+    constructor(address owner_) Ownable(owner_) {
+        maxJobDuration = 7 days;
+        minAgentStake = 1 ether;
+        minValidatorStake = 1 ether;
+        maxConcurrentJobsPerAgent = 3;
+        minValidators = 3;
+        approvalThresholdBps = 6_000; // 60%
+        commitWindow = 1 days;
+        revealWindow = 1 days;
+        noRevealSlashBps = 100; // 1%
+        maliciousSlashBps = 500; // 5%
+    }
+
+    function setMaxJobDuration(uint256 value) external onlyOwner {
+        if (value == 0) revert InvalidValue();
+        maxJobDuration = value;
+        emit MaxJobDurationUpdated(value);
+    }
+
+    function setMinAgentStake(uint256 value) external onlyOwner {
+        if (value == 0) revert InvalidValue();
+        minAgentStake = value;
+        emit MinAgentStakeUpdated(value);
+    }
+
+    function setMinValidatorStake(uint256 value) external onlyOwner {
+        if (value == 0) revert InvalidValue();
+        minValidatorStake = value;
+        emit MinValidatorStakeUpdated(value);
+    }
+
+    function setMaxConcurrentJobs(uint256 value) external onlyOwner {
+        if (value == 0) revert InvalidValue();
+        maxConcurrentJobsPerAgent = value;
+        emit MaxConcurrentJobsUpdated(value);
+    }
+
+    function setValidatorParams(uint256 minVals, uint256 approvalBps) external onlyOwner {
+        if (minVals == 0 || approvalBps == 0 || approvalBps > 10_000) revert InvalidValue();
+        minValidators = minVals;
+        approvalThresholdBps = approvalBps;
+        emit ValidatorParamsUpdated(minVals, approvalBps);
+    }
+
+    function setWindows(uint256 commit, uint256 reveal) external onlyOwner {
+        if (commit == 0 || reveal == 0) revert InvalidValue();
+        commitWindow = commit;
+        revealWindow = reveal;
+        emit WindowsUpdated(commit, reveal);
+    }
+
+    function setNoRevealSlash(uint256 bps) external onlyOwner {
+        if (bps > 10_000) revert InvalidValue();
+        noRevealSlashBps = bps;
+        emit NoRevealSlashUpdated(bps);
+    }
+
+    function setMaliciousSlash(uint256 bps) external onlyOwner {
+        if (bps > 10_000) revert InvalidValue();
+        maliciousSlashBps = bps;
+        emit MaliciousSlashUpdated(bps);
+    }
+}

--- a/contracts/v2/kernel/EscrowVault.sol
+++ b/contracts/v2/kernel/EscrowVault.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title EscrowVault
+/// @notice Holds job rewards until the registry resolves the job outcome.
+contract EscrowVault is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable token;
+    address public controller;
+
+    address public constant BURN_ADDRESS = 0x000000000000000000000000000000000000dEaD;
+
+    mapping(uint256 => uint256) private _escrowed;
+
+    event ControllerUpdated(address indexed controller);
+    event EscrowDeposited(uint256 indexed jobId, address indexed from, uint256 amount);
+    event EscrowReleased(uint256 indexed jobId, address indexed to, uint256 amount);
+    event EscrowRefunded(uint256 indexed jobId, address indexed to, uint256 amount);
+    event EscrowBurned(uint256 indexed jobId, uint256 amount);
+
+    error ZeroAddress();
+    error NotController();
+    error ZeroAmount();
+    error InsufficientEscrow();
+
+    constructor(IERC20 token_, address owner_) Ownable(owner_) {
+        if (address(token_) == address(0)) revert ZeroAddress();
+        token = token_;
+    }
+
+    modifier onlyController() {
+        if (msg.sender != controller) revert NotController();
+        _;
+    }
+
+    function setController(address controller_) external onlyOwner {
+        if (controller_ == address(0)) revert ZeroAddress();
+        controller = controller_;
+        emit ControllerUpdated(controller_);
+    }
+
+    function balanceOf(uint256 jobId) external view returns (uint256) {
+        return _escrowed[jobId];
+    }
+
+    function deposit(uint256 jobId, address from, uint256 amount) external onlyController nonReentrant {
+        if (from == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        token.safeTransferFrom(from, address(this), amount);
+        _escrowed[jobId] += amount;
+        emit EscrowDeposited(jobId, from, amount);
+    }
+
+    function release(uint256 jobId, address to, uint256 amount) external onlyController nonReentrant {
+        if (to == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        uint256 balance = _escrowed[jobId];
+        if (balance < amount) revert InsufficientEscrow();
+        _escrowed[jobId] = balance - amount;
+        token.safeTransfer(to, amount);
+        emit EscrowReleased(jobId, to, amount);
+    }
+
+    function refund(uint256 jobId, address to) external onlyController nonReentrant {
+        if (to == address(0)) revert ZeroAddress();
+        uint256 amount = _escrowed[jobId];
+        if (amount == 0) revert ZeroAmount();
+        _escrowed[jobId] = 0;
+        token.safeTransfer(to, amount);
+        emit EscrowRefunded(jobId, to, amount);
+    }
+
+    function burn(uint256 jobId, uint256 amount) external onlyController nonReentrant {
+        if (amount == 0) revert ZeroAmount();
+        uint256 balance = _escrowed[jobId];
+        if (balance < amount) revert InsufficientEscrow();
+        _escrowed[jobId] = balance - amount;
+        token.safeTransfer(BURN_ADDRESS, amount);
+        emit EscrowBurned(jobId, amount);
+    }
+}

--- a/contracts/v2/kernel/JobRegistry.sol
+++ b/contracts/v2/kernel/JobRegistry.sol
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {KernelStakeManager} from "./StakeManager.sol";
+import {EscrowVault} from "./EscrowVault.sol";
+import {RewardEngine} from "./RewardEngine.sol";
+import {KernelConfig} from "./Config.sol";
+import {ValidationModule} from "./ValidationModule.sol";
+import {IJobRegistryKernel} from "./interfaces/IJobRegistryKernel.sol";
+
+/// @title KernelJobRegistry
+/// @notice Coordinates job lifecycle, escrow, and validation outcomes.
+contract KernelJobRegistry is Ownable, ReentrancyGuard, IJobRegistryKernel {
+    struct Job {
+        address employer;
+        address agent;
+        uint256 reward;
+        uint64 deadline;
+        uint64 submittedAt;
+        bool submitted;
+        bool finalized;
+        bool success;
+        bytes32 specHash;
+    }
+
+    uint256 public nextJobId = 1;
+    address public opsTreasury;
+
+    KernelStakeManager public stakeManager;
+    EscrowVault public escrowVault;
+    RewardEngine public rewardEngine;
+    KernelConfig public config;
+    ValidationModule public validationModule;
+
+    mapping(uint256 => Job) public jobs;
+    mapping(address => uint256) public activeJobs;
+
+    event OpsTreasuryUpdated(address indexed treasury);
+    event StakeManagerUpdated(address indexed manager);
+    event EscrowVaultUpdated(address indexed vault);
+    event RewardEngineUpdated(address indexed engine);
+    event ValidationModuleUpdated(address indexed module);
+    event ConfigUpdated(address indexed config);
+
+    event JobCreated(
+        uint256 indexed jobId,
+        address indexed employer,
+        address indexed agent,
+        uint256 reward,
+        uint64 deadline,
+        bytes32 specHash,
+        address[] validators
+    );
+    event JobSubmitted(uint256 indexed jobId);
+    event JobFinalized(uint256 indexed jobId, bool success);
+    event JobCancelled(uint256 indexed jobId);
+
+    event ParticipantSlashed(
+        uint256 indexed jobId,
+        address indexed offender,
+        uint256 bps,
+        string reason
+    );
+
+    error ZeroAddress();
+    error InvalidReward();
+    error InvalidDeadline();
+    error InvalidCaller();
+    error JobNotFound();
+    error AlreadySubmitted();
+    error AlreadyFinalized();
+    error DeadlinePassed();
+    error InsufficientStake();
+    error ValidatorStakeTooLow(address validator);
+    error TooManyJobs();
+    error InvalidValidators();
+    error NotEmployer();
+    error NotExpired();
+
+    modifier onlyValidationModule() {
+        if (msg.sender != address(validationModule)) revert InvalidCaller();
+        _;
+    }
+
+    constructor(
+        KernelStakeManager stakeManager_,
+        EscrowVault escrowVault_,
+        RewardEngine rewardEngine_,
+        KernelConfig config_,
+        ValidationModule validationModule_,
+        address owner_,
+        address opsTreasury_
+    ) Ownable(owner_) {
+        if (
+            address(stakeManager_) == address(0) ||
+            address(escrowVault_) == address(0) ||
+            address(rewardEngine_) == address(0) ||
+            address(config_) == address(0)
+        ) revert ZeroAddress();
+
+        stakeManager = stakeManager_;
+        escrowVault = escrowVault_;
+        rewardEngine = rewardEngine_;
+        config = config_;
+        validationModule = validationModule_;
+        opsTreasury = opsTreasury_;
+    }
+
+    // ---------------------------------------------------------------------
+    // Governance setters
+    // ---------------------------------------------------------------------
+
+    function setStakeManager(KernelStakeManager manager) external onlyOwner {
+        if (address(manager) == address(0)) revert ZeroAddress();
+        stakeManager = manager;
+        emit StakeManagerUpdated(address(manager));
+    }
+
+    function setEscrowVault(EscrowVault vault) external onlyOwner {
+        if (address(vault) == address(0)) revert ZeroAddress();
+        escrowVault = vault;
+        emit EscrowVaultUpdated(address(vault));
+    }
+
+    function setRewardEngine(RewardEngine engine) external onlyOwner {
+        if (address(engine) == address(0)) revert ZeroAddress();
+        rewardEngine = engine;
+        emit RewardEngineUpdated(address(engine));
+    }
+
+    function setConfig(KernelConfig config_) external onlyOwner {
+        if (address(config_) == address(0)) revert ZeroAddress();
+        config = config_;
+        emit ConfigUpdated(address(config_));
+    }
+
+    function setValidationModule(ValidationModule module) external onlyOwner {
+        if (address(module) == address(0)) revert ZeroAddress();
+        validationModule = module;
+        emit ValidationModuleUpdated(address(module));
+    }
+
+    function setOpsTreasury(address treasury) external onlyOwner {
+        opsTreasury = treasury;
+        emit OpsTreasuryUpdated(treasury);
+    }
+
+    // ---------------------------------------------------------------------
+    // Job lifecycle
+    // ---------------------------------------------------------------------
+
+    function createJob(
+        address agent,
+        address[] calldata validators,
+        uint256 reward,
+        uint64 deadline,
+        bytes32 specHash
+    ) external nonReentrant returns (uint256 jobId) {
+        if (agent == address(0)) revert ZeroAddress();
+        if (reward == 0) revert InvalidReward();
+        if (deadline <= block.timestamp) revert InvalidDeadline();
+        uint256 maxDuration = config.maxJobDuration();
+        if (deadline - block.timestamp > maxDuration) revert InvalidDeadline();
+        if (stakeManager.stakeOf(agent) < config.minAgentStake()) revert InsufficientStake();
+        if (validators.length < config.minValidators()) revert InvalidValidators();
+
+        uint256 active = activeJobs[agent] + 1;
+        uint256 limit = config.maxConcurrentJobsPerAgent();
+        if (limit > 0 && active > limit) revert TooManyJobs();
+
+        uint256 minValidatorStake = config.minValidatorStake();
+        for (uint256 i = 0; i < validators.length; i++) {
+            address validator = validators[i];
+            if (validator == address(0)) revert InvalidValidators();
+            if (stakeManager.stakeOf(validator) < minValidatorStake) {
+                revert ValidatorStakeTooLow(validator);
+            }
+        }
+
+        jobId = nextJobId++;
+        jobs[jobId] = Job({
+            employer: msg.sender,
+            agent: agent,
+            reward: reward,
+            deadline: deadline,
+            submittedAt: 0,
+            submitted: false,
+            finalized: false,
+            success: false,
+            specHash: specHash
+        });
+        activeJobs[agent] = active;
+
+        escrowVault.deposit(jobId, msg.sender, reward);
+        validationModule.configureRound(jobId, validators);
+
+        emit JobCreated(jobId, msg.sender, agent, reward, deadline, specHash, validators);
+    }
+
+    function submitResult(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        if (job.employer == address(0)) revert JobNotFound();
+        if (job.finalized) revert AlreadyFinalized();
+        if (msg.sender != job.agent) revert InvalidCaller();
+        if (job.submitted) revert AlreadySubmitted();
+        if (block.timestamp > job.deadline) revert DeadlinePassed();
+
+        job.submitted = true;
+        job.submittedAt = uint64(block.timestamp);
+        validationModule.startRound(jobId);
+        emit JobSubmitted(jobId);
+    }
+
+    function cancelExpiredJob(uint256 jobId) external nonReentrant {
+        Job storage job = jobs[jobId];
+        if (job.employer == address(0)) revert JobNotFound();
+        if (job.finalized) revert AlreadyFinalized();
+        if (block.timestamp <= job.deadline) revert NotExpired();
+        if (msg.sender != job.employer && msg.sender != owner()) revert InvalidCaller();
+
+        job.finalized = true;
+        if (activeJobs[job.agent] > 0) {
+            activeJobs[job.agent] -= 1;
+        }
+        escrowVault.refund(jobId, job.employer);
+        _slashParticipant(jobId, job.agent, config.maliciousSlashBps(), "ttl_expired");
+        emit JobCancelled(jobId);
+    }
+
+    // ---------------------------------------------------------------------
+    // Validation callbacks
+    // ---------------------------------------------------------------------
+
+    function onValidationApproved(
+        uint256 jobId,
+        address[] calldata validators,
+        address[] calldata nonRevealers
+    ) external override onlyValidationModule nonReentrant {
+        _handleNonRevealers(jobId, nonRevealers);
+        _finalize(jobId, true, validators);
+    }
+
+    function onValidationRejected(
+        uint256 jobId,
+        address[] calldata validators,
+        address[] calldata nonRevealers
+    ) external override onlyValidationModule nonReentrant {
+        _handleNonRevealers(jobId, nonRevealers);
+        _slashParticipant(jobId, jobs[jobId].agent, config.maliciousSlashBps(), "validation_rejected");
+        _finalize(jobId, false, validators);
+    }
+
+    function onValidationQuorumFailure(uint256 jobId, address[] calldata nonRevealers)
+        external
+        override
+        onlyValidationModule
+        nonReentrant
+    {
+        _handleNonRevealers(jobId, nonRevealers);
+        _finalize(jobId, false, new address[](0));
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal helpers
+    // ---------------------------------------------------------------------
+
+    function _handleNonRevealers(uint256 jobId, address[] calldata nonRevealers) internal {
+        uint256 bps = config.noRevealSlashBps();
+        if (bps == 0) return;
+        for (uint256 i = 0; i < nonRevealers.length; i++) {
+            _slashParticipant(jobId, nonRevealers[i], bps, "no_reveal");
+        }
+    }
+
+    function _slashParticipant(uint256 jobId, address offender, uint256 bps, string memory reason) internal {
+        if (offender == address(0) || bps == 0) return;
+        address beneficiary = jobs[jobId].employer;
+        if (stakeManager.stakeOf(offender) == 0) return;
+        stakeManager.slash(offender, bps, beneficiary, reason);
+        emit ParticipantSlashed(jobId, offender, bps, reason);
+    }
+
+    function _finalize(uint256 jobId, bool success, address[] memory rewardedValidators) internal {
+        Job storage job = jobs[jobId];
+        if (job.employer == address(0)) revert JobNotFound();
+        if (job.finalized) revert AlreadyFinalized();
+        job.finalized = true;
+        job.success = success;
+        if (activeJobs[job.agent] > 0) {
+            activeJobs[job.agent] -= 1;
+        }
+
+        if (success) {
+            RewardEngine.SplitResult memory split = rewardEngine.split(jobId, job.reward);
+
+            if (split.agentAmount > 0) {
+                escrowVault.release(jobId, job.agent, split.agentAmount);
+            }
+
+            uint256 validatorCount = rewardedValidators.length;
+            if (split.validatorAmount > 0 && validatorCount > 0) {
+                uint256 base = split.validatorAmount / validatorCount;
+                uint256 remainder = split.validatorAmount - (base * validatorCount);
+                for (uint256 i = 0; i < validatorCount; i++) {
+                    uint256 payout = base;
+                    if (i == 0) payout += remainder;
+                    escrowVault.release(jobId, rewardedValidators[i], payout);
+                }
+            }
+
+            if (split.opsAmount > 0 && opsTreasury != address(0)) {
+                escrowVault.release(jobId, opsTreasury, split.opsAmount);
+            }
+
+            if (split.employerRebateAmount > 0) {
+                escrowVault.release(jobId, job.employer, split.employerRebateAmount);
+            }
+
+            if (split.burnAmount > 0) {
+                escrowVault.burn(jobId, split.burnAmount);
+            }
+
+            uint256 remaining = escrowVault.balanceOf(jobId);
+            if (remaining > 0) {
+                escrowVault.refund(jobId, job.employer);
+            }
+        } else {
+            escrowVault.refund(jobId, job.employer);
+        }
+
+        emit JobFinalized(jobId, success);
+    }
+}

--- a/contracts/v2/kernel/RewardEngine.sol
+++ b/contracts/v2/kernel/RewardEngine.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title RewardEngine
+/// @notice Computes protocol reward splits and emits accounting events.
+contract RewardEngine is Ownable {
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    struct SplitConfig {
+        uint256 agentsBps;
+        uint256 validatorsBps;
+        uint256 opsBps;
+        uint256 employerRebateBps;
+        uint256 burnBps;
+    }
+
+    struct SplitResult {
+        uint256 agentAmount;
+        uint256 validatorAmount;
+        uint256 opsAmount;
+        uint256 employerRebateAmount;
+        uint256 burnAmount;
+    }
+
+    SplitConfig public splits;
+
+    event SplitsUpdated(SplitConfig config);
+    event RewardSplit(
+        uint256 indexed jobId,
+        uint256 total,
+        uint256 agentAmount,
+        uint256 validatorAmount,
+        uint256 opsAmount,
+        uint256 employerRebateAmount,
+        uint256 burnAmount
+    );
+
+    error InvalidSplits();
+
+    constructor(address owner_) Ownable(owner_) {
+        splits = SplitConfig({
+            agentsBps: 6_500,
+            validatorsBps: 2_000,
+            opsBps: 1_000,
+            employerRebateBps: 400,
+            burnBps: 100
+        });
+        emit SplitsUpdated(splits);
+    }
+
+    function setSplits(SplitConfig calldata config) external onlyOwner {
+        uint256 sum = config.agentsBps + config.validatorsBps + config.opsBps + config.employerRebateBps + config.burnBps;
+        if (sum > BPS_DENOMINATOR) revert InvalidSplits();
+        splits = config;
+        emit SplitsUpdated(config);
+    }
+
+    function split(uint256 jobId, uint256 amount) external returns (SplitResult memory result) {
+        SplitConfig memory config = splits;
+        uint256 agents = (amount * config.agentsBps) / BPS_DENOMINATOR;
+        uint256 validators = (amount * config.validatorsBps) / BPS_DENOMINATOR;
+        uint256 ops = (amount * config.opsBps) / BPS_DENOMINATOR;
+        uint256 employer = (amount * config.employerRebateBps) / BPS_DENOMINATOR;
+        uint256 burn = (amount * config.burnBps) / BPS_DENOMINATOR;
+        result = SplitResult({
+            agentAmount: agents,
+            validatorAmount: validators,
+            opsAmount: ops,
+            employerRebateAmount: employer,
+            burnAmount: burn
+        });
+        emit RewardSplit(jobId, amount, agents, validators, ops, employer, burn);
+    }
+}

--- a/contracts/v2/kernel/StakeManager.sol
+++ b/contracts/v2/kernel/StakeManager.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title KernelStakeManager
+/// @notice Minimal staking contract shared by agents and validators.
+/// @dev Funds remain in the contract until explicitly claimed, implementing a
+///      pull-payment flow that mitigates reentrancy vectors.
+contract KernelStakeManager is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    IERC20 public immutable stakingToken;
+
+    /// @notice staking balance for each participant.
+    mapping(address => uint256) private _stakes;
+
+    /// @notice queued withdrawals and slash rewards awaiting manual claim.
+    mapping(address => uint256) public pendingWithdrawals;
+
+    /// @notice addresses allowed to operate on behalf of stakers (e.g. JobRegistry).
+    mapping(address => bool) public operators;
+
+    event OperatorUpdated(address indexed operator, bool allowed);
+    event StakeDeposited(address indexed who, uint256 amount);
+    event StakeWithdrawn(address indexed who, uint256 amount);
+    event WithdrawalClaimed(address indexed who, uint256 amount);
+    event StakeSlashed(
+        address indexed who,
+        uint256 bps,
+        address indexed beneficiary,
+        string reason,
+        uint256 amount
+    );
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error NotAuthorized();
+    error InvalidBps();
+    error InsufficientStake();
+
+    constructor(IERC20 token_, address owner_) Ownable(owner_) {
+        if (address(token_) == address(0)) revert ZeroAddress();
+        stakingToken = token_;
+    }
+
+    /// @notice Allow governance to authorize or revoke operator permissions.
+    function setOperator(address operator, bool allowed) external onlyOwner {
+        if (operator == address(0)) revert ZeroAddress();
+        operators[operator] = allowed;
+        emit OperatorUpdated(operator, allowed);
+    }
+
+    /// @notice Current stake for a participant.
+    function stakeOf(address who) external view returns (uint256) {
+        return _stakes[who];
+    }
+
+    /// @notice Deposit $AGIALPHA for `who`.
+    /// @param who Address receiving the staked balance.
+    /// @param amount Token amount to deposit.
+    function deposit(address who, uint256 amount) external nonReentrant {
+        if (who == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        if (msg.sender != who && !operators[msg.sender]) revert NotAuthorized();
+
+        stakingToken.safeTransferFrom(msg.sender, address(this), amount);
+        _stakes[who] += amount;
+        emit StakeDeposited(who, amount);
+    }
+
+    /// @notice Queue a withdrawal for `who` and move the balance into
+    ///         `pendingWithdrawals`.
+    /// @param who Address whose stake is being withdrawn.
+    /// @param amount Amount of stake to withdraw.
+    function withdraw(address who, uint256 amount) external nonReentrant {
+        if (who == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        if (msg.sender != who && !operators[msg.sender]) revert NotAuthorized();
+
+        uint256 balance = _stakes[who];
+        if (balance < amount) revert InsufficientStake();
+        _stakes[who] = balance - amount;
+        pendingWithdrawals[who] += amount;
+        emit StakeWithdrawn(who, amount);
+    }
+
+    /// @notice Slash a percentage of stake from `who` and credit the
+    ///         beneficiary's withdrawal balance.
+    /// @param who Address being slashed.
+    /// @param bps Basis points of the stake to slash (max 10_000).
+    /// @param beneficiary Recipient credited with the slashed amount.
+    /// @param reason Human readable reason for observability.
+    function slash(address who, uint256 bps, address beneficiary, string calldata reason)
+        external
+        nonReentrant
+    {
+        if (!operators[msg.sender]) revert NotAuthorized();
+        if (who == address(0) || beneficiary == address(0)) revert ZeroAddress();
+        if (bps == 0 || bps > BPS_DENOMINATOR) revert InvalidBps();
+
+        uint256 balance = _stakes[who];
+        if (balance == 0) revert InsufficientStake();
+        uint256 amount = (balance * bps) / BPS_DENOMINATOR;
+        if (amount == 0) revert InsufficientStake();
+
+        _stakes[who] = balance - amount;
+        pendingWithdrawals[beneficiary] += amount;
+        emit StakeSlashed(who, bps, beneficiary, reason, amount);
+    }
+
+    /// @notice Claim accumulated withdrawals and slash rewards.
+    function claim() external nonReentrant returns (uint256 amount) {
+        amount = pendingWithdrawals[msg.sender];
+        if (amount == 0) revert ZeroAmount();
+        pendingWithdrawals[msg.sender] = 0;
+        stakingToken.safeTransfer(msg.sender, amount);
+        emit WithdrawalClaimed(msg.sender, amount);
+    }
+}

--- a/contracts/v2/kernel/ValidationModule.sol
+++ b/contracts/v2/kernel/ValidationModule.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IJobRegistryKernel} from "./interfaces/IJobRegistryKernel.sol";
+import {KernelConfig} from "./Config.sol";
+
+/// @title ValidationModule
+/// @notice Handles commit–reveal voting and enforces quorum thresholds.
+contract ValidationModule is Ownable {
+    KernelConfig public config;
+    IJobRegistryKernel public jobRegistry;
+
+    struct Round {
+        address[] validators;
+        uint64 commitDeadline;
+        uint64 revealDeadline;
+        bool configured;
+        bool started;
+        bool finalized;
+        uint256 yesVotes;
+        uint256 totalReveals;
+        mapping(address => bytes32) commits;
+        mapping(address => bool) revealed;
+    }
+
+    mapping(uint256 => Round) private rounds;
+
+    event JobRegistryUpdated(address indexed jobRegistry);
+    event ConfigUpdated(address indexed config);
+    event RoundConfigured(uint256 indexed jobId, address[] validators);
+    event RoundStarted(uint256 indexed jobId, uint64 commitDeadline, uint64 revealDeadline);
+    event VoteCommitted(uint256 indexed jobId, address indexed validator, bytes32 commitment);
+    event VoteRevealed(uint256 indexed jobId, address indexed validator, bool approve);
+    event RoundFinalized(uint256 indexed jobId, bool approved, bool quorumMet);
+
+    error ZeroAddress();
+    error InvalidCaller();
+    error InvalidValidators();
+    error AlreadyConfigured();
+    error NotConfigured();
+    error AlreadyStarted();
+    error NotStarted();
+    error CommitClosed();
+    error RevealClosed();
+    error CommitMissing();
+    error AlreadyRevealed();
+    error RoundAlreadyFinalized();
+
+    modifier onlyJobRegistry() {
+        if (msg.sender != address(jobRegistry)) revert InvalidCaller();
+        _;
+    }
+
+    constructor(KernelConfig config_, address owner_) Ownable(owner_) {
+        if (address(config_) == address(0)) revert ZeroAddress();
+        config = config_;
+    }
+
+    function setConfig(KernelConfig config_) external onlyOwner {
+        if (address(config_) == address(0)) revert ZeroAddress();
+        config = config_;
+        emit ConfigUpdated(address(config_));
+    }
+
+    function setJobRegistry(IJobRegistryKernel registry) external onlyOwner {
+        if (address(registry) == address(0)) revert ZeroAddress();
+        jobRegistry = registry;
+        emit JobRegistryUpdated(address(registry));
+    }
+
+    function configureRound(uint256 jobId, address[] calldata validators) external onlyJobRegistry {
+        if (validators.length < config.minValidators()) revert InvalidValidators();
+        Round storage round = rounds[jobId];
+        if (round.configured) revert AlreadyConfigured();
+        round.validators = validators;
+        round.configured = true;
+        emit RoundConfigured(jobId, validators);
+    }
+
+    function startRound(uint256 jobId) external onlyJobRegistry {
+        Round storage round = rounds[jobId];
+        if (!round.configured) revert NotConfigured();
+        if (round.started) revert AlreadyStarted();
+        uint256 commitWindow = config.commitWindow();
+        uint256 revealWindow = config.revealWindow();
+        round.started = true;
+        round.commitDeadline = uint64(block.timestamp + commitWindow);
+        round.revealDeadline = uint64(block.timestamp + commitWindow + revealWindow);
+        emit RoundStarted(jobId, round.commitDeadline, round.revealDeadline);
+    }
+
+    function commit(uint256 jobId, bytes32 commitment) external {
+        Round storage round = rounds[jobId];
+        if (!round.started) revert NotStarted();
+        if (block.timestamp > round.commitDeadline) revert CommitClosed();
+        if (!_isValidator(round.validators, msg.sender)) revert InvalidCaller();
+        if (round.commits[msg.sender] != bytes32(0)) revert AlreadyRevealed();
+        if (commitment == bytes32(0)) revert CommitMissing();
+        round.commits[msg.sender] = commitment;
+        emit VoteCommitted(jobId, msg.sender, commitment);
+    }
+
+    function reveal(uint256 jobId, bool approve, bytes32 salt) external {
+        Round storage round = rounds[jobId];
+        if (!round.started) revert NotStarted();
+        if (round.finalized) revert RoundAlreadyFinalized();
+        if (block.timestamp <= round.commitDeadline) revert CommitClosed();
+        if (block.timestamp > round.revealDeadline) revert RevealClosed();
+        if (!_isValidator(round.validators, msg.sender)) revert InvalidCaller();
+        bytes32 commitment = round.commits[msg.sender];
+        if (commitment == bytes32(0)) revert CommitMissing();
+        if (round.revealed[msg.sender]) revert AlreadyRevealed();
+        bytes32 expected = keccak256(abi.encodePacked(jobId, msg.sender, approve, salt));
+        if (expected != commitment) revert CommitMissing();
+        round.revealed[msg.sender] = true;
+        round.totalReveals += 1;
+        if (approve) {
+            round.yesVotes += 1;
+        }
+        emit VoteRevealed(jobId, msg.sender, approve);
+    }
+
+    function finalize(uint256 jobId) external {
+        Round storage round = rounds[jobId];
+        if (!round.started) revert NotStarted();
+        if (round.finalized) revert RoundAlreadyFinalized();
+        if (block.timestamp <= round.revealDeadline && round.totalReveals < round.validators.length) {
+            revert RevealClosed();
+        }
+        round.finalized = true;
+
+        address[] memory validators = round.validators;
+        uint256 validatorCount = validators.length;
+        address[] memory nonRevealers = new address[](validatorCount - round.totalReveals);
+        address[] memory revealedValidators = new address[](round.totalReveals);
+        uint256 nonRevealIdx;
+        uint256 revealIdx;
+        for (uint256 i = 0; i < validatorCount; i++) {
+            address validator = validators[i];
+            if (round.revealed[validator]) {
+                revealedValidators[revealIdx++] = validator;
+            } else {
+                nonRevealers[nonRevealIdx++] = validator;
+            }
+        }
+
+        bool quorumMet = round.totalReveals >= config.minValidators();
+        bool approved;
+        if (quorumMet) {
+            uint256 yesBps = round.yesVotes * 10_000 / round.totalReveals;
+            approved = yesBps >= config.approvalThresholdBps();
+            if (approved) {
+                jobRegistry.onValidationApproved(jobId, revealedValidators, nonRevealers);
+            } else {
+                jobRegistry.onValidationRejected(jobId, revealedValidators, nonRevealers);
+            }
+        } else {
+            jobRegistry.onValidationQuorumFailure(jobId, nonRevealers);
+        }
+
+        emit RoundFinalized(jobId, approved, quorumMet);
+    }
+
+    function _isValidator(address[] memory validators, address account) private pure returns (bool) {
+        for (uint256 i = 0; i < validators.length; i++) {
+            if (validators[i] == account) return true;
+        }
+        return false;
+    }
+}

--- a/contracts/v2/kernel/interfaces/IJobRegistryKernel.sol
+++ b/contracts/v2/kernel/interfaces/IJobRegistryKernel.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IJobRegistryKernel {
+    function onValidationApproved(
+        uint256 jobId,
+        address[] calldata validators,
+        address[] calldata nonRevealers
+    ) external;
+
+    function onValidationRejected(
+        uint256 jobId,
+        address[] calldata validators,
+        address[] calldata nonRevealers
+    ) external;
+
+    function onValidationQuorumFailure(uint256 jobId, address[] calldata nonRevealers) external;
+}

--- a/test/v2/kernel/KernelPipeline.t.sol
+++ b/test/v2/kernel/KernelPipeline.t.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+
+import {KernelStakeManager} from "../../../contracts/v2/kernel/StakeManager.sol";
+import {EscrowVault} from "../../../contracts/v2/kernel/EscrowVault.sol";
+import {KernelJobRegistry} from "../../../contracts/v2/kernel/JobRegistry.sol";
+import {RewardEngine} from "../../../contracts/v2/kernel/RewardEngine.sol";
+import {KernelConfig} from "../../../contracts/v2/kernel/Config.sol";
+import {ValidationModule} from "../../../contracts/v2/kernel/ValidationModule.sol";
+import {MockERC20} from "../../../contracts/test/MockERC20.sol";
+
+contract KernelPipelineTest is Test {
+    KernelStakeManager internal stakeManager;
+    EscrowVault internal escrowVault;
+    KernelJobRegistry internal jobRegistry;
+    RewardEngine internal rewardEngine;
+    KernelConfig internal config;
+    ValidationModule internal validationModule;
+    MockERC20 internal token;
+
+    address internal governance = address(this);
+    address internal opsTreasury = address(0x0A05);
+    address internal employer = address(0xE);
+    address internal agent = address(0xA);
+    address[] internal validators;
+
+    function setUp() public {
+        token = new MockERC20();
+        stakeManager = new KernelStakeManager(token, governance);
+        escrowVault = new EscrowVault(token, governance);
+        config = new KernelConfig(governance);
+        rewardEngine = new RewardEngine(governance);
+        validationModule = new ValidationModule(config, governance);
+        jobRegistry = new KernelJobRegistry(
+            stakeManager,
+            escrowVault,
+            rewardEngine,
+            config,
+            validationModule,
+            governance,
+            opsTreasury
+        );
+
+        validationModule.setJobRegistry(jobRegistry);
+        escrowVault.setController(address(jobRegistry));
+        stakeManager.setOperator(address(jobRegistry), true);
+
+        validators = new address[](2);
+        validators[0] = address(0xB1);
+        validators[1] = address(0xB2);
+
+        // Ensure validators count aligns with config expectations.
+        config.setValidatorParams(2, 6_000);
+        config.setNoRevealSlash(500); // 5%
+        config.setMaliciousSlash(1_000); // 10%
+
+        // Fund participants with stake.
+        _stake(agent, 50 ether);
+        _stake(validators[0], 20 ether);
+        _stake(validators[1], 20 ether);
+
+        // Fund employer with reward tokens and approve escrow vault.
+        token.mint(employer, 200 ether);
+        vm.prank(employer);
+        token.approve(address(escrowVault), type(uint256).max);
+    }
+
+    function _stake(address participant, uint256 amount) internal {
+        token.mint(participant, amount);
+        vm.startPrank(participant);
+        token.approve(address(stakeManager), amount);
+        stakeManager.deposit(participant, amount);
+        vm.stopPrank();
+    }
+
+    function testHappyPathValidationAndPayout() public {
+        uint256 reward = 120 ether;
+        uint64 deadline = uint64(block.timestamp + 3 days);
+        bytes32 specHash = keccak256("job-spec");
+
+        uint256 employerInitial = token.balanceOf(employer);
+        vm.prank(employer);
+        uint256 jobId = jobRegistry.createJob(agent, validators, reward, deadline, specHash);
+        assertEq(jobRegistry.nextJobId(), jobId + 1);
+        assertEq(escrowVault.balanceOf(jobId), reward);
+
+        // Agent submits the result triggering validation windows.
+        vm.prank(agent);
+        jobRegistry.submitResult(jobId);
+
+        // Validators commit approvals.
+        bytes32[] memory salts = new bytes32[](validators.length);
+        for (uint256 i = 0; i < validators.length; i++) {
+            salts[i] = keccak256(abi.encodePacked("salt", i));
+            bytes32 commitment = keccak256(abi.encodePacked(jobId, validators[i], true, salts[i]));
+            vm.prank(validators[i]);
+            validationModule.commit(jobId, commitment);
+        }
+
+        // Move past commit window to allow reveals.
+        vm.warp(block.timestamp + config.commitWindow() + 1);
+
+        for (uint256 i = 0; i < validators.length; i++) {
+            vm.prank(validators[i]);
+            validationModule.reveal(jobId, true, salts[i]);
+        }
+
+        validationModule.finalize(jobId);
+
+        // Ensure job finalized successfully.
+        (,,, uint64 deadlineStored,, bool finalized, bool success,,,) = jobRegistry.jobs(jobId);
+        assertEq(deadlineStored, deadline);
+        assertTrue(finalized);
+        assertTrue(success);
+
+        RewardEngine.SplitResult memory split = rewardEngine.split(jobId, reward);
+
+        // Agent received split.
+        assertEq(token.balanceOf(agent), split.agentAmount);
+
+        // Validators share equally with rounding dust to first validator.
+        uint256 expectedValidatorTotal = split.validatorAmount;
+        uint256 base = expectedValidatorTotal / validators.length;
+        uint256 remainder = expectedValidatorTotal - (base * validators.length);
+        uint256 validatorOne = token.balanceOf(validators[0]);
+        uint256 validatorTwo = token.balanceOf(validators[1]);
+        assertEq(validatorOne, base + remainder);
+        assertEq(validatorTwo, base);
+
+        // Employer receives rebate plus any remainder from rounding.
+        uint256 leftover = reward
+            - (split.agentAmount + split.validatorAmount + split.opsAmount + split.employerRebateAmount + split.burnAmount);
+        uint256 employerExpected = employerInitial - reward + split.employerRebateAmount + leftover;
+        uint256 remainingEscrow = escrowVault.balanceOf(jobId);
+        assertEq(remainingEscrow, 0);
+        assertEq(token.balanceOf(employer), employerExpected);
+
+        // Ops treasury receives allocation when configured.
+        uint256 opsExpected = split.opsAmount;
+        assertEq(token.balanceOf(opsTreasury), opsExpected);
+
+        // Burn address receives burn amount.
+        assertEq(token.balanceOf(escrowVault.BURN_ADDRESS()), split.burnAmount);
+    }
+
+    function testNoRevealSlashesAndRefunds() public {
+        uint256 reward = 80 ether;
+        uint64 deadline = uint64(block.timestamp + 2 days);
+        vm.prank(employer);
+        uint256 jobId = jobRegistry.createJob(agent, validators, reward, deadline, keccak256("job2"));
+
+        vm.prank(agent);
+        jobRegistry.submitResult(jobId);
+
+        // Only first validator participates.
+        bytes32 salt = keccak256("salt-no-reveal");
+        bytes32 commitment = keccak256(abi.encodePacked(jobId, validators[0], true, salt));
+        vm.prank(validators[0]);
+        validationModule.commit(jobId, commitment);
+
+        vm.warp(block.timestamp + config.commitWindow() + 1);
+        vm.prank(validators[0]);
+        validationModule.reveal(jobId, true, salt);
+
+        // Advance beyond reveal window to trigger quorum failure.
+        vm.warp(block.timestamp + config.revealWindow() + 1);
+        validationModule.finalize(jobId);
+
+        (, , , , , bool finalized, bool success, , ,) = jobRegistry.jobs(jobId);
+        assertTrue(finalized);
+        assertFalse(success);
+
+        // Employer refunded escrow and credited with slashed stake from non-revealer.
+        assertEq(token.balanceOf(employer), reward);
+        uint256 pending = stakeManager.pendingWithdrawals(employer);
+        assertGt(pending, 0);
+
+        // Claim slashed amount.
+        vm.prank(employer);
+        stakeManager.claim();
+        assertGt(token.balanceOf(employer), reward);
+    }
+}

--- a/test/v2/kernel/RewardEngineKernel.t.sol
+++ b/test/v2/kernel/RewardEngineKernel.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+
+import {RewardEngine} from "../../../contracts/v2/kernel/RewardEngine.sol";
+
+contract RewardEngineKernelTest is Test {
+    RewardEngine internal engine;
+    address internal governance = address(0x1234);
+
+    function setUp() public {
+        engine = new RewardEngine(governance);
+    }
+
+    function testDefaultSplitSumsBelowDenominator() public {
+        (uint256 agents,, uint256 ops, uint256 employer, uint256 burn) = _currentBps();
+        assertLt(agents + engine.splits().validatorsBps + ops + employer + burn, 10_001);
+    }
+
+    function testSplitProducesExpectedAmounts() public {
+        RewardEngine.SplitResult memory split = engine.split(1, 100 ether);
+        RewardEngine.SplitConfig memory config = engine.splits();
+        assertEq(split.agentAmount, (100 ether * config.agentsBps) / 10_000);
+        assertEq(split.validatorAmount, (100 ether * config.validatorsBps) / 10_000);
+        assertEq(split.opsAmount, (100 ether * config.opsBps) / 10_000);
+        assertEq(split.employerRebateAmount, (100 ether * config.employerRebateBps) / 10_000);
+        assertEq(split.burnAmount, (100 ether * config.burnBps) / 10_000);
+    }
+
+    function testUpdateSplits() public {
+        RewardEngine.SplitConfig memory config = RewardEngine.SplitConfig({
+            agentsBps: 5_000,
+            validatorsBps: 3_000,
+            opsBps: 1_000,
+            employerRebateBps: 500,
+            burnBps: 400
+        });
+        vm.prank(governance);
+        engine.setSplits(config);
+        RewardEngine.SplitConfig memory updated = engine.splits();
+        assertEq(updated.validatorsBps, 3_000);
+    }
+
+    function testUpdateSplitsRevertsOnOverflow() public {
+        RewardEngine.SplitConfig memory config = RewardEngine.SplitConfig({
+            agentsBps: 9_000,
+            validatorsBps: 1_500,
+            opsBps: 0,
+            employerRebateBps: 0,
+            burnBps: 0
+        });
+        vm.prank(governance);
+        vm.expectRevert(RewardEngine.InvalidSplits.selector);
+        engine.setSplits(config);
+    }
+
+    function _currentBps() internal view returns (uint256, uint256, uint256, uint256, uint256) {
+        RewardEngine.SplitConfig memory config = engine.splits();
+        return (
+            config.agentsBps,
+            config.validatorsBps,
+            config.opsBps,
+            config.employerRebateBps,
+            config.burnBps
+        );
+    }
+}

--- a/test/v2/kernel/StakeManagerKernel.t.sol
+++ b/test/v2/kernel/StakeManagerKernel.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+
+import {KernelStakeManager} from "../../../contracts/v2/kernel/StakeManager.sol";
+import {MockERC20} from "../../../contracts/test/MockERC20.sol";
+
+contract StakeManagerKernelTest is Test {
+    KernelStakeManager internal stakeManager;
+    MockERC20 internal token;
+
+    address internal governance = address(0xA11CE);
+    address internal operator = address(0xB0B);
+    address internal alice = address(0xC0FFEE);
+    address internal employer = address(0xE);
+
+    function setUp() public {
+        token = new MockERC20();
+        stakeManager = new KernelStakeManager(token, governance);
+        vm.prank(governance);
+        stakeManager.setOperator(operator, true);
+    }
+
+    function _deposit(address from, address who, uint256 amount) internal {
+        token.mint(from, amount);
+        vm.prank(from);
+        token.approve(address(stakeManager), amount);
+        vm.prank(from);
+        stakeManager.deposit(who, amount);
+    }
+
+    function testDepositAndWithdraw() public {
+        _deposit(alice, alice, 10 ether);
+        assertEq(stakeManager.stakeOf(alice), 10 ether);
+
+        vm.prank(alice);
+        stakeManager.withdraw(alice, 4 ether);
+        assertEq(stakeManager.stakeOf(alice), 6 ether);
+        assertEq(stakeManager.pendingWithdrawals(alice), 4 ether);
+
+        vm.prank(alice);
+        uint256 claimed = stakeManager.claim();
+        assertEq(claimed, 4 ether);
+        assertEq(token.balanceOf(alice), 4 ether);
+    }
+
+    function testOperatorCanDepositForUser() public {
+        token.mint(operator, 5 ether);
+        vm.prank(operator);
+        token.approve(address(stakeManager), 5 ether);
+        vm.prank(operator);
+        stakeManager.deposit(alice, 5 ether);
+        assertEq(stakeManager.stakeOf(alice), 5 ether);
+    }
+
+    function testSlashQueuesWithdrawalForBeneficiary() public {
+        _deposit(alice, alice, 20 ether);
+        vm.prank(operator);
+        stakeManager.slash(alice, 2_000, employer, "policy_violation");
+
+        assertEq(stakeManager.stakeOf(alice), 16 ether);
+        assertEq(stakeManager.pendingWithdrawals(employer), 4 ether);
+
+        vm.prank(employer);
+        stakeManager.claim();
+        assertEq(token.balanceOf(employer), 4 ether);
+    }
+
+    function testCannotOverSlash() public {
+        _deposit(alice, alice, 1 ether);
+        vm.expectRevert(KernelStakeManager.InvalidBps.selector);
+        vm.prank(operator);
+        stakeManager.slash(alice, 20_000, employer, "over");
+    }
+}


### PR DESCRIPTION
## Summary
- add a governance-owned kernel configuration, staking manager, escrow vault, reward engine, validation module, and job registry implementing quorum-gated commit–reveal with policy-based slashing
- expose reward split governance controls and pull-payment staking withdrawals with beneficiary accounting and burn routing
- cover the new kernel contracts with Foundry tests for staking flows, reward splits, and validation pipelines

## Testing
- pnpm exec hardhat compile *(terminated due to long compile time)*
- pnpm exec forge test --match-path test/v2/kernel/* -vv *(fails: forge not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3f62d54483339e46064de699fc32