### PR TITLE
Fix Trivy vulnerabilities in owner-console image

### DIFF
--- a/apps/console/Dockerfile
+++ b/apps/console/Dockerfile
@@ -8,6 +8,9 @@ COPY . .
 RUN npm run build
 
 FROM nginx:1.27-alpine AS runner
+RUN apk upgrade --no-cache \
+    libexpat \
+    libxml2
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80


### PR DESCRIPTION
## Summary
- upgrade the owner console runtime image by applying security updates for libexpat and libxml2
- keep the Dockerfile otherwise unchanged so nginx continues to serve the built console

## Testing
- npm run webapp:build

------
https://chatgpt.com/codex/tasks/task_e_68e54c9a623083339e8ab19f148f0c7c