### PR TITLE
Enforce strict lint failures in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Lint
+      - name: Lint (strict)
         run: npm run lint:check
 
       - name: Start Ganache (deterministic)

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "migrate:sepolia": "DEPLOY_LOCAL_ERC20=1 TRUFFLE_NETWORK=sepolia npm run compile:sepolia && npx truffle migrate --network sepolia --reset && TRUFFLE_NETWORK=sepolia npm run wire:verify",
     "migrate:preflight": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/truffle-preflight.ts",
     "migrate:wizard": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/truffle-migration-wizard.ts",
-    "lint:check": "solhint 'contracts/**/*.sol' && eslint . --ext .js,.ts,.tsx --max-warnings=0",
+    "lint:check": "solhint --max-warnings 0 'contracts/**/*.sol' && eslint . --ext .js,.ts,.tsx --max-warnings=0",
     "lint:fix": "solhint --fix 'contracts/**/*.sol' && eslint . --ext .js,.ts,.tsx --fix",
     "format:fix": "prettier --write \".github/workflows/**/*.yml\" \"scripts/ci/**/*.{js,mjs}\" \"hardhat.config.js\" \"package.json\" \".solcover.js\"",
     "onebox:build": "node apps/onebox/scripts/build.mjs",


### PR DESCRIPTION
## Summary
- update the CI lint step to reflect strict enforcement
- configure lint:check to fail on any Solhint warning by using --max-warnings 0

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd8b21918c8333bc7e12016ec1d4a8