### PR TITLE
Add owner-focused guides for token constants and energy oracle operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Agents and validators must own ENS subdomains under `agent.agi.eth` and `club.ag
 
 ### AGIALPHA configuration
 
-Token parameters are defined once in [`config/agialpha.json`](config/agialpha.json). Run `npm run compile` after editing this file to regenerate `contracts/v2/Constants.sol` with the canonical token address, symbol, name, decimals, scaling factor and burn address. Any change to `config/agialpha.json` must be followed by `npm run compile` or the constants check in CI will fail.
+Token parameters are defined once in [`config/agialpha.json`](config/agialpha.json). Run `npm run compile` after editing this file to regenerate `contracts/v2/Constants.sol` with the canonical token address, symbol, name, decimals, scaling factor and burn address. Any change to `config/agialpha.json` must be followed by `npm run compile` or the constants check in CI will fail. See the non-technical [Token Operations Control Guide](docs/token-operations.md) for a checklist, Mermaid diagrams and a zero-downtime rollout plan.
 
 `npm run compile` validates the configured addresses, ERC‑20 metadata and decimals before writing the Solidity constants. The command halts if the token or burn addresses are malformed, zero (where disallowed), the symbol/name fields are empty or the decimals fall outside the supported `0-255` range, preventing a bad configuration from reaching production contracts.
 
@@ -115,7 +115,7 @@ Pass `--execute` once the dry run looks correct to submit the queued actions. Us
 
 ### Energy oracle signer management
 
-Governance controls which off-chain measurement nodes can sign energy attestations. Update [`config/energy-oracle.json`](config/energy-oracle.json) (or its per-network override) with the authorised signer list. Run the helper to review the planned changes and, once satisfied, apply them on-chain:
+Governance controls which off-chain measurement nodes can sign energy attestations. Update [`config/energy-oracle.json`](config/energy-oracle.json) (or its per-network override) with the authorised signer list. Run the helper to review the planned changes and, once satisfied, apply them on-chain. The [Energy Oracle Operations Guide](docs/energy-oracle-operations.md) covers signer due diligence, quorum rotations and verification workflows with step-by-step diagrams:
 
 ```bash
 npx hardhat run scripts/v2/updateEnergyOracle.ts --network <network>

--- a/docs/energy-oracle-operations.md
+++ b/docs/energy-oracle-operations.md
@@ -1,0 +1,183 @@
+# Energy Oracle Operations Guide
+
+The Energy Oracle secures the thermodynamic reward engine by attesting to task
+energy, entropy and timestamp data. This guide equips owners and operators with
+precise, audit-ready procedures for onboarding or retiring signers, rotating
+quorum thresholds and validating end-to-end observability.
+
+```mermaid
+flowchart TD
+    subgraph Configuration Layer
+        A[config/energy-oracle.json]
+        B[config/thermodynamics.json]
+    end
+    subgraph Control Scripts
+        C[scripts/v2/updateEnergyOracle.ts]
+        D[scripts/v2/updateThermodynamics.ts]
+    end
+    subgraph On-chain Contracts
+        E( EnergyOracle )
+        F( RewardEngineMB )
+    end
+    subgraph Assurance
+        G[npm run owner:verify-control]
+        H[Monitoring dashboards]
+    end
+
+    A --> C
+    B --> D
+    C --> E
+    D --> F
+    E --> G
+    F --> G
+    E --> H
+    F --> H
+```
+
+## Key responsibilities
+
+| Persona | Primary focus | Tooling |
+| ------- | ------------- | ------- |
+| Governance owner | Approves signer changes and quorum policy. | `npm run owner:update-all`, Gnosis Safe or timelock |
+| Operations engineer | Executes helper scripts, validates configs, monitors telemetry. | `npx hardhat`, `npm run owner:verify-control` |
+| Auditor / compliance | Verifies signer provenance and stores evidence. | Parameter matrix reports, monitoring exports |
+
+## Configuration reference
+
+`config/energy-oracle.json` contains per-network signer configuration and quorum
+targets. A typical structure:
+
+```jsonc
+{
+  "signers": [
+    {
+      "address": "0xabc...",
+      "label": "North America",
+      "pgpFingerprint": "1A2B3C...",
+      "endpoint": "https://oracle-na.example.com/attest"
+    },
+    {
+      "address": "0xdef...",
+      "label": "EU",
+      "pgpFingerprint": "4D5E6F...",
+      "endpoint": "https://oracle-eu.example.com/attest"
+    }
+  ],
+  "quorum": 2,
+  "retainUnknown": true,
+  "threshold": {
+    "entropyMax": "900000000000000000",
+    "latencyToleranceMs": 8000
+  }
+}
+```
+
+- **`signers`** – Authorised addresses. Labels & metadata help auditors trace
+  real-world operators.
+- **`quorum`** – Minimum signer count required per energy attestation.
+- **`retainUnknown`** – When `true`, existing on-chain signers not listed in the
+  configuration remain whitelisted (useful during gradual rotation).
+- **`threshold`** – Optional guard-rails for entropy variance and reporting
+  latency.
+
+Network-specific overrides live in `config/networks/<network>/energy-oracle.json`.
+The loader merges overrides automatically when you supply `--network`.
+
+## End-to-end workflow
+
+1. **Pre-change assessment**
+   - Run `npm run owner:surface -- --network <network> --only=rewardEngine` to
+     capture the live signer list and quorum.
+   - Perform due diligence on new signers (legal agreements, infrastructure
+     review, PGP fingerprint verification).
+
+2. **Edit configuration**
+   - Update the JSON file(s) with the desired signer set and quorum.
+   - Use descriptive `label` values so the parameter matrix output is readable.
+   - Commit the changes for peer review.
+
+3. **Dry run the helper**
+   - Execute:
+     ```bash
+     npx hardhat run scripts/v2/updateEnergyOracle.ts --network <network>
+     ```
+   - The script prints a diff table showing additions, removals and retained
+     signers. Ensure the planned transactions match the approved governance
+     intent.
+
+4. **Execute on-chain**
+   - Re-run the helper with `--execute` from the authorised governance signer or
+     through the Gnosis Safe transaction bundle:
+     ```bash
+     npx hardhat run scripts/v2/updateEnergyOracle.ts --network <network> --execute
+     ```
+   - Record transaction hashes for the governance log.
+
+5. **Update dependent thermodynamics**
+   - If quorum or signer latency affects reward smoothing, tune
+     `config/thermodynamics.json` accordingly and run
+     `npx hardhat run scripts/v2/updateThermodynamics.ts --network <network> [--execute]`.
+
+6. **Verification**
+   - Run `npm run owner:verify-control -- --network <network> --modules=rewardEngine`
+     to ensure the on-chain configuration matches the JSON.
+   - Generate a fresh parameter matrix report for auditors:
+     ```bash
+     npm run owner:parameters -- --network <network> --out reports/<network>/energy-oracle-matrix.md
+     ```
+   - Export monitoring snapshots (latency histograms, signer uptime) for
+     compliance archives.
+
+7. **Operational monitoring**
+   - Confirm each signer emits heartbeats and attestation telemetry. Update the
+     runbooks in `docs/operator-telemetry.md` if thresholds change.
+   - Configure alerts for signer downtime or quorum failure. Suggested metrics:
+     - Attestations per minute per signer
+     - Percentage of tasks meeting the entropy threshold
+     - RPC latency to each signer endpoint
+
+## Governance sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Gov as Governance Multisig
+    participant Repo as Config Repo
+    participant Helper as updateEnergyOracle.ts
+    participant Chain as EnergyOracle Contract
+    participant Monitor as Observability Stack
+
+    Gov->>Repo: Approve signer/quorum change
+    Repo-->>Helper: Provide config diff
+    Helper->>Chain: Submit add/remove/retain transactions
+    Chain-->>Monitor: Emit events (SignerAdded/SignerRemoved)
+    Monitor-->>Gov: Alert & dashboards confirm success
+    Helper->>Gov: Exit code 0 indicates execution finished
+```
+
+## Safety checklist
+
+- [ ] Governance approval recorded with signer legal names + wallets.
+- [ ] Dry-run output archived before execution.
+- [ ] Transactions executed from authorised key / Safe.
+- [ ] Post-change verification (`owner:verify-control`) stored with logs.
+- [ ] Monitoring alerts re-armed after signer rotation.
+
+## Incident response quick actions
+
+| Issue | Impact | Immediate action | Follow-up |
+| ----- | ------ | ---------------- | --------- |
+| Signer goes offline | Reduced redundancy; quorum may fail. | Toggle `retainUnknown` to true and redeploy config to keep backup signers. | Engage operator, capture RCA, update telemetry doc. |
+| Incorrect signer added | Potentially malicious attestations. | Execute helper with corrected config to remove signer; trigger emergency pause if suspicious activity detected. | Review approval process; update due diligence checklist. |
+| Quorum too high | Attestations stall, rewards halt. | Lower `quorum` in config and redeploy; ensure governance sign-off. | Update governance documentation to reflect new risk model. |
+
+## Reference links
+
+- [docs/owner-control-command-center.md](owner-control-command-center.md)
+- [docs/owner-parameter-matrix.md](owner-parameter-matrix.md)
+- [docs/thermodynamics-operations.md](thermodynamics-operations.md)
+- [docs/operator-telemetry.md](operator-telemetry.md)
+- [docs/reward-settlement-process.md](reward-settlement-process.md)
+
+With this guide, the contract owner retains full control over the Energy Oracle
+while ensuring every signer change is deliberate, transparent, and verifiable by
+non-technical stakeholders.

--- a/docs/token-operations.md
+++ b/docs/token-operations.md
@@ -1,0 +1,147 @@
+# Token Operations Control Guide
+
+This guide gives the contract owner and non-technical operators a repeatable,
+auditable playbook for updating the `$AGIALPHA` token constants that feed every
+Solidity module and TypeScript client. Follow the flow to change token metadata,
+addresses or scaling constants with zero downtime and guaranteed verification.
+
+```mermaid
+sequenceDiagram
+    participant Owner as Contract Owner
+    participant Repo as Repo Config (config/agialpha.json)
+    participant Helper as npm run compile
+    participant Contracts as Deployed Contracts
+    participant Monitor as npm run verify:agialpha
+
+    Owner->>Repo: Edit token metadata & addresses
+    Repo-->>Owner: Git diff + review
+    Owner->>Helper: npm run compile
+    Helper-->>Repo: Regenerate contracts/v2/Constants.sol
+    Helper-->>Owner: Validation report (halts on invalid values)
+    Owner->>Contracts: Deploy / upgrade modules
+    Owner->>Monitor: npm run verify:agialpha -- --rpc <url>
+    Monitor-->>Owner: Cross-check on-chain vs config
+```
+
+## At-a-glance responsibilities
+
+| Role | Focus | Key tooling |
+| ---- | ----- | ----------- |
+| Contract owner | Approves configuration changes and signs deployments. | Governance multisig / timelock, `npm run owner:parameters`. |
+| Operations lead | Edits `config/agialpha.json`, runs compilation + verification. | VS Code or JSON editor, `npm run compile`, `npm run verify:agialpha`. |
+| Observability | Confirms runtime monitoring & dashboards reflect new token info. | Grafana dashboards, `scripts/v2/updateThermodynamics.ts` dry runs. |
+
+## Prerequisites
+
+- Node.js 20.x and npm 10+ (run `nvm use` from the repo root).
+- Access to the governance signer capable of executing deployments.
+- RPC endpoint for the target network with archive or full-node access for
+  verification (HTTPS or WebSocket).
+- Clean working tree with no uncommitted changes before starting the process.
+
+## Configuration primer
+
+The canonical token metadata lives in `config/agialpha.json`. It contains:
+
+```jsonc
+{
+  "address": "0x...",         // Canonical ERC-20 deployment
+  "symbol": "AGIALPHA",        // Up to 11 characters
+  "name": "AGI Alpha Token",   // Display name
+  "decimals": 18,               // Integer 0–255
+  "burnAddress": "0x...",      // Optional burn sink (non-zero)
+  "scalingFactor": "1000000000000000000" // bigint string used by rewards
+}
+```
+
+> **Immutable reminder:** The contracts assume the token address never
+> changes after production launch. Update the metadata only for new networks
+> or emergency redeployments that migrate all dependent balances.
+
+## Update workflow (non-technical edition)
+
+1. **Plan the change**
+   - Run `npm run owner:parameters -- --format human` to grab the current
+     token section for your records.
+   - Confirm upstream stakeholders (treasury, accounting, rewards ops) are
+     aware of the new metadata.
+
+2. **Edit the configuration**
+   - Open `config/agialpha.json` in a JSON-aware editor.
+   - Update only the fields that changed (address, metadata, burn sink,
+     scaling factor). Keep the JSON strictly formatted; trailing commas are
+     invalid.
+   - Save the file and run `git diff config/agialpha.json` to review changes.
+
+3. **Regenerate constants**
+   - Execute `npm run compile`.
+   - The helper validates:
+     - Addresses are 20 bytes and non-zero (except burn if intentionally zero).
+     - Symbol, name and decimals match ERC-20 constraints.
+     - Scaling factor parses as a bigint.
+   - If validation fails, correct the JSON and rerun the command.
+
+4. **Verify regenerated artifacts**
+   - Inspect `contracts/v2/Constants.sol` to confirm the emitted values.
+   - Stage the JSON + Solidity changes (`git add config/agialpha.json contracts/v2/Constants.sol`).
+
+5. **Deploy / promote**
+   - Use the appropriate deployment helper (for example
+     `npx hardhat run scripts/v2/deployDefaults.ts --network <network>`).
+   - Ensure every module depending on the constants is redeployed or upgraded.
+
+6. **Post-deployment verification**
+   - Run `npm run verify:agialpha -- --rpc https://...` using an endpoint that
+     exposes the final chain state.
+   - The script fetches the ERC-20 metadata from the blockchain and compares it
+     against `config/agialpha.json` and `contracts/v2/Constants.sol`. It exits
+     non-zero if any field diverges.
+   - Archive the verification output with the governance ticket.
+
+7. **Broadcast update**
+   - Notify dependent teams (staking, treasury, analytics) with the new token
+     metadata and links to the verification artefacts.
+
+## Governance checkpoints
+
+```mermaid
+flowchart LR
+    A[Edit config/agialpha.json] --> B[Run npm run compile]
+    B --> C{Validation passes?}
+    C -- No --> A
+    C -- Yes --> D[Submit PR for review]
+    D --> E[Governance approves + merges]
+    E --> F[Execute deployment helper]
+    F --> G[Run npm run verify:agialpha]
+    G --> H{On-chain matches config?}
+    H -- No --> A
+    H -- Yes --> I[Archive + notify stakeholders]
+```
+
+## Zero-downtime checklist
+
+- [ ] New token address funded and fully synced before switching consumers.
+- [ ] All relayers, paymasters and reward engines reconfigured to the new address.
+- [ ] Off-chain services (indexers, analytics, dashboards) updated to expect the
+      revised symbol/name.
+- [ ] Governance and treasury sign-off documented with links to the verification
+      output and git commit.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+| ------- | ------------ | ---------- |
+| `npm run compile` rejects the config with `Invalid address length`. | Address missing `0x` prefix or not 40 hex chars. | Re-enter the address; use checksum casing to avoid typos. |
+| `verify:agialpha` reports decimal mismatch. | On-chain token decimals differ from config. | Double-check the live token contract; update config and rerun compile. |
+| Deployments still point to the old token. | Dependent modules not redeployed. | Re-run the deployment helper with `--execute` after staging the new constants. |
+
+## Reference material
+
+- [docs/owner-parameter-matrix.md](owner-parameter-matrix.md)
+- [docs/thermodynamic-incentives.md](thermodynamic-incentives.md)
+- [docs/reward-settlement-process.md](reward-settlement-process.md)
+- [docs/owner-control-command-center.md](owner-control-command-center.md)
+
+By following this guide, the contract owner retains complete control over the
+token parameters that drive the AGI Jobs platform while preserving a verifiable,
+production-ready audit trail.


### PR DESCRIPTION
## Summary
- add a token operations control guide with zero-downtime workflow, diagrams, and troubleshooting for config/agialpha.json changes
- document end-to-end energy oracle signer management with governance checklists and monitoring guidance
- reference the new guides from the root README so owners can quickly discover the playbooks

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68ddbb6765688333a0e3b15bd0d3b3e5