### PR TITLE
Stabilise Cypress mocks in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,9 @@ jobs:
   orchestrator-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      TERM: xterm
+      CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
     specPattern: 'cypress/e2e/**/*.cy.ts',
     supportFile: 'cypress/support/e2e.ts',
     chromeWebSecurity: false,
+    defaultCommandTimeout: 10000,
   },
 });

--- a/cypress/e2e/job-flow.cy.ts
+++ b/cypress/e2e/job-flow.cy.ts
@@ -1,5 +1,10 @@
 describe('Owner governance job flow', () => {
   beforeEach(() => {
+    cy.intercept('GET', '/api/jobs/*/status', {
+      statusCode: 200,
+      fixture: 'status-agent-win.json',
+    }).as('jobStatus');
+
     cy.intercept('GET', 'https://orchestrator.example/governance/snapshot', {
       statusCode: 200,
       body: {
@@ -36,6 +41,7 @@ describe('Owner governance job flow', () => {
   it('previews configuration updates and inspects receipts', () => {
     cy.visit('/');
     cy.wait('@snapshot');
+    cy.wait('@jobStatus');
 
     cy.get('#governance-key').select('jobRegistry.setJobStake');
     cy.get('#governance-value').clear().type('150');

--- a/cypress/fixtures/status-agent-win.json
+++ b/cypress/fixtures/status-agent-win.json
@@ -1,0 +1,3 @@
+{
+  "status": "agent_win"
+}


### PR DESCRIPTION
## Summary
- add deterministic job status fixture and intercept for the governance Cypress flow
- increase Cypress command timeout and configure e2e workflow environment for terminal compatibility

## Testing
- npm run lint -- --max-warnings=0 *(fails: repository has pre-existing solhint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e04e4da2ec833393b1596faf5f5ef6