### PR TITLE
Refine enterprise portal validation phases

### DIFF
--- a/apps/enterprise-portal/src/components/JobLifecycleDashboard.helpers.ts
+++ b/apps/enterprise-portal/src/components/JobLifecycleDashboard.helpers.ts
@@ -1,0 +1,119 @@
+import type { JobSummary } from '../types';
+import { formatDurationBetween } from '../lib/time.js';
+
+export const formatTimestamp = (timestamp?: number) => {
+  if (!timestamp) return '—';
+  return new Date(timestamp * 1000).toLocaleString();
+};
+
+export const shortenAddress = (value?: string) => {
+  if (!value) return '—';
+  return `${value.slice(0, 6)}…${value.slice(-4)}`;
+};
+
+export const safeDurationBetween = (from: number, to: number) => {
+  try {
+    return formatDurationBetween(from, to);
+  } catch {
+    return undefined;
+  }
+};
+
+export const relativeTime = (
+  timestamp: number | undefined,
+  now: number
+): string | undefined => {
+  if (!timestamp) return undefined;
+  return safeDurationBetween(timestamp, now);
+};
+
+export interface StatusBanner {
+  message: string;
+  variant: 'alert' | 'alert success' | 'alert error';
+}
+
+export const deriveStatusBanner = ({
+  job,
+  now,
+  validationCountdown,
+}: {
+  job: JobSummary;
+  now: number;
+  validationCountdown?: string;
+}): StatusBanner | undefined => {
+  const validatorProgress = job.totalValidators
+    ? `${job.validatorVotes ?? 0} of ${job.totalValidators} votes`
+    : undefined;
+  const agentLabel = shortenAddress(job.agent);
+  const createdRelative = relativeTime(job.createdAt ?? job.lastUpdated, now);
+  const submittedRelative = relativeTime(job.resultSubmittedAt, now);
+  const validationRelative = relativeTime(job.validationStartedAt, now);
+  const validatedRelative = relativeTime(job.lastUpdated, now);
+
+  switch (job.phase) {
+    case 'Created':
+      return {
+        message: `Job posted${createdRelative ? ` ${createdRelative}` : ''}. Awaiting agent assignment.`,
+        variant: 'alert',
+      } as const;
+    case 'Assigned':
+      return {
+        message: `Assigned to ${agentLabel}. Deliverable due by ${formatTimestamp(job.deadline)}.`,
+        variant: 'alert',
+      } as const;
+    case 'Submitted':
+      return {
+        message: `Deliverable submitted${
+          submittedRelative ? ` ${submittedRelative}` : ''
+        }. Awaiting validator review.`,
+        variant: 'alert',
+      } as const;
+    case 'InValidation':
+      return {
+        message: `In validation${
+          validationRelative ? ` since ${validationRelative}` : ''
+        } — ${validatorProgress ?? 'awaiting committee formation'}${
+          validationCountdown
+            ? `. Decision window closes ${validationCountdown}.`
+            : ''
+        }`,
+        variant: 'alert',
+      } as const;
+    case 'Validated': {
+      const outcomeText =
+        job.success === false
+          ? 'Outcome rejected. Awaiting finalization or dispute.'
+          : 'Outcome approved. Awaiting finalization.';
+      return {
+        message: `Validation completed${
+          validatedRelative ? ` ${validatedRelative}` : ''
+        }. ${outcomeText}`,
+        variant: job.success === false ? 'alert error' : 'alert success',
+      } as const;
+    }
+    case 'Finalized':
+      return {
+        message: `Job finalized on ${formatTimestamp(
+          job.lastUpdated
+        )}. Payouts settled and certificates issued.`,
+        variant: 'alert success',
+      } as const;
+    case 'Disputed':
+      return {
+        message: `Dispute raised${
+          validationRelative ? ` ${validationRelative}` : ''
+        }. Monitor validator votes and SLA evidence.`,
+        variant: 'alert error',
+      } as const;
+    case 'Cancelled':
+    case 'Expired':
+      return {
+        message: `Job is no longer active. Last update ${formatTimestamp(
+          job.lastUpdated
+        )}.`,
+        variant: 'alert error',
+      } as const;
+    default:
+      return undefined;
+  }
+};

--- a/apps/enterprise-portal/src/components/__tests__/JobLifecycleDashboard.test.ts
+++ b/apps/enterprise-portal/src/components/__tests__/JobLifecycleDashboard.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { deriveStatusBanner } from '../JobLifecycleDashboard.helpers.js';
+import type { JobSummary } from '../../types/index.js';
+
+const ZERO_HASH = `0x${'0'.repeat(64)}`;
+const BASE_JOB: JobSummary = {
+  jobId: 1n,
+  employer: '0x0000000000000000000000000000000000000000',
+  reward: 0n,
+  stake: 0n,
+  fee: 0n,
+  status: 0,
+  phase: 'Submitted',
+  lastUpdated: 2_000,
+  deadline: 3_600,
+  specHash: ZERO_HASH,
+};
+
+describe('deriveStatusBanner', () => {
+  it('highlights submission awaiting validation', () => {
+    const banner = deriveStatusBanner({
+      job: {
+        ...BASE_JOB,
+        phase: 'Submitted',
+        agent: '0x1234567890abcdef1234567890abcdef12345678',
+        resultSubmittedAt: 1_900,
+      },
+      now: 2_000,
+    });
+
+    assert.ok(banner, 'banner should be returned');
+    assert.equal(banner.variant, 'alert');
+    assert.match(banner.message, /Deliverable submitted/);
+    assert.match(banner.message, /Awaiting validator review/);
+  });
+
+  it('shows validation progress while committee is active', () => {
+    const banner = deriveStatusBanner({
+      job: {
+        ...BASE_JOB,
+        phase: 'InValidation',
+        totalValidators: 3,
+        validatorVotes: 1,
+        validationStartedAt: 1_950,
+      },
+      now: 2_000,
+      validationCountdown: 'in 1 hour',
+    });
+
+    assert.ok(banner, 'banner should be returned');
+    assert.equal(banner.variant, 'alert');
+    assert.match(banner.message, /In validation/);
+    assert.match(banner.message, /1 of 3 votes/);
+    assert.match(banner.message, /Decision window closes in 1 hour/);
+  });
+
+  it('confirms validation completion with outcome messaging', () => {
+    const banner = deriveStatusBanner({
+      job: {
+        ...BASE_JOB,
+        phase: 'Validated',
+        success: true,
+        validationStartedAt: 1_950,
+        lastUpdated: 2_050,
+      },
+      now: 2_100,
+    });
+
+    assert.ok(banner, 'banner should be returned');
+    assert.equal(banner.variant, 'alert success');
+    assert.match(banner.message, /Validation completed/);
+    assert.ok(!banner.message.includes('In validation'));
+  });
+
+  it('tracks finalised jobs separately from validation', () => {
+    const banner = deriveStatusBanner({
+      job: {
+        ...BASE_JOB,
+        phase: 'Finalized',
+        lastUpdated: 2_500,
+      },
+      now: 2_600,
+    });
+
+    assert.ok(banner, 'banner should be returned');
+    assert.equal(banner.variant, 'alert success');
+    assert.match(banner.message, /Job finalized/);
+  });
+});

--- a/apps/enterprise-portal/src/hooks/useJobFeed.ts
+++ b/apps/enterprise-portal/src/hooks/useJobFeed.ts
@@ -23,6 +23,7 @@ const JOB_EVENT_NAMES = [
   'AgentAssigned',
   'ResultSubmitted',
   'ValidationStartTriggered',
+  'JobCompleted',
   'JobFinalized',
   'JobDisputed',
 ] as const;
@@ -198,6 +199,7 @@ const toTimelineEvent = (
     AgentAssigned: 'Agent assignment confirmed',
     ResultSubmitted: 'Agent deliverables submitted',
     ValidationStartTriggered: 'Validator committee engaged',
+    JobCompleted: 'Validator committee reached an outcome',
     JobFinalized: 'Job finalized and payout settled',
     JobDisputed: 'Dispute raised for this job',
   };
@@ -206,6 +208,7 @@ const toTimelineEvent = (
     AgentAssigned: 'Assigned',
     ResultSubmitted: 'Submitted',
     ValidationStartTriggered: 'InValidation',
+    JobCompleted: 'Validated',
     JobFinalized: 'Finalized',
     JobDisputed: 'Disputed',
   };
@@ -422,7 +425,10 @@ export const useJobFeed = (options: UseJobFeedOptions = {}): JobFeedState => {
           createdArgs: createdEvent?.meta?.args,
         });
 
-        const phase = jobStateToPhase(statusValue);
+        let phase = jobStateToPhase(statusValue);
+        if (phase === 'Submitted' && validationEvent) {
+          phase = 'InValidation';
+        }
         const summary: JobSummary = {
           jobId,
           employer,

--- a/apps/enterprise-portal/src/lib/__tests__/jobStatus.test.ts
+++ b/apps/enterprise-portal/src/lib/__tests__/jobStatus.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { jobStateToPhase, phaseToTagColor } from '../jobStatus.js';
+
+describe('jobStateToPhase', () => {
+  it('maps submitted state to Submitted phase', () => {
+    assert.equal(jobStateToPhase(3), 'Submitted');
+  });
+
+  it('maps completed state to Validated phase', () => {
+    assert.equal(jobStateToPhase(4), 'Validated');
+  });
+});
+
+describe('phaseToTagColor', () => {
+  it('returns green for validated jobs', () => {
+    assert.equal(phaseToTagColor('Validated'), 'green');
+  });
+});

--- a/apps/enterprise-portal/src/lib/jobStatus.ts
+++ b/apps/enterprise-portal/src/lib/jobStatus.ts
@@ -11,7 +11,7 @@ export const jobStateToPhase = (state: number): JobPhase => {
     case 3:
       return 'Submitted';
     case 4:
-      return 'InValidation';
+      return 'Validated';
     case 5:
       return 'Disputed';
     case 6:
@@ -33,6 +33,8 @@ export const phaseToTagColor = (phase: JobPhase): string => {
       return 'purple';
     case 'InValidation':
       return 'orange';
+    case 'Validated':
+      return 'green';
     case 'Finalized':
       return 'green';
     case 'Disputed':

--- a/apps/enterprise-portal/src/types/index.ts
+++ b/apps/enterprise-portal/src/types/index.ts
@@ -3,6 +3,7 @@ export type JobPhase =
   | 'Assigned'
   | 'Submitted'
   | 'InValidation'
+  | 'Validated'
   | 'Finalized'
   | 'Disputed'
   | 'Expired'


### PR DESCRIPTION
## Summary
- add an explicit Validated phase and map the Completed registry state plus timeline events to it
- refactor the lifecycle dashboard to share status banner helpers and show post-validation messaging and colours
- add unit coverage for the new lifecycle transitions and tag colours

## Testing
- TS_NODE_PROJECT=apps/enterprise-portal/tsconfig.json node --loader ts-node/esm --test apps/enterprise-portal/src/lib/__tests__/jobStatus.test.ts apps/enterprise-portal/src/components/__tests__/JobLifecycleDashboard.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd5ef55f0c833380233d77175d0183