### PR TITLE
docs: expand owner parameter matrix playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,9 +528,17 @@ The script expands per-module JSON into Markdown tables, injects copy/paste upda
 and verification commands, and embeds Mermaid control-loop diagrams so a
 non-technical owner can stage, execute, and audit parameter changes without
 touching Solidity. Explore the full workflow in the
-[Owner Parameter Matrix guide](docs/owner-parameter-matrix.md) and pair it with
-`npm run owner:surface` plus `npm run owner:verify-control` to archive a complete
-change-control artefact set.
+[Owner Parameter Matrix guide](docs/owner-parameter-matrix.md)—it now ships with:
+
+- **Quick-start blueprints** for non-technical operators, complete with Mermaid
+  flowcharts and sequence diagrams covering staging, execution, and validation.
+- **Parameter family tables** mapping each config file to the helper scripts
+  required to update and verify it.
+- **Risk/verification gates** that call out when to escalate into
+  `owner:mission-control`, `owner:verify-control`, or the emergency runbook.
+
+Pair the matrix with `npm run owner:surface` plus `npm run owner:verify-control`
+to archive a complete change-control artefact set.
 
 ### Production launch blueprint
 

--- a/docs/owner-parameter-matrix.md
+++ b/docs/owner-parameter-matrix.md
@@ -1,114 +1,171 @@
-# Owner Parameter Matrix
+# Owner Parameter Matrix Guide
 
-The owner parameter matrix gives contract owners a single command that flattens every
-production-facing configuration file into a navigable control sheet. The matrix combines
-Mermaid visualisations, subsystem summaries and ready-to-run update & verification commands
-so non-technical operators can tune the platform while preserving auditable guard rails.
+> **Audience:** Contract owners, governance stewards, and non-technical operators who
+> need a single control surface for every configurable parameter in the AGIJobs v2
+> deployment.
+>
+> **Outcome:** Produce a network-aware matrix that captures every mutable knob,
+> the exact config file, the command to update it, the verification flow, and the
+> owner-approved documentation so changes can ship safely—even under time pressure.
+>
+> **Primary tool:**
+>
+> ```bash
+> npm run owner:parameters -- --network <network> \
+>   --out reports/<network>/parameter-matrix.md
+> ```
+>
+> The script expands JSON/YAML configuration into rich Markdown (or JSON/human
+> formats) and injects Mermaid diagrams, helper commands, and documentation links.
+
+---
+
+## 1. Quick start — non-technical operator
 
 ```mermaid
 flowchart TD
-    A[Edit config/*.json] --> B[Run npm run owner:parameters]
-    B --> C{Review matrix output}
-    C -->|Looks good| D[Execute subsystem update helper]
-    D --> E[Verify with owner:verify-control]
-    C -->|Needs change| A
-    E --> F[Archive report for compliance]
+    subgraph Prep[Preparation]
+        A[Select target network] --> B[Check out release tag]
+        B --> C[Copy configs to reports/<network>/inputs]
+    end
+    subgraph Run[Run matrix]
+        C --> D[npm run owner:parameters]
+        D --> E{Warnings?}
+    end
+    E -- no --> F[Share matrix with stakeholders]
+    E -- yes --> G[Resolve config gaps]
+    G --> D
+    F --> H[Attach matrix to change ticket]
 ```
 
-## Quick start
+1. **Pick your network** – Use `--network mainnet` or `--network sepolia`. The helper
+   auto-detects Hardhat context if omitted.
+2. **Stage configuration files** – Copy or symlink per-network overrides into
+   `reports/<network>/inputs/` so diffs stay reviewable.
+3. **Run the generator** – Execute the command above. Pass `--format human` for
+   plain text or `--format json` for automation pipelines.
+4. **Inspect the matrix** – Each section shows the configuration path, parameters,
+   update script, verification script, and the official documentation bundle.
+5. **Escalate gaps immediately** – Any `&lt;error&gt;` row signals a missing or malformed
+   config. Fix the JSON and rerun before touching production.
 
-1. Decide which network context you want to review (for example `mainnet` or `sepolia`).
-2. Run the CLI helper:
+---
 
-   ```bash
-   npm run owner:parameters -- --network sepolia --out runtime/sepolia-parameter-matrix.md
-   ```
+## 2. Parameter families at a glance
 
-3. Inspect the generated Markdown report. Each subsystem block lists:
-   - The configuration file location.
-   - Copy/paste update commands with the selected network inserted automatically.
-   - Verification steps that close the control loop.
-   - A flattened table of every configurable field so nothing is hidden.
-4. Hand the artefact to reviewers or attach it to the change-control ticket before executing
-   the matching update helper (for example `npm run owner:update-all -- --network sepolia --only=stakeManager`).
-5. After executing changes, rerun `npm run owner:parameters` and `npm run owner:verify-control`
-   to confirm production matches the desired state.
+| Module | Config file(s) | Update command | Verify command | Notes |
+| --- | --- | --- | --- | --- |
+| $AGIALPHA constants | `config/agialpha.json` (+ overrides) | `npm run compile` | `npm run verify:agialpha -- --rpc <url>` | Locks token metadata and scaling constants shared by Solidity/TypeScript.
+| StakeManager | `config/stake-manager.json` | `npx hardhat run scripts/v2/updateStakeManager.ts --network <network>` | `npm run owner:verify-control -- --network <network> --modules=stakeManager` | Governs staking minima, unbonding, slashing, treasuries.
+| JobRegistry | `config/job-registry.json` | `npx hardhat run scripts/v2/updateJobRegistry.ts --network <network>` | `npm run owner:verify-control -- --network <network> --modules=jobRegistry` | Controls job lifecycle bounds, routing, job creation policy.
+| FeePool | `config/fee-pool.json` | `npx hardhat run scripts/v2/updateFeePool.ts --network <network>` | `npm run owner:verify-control -- --network <network> --modules=feePool` | Splits protocol fees, sets burns, routes treasuries.
+| Thermodynamics & Thermostat | `config/thermodynamics.json` | `npx hardhat run scripts/v2/updateThermodynamics.ts --network <network>` and `npx hardhat run scripts/v2/updateThermostat.ts --network <network>` | `npm run owner:verify-control -- --network <network> --modules=rewardEngine,thermostat` | Tunes reward gradients, PID controls, energy budget.
+| HamiltonianMonitor | `config/hamiltonian-monitor.json` | `npx hardhat run scripts/v2/updateHamiltonianMonitor.ts --network <network>` | `npm run owner:verify-control -- --network <network> --modules=rewardEngine` | Governs energy safety-rails and monitoring windows.
+| EnergyOracle | `config/energy-oracle.json` | `npx hardhat run scripts/v2/updateEnergyOracle.ts --network <network>` | `npm run owner:verify-control -- --network <network> --modules=rewardEngine` and `npm run owner:surface -- --network <network> --only=rewardEngine` | Manages oracle signer sets, quorum, decay rules.
+| TaxPolicy (optional) | `config/tax-policy.json` | `npx hardhat run scripts/v2/updateTaxPolicy.ts --network <network>` | `npm run owner:verify-control -- --network <network> --modules=taxPolicy` | Enables bracketed employer levies and exemptions.
+| PlatformIncentives (optional) | `config/platform-incentives.json` | `npx hardhat run scripts/v2/updatePlatformIncentives.ts --network <network>` | `npm run owner:verify-control -- --network <network> --modules=platformIncentives` | Applies bonus multipliers for partner cohorts.
+| IdentityRegistry | `config/identity-registry.json` (or `.network.json`) | `npx hardhat run scripts/v2/updateIdentityRegistry.ts --network <network>` | `npm run owner:verify-control -- --network <network> --modules=identityRegistry` | Maintains ENS roots, allowlists, emergency overrides.
 
-> **Tip:** Omit `--out` to print the report directly to stdout, or add `--format human`
-> for a plaintext briefing that fits easily in chat applications.
+---
 
-## Matrix anatomy
-
-The generated Markdown report is structured as follows:
-
-- **Global metadata** – Timestamp, optional network context and an embedded Mermaid
-  workflow diagram that mirrors the governance control loop.
-- **Subsystem sections** – Each configurable module appears under its own heading with
-  a narrative summary, configuration path, update & verification commands and reference
-  documentation.
-- **Flattened parameter table** – Every primitive value in the underlying JSON is rendered
-  as a `parameter → value` row so operators can review all tunables without digging through
-  nested structures.
-
-```markdown
-## StakeManager parameters
-
-Controls staking minimums, slashing weights, treasury routing, and validator incentives.
-
-- **Config file:** `config/stake-manager.json`
-- **Update with:**
-  - `npx hardhat run scripts/v2/updateStakeManager.ts --network sepolia`
-- **Verify with:**
-  - `npm run owner:verify-control -- --network sepolia --modules=stakeManager`
-- **Reference docs:**
-  - [docs/owner-control-handbook.md](docs/owner-control-handbook.md)
-  - [docs/owner-control-command-center.md](docs/owner-control-command-center.md)
-  - [docs/thermodynamics-operations.md](docs/thermodynamics-operations.md)
-
-| Parameter | Value |
-| --- | --- |
-| `minStakeTokens` | 10 |
-| `employerSlashPct` | 50 |
-| `treasury` | 0x0000000000000000000000000000000000000000 |
-| `autoStake.enabled` | false |
-| … | … |
-```
-
-## Decision companion
-
-Pair the matrix with the existing owner-control helpers to drive safe changes:
+## 3. Change workflow blueprint
 
 ```mermaid
-stateDiagram-v2
-    [*] --> Review
-    Review --> Plan : owner:parameters
-    Plan --> DryRun : owner:update-all -- --network <n> --only=<modules>
-    DryRun --> Approve : Governance sign-off
-    Approve --> Execute : owner:update-all -- --network <n> --only=<modules> --execute
-    Execute --> Verify : owner:verify-control -- --network <n> --modules=<modules>
-    Verify --> Archive : owner:surface -- --network <n> --format markdown
-    Archive --> [*]
+sequenceDiagram
+    participant Owner as Contract Owner
+    participant Matrix as Parameter Matrix CLI
+    participant Git as Version Control
+    participant Chain as Blockchain
+    participant Monitor as Observability Stack
+
+    Owner->>Matrix: Run owner:parameters (--format markdown)
+    Matrix-->>Owner: Matrix report + commands
+    Owner->>Git: Commit updated configs + matrix
+    Owner->>Chain: Execute update script (--execute)
+    Chain-->>Owner: Transaction receipts
+    Owner->>Matrix: Re-run owner:parameters (--format markdown)
+    Matrix-->>Owner: Updated matrix (post-change)
+    Owner->>Monitor: Update dashboards / alerts
 ```
 
-## Options reference
+- **Matrix first, transactions later** – Always generate, review, and commit the matrix
+  before broadcasting state-changing transactions.
+- **Dual snapshots** – Capture the matrix _before_ and _after_ execution to demonstrate
+  intent vs. actual on-chain state.
+- **Observability hook** – Feed the resulting Markdown/JSON into dashboards or the
+  Owner Control Console so everyone shares a live source of truth.
 
-| Flag | Description |
-| ---- | ----------- |
-| `--network <name>` | Applies per-network configuration overrides and injects the network name into commands. |
-| `--format markdown|json|human` | Choose between Markdown (default), structured JSON or a plain-text briefing. |
-| `--out <path>` | Write the matrix to disk (directories are created automatically). |
-| `--no-mermaid` | Skip Mermaid diagrams for environments that cannot render them. |
-| `--help` | Display inline documentation for the CLI tool. |
+---
 
-## Operational playbook
+## 4. Validation gates & risk checks
 
-1. **Snapshot current state:** `npm run owner:surface -- --network <network> --format markdown --out reports/<network>-surface.md`
-2. **Generate the matrix:** `npm run owner:parameters -- --network <network> --out reports/<network>-matrix.md`
-3. **Dry-run updates:** `npm run owner:update-all -- --network <network> --only=<module>`
-4. **Execute changes:** rerun the updater with `--execute` once reviewers approve the plan.
-5. **Verify ownership:** `npm run owner:verify-control -- --network <network> --strict`
-6. **Archive artefacts:** Store the surface snapshot, matrix and verification output alongside the governance decision log.
+```mermaid
+flowchart LR
+    A[Matrix generated] --> B{Config errors?}
+    B -- yes --> C[Fix JSON/YAML, rerun]
+    B -- no --> D{High-impact change?}
+    D -- yes --> E[Run npm run owner:mission-control]
+    D -- no --> F[Proceed with dry-run scripts]
+    E --> F
+    F --> G[Capture dry-run receipts]
+    G --> H{On-chain mismatch?}
+    H -- yes --> I[Run npm run owner:verify-control]
+    H -- no --> J[Finalize change ticket]
+```
 
-This workflow ensures the contract owner retains full, provable control over every parameter
-without touching Solidity code, while surfacing the exact JSON paths and commands needed to
-apply or roll back changes safely.
+- **Syntax guard:** The matrix call fails fast on malformed JSON. Treat every failure
+  as a stop-ship until corrected.
+- **High-impact detection:** Large stake shifts, fee changes & identity rewires should
+  route through `owner:mission-control` (multi-module planner) for extra validation.
+- **Verification pairing:** After execution, rerun `owner:verify-control` and attach the
+  output next to the matrix to prove the on-chain state matches the staged config.
+
+---
+
+## 5. Parameter-by-parameter playbook
+
+Each matrix section mirrors the structure below. Use it to brief stakeholders or delegate
+execution to ops engineers while keeping the owner firmly in control.
+
+| Column | Meaning | Owner action |
+| --- | --- | --- |
+| **Parameter** | Dot/bracket path into the JSON config. | Review proposed values, adjust in JSON overrides, and rerun the matrix. |
+| **Value** | The formatted value pulled from the staged config. | Confirm against business intent (e.g., stake levels, fee percentages). |
+| **Update with** | Copy/paste script snippet (with network prefilled). | Run with `--dry-run` first; add `--execute` only after peer review. |
+| **Verify with** | Follow-up command to confirm the on-chain state. | Execute post-transaction and archive output with the change ticket. |
+| **Reference docs** | Deep dives, diagrams, and recovery guides. | Share with stakeholders or auditors needing more context. |
+
+---
+
+## 6. Owner safekeeping checklist
+
+1. **Version lock:** Tag the Git commit used to generate the matrix so the config,
+   scripts, and documentation remain in sync.
+2. **Receipts:** Store `reports/<network>/parameter-matrix.md` (or JSON) alongside
+   execution receipts under `reports/<network>/receipts/`.
+3. **Alerting:** Wire a watcher (e.g., GitHub Actions, cron job) to regenerate the matrix
+   daily. Diff the output to spot config drift or unauthorised edits.
+4. **Emergency brake:** If any subsystem must be paused mid-change, pair the matrix with
+   `npm run owner:emergency -- --network <network>` (see
+   [owner-control-emergency-runbook](owner-control-emergency-runbook.md)).
+5. **Custody review:** When rotating keys or treasuries, confirm the matrix lists the new
+   addresses before executing `owner:rotate`.
+
+---
+
+## 7. Appendix — automation tips
+
+- **CI enforcement:** Add a CI step that runs
+  `npm run owner:parameters -- --network <network> --format json` and checks the output
+  into an artefact. Fail the pipeline if the command errors or if critical parameters
+  differ from expected thresholds.
+- **Custom templates:** Pipe the Markdown output through Pandoc or md-to-pdf for
+  executive-friendly reports. The CLI keeps all tables and Mermaid diagrams intact.
+- **Environment overrides:** Use `OWNER_PARAMETER_OVERRIDES="module.path=value"` (see
+  the script README) for ad-hoc experiments without editing disk configs.
+- **Integrations:** Export JSON to the Owner Console or data warehouse to power dashboards
+  tracking parameter history across networks.
+
+By using the Owner Parameter Matrix as the canonical change surface, the contract owner
+retains complete, auditable control over every configurable parameter while empowering
+non-technical operators to execute updates with confidence.

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -222,7 +222,11 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix
       title: '$AGIALPHA token constants',
       summary:
         'Canonical ERC-20 metadata and module addresses consumed by Solidity constants and TypeScript clients.',
-      documentation: ['docs/token-operations.md', 'docs/thermodynamics-operations.md'],
+      documentation: [
+        'docs/owner-parameter-matrix.md',
+        'docs/token-operations.md',
+        'docs/thermodynamics-operations.md',
+      ],
       updateCommands: ['npm run compile'],
       verifyCommands: ['npm run verify:agialpha -- --rpc <https-or-ws-url>'],
       fallbackConfigPath: 'config/agialpha.json',
@@ -234,6 +238,7 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix
       summary:
         'Controls staking minimums, slashing weights, treasury routing, and validator incentives.',
       documentation: [
+        'docs/owner-parameter-matrix.md',
         'docs/owner-control-handbook.md',
         'docs/owner-control-command-center.md',
         'docs/thermodynamics-operations.md',
@@ -250,6 +255,7 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix
       title: 'JobRegistry policy',
       summary: 'Job posting thresholds, fee splits, and lifecycle limits for employer contracts.',
       documentation: [
+        'docs/owner-parameter-matrix.md',
         'docs/owner-control-playbook.md',
         'docs/owner-control-zero-downtime-guide.md',
       ],
@@ -265,7 +271,7 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix
       title: 'FeePool distribution',
       summary:
         'Treasury routing, burn percentages, and payout pacing for escrowed protocol fees.',
-      documentation: ['docs/owner-control-visual-guide.md'],
+      documentation: ['docs/owner-parameter-matrix.md', 'docs/owner-control-visual-guide.md'],
       updateCommands: ['npx hardhat run scripts/v2/updateFeePool.ts --network <network>'],
       verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=feePool'],
       fallbackConfigPath: 'config/fee-pool.json',
@@ -277,6 +283,7 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix
       summary:
         'Energy budgeting, reward weights, and PID control surfaces that tune incentive gradients.',
       documentation: [
+        'docs/owner-parameter-matrix.md',
         'docs/thermodynamic-incentives.md',
         'docs/thermodynamics-operations.md',
         'docs/reward-settlement-process.md',
@@ -294,7 +301,7 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix
       title: 'HamiltonianMonitor windows',
       summary:
         'Observation window, historical energy records, and telemetry for system temperature guards.',
-      documentation: ['docs/thermodynamics-operations.md'],
+      documentation: ['docs/owner-parameter-matrix.md', 'docs/thermodynamics-operations.md'],
       updateCommands: ['npx hardhat run scripts/v2/updateHamiltonianMonitor.ts --network <network>'],
       verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=rewardEngine'],
       fallbackConfigPath: 'config/hamiltonian-monitor.json',
@@ -306,6 +313,7 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix
       summary:
         'Authorised measurement nodes and quorum settings for the energy attestation oracle.',
       documentation: [
+        'docs/owner-parameter-matrix.md',
         'docs/energy-oracle-operations.md',
         'docs/owner-control-command-center.md',
       ],
@@ -321,7 +329,7 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix
       id: 'taxPolicy',
       title: 'TaxPolicy controls',
       summary: 'Dynamic levy brackets for employer jobs and treasury burn ratios.',
-      documentation: ['docs/owner-control-command-center.md'],
+      documentation: ['docs/owner-parameter-matrix.md', 'docs/owner-control-command-center.md'],
       updateCommands: ['npx hardhat run scripts/v2/updateTaxPolicy.ts --network <network>'],
       verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=taxPolicy'],
       fallbackConfigPath: 'config/tax-policy.json',
@@ -331,7 +339,7 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix
       id: 'platformIncentives',
       title: 'PlatformIncentives weights',
       summary: 'Bonus multipliers, vesting schedules, and autopayout tolerances for ecosystem partners.',
-      documentation: ['docs/owner-control-visual-guide.md'],
+      documentation: ['docs/owner-parameter-matrix.md', 'docs/owner-control-visual-guide.md'],
       updateCommands: ['npx hardhat run scripts/v2/updatePlatformIncentives.ts --network <network>'],
       verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=platformIncentives'],
       fallbackConfigPath: 'config/platform-incentives.json',
@@ -342,6 +350,7 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemMatrix
       title: 'IdentityRegistry configuration',
       summary: 'ENS registries, root nodes, and emergency allowlists for identity proofs.',
       documentation: [
+        'docs/owner-parameter-matrix.md',
         'docs/ens-identity-policy.md',
         'docs/ens-identity-setup.md',
       ],


### PR DESCRIPTION
## Summary
- expand the Owner Parameter Matrix guide with quick-start workflow diagrams, validation gates, and module tables so non-technical operators can execute updates safely
- highlight the refreshed guide from the main README to showcase the new blueprints and risk checks
- wire the guide into every subsystem emitted by scripts/v2/ownerParameterMatrix.ts so generated reports always link to the canonical instructions

## Testing
- npm run owner:parameters -- --format human --network sepolia --no-mermaid


------
https://chatgpt.com/codex/tasks/task_e_68e02fa94b40833386a9ad67e1fdb840