### PR TITLE
Add regression test for simulator risk guidance deduplication

### DIFF
--- a/test/orchestrator/test_simulator.py
+++ b/test/orchestrator/test_simulator.py
@@ -69,6 +69,14 @@ def test_simulator_detects_missing_budget():
 
     assert "BUDGET_REQUIRED" in result.blockers
     assert "BUDGET_REQUIRED" in result.risks
+    assert any(
+        detail.get("code") == "BUDGET_REQUIRED"
+        and "Stake the minimum AGIALPHA" in detail.get("message", "")
+        for detail in result.risk_details
+    )
+    # Ensure repeated failures only surface a single guidance entry so the
+    # front-end never spams duplicate alerts when aggregating simulator output.
+    assert sum(1 for d in result.risk_details if d.get("code") == "BUDGET_REQUIRED") == 1
 
 
 def test_simulator_detects_over_budget():


### PR DESCRIPTION
## Summary
- add assertions that simulator risk guidance emits friendly copy and deduplicates codes for missing budgets

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/orchestrator/test_simulator.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/orchestrator -k 'not ics_golden'

------
https://chatgpt.com/codex/tasks/task_e_68e8ff58fa548333a24971bf15e494a4