### PR TITLE
Refactor deployment configs and secure defaults

### DIFF
--- a/deployment-config/mainnet.json
+++ b/deployment-config/mainnet.json
@@ -1,10 +1,27 @@
 {
+  "network": "mainnet",
   "governance": "0x0000000000000000000000000000000000000000",
   "agialpha": "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
-  "overrides": {
-    "feePct": 0.02,
-    "burnPct": 0.05,
-    "ensRoots": {
+  "tax": {
+    "enabled": true,
+    "uri": "ipfs://QmExamplePolicyHash",
+    "description": "All taxes on participants; contract and owner exempt"
+  },
+  "econ": {
+    "feePct": 5,
+    "burnPct": 1,
+    "employerSlashPct": 10,
+    "treasurySlashPct": 90,
+    "validatorSlashRewardPct": 0,
+    "commitWindow": "1d",
+    "revealWindow": "1d",
+    "minStake": "1000",
+    "jobStake": "500"
+  },
+  "identity": {
+    "ens": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+    "nameWrapper": "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401",
+    "roots": {
       "agentRoot": {
         "name": "agent.agi.eth",
         "hash": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d"
@@ -21,6 +38,16 @@
         "name": "",
         "hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
       }
-    }
-  }
+    },
+    "validatorMerkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "agentMerkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "secureDefaults": {
+    "pauseOnLaunch": true,
+    "maxJobRewardAgia": 25,
+    "maxJobDurationSeconds": 86400,
+    "validatorCommitWindowSeconds": 1,
+    "validatorRevealWindowSeconds": 1
+  },
+  "output": "deployment-config/latest-deployment.mainnet.json"
 }

--- a/deployment-config/sepolia.json
+++ b/deployment-config/sepolia.json
@@ -1,10 +1,27 @@
 {
+  "network": "sepolia",
   "governance": "0x0000000000000000000000000000000000000000",
   "agialpha": "0x0000000000000000000000000000000000000000",
-  "overrides": {
-    "feePct": 0.02,
-    "burnPct": 0.05,
-    "ensRoots": {
+  "tax": {
+    "enabled": true,
+    "uri": "ipfs://QmExamplePolicyHash",
+    "description": "All taxes on participants; contract and owner exempt"
+  },
+  "econ": {
+    "feePct": 5,
+    "burnPct": 1,
+    "employerSlashPct": 10,
+    "treasurySlashPct": 90,
+    "validatorSlashRewardPct": 0,
+    "commitWindow": "1d",
+    "revealWindow": "1d",
+    "minStake": "1000",
+    "jobStake": "500"
+  },
+  "identity": {
+    "ens": "0x0000000000000000000000000000000000000000",
+    "nameWrapper": "0x0000000000000000000000000000000000000000",
+    "roots": {
       "agentRoot": {
         "name": "",
         "hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
@@ -21,6 +38,16 @@
         "name": "",
         "hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
       }
-    }
-  }
+    },
+    "validatorMerkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "agentMerkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "secureDefaults": {
+    "pauseOnLaunch": true,
+    "maxJobRewardAgia": 25,
+    "maxJobDurationSeconds": 86400,
+    "validatorCommitWindowSeconds": 1,
+    "validatorRevealWindowSeconds": 1
+  },
+  "output": "deployment-config/latest-deployment.sepolia.json"
 }

--- a/scripts/v2/apply-secure-defaults.ts
+++ b/scripts/v2/apply-secure-defaults.ts
@@ -211,8 +211,29 @@ async function applySecureDefaults(config: DeployConfig, addresses: AddressBook)
 
 async function main() {
   const args = parseArgs();
-  const configPath = (args.config as string) ?? path.join('deployment-config', 'deployer.sample.json');
-  const addressesPath = (args.addresses as string) ?? path.join('docs', 'deployment-addresses.json');
+  const getArg = (key: string): string | boolean | undefined => {
+    if (Object.prototype.hasOwnProperty.call(args, key)) {
+      return args[key];
+    }
+    const lower = key.toLowerCase();
+    if (lower !== key && Object.prototype.hasOwnProperty.call(args, lower)) {
+      return args[lower];
+    }
+    const envKey = `ONECLICK_${key
+      .replace(/([A-Z])/g, '_$1')
+      .replace(/__/g, '_')
+      .toUpperCase()}`;
+    if (process.env[envKey] !== undefined) {
+      return process.env[envKey];
+    }
+    return undefined;
+  };
+
+  const configPath =
+    (getArg('config') as string) ??
+    path.join('deployment-config', 'deployer.sample.json');
+  const addressesPath =
+    (getArg('addresses') as string) ?? path.join('docs', 'deployment-addresses.json');
 
   const config = await readJson<DeployConfig>(configPath);
   const addresses = await readJson<AddressBook>(addressesPath);


### PR DESCRIPTION
## Summary
- restructure the sepolia and mainnet deployment configs to mirror the sample layout, including econ, identity, and secure-default sections
- update the one-click deployment script to feed arguments via environment variables, auto-select the deployer for zero governance, and expose launch guardrails
- enhance the deploy and apply-secure-defaults scripts to read lowercase/env overrides and tolerate Hardhat mock tokens during local runs

## Testing
- `npx hardhat compile`
- `npm run deploy:oneclick -- --config deployment-config/sepolia.json --network hardhat --yes` *(fails: reverts when StakeManager references the canonical AGIALPHA address on a non-forked Hardhat network)*

------
https://chatgpt.com/codex/tasks/task_e_68df3c66d84483339b13c617a9de2ed5