### PR TITLE
Fix apps image workflow provenance and scanning

### DIFF
--- a/.github/workflows/apps-images.yml
+++ b/.github/workflows/apps-images.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       digest: ${{ steps.get_digest.outputs.digest }}
+      subjects: ${{ steps.provenance_subjects.outputs.subjects }}
     steps:
       - uses: actions/checkout@v4
 
@@ -61,7 +62,16 @@ jobs:
           DIGEST=$(docker buildx imagetools inspect "$REF" | awk -F'[: ]+' '/Digest:/ {print $2; exit}')
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare Console provenance subjects (main)
+        id: provenance_subjects
+        if: github.ref == 'refs/heads/main'
+        run: |
+          REF="ghcr.io/${{ github.repository_owner }}/owner-console@${{ steps.get_digest.outputs.digest }}"
+          BASE64=$(printf '%s' "$REF" | base64 | tr -d '\n')
+          printf 'subjects=["%s"]\n' "$BASE64" >> "$GITHUB_OUTPUT"
+
       - name: Trivy (OS – enforce)
+        if: github.ref == 'refs/heads/main'
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -72,6 +82,7 @@ jobs:
               ghcr.io/${{ github.repository_owner }}/owner-console:${{ github.sha }}
 
       - name: Trivy (libraries – audit only)
+        if: github.ref == 'refs/heads/main'
         continue-on-error: true
         run: |
           docker run --rm \
@@ -86,6 +97,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       digest: ${{ steps.get_digest.outputs.digest }}
+      subjects: ${{ steps.provenance_subjects.outputs.subjects }}
     steps:
       - uses: actions/checkout@v4
 
@@ -133,7 +145,16 @@ jobs:
           DIGEST=$(docker buildx imagetools inspect "$REF" | awk -F'[: ]+' '/Digest:/ {print $2; exit}')
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare Portal provenance subjects (main)
+        id: provenance_subjects
+        if: github.ref == 'refs/heads/main'
+        run: |
+          REF="ghcr.io/${{ github.repository_owner }}/webapp@${{ steps.get_digest.outputs.digest }}"
+          BASE64=$(printf '%s' "$REF" | base64 | tr -d '\n')
+          printf 'subjects=["%s"]\n' "$BASE64" >> "$GITHUB_OUTPUT"
+
       - name: Trivy (OS – enforce)
+        if: github.ref == 'refs/heads/main'
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -144,6 +165,7 @@ jobs:
               ghcr.io/${{ github.repository_owner }}/webapp:${{ github.sha }}
 
       - name: Trivy (libraries – audit only)
+        if: github.ref == 'refs/heads/main'
         continue-on-error: true
         run: |
           docker run --rm \
@@ -163,7 +185,7 @@ jobs:
       contents: read
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
-      base64-subjects: ${{ toJson(format('ghcr.io/{0}/owner-console@{1}', github.repository_owner, needs.console.outputs.digest)) }}
+      base64-subjects: ${{ needs.console.outputs.subjects }}
 
   provenance-portal:
     if: github.ref == 'refs/heads/main'
@@ -174,4 +196,4 @@ jobs:
       contents: read
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
-      base64-subjects: ${{ toJson(format('ghcr.io/{0}/webapp@{1}', github.repository_owner, needs.portal.outputs.digest)) }}
+      base64-subjects: ${{ needs.portal.outputs.subjects }}


### PR DESCRIPTION
## Summary
- encode OCI image coordinates for console and portal builds so the SLSA generator receives valid base64 subjects
- gate Trivy enforcement to main pushes and expose provenance subjects as job outputs for downstream jobs

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2a92416288333960e293369706304