### PR TITLE
chore(ci): harden v2 workflows

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -100,7 +101,7 @@ jobs:
           tags: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.image.tag }}
 
       - name: Trivy scan
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && steps.build-push.outputs.digest
         env:
           IMAGE_REF: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ matrix.image.tag }}@${{ steps.build-push.outputs.digest }}
         run: |

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -24,6 +24,7 @@ jobs:
   contracts:
     name: contracts · node ${{ matrix.node }}
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   forge-fuzz:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,9 +54,7 @@ jobs:
           npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
           npx hardhat compile
 
-      - name: Run fuzzing invariants
+      - name: Foundry fuzz tests
         env:
           FOUNDRY_PROFILE: default
-        run: |
-          forge test -vvvv --ffi --fuzz-runs 256 \
-            --match-contract 'CommitReveal|Stake|Fee|Slashing'
+        run: forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -87,6 +88,7 @@ jobs:
     needs: prepare
     if: ${{ secrets.NPM_TOKEN != '' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -123,6 +125,7 @@ jobs:
   docker-publish:
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   webapp-ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add guard rails to container builds by enforcing timeouts and verifying image digests exist before running Trivy
- ensure fuzz workflow matches the v2 Foundry command and has a deterministic timeout
- add conservative timeouts to contracts, webapp, and release jobs to prevent runaway CI executions

## Testing
- not run (CI workflows only)


------
https://chatgpt.com/codex/tasks/task_e_68e1e8ea3ef08333922aafd89c6a06e6