### PR TITLE
fix: upgrade openssl libs in gateway image

### DIFF
--- a/agent-gateway/Dockerfile
+++ b/agent-gateway/Dockerfile
@@ -3,6 +3,7 @@
 FROM node:20.18.1-alpine3.20 AS base-build
 WORKDIR /app
 RUN apk add --no-cache python3 make g++ \
+    && apk upgrade --no-cache libssl3 libcrypto3 \
     && ln -sf python3 /usr/bin/python
 ENV PYTHON=/usr/bin/python3 \
     NPM_CONFIG_AUDIT=false \
@@ -34,7 +35,8 @@ COPY --from=builder /app/package-lock.json ./
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/agent-gateway/dist ./agent-gateway/dist
 COPY --from=builder /app/scripts/start-telemetry.sh ./scripts/start-telemetry.sh
-RUN chmod +x ./scripts/start-telemetry.sh \
+RUN apk upgrade --no-cache libssl3 libcrypto3 \
+    && chmod +x ./scripts/start-telemetry.sh \
     && mkdir -p /app/storage /app/logs \
     && chown -R node:node /app
 USER node


### PR DESCRIPTION
## Summary
- upgrade libssl3 and libcrypto3 in the agent gateway Docker image to pick up the 3.3.3 patch release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8529bbf4c833395e8b52d27833577