### PR TITLE
Add owner control verification workflow

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint Solidity and TypeScript surfaces
+        run: npm run lint:ci
+
       - name: Compile
         env:
           COVERAGE_MIN: 90

--- a/.github/workflows/owner-control.yml
+++ b/.github/workflows/owner-control.yml
@@ -1,0 +1,49 @@
+name: owner-control-v2
+
+on:
+  pull_request:
+    paths:
+      - 'contracts/v2/**'
+      - 'scripts/v2/**'
+      - 'config/owner-control*.json*'
+      - 'docs/OWNER_CONTROL*.md'
+      - '.github/workflows/owner-control.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'contracts/v2/**'
+      - 'scripts/v2/**'
+      - 'config/owner-control*.json*'
+      - 'docs/OWNER_CONTROL*.md'
+      - '.github/workflows/owner-control.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: owner-control-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-owner-control:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate constants
+        run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+
+      - name: Verify owner configuration surface
+        env:
+          OWNER_VERIFY_JSON: '1'
+        run: npm run owner:verify-control

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -4,6 +4,7 @@ To keep `main` deployable at all times, enable the following rules in the GitHub
 
 1. **Require status checks to pass before merging**
    - `contracts`
+   - `owner-control-v2 / verify-owner-control`
    - `security`
    - `fuzz`
    - `e2e`

--- a/docs/OWNER_CONTROL.md
+++ b/docs/OWNER_CONTROL.md
@@ -6,6 +6,15 @@
 
 The AGI Jobs v2 system preserves an owner-first operating model. A single Owner address (EOA or Safe) must retain the ability to configure, pause, upgrade, and recover assets across every module. Ownership is mediated through `Ownable2Step` on all upgradeable implementations and a central `OwnerConfigurator` facade for non-technical operators.
 
+### Automated Verification & CI Guardrail
+
+To make these guarantees actionable we ship an automated verification harness and CI check:
+
+- Run `npm run owner:verify-control` to inspect on-chain ownership for every module described below. The command accepts the optional environment variables `OWNER_VERIFY_JSON=1` for machine-readable output and `OWNER_VERIFY_STRICT=1` to fail the process when any module is misconfigured.
+- The `owner-control-v2` GitHub Actions workflow executes the same command on every pull request that touches v2 contracts, configuration, or this handbook. The JSON log surfaces in the job summary so operators can spot drift early.
+
+Populate `config/owner-control.json` and `docs/deployment-addresses.json` with the deployment addresses used in production so that the strict mode remains green.
+
 ### Operating Principles
 
 1. **Single Source of Truth** – Every mutable parameter appears here with the contract that guards it and the emitted `ParameterUpdated` event identifier.


### PR DESCRIPTION
## Summary
- add a lint gate to the contracts CI pipeline so Solidity and scripts fail fast
- add an owner-control-v2 workflow that runs the owner:verify-control script on relevant changes
- document the new guardrail in the owner control handbook and branch protection checklist

## Testing
- npm run lint:ci
- npm run owner:verify-control

------
https://chatgpt.com/codex/tasks/task_e_68e65fa6a73c8333bc237a8fd14982d4