### PR TITLE
Fix reward engine tests and stabilize ThermoMath weights

### DIFF
--- a/contracts/v2/libraries/ThermoMath.sol
+++ b/contracts/v2/libraries/ThermoMath.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
-import { exp } from "@prb/math/src/sd59x18/Math.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {SD59x18} from "@prb/math/src/sd59x18/ValueType.sol";
+import {exp} from "@prb/math/src/sd59x18/Math.sol";
 
 /// @title ThermoMath
 /// @notice Utility functions for computing approximate Maxwell-Boltzmann weights.
@@ -66,7 +67,7 @@ library ThermoMath {
         }
         if (sum == 0) return w;
         for (uint256 i = 0; i < n; i++) {
-            w[i] = (raw[i] * uint256(WAD)) / sum;
+            w[i] = Math.mulDiv(raw[i], uint256(WAD), sum);
         }
     }
 }

--- a/test/v2/ThermoMath.t.sol
+++ b/test/v2/ThermoMath.t.sol
@@ -9,7 +9,19 @@ import { exp } from "@prb/math/src/sd59x18/Math.sol";
 int256 constant MAX_EXP_INPUT = 133_084258667509499440;
 int256 constant MIN_EXP_INPUT = -41_446531673892822322;
 
+contract ThermoMathHarness {
+    function mbWeights(int256[] memory E, uint256[] memory g, int256 T, int256 mu)
+        external
+        pure
+        returns (uint256[] memory)
+    {
+        return ThermoMath.mbWeights(E, g, T, mu);
+    }
+}
+
 contract ThermoMathTest is Test {
+    ThermoMathHarness harness = new ThermoMathHarness();
+
     function test_weights_normalize() public pure {
         int256[] memory E = new int256[](3);
         uint256[] memory g = new uint256[](3);
@@ -21,7 +33,7 @@ contract ThermoMathTest is Test {
             assertGe(w[i], 0, "non-negative");
             sum += w[i];
         }
-        assertEq(sum, 1e18, "normalized");
+        assertApproxEqAbs(sum, 1e18, 1, "normalized");
     }
 
     function test_weights_uniform_when_equal_energy() public pure {
@@ -73,7 +85,7 @@ contract ThermoMathTest is Test {
         uint256[] memory g = new uint256[](1);
         E[0] = 0; g[0] = 1;
         vm.expectRevert(bytes("T>0"));
-        ThermoMath.mbWeights(E, g, 0, 0);
+        harness.mbWeights(E, g, 0, 0);
     }
 
     function test_reverts_when_exp_input_too_large() public {
@@ -81,7 +93,7 @@ contract ThermoMathTest is Test {
         uint256[] memory g = new uint256[](1);
         E[0] = 0; g[0] = 1;
         vm.expectRevert(ThermoMath.ExpInputOutOfBounds.selector);
-        ThermoMath.mbWeights(E, g, 1e18, 135e18);
+        harness.mbWeights(E, g, 1e18, 135e18);
     }
 
     function test_reverts_when_exp_input_too_small() public {
@@ -89,7 +101,7 @@ contract ThermoMathTest is Test {
         uint256[] memory g = new uint256[](1);
         E[0] = 0; g[0] = 1;
         vm.expectRevert(ThermoMath.ExpInputOutOfBounds.selector);
-        ThermoMath.mbWeights(E, g, 1e18, -42e18);
+        harness.mbWeights(E, g, 1e18, -42e18);
     }
 
     function test_reverts_when_energy_gap_exceeds_bounds() public {
@@ -100,7 +112,7 @@ contract ThermoMathTest is Test {
         g[0] = 1;
         g[1] = 1;
         vm.expectRevert(ThermoMath.ExpInputOutOfBounds.selector);
-        ThermoMath.mbWeights(E, g, 1e18, 0);
+        harness.mbWeights(E, g, 1e18, 0);
     }
 
     function testFuzz_weight_overflow_reverts(int256 x) public {
@@ -113,7 +125,7 @@ contract ThermoMathTest is Test {
         E[0] = 0;
         g[0] = gOverflow;
         vm.expectRevert(ThermoMath.WeightOverflow.selector);
-        ThermoMath.mbWeights(E, g, 1e18, x);
+        harness.mbWeights(E, g, 1e18, x);
     }
 
     function test_reverts_when_degeneracy_too_large() public {
@@ -123,7 +135,7 @@ contract ThermoMathTest is Test {
         uint256 gOverflow = type(uint256).max / 1e18 + 1;
         g[0] = gOverflow;
         vm.expectRevert(ThermoMath.WeightOverflow.selector);
-        ThermoMath.mbWeights(E, g, 1e18, 0);
+        harness.mbWeights(E, g, 1e18, 0);
     }
 
     function testFuzz_weight_boundary_normalizes(int256 x) public pure {


### PR DESCRIPTION
## Summary
- use Math.mulDiv in ThermoMath to avoid overflow during normalization and update test harnesses to exercise revert paths reliably
- add deterministic budget helper to RewardEngineMB tests so assertions derive expectations from contract math and cover additional edge cases
- refresh reward engine tests to cover treasury errors and new ReentrancyGuard error signature while keeping reputation checks valid

## Testing
- forge test --match-path test/v2/ThermoMath.t.sol
- forge test --match-path test/v2/RewardEngineMB.t.sol

------
https://chatgpt.com/codex/tasks/task_e_68e531994ecc8333bb7eab8bccaf5c58