### PR TITLE
Refine enterprise portal Docker runtime dependencies

### DIFF
--- a/apps/enterprise-portal/Dockerfile
+++ b/apps/enterprise-portal/Dockerfile
@@ -14,10 +14,10 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production \
     PORT=3000
+COPY apps/enterprise-portal/package.json apps/enterprise-portal/package-lock.json ./
+RUN npm ci --omit=dev
 COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/next.config.mjs ./next.config.mjs
 COPY --from=builder /app/public ./public
+COPY --from=builder /app/next.config.mjs ./next.config.mjs
 EXPOSE 3000
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- update the enterprise portal Dockerfile to install production dependencies in the runtime image
- limit the runtime layer to built Next.js assets, public files, and runtime configuration

## Testing
- docker build -f apps/enterprise-portal/Dockerfile apps/enterprise-portal *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e11e8846808333befb7added1d8b8b