### PR TITLE
Keep governance ownership of v2 core modules

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -39,8 +39,8 @@ import {TOKEN_SCALE} from "./Constants.sol";
 /// @title Deployer
 /// @notice One shot helper that deploys and wires the core module set.
 /// @dev Each module is deployed with default parameters (zero values) and
-///      ownership is transferred to the SystemPause contract or a supplied
-///      governance address once wiring is complete.
+///      ownership is transferred to the supplied governance address once
+///      wiring is complete.
 contract Deployer is Ownable {
     bool public deployed;
 
@@ -422,20 +422,20 @@ contract Deployer is Ownable {
             committee,
             governance
         );
-        // hand over governance to SystemPause
-        stake.setGovernance(address(pause));
-        registry.setGovernance(address(pause));
+        // restore governance to the supplied timelock / multisig address
+        stake.setGovernance(governance);
+        registry.setGovernance(governance);
 
         // Transfer ownership
-        validation.transferOwnership(address(pause));
-        reputation.transferOwnership(address(pause));
-        dispute.transferOwnership(address(pause));
-        committee.transferOwnership(address(pause));
+        validation.transferOwnership(governance);
+        reputation.transferOwnership(governance);
+        dispute.transferOwnership(governance);
+        committee.transferOwnership(governance);
         certificate.transferOwnership(governance);
-        pRegistry.transferOwnership(address(pause));
+        pRegistry.transferOwnership(governance);
         router.transferOwnership(governance);
         incentives.transferOwnership(governance);
-        pool.transferOwnership(address(pause));
+        pool.transferOwnership(governance);
         if (address(policy) != address(0)) {
             policy.transferOwnership(governance);
         }

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -247,6 +247,7 @@ async function main() {
   );
   const installer = await Installer.deploy();
   await installer.waitForDeployment();
+  await installer.transferOwnership(governance);
 
   await registry.setGovernance(await installer.getAddress());
   await stake.setGovernance(await installer.getAddress());
@@ -282,6 +283,9 @@ async function main() {
       ethers.ZeroHash,
       []
     );
+
+  await committee.transferOwnership(governance);
+  await attestation.transferOwnership(governance);
 
   const feePct = typeof args.feePct === 'string' ? Number(args.feePct) : 5;
   await registry.connect(governanceSigner).setFeePct(feePct);
@@ -344,33 +348,12 @@ async function main() {
   await stake.connect(governanceSigner).setPauser(pauseAddress);
   await validation.connect(governanceSigner).setPauser(pauseAddress);
   await dispute.connect(governanceSigner).setPauser(pauseAddress);
-  await platformRegistry
-    .connect(governanceSigner)
-    .setPauser(pauseAddress);
+  await platformRegistry.connect(governanceSigner).setPauser(pauseAddress);
   await feePool.connect(governanceSigner).setPauser(pauseAddress);
   await reputation.connect(governanceSigner).setPauser(pauseAddress);
   await committee.connect(governanceSigner).setPauser(pauseAddress);
-  await stake.connect(governanceSigner).setGovernance(await pause.getAddress());
-  await registry
-    .connect(governanceSigner)
-    .setGovernance(await pause.getAddress());
-  await validation
-    .connect(governanceSigner)
-    .transferOwnership(await pause.getAddress());
-  await dispute
-    .connect(governanceSigner)
-    .transferOwnership(await pause.getAddress());
-  await platformRegistry
-    .connect(governanceSigner)
-    .transferOwnership(await pause.getAddress());
-  await feePool
-    .connect(governanceSigner)
-    .transferOwnership(await pause.getAddress());
-  await reputation
-    .connect(governanceSigner)
-    .transferOwnership(await pause.getAddress());
-  await committee.transferOwnership(await pause.getAddress());
-  await attestation.transferOwnership(await pause.getAddress());
+  await stake.connect(governanceSigner).setGovernance(governance);
+  await registry.connect(governanceSigner).setGovernance(governance);
 
   console.log('JobRegistry deployed to:', await registry.getAddress());
   console.log('ValidationModule:', await validation.getAddress());
@@ -515,6 +498,7 @@ async function main() {
     await platformRegistry.getAddress(),
     await feePool.getAddress(),
     await reputation.getAddress(),
+    await committee.getAddress(),
     governance,
   ]);
   await verify(await installer.getAddress(), []);


### PR DESCRIPTION
## Summary
- keep the on-chain deployer wiring JobRegistry, StakeManager, and other modules back to the supplied governance address instead of SystemPause
- update the Hardhat deploy script to leave the DAO timelock as owner/governance while still configuring SystemPause as pauser
- adjust the SystemPause update helper to validate against the governance owner and skip refreshes when SystemPause no longer owns modules

## Testing
- npx eslint scripts/v2/deploy.ts scripts/v2/updateSystemPause.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcab3442088333812d62f82014bca6