### PR TITLE
docs: document CI v2 branch protection audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ flowchart LR
 
 Branch protection can now point at the `CI summary` check so that every job listed above must succeed before merges or deployments proceed. A non-technical maintainer can follow the [CI v2 operations guide](docs/v2-ci-operations.md) for a diagrammed overview of the workflow, required status checks, and day-to-day troubleshooting steps.
 
+### Branch protection self-test
+
+Keep the enforcement proof close at hand by running a quick audit whenever GitHub updates workflow metadata or a new maintainer joins the project:
+
+1. Visit **Settings → Branches → Branch protection rules → main** and confirm the five required contexts match the workflow job names exactly: `ci (v2) / Lint & static checks`, `ci (v2) / Tests`, `ci (v2) / Foundry`, `ci (v2) / Coverage thresholds`, and `ci (v2) / CI summary`. The names must stay in lockstep with the [`ci.yml` job definitions](.github/workflows/ci.yml).
+2. From the terminal, run `gh api repos/:owner/:repo/branches/main/protection --jq '{required_status_checks: .required_status_checks.contexts}'` and verify the output lists the same five contexts in order. Repeat with `gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled'` to ensure administrators cannot bypass the checks.
+3. Open the latest **ci (v2)** run under **Actions** and confirm the `CI summary` job reports every upstream result. The summary gate must remain required in branch protection so non-technical reviewers see a single ✅/❌ indicator.
+
+For a printable walkthrough (including remediation steps when a context drifts), use the [CI v2 branch protection checklist](docs/ci-v2-branch-protection-checklist.md).
+
 ## Table of Contents
 
 - [Identity policy](#identity-policy)

--- a/docs/ci-v2-branch-protection-checklist.md
+++ b/docs/ci-v2-branch-protection-checklist.md
@@ -1,0 +1,76 @@
+# CI v2 Branch Protection Checklist
+
+> **Audience:** Repository administrators, release captains, and governance stewards who must prove that the "ci (v2)" workflow is fully enforced on `main`.
+>
+> **Goal:** Provide a repeatable audit that verifies branch protection mirrors the workflow job names, that administrators cannot bypass checks, and that the CI summary gate remains the single source of truth for non-technical reviewers.
+
+---
+
+## Required status contexts
+
+| Context | Source job | Why it matters |
+| --- | --- | --- |
+| `ci (v2) / Lint & static checks` | [`lint`](../.github/workflows/ci.yml) | Blocks merges when formatting, ESLint, or Solhint find issues before tests run.【F:.github/workflows/ci.yml†L28-L60】 |
+| `ci (v2) / Tests` | [`tests`](../.github/workflows/ci.yml) | Runs Hardhat compilation, the unit test suite, ABI drift detection, and constants regeneration.【F:.github/workflows/ci.yml†L62-L116】 |
+| `ci (v2) / Foundry` | [`foundry`](../.github/workflows/ci.yml) | Executes fuzz tests after unit tests, even when they fail, to expose property violations.【F:.github/workflows/ci.yml†L118-L165】 |
+| `ci (v2) / Coverage thresholds` | [`coverage`](../.github/workflows/ci.yml) | Enforces ≥90 % coverage and access-control reporting while publishing LCOV artifacts.【F:.github/workflows/ci.yml†L167-L216】 |
+| `ci (v2) / CI summary` | [`summary`](../.github/workflows/ci.yml) | Aggregates upstream job results into a single ✅/❌ indicator required by branch protection.【F:.github/workflows/ci.yml†L218-L233】 |
+
+The job display names in GitHub Actions must stay in sync with these contexts. Any rename requires updating branch protection and this checklist.
+
+---
+
+## Verification steps
+
+### 1. Inspect branch protection in the GitHub UI
+
+1. Navigate to **Settings → Branches**.
+2. Edit the rule that applies to `main`.
+3. Under **Require status checks to pass before merging**, verify the five contexts above appear in the list, in order.
+4. Confirm **Require branches to be up to date before merging** and **Include administrators** are enabled. Both are required for audit compliance.
+5. Capture a screenshot or export the configuration for your change-control records.
+
+### 2. Confirm enforcement with the GitHub CLI
+
+Run these commands from a workstation authenticated with the `gh` CLI:
+
+```bash
+gh api repos/:owner/:repo/branches/main/protection --jq '{required_status_checks: .required_status_checks.contexts}'
+gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled'
+```
+
+- The first command must output the five contexts exactly as listed in the table above.
+- The second must print `true`, proving administrators cannot bypass the checks.
+- Record the command output (copy/paste or redirect to a dated text file) for auditors.
+
+### 3. Validate the CI summary gate
+
+1. Open **Actions → ci (v2)** and select the latest successful run on `main`.
+2. Verify the `CI summary` job lists every upstream job (Lint, Tests, Foundry, Coverage) with matching outcomes.
+3. Confirm the job is marked as **Required** in the run header. If it is missing, update branch protection immediately and re-run the workflow to refresh the badge.
+4. When troubleshooting, re-run the workflow with **Re-run failed jobs** so historical logs remain intact for incident reviews.
+
+### 4. Double-check companion workflows
+
+If your governance policy also requires `e2e`, `fuzz`, `webapp`, or `containers` workflows, repeat the UI and CLI verification to ensure their contexts are enforced. Document any optional workflows in the change ticket associated with the release.
+
+---
+
+## Remediation playbook
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| A context is missing from the CLI output | Workflow job renamed or branch rule edited | Update the branch rule via GitHub UI or `gh api`, then rerun this checklist. |
+| `CI summary` not marked as required | Branch rule removed the summary context | Add `ci (v2) / CI summary` back to the required list and save. |
+| Administrators can merge with red checks | **Include administrators** disabled | Enable the toggle and document the change in `owner-control-change-ticket.md`. |
+| Workflow run shows stale job names | Cached UI state | Refresh the page or open the run in a private window to confirm the latest metadata. |
+
+---
+
+## Change management
+
+- Run this checklist whenever `.github/workflows/ci.yml` changes job names or when GitHub introduces new workflow UI features.
+- Store completed checklists (including CLI outputs) in the governance document vault referenced by the [Production Readiness Index](production/deployment-readiness-index.md).
+- Update this document in the same pull request that changes workflow job names so auditors have a single source of truth.
+
+Maintaining this checklist alongside the CI v2 operations guide keeps branch protection verifiable for non-technical owners and satisfies the "fully green" enforcement requirement mandated by REDENOMINATION.


### PR DESCRIPTION
## Summary
- add a README branch-protection self-test so maintainers can quickly confirm ci (v2) enforcement
- publish a dedicated CI v2 branch protection checklist covering required contexts, CLI verification, and remediation steps

## Testing
- npm run lint:ci

------
https://chatgpt.com/codex/tasks/task_e_68e705118bdc8333abc9366f2e5f9e74