### PR TITLE
Add configuration setter event coverage tests

### DIFF
--- a/test/v2/CertificateNFTConfig.t.sol
+++ b/test/v2/CertificateNFTConfig.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {CertificateNFT} from "../../contracts/v2/modules/CertificateNFT.sol";
+
+contract CertificateNFTConfigTest is Test {
+    CertificateNFT nft;
+
+    function setUp() public {
+        nft = new CertificateNFT("Certificate", "CERT");
+        nft.setJobRegistry(address(this));
+    }
+
+    function testSetBaseURIEmitsAndUpdatesStorage() public {
+        string memory base = "https://example.com/";
+        vm.expectEmit(false, false, false, true, address(nft));
+        emit CertificateNFT.BaseURISet(base);
+        nft.setBaseURI(base);
+        uint256 tokenId = nft.mint(address(this), 1, bytes32(uint256(1)));
+        assertEq(nft.tokenURI(tokenId), string(abi.encodePacked(base, "1")), "base URI not applied");
+    }
+
+    function testUpdateBaseURIEmitsAndUpdatesStorage() public {
+        string memory initialBase = "https://initial/";
+        nft.setBaseURI(initialBase);
+        string memory updatedBase = "https://updated/";
+        vm.expectEmit(false, false, false, true, address(nft));
+        emit CertificateNFT.BaseURIUpdated(initialBase, updatedBase);
+        nft.updateBaseURI(updatedBase);
+        uint256 tokenId = nft.mint(address(this), 2, bytes32(uint256(2)));
+        assertEq(
+            nft.tokenURI(tokenId),
+            string(abi.encodePacked(updatedBase, "2")),
+            "updated base URI not applied"
+        );
+    }
+
+    function testSetBaseURIEmptyReverts() public {
+        vm.expectRevert(CertificateNFT.EmptyBaseURI.selector);
+        nft.setBaseURI("");
+    }
+}

--- a/test/v2/DisputeModuleConfig.t.sol
+++ b/test/v2/DisputeModuleConfig.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {DisputeModule} from "../../contracts/v2/modules/DisputeModule.sol";
+import {IJobRegistry} from "../../contracts/v2/interfaces/IJobRegistry.sol";
+import {Governable} from "../../contracts/v2/Governable.sol";
+
+contract DisputeModuleConfigTest is Test {
+    DisputeModule dispute;
+    TimelockController governance;
+
+    function setUp() public {
+        address[] memory proposers = new address[](1);
+        proposers[0] = address(this);
+        address[] memory executors = new address[](1);
+        executors[0] = address(this);
+        governance = new TimelockController(0, proposers, executors, address(this));
+        dispute = new DisputeModule(
+            IJobRegistry(address(0)),
+            0,
+            0,
+            address(0),
+            address(governance)
+        );
+    }
+
+    function testSetDisputeFeeEmitsAndUpdates() public {
+        uint256 target = 2e18;
+        vm.expectEmit(false, false, false, true, address(dispute));
+        emit DisputeModule.DisputeFeeUpdated(target);
+        vm.prank(address(governance));
+        dispute.setDisputeFee(target);
+        assertEq(dispute.disputeFee(), target, "fee not updated");
+    }
+
+    function testSetDisputeFeeOnlyGovernance() public {
+        vm.expectRevert(Governable.NotGovernance.selector);
+        dispute.setDisputeFee(1);
+    }
+}

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import "forge-std/Test.sol";
 import "contracts/v2/FeePool.sol";
 import "contracts/v2/interfaces/IFeePool.sol";
 import "contracts/legacy/MockV2.sol";
@@ -275,6 +276,34 @@ contract FeePoolTest {
         feePool.pause();
         vm.expectRevert();
         feePool.distributeFees();
+    }
+}
+
+contract FeePoolConfigurationTest is Test {
+    FeePool feePool;
+    MockStakeManager stakeManager;
+
+    function setUp() public {
+        stakeManager = new MockStakeManager();
+        feePool = new FeePool(
+            IStakeManager(address(stakeManager)),
+            0,
+            address(0),
+            ITaxPolicy(address(0))
+        );
+    }
+
+    function testSetBurnPctEmitsAndUpdates() public {
+        uint256 target = 7;
+        vm.expectEmit(false, false, false, true, address(feePool));
+        emit FeePool.BurnPctUpdated(target);
+        feePool.setBurnPct(target);
+        assertEq(feePool.burnPct(), target, "burn pct not updated");
+    }
+
+    function testSetBurnPctAboveHundredReverts() public {
+        vm.expectRevert(FeePool.InvalidPercentage.selector);
+        feePool.setBurnPct(101);
     }
 }
 

--- a/test/v2/IdentityRegistryConfig.t.sol
+++ b/test/v2/IdentityRegistryConfig.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {IdentityRegistry, ZeroAddress} from "../../contracts/v2/IdentityRegistry.sol";
+
+contract IdentityRegistryConfigTest is Test {
+    IdentityRegistry identity;
+
+    function setUp() public {
+        identity = new IdentityRegistry(
+            IENS(address(0)),
+            INameWrapper(address(0)),
+            IReputationEngine(address(0)),
+            bytes32(0),
+            bytes32(0)
+        );
+    }
+
+    function testSetENSEmitsAndUpdatesStorage() public {
+        address newEns = address(0x1234);
+        vm.expectEmit(true, false, false, true, address(identity));
+        emit IdentityRegistry.ENSUpdated(newEns);
+        identity.setENS(newEns);
+        assertEq(address(identity.ens()), newEns, "ens not updated");
+    }
+
+    function testSetENSZeroReverts() public {
+        vm.expectRevert(ZeroAddress.selector);
+        identity.setENS(address(0));
+    }
+}

--- a/test/v2/JobRegistryDeadlineFuzz.t.sol
+++ b/test/v2/JobRegistryDeadlineFuzz.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {
     JobRegistry,
     IValidationModule,
@@ -15,8 +16,14 @@ import {
 
 contract JobRegistryDeadlineFuzz is Test {
     JobRegistry registry;
+    TimelockController governance;
 
     function setUp() public {
+        address[] memory proposers = new address[](1);
+        proposers[0] = address(this);
+        address[] memory executors = new address[](1);
+        executors[0] = address(this);
+        governance = new TimelockController(0, proposers, executors, address(this));
         registry = new JobRegistry(
             IValidationModule(address(0)),
             IStakeManager(address(0)),
@@ -28,7 +35,7 @@ contract JobRegistryDeadlineFuzz is Test {
             0,
             0,
             new address[](0),
-            address(0)
+            address(governance)
         );
     }
 
@@ -40,6 +47,25 @@ contract JobRegistryDeadlineFuzz is Test {
         } else {
             registry.createJob(reward, deadline, bytes32(uint256(1)), "uri");
         }
+    }
+
+    function testSetFeePctEmitsWhenValueChanges() public {
+        uint256 target = 15;
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit JobRegistry.FeePctUpdated(target);
+        vm.prank(address(governance));
+        registry.setFeePct(target);
+        assertEq(registry.feePct(), target, "fee pct not updated");
+    }
+
+    function testSetFeePctNoEmitWhenUnchanged() public {
+        uint256 current = registry.feePct();
+        vm.prank(address(governance));
+        vm.recordLogs();
+        registry.setFeePct(current);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        assertEq(entries.length, 0, "unexpected events emitted");
+        assertEq(registry.feePct(), current, "fee pct changed unexpectedly");
     }
 }
 

--- a/test/v2/ReputationEngineConfig.t.sol
+++ b/test/v2/ReputationEngineConfig.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import {ReputationEngine} from "../../contracts/v2/ReputationEngine.sol";
+import {MockStakeManager} from "../../contracts/legacy/MockV2.sol";
+import {IStakeManager} from "../../contracts/v2/interfaces/IStakeManager.sol";
+
+contract ReputationEngineConfigTest is Test {
+    ReputationEngine engine;
+    MockStakeManager stakeManager;
+    address constant OTHER = address(0xBEEF);
+
+    function setUp() public {
+        stakeManager = new MockStakeManager();
+        engine = new ReputationEngine(IStakeManager(address(stakeManager)));
+    }
+
+    function testSetPremiumThresholdEmitsAndUpdatesStorage() public {
+        uint256 target = 1_000;
+        vm.expectEmit(false, false, false, true, address(engine));
+        emit ReputationEngine.PremiumThresholdUpdated(target);
+        engine.setPremiumThreshold(target);
+        assertEq(engine.premiumThreshold(), target, "threshold not updated");
+    }
+
+    function testSetPremiumThresholdOnlyOwner() public {
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", OTHER));
+        vm.prank(OTHER);
+        engine.setPremiumThreshold(500);
+    }
+}

--- a/test/v2/StakeManagerBurn.t.sol
+++ b/test/v2/StakeManagerBurn.t.sol
@@ -59,5 +59,35 @@ contract StakeManagerBurnTest is Test {
             assertEq(BURN_ADDRESS, address(0));
         }
     }
+
+    function testSetFeePctEmitsWhenValueChanges() public {
+        uint256 target = 12;
+        vm.expectEmit(false, false, false, true, address(stake));
+        emit StakeManager.FeePctUpdated(target);
+        stake.setFeePct(target);
+        assertEq(stake.feePct(), target, "fee pct not updated");
+    }
+
+    function testSetFeePctNoEmitWhenUnchanged() public {
+        uint256 current = stake.feePct();
+        vm.recordLogs();
+        stake.setFeePct(current);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "unexpected events emitted");
+        assertEq(stake.feePct(), current, "fee pct changed unexpectedly");
+    }
+
+    function testSetMinStakeEmitsAndUpdates() public {
+        uint256 target = 2e18;
+        vm.expectEmit(false, false, false, true, address(stake));
+        emit StakeManager.MinStakeUpdated(target);
+        stake.setMinStake(target);
+        assertEq(stake.minStake(), target, "min stake not updated");
+    }
+
+    function testSetMinStakeZeroReverts() public {
+        vm.expectRevert(StakeManager.InvalidMinStake.selector);
+        stake.setMinStake(0);
+    }
 }
 

--- a/test/v2/ValidationFinalizeGas.t.sol
+++ b/test/v2/ValidationFinalizeGas.t.sol
@@ -121,5 +121,21 @@ contract ValidationFinalizeGas is Test {
         vm.resumeGasMetering();
         validation.forceFinalize(jobId);
     }
+
+    function testSetCommitWindowEmitsAndUpdates() public {
+        uint256 newWindow = validation.commitWindow() + 5;
+        uint256 reveal = validation.revealWindow();
+        vm.expectEmit(false, false, false, true, address(validation));
+        emit ValidationModule.TimingUpdated(newWindow, reveal);
+        vm.expectEmit(false, false, false, true, address(validation));
+        emit ValidationModule.CommitWindowUpdated(newWindow);
+        validation.setCommitWindow(newWindow);
+        assertEq(validation.commitWindow(), newWindow, "commit window not updated");
+    }
+
+    function testSetCommitWindowZeroReverts() public {
+        vm.expectRevert(ValidationModule.InvalidCommitWindow.selector);
+        validation.setCommitWindow(0);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add governance setup to the JobRegistry fuzz suite and assert fee percentage setter emits when values change
- extend StakeManager, FeePool, and ValidationModule tests to cover configuration events and reverts
- add dedicated setter-focused suites for IdentityRegistry, DisputeModule, CertificateNFT, and ReputationEngine

## Testing
- not run (forge not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e13fcaa1288333b51711fcd0501a3d