### PR TITLE
Enhance Hamiltonian monitoring CLI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ npx hardhat run scripts/v2/updateHamiltonianMonitor.ts --network <network>
 
 Pass `--execute` once the dry run looks correct to submit the queued actions. Use `resetHistory: true` in the config to wipe accumulated observations and start fresh—either on its own or combined with a window change. The helper automatically skips recording duplicate observations if they already match the most recent on-chain history.
 
+> **Observe thermodynamics live:** Generate human, Markdown, CSV or JSON Hamiltonian reports with \`npm run hamiltonian:report\`. The script computes aggregate H/G stats, normalises budgets into token units, and can append block timestamps for compliance artefacts. See [docs/hamiltonian-monitor.md](docs/hamiltonian-monitor.md) for full examples.
+
 ### Energy oracle signer management
 
 Governance controls which off-chain measurement nodes can sign energy attestations. Update [`config/energy-oracle.json`](config/energy-oracle.json) (or its per-network override) with the authorised signer list. Run the helper to review the planned changes and, once satisfied, apply them on-chain. The [Energy Oracle Operations Guide](docs/energy-oracle-operations.md) covers signer due diligence, quorum rotations and verification workflows with step-by-step diagrams:

--- a/docs/hamiltonian-monitor.md
+++ b/docs/hamiltonian-monitor.md
@@ -1,29 +1,159 @@
-# Hamiltonian Monitor
+# Hamiltonian Monitor Operations Guide
 
-This script computes a simple Hamiltonian metric for reward epochs.
+> **Audience:** Protocol owners, risk officers, and operations engineers who need a
+> production-ready view of the reward Hamiltonian without exporting raw logs
+> manually.
+>
+> **Purpose:** Turn the `EpochSettled` events emitted by `RewardEngineMB` into a
+> rich, auditable report—complete with Markdown tables, CSV exports, or JSON feeds
+> that can plug directly into monitoring dashboards.
 
-It queries `EpochSettled` events from `RewardEngineMB` and reports the
-value
+---
 
-\[ H = \Delta H - \lambda R \]
+## 1. Quick start
 
-where `\Delta H` is the enthalpy change emitted by the contract,
-`R` is the reward budget and `\lambda` is a scaling coefficient passed on
-the command line. A free‑energy estimate is also shown using the epoch's
-entropy data.
+```bash
+# Display a human-readable console digest
+npm run hamiltonian:report -- \
+  --engine 0xRewardEngineAddress \
+  --from 18_900_000 \
+  --lambda 2
 
-## Usage
+# Generate a Markdown playbook with timestamps for change-management
+npm run hamiltonian:report -- \
+  --engine 0xRewardEngineAddress \
+  --format markdown \
+  --timestamps \
+  --out reports/mainnet/hamiltonian-$(date +%Y%m%d).md
 
+# Produce a machine-readable JSON payload for dashboards
+npm run hamiltonian:report -- \
+  --engine 0xRewardEngineAddress \
+  --format json \
+  --limit 30 \
+  --order desc \
+  --out runtime/hamiltonian-latest.json
 ```
-npx ts-node --compiler-options '{"module":"commonjs"}' scripts/hamiltonian-tracker.ts \
-  --engine <reward_engine_address> [--from <block>] [--to <block>] [--lambda <scale>]
+
+- **No RPC gymnastics.** The helper uses the active Hardhat network configuration
+  (`--network` works as usual) and validates the engine address before querying.
+- **Safe by default.** Every run starts in dry-report mode: no transactions are
+  sent, and the tool refuses obviously malformed parameters.
+- **One command, many formats.** Switch between human-readable, Markdown, CSV, or
+  JSON outputs without duplicating logic.
+
+---
+
+## 2. Output anatomy
+
+```mermaid
+flowchart TD
+    Start[RewardEngineMB EpochSettled events] --> Enrich[Hamiltonian tracker]
+    Enrich -->|Compute| Stats[Aggregate metrics]
+    Enrich -->|Format| Table[Epoch breakdown]
+    Enrich -->|Optional| JSON[Machine feed]
+    Enrich -->|Optional| Markdown[Runbook export]
+    Stats --> Ops[Operations Team]
+    Table --> Risk[Risk Review]
+    JSON --> Dashboards[Monitoring / BI]
 ```
 
-Each matching epoch prints a line:
+Each report contains three layers of insight:
 
-```
-epoch 1 h=123 free=45
+1. **Metadata** – engine address, block range, λ (lambda) scaling factor, and the
+   timestamp when the report was generated.
+2. **Aggregate metrics** – total reward budget processed, average Hamiltonian
+   value, and free-energy ranges to surface systemic drift.
+3. **Per-epoch breakdown** – token-normalised budget, ΔH, ΔS, temperature, and
+   derived Hamiltonian/free energy plus block, timestamp, and tx hash columns for
+   forensic traceability.
+
+---
+
+## 3. CLI parameters
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `--engine <address>` | **Required.** Address of the deployed `RewardEngineMB`. | – |
+| `--from <block>` / `--to <block>` | Restrict the block range queried. | `0` → latest |
+| `--lambda <int>` | Scaling factor applied to the reward budget in the Gibbs relation. | `1` |
+| `--format <human\|markdown\|json\|csv>` | Output renderer. | `human` |
+| `--out <file>` | Write the report to disk (directories are created automatically). | stdout |
+| `--limit <n>` | Only include the latest `n` epochs after filtering. | All |
+| `--order <asc\|desc>` | Sort chronological (`asc`) or reverse-chronological (`desc`). | `asc` |
+| `--decimals <n>` | Token decimal precision for formatting budgets. | `18` |
+| `--unit-label <symbol>` | Friendly token label in the report (e.g. `$AGIALPHA`). | `$AGIALPHA` |
+| `--timestamps` | Fetch block timestamps and add ISO-8601 columns. | Disabled |
+| `--help` | Print usage instructions. | – |
+
+---
+
+## 4. Example Markdown snippet
+
+```markdown
+# Hamiltonian Monitor Report
+
+- **Engine:** `0x1234...beef`
+- **λ (lambda):** `2`
+- **Block range:** `18900000 → 18912345`
+- **Events analysed:** `12`
+- **Unit label:** `$AGIALPHA`
+- **Epoch span:** `421 → 432`
+
+## Aggregate metrics
+
+- Total budget: **1,240.532 $AGIALPHA**
+- Average budget: 103.377 $AGIALPHA
+- Average H: `-182830008124530002`
+- H range: `-311509913840000000 → -78210100312000000`
+- Free energy range: `-255120001234500000 → -8812000112300000`
+
+```mermaid
+flowchart LR
+    Budget[Reward budget] -->|λ| Hamiltonian[H = ΔH − λ · budget]
+    Temperature[System temperature] --> FreeEnergy[G = ΔH − T · ΔS]
+    Entropy[Entropy ΔS] --> FreeEnergy
 ```
 
-The output can be ingested by monitoring systems or governance dashboards
-to track approach toward equilibrium.
+| Epoch | Budget ($AGIALPHA) | ΔH | ΔS | T | H | Free energy | Block | Timestamp | Tx hash |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 432 | 102.430 | 220000000000000000 | -95000000000000000 | 1100000000000000000 | -182830008124530002 | -12000000000000000 | 18912345 | 2024-03-12T18:42:02.000Z | `0xabcd…` |
+| … | … | … | … | … | … | … | … | … | … |
+```
+
+Use the rendered table for stakeholder reviews or as an attachment to production
+change records. CSV/JSON exports share the same data schema, making it trivial to
+pipe into BI dashboards or risk analytics notebooks.
+
+---
+
+## 5. Operational checklist
+
+1. **Snapshot** – Run `npm run hamiltonian:report -- --format markdown --timestamps`
+   and archive the output under `reports/<network>/` alongside other owner
+   artefacts.
+2. **Compare** – Monitor the free-energy band over successive runs; sudden spikes
+   indicate anomalous entropy measurements or temperature tuning drift.
+3. **Escalate** – If `H` drifts outside the expected window, coordinate with the
+   Thermostat operators and replay the reward settlement process to diagnose the
+   root cause.
+4. **Document** – Attach the Markdown or JSON output to your change ticket before
+   adjusting thermodynamic parameters. The report makes governance reviews and
+   audits trivial.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Remedy |
+| ------- | ------------ | ------ |
+| "Missing required --engine" | Address omitted. | Pass `--engine <reward_engine>` and ensure the network is configured. |
+| "call exception" when querying | Engine address incorrect for the selected network. | Double-check `--network` and verify the contract on the target chain. |
+| Empty report | No `EpochSettled` events in the block range. | Relax `--from/--to` bounds or remove `--limit`. |
+| Timestamps column missing | `--timestamps` flag not set. | Re-run with `--timestamps`. |
+
+---
+
+With these upgrades the Hamiltonian tracker is production ready: it is scriptable,
+mermaid-friendly, and designed so a non-technical owner can obtain a full physics
+snapshot in under a minute.

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "verify:sri": "node apps/onebox-static/scripts/verify-sri.mjs",
     "alpha-bridge:start": "node services/alpha-bridge/src/server.js",
     "alpha-bridge:test": "node --test services/alpha-bridge/test/alpha-bridge.test.js",
-    "validator:cli": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/validator/cli.ts"
+    "validator:cli": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/validator/cli.ts",
+    "hamiltonian:report": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/hamiltonian-tracker.ts"
   },
   "keywords": [],
   "author": "",

--- a/scripts/hamiltonian-tracker.ts
+++ b/scripts/hamiltonian-tracker.ts
@@ -1,52 +1,684 @@
-import hre from 'hardhat';
+import { promises as fs } from 'fs';
+import path from 'path';
+import hardhat from 'hardhat';
+import type { HardhatRuntimeEnvironment } from 'hardhat/types';
+import type { HardhatEthersHelpers } from '@nomicfoundation/hardhat-ethers/types';
 
-function parseArgs() {
-  const argv = process.argv.slice(2);
-  const args: Record<string, string> = {};
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg.startsWith('--')) {
-      const key = arg.slice(2);
-      const value = argv[i + 1];
-      if (value && !value.startsWith('--')) {
-        args[key] = value;
-        i++;
-      }
-    }
-  }
-  return args;
-}
+const hre = hardhat as HardhatRuntimeEnvironment & {
+  ethers: typeof import('ethers') & HardhatEthersHelpers;
+};
+
+const { ethers } = hre;
 
 const WAD = 10n ** 18n;
 
+type OutputFormat = 'human' | 'markdown' | 'json' | 'csv';
+
+type SortOrder = 'asc' | 'desc';
+
+interface CliOptions {
+  engine?: string;
+  fromBlock?: number;
+  toBlock?: number;
+  lambda: bigint;
+  format: OutputFormat;
+  decimals: number;
+  unitLabel: string;
+  outPath?: string;
+  limit?: number;
+  order: SortOrder;
+  includeTimestamps: boolean;
+  help?: boolean;
+}
+
+interface EpochEntry {
+  epoch: bigint;
+  budget: bigint;
+  dH: bigint;
+  dS: bigint;
+  systemTemperature: bigint;
+  leftover: bigint;
+  h: bigint;
+  freeEnergy: bigint;
+  blockNumber: number;
+  txHash: string;
+  timestamp?: number;
+}
+
+interface ReportMetadata {
+  engine: string;
+  lambda: string;
+  decimals: number;
+  unitLabel: string;
+  fromBlock: number;
+  toBlock: number;
+  totalEvents: number;
+  generatedAt: string;
+  order: SortOrder;
+}
+
+interface ReportStats {
+  firstEpoch?: bigint;
+  latestEpoch?: bigint;
+  totalBudget: bigint;
+  averageBudget?: bigint;
+  totalH: bigint;
+  averageH?: bigint;
+  minH?: bigint;
+  maxH?: bigint;
+  minFree?: bigint;
+  maxFree?: bigint;
+}
+
+interface ReportPayload {
+  metadata: ReportMetadata;
+  stats: ReportStats;
+  entries: EpochEntry[];
+}
+
+function usage(): string {
+  return `Hamiltonian tracker – analyse RewardEngineMB epochs\n\nUsage:\n  npx ts-node --compiler-options '{"module":"commonjs"}' scripts/hamiltonian-tracker.ts \\\n    --engine <address> [--from <block>] [--to <block>] [--lambda <scale>] \\\n    [--format human|markdown|json|csv] [--out <file>] [--limit <n>] \\\n    [--order asc|desc] [--decimals <n>] [--unit-label <name>] [--timestamps]\n\nExamples:\n  npm run hamiltonian:report -- --engine 0xabc... --format markdown --out reports/mainnet/hamiltonian.md\n  npx ts-node --compiler-options '{"module":"commonjs"}' scripts/hamiltonian-tracker.ts \\\n    --engine 0xabc... --from 19000000 --lambda 3 --format json --timestamps\n`;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    lambda: 1n,
+    format: 'human',
+    decimals: 18,
+    unitLabel: '$AGIALPHA',
+    order: 'asc',
+    includeTimestamps: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const raw = argv[i];
+    if (!raw.startsWith('--')) {
+      throw new Error(`Unexpected argument "${raw}"`);
+    }
+
+    const key = raw.slice(2);
+    switch (key) {
+      case 'help':
+      case 'h':
+        options.help = true;
+        break;
+      case 'engine': {
+        const value = argv[i + 1];
+        if (!value || value.startsWith('--')) {
+          throw new Error('--engine requires an address');
+        }
+        options.engine = value;
+        i += 1;
+        break;
+      }
+      case 'from': {
+        const value = argv[i + 1];
+        if (!value || value.startsWith('--')) {
+          throw new Error('--from requires a block number');
+        }
+        const parsed = Number(value);
+        if (!Number.isInteger(parsed) || parsed < 0) {
+          throw new Error('--from must be a positive integer');
+        }
+        options.fromBlock = parsed;
+        i += 1;
+        break;
+      }
+      case 'to': {
+        const value = argv[i + 1];
+        if (!value || value.startsWith('--')) {
+          throw new Error('--to requires a block number');
+        }
+        const parsed = Number(value);
+        if (!Number.isInteger(parsed) || parsed < 0) {
+          throw new Error('--to must be a positive integer');
+        }
+        options.toBlock = parsed;
+        i += 1;
+        break;
+      }
+      case 'lambda': {
+        const value = argv[i + 1];
+        if (!value || value.startsWith('--')) {
+          throw new Error('--lambda requires an integer scale');
+        }
+        try {
+          options.lambda = BigInt(value);
+        } catch (err) {
+          throw new Error(`--lambda must be an integer: ${(err as Error).message}`);
+        }
+        i += 1;
+        break;
+      }
+      case 'format': {
+        const value = argv[i + 1];
+        if (!value || value.startsWith('--')) {
+          throw new Error('--format requires a value');
+        }
+        const normalised = value.toLowerCase();
+        if (normalised === 'human' || normalised === 'text') {
+          options.format = 'human';
+        } else if (normalised === 'markdown' || normalised === 'md') {
+          options.format = 'markdown';
+        } else if (normalised === 'json') {
+          options.format = 'json';
+        } else if (normalised === 'csv') {
+          options.format = 'csv';
+        } else {
+          throw new Error(`Unsupported format "${value}"`);
+        }
+        i += 1;
+        break;
+      }
+      case 'out':
+      case 'output': {
+        const value = argv[i + 1];
+        if (!value || value.startsWith('--')) {
+          throw new Error('--out requires a file path');
+        }
+        options.outPath = value;
+        i += 1;
+        break;
+      }
+      case 'limit': {
+        const value = argv[i + 1];
+        if (!value || value.startsWith('--')) {
+          throw new Error('--limit requires a positive integer');
+        }
+        const parsed = Number(value);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          throw new Error('--limit must be a positive integer');
+        }
+        options.limit = parsed;
+        i += 1;
+        break;
+      }
+      case 'order': {
+        const value = argv[i + 1];
+        if (!value || value.startsWith('--')) {
+          throw new Error('--order requires "asc" or "desc"');
+        }
+        const normalised = value.toLowerCase();
+        if (normalised === 'asc' || normalised === 'ascending') {
+          options.order = 'asc';
+        } else if (normalised === 'desc' || normalised === 'descending') {
+          options.order = 'desc';
+        } else {
+          throw new Error('--order must be "asc" or "desc"');
+        }
+        i += 1;
+        break;
+      }
+      case 'decimals': {
+        const value = argv[i + 1];
+        if (!value || value.startsWith('--')) {
+          throw new Error('--decimals requires a number between 0 and 36');
+        }
+        const parsed = Number(value);
+        if (!Number.isInteger(parsed) || parsed < 0 || parsed > 36) {
+          throw new Error('--decimals must be an integer between 0 and 36');
+        }
+        options.decimals = parsed;
+        i += 1;
+        break;
+      }
+      case 'unit-label':
+      case 'unit': {
+        const value = argv[i + 1];
+        if (!value || value.startsWith('--')) {
+          throw new Error('--unit-label requires a string');
+        }
+        options.unitLabel = value;
+        i += 1;
+        break;
+      }
+      case 'timestamps':
+      case 'with-timestamps':
+        options.includeTimestamps = true;
+        break;
+      default:
+        throw new Error(`Unknown flag --${key}`);
+    }
+  }
+
+  return options;
+}
+
+function toChecksumAddress(address: string): string {
+  return ethers.getAddress(address);
+}
+
+function formatUnits(value: bigint, decimals: number): string {
+  return ethers.formatUnits(value, decimals);
+}
+
+function computeStats(entries: EpochEntry[]): ReportStats {
+  if (entries.length === 0) {
+    return {
+      totalBudget: 0n,
+      totalH: 0n,
+    };
+  }
+
+  let totalBudget = 0n;
+  let totalH = 0n;
+  let minH = entries[0].h;
+  let maxH = entries[0].h;
+  let minFree = entries[0].freeEnergy;
+  let maxFree = entries[0].freeEnergy;
+  let firstEpoch = entries[0].epoch;
+  let latestEpoch = entries[0].epoch;
+
+  for (const entry of entries) {
+    totalBudget += entry.budget;
+    totalH += entry.h;
+    if (entry.h < minH) minH = entry.h;
+    if (entry.h > maxH) maxH = entry.h;
+    if (entry.freeEnergy < minFree) minFree = entry.freeEnergy;
+    if (entry.freeEnergy > maxFree) maxFree = entry.freeEnergy;
+    if (entry.epoch < firstEpoch) firstEpoch = entry.epoch;
+    if (entry.epoch > latestEpoch) latestEpoch = entry.epoch;
+  }
+
+  const divisor = BigInt(entries.length);
+
+  return {
+    firstEpoch,
+    latestEpoch,
+    totalBudget,
+    averageBudget: totalBudget / divisor,
+    totalH,
+    averageH: totalH / divisor,
+    minH,
+    maxH,
+    minFree,
+    maxFree,
+  };
+}
+
+function bigIntToString(value?: bigint): string | undefined {
+  return value === undefined ? undefined : value.toString();
+}
+
+function renderHuman(report: ReportPayload, decimals: number): string {
+  const { metadata, stats, entries } = report;
+  const lines: string[] = [];
+  lines.push('Hamiltonian Monitor Report');
+  lines.push('===========================');
+  lines.push(`Engine: ${metadata.engine}`);
+  lines.push(`Block range: ${metadata.fromBlock} → ${metadata.toBlock}`);
+  lines.push(`Events analysed: ${metadata.totalEvents}`);
+  lines.push(`λ (lambda): ${metadata.lambda}`);
+  lines.push(`Unit label: ${metadata.unitLabel}`);
+  if (stats.firstEpoch !== undefined && stats.latestEpoch !== undefined) {
+    lines.push(`Epoch span: ${stats.firstEpoch.toString()} → ${stats.latestEpoch.toString()}`);
+  }
+  lines.push('');
+
+  lines.push('Aggregate metrics:');
+  lines.push(`  • Total budget: ${formatUnits(stats.totalBudget, decimals)} ${metadata.unitLabel}`);
+  if (stats.averageBudget !== undefined) {
+    lines.push(`  • Average budget: ${formatUnits(stats.averageBudget, decimals)} ${metadata.unitLabel}`);
+  }
+  if (stats.averageH !== undefined) {
+    lines.push(`  • Average H: ${stats.averageH.toString()}`);
+  }
+  if (stats.minH !== undefined && stats.maxH !== undefined) {
+    lines.push(`  • H range: ${stats.minH.toString()} → ${stats.maxH.toString()}`);
+  }
+  if (stats.minFree !== undefined && stats.maxFree !== undefined) {
+    lines.push(`  • Free energy range: ${stats.minFree.toString()} → ${stats.maxFree.toString()}`);
+  }
+  lines.push('');
+
+  if (entries.length === 0) {
+    lines.push('No EpochSettled events found for the provided range.');
+    return lines.join('\n');
+  }
+
+  const headers = [
+    'Epoch',
+    `Budget (${metadata.unitLabel})`,
+    'ΔH',
+    'ΔS',
+    'T',
+    'H',
+    'Free',
+    'Block',
+  ];
+  const rows = entries.map((entry) => [
+    entry.epoch.toString(),
+    formatUnits(entry.budget, decimals),
+    entry.dH.toString(),
+    entry.dS.toString(),
+    entry.systemTemperature.toString(),
+    entry.h.toString(),
+    entry.freeEnergy.toString(),
+    entry.blockNumber.toString(),
+  ]);
+
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index]?.length ?? 0)),
+  );
+
+  const formatRow = (row: string[]) =>
+    row.map((cell, index) => cell.padEnd(widths[index])).join('  ');
+
+  lines.push(formatRow(headers));
+  lines.push(widths.map((width) => '-'.repeat(width)).join('  '));
+  rows.forEach((row) => lines.push(formatRow(row)));
+
+  if (report.entries.some((entry) => entry.timestamp !== undefined)) {
+    lines.push('');
+    lines.push('Timestamps (unix seconds):');
+    report.entries.forEach((entry) => {
+      if (entry.timestamp !== undefined) {
+        lines.push(`  • Epoch ${entry.epoch.toString()}: ${entry.timestamp}`);
+      }
+    });
+  }
+
+  return lines.join('\n');
+}
+
+function renderMarkdown(report: ReportPayload, decimals: number): string {
+  const { metadata, stats, entries } = report;
+  const summaryLines = [
+    '# Hamiltonian Monitor Report',
+    '',
+    `- **Engine:** \`${metadata.engine}\``,
+    `- **λ (lambda):** \`${metadata.lambda}\``,
+    `- **Block range:** \`${metadata.fromBlock} → ${metadata.toBlock}\``,
+    `- **Events analysed:** \`${metadata.totalEvents}\``,
+    `- **Unit label:** \`${metadata.unitLabel}\``,
+  ];
+
+  if (stats.firstEpoch !== undefined && stats.latestEpoch !== undefined) {
+    summaryLines.push(
+      `- **Epoch span:** \`${stats.firstEpoch.toString()} → ${stats.latestEpoch.toString()}\``,
+    );
+  }
+
+  summaryLines.push('');
+  summaryLines.push('## Aggregate metrics');
+  summaryLines.push('');
+  summaryLines.push(
+    `- Total budget: **${formatUnits(stats.totalBudget, decimals)} ${metadata.unitLabel}**`,
+  );
+  if (stats.averageBudget !== undefined) {
+    summaryLines.push(
+      `- Average budget: ${formatUnits(stats.averageBudget, decimals)} ${metadata.unitLabel}`,
+    );
+  }
+  if (stats.averageH !== undefined) {
+    summaryLines.push(`- Average H: \`${stats.averageH.toString()}\``);
+  }
+  if (stats.minH !== undefined && stats.maxH !== undefined) {
+    summaryLines.push(
+      `- H range: \`${stats.minH.toString()} → ${stats.maxH.toString()}\``,
+    );
+  }
+  if (stats.minFree !== undefined && stats.maxFree !== undefined) {
+    summaryLines.push(
+      `- Free energy range: \`${stats.minFree.toString()} → ${stats.maxFree.toString()}\``,
+    );
+  }
+
+  summaryLines.push('');
+  summaryLines.push('```mermaid');
+  summaryLines.push('flowchart LR');
+  summaryLines.push('    Budget[Reward budget] -->|λ| Hamiltonian[H = ΔH − λ · budget]');
+  summaryLines.push('    Temperature[System temperature] --> FreeEnergy[G = ΔH − T · ΔS]');
+  summaryLines.push('    Entropy[Entropy ΔS] --> FreeEnergy');
+  summaryLines.push('```');
+  summaryLines.push('');
+
+  if (entries.length === 0) {
+    summaryLines.push('No `EpochSettled` events were found.');
+    return summaryLines.join('\n');
+  }
+
+  summaryLines.push('## Epoch breakdown');
+  summaryLines.push('');
+  summaryLines.push(
+    '| Epoch | Budget (' +
+      metadata.unitLabel +
+      ') | ΔH | ΔS | T | H | Free energy | Block | Timestamp | Tx hash |',
+  );
+  summaryLines.push('| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |');
+
+  entries.forEach((entry) => {
+    const timestamp = entry.timestamp
+      ? new Date(entry.timestamp * 1000).toISOString()
+      : '—';
+    summaryLines.push(
+      `| ${entry.epoch.toString()} | ${formatUnits(entry.budget, decimals)} | ${entry.dH.toString()} | ${entry.dS.toString()} | ${entry.systemTemperature.toString()} | ${entry.h.toString()} | ${entry.freeEnergy.toString()} | ${entry.blockNumber.toString()} | ${timestamp} | \`${entry.txHash}\` |`,
+    );
+  });
+
+  return summaryLines.join('\n');
+}
+
+function renderJson(report: ReportPayload, decimals: number): string {
+  const serialised = {
+    metadata: report.metadata,
+    stats: {
+      ...report.stats,
+      firstEpoch: bigIntToString(report.stats.firstEpoch),
+      latestEpoch: bigIntToString(report.stats.latestEpoch),
+      totalBudget: formatUnits(report.stats.totalBudget, decimals),
+      averageBudget: report.stats.averageBudget
+        ? formatUnits(report.stats.averageBudget, decimals)
+        : undefined,
+      totalH: bigIntToString(report.stats.totalH),
+      averageH: bigIntToString(report.stats.averageH),
+      minH: bigIntToString(report.stats.minH),
+      maxH: bigIntToString(report.stats.maxH),
+      minFree: bigIntToString(report.stats.minFree),
+      maxFree: bigIntToString(report.stats.maxFree),
+    },
+    entries: report.entries.map((entry) => ({
+      epoch: entry.epoch.toString(),
+      budget: {
+        raw: entry.budget.toString(),
+        formatted: formatUnits(entry.budget, decimals),
+      },
+      dH: entry.dH.toString(),
+      dS: entry.dS.toString(),
+      systemTemperature: entry.systemTemperature.toString(),
+      h: entry.h.toString(),
+      freeEnergy: entry.freeEnergy.toString(),
+      leftover: entry.leftover.toString(),
+      blockNumber: entry.blockNumber,
+      timestamp: entry.timestamp,
+      txHash: entry.txHash,
+    })),
+  };
+
+  return `${JSON.stringify(serialised, null, 2)}\n`;
+}
+
+function renderCsv(report: ReportPayload, decimals: number): string {
+  const header = [
+    'epoch',
+    'budget_raw',
+    `budget_${report.metadata.unitLabel}`,
+    'delta_h',
+    'delta_s',
+    'temperature',
+    'hamiltonian',
+    'free_energy',
+    'leftover',
+    'block',
+    'timestamp',
+    'tx_hash',
+  ];
+
+  const rows = report.entries.map((entry) => [
+    entry.epoch.toString(),
+    entry.budget.toString(),
+    formatUnits(entry.budget, decimals),
+    entry.dH.toString(),
+    entry.dS.toString(),
+    entry.systemTemperature.toString(),
+    entry.h.toString(),
+    entry.freeEnergy.toString(),
+    entry.leftover.toString(),
+    entry.blockNumber.toString(),
+    entry.timestamp ? new Date(entry.timestamp * 1000).toISOString() : '',
+    entry.txHash,
+  ]);
+
+  return [header.join(','), ...rows.map((row) => row.join(','))].join('\n') + '\n';
+}
+
+async function maybeWriteFile(output: string, outPath?: string): Promise<void> {
+  if (!outPath) {
+    return;
+  }
+  const resolved = path.resolve(outPath);
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  await fs.writeFile(resolved, output);
+  console.error(`Report written to ${resolved}`);
+}
+
+async function enrichTimestamps(entries: EpochEntry[]): Promise<void> {
+  const uniqueBlocks = Array.from(new Set(entries.map((entry) => entry.blockNumber)));
+  const provider = ethers.provider;
+  const blockTimestamps = new Map<number, number>();
+
+  await Promise.all(
+    uniqueBlocks.map(async (blockNumber) => {
+      const block = await provider.getBlock(blockNumber);
+      if (block) {
+        blockTimestamps.set(blockNumber, block.timestamp);
+      }
+    }),
+  );
+
+  entries.forEach((entry) => {
+    const timestamp = blockTimestamps.get(entry.blockNumber);
+    if (timestamp !== undefined) {
+      entry.timestamp = timestamp;
+    }
+  });
+}
+
 async function main() {
-  const args = parseArgs();
-  const engine = args['engine'];
-  if (!engine) throw new Error('--engine <address> required');
-  const fromBlock = args['from'] ? parseInt(args['from']) : 0;
-  const toBlock = args['to']
-    ? parseInt(args['to'])
-    : await hre.ethers.provider.getBlockNumber();
-  const lambda = BigInt(args['lambda'] ?? '1');
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+  if (!options.engine) {
+    throw new Error('Missing required --engine <address>');
+  }
+
+  const engineAddress = toChecksumAddress(options.engine);
+
+  const latestBlock = await ethers.provider.getBlockNumber();
+  const fromBlock = options.fromBlock ?? 0;
+  const toBlock = options.toBlock ?? latestBlock;
+  if (fromBlock > toBlock) {
+    throw new Error('--from cannot be greater than --to');
+  }
 
   const abi = [
     'event EpochSettled(uint256 indexed epoch,uint256 budget,int256 dH,int256 dS,int256 systemTemperature,uint256 leftover)',
   ];
-  const contract = new hre.ethers.Contract(engine, abi, hre.ethers.provider);
+  const contract = new ethers.Contract(
+    engineAddress,
+    abi,
+    ethers.provider,
+  );
+
   const events = await contract.queryFilter(
     contract.filters.EpochSettled(),
     fromBlock,
-    toBlock
+    toBlock,
   );
 
-  for (const ev of events) {
-    const { epoch, budget, dH, dS, systemTemperature } = ev.args as any;
-    const h = BigInt(dH) - lambda * BigInt(budget);
-    const free = BigInt(dH) - (BigInt(systemTemperature) * BigInt(dS)) / WAD;
-    console.log(
-      `epoch ${epoch.toString()} h=${h.toString()} free=${free.toString()}`
-    );
+  let entries: EpochEntry[] = events.map((ev) => {
+    if (!('args' in ev) || !ev.args) {
+      throw new Error('Encountered log without decoded EpochSettled args');
+    }
+    const { epoch, budget, dH, dS, systemTemperature, leftover } = ev.args as Record<string, unknown>;
+    const epochBig = BigInt((epoch as bigint | number | string).toString());
+    const budgetBig = BigInt((budget as bigint | number | string).toString());
+    const dHBig = BigInt((dH as bigint | number | string).toString());
+    const dSBig = BigInt((dS as bigint | number | string).toString());
+    const temperatureBig = BigInt((systemTemperature as bigint | number | string).toString());
+    const leftoverBig = BigInt((leftover as bigint | number | string).toString());
+
+    const h = dHBig - options.lambda * budgetBig;
+    const freeEnergy = dHBig - (temperatureBig * dSBig) / WAD;
+
+    return {
+      epoch: epochBig,
+      budget: budgetBig,
+      dH: dHBig,
+      dS: dSBig,
+      systemTemperature: temperatureBig,
+      leftover: leftoverBig,
+      h,
+      freeEnergy,
+      blockNumber: ev.blockNumber,
+      txHash: ev.transactionHash,
+    };
+  });
+
+  if (options.limit !== undefined && entries.length > options.limit) {
+    entries = entries.slice(entries.length - options.limit);
   }
+
+  if (options.order === 'desc') {
+    entries = entries.slice().reverse();
+  }
+
+  if (options.includeTimestamps && entries.length > 0) {
+    await enrichTimestamps(entries);
+  }
+
+  const stats = computeStats(entries);
+
+  const report: ReportPayload = {
+    metadata: {
+      engine: engineAddress,
+      lambda: options.lambda.toString(),
+      decimals: options.decimals,
+      unitLabel: options.unitLabel,
+      fromBlock,
+      toBlock,
+      totalEvents: entries.length,
+      generatedAt: new Date().toISOString(),
+      order: options.order,
+    },
+    stats,
+    entries,
+  };
+
+  let output: string;
+  switch (options.format) {
+    case 'human':
+      output = renderHuman(report, options.decimals);
+      break;
+    case 'markdown':
+      output = renderMarkdown(report, options.decimals);
+      break;
+    case 'json':
+      output = renderJson(report, options.decimals);
+      break;
+    case 'csv':
+      output = renderCsv(report, options.decimals);
+      break;
+    default:
+      throw new Error(`Unsupported format ${options.format}`);
+  }
+
+  if (!options.outPath) {
+    process.stdout.write(output);
+  }
+  await maybeWriteFile(output, options.outPath);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- expand `hamiltonian-tracker.ts` into a full-featured reporter with filtering, multi-format output, timestamp enrichment, and aggregate metrics
- add an npm helper (`npm run hamiltonian:report`) plus README guidance to surface the richer telemetry workflow
- rewrite the Hamiltonian monitor operations guide with quick-start commands, diagrams, tables, and troubleshooting for non-technical operators

## Testing
- npm run hamiltonian:report -- --help

------
https://chatgpt.com/codex/tasks/task_e_68decf93e67c83339017b475b59819b1