### PR TITLE
Fix CI constants generation command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,10 @@ jobs:
         run: npm ci
       - name: Compile contracts
         run: |
-          node --loader ts-node/esm scripts/generate-constants.ts
+          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
           npx hardhat compile
       - name: Regenerate constants for tests
-        run: node --loader ts-node/esm scripts/generate-constants.ts
+        run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
       - name: Hardhat tests
         run: npm test
       - name: Install Foundry

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -58,11 +58,11 @@ jobs:
         env:
           COVERAGE_MIN: 90
         run: |
-          node --loader ts-node/esm scripts/generate-constants.ts
+          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Regenerate constants for tests
-        run: node --loader ts-node/esm scripts/generate-constants.ts
+        run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
 
       - name: Node/Hardhat tests
         run: npm test

--- a/.github/workflows/release-mainnet.yml
+++ b/.github/workflows/release-mainnet.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Compile (scripts & constants)
         run: |
-          node --loader ts-node/esm scripts/generate-constants.ts
+          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
           npx hardhat compile
 
       - name: Build Safe execution plan

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agijobsv0",
   "version": "1.0.0",
-  "description": "[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)",
+  "description": "[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml?query=branch%3Amain)",
   "main": "index.js",
   "scripts": {
     "build": "truffle compile",


### PR DESCRIPTION
## Summary
- replace node --loader invocations in CI-related workflows with ts-node CLI to avoid require cycle failures
- update the package description CI badge to target the main branch explicitly

## Testing
- npm run format:check
- npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2bc3a4ce88333803076a3c2993ea3