### PR TITLE
Add CI v2 operations guide and owner control parameter playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The `ci (v2)` GitHub Actions workflow enforces quality gates on every pull reque
 - **Coverage thresholds** – regenerates constants, recomputes coverage, enforces the 90% minimum, and uploads the LCOV artifact.
 - **Summary gate** – publishes a human-readable status table and fails the workflow if any upstream job is unsuccessful, giving non-technical reviewers a single green/red indicator.
 
-Branch protection can now point at the `CI summary` check so that every job listed above must succeed before merges or deployments proceed.
+Branch protection can now point at the `CI summary` check so that every job listed above must succeed before merges or deployments proceed. A non-technical maintainer can follow the [CI v2 operations guide](docs/v2-ci-operations.md) for a diagrammed overview of the workflow, required status checks, and day-to-day troubleshooting steps.
 
 ## Table of Contents
 
@@ -66,6 +66,7 @@ Branch protection can now point at the `CI summary` check so that every job list
 - [Owner mission control](#owner-mission-control)
 - [Owner control visual guide](#owner-control-visual-guide)
 - [Owner parameter matrix](#owner-parameter-matrix)
+- [Owner control parameter playbook](#owner-control-parameter-playbook)
 - [Production launch blueprint](#production-launch-blueprint)
 
 ### Identity policy
@@ -544,6 +545,16 @@ touching Solidity. Explore the full workflow in the
 [Owner Parameter Matrix guide](docs/owner-parameter-matrix.md) and pair it with
 `npm run owner:surface` plus `npm run owner:verify-control` to archive a complete
 change-control artefact set.
+
+### Owner control parameter playbook
+
+Need a concise, action-oriented walkthrough for running updates through the on-chain [`OwnerConfigurator`](contracts/v2/admin/OwnerConfigurator.sol)? The new [Owner Control Parameter Playbook](docs/owner-control-parameter-playbook.md) provides:
+
+- A Mermaid flowchart mapping Safe interactions to emitted `ParameterUpdated` events.
+- Step-by-step Safe execution instructions, including calldata encoding commands.
+- Validation and rollback checklists so non-technical operators can revert quickly.
+
+Link the playbook in change tickets whenever parameter updates are planned to keep the governance surface consistent with CI guardrails and audit expectations.
 
 ### Production launch blueprint
 

--- a/docs/owner-control-parameter-playbook.md
+++ b/docs/owner-control-parameter-playbook.md
@@ -1,0 +1,63 @@
+# Owner Control Parameter Playbook (V2)
+
+This playbook gives the contract owner a single reference for adjusting AGI Jobs v2 parameters across the deployed module set. It complements the existing owner-control documentation and focuses on the `OwnerConfigurator` facade that batches privileged changes.
+
+```mermaid
+flowchart TD
+    A[Owner console / Safe] -->|encode setter| B(OwnerConfigurator)
+    B -->|configure| C{Target module}
+    C -->|emit events| D[Subgraph / telemetry]
+    B -->|ParameterUpdated| D
+```
+
+## Core tool: `OwnerConfigurator`
+
+The [`OwnerConfigurator`](../contracts/v2/admin/OwnerConfigurator.sol) contract exposes two methods:
+
+| Method | Purpose | When to use |
+| --- | --- | --- |
+| `configure` | Execute a single setter on a target module. | Quick one-off parameter update. |
+| `configureBatch` | Execute multiple setters in sequence. | Release workflows or multi-module rollouts. |
+
+Both methods require the caller to be the configured owner (Safe or EOA). Ownership can be rotated using the inherited `transferOwnership` flow, giving the platform operator full control.
+
+## Preparing a change
+
+1. **Identify the module:** Use `docs/v2-module-interface-reference.md` to locate the contract exposing the setter you need (e.g., `JobRegistry`, `StakeManager`).
+2. **Confirm governance state:** Verify that the new owner address is set in `Governable` contracts if a timelock coordinates the change. The [governance runbooks](owner-control-handbook.md) explain how to update timelock addresses.
+3. **Capture current values:** Read the module's getter (via CLI or block explorer) and record the value in the change ticket.
+4. **Encode calldata:** With `ethers` or `cast`, encode the setter call—for example:
+
+   ```bash
+   cast calldata "setCommitWindow(uint256)" 1800
+   ```
+
+5. **Populate metadata:** Choose descriptive `moduleKey` / `parameterKey` pairs (e.g., `keccak256("JOB_REGISTRY")`) to keep analytics dashboards consistent.
+
+## Executing via Safe transaction
+
+1. Open the Safe app connected to the deployment network.
+2. Add a **Contract interaction** targeting the `OwnerConfigurator` address.
+3. Paste the encoded calldata for `configure` or `configureBatch`.
+4. Insert the `moduleKey`, `parameterKey`, `oldValue`, and `newValue` fields as hex strings. The console export tool can autofill these values.
+5. Submit the transaction for signatures and execute once the threshold is met.
+
+The emitted `ParameterUpdated` event includes all metadata, enabling real-time monitoring in the owner console and subgraph.
+
+## Validation checklist
+
+- [ ] The target contract supports the setter being called (cross-check `abi:diff` reports when upgrading).
+- [ ] Required governance approvals (timelock delay, Safe signatures) are met.
+- [ ] Monitoring alerts (Hamiltonian Monitor, Thermostat) stay green after the change.
+- [ ] The change ticket references the relevant documentation and includes before/after values.
+
+## Emergency rollback
+
+If a parameter change behaves unexpectedly, submit a new `configure` call reverting to the previous value captured in the ticket. Because ownership remains with the platform operator, no external coordination is required.
+
+## Integration with CI & audits
+
+- CI enforces access-control coverage on contracts under `contracts/v2/admin` and `contracts/v2/governance`, ensuring mutator functions stay guarded by owner or governance modifiers.
+- The audit trail from `ParameterUpdated` is ingested into `docs/owner-control-pulse.md`. Update that log whenever a production change is executed.
+
+Following this playbook ensures the contract owner retains complete operational control of AGI Jobs v2 while keeping documentation, telemetry, and governance processes synchronized.

--- a/docs/v2-ci-operations.md
+++ b/docs/v2-ci-operations.md
@@ -1,0 +1,82 @@
+# AGI Jobs v0 — CI v2 Operations Guide
+
+This guide describes the CI v2 pipeline that protects the AGI Jobs v0 codebase. It documents the workflows that run on `main` and every pull request, shows how the jobs depend on each other, and captures the branch protection settings that need to be enforced so the checks are always visible.
+
+```mermaid
+digraph CIv2 {
+  rankdir=LR;
+  node [shape=rect, style=rounded, fontsize=12];
+  Lint[label="Lint & static checks" ];
+  Tests[label="Hardhat tests" ];
+  Foundry[label="Foundry fuzzing" ];
+  Coverage[label="Coverage thresholds" ];
+  Summary[label="CI summary" shape=parallelogram];
+
+  Lint -> Summary;
+  Tests -> Foundry;
+  Tests -> Coverage;
+  Tests -> Summary;
+  Foundry -> Summary;
+  Coverage -> Summary;
+}
+```
+
+## Workflow triggers
+
+The [`ci.yml`](../.github/workflows/ci.yml) workflow runs when:
+
+- A pull request targets `main`.
+- A push lands on `main`.
+- A maintainer manually triggers a run with **Run workflow**.
+
+These triggers ensure every change to production code surfaces in the pipeline and the final **CI summary** job remains visible in the PR checks list.
+
+## Required jobs and branch protection
+
+Enable branch protection on `main` with these required status checks:
+
+| Check name | Source job | Notes |
+| --- | --- | --- |
+| `Lint & static checks` | `lint` job | Blocks merge when linting fails. |
+| `Tests` | `tests` job | Runs Hardhat compilation and the main test suite. |
+| `Foundry` | `foundry` job | Always runs after the `tests` job, even when it fails, to expose fuzz failures. |
+| `Coverage thresholds` | `coverage` job | Enforces `COVERAGE_MIN` and access-control coverage. |
+| `CI summary` | `summary` job | Fails when any dependency job fails so the PR badge stays red. |
+
+> ✅ **Tip:** In GitHub branch protection, mark `Require branches to be up to date` to guarantee pull requests re-run the workflow when `main` advances.
+
+## Pull request hygiene checklist
+
+1. Confirm that the **Checks** tab shows all five required jobs in the table above.
+2. Inspect the **Artifacts** section for `coverage-lcov` when coverage needs auditing.
+3. Review the `CI summary` job output for a condensed Markdown table of job results.
+4. When re-running failed jobs, choose **Re-run failed jobs** to keep historical logs.
+
+## Local dry run for contributors
+
+Developers can approximate the pipeline locally with:
+
+```bash
+npm ci
+npm run format:check
+npm run lint:ci
+npm test
+npm run coverage
+forge test -vvvv --ffi --fuzz-runs 256
+```
+
+Running the commands in this order matches the GitHub workflow dependencies, letting contributors catch failures before opening a pull request.
+
+## Operational playbook
+
+- **Incident response:** When a CI job fails on `main`, triage by inspecting the job logs, then open an incident ticket using the `owner-control-change-ticket.md` template.
+- **Temporarily skipping jobs:** Use GitHub's `workflow_dispatch` trigger to run a targeted branch with fixes instead of editing the workflow file.
+- **Infrastructure updates:** Record any changes to cache keys or environment variables in `docs/release-checklist.md` and attach a PR link for traceability.
+
+## Audit checkpoints
+
+- CI secrets should be scoped to read-only access; verify them quarterly and record the review in `docs/owner-control-audit.md`.
+- Review branch protection rules weekly to ensure required checks still match the workflow job names.
+- Capture coverage threshold decisions in `docs/green-path-checklist.md` so downstream owners understand the rationale for the configured `COVERAGE_MIN`.
+
+Maintaining these guardrails keeps AGI Jobs v0 deployable by non-technical stakeholders while satisfying the "fully green" CI expectation.


### PR DESCRIPTION
## Summary
- document the GitHub Actions ci (v2) workflow with triggers, required checks, and operator checklists
- add an owner control parameter playbook describing how to run updates through OwnerConfigurator with Safe-ready steps
- cross-link the README to the new guides so non-technical maintainers can reach them quickly

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e66e691ea483338d793271335925e9