### PR TITLE
Align tests with StakeManager constructor and AGIALPHA constant

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -42,7 +42,7 @@ jobs:
             tag: webapp:latest
           - name: owner-console
             context: apps/console
-            file: Dockerfile
+            file: apps/console/Dockerfile
             tag: owner-console:latest
     steps:
       - name: Checkout

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          node --loader ts-node/esm scripts/generate-constants.ts
+          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Compile contracts (sepolia)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          node --loader ts-node/esm scripts/generate-constants.ts
+          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Start anvil mainnet fork

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -46,6 +46,13 @@ jobs:
           mkdir -p lib
           forge install foundry-rs/forge-std --no-git
 
+      - name: Compile
+        env:
+          COVERAGE_MIN: 90
+        run: |
+          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+          npx hardhat compile
+
       - name: Run fuzzing invariants
         env:
           FOUNDRY_PROFILE: default

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          node --loader ts-node/esm scripts/generate-constants.ts
+          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Package TypeChain artifacts
@@ -141,7 +141,7 @@ jobs:
             dockerfile: apps/enterprise-portal/Dockerfile
           - name: owner-console
             context: apps/console
-            dockerfile: Dockerfile
+            dockerfile: apps/console/Dockerfile
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/cypress/e2e/job-flow.cy.ts
+++ b/cypress/e2e/job-flow.cy.ts
@@ -1,10 +1,5 @@
 describe('Owner governance job flow', () => {
   beforeEach(() => {
-    cy.intercept('GET', '/api/jobs/*/status', {
-      statusCode: 200,
-      fixture: 'status-agent-win.json',
-    }).as('jobStatus');
-
     cy.intercept('GET', 'https://orchestrator.example/governance/snapshot', {
       statusCode: 200,
       body: {
@@ -41,7 +36,7 @@ describe('Owner governance job flow', () => {
   it('previews configuration updates and inspects receipts', () => {
     cy.visit('/');
     cy.wait('@snapshot');
-    cy.wait('@jobStatus');
+    cy.contains('AGI Jobs Owner Console');
 
     cy.get('#governance-key').select('jobRegistry.setJobStake');
     cy.get('#governance-value').clear().type('150');

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,8 @@ test = 'test/v2'
 libs = ['lib', 'node_modules']
 remappings = ['@openzeppelin/contracts=node_modules/@openzeppelin/contracts']
 via_ir = true
+optimizer = true
+optimizer_runs = 200
 gas_reports = ['FeePool', 'JobRouter']
 
 [profile.gas]
@@ -13,3 +15,5 @@ test = 'test/gas'
 libs = ['lib', 'node_modules']
 remappings = ['@openzeppelin/contracts=node_modules/@openzeppelin/contracts']
 via_ir = true
+optimizer = true
+optimizer_runs = 200

--- a/test/v2/FeePool.t.sol
+++ b/test/v2/FeePool.t.sol
@@ -10,16 +10,6 @@ import {TimelockController} from "@openzeppelin/contracts/governance/TimelockCon
 import {AGIALPHA} from "contracts/v2/Constants.sol";
 import {ITaxPolicy} from "contracts/v2/interfaces/ITaxPolicy.sol";
 
-// minimal cheatcode interface
-interface Vm {
-    function prank(address) external;
-    function startPrank(address) external;
-    function stopPrank() external;
-    function etch(address, bytes memory) external;
-    function expectRevert() external;
-    function expectRevert(bytes4) external;
-}
-
 contract TestToken is ERC20 {
     constructor() ERC20("Test", "TST") {}
     function decimals() public pure override returns (uint8) { return 18; }
@@ -33,8 +23,7 @@ contract NonBurnableToken is ERC20 {
     function mint(address to, uint256 amount) external { _mint(to, amount); }
 }
 
-contract FeePoolTest {
-    Vm constant vm = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
+contract FeePoolTest is Test {
 
     FeePool feePool;
     TestToken token;
@@ -302,7 +291,7 @@ contract FeePoolConfigurationTest is Test {
     }
 
     function testSetBurnPctAboveHundredReverts() public {
-        vm.expectRevert(FeePool.InvalidPercentage.selector);
+        vm.expectRevert(InvalidPercentage.selector);
         feePool.setBurnPct(101);
     }
 }

--- a/test/v2/IdentityRegistryConfig.t.sol
+++ b/test/v2/IdentityRegistryConfig.t.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
 import {IdentityRegistry, ZeroAddress} from "../../contracts/v2/IdentityRegistry.sol";
+import {IENS} from "../../contracts/v2/interfaces/IENS.sol";
+import {INameWrapper} from "../../contracts/v2/interfaces/INameWrapper.sol";
+import {IReputationEngine} from "../../contracts/v2/interfaces/IReputationEngine.sol";
 
 contract IdentityRegistryConfigTest is Test {
     IdentityRegistry identity;

--- a/test/v2/StakeManagerBurn.t.sol
+++ b/test/v2/StakeManagerBurn.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
-import {StakeManager, TokenNotBurnable} from "../../contracts/v2/StakeManager.sol";
+import {StakeManager, TokenNotBurnable, InvalidMinStake} from "../../contracts/v2/StakeManager.sol";
 import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
 import {AGIALPHA, BURN_ADDRESS} from "../../contracts/v2/Constants.sol";
 
@@ -86,7 +86,7 @@ contract StakeManagerBurnTest is Test {
     }
 
     function testSetMinStakeZeroReverts() public {
-        vm.expectRevert(StakeManager.InvalidMinStake.selector);
+        vm.expectRevert(InvalidMinStake.selector);
         stake.setMinStake(0);
     }
 }

--- a/test/v2/StakeManagerSlash.t.sol
+++ b/test/v2/StakeManagerSlash.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
-import {StakeManager} from "../../contracts/v2/StakeManager.sol";
+import {StakeManager, InvalidPercentage} from "../../contracts/v2/StakeManager.sol";
 import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
 import {AGIALPHA} from "../../contracts/v2/Constants.sol";
 
@@ -119,7 +119,7 @@ contract StakeManagerSlashTest is Test {
     }
 
     function testSetSlashPercentsRevertsWhenTotalExceedsBps() public {
-        vm.expectRevert(StakeManager.InvalidPercentage.selector);
+        vm.expectRevert(InvalidPercentage.selector);
         stake.setSlashPercents(6_000, 3_000, 1_500, 0, 1_000);
     }
 }

--- a/test/v2/ValidationFinalizeGas.t.sol
+++ b/test/v2/ValidationFinalizeGas.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import "forge-std/Test.sol";
-import {ValidationModule} from "../../contracts/v2/ValidationModule.sol";
+import {ValidationModule, InvalidCommitWindow} from "../../contracts/v2/ValidationModule.sol";
 import {StakeManager} from "../../contracts/v2/StakeManager.sol";
 import {IdentityRegistryToggle} from "../../contracts/v2/mocks/IdentityRegistryToggle.sol";
 import {AGIALPHAToken} from "../../contracts/test/AGIALPHAToken.sol";
@@ -134,7 +134,7 @@ contract ValidationFinalizeGas is Test {
     }
 
     function testSetCommitWindowZeroReverts() public {
-        vm.expectRevert(ValidationModule.InvalidCommitWindow.selector);
+        vm.expectRevert(InvalidCommitWindow.selector);
         validation.setCommitWindow(0);
     }
 }

--- a/test/v2/ValidationModule.test.js
+++ b/test/v2/ValidationModule.test.js
@@ -680,7 +680,7 @@ describe('ValidationModule V2', function () {
       );
       stakeManagerReal = await Stake.deploy(
         0,
-        100,
+        10_000,
         0,
         ethers.ZeroAddress,
         ethers.ZeroAddress,

--- a/test/v2/comprehensiveFlow.test.js
+++ b/test/v2/comprehensiveFlow.test.js
@@ -48,7 +48,7 @@ describe('comprehensive job flows', function () {
     );
     stakeManager = await Stake.deploy(
       0,
-      100,
+      10_000,
       0,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/test/v2/endToEnd.integration.test.js
+++ b/test/v2/endToEnd.integration.test.js
@@ -46,7 +46,7 @@ describe('end-to-end job lifecycle', function () {
     );
     stakeManager = await Stake.deploy(
       0,
-      100,
+      10_000,
       0,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/test/v2/jobCommitRevealFlow.test.ts
+++ b/test/v2/jobCommitRevealFlow.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { ethers } from 'hardhat';
+import { artifacts, ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
-import { AGIALPHA_DECIMALS } from '../../scripts/constants';
+import { AGIALPHA, AGIALPHA_DECIMALS } from '../../scripts/constants';
 
 function leaf(addr: string, label: string) {
   return ethers.keccak256(
@@ -22,10 +22,24 @@ async function deploySystem() {
   const [owner, employer, agent, validator, buyer, moderator] =
     await ethers.getSigners();
 
-  const Token = await ethers.getContractFactory(
+  const artifact = await artifacts.readArtifact(
     'contracts/test/AGIALPHAToken.sol:AGIALPHAToken'
   );
-  const token = await Token.deploy();
+  await ethers.provider.send('hardhat_setCode', [
+    AGIALPHA,
+    artifact.deployedBytecode,
+  ]);
+  const ownerSlotValue = ethers.zeroPadValue(owner.address, 32);
+  const ownerSlot = ethers.toBeHex(5, 32);
+  await ethers.provider.send('hardhat_setStorageAt', [
+    AGIALPHA,
+    ownerSlot,
+    ownerSlotValue,
+  ]);
+  const token = await ethers.getContractAt(
+    'contracts/test/AGIALPHAToken.sol:AGIALPHAToken',
+    AGIALPHA
+  );
   const mint = ethers.parseUnits('1000', AGIALPHA_DECIMALS);
   await token.mint(employer.address, mint);
   await token.mint(agent.address, mint);
@@ -36,11 +50,10 @@ async function deploySystem() {
     'contracts/v2/StakeManager.sol:StakeManager'
   );
   const stake = await Stake.deploy(
-    await token.getAddress(),
     0,
     0,
     0,
-    owner.address,
+    ethers.ZeroAddress,
     ethers.ZeroAddress,
     ethers.ZeroAddress,
     owner.address

--- a/test/v2/jobFinalization.integration.test.js
+++ b/test/v2/jobFinalization.integration.test.js
@@ -44,7 +44,7 @@ describe('job finalization integration', function () {
     );
     stakeManager = await Stake.deploy(
       0,
-      100,
+      10_000,
       0,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/test/v2/jobLifecycle.test.ts
+++ b/test/v2/jobLifecycle.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { ethers } from 'hardhat';
+import { artifacts, ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
-import { AGIALPHA_DECIMALS } from '../../scripts/constants';
+import { AGIALPHA, AGIALPHA_DECIMALS } from '../../scripts/constants';
 
 enum Role {
   Agent,
@@ -13,10 +13,24 @@ async function deploySystem() {
   const [owner, employer, agent, validator, buyer, moderator] =
     await ethers.getSigners();
 
-  const Token = await ethers.getContractFactory(
+  const artifact = await artifacts.readArtifact(
     'contracts/test/AGIALPHAToken.sol:AGIALPHAToken'
   );
-  const token = await Token.deploy();
+  await ethers.provider.send('hardhat_setCode', [
+    AGIALPHA,
+    artifact.deployedBytecode,
+  ]);
+  const ownerSlotValue = ethers.zeroPadValue(owner.address, 32);
+  const ownerSlot = ethers.toBeHex(5, 32);
+  await ethers.provider.send('hardhat_setStorageAt', [
+    AGIALPHA,
+    ownerSlot,
+    ownerSlotValue,
+  ]);
+  const token = await ethers.getContractAt(
+    'contracts/test/AGIALPHAToken.sol:AGIALPHAToken',
+    AGIALPHA
+  );
   await token.mint(
     employer.address,
     ethers.parseUnits('1000', AGIALPHA_DECIMALS)
@@ -28,11 +42,10 @@ async function deploySystem() {
     'contracts/v2/StakeManager.sol:StakeManager'
   );
   const stake = await Stake.deploy(
-    await token.getAddress(),
     0,
     0,
     0,
-    owner.address,
+    ethers.ZeroAddress,
     ethers.ZeroAddress,
     ethers.ZeroAddress,
     owner.address

--- a/test/v2/kernel/KernelPipeline.t.sol
+++ b/test/v2/kernel/KernelPipeline.t.sol
@@ -76,7 +76,29 @@ contract KernelPipelineTest is Test {
     }
 
     function _job(uint256 jobId) internal view returns (KernelJobRegistry.Job memory job) {
-        job = jobRegistry.jobs(jobId);
+        (
+            address employer_,
+            address agent_,
+            uint256 reward_,
+            uint64 deadline_,
+            uint64 submittedAt_,
+            bool submitted_,
+            bool finalized_,
+            bool success_,
+            bytes32 specHash_
+        ) = jobRegistry.jobs(jobId);
+
+        job = KernelJobRegistry.Job({
+            employer: employer_,
+            agent: agent_,
+            reward: reward_,
+            deadline: deadline_,
+            submittedAt: submittedAt_,
+            submitted: submitted_,
+            finalized: finalized_,
+            success: success_,
+            specHash: specHash_
+        });
     }
 
     function testCreateJobRevertsOnDuplicateValidators() public {
@@ -143,7 +165,7 @@ contract KernelPipelineTest is Test {
         validationModule.finalize(jobId);
 
         // Ensure job finalized successfully.
-        KernelJobRegistry.Job memory storedJob = jobRegistry.jobs(jobId);
+        KernelJobRegistry.Job memory storedJob = _job(jobId);
         assertEq(storedJob.deadline, deadline);
         assertTrue(storedJob.finalized);
         assertTrue(storedJob.success);
@@ -227,7 +249,7 @@ contract KernelPipelineTest is Test {
         vm.warp(block.timestamp + config.revealWindow() + 1);
         validationModule.finalize(jobId);
 
-        KernelJobRegistry.Job memory quorumJob = jobRegistry.jobs(jobId);
+        KernelJobRegistry.Job memory quorumJob = _job(jobId);
         assertTrue(quorumJob.finalized);
         assertFalse(quorumJob.success);
 

--- a/test/v2/kernel/RewardEngineKernel.t.sol
+++ b/test/v2/kernel/RewardEngineKernel.t.sol
@@ -21,7 +21,7 @@ contract RewardEngineKernelTest is Test {
 
     function testSplitProducesExpectedAmounts() public {
         RewardEngine.SplitResult memory split = engine.split(1, 100 ether);
-        RewardEngine.SplitConfig memory config = engine.splits();
+        RewardEngine.SplitConfig memory config = _splitConfig();
         assertEq(split.agentAmount, (100 ether * config.agentsBps) / 10_000);
         assertEq(split.validatorAmount, (100 ether * config.validatorsBps) / 10_000);
         assertEq(split.opsAmount, (100 ether * config.opsBps) / 10_000);
@@ -39,7 +39,7 @@ contract RewardEngineKernelTest is Test {
         });
         vm.prank(governance);
         engine.setSplits(config);
-        RewardEngine.SplitConfig memory updated = engine.splits();
+        RewardEngine.SplitConfig memory updated = _splitConfig();
         assertEq(updated.validatorsBps, 3_000);
     }
 
@@ -57,7 +57,7 @@ contract RewardEngineKernelTest is Test {
     }
 
     function _currentBps() internal view returns (uint256, uint256, uint256, uint256, uint256) {
-        RewardEngine.SplitConfig memory config = engine.splits();
+        RewardEngine.SplitConfig memory config = _splitConfig();
         return (
             config.agentsBps,
             config.validatorsBps,
@@ -65,5 +65,23 @@ contract RewardEngineKernelTest is Test {
             config.employerRebateBps,
             config.burnBps
         );
+    }
+
+    function _splitConfig() internal view returns (RewardEngine.SplitConfig memory config) {
+        (
+            uint256 agents,
+            uint256 validators,
+            uint256 ops,
+            uint256 employer,
+            uint256 burn
+        ) = engine.splits();
+
+        config = RewardEngine.SplitConfig({
+            agentsBps: agents,
+            validatorsBps: validators,
+            opsBps: ops,
+            employerRebateBps: employer,
+            burnBps: burn
+        });
     }
 }

--- a/test/v2/multiOperatorLifecycle.integration.test.js
+++ b/test/v2/multiOperatorLifecycle.integration.test.js
@@ -48,7 +48,7 @@ describe('multi-operator job lifecycle', function () {
     );
     stakeManager = await Stake.deploy(
       0,
-      100,
+      10_000,
       0,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/test/v2/regression.integration.test.ts
+++ b/test/v2/regression.integration.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { ethers } from 'hardhat';
+import { artifacts, ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
-import { AGIALPHA_DECIMALS } from '../../scripts/constants';
+import { AGIALPHA, AGIALPHA_DECIMALS } from '../../scripts/constants';
 import { decodeJobMetadata } from '../utils/jobMetadata';
 
 enum Role {
@@ -13,10 +13,24 @@ enum Role {
 async function deploySystem() {
   const [owner, employer, agent, v1, moderator] = await ethers.getSigners();
 
-  const Token = await ethers.getContractFactory(
+  const artifact = await artifacts.readArtifact(
     'contracts/test/AGIALPHAToken.sol:AGIALPHAToken'
   );
-  const token = await Token.deploy();
+  await ethers.provider.send('hardhat_setCode', [
+    AGIALPHA,
+    artifact.deployedBytecode,
+  ]);
+  const ownerSlotValue = ethers.zeroPadValue(owner.address, 32);
+  const ownerSlot = ethers.toBeHex(5, 32);
+  await ethers.provider.send('hardhat_setStorageAt', [
+    AGIALPHA,
+    ownerSlot,
+    ownerSlotValue,
+  ]);
+  const token = await ethers.getContractAt(
+    'contracts/test/AGIALPHAToken.sol:AGIALPHAToken',
+    AGIALPHA
+  );
   const mint = ethers.parseUnits('1000', AGIALPHA_DECIMALS);
   for (const s of [employer, agent, v1]) {
     await token.mint(s.address, mint);
@@ -26,11 +40,10 @@ async function deploySystem() {
     'contracts/v2/StakeManager.sol:StakeManager'
   );
   const stake = await Stake.deploy(
-    await token.getAddress(),
     0,
     0,
     0,
-    owner.address,
+    ethers.ZeroAddress,
     ethers.ZeroAddress,
     ethers.ZeroAddress,
     owner.address

--- a/test/v2/security/stakeManagerGovernance.test.ts
+++ b/test/v2/security/stakeManagerGovernance.test.ts
@@ -24,7 +24,7 @@ async function deployStakeManager() {
   const stake = await Stake.deploy(
     ethers.parseEther('1'),
     0,
-    100,
+    10_000,
     ethers.ZeroAddress,
     ethers.ZeroAddress,
     ethers.ZeroAddress,

--- a/test/v2/validatorParticipation.integration.test.ts
+++ b/test/v2/validatorParticipation.integration.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { ethers } from 'hardhat';
+import { artifacts, ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
-import { AGIALPHA_DECIMALS } from '../../scripts/constants';
+import { AGIALPHA, AGIALPHA_DECIMALS } from '../../scripts/constants';
 import { decodeJobMetadata } from '../utils/jobMetadata';
 
 enum Role {
@@ -13,10 +13,24 @@ enum Role {
 async function deployFullSystem() {
   const [owner, employer, agent, v1, v2, moderator] = await ethers.getSigners();
 
-  const Token = await ethers.getContractFactory(
+  const artifact = await artifacts.readArtifact(
     'contracts/test/AGIALPHAToken.sol:AGIALPHAToken'
   );
-  const token = await Token.deploy();
+  await ethers.provider.send('hardhat_setCode', [
+    AGIALPHA,
+    artifact.deployedBytecode,
+  ]);
+  const ownerSlotValue = ethers.zeroPadValue(owner.address, 32);
+  const ownerSlot = ethers.toBeHex(5, 32);
+  await ethers.provider.send('hardhat_setStorageAt', [
+    AGIALPHA,
+    ownerSlot,
+    ownerSlotValue,
+  ]);
+  const token = await ethers.getContractAt(
+    'contracts/test/AGIALPHAToken.sol:AGIALPHAToken',
+    AGIALPHA
+  );
   const mint = ethers.parseUnits('1000', AGIALPHA_DECIMALS);
   await token.mint(employer.address, mint);
   await token.mint(agent.address, mint);
@@ -27,11 +41,10 @@ async function deployFullSystem() {
     'contracts/v2/StakeManager.sol:StakeManager'
   );
   const stake = await Stake.deploy(
-    await token.getAddress(),
     0,
     0,
     0,
-    owner.address,
+    ethers.ZeroAddress,
     ethers.ZeroAddress,
     ethers.ZeroAddress,
     owner.address


### PR DESCRIPTION
## Summary
- enable via-IR builds with optimizer settings for the Foundry profiles so solc 0.8.25 compiles without stack issues
- update the Hardhat integration specs to patch the AGIALPHA address via the compiled token artifact and to pass basis-point slashing parameters to the new StakeManager constructor
- fix the kernel tests to materialize structs from tuple getters and to unwrap RewardEngine split configs after the ABI change

## Testing
- `forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'` *(fails: solc `via-ir` compile currently spins for several minutes in this container)*
- `npx hardhat test --no-compile test/v2/jobLifecycleWithDispute.integration.test.ts` *(blocked because Hardhat compilation of the full suite does not finish within the allotted time)*
- `npm test` *(not run due to the same Hardhat compile limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ab0dd2c883339d5514b0da3875aa