### PR TITLE
Support payable owner configuration and document pause workflow

### DIFF
--- a/contracts/coverage/OwnerConfiguratorHarness.sol
+++ b/contracts/coverage/OwnerConfiguratorHarness.sol
@@ -8,8 +8,12 @@ contract OwnerConfiguratorHarness is OwnerConfigurator {
 
     function applyConfiguration(ConfigurationCall memory call)
         external
+        payable
         returns (bytes memory)
     {
+        if (msg.value != call.value) {
+            revert OwnerConfigurator__ValueMismatch(call.value, msg.value);
+        }
         return _applyConfiguration(call);
     }
 }

--- a/test/coverage/accessControl.coverage.test.js
+++ b/test/coverage/accessControl.coverage.test.js
@@ -62,6 +62,7 @@ describe('OwnerConfigurator (coverage)', function () {
         parameterKey,
         oldValue: abi.encode(['uint256'], [123]),
         newValue: abi.encode(['uint256'], [456]),
+        value: 0,
       },
       {
         target: await target.getAddress(),
@@ -74,6 +75,7 @@ describe('OwnerConfigurator (coverage)', function () {
         parameterKey,
         oldValue: abi.encode(['uint256'], [456]),
         newValue: abi.encode(['uint256'], [789]),
+        value: 0,
       },
     ];
 
@@ -99,6 +101,7 @@ describe('OwnerConfigurator (coverage)', function () {
         parameterKey,
         oldValue: '0x',
         newValue: '0x',
+        value: 0,
       })
     ).to.be.revertedWithCustomError(configurator, 'OwnerConfigurator__ZeroTarget');
   });


### PR DESCRIPTION
## Summary
- allow `OwnerConfigurator` to forward ETH, validate batch values, and reject direct transfers so the owner can fund deposits safely
- expand the configurator harness, mock module, and test suite to cover payable flows and value mismatch behaviour
- document payable usage and pause/unpause guidance in the owner control playbook

## Testing
- npx hardhat test test/v2/OwnerConfigurator.test.js
- npx hardhat test test/coverage/accessControl.coverage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e919e321748333bcd4eace2d14f049