### PR TITLE
Enforce non-empty ENS subdomains and update identity tests

### DIFF
--- a/contracts/v2/IdentityRegistry.sol
+++ b/contracts/v2/IdentityRegistry.sol
@@ -13,6 +13,7 @@ error ZeroNode();
 error UnauthorizedAgent();
 error EtherNotAccepted();
 error IncompatibleReputationEngine();
+error EmptySubdomain();
 
 /// @title IdentityRegistry
 /// @notice Verifies ENS subdomain ownership and tracks manual allowlists
@@ -121,6 +122,10 @@ contract IdentityRegistry is Ownable2Step {
         bytes32 agentMerkleRoot;
         bool setValidatorMerkleRoot;
         bytes32 validatorMerkleRoot;
+    }
+
+    function _assertSubdomain(string memory subdomain) private pure {
+        if (bytes(subdomain).length == 0) revert EmptySubdomain();
     }
 
     struct AdditionalAgentConfig {
@@ -592,6 +597,7 @@ contract IdentityRegistry is Ownable2Step {
         string calldata subdomain,
         bytes32[] calldata proof
     ) internal view returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle) {
+        _assertSubdomain(subdomain);
         if (agentRootNode != bytes32(0)) {
             (ok, node, viaWrapper, viaMerkle) = ENSIdentityVerifier.checkOwnership(
                 ens,
@@ -640,6 +646,7 @@ contract IdentityRegistry is Ownable2Step {
         string calldata subdomain,
         bytes32[] calldata proof
     ) internal view returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle) {
+        _assertSubdomain(subdomain);
         if (clubRootNode != bytes32(0)) {
             (ok, node, viaWrapper, viaMerkle) = ENSIdentityVerifier.checkOwnership(
                 ens,
@@ -688,6 +695,7 @@ contract IdentityRegistry is Ownable2Step {
         string calldata subdomain,
         bytes32[] calldata proof
     ) internal returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle) {
+        _assertSubdomain(subdomain);
         if (agentRootNode != bytes32(0)) {
             (ok, node, viaWrapper, viaMerkle) = ENSIdentityVerifier.verifyOwnership(
                 ens,
@@ -736,6 +744,7 @@ contract IdentityRegistry is Ownable2Step {
         string calldata subdomain,
         bytes32[] calldata proof
     ) internal returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle) {
+        _assertSubdomain(subdomain);
         if (clubRootNode != bytes32(0)) {
             (ok, node, viaWrapper, viaMerkle) = ENSIdentityVerifier.verifyOwnership(
                 ens,
@@ -784,6 +793,7 @@ contract IdentityRegistry is Ownable2Step {
         string calldata subdomain,
         bytes32[] calldata proof
     ) public view returns (bool) {
+        _assertSubdomain(subdomain);
         if (
             address(reputationEngine) != address(0) &&
             reputationEngine.isBlacklisted(claimant)
@@ -834,6 +844,7 @@ contract IdentityRegistry is Ownable2Step {
         string calldata subdomain,
         bytes32[] calldata proof
     ) public view returns (bool) {
+        _assertSubdomain(subdomain);
         if (
             address(reputationEngine) != address(0) &&
             reputationEngine.isBlacklisted(claimant)
@@ -887,6 +898,7 @@ contract IdentityRegistry is Ownable2Step {
         internal
         returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
     {
+        _assertSubdomain(subdomain);
         if (
             address(reputationEngine) != address(0) &&
             reputationEngine.isBlacklisted(claimant)
@@ -984,6 +996,7 @@ contract IdentityRegistry is Ownable2Step {
         external
         returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
     {
+        _assertSubdomain(subdomain);
         if (
             address(reputationEngine) != address(0) &&
             reputationEngine.isBlacklisted(claimant)

--- a/contracts/v2/mocks/IdentityRegistryMock.sol
+++ b/contracts/v2/mocks/IdentityRegistryMock.sol
@@ -8,6 +8,12 @@ contract IdentityRegistryMock is Ownable {
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 2;
 
+    error EmptySubdomain();
+
+    function _assertSubdomain(string memory subdomain) private pure {
+        if (bytes(subdomain).length == 0) revert EmptySubdomain();
+    }
+
     address public ens;
     address public nameWrapper;
     address public reputationEngine;
@@ -98,44 +104,48 @@ contract IdentityRegistryMock is Ownable {
 
     function isAuthorizedAgent(
         address claimant,
-        string calldata,
+        string calldata subdomain,
         bytes32[] calldata
     ) external view returns (bool) {
         claimant; // silence unused
+        _assertSubdomain(subdomain);
         return true;
     }
 
     function isAuthorizedValidator(
         address claimant,
-        string calldata,
+        string calldata subdomain,
         bytes32[] calldata
     ) external view returns (bool) {
         claimant; // silence unused
+        _assertSubdomain(subdomain);
         return true;
     }
 
     function verifyAgent(
         address claimant,
-        string calldata,
+        string calldata subdomain,
         bytes32[] calldata
     )
         external
         returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
     {
         claimant; // silence unused
+        _assertSubdomain(subdomain);
         node = bytes32(0);
         ok = true;
     }
 
     function verifyValidator(
         address claimant,
-        string calldata,
+        string calldata subdomain,
         bytes32[] calldata
     )
         external
         returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
     {
         claimant; // silence unused
+        _assertSubdomain(subdomain);
         node = bytes32(0);
         ok = true;
     }

--- a/contracts/v2/mocks/IdentityRegistryToggle.sol
+++ b/contracts/v2/mocks/IdentityRegistryToggle.sol
@@ -8,6 +8,12 @@ contract IdentityRegistryToggle is Ownable {
     /// @notice Module version for compatibility checks.
     uint256 public constant version = 2;
 
+    error EmptySubdomain();
+
+    function _assertSubdomain(string memory subdomain) private pure {
+        if (bytes(subdomain).length == 0) revert EmptySubdomain();
+    }
+
     bool public result;
     bytes32 public clubRootNode;
     bytes32 public agentRootNode;
@@ -91,29 +97,31 @@ contract IdentityRegistryToggle is Ownable {
 
     function isAuthorizedAgent(
         address claimant,
-        string calldata,
+        string calldata subdomain,
         bytes32[] calldata
     ) external view returns (bool) {
         if (additionalAgents[claimant]) {
             return true;
         }
+        _assertSubdomain(subdomain);
         return result;
     }
 
     function isAuthorizedValidator(
         address claimant,
-        string calldata,
+        string calldata subdomain,
         bytes32[] calldata
     ) external view returns (bool) {
         if (additionalValidators[claimant]) {
             return true;
         }
+        _assertSubdomain(subdomain);
         return result;
     }
 
     function verifyAgent(
         address claimant,
-        string calldata,
+        string calldata subdomain,
         bytes32[] calldata
     )
         external
@@ -125,11 +133,12 @@ contract IdentityRegistryToggle is Ownable {
         } else {
             ok = result;
         }
+        _assertSubdomain(subdomain);
     }
 
     function verifyValidator(
         address claimant,
-        string calldata,
+        string calldata subdomain,
         bytes32[] calldata
     )
         external
@@ -141,6 +150,7 @@ contract IdentityRegistryToggle is Ownable {
         } else {
             ok = result;
         }
+        _assertSubdomain(subdomain);
     }
 }
 

--- a/test/v2/ContractEmployerFinalize.test.js
+++ b/test/v2/ContractEmployerFinalize.test.js
@@ -122,10 +122,10 @@ describe('Job finalization with contract employer', function () {
       'uri'
     );
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
 
     await setJobState(jobId, true);
     const burnTxHash = ethers.ZeroHash;
@@ -158,10 +158,10 @@ describe('Job finalization with contract employer', function () {
       'uri'
     );
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
 
     await setJobState(jobId, true);
     await registry.connect(owner).finalize(jobId);

--- a/test/v2/ENSOwnershipVerifier.test.js
+++ b/test/v2/ENSOwnershipVerifier.test.js
@@ -147,27 +147,27 @@ describe('ENSOwnershipVerifier verification', function () {
 
   it('requires merkle proof without subdomain and invalidates on root update', async () => {
     expect(
-      await verifier.verifyAgent.staticCall(agent.address, '', [])
+      await verifier.verifyAgent.staticCall(agent.address, 'agent', [])
     ).to.equal(false);
     expect(
-      await verifier.verifyValidator.staticCall(validator.address, '', [])
+      await verifier.verifyValidator.staticCall(validator.address, 'validator', [])
     ).to.equal(false);
 
-    const agentLeaf = leaf(agent.address, '');
-    const validatorLeaf = leaf(validator.address, '');
+    const agentLeaf = leaf(agent.address, 'agent');
+    const validatorLeaf = leaf(validator.address, 'validator');
     await verifier.setAgentMerkleRoot(agentLeaf);
     await verifier.setValidatorMerkleRoot(validatorLeaf);
 
-    const txA = await verifier.verifyAgent(agent.address, '', []);
+    const txA = await verifier.verifyAgent(agent.address, 'agent', []);
     await txA.wait();
-    const txV = await verifier.verifyValidator(validator.address, '', []);
+    const txV = await verifier.verifyValidator(validator.address, 'validator', []);
     await txV.wait();
 
     expect(
-      await verifier.verifyAgent.staticCall(agent.address, '', [])
+      await verifier.verifyAgent.staticCall(agent.address, 'agent', [])
     ).to.equal(true);
     expect(
-      await verifier.verifyValidator.staticCall(validator.address, '', [])
+      await verifier.verifyValidator.staticCall(validator.address, 'validator', [])
     ).to.equal(true);
 
     const newRoot = ethers.id('newRoot');
@@ -175,10 +175,10 @@ describe('ENSOwnershipVerifier verification', function () {
     await verifier.setValidatorMerkleRoot(newRoot);
 
     expect(
-      await verifier.verifyAgent.staticCall(agent.address, '', [])
+      await verifier.verifyAgent.staticCall(agent.address, 'agent', [])
     ).to.equal(false);
     expect(
-      await verifier.verifyValidator.staticCall(validator.address, '', [])
+      await verifier.verifyValidator.staticCall(validator.address, 'validator', [])
     ).to.equal(false);
   });
 

--- a/test/v2/EmployerReputation.test.js
+++ b/test/v2/EmployerReputation.test.js
@@ -167,11 +167,11 @@ describe('Employer reputation', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.connect(owner).setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
     await validation.finalize(jobId);
     await registry.connect(employer).finalize(jobId);
     const [successful, failed] = await registry.getEmployerReputation(
@@ -193,11 +193,11 @@ describe('Employer reputation', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.connect(owner).setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
     await validation.finalize(jobId);
     await registry
       .connect(agent)

--- a/test/v2/GovernanceFinalizeBlacklist.test.js
+++ b/test/v2/GovernanceFinalizeBlacklist.test.js
@@ -132,10 +132,10 @@ describe('JobRegistry governance finalization', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
 
     await rep.connect(owner).blacklist(agent.address, true);
     await setJobState(jobId, true);
@@ -163,10 +163,10 @@ describe('JobRegistry governance finalization', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
 
     await rep.connect(owner).blacklist(employer.address, true);
     await setJobState(jobId, false);

--- a/test/v2/IdentityVerification.test.js
+++ b/test/v2/IdentityVerification.test.js
@@ -220,19 +220,19 @@ describe('Identity verification enforcement', function () {
         [1n, nonce, true, burnTxHash, salt, ethers.ZeroHash]
       );
       await expect(
-        validation.connect(signer).commitValidation(1, commit, '', [])
+        validation.connect(signer).commitValidation(1, commit, 'validator', [])
       ).to.be.revertedWithCustomError(validation, 'UnauthorizedValidator');
 
       await identity.addAdditionalValidator(val);
       await (
-        await validation.connect(signer).commitValidation(1, commit, '', [])
+        await validation.connect(signer).commitValidation(1, commit, 'validator', [])
       ).wait();
       await advance(61);
       await identity.removeAdditionalValidator(val);
       await expect(
         validation
           .connect(signer)
-          .revealValidation(1, true, burnTxHash, salt, '', [])
+          .revealValidation(1, true, burnTxHash, salt, 'validator', [])
       ).to.be.revertedWithCustomError(validation, 'UnauthorizedValidator');
     });
   });

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -147,7 +147,7 @@ describe('Job expiration', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await time.increase(200);
     await expect(
       registry.connect(treasury).cancelExpiredJob(jobId)
@@ -173,7 +173,7 @@ describe('Job expiration', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await expect(
       registry.connect(employer).cancelExpiredJob(jobId)
     ).to.be.revertedWithCustomError(registry, 'DeadlineNotReached');
@@ -187,7 +187,7 @@ describe('Job expiration', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await time.increase(120);
     await expect(
       registry.connect(employer).cancelExpiredJob(jobId)

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -148,7 +148,7 @@ describe('Job expiration boundary', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await time.increase(deadline + grace - 1 - (await time.latest()));
     await expect(
       registry.connect(employer).cancelExpiredJob(jobId)
@@ -164,7 +164,7 @@ describe('Job expiration boundary', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await time.increase(deadline + grace - (await time.latest()));
     await expect(registry.connect(employer).cancelExpiredJob(jobId))
       .to.emit(registry, 'JobExpired')

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -191,24 +191,24 @@ describe('JobRegistry integration', function () {
     const created = await registry.jobs(1);
     expect(created.specHash).to.equal(specHash);
     const jobId = 1;
-    await expect(registry.connect(agent).applyForJob(jobId, '', []))
+    await expect(registry.connect(agent).applyForJob(jobId, 'agent', []))
       .to.emit(registry, 'AgentIdentityVerified')
-      .withArgs(agent.address, ethers.ZeroHash, '', false, false)
+      .withArgs(agent.address, ethers.ZeroHash, 'agent', false, false)
       .and.to.emit(registry, 'ApplicationSubmitted')
-      .withArgs(jobId, agent.address, '')
+      .withArgs(jobId, agent.address, 'agent')
       .and.to.emit(registry, 'AgentAssigned')
-      .withArgs(jobId, agent.address, '');
+      .withArgs(jobId, agent.address, 'agent');
     await validation.connect(owner).setResult(true);
     const committee = [owner.address, treasury.address];
     await validation.connect(owner).setValidators(committee);
     const resultHash = ethers.id('result');
     await expect(
-      registry.connect(agent).submit(jobId, resultHash, 'result', '', [])
+      registry.connect(agent).submit(jobId, resultHash, 'result', 'agent', [])
     )
       .to.emit(registry, 'AgentIdentityVerified')
-      .withArgs(agent.address, ethers.ZeroHash, '', false, false)
+      .withArgs(agent.address, ethers.ZeroHash, 'agent', false, false)
       .and.to.emit(registry, 'ResultSubmitted')
-      .withArgs(jobId, agent.address, resultHash, 'result', '');
+      .withArgs(jobId, agent.address, resultHash, 'result', 'agent');
     await expect(validation.finalize(jobId))
       .to.emit(registry, 'JobCompleted')
       .withArgs(jobId, true);
@@ -250,13 +250,13 @@ describe('JobRegistry integration', function () {
         specHash,
         'uri'
       );
-    await expect(registry.connect(newAgent).acknowledgeAndApply(1, '', []))
+    await expect(registry.connect(newAgent).acknowledgeAndApply(1, 'agent', []))
       .to.emit(registry, 'AgentIdentityVerified')
-      .withArgs(newAgent.address, ethers.ZeroHash, '', false, false)
+      .withArgs(newAgent.address, ethers.ZeroHash, 'agent', false, false)
       .and.to.emit(registry, 'ApplicationSubmitted')
-      .withArgs(1, newAgent.address, '')
+      .withArgs(1, newAgent.address, 'agent')
       .and.to.emit(registry, 'AgentAssigned')
-      .withArgs(1, newAgent.address, '');
+      .withArgs(1, newAgent.address, 'agent');
     expect(await policy.hasAcknowledged(newAgent.address)).to.equal(true);
   });
 
@@ -280,12 +280,12 @@ describe('JobRegistry integration', function () {
         'uri'
       );
 
-    await expect(registry.connect(agent).applyForJob(1, '', []))
+    await expect(registry.connect(agent).applyForJob(1, 'agent', []))
       .to.emit(registry, 'AgentAssigned')
-      .withArgs(1, agent.address, '');
+      .withArgs(1, agent.address, 'agent');
 
     await expect(
-      registry.connect(secondAgent).applyForJob(1, '', [])
+      registry.connect(secondAgent).applyForJob(1, 'agent', [])
     ).to.be.revertedWithCustomError(registry, 'NotOpen');
 
     const job = await registry.jobs(1);
@@ -325,11 +325,11 @@ describe('JobRegistry integration', function () {
         'uri'
       );
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.connect(owner).setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('result'), 'result', '', []);
+      .submit(jobId, ethers.id('result'), 'result', 'agent', []);
     await validation.finalize(jobId);
     const burnTxHash = ethers.ZeroHash;
     const burnAmt = (BigInt(reward) * 10n) / 100n;
@@ -357,11 +357,11 @@ describe('JobRegistry integration', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.connect(owner).setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
     await validation.finalize(jobId);
     await policy.connect(treasury).acknowledge();
     await expect(
@@ -381,11 +381,11 @@ describe('JobRegistry integration', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.connect(owner).setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('result'), 'result', '', []);
+      .submit(jobId, ethers.id('result'), 'result', 'agent', []);
     await validation.finalize(jobId);
     const burnTxHash2 = ethers.ZeroHash;
     await registry
@@ -412,11 +412,11 @@ describe('JobRegistry integration', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.connect(owner).setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
     await validation.finalize(jobId);
     await expect(
       registry.connect(agent).finalize(jobId)
@@ -436,11 +436,11 @@ describe('JobRegistry integration', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.connect(owner).setResult(false);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
     await validation.finalize(jobId);
     const registryAddr = await registry.getAddress();
     await network.provider.send('hardhat_setBalance', [
@@ -477,10 +477,10 @@ describe('JobRegistry integration', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
     const validationAddr = await validation.getAddress();
     await ethers.provider.send('hardhat_impersonateAccount', [validationAddr]);
     await ethers.provider.send('hardhat_setBalance', [
@@ -611,11 +611,11 @@ describe('JobRegistry integration', function () {
         'uri'
       );
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.connect(owner).setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('result'), 'result', '', []);
+      .submit(jobId, ethers.id('result'), 'result', 'agent', []);
     await validation.finalize(jobId);
     await registry.connect(employer).finalize(jobId);
 
@@ -740,7 +740,7 @@ describe('JobRegistry integration', function () {
 
     await stakeManager.connect(agent).withdrawStake(0, stake);
 
-    await expect(registry.connect(agent).applyForJob(jobId, '', []))
+    await expect(registry.connect(agent).applyForJob(jobId, 'agent', []))
       .to.be.revertedWithCustomError(registry, 'InsufficientAgentStake')
       .withArgs(minStake, 0);
 
@@ -749,12 +749,12 @@ describe('JobRegistry integration', function () {
       .approve(await stakeManager.getAddress(), minStake);
     await stakeManager.connect(agent).depositStake(0, minStake);
 
-    await expect(registry.connect(agent).applyForJob(jobId, '', []))
+    await expect(registry.connect(agent).applyForJob(jobId, 'agent', []))
       .to.emit(registry, 'AgentIdentityVerified')
-      .withArgs(agent.address, ethers.ZeroHash, '', false, false)
+      .withArgs(agent.address, ethers.ZeroHash, 'agent', false, false)
       .and.to.emit(registry, 'ApplicationSubmitted')
-      .withArgs(jobId, agent.address, '')
+      .withArgs(jobId, agent.address, 'agent')
       .and.to.emit(registry, 'AgentAssigned')
-      .withArgs(jobId, agent.address, '');
+      .withArgs(jobId, agent.address, 'agent');
   });
 });

--- a/test/v2/JobRegistryBurnReceipt.test.js
+++ b/test/v2/JobRegistryBurnReceipt.test.js
@@ -103,9 +103,9 @@ describe('JobRegistry burn receipt validation', function () {
       .createJob(reward, deadline, specHash, 'ipfs://job');
     const jobId = 1;
 
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     const resHash = ethers.keccak256(ethers.toUtf8Bytes('result'));
-    await registry.connect(agent).submit(jobId, resHash, 'ipfs://res', '', []);
+    await registry.connect(agent).submit(jobId, resHash, 'ipfs://res', 'agent', []);
     await validation.setResult(true);
     await validation.finalize(jobId);
 
@@ -275,11 +275,11 @@ describe('Validation burn evidence gating', function () {
       .connect(employer)
       .createJob(1, deadline, specHash, 'ipfs://job');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     const resultHash = ethers.keccak256(ethers.toUtf8Bytes('result'));
     await registry
       .connect(agent)
-      .submit(jobId, resultHash, 'ipfs://res', '', []);
+      .submit(jobId, resultHash, 'ipfs://res', 'agent', []);
     return { jobId, resultHash };
   }
 

--- a/test/v2/JobRegistryPause.test.js
+++ b/test/v2/JobRegistryPause.test.js
@@ -59,17 +59,17 @@ describe('JobRegistry pause', function () {
 
     await registry.connect(owner).pause();
     await expect(
-      registry.connect(agent).applyForJob(1, '', [])
+      registry.connect(agent).applyForJob(1, 'agent', [])
     ).to.be.revertedWithCustomError(registry, 'EnforcedPause');
 
     await registry.connect(owner).unpause();
-    await expect(registry.connect(agent).applyForJob(1, '', []))
+    await expect(registry.connect(agent).applyForJob(1, 'agent', []))
       .to.emit(registry, 'AgentIdentityVerified')
-      .withArgs(agent.address, ethers.ZeroHash, '', false, false)
+      .withArgs(agent.address, ethers.ZeroHash, 'agent', false, false)
       .and.to.emit(registry, 'ApplicationSubmitted')
-      .withArgs(1, agent.address, '')
+      .withArgs(1, agent.address, 'agent')
       .and.to.emit(registry, 'AgentAssigned')
-      .withArgs(1, agent.address, '');
+      .withArgs(1, agent.address, 'agent');
   });
 
   it('pauses job expiration', async () => {
@@ -77,7 +77,7 @@ describe('JobRegistry pause', function () {
     const specHash = ethers.id('spec');
 
     await registry.connect(employer).createJob(1, deadline, specHash, 'uri');
-    await registry.connect(agent).applyForJob(1, '', []);
+    await registry.connect(agent).applyForJob(1, 'agent', []);
 
     await time.increase(200);
 

--- a/test/v2/JobRegistrySnapshot.test.js
+++ b/test/v2/JobRegistrySnapshot.test.js
@@ -112,14 +112,14 @@ describe('JobRegistry payout snapshot', function () {
   it('uses snapshot when NFT transferred after assignment', async () => {
     await nft.mint(agent.address);
     const { reward, jobId } = await createJob();
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     let job = enrichJob(await registry.jobs(jobId));
     expect(job.agentPct).to.equal(150n);
     await nft.connect(agent).transferFrom(agent.address, other.address, 0n);
 
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
     await validation.setResult(true);
     await validation.finalize(jobId);
 
@@ -132,14 +132,14 @@ describe('JobRegistry payout snapshot', function () {
 
   it('ignores NFTs gained after assignment', async () => {
     const { reward, jobId } = await createJob();
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     let job = enrichJob(await registry.jobs(jobId));
     expect(job.agentPct).to.equal(100n);
     await nft.mint(agent.address);
 
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('res'), 'res', '', []);
+      .submit(jobId, ethers.id('res'), 'res', 'agent', []);
     await validation.setResult(true);
     await validation.finalize(jobId);
 

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -315,24 +315,24 @@ describe('ValidationModule V2', function () {
       [1n, nonce, true, burnTxHash, salt3, ethers.ZeroHash]
     );
     await (
-      await validation.connect(v1).commitValidation(1, commit1, '', [])
+      await validation.connect(v1).commitValidation(1, commit1, 'validator', [])
     ).wait();
     await (
-      await validation.connect(v2).commitValidation(1, commit2, '', [])
+      await validation.connect(v2).commitValidation(1, commit2, 'validator', [])
     ).wait();
     await (
-      await validation.connect(v3).commitValidation(1, commit3, '', [])
+      await validation.connect(v3).commitValidation(1, commit3, 'validator', [])
     ).wait();
     await advance(61);
     await validation
       .connect(v1)
-      .revealValidation(1, true, burnTxHash, salt1, '', []);
+      .revealValidation(1, true, burnTxHash, salt1, 'validator', []);
     await validation
       .connect(v2)
-      .revealValidation(1, true, burnTxHash, salt2, '', []);
+      .revealValidation(1, true, burnTxHash, salt2, 'validator', []);
     await validation
       .connect(v3)
-      .revealValidation(1, true, burnTxHash, salt3, '', []);
+      .revealValidation(1, true, burnTxHash, salt3, 'validator', []);
     await advance(61);
     expect(await validation.finalize.staticCall(1)).to.equal(true);
     await validation.finalize(1);
@@ -369,25 +369,25 @@ describe('ValidationModule V2', function () {
       [1n, nonce, false, burnTxHash, salt3, ethers.ZeroHash]
     );
     await (
-      await validation.connect(v1).commitValidation(1, commit1, '', [])
+      await validation.connect(v1).commitValidation(1, commit1, 'validator', [])
     ).wait();
     await (
-      await validation.connect(v2).commitValidation(1, commit2, '', [])
+      await validation.connect(v2).commitValidation(1, commit2, 'validator', [])
     ).wait();
     await (
-      await validation.connect(v3).commitValidation(1, commit3, '', [])
+      await validation.connect(v3).commitValidation(1, commit3, 'validator', [])
     ).wait();
     await advance(61);
     const stakeBefore = await stakeManager.stakeOf(v3.address, 1);
     await validation
       .connect(v1)
-      .revealValidation(1, true, burnTxHash, salt1, '', []);
+      .revealValidation(1, true, burnTxHash, salt1, 'validator', []);
     await validation
       .connect(v2)
-      .revealValidation(1, true, burnTxHash, salt2, '', []);
+      .revealValidation(1, true, burnTxHash, salt2, 'validator', []);
     await validation
       .connect(v3)
-      .revealValidation(1, false, burnTxHash, salt3, '', []);
+      .revealValidation(1, false, burnTxHash, salt3, 'validator', []);
     await advance(61);
     await validation.finalize(1);
     expect(await stakeManager.stakeOf(v3.address, 1)).to.equal(
@@ -407,11 +407,11 @@ describe('ValidationModule V2', function () {
       [1n, wrongNonce, true, burnTxHash, salt, ethers.ZeroHash]
     );
     await (
-      await validation.connect(v1).commitValidation(1, commit, '', [])
+      await validation.connect(v1).commitValidation(1, commit, 'validator', [])
     ).wait();
     await advance(61);
     await expect(
-      validation.connect(v1).revealValidation(1, true, burnTxHash, salt, '', [])
+      validation.connect(v1).revealValidation(1, true, burnTxHash, salt, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'InvalidReveal');
   });
 
@@ -424,13 +424,13 @@ describe('ValidationModule V2', function () {
       [1n, nonce, true, burnTxHash, salt, ethers.ZeroHash]
     );
     await (
-      await validation.connect(v1).commitValidation(1, commit, '', [])
+      await validation.connect(v1).commitValidation(1, commit, 'validator', [])
     ).wait();
     await advance(61);
     await expect(
       validation
         .connect(v1)
-        .revealValidation(1, false, burnTxHash, salt, '', [])
+        .revealValidation(1, false, burnTxHash, salt, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'InvalidReveal');
   });
 
@@ -448,13 +448,13 @@ describe('ValidationModule V2', function () {
       [1n, nonce, true, burnTxHash, salt, ethers.ZeroHash]
     );
     await (
-      await validation.connect(v1).commitValidation(1, commit, '', [])
+      await validation.connect(v1).commitValidation(1, commit, 'validator', [])
     ).wait();
     expect(await validation.commitments(1, v1.address, nonce)).to.equal(commit);
     await advance(61);
     await validation
       .connect(v1)
-      .revealValidation(1, true, burnTxHash, salt, '', []);
+      .revealValidation(1, true, burnTxHash, salt, 'validator', []);
     await advance(61);
     await validation.finalize(1);
     expect(await validation.commitments(1, v1.address, nonce)).to.equal(
@@ -476,11 +476,11 @@ describe('ValidationModule V2', function () {
       [1n, nonce1, true, burnTxHash, salt, ethers.ZeroHash]
     );
     await (
-      await validation.connect(v1).commitValidation(1, commit1, '', [])
+      await validation.connect(v1).commitValidation(1, commit1, 'validator', [])
     ).wait();
 
     await expect(
-      validation.connect(v1).commitValidation(1, commit1, '', [])
+      validation.connect(v1).commitValidation(1, commit1, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'AlreadyCommitted');
 
     await validation.connect(owner).resetJobNonce(1);
@@ -494,7 +494,7 @@ describe('ValidationModule V2', function () {
       ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
       [1n, nonce2, true, burnTxHash, salt, ethers.ZeroHash]
     );
-    await expect(validation.connect(v1).commitValidation(1, commit2, '', [])).to
+    await expect(validation.connect(v1).commitValidation(1, commit2, 'validator', [])).to
       .not.be.reverted;
   });
 
@@ -518,7 +518,7 @@ describe('ValidationModule V2', function () {
       [1n, nonce, true, burnTxHash, salt, ethers.ZeroHash]
     );
     await expect(
-      validation.connect(v1).commitValidation(1, commit, '', [])
+      validation.connect(v1).commitValidation(1, commit, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'NotValidator');
   });
 
@@ -586,23 +586,23 @@ describe('ValidationModule V2', function () {
       [1n, nonce, true, burnTxHash, salt, ethers.ZeroHash]
     );
 
-    await expect(validation.connect(val).commitValidation(1, commit, '', []))
+    await expect(validation.connect(val).commitValidation(1, commit, 'validator', []))
       .to.be.revertedWithCustomError(validation, 'TaxPolicyNotAcknowledged')
       .withArgs(val.address);
 
     await policy.connect(val).acknowledge();
-    await expect(validation.connect(val).commitValidation(1, commit, '', []))
+    await expect(validation.connect(val).commitValidation(1, commit, 'validator', []))
       .to.emit(validation, 'ValidatorIdentityVerified')
-      .withArgs(val.address, ethers.ZeroHash, '', false, false)
+      .withArgs(val.address, ethers.ZeroHash, 'validator', false, false)
       .and.to.emit(validation, 'ValidationCommitted')
-      .withArgs(1, val.address, commit, '');
+      .withArgs(1, val.address, commit, 'validator');
 
     await advance(61);
     await policy.bumpPolicyVersion();
     await expect(
       validation
         .connect(val)
-        .revealValidation(1, true, burnTxHash, salt, '', [])
+        .revealValidation(1, true, burnTxHash, salt, 'validator', [])
     )
       .to.be.revertedWithCustomError(validation, 'TaxPolicyNotAcknowledged')
       .withArgs(val.address);
@@ -611,12 +611,12 @@ describe('ValidationModule V2', function () {
     await expect(
       validation
         .connect(val)
-        .revealValidation(1, true, burnTxHash, salt, '', [])
+        .revealValidation(1, true, burnTxHash, salt, 'validator', [])
     )
       .to.emit(validation, 'ValidatorIdentityVerified')
-      .withArgs(val.address, ethers.ZeroHash, '', false, false)
+      .withArgs(val.address, ethers.ZeroHash, 'validator', false, false)
       .and.to.emit(validation, 'ValidationRevealed')
-      .withArgs(1, val.address, true, burnTxHash, '');
+      .withArgs(1, val.address, true, burnTxHash, 'validator');
   });
 
   it('updates additional validators individually', async () => {
@@ -818,17 +818,17 @@ describe('ValidationModule V2', function () {
       await (
         await validationReal
           .connect(validatorA)
-          .commitValidation(1, commit1, '', [])
+          .commitValidation(1, commit1, 'validator', [])
       ).wait();
       await (
         await validationReal
           .connect(validatorB)
-          .commitValidation(1, commit2, '', [])
+          .commitValidation(1, commit2, 'validator', [])
       ).wait();
       await (
         await validationReal
           .connect(validatorC)
-          .commitValidation(1, commit3, '', [])
+          .commitValidation(1, commit3, 'validator', [])
       ).wait();
 
       await advance(61);
@@ -839,13 +839,13 @@ describe('ValidationModule V2', function () {
 
       await validationReal
         .connect(validatorA)
-        .revealValidation(1, true, burnHashReal, salt1, '', []);
+        .revealValidation(1, true, burnHashReal, salt1, 'validator', []);
       await validationReal
         .connect(validatorB)
-        .revealValidation(1, true, burnHashReal, salt2, '', []);
+        .revealValidation(1, true, burnHashReal, salt2, 'validator', []);
       await validationReal
         .connect(validatorC)
-        .revealValidation(1, false, burnHashReal, salt3, '', []);
+        .revealValidation(1, false, burnHashReal, salt3, 'validator', []);
 
       await advance(61);
       await validationReal.finalize(1);

--- a/test/v2/ValidationModuleAccess.test.js
+++ b/test/v2/ValidationModuleAccess.test.js
@@ -127,14 +127,14 @@ describe('ValidationModule access controls', function () {
       [1n, nonce, true, burnTxHash, salt, ethers.ZeroHash]
     );
     await expect(
-      validation.connect(signer).commitValidation(1, commit, '', [])
+      validation.connect(signer).commitValidation(1, commit, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'UnauthorizedValidator');
 
     // allow commit then block reveal
     await identity.addAdditionalValidator(val);
     await toggle.setResult(true);
     await (
-      await validation.connect(signer).commitValidation(1, commit, '', [])
+      await validation.connect(signer).commitValidation(1, commit, 'validator', [])
     ).wait();
     await advance(61);
     await identity.removeAdditionalValidator(val);
@@ -142,7 +142,7 @@ describe('ValidationModule access controls', function () {
     await expect(
       validation
         .connect(signer)
-        .revealValidation(1, true, burnTxHash, salt, '', [])
+        .revealValidation(1, true, burnTxHash, salt, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'UnauthorizedValidator');
   });
 
@@ -168,19 +168,19 @@ describe('ValidationModule access controls', function () {
     );
     await reputation.setBlacklist(val, true);
     await expect(
-      validation.connect(signer).commitValidation(1, commit, '', [])
+      validation.connect(signer).commitValidation(1, commit, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'BlacklistedValidator');
 
     await reputation.setBlacklist(val, false);
     await (
-      await validation.connect(signer).commitValidation(1, commit, '', [])
+      await validation.connect(signer).commitValidation(1, commit, 'validator', [])
     ).wait();
     await advance(61);
     await reputation.setBlacklist(val, true);
     await expect(
       validation
         .connect(signer)
-        .revealValidation(1, true, burnTxHash, salt, '', [])
+        .revealValidation(1, true, burnTxHash, salt, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'BlacklistedValidator');
   });
 
@@ -218,33 +218,33 @@ describe('ValidationModule access controls', function () {
     await (
       await validation
         .connect(signerMap[vA.toLowerCase()])
-        .commitValidation(1, commitA, '', [])
+        .commitValidation(1, commitA, 'validator', [])
     ).wait();
     await (
       await validation
         .connect(signerMap[vB.toLowerCase()])
-        .commitValidation(1, commitB, '', [])
+        .commitValidation(1, commitB, 'validator', [])
     ).wait();
     await (
       await validation
         .connect(signerMap[vC.toLowerCase()])
-        .commitValidation(1, commitC, '', [])
+        .commitValidation(1, commitC, 'validator', [])
     ).wait();
     await advance(61);
     await (
       await validation
         .connect(signerMap[vA.toLowerCase()])
-        .revealValidation(1, false, burnTxHash, saltA, '', [])
+        .revealValidation(1, false, burnTxHash, saltA, 'validator', [])
     ).wait();
     await (
       await validation
         .connect(signerMap[vB.toLowerCase()])
-        .revealValidation(1, false, burnTxHash, saltB, '', [])
+        .revealValidation(1, false, burnTxHash, saltB, 'validator', [])
     ).wait();
     await (
       await validation
         .connect(signerMap[vC.toLowerCase()])
-        .revealValidation(1, false, burnTxHash, saltC, '', [])
+        .revealValidation(1, false, burnTxHash, saltC, 'validator', [])
     ).wait();
     await advance(61);
     await validation.finalize(1);
@@ -283,33 +283,33 @@ describe('ValidationModule access controls', function () {
     await (
       await validation
         .connect(signerMap[vA.toLowerCase()])
-        .commitValidation(1, c1, '', [])
+        .commitValidation(1, c1, 'validator', [])
     ).wait();
     await (
       await validation
         .connect(signerMap[vB.toLowerCase()])
-        .commitValidation(1, c2, '', [])
+        .commitValidation(1, c2, 'validator', [])
     ).wait();
     await (
       await validation
         .connect(signerMap[vC.toLowerCase()])
-        .commitValidation(1, c3, '', [])
+        .commitValidation(1, c3, 'validator', [])
     ).wait();
     await advance(61);
     await (
       await validation
         .connect(signerMap[vA.toLowerCase()])
-        .revealValidation(1, true, burnTxHash, s1, '', [])
+        .revealValidation(1, true, burnTxHash, s1, 'validator', [])
     ).wait();
     await (
       await validation
         .connect(signerMap[vB.toLowerCase()])
-        .revealValidation(1, true, burnTxHash, s2, '', [])
+        .revealValidation(1, true, burnTxHash, s2, 'validator', [])
     ).wait();
     await (
       await validation
         .connect(signerMap[vC.toLowerCase()])
-        .revealValidation(1, true, burnTxHash, s3, '', [])
+        .revealValidation(1, true, burnTxHash, s3, 'validator', [])
     ).wait();
     await advance(61);
     await validation.finalize(1);

--- a/test/v2/ValidationModuleCommitteeSize.test.js
+++ b/test/v2/ValidationModuleCommitteeSize.test.js
@@ -143,18 +143,18 @@ describe('ValidationModule committee size', function () {
 
     await validation
       .connect(signerMap[selected[0].toLowerCase()])
-      .commitValidation(4, commit1, '', []);
+      .commitValidation(4, commit1, 'validator', []);
     await validation
       .connect(signerMap[selected[1].toLowerCase()])
-      .commitValidation(4, commit2, '', []);
+      .commitValidation(4, commit2, 'validator', []);
 
     await advance(61);
     await validation
       .connect(signerMap[selected[0].toLowerCase()])
-      .revealValidation(4, true, burnTxHash, salt1, '', []);
+      .revealValidation(4, true, burnTxHash, salt1, 'validator', []);
     await validation
       .connect(signerMap[selected[1].toLowerCase()])
-      .revealValidation(4, true, burnTxHash, salt2, '', []);
+      .revealValidation(4, true, burnTxHash, salt2, 'validator', []);
     await advance(61);
 
     expect(await validation.finalize.staticCall(4)).to.equal(false);

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -176,22 +176,22 @@ describe('ValidationModule finalize flows', function () {
       domain,
       chainId
     );
-    await validation.connect(v1).commitValidation(1, commit1, '', []);
-    await validation.connect(v2).commitValidation(1, commit2, '', []);
-    await validation.connect(v3).commitValidation(1, commit3, '', []);
+    await validation.connect(v1).commitValidation(1, commit1, 'validator', []);
+    await validation.connect(v2).commitValidation(1, commit2, 'validator', []);
+    await validation.connect(v3).commitValidation(1, commit3, 'validator', []);
     expect(await validation.validatorStakes(1, v1.address)).to.equal(
       ethers.parseEther('100')
     );
     await advance(61);
     await validation
       .connect(v1)
-      .revealValidation(1, true, burnTxHash, salt1, '', []);
+      .revealValidation(1, true, burnTxHash, salt1, 'validator', []);
     await validation
       .connect(v2)
-      .revealValidation(1, false, burnTxHash, salt2, '', []);
+      .revealValidation(1, false, burnTxHash, salt2, 'validator', []);
     await validation
       .connect(v3)
-      .revealValidation(1, false, burnTxHash, salt3, '', []);
+      .revealValidation(1, false, burnTxHash, salt3, 'validator', []);
     await advance(61);
     await validation.finalize(1);
     await jobRegistry.connect(employer).confirmEmployerBurn(1, burnTxHash);
@@ -245,9 +245,9 @@ describe('ValidationModule finalize flows', function () {
       domain,
       chainId
     );
-    await validation.connect(v1).commitValidation(1, commit1, '', []);
-    await validation.connect(v2).commitValidation(1, commit2, '', []);
-    await validation.connect(v3).commitValidation(1, commit3, '', []);
+    await validation.connect(v1).commitValidation(1, commit1, 'validator', []);
+    await validation.connect(v2).commitValidation(1, commit2, 'validator', []);
+    await validation.connect(v3).commitValidation(1, commit3, 'validator', []);
     await expect(validation.finalize(1)).to.be.revertedWithCustomError(
       validation,
       'RevealPending'
@@ -265,7 +265,7 @@ describe('ValidationModule finalize flows', function () {
     );
     await advance(61);
     await expect(
-      validation.connect(v1).commitValidation(1, commit, '', [])
+      validation.connect(v1).commitValidation(1, commit, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'CommitPhaseClosed');
   });
 
@@ -289,19 +289,19 @@ describe('ValidationModule finalize flows', function () {
       ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
       [1n, nonce, true, burnTxHash, salt3, ethers.ZeroHash]
     );
-    await validation.connect(v1).commitValidation(1, commit1, '', []);
-    await validation.connect(v2).commitValidation(1, commit2, '', []);
-    await validation.connect(v3).commitValidation(1, commit3, '', []);
+    await validation.connect(v1).commitValidation(1, commit1, 'validator', []);
+    await validation.connect(v2).commitValidation(1, commit2, 'validator', []);
+    await validation.connect(v3).commitValidation(1, commit3, 'validator', []);
     await advance(61);
     await validation
       .connect(v1)
-      .revealValidation(1, false, burnTxHash, salt1, '', []);
+      .revealValidation(1, false, burnTxHash, salt1, 'validator', []);
     await validation
       .connect(v2)
-      .revealValidation(1, false, burnTxHash, salt2, '', []);
+      .revealValidation(1, false, burnTxHash, salt2, 'validator', []);
     await validation
       .connect(v3)
-      .revealValidation(1, true, burnTxHash, salt3, '', []);
+      .revealValidation(1, true, burnTxHash, salt3, 'validator', []);
     await advance(61);
     await validation.finalize(1);
     const job = enrichJob(await jobRegistry.jobs(1));
@@ -327,11 +327,11 @@ describe('ValidationModule finalize flows', function () {
       ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
       [1n, nonce, true, burnTxHash, salt, ethers.ZeroHash]
     );
-    await validation.connect(v1).commitValidation(1, commit, '', []);
+    await validation.connect(v1).commitValidation(1, commit, 'validator', []);
     await advance(61); // end commit
     await advance(61); // end reveal
     await expect(
-      validation.connect(v1).revealValidation(1, true, burnTxHash, salt, '', [])
+      validation.connect(v1).revealValidation(1, true, burnTxHash, salt, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'RevealPhaseClosed');
   });
 
@@ -364,13 +364,13 @@ describe('ValidationModule finalize flows', function () {
       ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
       [1n, nonce, true, burnTxHash, salt3, ethers.ZeroHash]
     );
-    await validation.connect(v1).commitValidation(1, commit1, '', []);
-    await validation.connect(v2).commitValidation(1, commit2, '', []);
-    await validation.connect(v3).commitValidation(1, commit3, '', []);
+    await validation.connect(v1).commitValidation(1, commit1, 'validator', []);
+    await validation.connect(v2).commitValidation(1, commit2, 'validator', []);
+    await validation.connect(v3).commitValidation(1, commit3, 'validator', []);
     await advance(61);
     await validation
       .connect(v1)
-      .revealValidation(1, true, burnTxHash, salt1, '', []);
+      .revealValidation(1, true, burnTxHash, salt1, 'validator', []);
     await advance(61);
     await validation.finalize(1);
     expect(await stakeManager.stakeOf(v1.address, 1)).to.equal(
@@ -443,9 +443,9 @@ describe('ValidationModule finalize flows', function () {
       domain,
       chainId
     );
-    await validation.connect(v1).commitValidation(1, commit1, '', []);
-    await validation.connect(v2).commitValidation(1, commit2, '', []);
-    await validation.connect(v3).commitValidation(1, commit3, '', []);
+    await validation.connect(v1).commitValidation(1, commit1, 'validator', []);
+    await validation.connect(v2).commitValidation(1, commit2, 'validator', []);
+    await validation.connect(v3).commitValidation(1, commit3, 'validator', []);
     await advance(61); // end commit
     await advance(61 + 3600 + 1); // end reveal + grace
     await expect(validation.forceFinalize(1))
@@ -541,19 +541,19 @@ describe('ValidationModule finalize flows', function () {
       ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
       [1n, nonce, false, burnTxHash, salt3, ethers.ZeroHash]
     );
-    await validation.connect(v1).commitValidation(1, commit1, '', []);
-    await validation.connect(v2).commitValidation(1, commit2, '', []);
-    await validation.connect(v3).commitValidation(1, commit3, '', []);
+    await validation.connect(v1).commitValidation(1, commit1, 'validator', []);
+    await validation.connect(v2).commitValidation(1, commit2, 'validator', []);
+    await validation.connect(v3).commitValidation(1, commit3, 'validator', []);
     await advance(61);
     await validation
       .connect(v1)
-      .revealValidation(1, true, burnTxHash, salt1, '', []);
+      .revealValidation(1, true, burnTxHash, salt1, 'validator', []);
     await validation
       .connect(v2)
-      .revealValidation(1, false, burnTxHash, salt2, '', []);
+      .revealValidation(1, false, burnTxHash, salt2, 'validator', []);
     await validation
       .connect(v3)
-      .revealValidation(1, false, burnTxHash, salt3, '', []);
+      .revealValidation(1, false, burnTxHash, salt3, 'validator', []);
     await advance(61);
     await validation.finalize(1);
     const job = enrichJob(await jobRegistry.jobs(1));

--- a/test/v2/ValidationModuleQuorumPenalty.test.js
+++ b/test/v2/ValidationModuleQuorumPenalty.test.js
@@ -220,13 +220,13 @@ describe('ValidationModule quorum penalties', function () {
       chainId
     );
 
-    await validation.connect(v1).commitValidation(jobId, commitHash, '', []);
+    await validation.connect(v1).commitValidation(jobId, commitHash, 'validator', []);
 
     await advance(COMMIT_WINDOW + 1);
 
     await validation
       .connect(v1)
-      .revealValidation(jobId, true, burnTxHash, salt, '', []);
+      .revealValidation(jobId, true, burnTxHash, salt, 'validator', []);
 
     await advance(REVEAL_WINDOW + 1);
     const grace = await validation.forceFinalizeGrace();

--- a/test/v2/ValidationModuleReentrancy.test.js
+++ b/test/v2/ValidationModuleReentrancy.test.js
@@ -113,7 +113,7 @@ describe('ValidationModule reentrancy', function () {
     );
     await identity.attackCommit(1, commitHash);
     await expect(
-      validation.connect(validator).commitValidation(1, commitHash, '', [])
+      validation.connect(validator).commitValidation(1, commitHash, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'ReentrancyGuardReentrantCall');
   });
 
@@ -127,13 +127,13 @@ describe('ValidationModule reentrancy', function () {
       ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
       [1n, nonce, true, burnTxHash, salt, ethers.ZeroHash]
     );
-    await validation.connect(validator).commitValidation(1, commitHash, '', []);
+    await validation.connect(validator).commitValidation(1, commitHash, 'validator', []);
     await advance(61);
     await identity.attackReveal(1, true, burnTxHash, salt);
     await expect(
       validation
         .connect(validator)
-        .revealValidation(1, true, burnTxHash, salt, '', [])
+        .revealValidation(1, true, burnTxHash, salt, 'validator', [])
     ).to.be.revertedWithCustomError(validation, 'ReentrancyGuardReentrantCall');
   });
 

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -175,11 +175,11 @@ describe('comprehensive job flows', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('result'), 'result', '', []);
+      .submit(jobId, ethers.id('result'), 'result', 'agent', []);
     await validation.finalize(jobId);
     const burnTxHash = ethers.ZeroHash;
     await registry
@@ -216,7 +216,7 @@ describe('comprehensive job flows', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     await expect(
-      registry.connect(agent).applyForJob(1, '', [])
+      registry.connect(agent).applyForJob(1, 'agent', [])
     ).to.be.revertedWithCustomError(registry, 'NotAuthorizedAgent');
   });
 
@@ -236,11 +236,11 @@ describe('comprehensive job flows', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.setResult(false);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('bad'), 'bad', '', []);
+      .submit(jobId, ethers.id('bad'), 'bad', 'agent', []);
     await validation.finalize(jobId);
     // fund and impersonate dispute module to resolve
     await network.provider.send('hardhat_setBalance', [
@@ -283,7 +283,7 @@ describe('comprehensive job flows', function () {
       .createJob(reward, deadline, specHash, 'uri');
     await rep.setBlacklist(agent.address, true);
     await expect(
-      registry.connect(agent).applyForJob(1, '', [])
+      registry.connect(agent).applyForJob(1, 'agent', [])
     ).to.be.revertedWithCustomError(registry, 'BlacklistedAgent');
   });
 

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -177,11 +177,11 @@ describe('end-to-end job lifecycle', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.connect(owner).setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('result'), 'result', '', []);
+      .submit(jobId, ethers.id('result'), 'result', 'agent', []);
     await validation.finalize(jobId);
     const burnTxHash = ethers.ZeroHash;
     await registry

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -190,7 +190,7 @@ describe('Commit-reveal job lifecycle', function () {
     );
     await wrapper.setOwner(BigInt(node), agent.address);
 
-    const vLeaf = leaf(validator.address, '');
+    const vLeaf = leaf(validator.address, 'validator');
     await identity.setValidatorMerkleRoot(vLeaf);
 
     await token.connect(agent).approve(await stake.getAddress(), stakeAmt);
@@ -224,11 +224,11 @@ describe('Commit-reveal job lifecycle', function () {
       ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
       [1n, nonce, true, burnTxHash, salt, specHash]
     );
-    await validation.connect(validator).commitValidation(1, commit, '', []);
+    await validation.connect(validator).commitValidation(1, commit, 'validator', []);
     await time.increase(2);
     await validation
       .connect(validator)
-      .revealValidation(1, true, burnTxHash, salt, '', []);
+      .revealValidation(1, true, burnTxHash, salt, 'validator', []);
     await time.increase(2);
     await validation.finalize(1);
     await registry.connect(employer).confirmEmployerBurn(1, burnTxHash);
@@ -270,7 +270,7 @@ describe('Commit-reveal job lifecycle', function () {
       )
     );
     await wrapper.setOwner(BigInt(node), agent.address);
-    const vLeaf = leaf(validator.address, '');
+    const vLeaf = leaf(validator.address, 'validator');
     await identity.setValidatorMerkleRoot(vLeaf);
 
     await token.connect(agent).approve(await stake.getAddress(), stakeAmt);
@@ -304,11 +304,11 @@ describe('Commit-reveal job lifecycle', function () {
       ['uint256', 'uint256', 'bool', 'bytes32', 'bytes32', 'bytes32'],
       [1n, nonce, false, burnTxHash, salt, specHash]
     );
-    await validation.connect(validator).commitValidation(1, commit, '', []);
+    await validation.connect(validator).commitValidation(1, commit, 'validator', []);
     await time.increase(2);
     await validation
       .connect(validator)
-      .revealValidation(1, false, burnTxHash, salt, '', []);
+      .revealValidation(1, false, burnTxHash, salt, 'validator', []);
     await time.increase(2);
     await validation.finalize(1);
 

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -174,11 +174,11 @@ describe('job finalization integration', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).acknowledgeAndApply(jobId, '', []);
+    await registry.connect(agent).acknowledgeAndApply(jobId, 'agent', []);
     await validation.setResult(result);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('result'), 'result', '', []);
+      .submit(jobId, ethers.id('result'), 'result', 'agent', []);
     return { jobId, fee, vReward };
   }
 
@@ -364,7 +364,7 @@ describe('job finalization integration', function () {
       .createJob(reward, deadline, specHash, 'timeout://job');
 
     const jobId = 1;
-    await registry.connect(agent).acknowledgeAndApply(jobId, '', []);
+    await registry.connect(agent).acknowledgeAndApply(jobId, 'agent', []);
 
     await expect(
       registry.connect(employer).claimTimeout(jobId)
@@ -422,11 +422,11 @@ describe('job finalization integration', function () {
       .createJob(reward, deadline, specHash, 'uri');
 
     const jobId = 1;
-    await registry.connect(agent).acknowledgeAndApply(jobId, '', []);
+    await registry.connect(agent).acknowledgeAndApply(jobId, 'agent', []);
     await validation.setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('result'), 'result', '', []);
+      .submit(jobId, ethers.id('result'), 'result', 'agent', []);
 
     await validation.finalize(jobId);
     await registry.connect(employer).finalize(jobId);

--- a/test/v2/jobLifecycleWithDispute.integration.test.ts
+++ b/test/v2/jobLifecycleWithDispute.integration.test.ts
@@ -179,7 +179,7 @@ describe('job lifecycle with dispute and validator failure', function () {
         [1n, nonce, true, burnTxHash, salt1, specHash]
       )
     );
-    await validation.connect(v1).commitValidation(1, commit1, '', []);
+    await validation.connect(v1).commitValidation(1, commit1, 'validator', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
@@ -187,12 +187,12 @@ describe('job lifecycle with dispute and validator failure', function () {
         [1n, nonce, false, burnTxHash, salt2, specHash]
       )
     );
-    await validation.connect(v2).commitValidation(1, commit2, '', []);
+    await validation.connect(v2).commitValidation(1, commit2, 'validator', []);
 
     await time.increase(2);
     await validation
       .connect(v1)
-      .revealValidation(1, true, burnTxHash, salt1, '', []);
+      .revealValidation(1, true, burnTxHash, salt1, 'validator', []);
     // v2 fails to reveal
     await time.increase(2);
     await validation.finalize(1);

--- a/test/v2/klerosArbitration.integration.test.ts
+++ b/test/v2/klerosArbitration.integration.test.ts
@@ -180,7 +180,7 @@ describe('Kleros dispute module', function () {
         [1n, nonce, true, burnTxHash, salt1, specHash]
       )
     );
-    await validation.connect(v1).commitValidation(1, commit1, '', []);
+    await validation.connect(v1).commitValidation(1, commit1, 'validator', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
@@ -188,12 +188,12 @@ describe('Kleros dispute module', function () {
         [1n, nonce, false, burnTxHash, salt2, specHash]
       )
     );
-    await validation.connect(v2).commitValidation(1, commit2, '', []);
+    await validation.connect(v2).commitValidation(1, commit2, 'validator', []);
 
     await time.increase(2);
     await validation
       .connect(v1)
-      .revealValidation(1, true, burnTxHash, salt1, '', []);
+      .revealValidation(1, true, burnTxHash, salt1, 'validator', []);
     // v2 fails to reveal
     await time.increase(2);
     await validation.finalize(1);

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -198,11 +198,11 @@ describe('multi-operator job lifecycle', function () {
       .connect(employer)
       .createJob(reward, deadline, specHash, 'uri');
     const jobId = 1;
-    await registry.connect(agent).applyForJob(jobId, '', []);
+    await registry.connect(agent).applyForJob(jobId, 'agent', []);
     await validation.connect(owner).setResult(true);
     await registry
       .connect(agent)
-      .submit(jobId, ethers.id('result'), 'result', '', []);
+      .submit(jobId, ethers.id('result'), 'result', 'agent', []);
     await validation.finalize(jobId);
     const burnTxHash = ethers.ZeroHash;
     await registry

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -189,11 +189,11 @@ describe('regression scenarios', function () {
         [1n, nonce, false, burnTxHash, salt, specHash]
       )
     );
-    await validation.connect(v1).commitValidation(1, commit, '', []);
+    await validation.connect(v1).commitValidation(1, commit, 'validator', []);
     await time.increase(2);
     await validation
       .connect(v1)
-      .revealValidation(1, false, burnTxHash, salt, '', []);
+      .revealValidation(1, false, burnTxHash, salt, 'validator', []);
     await time.increase(2);
     await validation.finalize(1);
     await registry.connect(employer).confirmEmployerBurn(1, burnTxHash);

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -166,7 +166,7 @@ describe('validator participation', function () {
         [1n, nonce, true, burnTxHash, salt1, specHash]
       )
     );
-    await validation.connect(v1).commitValidation(1, commit1, '', []);
+    await validation.connect(v1).commitValidation(1, commit1, 'validator', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
@@ -174,15 +174,15 @@ describe('validator participation', function () {
         [1n, nonce, true, burnTxHash, salt2, specHash]
       )
     );
-    await validation.connect(v2).commitValidation(1, commit2, '', []);
+    await validation.connect(v2).commitValidation(1, commit2, 'validator', []);
 
     await time.increase(2);
     await validation
       .connect(v1)
-      .revealValidation(1, true, burnTxHash, salt1, '', []);
+      .revealValidation(1, true, burnTxHash, salt1, 'validator', []);
     await validation
       .connect(v2)
-      .revealValidation(1, true, burnTxHash, salt2, '', []);
+      .revealValidation(1, true, burnTxHash, salt2, 'validator', []);
     await time.increase(2);
     await validation.finalize(1);
     await registry.connect(employer).confirmEmployerBurn(1, burnTxHash);
@@ -242,7 +242,7 @@ describe('validator participation', function () {
         [1n, nonce, false, burnTxHash, salt1, specHash]
       )
     );
-    await validation.connect(v1).commitValidation(1, commit1, '', []);
+    await validation.connect(v1).commitValidation(1, commit1, 'validator', []);
     const salt2 = ethers.randomBytes(32);
     const commit2 = ethers.keccak256(
       ethers.solidityPacked(
@@ -250,15 +250,15 @@ describe('validator participation', function () {
         [1n, nonce, false, burnTxHash, salt2, specHash]
       )
     );
-    await validation.connect(v2).commitValidation(1, commit2, '', []);
+    await validation.connect(v2).commitValidation(1, commit2, 'validator', []);
 
     await time.increase(2);
     await validation
       .connect(v1)
-      .revealValidation(1, false, burnTxHash, salt1, '', []);
+      .revealValidation(1, false, burnTxHash, salt1, 'validator', []);
     await validation
       .connect(v2)
-      .revealValidation(1, false, burnTxHash, salt2, '', []);
+      .revealValidation(1, false, burnTxHash, salt2, 'validator', []);
     await time.increase(2);
     await validation.finalize(1);
 


### PR DESCRIPTION
## Summary
- require non-empty ENS subdomains throughout IdentityRegistry verification flows and surface an `EmptySubdomain` error, mirroring the behavior in the mock registries
- adjust all identity, job, and validation tests to supply explicit agent/validator subdomain labels and update expectations to reflect the stricter checks

## Testing
- npx hardhat test test/v2/identity.test.ts *(aborted: compiler download stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68dddac10b8c8333a8b7c228c4575273