### PR TITLE
feat: support validator challenge responses

### DIFF
--- a/config/contracts.orchestrator.json
+++ b/config/contracts.orchestrator.json
@@ -74,6 +74,7 @@
     "abi": [
       "function raiseDispute(uint256 jobId, address claimant, bytes32 evidenceHash, string reason)",
       "function raiseGovernanceDispute(uint256 jobId, string reason)",
+      "function submitEvidence(uint256 jobId, bytes32 evidenceHash, string uri)",
       "function disputes(uint256 jobId) view returns (address claimant,uint256 raisedAt,bool resolved,uint256 fee,bytes32 evidenceHash,string reason)",
       "function disputeFee() view returns (uint256)"
     ]

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -17,6 +17,12 @@ interface IDisputeModule {
 
     function resolveDispute(uint256 jobId, bool employerWins) external;
 
+    function submitEvidence(
+        uint256 jobId,
+        bytes32 evidenceHash,
+        string calldata uri
+    ) external;
+
     function slashValidator(
         address juror,
         uint256 amount,

--- a/docs/disputes.md
+++ b/docs/disputes.md
@@ -12,3 +12,13 @@ Governance can deploy this contract and activate it via
 arbitration service such as Kleros and expects the arbitrator to call
 back with the final ruling. Once a ruling is returned the job is
 finalised and escrowed funds are distributed according to the decision.
+
+## Evidence workflow
+
+During an active dispute any job participant or validator assigned to the
+committee can broadcast supplemental evidence using
+`DisputeModule.submitEvidence`. The function only emits the
+`EvidenceSubmitted` event so that log indexers (subgraph, monitoring, and the
+DAO) can review counter-claims without incurring additional storage costs. The
+validator CLI exposes this via `validator-cli challenge respond <jobId>` which
+either publishes a keccak256 hash for off-chain blobs or an inline URI/summary.

--- a/docs/governance/emergency-runbook.md
+++ b/docs/governance/emergency-runbook.md
@@ -48,7 +48,10 @@ Validators can use `scripts/validator/cli.ts` to:
 - deposit or withdraw validator stake,
 - commit and reveal votes with automatic hash generation and
   deadline warnings, and
-- raise or inspect disputes ("challenges") when job results are contested.
+- raise, respond to, or inspect disputes ("challenges") when job results are
+  contested. The new `challenge respond` command emits an on-chain evidence
+  event so arbitrators and the community can review counter-claims during an
+  incident.
 
 The CLI reads the same configuration JSON as the orchestrator tooling and will
 emit warnings if a reveal is attempted before the commit window closes.


### PR DESCRIPTION
## Summary
- add `submitEvidence` support to the dispute module and expose it through the interface/ABI so validators can respond on-chain
- extend the validator CLI with a `challenge respond` flow that verifies dispute status before calling the new helper
- document the evidence workflow and update the emergency runbook to highlight the new CLI capability

## Testing
- `npx eslint scripts/validator/cli.ts`
- `npx hardhat compile --quiet` *(fails: repository currently contains Solidity constructs that require Cancun support and abstract stubs)*

------
https://chatgpt.com/codex/tasks/task_e_68dca59206b48333bafefa0777da3b2d