### PR TITLE
Clarify one-click deployment wizard documentation

### DIFF
--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -53,8 +53,10 @@ so operators can launch safely with minimal manual steps.
   [`docs/owner-control-non-technical-guide.md`](../owner-control-non-technical-guide.md),
   [`docs/operations_guide.md`](../operations_guide.md), and the detailed sections below mirror every command emitted by the
   automation scripts, complete with screenshots/log samples.
-- **Wizard & prompts** – The deployment wizard asks human-friendly questions (governance multisig, RPC URLs, optional Compose
-  launch) and catches common mistakes before submitting transactions.
+- **Wizard & prompts** – The deployment wizard verifies the `deployment-config/oneclick.env` file exists, runs
+  `npm run deploy:oneclick` under the hood, rewrites the environment file with the emitted addresses, and can trigger Docker
+  Compose for you. It expects governance signers, RPC URLs, and other required inputs to already be populated in the config
+  files before you launch it, surfacing prompts only for confirmation.
 - **Auditable artefacts** – Address books, `.env` files, and Compose overrides are generated automatically and stored under
   version control-friendly paths so operators can file change tickets, share bundles with auditors, or restore systems quickly.
 
@@ -74,11 +76,14 @@ Prefer a guided experience? Run the wizard once you have Node.js and Docker inst
 npm run deploy:oneclick:wizard -- --config deployment-config/sepolia.json --network sepolia
 ```
 
-The wizard ensures `deployment-config/oneclick.env` exists (copying from the bundled
-template if necessary), executes the contract deployment, rewrites the environment file
-with the emitted addresses, and optionally launches `docker compose` for you. Supply
-`--yes --compose` to accept all prompts automatically; add `--env <path>` or
-`--compose-file <path>` when customising secrets or Kubernetes translations.
+The wizard first checks that `deployment-config/oneclick.env` is present (copying from
+the bundled template if necessary), runs the full `npm run deploy:oneclick` flow,
+rewrites the environment file with the emitted addresses, and optionally launches
+`docker compose` for you. Provide `--yes --compose` to accept all prompts
+automatically; add `--env <path>` or `--compose-file <path>` when customising secrets
+or Kubernetes translations. Ensure `deployment-config/deployer.sample.json` (or your
+environment-specific copy) and `deployment-config/oneclick.env` already contain the
+governance, RPC, and credential values the wizard will validate.
 
 Want a single command with no prompts? Use the non-interactive wrapper, which simply
 forwards any flags to the wizard but defaults to launching Docker Compose in detached

--- a/docs/operations_guide.md
+++ b/docs/operations_guide.md
@@ -59,8 +59,11 @@ Follow the [One-Click Deployment Guide](./deployment/one-click.md) for a full wa
    npm run deploy:oneclick:wizard -- --config deployment-config/sepolia.json --network sepolia
    ```
 
-   The wizard ensures `deployment-config/oneclick.env` exists, validates required environment variables, and stages the
-   deployment artefacts for the next steps.
+   The wizard verifies `deployment-config/oneclick.env` exists (seeding it from the template if needed), runs the same
+   `npm run deploy:oneclick` flow, rewrites the environment file with the emitted addresses, and can launch Docker Compose.
+   Make sure `deployment-config/oneclick.env` and your config JSON (for example `deployment-config/deployer.sample.json`
+   copied to an environment-specific file) already include the governance, RPC, and credential values the prompts will
+   confirm.
 
 ### 2. Deploy Smart Contracts
 


### PR DESCRIPTION
## Summary
- clarify the one-click deployment wizard responsibilities and prerequisites in the deployment guide
- align the operations guide description with the wizard flow and reference the relevant configuration files

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68df4e5580208333b1fa96b97c9a91e5