### PR TITLE
Ensure CI separates tests, Foundry, and coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,14 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Prettier formatting check
         run: npm run format:check
 
-  contracts:
-    name: Contracts compile & tests
+  tests:
+    name: Tests
     runs-on: ubuntu-24.04
     env:
       COVERAGE_MIN: '90'
@@ -48,31 +49,32 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Generate constants
+        run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
       - name: Compile contracts
-        run: |
-          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
-          npx hardhat compile
+        run: npx hardhat compile
       - name: Regenerate constants for tests
         run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
       - name: Hardhat tests
         run: npm test
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: stable
-      - name: Foundry tests
-        run: forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'
       - name: ABI diff check
         run: npm run abi:diff
 
-  coverage:
-    name: Coverage thresholds
-    needs: contracts
+  foundry:
+    name: Foundry
     runs-on: ubuntu-24.04
     env:
-      COVERAGE_MIN: '90'
+      ACCESS_CONTROL_PATHS: 'contracts/v2/admin,contracts/v2/governance'
+      FEE_PCT: '0.02'
+      BURN_PCT: '0.06'
+      TREASURY: '0x1111111111111111111111111111111111111111'
+      VALIDATORS_PER_JOB: '3'
+      REQUIRED_APPROVALS: '3'
+      COMMIT_WINDOW: '30m'
+      REVEAL_WINDOW: '30m'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -80,11 +82,58 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Generate constants
+        run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+      - name: Compile contracts
+        run: npx hardhat compile
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+      - name: Foundry tests
+        run: forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'
+
+  coverage:
+    name: Coverage thresholds
+    needs: tests
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    env:
+      COVERAGE_MIN: '90'
+      ACCESS_CONTROL_PATHS: 'contracts/v2/admin,contracts/v2/governance'
+      FEE_PCT: '0.02'
+      BURN_PCT: '0.06'
+      TREASURY: '0x1111111111111111111111111111111111111111'
+      VALIDATORS_PER_JOB: '3'
+      REQUIRED_APPROVALS: '3'
+      COMMIT_WINDOW: '30m'
+      REVEAL_WINDOW: '30m'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Generate constants
+        run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+      - name: Compile contracts
+        run: npx hardhat compile
       - name: Generate coverage report
         run: npm run coverage
       - name: Check access control coverage
         run: npm run check:access-control
       - name: Enforce coverage threshold
-        run: npm run check:coverage
+        run: node scripts/check-coverage.js "$COVERAGE_MIN"
+      - name: Upload coverage artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## v2
 
+- Ensured the `ci` workflow runs dedicated Tests, Foundry, and Coverage thresholds jobs on Ubuntu 24.04 with Node.js 20, enforcing coverage gating and publishing artefacts for AGI Jobs v2.
 - Bumped all `contracts/v2` module `version` constants to `2` and updated related checks and documentation.
 - `RandaoCoordinator.random` now mixes the XORed seed with `block.prevrandao` for block-dependent entropy.
 - Default identity cache durations for agents and validators are now zero so every job application and validation commit requires a fresh ENS proof; governance can extend the cache via on-chain setters if necessary.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AGIJob Manager
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml?query=branch%3Amain)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labour markets among autonomous agents. The **v2** release under `contracts/v2` is the only supported version. Deprecated v0 artifacts now live in `contracts/legacy/` and were never audited. For help migrating older deployments, see [docs/migration-guide.md](docs/migration-guide.md).
 


### PR DESCRIPTION
## Summary
- split the CI workflow into dedicated Tests, Foundry, and Coverage thresholds jobs on ubuntu-24.04 with Node.js 20 caching
- make the coverage job unconditional on PRs, enforce the configured minimum from coverage/lcov.info, and upload artefacts
- update the README badge link and note the CI overhaul in the changelog

## Testing
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68e3e7a5720083339c736aca9ae10829