### PR TITLE
Fix docker workflows and stabilise Cypress job flow test

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -23,20 +23,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - image: node-runner
+        image:
+          - name: node-runner
             context: .
             file: deploy/docker/orchestrator.Dockerfile
-          - image: validator-runner
+          - name: validator-runner
             context: .
             file: deploy/docker/attester.Dockerfile
-          - image: gateway
+          - name: gateway
             context: .
             file: agent-gateway/Dockerfile
-          - image: webapp
+          - name: webapp
             context: .
             file: apps/enterprise-portal/Dockerfile
-          - image: owner-console
+          - name: owner-console
             context: apps/console
             file: Dockerfile
     steps:
@@ -70,32 +70,32 @@ jobs:
         id: build-pr
         uses: docker/build-push-action@v6
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.file }}
           platforms: linux/amd64
           load: true
           push: false
           provenance: false
           sbom: false
           outputs: type=docker
-          tags: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.image }}:latest
+          tags: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.image.name }}:latest
 
       - name: Build & Push (main/tags, multi-arch, attestations)
         if: github.event_name != 'pull_request'
         id: build-push
         uses: docker/build-push-action@v6
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.file }}
           platforms: linux/amd64,linux/arm64
           load: false
           push: true
           provenance: mode=max
           sbom: true
-          tags: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.image }}:latest
+          tags: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.image.name }}:latest
 
       - name: Trivy scan
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.build-pr.outputs.imageid
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -113,5 +113,5 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.image }}-digest
+          name: ${{ matrix.image.name }}-digest
           path: digest.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,11 +163,12 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:latest
             ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ needs.prepare.outputs.version }}
-          provenance: true
+          provenance: mode=max
           sbom: true
 
       - name: Install cosign

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Generate provenance attestation
         if: startsWith(github.ref, 'refs/tags/')
-        uses: slsa-framework/slsa-github-generator/actions/attest-generic@v2.0.0
+        uses: slsa-framework/slsa-github-generator/actions/delegator-generic@v2.0.0
         with:
           predicate-type: https://slsa.dev/provenance/v1
           subject-path: reports/sbom/spdx.json

--- a/cypress/e2e/job-flow.cy.ts
+++ b/cypress/e2e/job-flow.cy.ts
@@ -50,7 +50,8 @@ describe('Owner governance job flow', () => {
     cy.wait('@receipts');
     cy.contains('job.finalized');
     cy.contains('Details').click();
-    cy.get('[data-testid="receipt-status-value"]', { timeout: 10000 }).should(
+    cy.findByTestId('receipt-details', { timeout: 10000 }).should('exist');
+    cy.findByTestId('receipt-status-value', { timeout: 10000 }).should(
       'have.text',
       'agent_win'
     );

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,0 +1,18 @@
+export {};
+
+Cypress.Commands.add(
+  'findByTestId',
+  (testId: string, options?: Partial<Cypress.Timeoutable & Cypress.Loggable & Cypress.Withinable & Cypress.Shadow>) =>
+    cy.get(`[data-testid="${testId}"]`, options)
+);
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      findByTestId<E extends Node = HTMLElement>(
+        testId: string,
+        options?: Partial<Cypress.Timeoutable & Cypress.Loggable & Cypress.Withinable & Cypress.Shadow>
+      ): Chainable<JQuery<E>>;
+    }
+  }
+}

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+import './commands';
 
 Cypress.on('window:before:load', (win) => {
   try {

--- a/tsconfig.cypress.json
+++ b/tsconfig.cypress.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "types": ["cypress", "node"],
     "noEmit": true,
-    "allowJs": false
+    "allowJs": false,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["apps/console/src/*"]
+    }
   },
   "include": ["cypress/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- restructure the container build workflow to use a single-arch load path for PRs and multi-arch pushes with provenance
- ensure release builds publish multi-architecture images with provenance mode set to max and pin the SLSA generator to the delegator action
- stabilise the Cypress job-flow test via a dedicated findByTestId helper and add tsconfig path hints for the console tests

## Testing
- npx cypress run --config-file cypress.config.ts --config baseUrl=http://127.0.0.1:4175 --spec cypress/e2e/job-flow.cy.ts *(fails: missing Xvfb dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e033c25c2883339f8f377069c111c6