### PR TITLE
Add validator committee data to enterprise portal feed

### DIFF
--- a/apps/enterprise-portal/src/components/PortalPage.tsx
+++ b/apps/enterprise-portal/src/components/PortalPage.tsx
@@ -10,14 +10,18 @@ import { SlaViewer } from './SlaViewer';
 import { useJobFeed } from '../hooks/useJobFeed';
 
 export const PortalPage = () => {
-  const { jobs, events, loading, error } = useJobFeed({ watch: true });
+  const { jobs, events, validators, loading, error, hasValidationModule } = useJobFeed({ watch: true });
 
   return (
     <div className="grid" style={{ gap: '2.5rem' }}>
       <ConnectionPanel />
       <JobSubmissionForm />
       <JobLifecycleDashboard jobs={jobs} events={events} loading={loading} error={error} />
-      <ValidatorLogPanel events={events} />
+      <ValidatorLogPanel
+        validators={validators}
+        loading={loading}
+        hasValidationModule={hasValidationModule}
+      />
       <div className="grid two-column">
         <DeliverableVerificationPanel events={events} />
         <div className="grid">

--- a/apps/enterprise-portal/src/hooks/useJobFeed.ts
+++ b/apps/enterprise-portal/src/hooks/useJobFeed.ts
@@ -2,9 +2,9 @@
 
 import { EventFilter, EventLog, JsonRpcProvider } from 'ethers';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { createReadOnlyProvider, getJobRegistryContract } from '../lib/contracts';
+import { createReadOnlyProvider, getJobRegistryContract, getValidationModuleContract, portalConfig } from '../lib/contracts';
 import { jobStateToPhase } from '../lib/jobStatus';
-import type { JobSummary, JobTimelineEvent } from '../types';
+import type { JobSummary, JobTimelineEvent, ValidatorInsight } from '../types';
 import { computeFromBlock } from './useJobFeed.helpers';
 
 const JOB_EVENT_NAMES = [
@@ -27,8 +27,10 @@ interface UseJobFeedOptions {
 interface JobFeedState {
   jobs: JobSummary[];
   events: JobTimelineEvent[];
+  validators: ValidatorInsight[];
   loading: boolean;
   error?: string;
+  hasValidationModule: boolean;
   refresh: () => Promise<void>;
 }
 
@@ -93,6 +95,7 @@ const hydrateTimestamps = async (
 export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
   const [jobs, setJobs] = useState<JobSummary[]>([]);
   const [events, setEvents] = useState<JobTimelineEvent[]>([]);
+  const [validators, setValidators] = useState<ValidatorInsight[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const provider = useMemo(() => createReadOnlyProvider(), []);
@@ -107,6 +110,7 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
     setError(undefined);
     try {
       const contract = getJobRegistryContract(provider);
+      const validationModule = getValidationModuleContract(provider);
       const fromBlock = await resolveFromBlock();
       const logs: EventLog[] = [];
       for (const eventName of JOB_EVENT_NAMES) {
@@ -132,7 +136,11 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
         .filter((evt) => (options.jobId ? evt.jobId === options.jobId : true));
       const timeline = await hydrateTimestamps(provider, timelineRaw);
 
-      const jobIds = Array.from(new Set(timeline.map((evt) => evt.jobId.toString())));
+      const jobIdSet = new Set(timeline.map((evt) => evt.jobId.toString()));
+      if (options.jobId) {
+        jobIdSet.add(options.jobId.toString());
+      }
+      const jobIds = Array.from(jobIdSet);
       const summaries: JobSummary[] = [];
       for (const idStr of jobIds) {
         const jobId = BigInt(idStr);
@@ -155,8 +163,158 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
         summaries.push(summary);
       }
 
+      const validatorMap = new Map<string, Map<string, ValidatorInsight>>();
+      const ensureInsight = (jobId: bigint, address: string): ValidatorInsight => {
+        const normalizedAddress = address.toLowerCase();
+        const jobKey = jobId.toString();
+        if (!validatorMap.has(jobKey)) {
+          validatorMap.set(jobKey, new Map());
+        }
+        const jobValidators = validatorMap.get(jobKey)!;
+        let insight = jobValidators.get(normalizedAddress);
+        if (!insight) {
+          insight = {
+            jobId,
+            validator: address,
+            stake: validationModule ? 0n : undefined
+          };
+          jobValidators.set(normalizedAddress, insight);
+        }
+        if (!insight.validator) {
+          insight.validator = address;
+        }
+        return insight;
+      };
+
+      for (const idStr of jobIds) {
+        const jobId = BigInt(idStr);
+        try {
+          const committee = await (contract as unknown as { getJobValidators: (jobId: bigint) => Promise<string[]> }).getJobValidators(jobId);
+          committee.forEach((address) => {
+            if (address && address !== '0x0000000000000000000000000000000000000000') {
+              ensureInsight(jobId, String(address));
+            }
+          });
+        } catch (err) {
+          console.warn('Failed to load validator committee from registry', jobId.toString(), err);
+        }
+      }
+
+      if (validationModule) {
+        const moduleLogs: EventLog[] = [];
+        const vmFilters = validationModule.filters as Record<string, (...args: never[]) => EventFilter>;
+        const selectedFilter = vmFilters.ValidatorsSelected(options.jobId ?? null);
+        const commitFilter = vmFilters.ValidationCommitted(options.jobId ?? null, null);
+        const revealFilter = vmFilters.ValidationRevealed(options.jobId ?? null, null);
+        const selectedLogs = await validationModule.queryFilter(selectedFilter, fromBlock);
+        const commitLogs = await validationModule.queryFilter(commitFilter, fromBlock);
+        const revealLogs = await validationModule.queryFilter(revealFilter, fromBlock);
+        moduleLogs.push(...selectedLogs, ...commitLogs, ...revealLogs);
+
+        const blockNumbers = Array.from(
+          new Set(
+            moduleLogs
+              .map((log) => (typeof log.blockNumber === 'number' ? log.blockNumber : Number(log.blockNumber ?? 0)))
+              .filter((value) => Number.isFinite(value) && value > 0)
+          )
+        );
+        const timestampCache = new Map<number, number>();
+        for (const blockNumber of blockNumbers) {
+          const block = await provider.getBlock(blockNumber);
+          if (block?.timestamp) {
+            timestampCache.set(blockNumber, Number(block.timestamp));
+          }
+        }
+
+        const logTimestamp = (log: EventLog): number | undefined => {
+          const blockNumber = typeof log.blockNumber === 'number' ? log.blockNumber : Number(log.blockNumber ?? 0);
+          if (!Number.isFinite(blockNumber) || blockNumber <= 0) return undefined;
+          return timestampCache.get(blockNumber);
+        };
+
+        for (const log of selectedLogs) {
+          const jobIdValue = log.args?.jobId ?? (log.topics?.[1] ? BigInt(log.topics[1]) : undefined);
+          if (jobIdValue === undefined) continue;
+          const jobId = typeof jobIdValue === 'bigint' ? jobIdValue : BigInt(jobIdValue);
+          const validatorsFromLog = (log.args?.validators ?? []) as string[];
+          const timestamp = logTimestamp(log);
+          validatorsFromLog.forEach((address) => {
+            if (!address) return;
+            const insight = ensureInsight(jobId, String(address));
+            if (timestamp && (!insight.selectedAt || insight.selectedAt < timestamp)) {
+              insight.selectedAt = timestamp;
+            }
+          });
+        }
+
+        for (const log of commitLogs) {
+          const jobIdValue = log.args?.jobId ?? (log.topics?.[1] ? BigInt(log.topics[1]) : undefined);
+          const validatorAddress = log.args?.validator ?? (log.topics?.[2] ? `0x${log.topics[2].slice(26)}` : undefined);
+          if (jobIdValue === undefined || !validatorAddress) continue;
+          const jobId = typeof jobIdValue === 'bigint' ? jobIdValue : BigInt(jobIdValue);
+          const insight = ensureInsight(jobId, String(validatorAddress));
+          const timestamp = logTimestamp(log);
+          if (timestamp && (!insight.committedAt || insight.committedAt < timestamp)) {
+            insight.committedAt = timestamp;
+          }
+          if (!insight.commitTx) {
+            insight.commitTx = log.transactionHash;
+          }
+        }
+
+        for (const log of revealLogs) {
+          const jobIdValue = log.args?.jobId ?? (log.topics?.[1] ? BigInt(log.topics[1]) : undefined);
+          const validatorAddress = log.args?.validator ?? (log.topics?.[2] ? `0x${log.topics[2].slice(26)}` : undefined);
+          if (jobIdValue === undefined || !validatorAddress) continue;
+          const jobId = typeof jobIdValue === 'bigint' ? jobIdValue : BigInt(jobIdValue);
+          const insight = ensureInsight(jobId, String(validatorAddress));
+          const timestamp = logTimestamp(log);
+          if (timestamp && (!insight.revealedAt || insight.revealedAt < timestamp)) {
+            insight.revealedAt = timestamp;
+          }
+          insight.vote = log.args?.approve ? 'approve' : 'reject';
+          if (!insight.revealTx) {
+            insight.revealTx = log.transactionHash;
+          }
+        }
+
+        const stakeFetches: Promise<void>[] = [];
+        validatorMap.forEach((validatorsForJob) => {
+          validatorsForJob.forEach((insight) => {
+            stakeFetches.push(
+              validationModule
+                .validatorStakes(insight.jobId, insight.validator)
+                .then((value: bigint) => {
+                  try {
+                    insight.stake = typeof value === 'bigint' ? value : BigInt(value);
+                  } catch (err) {
+                    insight.stake = 0n;
+                  }
+                })
+                .catch(() => {
+                  if (typeof insight.stake === 'undefined') {
+                    insight.stake = 0n;
+                  }
+                })
+            );
+          });
+        });
+        await Promise.allSettled(stakeFetches);
+      }
+
+      const validatorList = Array.from(validatorMap.values()).flatMap((collection) => Array.from(collection.values()));
+
+      validatorList.sort((a, b) => {
+        const timestampA = a.revealedAt ?? a.committedAt ?? a.selectedAt ?? 0;
+        const timestampB = b.revealedAt ?? b.committedAt ?? b.selectedAt ?? 0;
+        if (timestampA !== timestampB) return timestampB - timestampA;
+        if (a.jobId !== b.jobId) return Number(b.jobId - a.jobId);
+        return a.validator.localeCompare(b.validator);
+      });
+
       setEvents(timeline);
       setJobs(summaries);
+      setValidators(validatorList);
     } catch (err) {
       console.error(err);
       setError((err as Error).message ?? 'Failed to load job activity');
@@ -172,6 +330,7 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
   useEffect(() => {
     if (!options.watch) return;
     const contract = getJobRegistryContract(provider);
+    const validationModule = getValidationModuleContract(provider);
     const handlers = JOB_EVENT_NAMES.map((name) => {
       const handler = () => {
         load().catch((err) => console.error(err));
@@ -179,10 +338,30 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
       contract.on(name, handler);
       return { name, handler };
     });
+    const validationHandlers = validationModule
+      ? ['ValidatorsSelected', 'ValidationCommitted', 'ValidationRevealed'].map((name) => {
+          const handler = () => {
+            load().catch((err) => console.error(err));
+          };
+          validationModule.on(name, handler);
+          return { name, handler };
+        })
+      : [];
     return () => {
       handlers.forEach(({ name, handler }) => contract.off(name, handler));
+      validationHandlers.forEach(({ name, handler }) => {
+        validationModule?.off(name, handler);
+      });
     };
   }, [load, options.watch, provider]);
 
-  return { jobs, events, loading, error, refresh: load };
+  return {
+    jobs,
+    events,
+    validators,
+    loading,
+    error,
+    hasValidationModule: Boolean(portalConfig.validationModuleAddress),
+    refresh: load
+  };
 };

--- a/apps/enterprise-portal/src/lib/abis/jobRegistry.ts
+++ b/apps/enterprise-portal/src/lib/abis/jobRegistry.ts
@@ -68,6 +68,23 @@ export const jobRegistryAbi = [
     stateMutability: 'view'
   },
   {
+    type: 'function',
+    name: 'getJobValidators',
+    inputs: [{ name: 'jobId', type: 'uint256' }],
+    outputs: [{ name: '', type: 'address[]' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'getJobValidatorVote',
+    inputs: [
+      { name: 'jobId', type: 'uint256' },
+      { name: 'validator', type: 'address' }
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+    stateMutability: 'view'
+  },
+  {
     type: 'event',
     name: 'JobCreated',
     inputs: [

--- a/apps/enterprise-portal/src/lib/abis/validationModule.ts
+++ b/apps/enterprise-portal/src/lib/abis/validationModule.ts
@@ -1,0 +1,41 @@
+export const validationModuleAbi = [
+  {
+    type: 'event',
+    name: 'ValidatorsSelected',
+    inputs: [
+      { name: 'jobId', type: 'uint256', indexed: true },
+      { name: 'validators', type: 'address[]', indexed: false }
+    ]
+  },
+  {
+    type: 'event',
+    name: 'ValidationCommitted',
+    inputs: [
+      { name: 'jobId', type: 'uint256', indexed: true },
+      { name: 'validator', type: 'address', indexed: true },
+      { name: 'commitHash', type: 'bytes32', indexed: false },
+      { name: 'subdomain', type: 'string', indexed: false }
+    ]
+  },
+  {
+    type: 'event',
+    name: 'ValidationRevealed',
+    inputs: [
+      { name: 'jobId', type: 'uint256', indexed: true },
+      { name: 'validator', type: 'address', indexed: true },
+      { name: 'approve', type: 'bool', indexed: false },
+      { name: 'burnTxHash', type: 'bytes32', indexed: false },
+      { name: 'subdomain', type: 'string', indexed: false }
+    ]
+  },
+  {
+    type: 'function',
+    name: 'validatorStakes',
+    inputs: [
+      { name: 'jobId', type: 'uint256' },
+      { name: 'validator', type: 'address' }
+    ],
+    outputs: [{ name: '', type: 'uint256' }],
+    stateMutability: 'view'
+  }
+] as const;

--- a/apps/enterprise-portal/src/lib/contracts.ts
+++ b/apps/enterprise-portal/src/lib/contracts.ts
@@ -2,6 +2,7 @@ import { Contract, JsonRpcProvider, Signer } from 'ethers';
 import { jobRegistryAbi } from './abis/jobRegistry';
 import { taxPolicyAbi } from './abis/taxPolicy';
 import { certificateNftAbi } from './abis/certificateNft';
+import { validationModuleAbi } from './abis/validationModule';
 import { loadPortalConfiguration } from './config';
 
 export const portalConfig = loadPortalConfiguration();
@@ -45,6 +46,23 @@ export const getCertificateNFTContract = (signerOrProvider?: Signer | JsonRpcPro
     return providerCache.get(key)!;
   }
   const contract = new Contract(portalConfig.certificateNFTAddress, certificateNftAbi, conn);
+  if (!signerOrProvider) {
+    providerCache.set(key, contract);
+  }
+  return contract;
+};
+
+export const getValidationModuleContract = (
+  signerOrProvider?: Signer | JsonRpcProvider
+) => {
+  const address = portalConfig.validationModuleAddress;
+  if (!address) return undefined;
+  const conn = signerOrProvider ?? createReadOnlyProvider();
+  const key = `validationModule:${conn instanceof JsonRpcProvider ? 'provider' : 'signer'}`;
+  if (!signerOrProvider && providerCache.has(key)) {
+    return providerCache.get(key)!;
+  }
+  const contract = new Contract(address, validationModuleAbi, conn);
   if (!signerOrProvider) {
     providerCache.set(key, contract);
   }

--- a/apps/enterprise-portal/src/types/index.ts
+++ b/apps/enterprise-portal/src/types/index.ts
@@ -40,10 +40,15 @@ export interface JobSummary {
 }
 
 export interface ValidatorInsight {
+  jobId: bigint;
   validator: string;
   vote?: 'approve' | 'reject' | 'timeout';
-  stake: bigint;
+  stake?: bigint;
+  selectedAt?: number;
+  committedAt?: number;
+  commitTx?: string;
   revealedAt?: number;
+  revealTx?: string;
   comment?: string;
 }
 


### PR DESCRIPTION
## Summary
- extend the job feed hook to collect validator committees via JobRegistry and ValidationModule commit/reveal events
- add a ValidationModule ABI and contract accessor to support stake lookups
- refresh the validator panel to show validator addresses, stakes, status, and votes from the enriched dataset

## Testing
- npm exec -- eslint apps/enterprise-portal/src/components/ValidatorLogPanel.tsx apps/enterprise-portal/src/hooks/useJobFeed.ts *(fails: npm not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4791db6c83338c3728e8c898ca63