### PR TITLE
Enforce SystemPause ownership guard before rewiring modules

### DIFF
--- a/contracts/v2/SystemPause.sol
+++ b/contracts/v2/SystemPause.sol
@@ -146,6 +146,17 @@ contract SystemPause is Governable, ReentrancyGuard {
             address(_arbitratorCommittee).code.length == 0
         ) revert InvalidArbitratorCommittee(address(_arbitratorCommittee));
 
+        _requireModuleOwnership(
+            _jobRegistry,
+            _stakeManager,
+            _validationModule,
+            _disputeModule,
+            _platformRegistry,
+            _feePool,
+            _reputationEngine,
+            _arbitratorCommittee
+        );
+
         jobRegistry = _jobRegistry;
         stakeManager = _stakeManager;
         validationModule = _validationModule;

--- a/docs/governance/emergency-runbook.md
+++ b/docs/governance/emergency-runbook.md
@@ -25,7 +25,9 @@ incident.
   ```
 
   The script now fails if any module is not owned by `SystemPause`, preventing
-  partial wiring. Re-run the same command with `--execute` once the dry run is
+  partial wiring. `SystemPause.setModules` enforces the same rule on-chain,
+  reverting if governance attempts to wire an address that is not already owned
+  by the pause contract. Re-run the command with `--execute` once the dry run is
   clean to apply module or pauser updates.
 
 ## Circuit Breaker Operations

--- a/docs/system-pause.md
+++ b/docs/system-pause.md
@@ -30,7 +30,10 @@ non-zero address pointing to a deployed contract. The contract reverts with
   ```
 
   The script aborts if any module is not owned by `SystemPause`, ensuring a
-  single on-chain switch guards every critical flow.
+  single on-chain switch guards every critical flow. The on-chain
+  `SystemPause.setModules` call also reverts when a module has not transferred
+  ownership to the pause contract, so governance cannot wire an address that
+  cannot be halted during an emergency.
 - Re-run with `--execute` once the dry run is clean to update module wiring and
   refresh the pauser roles under governance control.
 


### PR DESCRIPTION
## Summary
- require SystemPause to already own each module before accepting new wiring
- refresh the SystemPause tests to transfer ownership prior to setModules calls and assert the new guard
- update the emergency pause runbook and SystemPause documentation to describe the ownership check

## Testing
- npx hardhat test --grep SystemPause

------
https://chatgpt.com/codex/tasks/task_e_68ddd20f93fc8333affaeaa2f3cb8328