### PR TITLE
Fix certificate signature verification

### DIFF
--- a/apps/enterprise-portal/.gitignore
+++ b/apps/enterprise-portal/.gitignore
@@ -1,0 +1,1 @@
+dist-test/

--- a/apps/enterprise-portal/src/lib/crypto.ts
+++ b/apps/enterprise-portal/src/lib/crypto.ts
@@ -1,4 +1,10 @@
-import { keccak256, toUtf8Bytes, verifyMessage } from 'ethers';
+import {
+  keccak256,
+  toUtf8Bytes,
+  verifyMessage,
+  getBytes,
+  isHexString
+} from 'ethers';
 
 type Hex = `0x${string}`;
 
@@ -8,8 +14,6 @@ export interface VerificationResult {
   matchesHash: boolean;
   normalizedHash: string;
 }
-
-const HASH_32_REGEX = /^0x[0-9a-fA-F]{64}$/;
 
 const orderValue = (value: unknown): unknown => {
   if (Array.isArray(value)) {
@@ -52,9 +56,11 @@ export const verifyDeliverableSignature = async (
   agentAddress: string
 ): Promise<VerificationResult> => {
   const normalizedHash = expectedHash.trim();
-  const recovered = await verifyMessage(normalizedHash, signature);
+  const isHashHex = isHexString(normalizedHash, 32);
+  const message = isHashHex ? getBytes(normalizedHash) : normalizedHash;
+  const recovered = await verifyMessage(message, signature);
   const matchesAgent = recovered.toLowerCase() === agentAddress.toLowerCase();
-  const matchesHash = HASH_32_REGEX.test(normalizedHash);
+  const matchesHash = isHashHex;
   return {
     recoveredAddress: recovered,
     matchesAgent,

--- a/apps/enterprise-portal/test/global.d.ts
+++ b/apps/enterprise-portal/test/global.d.ts
@@ -1,0 +1,3 @@
+declare module '../src/lib/crypto.js' {
+  export * from '../src/lib/crypto';
+}

--- a/apps/enterprise-portal/test/verifyDeliverableSignature.test.ts
+++ b/apps/enterprise-portal/test/verifyDeliverableSignature.test.ts
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Wallet, ethers } from 'ethers';
+import { verifyDeliverableSignature } from '../src/lib/crypto.js';
+
+test('verifies agent signatures over 32-byte digests', async () => {
+  const wallet = Wallet.createRandom();
+  const digest = ethers.keccak256(ethers.toUtf8Bytes('result-payload'));
+  const signature = await wallet.signMessage(ethers.getBytes(digest));
+
+  const verification = await verifyDeliverableSignature(
+    signature,
+    digest,
+    wallet.address
+  );
+
+  assert.equal(verification.matchesHash, true);
+  assert.equal(verification.matchesAgent, true);
+  assert.equal(verification.recoveredAddress, wallet.address);
+  assert.equal(verification.normalizedHash.toLowerCase(), digest.toLowerCase());
+});
+
+test('flags mismatched agent signatures', async () => {
+  const signer = Wallet.createRandom();
+  const other = Wallet.createRandom();
+  const digest = ethers.keccak256(ethers.toUtf8Bytes('result-payload'));
+  const signature = await signer.signMessage(ethers.getBytes(digest));
+
+  const verification = await verifyDeliverableSignature(
+    signature,
+    digest,
+    other.address
+  );
+
+  assert.equal(verification.matchesHash, true);
+  assert.equal(verification.matchesAgent, false);
+  assert.equal(verification.recoveredAddress, signer.address);
+});
+
+test('falls back to string verification for non-hex payloads', async () => {
+  const signer = Wallet.createRandom();
+  const message = 'custom-result-reference';
+  const signature = await signer.signMessage(message);
+
+  const verification = await verifyDeliverableSignature(
+    signature,
+    message,
+    signer.address
+  );
+
+  assert.equal(verification.matchesHash, false);
+  assert.equal(verification.matchesAgent, true);
+  assert.equal(verification.recoveredAddress, signer.address);
+  assert.equal(verification.normalizedHash, message);
+});

--- a/apps/enterprise-portal/tsconfig.test.json
+++ b/apps/enterprise-portal/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": false,
+    "declaration": false,
+    "declarationMap": false,
+    "module": "es2020",
+    "outDir": "./dist-test",
+    "rootDir": "."
+  },
+  "include": [
+    "src/lib/crypto.ts",
+    "test/verifyDeliverableSignature.test.ts",
+    "test/global.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "compile:mainnet": "npm run compile -- --network mainnet",
     "compile:sepolia": "npm run compile -- --network sepolia",
     "lint": "npm run lint:check",
-    "pretest": "npx tsc --skipLibCheck scripts/constants.ts && node --test apps/onebox/test/error-catalog.test.mjs attestation/eas/test/receipt-digest.test.mjs",
+    "pretest": "npx tsc --skipLibCheck scripts/constants.ts && node --test apps/onebox/test/error-catalog.test.mjs attestation/eas/test/receipt-digest.test.mjs && npx tsc --project apps/enterprise-portal/tsconfig.test.json && node --test apps/enterprise-portal/dist-test/test/verifyDeliverableSignature.test.js",
     "verify:agialpha": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/verify-agialpha.ts",
     "wire:verify": "node scripts/run-wire-verify.js",
     "verify:wiring": "npm run wire:verify",


### PR DESCRIPTION
## Summary
- ensure deliverable signature verification uses raw digest bytes when the agent signed a 32-byte hash
- add browser-side unit tests for certificate signature validation and supporting TypeScript config
- wire the portal pretest script to compile and execute the new verification tests

## Testing
- npm run pretest

------
https://chatgpt.com/codex/tasks/task_e_68dea9153a4483338a032294ea443814