### PR TITLE
Wire dispute module tax policy hooks

### DIFF
--- a/contracts/v2/ModuleInstaller.sol
+++ b/contracts/v2/ModuleInstaller.sol
@@ -102,6 +102,7 @@ contract ModuleInstaller is Ownable {
         );
         if (address(taxPolicy) != address(0)) {
             jobRegistry.setTaxPolicy(taxPolicy);
+            disputeModule.setTaxPolicy(taxPolicy);
         }
         jobRegistry.setIdentityRegistry(identityRegistry);
         validationModule.setIdentityRegistry(identityRegistry);

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import {ITaxPolicy} from "./ITaxPolicy.sol";
+
 /// @title IDisputeModule
 /// @notice Minimal interface for the dispute module used by the arbitrator committee.
 interface IDisputeModule {
     function version() external view returns (uint256);
+
+    function setTaxPolicy(ITaxPolicy policy) external;
 
     function raiseDispute(
         uint256 jobId,

--- a/contracts/v2/mocks/TaxPolicyNonExempt.sol
+++ b/contracts/v2/mocks/TaxPolicyNonExempt.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ITaxPolicy} from "../interfaces/ITaxPolicy.sol";
+
+/// @title TaxPolicyNonExempt
+/// @notice Mock tax policy that reports non-exempt status for testing.
+contract TaxPolicyNonExempt is ITaxPolicy {
+    function acknowledge() external pure override returns (string memory) {
+        return "";
+    }
+
+    function acknowledgeFor(address) external pure override returns (string memory) {
+        return "";
+    }
+
+    function setAcknowledger(address, bool) external pure override {}
+
+    function setAcknowledgers(address[] calldata, bool[] calldata) external pure override {}
+
+    function revokeAcknowledgement(address) external pure override {}
+
+    function revokeAcknowledgements(address[] calldata) external pure override {}
+
+    function hasAcknowledged(address) external pure override returns (bool) {
+        return false;
+    }
+
+    function acknowledgerAllowed(address) external pure override returns (bool) {
+        return false;
+    }
+
+    function acknowledgedVersion(address) external pure override returns (uint256) {
+        return 0;
+    }
+
+    function acknowledgement() external pure override returns (string memory) {
+        return "";
+    }
+
+    function policyURI() external pure override returns (string memory) {
+        return "";
+    }
+
+    function policyDetails()
+        external
+        pure
+        override
+        returns (string memory ack, string memory uri)
+    {
+        ack = "";
+        uri = "";
+    }
+
+    function policyVersion() external pure override returns (uint256) {
+        return 0;
+    }
+
+    function bumpPolicyVersion() external pure override {}
+
+    function isTaxExempt() external pure override returns (bool) {
+        return false;
+    }
+}

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -198,6 +198,7 @@ async function main() {
     []
   );
   await registry.setIdentityRegistry(await identity.getAddress());
+  await dispute.setTaxPolicy(await tax.getAddress());
   await validation.setIdentityRegistry(await identity.getAddress());
   await reputation.setCaller(await registry.getAddress(), true);
 

--- a/scripts/deploy/providerAgnosticDeploy.ts
+++ b/scripts/deploy/providerAgnosticDeploy.ts
@@ -355,6 +355,7 @@ async function deployContracts(ctx: DeploymentContext) {
   );
   await registry.setIdentityRegistry(await identity.getAddress());
   await registry.setTaxPolicy(await taxPolicy.getAddress());
+  await dispute.setTaxPolicy(await taxPolicy.getAddress());
 
   await reputation.setCaller(await registry.getAddress(), true);
   await reputation.setCaller(await validation.getAddress(), true);

--- a/test/v2/KlerosDisputeModuleNoEther.test.js
+++ b/test/v2/KlerosDisputeModuleNoEther.test.js
@@ -35,4 +35,31 @@ describe('KlerosDisputeModule ether rejection', function () {
       })
     ).to.be.revertedWith('KlerosDisputeModule: no ether');
   });
+
+  it('allows governance to set tax policy when exempt', async () => {
+    const Policy = await ethers.getContractFactory(
+      'contracts/v2/TaxPolicy.sol:TaxPolicy'
+    );
+    const policy = await Policy.deploy('ipfs://policy', 'ack');
+    await policy.waitForDeployment();
+    await expect(module.connect(owner).setTaxPolicy(await policy.getAddress()))
+      .to.emit(module, 'TaxPolicyUpdated')
+      .withArgs(await policy.getAddress());
+    expect(await module.taxPolicy()).to.equal(await policy.getAddress());
+  });
+
+  it('rejects invalid tax policies', async () => {
+    await expect(
+      module.connect(owner).setTaxPolicy(ethers.ZeroAddress)
+    ).to.be.revertedWithCustomError(module, 'InvalidTaxPolicy');
+
+    const NonExempt = await ethers.getContractFactory(
+      'contracts/v2/mocks/TaxPolicyNonExempt.sol:TaxPolicyNonExempt'
+    );
+    const mockPolicy = await NonExempt.deploy();
+    await mockPolicy.waitForDeployment();
+    await expect(
+      module.connect(owner).setTaxPolicy(await mockPolicy.getAddress())
+    ).to.be.revertedWithCustomError(module, 'PolicyNotTaxExempt');
+  });
 });


### PR DESCRIPTION
## Summary
- allow the DisputeModule and KlerosDisputeModule to store validated tax policy references and emit updates
- update ModuleInstaller and deployment scripts so dispute modules receive the tax policy when wiring core contracts
- add a non-exempt tax policy mock plus tests covering the new dispute module setters

## Testing
- npx hardhat test test/v2/DisputeModuleModuleNoEther.test.js test/v2/KlerosDisputeModuleNoEther.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dde79b99a08333b1a59b61e01f10a7