### PR TITLE
Add validator stake locking to validation flow

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -38,6 +38,7 @@ contract MockStakeManager is IStakeManager {
     function acknowledgeAndWithdraw(Role, uint256) external override {}
     function withdrawStake(Role, uint256) external override {}
     function lockStake(address, uint256, uint64) external override {}
+    function lockValidatorStake(address, uint256, uint64) external override {}
     function lockReward(bytes32, address, uint256) external override {}
     function lock(address, uint256) external override {}
     function releaseReward(bytes32, address, address, uint256, bool) external override {}
@@ -45,6 +46,7 @@ contract MockStakeManager is IStakeManager {
     function redistributeEscrow(bytes32, address, uint256) external override {}
     function redistributeEscrow(bytes32, address, uint256, address[] calldata) external override {}
     function releaseStake(address, uint256) external override {}
+    function unlockValidatorStake(address, uint256) external override {}
     function release(address, address, uint256, bool) external override {}
     function finalizeJobFunds(
         bytes32,

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -140,6 +140,12 @@ interface IStakeManager {
     /// @param lockTime seconds until the stake unlocks
     function lockStake(address user, uint256 amount, uint64 lockTime) external;
 
+    /// @notice lock validator stake for a validation round
+    /// @param user validator address whose stake is being locked
+    /// @param amount token amount with 18 decimals
+    /// @param lockTime seconds until the stake unlocks
+    function lockValidatorStake(address user, uint256 amount, uint64 lockTime) external;
+
     /// @notice lock job reward from an employer
     function lockReward(bytes32 jobId, address from, uint256 amount) external;
 
@@ -175,6 +181,9 @@ interface IStakeManager {
 
     /// @notice release previously locked stake for a user
     function releaseStake(address user, uint256 amount) external;
+
+    /// @notice release stake locked for validation
+    function unlockValidatorStake(address user, uint256 amount) external;
 
     /// @notice release funds locked via {lock}
     /// @param employer employer responsible for burns

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -39,6 +39,7 @@ contract ReentrantStakeManager is IStakeManager {
     function acknowledgeAndWithdraw(Role, uint256) external override {}
     function withdrawStake(Role, uint256) external override {}
     function lockStake(address, uint256, uint64) external override {}
+    function lockValidatorStake(address, uint256, uint64) external override {}
     function lockReward(bytes32, address, uint256) external override {}
     function lock(address, uint256) external override {}
     function releaseReward(bytes32, address, address, uint256, bool) external override {}
@@ -46,6 +47,7 @@ contract ReentrantStakeManager is IStakeManager {
     function redistributeEscrow(bytes32, address, uint256) external override {}
     function redistributeEscrow(bytes32, address, uint256, address[] calldata) external override {}
     function releaseStake(address, uint256) external override {}
+    function unlockValidatorStake(address, uint256) external override {}
     function release(address, address, uint256, bool) external override {}
     function finalizeJobFunds(
         bytes32,

--- a/test/v2/ValidatorSelectionFuzz.t.sol
+++ b/test/v2/ValidatorSelectionFuzz.t.sol
@@ -43,6 +43,7 @@ contract ValidatorSelectionFuzz is Test {
             new address[](0)
         );
         validation.setIdentityRegistry(IIdentityRegistry(address(identity)));
+        stake.setValidationModule(address(validation));
     }
 
     function testFuzz_validatorSelection(uint8 poolSize, uint8 selectCount) public {


### PR DESCRIPTION
## Summary
- add validator-specific stake locking helpers to the stake manager and update the public interface for validation use
- lock and release validator stakes during commit/reveal rounds in the validation module and track per-validator lock balances
- extend test coverage with regression tests for validator withdrawals and short unbonding slashing while updating existing harnesses

## Testing
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_68dee58cd58c8333ab3fd55bcb64de7b