### PR TITLE
Configure validator approval supermajority defaults

### DIFF
--- a/contracts/v2/interfaces/IValidationModule.sol
+++ b/contracts/v2/interfaces/IValidationModule.sol
@@ -143,6 +143,9 @@ interface IValidationModule {
     /// @notice Update approval threshold percentage
     function setApprovalThreshold(uint256 pct) external;
 
+    /// @notice Toggle automatic tracking of the supermajority approval target.
+    function setAutoApprovalTarget(bool enabled) external;
+
     /// @notice Update percentage of stake slashed for incorrect validator votes
     function setValidatorSlashingPct(uint256 pct) external;
 

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -90,6 +90,8 @@ contract ValidationStub is IValidationModule {
 
     function setApprovalThreshold(uint256) external override {}
 
+    function setAutoApprovalTarget(bool) external override {}
+
     function setValidatorSlashingPct(uint256) external override {}
 
     function setNonRevealPenalty(uint256, uint256) external override {}

--- a/contracts/v2/modules/NoValidationModule.sol
+++ b/contracts/v2/modules/NoValidationModule.sol
@@ -126,6 +126,9 @@ contract NoValidationModule is IValidationModule, Ownable {
     function setApprovalThreshold(uint256) external pure override {}
 
     /// @inheritdoc IValidationModule
+    function setAutoApprovalTarget(bool) external pure override {}
+
+    /// @inheritdoc IValidationModule
     function setValidatorSlashingPct(uint256) external pure override {}
 
     /// @inheritdoc IValidationModule

--- a/contracts/v2/modules/OracleValidationModule.sol
+++ b/contracts/v2/modules/OracleValidationModule.sol
@@ -149,6 +149,9 @@ contract OracleValidationModule is IValidationModule, Ownable {
     function setApprovalThreshold(uint256) external pure override {}
 
     /// @inheritdoc IValidationModule
+    function setAutoApprovalTarget(bool) external pure override {}
+
+    /// @inheritdoc IValidationModule
     function setValidatorSlashingPct(uint256) external pure override {}
 
     /// @inheritdoc IValidationModule

--- a/test/v2/ValidationModuleApprovals.test.js
+++ b/test/v2/ValidationModuleApprovals.test.js
@@ -22,6 +22,20 @@ describe('ValidationModule required approvals', function () {
     await validation.waitForDeployment();
   });
 
+  it('defaults to automatic supermajority approvals', async () => {
+    expect(await validation.autoApprovalTarget()).to.equal(true);
+    expect(await validation.requiredValidatorApprovals()).to.equal(3n);
+
+    await validation.connect(owner).setValidatorsPerJob(4);
+    expect(await validation.requiredValidatorApprovals()).to.equal(3n);
+
+    await validation.connect(owner).setApprovalThreshold(75);
+    expect(await validation.requiredValidatorApprovals()).to.equal(3n);
+
+    await validation.connect(owner).setApprovalThreshold(80);
+    expect(await validation.requiredValidatorApprovals()).to.equal(4n);
+  });
+
   it('reverts for invalid counts', async () => {
     await expect(
       validation.connect(owner).setRequiredValidatorApprovals(0)
@@ -34,6 +48,7 @@ describe('ValidationModule required approvals', function () {
   it('updates and clamps to committee size', async () => {
     await validation.connect(owner).setRequiredValidatorApprovals(2);
     expect(await validation.requiredValidatorApprovals()).to.equal(2n);
+    expect(await validation.autoApprovalTarget()).to.equal(false);
 
     await validation.connect(owner).setRequiredValidatorApprovals(4);
     expect(await validation.requiredValidatorApprovals()).to.equal(3n);
@@ -43,6 +58,10 @@ describe('ValidationModule required approvals', function () {
     expect(await validation.requiredValidatorApprovals()).to.equal(4n);
 
     await validation.connect(owner).setValidatorsPerJob(3);
+    expect(await validation.requiredValidatorApprovals()).to.equal(3n);
+
+    await validation.connect(owner).setAutoApprovalTarget(true);
+    expect(await validation.autoApprovalTarget()).to.equal(true);
     expect(await validation.requiredValidatorApprovals()).to.equal(3n);
   });
 });


### PR DESCRIPTION
## Summary
- default the validation module to a 67% supermajority threshold and quorum, automatically syncing required approvals with committee size
- expose governance controls to toggle the automatic approval target and emit new telemetry for configuration changes
- update validation module interfaces, mocks, and tests to cover the new approval targeting behaviour

## Testing
- npx hardhat test test/v2/ValidationModuleApprovals.test.js --no-compile

------
https://chatgpt.com/codex/tasks/task_e_68dc9bc77cc083339cb57f546fc67909