### PR TITLE
Fix dispute helper overload selection and add regression tests

### DIFF
--- a/packages/orchestrator/test/disputeOverloads.test.ts
+++ b/packages/orchestrator/test/disputeOverloads.test.ts
@@ -1,0 +1,91 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import type { Contract } from "ethers";
+
+import { __test__ } from "../src/tools/dispute.js";
+
+const { callRaiseDispute } = __test__;
+
+type RegistryCall = { method: string; args: unknown[] };
+
+type CallSpy = ((...args: unknown[]) => Promise<unknown>) & {
+  populateTransaction?: (...args: unknown[]) => Promise<unknown>;
+};
+
+type RegistryStub = Record<string, CallSpy>;
+
+function createStub() {
+  const calls: RegistryCall[] = [];
+  const build = (label: string): CallSpy => {
+    const fn: CallSpy = (...args: unknown[]) => {
+      calls.push({ method: label, args });
+      return Promise.resolve({ hash: `${label}-hash` });
+    };
+    fn.populateTransaction = (...args: unknown[]) => {
+      calls.push({ method: `${label}:populate`, args });
+      return Promise.resolve({ to: "0x0", data: "0x", value: 0n });
+    };
+    return fn;
+  };
+
+  const registry: RegistryStub = {
+    dispute: build("dispute"),
+    "raiseDispute(uint256,bytes32)": build("bytes32"),
+    "raiseDispute(uint256,string)": build("string"),
+  };
+
+  return { registry, calls };
+}
+
+test("callRaiseDispute uses bytes32 overload during populate", async () => {
+  const { registry, calls } = createStub();
+  const overrides = { customData: { policy: { jobId: "8" } } };
+  const hash = "0x" + "aa".repeat(32);
+
+  await callRaiseDispute(
+    registry as unknown as Contract,
+    { jobId: 8n, evidenceHash: hash },
+    overrides,
+    "populate"
+  );
+
+  assert.equal(calls[0]?.method, "bytes32:populate");
+  assert.equal(calls[0]?.args[0], 8n);
+  assert.equal(calls[0]?.args[1], hash);
+  assert.deepEqual(calls[0]?.args[2], overrides);
+});
+
+test("callRaiseDispute sends dispute for combined evidence", async () => {
+  const { registry, calls } = createStub();
+  const overrides = { customData: { policy: { jobId: "9" } } };
+  const hash = "0x" + "bb".repeat(32);
+  const reason = "ipfs://evidence/9";
+
+  await callRaiseDispute(
+    registry as unknown as Contract,
+    { jobId: 9n, evidenceHash: hash, reason },
+    overrides,
+    "execute"
+  );
+
+  assert.equal(calls[0]?.method, "dispute");
+  assert.equal(calls[0]?.args[0], 9n);
+  assert.equal(calls[0]?.args[1], hash);
+  assert.equal(calls[0]?.args[2], reason);
+  assert.deepEqual(calls[0]?.args[3], overrides);
+});
+
+test("callRaiseDispute uses string overload when only a reason is provided", async () => {
+  const { registry, calls } = createStub();
+  await callRaiseDispute(
+    registry as unknown as Contract,
+    { jobId: 10n, reason: "ipfs://only-reason" },
+    undefined,
+    "execute"
+  );
+
+  assert.equal(calls[0]?.method, "string");
+  assert.equal(calls[0]?.args[0], 10n);
+  assert.equal(calls[0]?.args[1], "ipfs://only-reason");
+});

--- a/test/scripts/dispute-overloads.test.js
+++ b/test/scripts/dispute-overloads.test.js
@@ -1,0 +1,101 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('ts-node').register({
+  transpileOnly: true,
+  compilerOptions: { module: 'commonjs' },
+});
+
+process.env.RPC_URL ??= 'http://127.0.0.1:8545';
+process.env.PRIVATE_KEY ??= '0x' + '11'.repeat(32);
+process.env.JOB_REGISTRY ??= '0x' + '01'.repeat(20);
+process.env.STAKE_MANAGER ??= '0x' + '02'.repeat(20);
+process.env.AGIALPHA_TOKEN ??= '0x' + '03'.repeat(20);
+process.env.VALIDATION_MODULE ??= '0x' + '04'.repeat(20);
+process.env.ATTESTATION_REGISTRY ??= '0x' + '05'.repeat(20);
+
+const quickstart = require('../../examples/ethers-quickstart.js');
+const cli = require('../../scripts/validator/cli.ts');
+const quickstartTest = quickstart.__test__;
+const { raiseDisputeWithOverloads } = cli;
+
+function createRegistryStub() {
+  const calls = [];
+  const txResponse = { hash: '0xdeadbeef', wait: async () => ({ status: 1 }) };
+  const buildCall = (label) => {
+    const fn = (...args) => {
+      calls.push({ method: label, args });
+      return Promise.resolve(txResponse);
+    };
+    fn.populateTransaction = (...args) => {
+      calls.push({ method: `${label}:populate`, args });
+      return Promise.resolve({ to: '0x0', data: '0x', value: 0n });
+    };
+    return fn;
+  };
+
+  const registry = {};
+  registry.dispute = buildCall('dispute');
+  registry['raiseDispute(uint256,bytes32)'] = buildCall('bytes32');
+  registry['raiseDispute(uint256,string)'] = buildCall('string');
+
+  return { registry, calls, txResponse };
+}
+
+test('quickstart helper routes 32-byte hashes to the bytes32 overload', async () => {
+  const { registry, calls } = createRegistryStub();
+  const jobId = 1n;
+  const hash = '0x' + 'ab'.repeat(32);
+
+  await quickstartTest.callRaiseDispute(registry, jobId, hash);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, 'bytes32');
+  assert.equal(calls[0].args[0], jobId);
+  assert.equal(calls[0].args[1], hash);
+});
+
+test('quickstart helper routes strings to the string overload', async () => {
+  const { registry, calls } = createRegistryStub();
+  const jobId = 2n;
+  const reason = 'ipfs://evidence/123';
+
+  await quickstartTest.callRaiseDispute(registry, jobId, reason);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, 'string');
+  assert.equal(calls[0].args[0], jobId);
+  assert.equal(calls[0].args[1], reason);
+});
+
+test('validator CLI helper supports reason-only disputes', async () => {
+  const { registry, calls } = createRegistryStub();
+  const jobId = 3n;
+  const reason = 'ipfs://evidence/456';
+
+  await raiseDisputeWithOverloads(registry, jobId, { reason });
+
+  assert.equal(calls[0].method, 'string');
+});
+
+test('validator CLI helper supports hash-only disputes', async () => {
+  const { registry, calls } = createRegistryStub();
+  const jobId = 4n;
+  const hash = '0x' + 'cd'.repeat(32);
+
+  await raiseDisputeWithOverloads(registry, jobId, { evidenceHash: hash });
+
+  assert.equal(calls[0].method, 'bytes32');
+});
+
+test('validator CLI helper supports combined disputes', async () => {
+  const { registry, calls } = createRegistryStub();
+  const jobId = 5n;
+  const hash = '0x' + 'ef'.repeat(32);
+  const reason = 'ipfs://evidence/789';
+
+  await raiseDisputeWithOverloads(registry, jobId, { evidenceHash: hash, reason });
+
+  assert.equal(calls[0].method, 'dispute');
+});
+


### PR DESCRIPTION
## Summary
- ensure the ethers quickstart helper explicitly selects the correct raiseDispute overload based on bytes32 hashes or text reasons
- share an overload-aware helper for the validator CLI and update dispute execution to use it
- update the orchestrator dispute tool to resolve raiseDispute overloads in both populate and execution paths and add targeted tests for each helper

## Testing
- node --test test/scripts/dispute-overloads.test.js
- npm --prefix packages/orchestrator run test

------
https://chatgpt.com/codex/tasks/task_e_68dec2c373b88333bb841ce96032578e