### PR TITLE
Harden FeePool invariants and monitoring guidance

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -8,13 +8,33 @@ further invariants will be appended as coverage grows.
 ## StakeManager
 
 * **Total stake accounting** – the aggregate stake tracked per role must
-  equal the sum of per-account balances.  Violations point to corruption
+  equal the sum of per-account balances. Violations point to corruption
   in `_deposit`/`_withdraw` flows or boosts that double-count balances.
 * **Solvency** – the contract balance of $AGI must always cover the sum
   of liabilities (total stake across roles plus the operator reward
-  pool).  Any failure indicates that tokens were transferred without the
+  pool). Any failure indicates that tokens were transferred without the
   appropriate accounting update.
 
 Each invariant is enforced by the Forge suite in
 `test/v2/invariant/StakeManagerAccountingInvariant.t.sol` and executed in
 CI with the rest of the Foundry tests (`forge test`).
+
+## FeePool
+
+* **Pending fees must be asset-backed** – `pendingFees` may never exceed
+  the ERC20 balance held by the pool. This guarantees that queued
+  distributions are always redeemable without depending on external
+  treasury replenishment.
+* **Cumulative reward growth is monotonic** –
+  `cumulativePerToken` increases only when fees are distributed and can
+  never decrease. This prevents retroactive reward clawbacks or
+  accounting rollbacks that would undermine validator/agent payouts.
+* **Treasury reward ledger is conservative** – the tracked
+  `treasuryRewards` total must always be less than or equal to the actual
+  ERC20 balance at the configured treasury address. The invariant guards
+  against scenarios where bookkeeping overstates what the treasury has
+  received.
+
+These properties are enforced in
+`test/v2/invariant/FeePoolInvariant.t.sol`, extending the Foundry
+invariant job that already runs inside the v2 CI pipeline.

--- a/docs/security/onchain-monitoring.md
+++ b/docs/security/onchain-monitoring.md
@@ -1,0 +1,79 @@
+# On-Chain Monitoring & Alerting Runbook
+
+This runbook hardens the production deployment to the "institutional" bar by
+providing actionable monitoring for every privileged action exposed by the AGI
+Jobs v0 (v2) contracts. It assumes a non-technical operator can deploy the
+sensors, receive alerts, and escalate using the incident-response playbook.
+
+## 1. Sentinel policy (OpenZeppelin Defender)
+
+Create a Defender Sentinel named **AGI Jobs v2 – Privileged Actions** with the
+following configuration:
+
+| Setting | Value |
+| --- | --- |
+| Network | Ethereum mainnet (add Sepolia as secondary for rehearsals) |
+| Contracts | FeePool, StakeManager, JobRouter, IdentityRegistry, TaxPolicy, Thermostat |
+| Function selectors | `setGovernance`, `setRewarder`, `setStakeManager`, `pause`, `unpause`, `governanceWithdraw`, `upgradeTo`, `grantRole`, `revokeRole` |
+| Event filters | `Paused(address)`, `Unpaused(address)`, `GovernanceWithdrawal(address,address,uint256)`, `OwnerAction(address,bytes4)` |
+| Alert channels | PagerDuty (Critical), Slack (Ops channel), Email (compliance archive) |
+
+Enable **Autotasks** that invoke `scripts/v2/ownerControlPulse.ts` whenever the
+Sentinel fires. The autotask posts the owner dashboard snapshot into the PagerDuty
+alert so the incident commander can see module state without running local scripts.
+All Defender projects should be linked to the GitHub OIDC trust relationship
+outlined in `docs/release-signing.md` so credentials remain short-lived.
+
+## 2. Forta agent cluster
+
+Deploy the [Forta](https://forta.org) bot template stored in
+`monitoring/forta/bot-template/` (create the directory if it does not yet exist)
+with the following detectors:
+
+1. **Pause/Unpause watcher** – emits `Critical` findings when any module is
+   paused or unpaused outside the approved timelock queue.
+2. **Treasury drain watcher** – tracks cumulative token outflows from FeePool and
+   StakeManager. Raise a `High` severity alert if the 1-hour rolling delta exceeds
+   5% of the operator treasury or if the recipient is not in the allowlist defined
+   in `deployment-config/mainnet.json`.
+3. **Governance executor watcher** – verifies that every privileged call is
+   submitted by the authorised Safe or timelock. Anything else is tagged `Critical`.
+
+Bots publish alerts to the Forta scan node you control plus a webhook that bridges
+into the Ops Slack channel. Configure the webhook to include links to the Defender
+Sentinel alert and the incident-response runbook section (§4). Forta findings are
+retained for 180 days to satisfy institutional audit requirements.
+
+## 3. Prometheus bridge for on-chain metrics
+
+The Grafana dashboard already exposes off-chain service SLOs. Extend
+`monitoring/prometheus/prometheus.yml` with the [forta-exporter](https://github.com/forta-network/forta-node/tree/master/exporter)
+job so that critical Forta alerts appear as Prometheus series. Suggested rule:
+
+```yaml
+- alert: FortaCriticalFinding
+  expr: forta_findings_severity{severity="critical"} > 0
+  for: 1m
+  labels:
+    severity: critical
+    runbook: https://github.com/MontrealAI/AGIJobsv0/blob/main/docs/incident-response.md
+  annotations:
+    summary: "Forta reported a critical on-chain event"
+    description: "Check Defender Sentinel and execute the emergency pause procedure."
+```
+
+This keeps PagerDuty, Forta, and Defender alerts consistent while delivering a
+single timeline inside Grafana for audits.
+
+## 4. Tabletop validation cadence
+
+After every production release tag, schedule a tabletop exercise that rehearses:
+
+1. Defender Sentinel triggers on an unexpected pause.
+2. Forta detects an unapproved governance withdrawal.
+3. Prometheus forwards the alert to Alertmanager, which escalates to PagerDuty.
+
+Document learnings in `docs/incident-response.md` and close the loop by updating
+Sentinel/Forta thresholds if false positives occurred. Maintaining this cadence
+keeps the monitoring configuration aligned with protocol changes and meets the
+"monitoring & incident response" pillar of the institutional readiness checklist.

--- a/test/v2/invariant/FeePoolInvariant.t.sol
+++ b/test/v2/invariant/FeePoolInvariant.t.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/StdInvariant.sol";
+import "forge-std/Test.sol";
+import "forge-std/Vm.sol";
+
+import {FeePool} from "../../../contracts/v2/FeePool.sol";
+import {MockStakeManager} from "../../../contracts/legacy/MockV2.sol";
+import {TaxPolicy} from "../../../contracts/v2/TaxPolicy.sol";
+import {AGIALPHAToken} from "../../../contracts/test/AGIALPHAToken.sol";
+import {IStakeManager} from "../../../contracts/v2/interfaces/IStakeManager.sol";
+import {AGIALPHA} from "../../../contracts/v2/Constants.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+contract FeePoolHandler {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    uint256 internal constant MIN_TRANSFER = 1e15; // 0.001 AGIALPHA
+    uint256 internal constant MAX_TRANSFER = 5_000e18;
+
+    FeePool public immutable feePool;
+    MockStakeManager public immutable stakeManager;
+    AGIALPHAToken public immutable token;
+    TaxPolicy public immutable taxPolicy;
+    address public immutable tokenOwner;
+    address public immutable governance;
+    address public immutable treasury;
+
+    address[] internal stakers;
+
+    uint256 public maxCumulativePerToken;
+
+    constructor(
+        FeePool _feePool,
+        MockStakeManager _stakeManager,
+        AGIALPHAToken _token,
+        TaxPolicy _taxPolicy,
+        address[] memory _stakers,
+        address _tokenOwner,
+        address _governance,
+        address _treasury
+    ) {
+        feePool = _feePool;
+        stakeManager = _stakeManager;
+        token = _token;
+        taxPolicy = _taxPolicy;
+        stakers = _stakers;
+        tokenOwner = _tokenOwner;
+        governance = _governance;
+        treasury = _treasury;
+        maxCumulativePerToken = _feePool.cumulativePerToken();
+
+        // Prime tax acknowledgements for all actors interacting with the pool.
+        _acknowledge(address(_stakeManager));
+        _acknowledge(_governance);
+        uint256 len = stakers.length;
+        for (uint256 i; i < len; ++i) {
+            _acknowledge(stakers[i]);
+        }
+    }
+
+    function depositFees(uint96 rawAmount) external {
+        uint256 amount = _boundAmount(rawAmount);
+        vm.startPrank(tokenOwner);
+        token.mint(address(feePool), amount);
+        vm.stopPrank();
+
+        vm.prank(address(stakeManager));
+        feePool.depositFee(amount);
+        _recordCumulative();
+    }
+
+    function contribute(uint96 rawAmount, uint8 who) external {
+        address user = stakers[who % stakers.length];
+        uint256 amount = _boundAmount(rawAmount);
+
+        vm.startPrank(tokenOwner);
+        token.mint(user, amount);
+        vm.stopPrank();
+
+        _acknowledge(user);
+
+        vm.startPrank(user);
+        token.approve(address(feePool), amount);
+        feePool.contribute(amount);
+        vm.stopPrank();
+        _recordCumulative();
+    }
+
+    function distribute(uint8 whoCalls) external {
+        address caller = stakers[whoCalls % stakers.length];
+        _acknowledge(caller);
+        vm.prank(caller);
+        feePool.distributeFees();
+        _recordCumulative();
+    }
+
+    function claim(uint8 who) external {
+        address user = stakers[who % stakers.length];
+        _acknowledge(user);
+        vm.prank(user);
+        feePool.claimRewards();
+        _recordCumulative();
+    }
+
+    function governanceWithdraw(uint96 rawAmount, bool toTreasury) external {
+        uint256 balance = token.balanceOf(address(feePool));
+        uint256 pending = feePool.pendingFees();
+        if (balance <= pending) return;
+
+        uint256 available = balance - pending;
+        uint256 amount = _boundAmount(rawAmount) % available;
+        if (amount == 0) {
+            amount = available;
+        }
+
+        address recipient = toTreasury && treasury != address(0) ? treasury : address(0);
+
+        _acknowledge(governance);
+        vm.prank(governance);
+        feePool.governanceWithdraw(recipient, amount);
+        _recordCumulative();
+    }
+
+    function reward(uint96 rawAmount, uint8 who, bool sendTreasury) external {
+        uint256 balance = token.balanceOf(address(feePool));
+        uint256 pending = feePool.pendingFees();
+        if (balance <= pending) return;
+
+        uint256 available = balance - pending;
+        uint256 amount = _boundAmount(rawAmount) % available;
+        if (amount == 0) {
+            amount = available;
+        }
+
+        address recipient = sendTreasury && treasury != address(0) ? treasury : stakers[who % stakers.length];
+        feePool.reward(recipient, amount);
+        _recordCumulative();
+    }
+
+    function rebalanceStake(uint8 who, uint96 rawAmount) external {
+        address user = stakers[who % stakers.length];
+        uint256 amount = MIN_TRANSFER + (uint256(rawAmount) % (MAX_TRANSFER * 2));
+        stakeManager.setStake(user, IStakeManager.Role.Platform, amount);
+        _recordCumulative();
+    }
+
+    function _recordCumulative() internal {
+        uint256 current = feePool.cumulativePerToken();
+        if (current > maxCumulativePerToken) {
+            maxCumulativePerToken = current;
+        }
+    }
+
+    function _boundAmount(uint96 rawAmount) internal pure returns (uint256) {
+        uint256 amount = MIN_TRANSFER + (uint256(rawAmount) % MAX_TRANSFER);
+        return amount;
+    }
+
+    function _acknowledge(address user) internal {
+        if (!taxPolicy.hasAcknowledged(user)) {
+            vm.prank(user);
+            taxPolicy.acknowledge();
+        }
+    }
+}
+
+contract FeePoolInvariantTest is StdInvariant, Test {
+    FeePool public feePool;
+    MockStakeManager public stakeManager;
+    TaxPolicy public taxPolicy;
+    AGIALPHAToken public token;
+    TimelockController public governance;
+    FeePoolHandler public handler;
+
+    address public constant TREASURY = address(0xCAFE);
+
+    function setUp() public {
+        AGIALPHAToken impl = new AGIALPHAToken();
+        vm.etch(AGIALPHA, address(impl).code);
+        vm.store(AGIALPHA, bytes32(uint256(5)), bytes32(uint256(uint160(address(this)))));
+        token = AGIALPHAToken(payable(AGIALPHA));
+
+        stakeManager = new MockStakeManager();
+        stakeManager.setJobRegistry(address(0x1234));
+
+        taxPolicy = new TaxPolicy("ipfs://policy", "ack");
+
+        feePool = new FeePool(stakeManager, 2, TREASURY, taxPolicy);
+
+        address[] memory proposers = new address[](1);
+        proposers[0] = address(this);
+        address[] memory executors = new address[](1);
+        executors[0] = address(this);
+        governance = new TimelockController(0, proposers, executors, address(this));
+
+        feePool.setGovernance(address(governance));
+        feePool.setTreasuryAllowlist(TREASURY, true);
+        feePool.setRewarder(address(this), true);
+
+        address[] memory stakers = new address[](3);
+        stakers[0] = address(0xA11CE);
+        stakers[1] = address(0xB0B);
+        stakers[2] = address(0xC0FFEE);
+
+        for (uint256 i; i < stakers.length; ++i) {
+            stakeManager.setStake(stakers[i], IStakeManager.Role.Platform, 1_000e18);
+        }
+
+        handler = new FeePoolHandler(
+            feePool,
+            stakeManager,
+            token,
+            taxPolicy,
+            stakers,
+            address(this),
+            address(governance),
+            TREASURY
+        );
+
+        feePool.setRewarder(address(handler), true);
+
+        targetContract(address(handler));
+    }
+
+    function invariant_pendingFeesBackedByBalance() public view {
+        uint256 balance = token.balanceOf(address(feePool));
+        assertGe(balance, feePool.pendingFees(), "pending fees exceed backing");
+    }
+
+    function invariant_cumulativePerTokenMonotonic() public view {
+        assertGe(
+            feePool.cumulativePerToken(),
+            handler.maxCumulativePerToken(),
+            "cumulativePerToken decreased"
+        );
+    }
+
+    function invariant_treasuryRewardsAccounted() public view {
+        uint256 tracked = feePool.treasuryRewards(TREASURY);
+        uint256 balance = token.balanceOf(TREASURY);
+        assertLe(tracked, balance, "treasury rewards exceed balance");
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Foundry invariant suite for FeePool covering fee backing, cumulative accounting and treasury reward safety
- document the new FeePool properties alongside the existing invariant catalogue
- publish an on-chain monitoring runbook with Defender, Forta and Prometheus integrations for privileged actions

## Testing
- forge test --match-path test/v2/invariant/FeePoolInvariant.t.sol --ffi

------
https://chatgpt.com/codex/tasks/task_e_68e98403a4148333bdcfaf6beb7298c1