### PR TITLE
Add owner control doctor CLI and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 - [Owner control playbook](#owner-control-playbook)
 - [Owner control blueprint](#owner-control-blueprint)
 - [Owner control command center](#owner-control-command-center)
+- [Owner control doctor](#owner-control-doctor)
 - [Owner control quick reference CLI](#owner-control-quick-reference-cli)
 - [Owner control zero-downtime guide](#owner-control-zero-downtime-guide)
 - [Owner control handbook](#owner-control-handbook)
@@ -215,6 +216,16 @@ Change managers who need a single-page, production-ready operating model can use
 ### Owner control command center
 
 Need a single, visualised briefing before making governance changes? The new [Owner Command Center](docs/owner-control-command-center.md) combines Mermaid journey maps, validation matrices, and step-by-step scenario playbooks so a non-technical contract owner can stage, approve, execute, and verify any parameter update with complete confidence. Pair it with `npm run owner:surface` for a baseline snapshot, then follow the mission map checklists to close the loop from diff preview to post-change artefacts.
+
+### Owner control doctor
+
+Before broadcasting any change, run the automated readiness sweep to surface missing addresses, invalid reward splits and unassigned guardians:
+
+```bash
+npm run owner:doctor -- --network <network>
+```
+
+Use `--strict` to fail on warnings inside CI and `--json` to feed dashboards or alerting bots. The command emits a severity-sorted punch list (with copy/paste remediation steps) so a non-technical operator can fix the highlighted configuration issues, rerun the doctor, and only proceed once the report is fully green. Full guidance, diagrams and automation patterns live in [docs/owner-control-doctor.md](docs/owner-control-doctor.md).
 
 ### Owner control quick reference CLI
 

--- a/docs/owner-control-doctor.md
+++ b/docs/owner-control-doctor.md
@@ -1,0 +1,133 @@
+# Owner Control Doctor
+
+> **Audience:** Contract owners, compliance teams and operations leads who need an
+> objective, automation-friendly readiness score before touching production.
+>
+> **Goal:** Continuously validate that every owner-editable parameter is wired,
+> non-zero and internally consistent before executing the update playbooks.
+
+---
+
+## Quick Start
+
+```bash
+# Human-friendly audit with severity ordering
+npm run owner:doctor -- --network <network>
+
+# Strict mode fails on warnings to gate CI pipelines
+npm run owner:doctor -- --network <network> --strict
+
+# Machine-readable JSON for dashboards or bots
+npm run owner:doctor -- --network <network> --json
+```
+
+> **Tip:** The `--network` flag resolves per-network overrides exactly like the
+> other owner helpers. Omit it when running against the default environment in
+> `.env`/Hardhat.
+
+---
+
+## What It Checks
+
+| Area                     | Validation Highlights                                                  | Why It Matters |
+| ------------------------ | ---------------------------------------------------------------------- | -------------- |
+| Owner control manifest   | Ensures every module exposes type, owner/governance targets & address. | Prevents tooling from skipping a contract due to missing metadata. |
+| Reward engine + thermostat | Verifies share splits sum to 100, contract wiring is non-zero, and PID bounds are sane. | Stops mispriced rewards and temperature drift pre-deployment. |
+| Energy oracle            | Confirms signer quorum is non-empty.                                   | Guards against stalled attestations. |
+| Job registry             | Validates dependency addresses, fee percentages and tax/treasury routing. | Avoids jobs executing against incomplete wiring. |
+| Stake manager            | Checks job registry linkage, pauser/thermostat wiring and staking thresholds. | Prevents slash routing issues and guarantees emergency controls. |
+| Fee pool                 | Confirms stake manager link, burn percentages and treasury/gov wiring. | Stops reward accrual from disappearing into the zero address. |
+
+> **Escalation policy:** Critical misconfigurations (missing addresses, broken
+> share totals) surface as **✖ failures**. Optional-but-important fields (like
+> treasury addresses) are **⚠ warnings**.
+
+---
+
+## Visual Overview
+
+```mermaid
+flowchart TD
+    subgraph Configs[Configuration Files]
+      OC[config/owner-control.json]
+      JD[config/job-registry.json]
+      SM[config/stake-manager.json]
+      FP[config/fee-pool.json]
+      TH[config/thermodynamics.json]
+      EO[config/energy-oracle.json]
+    end
+
+    subgraph Doctor[owner:doctor]
+      Parse[Static analysis]
+      Inspect[Cross-check invariants]
+      Report[Status + remediation]
+    end
+
+    OC --> Parse
+    JD --> Parse
+    SM --> Parse
+    FP --> Parse
+    TH --> Parse
+    EO --> Parse
+
+    Parse --> Inspect --> Report
+
+    Report -->|Human| CLI[Console summary]
+    Report -->|Machine| JSON[JSON output]
+```
+
+---
+
+## Reading the Output
+
+- **Summary header** – Shows pass/warn/fail counts and resolved networks.
+- **Per-config blocks** – Sorted with failures first. Each bullet explains the
+  issue and lists the exact field to edit.
+- **Suggested actions** – Copy/paste guidance for non-technical operators; feed
+  into tickets or runbooks.
+- **Exit codes** – `0` on success/warnings (unless `--strict`) and `1` when
+  failures are detected.
+
+### Sample (abbreviated)
+
+```
+AGIJobs owner control doctor (network: mainnet)
+Summary: 1 pass · 3 warn · 2 fail
+
+✖ Thermodynamics & reward engine configuration (config/thermodynamics.json)
+    - RewardEngine address is unset or zero.
+    - Thermostat contract address is unset.
+    Suggested actions:
+      • Set rewardEngine.address in config/thermodynamics.json to the deployed RewardEngine contract.
+      • Set thermostat.address to the deployed Thermostat contract.
+
+⚠ FeePool configuration (config/fee-pool.json)
+    - treasury defaults to zero; residual fees will burn.
+    Suggested actions:
+      • Assign fee-pool.treasury to the treasury wallet if dust should be captured.
+```
+
+Use the failed entries as a punch list: edit the referenced JSON file, rerun the
+doctor until only passes remain, then execute `npm run owner:update-all`.
+
+---
+
+## Embedding in Automation
+
+1. **Pre-commit hook** – Add `npm run owner:doctor -- --strict` to prevent
+   accidental commits with zero addresses.
+2. **Continuous delivery** – Run inside CI before broadcasting multisig bundles
+   so production pipelines halt on configuration drift.
+3. **Alerting** – Schedule the JSON mode hourly; diff the resulting payload to
+   alert operations whenever someone edits a config without broadcasting updates.
+
+---
+
+## Next Steps
+
+Once the doctor reports green across the board:
+
+1. Generate the latest control surface: `npm run owner:surface -- --network <network>`.
+2. Dry-run updates: `npm run owner:update-all -- --network <network>`.
+3. Execute with `--execute` once the plan matches expectations.
+4. Archive the doctor report alongside receipts for auditors.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "owner:wizard": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/owner-config-wizard.ts",
     "owner:dashboard": "npx hardhat run --no-compile scripts/v2/owner-dashboard.ts",
     "owner:diagram": "npx hardhat run --no-compile scripts/v2/renderOwnerMermaid.ts",
+    "owner:doctor": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlDoctor.ts",
     "owner:parameters": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerParameterMatrix.ts",
     "owner:mission-control": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerMissionControl.ts",
     "owner:verify-control": "npx hardhat run --no-compile scripts/v2/verifyOwnerControl.ts",

--- a/scripts/v2/ownerControlDoctor.ts
+++ b/scripts/v2/ownerControlDoctor.ts
@@ -1,0 +1,808 @@
+#!/usr/bin/env ts-node
+import path from 'path';
+import { ethers } from 'ethers';
+import {
+  loadOwnerControlConfig,
+  loadThermodynamicsConfig,
+  loadEnergyOracleConfig,
+  loadJobRegistryConfig,
+  loadStakeManagerConfig,
+  loadFeePoolConfig,
+} from '../config';
+import type {
+  OwnerControlModuleConfig,
+  RewardEngineThermoConfig,
+  ThermostatConfigInput,
+} from '../config';
+
+type Status = 'pass' | 'warn' | 'fail';
+
+type Severity = 'warn' | 'fail';
+
+interface CheckEntry {
+  id: string;
+  label: string;
+  status: Status;
+  path?: string;
+  details: string[];
+  actions: string[];
+  network?: string;
+}
+
+interface CliOptions {
+  network?: string;
+  json: boolean;
+  strict: boolean;
+  help?: boolean;
+}
+
+const STATUS_ORDER: Record<Status, number> = {
+  fail: 0,
+  warn: 1,
+  pass: 2,
+};
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    json: false,
+    strict: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--json':
+        options.json = true;
+        break;
+      case '--strict':
+      case '--fail-on-warn':
+        options.strict = true;
+        break;
+      case '--network': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--network requires a value');
+        }
+        options.network = value;
+        i += 1;
+        break;
+      }
+      default:
+        if (arg.startsWith('-')) {
+          throw new Error(`Unknown flag ${arg}`);
+        }
+    }
+  }
+
+  return options;
+}
+
+function createCheck(id: string, label: string, configPath?: string): CheckEntry {
+  return {
+    id,
+    label,
+    status: 'pass',
+    path: configPath,
+    details: [],
+    actions: [],
+  };
+}
+
+function escalateStatus(current: Status, severity: Severity): Status {
+  if (severity === 'fail') {
+    return 'fail';
+  }
+  return current === 'pass' ? 'warn' : current;
+}
+
+function registerIssue(
+  check: CheckEntry,
+  severity: Severity,
+  message: string,
+  action?: string
+): void {
+  check.status = escalateStatus(check.status, severity);
+  check.details.push(message);
+  if (action) {
+    check.actions.push(action);
+  }
+}
+
+function normaliseAddress(value?: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const text = String(value).trim();
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return ethers.getAddress(text);
+  } catch (_) {
+    return undefined;
+  }
+}
+
+function isZeroAddress(value?: unknown): boolean {
+  const address = normaliseAddress(value);
+  if (!address) {
+    return true;
+  }
+  return address === ethers.ZeroAddress;
+}
+
+function formatRelativePath(filePath?: string): string | undefined {
+  if (!filePath) {
+    return undefined;
+  }
+  return path.relative(process.cwd(), filePath);
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function asBigInt(value: unknown): bigint | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  try {
+    if (typeof value === 'bigint') {
+      return value;
+    }
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) {
+        return undefined;
+      }
+      return BigInt(Math.trunc(value));
+    }
+    const text = String(value).trim();
+    if (!text) {
+      return undefined;
+    }
+    return BigInt(text);
+  } catch (_) {
+    return undefined;
+  }
+}
+
+function evaluateOwnerControl(options: CliOptions, checks: CheckEntry[]): string | undefined {
+  const check = createCheck('owner-control', 'Owner control configuration');
+  let network: string | undefined;
+
+  try {
+    const result = loadOwnerControlConfig({ network: options.network });
+    network = result.network ?? network;
+    check.path = formatRelativePath(result.path);
+    check.network = result.network ?? undefined;
+
+    const { config } = result;
+    if (!config.owner) {
+      registerIssue(
+        check,
+        'warn',
+        'Default owner fallback is not configured.',
+        'Set "owner" in config/owner-control.json to the operational owner address.'
+      );
+    }
+    if (!config.governance) {
+      registerIssue(
+        check,
+        'warn',
+        'Default governance signer is not configured.',
+        'Set "governance" in config/owner-control.json to the timelock or multisig controller.'
+      );
+    }
+
+    const modules = (config.modules ?? {}) as Record<string, OwnerControlModuleConfig>;
+    const moduleKeys = Object.keys(modules);
+    if (moduleKeys.length === 0) {
+      registerIssue(
+        check,
+        'fail',
+        'No modules are defined under "modules"; owner tooling cannot discover contracts.',
+        'Populate config/owner-control.json with each deployed module under the "modules" key.'
+      );
+    }
+
+    for (const [key, entry] of Object.entries(modules)) {
+      const label = entry.label ?? key;
+      const moduleIssues: string[] = [];
+      let severity: Severity = 'warn';
+
+      if (!entry.type) {
+        moduleIssues.push('controller type missing');
+      } else {
+        const normalisedType = String(entry.type).trim().toLowerCase();
+        if (!['governable', 'ownable', 'ownable2step'].includes(normalisedType)) {
+          moduleIssues.push(`unsupported controller type "${entry.type}"`);
+          severity = 'fail';
+        }
+      }
+
+      if (!entry.address) {
+        moduleIssues.push('on-chain contract address not recorded');
+      }
+
+      if (!entry.owner && !entry.governance) {
+        moduleIssues.push('expected owner/governance target missing');
+      }
+
+      if (moduleIssues.length > 0) {
+        registerIssue(
+          check,
+          severity,
+          `Module ${label} (${key}): ${moduleIssues.join('; ')}.`,
+          `Update config/owner-control.json → modules.${key} with type, address, and controller targets.`
+        );
+      }
+    }
+
+    if (check.details.length === 0) {
+      check.details.push('All tracked modules expose owner/governance metadata.');
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    registerIssue(
+      check,
+      'fail',
+      `Failed to load owner-control configuration: ${message}`,
+      'Review config/owner-control.json for syntax or address errors.'
+    );
+  }
+
+  checks.push(check);
+  return network;
+}
+
+function evaluateThermodynamics(options: CliOptions, checks: CheckEntry[]): string | undefined {
+  const check = createCheck(
+    'thermodynamics',
+    'Thermodynamics & reward engine configuration'
+  );
+  let network: string | undefined;
+
+  try {
+    const result = loadThermodynamicsConfig({ network: options.network });
+    network = result.network ?? network;
+    check.path = formatRelativePath(result.path);
+    check.network = result.network ?? undefined;
+    const { config } = result;
+
+    const reward = config.rewardEngine as RewardEngineThermoConfig | undefined;
+    if (!reward) {
+      registerIssue(
+        check,
+        'fail',
+        'Reward engine section missing.',
+        'Add a rewardEngine block to config/thermodynamics.json with contract wiring and share splits.'
+      );
+    } else {
+      const shares = reward.roleShares ?? {};
+      const expectedRoles = ['agent', 'validator', 'operator', 'employer'];
+      const shareTotals: number[] = [];
+
+      for (const role of expectedRoles) {
+        const value = asNumber(shares[role]);
+        if (value === undefined) {
+          registerIssue(
+            check,
+            'fail',
+            `Missing roleShares.${role}; all four splits must be specified.`,
+            'Define roleShares for agent, validator, operator, and employer so they sum to 100%.'
+          );
+        } else {
+          shareTotals.push(value);
+          if (value < 0) {
+            registerIssue(
+              check,
+              'fail',
+              `roleShares.${role} is negative (${value}).`,
+              'Use non-negative integers that sum to 100.'
+            );
+          }
+        }
+      }
+
+      if (shareTotals.length === expectedRoles.length) {
+        const total = shareTotals.reduce((acc, value) => acc + value, 0);
+        if (Math.abs(total - 100) > 0.0001) {
+          registerIssue(
+            check,
+            'fail',
+            `roleShares total ${total} ≠ 100.`,
+            'Adjust roleShares to allocate exactly 100% across all roles.'
+          );
+        }
+      }
+
+      if (!reward.address) {
+        registerIssue(
+          check,
+          'fail',
+          'RewardEngine address is unset or zero.',
+          'Set rewardEngine.address in config/thermodynamics.json to the deployed RewardEngine contract.'
+        );
+      }
+
+      if (isZeroAddress(reward.treasury)) {
+        registerIssue(
+          check,
+          'warn',
+          'RewardEngine treasury defaults to the zero address (all residuals burned).',
+          'Point rewardEngine.treasury to the protocol treasury wallet if burns are not intended.'
+        );
+      }
+
+      if (isZeroAddress(reward.thermostat)) {
+        registerIssue(
+          check,
+          'fail',
+          'Thermostat controller address is unset.',
+          'Assign rewardEngine.thermostat to the Thermostat contract address before deployment.'
+        );
+      }
+    }
+
+    const thermostat = config.thermostat as ThermostatConfigInput | undefined;
+    if (!thermostat || Object.keys(thermostat).length === 0) {
+      registerIssue(
+        check,
+        'fail',
+        'Thermostat parameters are missing.',
+        'Provide a thermostat block in config/thermodynamics.json or config/thermostat.json.'
+      );
+    } else {
+      if (isZeroAddress(thermostat.address)) {
+        registerIssue(
+          check,
+          'fail',
+          'Thermostat contract address is unset.',
+          'Set thermostat.address to the deployed Thermostat contract.'
+        );
+      }
+
+      const bounds = thermostat.bounds ?? {};
+      const min = asBigInt(bounds.min);
+      const max = asBigInt(bounds.max);
+      const systemTemperature = asBigInt(thermostat.systemTemperature);
+
+      if (min !== undefined && max !== undefined && min > max) {
+        registerIssue(
+          check,
+          'fail',
+          `Thermostat bounds are inverted: min (${min}) > max (${max}).`,
+          'Ensure bounds.min ≤ bounds.max to avoid runtime reverts.'
+        );
+      }
+
+      if (
+        systemTemperature !== undefined &&
+        min !== undefined &&
+        max !== undefined &&
+        (systemTemperature < min || systemTemperature > max)
+      ) {
+        registerIssue(
+          check,
+          'warn',
+          `systemTemperature ${systemTemperature} sits outside the configured bounds (${min} – ${max}).`,
+          'Align systemTemperature with the thermostat bounds.'
+        );
+      }
+    }
+
+    if (check.details.length === 0) {
+      check.details.push('Reward engine and thermostat parameters satisfy baseline invariants.');
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    registerIssue(
+      check,
+      'fail',
+      `Failed to load thermodynamics configuration: ${message}`,
+      'Review config/thermodynamics.json for placeholder addresses or malformed values.'
+    );
+  }
+
+  checks.push(check);
+  return network;
+}
+
+function evaluateEnergyOracle(options: CliOptions, checks: CheckEntry[]): string | undefined {
+  const check = createCheck('energy-oracle', 'Energy oracle signer configuration');
+  let network: string | undefined;
+
+  try {
+    const result = loadEnergyOracleConfig({ network: options.network });
+    network = result.network ?? network;
+    check.path = formatRelativePath(result.path);
+    check.network = result.network ?? undefined;
+
+    const { config } = result;
+    const signers = config.signers ?? [];
+
+    if (signers.length === 0) {
+      registerIssue(
+        check,
+        'fail',
+        'No authorised energy oracle signers are configured.',
+        'Populate config/energy-oracle.json with the signer addresses responsible for attestations.'
+      );
+    }
+
+    if (signers.length > 0) {
+      check.details.push(`Configured signers: ${signers.length}.`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    registerIssue(
+      check,
+      'fail',
+      `Failed to load energy oracle configuration: ${message}`,
+      'Review config/energy-oracle.json for syntax issues.'
+    );
+  }
+
+  checks.push(check);
+  return network;
+}
+
+function evaluateJobRegistry(options: CliOptions, checks: CheckEntry[]): string | undefined {
+  const check = createCheck('job-registry', 'JobRegistry parameter configuration');
+  let network: string | undefined;
+
+  try {
+    const result = loadJobRegistryConfig({ network: options.network });
+    network = result.network ?? network;
+    check.path = formatRelativePath(result.path);
+    check.network = result.network ?? undefined;
+
+    const { config } = result;
+    if (isZeroAddress(config.identityRegistry)) {
+      registerIssue(
+        check,
+        'fail',
+        'identityRegistry address is missing.',
+        'Set job-registry.identityRegistry to the deployed IdentityRegistry contract.'
+      );
+    }
+    if (isZeroAddress(config.validationModule)) {
+      registerIssue(
+        check,
+        'fail',
+        'validationModule address is missing.',
+        'Set job-registry.validationModule to the deployed ValidationModule contract.'
+      );
+    }
+    if (isZeroAddress(config.stakeManager)) {
+      registerIssue(
+        check,
+        'fail',
+        'stakeManager address is missing.',
+        'Set job-registry.stakeManager to the deployed StakeManager contract.'
+      );
+    }
+    if (isZeroAddress(config.feePool)) {
+      registerIssue(
+        check,
+        'warn',
+        'feePool address defaults to zero; protocol fees will burn by default.',
+        'Set job-registry.feePool to the deployed FeePool contract to route fees.'
+      );
+    }
+    if (isZeroAddress(config.taxPolicy)) {
+      registerIssue(
+        check,
+        'warn',
+        'taxPolicy is zero, disabling tax collection.',
+        'Assign job-registry.taxPolicy if tax routing is required.'
+      );
+    }
+
+    const feePct = asNumber((config as Record<string, unknown>).feePct);
+    if (feePct === undefined || feePct < 0 || feePct > 100) {
+      registerIssue(
+        check,
+        'warn',
+        `feePct ${feePct ?? 'undefined'} is outside the 0-100 range.`,
+        'Tune job-registry.feePct to a percentage between 0 and 100.'
+      );
+    }
+
+    if (check.details.length === 0) {
+      check.details.push('JobRegistry dependencies and fees look consistent.');
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    registerIssue(
+      check,
+      'fail',
+      `Failed to load job-registry configuration: ${message}`,
+      'Review config/job-registry.json for missing fields or malformed addresses.'
+    );
+  }
+
+  checks.push(check);
+  return network;
+}
+
+function evaluateStakeManager(options: CliOptions, checks: CheckEntry[]): string | undefined {
+  const check = createCheck('stake-manager', 'StakeManager configuration');
+  let network: string | undefined;
+
+  try {
+    const result = loadStakeManagerConfig({ network: options.network });
+    network = result.network ?? network;
+    check.path = formatRelativePath(result.path);
+    check.network = result.network ?? undefined;
+
+    const { config } = result;
+    if (isZeroAddress(config.jobRegistry)) {
+      registerIssue(
+        check,
+        'fail',
+        'jobRegistry address is missing.',
+        'Set stake-manager.jobRegistry to the deployed JobRegistry contract.'
+      );
+    }
+    if (isZeroAddress(config.feePool)) {
+      registerIssue(
+        check,
+        'warn',
+        'feePool address is zero; slashed funds cannot be forwarded.',
+        'Set stake-manager.feePool to the FeePool contract to route slashes.'
+      );
+    }
+    if (isZeroAddress(config.pauser)) {
+      registerIssue(
+        check,
+        'warn',
+        'pauser is zero, preventing emergency pause delegation.',
+        'Assign stake-manager.pauser to the pause guardian or SystemPause contract.'
+      );
+    }
+    if (isZeroAddress(config.thermostat)) {
+      registerIssue(
+        check,
+        'warn',
+        'thermostat address is zero; auto-stake feedback will be disabled.',
+        'Set stake-manager.thermostat to the Thermostat contract for adaptive staking.'
+      );
+    }
+
+    const minStake = asBigInt((config as Record<string, unknown>).minStakeTokens);
+    if (minStake !== undefined && minStake <= 0n) {
+      registerIssue(
+        check,
+        'warn',
+        `minStakeTokens is ${minStake}; agents can join with zero stake.`,
+        'Set minStakeTokens to a positive quantity that enforces skin-in-the-game.'
+      );
+    }
+
+    if (check.details.length === 0) {
+      check.details.push('StakeManager parameters and wiring appear complete.');
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    registerIssue(
+      check,
+      'fail',
+      `Failed to load stake-manager configuration: ${message}`,
+      'Review config/stake-manager.json for missing fields or malformed addresses.'
+    );
+  }
+
+  checks.push(check);
+  return network;
+}
+
+function evaluateFeePool(options: CliOptions, checks: CheckEntry[]): string | undefined {
+  const check = createCheck('fee-pool', 'FeePool configuration');
+  let network: string | undefined;
+
+  try {
+    const result = loadFeePoolConfig({ network: options.network });
+    network = result.network ?? network;
+    check.path = formatRelativePath(result.path);
+    check.network = result.network ?? undefined;
+
+    const { config } = result;
+    if (isZeroAddress(config.stakeManager)) {
+      registerIssue(
+        check,
+        'fail',
+        'stakeManager address is missing; rewards cannot settle.',
+        'Set fee-pool.stakeManager to the deployed StakeManager contract.'
+      );
+    }
+    if (isZeroAddress(config.treasury)) {
+      registerIssue(
+        check,
+        'warn',
+        'treasury defaults to zero; residual fees will burn.',
+        'Assign fee-pool.treasury to the treasury wallet if dust should be captured.'
+      );
+    }
+    if (isZeroAddress(config.governance)) {
+      registerIssue(
+        check,
+        'warn',
+        'governance is zero; only the owner can tune parameters.',
+        'Set fee-pool.governance to the multisig or timelock responsible for updates.'
+      );
+    }
+    if (isZeroAddress(config.pauser)) {
+      registerIssue(
+        check,
+        'warn',
+        'pauser is zero; FeePool cannot be paused independently.',
+        'Assign fee-pool.pauser to SystemPause or a dedicated guardian.'
+      );
+    }
+
+    const burnPct = asNumber((config as Record<string, unknown>).burnPct);
+    if (burnPct === undefined || burnPct < 0 || burnPct > 100) {
+      registerIssue(
+        check,
+        'warn',
+        `burnPct ${burnPct ?? 'undefined'} is outside 0-100.`,
+        'Configure fee-pool.burnPct within the inclusive 0-100 range.'
+      );
+    }
+
+    if (check.details.length === 0) {
+      check.details.push('FeePool wiring and split percentages look sane.');
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    registerIssue(
+      check,
+      'fail',
+      `Failed to load fee-pool configuration: ${message}`,
+      'Review config/fee-pool.json for missing fields or malformed addresses.'
+    );
+  }
+
+  checks.push(check);
+  return network;
+}
+
+function formatHuman(checks: CheckEntry[], options: CliOptions, networks: string[]): void {
+  const pass = checks.filter((entry) => entry.status === 'pass').length;
+  const warn = checks.filter((entry) => entry.status === 'warn').length;
+  const fail = checks.filter((entry) => entry.status === 'fail').length;
+  const headerNetwork = networks.length > 0 ? networks.join(', ') : 'auto';
+
+  console.log(`AGIJobs owner control doctor (network: ${headerNetwork})`);
+  console.log(`Summary: ${pass} pass · ${warn} warn · ${fail} fail`);
+  console.log('');
+
+  const sorted = [...checks].sort((a, b) => {
+    const severity = STATUS_ORDER[a.status] - STATUS_ORDER[b.status];
+    if (severity !== 0) {
+      return severity;
+    }
+    return a.label.localeCompare(b.label);
+  });
+
+  for (const entry of sorted) {
+    const symbol = entry.status === 'pass' ? '✓' : entry.status === 'warn' ? '⚠' : '✖';
+    const location = entry.path ? ` (${entry.path})` : '';
+    console.log(`${symbol} ${entry.label}${location}`);
+    if (entry.details.length > 0) {
+      for (const detail of entry.details) {
+        console.log(`    - ${detail}`);
+      }
+    }
+    if (entry.actions.length > 0) {
+      console.log('    Suggested actions:');
+      for (const action of entry.actions) {
+        console.log(`      • ${action}`);
+      }
+    }
+    console.log('');
+  }
+
+  if (fail > 0) {
+    console.log('❗ One or more checks failed. Address the issues above before production deployment.');
+  } else if (warn > 0) {
+    console.log(
+      options.strict
+        ? '⚠ Warnings treated as failures via --strict. Resolve them before proceeding.'
+        : '⚠ Warnings detected. Review them to confirm they are intentional.'
+    );
+  } else {
+    console.log('All owner-facing configuration looks production ready.');
+  }
+}
+
+function formatJson(checks: CheckEntry[], networks: string[]): void {
+  const payload = {
+    summary: {
+      pass: checks.filter((entry) => entry.status === 'pass').length,
+      warn: checks.filter((entry) => entry.status === 'warn').length,
+      fail: checks.filter((entry) => entry.status === 'fail').length,
+      networks,
+    },
+    checks,
+  };
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+async function main(): Promise<void> {
+  let options: CliOptions;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.help) {
+    console.log(`Usage: ts-node ownerControlDoctor.ts [--network <network>] [--json] [--strict]\n`);
+    console.log('Checks production readiness of owner-editable configuration files.');
+    console.log('--network <name>  Hardhat network name or chain ID to resolve per-network overrides.');
+    console.log('--json            Emit machine-readable JSON instead of human output.');
+    console.log('--strict          Exit with code 1 when warnings are present.');
+    return;
+  }
+
+  const checks: CheckEntry[] = [];
+  const networks: Set<string> = new Set();
+
+  const ownerNetwork = evaluateOwnerControl(options, checks);
+  if (ownerNetwork) {
+    networks.add(ownerNetwork);
+  }
+  const thermoNetwork = evaluateThermodynamics(options, checks);
+  if (thermoNetwork) {
+    networks.add(thermoNetwork);
+  }
+  const energyNetwork = evaluateEnergyOracle(options, checks);
+  if (energyNetwork) {
+    networks.add(energyNetwork);
+  }
+  const jobNetwork = evaluateJobRegistry(options, checks);
+  if (jobNetwork) {
+    networks.add(jobNetwork);
+  }
+  const stakeNetwork = evaluateStakeManager(options, checks);
+  if (stakeNetwork) {
+    networks.add(stakeNetwork);
+  }
+  const feeNetwork = evaluateFeePool(options, checks);
+  if (feeNetwork) {
+    networks.add(feeNetwork);
+  }
+
+  const hasFail = checks.some((entry) => entry.status === 'fail');
+  const hasWarn = checks.some((entry) => entry.status === 'warn');
+
+  if (options.json) {
+    formatJson(checks, Array.from(networks));
+  } else {
+    formatHuman(checks, options, Array.from(networks));
+  }
+
+  if (hasFail || (options.strict && hasWarn)) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add an owner configuration "doctor" CLI that audits core JSON modules and highlights missing wiring before governance changes
- document the workflow, automation patterns, and diagrams for the doctor command and reference it from the README
- expose the helper via `npm run owner:doctor` so non-technical operators can run readiness checks from scripts

## Testing
- npm run owner:doctor -- --network mainnet *(fails as expected because placeholder configs trigger validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68dc65a9a06483338b292b1573094c81