### PR TITLE
Update enterprise portal job feed for registry v2 ABI

### DIFF
--- a/apps/enterprise-portal/src/components/JobLifecycleDashboard.tsx
+++ b/apps/enterprise-portal/src/components/JobLifecycleDashboard.tsx
@@ -23,9 +23,9 @@ const formatTokenAmount = (value: bigint) => {
   try {
     return Number.parseFloat(formatUnits(value, 18)).toLocaleString(undefined, {
       minimumFractionDigits: 2,
-      maximumFractionDigits: 2
+      maximumFractionDigits: 2,
     });
-  } catch (err) {
+  } catch {
     return value.toString();
   }
 };
@@ -40,12 +40,15 @@ const formatTokenDisplay = (value?: bigint) => {
 const safeDurationBetween = (from: number, to: number) => {
   try {
     return formatDurationBetween(from, to);
-  } catch (err) {
+  } catch {
     return undefined;
   }
 };
 
-const relativeTime = (timestamp: number | undefined, now: number): string | undefined => {
+const relativeTime = (
+  timestamp: number | undefined,
+  now: number
+): string | undefined => {
   if (!timestamp) return undefined;
   return safeDurationBetween(timestamp, now);
 };
@@ -59,25 +62,40 @@ const Timeline = ({ events }: { events: JobTimelineEvent[] }) => (
         typeof args?.resultURI === 'string'
           ? args.resultURI
           : Array.isArray(args)
-            ? (args[3] as string | undefined)
-            : undefined;
+          ? (args[3] as string | undefined)
+          : undefined;
       const resolvedResultUri = resolveResourceUri(resultUri) ?? resultUri;
       return (
         <div className="timeline-item" key={event.id}>
-          <div className={`tag ${phaseToTagColor(event.phase)}`} style={{ marginBottom: '0.5rem' }}>
+          <div
+            className={`tag ${phaseToTagColor(event.phase)}`}
+            style={{ marginBottom: '0.5rem' }}
+          >
             {event.phase}
           </div>
           <h4 style={{ marginBottom: '0.25rem' }}>{event.name}</h4>
           <div className="small">{formatTimestamp(event.timestamp)}</div>
           <p>{event.description}</p>
-          {event.actor && <div className="small">Actor: {shortenAddress(event.actor)}</div>}
+          {event.actor && (
+            <div className="small">Actor: {shortenAddress(event.actor)}</div>
+          )}
           {resolvedResultUri && (
-            <a className="small" href={resolvedResultUri} target="_blank" rel="noreferrer">
+            <a
+              className="small"
+              href={resolvedResultUri}
+              target="_blank"
+              rel="noreferrer"
+            >
               View deliverable
             </a>
           )}
           {event.txHash && (
-            <a className="small" href={`https://sepolia.etherscan.io/tx/${event.txHash}`} target="_blank" rel="noreferrer">
+            <a
+              className="small"
+              href={`https://sepolia.etherscan.io/tx/${event.txHash}`}
+              target="_blank"
+              rel="noreferrer"
+            >
               View transaction
             </a>
           )}
@@ -94,7 +112,12 @@ interface Props {
   error?: string;
 }
 
-export const JobLifecycleDashboard = ({ jobs, events, loading, error }: Props) => {
+export const JobLifecycleDashboard = ({
+  jobs,
+  events,
+  loading,
+  error,
+}: Props) => {
   const [selectedJobId, setSelectedJobId] = useState<bigint>();
   const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
 
@@ -117,12 +140,20 @@ export const JobLifecycleDashboard = ({ jobs, events, loading, error }: Props) =
   );
 
   const selectedEvents = useMemo(
-    () => events.filter((event) => (selectedJobId ? event.jobId === selectedJobId : false)),
+    () =>
+      events.filter((event) =>
+        selectedJobId ? event.jobId === selectedJobId : false
+      ),
     [events, selectedJobId]
   );
 
-  const { metadata, loading: metadataLoading, error: metadataError, resolvedUri: resolvedSpecUri, refresh: refreshMetadata } =
-    useJobMetadata(selectedJob?.uri);
+  const {
+    metadata,
+    loading: metadataLoading,
+    error: metadataError,
+    resolvedUri: resolvedSpecUri,
+    refresh: refreshMetadata,
+  } = useJobMetadata(selectedJob?.specUri);
 
   const validationCountdown = useMemo(() => {
     if (!selectedJob) return undefined;
@@ -134,51 +165,75 @@ export const JobLifecycleDashboard = ({ jobs, events, loading, error }: Props) =
   const statusBanner = useMemo(() => {
     if (!selectedJob) return undefined;
     const validatorProgress = selectedJob.totalValidators
-      ? `${selectedJob.validatorVotes ?? 0} of ${selectedJob.totalValidators} votes`
+      ? `${selectedJob.validatorVotes ?? 0} of ${
+          selectedJob.totalValidators
+        } votes`
       : undefined;
     const agentLabel = shortenAddress(selectedJob.agent);
-    const createdRelative = relativeTime(selectedJob.createdAt ?? selectedJob.lastUpdated, now);
+    const createdRelative = relativeTime(
+      selectedJob.createdAt ?? selectedJob.lastUpdated,
+      now
+    );
     const submittedRelative = relativeTime(selectedJob.resultSubmittedAt, now);
-    const validationRelative = relativeTime(selectedJob.validationStartedAt, now);
+    const validationRelative = relativeTime(
+      selectedJob.validationStartedAt,
+      now
+    );
 
     switch (selectedJob.phase) {
       case 'Created':
         return {
-          message: `Job posted${createdRelative ? ` ${createdRelative}` : ''}. Awaiting agent assignment.`,
-          variant: 'alert'
+          message: `Job posted${
+            createdRelative ? ` ${createdRelative}` : ''
+          }. Awaiting agent assignment.`,
+          variant: 'alert',
         } as const;
       case 'Assigned':
         return {
-          message: `Assigned to ${agentLabel}. Deliverable due by ${formatTimestamp(selectedJob.deadline)}.`,
-          variant: 'alert'
+          message: `Assigned to ${agentLabel}. Deliverable due by ${formatTimestamp(
+            selectedJob.deadline
+          )}.`,
+          variant: 'alert',
         } as const;
       case 'Submitted':
         return {
-          message: `Deliverable submitted${submittedRelative ? ` ${submittedRelative}` : ''}. Awaiting validator review.`,
-          variant: 'alert'
+          message: `Deliverable submitted${
+            submittedRelative ? ` ${submittedRelative}` : ''
+          }. Awaiting validator review.`,
+          variant: 'alert',
         } as const;
       case 'InValidation':
         return {
-          message: `In validation${validationRelative ? ` since ${validationRelative}` : ''} — ${
-            validatorProgress ?? 'awaiting committee formation'
-          }${validationCountdown ? `. Decision window closes ${validationCountdown}.` : ''}`,
-          variant: 'alert'
+          message: `In validation${
+            validationRelative ? ` since ${validationRelative}` : ''
+          } — ${validatorProgress ?? 'awaiting committee formation'}${
+            validationCountdown
+              ? `. Decision window closes ${validationCountdown}.`
+              : ''
+          }`,
+          variant: 'alert',
         } as const;
       case 'Finalized':
         return {
-          message: `Job finalized on ${formatTimestamp(selectedJob.lastUpdated)}. Payouts settled and certificates issued.`,
-          variant: 'alert success'
+          message: `Job finalized on ${formatTimestamp(
+            selectedJob.lastUpdated
+          )}. Payouts settled and certificates issued.`,
+          variant: 'alert success',
         } as const;
       case 'Disputed':
         return {
-          message: `Dispute raised${validationRelative ? ` ${validationRelative}` : ''}. Monitor validator votes and SLA evidence.`,
-          variant: 'alert error'
+          message: `Dispute raised${
+            validationRelative ? ` ${validationRelative}` : ''
+          }. Monitor validator votes and SLA evidence.`,
+          variant: 'alert error',
         } as const;
       case 'Cancelled':
       case 'Expired':
         return {
-          message: `Job is no longer active. Last update ${formatTimestamp(selectedJob.lastUpdated)}.`,
-          variant: 'alert error'
+          message: `Job is no longer active. Last update ${formatTimestamp(
+            selectedJob.lastUpdated
+          )}.`,
+          variant: 'alert error',
         } as const;
       default:
         return undefined;
@@ -190,9 +245,16 @@ export const JobLifecycleDashboard = ({ jobs, events, loading, error }: Props) =
       <div className="card-title">
         <div>
           <h2>Job Lifecycle Monitoring</h2>
-          <p>Observe real-time status, validator checkpoints, and dispute signals across your enterprise job portfolio.</p>
+          <p>
+            Observe real-time status, validator checkpoints, and dispute signals
+            across your enterprise job portfolio.
+          </p>
         </div>
-        <div className={`tag ${selectedJob ? phaseToTagColor(selectedJob.phase) : 'purple'}`}>
+        <div
+          className={`tag ${
+            selectedJob ? phaseToTagColor(selectedJob.phase) : 'purple'
+          }`}
+        >
           {selectedJob ? selectedJob.phase : 'Waiting'}
         </div>
       </div>
@@ -216,52 +278,86 @@ export const JobLifecycleDashboard = ({ jobs, events, loading, error }: Props) =
                 <tr
                   key={job.jobId.toString()}
                   onClick={() => setSelectedJobId(job.jobId)}
-                  style={{ cursor: 'pointer', backgroundColor: selectedJobId === job.jobId ? 'rgba(124,136,255,0.12)' : undefined }}
+                  style={{
+                    cursor: 'pointer',
+                    backgroundColor:
+                      selectedJobId === job.jobId
+                        ? 'rgba(124,136,255,0.12)'
+                        : undefined,
+                  }}
                 >
                   <td>#{job.jobId.toString()}</td>
                   <td>{formatTokenDisplay(job.reward)}</td>
                   <td>{shortenAddress(job.agent)}</td>
                   <td>
-                    <span className={`tag ${phaseToTagColor(job.phase)}`}>{job.phase}</span>
+                    <span className={`tag ${phaseToTagColor(job.phase)}`}>
+                      {job.phase}
+                    </span>
                   </td>
-                  <td>{job.totalValidators ? `${job.validatorVotes ?? 0}/${job.totalValidators}` : '—'}</td>
+                  <td>
+                    {job.totalValidators
+                      ? `${job.validatorVotes ?? 0}/${job.totalValidators}`
+                      : '—'}
+                  </td>
                   <td>{formatTimestamp(job.lastUpdated)}</td>
                 </tr>
               ))}
             </tbody>
           </table>
-          {jobs.length === 0 && !loading && <div className="small">No jobs posted yet. Create one to activate monitoring.</div>}
+          {jobs.length === 0 && !loading && (
+            <div className="small">
+              No jobs posted yet. Create one to activate monitoring.
+            </div>
+          )}
         </div>
         <div>
           {selectedJob ? (
             <div className="grid">
-              {statusBanner && <div className={statusBanner.variant}>{statusBanner.message}</div>}
+              {statusBanner && (
+                <div className={statusBanner.variant}>
+                  {statusBanner.message}
+                </div>
+              )}
               <div className="data-grid">
                 <div>
                   <div className="stat-label">Employer</div>
-                  <div className="stat-value">{shortenAddress(selectedJob.employer)}</div>
+                  <div className="stat-value">
+                    {shortenAddress(selectedJob.employer)}
+                  </div>
                 </div>
                 <div>
                   <div className="stat-label">Deadline</div>
-                  <div className="stat-value">{formatTimestamp(selectedJob.deadline)}</div>
+                  <div className="stat-value">
+                    {formatTimestamp(selectedJob.deadline)}
+                  </div>
                 </div>
                 <div>
                   <div className="stat-label">Reward</div>
-                  <div className="stat-value">{formatTokenDisplay(selectedJob.reward)}</div>
+                  <div className="stat-value">
+                    {formatTokenDisplay(selectedJob.reward)}
+                  </div>
                 </div>
                 <div>
                   <div className="stat-label">Agent Stake</div>
-                  <div className="stat-value">{formatTokenDisplay(selectedJob.stake)}</div>
+                  <div className="stat-value">
+                    {formatTokenDisplay(selectedJob.stake)}
+                  </div>
                 </div>
                 <div>
                   <div className="stat-label">Validator Votes</div>
                   <div className="stat-value">
-                    {selectedJob.totalValidators ? `${selectedJob.validatorVotes ?? 0}/${selectedJob.totalValidators}` : '—'}
+                    {selectedJob.totalValidators
+                      ? `${selectedJob.validatorVotes ?? 0}/${
+                          selectedJob.totalValidators
+                        }`
+                      : '—'}
                   </div>
                 </div>
                 <div>
                   <div className="stat-label">Validator Stake</div>
-                  <div className="stat-value">{formatTokenDisplay(selectedJob.stakedByValidators)}</div>
+                  <div className="stat-value">
+                    {formatTokenDisplay(selectedJob.stakedByValidators)}
+                  </div>
                 </div>
               </div>
               <div className="alert">
@@ -269,62 +365,108 @@ export const JobLifecycleDashboard = ({ jobs, events, loading, error }: Props) =
               </div>
               <div className="code-block">
                 <strong>Specification</strong>
-                <div>Hash: {selectedJob.specHash}</div>
-                {selectedJob.uri && (
+                <div>Spec hash: {selectedJob.specHash}</div>
+                {selectedJob.uriHash && (
+                  <div>URI hash: {selectedJob.uriHash}</div>
+                )}
+                {selectedJob.specUri && (
                   <div>
                     URI:{' '}
-                    <a href={resolvedSpecUri ?? selectedJob.uri} target="_blank" rel="noreferrer">
-                      {selectedJob.uri}
+                    <a
+                      href={resolvedSpecUri ?? selectedJob.specUri}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {selectedJob.specUri}
                     </a>
                   </div>
                 )}
               </div>
-              {metadataLoading && <div className="small">Loading job metadata…</div>}
-              {metadataError && <div className="alert error">{metadataError}</div>}
+              {metadataLoading && (
+                <div className="small">Loading job metadata…</div>
+              )}
+              {metadataError && (
+                <div className="alert error">{metadataError}</div>
+              )}
               {metadata && (
                 <div className="surface-card">
-                  <div className="card-title" style={{ marginBottom: '0.5rem' }}>
+                  <div
+                    className="card-title"
+                    style={{ marginBottom: '0.5rem' }}
+                  >
                     <div>
                       <h3>Specification overview</h3>
                       <p className="small" style={{ marginTop: '0.35rem' }}>
-                        Details resolved from the job metadata URI. Use these snapshots to verify requirements with your
-                        compliance and delivery teams.
+                        Details resolved from the job metadata URI. Use these
+                        snapshots to verify requirements with your compliance
+                        and delivery teams.
                       </p>
                     </div>
-                    <button className="secondary" type="button" onClick={refreshMetadata}>
+                    <button
+                      className="secondary"
+                      type="button"
+                      onClick={refreshMetadata}
+                    >
                       Refresh
                     </button>
                   </div>
                   {metadata.title && (
                     <div>
                       <div className="stat-label">Title</div>
-                      <div className="stat-value" style={{ fontSize: '1rem', marginTop: '0.25rem' }}>
+                      <div
+                        className="stat-value"
+                        style={{ fontSize: '1rem', marginTop: '0.25rem' }}
+                      >
                         {metadata.title}
                       </div>
                     </div>
                   )}
-                  {metadata.description && <p style={{ marginTop: '0.75rem' }}>{metadata.description}</p>}
+                  {metadata.description && (
+                    <p style={{ marginTop: '0.75rem' }}>
+                      {metadata.description}
+                    </p>
+                  )}
                   <div className="data-grid" style={{ marginTop: '1rem' }}>
                     {typeof metadata.ttlHours !== 'undefined' && (
                       <div>
                         <div className="stat-label">TTL (hours)</div>
-                        <div className="stat-value" style={{ fontSize: '1.1rem' }}>{metadata.ttlHours}</div>
+                        <div
+                          className="stat-value"
+                          style={{ fontSize: '1.1rem' }}
+                        >
+                          {metadata.ttlHours}
+                        </div>
                       </div>
                     )}
                     {metadata.reward && (
                       <div>
                         <div className="stat-label">Proposed reward</div>
-                        <div className="stat-value" style={{ fontSize: '1.1rem' }}>{metadata.reward}</div>
+                        <div
+                          className="stat-value"
+                          style={{ fontSize: '1.1rem' }}
+                        >
+                          {metadata.reward}
+                        </div>
                       </div>
                     )}
                     {metadata.attachments.length > 0 && (
                       <div>
                         <div className="stat-label">Reference materials</div>
-                        <div className="chip-row" style={{ marginTop: '0.5rem' }}>
+                        <div
+                          className="chip-row"
+                          style={{ marginTop: '0.5rem' }}
+                        >
                           {metadata.attachments.map((attachment) => {
-                            const resolvedAttachment = resolveResourceUri(attachment) ?? attachment;
+                            const resolvedAttachment =
+                              resolveResourceUri(attachment) ?? attachment;
                             return (
-                              <a key={attachment} className="chip" href={resolvedAttachment} target="_blank" rel="noreferrer">
+                              <a
+                                key={attachment}
+                                className="chip"
+                                href={resolvedAttachment}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
                                 {attachment}
                               </a>
                             );
@@ -357,24 +499,34 @@ export const JobLifecycleDashboard = ({ jobs, events, loading, error }: Props) =
                   )}
                   {metadata.sla && (
                     <div className="alert" style={{ marginTop: '1rem' }}>
-                      {metadata.sla.title ? `${metadata.sla.title} — ` : ''}SLA attached
-                      {metadata.sla.version ? ` (v${metadata.sla.version})` : ''}.
-                      {metadata.sla.requiresSignature && ' Agent signature required before assignment.'}
+                      {metadata.sla.title ? `${metadata.sla.title} — ` : ''}SLA
+                      attached
+                      {metadata.sla.version
+                        ? ` (v${metadata.sla.version})`
+                        : ''}
+                      .
+                      {metadata.sla.requiresSignature &&
+                        ' Agent signature required before assignment.'}
                       {metadata.sla.summary && (
-                        <span>
-                          {' '}
-                          {metadata.sla.summary}
-                        </span>
+                        <span> {metadata.sla.summary}</span>
                       )}
                       {metadata.sla.uri && (
                         <span>
                           {' '}
-                          <a href={resolveResourceUri(metadata.sla.uri) ?? metadata.sla.uri} target="_blank" rel="noreferrer">
+                          <a
+                            href={
+                              resolveResourceUri(metadata.sla.uri) ??
+                              metadata.sla.uri
+                            }
+                            target="_blank"
+                            rel="noreferrer"
+                          >
                             Open SLA document
                           </a>
                         </span>
                       )}
-                      {(metadata.sla.obligations.length > 0 || metadata.sla.successCriteria.length > 0) && (
+                      {(metadata.sla.obligations.length > 0 ||
+                        metadata.sla.successCriteria.length > 0) && (
                         <div style={{ marginTop: '0.75rem' }}>
                           {metadata.sla.obligations.length > 0 && (
                             <>
@@ -388,7 +540,10 @@ export const JobLifecycleDashboard = ({ jobs, events, loading, error }: Props) =
                           )}
                           {metadata.sla.successCriteria.length > 0 && (
                             <>
-                              <div className="stat-label" style={{ marginTop: '0.75rem' }}>
+                              <div
+                                className="stat-label"
+                                style={{ marginTop: '0.75rem' }}
+                              >
                                 Success criteria
                               </div>
                               <ul className="metadata-list">
@@ -407,16 +562,27 @@ export const JobLifecycleDashboard = ({ jobs, events, loading, error }: Props) =
               {selectedJob.resultUri && (
                 <div className="code-block">
                   <strong>Latest deliverable</strong>
-                  {selectedJob.resultHash && <div>Result hash: {selectedJob.resultHash}</div>}
+                  {selectedJob.resultHash && (
+                    <div>Result hash: {selectedJob.resultHash}</div>
+                  )}
                   <div>
                     URI:{' '}
-                    <a href={resolveResourceUri(selectedJob.resultUri) ?? selectedJob.resultUri} target="_blank" rel="noreferrer">
+                    <a
+                      href={
+                        resolveResourceUri(selectedJob.resultUri) ??
+                        selectedJob.resultUri
+                      }
+                      target="_blank"
+                      rel="noreferrer"
+                    >
                       {selectedJob.resultUri}
                     </a>
                   </div>
                   {selectedJob.resultSubmittedAt && (
                     <div className="small" style={{ marginTop: '0.5rem' }}>
-                      Submitted {relativeTime(selectedJob.resultSubmittedAt, now) ?? 'recently'}
+                      Submitted{' '}
+                      {relativeTime(selectedJob.resultSubmittedAt, now) ??
+                        'recently'}
                     </div>
                   )}
                 </div>

--- a/apps/enterprise-portal/src/lib/abis/jobRegistry.ts
+++ b/apps/enterprise-portal/src/lib/abis/jobRegistry.ts
@@ -81,7 +81,7 @@ export const jobRegistryAbi = [
         name: '',
         type: 'tuple',
         components: [
-          { name: 'state', type: 'uint8' },
+          { name: 'status', type: 'uint8' },
           { name: 'success', type: 'bool' },
           { name: 'burnConfirmed', type: 'bool' },
           { name: 'agentTypes', type: 'uint8' },
@@ -92,7 +92,7 @@ export const jobRegistryAbi = [
         ],
       },
     ],
-    stateMutability: 'view',
+    stateMutability: 'pure',
   },
   {
     type: 'function',
@@ -122,7 +122,16 @@ export const jobRegistryAbi = [
       { name: 'stake', type: 'uint256', indexed: false },
       { name: 'fee', type: 'uint256', indexed: false },
       { name: 'specHash', type: 'bytes32', indexed: false },
-      { name: 'uri', type: 'string', indexed: false },
+      { name: 'uriHash', type: 'bytes32', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'ApplicationSubmitted',
+    inputs: [
+      { name: 'jobId', type: 'uint256', indexed: true },
+      { name: 'applicant', type: 'address', indexed: true },
+      { name: 'subdomain', type: 'string', indexed: false },
     ],
   },
   {

--- a/apps/enterprise-portal/src/types/index.ts
+++ b/apps/enterprise-portal/src/types/index.ts
@@ -29,7 +29,8 @@ export interface JobSummary {
   fee: bigint;
   deadline: number;
   specHash: string;
-  uri: string;
+  specUri?: string;
+  uriHash?: string;
   phase: JobPhase;
   lastUpdated: number;
   createdAt?: number;


### PR DESCRIPTION
## Summary
- replace the enterprise portal job registry ABI with the v2 tuple metadata and uri hash definition
- refactor the job feed hook to decode packed metadata, surface uri hashes, and derive spec URIs from hashes
- refresh the lifecycle dashboard to consume the new spec URI field and display hashed identifiers

## Testing
- npx eslint apps/enterprise-portal/src/hooks/useJobFeed.ts apps/enterprise-portal/src/components/JobLifecycleDashboard.tsx apps/enterprise-portal/src/types/index.ts --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68dd58f61c7883338d106f3a08edce2c