### PR TITLE
Add interactive wizard for one-click deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,10 @@ along without context switching across multiple docs.
   deployment, copies the generated address book, and enforces secure launch defaults (paused modules, capped job rewards,
   minimal validator windows) as defined in [`deployment-config/deployer.sample.json`](deployment-config/deployer.sample.json).
   Follow up with `npm run deploy:env` to inject the resulting addresses into `deployment-config/oneclick.env` automatically.
+- **Guided wizard:** `npm run deploy:oneclick:wizard -- --config <path>` stitches the deployment, environment update, and optional
+  Docker Compose launch into a single interactive prompt (pass `--yes --compose` for non-interactive runs). The helper ensures
+  the `.env` template exists, forwards custom `--network`, `--env` or `--compose-file` flags, and prints the final manual commands
+  if Docker is unavailable.
 - **Step-by-step runbook:** see [docs/deployment/one-click.md](docs/deployment/one-click.md) for the full workflow, including
   prerequisites, environment preparation, post-launch checklist, and troubleshooting tips.
 

--- a/deployment-config/oneclick.env
+++ b/deployment-config/oneclick.env
@@ -2,6 +2,8 @@
 # Safe defaults are intentionally restrictive; update values once you verify your
 # deployment and pause state. After running the one-click deployer, invoke
 # `npm run deploy:env` to inject the generated contract addresses automatically.
+# The `npm run deploy:oneclick:wizard` helper chains the deployment, env update, and optional
+# docker-compose launch with friendly prompts.
 
 # Blockchain connectivity
 RPC_URL=http://anvil:8545

--- a/deployment-config/oneclick.env.example
+++ b/deployment-config/oneclick.env.example
@@ -2,6 +2,8 @@
 # Safe defaults are intentionally restrictive; update values once you verify your
 # deployment and pause state. After running the one-click deployer, invoke
 # `npm run deploy:env` to inject the generated contract addresses automatically.
+# The `npm run deploy:oneclick:wizard` helper chains the deployment, env update, and optional
+# docker-compose launch with friendly prompts.
 
 # Blockchain connectivity
 RPC_URL=http://anvil:8545

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -14,6 +14,18 @@ so operators can launch safely with minimal manual steps.
 
 ## Step 1: Prepare configuration
 
+Prefer a guided experience? Run the wizard once you have Node.js and Docker installed:
+
+```bash
+npm run deploy:oneclick:wizard -- --config deployment-config/sepolia.json --network sepolia
+```
+
+The wizard ensures `deployment-config/oneclick.env` exists (copying from the bundled
+template if necessary), executes the contract deployment, rewrites the environment file
+with the emitted addresses, and optionally launches `docker compose` for you. Supply
+`--yes --compose` to accept all prompts automatically; add `--env <path>` or
+`--compose-file <path>` when customising secrets or Kubernetes translations.
+
 1. Review `deployment-config/oneclick.env`, which ships with conservative defaults suitable for local testing. Update RPC URLs,
    API tokens, and address placeholders once contracts have been deployed.
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "namehash:sepolia": "node scripts/compute-namehash.js deployment-config/sepolia.json",
     "deploy:protocol": "npx hardhat run scripts/deploy/providerAgnosticDeploy.ts",
     "deploy:oneclick": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/oneclick-deploy.ts",
+    "deploy:oneclick:wizard": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/oneclick-wizard.ts",
     "deploy:env": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/generate-oneclick-env.ts",
     "deploy:checklist": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/deployment-checklist.ts",
     "subgraph:e2e": "node scripts/subgraph-e2e.js",

--- a/scripts/v2/oneclick-wizard.ts
+++ b/scripts/v2/oneclick-wizard.ts
@@ -1,0 +1,205 @@
+import { spawn } from 'child_process';
+import { promises as fs } from 'fs';
+import path from 'path';
+import readline from 'readline';
+
+interface DeployConfig {
+  network?: string;
+  governance?: string;
+  output?: string;
+}
+
+type Args = Record<string, string | boolean>;
+
+type RunCommandOptions = {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const args: Args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      args[key] = next;
+      i += 1;
+    } else {
+      args[key] = true;
+    }
+  }
+  return args;
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  const absolute = path.resolve(filePath);
+  const raw = await fs.readFile(absolute, 'utf8');
+  return JSON.parse(raw) as T;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function ensureEnvFile(envPath: string) {
+  const resolved = path.resolve(envPath);
+  if (await fileExists(resolved)) {
+    return;
+  }
+
+  const directory = path.dirname(resolved);
+  const base = path.basename(resolved);
+  const candidates = [
+    `${resolved}.example`,
+    path.join(directory, `${base}.example`),
+    path.join(directory, 'oneclick.env.example'),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (await fileExists(candidate)) {
+      await fs.copyFile(candidate, resolved);
+      console.log(`📄 Created ${resolved} from ${candidate}`);
+      return;
+    }
+  }
+
+  throw new Error(
+    `Environment file ${resolved} is missing and no template was found. Check deployment-config/oneclick.env.example.`,
+  );
+}
+
+async function confirm(question: string, autoYes: boolean, defaultValue = false): Promise<boolean> {
+  if (autoYes) {
+    return true;
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const suffix = defaultValue ? ' [Y/n] ' : ' [y/N] ';
+  const answer: string = await new Promise((resolve) => {
+    rl.question(`${question}${suffix}`, resolve);
+  });
+  rl.close();
+
+  const normalised = answer.trim().toLowerCase();
+  if (!normalised) {
+    return defaultValue;
+  }
+  return ['y', 'yes'].includes(normalised);
+}
+
+async function runCommand(command: string, args: string[], options: RunCommandOptions = {}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      cwd: options.cwd ?? process.cwd(),
+      env: { ...process.env, ...options.env },
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+
+    child.on('error', (error) => reject(error));
+  });
+}
+
+function resolveBool(arg: string | boolean | undefined): boolean | undefined {
+  if (typeof arg === 'boolean') {
+    return arg;
+  }
+  if (typeof arg === 'string') {
+    const lowered = arg.toLowerCase();
+    if (['true', 'yes', 'y', '1'].includes(lowered)) return true;
+    if (['false', 'no', 'n', '0'].includes(lowered)) return false;
+  }
+  return undefined;
+}
+
+async function main() {
+  const args = parseArgs();
+
+  const configPath = (args.config as string) ?? path.join('deployment-config', 'deployer.sample.json');
+  if (!(await fileExists(configPath))) {
+    throw new Error(`Configuration file not found: ${configPath}`);
+  }
+
+  const config = await readJson<DeployConfig>(configPath);
+  const network = (args.network as string) ?? config.network ?? 'sepolia';
+  const envFile = (args.env as string) ?? path.join('deployment-config', 'oneclick.env');
+  const composeFile = (args.composeFile as string) ?? 'compose.yaml';
+  const deploymentOutput = (args['deployment-output'] as string) ?? config.output ?? path.join('deployment-config', 'latest-deployment.json');
+
+  const autoYes = Boolean(resolveBool(args.yes) ?? resolveBool(args['non-interactive']));
+  const forceCompose = Boolean(resolveBool(args.compose));
+  const skipCompose = Boolean(resolveBool(args['no-compose']) ?? resolveBool(args['skip-compose']));
+
+  console.log('🔧 One-click deployment wizard');
+  console.log(`  • Config file:       ${path.resolve(configPath)}`);
+  console.log(`  • Target network:    ${network}`);
+  console.log(`  • Env file:          ${path.resolve(envFile)}`);
+  console.log(`  • Compose file:      ${path.resolve(composeFile)}`);
+  console.log(`  • Address artefacts: ${path.resolve(deploymentOutput)}`);
+  if (config.governance) {
+    console.log(`  • Governance:        ${config.governance}`);
+  }
+
+  await ensureEnvFile(envFile);
+
+  const proceed = await confirm('Deploy contracts with npm run deploy:oneclick?', autoYes);
+  if (!proceed) {
+    console.log('🚫 Deployment aborted by user');
+    return;
+  }
+
+  await runCommand('npm', ['run', 'deploy:oneclick', '--', '--config', path.resolve(configPath), '--network', network, '--yes']);
+
+  const envArgs = ['run', 'deploy:env', '--', '--input', path.resolve(deploymentOutput), '--template', path.resolve(envFile), '--output', path.resolve(envFile), '--force'];
+  console.log('📝 Updating environment file with deployed addresses');
+  await runCommand('npm', envArgs);
+
+  let startCompose = forceCompose;
+  if (!forceCompose && !skipCompose) {
+    startCompose = await confirm('Launch Docker Compose stack now?', autoYes);
+  }
+
+  if (startCompose) {
+    const composeArgs = ['compose', '--env-file', path.resolve(envFile), '-f', path.resolve(composeFile), 'up', '--build'];
+    const detach = resolveBool(args.detach);
+    if (detach !== false) {
+      composeArgs.push('--detach');
+    }
+    try {
+      await runCommand('docker', composeArgs);
+      console.log('🚀 Docker Compose stack is starting...');
+    } catch (error) {
+      console.error('⚠️  Failed to launch Docker Compose stack:', error instanceof Error ? error.message : error);
+      console.error('You can launch it manually with:');
+      console.error(`  docker compose --env-file ${path.resolve(envFile)} -f ${path.resolve(composeFile)} up --build${(resolveBool(args.detach) !== false) ? ' --detach' : ''}`);
+    }
+  } else {
+    console.log('ℹ️  Skipping Docker Compose launch. Start manually when ready.');
+  }
+
+  console.log('✅ One-click workflow completed. Review the generated artefacts before unpausing the protocol.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a TypeScript wizard that chains the contract deployment, env update, and optional Docker Compose launch for the one-click stack
- expose the wizard through an npm script and document the new flow in the README and one-click deployment guide
- mention the helper in the default oneclick.env templates so operators discover the automated workflow

## Testing
- npm run lint:check *(fails: existing solhint warnings exceed max warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68df371eca2883339eec7cf6c092b318