### PR TITLE
Fix ValidationModule deployment defaults

### DIFF
--- a/deployment-config/deployer.sample.json
+++ b/deployment-config/deployer.sample.json
@@ -1,6 +1,6 @@
 {
   "network": "localhost",
-  "governance": "0x0123456789aBcDEF0123456789abCDef01234567",
+  "governance": "0x0000000000000000000000000000000000000000",
   "tax": {
     "enabled": true,
     "uri": "ipfs://QmExamplePolicyHash",


### PR DESCRIPTION
## Summary
- ensure the ValidationModule is deployed with a 3 validator minimum (5 max) and wire the StakeManager into the ReputationEngine
- inject mock AGIALPHA bytecode and auto-accept two-step ownership when running on Hardhat so the deployment script can complete locally
- skip the SystemPause#setModules call during dry runs and set the sample config governance to zero so the deployer account is reused by default

## Testing
- npx hardhat compile
- npm run deploy:oneclick -- --config deployment-config/deployer.sample.json --network hardhat --yes

------
https://chatgpt.com/codex/tasks/task_e_68df43fa2d5c8333b556b1ff2afc360f