### PR TITLE
Add CI workflow for linting and formatting checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Run lint checks
+        run: npm run lint


### PR DESCRIPTION
## Summary
- add a dedicated CI workflow that installs dependencies and runs formatting and lint checks
- ensure the workflow name matches the README badge so the status badge renders correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b735ae58833382d927ae3c7cd278