### PR TITLE
Add moderator quorum support to dispute module

### DIFF
--- a/contracts/v2/Deployer.sol
+++ b/contracts/v2/Deployer.sol
@@ -325,7 +325,8 @@ contract Deployer is Ownable {
             IJobRegistry(address(registry)),
             0,
             0,
-            address(0)
+            address(0),
+            governance
         );
 
         ArbitratorCommittee committee = new ArbitratorCommittee(

--- a/contracts/v2/interfaces/IDisputeModule.sol
+++ b/contracts/v2/interfaces/IDisputeModule.sol
@@ -21,6 +21,12 @@ interface IDisputeModule {
 
     function resolveDispute(uint256 jobId, bool employerWins) external;
 
+    function resolveWithSignatures(
+        uint256 jobId,
+        bool employerWins,
+        bytes[] calldata signatures
+    ) external;
+
     function submitEvidence(
         uint256 jobId,
         bytes32 evidenceHash,

--- a/contracts/v2/modules/KlerosDisputeModule.sol
+++ b/contracts/v2/modules/KlerosDisputeModule.sol
@@ -143,6 +143,15 @@ contract KlerosDisputeModule is IDisputeModule {
         emit DisputeResolved(jobId, employerWins);
     }
 
+    /// @inheritdoc IDisputeModule
+    function resolveWithSignatures(
+        uint256,
+        bool,
+        bytes[] calldata
+    ) external pure override {
+        revert Unsupported();
+    }
+
     /// @notice Backwards compatible alias for existing integrations.
     function resolve(uint256 jobId, bool employerWins) external onlyArbitrator {
         resolveDispute(jobId, employerWins);

--- a/scripts/deploy-v2.ts
+++ b/scripts/deploy-v2.ts
@@ -93,7 +93,8 @@ async function main() {
     await registry.getAddress(),
     0,
     0,
-    ethers.ZeroAddress
+    ethers.ZeroAddress,
+    deployer.address
   );
   await dispute.waitForDeployment();
   const Committee = await ethers.getContractFactory(

--- a/scripts/deploy/providerAgnosticDeploy.ts
+++ b/scripts/deploy/providerAgnosticDeploy.ts
@@ -262,7 +262,8 @@ async function deployContracts(ctx: DeploymentContext) {
     ethers.ZeroAddress,
     disputeFee,
     disputeWindow,
-    ethers.ZeroAddress
+    ethers.ZeroAddress,
+    ctx.governanceTarget
   );
   await dispute.waitForDeployment();
 

--- a/scripts/v2/deploy.ts
+++ b/scripts/v2/deploy.ts
@@ -187,7 +187,8 @@ async function main() {
     await registry.getAddress(),
     appealFee,
     disputeWindow,
-    ethers.ZeroAddress
+    ethers.ZeroAddress,
+    governance
   );
   await dispute.waitForDeployment();
   const Committee = await ethers.getContractFactory(

--- a/test/fork/mainnet-job-lifecycle.fork.test.ts
+++ b/test/fork/mainnet-job-lifecycle.fork.test.ts
@@ -181,7 +181,8 @@ describeFork('Mainnet fork · job lifecycle drill', function () {
       await registry.getAddress(),
       0,
       0,
-      moderator.address
+      moderator.address,
+      owner.address
     );
 
     const FeePool = await ethers.getContractFactory(

--- a/test/v2/ArbitratorCommittee.test.js
+++ b/test/v2/ArbitratorCommittee.test.js
@@ -54,7 +54,8 @@ describe('ArbitratorCommittee', function () {
       await registry.getAddress(),
       FEE,
       10n,
-      ethers.ZeroAddress
+      ethers.ZeroAddress,
+      owner.address
     );
     await dispute.waitForDeployment();
     await registry.setDisputeModule(await dispute.getAddress());

--- a/test/v2/DisputeModuleModuleNoEther.test.js
+++ b/test/v2/DisputeModuleModuleNoEther.test.js
@@ -16,7 +16,8 @@ describe('DisputeModule module ether rejection', function () {
       await registry.getAddress(),
       0,
       0,
-      ethers.ZeroAddress
+      ethers.ZeroAddress,
+      owner.address
     );
     await dispute.waitForDeployment();
   });

--- a/test/v2/EmployerReputation.test.js
+++ b/test/v2/EmployerReputation.test.js
@@ -91,7 +91,8 @@ describe('Employer reputation', function () {
       await registry.getAddress(),
       0,
       0,
-      ethers.ZeroAddress
+      ethers.ZeroAddress,
+      owner.address
     );
     await dispute.connect(owner).setDisputeFee(disputeFee);
     const Policy = await ethers.getContractFactory(

--- a/test/v2/JobExpiration.test.js
+++ b/test/v2/JobExpiration.test.js
@@ -82,7 +82,8 @@ describe('Job expiration', function () {
       await registry.getAddress(),
       0,
       0,
-      ethers.ZeroAddress
+      ethers.ZeroAddress,
+      owner.address
     );
     await stakeManager
       .connect(owner)

--- a/test/v2/JobExpirationBoundary.test.js
+++ b/test/v2/JobExpirationBoundary.test.js
@@ -82,7 +82,8 @@ describe('Job expiration boundary', function () {
       await registry.getAddress(),
       0,
       0,
-      ethers.ZeroAddress
+      ethers.ZeroAddress,
+      owner.address
     );
     await stakeManager
       .connect(owner)

--- a/test/v2/JobRegistry.test.js
+++ b/test/v2/JobRegistry.test.js
@@ -92,7 +92,8 @@ describe('JobRegistry integration', function () {
       await registry.getAddress(),
       0,
       0,
-      ethers.ZeroAddress
+      ethers.ZeroAddress,
+      owner.address
     );
     await dispute.connect(owner).setDisputeFee(disputeFee);
     const Policy = await ethers.getContractFactory(

--- a/test/v2/MidJobUpgrade.test.js
+++ b/test/v2/MidJobUpgrade.test.js
@@ -85,6 +85,7 @@ async function deploySystem() {
     await registry.getAddress(),
     0,
     0,
+    owner.address,
     owner.address
   );
   await dispute.waitForDeployment();

--- a/test/v2/ModuleReplacement.test.js
+++ b/test/v2/ModuleReplacement.test.js
@@ -85,6 +85,7 @@ async function deploySystem() {
     await registry.getAddress(),
     0,
     0,
+    owner.address,
     owner.address
   );
   await dispute.waitForDeployment();

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -97,6 +97,7 @@ describe('comprehensive job flows', function () {
       await registry.getAddress(),
       0,
       0,
+      owner.address,
       owner.address
     );
     await dispute.setDisputeFee(disputeFee);

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -95,7 +95,8 @@ describe('end-to-end job lifecycle', function () {
       await registry.getAddress(),
       0,
       0,
-      ethers.ZeroAddress
+      ethers.ZeroAddress,
+      owner.address
     );
     await dispute.connect(owner).setDisputeFee(disputeFee);
 

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -110,7 +110,8 @@ async function deploySystem() {
     await registry.getAddress(),
     0,
     0,
-    moderator.address
+    moderator.address,
+    owner.address
   );
 
   await stake.setModules(

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -93,7 +93,8 @@ describe('job finalization integration', function () {
       await registry.getAddress(),
       0,
       0,
-      ethers.ZeroAddress
+      ethers.ZeroAddress,
+      owner.address
     );
     await dispute.connect(owner).setDisputeFee(0);
     await dispute.connect(owner).setDisputeWindow(0);

--- a/test/v2/jobLifecycle.test.ts
+++ b/test/v2/jobLifecycle.test.ts
@@ -93,7 +93,8 @@ async function deploySystem() {
     await registry.getAddress(),
     0,
     0,
-    moderator.address
+    moderator.address,
+    owner.address
   );
 
   await stake.setModules(

--- a/test/v2/midJobReplacementFuzz.test.js
+++ b/test/v2/midJobReplacementFuzz.test.js
@@ -84,6 +84,7 @@ async function deploySystem() {
     await registry.getAddress(),
     0,
     0,
+    owner.address,
     owner.address
   );
 

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -97,7 +97,8 @@ describe('multi-operator job lifecycle', function () {
       await registry.getAddress(),
       0,
       0,
-      ethers.ZeroAddress
+      ethers.ZeroAddress,
+      owner.address
     );
 
     const FeePoolF = await ethers.getContractFactory(

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -89,7 +89,8 @@ async function deploySystem() {
     await registry.getAddress(),
     0,
     0,
-    moderator.address
+    moderator.address,
+    owner.address
   );
   await dispute.waitForDeployment();
   await dispute.setStakeManager(await stake.getAddress());

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -90,7 +90,8 @@ async function deployFullSystem() {
     await registry.getAddress(),
     0,
     0,
-    moderator.address
+    moderator.address,
+    owner.address
   );
   await dispute.waitForDeployment();
   await dispute.setStakeManager(await stake.getAddress());


### PR DESCRIPTION
## Summary
- convert the DisputeModule to use the shared Governable pattern, add moderator weight tracking, and introduce a signature-based dispute resolution path alongside stricter pause controls
- extend the IDisputeModule interface (and KlerosDisputeModule stub) plus deployment scripts to accept the governance address
- update dispute-related tests to cover the new signature quorum flow and adjust constructor arguments accordingly

## Testing
- `npx hardhat compile --force` *(hangs in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deee96559c8333855d178678855642