### PR TITLE
Clarify default treasury slashing split in one-click docs

### DIFF
--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -38,8 +38,10 @@ so operators can launch safely with minimal manual steps.
 - **Conservative limits** – Initial job caps, validator commit/reveal windows, dispute horizons, and stake requirements are
   enforced from the `secureDefaults` block in the JSON config. The provided templates favour short horizons and low ceilings so
   a new network launches in a tightly controlled state.
-- **Treasury-first slashing** – `StakeManager` defaults to directing slashed tokens entirely to the treasury, avoiding accidental
-  payouts during early testing.
+- **Treasury-first slashing** – `StakeManager` defaults to routing 90% of slashed stakes to the treasury and the remaining 10%
+  to the employer, with `validatorSlashRewardPct` disabled. Adjust `treasurySlashPct`, `employerSlashPct`, and
+  `validatorSlashRewardPct` in `deployment-config/*.json` before running `npm run deploy:oneclick` if you prefer a 100% treasury
+  configuration.
 - **Allowlist bootstrapping** – Configuration files accept optional agent/validator allowlists that are applied automatically,
   letting operators start with a known set of participants before opening registration more broadly.
 


### PR DESCRIPTION
## Summary
- update the one-click deployment guide to describe the default 90/10 treasury versus employer slashing split
- document how to adjust the slashing percentages in deployment-config JSON before running `npm run deploy:oneclick`
- confirm the sample, Sepolia, and mainnet deployment configs already reflect the documented 90/10 split with validator rewards disabled

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df4ccc31208333ae352e0f4131a4a7