### PR TITLE
feat: delegate global pause management to SystemPause

### DIFF
--- a/contracts/v2/SystemPause.sol
+++ b/contracts/v2/SystemPause.sol
@@ -38,6 +38,7 @@ contract SystemPause is Governable, ReentrancyGuard {
     error InvalidArbitratorCommittee(address module);
     error ModuleNotOwned(address module, address owner);
     error InvalidPauser(address pauser);
+    error PauserManagerNotDelegated(address module);
 
     event ModulesUpdated(
         address jobRegistry,
@@ -264,6 +265,55 @@ contract SystemPause is Governable, ReentrancyGuard {
         if (pauser == address(0)) {
             revert InvalidPauser(pauser);
         }
+        if (jobRegistry.pauserManager() != address(this)) {
+            try jobRegistry.setPauserManager(address(this)) {} catch {}
+        }
+        if (jobRegistry.pauserManager() != address(this)) {
+            revert PauserManagerNotDelegated(address(jobRegistry));
+        }
+        if (stakeManager.pauserManager() != address(this)) {
+            try stakeManager.setPauserManager(address(this)) {} catch {}
+        }
+        if (stakeManager.pauserManager() != address(this)) {
+            revert PauserManagerNotDelegated(address(stakeManager));
+        }
+        if (validationModule.pauserManager() != address(this)) {
+            try validationModule.setPauserManager(address(this)) {} catch {}
+        }
+        if (validationModule.pauserManager() != address(this)) {
+            revert PauserManagerNotDelegated(address(validationModule));
+        }
+        if (disputeModule.pauserManager() != address(this)) {
+            try disputeModule.setPauserManager(address(this)) {} catch {}
+        }
+        if (disputeModule.pauserManager() != address(this)) {
+            revert PauserManagerNotDelegated(address(disputeModule));
+        }
+        if (platformRegistry.pauserManager() != address(this)) {
+            try platformRegistry.setPauserManager(address(this)) {} catch {}
+        }
+        if (platformRegistry.pauserManager() != address(this)) {
+            revert PauserManagerNotDelegated(address(platformRegistry));
+        }
+        if (feePool.pauserManager() != address(this)) {
+            try feePool.setPauserManager(address(this)) {} catch {}
+        }
+        if (feePool.pauserManager() != address(this)) {
+            revert PauserManagerNotDelegated(address(feePool));
+        }
+        if (reputationEngine.pauserManager() != address(this)) {
+            try reputationEngine.setPauserManager(address(this)) {} catch {}
+        }
+        if (reputationEngine.pauserManager() != address(this)) {
+            revert PauserManagerNotDelegated(address(reputationEngine));
+        }
+        if (arbitratorCommittee.pauserManager() != address(this)) {
+            try arbitratorCommittee.setPauserManager(address(this)) {} catch {}
+        }
+        if (arbitratorCommittee.pauserManager() != address(this)) {
+            revert PauserManagerNotDelegated(address(arbitratorCommittee));
+        }
+
         jobRegistry.setPauser(pauser);
         stakeManager.setPauser(pauser);
         validationModule.setPauser(pauser);

--- a/docs/system-pause.md
+++ b/docs/system-pause.md
@@ -4,7 +4,11 @@
 transaction. After deployment you must complete two governance steps:
 
 1. Wire module addresses using `setModules`.
-2. Once ownership of each module is transferred to `SystemPause`, call
+2. Delegate pauser management to `SystemPause` by calling
+   `setPauserManager(systemPauseAddress)` on every module (JobRegistry,
+   StakeManager, ValidationModule, DisputeModule, PlatformRegistry, FeePool,
+   ReputationEngine, ArbitratorCommittee) from governance/owner.
+3. Once ownership of each module is transferred to `SystemPause`, call
    `refreshPausers` so it regains the `setPauser` permissions required for
    `pauseAll` / `unpauseAll`.
 
@@ -32,6 +36,9 @@ the deployed `SystemPause` address together with module pointers for
   ValidationModule, DisputeModule, PlatformRegistry, FeePool, ReputationEngine,
   ArbitratorCommittee) to the deployed `SystemPause` contract before wiring
   updates. Without ownership the helper cannot reapply pauser roles.
+- After ownership transfer, set each module's `pauserManager` to the
+  `SystemPause` address so on-chain delegation succeeds without manual pauser
+  rotations.
 - Run a dry run to confirm wiring, ownership, and pauser status before sending
   transactions:
 

--- a/test/v2/GovernanceConfiguration.test.js
+++ b/test/v2/GovernanceConfiguration.test.js
@@ -252,6 +252,8 @@ describe('Governance configuration surfaces', function () {
         taxPolicy: await newPolicy.getAddress(),
         setPauser: true,
         pauser: pauser.address,
+        setPauserManager: true,
+        pauserManager: owner.address,
       };
 
       await expect(
@@ -267,6 +269,7 @@ describe('Governance configuration surfaces', function () {
       expect(await pool.governance()).to.equal(await timelock.getAddress());
       expect(await pool.taxPolicy()).to.equal(await newPolicy.getAddress());
       expect(await pool.pauser()).to.equal(pauser.address);
+      expect(await pool.pauserManager()).to.equal(owner.address);
       expect(await pool.treasuryAllowlist(treasury.address)).to.equal(true);
       expect(await pool.treasuryAllowlist(newTreasury.address)).to.equal(true);
       expect(await pool.rewarders(rewarder.address)).to.equal(true);
@@ -297,6 +300,8 @@ describe('Governance configuration surfaces', function () {
       const config = {
         setPauser: true,
         pauser: pauser.address,
+        setPauserManager: true,
+        pauserManager: owner.address,
         setThermostat: true,
         thermostat: ethers.ZeroAddress,
         setHamiltonianFeed: true,
@@ -393,6 +398,7 @@ describe('Governance configuration surfaces', function () {
       expect(await stake.maxAGITypes()).to.equal(25n);
       expect(await stake.maxTotalPayoutPct()).to.equal(150n);
       expect(await stake.paused()).to.equal(true);
+      expect(await stake.pauserManager()).to.equal(owner.address);
     });
   });
 
@@ -487,6 +493,8 @@ describe('Governance configuration surfaces', function () {
       const config = {
         setPauser: true,
         pauser: pauser.address,
+        setPauserManager: true,
+        pauserManager: owner.address,
         setModuleBundle: true,
         modules: {
           validation: await replacementValidation.getAddress(),
@@ -552,6 +560,7 @@ describe('Governance configuration surfaces', function () {
       ).to.emit(registry, 'ConfigurationApplied');
 
       expect(await registry.pauser()).to.equal(pauser.address);
+      expect(await registry.pauserManager()).to.equal(owner.address);
       expect(await registry.identityRegistry()).to.equal(await identity.getAddress());
       expect(await registry.disputeModule()).to.equal(
         await replacementDispute.getAddress()

--- a/test/v2/PlatformRegistry.test.js
+++ b/test/v2/PlatformRegistry.test.js
@@ -391,6 +391,8 @@ describe('PlatformRegistry', function () {
           minPlatformStake: newMinStake,
           setPauser: true,
           pauser: pauser.address,
+          setPauserManager: true,
+          pauserManager: owner.address,
         },
         registrarUpdates,
         blacklistUpdates
@@ -413,12 +415,13 @@ describe('PlatformRegistry', function () {
       .and.to.emit(registry, 'ModulesUpdated')
       .withArgs(newStakeManager, newReputationEngine)
       .and.to.emit(registry, 'ConfigurationApplied')
-      .withArgs(owner.address, true, true, true, true, 1, 2);
+      .withArgs(owner.address, true, true, true, true, true, 1, 2);
 
     expect(await registry.stakeManager()).to.equal(newStakeManager);
     expect(await registry.reputationEngine()).to.equal(newReputationEngine);
     expect(await registry.minPlatformStake()).to.equal(newMinStake);
     expect(await registry.pauser()).to.equal(pauser.address);
+    expect(await registry.pauserManager()).to.equal(owner.address);
     expect(await registry.registrars(registrar.address)).to.equal(true);
     expect(await registry.blacklist(platform.address)).to.equal(false);
     expect(await registry.blacklist(sybil.address)).to.equal(true);


### PR DESCRIPTION
## Summary
- add pauser manager delegation to every v2 module so owners can hand pause control to SystemPause
- have SystemPause enforce and, when possible, auto-configure pauser manager assignments before broadcasting pause updates
- document the new wiring step and extend governance tests to cover pauser manager configuration

## Testing
- npx hardhat test test/v2/SystemPause.test.js test/v2/PlatformRegistry.test.js test/v2/GovernanceConfiguration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e929fae0e08333a851f43a4197feb2