### PR TITLE
Add conversational portal user guides and update help center links

### DIFF
--- a/apps/enterprise-portal/src/components/SupportHelpCenter.tsx
+++ b/apps/enterprise-portal/src/components/SupportHelpCenter.tsx
@@ -5,15 +5,15 @@ import { useTranslation } from '../context/LanguageContext';
 const resources = [
   {
     key: 'helpCenter.employerGuide',
-    href: 'https://github.com/MontrealAI/AGIJobsv0/tree/main/docs/employer',
+    href: 'https://github.com/MontrealAI/AGIJobsv0/blob/main/docs/user-guides/employer.md',
   },
   {
     key: 'helpCenter.agentGuide',
-    href: 'https://github.com/MontrealAI/AGIJobsv0/tree/main/docs/agent',
+    href: 'https://github.com/MontrealAI/AGIJobsv0/blob/main/docs/user-guides/agent.md',
   },
   {
     key: 'helpCenter.validatorGuide',
-    href: 'https://github.com/MontrealAI/AGIJobsv0/tree/main/docs/validator',
+    href: 'https://github.com/MontrealAI/AGIJobsv0/blob/main/docs/user-guides/validator.md',
   },
   {
     key: 'helpCenter.faq',

--- a/docs/user-guides/README.md
+++ b/docs/user-guides/README.md
@@ -1,0 +1,27 @@
+# AGI Jobs Portal – User Guides
+
+The AGI Jobs conversational portal makes it easy for every role to participate in the
+marketplace without needing to understand the underlying smart contracts. These
+role-specific guides explain the workflows surfaced in the new chat-style interface and
+link to additional resources for power users.
+
+## Available guides
+
+| Role | Guide |
+| --- | --- |
+| Employers | [Create and manage work requests](./employer.md) |
+| Agents | [Qualify for jobs and submit results](./agent.md) |
+| Validators | [Review results and commit–reveal votes](./validator.md) |
+
+Each document includes:
+
+- Step-by-step walkthroughs matching the prompts displayed in the portal UI
+- Screenshots or descriptions of the key chat interactions, including multilingual tips
+- Links to advanced documentation and smart-contract references for teams who want to
+  look under the hood
+
+## Staying up to date
+
+The UI is designed to evolve quickly. Whenever new capabilities land, this directory will
+be updated so you always have the most accurate information. You can also open a pull
+request with improvements or translations—community contributions are welcome.

--- a/docs/user-guides/agent.md
+++ b/docs/user-guides/agent.md
@@ -1,0 +1,39 @@
+# Agent Guide
+
+Agents interact with AGI Jobs through an inbox that feels like responding to a chat
+invitation. This guide covers the setup steps, how to evaluate opportunities, and how to
+submit work for validation.
+
+## 1. Complete prerequisites
+
+1. Connect your wallet and ensure you have sufficient stake for the tiers you want to
+   access.
+2. Use the onboarding checklist to track ENS verification, staking progress, and the
+   compliance acknowledgement.
+3. The smart tips panel will notify you if your stake is too low to unlock higher-value
+   jobs—follow the link provided to add more stake.
+
+## 2. Review new jobs
+
+1. Navigate to the **Available jobs** panel. New listings appear automatically thanks to
+   the live on-chain feed.
+2. Each card shows the reward, deadline, and required agent type in plain language. The
+   system automatically formats dates and numbers to your locale.
+3. Click **Accept** to commit to the job or **Decline** to pass. The portal records your
+   response locally and can surface confirmations or reminders.
+
+## 3. Work on accepted jobs
+
+1. Once accepted, details become available in your job workspace (outside the scope of
+   this portal). Follow any SLA links provided by the employer before starting.
+2. Submit results using your preferred workflow or integrations. The validator console will
+   show when reviews begin and end.
+3. Keep communication channels open—employers can reach you through the job thread.
+
+## 4. Tips for success
+
+- Respond quickly to maintain a strong assignment history.
+- Provide quality deliverables before the stated deadline; validators use the same portal
+  to confirm timing.
+- Monitor staking requirements. The UI highlights when larger jobs require additional
+  stake, so you can plan ahead.

--- a/docs/user-guides/employer.md
+++ b/docs/user-guides/employer.md
@@ -1,0 +1,54 @@
+# Employer Guide
+
+The enterprise portal turns job creation into a guided conversation. This guide walks
+through each step, from drafting a request to monitoring validator feedback.
+
+## 1. Prepare your wallet and identity
+
+1. Connect a wallet from the header of the portal. Supported wallets include MetaMask
+   and other EIP-1193 compatible providers.
+2. Verify your ENS name and compliance acknowledgement through the onboarding checklist.
+   - The checklist keeps local progress, so you can complete prerequisites across
+     sessions.
+   - Click **Refresh status** if you recently updated your acknowledgement on-chain.
+
+## 2. Draft a job in the conversational composer
+
+1. Open the **Create a job like a conversation** panel.
+2. Answer the assistant prompts one at a time:
+   - **Title & description** — describe the deliverable in natural language.
+   - **Attachments** — upload reference files or provide an IPFS/HTTP link.
+   - **Reward** — enter the token amount to pay (the UI will convert to on-chain units).
+   - **Deadline** — choose a calendar date or leave blank for flexible delivery.
+   - **Skills & agent type** — highlight the expertise required; the assistant will map
+     the selection to allowed agent types.
+   - **Validation window & SLA** — configure validator timing and any SLA link.
+3. Review the auto-generated summary. You can jump back to earlier questions with
+   **Edit answers** or reset the entire flow with **Start over**.
+
+## 3. Submit on-chain
+
+1. Ensure your wallet is connected and the compliance acknowledgement is complete.
+2. Press **Submit job**. The portal will:
+   - Hash the job spec and attachments list locally for transparency.
+   - Call the JobRegistry contract using your connected signer.
+   - Display submission status and the resulting transaction hash for tracking on
+     Etherscan.
+3. Once confirmed, the job appears in the Agent inbox feed and the validator timeline.
+
+## 4. Monitor progress
+
+- The **Smart tips** panel highlights jobs that have been idle and suggests actions such
+  as increasing the reward.
+- Validator events stream into the **Validator review queue**, allowing employers to see
+  when reviews start and finish.
+- Use the help center links to access deeper technical docs, dispute processes, and
+  governance policies.
+
+## 5. Best practices
+
+- Keep instructions concise and provide structured attachments when possible.
+- Set realistic validation windows to give validators enough time for the commit–reveal
+  process.
+- Revisit the onboarding checklist periodically to confirm your identity and stake are
+  still valid.

--- a/docs/user-guides/validator.md
+++ b/docs/user-guides/validator.md
@@ -1,0 +1,39 @@
+# Validator Guide
+
+Validators receive commit–reveal tasks through the same conversational portal used by
+employers and agents. This guide explains how to keep your validation workflow efficient
+and compliant.
+
+## 1. Meet validator requirements
+
+1. Ensure your validator keys are registered and you have the necessary staking balance.
+2. Complete the compliance acknowledgement via the onboarding checklist; the portal will
+   read your on-chain status and show whether you are ready to review jobs.
+3. Familiarize yourself with the [commit–reveal protocol](../job-validation-lifecycle.md)
+   for background on deadlines and dispute resolution.
+
+## 2. Review submissions
+
+1. Open the **Validator review queue**. Jobs that are ready for validation will be listed
+   with submission timestamps and direct links to the result URI (IPFS, HTTPS, etc.).
+2. Inspect the deliverable. You can open attachments or links in a new tab for a closer
+   look.
+3. Choose **Approve** or **Reject**, optionally leaving a comment. The portal captures your
+   decision locally so you can track what you have already reviewed.
+
+## 3. Complete the on-chain vote
+
+1. After recording your decision in the UI, follow the prompt to submit your commit
+   transaction through your validator tooling.
+2. When the reveal window opens, submit the reveal transaction. The portal will remind you
+   via the smart tips panel if a reveal deadline is approaching.
+3. Monitor the job timeline to confirm the finalization state or any disputes that arise.
+
+## 4. Validation best practices
+
+- Keep time zone differences in mind. The UI formats deadlines according to your locale,
+  but commit and reveal windows still follow block time—plan to review early.
+- Use concise, actionable comments when rejecting work so employers and agents understand
+  what must be improved.
+- Stay engaged with the community forum linked in the help center for policy updates and
+  security advisories.


### PR DESCRIPTION
## Summary
- add a documentation hub with employer, agent, and validator user guides for the conversational portal
- update the portal help center links so in-app guidance directs users to the new guides

## Testing
- npm run lint *(fails: Invalid Options: - Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68df5758dc288333b29487d5867794f8