### PR TITLE
Improve orchestrator Docker build npm reliability

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+fetch-retries=5
+fetch-retry-mintimeout=20000
+fetch-retry-maxtimeout=120000
+fetch-timeout=120000
+registry=https://registry.npmjs.org/

--- a/deploy/docker/orchestrator.Dockerfile
+++ b/deploy/docker/orchestrator.Dockerfile
@@ -1,7 +1,15 @@
 FROM node:20-alpine AS build
 WORKDIR /srv/app
+
+# Increase npm network resiliency to avoid transient registry outages during CI.
+ENV \
+    NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 \
+    NPM_CONFIG_FETCH_TIMEOUT=120000
+
 RUN apk add --no-cache python3 make g++
-COPY package*.json ./
+COPY package*.json .npmrc ./
 RUN npm ci
 COPY . .
 RUN npx tsc -p apps/orchestrator/tsconfig.json
@@ -9,8 +17,16 @@ RUN npx tsc -p apps/orchestrator/tsconfig.json
 FROM node:20-alpine
 WORKDIR /srv/app
 ENV NODE_ENV=production
+
+# Reuse npm network configuration in the runtime image as well.
+ENV \
+    NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 \
+    NPM_CONFIG_FETCH_TIMEOUT=120000
+
 RUN apk add --no-cache python3 make g++
-COPY package*.json ./
+COPY package*.json .npmrc ./
 RUN npm ci --omit=dev
 COPY --from=build /srv/app/apps/orchestrator/dist ./apps/orchestrator/dist
 COPY --from=build /srv/app/apps/orchestrator/*.json ./apps/orchestrator/


### PR DESCRIPTION
## Summary
- add default npm network retry configuration for the orchestrator image build and runtime stages
- include the shared .npmrc in Docker builds to reduce transient registry failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6f247d1a08333ad6476442d698540