### PR TITLE
docs: backfill owner control reference manuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ npm run owner:verify-control -- --network <network>
 npm run owner:verify-control -- --network <network> --json --strict > owner-control-report.json
 ```
 
-Provide per-module addresses via `modules.<name>.address`, the `AGJ_<NAME>_ADDRESS` environment variable, or `--address name=0x…` at runtime. Use `--modules`/`--skip` to scope checks and `--address-book` to point at alternative deployment records. The command exits non-zero when `--strict` is enabled and any contract lacks the expected governance, keeping change-control pipelines safe for non-technical operators.
+Provide per-module addresses via `modules.<name>.address`, the `AGJ_<NAME>_ADDRESS` environment variable, or `--address name=0x…` at runtime. Use `--modules`/`--skip` to scope checks and `--address-book` to point at alternative deployment records. The command exits non-zero when `--strict` is enabled and any contract lacks the expected governance, keeping change-control pipelines safe for non-technical operators. For a step-by-step evidence workflow (including JSON export patterns, module scope tips, and troubleshooting), see the [Owner Control Verification Guide](docs/owner-control-verification.md).
 
 ### Owner control playbook
 
@@ -356,7 +356,7 @@ npm run owner:snapshot -- --network <network>
 npm run owner:snapshot -- --network mainnet --out reports/mainnet/control-kit --no-mermaid
 ```
 
-The helper copies every owner-governed config into `reports/<network>/owner-control-snapshot-<timestamp>/`, computes SHA-256 hashes for tamper evidence, and writes a Markdown briefing that cross-links remediation guides. Each subsystem section embeds Mermaid diagrams, update/verify command palettes and flattened parameter tables so non-technical reviewers can approve changes without opening Solidity. A machine-readable `manifest.json` summarises source paths, hashes and regeneration commands for CI or Safe pipelines. Full illustrations, compliance tips and troubleshooting advice live in [docs/owner-control-snapshot.md](docs/owner-control-snapshot.md).
+The helper copies every owner-governed config into `reports/<network>/owner-control-snapshot-<timestamp>/`, computes SHA-256 hashes for tamper evidence, and writes a Markdown briefing that cross-links remediation guides. Each subsystem section embeds Mermaid diagrams, update/verify command palettes and flattened parameter tables so non-technical reviewers can approve changes without opening Solidity. A machine-readable `manifest.json` summarises source paths, hashes and regeneration commands for CI or Safe pipelines. Extended examples, approval checklists, and integration ideas live in [docs/owner-control-snapshot-kit.md](docs/owner-control-snapshot-kit.md) (with additional context in [docs/owner-control-snapshot.md](docs/owner-control-snapshot.md)).
 
 ### Owner control pulse
 

--- a/docs/owner-control-index.md
+++ b/docs/owner-control-index.md
@@ -1,0 +1,66 @@
+# Owner Control Index
+
+> **Audience:** Contract owners, governance stewards, compliance reviewers.
+>
+> **Purpose:** Provide a single flight deck that catalogues every adjustable governance input, its source manifest, the automation helpers that mutate it, and the verification commands that prove the change landed correctly—without requiring Solidity expertise.
+
+---
+
+## Quick orientation
+
+The index groups the AGI Jobs v2 control surface into domains that map to the JSON manifests under `config/`. Each entry lists:
+
+1. **What you can tune** (e.g., thermodynamic weights, fee splits, signer rosters).
+2. **Where the configuration lives** (path to the canonical manifest plus optional per-network overrides in `config/<network>/`).
+3. **Which helper executes the change** (npm script or Hardhat task).
+4. **How to validate post-change** (owner verification commands, CI expectations, or on-chain calls).
+
+```mermaid
+flowchart LR
+    Configs[config/*.json manifests] --> Surface[npm run owner:surface]
+    Surface --> Doctor[npm run owner:doctor]
+    Doctor --> Plan[npm run owner:plan]
+    Plan --> Execute[npm run owner:update-all -- --network <network> --execute]
+    Execute --> Verify[npm run owner:verify-control]
+    Verify --> Archive[npm run owner:audit]
+```
+
+---
+
+## Catalogue
+
+| Domain | What you control | Source manifest(s) | Execute helper | Verification |
+| --- | --- | --- | --- | --- |
+| **Token & payouts** | Reward role shares, thermostat PID, treasury routing | `config/thermodynamics.json` (incl. `thermostat` block), `config/fee-pool.json` | `npm run owner:update-all -- --only rewardEngine,thermostat,feePool` | `npm run owner:verify-control -- --modules rewardEngine,thermostat,feePool` |
+| **Job lifecycle** | Employer fee percentages, escrow stakes, identity registry wiring | `config/job-registry.json`, `config/identity-registry.json` | `npm run owner:update-all -- --only jobRegistry,identityRegistry` | `npm run owner:verify-control -- --modules jobRegistry,identityRegistry` |
+| **Stake management** | Minimum stakes, fee/burn percentages, treasury allowlists | `config/stake-manager.json` | `npm run owner:update-all -- --only stakeManager` | `npm run owner:verify-control -- --modules stakeManager` |
+| **Energy oracle** | Signer roster, quorum thresholds, reporting cadence, commit/reveal windows | `config/energy-oracle.json`, `config/randao-coordinator.json` | `npm run owner:update-all -- --only energyOracle,randao` | `npm run owner:pulse -- --network <network>` |
+| **System pause & governance** | Pauser handoff, module wiring, guardian rotation | `config/system-pause.json`, `config/owner-control.json` | `npx hardhat run scripts/v2/updateSystemPause.ts --network <network> --execute` | `npm run owner:verify-control -- --modules systemPause`<br>`npx hardhat run scripts/v2/updateSystemPause.ts --network <network> --status` |
+| **Tax policy** | Custom tax slabs, exemptions, metadata strings | `config/tax-policy.json` | `npm run owner:update-all -- --only taxPolicy` | `npm run owner:verify-control -- --modules taxPolicy` |
+| **Attestation** | ENS validator/agent overrides, emergency allowlists | `config/identity-registry.json` | `npm run owner:update-all -- --only identityRegistry` | `npm run owner:verify-control -- --modules identityRegistry` |
+
+> **Per-network overrides:** When a directory like `config/mainnet/` exists, the owner tooling automatically merges it with the base manifest. Always edit the network-specific file for production deployments so your staging defaults remain untouched.
+
+---
+
+## Daily driver checklist
+
+1. `npm run owner:surface -- --network <network>` to render the active parameter map and highlight mutable knobs.
+2. `npm run owner:doctor -- --network <network>` for readiness; rerun until it reports only ✅ entries (or acceptable ⚠ warnings).
+3. `npm run owner:plan -- --network <network>` to preview the Hardhat transactions with human-readable annotations.
+4. Capture approvals and multisig sign-offs using the [Owner Control Change Ticket](owner-control-change-ticket.md) template.
+5. Execute with `npm run owner:update-all -- --network <network> --only <modules> --execute` once approvals land.
+6. `npm run owner:verify-control -- --network <network>` to confirm the chain matches your manifests.
+7. Archive artefacts using `npm run owner:audit -- --network <network> --out reports/<network>-owner-audit.md`.
+
+---
+
+## Cross-links
+
+- [Owner Control Surface Snapshot](owner-control-surface-snapshot.md) – quick visual map of every governance touchpoint.
+- [Owner Control Blueprint](owner-control-blueprint.md) – step-by-step execution guide with sign-off milestones.
+- [Owner Control Parameter Playbook](owner-control-parameter-playbook.md) – granular breakdown of each adjustable field.
+- [Owner Control Verification Guide](owner-control-verification.md) – detailed post-change validation drills.
+- [Owner Control Snapshot Kit](owner-control-snapshot-kit.md) – automation patterns for archiving parameter states.
+
+Keep this index bookmarked inside the owner’s runbook so non-technical operators can jump directly to the relevant manuals.

--- a/docs/owner-control-snapshot-kit.md
+++ b/docs/owner-control-snapshot-kit.md
@@ -1,0 +1,80 @@
+# Owner Control Snapshot Kit
+
+> **Goal:** Capture, diff, and archive the full governance surface before and after every change window without manual copy/paste.
+>
+> **Audience:** Contract owners, ops leads, risk teams who need evidence packages for audits and incident response.
+
+---
+
+## Snapshot pipeline overview
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant CLI as owner:snapshot
+    participant Disk as reports/
+    participant Repo as Git history
+
+    Operator->>CLI: npm run owner:snapshot -- --network <network>
+    CLI->>Disk: Write Markdown dossier + manifest
+    CLI->>Disk: Copy config/*.json with SHA-256 hashes
+    Operator->>Repo: Commit snapshot artefacts
+    Operator->>Risk: Share permalink / artefacts
+```
+
+The `owner:snapshot` helper fans out across every `config/*.json` manifest (plus per-network overrides) and records:
+
+- **Effective parameter tables** – resolved values after merging overrides.
+- **Contract wiring** – owner, pauser, and treasury addresses with ENS labels when available.
+- **Change detection hashes** – SHA-256 of each manifest so auditors can prove no hidden edits occurred between approval and execution.
+- **Regeneration commands** – copy/paste references to rerun `owner:verify-control` or targeted automation.
+
+---
+
+## Command reference
+
+```bash
+# Default console output + snapshot directory under reports/<network>/
+npm run owner:snapshot -- --network <network>
+
+# Persist to a custom directory
+npm run owner:snapshot -- --network mainnet --out reports/mainnet/control-kit
+
+# Skip Mermaid diagrams (for PDF exports)
+npm run owner:snapshot -- --network mainnet --no-mermaid
+```
+
+Flags supported today:
+
+| Flag | Description |
+| --- | --- |
+| `--network <name>` | Selects the Hardhat network configuration and merges `config/<name>/` overrides. |
+| `--out <path>` / `--output <path>` | Saves the snapshot folder to a custom location. The helper creates the directory if it does not exist. |
+| `--no-mermaid` | Omits Mermaid diagrams from the Markdown briefing for compatibility with restrictive PDF converters. |
+| `--help` | Prints usage information and exits. |
+
+Snapshot output includes:
+
+- `README.md` – executive briefing with subsystem breakdowns and embedded checklists.
+- `manifest.json` – machine-readable listing of each subsystem, source path, SHA-256 hash, regeneration commands, and verification hints.
+- `configs/` – exact copies of every config file consumed while generating the kit, preserving per-network overrides.
+
+---
+
+## Embedding in approvals
+
+1. Generate a **pre-change** snapshot and attach it to the [Owner Control Change Ticket](owner-control-change-ticket.md).
+2. Secure approvals and signatures referencing the snapshot’s SHA-256 manifest hashes.
+3. Execute the approved plan using `npm run owner:update-all -- --network <network> --only <modules> --execute`.
+4. Generate a **post-change** snapshot; compare the `manifest.json` hashes with `jq '.files[] | {id, sha256}'` to confirm only expected domains changed.
+5. Store both artefacts in your compliance drive and link them from the ticket or incident report.
+
+---
+
+## Integration ideas
+
+- **CI gating:** Run the helper inside the `ci (v2)` workflow on release branches and upload the snapshot directory as an artefact so reviewers can inspect effective parameters before approving a deploy.
+- **Monitoring:** Schedule hourly snapshots on production; trigger alerts if any subsystem hash drifts without a matching change ticket.
+- **Incident response:** Use descriptive output paths (`--out reports/mainnet/outage-2024-09-14`) to preserve the exact configuration active during emergency freezes.
+
+Cross-reference the [Owner Control Verification Guide](owner-control-verification.md) to confirm on-chain state matches the archived snapshots, and pair with the [Owner Control Doctor](owner-control-doctor.md) for pre-change readiness checks.

--- a/docs/owner-control-surface-snapshot.md
+++ b/docs/owner-control-surface-snapshot.md
@@ -1,0 +1,63 @@
+# Owner Control Surface Snapshot
+
+> **Objective:** Give stakeholders a fast, visual understanding of every governance lever the contract owner can pull across AGI Jobs v2.
+>
+> **Use cases:** Executive briefings, onboarding decks, change window kick-offs, due diligence packets.
+
+---
+
+## At-a-glance map
+
+```mermaid
+mindmap
+  root((AGI Jobs v2 Owner Surface))
+    Tokenomics
+      RewardEngineMB
+      Thermostat
+      FeePool
+    Job Lifecycle
+      JobRegistry
+      ValidationModule
+      IdentityRegistry
+    Capital Flows
+      StakeManager
+      SystemPause
+      Treasury routes
+    Signals & Oracles
+      EnergyOracle
+      RewardEngineMB::Thermodynamics
+    Tooling
+      owner:surface
+      owner:doctor
+      owner:update-all
+      owner:verify-control
+```
+
+---
+
+## Surface checklist
+
+| Layer | Primary knobs | Artefact | Change helper | Verification |
+| --- | --- | --- | --- | --- |
+| **Governance root** | `owner`, `guardian`, `pauser` addresses | `config/owner-control.json` | `npm run owner:rotate -- --network <network>` | `npm run owner:verify-control -- --network <network>` |
+| **Safety net** | `SystemPause` wiring, module pause status | `config/system-pause.json` | `npx hardhat run scripts/v2/updateSystemPause.ts --network <network> --execute` | `npm run owner:verify-control -- --modules systemPause`<br>`npx hardhat run scripts/v2/updateSystemPause.ts --network <network> --status` |
+| **Economic parameters** | Thermodynamic shares, PID, burns, treasuries | `config/thermodynamics.json` (thermostat block), `config/fee-pool.json` | `npm run owner:update-all -- --only rewardEngine,thermostat,feePool` | `npm run owner:verify-control -- --modules rewardEngine,thermostat,feePool` |
+| **Market access** | Job fees, escrow stake, identity roots, emergency allowlists | `config/job-registry.json`, `config/identity-registry.json` | `npm run owner:update-all -- --only jobRegistry,identityRegistry` | `npm run owner:verify-control -- --modules jobRegistry,identityRegistry` |
+| **Capital risk** | Min stakes, fee splits, treasury allowlists | `config/stake-manager.json` | `npm run owner:update-all -- --only stakeManager` | `npm run owner:verify-control -- --modules stakeManager` |
+| **Signal integrity** | Oracle signers, commit/reveal windows, quorum | `config/energy-oracle.json`, `config/randao-coordinator.json` | `npm run owner:update-all -- --only energyOracle,randao` | `npm run owner:pulse -- --network <network>` |
+| **Taxation** | Policy metadata, brackets, exemptions | `config/tax-policy.json` | `npm run owner:update-all -- --only taxPolicy` | `npm run owner:verify-control -- --modules taxPolicy` |
+
+> **Tip:** Run `npm run owner:surface -- --network <network>` before every change window; the command emits an updated version of this table with live addresses, ENS labels, and pending TODOs.
+
+---
+
+## Operating rhythm
+
+1. **Visualise:** Start with `owner:surface` output or embed the Mermaid mind map above into meeting slides.
+2. **Assess readiness:** Execute `owner:doctor` to highlight incomplete wiring or zeroed parameters.
+3. **Plan:** Use `owner:plan` to simulate exact transaction payloads, copy the diff table into the [Owner Control Change Ticket](owner-control-change-ticket.md).
+4. **Execute:** `owner:update-all` with scoped modules and `--execute` once approvals land.
+5. **Verify:** `owner:verify-control` plus targeted scripts from the [Owner Control Verification Guide](owner-control-verification.md).
+6. **Archive:** Snapshots via the [Owner Control Snapshot Kit](owner-control-snapshot-kit.md).
+
+This snapshot is deliberately lightweight: print it, share it with exec sponsors, and use it as the first step in any governance change conversation.

--- a/docs/owner-control-verification.md
+++ b/docs/owner-control-verification.md
@@ -1,0 +1,92 @@
+# Owner Control Verification Guide
+
+> **Mission:** Prove that on-chain state matches the approved manifests immediately after an owner change—and keep those proofs organised for auditors.
+>
+> **Audience:** Contract owners, reviewers, internal audit, site reliability engineers.
+
+---
+
+## Verification strategy
+
+1. **Config truth source** – the JSON manifests in `config/` (plus per-network overrides).
+2. **Execution receipts** – transaction hashes produced by `owner:update-all` or targeted Hardhat scripts.
+3. **On-chain checks** – read-only calls driven by `owner:verify-control` and supporting scripts.
+4. **Evidence bundle** – Markdown/JSON exports stored under `reports/` and linked from the change ticket.
+
+```mermaid
+flowchart TD
+    Manifest[config/*.json] -->|plan| Update[npm run owner:update-all]
+    Update --> Tx[Transaction receipts]
+    Manifest --> Verify[npm run owner:verify-control]
+    Tx --> Verify
+    Verify --> Evidence[reports/<network>-owner-verify*.json]
+    Evidence --> Audit[Compliance archive]
+```
+
+---
+
+## Core command
+
+```bash
+# Console summary
+npm run owner:verify-control -- --network <network>
+
+# JSON output for diffing or CI bots
+npm run owner:verify-control -- --network <network> --json > reports/<network>-verify.json
+
+# Strict mode (non-zero exit code on mismatches)
+npm run owner:verify-control -- --network <network> --strict
+```
+
+Available scopes and overrides:
+
+| Flag | Description |
+| --- | --- |
+| `--modules rewardEngine,stakeManager,…` | Restrict checks to specific modules (comma separated). Use the exact keys from `config/owner-control.json` such as `rewardEngine`, `thermostat`, `feePool`, `jobRegistry`, `identityRegistry`, `stakeManager`, `systemPause`, `taxPolicy`, etc. |
+| `--skip rewardEngine,…` | Exclude modules temporarily (use sparingly and document the reason in your ticket). |
+| `--address-book <path>` | Point at an alternative deployment record (defaults to `docs/deployment-addresses.json`). |
+| `--address module=0x…` | Override a single module address for the current run; supports multiple invocations. |
+| `--config-network <name>` | Force the loader to merge `config/<name>/` overrides when Hardhat is connected to a different network. |
+| Environment variables | `OWNER_VERIFY_MODULES`, `OWNER_VERIFY_SKIP`, `OWNER_VERIFY_STRICT`, `OWNER_VERIFY_ADDRESS_OVERRIDES`, etc. mirror the CLI flags for automation. |
+
+The command prints a summary banner, per-module diff tables, and remediation hints (`npm run owner:update-all -- --only …`) so non-technical operators can resolve drift quickly.
+
+---
+
+## Companion tooling
+
+| Goal | Command |
+| --- | --- |
+| Render the current control surface | `npm run owner:surface -- --network <network>` |
+| Inspect staking/fee parameters | `npm run owner:parameters -- --network <network>` |
+| Audit ENS and emergency allowlists | `npx hardhat run scripts/v2/auditIdentityRegistry.ts --network <network>` |
+| Capture tamper-evident dossier | `npm run owner:snapshot -- --network <network>` |
+| Generate change ticket template | `npm run owner:change-ticket -- --network <network>` |
+
+Use these helpers alongside `owner:verify-control` to build an evidence package that survives legal, compliance, and security review.
+
+---
+
+## Evidence workflow
+
+1. Run the verifier in both human and JSON modes:
+   ```bash
+   npm run owner:verify-control -- --network mainnet
+   npm run owner:verify-control -- --network mainnet --json > reports/mainnet-verify-$(date +%Y%m%d).json
+   ```
+2. Append the JSON artefact and console transcript to the [Owner Control Change Ticket](owner-control-change-ticket.md).
+3. Cross-reference the recorded transaction hashes from `owner:update-all` in the ticket body. Ensure they match the modules marked as updated.
+4. Store the outputs next to the [Owner Control Snapshot Kit](owner-control-snapshot-kit.md) directory for the same change window.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+| --- | --- | --- |
+| Module shows `expected 0x…` vs `actual 0x…` | Wrong address in deployment record | Update `docs/deployment-addresses.json` (or your alternate address book) and re-run; broadcast a fix if the on-chain owner is wrong. |
+| `No address configured for module` warning | Missing entry in manifest | Add the module address to `config/owner-control.json` or supply `--address module=…`. |
+| CLI exits 1 with `Ownership pending acceptance` | `Ownable2Step` transfer not finalised | Complete `acceptOwnership` on the target contract, then rerun verification. |
+| JSON output empty | `--modules` filtered out all checks | Remove conflicting filters or provide a broader module list. |
+
+Pair this guide with the [Owner Control Doctor](owner-control-doctor.md) for pre-change readiness and the [Owner Control Snapshot Kit](owner-control-snapshot-kit.md) for archival proofs to maintain an end-to-end assurance trail.


### PR DESCRIPTION
## Summary
- add Owner Control Index, Snapshot Kit, Surface Snapshot, and Verification guide documents with updated workflows and diagrams
- refresh README owner-control sections to point at the new guides and highlight the verification handbook

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e68539f984833391067f53c13c8dd0