### PR TITLE
Update secure default validator windows to 60 seconds

### DIFF
--- a/deployment-config/deployer.sample.json
+++ b/deployment-config/deployer.sample.json
@@ -29,8 +29,8 @@
     "pauseOnLaunch": true,
     "maxJobRewardAgia": 25,
     "maxJobDurationSeconds": 86400,
-    "validatorCommitWindowSeconds": 1,
-    "validatorRevealWindowSeconds": 1
+    "validatorCommitWindowSeconds": 60,
+    "validatorRevealWindowSeconds": 60
   },
   "output": "deployment-config/latest-deployment.json"
 }

--- a/deployment-config/mainnet.json
+++ b/deployment-config/mainnet.json
@@ -46,8 +46,8 @@
     "pauseOnLaunch": true,
     "maxJobRewardAgia": 25,
     "maxJobDurationSeconds": 86400,
-    "validatorCommitWindowSeconds": 1,
-    "validatorRevealWindowSeconds": 1
+    "validatorCommitWindowSeconds": 60,
+    "validatorRevealWindowSeconds": 60
   },
   "output": "deployment-config/latest-deployment.mainnet.json"
 }

--- a/deployment-config/sepolia.json
+++ b/deployment-config/sepolia.json
@@ -46,8 +46,8 @@
     "pauseOnLaunch": true,
     "maxJobRewardAgia": 25,
     "maxJobDurationSeconds": 86400,
-    "validatorCommitWindowSeconds": 1,
-    "validatorRevealWindowSeconds": 1
+    "validatorCommitWindowSeconds": 60,
+    "validatorRevealWindowSeconds": 60
   },
   "output": "deployment-config/latest-deployment.sepolia.json"
 }


### PR DESCRIPTION
## Summary
- set the secure default validator commit and reveal windows to 60 seconds in the sample, Sepolia, and mainnet deployment configs so they start with realistic timings

## Testing
- npm run deploy:oneclick -- --config deployment-config/sepolia.json --network sepolia --yes *(fails: Hardhat HH117 – missing RPC URL in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df4b95c4c88333b3bf0b882a25be16