### PR TITLE
chore: enforce strict linting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,8 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Lint (best-effort)
-        run: |
-          npx --yes solhint -V >/dev/null 2>&1 && npx solhint 'contracts/**/*.sol' || true
-          npx --yes eslint -v   >/dev/null 2>&1 && npx eslint . --ext .js,.cjs,.mjs || true
+      - name: Lint
+        run: npm run lint:check
 
       - name: Start Ganache (deterministic)
         run: |


### PR DESCRIPTION
## Summary
- update the CI lint step to run the strict npm lint:check script without best-effort fallbacks

## Testing
- npm run lint:check (fails as expected due to existing lint issues)


------
https://chatgpt.com/codex/tasks/task_e_68dd7f97a6048333949946538c314b57