### PR TITLE
Update slashing distribution to basis points

### DIFF
--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -84,6 +84,7 @@ contract MockStakeManager is IStakeManager {
     function setMinStake(uint256) external override {}
     function setRoleMinimums(uint256, uint256, uint256) external override {}
     function setRoleMinimum(Role, uint256) external override {}
+    function setSlashPercents(uint16, uint16, uint16, uint16, uint16) external override {}
     function setSlashingPercentages(uint256, uint256) external override {}
     function setSlashingParameters(uint256, uint256) external override {}
     function setTreasury(address) external override {}

--- a/contracts/v2/interfaces/IStakeManager.sol
+++ b/contracts/v2/interfaces/IStakeManager.sol
@@ -80,6 +80,13 @@ interface IStakeManager {
         uint256 operatorSlashPct,
         uint256 validatorSlashRewardPct
     );
+    event SlashPercentsUpdated(
+        uint256 employerSlashPct,
+        uint256 treasurySlashPct,
+        uint256 validatorSlashRewardPct,
+        uint256 operatorSlashPct,
+        uint256 burnSlashPct
+    );
     event OperatorSlashShareAllocated(address indexed user, Role indexed role, uint256 amount);
     event TreasuryUpdated(address indexed treasury);
     event TreasuryAllowlistUpdated(address indexed treasury, bool allowed);
@@ -299,6 +306,14 @@ interface IStakeManager {
 
     /// @notice owner configuration helpers
     function setMinStake(uint256 _minStake) external;
+    function setSlashPercents(
+        uint16 employerSlashPct,
+        uint16 treasurySlashPct,
+        uint16 validatorSlashPct,
+        uint16 operatorSlashPct,
+        uint16 burnSlashPct
+    ) external;
+
     function setSlashingPercentages(uint256 _employerSlashPct, uint256 _treasurySlashPct) external;
     function setSlashingParameters(uint256 _employerSlashPct, uint256 _treasurySlashPct) external;
     function setValidatorSlashRewardPct(uint256 _validatorSlashPct) external;

--- a/contracts/v2/mocks/ReentrantStakeManager.sol
+++ b/contracts/v2/mocks/ReentrantStakeManager.sol
@@ -81,6 +81,7 @@ contract ReentrantStakeManager is IStakeManager {
     function setMinStake(uint256) external override {}
     function setRoleMinimums(uint256, uint256, uint256) external override {}
     function setRoleMinimum(Role, uint256) external override {}
+    function setSlashPercents(uint16, uint16, uint16, uint16, uint16) external override {}
     function setSlashingPercentages(uint256, uint256) external override {}
     function setSlashingParameters(uint256, uint256) external override {}
     function setTreasury(address) external override {}

--- a/docs/OWNER_CONTROL.md
+++ b/docs/OWNER_CONTROL.md
@@ -41,7 +41,7 @@ The AGI Jobs v2 system preserves an owner-first operating model. A single Owner 
 | ValidationModule | `setLateRevealPenalty(uint16)` | Basis points | uint16 |
 | StakeManager | `setMinStake(uint8,uint256)` | Role => stake amount | uint256 |
 | StakeManager | `setUnbondingPeriod(uint256)` | Seconds | uint256 |
-| StakeManager | `setSlashPercents(uint16,uint16,uint16,uint16)` | bps per offense | uint16 |
+| StakeManager | `setSlashPercents(uint16,uint16,uint16,uint16,uint16)` | bps per offense | uint16 |
 | StakeManager | `setTreasury(address)` | Treasury receiver | address |
 | StakeManager | `setTreasuryAllowlist(address,bool)` | Access control | address,bool |
 | StakeManager | `rescueERC20(address,address,uint256)` | Token, to, amount | addresses,uint256 |

--- a/test/v2/StakeManagerBurn.t.sol
+++ b/test/v2/StakeManagerBurn.t.sol
@@ -8,7 +8,7 @@ import {AGIALPHA, BURN_ADDRESS} from "../../contracts/v2/Constants.sol";
 
 contract StakeManagerBurnHarness is StakeManager {
     constructor(address gov)
-        StakeManager(1e18, 0, 100, address(0), address(0), address(0), gov)
+        StakeManager(1e18, 0, 10_000, address(0), address(0), address(0), gov)
     {}
 
     function exposedBurn(uint256 amt) external {


### PR DESCRIPTION
## Summary
- convert StakeManager slashing ratios to 10_000 basis points and persist a burn share
- add the governance-only setSlashPercents setter and SlashPercentsUpdated event while updating interfaces and config flow
- refresh Foundry slashing tests to cover the new setter, event payload, and basis-point overflow guard

## Testing
- not run (forge unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e113405b508333afa7307b5c1806d1