### PR TITLE
Add owner configurator scaffold and owner control matrix

### DIFF
--- a/contracts/v2/admin/OwnerConfigurator.sol
+++ b/contracts/v2/admin/OwnerConfigurator.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/// @title OwnerConfigurator
+/// @notice Minimal facade contract that allows the owner (Safe or EOA) to batch
+///         configuration calls across the AGI Jobs v2 module surface area. This
+///         contract is intentionally lightweight until the per-module adapters
+///         are wired in. It focuses on safely forwarding calls and emitting an
+///         auditable change log for the owner console and subgraph.
+contract OwnerConfigurator is Ownable2Step {
+    using Address for address;
+
+    /// @notice Emitted whenever the owner requests a parameter mutation via
+    ///         this configurator. `module` and `parameter` act as indexed
+    ///         tags for downstream analytics while the raw `oldValue` and
+    ///         `newValue` bytes capture the semantic payload supplied by the
+    ///         owner interface.
+    event ParameterUpdated(
+        bytes32 indexed module,
+        bytes32 indexed parameter,
+        bytes oldValue,
+        bytes newValue,
+        address indexed actor
+    );
+
+    error OwnerConfigurator__ZeroTarget();
+
+    /// @notice Deploys the configurator and optionally re-assigns ownership to
+    ///         a Safe or administrative EOA. Ownership can later be migrated
+    ///         through the standard `transferOwnership` flow.
+    /// @param initialOwner The owner address that should ultimately control
+    ///        configuration. Passing `address(0)` defaults ownership to the
+    ///        deployer to simplify local testing.
+    constructor(address initialOwner)
+        Ownable(initialOwner == address(0) ? _msgSender() : initialOwner)
+    {}
+
+    /// @notice Executes an owner-authorized configuration call on a target
+    ///         contract and emits a structured event describing the change.
+    /// @dev The owner console is responsible for populating `oldValue` and
+    ///      `newValue` with the UI-sourced values. Future iterations will
+    ///      perform on-chain reads to enforce idempotency, but this scaffolding
+    ///      allows integration work to begin without blocking.
+    /// @param target The contract that exposes the setter.
+    /// @param callData ABI-encoded calldata for the setter.
+    /// @param moduleKey Module identifier (e.g., keccak256("JOB_REGISTRY")).
+    /// @param parameterKey Parameter identifier (e.g., keccak256("SET_COMMIT_WINDOW")).
+    /// @param oldValue Bytes representation of the previous value (optional).
+    /// @param newValue Bytes representation of the desired value.
+    /// @return returnData Raw returndata from the executed call.
+    function configure(
+        address target,
+        bytes calldata callData,
+        bytes32 moduleKey,
+        bytes32 parameterKey,
+        bytes calldata oldValue,
+        bytes calldata newValue
+    ) external onlyOwner returns (bytes memory returnData) {
+        if (target == address(0)) {
+            revert OwnerConfigurator__ZeroTarget();
+        }
+
+        returnData = target.functionCall(callData);
+        emit ParameterUpdated(moduleKey, parameterKey, oldValue, newValue, _msgSender());
+    }
+}

--- a/docs/OWNER_CONTROL.md
+++ b/docs/OWNER_CONTROL.md
@@ -1,0 +1,93 @@
+# Owner Control Matrix (Draft)
+
+> **Status:** Draft coordination document for implementing the Owner Configurator surface area across all v2 contracts. This file enumerates the parameters that must remain owner-upgradeable and will be updated as modules are finalized.
+
+## Overview
+
+The AGI Jobs v2 system preserves an owner-first operating model. A single Owner address (EOA or Safe) must retain the ability to configure, pause, upgrade, and recover assets across every module. Ownership is mediated through `Ownable2Step` on all upgradeable implementations and a central `OwnerConfigurator` facade for non-technical operators.
+
+### Operating Principles
+
+1. **Single Source of Truth** – Every mutable parameter appears here with the contract that guards it and the emitted `ParameterUpdated` event identifier.
+2. **Idempotent Batched Updates** – The configurator will expose batch setters that no-op when the requested value already matches on-chain state.
+3. **Auditability** – Each change must emit `ParameterUpdated(name, oldValue, newValue, msg.sender)` and be indexed for the owner console and subgraph.
+4. **Safe Compatibility** – All configuration flows will be Safe Transaction Builder compatible and surfaced in the Owner Console UI.
+
+---
+
+## Owner Configurator Surface
+
+| Module | Setter | Parameter | Units / Notes |
+| ------ | ------ | --------- | ------------- |
+| JobRegistry | `setValidationModule(address)` | Validation module proxy | address |
+| JobRegistry | `setDisputeModule(address)` | Dispute module proxy | address |
+| JobRegistry | `setIdentityRegistry(address)` | Identity registry | address |
+| JobRegistry | `setFeePool(address)` | Fee pool address | address |
+| JobRegistry | `setTaxPolicy(address)` | Tax policy contract | address |
+| JobRegistry | `setCertificateNFT(address)` | Certificate NFT contract | address |
+| JobRegistry | `setRouter(address)` | Jobs router | address |
+| JobRegistry | `setMaxJobDuration(uint256)` | Upper bound in seconds | uint256 |
+| JobRegistry | `setMinJobReward(uint256)` | Minimum payment amount | uint256 |
+| JobRegistry | `setJobCreateWhitelist(bool)` | Toggle allowlist | bool |
+| JobRegistry | `setJobCreateMerkleRoot(bytes32)` | Allowlist root | bytes32 |
+| ValidationModule | `setCommitWindow(uint256)` | Seconds | uint256 |
+| ValidationModule | `setRevealWindow(uint256)` | Seconds | uint256 |
+| ValidationModule | `setValidatorBounds(uint256,uint256)` | min,max committee | uint256 |
+| ValidationModule | `setQuorum(uint16)` | Percentage (basis points) | uint16 |
+| ValidationModule | `setApprovalThreshold(uint16)` | Percentage (basis points) | uint16 |
+| ValidationModule | `setRandProvider(address)` | Randomness provider | address |
+| ValidationModule | `setVRFParams(uint64,bytes32,uint32,uint16)` | subId,keyHash,gasLimit,confirmations | mixed |
+| ValidationModule | `setNoRevealPenalty(uint16)` | Basis points | uint16 |
+| ValidationModule | `setLateRevealPenalty(uint16)` | Basis points | uint16 |
+| StakeManager | `setMinStake(uint8,uint256)` | Role => stake amount | uint256 |
+| StakeManager | `setUnbondingPeriod(uint256)` | Seconds | uint256 |
+| StakeManager | `setSlashPercents(uint16,uint16,uint16,uint16)` | bps per offense | uint16 |
+| StakeManager | `setTreasury(address)` | Treasury receiver | address |
+| StakeManager | `setTreasuryAllowlist(address,bool)` | Access control | address,bool |
+| StakeManager | `rescueERC20(address,address,uint256)` | Token, to, amount | addresses,uint256 |
+| StakeManager | `rescueETH(address,uint256)` | Recipient, amount | address,uint256 |
+| IdentityRegistry | `setAgentRootNode(bytes32)` | ENS node | bytes32 |
+| IdentityRegistry | `setValidatorRootNode(bytes32)` | ENS node | bytes32 |
+| IdentityRegistry | `setAgentMerkleRoot(bytes32)` | Allowlist root | bytes32 |
+| IdentityRegistry | `setValidatorMerkleRoot(bytes32)` | Allowlist root | bytes32 |
+| IdentityRegistry | `setAttestor(address,bool)` | Attestor allowlist | address,bool |
+| IdentityRegistry | `setENSResolver(address)` | ENS resolver | address |
+| DisputeModule | `setDisputeFee(uint256)` | Fee amount | uint256 |
+| DisputeModule | `setAppealWindow(uint256)` | Seconds | uint256 |
+| DisputeModule | `setMaxRounds(uint8)` | Arbitration rounds | uint8 |
+| DisputeModule | `setArbitratorCommittee(address)` | Committee contract | address |
+| DisputeModule | `setModerator(address,bool)` | Moderator ACL | address,bool |
+| ReputationEngine | `setWeights(uint16,uint16,uint16,uint16)` | success,fail,slash,decay | uint16 |
+| ReputationEngine | `setPremiumThreshold(uint256)` | Score threshold | uint256 |
+| ReputationEngine | `setBlacklist(address,bool)` | Exclusion list | address,bool |
+| FeePool | `setBurnPct(uint16)` | Basis points | uint16 |
+| FeePool | `setTreasury(address)` | Treasury recipient | address |
+| FeePool | `setSplit(uint16,uint16,uint16,uint16,uint16)` | agents,validators,operators,employers,treasury | uint16 |
+| CertificateNFT | `setBaseURI(string)` | Metadata URI | string |
+| CertificateNFT | `setMinter(address)` | Authorized minter | address |
+| CertificateNFT | `pause()` / `unpause()` | Circuit breaker | - |
+| SystemPause | `pauseAll()` | Global stop | - |
+| SystemPause | `unpauseAll()` | Resume | - |
+| SystemPause | `setPauser(address)` | Emergency delegate | address |
+| RandomnessWrapper | `setCoordinator(address)` | VRF coordinator | address |
+| RandomnessWrapper | `setSubId(uint64)` | Subscription id | uint64 |
+| RandomnessWrapper | `withdrawLINK(address,uint256)` | Rescue LINK | address,uint256 |
+| NodeRegistry | `setMinSpecs(bytes32)` | Hash of requirements | bytes32 |
+| NodeRegistry | `setHeartbeatWindow(uint256)` | Seconds | uint256 |
+| NodeRegistry | `setTEERequired(bool)` | Toggle attestation | bool |
+| NodeRegistry | `setMinNodeStake(uint256)` | Stake threshold | uint256 |
+| NodeRegistry | `setOperatorFeeBps(uint16)` | Fee share | uint16 |
+
+---
+
+## Event Naming
+
+All setter actions emit a canonical `ParameterUpdated(bytes32 indexed name, bytes32 indexed field, bytes oldValue, bytes newValue, address indexed actor)` event. The `name` encodes the module (e.g., `JOB_REGISTRY`) and `field` encodes the parameter (e.g., `SET_VALIDATION_MODULE`).
+
+## Next Steps
+
+1. Implement `contracts/admin/OwnerConfigurator.sol` with batched delegate calls to each module and per-parameter guard logic.
+2. Ensure every module exposes both setter and getter pairs and adheres to `Ownable2Step`.
+3. Extend Foundry/Hardhat test suites with exhaustive access control and event emission coverage (≥90% lines overall, 100% across access control paths).
+4. Update Owner Console to consume this matrix for form generation and Safe transaction templates.
+


### PR DESCRIPTION
## Summary
- add an OwnerConfigurator scaffold contract to centralize owner-driven parameter updates and emit normalized events
- document the draft Owner Control matrix capturing the required setters per module for the v2 governance surface

## Testing
- `npx solc --base-path . --include-path node_modules --abi contracts/v2/admin/OwnerConfigurator.sol`

------
https://chatgpt.com/codex/tasks/task_e_68dfd3e99c0083338f31607ceb3e7798