### PR TITLE
Add escrow redistribution for slashing outcomes

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -42,6 +42,8 @@ contract MockStakeManager is IStakeManager {
     function lock(address, uint256) external override {}
     function releaseReward(bytes32, address, address, uint256, bool) external override {}
     function refundEscrow(bytes32, address, uint256) external override {}
+    function redistributeEscrow(bytes32, address, uint256) external override {}
+    function redistributeEscrow(bytes32, address, uint256, address[] calldata) external override {}
     function releaseStake(address, uint256) external override {}
     function release(address, address, uint256, bool) external override {}
     function finalizeJobFunds(
@@ -93,6 +95,10 @@ contract MockStakeManager is IStakeManager {
         validatorSlashRewardPctValue = pct;
     }
     function setSlashingDistribution(uint256, uint256, uint256 pct) external override {
+        validatorSlashRewardPctValue = pct;
+    }
+    function setOperatorSlashPct(uint256) external override {}
+    function setSlashDistribution(uint256, uint256, uint256, uint256 pct) external override {
         validatorSlashRewardPctValue = pct;
     }
     function validatorSlashRewardPct() external view override returns (uint256) {

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -2304,10 +2304,11 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
                     fundsRedirected = true;
                 }
                 if (job.reward > 0) {
-                    stakeManager.refundEscrow(
+                    stakeManager.redistributeEscrow(
                         jobKey,
                         recipient,
-                        uint256(job.reward) + fee
+                        uint256(job.reward) + fee,
+                        validators
                     );
                 }
                 if (job.stake > 0) {
@@ -2452,7 +2453,8 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             uint256 fee = (uint256(reward) * feePctSnapshot) / 100;
             uint256 totalRefund = uint256(reward) + fee;
             if (totalRefund > 0) {
-                stakeManager.refundEscrow(jobKey, employer, totalRefund);
+                address[] memory validators = new address[](0);
+                stakeManager.redistributeEscrow(jobKey, employer, totalRefund, validators);
             }
             if (stakeAmount > 0 && agent != address(0)) {
                 stakeManager.slash(

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -38,6 +38,16 @@ interface IStakeManager {
         uint256 treasuryShare,
         uint256 burnShare
     );
+    event EscrowPenaltyApplied(
+        bytes32 indexed jobId,
+        address indexed recipient,
+        uint256 amount,
+        uint256 employerShare,
+        uint256 treasuryShare,
+        uint256 operatorShare,
+        uint256 validatorShare,
+        uint256 burnShare
+    );
     /// @notice Emitted when stake is slashed from a participant.
     /// @param agent Address whose stake was reduced.
     /// @param amount Total amount slashed from the agent.
@@ -56,7 +66,15 @@ interface IStakeManager {
     event ModulesUpdated(address jobRegistry, address disputeModule);
     event MinStakeUpdated(uint256 minStake);
     event SlashingPercentagesUpdated(uint256 employerSlashPct, uint256 treasurySlashPct);
+    event OperatorSlashPctUpdated(uint256 operatorSlashPct);
     event ValidatorSlashRewardPctUpdated(uint256 validatorSlashRewardPct);
+    event SlashDistributionUpdated(
+        uint256 employerSlashPct,
+        uint256 treasurySlashPct,
+        uint256 operatorSlashPct,
+        uint256 validatorSlashRewardPct
+    );
+    event OperatorSlashShareAllocated(address indexed user, Role indexed role, uint256 amount);
     event TreasuryUpdated(address indexed treasury);
     event TreasuryAllowlistUpdated(address indexed treasury, bool allowed);
     event MaxStakePerAddressUpdated(uint256 maxStake);
@@ -131,6 +149,17 @@ interface IStakeManager {
 
     /// @notice refund escrowed funds without fees or burns
     function refundEscrow(bytes32 jobId, address to, uint256 amount) external;
+
+    /// @notice redistribute escrowed funds according to the configured slash distribution
+    function redistributeEscrow(bytes32 jobId, address recipient, uint256 amount) external;
+
+    /// @notice redistribute escrowed funds with validator weighting
+    function redistributeEscrow(
+        bytes32 jobId,
+        address recipient,
+        uint256 amount,
+        address[] calldata validators
+    ) external;
 
     /// @notice release previously locked stake for a user
     function releaseStake(address user, uint256 amount) external;
@@ -243,6 +272,15 @@ interface IStakeManager {
         uint256 _treasurySlashPct,
         uint256 _validatorSlashPct
     ) external;
+
+    function setOperatorSlashPct(uint256 _operatorSlashPct) external;
+
+    function setSlashDistribution(
+        uint256 _employerSlashPct,
+        uint256 _treasurySlashPct,
+        uint256 _operatorSlashPct,
+        uint256 _validatorSlashPct
+    ) external;
     function setTreasury(address _treasury) external;
     function setTreasuryAllowlist(address _treasury, bool allowed) external;
     function setMaxStakePerAddress(uint256 maxStake) external;
@@ -294,4 +332,3 @@ interface IStakeManager {
     /// @dev Returns 100 when the user holds no approved NFTs.
     function getTotalPayoutPct(address user) external view returns (uint256);
 }
-

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -43,6 +43,8 @@ contract ReentrantStakeManager is IStakeManager {
     function lock(address, uint256) external override {}
     function releaseReward(bytes32, address, address, uint256, bool) external override {}
     function refundEscrow(bytes32, address, uint256) external override {}
+    function redistributeEscrow(bytes32, address, uint256) external override {}
+    function redistributeEscrow(bytes32, address, uint256, address[] calldata) external override {}
     function releaseStake(address, uint256) external override {}
     function release(address, address, uint256, bool) external override {}
     function finalizeJobFunds(
@@ -88,6 +90,10 @@ contract ReentrantStakeManager is IStakeManager {
         validatorSlashRewardPctValue = pct;
     }
     function setSlashingDistribution(uint256, uint256, uint256 pct) external override {
+        validatorSlashRewardPctValue = pct;
+    }
+    function setOperatorSlashPct(uint256) external override {}
+    function setSlashDistribution(uint256, uint256, uint256, uint256 pct) external override {
         validatorSlashRewardPctValue = pct;
     }
     function autoTuneStakes(bool) external override {}


### PR DESCRIPTION
## Summary
- add reusable slash helpers in `StakeManager` so failed jobs can redistribute escrow to employers, treasury, validators, and the operator pool
- expose the new `redistributeEscrow` API through the stake manager interface/mocks and call it from `JobRegistry` timeout/failure paths
- extend the slashing test suite to assert escrow penalties and validator payouts for multi-validator scenarios

## Testing
- npx hardhat test test/v2/StakeManagerSlashing.test.js test/v2/StakeManager.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc8ae1c5708333b37c5146ddb698b6