### PR TITLE
Add contributor summaries to agent gateway multi-agent pipeline

### DIFF
--- a/agent-gateway/README.md
+++ b/agent-gateway/README.md
@@ -110,6 +110,7 @@ GET  /efficiency/:agent[?category=categoryKey]
 GET  /telemetry/insights[?limit=10&includeJobs=true&jobsPerAgent=5]
 GET  /telemetry/insights/:agent[?includeJobs=true&jobLimit=5]
 GET  /telemetry/insights/:agent/jobs/:jobId
+GET  /jobs/:id/contributors[?includePrimary=false&address=0x...]
 GET  /opportunities/backtest[?limit=200&minConfidence=0.3&maxAgeHours=48]
 GET  /opportunities[?limit=25]
 GET  /opportunities/:jobId
@@ -163,7 +164,7 @@ gRPC service on `GRPC_PORT`. The protobuf definition lives at
 `agent-gateway/protos/agent_gateway.proto` and includes RPCs for submitting
 deliverables (`SubmitResult`), streaming heartbeats and Alpha-AGI telemetry
 (`RecordHeartbeat`/`RecordTelemetry`), querying the full job context
-(`GetJobInfo`), and orchestrating staking or reward claims
+(`GetJobInfo`, including contributor summaries for multi-agent workflows), and orchestrating staking or reward claims
 (`EnsureStake`/`GetStake`/`AutoClaimRewards`).
 
 Each RPC expects the caller to authenticate with a managed wallet, mirroring

--- a/agent-gateway/protos/agent_gateway.proto
+++ b/agent-gateway/protos/agent_gateway.proto
@@ -32,6 +32,31 @@ message DeliverableContributor {
   string metadata_json = 7;
 }
 
+message ContributorContribution {
+  string deliverable_id = 1;
+  string job_id = 2;
+  string submitted_at = 3;
+  bool primary = 4;
+  string role = 5;
+  string label = 6;
+  string signature = 7;
+  string payload_digest = 8;
+  string metadata_json = 9;
+}
+
+message ContributorSummary {
+  string address = 1;
+  repeated string ens_names = 2;
+  repeated string roles = 3;
+  repeated string labels = 4;
+  repeated string signatures = 5;
+  repeated string payload_digests = 6;
+  uint32 contribution_count = 7;
+  string first_contribution_at = 8;
+  string last_contribution_at = 9;
+  repeated ContributorContribution contributions = 10;
+}
+
 message DeliverableRecord {
   string id = 1;
   string job_id = 2;
@@ -167,6 +192,7 @@ message GetJobInfoResponse {
   repeated HeartbeatRecord heartbeats = 5;
   repeated TelemetryRecord telemetry = 6;
   repeated RewardPayoutRecord payouts = 7;
+  repeated ContributorSummary contributors = 8;
 }
 
 message EnsureStakeRequest {


### PR DESCRIPTION
## Summary
- add contributor aggregation utilities to capture primary and supporting agents on each deliverable
- expose the aggregated data via a new REST endpoint and include it in the gRPC GetJobInfo response with updated protobuf definitions
- document the contributor endpoint and multi-agent context in the gateway README

## Testing
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dd71ee5df08333b84fc1a97f27280d