### PR TITLE
Clarify one-click allowlist follow-up steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,9 @@ along without context switching across multiple docs.
   deployment, copies the generated address book, and enforces secure launch defaults (paused modules, capped job rewards,
   minimal validator windows) as defined in [`deployment-config/deployer.sample.json`](deployment-config/deployer.sample.json).
   Follow up with `npm run deploy:env` to inject the resulting addresses into `deployment-config/oneclick.env` automatically.
+- **Identity allowlists:** The one-click helpers leave the agent and validator allowlists empty. Once the deployment completes,
+  synchronise the desired entries via `npm run identity:update -- --network <network>` (or `scripts/v2/updateIdentityRegistry.ts`)
+  using the `config/identity-registry*.json` files so `IdentityRegistry` matches your intended roster.
 - **Guided wizard:** `npm run deploy:oneclick:wizard -- --config <path>` stitches the deployment, environment update, and optional
   Docker Compose launch into a single interactive prompt (pass `--yes --compose` for non-interactive runs). The helper ensures
   the `.env` template exists, forwards custom `--network`, `--env` or `--compose-file` flags, and prints the final manual commands

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -42,8 +42,10 @@ so operators can launch safely with minimal manual steps.
   to the employer, with `validatorSlashRewardPct` disabled. Adjust `treasurySlashPct`, `employerSlashPct`, and
   `validatorSlashRewardPct` in `deployment-config/*.json` before running `npm run deploy:oneclick` if you prefer a 100% treasury
   configuration.
-- **Allowlist bootstrapping** – Configuration files accept optional agent/validator allowlists that are applied automatically,
-  letting operators start with a known set of participants before opening registration more broadly.
+- **Allowlist bootstrapping** – Configuration files capture optional agent/validator allowlists, but the one-click deployment
+  does **not** seed them automatically. After contracts are live, sync the desired entries via
+  `npm run identity:update -- --network <network>` (or run `scripts/v2/updateIdentityRegistry.ts`) using the
+  `config/identity-registry*.json` files so the `IdentityRegistry` reflects your intended allowlists.
 
 ### Clear Deployment Guide & Support
 

--- a/docs/operations_guide.md
+++ b/docs/operations_guide.md
@@ -102,6 +102,10 @@ sequenceDiagram
    Add `--attach` to stream logs interactively. Reference the service list in the [one-click guide](./deployment/one-click.md#step-4-launch-the-container-stack)
    for exposed ports and responsibilities.
 
+   > **Identity allowlists:** The one-click deployment intentionally leaves the agent and validator allowlists empty. After
+   > verifying the contracts, apply any required entries with `npm run identity:update -- --network <network>` (or run
+   > `scripts/v2/updateIdentityRegistry.ts`) based on the committed `config/identity-registry*.json` files.
+
 ### 4. Roll Out Service Updates
 
 1. Commit code changes following repo coding standards.


### PR DESCRIPTION
## Summary
- clarify that the one-click deployment flow does not automatically populate agent or validator allowlists
- point operators to `npm run identity:update` / `scripts/v2/updateIdentityRegistry.ts` and the identity registry config files for post-deployment allowlist updates
- align the operations guide and README messaging with the updated guidance so operators see consistent instructions

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df4dd483188333852ad8d0dbefc0ea