### PR TITLE
Add Ownable2Step support to ownership rotation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,7 +643,10 @@ single key can change parameters:
 
    The script reads `docs/deployment-addresses.json` and issues the
    appropriate `setGovernance` or `transferOwnership` calls for each
-   deployed module.
+   deployed module. For two-step ownable contracts (`TaxPolicy`,
+   `IdentityRegistry`) it initiates the transfer and confirms the
+   multisig/timelock is the pending owner—signers must still execute
+   `acceptOwnership()` from the new control wallet.
 
 3. To rotate governance later, the current multisig executes
    `setGovernance(newOwner)` or `transferOwnership(newOwner)` as


### PR DESCRIPTION
## Summary
- extend the transfer-ownership helper to treat TaxPolicy and IdentityRegistry as Ownable2Step contracts and verify pending ownership
- document the follow-up acceptOwnership step for multisig or timelock controllers in the governance hand-off guide

## Testing
- not run (script and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68ddca507a488333a382b845ee697a11