### PR TITLE
Update SLSA generator workflows to v2.1.0

### DIFF
--- a/.github/workflows/apps-images.yml
+++ b/.github/workflows/apps-images.yml
@@ -161,7 +161,7 @@ jobs:
       actions: read
       id-token: write
       contents: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ toJson(format('ghcr.io/{0}/owner-console@{1}', github.repository_owner, needs.console.outputs.digest)) }}
 
@@ -172,6 +172,6 @@ jobs:
       actions: read
       id-token: write
       contents: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ toJson(format('ghcr.io/{0}/webapp@{1}', github.repository_owner, needs.portal.outputs.digest)) }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Generate provenance attestation
         if: startsWith(github.ref, 'refs/tags/')
         id: generate-provenance
-        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
         with:
           base64-subjects: ${{ steps.provenance-subjects.outputs.value }}
           provenance-name: provenance.intoto.jsonl


### PR DESCRIPTION
## Summary
- update the provenance jobs in security and apps-images workflows to use the v2.1.0 SLSA generator reusable workflow, which includes the required composite actions

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e29fef9630833384f24233db51961e