### PR TITLE
Add workflow context auditor script for CI v2 branch protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ scripts/**/*.js
 !scripts/ci/export-abis.js
 !scripts/ci/abi-targets.js
 !scripts/ci/remap-coverage-paths.js
+!scripts/ci/list-required-contexts.js
 !scripts/verify-wiring.js
 !scripts/run-wire-verify.js
 !scripts/subgraph-e2e.js

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Branch protection can now point at the `CI summary` check so that every job list
 
 Keep the enforcement proof close at hand by running a quick audit whenever GitHub updates workflow metadata or a new maintainer joins the project:
 
-1. Visit **Settings → Branches → Branch protection rules → main** and confirm the five required contexts match the workflow job names exactly: `ci (v2) / Lint & static checks`, `ci (v2) / Tests`, `ci (v2) / Foundry`, `ci (v2) / Coverage thresholds`, and `ci (v2) / CI summary`. The names must stay in lockstep with the [`ci.yml` job definitions](.github/workflows/ci.yml).
-2. From the terminal, run `gh api repos/:owner/:repo/branches/main/protection --jq '{required_status_checks: .required_status_checks.contexts}'` and verify the output lists the same five contexts in order. Repeat with `gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled'` to ensure administrators cannot bypass the checks.
-3. Open the latest **ci (v2)** run under **Actions** and confirm the `CI summary` job reports every upstream result. The summary gate must remain required in branch protection so non-technical reviewers see a single ✅/❌ indicator.
+1. Generate the canonical status check names and dependency graph straight from the workflow with `node scripts/ci/list-required-contexts.js`. The script fails if `foundry`, `coverage`, or `summary` ever lose their `always()` guards or if the summary gate stops depending on every upstream job.
+2. Visit **Settings → Branches → Branch protection rules → main** and confirm the five required contexts match the workflow job names printed in step&nbsp;1: `ci (v2) / Lint & static checks`, `ci (v2) / Tests`, `ci (v2) / Foundry`, `ci (v2) / Coverage thresholds`, and `ci (v2) / CI summary`. The names must stay in lockstep with the [`ci.yml` job definitions](.github/workflows/ci.yml).
+3. From the terminal, run `gh api repos/:owner/:repo/branches/main/protection --jq '{required_status_checks: .required_status_checks.contexts}'` and verify the output lists the same five contexts in order. Repeat with `gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled'` to ensure administrators cannot bypass the checks.
+4. Open the latest **ci (v2)** run under **Actions** and confirm the `CI summary` job reports every upstream result. The summary gate must remain required in branch protection so non-technical reviewers see a single ✅/❌ indicator.
 
 For a printable walkthrough (including remediation steps when a context drifts), use the [CI v2 branch protection checklist](docs/ci-v2-branch-protection-checklist.md).
 

--- a/docs/ci-v2-branch-protection-checklist.md
+++ b/docs/ci-v2-branch-protection-checklist.md
@@ -22,6 +22,16 @@ The job display names in GitHub Actions must stay in sync with these contexts. A
 
 ## Verification steps
 
+### 0. Derive canonical contexts from the workflow
+
+```bash
+node scripts/ci/list-required-contexts.js --json
+```
+
+- Produces the authoritative list of status contexts that branch protection must enforce.
+- Exits non-zero if `foundry`, `coverage`, or `summary` ever lose their `if: ${{ always() }}` guard.
+- Verifies the `summary` gate depends on `lint`, `tests`, `foundry`, and `coverage` before you compare GitHub settings.
+
 ### 1. Inspect branch protection in the GitHub UI
 
 1. Navigate to **Settings → Branches**.

--- a/docs/v2-ci-operations.md
+++ b/docs/v2-ci-operations.md
@@ -54,6 +54,14 @@ Enable branch protection on `main` with these required status checks (copy the c
 After applying or updating branch protection rules, verify them without leaving the terminal:
 
 ```bash
+node scripts/ci/list-required-contexts.js
+```
+
+- Confirms the canonical status check names emitted by the workflow itself.
+- Fails fast if the `foundry`, `coverage`, or `summary` jobs drop their `if: ${{ always() }}` guard.
+- Ensures the `summary` gate continues to depend on `lint`, `tests`, `foundry`, and `coverage`.
+
+```bash
 gh api repos/:owner/:repo/branches/main/protection --jq '{required_status_checks: .required_status_checks.contexts}'
 gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled'
 ```

--- a/scripts/ci/list-required-contexts.js
+++ b/scripts/ci/list-required-contexts.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_RELATIVE_PATH = path.join('..', '..', '.github', 'workflows', 'ci.yml');
+
+function loadWorkflowContents() {
+  const workflowPath = path.join(__dirname, WORKFLOW_RELATIVE_PATH);
+  return fs.readFileSync(workflowPath, 'utf8');
+}
+
+function extractWorkflowName(contents) {
+  const match = contents.match(/^name:\s*(.+)$/m);
+  if (!match) {
+    throw new Error('Unable to locate workflow name in ci.yml');
+  }
+  return match[1].trim();
+}
+
+function normalizeValue(value) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  if ((trimmed.startsWith("'") && trimmed.endsWith("'")) || (trimmed.startsWith('"') && trimmed.endsWith('"'))) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function parseJobs(contents) {
+  const lines = contents.split(/\r?\n/);
+  const jobs = [];
+  let inJobsSection = false;
+  let currentJob = null;
+  let collectingNeeds = false;
+  let needsIndent = 0;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const indentMatch = line.match(/^(\s*)/);
+    const indent = indentMatch ? indentMatch[1].length : 0;
+    const trimmed = line.trim();
+
+    if (!inJobsSection) {
+      if (trimmed === 'jobs:') {
+        inJobsSection = true;
+      }
+      continue;
+    }
+
+    if (indent === 0 && trimmed && trimmed !== 'jobs:') {
+      if (currentJob) {
+        jobs.push(currentJob);
+      }
+      break;
+    }
+
+    if (collectingNeeds) {
+      if (!trimmed) {
+        continue;
+      }
+      if (indent <= needsIndent || !trimmed.startsWith('- ')) {
+        collectingNeeds = false;
+        // Re-process the current line outside of the needs block.
+        index -= 1;
+        continue;
+      }
+      const need = normalizeValue(trimmed.slice(2));
+      if (need) {
+        currentJob.needs.push(need);
+      }
+      continue;
+    }
+
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const jobMatch = line.match(/^\s{2}([A-Za-z0-9_-]+):/);
+    if (jobMatch) {
+      if (currentJob) {
+        jobs.push(currentJob);
+      }
+      currentJob = {
+        id: jobMatch[1],
+        name: '',
+        needs: [],
+        ifCondition: '',
+      };
+      continue;
+    }
+
+    if (!currentJob) {
+      continue;
+    }
+
+    const nameMatch = line.match(/^\s{4}name:\s*(.+)$/);
+    if (nameMatch) {
+      currentJob.name = normalizeValue(nameMatch[1]);
+      continue;
+    }
+
+    const ifMatch = line.match(/^\s{4}if:\s*(.+)$/);
+    if (ifMatch) {
+      currentJob.ifCondition = ifMatch[1].trim();
+      continue;
+    }
+
+    const needsMatch = line.match(/^\s{4}needs:\s*(.*)$/);
+    if (needsMatch) {
+      const inlineValue = normalizeValue(needsMatch[1]);
+      if (inlineValue) {
+        inlineValue
+          .replace(/[\[\]]/g, '')
+          .split(',')
+          .map((part) => normalizeValue(part))
+          .filter(Boolean)
+          .forEach((value) => currentJob.needs.push(value));
+      } else {
+        collectingNeeds = true;
+        needsIndent = indent;
+      }
+      continue;
+    }
+  }
+
+  if (currentJob) {
+    jobs.push(currentJob);
+  }
+
+  return jobs;
+}
+
+function formatContexts(workflowName, jobs) {
+  return jobs
+    .filter((job) => job.name)
+    .map((job) => ({
+      id: job.id,
+      name: job.name,
+      context: `${workflowName} / ${job.name}`,
+      needs: job.needs.slice(),
+      ifCondition: job.ifCondition,
+    }));
+}
+
+function validateSummary(summaryJob, requiredUpstream) {
+  if (!summaryJob) {
+    throw new Error('Summary job not found in ci.yml');
+  }
+  const missing = requiredUpstream.filter((jobId) => !summaryJob.needs.includes(jobId));
+  if (missing.length > 0) {
+    throw new Error(
+      `Summary job is missing required dependencies: ${missing.join(', ')}`
+    );
+  }
+  if (!summaryJob.ifCondition.includes('always()')) {
+    throw new Error('Summary job must run with if: ${{ always() }}');
+  }
+}
+
+function validateAlwaysGuards(jobs, jobIds) {
+  for (const jobId of jobIds) {
+    const job = jobs.find((entry) => entry.id === jobId);
+    if (!job) {
+      throw new Error(`Expected job "${jobId}" not found in ci.yml`);
+    }
+    if (!job.ifCondition.includes('always()')) {
+      throw new Error(
+        `Job "${jobId}" must include an if guard with always(), found: ${job.ifCondition || '∅'}`
+      );
+    }
+  }
+}
+
+function validateDependencies(jobs, dependencyPairs) {
+  for (const [jobId, expectedNeeds] of dependencyPairs) {
+    const job = jobs.find((entry) => entry.id === jobId);
+    if (!job) {
+      throw new Error(`Expected job "${jobId}" not found in ci.yml`);
+    }
+    for (const expected of expectedNeeds) {
+      if (!job.needs.includes(expected)) {
+        throw new Error(
+          `Job "${jobId}" must depend on "${expected}" but the dependency was not found.`
+        );
+      }
+    }
+  }
+}
+
+function printHumanReadable(workflowName, contexts) {
+  console.log(`${workflowName} required status contexts`);
+  console.log('='.repeat(workflowName.length + 28));
+  for (const context of contexts) {
+    console.log(`- ${context.context}`);
+  }
+  const summary = contexts.find((entry) => entry.id === 'summary');
+  if (summary) {
+    console.log('\nSummary gate dependencies:');
+    for (const need of summary.needs) {
+      console.log(`  • ${need}`);
+    }
+  }
+}
+
+function main() {
+  try {
+    const args = new Set(process.argv.slice(2));
+    const asJson = args.has('--json');
+    const contents = loadWorkflowContents();
+    const workflowName = extractWorkflowName(contents);
+    const jobs = parseJobs(contents);
+    const contexts = formatContexts(workflowName, jobs);
+
+    validateSummary(
+      contexts.find((job) => job.id === 'summary'),
+      ['lint', 'tests', 'foundry', 'coverage']
+    );
+    validateAlwaysGuards(jobs, ['foundry', 'coverage', 'summary']);
+    validateDependencies(jobs, [
+      ['foundry', ['tests']],
+      ['coverage', ['tests']],
+    ]);
+
+    if (asJson) {
+      console.log(JSON.stringify(contexts, null, 2));
+    } else {
+      printHumanReadable(workflowName, contexts);
+    }
+  } catch (error) {
+    console.error(error.message || error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a CI helper that parses `.github/workflows/ci.yml`, prints the canonical status contexts, and enforces `always()`/dependency guards
- surface the helper throughout the README and CI v2 docs so non-technical owners can prove branch protection stays in sync
- allow the new helper script through `.gitignore` so it is tracked with the rest of the CI tooling

## Testing
- npm run lint:ci
- node scripts/ci/list-required-contexts.js
- node scripts/ci/list-required-contexts.js --json

------
https://chatgpt.com/codex/tasks/task_e_68e7ffca183883339a7e1a62d5ab7d82