### PR TITLE
Adjust SLSA generator version

### DIFF
--- a/.github/workflows/apps-images.yml
+++ b/.github/workflows/apps-images.yml
@@ -161,7 +161,7 @@ jobs:
       actions: read
       id-token: write
       contents: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: ${{ toJson(format('ghcr.io/{0}/owner-console@{1}', github.repository_owner, needs.console.outputs.digest)) }}
 
@@ -172,6 +172,6 @@ jobs:
       actions: read
       id-token: write
       contents: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: ${{ toJson(format('ghcr.io/{0}/webapp@{1}', github.repository_owner, needs.portal.outputs.digest)) }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Generate provenance attestation
         if: startsWith(github.ref, 'refs/tags/')
         id: generate-provenance
-        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
         with:
           base64-subjects: ${{ steps.provenance-subjects.outputs.value }}
           provenance-name: provenance.intoto.jsonl


### PR DESCRIPTION
## Summary
- update the apps-images provenance jobs to use the stable v1.10.0 release of the SLSA generator workflow
- align the security workflow's provenance step to the same SLSA generator version to avoid delegator lookup failures

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2a12be2bc833383615fd498beb85e