### PR TITLE
Prevent duplicate validators in kernel pipeline

### DIFF
--- a/contracts/v2/kernel/JobRegistry.sol
+++ b/contracts/v2/kernel/JobRegistry.sol
@@ -172,11 +172,15 @@ contract KernelJobRegistry is Ownable, ReentrancyGuard, IJobRegistryKernel {
         if (limit > 0 && active > limit) revert TooManyJobs();
 
         uint256 minValidatorStake = config.minValidatorStake();
-        for (uint256 i = 0; i < validators.length; i++) {
+        uint256 validatorCount = validators.length;
+        for (uint256 i = 0; i < validatorCount; i++) {
             address validator = validators[i];
             if (validator == address(0)) revert InvalidValidators();
             if (stakeManager.stakeOf(validator) < minValidatorStake) {
                 revert ValidatorStakeTooLow(validator);
+            }
+            for (uint256 j = 0; j < i; j++) {
+                if (validators[j] == validator) revert InvalidValidators();
             }
         }
 

--- a/test/v2/kernel/KernelPipeline.t.sol
+++ b/test/v2/kernel/KernelPipeline.t.sol
@@ -89,6 +89,35 @@ contract KernelPipelineTest is Test {
         ) = jobRegistry.jobs(jobId);
     }
 
+    function testCreateJobRevertsOnDuplicateValidators() public {
+        address[] memory duplicateValidators = new address[](2);
+        duplicateValidators[0] = validators[0];
+        duplicateValidators[1] = validators[0];
+
+        vm.expectRevert(KernelJobRegistry.InvalidValidators.selector);
+        vm.prank(employer);
+        jobRegistry.createJob(
+            agent,
+            duplicateValidators,
+            60 ether,
+            uint64(block.timestamp + 2 days),
+            keccak256("duplicate-validators")
+        );
+    }
+
+    function testCreateJobSucceedsWithUniqueValidatorsAfterDuplicateCheck() public {
+        vm.prank(employer);
+        uint256 jobId = jobRegistry.createJob(
+            agent,
+            validators,
+            70 ether,
+            uint64(block.timestamp + 2 days),
+            keccak256("unique-validators")
+        );
+
+        assertEq(jobRegistry.nextJobId(), jobId + 1);
+    }
+
     function testHappyPathValidationAndPayout() public {
         uint256 reward = 120 ether;
         uint64 deadline = uint64(block.timestamp + 3 days);


### PR DESCRIPTION
## Summary
- guard against duplicate validators during job creation and validation round configuration
- ensure the validation module persists only unique validator addresses
- add tests covering duplicate rejection and the unique validator happy path

## Testing
- `forge test --match-path test/v2/kernel/KernelPipeline.t.sol` *(fails: `forge` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5ee639848333b575e9a88ac7f2ca