### PR TITLE
Expose contributor summaries in job detail APIs

### DIFF
--- a/agent-gateway/README.md
+++ b/agent-gateway/README.md
@@ -110,6 +110,7 @@ GET  /efficiency/:agent[?category=categoryKey]
 GET  /telemetry/insights[?limit=10&includeJobs=true&jobsPerAgent=5]
 GET  /telemetry/insights/:agent[?includeJobs=true&jobLimit=5]
 GET  /telemetry/insights/:agent/jobs/:jobId
+GET  /jobs/:id[?includeContributors=false&includePrimary=false]
 GET  /jobs/:id/contributors[?includePrimary=false&address=0x...]
 GET  /opportunities/backtest[?limit=200&minConfidence=0.3&maxAgeHours=48]
 GET  /opportunities[?limit=25]
@@ -164,7 +165,7 @@ gRPC service on `GRPC_PORT`. The protobuf definition lives at
 `agent-gateway/protos/agent_gateway.proto` and includes RPCs for submitting
 deliverables (`SubmitResult`), streaming heartbeats and Alpha-AGI telemetry
 (`RecordHeartbeat`/`RecordTelemetry`), querying the full job context
-(`GetJobInfo`, including contributor summaries for multi-agent workflows), and orchestrating staking or reward claims
+(`GetJobInfo`, including contributor summaries for multi-agent workflows and a `contributorCount` hint), and orchestrating staking or reward claims
 (`EnsureStake`/`GetStake`/`AutoClaimRewards`).
 
 Each RPC expects the caller to authenticate with a managed wallet, mirroring

--- a/agent-gateway/grpc.ts
+++ b/agent-gateway/grpc.ts
@@ -275,6 +275,7 @@ interface GetJobInfoResponseMessage {
   telemetry?: TelemetryRecordMessage[];
   payouts?: RewardPayoutRecordMessage[];
   contributors?: ContributorSummaryMessage[];
+  contributor_count?: number;
 }
 
 interface EnsureStakeResponseMessage {
@@ -974,6 +975,7 @@ async function handleGetJobInfo(
     payouts: mapPayouts(getRewardPayouts(jobId)),
   };
   const contributors = listContributorSummaries({ jobId });
+  response.contributor_count = contributors.length;
   if (contributors.length > 0) {
     response.contributors = contributors.map(mapContributorSummary);
   }

--- a/agent-gateway/protos/agent_gateway.proto
+++ b/agent-gateway/protos/agent_gateway.proto
@@ -193,6 +193,7 @@ message GetJobInfoResponse {
   repeated TelemetryRecord telemetry = 6;
   repeated RewardPayoutRecord payouts = 7;
   repeated ContributorSummary contributors = 8;
+  uint32 contributor_count = 9;
 }
 
 message EnsureStakeRequest {


### PR DESCRIPTION
## Summary
- add contributor summary toggles to the REST job detail response so agents can fetch multi-agent metadata in one call
- include contributorCount in the GetJobInfo gRPC response and document the new REST and gRPC behaviour

## Testing
- npm run build:gateway

------
https://chatgpt.com/codex/tasks/task_e_68dd744ffa60833396d9c2472e0c3640