### PR TITLE
Add explicit SystemPause pauser refresh flow

### DIFF
--- a/contracts/v2/SystemPause.sol
+++ b/contracts/v2/SystemPause.sol
@@ -146,17 +146,6 @@ contract SystemPause is Governable, ReentrancyGuard {
             address(_arbitratorCommittee).code.length == 0
         ) revert InvalidArbitratorCommittee(address(_arbitratorCommittee));
 
-        _requireModuleOwnership(
-            _jobRegistry,
-            _stakeManager,
-            _validationModule,
-            _disputeModule,
-            _platformRegistry,
-            _feePool,
-            _reputationEngine,
-            _arbitratorCommittee
-        );
-
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
         validationModule = _validationModule;
@@ -165,7 +154,6 @@ contract SystemPause is Governable, ReentrancyGuard {
         feePool = _feePool;
         reputationEngine = _reputationEngine;
         arbitratorCommittee = _arbitratorCommittee;
-        _setPausers();
         emit ModulesUpdated(
             address(_jobRegistry),
             address(_stakeManager),
@@ -176,6 +164,23 @@ contract SystemPause is Governable, ReentrancyGuard {
             address(_reputationEngine),
             address(_arbitratorCommittee)
         );
+    }
+
+    /// @notice Re-assign SystemPause as the pauser for all managed modules.
+    /// @dev Requires ownership of each module to have been transferred to this contract.
+    function refreshPausers() external onlyGovernance {
+        _requireModuleOwnership(
+            jobRegistry,
+            stakeManager,
+            validationModule,
+            disputeModule,
+            platformRegistry,
+            feePool,
+            reputationEngine,
+            arbitratorCommittee
+        );
+
+        _setPausers();
     }
 
     /// @notice Pause all core modules.

--- a/docs/production-deployment-handbook.md
+++ b/docs/production-deployment-handbook.md
@@ -115,6 +115,10 @@ boundaries within minutes.
 1. Rotate ownership with `npm run owner:rotate -- --network <network> --safe owner-rotation.json --safe-name "AGIJobs Governance Rotation"`.
 2. Multisig signers review the generated Safe bundle; broadcast once unanimously approved.
 3. Confirm success via `npm run owner:verify-control -- --network <network>`.
+4. When each module lists `SystemPause` as owner/governance, execute
+   `SystemPause.refreshPausers()` (for example via
+   `npx hardhat run scripts/v2/updateSystemPause.ts --network <network> --refresh --execute`)
+   so the pause helper regains pauser rights before the next incident drill.
 
 ### Step 4 – Monitoring Enablement
 

--- a/docs/system-pause.md
+++ b/docs/system-pause.md
@@ -1,8 +1,12 @@
 # System Pause
 
 `SystemPause` lets governance halt or resume the core modules in one
-transaction. After deployment, wire module addresses using
-`setModules` and then use `pauseAll` or `unpauseAll` as needed.
+transaction. After deployment you must complete two governance steps:
+
+1. Wire module addresses using `setModules`.
+2. Once ownership of each module is transferred to `SystemPause`, call
+   `refreshPausers` so it regains the `setPauser` permissions required for
+   `pauseAll` / `unpauseAll`.
 
 Each module address passed to the constructor or `setModules` must be a
 non-zero address pointing to a deployed contract. The contract reverts with
@@ -25,6 +29,7 @@ npx hardhat console --network <network>
     "<feePool>",
     "<reputation>"
   );
+> await pause.connect(gov).refreshPausers();
 > await pause.connect(gov).pauseAll();
 > await pause.connect(gov).unpauseAll();
 ```
@@ -35,4 +40,6 @@ npx hardhat console --network <network>
    account connected.
 2. In **Write Contract**, call `setModules` with the module addresses if
    not already configured.
-3. Invoke `pauseAll` to stop the system or `unpauseAll` to resume.
+3. After transferring module ownership to `SystemPause`, call
+   `refreshPausers` so the helper can pause each contract.
+4. Invoke `pauseAll` to stop the system or `unpauseAll` to resume.

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -327,6 +327,7 @@ async function main() {
     governance
   );
   await pause.waitForDeployment();
+  const pauseAddress = await pause.getAddress();
   await pause
     .connect(governanceSigner)
     .setModules(
@@ -339,6 +340,16 @@ async function main() {
       await reputation.getAddress(),
       await committee.getAddress()
     );
+  await registry.connect(governanceSigner).setPauser(pauseAddress);
+  await stake.connect(governanceSigner).setPauser(pauseAddress);
+  await validation.connect(governanceSigner).setPauser(pauseAddress);
+  await dispute.connect(governanceSigner).setPauser(pauseAddress);
+  await platformRegistry
+    .connect(governanceSigner)
+    .setPauser(pauseAddress);
+  await feePool.connect(governanceSigner).setPauser(pauseAddress);
+  await reputation.connect(governanceSigner).setPauser(pauseAddress);
+  await committee.connect(governanceSigner).setPauser(pauseAddress);
   await stake.connect(governanceSigner).setGovernance(await pause.getAddress());
   await registry
     .connect(governanceSigner)


### PR DESCRIPTION
## Summary
- add a `refreshPausers` helper to `SystemPause` and stop enforcing ownership in `setModules`
- wire the v2 deployment and update scripts to assign pauser roles explicitly
- document the new two-step SystemPause setup so operators refresh pauser rights after wiring

## Testing
- npx hardhat compile *(fails: baseline repository has existing interface and abstract contract errors)*

------
https://chatgpt.com/codex/tasks/task_e_68dca98ae2fc8333a954aa135ae58644