### PR TITLE
fix: clean warnings and stabilize reward weight fuzz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Prettier formatting check
@@ -48,6 +49,7 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Compile contracts
@@ -81,6 +83,7 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Regenerate constants for Foundry
@@ -121,6 +124,7 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Regenerate constants for coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## v2
 
 - Hardened the CI workflow so the Tests, Foundry, and Coverage thresholds jobs run on Ubuntu 24.04, regenerate generated constants when needed, enforce the 90% coverage gate without being skippable, publish `coverage/lcov.info` artifacts for inspection, and execute the full Hardhat coverage suite so access-control modules are accounted for.
+- Documented the CI status badge in the README and enabled dependency-lock-aware npm caching in every job to keep the gate fast while remaining enforceable on `main` and pull requests.
 - Bumped all `contracts/v2` module `version` constants to `2` and updated related checks and documentation.
 - `RandaoCoordinator.random` now mixes the XORed seed with `block.prevrandao` for block-dependent entropy.
 - Default identity cache durations for agents and validators are now zero so every job application and validation commit requires a fresh ENS proof; governance can extend the cache via on-chain setters if necessary.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AGIJob Manager
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labour markets among autonomous agents. The **v2** release under `contracts/v2` is the only supported version. Deprecated v0 artifacts now live in `contracts/legacy/` and were never audited. For help migrating older deployments, see [docs/migration-guide.md](docs/migration-guide.md).
 

--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -892,7 +892,7 @@ contract MockReputationEngine is IReputationEngine {
         _blacklist[user] = val;
     }
 
-    function onApply(address user) external override {
+    function onApply(address user) external view override {
         require(!_blacklist[user], "blacklisted");
         require(_rep[user] >= threshold, "insufficient reputation");
     }

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -251,7 +251,7 @@ contract ReputationEngine is Ownable, Pausable, IReputationEngineV2 {
     // ---------------------------------------------------------------------
 
     /// @notice Ensure an applicant meets premium requirements and is not blacklisted.
-    function onApply(address user) external onlyCaller whenNotPaused {
+    function onApply(address user) external view onlyCaller whenNotPaused {
         require(!blacklisted[user], "Blacklisted agent");
         require(reputation[user] >= premiumThreshold, "insufficient reputation");
     }

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -2395,6 +2395,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
     /// @param employer address of the employer triggering finalization
     /// @param agent recipient of the job reward
     /// @param reward base amount paid to the agent with 18 decimals before AGI bonus
+    /// @param validatorReward total reward set aside for validators prior to agent payout
     /// @param fee amount forwarded to the fee pool with 18 decimals
     /// @param _feePool fee pool contract receiving protocol fees
     /// @param byGovernance true when governance is forcing finalization
@@ -2437,6 +2438,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         IFeePool _feePool,
         bool byGovernance
     ) internal {
+        byGovernance; // silence unused parameter without altering signature
         emit JobFundsFinalized(jobId, employer);
 
         uint256 rewardSpent = reward;

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1267,6 +1267,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         entropyContributorCount[jobId] = 1;
         entropyContributed[jobId][round][msg.sender] = true;
         selectionBlock[jobId] = block.number + 1;
+        selected; // silence unused return variable; selection occurs during finalization
     }
 
     /// @notice Internal commit logic shared by overloads.

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -87,7 +87,7 @@ interface IReputationEngine {
     function setBlacklist(address user, bool status) external;
 
     /// @notice Job lifecycle hooks
-    function onApply(address user) external;
+    function onApply(address user) external view;
 
     function onFinalize(address user, bool success, uint256 payout, uint256 duration) external;
 

--- a/contracts/v2/mocks/IdentityRegistryMock.sol
+++ b/contracts/v2/mocks/IdentityRegistryMock.sol
@@ -106,7 +106,7 @@ contract IdentityRegistryMock is Ownable {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata
-    ) external view returns (bool) {
+    ) external pure returns (bool) {
         claimant; // silence unused
         _assertSubdomain(subdomain);
         return true;
@@ -116,7 +116,7 @@ contract IdentityRegistryMock is Ownable {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata
-    ) external view returns (bool) {
+    ) external pure returns (bool) {
         claimant; // silence unused
         _assertSubdomain(subdomain);
         return true;
@@ -128,12 +128,15 @@ contract IdentityRegistryMock is Ownable {
         bytes32[] calldata
     )
         external
+        pure
         returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
     {
         claimant; // silence unused
         _assertSubdomain(subdomain);
         node = bytes32(0);
         ok = true;
+        viaWrapper = false;
+        viaMerkle = false;
     }
 
     function verifyValidator(
@@ -142,12 +145,15 @@ contract IdentityRegistryMock is Ownable {
         bytes32[] calldata
     )
         external
+        pure
         returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
     {
         claimant; // silence unused
         _assertSubdomain(subdomain);
         node = bytes32(0);
         ok = true;
+        viaWrapper = false;
+        viaMerkle = false;
     }
 }
 

--- a/contracts/v2/mocks/IdentityRegistryToggle.sol
+++ b/contracts/v2/mocks/IdentityRegistryToggle.sol
@@ -125,9 +125,12 @@ contract IdentityRegistryToggle is Ownable {
         bytes32[] calldata
     )
         external
+        view
         returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
     {
         node = bytes32(0);
+        viaWrapper = false;
+        viaMerkle = false;
         if (additionalAgents[claimant]) {
             ok = true;
         } else {
@@ -142,9 +145,12 @@ contract IdentityRegistryToggle is Ownable {
         bytes32[] calldata
     )
         external
+        view
         returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
     {
         node = bytes32(0);
+        viaWrapper = false;
+        viaMerkle = false;
         if (additionalValidators[claimant]) {
             ok = true;
         } else {

--- a/contracts/v2/mocks/ReentrantIdentityRegistry.sol
+++ b/contracts/v2/mocks/ReentrantIdentityRegistry.sol
@@ -62,6 +62,8 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
     {
         node = bytes32(0);
         ok = true;
+        viaWrapper = false;
+        viaMerkle = false;
     }
 
     function verifyValidator(
@@ -70,6 +72,8 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
         bytes32[] calldata
     ) external returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle) {
         node = bytes32(0);
+        viaWrapper = false;
+        viaMerkle = false;
         if (attack == Attack.Commit) {
             attack = Attack.None;
             validation.commitValidation(jobId, commitHash, "", new bytes32[](0));
@@ -87,6 +91,8 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
     ) external pure returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle) {
         ok = true;
         node = bytes32(0);
+        viaWrapper = false;
+        viaMerkle = false;
     }
 
     // profile metadata - no-ops

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -367,10 +367,17 @@ contract RewardEngineMBTest is Test {
     function testFuzz_mbWeights_normalization(int256 e1, int256 e2, int256 T) public {
         vm.assume(T > 0);
         vm.assume(T >= thermo.minTemp() && T <= thermo.maxTemp());
+        vm.assume(e1 != type(int256).min);
+        vm.assume(e2 != type(int256).min);
         int256 minE = e1 < e2 ? e1 : e2;
         int256 maxE = e1 > e2 ? e1 : e2;
-        int256 upper = (0 - minE) * 1e18 / T;
-        int256 lower = (0 - maxE) * 1e18 / T;
+        int256 diffMax = -minE;
+        int256 diffMin = -maxE;
+        int256 scaleLimit = type(int256).max / 1e18;
+        vm.assume(diffMax <= scaleLimit && diffMax >= -scaleLimit);
+        vm.assume(diffMin <= scaleLimit && diffMin >= -scaleLimit);
+        int256 upper = (diffMax * 1e18) / T;
+        int256 lower = (diffMin * 1e18) / T;
         vm.assume(upper <= MAX_EXP_INPUT && lower >= MIN_EXP_INPUT);
         int256[] memory E = new int256[](2);
         uint256[] memory g = new uint256[](2);


### PR DESCRIPTION
## Summary
- mark reputation-engine hooks and legacy mock implementations as `view` and update the shared interface so the compiler stops emitting mutability hints
- tighten identity registry mocks by returning explicit wrapper/merkle flags and adjusting pure/view annotations to silence unused-parameter warnings
- retain StakeManager and ValidationModule signatures while referencing unused values so solc 0.8.25 stays warning-free, and bound the RewardEngineMB fuzz domain to prevent overflow in mb weight normalization

## Testing
- `forge test -vvvv --ffi --fuzz-runs 256` *(fails: existing suites such as AttestationRegistryTest, CertificateNFTConfigTest, IntegrationTest, PlatformIncentivesTest, RewardEngineMBTest, ThermoMathTest currently fail without additional environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b3d7f3088333ba6d17bbd7f0328d