### PR TITLE
Allow validation module to slash validators

### DIFF
--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -1241,6 +1241,12 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         _;
     }
 
+    modifier onlyValidatorSlasher() {
+        address sender = msg.sender;
+        if (sender != disputeModule && sender != address(validationModule)) revert Unauthorized();
+        _;
+    }
+
     /// @notice lock a portion of a user's stake for a period of time
     /// @param user address whose stake is being locked
     /// @param amount token amount with 18 decimals
@@ -2111,7 +2117,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @param recipient address receiving the slashed share
     function slash(address user, uint256 amount, address recipient)
         external
-        onlyDisputeModule
+        onlyValidatorSlasher
         whenNotPaused
         nonReentrant
     {
@@ -2121,7 +2127,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
 
     function slash(address user, uint256 amount, address recipient, address[] calldata validators)
         external
-        onlyDisputeModule
+        onlyValidatorSlasher
         whenNotPaused
         nonReentrant
     {


### PR DESCRIPTION
## Summary
- add an `onlyValidatorSlasher` modifier so validator slashing can be invoked by the dispute or validation module
- protect the validator slash entrypoints with the new modifier
- expand the StakeManager slashing tests to cover a validation module initiated slash and update expectations for validator share math

## Testing
- npx hardhat test test/v2/StakeManagerSlashing.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc876a98ac8333887c6283ba4a06df