### PR TITLE
Add owner change ticket generator CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 - [Owner control quick reference CLI](#owner-control-quick-reference-cli)
 - [Owner control master checklist](#owner-control-master-checklist)
 - [Owner control atlas](#owner-control-atlas)
+- [Owner control change ticket](#owner-control-change-ticket)
 - [Owner control non-technical guide](#owner-control-non-technical-guide)
 - [Owner control zero-downtime guide](#owner-control-zero-downtime-guide)
 - [Owner control handbook](#owner-control-handbook)
@@ -300,6 +301,22 @@ npm run owner:atlas -- --network <network>
 
 Export with `--out reports/<network>-owner-atlas.md` to archive a Markdown briefing, choose `--format human` for a condensed terminal digest, or `--format json` for dashboard integrations. The Atlas automatically lists every module managed by the owner, highlights zero-address treasuries, missing signers and unbalanced reward weights, and embeds a Mermaid topology that maps JSON manifests → Hardhat helpers → deployed contracts. See [docs/owner-control-atlas.md](docs/owner-control-atlas.md) for a fully illustrated walkthrough.
 
+### Owner control change ticket
+
+Need a pre-filled change-management packet that a non-technical owner can hand to governance, compliance and auditors? Generate the new change ticket:
+
+```bash
+npm run owner:change-ticket -- --network <network>
+
+# Capture a Markdown artefact for approval workflows
+npm run owner:change-ticket -- --network mainnet --format markdown --out reports/mainnet-owner-change-ticket.md
+
+# Produce a JSON payload for bots or CI checks
+npm run owner:change-ticket -- --network mainnet --format json --out reports/mainnet-owner-change-ticket.json
+```
+
+The helper loads every owner-facing configuration manifest, hashes them with SHA-256, and emits a sequenced stage plan (baseline → plan → execute → verify → archive) alongside module-specific update/verify commands. Each ticket embeds a Mermaid flow, attachment checklist and links to the relevant illustrated handbooks, making it trivial for the contract owner to coordinate Safe signers, document intent and prove that every adjustable parameter stayed under explicit control. Full guidance lives in [docs/owner-control-change-ticket.md](docs/owner-control-change-ticket.md).
+
 ### Owner control non-technical guide
 
 Need a **no-code**, compliance-ready runbook for production changes? Follow the
@@ -537,10 +554,10 @@ Key options accepted by both helpers:
 
 Hardhat reads RPC endpoints and private keys from environment variables when running scripts or compilation targets. Use the following variables to connect to public testnets:
 
-| Network           | RPC variable              | Private key variable(s)                                             | Notes |
-| ----------------- | ------------------------- | ------------------------------------------------------------------- | ----- |
-| Ethereum Sepolia  | `SEPOLIA_RPC_URL`         | `SEPOLIA_PRIVATE_KEY` (falls back to `TESTNET_PRIVATE_KEY` if unset) | Existing Sepolia rehearsals continue to work unchanged. |
-| Optimism Sepolia  | `OP_SEPOLIA_RPC_URL`      | `OP_SEPOLIA_PRIVATE_KEY` (falls back to `TESTNET_PRIVATE_KEY` if unset) | Enables the `--network optimismSepolia` Hardhat target. |
+| Network          | RPC variable         | Private key variable(s)                                                 | Notes                                                   |
+| ---------------- | -------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------- |
+| Ethereum Sepolia | `SEPOLIA_RPC_URL`    | `SEPOLIA_PRIVATE_KEY` (falls back to `TESTNET_PRIVATE_KEY` if unset)    | Existing Sepolia rehearsals continue to work unchanged. |
+| Optimism Sepolia | `OP_SEPOLIA_RPC_URL` | `OP_SEPOLIA_PRIVATE_KEY` (falls back to `TESTNET_PRIVATE_KEY` if unset) | Enables the `--network optimismSepolia` Hardhat target. |
 
 Set the appropriate variables in your `.env` file (or export them in the shell) before invoking Hardhat commands such as `npx hardhat compile --network optimismSepolia` or deployment scripts.
 

--- a/docs/owner-control-change-ticket.md
+++ b/docs/owner-control-change-ticket.md
@@ -1,0 +1,154 @@
+# Owner Control Change Ticket
+
+> **Audience:** Contract owners, compliance leads and governance operators who
+> must ship parameter updates with provable change-control artefacts.
+>
+> **Outcome:** A single command produces a fully documented change ticket with
+> checklists, hashed configuration manifests, Mermaid flows and module-specific
+> remediation links so non-technical stakeholders can approve, execute and audit
+> the rollout.
+
+---
+
+## 1. Generate the ticket
+
+```bash
+# Human-readable console digest with Mermaid flow
+npm run owner:change-ticket -- --network <network>
+
+# Markdown artefact for approval workflows
+npm run owner:change-ticket -- --network <network> --format markdown \
+  --out reports/<network>/owner-change-ticket.md
+
+# JSON payload for bots / CI guards
+npm run owner:change-ticket -- --network <network> --format json \
+  --out reports/<network>/owner-change-ticket.json
+```
+
+Each ticket bundles:
+
+- **Control envelope** – Owner/governance addresses, canonical config paths,
+  SHA-256 hashes for `config/owner-control*.json` and `config/agialpha*.json`,
+  and the active Hardhat context (if available).
+- **Stage plan** – Five phases (Baseline → Plan → Execute → Verify → Archive)
+  with copy/paste commands that mirror the production runbook.
+- **Module surface** – Per-module summaries, key parameter snapshots, update
+  and verification commands plus the illustrated manuals to consult before
+  editing JSON.
+- **Checklists** – Environment preflight, Safe/multisig sign-off notes and the
+  attachment matrix for compliance archives.
+
+```mermaid
+flowchart LR
+    baseline(Baseline)
+    plan(Plan)
+    execute(Execute)
+    verify(Verify)
+    archive(Archive)
+
+    baseline --> plan --> execute --> verify --> archive
+```
+
+> **Tip:** The Mermaid block is automatically embedded in Markdown output and
+> can be pasted into the compliance ticket, GRC system or governance forum
+> discussion without manual edits.
+
+---
+
+## 2. Prepare the environment
+
+1. `export RPC_URL=https://...` for read/write access.
+2. `export OWNER_PRIVATE_KEY=0x...` and `export GOVERNANCE_PRIVATE_KEY=0x...`
+   inside a secure shell (never commit secrets).
+3. `mkdir -p reports/<network>/` to store generated artefacts. The directory is
+   already git-ignored.
+4. Run `npm run owner:surface -- --network <network> --format markdown \
+--out reports/<network>/owner-surface.md` to capture the baseline referenced
+   by the ticket.
+
+The generator validates the configuration loaders used by the production
+automation pipeline. If a JSON manifest is malformed, missing or unreadable, the
+ticket highlights it under **Blocking Issues** with a ❌ marker instead of
+crashing, delivering an immediate remediation pointer before any state changes.
+
+---
+
+## 3. Execute the stage plan
+
+The ticket includes the canonical commands; follow them verbatim or adapt them
+for automation systems.
+
+1. **Baseline** – Run `npm run owner:doctor -- --network <network>` to surface
+   missing addresses or miswired modules. Fix issues before continuing.
+2. **Plan** – Use `npm run owner:wizard -- --network <network>` to edit JSON
+   interactively, then `npm run owner:plan -- --network <network> --out ...` to
+   preview batched transactions.
+3. **Execute** – Generate Safe payloads via `npm run owner:plan:safe` or execute
+   directly with `npm run owner:update-all -- --network <network> --execute`.
+4. **Verify** – Run `npm run owner:verify-control` and `npm run verify:agialpha`
+   to ensure on-chain state matches the ticketed configuration.
+5. **Archive** – Capture artefacts with `npm run owner:audit` and
+   `npm run owner:atlas`, then attach them alongside transaction receipts to the
+   change record.
+
+The change ticket surfaces module-level docs such as the
+[Owner Control Blueprint](owner-control-blueprint.md),
+[Owner Control Handbook](owner-control-handbook.md) and
+[Thermodynamics Operations Guide](thermodynamics-operations.md) so operators
+always have targeted remediation steps.
+
+---
+
+## 4. Non-technical approval workflow
+
+```mermaid
+sequenceDiagram
+    participant Owner
+    participant Compliance
+    participant Safe as Safe Signers
+    participant Chain as On-Chain
+    participant Archive
+
+    Owner->>Owner: Run owner:change-ticket
+    Owner->>Compliance: Share Markdown ticket + baseline artefacts
+    Compliance-->>Owner: Approve / request edits
+    Owner->>Safe: Provide ticket + Safe bundle (if applicable)
+    Safe->>Chain: Execute signed transactions
+    Chain-->>Owner: Transaction receipts
+    Owner->>Archive: Store receipts, ticket, atlas, audit
+    Archive-->>Compliance: Provide immutable dossier
+```
+
+- **Owner** controls parameters entirely through JSON manifests and copy/paste
+  commands—no Solidity knowledge required.
+- **Compliance** validates hashes, checklists and attached reports to green-light
+  the change.
+- **Safe signers** can trust the provided bundle because it references the same
+  hashed configs captured in the ticket.
+- **Archive** ensures a verifiable trail exists for future audits or rollbacks.
+
+---
+
+## 5. Troubleshooting
+
+| Symptom                                                    | Resolution                                                                                                                                                 |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `owner:change-ticket failed: Cannot find module 'hardhat'` | Hardhat is optional; set `DEBUG_OWNER_TICKET=1` to confirm the warning is benign or run from a shell where `hardhat` is installed (e.g. inside `npm run`). |
+| Missing Mermaid block in Markdown                          | Remove `--no-mermaid` or rerun without the flag; Mermaid is included by default.                                                                           |
+| Config hash reads `sha256: undefined`                      | The referenced JSON file does not exist; regenerate from the template via `npm run owner:template -- --force`.                                             |
+| Attachment checklist contains unfamiliar files             | Consult the linked docs; every item corresponds to a recommended artefact for the compliance dossier.                                                      |
+
+---
+
+## 6. Next steps
+
+- Automate ticket generation in CI to compare proposed PR changes against the
+  latest committed configs.
+- Use the JSON output to gate deployments (e.g. ensure owners are not zero,
+  treasuries are configured and reward weights sum to 100%).
+- Combine with [owner:mission-control](../scripts/v2/ownerMissionControl.ts) for a
+  real-time dashboard before executing production changes.
+
+By anchoring every owner action to the ticket, the contract owner retains full
+control over parameters while providing auditors with immediate, verifiable
+proof of intent, execution and verification.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "owner:command-center": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerCommandCenter.ts",
     "owner:mission-control": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerMissionControl.ts",
     "owner:atlas": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlAtlas.ts",
+    "owner:change-ticket": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerChangeTicket.ts",
     "owner:blueprint": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlBlueprint.ts",
     "owner:verify-control": "npx hardhat run --no-compile scripts/v2/verifyOwnerControl.ts",
     "owner:rotate": "npx hardhat run --no-compile scripts/v2/rotateGovernance.ts",

--- a/scripts/v2/ownerChangeTicket.ts
+++ b/scripts/v2/ownerChangeTicket.ts
@@ -1,0 +1,812 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { createHash } from 'crypto';
+import {
+  loadOwnerControlConfig,
+  loadTokenConfig,
+  loadStakeManagerConfig,
+  loadJobRegistryConfig,
+  loadFeePoolConfig,
+  loadThermodynamicsConfig,
+  loadHamiltonianMonitorConfig,
+  loadEnergyOracleConfig,
+  loadPlatformIncentivesConfig,
+  loadTaxPolicyConfig,
+  loadIdentityRegistryConfig,
+  loadRandaoCoordinatorConfig,
+} from '../config';
+
+interface CliOptions {
+  network?: string;
+  outPath?: string;
+  format: OutputFormat;
+  includeMermaid: boolean;
+  help?: boolean;
+}
+
+type OutputFormat = 'markdown' | 'human' | 'json';
+
+interface HardhatContext {
+  name?: string;
+  chainId?: number;
+}
+
+interface StageDescriptor {
+  id: string;
+  title: string;
+  purpose: string;
+  commands: string[];
+}
+
+interface ModuleDescriptor {
+  key: string;
+  title: string;
+  loader: (options?: { network?: string }) => LoaderResult;
+  summary: string;
+  configDocs: string[];
+  updateCommands: string[];
+  verifyCommands: string[];
+}
+
+interface LoaderResult {
+  config: any;
+  path: string;
+  network?: string;
+}
+
+interface ModuleTicket {
+  key: string;
+  title: string;
+  configPath: string;
+  configHash?: string;
+  summary: string;
+  sampleParameters: ParameterSnippet[];
+  updateCommands: string[];
+  verifyCommands: string[];
+  docs: string[];
+  loadError?: string;
+}
+
+interface ParameterSnippet {
+  key: string;
+  value: string;
+}
+
+interface TicketPayload {
+  generatedAt: string;
+  network?: string;
+  hardhat?: HardhatContext;
+  ownerAddress?: string;
+  governanceAddress?: string;
+  ownerConfigPath?: string;
+  ownerConfigHash?: string;
+  tokenConfigPath?: string;
+  tokenConfigHash?: string;
+  stages: StageDescriptor[];
+  modules: ModuleTicket[];
+  environmentChecklist: string[];
+  attachmentChecklist: string[];
+  mermaid?: string;
+  blockingIssues?: string[];
+}
+
+const DEFAULT_FORMAT: OutputFormat = 'markdown';
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    format: DEFAULT_FORMAT,
+    includeMermaid: true,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--network': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--network requires a value');
+        }
+        options.network = value;
+        i += 1;
+        break;
+      }
+      case '--out':
+      case '--output': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a path`);
+        }
+        options.outPath = value;
+        i += 1;
+        break;
+      }
+      case '--format': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--format requires a value');
+        }
+        const normalised = value.trim().toLowerCase();
+        if (
+          normalised !== 'markdown' &&
+          normalised !== 'human' &&
+          normalised !== 'json'
+        ) {
+          throw new Error('Supported formats: markdown, human, json');
+        }
+        options.format = normalised as OutputFormat;
+        i += 1;
+        break;
+      }
+      case '--no-mermaid':
+        options.includeMermaid = false;
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new Error(`Unknown flag ${arg}`);
+        }
+    }
+  }
+
+  return options;
+}
+
+async function resolveHardhatContext(): Promise<HardhatContext> {
+  try {
+    const hardhat = await import('hardhat');
+    const { network } = hardhat;
+    return {
+      name: network?.name,
+      chainId: network?.config?.chainId,
+    };
+  } catch (error) {
+    if (process.env.DEBUG_OWNER_TICKET) {
+      console.warn('Failed to load hardhat context:', error);
+    }
+    return {};
+  }
+}
+
+async function computeHash(filePath?: string): Promise<string | undefined> {
+  if (!filePath) {
+    return undefined;
+  }
+  try {
+    const resolved = path.isAbsolute(filePath)
+      ? filePath
+      : path.resolve(filePath);
+    const data = await fs.readFile(resolved);
+    return createHash('sha256').update(data).digest('hex');
+  } catch (error) {
+    if (process.env.DEBUG_OWNER_TICKET) {
+      console.warn(`Unable to hash ${filePath}:`, error);
+    }
+    return undefined;
+  }
+}
+
+function normalisePath(filePath?: string): string | undefined {
+  if (!filePath) {
+    return undefined;
+  }
+  return path.relative(process.cwd(), filePath);
+}
+
+function toSnippetEntries(config: any): ParameterSnippet[] {
+  if (!config || typeof config !== 'object') {
+    return [];
+  }
+
+  const entries = Object.entries(config as Record<string, unknown>);
+  const snippets: ParameterSnippet[] = [];
+
+  for (const [key, value] of entries) {
+    if (Array.isArray(value)) {
+      snippets.push({ key, value: `array(${value.length})` });
+    } else if (value && typeof value === 'object') {
+      snippets.push({ key, value: `object(${Object.keys(value).length})` });
+    } else if (typeof value === 'bigint') {
+      snippets.push({ key, value: value.toString() });
+    } else if (value === undefined) {
+      snippets.push({ key, value: 'undefined' });
+    } else {
+      snippets.push({ key, value: String(value) });
+    }
+    if (snippets.length >= 8) {
+      break;
+    }
+  }
+
+  return snippets;
+}
+
+function formatSnippet(snippet: ParameterSnippet): string {
+  return `- **${snippet.key}:** ${snippet.value}`;
+}
+
+function buildMermaid(stages: StageDescriptor[]): string {
+  const lines = ['flowchart LR'];
+  for (let i = 0; i < stages.length; i += 1) {
+    const current = stages[i];
+    const next = stages[i + 1];
+    const currentId = current.id.replace(/[^a-zA-Z0-9]/g, '');
+    lines.push(`    ${currentId}[${current.title}]`);
+    if (next) {
+      const nextId = next.id.replace(/[^a-zA-Z0-9]/g, '');
+      lines.push(`    ${currentId} --> ${nextId}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function buildModuleTicket(
+  descriptor: ModuleDescriptor,
+  network?: string
+): Promise<ModuleTicket> {
+  try {
+    const result = descriptor.loader({ network });
+    const configPath = normalisePath(result.path) ?? result.path;
+    const configHash = await computeHash(result.path);
+    return {
+      key: descriptor.key,
+      title: descriptor.title,
+      configPath,
+      configHash,
+      summary: descriptor.summary,
+      sampleParameters: toSnippetEntries(result.config),
+      updateCommands: descriptor.updateCommands.map((command) =>
+        replaceNetworkPlaceholder(command, network)
+      ),
+      verifyCommands: descriptor.verifyCommands.map((command) =>
+        replaceNetworkPlaceholder(command, network)
+      ),
+      docs: descriptor.configDocs,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      key: descriptor.key,
+      title: descriptor.title,
+      configPath: 'unavailable',
+      summary: descriptor.summary,
+      sampleParameters: [],
+      updateCommands: descriptor.updateCommands.map((command) =>
+        replaceNetworkPlaceholder(command, network)
+      ),
+      verifyCommands: descriptor.verifyCommands.map((command) =>
+        replaceNetworkPlaceholder(command, network)
+      ),
+      docs: descriptor.configDocs,
+      loadError: message,
+    };
+  }
+}
+
+function replaceNetworkPlaceholder(command: string, network?: string): string {
+  if (!network) {
+    return command;
+  }
+  return command.replace(/<network>/g, network);
+}
+
+async function buildTicket(options: CliOptions): Promise<TicketPayload> {
+  const hardhatContext = await resolveHardhatContext();
+  const ownerControl = loadOwnerControlConfig({ network: options.network });
+  const token = loadTokenConfig({ network: options.network });
+
+  const stages: StageDescriptor[] = [
+    {
+      id: 'baseline',
+      title: 'Baseline',
+      purpose: 'Capture current control surface and credentials.',
+      commands: [
+        'npm run owner:surface -- --network <network> --format markdown --out reports/<network>/owner-surface.md',
+        'npm run owner:doctor -- --network <network>',
+      ],
+    },
+    {
+      id: 'plan',
+      title: 'Plan',
+      purpose: 'Edit JSON configs, document intent, and preview transactions.',
+      commands: [
+        'npm run owner:wizard -- --network <network>',
+        'npm run owner:plan -- --network <network> --out reports/<network>/owner-plan.json',
+      ],
+    },
+    {
+      id: 'execute',
+      title: 'Execute',
+      purpose:
+        'Submit Safe bundle or direct owner transactions once previews are clean.',
+      commands: [
+        'npm run owner:plan:safe -- --network <network> --safe reports/<network>/owner-safe-bundle.json',
+        'npm run owner:update-all -- --network <network> --execute',
+      ],
+    },
+    {
+      id: 'verify',
+      title: 'Verify',
+      purpose: 'Cross-check deployed state against the configuration manifest.',
+      commands: [
+        'npm run owner:verify-control -- --network <network>',
+        'npm run verify:agialpha -- --network <network>',
+      ],
+    },
+    {
+      id: 'archive',
+      title: 'Archive',
+      purpose: 'Store receipts, hashes, and documentation for compliance.',
+      commands: [
+        'npm run owner:audit -- --network <network> --out reports/<network>/owner-audit.md',
+        'npm run owner:atlas -- --network <network> --format markdown --out reports/<network>/owner-atlas.md',
+      ],
+    },
+  ];
+
+  const moduleDescriptors: ModuleDescriptor[] = [
+    {
+      key: 'jobRegistry',
+      title: 'Job Registry',
+      loader: loadJobRegistryConfig,
+      summary:
+        'Controls job lifecycle fees, treasury routing, and policy hooks.',
+      configDocs: [
+        'docs/owner-control-blueprint.md',
+        'docs/owner-control-handbook.md',
+      ],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updateJobRegistry.ts --network <network>',
+      ],
+      verifyCommands: ['npm run owner:verify-control -- --network <network>'],
+    },
+    {
+      key: 'stakeManager',
+      title: 'Stake Manager',
+      loader: loadStakeManagerConfig,
+      summary:
+        'Manages stake weights, cooldowns, treasuries, and slashing parameters.',
+      configDocs: [
+        'docs/owner-parameter-matrix.md',
+        'docs/owner-control-master-checklist.md',
+      ],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updateStakeManager.ts --network <network>',
+      ],
+      verifyCommands: ['npm run owner:verify-control -- --network <network>'],
+    },
+    {
+      key: 'feePool',
+      title: 'Fee Pool',
+      loader: loadFeePoolConfig,
+      summary:
+        'Allocates burn vs treasury split for protocol fees and rounding dust.',
+      configDocs: ['docs/owner-control-handbook.md'],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updateFeePool.ts --network <network>',
+      ],
+      verifyCommands: ['npm run owner:verify-control -- --network <network>'],
+    },
+    {
+      key: 'platformIncentives',
+      title: 'Platform Incentives',
+      loader: loadPlatformIncentivesConfig,
+      summary:
+        'Configures incentive programs for operators and off-chain services.',
+      configDocs: ['docs/owner-control-atlas.md'],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updatePlatformIncentives.ts --network <network>',
+      ],
+      verifyCommands: ['npm run owner:verify-control -- --network <network>'],
+    },
+    {
+      key: 'thermodynamics',
+      title: 'Thermodynamics',
+      loader: loadThermodynamicsConfig,
+      summary:
+        'Governs reward weights, PID controller values, and entropy balancing.',
+      configDocs: [
+        'docs/thermodynamics-operations.md',
+        'docs/owner-control-zero-downtime-guide.md',
+      ],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updateThermodynamics.ts --network <network>',
+      ],
+      verifyCommands: ['npm run owner:verify-control -- --network <network>'],
+    },
+    {
+      key: 'hamiltonian',
+      title: 'Hamiltonian Monitor',
+      loader: loadHamiltonianMonitorConfig,
+      summary:
+        'Controls Hamiltonian window, observation history, and reporting cadence.',
+      configDocs: ['docs/hamiltonian-monitor.md'],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updateHamiltonianMonitor.ts --network <network>',
+      ],
+      verifyCommands: [
+        'npm run owner:verify-control -- --network <network>',
+        'npm run hamiltonian:report -- --network <network>',
+      ],
+    },
+    {
+      key: 'energyOracle',
+      title: 'Energy Oracle',
+      loader: loadEnergyOracleConfig,
+      summary:
+        'Authorises measurement signers and quorum thresholds for energy attestations.',
+      configDocs: ['docs/energy-oracle-operations.md'],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updateEnergyOracle.ts --network <network>',
+      ],
+      verifyCommands: ['npm run owner:verify-control -- --network <network>'],
+    },
+    {
+      key: 'identityRegistry',
+      title: 'Identity Registry',
+      loader: loadIdentityRegistryConfig,
+      summary:
+        'Defines ENS roots, alias handling, and emergency allowlists for identities.',
+      configDocs: [
+        'docs/ens-identity-policy.md',
+        'docs/owner-control-non-technical-guide.md',
+      ],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updateIdentityRegistry.ts --network <network>',
+      ],
+      verifyCommands: ['npm run owner:verify-control -- --network <network>'],
+    },
+    {
+      key: 'randaoCoordinator',
+      title: 'Randao Coordinator',
+      loader: loadRandaoCoordinatorConfig,
+      summary:
+        'Coordinates randomness beacons, commit/reveal cadence, and slashing tolerances.',
+      configDocs: ['docs/owner-control-command-center.md'],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updateRandaoCoordinator.ts --network <network>',
+      ],
+      verifyCommands: ['npm run owner:verify-control -- --network <network>'],
+    },
+    {
+      key: 'taxPolicy',
+      title: 'Tax Policy',
+      loader: loadTaxPolicyConfig,
+      summary:
+        'Manages jurisdictional tax routing and optional withholding wallets.',
+      configDocs: [
+        'docs/owner-control-handbook.md',
+        'docs/owner-control-zero-downtime-guide.md',
+      ],
+      updateCommands: [
+        'npx hardhat run scripts/v2/updateTaxPolicy.ts --network <network>',
+      ],
+      verifyCommands: ['npm run owner:verify-control -- --network <network>'],
+    },
+  ];
+
+  const modules = await Promise.all(
+    moduleDescriptors.map((descriptor) =>
+      buildModuleTicket(descriptor, options.network)
+    )
+  );
+  const blockingIssues = modules
+    .filter((module) => module.loadError)
+    .map((module) => `${module.title}: ${module.loadError}`);
+
+  const ticket: TicketPayload = {
+    generatedAt: new Date().toISOString(),
+    network: ownerControl.network ?? options.network ?? token.network,
+    hardhat: hardhatContext,
+    ownerAddress: ownerControl.config.owner,
+    governanceAddress: ownerControl.config.governance,
+    ownerConfigPath: normalisePath(ownerControl.path),
+    ownerConfigHash: await computeHash(ownerControl.path),
+    tokenConfigPath: normalisePath(token.path),
+    tokenConfigHash: await computeHash(token.path),
+    stages: stages.map((stage) => ({
+      ...stage,
+      commands: stage.commands.map((command) =>
+        replaceNetworkPlaceholder(command, options.network)
+      ),
+    })),
+    modules,
+    environmentChecklist: [
+      'Set RPC_URL or pass --rpc to commands that require chain access.',
+      'Export OWNER_PRIVATE_KEY and GOVERNANCE_PRIVATE_KEY in a secure shell, never in Git.',
+      'Ensure reports/<network>/ exists and is git-ignored for sensitive artefacts.',
+      'Record multisig policy approvals before executing owner:update-all.',
+    ],
+    attachmentChecklist: [
+      'owner-surface.md snapshot',
+      'owner-plan.json dry-run',
+      'owner-safe-bundle.json (if Safe execution)',
+      'owner-audit.md and owner-atlas.md',
+      'Transaction receipts + Safe execution logs',
+    ],
+    mermaid: undefined,
+    blockingIssues: blockingIssues.length ? blockingIssues : undefined,
+  };
+
+  if (options.includeMermaid) {
+    ticket.mermaid = buildMermaid(ticket.stages);
+  }
+
+  return ticket;
+}
+
+function renderMarkdown(ticket: TicketPayload): string {
+  const lines: string[] = [];
+  lines.push('# Owner Change Ticket');
+  lines.push('');
+  lines.push(`Generated: ${ticket.generatedAt}`);
+  if (ticket.network) {
+    lines.push(`Network: **${ticket.network}**`);
+  }
+  if (ticket.hardhat?.name || ticket.hardhat?.chainId) {
+    lines.push(
+      `Hardhat Context: ${ticket.hardhat?.name ?? '—'} (chainId: ${
+        ticket.hardhat?.chainId ?? 'unknown'
+      })`
+    );
+  }
+  lines.push('');
+
+  lines.push('## Control Envelope');
+  lines.push('');
+  lines.push(`- Owner: \`${ticket.ownerAddress ?? 'unset'}\``);
+  lines.push(`- Governance: \`${ticket.governanceAddress ?? 'unset'}\``);
+  lines.push(
+    `- Owner Control Config: ${ticket.ownerConfigPath ?? 'unknown'}${
+      ticket.ownerConfigHash ? ` (sha256: ${ticket.ownerConfigHash})` : ''
+    }`
+  );
+  lines.push(
+    `- Token Config: ${ticket.tokenConfigPath ?? 'unknown'}${
+      ticket.tokenConfigHash ? ` (sha256: ${ticket.tokenConfigHash})` : ''
+    }`
+  );
+  lines.push('');
+
+  if (ticket.environmentChecklist.length) {
+    lines.push('### Environment Checklist');
+    lines.push('');
+    for (const item of ticket.environmentChecklist) {
+      lines.push(`- [ ] ${item}`);
+    }
+    lines.push('');
+  }
+
+  if (ticket.blockingIssues && ticket.blockingIssues.length) {
+    lines.push('### Blocking Issues');
+    lines.push('');
+    for (const issue of ticket.blockingIssues) {
+      lines.push(`- ❌ ${issue}`);
+    }
+    lines.push('');
+  }
+
+  if (ticket.mermaid) {
+    lines.push('```mermaid');
+    lines.push(ticket.mermaid);
+    lines.push('```');
+    lines.push('');
+  }
+
+  lines.push('## Stage Plan');
+  lines.push('');
+  for (const stage of ticket.stages) {
+    lines.push(`### ${stage.title}`);
+    lines.push('');
+    lines.push(`${stage.purpose}`);
+    lines.push('');
+    for (const command of stage.commands) {
+      lines.push(`- \`${command}\``);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Module Control Surface');
+  lines.push('');
+  for (const module of ticket.modules) {
+    lines.push(`### ${module.title}`);
+    lines.push('');
+    lines.push(`${module.summary}`);
+    lines.push('');
+    lines.push(
+      `- Config: ${module.configPath}${
+        module.configHash ? ` (sha256: ${module.configHash})` : ''
+      }`
+    );
+    if (module.loadError) {
+      lines.push('');
+      lines.push(`> **Load error:** ${module.loadError}`);
+      lines.push('');
+    }
+    if (module.sampleParameters.length) {
+      lines.push('');
+      lines.push('Key parameters:');
+      lines.push('');
+      for (const snippet of module.sampleParameters) {
+        lines.push(formatSnippet(snippet));
+      }
+      lines.push('');
+    }
+    if (module.updateCommands.length) {
+      lines.push('Update commands:');
+      lines.push('');
+      for (const command of module.updateCommands) {
+        lines.push(`- \`${command}\``);
+      }
+      lines.push('');
+    }
+    if (module.verifyCommands.length) {
+      lines.push('Verification commands:');
+      lines.push('');
+      for (const command of module.verifyCommands) {
+        lines.push(`- \`${command}\``);
+      }
+      lines.push('');
+    }
+    if (module.docs.length) {
+      lines.push('Docs:');
+      lines.push('');
+      for (const doc of module.docs) {
+        lines.push(`- [${path.basename(doc)}](${doc})`);
+      }
+      lines.push('');
+    }
+  }
+
+  if (ticket.attachmentChecklist.length) {
+    lines.push('## Attachments');
+    lines.push('');
+    for (const item of ticket.attachmentChecklist) {
+      lines.push(`- [ ] ${item}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+function renderHuman(ticket: TicketPayload): string {
+  const lines: string[] = [];
+  lines.push('=== Owner Change Ticket ===');
+  lines.push(`Generated: ${ticket.generatedAt}`);
+  lines.push(`Network: ${ticket.network ?? 'unknown'}`);
+  lines.push(
+    `Hardhat: ${ticket.hardhat?.name ?? 'n/a'} (chainId: ${
+      ticket.hardhat?.chainId ?? 'n/a'
+    })`
+  );
+  lines.push(`Owner: ${ticket.ownerAddress ?? 'unset'}`);
+  lines.push(`Governance: ${ticket.governanceAddress ?? 'unset'}`);
+  lines.push(
+    `Owner Config: ${ticket.ownerConfigPath ?? 'unknown'}${
+      ticket.ownerConfigHash ? ` (sha256: ${ticket.ownerConfigHash})` : ''
+    }`
+  );
+  lines.push(
+    `Token Config: ${ticket.tokenConfigPath ?? 'unknown'}${
+      ticket.tokenConfigHash ? ` (sha256: ${ticket.tokenConfigHash})` : ''
+    }`
+  );
+  lines.push('');
+
+  if (ticket.environmentChecklist.length) {
+    lines.push('Environment Checklist:');
+    for (const item of ticket.environmentChecklist) {
+      lines.push(`  [ ] ${item}`);
+    }
+    lines.push('');
+  }
+
+  if (ticket.blockingIssues && ticket.blockingIssues.length) {
+    lines.push('Blocking Issues:');
+    for (const issue of ticket.blockingIssues) {
+      lines.push(`  ❌ ${issue}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('Stage Plan:');
+  for (const stage of ticket.stages) {
+    lines.push(`- ${stage.title}: ${stage.purpose}`);
+    for (const command of stage.commands) {
+      lines.push(`    • ${command}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('Modules:');
+  for (const module of ticket.modules) {
+    lines.push(`- ${module.title}: ${module.summary}`);
+    lines.push(
+      `    Config: ${module.configPath}${
+        module.configHash ? ` (sha256: ${module.configHash})` : ''
+      }`
+    );
+    if (module.loadError) {
+      lines.push(`    Load error: ${module.loadError}`);
+    }
+    if (module.sampleParameters.length) {
+      lines.push('    Parameters:');
+      for (const snippet of module.sampleParameters) {
+        lines.push(`      - ${snippet.key}: ${snippet.value}`);
+      }
+    }
+    if (module.updateCommands.length) {
+      lines.push('    Update:');
+      for (const command of module.updateCommands) {
+        lines.push(`      • ${command}`);
+      }
+    }
+    if (module.verifyCommands.length) {
+      lines.push('    Verify:');
+      for (const command of module.verifyCommands) {
+        lines.push(`      • ${command}`);
+      }
+    }
+    if (module.docs.length) {
+      lines.push('    Docs:');
+      for (const doc of module.docs) {
+        lines.push(`      • ${doc}`);
+      }
+    }
+  }
+  lines.push('');
+
+  if (ticket.attachmentChecklist.length) {
+    lines.push('Attachments:');
+    for (const item of ticket.attachmentChecklist) {
+      lines.push(`  [ ] ${item}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+async function emit(ticket: TicketPayload, options: CliOptions): Promise<void> {
+  let output: string;
+  if (options.format === 'json') {
+    output = `${JSON.stringify(ticket, null, 2)}\n`;
+  } else if (options.format === 'human') {
+    output = `${renderHuman(ticket)}\n`;
+  } else {
+    output = `${renderMarkdown(ticket)}\n`;
+  }
+
+  if (options.outPath) {
+    const outDir = path.dirname(options.outPath);
+    await fs.mkdir(outDir, { recursive: true });
+    await fs.writeFile(options.outPath, output, 'utf8');
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+function printUsage(): void {
+  console.log(
+    'Usage: ts-node ownerChangeTicket.ts [--network <network>] [--out <path>] [--format markdown|human|json] [--no-mermaid]'
+  );
+}
+
+async function main(): Promise<void> {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printUsage();
+      return;
+    }
+    const ticket = await buildTicket(options);
+    await emit(ticket, options);
+  } catch (error) {
+    console.error('owner:change-ticket failed:', error);
+    process.exitCode = 1;
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary
- add `owner:change-ticket` CLI that collects owner configuration metadata, hashes manifests, and tolerates loader issues by surfacing blocking items in the output
- document the workflow in a new illustrated Owner Control Change Ticket guide and reference it from the README

## Testing
- `npx eslint scripts/v2/ownerChangeTicket.ts --max-warnings=0`
- `npm run owner:change-ticket -- --network sepolia --no-mermaid --format human | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_68dedabcca34833383ae9a2f13a6fed8