### PR TITLE
Increase npm network resiliency for orchestrator builds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,5 @@
-fetch-retries=5
+fetch-retries=10
 fetch-retry-mintimeout=20000
-fetch-retry-maxtimeout=120000
-fetch-timeout=120000
+fetch-retry-maxtimeout=300000
+fetch-timeout=600000
 registry=https://registry.npmjs.org/

--- a/deploy/docker/orchestrator.Dockerfile
+++ b/deploy/docker/orchestrator.Dockerfile
@@ -3,10 +3,10 @@ WORKDIR /srv/app
 
 # Increase npm network resiliency to avoid transient registry outages during CI.
 ENV \
-    NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRIES=10 \
     NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
-    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 \
-    NPM_CONFIG_FETCH_TIMEOUT=120000
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=300000 \
+    NPM_CONFIG_FETCH_TIMEOUT=600000
 
 RUN apk add --no-cache python3 make g++
 COPY package*.json .npmrc ./
@@ -20,10 +20,10 @@ ENV NODE_ENV=production
 
 # Reuse npm network configuration in the runtime image as well.
 ENV \
-    NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRIES=10 \
     NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
-    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 \
-    NPM_CONFIG_FETCH_TIMEOUT=120000
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=300000 \
+    NPM_CONFIG_FETCH_TIMEOUT=600000
 
 RUN apk add --no-cache python3 make g++
 COPY package*.json .npmrc ./


### PR DESCRIPTION
## Summary
- raise npm fetch retries and timeouts to better tolerate transient registry latency during orchestrator builds
- propagate the hardened npm network configuration into the orchestrator Docker build and runtime stages for consistent behavior

## Testing
- npm run lint:ci


------
https://chatgpt.com/codex/tasks/task_e_68e7a6a3c4388333955747bd4b10396e