### PR TITLE
Fix Solidity shadowing warnings in governance modules

### DIFF
--- a/contracts/v2/HamiltonianMonitor.sol
+++ b/contracts/v2/HamiltonianMonitor.sol
@@ -45,12 +45,12 @@ contract HamiltonianMonitor is Governable, IHamiltonian {
     /// @notice Update the rolling window size used for averages.
     /// @dev Optionally clears the stored history to restart accumulation.
     /// @param newWindow New number of periods to retain.
-    /// @param resetHistory Whether to clear all stored observations.
-    function setWindow(uint256 newWindow, bool resetHistory) external onlyGovernance {
+    /// @param resetHistoryFlag Whether to clear all stored observations.
+    function setWindow(uint256 newWindow, bool resetHistoryFlag) external onlyGovernance {
         require(newWindow > 0, "window");
 
         uint256 previousWindow = window;
-        if (resetHistory) {
+        if (resetHistoryFlag) {
             uint256 previousCount = dHistory.length;
             _clearHistory();
             window = newWindow;

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -1023,7 +1023,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         IValidationModule _validation,
         IStakeManager _stakeMgr,
         IReputationEngine _reputation,
-        IDisputeModule _dispute,
+        IDisputeModule _disputeModule,
         ICertificateNFT _certNFT,
         IFeePool _feePool,
         ITaxPolicy _policy,
@@ -1056,11 +1056,11 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             emit ReputationEngineUpdated(address(_reputation));
             emit ModuleUpdated("ReputationEngine", address(_reputation));
         }
-        if (address(_dispute) != address(0)) {
-            if (_dispute.version() != 2) revert InvalidDisputeModule();
-            disputeModule = _dispute;
-            emit DisputeModuleUpdated(address(_dispute));
-            emit ModuleUpdated("DisputeModule", address(_dispute));
+        if (address(_disputeModule) != address(0)) {
+            if (_disputeModule.version() != 2) revert InvalidDisputeModule();
+            disputeModule = _disputeModule;
+            emit DisputeModuleUpdated(address(_disputeModule));
+            emit ModuleUpdated("DisputeModule", address(_disputeModule));
         }
         if (address(_certNFT) != address(0)) {
             if (_certNFT.version() != 2) revert InvalidCertificateNFT();
@@ -1097,7 +1097,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
         IValidationModule _validation,
         IStakeManager _stakeMgr,
         IReputationEngine _reputation,
-        IDisputeModule _dispute,
+        IDisputeModule _disputeModule,
         ICertificateNFT _certNFT,
         IFeePool _feePool,
         address[] calldata _ackModules
@@ -1106,7 +1106,7 @@ contract JobRegistry is Governable, ReentrancyGuard, TaxAcknowledgement, Pausabl
             validation: _validation,
             stakeManager: _stakeMgr,
             reputation: _reputation,
-            dispute: _dispute,
+            dispute: _disputeModule,
             certificateNFT: _certNFT,
             feePool: _feePool
         });

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -794,18 +794,18 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
             return (0, validatorTarget);
         }
         uint256[] memory stakesCache = new uint256[](len);
-        uint256 totalStake;
+        uint256 totalStakeSum;
         for (uint256 i; i < len; ++i) {
             uint256 stakeAmt = stakes[validators[i]][Role.Validator];
             stakesCache[i] = stakeAmt;
-            totalStake += stakeAmt;
+            totalStakeSum += stakeAmt;
         }
-        if (totalStake == 0) {
+        if (totalStakeSum == 0) {
             return (0, validatorTarget);
         }
         remainder = validatorTarget;
         for (uint256 i; i < len; ++i) {
-            uint256 reward = (validatorTarget * stakesCache[i]) / totalStake;
+            uint256 reward = (validatorTarget * stakesCache[i]) / totalStakeSum;
             if (reward > 0) {
                 remainder -= reward;
                 validatorShare += reward;
@@ -902,13 +902,13 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     ) internal returns (SlashPayout memory totals) {
         uint256 len = validators.length;
         uint256[] memory stakesCache = new uint256[](len);
-        uint256 totalStake;
+        uint256 totalStakeSum;
         for (uint256 i; i < len; ++i) {
             uint256 stakeAmt = stakes[validators[i]][Role.Validator];
             stakesCache[i] = stakeAmt;
-            totalStake += stakeAmt;
+            totalStakeSum += stakeAmt;
         }
-        if (totalStake == 0) {
+        if (totalStakeSum == 0) {
             address[] memory empty;
             totals = _distributeEscrowPenalty(jobId, recipient, amount, empty, true);
             return totals;
@@ -923,7 +923,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
             for (uint256 i = start; i < end; ++i) {
                 chunkStake += stakesCache[i];
             }
-            uint256 chunkAmount = (amount * chunkStake) / totalStake;
+            uint256 chunkAmount = (amount * chunkStake) / totalStakeSum;
             if (end == len && allocated + chunkAmount < amount) {
                 chunkAmount = amount - allocated;
             }


### PR DESCRIPTION
## Summary
- rename JobRegistry dispute module constructor and setter parameters to avoid private function shadowing
- adjust StakeManager accumulator variable names to prevent collisions with totalStake getter
- update HamiltonianMonitor window setter flag name to avoid conflicts with resetHistory function

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e03954cfb08333b456858d04afe6d3