### PR TITLE
feat: surface certificate metadata verification in enterprise portal

### DIFF
--- a/apps/enterprise-portal/src/components/CertificateGallery.tsx
+++ b/apps/enterprise-portal/src/components/CertificateGallery.tsx
@@ -3,6 +3,29 @@
 import { useEffect } from 'react';
 import { useCertificates } from '../hooks/useCertificates';
 import { useWeb3 } from '../context/Web3Context';
+import { displayResourceUri, resolveResourceUri } from '../lib/uri';
+
+const formatAddress = (value?: string): string => {
+  if (!value || value === 'Unknown') return 'Unknown';
+  if (value.length <= 10) return value;
+  return `${value.slice(0, 6)}…${value.slice(-4)}`;
+};
+
+const truncateValue = (
+  value?: string,
+  lead = 10,
+  tail = 6
+): string | undefined => {
+  if (!value) return undefined;
+  if (value.length <= lead + tail + 3) return value;
+  return `${value.slice(0, lead)}…${value.slice(-tail)}`;
+};
+
+const formatCid = (value?: string): string | undefined => {
+  if (!value) return undefined;
+  if (value.length <= 24) return value;
+  return `${value.slice(0, 12)}…${value.slice(-8)}`;
+};
 
 export const CertificateGallery = () => {
   const { address } = useWeb3();
@@ -19,24 +42,236 @@ export const CertificateGallery = () => {
       <div className="card-title">
         <div>
           <h2>Completion Certificates &amp; SLA Badges</h2>
-          <p>Agents receive NFTs documenting successful delivery and SLA compliance for auditability and credentials.</p>
+          <p>
+            Agents receive NFTs documenting successful delivery, SLA compliance
+            and signed result proofs. Each badge links to IPFS metadata and
+            exposes signature verification against the on-chain result hash for
+            employers and auditors.
+          </p>
         </div>
         <div className="tag purple">NFT</div>
       </div>
       {loading && <div className="small">Loading certificates…</div>}
       {error && <div className="alert error">{error}</div>}
       <div className="badge-grid">
-        {certificates.map((certificate) => (
-          <div className="badge-card" key={certificate.tokenId.toString()}>
-            <h4>Certificate #{certificate.tokenId.toString()}</h4>
-            <p>Agent: {certificate.agent.slice(0, 6)}…{certificate.agent.slice(-4)}</p>
-            <p>Metadata: <a href={certificate.metadataURI} target="_blank" rel="noreferrer">{certificate.metadataURI}</a></p>
-            <p className="small">Issued: {new Date(certificate.issuedAt * 1000).toLocaleString()}</p>
-          </div>
-        ))}
+        {certificates.map((certificate) => {
+          const metadataLink =
+            certificate.metadataGatewayURI ??
+            resolveResourceUri(certificate.metadataURI) ??
+            certificate.metadataURI;
+          const metadataLabel =
+            displayResourceUri(certificate.metadataURI) ??
+            certificate.metadataURI;
+          const deliverableLink = certificate.deliverableUri
+            ? resolveResourceUri(certificate.deliverableUri) ??
+              certificate.deliverableUri
+            : undefined;
+          const deliverableLabel = certificate.deliverableUri
+            ? displayResourceUri(certificate.deliverableUri) ??
+              certificate.deliverableUri
+            : undefined;
+          const slaLink = certificate.slaUri
+            ? resolveResourceUri(certificate.slaUri) ?? certificate.slaUri
+            : undefined;
+          const issuedAt = new Date(
+            certificate.issuedAt * 1000
+          ).toLocaleString();
+          const metadataResultHashLabel = truncateValue(
+            certificate.metadataResultHash ?? undefined
+          );
+          const normalizedHashLabel = truncateValue(
+            certificate.verification?.normalizedHash
+          );
+          return (
+            <div className="badge-card" key={certificate.tokenId.toString()}>
+              <div className="card-title" style={{ marginBottom: '1rem' }}>
+                <div>
+                  <h4>
+                    {certificate.metadataName ??
+                      `Certificate #${certificate.tokenId.toString()}`}
+                  </h4>
+                  <div className="small">
+                    Job #{certificate.jobId.toString()} • Agent{' '}
+                    {formatAddress(certificate.agent)}
+                  </div>
+                </div>
+                <div className="tag green">Finalized</div>
+              </div>
+              <p>
+                {certificate.metadataDescription ?? certificate.description}
+              </p>
+              <div
+                className="grid two-column"
+                style={{ gap: '1.25rem', marginTop: '1rem' }}
+              >
+                <div>
+                  <div className="stat-label">Issued</div>
+                  <div>{issuedAt}</div>
+                  <div className="small">
+                    Employer: {formatAddress(certificate.employer)}
+                  </div>
+                </div>
+                <div>
+                  <div className="stat-label">Result hash</div>
+                  {certificate.resultHash ? (
+                    <code title={certificate.resultHash}>
+                      {truncateValue(certificate.resultHash)}
+                    </code>
+                  ) : (
+                    <div className="small">No result hash recorded.</div>
+                  )}
+                  {certificate.metadataResultHash && (
+                    <div
+                      className="small"
+                      title={certificate.metadataResultHash}
+                    >
+                      Metadata result hash: {metadataResultHashLabel}
+                    </div>
+                  )}
+                  {certificate.hashMatchesOnChain === false && (
+                    <div
+                      className="alert warning"
+                      style={{ marginTop: '0.5rem' }}
+                    >
+                      Metadata result hash differs from the on-chain value.
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div
+                className="grid two-column"
+                style={{ gap: '1.25rem', marginTop: '1rem' }}
+              >
+                <div>
+                  <div className="stat-label">Metadata</div>
+                  {metadataLink ? (
+                    <a href={metadataLink} target="_blank" rel="noreferrer">
+                      {metadataLabel ?? 'Open metadata'}
+                    </a>
+                  ) : (
+                    <div className="small">Metadata URI unavailable.</div>
+                  )}
+                  {certificate.metadataCid && (
+                    <div className="small">
+                      CID: {formatCid(certificate.metadataCid)}
+                    </div>
+                  )}
+                  {certificate.uriHash && (
+                    <div className="small" title={certificate.uriHash}>
+                      On-chain URI hash: {truncateValue(certificate.uriHash)}
+                    </div>
+                  )}
+                  {certificate.metadataError && (
+                    <div
+                      className="alert warning"
+                      style={{ marginTop: '0.5rem' }}
+                    >
+                      {certificate.metadataError}
+                    </div>
+                  )}
+                </div>
+                <div>
+                  <div className="stat-label">Deliverable</div>
+                  {deliverableLink ? (
+                    <a href={deliverableLink} target="_blank" rel="noreferrer">
+                      {deliverableLabel ?? 'Open deliverable'}
+                    </a>
+                  ) : (
+                    <div className="small">Deliverable link not provided.</div>
+                  )}
+                  {certificate.deliverableCid && (
+                    <div className="small">
+                      CID: {formatCid(certificate.deliverableCid)}
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div
+                className="grid two-column"
+                style={{ gap: '1.25rem', marginTop: '1rem' }}
+              >
+                <div>
+                  <div className="stat-label">Signature</div>
+                  {certificate.signature ? (
+                    <>
+                      <code title={certificate.signature}>
+                        {truncateValue(certificate.signature)}
+                      </code>
+                      {certificate.signatureVerified ? (
+                        <div
+                          className="tag green"
+                          style={{
+                            marginTop: '0.5rem',
+                            display: 'inline-block',
+                          }}
+                        >
+                          Signature verified
+                        </div>
+                      ) : certificate.verificationError ? (
+                        <div
+                          className="alert warning"
+                          style={{ marginTop: '0.5rem' }}
+                        >
+                          {certificate.verificationError}
+                        </div>
+                      ) : (
+                        <div className="small">
+                          Signature present. Verification pending.
+                        </div>
+                      )}
+                      {certificate.verificationMessage &&
+                        certificate.signatureVerified && (
+                          <div
+                            className="small"
+                            style={{ marginTop: '0.5rem' }}
+                          >
+                            {certificate.verificationMessage}
+                          </div>
+                        )}
+                      {certificate.verification?.recoveredAddress && (
+                        <div className="small">
+                          Recovered signer:{' '}
+                          {formatAddress(
+                            certificate.verification.recoveredAddress
+                          )}
+                        </div>
+                      )}
+                      {normalizedHashLabel && (
+                        <div
+                          className="small"
+                          title={certificate.verification?.normalizedHash}
+                        >
+                          Signed hash: {normalizedHashLabel}
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <div className="small">No signature found in metadata.</div>
+                  )}
+                </div>
+                <div>
+                  <div className="stat-label">SLA reference</div>
+                  {certificate.slaUri ? (
+                    <a href={slaLink} target="_blank" rel="noreferrer">
+                      {displayResourceUri(certificate.slaUri) ??
+                        certificate.slaUri}
+                    </a>
+                  ) : (
+                    <div className="small">
+                      No SLA URI recorded for this certificate.
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
       </div>
       {certificates.length === 0 && !loading && (
-        <div className="small">Certificates will appear once jobs are finalized and SLA terms satisfied.</div>
+        <div className="small">
+          Certificates will appear once jobs are finalized, validators approve
+          the result, and the deliverable signature is recorded on IPFS.
+        </div>
       )}
     </section>
   );

--- a/apps/enterprise-portal/src/hooks/useCertificates.ts
+++ b/apps/enterprise-portal/src/hooks/useCertificates.ts
@@ -9,6 +9,8 @@ import {
 } from '../lib/contracts';
 import { jobStateToPhase } from '../lib/jobStatus';
 import type { CertificateBadge, JobPhase } from '../types';
+import { verifyDeliverableSignature } from '../lib/crypto';
+import { resolveResourceUri } from '../lib/uri';
 
 interface CertificateState {
   certificates: CertificateBadge[];
@@ -69,6 +71,10 @@ const sortCertificates = (items: CertificateBadge[]): CertificateBadge[] => {
 };
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const ZERO_HASH =
+  '0x0000000000000000000000000000000000000000000000000000000000000000';
+const HEX_32_REGEX = /^0x[0-9a-fA-F]{64}$/;
+const SIGNATURE_REGEX = /^0x[0-9a-fA-F]{130,132}$/;
 
 const normalizeNumber = (value: unknown): number | undefined => {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -99,6 +105,535 @@ const normalizeAddress = (value: unknown): string | undefined => {
   return undefined;
 };
 
+const normalizeBytes32 = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    if (typeof value === 'number') {
+      const hex = value.toString(16);
+      const prefixed = hex.length % 2 === 0 ? `0x${hex}` : `0x0${hex}`;
+      return HEX_32_REGEX.test(prefixed) ? prefixed.toLowerCase() : undefined;
+    }
+    if (typeof value === 'bigint') {
+      const hex = value.toString(16);
+      const prefixed = hex.length % 2 === 0 ? `0x${hex}` : `0x0${hex}`;
+      return HEX_32_REGEX.test(prefixed) ? prefixed.toLowerCase() : undefined;
+    }
+    if (value instanceof Uint8Array) {
+      const hex = hexlify(value);
+      return HEX_32_REGEX.test(hex) ? hex.toLowerCase() : undefined;
+    }
+    if (
+      value &&
+      typeof value === 'object' &&
+      'toString' in (value as { toString?: () => string })
+    ) {
+      try {
+        const text = (value as { toString: () => string }).toString();
+        const prefixed = text.startsWith('0x') ? text : `0x${text}`;
+        return HEX_32_REGEX.test(prefixed) ? prefixed.toLowerCase() : undefined;
+      } catch (err) {
+        console.warn('Unable to normalise bytes32 value', value, err);
+        return undefined;
+      }
+    }
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const prefixed = trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`;
+  return HEX_32_REGEX.test(prefixed) ? prefixed.toLowerCase() : undefined;
+};
+
+const normalizeSignature = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const prefixed = trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`;
+  return SIGNATURE_REGEX.test(prefixed) ? prefixed.toLowerCase() : undefined;
+};
+
+const isUriLike = (value: string | undefined): value is string => {
+  if (!value) return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return /^(ipfs|https?|ar):\/\//i.test(trimmed);
+};
+
+const isCidLike = (value: string | undefined): value is string => {
+  if (!value) return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith('ipfs://')) return true;
+  if (trimmed.startsWith('Qm') && trimmed.length >= 46) return true;
+  if (
+    trimmed.startsWith('bafy') ||
+    trimmed.startsWith('bag') ||
+    trimmed.startsWith('ba')
+  )
+    return true;
+  return false;
+};
+
+const extractCidFromUri = (value?: string): string | undefined => {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith('ipfs://')) {
+    const path = trimmed.slice(7).replace(/^ipfs\//, '');
+    return path.split(/[/?#]/)[0] ?? undefined;
+  }
+  const ipfsMatch = trimmed.match(/\/ipfs\/([^/?#]+)/i);
+  if (ipfsMatch?.[1]) {
+    return ipfsMatch[1];
+  }
+  if (isCidLike(trimmed)) {
+    return trimmed.split(/[/?#]/)[0];
+  }
+  return undefined;
+};
+
+interface Candidate {
+  value: string;
+  path: string[];
+}
+
+interface FieldCandidates {
+  uris: Candidate[];
+  cids: Candidate[];
+  hashes: Candidate[];
+  signatures: Candidate[];
+}
+
+const collectCandidates = (
+  value: unknown,
+  path: string[] = [],
+  acc: FieldCandidates = { uris: [], cids: [], hashes: [], signatures: [] }
+): FieldCandidates => {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => {
+      const nextPath = [...path, `[${index}]`];
+      if (typeof entry === 'string') {
+        const trimmed = entry.trim();
+        if (!trimmed) return;
+        const candidate: Candidate = { value: trimmed, path: nextPath };
+        if (isUriLike(trimmed)) acc.uris.push(candidate);
+        if (isCidLike(trimmed)) acc.cids.push(candidate);
+        const hash = normalizeBytes32(trimmed);
+        if (hash) acc.hashes.push({ value: hash, path: nextPath });
+        const signature = normalizeSignature(trimmed);
+        if (signature)
+          acc.signatures.push({ value: signature, path: nextPath });
+      } else {
+        collectCandidates(entry, nextPath, acc);
+      }
+    });
+    return acc;
+  }
+
+  if (!value || typeof value !== 'object') {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) return acc;
+      const candidate: Candidate = { value: trimmed, path };
+      if (isUriLike(trimmed)) acc.uris.push(candidate);
+      if (isCidLike(trimmed)) acc.cids.push(candidate);
+      const hash = normalizeBytes32(trimmed);
+      if (hash) acc.hashes.push({ value: hash, path });
+      const signature = normalizeSignature(trimmed);
+      if (signature) acc.signatures.push({ value: signature, path });
+    }
+    return acc;
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const [key, child] of Object.entries(record)) {
+    const nextPath = [...path, key];
+    const lowerKey = key.toLowerCase();
+    if (typeof child === 'string') {
+      const trimmed = child.trim();
+      if (!trimmed) continue;
+      const candidate: Candidate = { value: trimmed, path: nextPath };
+      if (
+        lowerKey.includes('uri') ||
+        lowerKey.includes('url') ||
+        isUriLike(trimmed)
+      ) {
+        acc.uris.push(candidate);
+      }
+      if (lowerKey.includes('cid') || isCidLike(trimmed)) {
+        acc.cids.push(candidate);
+      }
+      const hash = normalizeBytes32(trimmed);
+      if (hash) acc.hashes.push({ value: hash, path: nextPath });
+      const signature = normalizeSignature(trimmed);
+      if (signature) acc.signatures.push({ value: signature, path: nextPath });
+    } else if (Array.isArray(child)) {
+      collectCandidates(child, nextPath, acc);
+    } else if (child && typeof child === 'object') {
+      const possibleTrait =
+        'trait_type' in (child as { trait_type?: unknown }) &&
+        'value' in (child as { value?: unknown });
+      if (possibleTrait) {
+        const trait = String(
+          (child as { trait_type?: unknown }).trait_type ?? ''
+        )
+          .toLowerCase()
+          .trim();
+        const traitValue = (child as { value?: unknown }).value;
+        const traitPath = [...nextPath, trait || 'trait'];
+        if (typeof traitValue === 'string') {
+          const trimmed = traitValue.trim();
+          if (trimmed) {
+            const candidate: Candidate = { value: trimmed, path: traitPath };
+            if (
+              trait.includes('uri') ||
+              trait.includes('url') ||
+              isUriLike(trimmed)
+            ) {
+              acc.uris.push(candidate);
+            }
+            if (trait.includes('cid') || isCidLike(trimmed)) {
+              acc.cids.push(candidate);
+            }
+            const hash = normalizeBytes32(trimmed);
+            if (hash) acc.hashes.push({ value: hash, path: traitPath });
+            const signature = normalizeSignature(trimmed);
+            if (signature)
+              acc.signatures.push({ value: signature, path: traitPath });
+          }
+        } else {
+          collectCandidates(traitValue, traitPath, acc);
+        }
+      } else {
+        collectCandidates(child, nextPath, acc);
+      }
+    }
+  }
+  return acc;
+};
+
+const scoreCandidate = (candidate: Candidate, keywords: string[]): number => {
+  const pathText = candidate.path.join('.').toLowerCase();
+  let score = 0;
+  keywords.forEach((keyword, index) => {
+    if (pathText.includes(keyword)) {
+      score += (keywords.length - index) * 10;
+    }
+  });
+  const value = candidate.value.toLowerCase();
+  if (value.startsWith('ipfs://')) score += 6;
+  if (value.includes('/ipfs/')) score += 4;
+  if (value.startsWith('https://') || value.startsWith('http://')) score += 3;
+  if (
+    value.startsWith('qm') ||
+    value.startsWith('bafy') ||
+    value.startsWith('bag')
+  )
+    score += 5;
+  if (HEX_32_REGEX.test(value)) score += 4;
+  if (SIGNATURE_REGEX.test(value)) score += 4;
+  return score;
+};
+
+const pickCandidate = (
+  candidates: Candidate[],
+  keywords: string[],
+  predicate?: (value: string) => boolean
+): Candidate | undefined => {
+  const filtered = predicate
+    ? candidates.filter((candidate) => predicate(candidate.value))
+    : candidates;
+  if (filtered.length === 0) return undefined;
+  const scored = filtered
+    .map((candidate) => ({
+      candidate,
+      score: scoreCandidate(candidate, keywords),
+    }))
+    .sort((a, b) => b.score - a.score);
+  return scored[0]?.candidate;
+};
+
+interface CertificateMetadataDetail {
+  name?: string;
+  description?: string;
+  deliverableUri?: string;
+  deliverableCid?: string;
+  resultHash?: string;
+  signature?: string;
+  slaUri?: string;
+}
+
+const toStringOrUndefined = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return String(value);
+  }
+  return undefined;
+};
+
+const parseCertificateMetadata = (
+  payload: unknown
+): CertificateMetadataDetail => {
+  if (!payload || typeof payload !== 'object') {
+    return {};
+  }
+  const record = payload as Record<string, unknown>;
+
+  const work =
+    (record.work as Record<string, unknown> | undefined) ?? undefined;
+  const deliverable =
+    (record.deliverable as Record<string, unknown> | undefined) ?? undefined;
+
+  const directDeliverableUris = [
+    toStringOrUndefined(
+      record.deliverableUri ?? record.resultUri ?? record.artifactUri
+    ),
+    toStringOrUndefined(work?.deliverableUri ?? work?.resultUri ?? work?.uri),
+    toStringOrUndefined(deliverable?.uri ?? deliverable?.url),
+  ].filter(isUriLike);
+
+  const directDeliverableCids = [
+    toStringOrUndefined(record.deliverableCid ?? record.resultCid),
+    toStringOrUndefined(work?.deliverableCid ?? work?.resultCid ?? work?.cid),
+    toStringOrUndefined(deliverable?.cid ?? deliverable?.contentId),
+  ].filter(isCidLike);
+
+  const directResultHashes = [
+    normalizeBytes32(
+      record.resultHash ?? record.outputHash ?? record.artifactHash
+    ),
+    normalizeBytes32(work?.resultHash ?? work?.hash),
+    normalizeBytes32(deliverable?.hash),
+  ].filter(Boolean) as string[];
+
+  const directSignatures = [
+    normalizeSignature(
+      record.signature ?? record.agentSignature ?? record.resultSignature
+    ),
+    normalizeSignature(work?.signature),
+    normalizeSignature(deliverable?.signature ?? deliverable?.agentSignature),
+  ].filter(Boolean) as string[];
+
+  const directSlaUris = [
+    toStringOrUndefined(
+      (record.sla as Record<string, unknown> | undefined)?.uri ??
+        (record.sla as Record<string, unknown> | undefined)?.url
+    ),
+    toStringOrUndefined(record.slaUri ?? record.slaURL ?? record.slaLink),
+  ].filter(isUriLike);
+
+  const candidates = collectCandidates(payload);
+
+  const deliverableUriCandidate =
+    directDeliverableUris[0] ??
+    pickCandidate(
+      candidates.uris,
+      ['deliverable', 'result', 'work', 'evidence'],
+      isUriLike
+    )?.value;
+
+  const deliverableCidCandidate =
+    directDeliverableCids[0] ??
+    pickCandidate(
+      candidates.cids,
+      ['deliverable', 'result', 'work', 'evidence'],
+      isCidLike
+    )?.value;
+
+  const resultHashCandidate =
+    directResultHashes[0] ??
+    pickCandidate(candidates.hashes, ['result', 'deliverable', 'work'])?.value;
+
+  const signatureCandidate =
+    directSignatures[0] ??
+    pickCandidate(candidates.signatures, ['signature', 'deliverable', 'result'])
+      ?.value;
+
+  const slaUriCandidate =
+    directSlaUris[0] ??
+    pickCandidate(candidates.uris, ['sla', 'agreement', 'contract'], isUriLike)
+      ?.value;
+
+  let deliverableUri = deliverableUriCandidate;
+  let deliverableCid = deliverableCidCandidate;
+  if (!deliverableCid && deliverableUri) {
+    deliverableCid = extractCidFromUri(deliverableUri);
+  }
+  if (!deliverableUri && deliverableCid) {
+    deliverableUri = `ipfs://${deliverableCid}`;
+  }
+
+  const resultHash =
+    resultHashCandidate && resultHashCandidate !== ZERO_HASH
+      ? resultHashCandidate
+      : undefined;
+
+  const signature = signatureCandidate ?? undefined;
+
+  const name = toStringOrUndefined(record.name ?? record.title);
+  const description = toStringOrUndefined(record.description ?? record.summary);
+
+  return {
+    name,
+    description,
+    deliverableUri,
+    deliverableCid,
+    resultHash,
+    signature,
+    slaUri: slaUriCandidate,
+  };
+};
+
+const fetchCertificateMetadata = async (
+  uri: string
+): Promise<CertificateMetadataDetail> => {
+  const resolved = resolveResourceUri(uri);
+  if (!resolved) {
+    throw new Error('Unable to resolve certificate metadata URI.');
+  }
+  const response = await fetch(resolved);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch certificate metadata: ${response.status} ${response.statusText}`
+    );
+  }
+  try {
+    const json = await response.json();
+    return parseCertificateMetadata(json);
+  } catch {
+    throw new Error('Certificate metadata is not valid JSON.');
+  }
+};
+
+const assembleBadge = async (params: {
+  jobId: bigint;
+  issuedAt: number;
+  metadataURI: string;
+  jobSnapshot: JobSnapshot;
+  uriHash?: string;
+  metadataDetail?: CertificateMetadataDetail;
+  metadataError?: string;
+}): Promise<CertificateBadge> => {
+  const {
+    jobId,
+    issuedAt,
+    metadataURI,
+    jobSnapshot,
+    uriHash,
+    metadataDetail,
+    metadataError,
+  } = params;
+  const metadataCid = extractCidFromUri(metadataURI);
+  const metadataGatewayURI =
+    metadataURI && metadataURI.trim().length > 0
+      ? resolveResourceUri(metadataURI) ?? metadataURI
+      : undefined;
+  const deliverableUri =
+    metadataDetail?.deliverableUri ??
+    (metadataDetail?.deliverableCid
+      ? `ipfs://${metadataDetail.deliverableCid}`
+      : undefined);
+  const deliverableCid =
+    metadataDetail?.deliverableCid ?? extractCidFromUri(deliverableUri);
+  const metadataResultHash = metadataDetail?.resultHash;
+  const signature = metadataDetail?.signature;
+  const slaUri = metadataDetail?.slaUri;
+
+  const onChainResultHash =
+    jobSnapshot.resultHash && jobSnapshot.resultHash !== ZERO_HASH
+      ? jobSnapshot.resultHash
+      : undefined;
+  const resultHash = onChainResultHash ?? metadataResultHash;
+
+  const hashMatchesOnChain =
+    metadataResultHash && onChainResultHash
+      ? metadataResultHash.toLowerCase() === onChainResultHash.toLowerCase()
+      : undefined;
+
+  let signatureVerified: boolean | undefined;
+  let verificationMessage: string | undefined;
+  let verificationError: string | undefined;
+  let verificationDetails: CertificateBadge['verification'];
+
+  if (signature) {
+    if (!resultHash) {
+      verificationError = 'Missing result hash for verification.';
+    } else if (!jobSnapshot.agent || jobSnapshot.agent === 'Unknown') {
+      verificationError = 'Agent address unavailable for verification.';
+    } else {
+      try {
+        const verification = await verifyDeliverableSignature(
+          signature,
+          resultHash,
+          jobSnapshot.agent
+        );
+        verificationDetails = {
+          normalizedHash: verification.normalizedHash,
+          recoveredAddress: verification.recoveredAddress,
+          matchesAgent: verification.matchesAgent,
+          matchesHash: verification.matchesHash,
+        };
+
+        if (!verification.matchesHash) {
+          verificationError =
+            'Result hash must be a 32-byte hex string prefixed with 0x.';
+          signatureVerified = false;
+        } else if (!verification.matchesAgent) {
+          verificationError = `Recovered signer ${verification.recoveredAddress} does not match agent ${jobSnapshot.agent}.`;
+          signatureVerified = false;
+        } else if (
+          onChainResultHash &&
+          verification.normalizedHash.toLowerCase() !==
+            onChainResultHash.toLowerCase()
+        ) {
+          verificationError =
+            'Signature hash does not match on-chain result hash.';
+          signatureVerified = false;
+        } else {
+          signatureVerified = true;
+          verificationMessage =
+            'Signature matches assigned agent and on-chain result hash.';
+        }
+      } catch (err) {
+        verificationError =
+          (err as Error).message ?? 'Failed to verify deliverable signature.';
+        signatureVerified = false;
+      }
+    }
+  }
+
+  const description = buildCertificateDescription(jobId, jobSnapshot);
+
+  return {
+    tokenId: jobId,
+    jobId,
+    metadataURI,
+    metadataCid,
+    metadataGatewayURI,
+    metadataName: metadataDetail?.name,
+    metadataDescription: metadataDetail?.description,
+    uriHash: uriHash ?? jobSnapshot.uriHash,
+    slaUri,
+    issuedAt,
+    employer: jobSnapshot.employer,
+    agent: jobSnapshot.agent,
+    description,
+    resultHash,
+    metadataResultHash,
+    hashMatchesOnChain,
+    deliverableUri,
+    deliverableCid,
+    signature,
+    signatureVerified,
+    verification: verificationDetails,
+    verificationMessage,
+    verificationError,
+    metadataError,
+  };
+};
+
 type JobRegistryReader = {
   jobs: (jobId: bigint) => Promise<unknown>;
   decodeJobMetadata: (packed: bigint) => Promise<unknown>;
@@ -109,6 +644,8 @@ interface JobSnapshot {
   agent: string;
   deadline?: number;
   phase?: JobPhase;
+  resultHash?: string;
+  uriHash?: string;
 }
 
 const buildCertificateDescription = (
@@ -184,7 +721,9 @@ const readJobSnapshot = async (
   }
 
   const agent = agentCandidate ?? fallbackAgent ?? 'Unknown';
-  return { employer, agent, deadline, phase };
+  const resultHash = normalizeBytes32(jobRecord.resultHash ?? jobRecord[6]);
+  const uriHash = normalizeBytes32(jobRecord.uriHash ?? jobRecord[5]);
+  return { employer, agent, deadline, phase, resultHash, uriHash };
 };
 
 export const useCertificates = (owner?: string): CertificateState => {
@@ -286,6 +825,35 @@ export const useCertificates = (owner?: string): CertificateState => {
         }
       }
 
+      const metadataDetails = new Map<bigint, CertificateMetadataDetail>();
+      const metadataErrors = new Map<bigint, string>();
+      await Promise.all(
+        jobIds.map(async (jobId) => {
+          const metadataURI = metadataCache.get(jobId);
+          if (!metadataURI || metadataURI.trim().length === 0) {
+            metadataErrors.set(
+              jobId,
+              'Metadata URI not configured for certificate.'
+            );
+            return;
+          }
+          try {
+            const detail = await fetchCertificateMetadata(metadataURI);
+            metadataDetails.set(jobId, detail);
+          } catch (metadataErr) {
+            console.warn(
+              'Unable to load certificate metadata for job',
+              jobId.toString(),
+              metadataErr
+            );
+            const message =
+              (metadataErr as Error).message ??
+              'Unable to load certificate metadata';
+            metadataErrors.set(jobId, message);
+          }
+        })
+      );
+
       const jobInfoCache = new Map<bigint, JobSnapshot>();
       const registryReader = jobRegistry as unknown as JobRegistryReader;
       for (const jobId of jobIds) {
@@ -302,11 +870,13 @@ export const useCertificates = (owner?: string): CertificateState => {
             employer: 'Unknown',
             agent: owner ?? 'Unknown',
             phase: jobStateToPhase(0),
+            resultHash: undefined,
+            uriHash: undefined,
           });
         }
       }
 
-      const badgeMap = new Map<string, CertificateBadge>();
+      const mintedLogsByJob = new Map<string, EventLog>();
       for (const log of orderedLogs) {
         const args = log.args ?? [];
         const jobArg =
@@ -315,36 +885,51 @@ export const useCertificates = (owner?: string): CertificateState => {
           log.topics?.[2];
         const jobId = normalizeBigInt(jobArg);
         if (!jobId) continue;
-        const blockNumber =
-          typeof log.blockNumber === 'number' ? log.blockNumber : undefined;
-        const issuedAt = blockNumber
-          ? blockTimestampCache.get(blockNumber) ??
-            Math.floor(Date.now() / 1000)
-          : Math.floor(Date.now() / 1000);
-        const uriHash = normalizeUriHash(
-          (args as { uriHash?: unknown })?.uriHash ?? (args as unknown[])[2]
-        );
-        const metadataURI = metadataCache.get(jobId) ?? '';
-        const jobInfo = jobInfoCache.get(jobId) ?? {
-          employer: 'Unknown',
-          agent: owner ?? 'Unknown',
-          phase: jobStateToPhase(0),
-        };
-        const description = buildCertificateDescription(jobId, jobInfo);
-        const badge: CertificateBadge = {
-          tokenId: jobId,
-          jobId,
-          metadataURI,
-          slaURI: uriHash,
-          issuedAt,
-          employer: jobInfo.employer,
-          agent: jobInfo.agent,
-          description,
-        };
-        badgeMap.set(jobId.toString(), badge);
+        mintedLogsByJob.set(jobId.toString(), log);
       }
 
-      setCertificates(sortCertificates(Array.from(badgeMap.values())));
+      const badges = (
+        await Promise.all(
+          jobIds.map(async (jobId) => {
+            const log = mintedLogsByJob.get(jobId.toString());
+            if (!log) return undefined;
+            const blockNumber =
+              typeof log.blockNumber === 'number' ? log.blockNumber : undefined;
+            const issuedAt = blockNumber
+              ? blockTimestampCache.get(blockNumber) ??
+                Math.floor(Date.now() / 1000)
+              : Math.floor(Date.now() / 1000);
+            const args = log.args ?? [];
+            const uriHash = normalizeUriHash(
+              (args as { uriHash?: unknown })?.uriHash ?? (args as unknown[])[2]
+            );
+            const metadataURI = metadataCache.get(jobId) ?? '';
+            const jobInfo =
+              jobInfoCache.get(jobId) ??
+              ({
+                employer: 'Unknown',
+                agent: owner ?? 'Unknown',
+                phase: jobStateToPhase(0),
+                resultHash: undefined,
+                uriHash: undefined,
+              } as JobSnapshot);
+            const metadataDetail = metadataDetails.get(jobId);
+            const metadataError = metadataErrors.get(jobId);
+
+            return assembleBadge({
+              jobId,
+              issuedAt,
+              metadataURI,
+              jobSnapshot: jobInfo,
+              uriHash,
+              metadataDetail,
+              metadataError,
+            });
+          })
+        )
+      ).filter((badge): badge is CertificateBadge => Boolean(badge));
+
+      setCertificates(sortCertificates(badges));
     } catch (err) {
       console.error(err);
       setError((err as Error).message ?? 'Unable to load certificates');
@@ -403,29 +988,45 @@ export const useCertificates = (owner?: string): CertificateState => {
             : Promise.resolve(undefined),
         ]);
 
-        const jobSnapshot = snapshot ?? {
-          employer: 'Unknown',
-          agent: owner ?? 'Unknown',
-          phase: jobStateToPhase(0),
-        };
+        let metadataDetail: CertificateMetadataDetail | undefined;
+        let metadataError: string | undefined;
+        if (metadataURI && metadataURI.trim().length > 0) {
+          try {
+            metadataDetail = await fetchCertificateMetadata(metadataURI);
+          } catch (metaErr) {
+            metadataError =
+              (metaErr as Error).message ??
+              'Unable to load certificate metadata';
+          }
+        } else {
+          metadataError = 'Metadata URI not configured for certificate.';
+        }
+
+        const jobSnapshot =
+          snapshot ??
+          ({
+            employer: 'Unknown',
+            agent: owner ?? 'Unknown',
+            phase: jobStateToPhase(0),
+            resultHash: undefined,
+            uriHash: undefined,
+          } as JobSnapshot);
         const issuedAt = block?.timestamp
           ? Number(block.timestamp)
           : Math.floor(Date.now() / 1000);
         const uriHash = normalizeUriHash(
           uriHashRaw ?? (event.args as { uriHash?: unknown })?.uriHash
         );
-        const description = buildCertificateDescription(jobId, jobSnapshot);
 
-        const badge: CertificateBadge = {
-          tokenId: jobId,
+        const badge = await assembleBadge({
           jobId,
-          metadataURI,
-          slaURI: uriHash,
           issuedAt,
-          employer: jobSnapshot.employer,
-          agent: jobSnapshot.agent ?? owner ?? 'Unknown',
-          description,
-        };
+          metadataURI,
+          jobSnapshot,
+          uriHash,
+          metadataDetail,
+          metadataError,
+        });
 
         setCertificates((prev) => {
           const map = new Map(

--- a/apps/enterprise-portal/src/types/index.ts
+++ b/apps/enterprise-portal/src/types/index.ts
@@ -79,11 +79,32 @@ export interface CertificateBadge {
   tokenId: bigint;
   jobId: bigint;
   metadataURI: string;
-  slaURI?: string;
+  metadataCid?: string;
+  metadataGatewayURI?: string;
+  metadataName?: string;
+  metadataDescription?: string;
+  uriHash?: string;
+  slaUri?: string;
   issuedAt: number;
   employer: string;
   agent: string;
   description: string;
+  resultHash?: string;
+  metadataResultHash?: string;
+  hashMatchesOnChain?: boolean;
+  deliverableUri?: string;
+  deliverableCid?: string;
+  signature?: string;
+  signatureVerified?: boolean;
+  verification?: {
+    normalizedHash?: string;
+    recoveredAddress?: string;
+    matchesAgent: boolean;
+    matchesHash: boolean;
+  };
+  verificationMessage?: string;
+  verificationError?: string;
+  metadataError?: string;
 }
 
 export interface SlaDocument {


### PR DESCRIPTION
## Summary
- extend the enterprise portal certificate hook to resolve IPFS metadata, extract deliverable details, and verify agent signatures against on-chain result hashes
- enhance the certificate gallery UI to surface metadata CIDs, deliverable links, SLA references, and signature verification status for each badge
- expand certificate typings to capture metadata, verification, and deliverable fields used by the gallery

## Testing
- npx eslint apps/enterprise-portal/src/components/CertificateGallery.tsx apps/enterprise-portal/src/hooks/useCertificates.ts

------
https://chatgpt.com/codex/tasks/task_e_68de9cb1586c833391e4a19b96d7078a