### PR TITLE
Fix SLSA generator pin for Ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/apps-images.yml
+++ b/.github/workflows/apps-images.yml
@@ -161,7 +161,9 @@ jobs:
       actions: read
       id-token: write
       contents: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    # v2.0.0 references a missing actions/delegator-generic definition on Ubuntu 24.04
+    # runners; keep the last v1 release until upstream publishes a fixed v2 build.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: ${{ toJson(format('ghcr.io/{0}/owner-console@{1}', github.repository_owner, needs.console.outputs.digest)) }}
 
@@ -172,6 +174,8 @@ jobs:
       actions: read
       id-token: write
       contents: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    # v2.0.0 references a missing actions/delegator-generic definition on Ubuntu 24.04
+    # runners; keep the last v1 release until upstream publishes a fixed v2 build.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: ${{ toJson(format('ghcr.io/{0}/webapp@{1}', github.repository_owner, needs.portal.outputs.digest)) }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -112,7 +112,10 @@ jobs:
       - name: Generate provenance attestation
         if: startsWith(github.ref, 'refs/tags/')
         id: generate-provenance
-        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+        # v2.0.0 currently references a non-existent actions/delegator-generic path on
+        # GitHub-hosted Ubuntu 24.04 runners, so we stay on the latest v1 release until
+        # the upstream issue is resolved.
+        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
         with:
           base64-subjects: ${{ steps.provenance-subjects.outputs.value }}
           provenance-name: provenance.intoto.jsonl


### PR DESCRIPTION
## Summary
- pin the SLSA provenance reusable workflow back to v1.10.0 to avoid the missing actions/delegator-generic path on ubuntu-24.04 runners

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e299ed566883339a934768dac3ed1c