### PR TITLE
Add pausability controls to AuditModule

### DIFF
--- a/docs/OWNER_CONTROL_INDEX.md
+++ b/docs/OWNER_CONTROL_INDEX.md
@@ -319,6 +319,30 @@ Manifest: `config/job-registry.json`. CLI: `npx hardhat run scripts/v2/updateAll
     5. Press `Write` and sign the transaction; capture the transaction hash for the change record.
     6. Run `npm run owner:plan -- --network <network>` and `npm run owner:verify-control -- --network <network>` to confirm the state update.
 
+* `pause` — ABI `pause()`
+  - **Emits:** Paused
+  - **Purpose:** Temporarily halts audit scheduling and processing during incidents.
+  - **Parameters:** None
+  - **Etherscan steps:**
+    1. Navigate to the contract's page on the target network's Etherscan instance.
+    2. Select the `Write Contract` tab and press `Connect` to use the authorised signer.
+    3. Expand `pause`.
+    4. No parameters to supply; confirm the incident context in the change ticket.
+    5. Press `Write` and sign the transaction; capture the transaction hash for the change record.
+    6. Run `npm run owner:plan -- --network <network>` and `npm run owner:verify-control -- --network <network>` to confirm the state update.
+
+* `unpause` — ABI `unpause()`
+  - **Emits:** Unpaused
+  - **Purpose:** Resumes audit scheduling and processing once the incident is resolved.
+  - **Parameters:** None
+  - **Etherscan steps:**
+    1. Navigate to the contract's page on the target network's Etherscan instance.
+    2. Select the `Write Contract` tab and press `Connect` to use the authorised signer.
+    3. Expand `unpause`.
+    4. No parameters to supply; confirm the recovery context in the change ticket.
+    5. Press `Write` and sign the transaction; capture the transaction hash for the change record.
+    6. Run `npm run owner:plan -- --network <network>` and `npm run owner:verify-control -- --network <network>` to confirm the state update.
+
 
 ### CertificateNFT
 

--- a/test/v2/AuditModule.test.js
+++ b/test/v2/AuditModule.test.js
@@ -1,0 +1,50 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+const ZERO_ADDRESS = ethers.ZeroAddress;
+
+describe('AuditModule', function () {
+  let owner;
+  let jobRegistry;
+  let audit;
+
+  beforeEach(async function () {
+    [owner, jobRegistry] = await ethers.getSigners();
+
+    const Audit = await ethers.getContractFactory(
+      'contracts/v2/AuditModule.sol:AuditModule'
+    );
+    audit = await Audit.deploy(jobRegistry.address, ZERO_ADDRESS);
+  });
+
+  it('allows the owner to pause and unpause audit processing', async function () {
+    await expect(audit.connect(owner).pause()).to.emit(audit, 'Paused');
+    await expect(audit.connect(owner).unpause()).to.emit(audit, 'Unpaused');
+  });
+
+  it('blocks job finalization callbacks while paused', async function () {
+    await audit.connect(owner).setAuditProbabilityBps(10_000);
+    await expect(audit.connect(owner).pause()).to.emit(audit, 'Paused');
+
+    await expect(
+      audit
+        .connect(jobRegistry)
+        .onJobFinalized(1, owner.address, true, ethers.ZeroHash)
+    ).to.be.revertedWithCustomError(audit, 'EnforcedPause');
+  });
+
+  it('blocks audit recording while paused', async function () {
+    await audit.connect(owner).setAuditProbabilityBps(10_000);
+    await audit.connect(owner).setAuditor(owner.address, true);
+
+    await audit
+      .connect(jobRegistry)
+      .onJobFinalized(1, owner.address, true, ethers.ZeroHash);
+
+    await expect(audit.connect(owner).pause()).to.emit(audit, 'Paused');
+
+    await expect(
+      audit.connect(owner).recordAudit(1, true, 'ok')
+    ).to.be.revertedWithCustomError(audit, 'EnforcedPause');
+  });
+});


### PR DESCRIPTION
## Summary
- add OpenZeppelin Pausable support to the AuditModule so owners can halt and resume callbacks
- document the new pause and unpause operations in the owner control index
- add hardhat tests covering pause behaviour for audit scheduling and recording

## Testing
- npx hardhat test test/v2/AuditModule.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e905df8b848333adad395a5c2613a5