### PR TITLE
Align validation timing defaults and committee bounds

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -94,10 +94,10 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     /// @notice Hard limit on the number of validators any single job may use.
     uint256 public maxValidatorsPerJob = 100;
 
-    uint256 public constant DEFAULT_COMMIT_WINDOW = 1 days;
-    uint256 public constant DEFAULT_REVEAL_WINDOW = 1 days;
+    uint256 public constant DEFAULT_COMMIT_WINDOW = 30 minutes;
+    uint256 public constant DEFAULT_REVEAL_WINDOW = 30 minutes;
     uint256 public constant DEFAULT_MIN_VALIDATORS = 3;
-    uint256 public constant DEFAULT_MAX_VALIDATORS = 3;
+    uint256 public constant DEFAULT_MAX_VALIDATORS = 5;
     uint256 public constant DEFAULT_APPROVAL_THRESHOLD = 67;
     uint256 public constant DEFAULT_REVEAL_QUORUM_PCT = 67;
     uint256 public constant DEFAULT_FORCE_FINALIZE_GRACE = 1 hours;

--- a/docs/agi-jobs-v2-mainnet.md
+++ b/docs/agi-jobs-v2-mainnet.md
@@ -308,8 +308,9 @@
 
 ### A) Safe defaults (owner may tune later)
 
-- `commitWindow = 86400` (24h), `revealWindow = 86400`
-- `minValidators = 1`, `maxValidators = 3`
+- `commitWindow = 1800` (30m), `revealWindow = 1800`
+- `minValidators = 3`, `maxValidators = 5`
+- Baseline committees: operate with 3-validator draws initially, leaving headroom to scale toward 5 as throughput data allows.
 - `JobRegistry.feePctBps = 500` (5%)
 - `FeePool.burnPct = 5` (start small; can increase)
 - `StakeManager.minStake = 1e18` (1 $AGIALPHA) per role  

--- a/docs/deployment-production-guide.md
+++ b/docs/deployment-production-guide.md
@@ -36,7 +36,7 @@ Deploy each contract through Etherscan and note its address. Verify the source c
    - `verifyAgent`/`verifyValidator` return `(ok, node, viaWrapper, viaMerkle)` and emit `ENSVerified`; modules that call them re-emit `AgentIdentityVerified` or `ValidatorIdentityVerified`.
 4. **ValidationModule**
    - Parameters: `_jobRegistry` placeholder, `stakeManager`, `commitWindow`, `revealWindow`, `minValidators`, `maxValidators`, `validatorPool` (usually empty array).
-   - Recommended defaults: `commitWindow` = `86400`, `revealWindow` = `86400`, `minValidators` = `1`, `maxValidators` = `3`.
+   - Recommended defaults: `commitWindow` = `1800`, `revealWindow` = `1800`, `minValidators` = `3`, `maxValidators` = `5`.
 5. **DisputeModule**
    - Parameters: `_jobRegistry` placeholder, `disputeFee`, `disputeWindow`, `moderator` (or `0x0`).
    - Set `disputeFee` to `0` for a free dispute process or provide a value in wei (e.g. `1e18` for 1 $AGIALPHA).

--- a/docs/legacy/agi-jobs-v2-production-deployment-guide.md
+++ b/docs/legacy/agi-jobs-v2-production-deployment-guide.md
@@ -39,7 +39,7 @@ Deploy each contract via **Contract → Deploy** on Etherscan, supplying constru
    - `_commitWindow`: seconds for the commit phase, e.g. `86400` (24h) or `0` for default.
    - `_revealWindow`: seconds for the reveal phase, e.g. `86400` (24h) or `0` for default.
    - `_minValidators`: usually `1`.
-   - `_maxValidators`: typically `3`.
+- `_maxValidators`: typically `5` (paired with a 3-validator minimum for 3-of-5 committees).
    - `_validatorPool`: preset validator addresses or `[]` for open participation.
 5. **DisputeModule**
    - `_jobRegistry`: `0x0` (set later).

--- a/docs/legacy/deployment-agialpha.md
+++ b/docs/legacy/deployment-agialpha.md
@@ -21,7 +21,7 @@ Deploy each contract **in the order listed below** from the **Write Contract** t
 1. Use the existing `$AGIALPHA` token. Deploy [`AGIALPHAToken.sol`](../contracts/test/AGIALPHAToken.sol) only on local networks and call `mint(to, amount)` to create a test supply.
 2. `StakeManager(token, minStake, employerPct, treasuryPct, treasury)` – pass `address(0)` for `token` to use the default $AGIALPHA and `0,0` for the slashing percentages to send 100% of any slash to the treasury.
 3. `JobRegistry(validation, stakeMgr, reputation, dispute, certNFT, feePool, taxPolicy, feePct, jobStake)` – leaving `feePct = 0` applies a 5% protocol fee. Supplying a nonzero `taxPolicy` sets the disclaimer at deployment; otherwise the owner may call `setTaxPolicy` later.
-4. `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators, validatorPool)` – zero values default to 1‑day windows and a 1–3 validator set.
+4. `ValidationModule(jobRegistry, stakeManager, commitWindow, revealWindow, minValidators, maxValidators, validatorPool)` – zero values default to 30‑minute windows and a 3–5 validator set.
 5. `ReputationEngine(stakeManager)` – requires a valid `StakeManager` address.
 6. `DisputeModule(jobRegistry, disputeFee, disputeWindow, moderator)` – manages
    appeals and dispute fees. The fourth argument optionally seeds an initial

--- a/docs/legacy/deployment-guide-nontechnical.md
+++ b/docs/legacy/deployment-guide-nontechnical.md
@@ -48,7 +48,7 @@ Deploy each contract through Etherscan and note its address. Use `0x000...000` a
    - Use `0x00` for any ENS gates you wish to disable.
 4. **ValidationModule**
    - Parameters: `_jobRegistry` placeholder, `stakeManager`, `commitWindow`, `revealWindow`, `minValidators`, `maxValidators`, `validatorPool` (usually empty array).
-   - Recommended defaults: `commitWindow` = `86400`, `revealWindow` = `86400`, `minValidators` = `1`, `maxValidators` = `3`.
+   - Recommended defaults: `commitWindow` = `1800`, `revealWindow` = `1800`, `minValidators` = `3`, `maxValidators` = `5`.
 5. **DisputeModule**
    - Parameters: `_jobRegistry` placeholder, `disputeFee`, `disputeWindow`, `moderator` (or `0x0`).
    - Set `disputeFee` to `0` for a free dispute process or provide a value in wei (e.g. `1e18` for 1 $AGIALPHA).

--- a/docs/master-guide.md
+++ b/docs/master-guide.md
@@ -118,10 +118,10 @@ Deploy in this order. For any constructor parameter that expects an address that
 
    - `jobRegistry`: `0x0` (wire later)
    - `stakeManager`: StakeManager address
-   - `commitWindow`: e.g., `86400` (24h)
-   - `revealWindow`: e.g., `86400` (24h)
-   - `minValidators`: e.g., `1`
-   - `maxValidators`: e.g., `3`
+   - `commitWindow`: e.g., `1800` (30m)
+   - `revealWindow`: e.g., `1800` (30m)
+   - `minValidators`: e.g., `3`
+   - `maxValidators`: e.g., `5`
    - `validatorPool`: `[]` (open) or addresses
 
 5. **DisputeModule**
@@ -659,8 +659,8 @@ Record each address.
 
    - `_jobRegistry`: `0x0` (wire later)
    - `_stakeManager`: (1)
-   - `commitWindow`,`revealWindow`: e.g. `86400`,`86400`
-   - `minValidators`,`maxValidators`: e.g. `1`,`3`
+   - `commitWindow`,`revealWindow`: e.g. `1800`,`1800`
+   - `minValidators`,`maxValidators`: e.g. `3`,`5`
 
 5. **DisputeModule**
 

--- a/scripts/deploy/providerAgnosticDeploy.ts
+++ b/scripts/deploy/providerAgnosticDeploy.ts
@@ -422,8 +422,8 @@ async function runIntegrationScenario(
     validators.map((validator) => validator.address)
   );
   await validation.setValidatorsPerJob(validators.length);
-  await validation.setCommitWindow(30);
-  await validation.setRevealWindow(30);
+  await validation.setCommitWindow(1800);
+  await validation.setRevealWindow(1800);
   await validation.setRequiredValidatorApprovals(validators.length);
 
   await registry.setJobParameters(ethers.parseUnits('100000', decimals), 0);

--- a/scripts/v2/deployDefaults.ts
+++ b/scripts/v2/deployDefaults.ts
@@ -521,9 +521,9 @@ async function main() {
       ? 0
       : econ.validatorSlashRewardPct;
   const effectiveCommitWindow =
-    econ.commitWindow === 0 ? 86_400 : econ.commitWindow;
+    econ.commitWindow === 0 ? 1_800 : econ.commitWindow;
   const effectiveRevealWindow =
-    econ.revealWindow === 0 ? 86_400 : econ.revealWindow;
+    econ.revealWindow === 0 ? 1_800 : econ.revealWindow;
   const defaultStake = ethers.parseUnits('1', AGIALPHA_DECIMALS);
   const effectiveMinStake = econ.minStake === 0n ? defaultStake : econ.minStake;
   const effectiveJobStake = econ.jobStake === 0n ? defaultStake : econ.jobStake;

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -74,6 +74,10 @@ async function setup() {
   await identity.addAdditionalValidator(v1.address);
   await identity.addAdditionalValidator(v2.address);
   await identity.addAdditionalValidator(v3.address);
+  await validation.connect(owner).setValidatorSubdomains(
+    [v1.address, v2.address, v3.address],
+    ['validator', 'validator', 'validator']
+  );
 
   await stakeManager.setStake(v1.address, 1, ethers.parseEther('100'));
   await stakeManager.setStake(v2.address, 1, ethers.parseEther('50'));
@@ -487,6 +491,10 @@ describe('ValidationModule finalize flows', function () {
     await validation
       .connect(owner)
       .setValidatorPool([v1.address, v2.address, v3.address, v4.address]);
+    await validation.connect(owner).setValidatorSubdomains(
+      [v4.address],
+      ['validator']
+    );
     await select(1);
     const chosen = await validation.validators(1);
     const beforeV4 = await stakeManager.stakeOf(v4.address, 1);


### PR DESCRIPTION
## Summary
- shorten the ValidationModule's default commit and reveal windows to 30 minutes and raise the default maximum committee size to five validators
- refresh deployment guides and operator documentation to call out the new 30-minute / 3-5 validator defaults
- update helper scripts and validation flow tests to set validator subdomains and honour the revised timing defaults

## Testing
- not run (Hardhat test suite is lengthy and was not executed in this pass)

------
https://chatgpt.com/codex/tasks/task_e_68de7729403c8333b643f4cc81bd1782