### PR TITLE
Update enterprise portal job feed for JobRegistry v2

### DIFF
--- a/apps/enterprise-portal/src/hooks/useCertificates.ts
+++ b/apps/enterprise-portal/src/hooks/useCertificates.ts
@@ -2,8 +2,13 @@
 
 import { EventFilter, EventLog, hexlify } from 'ethers';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { createReadOnlyProvider, getCertificateNFTContract, getJobRegistryContract } from '../lib/contracts';
-import type { CertificateBadge } from '../types';
+import {
+  createReadOnlyProvider,
+  getCertificateNFTContract,
+  getJobRegistryContract,
+} from '../lib/contracts';
+import { jobStateToPhase } from '../lib/jobStatus';
+import type { CertificateBadge, JobPhase } from '../types';
 
 interface CertificateState {
   certificates: CertificateBadge[];
@@ -45,7 +50,10 @@ const normalizeUriHash = (value: unknown): string | undefined => {
       return undefined;
     }
   }
-  if (typeof value === 'object' && 'toString' in (value as { toString?: () => string })) {
+  if (
+    typeof value === 'object' &&
+    'toString' in (value as { toString?: () => string })
+  ) {
     return (value as { toString: () => string }).toString();
   }
   return undefined;
@@ -58,6 +66,125 @@ const sortCertificates = (items: CertificateBadge[]): CertificateBadge[] => {
     }
     return compareJobIds(a.jobId, b.jobId);
   });
+};
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const normalizeNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'bigint') return Number(value);
+  if (typeof value === 'string' && value.length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+};
+
+const normalizeAddress = (value: unknown): string | undefined => {
+  if (!value) return undefined;
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (
+    value &&
+    typeof value === 'object' &&
+    'toString' in (value as { toString?: () => string })
+  ) {
+    try {
+      const text = (value as { toString: () => string }).toString();
+      return text.length > 0 ? text : undefined;
+    } catch (err) {
+      console.warn('Unable to normalise address value', value, err);
+      return undefined;
+    }
+  }
+  return undefined;
+};
+
+type JobRegistryReader = {
+  jobs: (jobId: bigint) => Promise<unknown>;
+  decodeJobMetadata: (packed: bigint) => Promise<unknown>;
+};
+
+interface JobSnapshot {
+  employer: string;
+  agent: string;
+  deadline?: number;
+  phase?: JobPhase;
+}
+
+const buildCertificateDescription = (
+  jobId: bigint,
+  snapshot: JobSnapshot
+): string => {
+  const parts = [`Certificate minted for job ${jobId.toString()}`];
+  if (snapshot.phase) {
+    parts.push(`Phase: ${snapshot.phase}`);
+  }
+  if (snapshot.deadline) {
+    try {
+      const formatted = new Date(snapshot.deadline * 1000).toLocaleDateString();
+      parts.push(`Deadline: ${formatted}`);
+    } catch (err) {
+      console.warn(
+        'Unable to format deadline for certificate badge',
+        snapshot.deadline,
+        err
+      );
+    }
+  }
+  return parts.join('. ');
+};
+
+const readJobSnapshot = async (
+  contract: JobRegistryReader,
+  jobId: bigint,
+  fallbackAgent?: string
+): Promise<JobSnapshot> => {
+  const jobData = await contract.jobs(jobId);
+  const jobRecord = jobData as Record<string, unknown> & {
+    [index: number]: unknown;
+  };
+  const employer =
+    normalizeAddress(jobRecord.employer ?? jobRecord[0]) ?? 'Unknown';
+  const rawAgent = normalizeAddress(jobRecord.agent ?? jobRecord[1]);
+  const agentCandidate =
+    rawAgent && rawAgent.toLowerCase() !== ZERO_ADDRESS ? rawAgent : undefined;
+  const packedMetadata =
+    normalizeBigInt(jobRecord.packedMetadata ?? jobRecord[8]) ?? 0n;
+
+  let phase: JobPhase | undefined;
+  let deadline: number | undefined;
+  try {
+    const metadata = await contract.decodeJobMetadata(packedMetadata);
+    const metadataRecord = metadata as Record<string, unknown> & {
+      [index: number]: unknown;
+    };
+    const stateValue =
+      normalizeNumber(metadataRecord.state ?? metadataRecord[0]) ?? 0;
+    phase = jobStateToPhase(stateValue);
+    const deadlineValue = normalizeNumber(
+      metadataRecord.deadline ?? metadataRecord[6]
+    );
+    if (
+      typeof deadlineValue === 'number' &&
+      Number.isFinite(deadlineValue) &&
+      deadlineValue > 0
+    ) {
+      deadline = deadlineValue;
+    }
+  } catch (err) {
+    console.warn(
+      'Unable to decode job metadata for certificate snapshot',
+      jobId.toString(),
+      err
+    );
+  }
+
+  if (!phase) {
+    phase = jobStateToPhase(0);
+  }
+
+  const agent = agentCandidate ?? fallbackAgent ?? 'Unknown';
+  return { employer, agent, deadline, phase };
 };
 
 export const useCertificates = (owner?: string): CertificateState => {
@@ -77,23 +204,38 @@ export const useCertificates = (owner?: string): CertificateState => {
     try {
       const certificateContract = getCertificateNFTContract(provider);
       const jobRegistry = getJobRegistryContract(provider);
-      const filterFactory = (certificateContract.filters as Record<string, (...args: never[]) => EventFilter>).CertificateMinted;
+      const filterFactory = (
+        certificateContract.filters as Record<
+          string,
+          (...args: never[]) => EventFilter
+        >
+      ).CertificateMinted;
       if (!filterFactory) {
         setCertificates([]);
         setLoading(false);
         return;
       }
       const filter = filterFactory(owner);
-      const logs = await (certificateContract as unknown as {
-        queryFilter: (f: EventFilter, fromBlock?: number, toBlock?: number) => Promise<EventLog[]>;
-      }).queryFilter(filter);
+      const logs = await (
+        certificateContract as unknown as {
+          queryFilter: (
+            f: EventFilter,
+            fromBlock?: number,
+            toBlock?: number
+          ) => Promise<EventLog[]>;
+        }
+      ).queryFilter(filter);
 
-      const orderedLogs = [...logs].sort((a, b) => a.blockNumber - b.blockNumber || a.index - b.index);
+      const orderedLogs = [...logs].sort(
+        (a, b) => a.blockNumber - b.blockNumber || a.index - b.index
+      );
 
       const blockNumbers = Array.from(
         new Set(
           orderedLogs
-            .map((log) => (typeof log.blockNumber === 'number' ? log.blockNumber : undefined))
+            .map((log) =>
+              typeof log.blockNumber === 'number' ? log.blockNumber : undefined
+            )
             .filter((value): value is number => typeof value === 'number')
         )
       );
@@ -103,7 +245,10 @@ export const useCertificates = (owner?: string): CertificateState => {
           orderedLogs
             .map((log) => {
               const args = log.args ?? [];
-              const jobArg = (args as { jobId?: unknown })?.jobId ?? (args as unknown[])[1] ?? log.topics?.[2];
+              const jobArg =
+                (args as { jobId?: unknown })?.jobId ??
+                (args as unknown[])[1] ??
+                log.topics?.[2];
               return normalizeBigInt(jobArg);
             })
             .filter((value): value is bigint => typeof value === 'bigint')
@@ -118,7 +263,11 @@ export const useCertificates = (owner?: string): CertificateState => {
             blockTimestampCache.set(blockNumber, Number(block.timestamp));
           }
         } catch (blockErr) {
-          console.warn('Unable to fetch block timestamp', blockNumber, blockErr);
+          console.warn(
+            'Unable to fetch block timestamp',
+            blockNumber,
+            blockErr
+          );
         }
       }
 
@@ -128,43 +277,60 @@ export const useCertificates = (owner?: string): CertificateState => {
           const uri = await certificateContract.tokenURI(jobId);
           metadataCache.set(jobId, uri);
         } catch (uriErr) {
-          console.warn('Unable to fetch metadata for job', jobId.toString(), uriErr);
+          console.warn(
+            'Unable to fetch metadata for job',
+            jobId.toString(),
+            uriErr
+          );
           metadataCache.set(jobId, '');
         }
       }
 
-      const jobInfoCache = new Map<bigint, { employer: string; agent: string }>();
+      const jobInfoCache = new Map<bigint, JobSnapshot>();
+      const registryReader = jobRegistry as unknown as JobRegistryReader;
       for (const jobId of jobIds) {
         try {
-          const jobData = await jobRegistry.job(jobId);
-          const employer = String((jobData as { employer?: string })?.employer ?? (jobData as unknown[])[0] ?? 'Unknown');
-          const agent = String(
-            (jobData as { worker?: string })?.worker ??
-              (jobData as { agent?: string })?.agent ??
-              (jobData as unknown[])[1] ??
-              owner ??
-              'Unknown'
-          );
-          jobInfoCache.set(jobId, { employer, agent });
+          const snapshot = await readJobSnapshot(registryReader, jobId, owner);
+          jobInfoCache.set(jobId, snapshot);
         } catch (jobErr) {
-          console.warn('Unable to fetch job info for', jobId.toString(), jobErr);
-          jobInfoCache.set(jobId, { employer: 'Unknown', agent: owner ?? 'Unknown' });
+          console.warn(
+            'Unable to fetch job info for',
+            jobId.toString(),
+            jobErr
+          );
+          jobInfoCache.set(jobId, {
+            employer: 'Unknown',
+            agent: owner ?? 'Unknown',
+            phase: jobStateToPhase(0),
+          });
         }
       }
 
       const badgeMap = new Map<string, CertificateBadge>();
       for (const log of orderedLogs) {
         const args = log.args ?? [];
-        const jobArg = (args as { jobId?: unknown })?.jobId ?? (args as unknown[])[1] ?? log.topics?.[2];
+        const jobArg =
+          (args as { jobId?: unknown })?.jobId ??
+          (args as unknown[])[1] ??
+          log.topics?.[2];
         const jobId = normalizeBigInt(jobArg);
         if (!jobId) continue;
-        const blockNumber = typeof log.blockNumber === 'number' ? log.blockNumber : undefined;
+        const blockNumber =
+          typeof log.blockNumber === 'number' ? log.blockNumber : undefined;
         const issuedAt = blockNumber
-          ? blockTimestampCache.get(blockNumber) ?? Math.floor(Date.now() / 1000)
+          ? blockTimestampCache.get(blockNumber) ??
+            Math.floor(Date.now() / 1000)
           : Math.floor(Date.now() / 1000);
-        const uriHash = normalizeUriHash((args as { uriHash?: unknown })?.uriHash ?? (args as unknown[])[2]);
+        const uriHash = normalizeUriHash(
+          (args as { uriHash?: unknown })?.uriHash ?? (args as unknown[])[2]
+        );
         const metadataURI = metadataCache.get(jobId) ?? '';
-        const jobInfo = jobInfoCache.get(jobId) ?? { employer: 'Unknown', agent: owner ?? 'Unknown' };
+        const jobInfo = jobInfoCache.get(jobId) ?? {
+          employer: 'Unknown',
+          agent: owner ?? 'Unknown',
+          phase: jobStateToPhase(0),
+        };
+        const description = buildCertificateDescription(jobId, jobInfo);
         const badge: CertificateBadge = {
           tokenId: jobId,
           jobId,
@@ -173,7 +339,7 @@ export const useCertificates = (owner?: string): CertificateState => {
           issuedAt,
           employer: jobInfo.employer,
           agent: jobInfo.agent,
-          description: `Certificate minted for job ${jobId.toString()}`
+          description,
         };
         badgeMap.set(jobId.toString(), badge);
       }
@@ -195,6 +361,7 @@ export const useCertificates = (owner?: string): CertificateState => {
     if (!owner) return;
     const certificateContract = getCertificateNFTContract(provider);
     const jobRegistry = getJobRegistryContract(provider);
+    const registryReader = jobRegistry as unknown as JobRegistryReader;
     const ownerLower = owner.toLowerCase();
 
     const handler = async (
@@ -207,40 +374,47 @@ export const useCertificates = (owner?: string): CertificateState => {
       try {
         const jobId = normalizeBigInt(jobIdRaw ?? event.topics?.[2]);
         if (!jobId) return;
-        const [metadataURI, jobData, block] = await Promise.all([
-          certificateContract
-            .tokenURI(jobId)
-            .catch((uriErr) => {
-              console.warn('Unable to fetch metadata for job', jobId.toString(), uriErr);
-              return '';
-            }),
-          jobRegistry
-            .job(jobId)
-            .catch((jobErr) => {
-              console.warn('Unable to fetch job info for', jobId.toString(), jobErr);
-              return undefined;
-            }),
+        const [metadataURI, snapshot, block] = await Promise.all([
+          certificateContract.tokenURI(jobId).catch((uriErr) => {
+            console.warn(
+              'Unable to fetch metadata for job',
+              jobId.toString(),
+              uriErr
+            );
+            return '';
+          }),
+          readJobSnapshot(registryReader, jobId, owner).catch((jobErr) => {
+            console.warn(
+              'Unable to fetch job info for',
+              jobId.toString(),
+              jobErr
+            );
+            return undefined;
+          }),
           typeof event.blockNumber === 'number'
             ? provider.getBlock(event.blockNumber).catch((blockErr) => {
-                console.warn('Unable to fetch block timestamp', event.blockNumber, blockErr);
+                console.warn(
+                  'Unable to fetch block timestamp',
+                  event.blockNumber,
+                  blockErr
+                );
                 return undefined;
               })
-            : Promise.resolve(undefined)
+            : Promise.resolve(undefined),
         ]);
 
-        const employer = jobData
-          ? String((jobData as { employer?: string })?.employer ?? (jobData as unknown[])[0] ?? 'Unknown')
-          : 'Unknown';
-        const agent = jobData
-          ? String(
-              (jobData as { worker?: string })?.worker ??
-                (jobData as { agent?: string })?.agent ??
-                (jobData as unknown[])[1] ??
-                owner
-            )
-          : owner;
-        const issuedAt = block?.timestamp ? Number(block.timestamp) : Math.floor(Date.now() / 1000);
-        const uriHash = normalizeUriHash(uriHashRaw ?? (event.args as { uriHash?: unknown })?.uriHash);
+        const jobSnapshot = snapshot ?? {
+          employer: 'Unknown',
+          agent: owner ?? 'Unknown',
+          phase: jobStateToPhase(0),
+        };
+        const issuedAt = block?.timestamp
+          ? Number(block.timestamp)
+          : Math.floor(Date.now() / 1000);
+        const uriHash = normalizeUriHash(
+          uriHashRaw ?? (event.args as { uriHash?: unknown })?.uriHash
+        );
+        const description = buildCertificateDescription(jobId, jobSnapshot);
 
         const badge: CertificateBadge = {
           tokenId: jobId,
@@ -248,13 +422,15 @@ export const useCertificates = (owner?: string): CertificateState => {
           metadataURI,
           slaURI: uriHash,
           issuedAt,
-          employer,
-          agent: agent ?? owner,
-          description: `Certificate minted for job ${jobId.toString()}`
+          employer: jobSnapshot.employer,
+          agent: jobSnapshot.agent ?? owner ?? 'Unknown',
+          description,
         };
 
         setCertificates((prev) => {
-          const map = new Map(prev.map((entry) => [entry.tokenId.toString(), entry]));
+          const map = new Map(
+            prev.map((entry) => [entry.tokenId.toString(), entry])
+          );
           map.set(jobId.toString(), badge);
           return sortCertificates(Array.from(map.values()));
         });

--- a/apps/enterprise-portal/src/hooks/useJobFeed.ts
+++ b/apps/enterprise-portal/src/hooks/useJobFeed.ts
@@ -2,7 +2,12 @@
 
 import { EventFilter, EventLog, JsonRpcProvider } from 'ethers';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { createReadOnlyProvider, getJobRegistryContract, getValidationModuleContract, portalConfig } from '../lib/contracts';
+import {
+  createReadOnlyProvider,
+  getJobRegistryContract,
+  getValidationModuleContract,
+  portalConfig,
+} from '../lib/contracts';
 import { jobStateToPhase } from '../lib/jobStatus';
 import type { JobSummary, JobTimelineEvent, ValidatorInsight } from '../types';
 import { computeFromBlock } from './useJobFeed.helpers';
@@ -13,7 +18,7 @@ const JOB_EVENT_NAMES = [
   'ResultSubmitted',
   'ValidationStartTriggered',
   'JobFinalized',
-  'JobDisputed'
+  'JobDisputed',
 ] as const;
 
 type JobEventName = (typeof JOB_EVENT_NAMES)[number];
@@ -21,14 +26,18 @@ type JobEventName = (typeof JOB_EVENT_NAMES)[number];
 const normaliseString = (value: unknown): string | undefined => {
   if (!value) return undefined;
   if (typeof value === 'string') return value;
-  if (typeof value === 'number' || typeof value === 'bigint') return String(value);
+  if (typeof value === 'number' || typeof value === 'bigint')
+    return String(value);
   if (Array.isArray(value)) {
     for (const entry of value) {
       const normalised = normaliseString(entry);
       if (normalised) return normalised;
     }
   }
-  if (typeof value === 'object' && 'toString' in (value as { toString?: () => string })) {
+  if (
+    typeof value === 'object' &&
+    'toString' in (value as { toString?: () => string })
+  ) {
     return (value as { toString: () => string }).toString();
   }
   return undefined;
@@ -43,6 +52,35 @@ const extractResultDetails = (
   const resultHash = normaliseString(record.resultHash ?? arrayArgs?.[2]);
   const resultURI = normaliseString(record.resultURI ?? arrayArgs?.[3]);
   return { resultHash, resultURI };
+};
+
+const normaliseBigInt = (value: unknown, fallback = 0n): bigint => {
+  try {
+    if (typeof value === 'bigint') return value;
+    if (typeof value === 'number') return BigInt(value);
+    if (typeof value === 'string' && value.length > 0) return BigInt(value);
+    if (
+      value &&
+      typeof value === 'object' &&
+      'toString' in (value as { toString?: () => string })
+    ) {
+      const text = (value as { toString: () => string }).toString();
+      if (text.length > 0) return BigInt(text);
+    }
+  } catch (err) {
+    console.warn('Unable to normalise bigint value', value, err);
+  }
+  return fallback;
+};
+
+const normaliseNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'bigint') return Number(value);
+  if (typeof value === 'string' && value.length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
 };
 
 interface UseJobFeedOptions {
@@ -61,10 +99,14 @@ interface JobFeedState {
   refresh: () => Promise<void>;
 }
 
-const toTimelineEvent = (event: JobEventName, log: EventLog): JobTimelineEvent => {
+const toTimelineEvent = (
+  event: JobEventName,
+  log: EventLog
+): JobTimelineEvent => {
   const jobId = BigInt(log.topics[1]);
   const actorTopic = log.topics[2];
-  const actor = actorTopic && actorTopic !== '0x' ? `0x${actorTopic.slice(26)}` : undefined;
+  const actor =
+    actorTopic && actorTopic !== '0x' ? `0x${actorTopic.slice(26)}` : undefined;
   const timestamp = 0; // placeholder
   const descriptionMap: Record<JobEventName, string> = {
     JobCreated: 'Job posted to the network',
@@ -72,7 +114,7 @@ const toTimelineEvent = (event: JobEventName, log: EventLog): JobTimelineEvent =
     ResultSubmitted: 'Agent deliverables submitted',
     ValidationStartTriggered: 'Validator committee engaged',
     JobFinalized: 'Job finalized and payout settled',
-    JobDisputed: 'Dispute raised for this job'
+    JobDisputed: 'Dispute raised for this job',
   };
   const phaseMap: Record<JobEventName, JobTimelineEvent['phase']> = {
     JobCreated: 'Created',
@@ -80,7 +122,7 @@ const toTimelineEvent = (event: JobEventName, log: EventLog): JobTimelineEvent =
     ResultSubmitted: 'Submitted',
     ValidationStartTriggered: 'InValidation',
     JobFinalized: 'Finalized',
-    JobDisputed: 'Disputed'
+    JobDisputed: 'Disputed',
   };
   return {
     id: `${event}-${log.transactionHash}-${log.index}`,
@@ -93,8 +135,8 @@ const toTimelineEvent = (event: JobEventName, log: EventLog): JobTimelineEvent =
     phase: phaseMap[event],
     meta: {
       blockNumber: log.blockNumber,
-      args: log.args
-    }
+      args: log.args,
+    },
   };
 };
 
@@ -103,7 +145,13 @@ const hydrateTimestamps = async (
   items: JobTimelineEvent[]
 ): Promise<JobTimelineEvent[]> => {
   const blockNumbers = Array.from(
-    new Set(items.map((item) => (typeof item.meta?.blockNumber === 'number' ? item.meta.blockNumber : undefined)))
+    new Set(
+      items.map((item) =>
+        typeof item.meta?.blockNumber === 'number'
+          ? item.meta.blockNumber
+          : undefined
+      )
+    )
   ).filter((value): value is number => typeof value === 'number');
   const cache = new Map<number, number>();
   for (const blockNumber of blockNumbers) {
@@ -113,8 +161,13 @@ const hydrateTimestamps = async (
     }
   }
   return items.map((item) => {
-    const blockNumber = typeof item.meta?.blockNumber === 'number' ? item.meta.blockNumber : undefined;
-    const timestamp = blockNumber ? cache.get(blockNumber) ?? item.timestamp : item.timestamp;
+    const blockNumber =
+      typeof item.meta?.blockNumber === 'number'
+        ? item.meta.blockNumber
+        : undefined;
+    const timestamp = blockNumber
+      ? cache.get(blockNumber) ?? item.timestamp
+      : item.timestamp;
     return { ...item, timestamp };
   });
 };
@@ -141,13 +194,16 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
       const fromBlock = await resolveFromBlock();
       const logs: EventLog[] = [];
       for (const eventName of JOB_EVENT_NAMES) {
-        const filterFactory = (contract.filters as Record<string, (...args: never[]) => EventFilter>)[eventName];
+        const filterFactory = (
+          contract.filters as Record<string, (...args: never[]) => EventFilter>
+        )[eventName];
         if (!filterFactory) continue;
         const filter = filterFactory();
-        const result = await (contract as unknown as { queryFilter: (f: EventFilter, from?: number) => Promise<EventLog[]> }).queryFilter(
-          filter,
-          fromBlock
-        );
+        const result = await (
+          contract as unknown as {
+            queryFilter: (f: EventFilter, from?: number) => Promise<EventLog[]>;
+          }
+        ).queryFilter(filter, fromBlock);
         logs.push(...(result as EventLog[]));
       }
       logs.sort((a, b) => a.blockNumber - b.blockNumber || a.index - b.index);
@@ -180,11 +236,53 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
       const summaryMap = new Map<string, JobSummary>();
       for (const idStr of jobIdStrings) {
         const jobId = BigInt(idStr);
-        const jobData = await contract.job(jobId);
-        const phase = jobStateToPhase(Number(jobData.state ?? jobData[7] ?? 0));
+        const jobData = await contract.jobs(jobId);
+        const jobRecord = jobData as Record<string, unknown> & {
+          [index: number]: unknown;
+        };
+        const packedMetadata = normaliseBigInt(
+          jobRecord.packedMetadata ?? jobRecord[8] ?? 0n,
+          0n
+        );
+        let metadataRecord:
+          | (Record<string, unknown> & { [index: number]: unknown })
+          | undefined;
+        try {
+          const metadata = await contract.decodeJobMetadata(packedMetadata);
+          metadataRecord = metadata as Record<string, unknown> & {
+            [index: number]: unknown;
+          };
+        } catch (metadataErr) {
+          console.warn(
+            'Failed to decode job metadata',
+            jobId.toString(),
+            metadataErr
+          );
+        }
+
+        const stateValue = metadataRecord
+          ? normaliseNumber(metadataRecord.state ?? metadataRecord[0], 0)
+          : 0;
+        const feePctValue = metadataRecord
+          ? normaliseBigInt(
+              metadataRecord.feePct ?? metadataRecord[4] ?? 0n,
+              0n
+            )
+          : 0n;
+        const deadlineValue = metadataRecord
+          ? normaliseNumber(metadataRecord.deadline ?? metadataRecord[6], 0)
+          : 0;
+        const assignedAtOnchain = metadataRecord
+          ? normaliseNumber(metadataRecord.assignedAt ?? metadataRecord[7], 0)
+          : 0;
+
         const relatedEvents = eventsByJob.get(idStr) ?? [];
-        const createdEvent = relatedEvents.find((evt) => evt.name === 'JobCreated');
-        const assignedEvent = relatedEvents.find((evt) => evt.name === 'AgentAssigned');
+        const createdEvent = relatedEvents.find(
+          (evt) => evt.name === 'JobCreated'
+        );
+        const assignedEvent = relatedEvents.find(
+          (evt) => evt.name === 'AgentAssigned'
+        );
         const resultEvent = [...relatedEvents]
           .filter((evt) => evt.name === 'ResultSubmitted')
           .sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0))
@@ -193,32 +291,73 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
           .filter((evt) => evt.name === 'ValidationStartTriggered')
           .sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0))
           .pop();
-        const { resultHash, resultURI } = extractResultDetails(resultEvent?.meta?.args);
+        const { resultHash: submittedResultHash, resultURI } =
+          extractResultDetails(resultEvent?.meta?.args);
+        const storedResultHash = normaliseString(
+          jobRecord.resultHash ?? jobRecord[6]
+        );
+        const employer =
+          normaliseString(jobRecord.employer ?? jobRecord[0]) ??
+          '0x0000000000000000000000000000000000000000';
+        const agentRaw = normaliseString(jobRecord.agent ?? jobRecord[1]);
+        const agent =
+          agentRaw && agentRaw !== '0x0000000000000000000000000000000000000000'
+            ? agentRaw
+            : undefined;
+        const reward = normaliseBigInt(
+          jobRecord.reward ?? jobRecord[2] ?? 0n,
+          0n
+        );
+        const stake = normaliseBigInt(
+          jobRecord.stake ?? jobRecord[3] ?? 0n,
+          0n
+        );
+        const fee = feePctValue > 0n ? (reward * feePctValue) / 100n : 0n;
+        const specHash =
+          normaliseString(jobRecord.specHash ?? jobRecord[7]) ?? '0x';
+        const createdArgs = createdEvent?.meta?.args;
+        const specUri =
+          normaliseString(
+            (createdArgs as { uri?: unknown })?.uri ??
+              (Array.isArray(createdArgs)
+                ? (createdArgs as unknown[])[7]
+                : undefined)
+          ) ?? '';
+
+        const phase = jobStateToPhase(stateValue);
         const summary: JobSummary = {
           jobId,
-          employer: String(jobData.employer ?? jobData[0]),
-          agent: jobData.worker ?? jobData.agent ?? jobData[1] ?? undefined,
-          reward: BigInt(jobData.reward ?? jobData[2] ?? 0),
-          stake: BigInt(jobData.stake ?? jobData[3] ?? 0),
-          fee: BigInt(jobData.fee ?? jobData[4] ?? 0),
-          deadline: Number(jobData.deadline ?? jobData[6] ?? 0),
-          specHash: String(jobData.specHash ?? jobData[8] ?? '0x'),
-          uri: String(jobData.uri ?? jobData[9] ?? ''),
+          employer,
+          agent,
+          reward,
+          stake,
+          fee,
+          deadline: deadlineValue,
+          specHash,
+          uri: specUri,
           phase,
-          lastUpdated: relatedEvents.reduce((acc, evt) => Math.max(acc, evt.timestamp ?? 0), 0),
+          lastUpdated: relatedEvents.reduce(
+            (acc, evt) => Math.max(acc, evt.timestamp ?? 0),
+            0
+          ),
           createdAt: createdEvent?.timestamp,
-          assignedAt: assignedEvent?.timestamp,
+          assignedAt:
+            assignedEvent?.timestamp ??
+            (assignedAtOnchain ? assignedAtOnchain : undefined),
           resultSubmittedAt: resultEvent?.timestamp,
-          resultHash,
+          resultHash: submittedResultHash ?? storedResultHash,
           resultUri: resultURI,
           validationStartedAt: validationEvent?.timestamp,
-          validationEndsAt: Number(jobData.deadline ?? jobData[6] ?? 0) || undefined
+          validationEndsAt: deadlineValue || undefined,
         };
         summaryMap.set(idStr, summary);
       }
 
       const validatorMap = new Map<string, Map<string, ValidatorInsight>>();
-      const ensureInsight = (jobId: bigint, address: string): ValidatorInsight => {
+      const ensureInsight = (
+        jobId: bigint,
+        address: string
+      ): ValidatorInsight => {
         const normalizedAddress = address.toLowerCase();
         const jobKey = jobId.toString();
         if (!validatorMap.has(jobKey)) {
@@ -230,7 +369,7 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
           insight = {
             jobId,
             validator: address,
-            stake: validationModule ? 0n : undefined
+            stake: validationModule ? 0n : undefined,
           };
           jobValidators.set(normalizedAddress, insight);
         }
@@ -243,32 +382,67 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
       for (const idStr of jobIdStrings) {
         const jobId = BigInt(idStr);
         try {
-          const committee = await (contract as unknown as { getJobValidators: (jobId: bigint) => Promise<string[]> }).getJobValidators(jobId);
+          const committee = await (
+            contract as unknown as {
+              getJobValidators: (jobId: bigint) => Promise<string[]>;
+            }
+          ).getJobValidators(jobId);
           committee.forEach((address) => {
-            if (address && address !== '0x0000000000000000000000000000000000000000') {
+            if (
+              address &&
+              address !== '0x0000000000000000000000000000000000000000'
+            ) {
               ensureInsight(jobId, String(address));
             }
           });
         } catch (err) {
-          console.warn('Failed to load validator committee from registry', jobId.toString(), err);
+          console.warn(
+            'Failed to load validator committee from registry',
+            jobId.toString(),
+            err
+          );
         }
       }
 
       if (validationModule) {
         const moduleLogs: EventLog[] = [];
-        const vmFilters = validationModule.filters as Record<string, (...args: never[]) => EventFilter>;
-        const selectedFilter = vmFilters.ValidatorsSelected(options.jobId ?? null);
-        const commitFilter = vmFilters.ValidationCommitted(options.jobId ?? null, null);
-        const revealFilter = vmFilters.ValidationRevealed(options.jobId ?? null, null);
-        const selectedLogs = await validationModule.queryFilter(selectedFilter, fromBlock);
-        const commitLogs = await validationModule.queryFilter(commitFilter, fromBlock);
-        const revealLogs = await validationModule.queryFilter(revealFilter, fromBlock);
+        const vmFilters = validationModule.filters as Record<
+          string,
+          (...args: never[]) => EventFilter
+        >;
+        const selectedFilter = vmFilters.ValidatorsSelected(
+          options.jobId ?? null
+        );
+        const commitFilter = vmFilters.ValidationCommitted(
+          options.jobId ?? null,
+          null
+        );
+        const revealFilter = vmFilters.ValidationRevealed(
+          options.jobId ?? null,
+          null
+        );
+        const selectedLogs = await validationModule.queryFilter(
+          selectedFilter,
+          fromBlock
+        );
+        const commitLogs = await validationModule.queryFilter(
+          commitFilter,
+          fromBlock
+        );
+        const revealLogs = await validationModule.queryFilter(
+          revealFilter,
+          fromBlock
+        );
         moduleLogs.push(...selectedLogs, ...commitLogs, ...revealLogs);
 
         const blockNumbers = Array.from(
           new Set(
             moduleLogs
-              .map((log) => (typeof log.blockNumber === 'number' ? log.blockNumber : Number(log.blockNumber ?? 0)))
+              .map((log) =>
+                typeof log.blockNumber === 'number'
+                  ? log.blockNumber
+                  : Number(log.blockNumber ?? 0)
+              )
               .filter((value) => Number.isFinite(value) && value > 0)
           )
         );
@@ -281,34 +455,52 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
         }
 
         const logTimestamp = (log: EventLog): number | undefined => {
-          const blockNumber = typeof log.blockNumber === 'number' ? log.blockNumber : Number(log.blockNumber ?? 0);
-          if (!Number.isFinite(blockNumber) || blockNumber <= 0) return undefined;
+          const blockNumber =
+            typeof log.blockNumber === 'number'
+              ? log.blockNumber
+              : Number(log.blockNumber ?? 0);
+          if (!Number.isFinite(blockNumber) || blockNumber <= 0)
+            return undefined;
           return timestampCache.get(blockNumber);
         };
 
         for (const log of selectedLogs) {
-          const jobIdValue = log.args?.jobId ?? (log.topics?.[1] ? BigInt(log.topics[1]) : undefined);
+          const jobIdValue =
+            log.args?.jobId ??
+            (log.topics?.[1] ? BigInt(log.topics[1]) : undefined);
           if (jobIdValue === undefined) continue;
-          const jobId = typeof jobIdValue === 'bigint' ? jobIdValue : BigInt(jobIdValue);
+          const jobId =
+            typeof jobIdValue === 'bigint' ? jobIdValue : BigInt(jobIdValue);
           const validatorsFromLog = (log.args?.validators ?? []) as string[];
           const timestamp = logTimestamp(log);
           validatorsFromLog.forEach((address) => {
             if (!address) return;
             const insight = ensureInsight(jobId, String(address));
-            if (timestamp && (!insight.selectedAt || insight.selectedAt < timestamp)) {
+            if (
+              timestamp &&
+              (!insight.selectedAt || insight.selectedAt < timestamp)
+            ) {
               insight.selectedAt = timestamp;
             }
           });
         }
 
         for (const log of commitLogs) {
-          const jobIdValue = log.args?.jobId ?? (log.topics?.[1] ? BigInt(log.topics[1]) : undefined);
-          const validatorAddress = log.args?.validator ?? (log.topics?.[2] ? `0x${log.topics[2].slice(26)}` : undefined);
+          const jobIdValue =
+            log.args?.jobId ??
+            (log.topics?.[1] ? BigInt(log.topics[1]) : undefined);
+          const validatorAddress =
+            log.args?.validator ??
+            (log.topics?.[2] ? `0x${log.topics[2].slice(26)}` : undefined);
           if (jobIdValue === undefined || !validatorAddress) continue;
-          const jobId = typeof jobIdValue === 'bigint' ? jobIdValue : BigInt(jobIdValue);
+          const jobId =
+            typeof jobIdValue === 'bigint' ? jobIdValue : BigInt(jobIdValue);
           const insight = ensureInsight(jobId, String(validatorAddress));
           const timestamp = logTimestamp(log);
-          if (timestamp && (!insight.committedAt || insight.committedAt < timestamp)) {
+          if (
+            timestamp &&
+            (!insight.committedAt || insight.committedAt < timestamp)
+          ) {
             insight.committedAt = timestamp;
           }
           if (!insight.commitTx) {
@@ -317,13 +509,21 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
         }
 
         for (const log of revealLogs) {
-          const jobIdValue = log.args?.jobId ?? (log.topics?.[1] ? BigInt(log.topics[1]) : undefined);
-          const validatorAddress = log.args?.validator ?? (log.topics?.[2] ? `0x${log.topics[2].slice(26)}` : undefined);
+          const jobIdValue =
+            log.args?.jobId ??
+            (log.topics?.[1] ? BigInt(log.topics[1]) : undefined);
+          const validatorAddress =
+            log.args?.validator ??
+            (log.topics?.[2] ? `0x${log.topics[2].slice(26)}` : undefined);
           if (jobIdValue === undefined || !validatorAddress) continue;
-          const jobId = typeof jobIdValue === 'bigint' ? jobIdValue : BigInt(jobIdValue);
+          const jobId =
+            typeof jobIdValue === 'bigint' ? jobIdValue : BigInt(jobIdValue);
           const insight = ensureInsight(jobId, String(validatorAddress));
           const timestamp = logTimestamp(log);
-          if (timestamp && (!insight.revealedAt || insight.revealedAt < timestamp)) {
+          if (
+            timestamp &&
+            (!insight.revealedAt || insight.revealedAt < timestamp)
+          ) {
             insight.revealedAt = timestamp;
           }
           insight.vote = log.args?.approve ? 'approve' : 'reject';
@@ -340,8 +540,9 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
                 .validatorStakes(insight.jobId, insight.validator)
                 .then((value: bigint) => {
                   try {
-                    insight.stake = typeof value === 'bigint' ? value : BigInt(value);
-                  } catch (err) {
+                    insight.stake =
+                      typeof value === 'bigint' ? value : BigInt(value);
+                  } catch {
                     insight.stake = 0n;
                   }
                 })
@@ -379,9 +580,13 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
         summary.stakedByValidators = totalStake;
       });
 
-      const summaries = Array.from(summaryMap.values()).sort((a, b) => Number(b.jobId - a.jobId));
+      const summaries = Array.from(summaryMap.values()).sort((a, b) =>
+        Number(b.jobId - a.jobId)
+      );
 
-      const validatorList = Array.from(validatorMap.values()).flatMap((collection) => Array.from(collection.values()));
+      const validatorList = Array.from(validatorMap.values()).flatMap(
+        (collection) => Array.from(collection.values())
+      );
 
       validatorList.sort((a, b) => {
         const timestampA = a.revealedAt ?? a.committedAt ?? a.selectedAt ?? 0;
@@ -418,13 +623,15 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
       return { name, handler };
     });
     const validationHandlers = validationModule
-      ? ['ValidatorsSelected', 'ValidationCommitted', 'ValidationRevealed'].map((name) => {
-          const handler = () => {
-            load().catch((err) => console.error(err));
-          };
-          validationModule.on(name, handler);
-          return { name, handler };
-        })
+      ? ['ValidatorsSelected', 'ValidationCommitted', 'ValidationRevealed'].map(
+          (name) => {
+            const handler = () => {
+              load().catch((err) => console.error(err));
+            };
+            validationModule.on(name, handler);
+            return { name, handler };
+          }
+        )
       : [];
     return () => {
       handlers.forEach(({ name, handler }) => contract.off(name, handler));
@@ -441,6 +648,6 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
     loading,
     error,
     hasValidationModule: Boolean(portalConfig.validationModuleAddress),
-    refresh: load
+    refresh: load,
   };
 };

--- a/apps/enterprise-portal/src/lib/abis/jobRegistry.ts
+++ b/apps/enterprise-portal/src/lib/abis/jobRegistry.ts
@@ -6,10 +6,10 @@ export const jobRegistryAbi = [
       { name: 'reward', type: 'uint256' },
       { name: 'deadline', type: 'uint64' },
       { name: 'specHash', type: 'bytes32' },
-      { name: 'uri', type: 'string' }
+      { name: 'uri', type: 'string' },
     ],
     outputs: [{ name: 'jobId', type: 'uint256' }],
-    stateMutability: 'nonpayable'
+    stateMutability: 'nonpayable',
   },
   {
     type: 'function',
@@ -19,10 +19,10 @@ export const jobRegistryAbi = [
       { name: 'deadline', type: 'uint64' },
       { name: 'agentTypes', type: 'uint8' },
       { name: 'specHash', type: 'bytes32' },
-      { name: 'uri', type: 'string' }
+      { name: 'uri', type: 'string' },
     ],
     outputs: [{ name: 'jobId', type: 'uint256' }],
-    stateMutability: 'nonpayable'
+    stateMutability: 'nonpayable',
   },
   {
     type: 'function',
@@ -31,10 +31,10 @@ export const jobRegistryAbi = [
       { name: 'reward', type: 'uint256' },
       { name: 'deadline', type: 'uint64' },
       { name: 'specHash', type: 'bytes32' },
-      { name: 'uri', type: 'string' }
+      { name: 'uri', type: 'string' },
     ],
     outputs: [{ name: 'jobId', type: 'uint256' }],
-    stateMutability: 'nonpayable'
+    stateMutability: 'nonpayable',
   },
   {
     type: 'function',
@@ -44,45 +44,72 @@ export const jobRegistryAbi = [
       { name: 'deadline', type: 'uint64' },
       { name: 'agentTypes', type: 'uint8' },
       { name: 'specHash', type: 'bytes32' },
-      { name: 'uri', type: 'string' }
+      { name: 'uri', type: 'string' },
     ],
     outputs: [{ name: 'jobId', type: 'uint256' }],
-    stateMutability: 'nonpayable'
+    stateMutability: 'nonpayable',
   },
   {
     type: 'function',
-    name: 'job',
+    name: 'jobs',
     inputs: [{ name: 'jobId', type: 'uint256' }],
     outputs: [
-      { name: 'employer', type: 'address' },
-      { name: 'worker', type: 'address' },
-      { name: 'reward', type: 'uint256' },
-      { name: 'stake', type: 'uint256' },
-      { name: 'fee', type: 'uint256' },
-      { name: 'createdAt', type: 'uint64' },
-      { name: 'deadline', type: 'uint64' },
-      { name: 'state', type: 'uint8' },
-      { name: 'specHash', type: 'bytes32' },
-      { name: 'uri', type: 'string' }
+      {
+        name: '',
+        type: 'tuple',
+        components: [
+          { name: 'employer', type: 'address' },
+          { name: 'agent', type: 'address' },
+          { name: 'reward', type: 'uint128' },
+          { name: 'stake', type: 'uint96' },
+          { name: 'burnReceiptAmount', type: 'uint128' },
+          { name: 'uriHash', type: 'bytes32' },
+          { name: 'resultHash', type: 'bytes32' },
+          { name: 'specHash', type: 'bytes32' },
+          { name: 'packedMetadata', type: 'uint256' },
+        ],
+      },
     ],
-    stateMutability: 'view'
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'decodeJobMetadata',
+    inputs: [{ name: 'packed', type: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        components: [
+          { name: 'state', type: 'uint8' },
+          { name: 'success', type: 'bool' },
+          { name: 'burnConfirmed', type: 'bool' },
+          { name: 'agentTypes', type: 'uint8' },
+          { name: 'feePct', type: 'uint32' },
+          { name: 'agentPct', type: 'uint32' },
+          { name: 'deadline', type: 'uint64' },
+          { name: 'assignedAt', type: 'uint64' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getJobValidators',
     inputs: [{ name: 'jobId', type: 'uint256' }],
     outputs: [{ name: '', type: 'address[]' }],
-    stateMutability: 'view'
+    stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getJobValidatorVote',
     inputs: [
       { name: 'jobId', type: 'uint256' },
-      { name: 'validator', type: 'address' }
+      { name: 'validator', type: 'address' },
     ],
     outputs: [{ name: '', type: 'bool' }],
-    stateMutability: 'view'
+    stateMutability: 'view',
   },
   {
     type: 'event',
@@ -95,8 +122,8 @@ export const jobRegistryAbi = [
       { name: 'stake', type: 'uint256', indexed: false },
       { name: 'fee', type: 'uint256', indexed: false },
       { name: 'specHash', type: 'bytes32', indexed: false },
-      { name: 'uri', type: 'string', indexed: false }
-    ]
+      { name: 'uri', type: 'string', indexed: false },
+    ],
   },
   {
     type: 'event',
@@ -104,8 +131,8 @@ export const jobRegistryAbi = [
     inputs: [
       { name: 'jobId', type: 'uint256', indexed: true },
       { name: 'agent', type: 'address', indexed: true },
-      { name: 'subdomain', type: 'string', indexed: false }
-    ]
+      { name: 'subdomain', type: 'string', indexed: false },
+    ],
   },
   {
     type: 'event',
@@ -115,28 +142,28 @@ export const jobRegistryAbi = [
       { name: 'worker', type: 'address', indexed: true },
       { name: 'resultHash', type: 'bytes32', indexed: false },
       { name: 'resultURI', type: 'string', indexed: false },
-      { name: 'subdomain', type: 'string', indexed: false }
-    ]
+      { name: 'subdomain', type: 'string', indexed: false },
+    ],
   },
   {
     type: 'event',
     name: 'ValidationStartTriggered',
-    inputs: [{ name: 'jobId', type: 'uint256', indexed: true }]
+    inputs: [{ name: 'jobId', type: 'uint256', indexed: true }],
   },
   {
     type: 'event',
     name: 'JobFinalized',
     inputs: [
       { name: 'jobId', type: 'uint256', indexed: true },
-      { name: 'worker', type: 'address', indexed: true }
-    ]
+      { name: 'worker', type: 'address', indexed: true },
+    ],
   },
   {
     type: 'event',
     name: 'JobDisputed',
     inputs: [
       { name: 'jobId', type: 'uint256', indexed: true },
-      { name: 'caller', type: 'address', indexed: true }
-    ]
-  }
+      { name: 'caller', type: 'address', indexed: true },
+    ],
+  },
 ] as const;

--- a/apps/enterprise-portal/src/lib/jobStatus.ts
+++ b/apps/enterprise-portal/src/lib/jobStatus.ts
@@ -2,6 +2,8 @@ import type { JobPhase } from '../types';
 
 export const jobStateToPhase = (state: number): JobPhase => {
   switch (state) {
+    case 0:
+      return 'Created';
     case 1:
       return 'Created';
     case 2:


### PR DESCRIPTION
## Summary
- update the enterprise portal JobRegistry ABI to expose the v2 `jobs` mapping and `decodeJobMetadata`
- switch the job feed hook to consume v2 metadata for fee/deadline calculations and pull the spec URI from creation events
- resolve certificate badges via `jobs()` snapshots and decoded metadata so v2 registries still display participant details

## Testing
- npx eslint apps/enterprise-portal/src/hooks/useJobFeed.ts apps/enterprise-portal/src/hooks/useCertificates.ts apps/enterprise-portal/src/lib/jobStatus.ts apps/enterprise-portal/src/lib/abis/jobRegistry.ts


------
https://chatgpt.com/codex/tasks/task_e_68dd563594e883338e5abb17262cd7fe