### PR TITLE
chore: harden contract ci gatekeepers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require review from the core maintainers on every change
+* @MontrealAI

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -49,11 +49,20 @@ jobs:
       - name: Compile contracts (sepolia)
         run: npm run compile:sepolia
 
+      - name: Compile contracts (mainnet)
+        run: npm run compile:mainnet
+
       - name: Generate typechain bindings
         run: npx hardhat typechain
 
       - name: Hardhat unit tests
         run: npm test
+
+      - name: Generate gas report
+        if: matrix.node == '20'
+        run: |
+          mkdir -p reports/gas
+          npm run gas:report
 
       - name: Solidity coverage
         if: matrix.node == '20'
@@ -172,6 +181,7 @@ jobs:
           if [ -f gas-snapshots/.gas-snapshot ]; then cp gas-snapshots/.gas-snapshot artifact-bundle/contracts/gas-snapshot.txt; fi
           if [ -f coverage/lcov.info ]; then cp coverage/lcov.info artifact-bundle/contracts/lcov.info; fi
           if [ -f coverage/badge.json ]; then cp coverage/badge.json artifact-bundle/contracts/coverage-badge.json; fi
+          if [ -f reports/gas/gas-report.txt ]; then cp reports/gas/gas-report.txt artifact-bundle/contracts/gas-report.txt; fi
           if [ -d subgraph ]; then
             mkdir -p artifact-bundle/contracts/subgraph
             if [ -f subgraph/schema.graphql ]; then cp subgraph/schema.graphql artifact-bundle/contracts/subgraph/schema.graphql; fi

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -113,9 +113,11 @@ module.exports = {
     require: ['ts-node/register', './test/setup.js'],
   },
   gasReporter: {
-    enabled: true,
+    enabled: process.env.REPORT_GAS === 'true',
     currency: 'USD',
     showTimeSpent: true,
+    noColors: true,
+    outputFile: 'reports/gas/gas-report.txt',
   },
   contractSizer: {
     alphaSort: true,

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "webapp:e2e": "start-server-and-test \"npm --prefix apps/console run preview -- --host 0.0.0.0 --port 4173\" http://127.0.0.1:4173 \"cypress run --config-file cypress.config.ts\"",
     "security:audit": "audit-ci --config ./audit-ci.json",
     "gas:check": "FOUNDRY_PROFILE=gas forge snapshot --match-contract CommitRevealGas --snap gas-snapshots/.gas-snapshot --check",
+    "gas:report": "REPORT_GAS=true npx hardhat test --no-compile",
     "gas:snapshot": "FOUNDRY_PROFILE=gas forge snapshot --match-contract CommitRevealGas --snap gas-snapshots/.gas-snapshot",
     "gateway": "npm run build:gateway && node agent-gateway/dist/index.js",
     "build:gateway": "tsc -p agent-gateway/tsconfig.json",


### PR DESCRIPTION
## Summary
- ensure the contracts workflow compiles mainnet targets, produces a hardhat gas report, and publishes it with other artifacts
- configure the gas reporter to emit a deterministic file for gating and add a CODEOWNERS roster for enforced reviews

## Testing
- not run (environment dependency install issues)


------
https://chatgpt.com/codex/tasks/task_e_68e009ebdf8c8333a7d27bca2e466f26