### PR TITLE
Update CI workflows for builds and tests

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -100,13 +100,15 @@ jobs:
           tags: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.image.tag }}
 
       - name: Trivy scan
-        if: github.event_name == 'pull_request' && steps.build-pr.outputs.imageid
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE_REF: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.image.tag }}@${{ steps.build-push.outputs.digest }}
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             aquasec/trivy:0.53.0 \
             image --exit-code 1 --severity HIGH,CRITICAL \
-            ${{ steps.build-pr.outputs.imageid }}
+            "$IMAGE_REF"
 
       - name: Upload container digest
         if: github.event_name != 'pull_request'

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -43,8 +43,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Compile contracts (default)
-        run: npm run compile
+      - name: Compile
+        env:
+          COVERAGE_MIN: '90'
+        run: |
+          node --loader ts-node/esm scripts/generate-constants.ts
+          npx hardhat compile
 
       - name: Compile contracts (sepolia)
         run: npm run compile:sepolia
@@ -98,6 +102,10 @@ jobs:
         run: |
           mkdir -p lib
           forge install foundry-rs/forge-std --no-git
+
+      - name: Foundry tests
+        if: matrix.node == '20'
+        run: forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'
 
       - name: Gas snapshot
         if: matrix.node == '20'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,13 +35,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Orchestrator tsc
+        run: npx tsc -p apps/orchestrator/tsconfig.json
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
 
-      - name: Compile contracts
-        run: npm run compile
+      - name: Compile
+        env:
+          COVERAGE_MIN: '90'
+        run: |
+          node --loader ts-node/esm scripts/generate-constants.ts
+          npx hardhat compile
 
       - name: Start anvil mainnet fork
         id: anvil

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -40,8 +40,11 @@ jobs:
       - name: Lint webapp
         run: npm run webapp:lint
 
-      - name: Build webapp
+      - name: Owner console build
         run: npm run webapp:build
+
+      - name: Webapp build
+        run: npm --prefix apps/enterprise-portal run build
 
       - name: Cypress E2E
         env:


### PR DESCRIPTION
## Summary
- run the new combined constants generation and Hardhat compile step in contract CI and E2E workflows
- execute Foundry test suite during the contracts workflow
- add orchestrator TypeScript build and enterprise portal build checks
- scan only pushed container images with Trivy while retaining PR build coverage

## Testing
- not run (workflow changes)


------
https://chatgpt.com/codex/tasks/task_e_68e1a2f62d788333a52bd7bc60593305