### PR TITLE
Add CI guardrail scripts and document branch protections

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Prepare report directories
+        run: |
+          mkdir -p reports
+          mkdir -p reports/sbom
+
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ scripts/**/*.js
 !scripts/check-coverage.js
 !scripts/run-coverage.js
 !scripts/ci/run-coverage.js
+!scripts/ci/check-access-control-coverage.js
+!scripts/ci/generate-coverage-badge.js
+!scripts/ci/export-abis.js
+!scripts/ci/check-abi-diff.js
 !scripts/verify-wiring.js
 !scripts/run-wire-verify.js
 !scripts/subgraph-e2e.js

--- a/docs/branch-protection-rules.md
+++ b/docs/branch-protection-rules.md
@@ -1,0 +1,31 @@
+# Branch Protection Rules — AGI Jobs v0 V2
+
+To keep the V2 CI surface green and enforce the governance guarantees specified in the "REDENOMINATION / V2-CI-GREEN" sprint, branch protection on `main` **must** be configured with the following checks and policies:
+
+## Required status checks
+
+Require branches to be up to date before merging and enable the status checks below:
+
+- `contracts` (matrix of Node.js 18 & 20)
+- `security`
+- `fuzz`
+- `e2e`
+- `webapp`
+- `containers`
+- `release` (release workflow will only run on tags / manual dispatch, but it must remain green when invoked)
+
+These status checks cover the compilation matrix, coverage gates, ABI drift guard, security scanners, Foundry fuzzing, end-to-end orchestration suites, Cypress front-end coverage, container supply-chain scanning, and release provenance.
+
+## Pull request requirements
+
+- Require pull request reviews before merging (at least one approving review).
+- Enforce CODEOWNERS review requirements.
+- Dismiss stale approvals when new commits are pushed.
+- Require conversation resolution before merging.
+
+## Push restrictions
+
+- Block direct pushes to `main`; only merges via protected pull requests are allowed.
+- Restrict who can force push or delete the branch (ideally no one except repository administrators for break-glass scenarios).
+
+Keeping these protections in place ensures that every change to `main` has passed the full V2 CI/CD stack, providing confidence for institutional operators running AGI Jobs on Ethereum mainnet.

--- a/scripts/ci/check-abi-diff.js
+++ b/scripts/ci/check-abi-diff.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+function getArg(flag, defaultValue) {
+  const index = process.argv.indexOf(flag);
+  if (index !== -1 && index + 1 < process.argv.length) {
+    return process.argv[index + 1];
+  }
+  return defaultValue;
+}
+
+function canonicalise(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalise);
+  }
+  if (value && typeof value === 'object') {
+    const sorted = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = canonicalise(value[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+function hashFor(value) {
+  return crypto.createHash('sha256').update(JSON.stringify(canonicalise(value))).digest('hex');
+}
+
+function loadAbiDirectory(dir) {
+  const result = new Map();
+  if (!dir || !fs.existsSync(dir)) {
+    return result;
+  }
+  const stack = [dir];
+  while (stack.length) {
+    const current = stack.pop();
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile() && entry.name.endsWith('.json')) {
+        const relative = path.relative(dir, entryPath).replace(/\\/g, '/');
+        try {
+          const parsed = JSON.parse(fs.readFileSync(entryPath, 'utf8'));
+          result.set(relative, {
+            contractName: parsed.contractName,
+            sourceName: parsed.sourceName,
+            abi: parsed.abi ?? parsed,
+            hash: hashFor(parsed.abi ?? parsed),
+          });
+        } catch (error) {
+          console.warn(`Unable to parse ABI JSON: ${entryPath}`);
+        }
+      }
+    }
+  }
+  return result;
+}
+
+const baseDir = getArg('--base', 'reports/abis/base');
+const headDir = getArg('--head', 'reports/abis/head');
+const reportPath = getArg('--report', 'reports/abis/diff.json');
+
+const baseAbis = loadAbiDirectory(path.resolve(baseDir));
+const headAbis = loadAbiDirectory(path.resolve(headDir));
+
+const added = [];
+const removed = [];
+const changed = [];
+
+const seen = new Set([...baseAbis.keys(), ...headAbis.keys()]);
+for (const file of seen) {
+  const baseEntry = baseAbis.get(file);
+  const headEntry = headAbis.get(file);
+  if (!baseEntry && headEntry) {
+    added.push({ file, hash: headEntry.hash, contractName: headEntry.contractName });
+  } else if (baseEntry && !headEntry) {
+    removed.push({ file, hash: baseEntry.hash, contractName: baseEntry.contractName });
+  } else if (baseEntry && headEntry && baseEntry.hash !== headEntry.hash) {
+    changed.push({
+      file,
+      contractName: headEntry.contractName || baseEntry.contractName,
+      baseHash: baseEntry.hash,
+      headHash: headEntry.hash,
+    });
+  }
+}
+
+const hasDiff = added.length > 0 || removed.length > 0 || changed.length > 0;
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  hasDiff,
+  added,
+  removed,
+  changed,
+};
+
+fs.mkdirSync(path.dirname(path.resolve(reportPath)), { recursive: true });
+fs.writeFileSync(path.resolve(reportPath), JSON.stringify(report, null, 2));
+
+if (hasDiff) {
+  console.log('ABI differences detected:');
+  if (added.length) {
+    console.log(`  Added (${added.length}):`);
+    for (const entry of added) {
+      console.log(`    + ${entry.file}`);
+    }
+  }
+  if (removed.length) {
+    console.log(`  Removed (${removed.length}):`);
+    for (const entry of removed) {
+      console.log(`    - ${entry.file}`);
+    }
+  }
+  if (changed.length) {
+    console.log(`  Changed (${changed.length}):`);
+    for (const entry of changed) {
+      console.log(`    * ${entry.file}`);
+    }
+  }
+} else {
+  console.log('No ABI differences detected.');
+}

--- a/scripts/ci/check-access-control-coverage.js
+++ b/scripts/ci/check-access-control-coverage.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const COVERAGE_PATH = path.resolve(process.env.LCOV_FILE || 'coverage/lcov.info');
+const pathsArg = process.env.ACCESS_CONTROL_PATHS || '';
+
+if (!pathsArg.trim()) {
+  console.log('No access control paths configured; skipping dedicated coverage gate.');
+  process.exit(0);
+}
+
+if (!fs.existsSync(COVERAGE_PATH)) {
+  console.error(`Coverage file not found: ${COVERAGE_PATH}`);
+  process.exit(1);
+}
+
+const requiredPrefixes = pathsArg
+  .split(',')
+  .map((entry) => entry.trim())
+  .filter(Boolean)
+  .map((entry) => entry.replace(/\\/g, '/').replace(/\/$/, ''));
+
+if (!requiredPrefixes.length) {
+  console.log('Access control path list resolved to empty set; skipping.');
+  process.exit(0);
+}
+
+const lcovRaw = fs.readFileSync(COVERAGE_PATH, 'utf8');
+
+const records = [];
+let current = null;
+for (const line of lcovRaw.split('\n')) {
+  if (line.startsWith('SF:')) {
+    if (current) {
+      records.push(current);
+    }
+    const filePath = line.substring(3).trim();
+    current = { file: filePath, lines: [] };
+    continue;
+  }
+  if (!current) {
+    continue;
+  }
+  if (line.startsWith('DA:')) {
+    const [lineNumber, hits] = line.substring(3).split(',');
+    current.lines.push({
+      line: Number(lineNumber),
+      hits: Number(hits),
+    });
+    continue;
+  }
+  if (line.startsWith('end_of_record')) {
+    records.push(current);
+    current = null;
+  }
+}
+if (current) {
+  records.push(current);
+}
+
+const failures = [];
+const observed = new Map();
+
+for (const record of records) {
+  const absolute = path.resolve(record.file);
+  const relative = path.relative(process.cwd(), absolute).replace(/\\/g, '/');
+  const hits = record.lines.filter((entry) => entry.hits > 0).length;
+  const total = record.lines.length;
+  const pct = total === 0 ? 100 : (hits / total) * 100;
+
+  for (const prefix of requiredPrefixes) {
+    if (relative.startsWith(prefix)) {
+      const entry = observed.get(prefix) || [];
+      entry.push({ file: relative, coverage: pct });
+      observed.set(prefix, entry);
+      if (pct < 100 - 1e-9) {
+        failures.push({ prefix, file: relative, coverage: pct });
+      }
+    }
+  }
+}
+
+let missing = false;
+for (const prefix of requiredPrefixes) {
+  if (!observed.has(prefix)) {
+    console.error(`No coverage data found for access control path: ${prefix}`);
+    missing = true;
+  }
+}
+
+if (failures.length) {
+  console.error('Access control coverage violations detected:');
+  for (const failure of failures) {
+    console.error(`  ${failure.file}: ${failure.coverage.toFixed(2)}% (required: 100%)`);
+  }
+}
+
+if (failures.length || missing) {
+  process.exit(1);
+}
+
+for (const [prefix, files] of observed.entries()) {
+  console.log(`Access control coverage OK for ${prefix}`);
+  for (const file of files) {
+    console.log(`  ${file.file}: ${file.coverage.toFixed(2)}%`);
+  }
+}

--- a/scripts/ci/export-abis.js
+++ b/scripts/ci/export-abis.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function getArg(flag, defaultValue) {
+  const index = process.argv.indexOf(flag);
+  if (index !== -1 && index + 1 < process.argv.length) {
+    return process.argv[index + 1];
+  }
+  return defaultValue;
+}
+
+const artifactsDir = path.resolve(getArg('--artifacts', 'artifacts/contracts'));
+const outDir = path.resolve(getArg('--out', 'reports/abis'));
+
+if (!fs.existsSync(artifactsDir)) {
+  console.error(`Artifacts directory does not exist: ${artifactsDir}`);
+  process.exit(1);
+}
+
+function walk(dir, files = []) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(entryPath, files);
+    } else if (entry.isFile() && entry.name.endsWith('.json') && !entry.name.endsWith('.dbg.json')) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+const artifactFiles = walk(artifactsDir);
+if (!artifactFiles.length) {
+  console.warn(`No Hardhat artifact files found under ${artifactsDir}`);
+}
+
+for (const filePath of artifactFiles) {
+  const relative = path.relative(artifactsDir, filePath);
+  const destination = path.join(outDir, relative);
+  const raw = fs.readFileSync(filePath, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.warn(`Skipping invalid JSON artifact: ${filePath}`);
+    continue;
+  }
+
+  const abi = parsed.abi ?? [];
+  const contractName = parsed.contractName || path.basename(filePath, '.json');
+  const sourceName = parsed.sourceName || null;
+  const output = {
+    contractName,
+    sourceName,
+    abi,
+  };
+
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, JSON.stringify(output, null, 2));
+}
+
+console.log(`Exported ${artifactFiles.length} ABI files to ${outDir}`);

--- a/scripts/ci/generate-coverage-badge.js
+++ b/scripts/ci/generate-coverage-badge.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const [,, lcovPathArg, outPathArg] = process.argv;
+const lcovPath = path.resolve(lcovPathArg || 'coverage/lcov.info');
+const outPath = path.resolve(outPathArg || 'coverage/badge.json');
+
+if (!fs.existsSync(lcovPath)) {
+  console.error(`Coverage file not found: ${lcovPath}`);
+  process.exit(1);
+}
+
+const lcovData = fs.readFileSync(lcovPath, 'utf8');
+let found = 0;
+let hit = 0;
+for (const line of lcovData.split('\n')) {
+  if (line.startsWith('DA:')) {
+    const [, count] = line.substring(3).split(',');
+    found += 1;
+    if (Number(count) > 0) {
+      hit += 1;
+    }
+  }
+}
+
+const percentage = found === 0 ? 0 : (hit / found) * 100;
+
+function coverageColor(pct) {
+  if (pct >= 95) return 'brightgreen';
+  if (pct >= 90) return 'green';
+  if (pct >= 80) return 'yellowgreen';
+  if (pct >= 70) return 'yellow';
+  if (pct >= 60) return 'orange';
+  return 'red';
+}
+
+const badge = {
+  schemaVersion: 1,
+  label: 'contracts coverage',
+  message: `${percentage.toFixed(2)}%`,
+  color: coverageColor(percentage),
+};
+
+fs.mkdirSync(path.dirname(outPath), { recursive: true });
+fs.writeFileSync(outPath, JSON.stringify(badge, null, 2));
+console.log(`Coverage badge written to ${outPath}`);


### PR DESCRIPTION
## Summary
- add CI helper scripts to export ABIs, diff ABI changes, generate coverage badges, and enforce 100% coverage on access control modules
- wire the security workflow to prepare deterministic report directories for SBOM and other artefacts
- document the required branch protection configuration for the V2 CI/CD hardening sprint

## Testing
- node scripts/ci/check-access-control-coverage.js
- node scripts/ci/generate-coverage-badge.js /tmp/sample.lcov /tmp/badge.json
- node scripts/ci/export-abis.js --artifacts /tmp/artifacts/contracts --out /tmp/abis


------
https://chatgpt.com/codex/tasks/task_e_68e00fb0d5948333a39d34400ddb35aa