### PR TITLE
Fix provenance attestation workflows for GitHub Actions

### DIFF
--- a/.github/workflows/apps-images.yml
+++ b/.github/workflows/apps-images.yml
@@ -16,6 +16,7 @@ permissions:
   packages: write
   security-events: write
   id-token: write
+  attestations: write
 
 concurrency:
   group: apps-${{ github.ref }}
@@ -81,6 +82,22 @@ jobs:
               --severity HIGH,CRITICAL \
               --exit-code 0 \
               ghcr.io/${{ github.repository_owner }}/owner-console:${{ github.sha }}
+
+      - name: Attest Console image provenance
+        if: github.ref == 'refs/heads/main'
+        id: attest-console
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/owner-console
+          subject-digest: ${{ steps.get_digest.outputs.digest }}
+          push-to-registry: true
+
+      - name: Upload Console attestation bundle
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: owner-console-provenance
+          path: ${{ steps.attest-console.outputs.bundle-path }}
 
   portal:
     runs-on: ubuntu-24.04
@@ -154,24 +171,18 @@ jobs:
               --exit-code 0 \
               ghcr.io/${{ github.repository_owner }}/webapp:${{ github.sha }}
 
-  provenance-console:
-    if: github.ref == 'refs/heads/main'
-    needs: [console]
-    permissions:
-      actions: read
-      id-token: write
-      contents: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: ${{ toJson(format('ghcr.io/{0}/owner-console@{1}', github.repository_owner, needs.console.outputs.digest)) }}
+      - name: Attest Portal image provenance
+        if: github.ref == 'refs/heads/main'
+        id: attest-portal
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/webapp
+          subject-digest: ${{ steps.get_digest.outputs.digest }}
+          push-to-registry: true
 
-  provenance-portal:
-    if: github.ref == 'refs/heads/main'
-    needs: [portal]
-    permissions:
-      actions: read
-      id-token: write
-      contents: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: ${{ toJson(format('ghcr.io/{0}/webapp@{1}', github.repository_owner, needs.portal.outputs.digest)) }}
+      - name: Upload Portal attestation bundle
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: webapp-provenance
+          path: ${{ steps.attest-portal.outputs.bundle-path }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   security-events: write
   id-token: write
+  attestations: write
 
 concurrency:
   group: security-${{ github.workflow }}-${{ github.ref }}
@@ -90,43 +91,16 @@ jobs:
             reports/license-summary.txt
             reports/sbom/spdx.json
 
-      - name: Prepare provenance subjects
+      - name: Generate SBOM provenance attestation
         if: startsWith(github.ref, 'refs/tags/')
-        id: provenance-subjects
-        run: |
-          set -euo pipefail
-          sha_value=$(sha256sum reports/sbom/spdx.json | awk '{print $1}')
-          subject_line="${sha_value}  reports/sbom/spdx.json"
-          if command -v base64 >/dev/null 2>&1; then
-            if [ "$(uname)" = "Darwin" ]; then
-              encoded=$(printf "%s" "$subject_line" | base64)
-            else
-              encoded=$(printf "%s" "$subject_line" | base64 -w0)
-            fi
-          else
-            echo "base64 utility not found" >&2
-            exit 1
-          fi
-          echo "value=$encoded" >> "$GITHUB_OUTPUT"
-
-      - name: Generate provenance attestation
-        if: startsWith(github.ref, 'refs/tags/')
-        id: generate-provenance
-        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+        id: sbom-provenance
+        uses: actions/attest-build-provenance@v1
         with:
-          base64-subjects: ${{ steps.provenance-subjects.outputs.value }}
-          provenance-name: provenance.intoto.jsonl
+          subject-path: reports/sbom/spdx.json
 
-      - name: Download provenance attestation
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ steps.generate-provenance.outputs.provenance-name }}
-          path: reports
-
-      - name: Upload provenance statement
+      - name: Upload SBOM attestation bundle
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
-          name: provenance
-          path: reports/provenance.intoto.jsonl
+          name: sbom-provenance
+          path: ${{ steps.sbom-provenance.outputs.bundle-path }}


### PR DESCRIPTION
## Summary
- replace the deprecated SLSA generator invocation with GitHub's `actions/attest-build-provenance` for container images and SBOMs
- upload attestation bundles as workflow artifacts and grant the required permissions to persist attestations

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e299ed566883339a934768dac3ed1c