### PR TITLE
Stabilize apps image CI workflow

### DIFF
--- a/.github/workflows/apps-images.yml
+++ b/.github/workflows/apps-images.yml
@@ -26,8 +26,12 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       digest: ${{ steps.get_digest.outputs.digest }}
+      image: ghcr.io/${{ github.repository_owner }}/owner-console
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR (main)
         if: github.ref == 'refs/heads/main'
@@ -62,6 +66,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Trivy (OS – enforce)
+        if: github.ref == 'refs/heads/main'
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -72,6 +77,7 @@ jobs:
               ghcr.io/${{ github.repository_owner }}/owner-console:${{ github.sha }}
 
       - name: Trivy (libraries – audit only)
+        if: github.ref == 'refs/heads/main'
         continue-on-error: true
         run: |
           docker run --rm \
@@ -86,8 +92,12 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       digest: ${{ steps.get_digest.outputs.digest }}
+      image: ghcr.io/${{ github.repository_owner }}/webapp
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Setup Node for web build
         uses: actions/setup-node@v4
@@ -134,6 +144,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Trivy (OS – enforce)
+        if: github.ref == 'refs/heads/main'
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -144,6 +155,7 @@ jobs:
               ghcr.io/${{ github.repository_owner }}/webapp:${{ github.sha }}
 
       - name: Trivy (libraries – audit only)
+        if: github.ref == 'refs/heads/main'
         continue-on-error: true
         run: |
           docker run --rm \
@@ -161,9 +173,14 @@ jobs:
       actions: read
       id-token: write
       contents: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
     with:
-      base64-subjects: ${{ toJson(format('ghcr.io/{0}/owner-console@{1}', github.repository_owner, needs.console.outputs.digest)) }}
+      image: ${{ needs.console.outputs.image }}
+      digest: ${{ needs.console.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
 
   provenance-portal:
     if: github.ref == 'refs/heads/main'
@@ -172,6 +189,11 @@ jobs:
       actions: read
       id-token: write
       contents: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
     with:
-      base64-subjects: ${{ toJson(format('ghcr.io/{0}/webapp@{1}', github.repository_owner, needs.portal.outputs.digest)) }}
+      image: ${{ needs.portal.outputs.image }}
+      digest: ${{ needs.portal.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- set up Docker Buildx before building application container images
- restrict Trivy enforcement to pushed images on main while exposing image metadata for provenance
- generate SLSA provenance with the official container workflow using GHCR authentication

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e2a92416288333960e293369706304