### PR TITLE
Allow validation module validator slashing

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -1226,6 +1226,16 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         _;
     }
 
+    modifier onlySlasher(Role role) {
+        address sender = msg.sender;
+        if (sender != jobRegistry) {
+            if (role != Role.Validator || sender != address(validationModule)) {
+                revert OnlyJobRegistry();
+            }
+        }
+        _;
+    }
+
     modifier onlyDisputeModule() {
         if (msg.sender != disputeModule) revert OnlyDisputeModule();
         _;
@@ -2043,7 +2053,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @param employer recipient of the employer share
     function slash(address user, Role role, uint256 amount, address employer)
         external
-        onlyJobRegistry
+        onlySlasher(role)
         whenNotPaused
         nonReentrant
     {
@@ -2053,7 +2063,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     function slash(address user, Role role, uint256 amount, address employer, address[] calldata validators)
         external
-        onlyJobRegistry
+        onlySlasher(role)
         whenNotPaused
         nonReentrant
     {


### PR DESCRIPTION
## Summary
- allow StakeManager validator slashing to accept calls from the wired ValidationModule
- add an integration test that wires the real StakeManager and ensures finalize reduces validator stake

## Testing
- `npx hardhat test test/v2/ValidationModule.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68dc7e707e248333b2d0bb9ec62d18c7