### PR TITLE
Add signed release bundle publication workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,3 +239,78 @@ jobs:
         with:
           name: ${{ matrix.name }}-release-digest
           path: digest.txt
+
+  github-release:
+    needs:
+      - prepare
+      - docker-publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+
+      - name: Download release preparation artefacts
+        uses: actions/download-artifact@71f31b0d0be45612bc1db53de9b1aa6dc10e30f2
+        with:
+          name: release-prep
+          path: release-prep
+
+      - name: Assemble release bundle
+        id: bundle
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.prepare.outputs.version }}"
+          mkdir -p dist
+          tar -czf "dist/agi-jobs-v${VERSION}-artifacts.tar.gz" \
+            -C release-prep \
+            reports/abis/head \
+            reports/sbom \
+            typechain-types \
+            deployment-config
+          sha256sum "dist/agi-jobs-v${VERSION}-artifacts.tar.gz" > "dist/agi-jobs-v${VERSION}-artifacts.tar.gz.sha256"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
+
+      - name: Sign release bundle
+        env:
+          COSIGN_EXPERIMENTAL: '1'
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.bundle.outputs.version }}"
+          cosign sign-blob --yes --keyless \
+            --output-signature "dist/agi-jobs-v${VERSION}-artifacts.tar.gz.sig" \
+            --output-certificate "dist/agi-jobs-v${VERSION}-artifacts.tar.gz.pem" \
+            "dist/agi-jobs-v${VERSION}-artifacts.tar.gz"
+
+      - name: Generate build provenance
+        id: provenance
+        uses: actions/attest-build-provenance@128a63446a19441284efb5146ee5d521349b7ab6
+        with:
+          subject-path: dist/agi-jobs-v${{ steps.bundle.outputs.version }}-artifacts.tar.gz
+
+      - name: Publish signed release assets
+        uses: softprops/action-gh-release@39a9d95fda3fcb043b4d29d79d046a9e12dfc2a7
+        with:
+          tag_name: v${{ steps.bundle.outputs.version }}
+          name: AGI Jobs v${{ steps.bundle.outputs.version }}
+          draft: false
+          prerelease: ${{ contains(steps.bundle.outputs.version, '-') }}
+          files: |
+            dist/agi-jobs-v${{ steps.bundle.outputs.version }}-artifacts.tar.gz
+            dist/agi-jobs-v${{ steps.bundle.outputs.version }}-artifacts.tar.gz.sha256
+            dist/agi-jobs-v${{ steps.bundle.outputs.version }}-artifacts.tar.gz.sig
+            dist/agi-jobs-v${{ steps.bundle.outputs.version }}-artifacts.tar.gz.pem
+            ${{ steps.provenance.outputs.bundle-path }}

--- a/docs/production-launch-blueprint.md
+++ b/docs/production-launch-blueprint.md
@@ -193,6 +193,8 @@ Before opening the system to external participants, confirm the following:
       intended ENS changes.
 - [ ] `npx hardhat run scripts/v2/updateThermodynamics.ts --network <network>` dry run
       matches the desired reward distribution.
+- [ ] Validate release signatures and provenance following
+      `docs/release-signing.md` before distributing artefacts.
 - [ ] Incident response runbook stored in `docs/` references this blueprint and the latest
       Safe bundles.
 

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,0 +1,79 @@
+# Release Artifact Signing and Verification
+
+To guarantee chain-of-custody for AGI Jobs v0 (v2) releases, every workflow invocation
+packages the deployable artefacts into a single tarball, signs it with Sigstore
+Cosign, and generates an in-toto provenance bundle. This guide explains how to
+validate those files before you promote a release to production.
+
+## Artefacts published with each GitHub release
+
+Each release upload includes the following files:
+
+| File | Purpose |
+| --- | --- |
+| `agi-jobs-v<version>-artifacts.tar.gz` | Canonical bundle of ABIs, SBOM, TypeChain output, and deployment manifests prepared by CI. |
+| `agi-jobs-v<version>-artifacts.tar.gz.sha256` | SHA-256 checksum for offline integrity verification. |
+| `agi-jobs-v<version>-artifacts.tar.gz.sig` | Cosign signature, created via keyless signing with GitHub OIDC. |
+| `agi-jobs-v<version>-artifacts.tar.gz.pem` | Sigstore certificate containing the signing identity metadata. |
+| `<hash>.intoto.jsonl` | SLSA provenance bundle emitted by `actions/attest-build-provenance`. |
+
+## Verification prerequisites
+
+1. Install [Cosign](https://github.com/sigstore/cosign) v2.2.0 or later.
+2. Trust the Sigstore transparency log root certificates. Cosign manages this
+   automatically when using keyless verification.
+3. Download every artefact listed above from the matching GitHub release tag.
+
+## Verification workflow
+
+1. **Checksum validation**
+
+   ```bash
+   sha256sum --check agi-jobs-v<version>-artifacts.tar.gz.sha256
+   ```
+
+   The command must report `OK` for the tarball entry.
+
+2. **Cosign signature verification**
+
+   ```bash
+   cosign verify-blob \
+     --certificate agi-jobs-v<version>-artifacts.tar.gz.pem \
+     --signature agi-jobs-v<version>-artifacts.tar.gz.sig \
+     --certificate-identity "https://github.com/MontrealAI/AGIJobsv0/.github/workflows/release.yml@refs/tags/v<version>" \
+     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+     agi-jobs-v<version>-artifacts.tar.gz
+   ```
+
+   Cosign prints the signing certificate details and exits with status code 0
+   when the signature, certificate, and workflow identity all match.
+
+3. **SLSA provenance inspection**
+
+   ```bash
+   cosign verify-attestation \
+     --type slsaprovenance.dev/attestation/v1 \
+     --certificate-identity "https://github.com/MontrealAI/AGIJobsv0/.github/workflows/release.yml@refs/tags/v<version>" \
+     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+     --bundle <hash>.intoto.jsonl
+   ```
+
+   Replace `<hash>.intoto.jsonl` with the provenance bundle name from the
+   release assets. Cosign validates the bundle signature and prints the
+   attested subject digest. Confirm the digest matches the checksum from the
+   previous step.
+
+## Operational expectations
+
+- Store verified artefacts and provenance bundles in your long-term compliance
+  archive alongside deployment approvals.
+- Repeat the verification steps whenever you promote a release artefact to a new
+  environment (staging, pre-production, production) to ensure integrity at each
+  hop.
+- If verification fails, stop the deployment pipeline immediately and open an
+  incident following `docs/incident-response.md`.
+
+Maintaining verifiable supply-chain metadata is a key control for institutional
+platform operators. By checking signatures and provenance before distribution,
+you provide auditors and internal risk committees with a reproducible, tamper-
+proof deployment record.


### PR DESCRIPTION
## Summary
- add a dedicated github-release job that bundles deployment artefacts, signs them with cosign, and uploads provenance to GitHub releases
- generate sha256, signature, certificate, and SLSA provenance for the release artefacts alongside existing container images
- document the verification procedure and require release signature validation in the production launch checklist

## Testing
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68e97239e78c8333adb20f2d86c6aaac