### PR TITLE
chore: pin slsa provenance action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,26 @@ jobs:
           provenance: mode=max
           sbom: true
 
+      - name: Prepare SLSA provenance subjects
+        if: startsWith(github.ref, 'refs/tags/')
+        id: provenance
+        run: |
+          set -euo pipefail
+          subject="ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.build.outputs.digest }}"
+          echo "Subject: $subject"
+          if [ -z "${{ steps.build.outputs.digest }}" ]; then
+            echo "::error::Missing image digest for provenance generation" >&2
+            exit 1
+          fi
+          printf "%s" "$subject" | base64 -w0 > subjects.b64
+          echo "encoded=$(cat subjects.b64)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate SLSA provenance (tags only)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: slsa-framework/slsa-github-generator/actions/delegator-generic@v2.0.0
+        with:
+          base64-subjects: ${{ steps.provenance.outputs.encoded }}
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 


### PR DESCRIPTION
## Summary
- add a tag-gated step in the release workflow to base64-encode image digests for provenance
- generate SLSA provenance with the delegated action pinned to v2.0.0 for tagged builds

## Testing
- no automated tests were run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e072e33e4083339d68e5b2d3373a57