### PR TITLE
Allow 3-member validation committees to pass with two approvals

### DIFF
--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -98,7 +98,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     uint256 public constant DEFAULT_REVEAL_WINDOW = 30 minutes;
     uint256 public constant DEFAULT_MIN_VALIDATORS = 3;
     uint256 public constant DEFAULT_MAX_VALIDATORS = 5;
-    uint256 public constant DEFAULT_APPROVAL_THRESHOLD = 67;
+    uint256 public constant DEFAULT_APPROVAL_THRESHOLD = 66;
     uint256 public constant DEFAULT_REVEAL_QUORUM_PCT = 67;
     uint256 public constant DEFAULT_FORCE_FINALIZE_GRACE = 1 hours;
     uint256 public forceFinalizeGrace = DEFAULT_FORCE_FINALIZE_GRACE;

--- a/docs/incentive-analysis-v2.md
+++ b/docs/incentive-analysis-v2.md
@@ -21,7 +21,8 @@ sequenceDiagram
     VM->>JR: result
 ```
 
-Majority approval releases rewards; any minority can escalate to the `DisputeModule` by paying a dispute fee.
+Majority approval releases rewards; any minority can escalate to the `DisputeModule` by paying a dispute fee. With the revised
+default `approvalThreshold` of 66%, two validators in a three-member committee now satisfy the majority requirement.
 
 ## Slashing & Redistribution
 

--- a/docs/validator-handbook.md
+++ b/docs/validator-handbook.md
@@ -108,7 +108,7 @@ Call `revealValidation(jobId, approveBit, salt)` within the **reveal window**.
 
 **Finalize**  
 Anyone can call `finalize(jobId)` after reveal closes. The job passes if:
-- Reveals ≥ `minValidators` **and** approvals meet `approvalThreshold` (e.g., ≥⅔).  
+- Reveals ≥ `minValidators` **and** approvals meet `approvalThreshold` (default 66%, so two approvals finalise a three-validator round).
 - Results route rewards/penalties; reputation updates are emitted.
 
 ```mermaid
@@ -178,7 +178,7 @@ pie title Reward Budget (illustrative)
 - `burnPct` / treasury routing — fee policy.
 
 > **Typical starting points (tune per chain latency & volume):**  
-> `minStake`: ≥ 2–5× max per‑job validator payout • `K`: 5–9 • `approvalThreshold`: ≥66.7% • `commitWindow`: 30–60 min • `revealWindow`: 15–30 min.
+> `minStake`: ≥ 2–5× max per‑job validator payout • `K`: 5–9 • `approvalThreshold`: ≥66% (two approvals in a three-member committee) • `commitWindow`: 30–60 min • `revealWindow`: 15–30 min.
 
 ---
 

--- a/test/v2/ValidationModuleFlow.test.js
+++ b/test/v2/ValidationModuleFlow.test.js
@@ -162,7 +162,7 @@ describe('ValidationModule finalize flows', function () {
       1,
       nonce,
       v2.address,
-      false,
+      true,
       burnTxHash,
       salt2,
       specHash,
@@ -192,11 +192,12 @@ describe('ValidationModule finalize flows', function () {
       .revealValidation(1, true, burnTxHash, salt1, 'validator', []);
     await validation
       .connect(v2)
-      .revealValidation(1, false, burnTxHash, salt2, 'validator', []);
+      .revealValidation(1, true, burnTxHash, salt2, 'validator', []);
     await validation
       .connect(v3)
       .revealValidation(1, false, burnTxHash, salt3, 'validator', []);
     await advance(61);
+    expect(await validation.callStatic.finalize(1)).to.equal(true);
     await validation.finalize(1);
     await jobRegistry.connect(employer).confirmEmployerBurn(1, burnTxHash);
     await jobRegistry.connect(employer).finalize(1);


### PR DESCRIPTION
## Summary
- lower the default approval threshold to 66% so two validators can finalise a three-member committee
- extend the v2 validation flow test to assert finalize succeeds with two approvals and one rejection
- document the updated majority requirement for operators and validators

## Testing
- npx hardhat test test/v2/ValidationModuleFlow.test.js *(hangs while compiling solc 0.8.25 in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68def68ed26883338462e0a3e60659d4