### PR TITLE
Improve agent gateway Docker build resilience

### DIFF
--- a/agent-gateway/Dockerfile
+++ b/agent-gateway/Dockerfile
@@ -1,23 +1,31 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20-alpine AS builder
+FROM node:20-alpine AS base
 WORKDIR /app
 RUN apk add --no-cache python3 make g++ \
     && ln -sf python3 /usr/bin/python
-ENV PYTHON=/usr/bin/python3
+ENV PYTHON=/usr/bin/python3 \
+    NPM_CONFIG_AUDIT=false \
+    NPM_CONFIG_FUND=false \
+    NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=180000 \
+    NPM_CONFIG_FETCH_TIMEOUT=600000 \
+    NPM_CI_MAX_ATTEMPTS=5 \
+    NPM_CI_RETRY_DELAY=10
+COPY scripts/docker/npm-ci-retry.sh /usr/local/bin/npm-ci-retry.sh
+RUN chmod +x /usr/local/bin/npm-ci-retry.sh
+
+FROM base AS builder
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm-ci-retry.sh
 COPY . .
 RUN npm run build:gateway
 
-FROM node:20-alpine AS runner
-WORKDIR /app
+FROM base AS runner
 ENV NODE_ENV=production
-RUN apk add --no-cache python3 make g++ \
-    && ln -sf python3 /usr/bin/python
-ENV PYTHON=/usr/bin/python3
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm-ci-retry.sh --omit=dev
 COPY --from=builder /app/agent-gateway/dist ./agent-gateway/dist
 COPY --from=builder /app/scripts/start-telemetry.sh ./scripts/start-telemetry.sh
 RUN chmod +x ./scripts/start-telemetry.sh

--- a/scripts/docker/npm-ci-retry.sh
+++ b/scripts/docker/npm-ci-retry.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -euo pipefail
+
+attempt=1
+max_attempts=${NPM_CI_MAX_ATTEMPTS:-5}
+base_delay=${NPM_CI_RETRY_DELAY:-5}
+
+while [ "$attempt" -le "$max_attempts" ]; do
+  rm -rf node_modules
+
+  if npm ci "$@"; then
+    exit 0
+  fi
+
+  if [ "$attempt" -eq "$max_attempts" ]; then
+    echo "npm ci failed after ${max_attempts} attempts" >&2
+    exit 1
+  fi
+
+  attempt=$((attempt + 1))
+  wait_time=$((base_delay * attempt))
+  echo "npm ci failed, retrying in ${wait_time}s (attempt ${attempt}/${max_attempts})" >&2
+  sleep "$wait_time"
+done


### PR DESCRIPTION
## Summary
- add a shared base image layer that configures resilient npm networking defaults for both build and runtime stages
- introduce a reusable npm install helper with retries and backoff to stabilise multi-arch Docker builds

## Testing
- npm run build:gateway

------
https://chatgpt.com/codex/tasks/task_e_68e6a455bc808333935a98bffbcd57aa