### PR TITLE
Fix Next.js workspace config warnings for enterprise portal

### DIFF
--- a/apps/enterprise-portal/next.config.mjs
+++ b/apps/enterprise-portal/next.config.mjs
@@ -1,9 +1,13 @@
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const workspaceRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    typedRoutes: true
-  }
+  typedRoutes: true,
+  outputFileTracingRoot: workspaceRoot
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- set the enterprise portal Next.js config to enable typed routes without the deprecated `experimental` flag
- define the monorepo root for `outputFileTracingRoot` so Next.js stops warning about the inferred workspace root

## Testing
- npx tsc -p apps/orchestrator/tsconfig.json
- npm --prefix apps/enterprise-portal run build


------
https://chatgpt.com/codex/tasks/task_e_68e262db423c8333889043f72015e0be