### PR TITLE
Add strict mission control exit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,13 +327,17 @@ verification and telemetry sweep? Run the consolidated helper:
 
 ```bash
 npm run owner:mission-control -- --network <network> --out runtime/<network>-mission.md
+# Treat warnings as failures during high-stakes runs
+npm run owner:mission-control -- --network <network> --strict
 ```
 
 Mission control stitches the four core owner scripts together, emits a Markdown
 or JSON report (complete with Mermaid flow, metrics and logs), and respects new
 environment overrides (`OWNER_UPDATE_ALL_JSON`, `OWNER_VERIFY_JSON`,
 `OWNER_DASHBOARD_JSON`, and friends) so non-technical operators can automate
-dry-runs, Safe reviews and production verification. The full playbook lives in
+dry-runs, Safe reviews and production verification. Combine `--strict` with
+change-control pipelines to force a non-zero exit code whenever the summary
+contains warnings or errors. The full playbook lives in
 [docs/owner-mission-control.md](docs/owner-mission-control.md) with journey maps,
 step tables and troubleshooting guidance.
 

--- a/docs/owner-mission-bundle.md
+++ b/docs/owner-mission-bundle.md
@@ -17,6 +17,12 @@ npm run owner:mission-control -- \
   --network <network> \
   --bundle runtime/bundles \
   --bundle-name mission-control-<stamp>
+# Fail the pipeline on ⚠️ warnings as well as ❌ errors
+npm run owner:mission-control -- \
+  --network <network> \
+  --bundle runtime/bundles \
+  --bundle-name mission-control-<stamp> \
+  --strict
 ```
 
 - `--bundle` points at the folder that should receive the artefacts (it will be
@@ -75,8 +81,9 @@ Hashes use lowercase hex-encoded SHA-256 digests that match `sha256sum` and
    - JSON → automation, regression diffing, compliance archives.
    - TXT → non-technical operator logs or mobile readers.
 6. **Re-run** mission control against production RPC once governance signs off.
-   The new bundle should produce matching hashes except for live network
-   differences.
+   Add `--strict` so any lingering warnings halt the deployment rather than
+   slipping into production unnoticed. The new bundle should produce matching
+   hashes except for live network differences.
 
 ---
 

--- a/docs/owner-mission-control.md
+++ b/docs/owner-mission-control.md
@@ -40,7 +40,9 @@ The helper executes four guardrail-heavy stages, merges JSON outputs, then rende
      --bundle-name mission-control-dryrun
    ```
 5. Open `runtime/mission-control.md` or the bundle artefacts for the aggregated status report.
-6. Repeat with production RPC once the dry run is clean.
+6. Repeat with production RPC once the dry run is clean. Add `--strict` during
+   sign-off windows to force a non-zero exit when warnings appear so CI/CD
+   pipelines or manual operators cannot miss yellow flags.
 
 ## Step Reference Matrix
 
@@ -57,6 +59,17 @@ The helper executes four guardrail-heavy stages, merges JSON outputs, then rende
 - `--format json` – Machine-readable snapshot for pipelines or automated diffing.
 - `--format human` – Console-friendly plaintext with emoji statuses.
 - `--no-mermaid` – Disable diagrams when rendering for terminals without Mermaid support.
+
+## Exit Codes & Strict Mode
+
+- Mission control now returns exit code **1** whenever a step reports
+  `❌ ERROR`, regardless of other settings.
+- Pass `--strict` (or `--fail-on-warn`) to promote `⚠️ WARNING` outcomes to a
+  non-zero exit status as well. This keeps automated deployments, Safe
+  workflows, and CI pipelines from ignoring configuration drift or missing
+  owners.
+- Use `--allow-warnings` (or `--no-strict`) to restore the previous behaviour
+  where warnings still exit successfully.
 
 ## Mission Bundle Export
 


### PR DESCRIPTION
## Summary
- add strict/allow-warnings flags to the owner mission control CLI and return non-zero exit codes on errors
- document strict mode usage in the mission control docs, bundle playbook, and README so operators can wire it into change-control pipelines

## Testing
- npm run owner:mission-control -- --help

------
https://chatgpt.com/codex/tasks/task_e_68ddba4eabc883338dee6ce160b03aaf