### PR TITLE
Update ts-node invocation in CI workflows

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+          node --loader ts-node/esm scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Compile contracts (sepolia)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+          node --loader ts-node/esm scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Start anvil mainnet fork

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+          node --loader ts-node/esm scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Run fuzzing invariants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+          node --loader ts-node/esm scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Package TypeChain artifacts


### PR DESCRIPTION
## Summary
- replace the compile step's ts-node invocation in contract-related workflows to use the ts-node ESM loader

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e637ce3c8333a1784fee6b78a68d