### PR TITLE
Add conversational portal UX with localization

### DIFF
--- a/apps/enterprise-portal/src/app/globals.css
+++ b/apps/enterprise-portal/src/app/globals.css
@@ -25,6 +25,55 @@ main {
   padding: 2rem;
 }
 
+.portal-shell {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.portal-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .portal-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.portal-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 1100px) {
+  .portal-grid {
+    grid-template-columns: 2.2fr 1fr;
+    align-items: start;
+  }
+}
+
+.portal-lower-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 1100px) {
+  .portal-lower-grid {
+    grid-template-columns: 1.6fr 1fr;
+    align-items: start;
+  }
+}
+
+.primary-column,
+.secondary-column {
+  display: grid;
+  gap: 1.75rem;
+}
+
 section {
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 16px;
@@ -133,6 +182,251 @@ button.secondary {
   color: #ffc7d1;
 }
 
+.language-switcher select {
+  border-radius: 12px;
+  padding: 0.5rem 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.chat-composer {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.chat-thread {
+  display: grid;
+  gap: 1rem;
+  max-height: 360px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.chat-bubble {
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  line-height: 1.6;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.chat-bubble.user {
+  justify-self: end;
+  background: linear-gradient(135deg, rgba(45, 123, 255, 0.35), rgba(122, 59, 255, 0.35));
+}
+
+.chat-input {
+  display: grid;
+  gap: 1rem;
+}
+
+.chat-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.chat-summary ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.chat-summary li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.chat-summary strong {
+  color: #f2f4f7;
+  font-weight: 600;
+}
+
+.sla-step {
+  display: grid;
+  gap: 1rem;
+}
+
+.toggle-group {
+  display: inline-flex;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  overflow: hidden;
+}
+
+.toggle {
+  background: transparent;
+  color: inherit;
+  padding: 0.5rem 1.5rem;
+}
+
+.toggle.active {
+  background: linear-gradient(135deg, #2d7bff, #7a3bff);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.opportunity-feed {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.opportunity-card {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 16px;
+  padding: 1.25rem;
+  background: rgba(15, 22, 34, 0.85);
+  display: grid;
+  gap: 1rem;
+}
+
+.opportunity-card.accepted {
+  border-color: rgba(33, 197, 93, 0.5);
+}
+
+.opportunity-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.opportunity-card dl {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.opportunity-card dt {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.opportunity-card dd {
+  margin: 0;
+}
+
+.opportunity-card footer {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.validator-queue {
+  display: grid;
+  gap: 1rem;
+}
+
+.validator-card {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 14px;
+  padding: 1rem;
+  background: rgba(11, 16, 26, 0.8);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.validator-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.validator-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.validator-card textarea {
+  resize: vertical;
+  min-height: 90px;
+}
+
+.status {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.help-drawer {
+  display: grid;
+  gap: 1rem;
+}
+
+.help-content {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.help-links {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.faq-list {
+  list-style: disc;
+  margin: 0 0 0 1.5rem;
+  padding: 0;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.support-checklist {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.5rem;
+}
+
+.support-checklist ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.support-checklist li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.support-checklist .tip {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+@media (max-width: 768px) {
+  main {
+    padding: 1.25rem;
+  }
+
+  section {
+    padding: 1.25rem;
+  }
+
+  .chat-thread {
+    max-height: 280px;
+  }
+
+  .opportunity-card footer {
+    flex-direction: column;
+  }
+
+  .validator-actions {
+    flex-direction: column;
+  }
+}
 .data-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));

--- a/apps/enterprise-portal/src/app/layout.tsx
+++ b/apps/enterprise-portal/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import { LocalizationProvider } from '../context/LocalizationContext';
 
 export const metadata = {
   title: 'AGI Jobs Enterprise Portal',
@@ -11,7 +12,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <main>{children}</main>
+        <LocalizationProvider>
+          <main>{children}</main>
+        </LocalizationProvider>
       </body>
     </html>
   );

--- a/apps/enterprise-portal/src/components/AgentOpportunitiesPanel.tsx
+++ b/apps/enterprise-portal/src/components/AgentOpportunitiesPanel.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import type { JobSummary } from '../types';
+import { useLocalization } from '../context/LocalizationContext';
+import { formatUnits } from 'ethers';
+
+interface AgentOpportunitiesPanelProps {
+  jobs: JobSummary[];
+  loading: boolean;
+  error?: string;
+}
+
+const formatReward = (reward: bigint) => {
+  try {
+    return formatUnits(reward, 18);
+  } catch (err) {
+    return reward.toString();
+  }
+};
+
+export const AgentOpportunitiesPanel = ({ jobs, loading, error }: AgentOpportunitiesPanelProps) => {
+  const { t } = useLocalization();
+  const [acceptedJob, setAcceptedJob] = useState<bigint>();
+  const [dismissedJobs, setDismissedJobs] = useState<bigint[]>([]);
+
+  const availableJobs = jobs.filter((job) => !dismissedJobs.includes(job.jobId));
+
+  const handleAccept = (jobId: bigint) => {
+    setAcceptedJob(jobId);
+  };
+
+  const handleDecline = (jobId: bigint) => {
+    setDismissedJobs((prev) => [...prev, jobId]);
+  };
+
+  return (
+    <section>
+      <div className="card-title">
+        <div>
+          <h3>{t('agent.title')}</h3>
+          <p>{t('agent.subtitle')}</p>
+        </div>
+      </div>
+      {loading && <div className="status">{t('status.loading')}</div>}
+      {error && <div className="alert error">{error}</div>}
+      {!loading && availableJobs.length === 0 && <div className="status">{t('agent.empty')}</div>}
+      <div className="opportunity-feed">
+        {availableJobs.map((job) => (
+          <article key={job.jobId.toString()} className={`opportunity-card ${acceptedJob === job.jobId ? 'accepted' : ''}`}>
+            <header>
+              <h4>#{job.jobId.toString()}</h4>
+              <span className="tag green">{t('agent.reward')}: {formatReward(job.reward)}</span>
+            </header>
+            <dl>
+              <div>
+                <dt>{t('agent.deadline')}</dt>
+                <dd>{job.deadline ? new Date(job.deadline * 1000).toLocaleString() : t('employer.summary.none')}</dd>
+              </div>
+              <div>
+                <dt>{t('employer.summary.skills')}</dt>
+                <dd>{job.specUri ?? job.specHash}</dd>
+              </div>
+            </dl>
+            <footer>
+              <button className="primary" onClick={() => handleAccept(job.jobId)}>
+                {t('agent.accept')}
+              </button>
+              <button className="secondary" onClick={() => handleDecline(job.jobId)}>
+                {t('agent.decline')}
+              </button>
+            </footer>
+          </article>
+        ))}
+      </div>
+      {acceptedJob && <div className="alert success">{t('employer.status.success')}</div>}
+    </section>
+  );
+};

--- a/apps/enterprise-portal/src/components/ConversationalJobComposer.tsx
+++ b/apps/enterprise-portal/src/components/ConversationalJobComposer.tsx
@@ -1,0 +1,440 @@
+'use client';
+
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { portalConfig } from '../lib/contracts';
+import { defaultJobDraft, JobDraft, useJobCreation } from '../hooks/useJobCreation';
+import { useLocalization } from '../context/LocalizationContext';
+
+type ChatRole = 'assistant' | 'user';
+
+interface ChatMessage {
+  role: ChatRole;
+  content: string;
+}
+
+interface Step {
+  id: string;
+  field?: keyof JobDraft;
+  promptKey: string;
+  placeholderKey?: string;
+  type: 'text' | 'textarea' | 'number' | 'datetime' | 'optionalText' | 'sla' | 'select';
+  optional?: boolean;
+}
+
+const steps: Step[] = [
+  {
+    id: 'task',
+    field: 'title',
+    promptKey: 'employer.prompt.task',
+    placeholderKey: 'employer.placeholder.task',
+    type: 'text'
+  },
+  {
+    id: 'description',
+    field: 'description',
+    promptKey: 'employer.prompt.description',
+    placeholderKey: 'employer.placeholder.description',
+    type: 'textarea'
+  },
+  {
+    id: 'skills',
+    field: 'skills',
+    promptKey: 'employer.prompt.skills',
+    placeholderKey: 'employer.placeholder.skills',
+    type: 'text',
+    optional: true
+  },
+  {
+    id: 'reward',
+    field: 'reward',
+    promptKey: 'employer.prompt.reward',
+    placeholderKey: 'employer.placeholder.reward',
+    type: 'number'
+  },
+  {
+    id: 'deadline',
+    field: 'deadline',
+    promptKey: 'employer.prompt.deadline',
+    type: 'datetime',
+    optional: true
+  },
+  {
+    id: 'ttl',
+    field: 'ttl',
+    promptKey: 'employer.prompt.ttl',
+    placeholderKey: 'employer.placeholder.ttl',
+    type: 'number'
+  },
+  {
+    id: 'attachments',
+    field: 'uri',
+    promptKey: 'employer.prompt.attachments',
+    placeholderKey: 'employer.placeholder.attachments',
+    type: 'optionalText',
+    optional: true
+  },
+  {
+    id: 'sla',
+    promptKey: 'employer.prompt.sla',
+    type: 'sla'
+  },
+  {
+    id: 'agents',
+    field: 'agentTypes',
+    promptKey: 'employer.prompt.agents',
+    type: 'select'
+  }
+];
+
+const formatValue = (step: Step, value: string, t: ReturnType<typeof useLocalization>['t']) => {
+  if (!value) return step.optional ? t('employer.summary.none') : '';
+  if (step.id === 'reward') {
+    return `${value} ${portalConfig.stakingTokenSymbol}`;
+  }
+  if (step.id === 'deadline') {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleString();
+    }
+  }
+  if (step.id === 'ttl') {
+    return `${value}h`;
+  }
+  return value;
+};
+
+export const ConversationalJobComposer = () => {
+  const { t } = useLocalization();
+  const [draft, setDraft] = useState<JobDraft>(defaultJobDraft);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputValue, setInputValue] = useState('');
+  const [slaRequired, setSlaRequired] = useState<boolean>(defaultJobDraft.requiresSla);
+  const [slaUri, setSlaUri] = useState<string>(defaultJobDraft.slaUri);
+  const [txHash, setTxHash] = useState<string>();
+  const [jobId, setJobId] = useState<bigint>();
+  const [completed, setCompleted] = useState(false);
+
+  const { creating, error, submit, resetError, specHash } = useJobCreation({
+    ...draft,
+    requiresSla: slaRequired,
+    slaUri
+  });
+
+  const initialMessages = useMemo<ChatMessage[]>(
+    () => [
+      { role: 'assistant', content: t('employer.greeting') },
+      { role: 'assistant', content: t(steps[0].promptKey) }
+    ],
+    [t]
+  );
+
+  useEffect(() => {
+    setMessages(initialMessages);
+  }, [initialMessages]);
+
+  const currentStep = steps[stepIndex];
+
+  useEffect(() => {
+    if (!currentStep) return;
+    if (currentStep.type !== 'sla') {
+      const existing = draft[currentStep.field as keyof JobDraft];
+      setInputValue(typeof existing === 'string' ? existing : '');
+    } else {
+      setInputValue('');
+    }
+  }, [currentStep, draft]);
+
+  const advanceStep = (nextDraft: Partial<JobDraft>, userMessage: string) => {
+    setDraft((prev) => ({ ...prev, ...nextDraft }));
+    setMessages((prev) => {
+      const log = [...prev];
+      if (userMessage) {
+        log.push({ role: 'user', content: userMessage });
+      }
+      const next = steps[stepIndex + 1];
+      if (next) {
+        log.push({ role: 'assistant', content: t(next.promptKey) });
+      }
+      return log;
+    });
+    setStepIndex((index) => index + 1);
+    if (error) {
+      resetError();
+    }
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!currentStep) return;
+
+    if (currentStep.type === 'sla') {
+      const summary = slaRequired
+        ? `${t('employer.summary.sla')}: ${slaUri || t('employer.summary.none')}`
+        : t('employer.summary.sla') + ': ' + t('employer.summary.none');
+      advanceStep(
+        {
+          requiresSla: slaRequired,
+          slaUri
+        },
+        summary
+      );
+      setCompleted(false);
+      return;
+    }
+
+    const value = inputValue.trim();
+    if (!value && !currentStep.optional) {
+      return;
+    }
+
+    const displayValue = formatValue(currentStep, value, t);
+    advanceStep(
+      {
+        [currentStep.field as keyof JobDraft]: value
+      },
+      displayValue
+    );
+    setCompleted(false);
+  };
+
+  const isSummary = stepIndex >= steps.length;
+
+  const summaryRows = useMemo(() => {
+    return [
+      { label: t('employer.summary.reward'), value: formatValue(steps[3], draft.reward, t) },
+      { label: t('employer.summary.deadline'), value: formatValue(steps[4], draft.deadline, t) },
+      { label: t('employer.summary.skills'), value: draft.skills || t('employer.summary.none') },
+      { label: t('employer.summary.attachments'), value: draft.uri || t('employer.summary.none') },
+      {
+        label: t('employer.summary.sla'),
+        value: slaRequired ? slaUri || t('employer.summary.none') : t('employer.summary.none')
+      },
+      {
+        label: t('employer.summary.ttl'),
+        value: formatValue(steps[5], draft.ttl, t)
+      },
+      {
+        label: t('employer.summary.agents'),
+        value: agentTypeLabels[draft.agentTypes] ?? draft.agentTypes
+      }
+    ];
+  }, [draft, slaRequired, slaUri, t]);
+
+  const handleConfirm = async () => {
+    try {
+      const result = await submit();
+      setTxHash(result.txHash);
+      setJobId(result.jobId);
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: 'assistant',
+          content: t('employer.status.success')
+        }
+      ]);
+      setCompleted(true);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const agentTypeLabels = useMemo(
+    () => ({
+      '1': t('employer.agentLabels.1'),
+      '3': t('employer.agentLabels.3'),
+      '7': t('employer.agentLabels.7')
+    }),
+    [t]
+  );
+
+  const handleAgentTypeChange = (value: string) => {
+    setDraft((prev) => ({ ...prev, agentTypes: value }));
+    setMessages((prev) => [
+      ...prev,
+      { role: 'user', content: agentTypeLabels[value] ?? value },
+      { role: 'assistant', content: t('employer.summary.title') }
+    ]);
+    setStepIndex(steps.length);
+    setCompleted(false);
+    if (error) {
+      resetError();
+    }
+  };
+
+  const handleReset = () => {
+    setDraft(defaultJobDraft);
+    setSlaRequired(defaultJobDraft.requiresSla);
+    setSlaUri(defaultJobDraft.slaUri);
+    setTxHash(undefined);
+    setJobId(undefined);
+    setStepIndex(0);
+    setMessages(initialMessages);
+    setCompleted(false);
+    setInputValue('');
+    if (error) {
+      resetError();
+    }
+  };
+
+  const renderInput = () => {
+    if (!currentStep) return null;
+
+    switch (currentStep.type) {
+      case 'text':
+      case 'optionalText':
+        return (
+          <input
+            aria-label={t(currentStep.promptKey)}
+            value={inputValue}
+            placeholder={currentStep.placeholderKey ? t(currentStep.placeholderKey) : ''}
+            onChange={(event) => setInputValue(event.target.value)}
+          />
+        );
+      case 'textarea':
+        return (
+          <textarea
+            aria-label={t(currentStep.promptKey)}
+            value={inputValue}
+            rows={4}
+            placeholder={currentStep.placeholderKey ? t(currentStep.placeholderKey) : ''}
+            onChange={(event) => setInputValue(event.target.value)}
+          />
+        );
+      case 'number':
+        return (
+          <input
+            aria-label={t(currentStep.promptKey)}
+            type="number"
+            value={inputValue}
+            placeholder={currentStep.placeholderKey ? t(currentStep.placeholderKey) : ''}
+            onChange={(event) => setInputValue(event.target.value)}
+          />
+        );
+      case 'datetime':
+        return (
+          <input
+            aria-label={t(currentStep.promptKey)}
+            type="datetime-local"
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+          />
+        );
+      case 'sla':
+        return (
+          <div className="sla-step">
+            <div className="toggle-group" role="group" aria-label={t(currentStep.promptKey)}>
+              <button
+                type="button"
+                className={slaRequired ? 'toggle active' : 'toggle'}
+                onClick={() => setSlaRequired(true)}
+              >
+                {t('common.yes')}
+              </button>
+              <button
+                type="button"
+                className={!slaRequired ? 'toggle active' : 'toggle'}
+                onClick={() => setSlaRequired(false)}
+              >
+                {t('common.no')}
+              </button>
+            </div>
+            {slaRequired && (
+              <input
+                aria-label={t('employer.summary.sla')}
+                placeholder="ipfs://sla"
+                value={slaUri}
+                onChange={(event) => setSlaUri(event.target.value)}
+              />
+            )}
+          </div>
+        );
+        case 'select':
+          return (
+            <select
+              aria-label={t(currentStep.promptKey)}
+              value={draft.agentTypes}
+              onChange={(event) => handleAgentTypeChange(event.target.value)}
+            >
+              <option value="1">{agentTypeLabels['1']}</option>
+              <option value="3">{agentTypeLabels['3']}</option>
+              <option value="7">{agentTypeLabels['7']}</option>
+            </select>
+          );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <section className="chat-composer">
+      <header className="card-title">
+        <div>
+          <h2>{t('app.title')}</h2>
+          <p>{t('app.subtitle')}</p>
+        </div>
+      </header>
+      <div className="chat-thread" role="log" aria-live="polite">
+        {messages.map((message, index) => (
+          <div key={index} className={`chat-bubble ${message.role}`}>
+            <p>{message.content}</p>
+          </div>
+        ))}
+      </div>
+      {!isSummary && (
+        <form onSubmit={handleSubmit} className="chat-input">
+          {renderInput()}
+          {currentStep.type !== 'select' && (
+            <div className="chat-actions">
+              <button className="primary" type="submit" disabled={creating}>
+                {creating ? t('employer.status.submitting') : t('employer.actions.continue')}
+              </button>
+            </div>
+          )}
+        </form>
+      )}
+      {isSummary && (
+        <div className="chat-summary">
+          <h3>{t('employer.summary.title')}</h3>
+          <ul>
+            {summaryRows.map((row) => (
+              <li key={row.label}>
+                <span>{row.label}</span>
+                <strong>{row.value}</strong>
+              </li>
+            ))}
+          </ul>
+          {specHash && (
+            <div className="code-block">
+              <strong>Spec hash:</strong> {specHash}
+            </div>
+          )}
+          <div className="chat-actions">
+            <button className="primary" onClick={handleConfirm} disabled={creating}>
+              {creating ? t('employer.status.submitting') : t('employer.actions.confirm')}
+            </button>
+          </div>
+          {txHash && (
+            <a
+              className="tag purple"
+              href={`https://sepolia.etherscan.io/tx/${txHash}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t('employer.status.tx')}
+            </a>
+          )}
+          {jobId && <div className="alert success">#{jobId.toString()}</div>}
+          {error && <div className="alert error">{error}</div>}
+          {completed && (
+            <div className="chat-actions">
+              <button className="secondary" type="button" onClick={handleReset}>
+                {t('employer.actions.restart')}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/enterprise-portal/src/components/HelpCenterDrawer.tsx
+++ b/apps/enterprise-portal/src/components/HelpCenterDrawer.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { useLocalization } from '../context/LocalizationContext';
+
+export const HelpCenterDrawer = () => {
+  const { t } = useLocalization();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <section className={`help-drawer ${open ? 'open' : ''}`}>
+      <button className="secondary" type="button" onClick={() => setOpen((value) => !value)}>
+        {t('help.title')}
+      </button>
+      {open && (
+        <div className="help-content">
+          <p>{t('help.subtitle')}</p>
+          <div className="help-links">
+            <a href="/docs/enterprise-portal-user-guides" target="_blank" rel="noreferrer">
+              {t('help.guides.employer')}
+            </a>
+            <a href="/docs/enterprise-portal-user-guides#agent" target="_blank" rel="noreferrer">
+              {t('help.guides.agent')}
+            </a>
+            <a href="/docs/enterprise-portal-user-guides#validator" target="_blank" rel="noreferrer">
+              {t('help.guides.validator')}
+            </a>
+          </div>
+          <ul className="faq-list">
+            <li>{t('help.faq.agents')}</li>
+            <li>{t('help.faq.deadlines')}</li>
+            <li>{t('help.faq.disputes')}</li>
+          </ul>
+          <a className="tag purple" href="https://github.com/MontrealAI/AGIJobsv0" target="_blank" rel="noreferrer">
+            {t('help.cta')}
+          </a>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/enterprise-portal/src/components/LanguageSwitcher.tsx
+++ b/apps/enterprise-portal/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { ChangeEvent } from 'react';
+import { SupportedLanguage, useLocalization } from '../context/LocalizationContext';
+
+export const LanguageSwitcher = () => {
+  const { language, setLanguage, availableLanguages, t } = useLocalization();
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setLanguage(event.target.value as SupportedLanguage);
+  };
+
+  return (
+    <label className="language-switcher">
+      <span className="sr-only">{t('language.label')}</span>
+      <select aria-label={t('language.label')} value={language} onChange={handleChange}>
+        {availableLanguages.map(({ code, label }) => (
+          <option key={code} value={code}>
+            {label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+};

--- a/apps/enterprise-portal/src/components/PortalPage.tsx
+++ b/apps/enterprise-portal/src/components/PortalPage.tsx
@@ -1,28 +1,46 @@
 'use client';
 
 import { ConnectionPanel } from './ConnectionPanel';
-import { JobSubmissionForm } from './JobSubmissionForm';
 import { JobLifecycleDashboard } from './JobLifecycleDashboard';
 import { DeliverableVerificationPanel } from './DeliverableVerificationPanel';
-import { ValidatorLogPanel } from './ValidatorLogPanel';
 import { CertificateGallery } from './CertificateGallery';
 import { SlaViewer } from './SlaViewer';
 import { useJobFeed } from '../hooks/useJobFeed';
+import { LanguageSwitcher } from './LanguageSwitcher';
+import { ConversationalJobComposer } from './ConversationalJobComposer';
+import { AgentOpportunitiesPanel } from './AgentOpportunitiesPanel';
+import { ValidatorInbox } from './ValidatorInbox';
+import { HelpCenterDrawer } from './HelpCenterDrawer';
+import { SupportChecklist } from './SupportChecklist';
+import { useLocalization } from '../context/LocalizationContext';
 
 export const PortalPage = () => {
-  const { jobs, events, validators, loading, error, hasValidationModule } = useJobFeed({ watch: true });
+  const { jobs, events, loading, error } = useJobFeed({ watch: true });
+  const { t } = useLocalization();
 
   return (
-    <div className="grid" style={{ gap: '2.5rem' }}>
-      <ConnectionPanel />
-      <JobSubmissionForm />
-      <JobLifecycleDashboard jobs={jobs} events={events} loading={loading} error={error} />
-      <ValidatorLogPanel
-        validators={validators}
-        loading={loading}
-        hasValidationModule={hasValidationModule}
-      />
-      <div className="grid two-column">
+    <div className="portal-shell">
+      <header className="portal-header">
+        <div>
+          <h1>{t('app.title')}</h1>
+          <p>{t('app.subtitle')}</p>
+        </div>
+        <LanguageSwitcher />
+      </header>
+      <div className="portal-grid">
+        <div className="primary-column">
+          <ConnectionPanel />
+          <ConversationalJobComposer />
+          <JobLifecycleDashboard jobs={jobs} events={events} loading={loading} error={error} />
+        </div>
+        <aside className="secondary-column">
+          <AgentOpportunitiesPanel jobs={jobs} loading={loading} error={error} />
+          <ValidatorInbox events={events} loading={loading} />
+          <SupportChecklist />
+          <HelpCenterDrawer />
+        </aside>
+      </div>
+      <div className="portal-lower-grid">
         <DeliverableVerificationPanel events={events} />
         <div className="grid">
           <CertificateGallery />

--- a/apps/enterprise-portal/src/components/SupportChecklist.tsx
+++ b/apps/enterprise-portal/src/components/SupportChecklist.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useLocalization } from '../context/LocalizationContext';
+
+export const SupportChecklist = () => {
+  const { t } = useLocalization();
+
+  const items = [
+    { id: 'wallet', label: t('support.checklist.wallet') },
+    { id: 'ens', label: t('support.checklist.ens') },
+    { id: 'stake', label: t('support.checklist.stake') },
+    { id: 'job', label: t('support.checklist.job') }
+  ];
+
+  return (
+    <section className="support-checklist">
+      <h3>{t('support.checklist.title')}</h3>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>
+            <span aria-hidden="true">✅</span>
+            {item.label}
+          </li>
+        ))}
+      </ul>
+      <p className="tip">{t('support.checklist.tip')}</p>
+    </section>
+  );
+};

--- a/apps/enterprise-portal/src/components/ValidatorInbox.tsx
+++ b/apps/enterprise-portal/src/components/ValidatorInbox.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+import type { JobTimelineEvent } from '../types';
+import { useLocalization } from '../context/LocalizationContext';
+
+interface ValidatorInboxProps {
+  events: JobTimelineEvent[];
+  loading: boolean;
+}
+
+interface ReviewState {
+  decision?: 'approve' | 'reject';
+  comment: string;
+}
+
+const toLocaleString = (timestamp: number) => {
+  if (!timestamp) return '';
+  const date = new Date(timestamp * 1000);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString();
+};
+
+export const ValidatorInbox = ({ events, loading }: ValidatorInboxProps) => {
+  const { t } = useLocalization();
+  const [reviews, setReviews] = useState<Record<string, ReviewState>>({});
+
+  const submissions = events.filter((event) => event.name === 'ResultSubmitted');
+
+  const handleDecision = (jobId: string, decision: 'approve' | 'reject') => {
+    setReviews((prev) => ({
+      ...prev,
+      [jobId]: {
+        ...prev[jobId],
+        decision
+      }
+    }));
+  };
+
+  const handleCommentChange = (jobId: string, comment: string) => {
+    setReviews((prev) => ({
+      ...prev,
+      [jobId]: {
+        ...prev[jobId],
+        comment
+      }
+    }));
+  };
+
+  return (
+    <section>
+      <div className="card-title">
+        <div>
+          <h3>{t('validator.title')}</h3>
+          <p>{t('validator.subtitle')}</p>
+        </div>
+      </div>
+      {loading && <div className="status">{t('status.loading')}</div>}
+      {!loading && submissions.length === 0 && <div className="status">{t('validator.empty')}</div>}
+      <div className="validator-queue">
+        {submissions.map((submission) => {
+          const jobId = submission.jobId.toString();
+          const review = reviews[jobId] ?? { comment: '' };
+          const args = submission.meta?.args as Record<string, unknown> | undefined;
+          const resultUri =
+            (args?.resultURI as string | undefined) ??
+            (Array.isArray(args) ? ((args[3] as string | undefined) ?? '') : '') ??
+            submission.meta?.resultUri;
+
+          return (
+            <article key={jobId} className="validator-card">
+              <header>
+                <h4>#{jobId}</h4>
+                <span className="tag orange">{toLocaleString(submission.timestamp)}</span>
+              </header>
+              <p>{submission.description}</p>
+              {resultUri && (
+                <p>
+                  <strong>{t('validator.result')}:</strong>{' '}
+                  <a href={resultUri} target="_blank" rel="noreferrer">
+                    {resultUri}
+                  </a>
+                </p>
+              )}
+              <div className="validator-actions">
+                <button
+                  className={review.decision === 'approve' ? 'primary' : 'secondary'}
+                  type="button"
+                  onClick={() => handleDecision(jobId, 'approve')}
+                >
+                  {t('validator.approve')}
+                </button>
+                <button
+                  className={review.decision === 'reject' ? 'primary' : 'secondary'}
+                  type="button"
+                  onClick={() => handleDecision(jobId, 'reject')}
+                >
+                  {t('validator.reject')}
+                </button>
+              </div>
+              <label className="sr-only" htmlFor={`validator-comment-${jobId}`}>
+                {t('validator.comment')}
+              </label>
+              <textarea
+                id={`validator-comment-${jobId}`}
+                value={review.comment}
+                placeholder={t('validator.comment')}
+                onChange={(event) => handleCommentChange(jobId, event.target.value)}
+                rows={3}
+              />
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+};

--- a/apps/enterprise-portal/src/context/LocalizationContext.tsx
+++ b/apps/enterprise-portal/src/context/LocalizationContext.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+
+import en from '../i18n/en.json';
+import es from '../i18n/es.json';
+import fr from '../i18n/fr.json';
+import ja from '../i18n/ja.json';
+import zh from '../i18n/zh.json';
+
+type TranslationTree = Record<string, string | TranslationTree>;
+
+export type SupportedLanguage = 'en' | 'fr' | 'es' | 'ja' | 'zh';
+
+const translations: Record<SupportedLanguage, TranslationTree> = {
+  en,
+  fr,
+  es,
+  ja,
+  zh
+};
+
+interface LocalizationContextValue {
+  language: SupportedLanguage;
+  setLanguage: (language: SupportedLanguage) => void;
+  t: (key: string, fallback?: string) => string;
+  availableLanguages: { code: SupportedLanguage; label: string }[];
+}
+
+const labels: Record<SupportedLanguage, string> = {
+  en: 'English',
+  fr: 'Français',
+  es: 'Español',
+  ja: '日本語',
+  zh: '中文'
+};
+
+const LocalizationContext = createContext<LocalizationContextValue | undefined>(undefined);
+
+export const LocalizationProvider = ({ children }: { children: ReactNode }) => {
+  const [language, setLanguage] = useState<SupportedLanguage>('en');
+
+  const value = useMemo<LocalizationContextValue>(() => {
+    const dictionary = translations[language] ?? translations.en;
+
+    const translate = (key: string, fallback?: string) => {
+      if (!key) return fallback ?? key;
+      const resolved = dictionary[key];
+      if (typeof resolved === 'string') return resolved;
+      const nested = key.split('.').reduce<string | TranslationTree | undefined>((acc, part) => {
+        if (!acc) return undefined;
+        if (typeof acc === 'string') return acc;
+        return acc[part];
+      }, dictionary);
+      if (typeof nested === 'string') return nested;
+      return fallback ?? key;
+    };
+
+    const availableLanguages = (Object.keys(labels) as SupportedLanguage[]).map((code) => ({
+      code,
+      label: labels[code]
+    }));
+
+    return {
+      language,
+      setLanguage,
+      t: translate,
+      availableLanguages
+    };
+  }, [language]);
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = language;
+    }
+  }, [language]);
+
+  return <LocalizationContext.Provider value={value}>{children}</LocalizationContext.Provider>;
+};
+
+export const useLocalization = () => {
+  const context = useContext(LocalizationContext);
+  if (!context) {
+    throw new Error('useLocalization must be used within a LocalizationProvider');
+  }
+  return context;
+};

--- a/apps/enterprise-portal/src/hooks/useJobCreation.ts
+++ b/apps/enterprise-portal/src/hooks/useJobCreation.ts
@@ -1,0 +1,143 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { parseUnits } from 'ethers';
+import { useWeb3 } from '../context/Web3Context';
+import { getJobRegistryContract } from '../lib/contracts';
+import { computeSpecHash } from '../lib/crypto';
+
+export interface JobDraft {
+  title: string;
+  description: string;
+  reward: string;
+  deadline: string;
+  ttl: string;
+  skills: string;
+  uri: string;
+  requiresSla: boolean;
+  slaUri: string;
+  agentTypes: string;
+}
+
+export interface CreateJobResult {
+  txHash?: string;
+  jobId?: bigint;
+  specHash: string;
+}
+
+export interface JobCreationState {
+  creating: boolean;
+  error?: string;
+  submit: () => Promise<CreateJobResult>;
+  resetError: () => void;
+}
+
+export const defaultJobDraft: JobDraft = {
+  title: '',
+  description: '',
+  reward: '',
+  deadline: '',
+  ttl: '72',
+  skills: '',
+  uri: '',
+  requiresSla: false,
+  slaUri: '',
+  agentTypes: '3'
+};
+
+export const useJobCreation = (draft: JobDraft): JobCreationState & { specHash: string } => {
+  const { signer, address, hasAcknowledged } = useWeb3();
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const rewardInWei = useMemo(() => {
+    if (!draft.reward) return 0n;
+    try {
+      return parseUnits(draft.reward, 18);
+    } catch (err) {
+      return 0n;
+    }
+  }, [draft.reward]);
+
+  const specPayload = useMemo(() => {
+    const skills = draft.skills
+      .split(',')
+      .map((skill) => skill.trim())
+      .filter(Boolean);
+
+    return {
+      title: draft.title,
+      description: draft.description,
+      requiredSkills: skills,
+      ttlHours: Number(draft.ttl) || 0,
+      metadataURI: draft.uri,
+      sla: draft.requiresSla
+        ? {
+            uri: draft.slaUri,
+            requiresSignature: true
+          }
+        : undefined
+    };
+  }, [draft]);
+
+  const specHash = useMemo(() => computeSpecHash(specPayload), [specPayload]);
+
+  const submit = async (): Promise<CreateJobResult> => {
+    if (!signer || !address) {
+      const message = 'Connect a verified wallet before submitting a job.';
+      setError(message);
+      throw new Error(message);
+    }
+
+    setCreating(true);
+    setError(undefined);
+
+    try {
+      const contract = getJobRegistryContract(signer);
+      const now = Math.floor(Date.now() / 1000);
+      const ttlSeconds = Number(draft.ttl) * 3600;
+      const deadlineSeconds = draft.deadline
+        ? Math.floor(new Date(draft.deadline).getTime() / 1000)
+        : now + ttlSeconds;
+      const uri = draft.uri || `ipfs://job-spec/${specHash}`;
+      const agentTypes = Number(draft.agentTypes);
+      const method = hasAcknowledged ? 'createJobWithAgentTypes' : 'acknowledgeAndCreateJobWithAgentTypes';
+      const registryAddress = await contract.getAddress();
+      const tx = await contract[method](rewardInWei, BigInt(deadlineSeconds), agentTypes, specHash, uri);
+      const receipt = await tx.wait?.();
+
+      let jobId: bigint | undefined;
+      if (receipt?.logs) {
+        const jobLog = receipt.logs.find(
+          (log: any) => typeof log.address === 'string' && log.address.toLowerCase() === registryAddress.toLowerCase()
+        );
+        if (jobLog) {
+          try {
+            const parsed = contract.interface.parseLog(jobLog);
+            if (parsed?.name === 'JobCreated' && parsed.args?.jobId) {
+              jobId = BigInt(parsed.args.jobId);
+            }
+          } catch (parseError) {
+            console.error('Failed to parse JobCreated log', parseError);
+          }
+        }
+      }
+
+      return { txHash: tx.hash, jobId, specHash };
+    } catch (err) {
+      const message = (err as Error).message ?? 'Failed to create job';
+      setError(message);
+      throw err;
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return {
+    creating,
+    error,
+    submit,
+    resetError: () => setError(undefined),
+    specHash
+  };
+};

--- a/apps/enterprise-portal/src/i18n/en.json
+++ b/apps/enterprise-portal/src/i18n/en.json
@@ -1,0 +1,111 @@
+{
+  "app": {
+    "title": "AGI Jobs Assistant Portal",
+    "subtitle": "Create, review, and validate autonomous job workflows with a conversational interface."
+  },
+  "language": {
+    "label": "Language"
+  },
+  "common": {
+    "yes": "Yes",
+    "no": "No"
+  },
+  "employer": {
+    "greeting": "Hi there! Let's register your new job on AGI Jobs.",
+    "prompt": {
+      "task": "What task do you need done?",
+      "description": "Great. Could you add more detail so agents know exactly what success looks like?",
+      "skills": "Which skills or agent profiles are a good fit?",
+      "reward": "What reward would you like to offer?",
+      "deadline": "When should the result be delivered?",
+      "attachments": "Share any links or files an agent will need (optional).",
+      "sla": "Do you require an SLA acknowledgement before an agent starts?",
+      "ttl": "How long should validators have to review the submission (hours)?",
+      "agents": "Pick which agent archetypes can apply."
+    },
+    "placeholder": {
+      "task": "Draft a quarterly compliance report",
+      "description": "Include the scope, data sources, and handover expectations…",
+      "skills": "Compliance, Reporting, Python",
+      "reward": "500",
+      "attachments": "https://example.com/brief.pdf",
+      "deadline": "",
+      "ttl": "72"
+    },
+    "actions": {
+      "continue": "Continue",
+      "back": "Back",
+      "confirm": "Submit job",
+      "edit": "Edit",
+      "restart": "Start another job"
+    },
+    "summary": {
+      "title": "Confirm job details",
+      "reward": "Reward",
+      "deadline": "Deadline",
+      "skills": "Skills",
+      "attachments": "Reference material",
+      "sla": "SLA required",
+      "ttl": "Validator review window",
+      "agents": "Eligible agent types",
+      "none": "Not provided"
+    },
+    "agentLabels": {
+      "1": "Generalist",
+      "3": "Generalist + Specialist",
+      "7": "Multi-role"
+    },
+    "status": {
+      "submitting": "Submitting job…",
+      "success": "Job submitted successfully!",
+      "tx": "View transaction"
+    }
+  },
+  "agent": {
+    "title": "Opportunities feed",
+    "subtitle": "Newly published jobs will appear here for quick triage.",
+    "empty": "No open jobs yet. Check back soon!",
+    "accept": "Accept job",
+    "decline": "Decline",
+    "deadline": "Deadline",
+    "reward": "Reward"
+  },
+  "validator": {
+    "title": "Validator queue",
+    "subtitle": "Review submissions and record your decision without leaving the portal.",
+    "empty": "No submissions awaiting review right now.",
+    "approve": "Approve",
+    "reject": "Reject",
+    "comment": "Add a note for the submitter",
+    "result": "Result URI"
+  },
+  "help": {
+    "title": "Help center",
+    "subtitle": "Guides and quick answers while you work.",
+    "faq": {
+      "agents": "How do I qualify for higher paying jobs?",
+      "deadlines": "Can I extend a deadline after publishing?",
+      "disputes": "What happens if I dispute a result?"
+    },
+    "guides": {
+      "employer": "Employer guide",
+      "agent": "Agent onboarding",
+      "validator": "Validator handbook"
+    },
+    "cta": "Open full documentation"
+  },
+  "support": {
+    "checklist": {
+      "title": "Go-live checklist",
+      "wallet": "Wallet connected",
+      "ens": "ENS identity verified",
+      "stake": "Stake deposited",
+      "job": "Job published",
+      "tip": "Need help? Ask the assistant widget in the corner."
+    }
+  },
+  "status": {
+    "loading": "Loading…",
+    "error": "Something went wrong."
+  }
+}

--- a/apps/enterprise-portal/src/i18n/es.json
+++ b/apps/enterprise-portal/src/i18n/es.json
@@ -1,0 +1,111 @@
+{
+  "app": {
+    "title": "Portal asistente AGI Jobs",
+    "subtitle": "Crea, revisa y valida trabajos con una experiencia conversacional."
+  },
+  "language": {
+    "label": "Idioma"
+  },
+  "common": {
+    "yes": "Sí",
+    "no": "No"
+  },
+  "employer": {
+    "greeting": "Hola. Vamos a publicar tu nuevo trabajo en AGI Jobs.",
+    "prompt": {
+      "task": "¿Qué tarea necesitas realizar?",
+      "description": "Perfecto. ¿Puedes agregar detalles para que el agente sepa qué entregar?",
+      "skills": "¿Qué habilidades o perfiles encajan mejor?",
+      "reward": "¿Qué recompensa quieres ofrecer?",
+      "deadline": "¿Cuándo debe entregarse el resultado?",
+      "attachments": "Comparte enlaces o archivos útiles (opcional).",
+      "sla": "¿Necesitas una aceptación de SLA antes de comenzar?",
+      "ttl": "¿Cuántas horas para la revisión de validadores?",
+      "agents": "Selecciona los tipos de agentes elegibles."
+    },
+    "placeholder": {
+      "task": "Elaborar un informe trimestral",
+      "description": "Incluye alcance, fuentes de datos y entregables…",
+      "skills": "Cumplimiento, Reportes, Python",
+      "reward": "500",
+      "attachments": "https://example.com/brief.pdf",
+      "deadline": "",
+      "ttl": "72"
+    },
+    "actions": {
+      "continue": "Continuar",
+      "back": "Atrás",
+      "confirm": "Publicar trabajo",
+      "edit": "Editar",
+      "restart": "Crear otro trabajo"
+    },
+    "summary": {
+      "title": "Confirma los detalles",
+      "reward": "Recompensa",
+      "deadline": "Fecha límite",
+      "skills": "Habilidades",
+      "attachments": "Material de referencia",
+      "sla": "SLA requerido",
+      "ttl": "Ventana de validación",
+      "agents": "Tipos de agentes",
+      "none": "No proporcionado"
+    },
+    "agentLabels": {
+      "1": "Generalista",
+      "3": "Generalista + Especialista",
+      "7": "Multirrol"
+    },
+    "status": {
+      "submitting": "Publicando trabajo…",
+      "success": "¡Trabajo publicado!",
+      "tx": "Ver transacción"
+    }
+  },
+  "agent": {
+    "title": "Bandeja de oportunidades",
+    "subtitle": "Los trabajos recién publicados aparecerán aquí.",
+    "empty": "No hay trabajos abiertos por ahora.",
+    "accept": "Aceptar",
+    "decline": "Rechazar",
+    "deadline": "Fecha límite",
+    "reward": "Recompensa"
+  },
+  "validator": {
+    "title": "Cola de validación",
+    "subtitle": "Revisa los entregables y registra tu decisión sin salir del portal.",
+    "empty": "Sin entregas pendientes.",
+    "approve": "Aprobar",
+    "reject": "Rechazar",
+    "comment": "Añadir nota",
+    "result": "URI del resultado"
+  },
+  "help": {
+    "title": "Centro de ayuda",
+    "subtitle": "Guías y respuestas rápidas mientras trabajas.",
+    "faq": {
+      "agents": "¿Cómo accedo a trabajos mejor pagados?",
+      "deadlines": "¿Puedo extender una fecha límite?",
+      "disputes": "¿Qué sucede si disputo un resultado?"
+    },
+    "guides": {
+      "employer": "Guía para empleadores",
+      "agent": "Guía de agentes",
+      "validator": "Manual de validadores"
+    },
+    "cta": "Abrir documentación"
+  },
+  "support": {
+    "checklist": {
+      "title": "Lista de inicio",
+      "wallet": "Billetera conectada",
+      "ens": "Identidad ENS verificada",
+      "stake": "Stake depositado",
+      "job": "Trabajo publicado",
+      "tip": "¿Necesitas ayuda? Usa el asistente integrado."
+    }
+  },
+  "status": {
+    "loading": "Cargando…",
+    "error": "Algo salió mal."
+  }
+}

--- a/apps/enterprise-portal/src/i18n/fr.json
+++ b/apps/enterprise-portal/src/i18n/fr.json
@@ -1,0 +1,111 @@
+{
+  "app": {
+    "title": "Portail assistant AGI Jobs",
+    "subtitle": "Créez, suivez et validez les missions avec une interface conversationnelle."
+  },
+  "language": {
+    "label": "Langue"
+  },
+  "common": {
+    "yes": "Oui",
+    "no": "Non"
+  },
+  "employer": {
+    "greeting": "Bonjour ! Créons votre nouvelle mission sur AGI Jobs.",
+    "prompt": {
+      "task": "Quelle tâche devez-vous accomplir ?",
+      "description": "Parfait. Pouvez-vous ajouter des détails pour que les agents sachent ce qu'ils doivent livrer ?",
+      "skills": "Quelles compétences ou profils conviennent ?",
+      "reward": "Quelle récompense souhaitez-vous proposer ?",
+      "deadline": "Quand le résultat doit-il être livré ?",
+      "attachments": "Partagez des liens ou fichiers utiles (optionnel).",
+      "sla": "Souhaitez-vous un accord de niveau de service avant le démarrage ?",
+      "ttl": "Combien d'heures pour la validation ?",
+      "agents": "Choisissez les archétypes d'agents autorisés."
+    },
+    "placeholder": {
+      "task": "Rédiger un rapport de conformité trimestriel",
+      "description": "Inclure le périmètre, les données sources et les attentes…",
+      "skills": "Conformité, Reporting, Python",
+      "reward": "500",
+      "attachments": "https://example.com/brief.pdf",
+      "deadline": "",
+      "ttl": "72"
+    },
+    "actions": {
+      "continue": "Continuer",
+      "back": "Retour",
+      "confirm": "Publier la mission",
+      "edit": "Modifier",
+      "restart": "Créer une autre mission"
+    },
+    "summary": {
+      "title": "Confirmer les détails",
+      "reward": "Récompense",
+      "deadline": "Échéance",
+      "skills": "Compétences",
+      "attachments": "Ressources",
+      "sla": "SLA requis",
+      "ttl": "Fenêtre de validation",
+      "agents": "Types d'agents",
+      "none": "Non renseigné"
+    },
+    "agentLabels": {
+      "1": "Généraliste",
+      "3": "Généraliste + Spécialiste",
+      "7": "Multi-rôle"
+    },
+    "status": {
+      "submitting": "Publication en cours…",
+      "success": "Mission publiée !",
+      "tx": "Voir la transaction"
+    }
+  },
+  "agent": {
+    "title": "Flux d'opportunités",
+    "subtitle": "Les nouvelles missions apparaissent ici pour un tri rapide.",
+    "empty": "Aucune mission ouverte pour le moment.",
+    "accept": "Accepter",
+    "decline": "Refuser",
+    "deadline": "Échéance",
+    "reward": "Récompense"
+  },
+  "validator": {
+    "title": "File de validation",
+    "subtitle": "Examinez les livrables et consignez votre décision sans quitter le portail.",
+    "empty": "Aucun livrable à examiner.",
+    "approve": "Approuver",
+    "reject": "Rejeter",
+    "comment": "Ajouter une note",
+    "result": "URI du résultat"
+  },
+  "help": {
+    "title": "Centre d'aide",
+    "subtitle": "Guides et réponses rapides pendant votre travail.",
+    "faq": {
+      "agents": "Comment accéder à des missions mieux rémunérées ?",
+      "deadlines": "Puis-je prolonger une échéance après publication ?",
+      "disputes": "Que se passe-t-il en cas de contestation ?"
+    },
+    "guides": {
+      "employer": "Guide employeur",
+      "agent": "Onboarding agent",
+      "validator": "Guide validateur"
+    },
+    "cta": "Ouvrir la documentation"
+  },
+  "support": {
+    "checklist": {
+      "title": "Checklist de mise en service",
+      "wallet": "Portefeuille connecté",
+      "ens": "Identité ENS vérifiée",
+      "stake": "Stake déposé",
+      "job": "Mission publiée",
+      "tip": "Besoin d'aide ? Parlez au widget d'assistance."
+    }
+  },
+  "status": {
+    "loading": "Chargement…",
+    "error": "Une erreur est survenue."
+  }
+}

--- a/apps/enterprise-portal/src/i18n/ja.json
+++ b/apps/enterprise-portal/src/i18n/ja.json
@@ -1,0 +1,111 @@
+{
+  "app": {
+    "title": "AGI Jobs アシスタントポータル",
+    "subtitle": "会話型UIでジョブの作成・確認・検証を行います。"
+  },
+  "language": {
+    "label": "言語"
+  },
+  "common": {
+    "yes": "はい",
+    "no": "いいえ"
+  },
+  "employer": {
+    "greeting": "こんにちは。AGI Jobs にジョブを登録しましょう。",
+    "prompt": {
+      "task": "どのようなタスクが必要ですか？",
+      "description": "了解です。成功条件を詳しく教えてください。",
+      "skills": "必要なスキルや適したエージェントは？",
+      "reward": "報酬額を入力してください。",
+      "deadline": "成果物の期限はいつですか？",
+      "attachments": "参考リンクやファイルがあれば共有してください（任意）。",
+      "sla": "開始前にSLA同意が必要ですか？",
+      "ttl": "バリデーターのレビュー時間（時間）を設定してください。",
+      "agents": "参加可能なエージェントタイプを選択してください。"
+    },
+    "placeholder": {
+      "task": "四半期レポートの作成",
+      "description": "範囲、データソース、期待成果を記載…",
+      "skills": "コンプライアンス, レポート, Python",
+      "reward": "500",
+      "attachments": "https://example.com/brief.pdf",
+      "deadline": "",
+      "ttl": "72"
+    },
+    "actions": {
+      "continue": "次へ",
+      "back": "戻る",
+      "confirm": "ジョブを送信",
+      "edit": "編集",
+      "restart": "別のジョブを作成"
+    },
+    "summary": {
+      "title": "内容を確認",
+      "reward": "報酬",
+      "deadline": "期限",
+      "skills": "スキル",
+      "attachments": "参考資料",
+      "sla": "SLA必須",
+      "ttl": "検証期間",
+      "agents": "対象エージェント",
+      "none": "未設定"
+    },
+    "agentLabels": {
+      "1": "ジェネラリスト",
+      "3": "ジェネラリスト + スペシャリスト",
+      "7": "マルチロール"
+    },
+    "status": {
+      "submitting": "送信中…",
+      "success": "ジョブが登録されました！",
+      "tx": "トランザクションを表示"
+    }
+  },
+  "agent": {
+    "title": "ジョブフィード",
+    "subtitle": "新着ジョブがここに表示されます。",
+    "empty": "現在利用可能なジョブはありません。",
+    "accept": "承諾",
+    "decline": "辞退",
+    "deadline": "期限",
+    "reward": "報酬"
+  },
+  "validator": {
+    "title": "検証キュー",
+    "subtitle": "ポータル内でレビューと判断を完結できます。",
+    "empty": "レビュー待ちの成果物はありません。",
+    "approve": "承認",
+    "reject": "却下",
+    "comment": "送信者へのメモ",
+    "result": "結果URI"
+  },
+  "help": {
+    "title": "ヘルプセンター",
+    "subtitle": "作業中に役立つガイドとFAQ。",
+    "faq": {
+      "agents": "高単価ジョブに応募するには？",
+      "deadlines": "公開後に期限を延長できますか？",
+      "disputes": "結果に異議を唱えるとどうなりますか？"
+    },
+    "guides": {
+      "employer": "依頼者ガイド",
+      "agent": "エージェント登録",
+      "validator": "バリデーター手引き"
+    },
+    "cta": "ドキュメントを開く"
+  },
+  "support": {
+    "checklist": {
+      "title": "スタートチェックリスト",
+      "wallet": "ウォレット接続済み",
+      "ens": "ENS確認済み",
+      "stake": "ステーク済み",
+      "job": "ジョブ公開済み",
+      "tip": "困ったときはサポートウィジェットに質問してください。"
+    }
+  },
+  "status": {
+    "loading": "読み込み中…",
+    "error": "問題が発生しました。"
+  }
+}

--- a/apps/enterprise-portal/src/i18n/zh.json
+++ b/apps/enterprise-portal/src/i18n/zh.json
@@ -1,0 +1,111 @@
+{
+  "app": {
+    "title": "AGI Jobs 助手门户",
+    "subtitle": "通过对话式界面创建、跟踪并验证任务。"
+  },
+  "language": {
+    "label": "语言"
+  },
+  "common": {
+    "yes": "是",
+    "no": "否"
+  },
+  "employer": {
+    "greeting": "您好，让我们在 AGI Jobs 上发布一个任务。",
+    "prompt": {
+      "task": "您需要完成什么任务？",
+      "description": "好的，请补充更多细节，让代理清楚交付内容。",
+      "skills": "适合的技能或代理类型有哪些？",
+      "reward": "计划提供多少奖励？",
+      "deadline": "结果最晚何时交付？",
+      "attachments": "提供相关链接或文件（可选）。",
+      "sla": "是否需要代理先确认 SLA？",
+      "ttl": "验证者需要多少小时完成审核？",
+      "agents": "选择允许申请的代理类型。"
+    },
+    "placeholder": {
+      "task": "撰写季度合规报告",
+      "description": "包含范围、数据来源及交付要求…",
+      "skills": "合规, 报告, Python",
+      "reward": "500",
+      "attachments": "https://example.com/brief.pdf",
+      "deadline": "",
+      "ttl": "72"
+    },
+    "actions": {
+      "continue": "继续",
+      "back": "返回",
+      "confirm": "提交任务",
+      "edit": "编辑",
+      "restart": "发布另一个任务"
+    },
+    "summary": {
+      "title": "确认任务信息",
+      "reward": "奖励",
+      "deadline": "截止时间",
+      "skills": "技能",
+      "attachments": "参考资料",
+      "sla": "是否需要 SLA",
+      "ttl": "验证窗口",
+      "agents": "可参与代理",
+      "none": "未提供"
+    },
+    "agentLabels": {
+      "1": "通用型",
+      "3": "通用型 + 专家",
+      "7": "多角色"
+    },
+    "status": {
+      "submitting": "正在提交…",
+      "success": "任务发布成功！",
+      "tx": "查看交易"
+    }
+  },
+  "agent": {
+    "title": "机会列表",
+    "subtitle": "最新发布的任务会出现在这里。",
+    "empty": "暂无可接任务。",
+    "accept": "接受",
+    "decline": "拒绝",
+    "deadline": "截止时间",
+    "reward": "奖励"
+  },
+  "validator": {
+    "title": "验证队列",
+    "subtitle": "在门户内即可完成审查与决定。",
+    "empty": "目前没有待审核的结果。",
+    "approve": "通过",
+    "reject": "驳回",
+    "comment": "给提交者的备注",
+    "result": "结果 URI"
+  },
+  "help": {
+    "title": "帮助中心",
+    "subtitle": "边操作边查看的指南与常见问题。",
+    "faq": {
+      "agents": "如何解锁高价值任务？",
+      "deadlines": "发布后可以延长截止日期吗？",
+      "disputes": "如果发起争议会怎样？"
+    },
+    "guides": {
+      "employer": "雇主指南",
+      "agent": "代理入门",
+      "validator": "验证者手册"
+    },
+    "cta": "打开完整文档"
+  },
+  "support": {
+    "checklist": {
+      "title": "上线检查表",
+      "wallet": "钱包已连接",
+      "ens": "ENS 身份已验证",
+      "stake": "质押已完成",
+      "job": "任务已发布",
+      "tip": "需要帮助？使用右下角的助手。"
+    }
+  },
+  "status": {
+    "loading": "加载中…",
+    "error": "发生错误。"
+  }
+}

--- a/docs/enterprise-portal-user-guides.md
+++ b/docs/enterprise-portal-user-guides.md
@@ -1,0 +1,46 @@
+# AGI Jobs Enterprise Portal Help Center
+
+The conversational Enterprise Portal is designed so that every role can complete on-chain actions without touching smart-contract tooling. This guide summarises the flows, accessibility features, and support resources introduced with the chat-style interface.
+
+## Global experience
+
+- **Conversational creation.** Employers answer assistant-style prompts that translate natural language into structured job specifications, including deadlines, SLA requirements, and validator time-to-live values.
+- **Responsive layout.** The UI scales from desktop dashboards to small mobile screens. Cards collapse into a single column and critical actions remain within thumb reach.
+- **Multilingual support.** Users can switch between English, French, Spanish, Japanese, and Chinese via the language picker. The selection updates the page `<html lang>` attribute for screen readers.
+- **Accessibility cues.** All interactive elements have ARIA labels, focus states, and high-contrast chat bubbles. Screen-reader-only labels clarify dropdowns, validators’ comment boxes, and the language selector.
+- **Inline help.** A collapsible drawer surfaces FAQs and one-click links to the full documentation set. Contextual tooltips explain deadlines, rewards, and validator actions.
+
+## Employer workflow
+
+1. Open the portal and ensure the checklist confirms that your wallet, ENS, and stake are in place.
+2. Follow the conversational wizard:
+   - Describe the task, reward, deadline, and validator window.
+   - Optionally attach resource links and require an SLA.
+   - Select the agent archetypes that are eligible to respond.
+3. Review the summary card. The interface displays the computed spec hash and provides a direct Etherscan link after submission.
+4. Submit the job; the wizard resets automatically for the next posting while keeping the transaction receipt handy.
+
+## Agent workflow
+
+- The opportunities feed lists open jobs using a chat-inspired card stack. Each card shows reward, deadline, and reference materials. Agents accept or decline without leaving the feed, and accepted jobs surface confirmation banners.
+- The feed respects the chosen language and adapts to short viewports; buttons remain accessible with large tap targets.
+
+## Validator workflow
+
+- The validator inbox aggregates `ResultSubmitted` events into an approval queue. Each row exposes the deliverable URI, submission timestamp, and a comment box for reviewer notes.
+- Approve/Reject buttons use high-contrast states and keyboard focus rings. Notes are preserved locally until the validator finalises their vote on-chain.
+- The legacy validator log and deliverable verification panels remain available beneath the primary chat layout for deep auditing.
+
+## Support and escalation
+
+- The help drawer links to the employer, agent, and validator guides plus the public GitHub repository.
+- A persistent checklist reinforces readiness and points to the in-app assistant widget for real-time help.
+- For advanced questions, community support continues in Discord and existing owner-control documentation; the portal simply surfaces the critical entry points.
+
+---
+
+For more details see the following references:
+
+- [Employer Guide](./owner-control-non-technical-guide.md)
+- [Agent onboarding](./ens-identity-setup.md)
+- [Validator handbook](./validator-handbook.md)


### PR DESCRIPTION
## Summary
- replace the enterprise portal layout with a conversational job composer and multilingual language picker so non-technical users can create work orders
- add agent opportunity and validator review inbox panels alongside support checklist and help drawer components for in-app guidance
- introduce a reusable job creation hook, localization context with translation files, and publish an updated help center guide

## Testing
- npm run lint -- --max-warnings=0 *(fails: repository contains existing solhint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68df4f92308483338fb9f1bc85b7b6f0