### PR TITLE
Clamp job feed query from block

### DIFF
--- a/apps/enterprise-portal/src/hooks/useJobFeed.helpers.test.ts
+++ b/apps/enterprise-portal/src/hooks/useJobFeed.helpers.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { computeFromBlock } from './useJobFeed.helpers.ts';
+
+test('computeFromBlock returns undefined when querying a specific job', async () => {
+  const provider = { getBlockNumber: async () => 10 };
+  const result = await computeFromBlock(provider, { jobId: 1n });
+  assert.equal(result, undefined);
+});
+
+test('computeFromBlock clamps the fromBlock to zero on short chains', async () => {
+  const provider = { getBlockNumber: async () => 1000 };
+  const result = await computeFromBlock(provider, {});
+  assert.equal(result, 0);
+});
+
+test('computeFromBlock subtracts the history window when available', async () => {
+  const provider = { getBlockNumber: async () => 60_123 };
+  const result = await computeFromBlock(provider, {});
+  assert.equal(result, 10_123);
+});

--- a/apps/enterprise-portal/src/hooks/useJobFeed.helpers.ts
+++ b/apps/enterprise-portal/src/hooks/useJobFeed.helpers.ts
@@ -1,0 +1,15 @@
+import type { JsonRpcProvider } from 'ethers';
+
+export interface ComputeFromBlockOptions {
+  jobId?: bigint;
+}
+
+export const computeFromBlock = async (
+  provider: Pick<JsonRpcProvider, 'getBlockNumber'>,
+  options: ComputeFromBlockOptions
+): Promise<number | undefined> => {
+  if (options.jobId) return undefined;
+  const current = await provider.getBlockNumber();
+  // Clamp the subtraction to zero so the hook works even on very small chains.
+  return Math.max(0, current - 50_000);
+};


### PR DESCRIPTION
## Summary
- clamp the job feed query window to zero when the chain height is below the 50k block history window
- extract a reusable helper for the fromBlock calculation and cover it with node-based tests

## Testing
- TS_NODE_PROJECT=apps/enterprise-portal/tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node --test --loader ts-node/esm apps/enterprise-portal/src/hooks/useJobFeed.helpers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd43df9dc88333a293fd88d52d3708