### PR TITLE
Fix SLSA provenance step in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,6 +20,8 @@ concurrency:
 jobs:
   security-suite:
     runs-on: ubuntu-latest
+    outputs:
+      sbom-subjects: ${{ steps.sbom_subject.outputs.encoded }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,6 +83,20 @@ jobs:
           format: spdx-json
           output-file: reports/sbom/spdx.json
 
+      - name: Encode SBOM subject for provenance
+        id: sbom_subject
+        run: |
+          set -euo pipefail
+          sbom_path="reports/sbom/spdx.json"
+          if [[ ! -s "$sbom_path" ]]; then
+            echo "::error::SBOM not found at $sbom_path";
+            exit 1;
+          fi
+          read -r digest filename <<<"$(sha256sum "$sbom_path")"
+          subjects_line="$digest  $filename"
+          encoded=$(printf '%s\n' "$subjects_line" | base64 | tr -d '\n')
+          echo "encoded=$encoded" >> "$GITHUB_OUTPUT"
+
       - name: Upload security artefacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -90,16 +106,47 @@ jobs:
             reports/license-summary.txt
             reports/sbom/spdx.json
 
-      - name: Generate provenance attestation
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: slsa-framework/slsa-github-generator/actions/delegator-generic@v2.0.0
+  sbom-provenance:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: security-suite
+    permissions:
+      actions: read
+      id-token: write
+      contents: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: ${{ needs.security-suite.outputs.sbom-subjects }}
+      provenance-name: sbom-provenance.intoto.jsonl
+
+  publish-provenance:
+    if: needs.sbom-provenance.result == 'success'
+    needs: sbom-provenance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download signed provenance
+        uses: actions/download-artifact@v4
         with:
-          predicate-type: https://slsa.dev/provenance/v1
-          subject-path: reports/sbom/spdx.json
-          out-file: reports/provenance.intoto.jsonl
+          name: ${{ needs.sbom-provenance.outputs.provenance-name }}
+          path: provenance
+
+      - name: Prepare provenance artifact
+        run: |
+          set -euo pipefail
+          mkdir -p reports
+          mv "provenance/${{ needs.sbom-provenance.outputs.provenance-name }}" reports/provenance.intoto.jsonl
+
+      - name: Verify provenance digest
+        env:
+          EXPECTED: ${{ needs.sbom-provenance.outputs.provenance-sha256 }}
+        run: |
+          set -euo pipefail
+          actual=$(sha256sum reports/provenance.intoto.jsonl | awk '{print $1}')
+          if [[ "$actual" != "$EXPECTED" ]]; then
+            echo "::error::Provenance digest mismatch: expected $EXPECTED got $actual";
+            exit 1;
+          fi
 
       - name: Upload provenance statement
-        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: provenance


### PR DESCRIPTION
## Summary
- compute the SBOM digest inside the security workflow and expose it for reuse
- switch provenance generation to the supported SLSA v2 reusable workflow and verify the resulting bundle
- preserve the legacy provenance artifact by downloading, validating, and re-uploading the signed statement

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2943a0cc8833397695253cb75abbb