### PR TITLE
Fix provenance attestation step in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   security-events: write
   id-token: write
+  attestations: write
 
 concurrency:
   group: security-${{ github.workflow }}-${{ github.ref }}
@@ -91,15 +92,25 @@ jobs:
             reports/sbom/spdx.json
 
       - name: Generate provenance attestation
+        id: provenance
         if: startsWith(github.ref, 'refs/tags/')
-        uses: slsa-framework/slsa-github-generator/actions/delegator-generic@v2.0.0
+        uses: actions/attest-build-provenance@v1
         with:
-          predicate-type: https://slsa.dev/provenance/v1
           subject-path: reports/sbom/spdx.json
-          out-file: reports/provenance.intoto.jsonl
+
+      - name: Prepare provenance bundle artifact
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p reports
+          bundle_path="${{ steps.provenance.outputs.bundle-path }}"
+          if [ ! -f "$bundle_path" ]; then
+            echo "Expected provenance bundle not found at $bundle_path" >&2
+            exit 1
+          fi
+          cp "$bundle_path" reports/provenance.intoto.jsonl
 
       - name: Upload provenance statement
-        if: always()
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: provenance


### PR DESCRIPTION
## Summary
- update the security workflow to use the supported GitHub provenance attestation action
- grant the workflow the required attestation permission and persist the generated bundle in the expected location

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2943a0cc8833397695253cb75abbb