### PR TITLE
Add non-interactive one-click deployment wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,9 @@ along without context switching across multiple docs.
   mock AA providers, Alpha bridge, validator UI, and enterprise front-end with sensible defaults. The repository now ships a
   ready-to-edit `deployment-config/oneclick.env`; update any secrets and run `docker compose --env-file
   deployment-config/oneclick.env up --build` for a fully wired stack.
+- **Hands-off launcher:** `npm run deploy:oneclick:auto -- --config <path> --network <network>` runs the entire wizard in
+  non-interactive mode. The helper confirms the `.env` template exists, deploys contracts, applies secure defaults, rewrites
+  `deployment-config/oneclick.env`, and starts Docker Compose in detached mode unless you pass `--attach` or `--no-compose`.
 - **Automated contract bootstrap:** `npm run deploy:oneclick -- --config <path> --network <network>` executes the Hardhat
   deployment, copies the generated address book, and enforces secure launch defaults (paused modules, capped job rewards,
   minimal validator windows) as defined in [`deployment-config/deployer.sample.json`](deployment-config/deployer.sample.json).
@@ -517,6 +520,9 @@ along without context switching across multiple docs.
   if Docker is unavailable.
 - **Step-by-step runbook:** see [docs/deployment/one-click.md](docs/deployment/one-click.md) for the full workflow, including
   prerequisites, environment preparation, post-launch checklist, and troubleshooting tips.
+- **Configuration reference:** [docs/deployment/automated-network-configuration.md](docs/deployment/automated-network-configuration.md)
+  explains how the JSON config maps to on-chain actions, the helper commands that populate ENS namehashes, and how to customise
+  treasury, staking, and validator defaults without writing Solidity.
 
 ### Mainnet Deployment
 

--- a/docs/deployment/automated-network-configuration.md
+++ b/docs/deployment/automated-network-configuration.md
@@ -1,0 +1,102 @@
+# Automated Network Configuration
+
+The one-click deployment flow removes nearly every manual blockchain task. Operators
+feed a JSON configuration into the helper CLI and it deploys or wires the contracts,
+initialises launch parameters, and publishes the generated addresses for the rest of
+the stack.
+
+## 1. Describe the target network
+
+Start from [`deployment-config/deployer.sample.json`](../../deployment-config/deployer.sample.json)
+and copy it to a network-specific file (for example `deployment-config/sepolia.json`).
+The file captures the governance multisig, staking economics, ENS integration details,
+and secure defaults that are enforced immediately after deployment.
+
+Key fields:
+
+| Field | Purpose |
+| --- | --- |
+| `governance` | Address that owns the deployed modules. |
+| `econ` | Fee percentages, staking thresholds, dispute timing, and job stake limits. |
+| `identity` | ENS registry/namewrapper addresses plus agent/validator root nodes. |
+| `secureDefaults` | Launch guardrails such as pausing the system and capping job budgets. |
+| `output` | Optional custom location for the generated address book artifact. |
+
+Helper commands populate the ENS namehashes referenced by the identity block:
+
+```bash
+npm run namehash:sepolia           # writes deployment-config/sepolia.json in place
+npm run namehash:mainnet           # updates deployment-config/mainnet.json
+```
+
+## 2. Execute the deployment plan
+
+Run the automated bootstrapper with your JSON file and the desired Hardhat network. The
+helper orchestrates Hardhat, copies the address book, and applies the secure defaults in
+a single pass:
+
+```bash
+npm run deploy:oneclick -- --config deployment-config/sepolia.json --network sepolia --yes
+```
+
+Behind the scenes the script:
+
+1. Deploys the full contract suite with sane constructor parameters.
+2. Sets ENS registry and root nodes via `IdentityRegistry`.
+3. Connects `JobRegistry`, `StakeManager`, and `ValidationModule` together.
+4. Locks down the launch configuration (pause switch, staking minimums, job caps,
+   validator commit/reveal windows, slashing distribution).
+5. Writes the resulting addresses to both `docs/deployment-addresses.json` and the
+   configured `output` path for operators.
+
+Use the optional `--appealFee`, `--disputeWindow`, or treasury overrides defined in the
+JSON to customise the deployment without editing any Solidity.
+
+## 3. Update environment variables automatically
+
+Feed the generated address book into the `.env` template that ships with the repository.
+The helper preserves comments and unrelated settings while rewriting the address keys
+consumed by Docker Compose:
+
+```bash
+npm run deploy:env -- --input deployment-config/latest-deployment.json --template deployment-config/oneclick.env
+```
+
+The command validates every address, normalises casing, and refuses to overwrite an
+existing file unless `--force` is supplied.
+
+## 4. Launch the stack in one command
+
+Fire up the entire off-chain platform – orchestrator, APIs, gateways, notifications,
+front-ends, and optional mock AA infrastructure – without touching Docker manually:
+
+```bash
+npm run deploy:oneclick:auto -- --config deployment-config/sepolia.json --network sepolia
+```
+
+The wrapper ensures the `.env` file exists, executes the deployment, updates the
+environment file, and starts Docker Compose in detached mode. Add `--attach` to stream
+logs or `--no-compose` to skip container startup.
+
+## 5. Secure defaults out of the box
+
+Deployments begin in a locked-down posture:
+
+- `SystemPause.pauseAll()` is executed if the pause contract is present.
+- Job rewards and durations are capped, and validator commit/reveal windows default to
+  zero until explicitly set.
+- Slashing sends 100% of funds to the treasury by default, preventing accidental user
+  payouts.
+- Only the configured governance address can relax these controls through the dedicated
+  owner-control scripts.
+
+These defaults prevent an operator from unintentionally launching an unsafe configuration
+while still giving them straightforward knobs to adjust once they are ready.
+
+## 6. Production playbooks for non-technical operators
+
+Every command above is documented with screenshots, expected outputs, and troubleshooting
+notes in the [Non-Technical Deployment Guide](../owner-control-non-technical-guide.md) and
+[Master Operations Guide](../operations_guide.md). The new one-click helper integrates
+with those playbooks so an operations manager can follow the numbered checklist, paste
+commands, and record the resulting artifacts without writing code or using Etherscan.

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -26,6 +26,17 @@ with the emitted addresses, and optionally launches `docker compose` for you. Su
 `--yes --compose` to accept all prompts automatically; add `--env <path>` or
 `--compose-file <path>` when customising secrets or Kubernetes translations.
 
+Want a single command with no prompts? Use the non-interactive wrapper, which simply
+forwards any flags to the wizard but defaults to launching Docker Compose in detached
+mode:
+
+```bash
+npm run deploy:oneclick:auto -- --config deployment-config/sepolia.json --network sepolia
+```
+
+Add `--attach` to stream Compose logs or `--no-compose` if you only need the deployment
+artifacts.
+
 1. Review `deployment-config/oneclick.env`, which ships with conservative defaults suitable for local testing. Update RPC URLs,
    API tokens, and address placeholders once contracts have been deployed.
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "deploy:protocol": "npx hardhat run scripts/deploy/providerAgnosticDeploy.ts",
     "deploy:oneclick": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/oneclick-deploy.ts",
     "deploy:oneclick:wizard": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/oneclick-wizard.ts",
+    "deploy:oneclick:auto": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/oneclick-stack.ts",
     "deploy:env": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/generate-oneclick-env.ts",
     "deploy:checklist": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/deployment-checklist.ts",
     "subgraph:e2e": "node scripts/subgraph-e2e.js",

--- a/scripts/v2/oneclick-stack.ts
+++ b/scripts/v2/oneclick-stack.ts
@@ -1,0 +1,103 @@
+import { spawn } from 'child_process';
+import path from 'path';
+
+interface Args {
+  [key: string]: string | boolean;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const args: Args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      args[key] = next;
+      i += 1;
+    } else {
+      args[key] = true;
+    }
+  }
+  return args;
+}
+
+function resolveBoolean(value: string | boolean | undefined): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalised = value.trim().toLowerCase();
+    if (['true', '1', 'yes', 'y'].includes(normalised)) return true;
+    if (['false', '0', 'no', 'n'].includes(normalised)) return false;
+  }
+  return undefined;
+}
+
+function pushFlag(target: string[], flag: string, value?: string) {
+  if (value && value.length > 0) {
+    target.push(flag, value);
+  }
+}
+
+async function main() {
+  const args = parseArgs();
+
+  const composePreference = resolveBoolean(args.compose);
+  const skipCompose = resolveBoolean(args['no-compose']) ?? resolveBoolean(args['skip-compose']);
+  const compose = skipCompose === true ? false : composePreference ?? true;
+
+  const detachPreference = resolveBoolean(args.detach);
+  const attachPreference = resolveBoolean(args.attach);
+  const detach = attachPreference === true ? false : detachPreference ?? true;
+
+  const wizardArgs = ['run', 'deploy:oneclick:wizard', '--', '--yes'];
+  if (compose) {
+    wizardArgs.push('--compose');
+    if (!detach) {
+      wizardArgs.push('--detach=false');
+    }
+  } else {
+    wizardArgs.push('--no-compose');
+  }
+
+  const passthroughKeys: Array<[keyof Args, string]> = [
+    ['config', '--config'],
+    ['network', '--network'],
+    ['env', '--env'],
+    ['compose-file', '--compose-file'],
+    ['deployment-output', '--deployment-output'],
+  ];
+
+  for (const [key, flag] of passthroughKeys) {
+    const raw = args[key as string];
+    if (typeof raw === 'string' && raw.length > 0) {
+      const resolved = flag === '--config' || flag === '--env' || flag === '--compose-file' || flag === '--deployment-output'
+        ? path.resolve(raw)
+        : raw;
+      pushFlag(wizardArgs, flag, resolved);
+    }
+  }
+
+  const child = spawn('npm', wizardArgs, {
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`npm ${wizardArgs.join(' ')} exited with code ${code}`));
+      }
+    });
+    child.on('error', (error) => reject(error));
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a non-interactive `deploy:oneclick:auto` helper that wraps the guided wizard and defaults to launching Docker Compose
- document the new workflow in the README and one-click deployment guide
- publish a dedicated automated network configuration guide for operators

## Testing
- not run (documentation and CLI scaffolding only)


------
https://chatgpt.com/codex/tasks/task_e_68df39198fa08333900451c389ec3cb0