### PR TITLE
fix: clean up identity mocks and stabilize reward fuzz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Prettier formatting check
@@ -48,6 +49,7 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Compile contracts
@@ -81,6 +83,7 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Regenerate constants for Foundry
@@ -121,6 +124,7 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Regenerate constants for coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## v2
 
 - Hardened the CI workflow so the Tests, Foundry, and Coverage thresholds jobs run on Ubuntu 24.04, regenerate generated constants when needed, enforce the 90% coverage gate without being skippable, publish `coverage/lcov.info` artifacts for inspection, and execute the full Hardhat coverage suite so access-control modules are accounted for.
+- Documented the CI status badge in the README and enabled dependency-lock-aware npm caching in every job to keep the gate fast while remaining enforceable on `main` and pull requests.
 - Bumped all `contracts/v2` module `version` constants to `2` and updated related checks and documentation.
 - `RandaoCoordinator.random` now mixes the XORed seed with `block.prevrandao` for block-dependent entropy.
 - Default identity cache durations for agents and validators are now zero so every job application and validation commit requires a fresh ENS proof; governance can extend the cache via on-chain setters if necessary.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AGIJob Manager
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
 AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labour markets among autonomous agents. The **v2** release under `contracts/v2` is the only supported version. Deprecated v0 artifacts now live in `contracts/legacy/` and were never audited. For help migrating older deployments, see [docs/migration-guide.md](docs/migration-guide.md).
 

--- a/contracts/legacy/MockV2.sol
+++ b/contracts/legacy/MockV2.sol
@@ -892,7 +892,7 @@ contract MockReputationEngine is IReputationEngine {
         _blacklist[user] = val;
     }
 
-    function onApply(address user) external override {
+    function onApply(address user) external view override {
         require(!_blacklist[user], "blacklisted");
         require(_rep[user] >= threshold, "insufficient reputation");
     }

--- a/contracts/v2/ReputationEngine.sol
+++ b/contracts/v2/ReputationEngine.sol
@@ -251,7 +251,7 @@ contract ReputationEngine is Ownable, Pausable, IReputationEngineV2 {
     // ---------------------------------------------------------------------
 
     /// @notice Ensure an applicant meets premium requirements and is not blacklisted.
-    function onApply(address user) external onlyCaller whenNotPaused {
+    function onApply(address user) external view onlyCaller whenNotPaused {
         require(!blacklisted[user], "Blacklisted agent");
         require(reputation[user] >= premiumThreshold, "insufficient reputation");
     }

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -2437,6 +2437,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         IFeePool _feePool,
         bool byGovernance
     ) internal {
+        byGovernance; // silence unused parameter (reserved for governance overrides)
         emit JobFundsFinalized(jobId, employer);
 
         uint256 rewardSpent = reward;

--- a/contracts/v2/ValidationModule.sol
+++ b/contracts/v2/ValidationModule.sol
@@ -1242,7 +1242,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
     function start(
         uint256 jobId,
         uint256 entropy
-    ) external override whenNotPaused nonReentrant returns (address[] memory selected) {
+    ) external override whenNotPaused nonReentrant returns (address[] memory) {
         if (msg.sender != address(jobRegistry)) revert OnlyJobRegistry();
         IJobRegistry.Job memory jobSnapshot = jobRegistry.jobs(jobId);
         IJobRegistry.JobMetadata memory meta = jobRegistry.decodeJobMetadata(
@@ -1267,6 +1267,7 @@ contract ValidationModule is IValidationModule, Ownable, TaxAcknowledgement, Pau
         entropyContributorCount[jobId] = 1;
         entropyContributed[jobId][round][msg.sender] = true;
         selectionBlock[jobId] = block.number + 1;
+        return new address[](0);
     }
 
     /// @notice Internal commit logic shared by overloads.

--- a/contracts/v2/interfaces/IReputationEngine.sol
+++ b/contracts/v2/interfaces/IReputationEngine.sol
@@ -87,7 +87,7 @@ interface IReputationEngine {
     function setBlacklist(address user, bool status) external;
 
     /// @notice Job lifecycle hooks
-    function onApply(address user) external;
+    function onApply(address user) external view;
 
     function onFinalize(address user, bool success, uint256 payout, uint256 duration) external;
 

--- a/contracts/v2/mocks/IdentityRegistryMock.sol
+++ b/contracts/v2/mocks/IdentityRegistryMock.sol
@@ -106,7 +106,7 @@ contract IdentityRegistryMock is Ownable {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata
-    ) external view returns (bool) {
+    ) external pure returns (bool) {
         claimant; // silence unused
         _assertSubdomain(subdomain);
         return true;
@@ -116,7 +116,7 @@ contract IdentityRegistryMock is Ownable {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata
-    ) external view returns (bool) {
+    ) external pure returns (bool) {
         claimant; // silence unused
         _assertSubdomain(subdomain);
         return true;
@@ -126,28 +126,20 @@ contract IdentityRegistryMock is Ownable {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata
-    )
-        external
-        returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
-    {
+    ) external pure returns (bool, bytes32, bool, bool) {
         claimant; // silence unused
         _assertSubdomain(subdomain);
-        node = bytes32(0);
-        ok = true;
+        return (true, bytes32(0), false, false);
     }
 
     function verifyValidator(
         address claimant,
         string calldata subdomain,
         bytes32[] calldata
-    )
-        external
-        returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
-    {
+    ) external pure returns (bool, bytes32, bool, bool) {
         claimant; // silence unused
         _assertSubdomain(subdomain);
-        node = bytes32(0);
-        ok = true;
+        return (true, bytes32(0), false, false);
     }
 }
 

--- a/contracts/v2/mocks/IdentityRegistryToggle.sol
+++ b/contracts/v2/mocks/IdentityRegistryToggle.sol
@@ -123,34 +123,20 @@ contract IdentityRegistryToggle is Ownable {
         address claimant,
         string calldata subdomain,
         bytes32[] calldata
-    )
-        external
-        returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
-    {
-        node = bytes32(0);
-        if (additionalAgents[claimant]) {
-            ok = true;
-        } else {
-            ok = result;
-        }
+    ) external view returns (bool, bytes32, bool, bool) {
+        bool ok = additionalAgents[claimant] ? true : result;
         _assertSubdomain(subdomain);
+        return (ok, bytes32(0), false, false);
     }
 
     function verifyValidator(
         address claimant,
         string calldata subdomain,
         bytes32[] calldata
-    )
-        external
-        returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
-    {
-        node = bytes32(0);
-        if (additionalValidators[claimant]) {
-            ok = true;
-        } else {
-            ok = result;
-        }
+    ) external view returns (bool, bytes32, bool, bool) {
+        bool ok = additionalValidators[claimant] ? true : result;
         _assertSubdomain(subdomain);
+        return (ok, bytes32(0), false, false);
     }
 }
 

--- a/contracts/v2/mocks/ReentrantIdentityRegistry.sol
+++ b/contracts/v2/mocks/ReentrantIdentityRegistry.sol
@@ -43,11 +43,11 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
     }
 
     // IIdentityRegistry stubs
-    function isAuthorizedAgent(address, string calldata, bytes32[] calldata) external view returns (bool) {
+    function isAuthorizedAgent(address, string calldata, bytes32[] calldata) external pure returns (bool) {
         return true;
     }
 
-    function isAuthorizedValidator(address, string calldata, bytes32[] calldata) external view returns (bool) {
+    function isAuthorizedValidator(address, string calldata, bytes32[] calldata) external pure returns (bool) {
         return true;
     }
 
@@ -55,21 +55,15 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
         address,
         string calldata,
         bytes32[] calldata
-    )
-        external
-        pure
-        returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle)
-    {
-        node = bytes32(0);
-        ok = true;
+    ) external pure returns (bool, bytes32, bool, bool) {
+        return (true, bytes32(0), false, false);
     }
 
     function verifyValidator(
         address,
         string calldata,
         bytes32[] calldata
-    ) external returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle) {
-        node = bytes32(0);
+    ) external returns (bool, bytes32, bool, bool) {
         if (attack == Attack.Commit) {
             attack = Attack.None;
             validation.commitValidation(jobId, commitHash, "", new bytes32[](0));
@@ -77,16 +71,15 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
             attack = Attack.None;
             validation.revealValidation(jobId, approve, burnTxHash, salt, "", new bytes32[](0));
         }
-        ok = true;
+        return (true, bytes32(0), false, false);
     }
 
     function verifyNode(
         address,
         string calldata,
         bytes32[] calldata
-    ) external pure returns (bool ok, bytes32 node, bool viaWrapper, bool viaMerkle) {
-        ok = true;
-        node = bytes32(0);
+    ) external pure returns (bool, bytes32, bool, bool) {
+        return (true, bytes32(0), false, false);
     }
 
     // profile metadata - no-ops

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -32,7 +32,7 @@ contract ValidationStub is IValidationModule {
     function start(
         uint256 jobId,
         uint256 entropy
-    ) external override returns (address[] memory vals) {
+    ) external view override returns (address[] memory vals) {
         vals = selectValidators(jobId, entropy);
     }
 

--- a/test/v2/RewardEngineMB.t.sol
+++ b/test/v2/RewardEngineMB.t.sol
@@ -13,6 +13,7 @@ import {AGIALPHA} from "../../contracts/v2/Constants.sol";
 
 int256 constant MAX_EXP_INPUT = 133_084258667509499440;
 int256 constant MIN_EXP_INPUT = -41_446531673892822322;
+int256 constant MAX_SAFE_ENERGY = type(int256).max / int256(1e18);
 
 contract MockFeePool is IFeePool {
     mapping(address => uint256) public rewards;
@@ -369,6 +370,7 @@ contract RewardEngineMBTest is Test {
         vm.assume(T >= thermo.minTemp() && T <= thermo.maxTemp());
         int256 minE = e1 < e2 ? e1 : e2;
         int256 maxE = e1 > e2 ? e1 : e2;
+        vm.assume(minE >= -MAX_SAFE_ENERGY && maxE <= MAX_SAFE_ENERGY);
         int256 upper = (0 - minE) * 1e18 / T;
         int256 lower = (0 - maxE) * 1e18 / T;
         vm.assume(upper <= MAX_EXP_INPUT && lower >= MIN_EXP_INPUT);


### PR DESCRIPTION
## Summary
- remove unused-parameter nat-spec warnings by consuming governance flags and returning dummy arrays in the validation path
- tighten identity registry mocks to pure/view functions with explicit tuple returns and mark onApply hooks as view-safe across the interface and implementations
- bound the RewardEngine MB fuzz domain with a MAX_SAFE_ENERGY guard to prevent int256 overflow during coverage fuzzing

## Testing
- `forge test --ffi --fuzz-runs 256 --match-test testFuzz_mbWeights_normalization`


------
https://chatgpt.com/codex/tasks/task_e_68e4b3d7f3088333ba6d17bbd7f0328d