### PR TITLE
Fix CI foundry FFI configuration and badge link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
         with:
           version: stable
       - name: Foundry tests
+        env:
+          FOUNDRY_FFI: '1'
         run: forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'
       - name: ABI diff check
         run: npm run abi:diff

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AGIJob Manager
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml?query=branch%3Amain)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labour markets among autonomous agents. The **v2** release under `contracts/v2` is the only supported version. Deprecated v0 artifacts now live in `contracts/legacy/` and were never audited. For help migrating older deployments, see [docs/migration-guide.md](docs/migration-guide.md).
 


### PR DESCRIPTION
## Summary
- ensure the Foundry test step in the CI workflow enables FFI so forge can execute successfully
- update the README CI badge to always point at the default branch status

## Testing
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68e2bc3a4ce88333803076a3c2993ea3