### PR TITLE
Add owner control pulse report and shared verification module

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 - [Owner control audit](#owner-control-audit)
 - [Owner control systems map](#owner-control-systems-map)
 - [Owner control quick reference CLI](#owner-control-quick-reference-cli)
+- [Owner control pulse](#owner-control-pulse)
 - [Owner control master checklist](#owner-control-master-checklist)
 - [Owner control atlas](#owner-control-atlas)
 - [Owner control change ticket](#owner-control-change-ticket)
@@ -307,6 +308,29 @@ npm run owner:quickstart -- --network mainnet --format json --out reports/mainne
 ```
 
 The CLI stitches together `config/owner-control.json`, `config/agialpha*.json`, `config/stake-manager.json`, `config/fee-pool.json`, `config/reward-engine.json`, `config/thermodynamics.json`, `config/hamiltonian-monitor.json` and `config/energy-oracle.json`, then prints a deterministic operational checklist that mirrors the `owner:update-all` workflow. Full usage guidance—including troubleshooting tables, Mermaid diagrams and automation tips—lives in [docs/owner-control-quick-reference-cli.md](docs/owner-control-quick-reference-cli.md).
+
+### Owner control pulse
+
+Need an at-a-glance health score before approving a governance rotation or signing a Safe batch? The pulse helper wraps `verifyOwnerControl` into a colour-graded dashboard that non-technical owners can run in under a minute:
+
+```bash
+# Interactive terminal dashboard with JSON snapshot footer
+npm run owner:pulse -- --network <network>
+
+# Markdown artefact for change tickets or executive briefings
+OWNER_PULSE_FORMAT=markdown OWNER_PULSE_OUT=reports/mainnet-owner-pulse.md \
+  npm run owner:pulse -- --network mainnet
+
+# JSON-only output for bots, monitors or spreadsheets
+OWNER_PULSE_FORMAT=json OWNER_PULSE_OUT=reports/mainnet-owner-pulse.json \
+  npm run owner:pulse -- --network mainnet
+```
+
+> **Note:** Hardhat consumes unknown flags before the script runs. Use the
+> `OWNER_PULSE_*` environment variables when running via `npm run owner:pulse` or
+> invoke Hardhat directly with a trailing `--` to pass custom flags.
+
+The command scores every module, highlights mismatches, missing addresses and pending acceptOwnership calls, and emits both human-friendly and machine-readable summaries. Use the Markdown export to drop a Mermaid systems snapshot into a war-room deck, or pipe the JSON payload into monitoring dashboards to catch regressions automatically. Full illustrations, diagrams and workflow guidance live in [docs/owner-control-pulse.md](docs/owner-control-pulse.md).
 
 ### Owner control master checklist
 

--- a/docs/owner-control-pulse.md
+++ b/docs/owner-control-pulse.md
@@ -1,0 +1,183 @@
+# Owner Control Pulse
+
+> **Audience:** Contract owners, governance signers and operations leads who need an
+> instant view of whether production ownership matches the intended configuration.
+>
+> **Outcome:** A colour-graded health score, actionable remediation list and
+> machine-readable snapshot that can be dropped into change tickets, Safe bundles
+> or monitoring dashboards without touching Solidity.
+
+---
+
+## 1. Why the pulse matters
+
+```mermaid
+mindmap
+  root((Owner Pulse))
+    "Inputs"
+      "owner-control.json"
+      "docs/deployment-addresses.json"
+      "Environment overrides"
+    "On-chain queries"
+      "owner()"
+      "governance()"
+      "pendingOwner()"
+    "Outputs"
+      "Health score"
+      "Module timeline"
+      "JSON snapshot"
+      "Markdown brief"
+```
+
+- **Align stakeholders fast.** The pulse condenses the full
+  `verifyOwnerControl` dataset into a single grade that even non-technical
+  approvers can understand at a glance.
+- **Catch regressions before execution.** Run the command before authorising a
+  Safe bundle or rotation to confirm ownership, treasury wiring and pauser roles
+  still match configuration.
+- **Archive immutable evidence.** Every run can export Markdown and JSON so you
+  can prove compliance, trace sign-offs and feed observability pipelines.
+
+---
+
+## 2. Quick start workflow
+
+```bash
+# Human-readable output plus JSON footer for automation
+npm run owner:pulse -- --network <network>
+
+# Markdown artefact ready for change tickets or executive briefings
+OWNER_PULSE_FORMAT=markdown OWNER_PULSE_OUT=reports/mainnet-owner-pulse.md \
+  npm run owner:pulse -- --network mainnet
+
+# Strict machine output (no human prose)
+OWNER_PULSE_FORMAT=json OWNER_PULSE_OUT=reports/mainnet-owner-pulse.json \
+  npm run owner:pulse -- --network mainnet
+```
+
+```mermaid
+sequenceDiagram
+    participant You as Owner
+    participant Pulse as Pulse CLI
+    participant Chain as RPC / Contracts
+    participant Ledger as Outputs
+
+    You->>Pulse: npm run owner:pulse -- --network mainnet
+    Pulse->>Chain: Query owner(), governance(), pendingOwner()
+    Chain-->>Pulse: Live owner state + errors
+    Pulse->>Ledger: Health score + JSON snapshot + optional Markdown
+    Ledger-->>You: Attach to ticket, Safe bundle or monitoring system
+```
+
+- **No environment variables required.** The helper reads
+  `config/owner-control.json` and `docs/deployment-addresses.json` by default.
+  Override per run with `--address <module=0x...>` if you are testing new
+  deployments before updating the address book.
+- **JSON footer always on.** When `--format` is `human` or `markdown`, the CLI
+  prints a `JSON snapshot` section after the main report so automation can parse
+  the same run without a second command.
+- **Idempotent & read-only.** The helper never sends transactions; it only
+  inspects deployed contracts.
+
+---
+
+## 3. Understanding the health score
+
+```mermaid
+flowchart LR
+    Start[Start score 100] --> Mismatch{{Mismatch?}}
+    Mismatch -- yes -->|−35 each| Score
+    Start --> MissingAddr{{Missing address?}}
+    MissingAddr -- yes -->|−30 each| Score
+    Start --> MissingExpected{{Missing expected?}}
+    MissingExpected -- yes -->|−20 each| Score
+    Start --> Errors{{On-chain errors?}}
+    Errors -- yes -->|−45 each| Score
+    Start --> Skipped{{Skipped modules?}}
+    Skipped -- yes -->|−10 each| Score
+    Score --> Grade{Grade}
+    Grade -->|≥85| Green[Green]
+    Grade -->|60-84| Amber[Amber]
+    Grade -->|<60| Red[Red]
+```
+
+- **Green (≥85).** Everything matches configuration; archive the result as part
+  of your change ticket.
+- **Amber (60–84).** Issues exist but are typically recoverable via
+  configuration edits, address book updates or pending acceptOwnership calls.
+- **Red (<60).** Stop and remediate before signing any transactions. The
+  recommendations list will call out priority fixes.
+
+> **Pending owners:** Even when the current owner matches configuration, the CLI
+> highlights modules where `pendingOwner()` differs from `expectedOwner` so the
+> right signer can call `acceptOwnership`.
+
+---
+
+## 4. Options reference
+
+> **Tip:** When using the npm script (`npm run owner:pulse`) set script-specific
+> options via the `OWNER_PULSE_*` environment variables below. To pass flags
+> directly, invoke Hardhat manually (e.g. `npx hardhat run ... -- --format json`).
+
+| Flag | Description |
+| --- | --- |
+| `--network <name>` | Overrides the network key used to resolve config and address book entries. |
+| `--modules a,b` | Only include the listed modules in the pulse. |
+| `--skip a,b` | Exclude listed modules from the report. |
+| `--format <human\|markdown\|json>` | Chooses the output style. `--json` and `--markdown` are shortcuts. |
+| `--out <path>` | Writes the chosen format to disk. Parent folders are created automatically. |
+| `--address-book <path>` | Points to an alternative deployment address book file. |
+| `--address <module=0x...>` | Overrides a module address for the current run only. |
+
+Environment variables mirror the CLI flags for automation:
+
+- `OWNER_PULSE_NETWORK`, `OWNER_PULSE_MODULES`, `OWNER_PULSE_SKIP`
+- `OWNER_PULSE_FORMAT`, `OWNER_PULSE_JSON`
+- `OWNER_PULSE_ADDRESS_BOOK`, `OWNER_PULSE_ADDRESS_OVERRIDES`
+
+---
+
+## 5. Automating the pulse
+
+```mermaid
+flowchart TD
+    Cron[Cron / CI] --> PulseCLI[npm run owner:pulse -- --format json]
+    PulseCLI --> Artifact[reports/<network>/owner-pulse.json]
+    Artifact --> Monitor[SIEM / Dashboard]
+    Artifact --> Ticket[Change Ticket]
+```
+
+- **Continuous monitoring.** Schedule the pulse hourly against production RPC
+  endpoints. Feed the JSON payload into your SIEM or alerting stack to catch
+  unexpected ownership changes instantly.
+- **Change management.** Attach the Markdown export to Safe proposals and change
+  tickets. Auditors can see the health grade, module notes and action list in one
+  page.
+- **Disaster recovery drills.** Run the pulse immediately after executing
+  `owner:update-all` or `owner:rotate` to verify the system returned to the
+  expected state.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+| --- | --- | --- |
+| `❌ mismatch` rows | On-chain owner/governance differs from `owner-control.json`. | Queue a new `owner:rotate` plan or update the configuration to match intentional changes. |
+| `⚠️ missing-address` rows | Module address unknown in config/address book. | Populate `modules.<key>.address` or update `docs/deployment-addresses.json`, then rerun. |
+| `⚠️ missing-expected` rows | No expected owner configured. | Ensure `ownerControl.owner`/`governance` or module-level overrides are set. |
+| `❌ error` rows | RPC connectivity issues or ABI mismatch. | Retry with a healthy RPC; confirm the module exposes `owner()`/`governance()` as expected. |
+| Health score drops below threshold | Pending ownership acceptances or skipped modules. | Run `npm run owner:verify-control -- --strict` to pinpoint remaining issues and complete acceptances. |
+
+---
+
+## 7. Next steps
+
+- Pair the pulse report with the [Owner Control Surface](docs/owner-control-surface.md)
+  to archive a full governance snapshot.
+- Use the [Owner Control Change Ticket](docs/owner-control-change-ticket.md)
+  when proposing modifications—embed the pulse Markdown for instant context.
+- Feed the JSON snapshot into the telemetry pipeline outlined in
+  [owner-control-command-center.md](docs/owner-control-command-center.md) so the
+  health grade becomes part of your operational dashboards.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "owner:change-ticket": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerChangeTicket.ts",
     "owner:blueprint": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlBlueprint.ts",
     "owner:verify-control": "npx hardhat run --no-compile scripts/v2/verifyOwnerControl.ts",
+    "owner:pulse": "npx hardhat run --no-compile scripts/v2/ownerControlPulse.ts",
     "owner:rotate": "npx hardhat run --no-compile scripts/v2/rotateGovernance.ts",
     "owner:update-all": "npx hardhat run --no-compile scripts/v2/updateAllModules.ts",
     "owner:surface": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlSurface.ts",

--- a/scripts/v2/lib/ownerControlVerification.ts
+++ b/scripts/v2/lib/ownerControlVerification.ts
@@ -1,0 +1,528 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { ethers, network } from 'hardhat';
+import {
+  loadOwnerControlConfig,
+  inferNetworkKey,
+  type OwnerControlConfig,
+  type OwnerControlModuleConfig,
+} from '../../config';
+import { sameAddress } from './utils';
+
+export type ModuleType = 'governable' | 'ownable' | 'ownable2step';
+
+export type ModuleStatus =
+  | 'ok'
+  | 'mismatch'
+  | 'missing-address'
+  | 'missing-expected'
+  | 'skipped'
+  | 'error';
+
+export interface ModuleCheck {
+  key: string;
+  label: string;
+  type: ModuleType;
+  address?: string;
+  addressSource?: string;
+  expectedOwner?: string;
+  expectedSource?: string;
+  currentOwner?: string;
+  pendingOwner?: string | null;
+  status: ModuleStatus;
+  notes: string[];
+  error?: string;
+}
+
+export interface OwnerControlSummary {
+  ok: number;
+  mismatch: number;
+  missingAddress: number;
+  missingExpected: number;
+  skipped: number;
+  error: number;
+}
+
+export interface OwnerControlVerificationOptions {
+  configNetwork?: string;
+  modules?: string[];
+  skip?: string[];
+  addressBookPath?: string;
+  addressOverrides?: Record<string, string>;
+}
+
+export interface OwnerControlMetadata {
+  chainId: bigint;
+  networkName: string;
+  hardhatNetwork: string;
+  signer?: string | null;
+  configPath: string;
+  addressBookPath: string;
+}
+
+export interface OwnerControlVerificationResult {
+  metadata: OwnerControlMetadata;
+  results: ModuleCheck[];
+  summary: OwnerControlSummary;
+}
+
+const DEFAULT_ADDRESS_BOOK = path.join(
+  __dirname,
+  '..',
+  '..',
+  'docs',
+  'deployment-addresses.json'
+);
+
+function normaliseModuleType(value?: string): ModuleType {
+  if (!value) {
+    return 'governable';
+  }
+  const lower = value.toLowerCase();
+  if (lower === 'governable' || lower === 'ownable' || lower === 'ownable2step') {
+    return lower;
+  }
+  throw new Error(`Unsupported module type: ${value}`);
+}
+
+function normaliseAddress(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const address = ethers.getAddress(value);
+    return address === ethers.ZeroAddress ? undefined : address;
+  } catch (_) {
+    return undefined;
+  }
+}
+
+function envAddressKey(moduleKey: string): string {
+  const upper = moduleKey.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase();
+  return `AGJ_${upper}_ADDRESS`;
+}
+
+function matchModuleKey(target: string, candidates: string[]): string | undefined {
+  const lower = target.toLowerCase();
+  return candidates.find((candidate) => candidate.toLowerCase() === lower);
+}
+
+async function readAddressBook(filePath: string): Promise<Record<string, string>> {
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    const parsed = JSON.parse(content);
+    if (!parsed || typeof parsed !== 'object') {
+      return {};
+    }
+    const entries: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      const address = normaliseAddress(typeof value === 'string' ? value : undefined);
+      if (address) {
+        entries[key] = address;
+      }
+    }
+    return entries;
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
+}
+
+function resolveExpectedOwner(
+  moduleKey: string,
+  module: OwnerControlModuleConfig,
+  moduleType: ModuleType,
+  config: OwnerControlConfig
+): { owner?: string; source?: string } {
+  const sources: { owner?: string; source?: string }[] = [];
+
+  if (moduleType === 'governable' && module.governance) {
+    const address = normaliseAddress(module.governance);
+    if (address) {
+      sources.push({ owner: address, source: `modules.${moduleKey}.governance` });
+    }
+  }
+
+  if (moduleType !== 'governable' && module.owner) {
+    const address = normaliseAddress(module.owner);
+    if (address) {
+      sources.push({ owner: address, source: `modules.${moduleKey}.owner` });
+    }
+  }
+
+  if (moduleType === 'governable' && config.governance) {
+    const address = normaliseAddress(config.governance);
+    if (address) {
+      sources.push({ owner: address, source: 'ownerControl.governance' });
+    }
+  }
+
+  if (moduleType !== 'governable') {
+    if (config.owner) {
+      const address = normaliseAddress(config.owner);
+      if (address) {
+        sources.push({ owner: address, source: 'ownerControl.owner' });
+      }
+    }
+    if (config.governance) {
+      const address = normaliseAddress(config.governance);
+      if (address) {
+        sources.push({ owner: address, source: 'ownerControl.governance' });
+      }
+    }
+  }
+
+  return sources[0] ?? {};
+}
+
+function resolveModuleLabel(key: string, module: OwnerControlModuleConfig): string {
+  if (module.label) {
+    return module.label;
+  }
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+async function resolveModuleAddress(
+  key: string,
+  module: OwnerControlModuleConfig,
+  addressBook: Record<string, string>,
+  overrides: Record<string, string>
+): Promise<{ address?: string; source?: string; notes: string[] }> {
+  const notes: string[] = [];
+  const candidates: { value?: string; source: string }[] = [];
+
+  const overrideKey = matchModuleKey(key, Object.keys(overrides));
+  if (overrideKey) {
+    candidates.push({ value: overrides[overrideKey], source: `override:${overrideKey}` });
+  }
+
+  if (module.address) {
+    candidates.push({ value: module.address, source: `modules.${key}.address` });
+  }
+
+  const envKey = envAddressKey(key);
+  if (process.env[envKey]) {
+    candidates.push({ value: process.env[envKey], source: `env:${envKey}` });
+  }
+
+  const addressBookKey = matchModuleKey(key, Object.keys(addressBook));
+  if (addressBookKey) {
+    candidates.push({ value: addressBook[addressBookKey], source: `addressBook.${addressBookKey}` });
+  }
+
+  for (const candidate of candidates) {
+    const address = normaliseAddress(candidate.value);
+    if (address) {
+      return { address, source: candidate.source, notes };
+    }
+    if (candidate.value) {
+      notes.push(`Ignored invalid address from ${candidate.source}`);
+    }
+  }
+
+  return { notes };
+}
+
+async function detectContractOwner(
+  moduleType: ModuleType,
+  address: string
+): Promise<{ owner?: string; pending?: string | null }> {
+  const provider = ethers.provider;
+  const code = await provider.getCode(address);
+  if (!code || code === '0x') {
+    throw new Error('No contract code at address');
+  }
+
+  const governanceAbi = [
+    'function governance() view returns (address)',
+    'function owner() view returns (address)',
+  ];
+  const ownableAbi = ['function owner() view returns (address)'];
+  const ownable2StepAbi = [
+    'function owner() view returns (address)',
+    'function pendingOwner() view returns (address)',
+  ];
+
+  switch (moduleType) {
+    case 'governable': {
+      const contract = new ethers.Contract(address, governanceAbi, provider);
+      try {
+        const governance = await contract.governance();
+        if (typeof governance === 'string' && governance !== ethers.ZeroAddress) {
+          return { owner: ethers.getAddress(governance), pending: null };
+        }
+      } catch (_) {
+        // ignore, fallback to owner()
+      }
+      const owner = await contract.owner();
+      return { owner: ethers.getAddress(owner), pending: null };
+    }
+    case 'ownable': {
+      const contract = new ethers.Contract(address, ownableAbi, provider);
+      const owner = await contract.owner();
+      return { owner: ethers.getAddress(owner), pending: null };
+    }
+    case 'ownable2step': {
+      const contract = new ethers.Contract(address, ownable2StepAbi, provider);
+      const [owner, pending] = await Promise.all([
+        contract.owner(),
+        contract.pendingOwner().catch(() => ethers.ZeroAddress),
+      ]);
+      const pendingAddress = pending && pending !== ethers.ZeroAddress ? ethers.getAddress(pending) : null;
+      return { owner: ethers.getAddress(owner), pending: pendingAddress };
+    }
+    default:
+      throw new Error(`Unsupported module type ${moduleType}`);
+  }
+}
+
+async function verifyModule(
+  key: string,
+  module: OwnerControlModuleConfig,
+  moduleType: ModuleType,
+  config: OwnerControlConfig,
+  addressBook: Record<string, string>,
+  overrides: Record<string, string>
+): Promise<ModuleCheck> {
+  const label = resolveModuleLabel(key, module);
+  const notes: string[] = [];
+
+  if (module.skip) {
+    return {
+      key,
+      label,
+      type: moduleType,
+      status: 'skipped',
+      notes: [...(module.notes ?? []), 'Verification skipped by configuration'],
+    };
+  }
+
+  const expected = resolveExpectedOwner(key, module, moduleType, config);
+  if (module.notes) {
+    notes.push(...module.notes);
+  }
+
+  const addressResult = await resolveModuleAddress(key, module, addressBook, overrides);
+  notes.push(...addressResult.notes);
+
+  if (!addressResult.address) {
+    const hintSources = [
+      `Set modules.${key}.address`,
+      `define ${envAddressKey(key)}`,
+      'update docs/deployment-addresses.json',
+    ];
+    return {
+      key,
+      label,
+      type: moduleType,
+      expectedOwner: expected.owner,
+      expectedSource: expected.source,
+      status: 'missing-address',
+      notes: [
+        ...notes,
+        `No address found for ${label}. Provide one via ${hintSources.join(' or ')}.`,
+      ],
+    };
+  }
+
+  try {
+    const { owner, pending } = await detectContractOwner(moduleType, addressResult.address);
+    const check: ModuleCheck = {
+      key,
+      label,
+      type: moduleType,
+      address: addressResult.address,
+      addressSource: addressResult.source,
+      expectedOwner: expected.owner,
+      expectedSource: expected.source,
+      currentOwner: owner,
+      pendingOwner: pending ?? null,
+      status: 'ok',
+      notes,
+    };
+
+    if (!expected.owner) {
+      check.status = 'missing-expected';
+      check.notes = [
+        ...notes,
+        `Expected owner not configured for ${label}.`,
+        moduleType === 'governable'
+          ? 'Set ownerControl.governance or modules.<module>.governance.'
+          : 'Set ownerControl.owner or modules.<module>.owner.',
+      ];
+      return check;
+    }
+
+    if (!owner) {
+      check.status = 'error';
+      check.notes = [...notes, 'Owner not detected on-chain.'];
+      return check;
+    }
+
+    if (sameAddress(owner, expected.owner)) {
+      if (pending && !sameAddress(pending, expected.owner)) {
+        check.status = 'mismatch';
+        check.notes = [
+          ...notes,
+          `Pending owner ${pending} differs from expected ${expected.owner}.`,
+        ];
+      }
+      return check;
+    }
+
+    check.status = 'mismatch';
+    check.notes = [
+      ...notes,
+      `On-chain owner ${owner} differs from expected ${expected.owner}.`,
+      pending
+        ? `Pending owner ${pending} detected. Call acceptOwnership from ${pending} if correct.`
+        : 'Queue ownership transfer or update configuration.',
+    ];
+    check.pendingOwner = pending ?? null;
+    return check;
+  } catch (error: any) {
+    return {
+      key,
+      label,
+      type: moduleType,
+      address: addressResult.address,
+      addressSource: addressResult.source,
+      expectedOwner: expected.owner,
+      expectedSource: expected.source,
+      status: 'error',
+      notes,
+      error: error?.message ?? String(error),
+    };
+  }
+}
+
+export function summariseResults(results: ModuleCheck[]): OwnerControlSummary {
+  const summary: OwnerControlSummary = {
+    ok: 0,
+    mismatch: 0,
+    missingAddress: 0,
+    missingExpected: 0,
+    skipped: 0,
+    error: 0,
+  };
+
+  for (const result of results) {
+    switch (result.status) {
+      case 'ok':
+        summary.ok += 1;
+        break;
+      case 'mismatch':
+        summary.mismatch += 1;
+        break;
+      case 'missing-address':
+        summary.missingAddress += 1;
+        break;
+      case 'missing-expected':
+        summary.missingExpected += 1;
+        break;
+      case 'skipped':
+        summary.skipped += 1;
+        break;
+      case 'error':
+      default:
+        summary.error += 1;
+        break;
+    }
+  }
+
+  return summary;
+}
+
+export async function verifyOwnerControl(
+  options: OwnerControlVerificationOptions = {}
+): Promise<OwnerControlVerificationResult> {
+  const addressBookPath = options.addressBookPath
+    ? path.resolve(options.addressBookPath)
+    : DEFAULT_ADDRESS_BOOK;
+  const addressBook = await readAddressBook(addressBookPath);
+  const addressOverrides = { ...(options.addressOverrides ?? {}) };
+
+  const { config, path: configPath } = loadOwnerControlConfig({
+    network: options.configNetwork,
+  });
+
+  const provider = ethers.provider;
+  const [networkInfo, hardhatNetwork] = await Promise.all([
+    provider.getNetwork(),
+    Promise.resolve(inferNetworkKey(network) ?? network.name),
+  ]);
+
+  let signerAddress: string | null = null;
+  try {
+    const signers = await ethers.getSigners();
+    signerAddress = signers.length > 0 ? await signers[0].getAddress() : null;
+  } catch (_) {
+    signerAddress = null;
+  }
+
+  const modulesConfig = config.modules ?? {};
+  const moduleEntries = Object.keys(modulesConfig)
+    .sort((a, b) => a.localeCompare(b))
+    .filter((key) => {
+      if (options.modules && options.modules.length > 0) {
+        return options.modules.some((entry) => entry.toLowerCase() === key.toLowerCase());
+      }
+      if (options.skip && options.skip.length > 0) {
+        return !options.skip.some((entry) => entry.toLowerCase() === key.toLowerCase());
+      }
+      return true;
+    });
+
+  const results: ModuleCheck[] = [];
+  for (const key of moduleEntries) {
+    const moduleConfig = modulesConfig[key] ?? {};
+    let moduleType: ModuleType;
+    try {
+      moduleType = normaliseModuleType(
+        typeof moduleConfig.type === 'string' ? moduleConfig.type : undefined
+      );
+    } catch (error: any) {
+      results.push({
+        key,
+        label: resolveModuleLabel(key, moduleConfig),
+        type: 'governable',
+        status: 'error',
+        notes: moduleConfig.notes ?? [],
+        error: error?.message ?? String(error),
+      });
+      continue;
+    }
+
+    const check = await verifyModule(
+      key,
+      moduleConfig,
+      moduleType,
+      config,
+      addressBook,
+      addressOverrides
+    );
+    results.push(check);
+  }
+
+  const summary = summariseResults(results);
+
+  return {
+    metadata: {
+      chainId: networkInfo.chainId,
+      networkName: networkInfo.name,
+      hardhatNetwork,
+      signer: signerAddress,
+      configPath,
+      addressBookPath,
+    },
+    results,
+    summary,
+  };
+}
+
+export { DEFAULT_ADDRESS_BOOK };

--- a/scripts/v2/ownerControlPulse.ts
+++ b/scripts/v2/ownerControlPulse.ts
@@ -1,0 +1,610 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import {
+  verifyOwnerControl,
+  type ModuleCheck,
+  type OwnerControlSummary,
+} from './lib/ownerControlVerification';
+
+type OutputFormat = 'human' | 'markdown' | 'json';
+
+type Severity = 'pass' | 'warn' | 'fail' | 'info';
+
+type PulseCliOptions = {
+  format: OutputFormat;
+  outPath?: string;
+  configNetwork?: string;
+  modules?: string[];
+  skip?: string[];
+  addressBookPath?: string;
+  addressOverrides: Record<string, string>;
+};
+
+type HealthGrade = 'green' | 'amber' | 'red';
+
+type PulseCheck = {
+  key: string;
+  label: string;
+  status: ModuleCheck['status'];
+  severity: Severity;
+  address?: string;
+  expected?: string;
+  owner?: string;
+  pending?: string | null;
+  primaryNote?: string;
+  notes: string[];
+};
+
+type PulseReport = {
+  metadata: {
+    chainId: bigint;
+    networkName: string;
+    hardhatNetwork: string;
+    signer?: string | null;
+    configPath: string;
+    addressBookPath: string;
+  };
+  summary: OwnerControlSummary;
+  healthScore: number;
+  healthGrade: HealthGrade;
+  healthNarrative: string[];
+  checks: PulseCheck[];
+  recommendations: string[];
+};
+
+type CliFlags = {
+  formatSetByCli: boolean;
+};
+
+function parseBooleanEnv(value?: string | null): boolean | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const normalised = value.trim().toLowerCase();
+  if (!normalised) {
+    return undefined;
+  }
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalised)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalised)) {
+    return false;
+  }
+  return undefined;
+}
+
+function parseList(value?: string): string[] | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const entries = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  return entries.length > 0 ? entries : undefined;
+}
+
+function parseOverridesEnv(value?: string | null): Record<string, string> | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const entries = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const overrides: Record<string, string> = {};
+  for (const entry of entries) {
+    const [key, addr] = entry.split('=');
+    if (!key || !addr) {
+      throw new Error(
+        `OWNER_PULSE_ADDRESS_OVERRIDES entries must be <module>=<address>; received "${entry}"`
+      );
+    }
+    overrides[key.trim()] = addr.trim();
+  }
+  return overrides;
+}
+
+function parseArgs(argv: string[]): { options: PulseCliOptions; flags: CliFlags } {
+  const options: PulseCliOptions = {
+    format: 'human',
+    addressOverrides: {},
+  };
+  const flags: CliFlags = { formatSetByCli: false };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--format': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--format requires a value');
+        }
+        const normalised = value.trim().toLowerCase();
+        if (['human', 'text'].includes(normalised)) {
+          options.format = 'human';
+        } else if (['markdown', 'md'].includes(normalised)) {
+          options.format = 'markdown';
+        } else if (normalised === 'json') {
+          options.format = 'json';
+        } else {
+          throw new Error(`Unknown format ${value}`);
+        }
+        flags.formatSetByCli = true;
+        i += 1;
+        break;
+      }
+      case '--json':
+        options.format = 'json';
+        flags.formatSetByCli = true;
+        break;
+      case '--markdown':
+        options.format = 'markdown';
+        flags.formatSetByCli = true;
+        break;
+      case '--out':
+      case '--output': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a path`);
+        }
+        options.outPath = value;
+        i += 1;
+        break;
+      }
+      case '--network':
+      case '--config-network': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a value`);
+        }
+        options.configNetwork = value;
+        i += 1;
+        break;
+      }
+      case '--modules':
+      case '--include': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a comma-separated list`);
+        }
+        options.modules = value
+          .split(',')
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+        i += 1;
+        break;
+      }
+      case '--skip':
+      case '--exclude': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a comma-separated list`);
+        }
+        options.skip = value
+          .split(',')
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+        i += 1;
+        break;
+      }
+      case '--address-book': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--address-book requires a file path');
+        }
+        options.addressBookPath = value;
+        i += 1;
+        break;
+      }
+      case '--address':
+      case '--module-address': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires <module>=<address>`);
+        }
+        const [key, addr] = value.split('=');
+        if (!key || !addr) {
+          throw new Error(`${arg} expects <module>=<address>`);
+        }
+        options.addressOverrides[key.trim()] = addr.trim();
+        i += 1;
+        break;
+      }
+      case '--help':
+      case '-h':
+        console.log(`Usage: npx hardhat run --no-compile scripts/v2/ownerControlPulse.ts [options]
+
+Options:
+  --network <name>             Override configuration network key
+  --modules <a,b>              Only include the listed modules
+  --skip <a,b>                 Skip the listed modules
+  --format <human|markdown|json>
+  --json                       Shortcut for --format json
+  --markdown                   Shortcut for --format markdown
+  --out <path>                 Write output to file in addition to stdout
+  --address-book <path>        Custom deployment address book
+  --address <module=address>   Override module address for this run
+  --help                       Show this message
+`);
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return { options, flags };
+}
+
+function statusSeverity(status: ModuleCheck['status']): Severity {
+  switch (status) {
+    case 'ok':
+      return 'pass';
+    case 'missing-address':
+    case 'missing-expected':
+      return 'warn';
+    case 'skipped':
+      return 'info';
+    case 'mismatch':
+    case 'error':
+    default:
+      return 'fail';
+  }
+}
+
+function severityIcon(severity: Severity): string {
+  switch (severity) {
+    case 'pass':
+      return '✅';
+    case 'warn':
+      return '⚠️';
+    case 'fail':
+      return '❌';
+    case 'info':
+    default:
+      return '⏭️';
+  }
+}
+
+function formatScore(score: number): string {
+  return `${Math.round(score)} / 100`;
+}
+
+function computeHealth(summary: OwnerControlSummary, results: ModuleCheck[]): {
+  score: number;
+  grade: HealthGrade;
+  narrative: string[];
+} {
+  const weights = {
+    mismatch: 35,
+    missingAddress: 30,
+    missingExpected: 20,
+    error: 45,
+    skipped: 10,
+  };
+
+  const penalty =
+    summary.mismatch * weights.mismatch +
+    summary.missingAddress * weights.missingAddress +
+    summary.missingExpected * weights.missingExpected +
+    summary.error * weights.error +
+    summary.skipped * weights.skipped;
+
+  const score = Math.max(0, 100 - penalty);
+
+  let grade: HealthGrade = 'green';
+  if (score < 60) {
+    grade = 'red';
+  } else if (score < 85) {
+    grade = 'amber';
+  }
+
+  const narrative: string[] = [];
+  if (summary.mismatch > 0) {
+    narrative.push(`${summary.mismatch} module(s) report on-chain owner mismatches.`);
+  }
+  if (summary.missingAddress > 0) {
+    narrative.push(`${summary.missingAddress} module address entries missing.`);
+  }
+  if (summary.missingExpected > 0) {
+    narrative.push(`${summary.missingExpected} module(s) missing expected owner in config.`);
+  }
+  if (summary.error > 0) {
+    narrative.push(`${summary.error} module(s) returned on-chain access errors.`);
+  }
+  if (summary.skipped > 0) {
+    narrative.push(`${summary.skipped} module(s) marked as skip in owner-control.json.`);
+  }
+  if (narrative.length === 0) {
+    narrative.push('All modules align with expected governance plan.');
+  }
+
+  const flaggedPending = results.filter(
+    (check) => check.pendingOwner && check.pendingOwner !== check.expectedOwner
+  );
+  if (flaggedPending.length > 0) {
+    narrative.push(
+      `${flaggedPending.length} module(s) have pending owners awaiting acceptOwnership.`
+    );
+  }
+
+  return { score, grade, narrative };
+}
+
+function buildPulseChecks(results: ModuleCheck[]): PulseCheck[] {
+  return results.map((result) => ({
+    key: result.key,
+    label: result.label,
+    status: result.status,
+    severity: statusSeverity(result.status),
+    address: result.address,
+    expected: result.expectedOwner,
+    owner: result.currentOwner,
+    pending: result.pendingOwner ?? null,
+    primaryNote: result.notes[0],
+    notes: result.notes,
+  }));
+}
+
+function buildRecommendations(summary: OwnerControlSummary, results: ModuleCheck[]): string[] {
+  const actions: string[] = [];
+  if (summary.mismatch > 0) {
+    actions.push('Queue ownership transfers or update owner-control.json for mismatched modules.');
+  }
+  if (summary.missingAddress > 0) {
+    actions.push(
+      'Populate module addresses via config/modules.<key>.address or docs/deployment-addresses.json.'
+    );
+  }
+  if (summary.missingExpected > 0) {
+    actions.push('Set ownerControl.owner/governance fields so every module has a target owner.');
+  }
+  if (summary.error > 0) {
+    actions.push('Inspect ABI compatibility and RPC health for modules returning on-chain errors.');
+  }
+  const pending = results.filter((result) => result.pendingOwner);
+  if (pending.length > 0) {
+    actions.push(
+      'Have the pending owners execute acceptOwnership to finalise governance rotations.'
+    );
+  }
+  if (summary.skipped > 0) {
+    actions.push('Review modules marked skip:true to confirm intentional exclusion from checks.');
+  }
+  if (actions.length === 0) {
+    actions.push('No action required—record this pulse with the control surface artefacts.');
+  }
+  return actions;
+}
+
+function toMarkdown(report: PulseReport): string {
+  const header = `# Owner Control Pulse
+
+- **Network:** ${report.metadata.networkName} (chainId ${report.metadata.chainId})
+- **Hardhat profile:** ${report.metadata.hardhatNetwork}
+- **Config:** ${report.metadata.configPath}
+- **Address book:** ${report.metadata.addressBookPath}
+- **Signer:** ${report.metadata.signer ?? 'n/a'}
+- **Health:** ${formatScore(report.healthScore)} (${report.healthGrade.toUpperCase()})
+`;
+
+  const narrative = report.healthNarrative.map((line) => `- ${line}`).join('\n');
+  const recommendations = report.recommendations.map((line) => `- ${line}`).join('\n');
+
+  const tableHeader = '| Module | Status | On-chain Owner | Expected Owner | Primary Note |\n| --- | --- | --- | --- | --- |';
+  const rows = report.checks
+    .map((check) => {
+      const icon = severityIcon(check.severity);
+      const owner = check.owner ?? '—';
+      const expected = check.expected ?? '—';
+      const note = check.primaryNote ? check.primaryNote.replace(/\n/g, ' ') : '—';
+      return `| ${check.label} | ${icon} ${check.status} | ${owner} | ${expected} | ${note} |`;
+    })
+    .join('\n');
+
+  const mermaid = [
+    '```mermaid',
+    'flowchart LR',
+    '  Config[Config Targets] --> Pulse(Owner Control Pulse)',
+    `  Pulse -->|Health ${Math.round(report.healthScore)}| Grade[[${report.healthGrade.toUpperCase()}]]`,
+    '  Pulse --> Modules[Module Checks]',
+    `  Modules --> Mismatch{Mismatch: ${report.summary.mismatch}}`,
+    `  Modules --> MissingAddress{Missing Address: ${report.summary.missingAddress}}`,
+    `  Modules --> MissingExpected{Missing Expected: ${report.summary.missingExpected}}`,
+    `  Modules --> Errors{Errors: ${report.summary.error}}`,
+    `  Modules --> Skipped{Skipped: ${report.summary.skipped}}`,
+    '```',
+  ].join('\n');
+
+  return [header, '## Health Narrative', narrative, '## Module Summary', tableHeader, rows, mermaid, '## Recommended Actions', recommendations].join('\n\n');
+}
+
+function toHuman(report: PulseReport): string {
+  const lines: string[] = [];
+  lines.push('AGIJobs Owner Control Pulse');
+  lines.push('----------------------------');
+  lines.push(`Network: ${report.metadata.networkName} (chainId ${report.metadata.chainId})`);
+  lines.push(`Hardhat profile: ${report.metadata.hardhatNetwork}`);
+  lines.push(`Config: ${report.metadata.configPath}`);
+  lines.push(`Address book: ${report.metadata.addressBookPath}`);
+  lines.push(`Signer: ${report.metadata.signer ?? 'n/a'}`);
+  lines.push(`Health: ${formatScore(report.healthScore)} (${report.healthGrade.toUpperCase()})`);
+  lines.push('');
+  lines.push('Narrative:');
+  for (const entry of report.healthNarrative) {
+    lines.push(`  - ${entry}`);
+  }
+  lines.push('');
+  lines.push('Modules:');
+  lines.push('  Module                         Status      Owner                               Expected');
+  lines.push('  -------------------------------------------------------------------------------');
+  for (const check of report.checks) {
+    const name = check.label.padEnd(30);
+    const status = `${severityIcon(check.severity)} ${check.status}`.padEnd(12);
+    const owner = (check.owner ?? '—').padEnd(35);
+    const expected = check.expected ?? '—';
+    lines.push(`  ${name}${status}${owner}${expected}`);
+    if (check.primaryNote) {
+      lines.push(`      ↳ ${check.primaryNote}`);
+    }
+  }
+  lines.push('');
+  lines.push('Recommended Actions:');
+  for (const action of report.recommendations) {
+    lines.push(`  - ${action}`);
+  }
+  return lines.join('\n');
+}
+
+function toJson(report: PulseReport): any {
+  return {
+    metadata: {
+      chainId: report.metadata.chainId.toString(),
+      networkName: report.metadata.networkName,
+      hardhatNetwork: report.metadata.hardhatNetwork,
+      signer: report.metadata.signer,
+      configPath: report.metadata.configPath,
+      addressBookPath: report.metadata.addressBookPath,
+    },
+    summary: report.summary,
+    health: {
+      score: report.healthScore,
+      grade: report.healthGrade,
+      narrative: report.healthNarrative,
+    },
+    checks: report.checks.map((check) => ({
+      key: check.key,
+      label: check.label,
+      status: check.status,
+      severity: check.severity,
+      address: check.address,
+      owner: check.owner,
+      expected: check.expected,
+      pending: check.pending,
+      notes: check.notes,
+    })),
+    recommendations: report.recommendations,
+  };
+}
+
+function applyEnvDefaults(options: PulseCliOptions, flags: CliFlags): PulseCliOptions {
+  const resolved: PulseCliOptions = { ...options };
+
+  if (!flags.formatSetByCli) {
+    const envFormat = process.env.OWNER_PULSE_FORMAT?.trim().toLowerCase();
+    if (envFormat === 'json') {
+      resolved.format = 'json';
+    } else if (envFormat === 'markdown' || envFormat === 'md') {
+      resolved.format = 'markdown';
+    } else if (envFormat === 'human' || envFormat === 'text') {
+      resolved.format = 'human';
+    }
+    const envJson = parseBooleanEnv(process.env.OWNER_PULSE_JSON);
+    if (envJson) {
+      resolved.format = 'json';
+    }
+  }
+
+  if (!resolved.configNetwork && process.env.OWNER_PULSE_NETWORK) {
+    resolved.configNetwork = process.env.OWNER_PULSE_NETWORK.trim();
+  }
+
+  if (!resolved.modules && process.env.OWNER_PULSE_MODULES) {
+    resolved.modules = parseList(process.env.OWNER_PULSE_MODULES);
+  }
+
+  const envSkip = parseList(process.env.OWNER_PULSE_SKIP);
+  if (envSkip && envSkip.length > 0) {
+    const existing = new Set(resolved.skip ?? []);
+    envSkip.forEach((entry) => existing.add(entry));
+    resolved.skip = Array.from(existing);
+  }
+
+  if (!resolved.addressBookPath && process.env.OWNER_PULSE_ADDRESS_BOOK) {
+    resolved.addressBookPath = process.env.OWNER_PULSE_ADDRESS_BOOK.trim();
+  }
+
+  const envOverrides = parseOverridesEnv(process.env.OWNER_PULSE_ADDRESS_OVERRIDES);
+  if (envOverrides) {
+    const merged: Record<string, string> = { ...envOverrides };
+    for (const [key, value] of Object.entries(resolved.addressOverrides)) {
+      merged[key] = value;
+    }
+    resolved.addressOverrides = merged;
+  }
+
+  if (!resolved.outPath && process.env.OWNER_PULSE_OUT) {
+    resolved.outPath = process.env.OWNER_PULSE_OUT.trim();
+  }
+
+  return resolved;
+}
+
+async function main() {
+  const { options: cliOptions, flags } = parseArgs(process.argv.slice(2));
+  const options = applyEnvDefaults(cliOptions, flags);
+
+  const verification = await verifyOwnerControl({
+    configNetwork: options.configNetwork,
+    modules: options.modules,
+    skip: options.skip,
+    addressBookPath: options.addressBookPath,
+    addressOverrides: options.addressOverrides,
+  });
+
+  const summary = verification.summary;
+  const health = computeHealth(summary, verification.results);
+  const report: PulseReport = {
+    metadata: verification.metadata,
+    summary,
+    healthScore: health.score,
+    healthGrade: health.grade,
+    healthNarrative: health.narrative,
+    checks: buildPulseChecks(verification.results),
+    recommendations: buildRecommendations(summary, verification.results),
+  };
+
+  let output: string;
+  let jsonOutput: any | null = null;
+  switch (options.format) {
+    case 'markdown':
+      output = toMarkdown(report);
+      break;
+    case 'json':
+      jsonOutput = toJson(report);
+      output = JSON.stringify(jsonOutput, null, 2);
+      break;
+    case 'human':
+    default:
+      output = toHuman(report);
+      break;
+  }
+
+  console.log(output);
+
+  if (options.outPath) {
+    const outFile = path.resolve(options.outPath);
+    const data = options.format === 'json' ? output : `${output}\n`;
+    await fs.mkdir(path.dirname(outFile), { recursive: true });
+    await fs.writeFile(outFile, data, 'utf8');
+  }
+
+  if (options.format !== 'json') {
+    // Always emit machine-readable JSON to aid automations when stdout is human/markdown.
+    const fallback = jsonOutput ?? toJson(report);
+    process.stdout.write('\n');
+    process.stdout.write('---\n');
+    process.stdout.write('JSON snapshot:\n');
+    process.stdout.write(JSON.stringify(fallback, null, 2));
+    process.stdout.write('\n');
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : error);
+  process.exit(1);
+});

--- a/scripts/v2/verifyOwnerControl.ts
+++ b/scripts/v2/verifyOwnerControl.ts
@@ -1,25 +1,4 @@
-import { promises as fs } from 'fs';
-import path from 'path';
-import { ethers, network } from 'hardhat';
-import {
-  loadOwnerControlConfig,
-  inferNetworkKey,
-} from '../config';
-import type {
-  OwnerControlConfig,
-  OwnerControlModuleConfig,
-} from '../config';
-import { sameAddress } from './lib/utils';
-
-type ModuleType = 'governable' | 'ownable' | 'ownable2step';
-
-type ModuleStatus =
-  | 'ok'
-  | 'mismatch'
-  | 'missing-address'
-  | 'missing-expected'
-  | 'skipped'
-  | 'error';
+import { summariseResults, verifyOwnerControl, type ModuleCheck } from './lib/ownerControlVerification';
 
 type CliOptions = {
   json: boolean;
@@ -31,56 +10,12 @@ type CliOptions = {
   addressOverrides: Record<string, string>;
 };
 
-type ModuleCheck = {
-  key: string;
-  label: string;
-  type: ModuleType;
-  address?: string;
-  addressSource?: string;
-  expectedOwner?: string;
-  expectedSource?: string;
-  currentOwner?: string;
-  pendingOwner?: string | null;
-  status: ModuleStatus;
-  notes: string[];
-  error?: string;
+type CliFlags = {
+  jsonSetByCli: boolean;
+  strictSetByCli: boolean;
+  modulesSetByCli: boolean;
+  addressBookSetByCli: boolean;
 };
-
-const DEFAULT_ADDRESS_BOOK = path.join(
-  __dirname,
-  '..',
-  '..',
-  'docs',
-  'deployment-addresses.json'
-);
-
-function normaliseModuleType(value?: string): ModuleType {
-  if (!value) {
-    return 'governable';
-  }
-  const lower = value.toLowerCase();
-  if (lower === 'governable' || lower === 'ownable' || lower === 'ownable2step') {
-    return lower;
-  }
-  throw new Error(`Unsupported module type: ${value}`);
-}
-
-function normaliseAddress(value?: string | null): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  try {
-    const address = ethers.getAddress(value);
-    return address === ethers.ZeroAddress ? undefined : address;
-  } catch (_) {
-    return undefined;
-  }
-}
-
-function envAddressKey(moduleKey: string): string {
-  const upper = moduleKey.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase();
-  return `AGJ_${upper}_ADDRESS`;
-}
 
 function parseBooleanEnv(value?: string | null): boolean | undefined {
   if (value === undefined || value === null) {
@@ -110,9 +45,7 @@ function parseListEnv(value?: string | null): string[] | undefined {
   return entries.length > 0 ? entries : undefined;
 }
 
-function parseOverridesEnv(
-  value?: string | null
-): Record<string, string> | undefined {
+function parseOverridesEnv(value?: string | null): Record<string, string> | undefined {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -136,28 +69,30 @@ function parseOverridesEnv(
   return overrides;
 }
 
-function parseArgs(argv: string[]): CliOptions {
+function parseArgs(argv: string[]): { options: CliOptions; flags: CliFlags } {
   const options: CliOptions = {
     json: false,
     strict: false,
     addressOverrides: {},
   };
-  let jsonSetByCli = false;
-  let strictSetByCli = false;
-  let modulesSetByCli = false;
-  let addressBookSetByCli = false;
+  const flags: CliFlags = {
+    jsonSetByCli: false,
+    strictSetByCli: false,
+    modulesSetByCli: false,
+    addressBookSetByCli: false,
+  };
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     switch (arg) {
       case '--json':
         options.json = true;
-        jsonSetByCli = true;
+        flags.jsonSetByCli = true;
         break;
       case '--strict':
       case '--require':
         options.strict = true;
-        strictSetByCli = true;
+        flags.strictSetByCli = true;
         break;
       case '--config-network':
       case '--network-config': {
@@ -179,7 +114,7 @@ function parseArgs(argv: string[]): CliOptions {
           .split(',')
           .map((entry) => entry.trim())
           .filter(Boolean);
-        modulesSetByCli = true;
+        flags.modulesSetByCli = true;
         i += 1;
         break;
       }
@@ -202,7 +137,7 @@ function parseArgs(argv: string[]): CliOptions {
           throw new Error('--address-book requires a file path');
         }
         options.addressBookPath = value;
-        addressBookSetByCli = true;
+        flags.addressBookSetByCli = true;
         i += 1;
         break;
       }
@@ -225,344 +160,10 @@ function parseArgs(argv: string[]): CliOptions {
     }
   }
 
-  const envJson = parseBooleanEnv(process.env.OWNER_VERIFY_JSON);
-  if (!jsonSetByCli && envJson !== undefined) {
-    options.json = envJson;
-  }
-
-  const envStrict = parseBooleanEnv(process.env.OWNER_VERIFY_STRICT);
-  if (!strictSetByCli && envStrict !== undefined) {
-    options.strict = envStrict;
-  }
-
-  if (!options.configNetwork && process.env.OWNER_VERIFY_CONFIG_NETWORK) {
-    options.configNetwork = process.env.OWNER_VERIFY_CONFIG_NETWORK.trim();
-  }
-
-  const envModules = parseListEnv(process.env.OWNER_VERIFY_MODULES);
-  if (!modulesSetByCli && envModules) {
-    options.modules = envModules;
-  }
-
-  const envSkip = parseListEnv(process.env.OWNER_VERIFY_SKIP);
-  if (envSkip && envSkip.length > 0) {
-    const existing = new Set(options.skip ?? []);
-    envSkip.forEach((entry) => existing.add(entry));
-    options.skip = Array.from(existing);
-  }
-
-  if (!addressBookSetByCli && process.env.OWNER_VERIFY_ADDRESS_BOOK) {
-    options.addressBookPath = process.env.OWNER_VERIFY_ADDRESS_BOOK.trim();
-  }
-
-  const envOverrides = parseOverridesEnv(process.env.OWNER_VERIFY_ADDRESS_OVERRIDES);
-  if (envOverrides) {
-    const merged: Record<string, string> = { ...envOverrides };
-    for (const [key, value] of Object.entries(options.addressOverrides)) {
-      merged[key] = value;
-    }
-    options.addressOverrides = merged;
-  }
-
-  return options;
+  return { options, flags };
 }
 
-async function readAddressBook(filePath: string): Promise<Record<string, string>> {
-  try {
-    const content = await fs.readFile(filePath, 'utf8');
-    const parsed = JSON.parse(content);
-    if (!parsed || typeof parsed !== 'object') {
-      return {};
-    }
-    const entries: Record<string, string> = {};
-    for (const [key, value] of Object.entries(parsed)) {
-      const address = normaliseAddress(typeof value === 'string' ? value : undefined);
-      if (address) {
-        entries[key] = address;
-      }
-    }
-    return entries;
-  } catch (error: any) {
-    if (error?.code === 'ENOENT') {
-      return {};
-    }
-    throw error;
-  }
-}
-
-function matchModuleKey(target: string, candidates: string[]): string | undefined {
-  const lower = target.toLowerCase();
-  return candidates.find((candidate) => candidate.toLowerCase() === lower);
-}
-
-function resolveExpectedOwner(
-  moduleKey: string,
-  module: OwnerControlModuleConfig,
-  moduleType: ModuleType,
-  config: OwnerControlConfig
-): { owner?: string; source?: string } {
-  const sources: { owner?: string; source?: string }[] = [];
-
-  if (moduleType === 'governable' && module.governance) {
-    const address = normaliseAddress(module.governance);
-    if (address) {
-      sources.push({ owner: address, source: `modules.${moduleKey}.governance` });
-    }
-  }
-
-  if (moduleType !== 'governable' && module.owner) {
-    const address = normaliseAddress(module.owner);
-    if (address) {
-      sources.push({ owner: address, source: `modules.${moduleKey}.owner` });
-    }
-  }
-
-  if (moduleType === 'governable' && config.governance) {
-    const address = normaliseAddress(config.governance);
-    if (address) {
-      sources.push({ owner: address, source: 'ownerControl.governance' });
-    }
-  }
-
-  if (moduleType !== 'governable') {
-    if (config.owner) {
-      const address = normaliseAddress(config.owner);
-      if (address) {
-        sources.push({ owner: address, source: 'ownerControl.owner' });
-      }
-    }
-    if (config.governance) {
-      const address = normaliseAddress(config.governance);
-      if (address) {
-        sources.push({ owner: address, source: 'ownerControl.governance' });
-      }
-    }
-  }
-
-  return sources[0] ?? {};
-}
-
-function resolveModuleLabel(key: string, module: OwnerControlModuleConfig): string {
-  if (module.label) {
-    return module.label;
-  }
-  return key
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/[-_]+/g, ' ')
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-async function resolveModuleAddress(
-  key: string,
-  module: OwnerControlModuleConfig,
-  addressBook: Record<string, string>,
-  overrides: Record<string, string>
-): Promise<{ address?: string; source?: string; notes: string[] }> {
-  const notes: string[] = [];
-  const candidates: { value?: string; source: string }[] = [];
-
-  const overrideKey = matchModuleKey(key, Object.keys(overrides));
-  if (overrideKey) {
-    candidates.push({ value: overrides[overrideKey], source: `--address ${overrideKey}` });
-  }
-
-  if (module.address) {
-    candidates.push({ value: module.address, source: `modules.${key}.address` });
-  }
-
-  const envKey = envAddressKey(key);
-  if (process.env[envKey]) {
-    candidates.push({ value: process.env[envKey], source: `env:${envKey}` });
-  }
-
-  const addressBookKey = matchModuleKey(key, Object.keys(addressBook));
-  if (addressBookKey) {
-    candidates.push({ value: addressBook[addressBookKey], source: `addressBook.${addressBookKey}` });
-  }
-
-  for (const candidate of candidates) {
-    const address = normaliseAddress(candidate.value);
-    if (address) {
-      return { address, source: candidate.source, notes };
-    }
-    if (candidate.value) {
-      notes.push(`Ignored invalid address from ${candidate.source}`);
-    }
-  }
-
-  return { notes };
-}
-
-async function detectContractOwner(
-  moduleType: ModuleType,
-  address: string
-): Promise<{ owner?: string; pending?: string | null }> {
-  const provider = ethers.provider;
-  const code = await provider.getCode(address);
-  if (!code || code === '0x') {
-    throw new Error('No contract code at address');
-  }
-
-  const governanceAbi = [
-    'function governance() view returns (address)',
-    'function owner() view returns (address)',
-  ];
-  const ownableAbi = ['function owner() view returns (address)'];
-  const ownable2StepAbi = [
-    'function owner() view returns (address)',
-    'function pendingOwner() view returns (address)',
-  ];
-
-  switch (moduleType) {
-    case 'governable': {
-      const contract = new ethers.Contract(address, governanceAbi, provider);
-      try {
-        const governance = await contract.governance();
-        if (typeof governance === 'string' && governance !== ethers.ZeroAddress) {
-          return { owner: ethers.getAddress(governance), pending: null };
-        }
-      } catch (_) {
-        // ignore, fallback to owner()
-      }
-      const owner = await contract.owner();
-      return { owner: ethers.getAddress(owner), pending: null };
-    }
-    case 'ownable': {
-      const contract = new ethers.Contract(address, ownableAbi, provider);
-      const owner = await contract.owner();
-      return { owner: ethers.getAddress(owner), pending: null };
-    }
-    case 'ownable2step': {
-      const contract = new ethers.Contract(address, ownable2StepAbi, provider);
-      const [owner, pending] = await Promise.all([
-        contract.owner(),
-        contract.pendingOwner().catch(() => ethers.ZeroAddress),
-      ]);
-      const pendingAddress = pending && pending !== ethers.ZeroAddress ? ethers.getAddress(pending) : null;
-      return { owner: ethers.getAddress(owner), pending: pendingAddress };
-    }
-    default:
-      throw new Error(`Unsupported module type ${moduleType}`);
-  }
-}
-
-async function verifyModule(
-  key: string,
-  module: OwnerControlModuleConfig,
-  moduleType: ModuleType,
-  config: OwnerControlConfig,
-  addressBook: Record<string, string>,
-  overrides: Record<string, string>
-): Promise<ModuleCheck> {
-  const label = resolveModuleLabel(key, module);
-  const notes: string[] = [];
-
-  if (module.skip) {
-    return {
-      key,
-      label,
-      type: moduleType,
-      status: 'skipped',
-      notes: [...(module.notes ?? []), 'Verification skipped by configuration'],
-    };
-  }
-
-  const expected = resolveExpectedOwner(key, module, moduleType, config);
-  if (module.notes) {
-    notes.push(...module.notes);
-  }
-
-  const addressResult = await resolveModuleAddress(key, module, addressBook, overrides);
-  notes.push(...addressResult.notes);
-
-  if (!addressResult.address) {
-    const hintSources = [
-      `Set modules.${key}.address`,
-      `define ${envAddressKey(key)}`,
-      'update docs/deployment-addresses.json',
-    ];
-    return {
-      key,
-      label,
-      type: moduleType,
-      expectedOwner: expected.owner,
-      expectedSource: expected.source,
-      status: 'missing-address',
-      notes: [
-        ...notes,
-        `No address found for ${label}. Provide one via ${hintSources.join(' or ')}.`,
-      ],
-    };
-  }
-
-  try {
-    const { owner, pending } = await detectContractOwner(moduleType, addressResult.address);
-    const check: ModuleCheck = {
-      key,
-      label,
-      type: moduleType,
-      address: addressResult.address,
-      addressSource: addressResult.source,
-      expectedOwner: expected.owner,
-      expectedSource: expected.source,
-      currentOwner: owner,
-      pendingOwner: pending ?? null,
-      status: 'ok',
-      notes,
-    };
-
-    if (!expected.owner) {
-      check.status = 'missing-expected';
-      check.notes = [
-        ...notes,
-        `Expected owner not configured for ${label}.`,
-        moduleType === 'governable'
-          ? 'Set ownerControl.governance or modules.<module>.governance.'
-          : 'Set ownerControl.owner or modules.<module>.owner.',
-      ];
-      return check;
-    }
-
-    if (!sameAddress(owner, expected.owner)) {
-      check.status = 'mismatch';
-      check.notes = [
-        ...notes,
-        `${label} is controlled by ${owner}, expected ${expected.owner} (${expected.source}).`,
-      ];
-      return check;
-    }
-
-    if (moduleType === 'ownable2step' && pending && !sameAddress(pending, expected.owner)) {
-      check.status = 'mismatch';
-      check.notes = [
-        ...notes,
-        `${label} pending owner ${pending} differs from expected ${expected.owner}.`,
-      ];
-      return check;
-    }
-
-    check.notes = [
-      ...notes,
-      `Ownership matches expected ${expected.owner} (${expected.source}).`,
-    ];
-    return check;
-  } catch (error: any) {
-    return {
-      key,
-      label,
-      type: moduleType,
-      address: addressResult.address,
-      addressSource: addressResult.source,
-      expectedOwner: expected.owner,
-      expectedSource: expected.source,
-      status: 'error',
-      notes,
-      error: error?.message ?? String(error),
-    };
-  }
-}
-
-function formatStatus(status: ModuleStatus): string {
+function formatStatus(status: ModuleCheck['status']): string {
   switch (status) {
     case 'ok':
       return '✅ ok';
@@ -578,43 +179,6 @@ function formatStatus(status: ModuleStatus): string {
     default:
       return '❌ error';
   }
-}
-
-function summariseResults(results: ModuleCheck[]) {
-  const summary = {
-    ok: 0,
-    mismatch: 0,
-    missingAddress: 0,
-    missingExpected: 0,
-    skipped: 0,
-    error: 0,
-  };
-
-  for (const result of results) {
-    switch (result.status) {
-      case 'ok':
-        summary.ok += 1;
-        break;
-      case 'mismatch':
-        summary.mismatch += 1;
-        break;
-      case 'missing-address':
-        summary.missingAddress += 1;
-        break;
-      case 'missing-expected':
-        summary.missingExpected += 1;
-        break;
-      case 'skipped':
-        summary.skipped += 1;
-        break;
-      case 'error':
-      default:
-        summary.error += 1;
-        break;
-    }
-  }
-
-  return summary;
 }
 
 function printHumanReadable(
@@ -642,7 +206,11 @@ function printHumanReadable(
   for (const result of results) {
     console.log(`${formatStatus(result.status)}  ${result.label}`);
     if (result.address) {
-      console.log(`    Address:   ${result.address}${result.addressSource ? ` (${result.addressSource})` : ''}`);
+      console.log(
+        `    Address:   ${result.address}${
+          result.addressSource ? ` (${result.addressSource})` : ''
+        }`
+      );
     }
     if (result.currentOwner) {
       console.log(`    Owner:     ${result.currentOwner}`);
@@ -681,84 +249,66 @@ function printHumanReadable(
 }
 
 async function main() {
-  const options = parseArgs(process.argv.slice(2));
-  const addressBookPath = options.addressBookPath
-    ? path.resolve(options.addressBookPath)
-    : DEFAULT_ADDRESS_BOOK;
-  const addressBook = await readAddressBook(addressBookPath);
-  const { config, path: configPath } = loadOwnerControlConfig({
-    network: options.configNetwork,
+  const { options: cliOptions, flags } = parseArgs(process.argv.slice(2));
+  const resolvedOptions: CliOptions = { ...cliOptions };
+
+  const envJson = parseBooleanEnv(process.env.OWNER_VERIFY_JSON);
+  if (!flags.jsonSetByCli && envJson !== undefined) {
+    resolvedOptions.json = envJson;
+  }
+
+  const envStrict = parseBooleanEnv(process.env.OWNER_VERIFY_STRICT);
+  if (!flags.strictSetByCli && envStrict !== undefined) {
+    resolvedOptions.strict = envStrict;
+  }
+
+  if (!resolvedOptions.configNetwork && process.env.OWNER_VERIFY_CONFIG_NETWORK) {
+    resolvedOptions.configNetwork = process.env.OWNER_VERIFY_CONFIG_NETWORK.trim();
+  }
+
+  const envModules = parseListEnv(process.env.OWNER_VERIFY_MODULES);
+  if (!flags.modulesSetByCli && envModules) {
+    resolvedOptions.modules = envModules;
+  }
+
+  const envSkip = parseListEnv(process.env.OWNER_VERIFY_SKIP);
+  if (envSkip && envSkip.length > 0) {
+    const existing = new Set(resolvedOptions.skip ?? []);
+    envSkip.forEach((entry) => existing.add(entry));
+    resolvedOptions.skip = Array.from(existing);
+  }
+
+  if (!flags.addressBookSetByCli && process.env.OWNER_VERIFY_ADDRESS_BOOK) {
+    resolvedOptions.addressBookPath = process.env.OWNER_VERIFY_ADDRESS_BOOK.trim();
+  }
+
+  const envOverrides = parseOverridesEnv(process.env.OWNER_VERIFY_ADDRESS_OVERRIDES);
+  if (envOverrides) {
+    const merged: Record<string, string> = { ...envOverrides };
+    for (const [key, value] of Object.entries(resolvedOptions.addressOverrides)) {
+      merged[key] = value;
+    }
+    resolvedOptions.addressOverrides = merged;
+  }
+
+  const verification = await verifyOwnerControl({
+    configNetwork: resolvedOptions.configNetwork,
+    modules: resolvedOptions.modules,
+    skip: resolvedOptions.skip,
+    addressBookPath: resolvedOptions.addressBookPath,
+    addressOverrides: resolvedOptions.addressOverrides,
   });
 
-  const provider = ethers.provider;
-  const [networkInfo, hardhatNetwork] = await Promise.all([
-    provider.getNetwork(),
-    Promise.resolve(inferNetworkKey(network) ?? network.name),
-  ]);
-
-  let signerAddress: string | null = null;
-  try {
-    const signers = await ethers.getSigners();
-    signerAddress = signers.length > 0 ? await signers[0].getAddress() : null;
-  } catch (_) {
-    signerAddress = null;
-  }
-
-  const modulesConfig = config.modules ?? {};
-  const moduleEntries = Object.keys(modulesConfig)
-    .sort((a, b) => a.localeCompare(b))
-    .filter((key) => {
-      if (options.modules && options.modules.length > 0) {
-        return options.modules.some((entry) => entry.toLowerCase() === key.toLowerCase());
-      }
-      if (options.skip && options.skip.length > 0) {
-        return !options.skip.some((entry) => entry.toLowerCase() === key.toLowerCase());
-      }
-      return true;
-    });
-
-  const results: ModuleCheck[] = [];
-  for (const key of moduleEntries) {
-    const moduleConfig = modulesConfig[key] ?? {};
-    let moduleType: ModuleType;
-    try {
-      moduleType = normaliseModuleType(
-        typeof moduleConfig.type === 'string' ? moduleConfig.type : undefined
-      );
-    } catch (error: any) {
-      results.push({
-        key,
-        label: resolveModuleLabel(key, moduleConfig),
-        type: 'governable',
-        status: 'error',
-        notes: moduleConfig.notes ?? [],
-        error: error?.message ?? String(error),
-      });
-      continue;
-    }
-
-    const check = await verifyModule(
-      key,
-      moduleConfig,
-      moduleType,
-      config,
-      addressBook,
-      options.addressOverrides
-    );
-    results.push(check);
-  }
-
-  const summary = summariseResults(results);
   const jsonOutput = {
     network: {
-      chainId: networkInfo.chainId.toString(),
-      name: networkInfo.name,
-      hardhat: hardhatNetwork,
+      chainId: verification.metadata.chainId.toString(),
+      name: verification.metadata.networkName,
+      hardhat: verification.metadata.hardhatNetwork,
     },
-    signer: signerAddress,
-    configPath,
-    addressBookPath,
-    results: results.map((result) => ({
+    signer: verification.metadata.signer,
+    configPath: verification.metadata.configPath,
+    addressBookPath: verification.metadata.addressBookPath,
+    results: verification.results.map((result) => ({
       key: result.key,
       label: result.label,
       type: result.type,
@@ -772,28 +322,28 @@ async function main() {
       notes: result.notes,
       error: result.error,
     })),
-    summary,
+    summary: verification.summary,
   };
 
-  if (options.json) {
+  if (resolvedOptions.json) {
     console.log(JSON.stringify(jsonOutput, null, 2));
   } else {
     printHumanReadable(
       {
-        chainId: networkInfo.chainId,
-        networkName: networkInfo.name,
-        hardhatNetwork,
-        signer: signerAddress,
-        configPath,
-        addressBookPath,
+        chainId: verification.metadata.chainId,
+        networkName: verification.metadata.networkName,
+        hardhatNetwork: verification.metadata.hardhatNetwork,
+        signer: verification.metadata.signer,
+        configPath: verification.metadata.configPath,
+        addressBookPath: verification.metadata.addressBookPath,
       },
-      results
+      verification.results
     );
   }
 
-  if (options.strict) {
-    const failures =
-      summary.mismatch + summary.missingAddress + summary.missingExpected + summary.error;
+  if (resolvedOptions.strict) {
+    const { mismatch, missingAddress, missingExpected, error } = verification.summary;
+    const failures = mismatch + missingAddress + missingExpected + error;
     if (failures > 0) {
       throw new Error('Owner control verification failed.');
     }


### PR DESCRIPTION
## Summary
- extract the owner control verification logic into a reusable library for CLI tools
- add an owner:pulse script that surfaces a health score, module notes, recommendations and Markdown/JSON exports
- document the workflow in README plus a dedicated owner-control-pulse guide with mermaid diagrams and environment-driven examples

## Testing
- npm run owner:pulse -- --network hardhat
- npm run lint:check *(fails: solhint reports existing warnings in Solidity mocks and modules)*

------
https://chatgpt.com/codex/tasks/task_e_68df0ebb352483339f38e9085dc381c3