### PR TITLE
Add owner control configuration template workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 - [Owner control non-technical guide](#owner-control-non-technical-guide)
 - [Owner control zero-downtime guide](#owner-control-zero-downtime-guide)
 - [Owner control handbook](#owner-control-handbook)
+- [Owner control configuration template](#owner-control-configuration-template)
 - [Owner mission control](#owner-mission-control)
 - [Owner control visual guide](#owner-control-visual-guide)
 - [Owner parameter matrix](#owner-parameter-matrix)
@@ -332,6 +333,24 @@ deploy updates confidently. Export the live surface with
 `npm run owner:surface -- --network <network> --format markdown --out
 reports/<network>-owner-surface.md` and attach the resulting artefact to the
 runbook template shipped in the handbook for instant change-control packages.
+
+### Owner control configuration template
+
+Want a guided starting point for `config/owner-control.json` that stays in sync
+with the automation pipeline? Copy-edit the annotated
+[`config/owner-control.sample.jsonc`](config/owner-control.sample.jsonc) and run
+the new helper:
+
+```bash
+npm run owner:template -- --force            # write config/owner-control.json
+npm run owner:template -- --stdout | tee /tmp/owner-control.json
+```
+
+The CLI strips comments, formats the JSON deterministically, and refuses to
+overwrite your working file unless `--force` is present. Pair it with
+`docs/owner-control-configuration-template.md` for Mermaid diagrams, field
+reference tables, and a change-control Gantt chart that non-technical owners can
+follow step-by-step before executing `npm run owner:update-all`.
 
 ### Owner mission control
 

--- a/config/owner-control.sample.jsonc
+++ b/config/owner-control.sample.jsonc
@@ -1,0 +1,129 @@
+{
+  // 🔐 Global governance controller (multisig or timelock). Replace with your production address.
+  "governance": "0x0000000000000000000000000000000000000000",
+  // 👑 Default owner fallback used when a module does not override the owner address. Replace with your operational owner.
+  "owner": "0x0000000000000000000000000000000000000000",
+  "modules": {
+    // === Core staking control ===
+    "stakeManager": {
+      "type": "governable",
+      // On-chain address for the StakeManager proxy/implementation.
+      "address": "0x0000000000000000000000000000000000000000",
+      // Optional override for governance (falls back to the global governance address).
+      "governance": "0x0000000000000000000000000000000000000000",
+      // Optional override for owner (falls back to the global owner address).
+      "owner": "0x0000000000000000000000000000000000000000",
+      // Set to true to exclude this module from automated updates while keeping it documented.
+      "skip": false,
+      // Notes appear in reports (owner:surface, owner:atlas, owner:mission-control).
+      "notes": [
+        "Treasury Safe: safe.agijobs.eth",
+        "Validator committee rotates quarterly"
+      ]
+    },
+    // === Job lifecycle configuration ===
+    "jobRegistry": {
+      "type": "governable",
+      "address": "0x0000000000000000000000000000000000000000",
+      "governance": "0x0000000000000000000000000000000000000000",
+      "owner": "0x0000000000000000000000000000000000000000",
+      "notes": [
+        "Keep in sync with config/job-registry.json",
+        "Requires pauser ownership hand-off before SystemPause updates"
+      ]
+    },
+    // === Reward distribution ===
+    "rewardEngine": {
+      "type": "governable",
+      "address": "0x0000000000000000000000000000000000000000",
+      "notes": [
+        "Thermodynamics weights live in config/thermodynamics.json",
+        "Verify Gibbs parameters with npm run owner:dashboard"
+      ]
+    },
+    // === Thermostat governor ===
+    "thermostat": {
+      "type": "governable",
+      "address": "0x0000000000000000000000000000000000000000",
+      "notes": [
+        "Pair changes with Thermodynamics update helper"
+      ]
+    },
+    // === Emergency pause ===
+    "systemPause": {
+      "type": "governable",
+      "address": "0x0000000000000000000000000000000000000000",
+      "notes": [
+        "All pausable modules must transfer ownership before wiring"
+      ]
+    },
+    // === Fee routing ===
+    "feePool": {
+      "type": "ownable",
+      "address": "0x0000000000000000000000000000000000000000",
+      "owner": "0x0000000000000000000000000000000000000000",
+      "notes": [
+        "Treasury allowlist lives in config/fee-pool.json"
+      ]
+    },
+    "platformRegistry": {
+      "type": "ownable",
+      "address": "0x0000000000000000000000000000000000000000",
+      "notes": [
+        "Mirrors config/platform-registry.json"
+      ]
+    },
+    "platformIncentives": {
+      "type": "ownable",
+      "address": "0x0000000000000000000000000000000000000000",
+      "notes": [
+        "Incentive weights defined in config/platform-incentives.json"
+      ]
+    },
+    "jobRouter": {
+      "type": "ownable",
+      "address": "0x0000000000000000000000000000000000000000"
+    },
+    "validationModule": {
+      "type": "ownable",
+      "address": "0x0000000000000000000000000000000000000000"
+    },
+    "reputationEngine": {
+      "type": "ownable",
+      "address": "0x0000000000000000000000000000000000000000"
+    },
+    "disputeModule": {
+      "type": "ownable",
+      "address": "0x0000000000000000000000000000000000000000",
+      "notes": [
+        "Committee membership tracked via config/dispute-module.json"
+      ]
+    },
+    "arbitratorCommittee": {
+      "type": "ownable",
+      "address": "0x0000000000000000000000000000000000000000"
+    },
+    "certificateNFT": {
+      "type": "ownable",
+      "address": "0x0000000000000000000000000000000000000000"
+    },
+    "taxPolicy": {
+      "type": "ownable2step",
+      "address": "0x0000000000000000000000000000000000000000",
+      "notes": [
+        "Requires acceptOwnership call after governance rotation"
+      ]
+    },
+    "identityRegistry": {
+      "type": "ownable2step",
+      "address": "0x0000000000000000000000000000000000000000",
+      "notes": [
+        "Ensure ENS controller matches config/identity-registry.json"
+      ]
+    },
+    "attestationRegistry": {
+      "type": "ownable",
+      "address": "0x0000000000000000000000000000000000000000"
+    }
+  }
+}

--- a/docs/owner-control-configuration-template.md
+++ b/docs/owner-control-configuration-template.md
@@ -1,0 +1,172 @@
+# Owner Control Configuration Template
+
+> **Audience:** Contract owners and operations stewards who need a safe, fully
+auditable way to edit `config/owner-control.json` without reverse-engineering the
+existing tooling. The companion CLI helper and template make it trivial to stage,
+review, execute and verify governance rotations from a single source of truth.
+
+## Why this exists
+
+```mermaid
+flowchart LR
+    template[Template JSONC<br/>config/owner-control.sample.jsonc] --> render[owner:template helper]
+    render --> json[config/owner-control.json]
+    json --> plan[npm run owner:update-all]
+    plan --> verify[npm run owner:verify-control]
+    verify --> archive[npm run owner:surface]
+    archive --> template
+    classDef primary fill:#eef5ff,stroke:#2e86de;
+    classDef action fill:#e8f9e9,stroke:#27ae60;
+    class template primary;
+    class render,json,plan,verify,archive action;
+```
+
+- **Annotated JSONC** keeps every requirement inline with the fields you must
+  edit. Comments describe where each address and override originates so you can
+  cross-check against deployment manifests.
+- **The `owner:template` helper** strips comments and produces a standards-compliant
+  JSON file that all existing owner-control tooling consumes.
+- **Guardrail scripts** (`owner:update-all`, `owner:verify-control`, `owner:surface`)
+  stay untouched—this workflow simply makes it effortless to prepare the JSON they
+  expect.
+
+## Quickstart: render a clean JSON file
+
+1. Inspect the annotated template:
+   ```bash
+   cat config/owner-control.sample.jsonc
+   ```
+2. Generate a production-ready JSON file (non-destructive by default):
+   ```bash
+   npm run owner:template
+   ```
+3. Overwrite an existing file intentionally:
+   ```bash
+   npm run owner:template -- --force
+   ```
+4. Capture the generated JSON for review in change-control tickets without
+   touching disk:
+   ```bash
+   npm run owner:template -- --stdout > /tmp/owner-control.json
+   ```
+5. Commit the updated `config/owner-control.json` and run the standard owner-control
+   pipeline before execution:
+   ```bash
+   npm run owner:update-all -- --network <network> --dry-run
+   npm run owner:verify-control -- --network <network> --strict
+   npm run owner:surface -- --network <network> --format markdown --out reports/<network>-surface.md
+   ```
+
+> **Safety check:** The helper refuses to overwrite an existing file unless you
+> pass `--force`. This prevents accidental loss of hand-edited parameters during
+> rehearsals or staged migrations.
+
+## Field reference
+
+| Field | Location | Purpose | Notes |
+| ----- | -------- | ------- | ----- |
+| `governance` | Root | Default multisig/timelock that controls modules marked `governable`. | Replace with the production governance Safe or timelock. Appears in reports and Safe bundles. |
+| `owner` | Root | Default operational owner for `ownable` modules. | Often a hot wallet or operations Safe responsible for day-to-day maintenance. |
+| `modules.*.type` | Module entry | Declares how the automation scripts interact with the module. | Supported values: `governable`, `ownable`, `ownable2step`. Custom strings are preserved for documentation but skipped during automation. |
+| `modules.*.address` | Module entry | On-chain contract address. | Copy from `docs/deployment-addresses.json`, Hardhat artifacts or subgraph outputs. |
+| `modules.*.governance` | Module entry | Optional override for the module governance address. | Falls back to the root `governance` if omitted. Use when a module is governed by a distinct Safe/timelock. |
+| `modules.*.owner` | Module entry | Optional override for the module owner address. | Falls back to the root `owner`. Useful for pausers or when a module remains operator-controlled. |
+| `modules.*.skip` | Module entry | Flag to exclude a module from automated updates while keeping it documented. | Reports still display the module with a "Skipped" banner so auditors know it is managed manually. |
+| `modules.*.notes[]` | Module entry | Free-form annotations surfaced in every owner-control report. | Record why the module exists, the change cadence, or operational caveats. |
+
+### Module cheat sheet
+
+```mermaid
+mindmap
+  root((Control Surface))
+    StakeManager
+      type: governable
+      config: config/stake-manager.json
+      helper: updateStakeManager.ts
+    JobRegistry
+      type: governable
+      config: config/job-registry.json
+      helper: updateJobRegistry.ts
+    RewardEngine
+      type: governable
+      config: config/reward-engine.json
+      helper: updateRewardEngine.ts
+    Thermostat
+      type: governable
+      config: config/thermodynamics.json
+      helper: updateThermostat.ts
+    SystemPause
+      type: governable
+      config: config/platform-registry.json
+      helper: updateSystemPause.ts
+    FeePool
+      type: ownable
+      config: config/fee-pool.json
+      helper: updateFeePool.ts
+    IdentityRegistry
+      type: ownable2step
+      config: config/identity-registry.json
+      helper: updateIdentityRegistry.ts
+```
+
+Use the cheat sheet to cross-reference the JSON template with the dedicated
+update helpers. The names in the template map directly to the module keys used by
+`owner:update-all --only=<module>` and the verification scripts.
+
+## Step-by-step change playbook
+
+```mermaid
+sequenceDiagram
+    participant Owner as Contract Owner
+    participant Repo as Git Repo
+    participant Helper as npm run owner:template
+    participant Planner as npm run owner:update-all
+    participant Verifier as npm run owner:verify-control
+    participant Archive as npm run owner:surface
+
+    Owner->>Repo: Edit config/owner-control.sample.jsonc
+    Owner->>Helper: npm run owner:template -- --force
+    Helper-->>Repo: Write config/owner-control.json
+    Owner->>Planner: npm run owner:update-all -- --network <net> --dry-run
+    Planner-->>Owner: Proposed transactions + Safe bundle
+    Owner->>Verifier: npm run owner:verify-control -- --network <net> --strict
+    Verifier-->>Owner: ✅ / ⚠️ / ❌ status report
+    Owner->>Archive: npm run owner:surface -- --network <net> --format markdown
+    Archive-->>Owner: Store artefacts for governance record
+```
+
+## Frequently asked questions
+
+- **Can I add new modules?** Yes. Add a new key under `modules` in the template,
+  fill in the required fields and rerun `npm run owner:template -- --force`. All
+  owner-control scripts automatically pick up the additional module and include it
+  in reports.
+- **How do I document multi-signature requirements?** Use the `notes` array to
+  reference Safe names, signer thresholds or escalation contacts. The notes appear
+  verbatim in command outputs and Markdown artefacts.
+- **What if a module is intentionally manual?** Set `"skip": true`. The automation
+  helpers will omit transactions but still surface the module in reports, reminding
+  reviewers that manual interventions are expected.
+
+## Change-control checklist
+
+```mermaid
+gantt
+    title Owner Control Update Window
+    dateFormat  HH:mm
+    axisFormat  %H:%M
+    section Preparation
+    Draft template (git branch)       :done,    prep1, 00:30, 00:30
+    Run owner:template --stdout       :done,    prep2, after prep1, 00:05
+    section Dry Run
+    owner:update-all --dry-run        :active,  dryrun, after prep2, 00:10
+    Review Safe bundle                :         review, after dryrun, 00:15
+    section Execution
+    owner:update-all --execute        :         exec1, after review, 00:10
+    section Verification
+    owner:verify-control --strict     :         verify1, after exec1, 00:05
+    owner:surface (archive)           :         archive1, after verify1, 00:05
+```
+
+Attach the completed checklist to your governance ticket to prove every control
+lever was handled methodically.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "owner:rotate": "npx hardhat run --no-compile scripts/v2/rotateGovernance.ts",
     "owner:update-all": "npx hardhat run --no-compile scripts/v2/updateAllModules.ts",
     "owner:surface": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlSurface.ts",
+    "owner:template": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlTemplate.ts",
     "test": "hardhat test --no-compile",
     "test:fork": "SKIP_MOCK_AGIALPHA=1 hardhat test --no-compile test/fork/mainnet-job-lifecycle.fork.test.ts",
     "e2e:local": "hardhat test --no-compile test/e2e/localnet.gateway.e2e.test.ts",

--- a/scripts/v2/ownerControlTemplate.ts
+++ b/scripts/v2/ownerControlTemplate.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env ts-node
+import fs from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+
+interface CliOptions {
+  out?: string;
+  force: boolean;
+  stdout: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    force: false,
+    stdout: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--out': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--out requires a value');
+        }
+        options.out = value;
+        i += 1;
+        break;
+      }
+      case '--force':
+        options.force = true;
+        break;
+      case '--stdout':
+        options.stdout = true;
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new Error(`Unknown flag ${arg}`);
+        }
+    }
+  }
+
+  return options;
+}
+
+async function pathExists(candidate: string): Promise<boolean> {
+  try {
+    await fs.access(candidate, fsConstants.F_OK);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function stripJsonComments(value: string): string {
+  let output = '';
+  let inString = false;
+  let inSingleLineComment = false;
+  let inMultiLineComment = false;
+  let stringQuote: string | undefined;
+  let isEscaped = false;
+
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    const next = value[i + 1];
+
+    if (inSingleLineComment) {
+      if (char === '\n' || char === '\r') {
+        inSingleLineComment = false;
+        output += char;
+        if (char === '\r' && next === '\n') {
+          // Preserve Windows line endings
+          i += 1;
+          output += value[i];
+        }
+      }
+      continue;
+    }
+
+    if (inMultiLineComment) {
+      if (char === '*' && next === '/') {
+        inMultiLineComment = false;
+        i += 1;
+        continue;
+      }
+      if (char === '\n' || char === '\r') {
+        output += char;
+        if (char === '\r' && next === '\n') {
+          i += 1;
+          output += value[i];
+        }
+      }
+      continue;
+    }
+
+    if (inString) {
+      output += char;
+      if (isEscaped) {
+        isEscaped = false;
+        continue;
+      }
+      if (char === '\\') {
+        isEscaped = true;
+        continue;
+      }
+      if (char === stringQuote) {
+        inString = false;
+        stringQuote = undefined;
+      }
+      continue;
+    }
+
+    if (char === "\"" || char === "'") {
+      inString = true;
+      stringQuote = char;
+      output += char;
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      inSingleLineComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      inMultiLineComment = true;
+      i += 1;
+      continue;
+    }
+
+    output += char;
+  }
+
+  return output;
+}
+
+async function ensureParentDirectory(filePath: string): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+}
+
+function formatUsage(): string {
+  return `Usage: npm run owner:template [-- --out <file> --force --stdout]\n\n` +
+    `Creates a production-ready config/owner-control.json from the annotated JSONC template.\n\n` +
+    `Options:\n` +
+    `  --out <file>   Write the sanitised JSON to <file> (default: config/owner-control.json).\n` +
+    `  --stdout       Print the sanitised JSON to stdout instead of writing a file.\n` +
+    `  --force        Overwrite the output file if it already exists.\n` +
+    `  --help         Show this message.`;
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    console.log(formatUsage());
+    return;
+  }
+
+  const samplePath = path.resolve(process.cwd(), 'config', 'owner-control.sample.jsonc');
+  const targetPath = options.out
+    ? path.resolve(process.cwd(), options.out)
+    : path.resolve(process.cwd(), 'config', 'owner-control.json');
+
+  const raw = await fs.readFile(samplePath, 'utf8');
+  const cleaned = stripJsonComments(raw);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch (error) {
+    throw new Error(`Failed to parse owner-control sample: ${(error as Error).message}`);
+  }
+
+  const serialised = `${JSON.stringify(parsed, null, 2)}\n`;
+
+  if (options.stdout) {
+    process.stdout.write(serialised);
+    return;
+  }
+
+  if (!options.force && (await pathExists(targetPath))) {
+    throw new Error(
+      `${path.relative(process.cwd(), targetPath)} already exists. Pass --force to overwrite.`
+    );
+  }
+
+  await ensureParentDirectory(targetPath);
+  await fs.writeFile(targetPath, serialised, 'utf8');
+
+  console.log(
+    `Wrote ${path.relative(process.cwd(), targetPath)} using config/owner-control.sample.jsonc. ` +
+      'Review the placeholders, commit the changes, and run `npm run owner:verify-control` before executing updates.'
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add an annotated JSONC template for owner-control parameters and a CLI helper to render production-ready JSON
- document the workflow with a dedicated owner-control configuration template guide and README entry so non-technical owners can follow it

## Testing
- npm run owner:template -- --help

------
https://chatgpt.com/codex/tasks/task_e_68ded2d79e508333a8247b224b313207