### PR TITLE
Add aggregate CI workflow and update README badge

### DIFF
--- a/.github/workflows/apps-images.yml
+++ b/.github/workflows/apps-images.yml
@@ -3,13 +3,13 @@ name: apps-images
 on:
   pull_request:
     paths:
-      - "apps/**"
-      - ".github/workflows/apps-images.yml"
+      - 'apps/**'
+      - '.github/workflows/apps-images.yml'
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - "apps/**"
-      - ".github/workflows/apps-images.yml"
+      - 'apps/**'
+      - '.github/workflows/apps-images.yml'
 
 permissions:
   contents: read
@@ -92,8 +92,8 @@ jobs:
       - name: Setup Node for web build
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: '20'
+          cache: 'npm'
 
       - name: Install root deps
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,39 @@
-name: contracts-ci
+name: ci
 
 on:
   pull_request:
-    paths:
-      - 'contracts/**'
-      - 'scripts/**'
-      - 'test/**'
-      - 'hardhat.config.*'
-      - 'package*.json'
-      - '.github/workflows/contracts.yml'
   push:
     branches: [main]
-    paths:
-      - 'contracts/**'
-      - 'scripts/**'
-      - 'test/**'
-      - 'hardhat.config.*'
-      - 'package*.json'
-      - '.github/workflows/contracts.yml'
 
 permissions:
   contents: read
 
 concurrency:
-  group: contracts-${{ github.ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  compile-and-test:
+  lint:
+    name: Lint & static checks
     runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Prettier formatting check
+        run: npm run format:check
 
+  contracts:
+    name: Contracts compile & tests
+    runs-on: ubuntu-24.04
     env:
       COVERAGE_MIN: '90'
       ACCESS_CONTROL_PATHS: 'contracts/v2/admin,contracts/v2/governance'
-
       FEE_PCT: '0.02'
       BURN_PCT: '0.06'
       TREASURY: '0x1111111111111111111111111111111111111111'
@@ -41,36 +41,50 @@ jobs:
       REQUIRED_APPROVALS: '3'
       COMMIT_WINDOW: '30m'
       REVEAL_WINDOW: '30m'
-
     steps:
       - uses: actions/checkout@v4
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-
+          cache: npm
       - name: Install dependencies
         run: npm ci
-
-      - name: Compile
-        env:
-          COVERAGE_MIN: 90
+      - name: Compile contracts
         run: |
           node --loader ts-node/esm scripts/generate-constants.ts
           npx hardhat compile
-
       - name: Regenerate constants for tests
         run: node --loader ts-node/esm scripts/generate-constants.ts
-
-      - name: Node/Hardhat tests
+      - name: Hardhat tests
         run: npm test
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
-
       - name: Foundry tests
         run: forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'
+      - name: ABI diff check
+        run: npm run abi:diff
+
+  coverage:
+    name: Coverage thresholds
+    needs: contracts
+    runs-on: ubuntu-24.04
+    env:
+      COVERAGE_MIN: '90'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Generate coverage report
+        run: npm run coverage
+      - name: Check access control coverage
+        run: npm run check:access-control
+      - name: Enforce coverage threshold
+        run: npm run check:coverage

--- a/.github/workflows/orchestrator-ci.yml
+++ b/.github/workflows/orchestrator-ci.yml
@@ -3,13 +3,13 @@ name: orchestrator-ci
 on:
   pull_request:
     paths:
-      - "apps/orchestrator/**"
-      - ".github/workflows/orchestrator-ci.yml"
+      - 'apps/orchestrator/**'
+      - '.github/workflows/orchestrator-ci.yml'
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - "apps/orchestrator/**"
-      - ".github/workflows/orchestrator-ci.yml"
+      - 'apps/orchestrator/**'
+      - '.github/workflows/orchestrator-ci.yml'
 
 permissions:
   contents: read
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: '20'
+          cache: 'npm'
       - run: npm ci
       - name: Orchestrator tsc
         run: npx tsc -p apps/orchestrator/tsconfig.json

--- a/.github/workflows/release-mainnet.yml
+++ b/.github/workflows/release-mainnet.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       network:
-        description: "Deploy target"
+        description: 'Deploy target'
         type: choice
-        options: [ mainnet, sepolia ]
+        options: [mainnet, sepolia]
         default: mainnet
       confirm:
-        description: "Type YES to confirm"
+        description: 'Type YES to confirm'
         required: true
-        default: "NO"
+        default: 'NO'
 
 permissions:
   contents: read
@@ -30,19 +30,19 @@ jobs:
     needs: guardrails
     runs-on: ubuntu-24.04
     env:
-      FEE_PCT: "0.02"
-      BURN_PCT: "0.06"
-      TREASURY: "0x1111111111111111111111111111111111111111"
-      VALIDATORS_PER_JOB: "3"
-      REQUIRED_APPROVALS: "3"
-      COMMIT_WINDOW: "30m"
-      REVEAL_WINDOW: "30m"
+      FEE_PCT: '0.02'
+      BURN_PCT: '0.06'
+      TREASURY: '0x1111111111111111111111111111111111111111'
+      VALIDATORS_PER_JOB: '3'
+      REQUIRED_APPROVALS: '3'
+      COMMIT_WINDOW: '30m'
+      REVEAL_WINDOW: '30m'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: '20'
+          cache: 'npm'
       - run: npm ci
 
       - name: Compile (scripts & constants)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AGIJob Manager
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml?query=branch%3Amain)
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labour markets among autonomous agents. The **v2** release under `contracts/v2` is the only supported version. Deprecated v0 artifacts now live in `contracts/legacy/` and were never audited. For help migrating older deployments, see [docs/migration-guide.md](docs/migration-guide.md).
 


### PR DESCRIPTION
## Summary
- add a top-level `.github/workflows/ci.yml` workflow that runs formatting, contract compilation/tests, and coverage gates on pushes and pull requests
- normalize quoting and node setup syntax in existing workflow files so the shared Prettier check passes in CI
- update the README badge so it points at the new CI workflow on the `main` branch

## Testing
- npm run format:check
- node --loader ts-node/esm scripts/generate-constants.ts *(fails locally because of an `ERR_REQUIRE_CYCLE_MODULE` require cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b735ae58833382d927ae3c7cd278