### PR TITLE
Update CI compile steps to use ts-node ESM loader

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+          node --loader ts-node/esm scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Compile contracts (sepolia)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+          node --loader ts-node/esm scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Start anvil mainnet fork

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+          node --loader ts-node/esm scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Run fuzzing invariants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+          node --loader ts-node/esm scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Package TypeChain artifacts


### PR DESCRIPTION
## Summary
- run the constants generation script with the ts-node ESM loader in all Compile steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e81e6aec8333ae7b343ab98741da