### PR TITLE
feat: add one-click env generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 .env
-deployment-config/oneclick.env
 artifacts/
 cache/
 coverage/

--- a/README.md
+++ b/README.md
@@ -504,12 +504,13 @@ along without context switching across multiple docs.
 ### One-Click Deployment
 
 - **Docker Compose bundle:** `compose.yaml` packages the meta API, orchestrator, agent/validator gateway, notification sink,
-  mock AA providers, Alpha bridge, validator UI, and enterprise front-end with sensible defaults. Copy
-  `deployment-config/oneclick.env.example` to `deployment-config/oneclick.env`, customise addresses, then run
-  `docker compose --env-file deployment-config/oneclick.env up --build` for a fully wired stack.
+  mock AA providers, Alpha bridge, validator UI, and enterprise front-end with sensible defaults. The repository now ships a
+  ready-to-edit `deployment-config/oneclick.env`; update any secrets and run `docker compose --env-file
+  deployment-config/oneclick.env up --build` for a fully wired stack.
 - **Automated contract bootstrap:** `npm run deploy:oneclick -- --config <path> --network <network>` executes the Hardhat
   deployment, copies the generated address book, and enforces secure launch defaults (paused modules, capped job rewards,
   minimal validator windows) as defined in [`deployment-config/deployer.sample.json`](deployment-config/deployer.sample.json).
+  Follow up with `npm run deploy:env` to inject the resulting addresses into `deployment-config/oneclick.env` automatically.
 - **Step-by-step runbook:** see [docs/deployment/one-click.md](docs/deployment/one-click.md) for the full workflow, including
   prerequisites, environment preparation, post-launch checklist, and troubleshooting tips.
 

--- a/deployment-config/oneclick.env
+++ b/deployment-config/oneclick.env
@@ -1,4 +1,4 @@
-# Copy this file to deployment-config/oneclick.env and customise for your network.
+# Default configuration for docker compose one-click stack.
 # Safe defaults are intentionally restrictive; update values once you verify your
 # deployment and pause state. After running the one-click deployer, invoke
 # `npm run deploy:env` to inject the generated contract addresses automatically.

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -14,13 +14,8 @@ so operators can launch safely with minimal manual steps.
 
 ## Step 1: Prepare configuration
 
-1. Copy the environment template and tailor values for your deployment:
-
-   ```bash
-   cp deployment-config/oneclick.env.example deployment-config/oneclick.env
-   ```
-
-   Update RPC URLs, API tokens, and address placeholders once contracts have been deployed.
+1. Review `deployment-config/oneclick.env`, which ships with conservative defaults suitable for local testing. Update RPC URLs,
+   API tokens, and address placeholders once contracts have been deployed.
 
 2. Customise `deployment-config/deployer.sample.json` and commit a copy (for example
    `deployment-config/sepolia.json`). Key fields:
@@ -50,8 +45,15 @@ Outputs:
 
 ## Step 3: Configure the runtime environment
 
-Update `deployment-config/oneclick.env` with the addresses from `latest-deployment.json`. The key variables consumed by the
-containers are:
+Update `deployment-config/oneclick.env` with the addresses from `latest-deployment.json`. You can do this automatically with
+the helper script:
+
+```bash
+npm run deploy:env -- --input deployment-config/latest-deployment.json
+```
+
+The script copies values from the deployment artefacts into the environment file while preserving existing comments and
+settings. The key variables consumed by the containers are:
 
 - `JOB_REGISTRY`, `STAKE_MANAGER_ADDRESS`, `VALIDATION_MODULE_ADDRESS`, `DISPUTE_MODULE_ADDRESS`, `REPUTATION_ENGINE_ADDRESS`
 - `SYSTEM_PAUSE_ADDRESS` (used to unpause later)

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "namehash:sepolia": "node scripts/compute-namehash.js deployment-config/sepolia.json",
     "deploy:protocol": "npx hardhat run scripts/deploy/providerAgnosticDeploy.ts",
     "deploy:oneclick": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/oneclick-deploy.ts",
+    "deploy:env": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/generate-oneclick-env.ts",
     "deploy:checklist": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/deployment-checklist.ts",
     "subgraph:e2e": "node scripts/subgraph-e2e.js",
     "migrate:mainnet": "TRUFFLE_NETWORK=mainnet npm run compile:mainnet && npx truffle migrate --network mainnet --reset && TRUFFLE_NETWORK=mainnet npm run wire:verify",

--- a/scripts/v2/generate-oneclick-env.ts
+++ b/scripts/v2/generate-oneclick-env.ts
@@ -1,0 +1,149 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { ethers } from 'ethers';
+
+interface AddressBook {
+  token?: string;
+  jobRegistry?: string;
+  stakeManager?: string;
+  validationModule?: string;
+  disputeModule?: string;
+  reputationEngine?: string;
+  systemPause?: string;
+}
+
+type Args = Record<string, string | boolean>;
+
+const ADDRESS_FIELDS: Record<string, keyof AddressBook> = {
+  AGIALPHA_TOKEN: 'token',
+  JOB_REGISTRY: 'jobRegistry',
+  STAKE_MANAGER_ADDRESS: 'stakeManager',
+  VALIDATION_MODULE_ADDRESS: 'validationModule',
+  DISPUTE_MODULE_ADDRESS: 'disputeModule',
+  REPUTATION_ENGINE_ADDRESS: 'reputationEngine',
+  SYSTEM_PAUSE_ADDRESS: 'systemPause',
+};
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const args: Args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      args[key] = next;
+      i += 1;
+    } else {
+      args[key] = true;
+    }
+  }
+  return args;
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  const absolute = path.resolve(filePath);
+  const raw = await fs.readFile(absolute, 'utf8');
+  return JSON.parse(raw) as T;
+}
+
+async function loadAddressBook(candidatePaths: string[]): Promise<AddressBook> {
+  for (const candidate of candidatePaths) {
+    try {
+      return await readJson<AddressBook>(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+  throw new Error(`Unable to locate deployment address book. Checked: ${candidatePaths.join(', ')}`);
+}
+
+function normaliseAddress(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  try {
+    return ethers.getAddress(trimmed);
+  } catch (error) {
+    throw new Error(`Invalid address detected: ${value}`);
+  }
+}
+
+function replaceLine(line: string, key: string, value: string): string {
+  const prefix = `${key}=`;
+  if (line.startsWith(prefix)) {
+    return `${prefix}${value}`;
+  }
+  return line;
+}
+
+async function ensureWritable(filePath: string, force: boolean) {
+  try {
+    await fs.access(filePath);
+    if (!force) {
+      throw new Error(
+        `Output file ${filePath} already exists. Pass --force to overwrite or remove the file before generating a new one.`,
+      );
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+async function main() {
+  const args = parseArgs();
+  const inputCandidates = [
+    (args.input as string) ?? path.join('deployment-config', 'latest-deployment.json'),
+    path.join('docs', 'deployment-addresses.json'),
+  ];
+  const templatePath = (args.template as string) ?? path.join('deployment-config', 'oneclick.env');
+  const outputPath = (args.output as string) ?? path.join('deployment-config', 'oneclick.env');
+  const force = Boolean(args.force);
+
+  const addresses = await loadAddressBook(inputCandidates);
+  await ensureWritable(outputPath, force);
+
+  let template = await fs.readFile(path.resolve(templatePath), 'utf8');
+  const lines = template.split(/\r?\n/);
+
+  const updates: string[] = [];
+  for (const [envKey, field] of Object.entries(ADDRESS_FIELDS)) {
+    const address = normaliseAddress(addresses[field]);
+    if (!address) {
+      continue;
+    }
+
+    const index = lines.findIndex((line) => line.startsWith(`${envKey}=`));
+    if (index === -1) {
+      lines.push(`${envKey}=${address}`);
+    } else {
+      lines[index] = replaceLine(lines[index], envKey, address);
+    }
+    updates.push(`${envKey} -> ${address}`);
+  }
+
+  template = lines.join('\n');
+  await fs.mkdir(path.dirname(path.resolve(outputPath)), { recursive: true });
+  await fs.writeFile(path.resolve(outputPath), template, 'utf8');
+
+  if (updates.length === 0) {
+    console.warn('⚠️  No address updates were applied; check that your deployment artefacts contain contract addresses.');
+  } else {
+    console.log('✅ Updated environment file with the following addresses:');
+    for (const update of updates) {
+      console.log(`  • ${update}`);
+    }
+  }
+  console.log(`ℹ️  Environment file written to ${path.resolve(outputPath)}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- ship a ready-to-edit deployment-config/oneclick.env with safe defaults and update the docs/README guidance
- add scripts/v2/generate-oneclick-env.ts and npm run deploy:env to populate container variables from deployment artefacts
- mention the automated env injection workflow across the one-click documentation set

## Testing
- npm run deploy:env -- --input docs/deployment-addresses.json --template deployment-config/oneclick.env.example --output /tmp/oneclick.env.test

------
https://chatgpt.com/codex/tasks/task_e_68df3585bf708333bdb333d9a82f3da8