### PR TITLE
Add mainnet fork lifecycle drill and audit documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,3 +182,30 @@ jobs:
 
       - name: Orchestrator chain provider tests
         run: npm run test --workspace packages/orchestrator
+
+  fork-drill:
+    name: Mainnet fork drill
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ secrets.MAINNET_RPC_URL != '' }}
+    env:
+      MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+      SKIP_MOCK_AGIALPHA: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Mainnet fork lifecycle drill
+        run: npm run test:fork

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,14 @@ When updating module addresses, ensure the transaction emits the expected events
 
 See [docs/security-deployment-guide.md](docs/security-deployment-guide.md) for a step-by-step guide that combines ownership transfers, pauser configuration, and emergency response procedures into a single checklist suitable for production launches.
 
+## Audit Drill Catalogue
+
+The reproducible scenarios that external reviewers should execute ahead of an
+audit are catalogued in
+[`docs/security/audit-test-vectors.md`](docs/security/audit-test-vectors.md).
+They include the new mainnet fork lifecycle drill (`npm run test:fork`) and the
+validator dispute flows that demonstrate slashing behaviour.
+
 ## Static Analysis Commands
 
 - **Slither:** `slither . --solc-remaps @openzeppelin=node_modules/@openzeppelin/`

--- a/docs/security/audit-test-vectors.md
+++ b/docs/security/audit-test-vectors.md
@@ -1,0 +1,53 @@
+# Audit Test Vectors & Drill Playbook
+
+This guide captures the reproducible flows we exercise before handing the
+protocol to external auditors.  It complements the unit/integration suites by
+collecting end-to-end scenarios, expected outcomes, and the commands that
+produce them.
+
+## Prerequisites
+
+1. Install dependencies once: `npm ci`
+2. Compile the contracts (required for scripts and Hardhat tests): `npm run compile`
+3. For forked drills export an Ethereum mainnet RPC endpoint with archive
+   history.  Either set `MAINNET_FORK_URL` or reuse `MAINNET_RPC_URL`.
+
+```bash
+export MAINNET_RPC_URL="https://mainnet.example"
+# optionally pin the block for deterministic forks
+export MAINNET_FORK_BLOCK=21543789
+```
+
+## Scenario Matrix
+
+| Scenario | Command | Purpose |
+| --- | --- | --- |
+| Happy-path lifecycle on forked mainnet state | `npm run test:fork` | Executes a complete job lifecycle against a forked mainnet, reusing the canonical `$AGIALPHA` token and verifying NFT/marketplace flows. |
+| Validator dispute and slashing (local hardhat) | `npx hardhat test --no-compile test/v2/jobLifecycleWithDispute.integration.test.ts` | Demonstrates dispute escalation, validator penalties, and treasury accounting. |
+| Stake invariants & withdrawal bounds | `npx hardhat test --no-compile test/v2/StakeManagerSlashing.test.js` | Validates that withdrawals and slashing never exceed the staked balance. |
+| Commit-reveal fuzz harness | `npm run echidna` | Runs Echidna assertions on the commit/reveal harness covering validator misbehaviour search space. |
+
+Each scenario logs success/failure details that should be attached to the audit
+package.  Store raw outputs under `internal_docs/security/drills/` when preparing
+an external report.
+
+## Generating Artefacts for Auditors
+
+1. Run each command above and capture the terminal output.
+2. For `npm run test:fork`, note the block number used and the resulting agent
+   token balances.  Auditors can replay the run by using the same block.
+3. Export the resulting JSON traces (if available) using Hardhat's
+   `--show-stack-traces` or by appending `> drills/<scenario>.log`.
+4. Update `SECURITY.md` with any deviations or discovered regressions.
+
+## Troubleshooting
+
+- **Fork setup fails with `insufficient data`** – ensure your RPC endpoint is an
+  archive node and the block number is within range.
+- **`test:fork` skips automatically** – the environment variables were not
+  provided.  Set `MAINNET_RPC_URL` or `MAINNET_FORK_URL` before running.
+- **Different `$AGIALPHA` balances** – rerun the fork at the same block height;
+  state drift between blocks affects holder balances and slashing expectations.
+
+Maintaining these artefacts ensures auditors and internal reviewers can quickly
+replay critical flows and verify the protocol's security posture.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "owner:update-all": "npx hardhat run --no-compile scripts/v2/updateAllModules.ts",
     "owner:surface": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlSurface.ts",
     "test": "hardhat test --no-compile",
+    "test:fork": "SKIP_MOCK_AGIALPHA=1 hardhat test --no-compile test/fork/mainnet-job-lifecycle.fork.test.ts",
     "e2e:local": "hardhat test --no-compile test/e2e/localnet.gateway.e2e.test.ts",
     "echidna:commit-reveal": "docker run --rm -v \"$PWD\":/src -v \"$PWD/tools/forge-shim\":/usr/local/bin/forge:ro -w /src ghcr.io/crytic/echidna/echidna:v2.2.7 echidna-test ./contracts/test/CommitRevealEchidna.sol --contract CommitRevealEchidnaHarness --config echidna/commit-reveal.yaml",
     "echidna": "npm run echidna:commit-reveal",

--- a/test/fork/mainnet-job-lifecycle.fork.test.ts
+++ b/test/fork/mainnet-job-lifecycle.fork.test.ts
@@ -1,0 +1,242 @@
+import { expect } from 'chai';
+import { ethers, network } from 'hardhat';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
+import { AGIALPHA, AGIALPHA_DECIMALS } from '../../scripts/constants';
+import { setErc20Balance, setUintStorage } from '../utils/tokenStorage';
+
+enum Role {
+  Agent,
+  Validator,
+  Platform,
+}
+
+const FORK_URL =
+  process.env.MAINNET_FORK_URL ||
+  process.env.HARDHAT_FORK_URL ||
+  process.env.MAINNET_RPC_URL;
+
+const describeFork = FORK_URL ? describe : describe.skip;
+
+describeFork('Mainnet fork · job lifecycle drill', function () {
+  this.timeout(240_000);
+
+  const TOTAL_SUPPLY_SLOT = 2;
+  const MINT_PER_ACCOUNT = '1000';
+  const NFT_PRICE = '50';
+  const JOB_REWARD = '100';
+
+  let snapshotId: string;
+
+  before(async function () {
+    if (!FORK_URL) {
+      this.skip();
+      return;
+    }
+
+    const blockNumber = process.env.MAINNET_FORK_BLOCK
+      ? Number(process.env.MAINNET_FORK_BLOCK)
+      : undefined;
+
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: FORK_URL,
+            ...(blockNumber ? { blockNumber } : {}),
+          },
+        },
+      ],
+    });
+
+    const token = await ethers.getContractAt(
+      '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol:IERC20Metadata',
+      AGIALPHA
+    );
+
+    const decimals = await token.decimals();
+    expect(decimals).to.equal(AGIALPHA_DECIMALS);
+
+    const [owner, employer, agent, validator, buyer, moderator, treasury] =
+      await ethers.getSigners();
+
+    const mintAmount = ethers.parseUnits(MINT_PER_ACCOUNT, decimals);
+    const holders = [
+      owner.address,
+      employer.address,
+      agent.address,
+      validator.address,
+      buyer.address,
+      treasury.address,
+    ];
+
+    for (const holder of holders) {
+      await setErc20Balance(AGIALPHA, holder, mintAmount);
+    }
+
+    const existingSupply = await token.totalSupply();
+    const additional = mintAmount * BigInt(holders.length);
+    await setUintStorage(
+      AGIALPHA,
+      TOTAL_SUPPLY_SLOT,
+      existingSupply + additional
+    );
+
+    for (const holder of holders) {
+      const balance = await token.balanceOf(holder);
+      expect(balance).to.equal(mintAmount);
+    }
+
+    snapshotId = await network.provider.send('evm_snapshot');
+  });
+
+  beforeEach(async function () {
+    if (!snapshotId) {
+      this.skip();
+      return;
+    }
+    await network.provider.send('evm_revert', [snapshotId]);
+    snapshotId = await network.provider.send('evm_snapshot');
+  });
+
+  it('executes the happy-path job lifecycle using forked $AGIALPHA state', async function () {
+    const [owner, employer, agent, validator, buyer, moderator, treasury] =
+      await ethers.getSigners();
+
+    const Validation = await ethers.getContractFactory(
+      'contracts/v2/mocks/ValidationStub.sol:ValidationStub'
+    );
+    const validation = await Validation.deploy();
+
+    const Stake = await ethers.getContractFactory(
+      'contracts/v2/StakeManager.sol:StakeManager'
+    );
+    const stake = await Stake.deploy(
+      0,
+      50,
+      50,
+      treasury.address,
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      owner.address
+    );
+
+    const Reputation = await ethers.getContractFactory(
+      'contracts/v2/ReputationEngine.sol:ReputationEngine'
+    );
+    const reputation = await Reputation.deploy(await stake.getAddress());
+
+    const ENS = await ethers.getContractFactory('MockENS');
+    const ens = await ENS.deploy();
+    const Wrapper = await ethers.getContractFactory('MockNameWrapper');
+    const wrapper = await Wrapper.deploy();
+
+    const Identity = await ethers.getContractFactory(
+      'contracts/v2/IdentityRegistry.sol:IdentityRegistry'
+    );
+    const identity = await Identity.deploy(
+      await ens.getAddress(),
+      await wrapper.getAddress(),
+      await reputation.getAddress(),
+      ethers.ZeroHash,
+      ethers.ZeroHash
+    );
+
+    const NFT = await ethers.getContractFactory(
+      'contracts/v2/CertificateNFT.sol:CertificateNFT'
+    );
+    const nft = await NFT.deploy('Cert', 'CERT');
+
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/JobRegistry.sol:JobRegistry'
+    );
+    const registry = await Registry.deploy(
+      await validation.getAddress(),
+      await stake.getAddress(),
+      await reputation.getAddress(),
+      ethers.ZeroAddress,
+      await nft.getAddress(),
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      0,
+      0,
+      [],
+      owner.address
+    );
+
+    const Dispute = await ethers.getContractFactory(
+      'contracts/v2/modules/DisputeModule.sol:DisputeModule'
+    );
+    const dispute = await Dispute.deploy(
+      await registry.getAddress(),
+      0,
+      0,
+      moderator.address
+    );
+
+    await stake.setModules(
+      await registry.getAddress(),
+      await dispute.getAddress()
+    );
+    await validation.setJobRegistry(await registry.getAddress());
+    await nft.setJobRegistry(await registry.getAddress());
+    await nft.setStakeManager(await stake.getAddress());
+    await registry.setModules(
+      await validation.getAddress(),
+      await stake.getAddress(),
+      await reputation.getAddress(),
+      await dispute.getAddress(),
+      await nft.getAddress(),
+      ethers.ZeroAddress,
+      []
+    );
+    await registry.setIdentityRegistry(await identity.getAddress());
+    await reputation.setCaller(await registry.getAddress(), true);
+    await reputation.setPremiumThreshold(10);
+
+    const token = await ethers.getContractAt(
+      '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol:IERC20Metadata',
+      AGIALPHA
+    );
+
+    const stakeAmount = ethers.parseUnits('1', AGIALPHA_DECIMALS);
+    await token.connect(agent).approve(await stake.getAddress(), stakeAmount);
+    await stake.connect(agent).depositStake(Role.Agent, stakeAmount);
+
+    const subdomain = 'agent';
+    const subnode = ethers.keccak256(
+      ethers.solidityPacked(
+        ['bytes32', 'bytes32'],
+        [ethers.ZeroHash, ethers.id(subdomain)]
+      )
+    );
+    await wrapper.setOwner(BigInt(subnode), agent.address);
+
+    const reward = ethers.parseUnits(JOB_REWARD, AGIALPHA_DECIMALS);
+    await token.connect(employer).approve(await stake.getAddress(), reward);
+    const deadline = BigInt((await time.latest()) + 3600);
+    const specHash = ethers.id('spec');
+    await registry
+      .connect(employer)
+      .createJob(reward, deadline, specHash, 'ipfs://job');
+
+    await registry.connect(agent).applyForJob(1, subdomain, []);
+    const resultHash = ethers.id('ipfs://result');
+    await registry
+      .connect(agent)
+      .submit(1, resultHash, 'ipfs://result', subdomain, []);
+    await validation.setResult(true);
+    await validation.finalize(1);
+    await registry.connect(employer).finalize(1);
+
+    const price = ethers.parseUnits(NFT_PRICE, AGIALPHA_DECIMALS);
+    await nft.connect(agent).list(1, price);
+    await token.connect(buyer).approve(await nft.getAddress(), price);
+    await nft.connect(buyer).purchase(1);
+
+    expect(await nft.ownerOf(1)).to.equal(buyer.address);
+    expect(await token.balanceOf(agent.address)).to.equal(
+      ethers.parseUnits('1149', AGIALPHA_DECIMALS)
+    );
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -7,9 +7,15 @@ process.env.PORT = '3000';
 process.env.STALE_JOB_MS = String(60 * 60 * 1000);
 process.env.SWEEP_INTERVAL_MS = String(60 * 1000);
 
+const shouldMockAgialpha = process.env.SKIP_MOCK_AGIALPHA !== '1';
+
 let snapshotId;
 
 before(async function () {
+  if (!shouldMockAgialpha) {
+    snapshotId = await network.provider.send('evm_snapshot');
+    return;
+  }
   // Load the test utility ERC20 used to stub the AGIALPHA token
   const artifact = await artifacts.readArtifact(
     'contracts/test/MockERC20.sol:MockERC20'
@@ -22,6 +28,9 @@ before(async function () {
 });
 
 beforeEach(async function () {
+  if (!snapshotId || !shouldMockAgialpha) {
+    return;
+  }
   await network.provider.send('evm_revert', [snapshotId]);
   snapshotId = await network.provider.send('evm_snapshot');
 });

--- a/test/utils/tokenStorage.ts
+++ b/test/utils/tokenStorage.ts
@@ -1,0 +1,43 @@
+import { ethers, network } from 'hardhat';
+
+function formatSlot(slot: number | bigint | string): string {
+  if (typeof slot === 'string') {
+    const trimmed = slot.startsWith('0x') ? slot : `0x${slot}`;
+    return ethers.zeroPadValue(trimmed, 32);
+  }
+  const value = typeof slot === 'number' ? BigInt(slot) : slot;
+  return ethers.zeroPadValue(ethers.toBeHex(value), 32);
+}
+
+export async function setErc20Balance(
+  tokenAddress: string,
+  account: string,
+  amount: bigint,
+  slot: number | bigint | string = 0
+): Promise<void> {
+  const storageSlot = formatSlot(slot);
+  const index = ethers.solidityPackedKeccak256(
+    ['bytes32', 'bytes32'],
+    [ethers.zeroPadValue(account, 32), storageSlot]
+  );
+  const value = ethers.zeroPadValue(ethers.toBeHex(amount), 32);
+  await network.provider.send('hardhat_setStorageAt', [
+    tokenAddress,
+    index,
+    value,
+  ]);
+}
+
+export async function setUintStorage(
+  contractAddress: string,
+  slot: number | bigint | string,
+  value: bigint
+): Promise<void> {
+  const targetSlot = formatSlot(slot);
+  const encoded = ethers.zeroPadValue(ethers.toBeHex(value), 32);
+  await network.provider.send('hardhat_setStorageAt', [
+    contractAddress,
+    targetSlot,
+    encoded,
+  ]);
+}


### PR DESCRIPTION
## Summary
- add a reusable Hardhat mainnet fork drill that seeds AGIALPHA balances and runs the job lifecycle against mainnet state
- wire the drill into CI behind a MAINNET_RPC_URL secret and expose an npm script for local runs
- publish an audit drill playbook and link it from SECURITY.md while making Hardhat test setup skip AGIALPHA mocking when instructed

## Testing
- npx eslint test/fork/mainnet-job-lifecycle.fork.test.ts
- npx eslint test/utils/tokenStorage.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd7a0cd1cc83338f60729e2d6a9737