### PR TITLE
Document and script continuous learning refresh workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "owner:blueprint": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlBlueprint.ts",
     "owner:snapshot": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerControlSnapshot.ts",
     "observability:smoke": "node scripts/observability-smoke-check.js",
+    "learning:refresh": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/train/updateModels.ts --once",
+    "learning:retrain": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/retrainAgent.ts",
     "owner:verify-control": "npx hardhat run --no-compile scripts/v2/verifyOwnerControl.ts",
     "owner:pulse": "npx hardhat run --no-compile scripts/v2/ownerControlPulse.ts",
     "owner:rotate": "npx hardhat run --no-compile scripts/v2/rotateGovernance.ts",


### PR DESCRIPTION
## Summary
- add npm scripts so operators can rerun the continuous learning model refresh and agent retraining loops with a single command
- update the ASI feasibility verification suite to reference the new commands, capture audit artefacts, and reinforce triple-review expectations

## Testing
- npm ci
- npm run learning:refresh

------
https://chatgpt.com/codex/tasks/task_e_68e7f0df8d208333ba969c7df91c51d3