### PR TITLE
Fix CI docker build configuration and stabilize receipt test

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
       - name: Normalise image namespace
         run: |
@@ -61,19 +63,37 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and (optionally) push ${{ matrix.name }}
+      - name: Build (pull request, single-arch load)
+        if: github.event_name == 'pull_request'
         id: build
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          tags: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.name }}:latest
-          provenance: true
-          sbom: true
+          platforms: linux/amd64
           load: true
+          push: false
+          outputs: type=docker
+          provenance: false
+          sbom: false
+          tags: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.name }}:latest
+
+      - name: Build and push (main branch, multi-arch)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          load: false
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.name }}:latest
 
       - name: Trivy scan
+        if: github.event_name == 'pull_request'
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -84,7 +104,7 @@ jobs:
       - name: Upload container digest
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          echo "${{ steps.build.outputs.digest }}" > digest.txt
+          echo "${{ steps.push.outputs.digest }}" > digest.txt
         shell: bash
 
       - name: Publish digest artefact

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,9 @@ jobs:
   orchestrator-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      TERM: xterm
+      CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -91,7 +91,8 @@ jobs:
             reports/sbom/spdx.json
 
       - name: Generate provenance attestation
-        uses: slsa-framework/slsa-github-generator/actions/attest-generic@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: slsa-framework/slsa-github-generator/actions/attest-generic@v2.0.0
         with:
           predicate-type: https://slsa.dev/provenance/v1
           subject-path: reports/sbom/spdx.json

--- a/apps/console/src/components/ReceiptsViewer.tsx
+++ b/apps/console/src/components/ReceiptsViewer.tsx
@@ -2,6 +2,18 @@ import { useState } from 'react';
 import { useApi } from '../context/ApiContext';
 import { StoredReceiptRecord } from '../types';
 
+function extractMetadataField(
+  metadata: Record<string, unknown> | null | undefined,
+  key: string
+): string | null {
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+  const record = metadata as Record<string, unknown>;
+  const value = record[key];
+  return typeof value === 'string' ? value : null;
+}
+
 const EAS_BASE_URL = 'https://easscan.org/attestation/';
 
 export function ReceiptsViewer() {
@@ -42,6 +54,11 @@ export function ReceiptsViewer() {
       setLoading(false);
     }
   }
+
+  const activeReceipt = expanded !== null ? receipts[expanded] ?? null : null;
+  const activeMetadata = activeReceipt?.metadata ?? activeReceipt?.payload ?? null;
+  const activeStatus = extractMetadataField(activeMetadata, 'status');
+  const activeOutcome = extractMetadataField(activeMetadata, 'outcome');
 
   return (
     <div className="panel">
@@ -129,11 +146,27 @@ export function ReceiptsViewer() {
               </tbody>
             </table>
           </div>
-          {expanded !== null && receipts[expanded] && (
+          {activeReceipt && (
             <div style={{ marginTop: '1rem' }}>
               <h4>Receipt Payload</h4>
+              {(activeStatus || activeOutcome) && (
+                <dl className="metadata-list">
+                  {activeStatus && (
+                    <>
+                      <dt>Status</dt>
+                      <dd data-testid="receipt-status">{activeStatus}</dd>
+                    </>
+                  )}
+                  {activeOutcome && (
+                    <>
+                      <dt>Outcome</dt>
+                      <dd data-testid="receipt-outcome">{activeOutcome}</dd>
+                    </>
+                  )}
+                </dl>
+              )}
               <pre className="json-inline">
-                {JSON.stringify(receipts[expanded], null, 2)}
+                {JSON.stringify(activeReceipt, null, 2)}
               </pre>
             </div>
           )}

--- a/apps/console/src/styles.css
+++ b/apps/console/src/styles.css
@@ -211,6 +211,24 @@ tbody tr:hover {
   color: rgba(242, 245, 248, 0.6);
 }
 
+.metadata-list {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.metadata-list dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(242, 245, 248, 0.6);
+}
+
+.metadata-list dd {
+  margin: 0;
+  font-weight: 600;
+}
+
 .status-dot {
   width: 10px;
   height: 10px;

--- a/apps/console/src/types.ts
+++ b/apps/console/src/types.ts
@@ -68,7 +68,7 @@ export interface GovernancePreviewResult {
 }
 
 export interface StoredReceiptRecord {
-  kind: 'PLAN' | 'EXECUTION';
+  kind: string;
   planHash: string;
   jobId?: number;
   createdAt: string;
@@ -78,4 +78,5 @@ export interface StoredReceiptRecord {
   attestationCid?: string | null;
   receipt?: Record<string, unknown> | null;
   payload?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
 }

--- a/cypress/e2e/job-flow.cy.ts
+++ b/cypress/e2e/job-flow.cy.ts
@@ -61,6 +61,7 @@ describe('Owner governance job flow', () => {
     cy.wait('@receipts');
     cy.contains('job.finalized');
     cy.contains('Details').click();
-    cy.contains('status: agent_win');
+    cy.get('[data-testid="receipt-status"]').should('have.text', 'paid');
+    cy.get('[data-testid="receipt-outcome"]').should('have.text', 'agent_win');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
     "types": ["node", "hardhat"],
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary
- split container builds so pull requests load a single-architecture image without attestations while main pushes publish multi-arch images with provenance
- pin the SLSA generator action to a released version and only run it for tagged builds
- surface receipt metadata in the console UI with deterministic data-testids and update the Cypress job flow to assert on them; add supporting styles and typings
- ensure TypeScript path resolution has a baseUrl and provide TERM/Cypress cache variables for the e2e workflow

## Testing
- npm run lint *(fails: existing solhint warnings in contracts directory)*

------
https://chatgpt.com/codex/tasks/task_e_68e0169c2218833386ada724836aef2f