### PR TITLE
Emit quorum failure event and fix kernel validator loop

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1401,6 +1401,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         if (quorumTarget == 0 || r.revealedCount >= quorumTarget) {
             return _finalize(jobId);
         }
+        emit ValidationQuorumFailed(jobId, r.revealedCount, quorumTarget);
         r.earlyFinalizeEligibleAt = 0;
 
         IJobRegistry.Job memory job = jobRegistry.jobs(jobId);
@@ -1497,6 +1498,9 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
                 unchecked { ++approvalCount; }
             }
             unchecked { ++i; }
+        }
+        if (!quorum && quorumTarget > 0) {
+            emit ValidationQuorumFailed(jobId, r.revealedCount, quorumTarget);
         }
         if (quorum && total > 0) {
             bool thresholdMet =

--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -32,6 +32,11 @@ interface IValidationModule {
         uint256 rejections
     );
     event ValidationResult(uint256 indexed jobId, bool success);
+    event ValidationQuorumFailed(
+        uint256 indexed jobId,
+        uint256 revealed,
+        uint256 quorumTarget
+    );
     event ValidatorSubdomainUpdated(address indexed validator, string subdomain);
     event SelectionStrategyUpdated(SelectionStrategy strategy);
     event ParametersUpdated(

--- a/contracts/v2/kernel/JobRegistry.sol
+++ b/contracts/v2/kernel/JobRegistry.sol
@@ -199,9 +199,9 @@ contract KernelJobRegistry is Ownable, ReentrancyGuard, IJobRegistryKernel {
         });
         activeJobs[agent] = active;
 
-        uint256 validatorCount = validators.length;
+        uint256 validatorTotal = validators.length;
         address[] storage storedValidators = jobValidators[jobId];
-        for (uint256 i = 0; i < validatorCount; i++) {
+        for (uint256 i = 0; i < validatorTotal; i++) {
             storedValidators.push(validators[i]);
         }
 

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -448,7 +448,9 @@ describe('ValidationModule finalize flows', function () {
     await validation.connect(v3).commitValidation(1, commit3, '', []);
     await advance(61); // end commit
     await advance(61 + 3600 + 1); // end reveal + grace
-    await validation.forceFinalize(1);
+    await expect(validation.forceFinalize(1))
+      .to.emit(validation, 'ValidationQuorumFailed')
+      .withArgs(1, 0, 3n);
     await jobRegistry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await jobRegistry.connect(employer).finalize(1);
     const job = enrichJob(await jobRegistry.jobs(1));
@@ -490,7 +492,10 @@ describe('ValidationModule finalize flows', function () {
     const beforeV4 = await stakeManager.stakeOf(v4.address, 1);
     await advance(61); // end commit
     await advance(61 + 3600 + 1); // end reveal + grace
-    await validation.forceFinalize(1);
+    const expectedQuorum = await validation.minRevealValidators();
+    await expect(validation.forceFinalize(1))
+      .to.emit(validation, 'ValidationQuorumFailed')
+      .withArgs(1, 0, expectedQuorum);
     await jobRegistry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await jobRegistry.connect(employer).finalize(1);
     const isV4Selected = chosen.includes(v4.address);


### PR DESCRIPTION
## Summary
- add a ValidationQuorumFailed event to the validation interface and emit it when quorum is missed during finalize or forceFinalize
- update quorum-related tests to expect the new event for insufficient reveal cases
- resolve duplicate variable declarations in the kernel JobRegistry validator loop

## Testing
- npx hardhat test --no-compile --grep "force finalize only slashes selected validators" test/v2/ValidationModuleFlow.test.js
- npx hardhat test --no-compile --grep "allows force finalize" test/v2/ValidationModuleFlow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc76fb71388333a0901eb19ca69c7b