### PR TITLE
chore: stabilize webapp ci workflow

### DIFF
--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   webapp-ci:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max_old_space_size=4096
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,6 +29,10 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            apps/console/package-lock.json
+            apps/enterprise-portal/package-lock.json
 
       - name: Install repository dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- increase memory headroom for the webapp GitHub Actions job to improve build reliability
- extend npm caching to cover console and enterprise portal lockfiles for faster installs

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1e8ea3ef08333922aafd89c6a06e6