### PR TITLE
Ensure coverage job regenerates constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,14 @@ jobs:
     needs: contracts
     runs-on: ubuntu-24.04
     env:
+      ACCESS_CONTROL_PATHS: 'contracts/v2/admin,contracts/v2/governance'
+      FEE_PCT: '0.02'
+      BURN_PCT: '0.06'
+      TREASURY: '0x1111111111111111111111111111111111111111'
+      VALIDATORS_PER_JOB: '3'
+      REQUIRED_APPROVALS: '3'
+      COMMIT_WINDOW: '30m'
+      REVEAL_WINDOW: '30m'
       COVERAGE_MIN: '90'
     steps:
       - uses: actions/checkout@v4
@@ -82,6 +90,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Regenerate constants for coverage run
+        run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
       - name: Generate coverage report
         run: npm run coverage
       - name: Check access control coverage


### PR DESCRIPTION
## Summary
- reuse the v2 configuration constants in the coverage job so it matches contract test execution
- rerun the TypeScript constant generator before coverage to avoid stale artefacts

## Testing
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68e2d179c4b48333998e913825d164e7