### PR TITLE
Fix SLSA provenance workflow permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -118,6 +118,10 @@ jobs:
   slsa-provenance:
     if: startsWith(github.ref, 'refs/tags/')
     needs: security-suite
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
       base64-subjects: ${{ needs.security-suite.outputs.provenance_subjects }}


### PR DESCRIPTION
## Summary
- grant the reusable SLSA provenance workflow the permissions it requires

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e564dafdc88333ad22a7f5031b04bd