### PR TITLE
Add payable configuration support to OwnerConfigurator

### DIFF
--- a/contracts/coverage/OwnerConfiguratorHarness.sol
+++ b/contracts/coverage/OwnerConfiguratorHarness.sol
@@ -10,6 +10,17 @@ contract OwnerConfiguratorHarness is OwnerConfigurator {
         external
         returns (bytes memory)
     {
-        return _applyConfiguration(call);
+        return _applyConfiguration(call, 0);
+    }
+
+    function applyConfigurationWithValue(
+        ConfigurationCall memory call,
+        uint256 value
+    ) external payable returns (bytes memory) {
+        if (msg.value != value) {
+            revert OwnerConfigurator__ValueMismatch(value, msg.value);
+        }
+
+        return _applyConfiguration(call, value);
     }
 }

--- a/contracts/test/ConfigurableModuleMock.sol
+++ b/contracts/test/ConfigurableModuleMock.sol
@@ -10,8 +10,10 @@ pragma solidity ^0.8.25;
 contract ConfigurableModuleMock {
     uint256 private _value;
     address public lastCaller;
+    uint256 public lastPaymentReceived;
 
     error ValueMismatch(uint256 expected, uint256 actual);
+    error PaymentMismatch(uint256 expected, uint256 supplied);
 
     event ValueChanged(uint256 previousValue, uint256 newValue, address caller);
 
@@ -24,6 +26,18 @@ contract ConfigurableModuleMock {
             revert ValueMismatch(expectedCurrent, _value);
         }
 
+        _setValue(newValue);
+    }
+
+    function setValueWithPayment(uint256 newValue, uint256 requiredPayment)
+        external
+        payable
+    {
+        if (msg.value != requiredPayment) {
+            revert PaymentMismatch(requiredPayment, msg.value);
+        }
+
+        lastPaymentReceived = msg.value;
         _setValue(newValue);
     }
 

--- a/docs/owner-control-parameter-playbook.md
+++ b/docs/owner-control-parameter-playbook.md
@@ -12,14 +12,18 @@ flowchart TD
 
 ## Core tool: `OwnerConfigurator`
 
-The [`OwnerConfigurator`](../contracts/v2/admin/OwnerConfigurator.sol) contract exposes two methods:
+The [`OwnerConfigurator`](../contracts/v2/admin/OwnerConfigurator.sol) contract exposes four execution paths:
 
 | Method | Purpose | When to use |
 | --- | --- | --- |
-| `configure` | Execute a single setter on a target module. | Quick one-off parameter update. |
-| `configureBatch` | Execute multiple setters in sequence. | Release workflows or multi-module rollouts. |
+| `configure` | Execute a single setter on a target module without forwarding ETH. | Quick one-off parameter update. |
+| `configureWithValue` | Execute a single setter while forwarding an exact ETH amount to the target. | Payable setters (e.g., escrow float top-ups, prepaid gas buffers). |
+| `configureBatch` | Execute multiple setters in sequence without forwarding ETH. | Release workflows or multi-module rollouts. |
+| `configureBatchWithValue` | Execute multiple payable setters with per-call ETH accounting. | Coordinated maintenance where several modules require funding in the same change window. |
 
-Both methods require the caller to be the configured owner (Safe or EOA). Ownership can be rotated using the inherited `transferOwnership` flow, giving the platform operator full control.
+All methods require the caller to be the configured owner (Safe or EOA). Ownership can be rotated using the inherited `transferOwnership` flow, giving the platform operator full control.
+
+When using the payable variants, make sure the Safe or EOA supplies the sum of all forwarded amounts as `msg.value`. The configurator enforces exact accounting via the `OwnerConfigurator__ValueMismatch` error, preventing stray ETH from remaining on the facade.
 
 ## Preparing a change
 


### PR DESCRIPTION
## Summary
- extend the OwnerConfigurator facade with payable single-call and batch configuration helpers that forward ETH safely
- harden the coverage harness and mocks so tests cover value-forwarding scenarios with strict accounting
- document the owner console workflow for payable operations in the parameter playbook

## Testing
- npx hardhat test --no-compile test/v2/OwnerConfigurator.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e919e321748333bcd4eace2d14f049