### PR TITLE
Handle text message property guards in ConversationalJobCreator

### DIFF
--- a/apps/enterprise-portal/src/components/ConversationalJobCreator.tsx
+++ b/apps/enterprise-portal/src/components/ConversationalJobCreator.tsx
@@ -593,7 +593,11 @@ export const ConversationalJobCreator = () => {
     switch (message.kind) {
       case 'text': {
         if ('key' in message) {
-          return <p>{t(message.key, message.params)}</p>;
+          const params =
+            'params' in message
+              ? (message.params as Record<string, string | number> | undefined)
+              : undefined;
+          return <p>{t(message.key, params)}</p>;
         }
         if ('text' in message) {
           return <p>{message.text}</p>;


### PR DESCRIPTION
## Summary
- guard access to assistant text message keys by checking property presence before use
- ensure translation parameters are cast safely when rendering assistant messages

## Testing
- npm run build *(fails: Next.js attempted to patch the lockfile but could not reach the network in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e178a1aff4833389c7df8e43b0fe27