### PR TITLE
Fix multi-arch gateway image build by installing Python dependencies

### DIFF
--- a/agent-gateway/Dockerfile
+++ b/agent-gateway/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM node:20-alpine AS builder
 WORKDIR /app
+RUN apk add --no-cache python3 make g++ \
+    && ln -sf python3 /usr/bin/python
+ENV PYTHON=/usr/bin/python3
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
@@ -10,6 +13,9 @@ RUN npm run build:gateway
 FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+RUN apk add --no-cache python3 make g++ \
+    && ln -sf python3 /usr/bin/python
+ENV PYTHON=/usr/bin/python3
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY --from=builder /app/agent-gateway/dist ./agent-gateway/dist


### PR DESCRIPTION
## Summary
- install Python and required build tooling in the gateway Docker builder stage to support native module compilation on all platforms
- ensure the runtime image also has Python available and explicitly set the PYTHON environment variable for node-gyp compatibility

## Testing
- npm run build:gateway


------
https://chatgpt.com/codex/tasks/task_e_68e5554ff81083338c01d627bfcf904f