### PR TITLE
Harden v2 CI pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,22 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ACCESS_CONTROL_PATHS: 'contracts/v2/admin,contracts/v2/governance'
+  FEE_PCT: '0.02'
+  BURN_PCT: '0.06'
+  TREASURY: '0x1111111111111111111111111111111111111111'
+  VALIDATORS_PER_JOB: '3'
+  REQUIRED_APPROVALS: '3'
+  COMMIT_WINDOW: '30m'
+  REVEAL_WINDOW: '30m'
+  COVERAGE_MIN: '90'
+
 jobs:
   lint:
     name: Lint & static checks
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -31,16 +43,7 @@ jobs:
   contracts:
     name: Contracts compile & tests
     runs-on: ubuntu-24.04
-    env:
-      COVERAGE_MIN: '90'
-      ACCESS_CONTROL_PATHS: 'contracts/v2/admin,contracts/v2/governance'
-      FEE_PCT: '0.02'
-      BURN_PCT: '0.06'
-      TREASURY: '0x1111111111111111111111111111111111111111'
-      VALIDATORS_PER_JOB: '3'
-      REQUIRED_APPROVALS: '3'
-      COMMIT_WINDOW: '30m'
-      REVEAL_WINDOW: '30m'
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -48,6 +51,13 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+      - name: Cache Hardhat compiler builds
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs
+          key: ${{ runner.os }}-hardhat-solc-${{ hashFiles('hardhat.config.*', 'package-lock.json', 'scripts/generate-constants.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
       - name: Install dependencies
         run: npm ci
       - name: Compile contracts
@@ -69,10 +79,11 @@ jobs:
 
   coverage:
     name: Coverage thresholds
-    needs: contracts
+    needs:
+      - lint
+      - contracts
     runs-on: ubuntu-24.04
-    env:
-      COVERAGE_MIN: '90'
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -80,8 +91,17 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+      - name: Cache Hardhat compiler builds
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs
+          key: ${{ runner.os }}-hardhat-solc-${{ hashFiles('hardhat.config.*', 'package-lock.json', 'scripts/generate-constants.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
       - name: Install dependencies
         run: npm ci
+      - name: Regenerate constants for coverage run
+        run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
       - name: Generate coverage report
         run: npm run coverage
       - name: Check access control coverage

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -26,22 +26,21 @@ concurrency:
   group: contracts-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ACCESS_CONTROL_PATHS: 'contracts/v2/admin,contracts/v2/governance'
+  FEE_PCT: '0.02'
+  BURN_PCT: '0.06'
+  TREASURY: '0x1111111111111111111111111111111111111111'
+  VALIDATORS_PER_JOB: '3'
+  REQUIRED_APPROVALS: '3'
+  COMMIT_WINDOW: '30m'
+  REVEAL_WINDOW: '30m'
+  COVERAGE_MIN: '90'
+
 jobs:
   compile-and-test:
     runs-on: ubuntu-24.04
-
-    env:
-      COVERAGE_MIN: '90'
-      ACCESS_CONTROL_PATHS: 'contracts/v2/admin,contracts/v2/governance'
-
-      FEE_PCT: '0.02'
-      BURN_PCT: '0.06'
-      TREASURY: '0x1111111111111111111111111111111111111111'
-      VALIDATORS_PER_JOB: '3'
-      REQUIRED_APPROVALS: '3'
-      COMMIT_WINDOW: '30m'
-      REVEAL_WINDOW: '30m'
-
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -50,6 +49,14 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+
+      - name: Cache Hardhat compiler builds
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs
+          key: ${{ runner.os }}-hardhat-solc-${{ hashFiles('hardhat.config.*', 'package-lock.json', 'scripts/generate-constants.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- expose the v2 protocol defaults as workflow-level environment variables so every job inherits the same parameters
- reuse cached Hardhat compiler builds and add timeouts so contract and coverage stages stay deterministic
- make the coverage stage depend on lint and contract jobs and mirror the improvements in the standalone contracts workflow

## Testing
- npm test *(fails: requires stake/slash configuration context even with CI defaults and reverts with InvalidPercentage/InsufficientValidators in local sandbox)*
- npm run lint:check *(fails: current solhint configuration emits thousands of warnings beyond the enforced zero threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d179c4b48333998e913825d164e7