### PR TITLE
Add validator-specific stake locks and regression tests

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -38,7 +38,8 @@ contract MockStakeManager is IStakeManager {
     function acknowledgeAndWithdraw(Role, uint256) external override {}
     function withdrawStake(Role, uint256) external override {}
     function lockStake(address, uint256, uint64) external override {}
-    function lockValidatorStake(address, uint256, uint64) external override {}
+    function setValidatorLockManager(address, bool) external override {}
+    function lockValidatorStake(uint256, address, uint256, uint64) external override {}
     function lockReward(bytes32, address, uint256) external override {}
     function lock(address, uint256) external override {}
     function releaseReward(bytes32, address, address, uint256, bool) external override {}
@@ -46,7 +47,7 @@ contract MockStakeManager is IStakeManager {
     function redistributeEscrow(bytes32, address, uint256) external override {}
     function redistributeEscrow(bytes32, address, uint256, address[] calldata) external override {}
     function releaseStake(address, uint256) external override {}
-    function unlockValidatorStake(address, uint256) external override {}
+    function unlockValidatorStake(uint256, address, uint256) external override {}
     function release(address, address, uint256, bool) external override {}
     function finalizeJobFunds(
         bytes32,

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -65,6 +65,9 @@ interface IStakeManager {
     event DisputeFeePaid(address indexed to, uint256 amount);
     event DisputeModuleUpdated(address module);
     event ValidationModuleUpdated(address module);
+    event ValidatorLockManagerUpdated(address indexed manager, bool allowed);
+    event ValidatorStakeLocked(uint256 indexed jobId, address indexed validator, uint256 amount, uint64 unlockTime);
+    event ValidatorStakeUnlocked(uint256 indexed jobId, address indexed validator, uint256 amount);
     event ModulesUpdated(address jobRegistry, address disputeModule);
     event MinStakeUpdated(uint256 minStake);
     event RoleMinimumUpdated(Role indexed role, uint256 minStake);
@@ -140,11 +143,15 @@ interface IStakeManager {
     /// @param lockTime seconds until the stake unlocks
     function lockStake(address user, uint256 amount, uint64 lockTime) external;
 
+    /// @notice update the allowlist of addresses permitted to manage validator locks
+    function setValidatorLockManager(address manager, bool allowed) external;
+
     /// @notice lock validator stake for a validation round
+    /// @param jobId identifier of the job requesting validation
     /// @param user validator address whose stake is being locked
     /// @param amount token amount with 18 decimals
     /// @param lockTime seconds until the stake unlocks
-    function lockValidatorStake(address user, uint256 amount, uint64 lockTime) external;
+    function lockValidatorStake(uint256 jobId, address user, uint256 amount, uint64 lockTime) external;
 
     /// @notice lock job reward from an employer
     function lockReward(bytes32 jobId, address from, uint256 amount) external;
@@ -183,7 +190,7 @@ interface IStakeManager {
     function releaseStake(address user, uint256 amount) external;
 
     /// @notice release stake locked for validation
-    function unlockValidatorStake(address user, uint256 amount) external;
+    function unlockValidatorStake(uint256 jobId, address user, uint256 amount) external;
 
     /// @notice release funds locked via {lock}
     /// @param employer employer responsible for burns

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -39,7 +39,8 @@ contract ReentrantStakeManager is IStakeManager {
     function acknowledgeAndWithdraw(Role, uint256) external override {}
     function withdrawStake(Role, uint256) external override {}
     function lockStake(address, uint256, uint64) external override {}
-    function lockValidatorStake(address, uint256, uint64) external override {}
+    function setValidatorLockManager(address, bool) external override {}
+    function lockValidatorStake(uint256, address, uint256, uint64) external override {}
     function lockReward(bytes32, address, uint256) external override {}
     function lock(address, uint256) external override {}
     function releaseReward(bytes32, address, address, uint256, bool) external override {}
@@ -47,7 +48,7 @@ contract ReentrantStakeManager is IStakeManager {
     function redistributeEscrow(bytes32, address, uint256) external override {}
     function redistributeEscrow(bytes32, address, uint256, address[] calldata) external override {}
     function releaseStake(address, uint256) external override {}
-    function unlockValidatorStake(address, uint256) external override {}
+    function unlockValidatorStake(uint256, address, uint256) external override {}
     function release(address, address, uint256, bool) external override {}
     function finalizeJobFunds(
         bytes32,


### PR DESCRIPTION
## Summary
- add validator lock manager allowlist, new events, and job-aware validator stake lock helpers in StakeManager
- update ValidationModule to use the new helpers, release locks on failover cleanup paths, and call locks before emitting ValidatorsSelected
- extend validator stake withdrawal tests to cover active job reverts and ensure finalization still succeeds after withdrawal attempts

## Testing
- `forge test --match-path test/v2/ValidatorStakeLock.t.sol` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68deea80c2d4833393512f24e6c98b17