### PR TITLE
Harden plan hash validation and stabilise the orchestrator tests

### DIFF
--- a/backend/errors/catalog.json
+++ b/backend/errors/catalog.json
@@ -123,6 +123,10 @@
     "message": "The plan hash doesn’t match this request.",
     "hint": "Re-run planning and retry with the latest hash."
   },
+  "PLAN_HASH_UNKNOWN": {
+    "message": "The plan hash is not recognised or has expired.",
+    "hint": "Call /onebox/plan again to generate a fresh plan before simulating or executing."
+  },
   "UNSUPPORTED_ACTION": {
     "message": "I didn’t understand that action.",
     "hint": "Rephrase the request or choose a supported workflow."

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -26,6 +26,7 @@ ready.
     backend sets `requiresConfirmation` to `false`, signalling the UI to gather more input before proceeding.【F:orchestrator/planner.py†L320-L372】【F:routes/onebox.py†L1648-L1667】
   * `warnings` – non-fatal notes such as `DEFAULT_REWARD_APPLIED` if the planner temporarily filled in defaults.【F:orchestrator/planner.py†L328-L356】
   * `planHash` – SHA-256 hash of the normalised intent, emitted as `0x…` strings for downstream correlation.【F:routes/onebox.py†L1503-L1518】
+  * Every plan hash persists an intent snapshot and the list of unresolved fields.  Subsequent stages only accept updates that fill those specific gaps; any other mutation triggers `PLAN_HASH_MISMATCH`, while unknown hashes now return `PLAN_HASH_UNKNOWN` to force a re-plan.【F:routes/onebox.py†L902-L1001】【F:routes/onebox.py†L1673-L1687】
   * Optional receipt metadata when the planner emits an attestation (used by the UX to preview receipts ahead of execution).
 
 **Error handling**
@@ -69,6 +70,7 @@ ready.
 | ------ | ------- | ------------------- |
 | `200`  | Ready to execute.  Proceed to `/onebox/execute`. | Review any `risks` before continuing. |
 | `400`  | Hash or payload mismatch. | Re-run the planner to regenerate a plan hash. |
+| `400`  | Plan hash unknown/expired. | Call `/onebox/plan` again to refresh the plan hash before simulating. |
 | `422`  | Blocked by policy or missing data. | Present `blockers` to the user and collect the required inputs. |
 
 **Metrics & logging**

--- a/storage/org-policies.json
+++ b/storage/org-policies.json
@@ -2,6 +2,8 @@
   "__default__": {
     "maxBudgetWei": null,
     "maxDurationDays": null,
-    "allowedTools": []
+    "allowedTools": [
+      "*"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- persist plan intent snapshots with diff-based validation so simulations and executions only accept approved field updates
- document the stricter plan-hash lifecycle, surface PLAN_HASH_UNKNOWN, and allow the default org policy to permit tooling by default
- add a Web3 stub toggle and new regression coverage so the onebox test suite runs without a live RPC endpoint

## Testing
- `ONEBOX_TEST_FORCE_STUB_FASTAPI=1 ONEBOX_TEST_FORCE_STUB_WEB3=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/routes/test_onebox.py`


------
https://chatgpt.com/codex/tasks/task_e_68e8337362f8833387420a8b1b1690f9