### PR TITLE
Add Slither baseline enforcement with fingerprint tracking

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -43,13 +43,30 @@ jobs:
       REVEAL_WINDOW: '30m'
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+
+      - name: Cache Hardhat compilers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/hardhat-nodejs
+          key: hardhat-${{ runner.os }}-${{ hashFiles('hardhat.config.js', 'package-lock.json') }}
+          restore-keys: |
+            hardhat-${{ runner.os }}-
 
       - name: Install dependencies
         run: npm ci
@@ -68,7 +85,7 @@ jobs:
         run: npm test
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
           version: 'v1.4.0'
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,99 @@
+name: static-analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '30 2 * * *'
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+concurrency:
+  group: static-analysis-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  slither:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            **/package-lock.json
+
+      - name: Cache Hardhat compilers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/hardhat-nodejs
+          key: hardhat-${{ runner.os }}-${{ hashFiles('hardhat.config.js', 'package-lock.json') }}
+          restore-keys: |
+            hardhat-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline --progress=false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.12'
+
+      - name: Install Slither toolchain
+        run: |
+          python -m pip install --upgrade pip
+          pip install slither-analyzer==0.10.4 solc-select==1.0.4
+
+      - name: Install solc versions
+        run: |
+          solc-select install 0.8.25 0.8.23 0.8.21
+          solc-select use 0.8.25
+
+      - name: Warm Hardhat build cache
+        run: |
+          npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+          npx hardhat compile
+
+      - name: Run Slither static analysis
+        run: |
+          set -euo pipefail
+          mkdir -p reports/security
+          slither . \
+            --compile-force-framework Hardhat \
+            --skip-clean \
+            --solc-remaps '@openzeppelin=node_modules/@openzeppelin/' \
+            --sarif reports/security/slither.sarif
+
+      - name: Enforce Slither baseline
+        run: node tools/ci/check-slither-baseline.mjs reports/security/slither.sarif reports/security/slither-baseline.json
+
+      - name: Upload SARIF to security tab
+        uses: github/codeql-action/upload-sarif@7dccf72e419e51b915f40df725d7c2e766b51b44
+        with:
+          sarif_file: reports/security/slither.sarif
+
+      - name: Upload Slither artefacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: slither-security-report
+          path: reports/security

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage.json
 !test/coverage/
 !test/coverage/**
 reports/sbom/
+reports/security/slither.sarif
 
 .next/
 

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ Docker-based analyzers (Slither/Echidna) run automatically on GitHub-hosted runn
 - **Compile, lint and unit tests** – Hardhat compilation and the full Mocha suite must succeed on every push/PR.
 - **Coverage** – `npm run coverage:full` produces `coverage/coverage-summary.json`; the CI gate enforces ≥90 % line coverage once reports exist. Until coverage output is generated the threshold check logs a warning and exits cleanly.
 - **Wiring and owner control** – `npm run verify:agialpha -- --skip-onchain` validates the `$AGIALPHA` constants, while `npm run owner:health` deploys the protocol on an ephemeral Hardhat network to prove privileged setters remain operable by governance.
-- **Static analysis (Slither)** – Runs from the pinned `trailofbits/eth-security-toolbox:nightly-20240902` Docker image when Docker is present. Self-hosted runners without Docker emit an informational skip message; GitHub-hosted runners always execute the analyzer.
+- **Static analysis (Slither)** – The dedicated `static-analysis` workflow installs a pinned Slither/solc toolchain, compiles the contracts via Hardhat, and uploads SARIF results to the repository security tab so reviewers see findings inline. The workflow enforces a checked-in baseline (`reports/security/slither-baseline.json`) so any newly introduced finding fails CI while pre-triaged items remain auditable.
 - **Property-based testing (Echidna)** – PRs run the smoke harness in assertion mode from `ghcr.io/crytic/echidna/echidna:v2.2.7`. A nightly workflow extends coverage with a long fuzzing session so deeper bugs surface without slowing the main CI pipeline.
 - **Security artifacts** – Coverage reports, gas snapshots and ABIs are uploaded automatically to aid review and downstream tooling.
 

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -116,6 +116,9 @@ Conduct quarterly tabletop drills covering:
 3. Chain reorganisation requiring redeployment of oracle attestations.
 
 Record outcomes, improvement actions, and track them in the compliance register.
+For a facilitator script and preparation checklist, follow
+`docs/security/incident-tabletop.md` so the rehearsal produces auditable
+evidence that all controls remain effective.
 
 ---
 

--- a/docs/security/incident-tabletop.md
+++ b/docs/security/incident-tabletop.md
@@ -1,0 +1,71 @@
+# Incident Response Tabletop Validation
+
+This guide operationalises the "tabletop validation cadence" referenced across the
+monitoring and incident-response playbooks. It gives the contract owner and the
+non-technical incident commander a repeatable process to rehearse emergency
+controls after every tagged release.
+
+## Objectives
+
+1. **Verify emergency controls** – Demonstrate that the Safe/Timelock pause,
+   owner command suite, and incident paging flows remain functional.
+2. **Exercise monitoring integrations** – Ensure Defender Sentinels, Forta bots,
+   and Prometheus/Alertmanager escalate real on-chain events inside five minutes.
+3. **Prove documentation accuracy** – Walk through `docs/incident-response.md`,
+   `docs/security/onchain-monitoring.md`, and the new Slither SARIF workflow so
+   that the team confirms procedures match the deployed automation.
+
+## Preparation checklist (T-7 days)
+
+- [ ] Schedule a 90-minute tabletop window with the Incident Commander (IC),
+      Technical Lead (TL), Communications (COMMS), and Treasury representative.
+- [ ] Export the latest signed release bundle and SBOM from the `release`
+      workflow artefacts. Store them in the incident exercise folder.
+- [ ] Run `npm run owner:snapshot` on a forked network to capture the baseline
+      module state used for comparison during the drill.
+- [ ] Trigger the `static-analysis` workflow on a staging branch to confirm the
+      Slither SARIF upload appears in the GitHub "Security" tab. Capture the
+      job URL for the exercise notes.
+
+## Exercise script (T-day)
+
+1. **Inject scenario** – Facilitator describes a Forta alert detecting an
+   unauthorised `pause()` call on `StakeManager`.
+2. **Monitoring validation** – Ops engineer opens Defender Sentinel, verifies
+   the alert payload, and posts the link into the incident chat.
+3. **Command execution** – TL runs `npm run owner:emergency` in dry-run mode and
+   presents the generated Safe transaction for multi-sig approval. Treasury
+   confirms signers are reachable.
+4. **Forensics bundle** – FORENSICS exports the latest Slither SARIF artefact
+   from the workflow run, compares it against the repository baseline
+   (`reports/security/slither-baseline.json`), and validates that findings are
+   triaged in the GitHub Security tab. Any `High` severities must be resolved or
+   waived prior to concluding the drill.
+5. **Comms dry-run** – COMMS drafts the SEV-1 holding statement using the
+   template in `docs/incident-response.md` §7 and circulates it for approval.
+6. **Debrief** – Capture timing, gaps, and tool issues. Update `docs/incident-response.md`
+   with lessons learned and ticket action items for backlog tracking.
+
+## Success criteria
+
+- All critical contacts acknowledged the page within 5 minutes.
+- Pause tooling produced a valid Safe bundle and owners confirmed signer
+  availability.
+- Monitoring dashboards showed correlated Forta, Defender, and Prometheus
+  alerts.
+- Slither SARIF artefact uploaded successfully to GitHub, demonstrating that the
+  static-analysis workflow is running green.
+- Post-exercise report stored in the compliance archive alongside the release
+  provenance attestation.
+
+## Follow-up (T+7 days)
+
+- [ ] Close or track remediation tickets spawned during the exercise.
+- [ ] Rotate the tabletop scenario (e.g., validator slashing, treasury drain) so
+      the next rehearsal covers a different failure mode.
+- [ ] Confirm that documentation updates were merged and referenced in the
+      `OWNER_CONTROL` index so the operator handbook stays authoritative.
+
+Maintaining this cadence satisfies the "monitoring & incident response" control
+in the institutional readiness rubric and creates auditable evidence that the
+team can execute emergency procedures under pressure.

--- a/reports/security/slither-baseline.json
+++ b/reports/security/slither-baseline.json
@@ -1,0 +1,6855 @@
+[
+  {
+    "ruleId": "0-0-arbitrary-send-erc20",
+    "message": "EscrowVault.deposit(uint256,address,uint256) (contracts/v2/kernel/EscrowVault.sol#52-58) uses arbitrary from in transferFrom: token.safeTransferFrom(from,address(this),amount) (contracts/v2/kernel/EscrowVault.sol#55)\n",
+    "uri": "contracts/v2/kernel/EscrowVault.sol",
+    "startLine": 52,
+    "fingerprint": "3e20a8f26c8371337bf9c3fa18edc5f9c139c50ada5642231f783ea590995122"
+  },
+  {
+    "ruleId": "0-0-arbitrary-send-erc20",
+    "message": "StakeManager.lockDisputeFee(address,uint256) (contracts/v2/StakeManager.sol#2615-2618) uses arbitrary from in transferFrom: token.safeTransferFrom(payer,address(this),amount) (contracts/v2/StakeManager.sol#2616)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2615,
+    "fingerprint": "5b5fa75a590eb3d9bb738068483cc0f82f8e38ec11bb014cde952d4383f39d4c"
+  },
+  {
+    "ruleId": "0-0-arbitrary-send-erc20",
+    "message": "StakeManager.lockReward(bytes32,address,uint256) (contracts/v2/StakeManager.sol#2234-2238) uses arbitrary from in transferFrom: token.safeTransferFrom(from,address(this),amount) (contracts/v2/StakeManager.sol#2235)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2234,
+    "fingerprint": "7406f36f63bad015d009854104a3cc47d5167be9f5e1d90770031ebf2db53706"
+  },
+  {
+    "ruleId": "0-0-arbitrary-send-erc20",
+    "message": "StakeManager.lock(address,uint256) (contracts/v2/StakeManager.sol#2246-2249) uses arbitrary from in transferFrom: token.safeTransferFrom(from,address(this),amount) (contracts/v2/StakeManager.sol#2247)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2246,
+    "fingerprint": "ea31c64d3a4e032c2fe4d0c4d0bc323a75fd7282677209461e04785434034fdd"
+  },
+  {
+    "ruleId": "0-1-arbitrary-send-eth",
+    "message": "TimelockController._execute(address,uint256,bytes) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#411-414) sends eth to arbitrary user\n\tDangerous calls:\n\t- (success,returndata) = target.call{value: value}(data) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#412)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/TimelockController.sol",
+    "startLine": 411,
+    "fingerprint": "228f5b9e3ff9425a496f3d4a8d2f9a0075f0e7b803bc50312593af3f6b0d69e7"
+  },
+  {
+    "ruleId": "0-1-arbitrary-send-eth",
+    "message": "Governor._executeOperations(uint256,address[],uint256[],bytes[],bytes32) (node_modules/@openzeppelin/contracts/governance/Governor.sol#434-445) sends eth to arbitrary user\n\tDangerous calls:\n\t- (success,returndata) = targets[i].call{value: values[i]}(calldatas[i]) (node_modules/@openzeppelin/contracts/governance/Governor.sol#442)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 434,
+    "fingerprint": "2a9654651ae4329e475676436359d67d7b0f2da2ed8e5223ae4c0bd923e85d25"
+  },
+  {
+    "ruleId": "0-1-arbitrary-send-eth",
+    "message": "Governor.relay(address,uint256,bytes) (node_modules/@openzeppelin/contracts/governance/Governor.sol#656-659) sends eth to arbitrary user\n\tDangerous calls:\n\t- (success,returndata) = target.call{value: value}(data) (node_modules/@openzeppelin/contracts/governance/Governor.sol#657)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 656,
+    "fingerprint": "5fd17b173450ccd7297a81adf71ad04efceb8299671ee5791e1cb106b5be2e63"
+  },
+  {
+    "ruleId": "0-1-weak-prng",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) uses a weak PRNG: \"offset = uint256(keccak256(bytes)(abi.encodePacked(randaoValue,bhash))) % n (contracts/v2/ValidationModule.sol#996-998)\" \n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "216ebe33b6b3ddba7932125f8b0ae587f124362dd24eaa189ed84ce281cc258b"
+  },
+  {
+    "ruleId": "0-1-weak-prng",
+    "message": "JobRouter.selectPlatform(bytes32) (contracts/v2/modules/JobRouter.sol#114-152) uses a weak PRNG: \"rand = uint256(keccak256(bytes)(abi.encodePacked(blockhash(uint256)(block.number - 1),seed))) % total (contracts/v2/modules/JobRouter.sol#133-134)\" \n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 114,
+    "fingerprint": "3bd5b3092a7232d1ac10e93c336865c51840d389a5fd081a0d8b56ea0e17dc71"
+  },
+  {
+    "ruleId": "0-1-weak-prng",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) uses a weak PRNG: \"validatorPoolRotation = (rotationStart + i) % n (contracts/v2/ValidationModule.sol#1081)\" \n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "408017752eb79c23c286e4a0e7190463b5752893dcda614fc91d866745a6fa7c"
+  },
+  {
+    "ruleId": "0-1-weak-prng",
+    "message": "RoutingModule.selectOperator(bytes32,bytes32) (contracts/v2/modules/RoutingModule.sol#124-187) uses a weak PRNG: \"rand = uint256(keccak256(bytes)(abi.encode(bh,seed))) % totalWeight (contracts/v2/modules/RoutingModule.sol#165)\" \n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 124,
+    "fingerprint": "62cbfa2d1537e3d918b3554bad33a482efc85ae922058667a2ef2dfd4455a0e1"
+  },
+  {
+    "ruleId": "0-1-weak-prng",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) uses a weak PRNG: \"pick = randomSeed % totalStake (contracts/v2/ValidationModule.sol#1188)\" \n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "6ebd25520182a98533f7fbb361314878ee45fe7b33d1a45cfba086825ae39999"
+  },
+  {
+    "ruleId": "0-1-weak-prng",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) uses a weak PRNG: \"j = randomSeed % eligible (contracts/v2/ValidationModule.sol#1169)\" \n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "87967cd00a9c20b892e980109173a4bc8177a9db4bb54733b0367e9da3656fc2"
+  },
+  {
+    "ruleId": "0-1-weak-prng",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) uses a weak PRNG: \"idx = (rotationStart + i) % n (contracts/v2/ValidationModule.sol#1002)\" \n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "95b4333923f3de72f090bda7458631f66a2b4629e8bd2d66501f19b529fb22da"
+  },
+  {
+    "ruleId": "0-1-weak-prng",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) uses a weak PRNG: \"rotationStart = (rotationStart + offset) % n (contracts/v2/ValidationModule.sol#999)\" \n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "ad036b80c8824e5b1ac650c7f5c5ba8a8ac6841cd550122c555159f46714b636"
+  },
+  {
+    "ruleId": "0-1-weak-prng",
+    "message": "AuditModule.onJobFinalized(uint256,address,bool,bytes32) (contracts/v2/AuditModule.sol#97-127) uses a weak PRNG: \"uint256(seed) % MAX_BPS >= auditProbabilityBps (contracts/v2/AuditModule.sol#113)\" \n",
+    "uri": "contracts/v2/AuditModule.sol",
+    "startLine": 97,
+    "fingerprint": "d3b823d7c1066bfbc1969faca71de1c3bd205db7119c2c4d72812227c99e6438"
+  },
+  {
+    "ruleId": "0-0-encode-packed-collision",
+    "message": "CertificateNFT.tokenURI(uint256) (contracts/v2/modules/CertificateNFT.sol#102-106) calls abi.encodePacked() with multiple dynamic arguments:\n\t- string(abi.encodePacked(_baseTokenURI,tokenId.toString())) (contracts/v2/modules/CertificateNFT.sol#105)\n",
+    "uri": "contracts/v2/modules/CertificateNFT.sol",
+    "startLine": 102,
+    "fingerprint": "a8800d6d70bb8292fc35570915870ea53613c75cd3b13e581aea303b4176cbb2"
+  },
+  {
+    "ruleId": "0-0-encode-packed-collision",
+    "message": "CertificateNFT.tokenURI(uint256) (contracts/v2/CertificateNFT.sol#165-169) calls abi.encodePacked() with multiple dynamic arguments:\n\t- string(abi.encodePacked(_baseTokenURI,tokenId.toString())) (contracts/v2/CertificateNFT.sol#168)\n",
+    "uri": "contracts/v2/CertificateNFT.sol",
+    "startLine": 165,
+    "fingerprint": "dee07be1cda6bded0d2711dafacfd35d281f49422ab97e9761a0cbe715a27393"
+  },
+  {
+    "ruleId": "0-1-incorrect-exp",
+    "message": "Math.mulDiv(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#204-275) has bitwise-xor operator ^ instead of the exponentiation operator **: \n\t - inverse = (3 * denominator) ^ 2 (node_modules/@openzeppelin/contracts/utils/math/Math.sol#257)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 204,
+    "fingerprint": "4d936ce201916582dc2961cee4ed7729f33d7e5e2f4c54e08aaf3d1ed886f21a"
+  },
+  {
+    "ruleId": "0-0-shadowing-state",
+    "message": "Governor._name (node_modules/@openzeppelin/contracts/governance/Governor.sol#48) shadows:\n\t- EIP712._name (node_modules/@openzeppelin/contracts/utils/cryptography/EIP712.sol#49)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 48,
+    "fingerprint": "1d54e2909079cdec62c8bfde52b3ad4cd372ff647fb6186889d7d276cb4164ee"
+  },
+  {
+    "ruleId": "0-1-unchecked-transfer",
+    "message": "SimpleJobRegistry.finalizeJob(uint256,string) (contracts/test/SimpleJobRegistry.sol#144-152) ignores return value by token.transfer(job.agent,job.reward) (contracts/test/SimpleJobRegistry.sol#150)\n",
+    "uri": "contracts/test/SimpleJobRegistry.sol",
+    "startLine": 144,
+    "fingerprint": "af99e0242ca1326434d6fed0332232145474cf4c3150ed8aee385973be81b0ae"
+  },
+  {
+    "ruleId": "0-1-unchecked-transfer",
+    "message": "SimpleJobRegistry.createJob(uint256,uint64,bytes32,string) (contracts/test/SimpleJobRegistry.sol#92-114) ignores return value by token.transferFrom(msg.sender,address(this),reward) (contracts/test/SimpleJobRegistry.sol#99)\n",
+    "uri": "contracts/test/SimpleJobRegistry.sol",
+    "startLine": 92,
+    "fingerprint": "ff37d59d778746d85654fa40c7d1704f668b731cd5da96a8953410d7e6143a13"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "StakeManager.release(address,address,uint256,bool) (contracts/v2/StakeManager.sol#2380-2413) performs a multiplication on the result of a division:\n\t- modified = (amount * pct) / 100 (contracts/v2/StakeManager.sol#2388)\n\t- burnAmount = (modified * burnPct) / 100 (contracts/v2/StakeManager.sol#2392)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2380,
+    "fingerprint": "1e702aa2d5a4b8028976c646158b101bfe260f31989712b12ba8ffceddc7a5c4"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495) performs a multiplication on the result of a division:\n\t- agentAmount = (rewardAfterValidator * agentPct) / 100 (contracts/v2/JobRegistry.sol#2347)\n\t- payout = agentAmount * 1e12 (contracts/v2/JobRegistry.sol#2411)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "2110762b981e8a7c65c0716fdf6f33f4de7b8a349e54c5f296f9b134593b9eb3"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "StakeManager.releaseReward(bytes32,address,address,uint256,bool) (contracts/v2/StakeManager.sol#2260-2310) performs a multiplication on the result of a division:\n\t- modified = (amount * pct) / 100 (contracts/v2/StakeManager.sol#2273)\n\t- feeAmount = (modified * feePct) / 100 (contracts/v2/StakeManager.sol#2274)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2260,
+    "fingerprint": "2f94684af2589d7e048e39f770f8829be2fe9be2539f47fa14257ff87de86b9b"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "Math.mulDiv(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#204-275) performs a multiplication on the result of a division:\n\t- denominator = denominator / twos (node_modules/@openzeppelin/contracts/utils/math/Math.sol#242)\n\t- inverse *= 2 - denominator * inverse (node_modules/@openzeppelin/contracts/utils/math/Math.sol#265)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 204,
+    "fingerprint": "3d48e88a78e6c2ea76ea46494733ec31da351636c3208631f9ab09d6ec7bad6e"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "Math.mulDiv(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#204-275) performs a multiplication on the result of a division:\n\t- denominator = denominator / twos (node_modules/@openzeppelin/contracts/utils/math/Math.sol#242)\n\t- inverse *= 2 - denominator * inverse (node_modules/@openzeppelin/contracts/utils/math/Math.sol#261)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 204,
+    "fingerprint": "4aeacef08ff359131ba81eb4ef200bd41b2c46a241e71099f370b99d0fc83623"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "Math.mulDiv(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#204-275) performs a multiplication on the result of a division:\n\t- denominator = denominator / twos (node_modules/@openzeppelin/contracts/utils/math/Math.sol#242)\n\t- inverse *= 2 - denominator * inverse (node_modules/@openzeppelin/contracts/utils/math/Math.sol#264)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 204,
+    "fingerprint": "4cb35ca2c0908489e42a2323d54743d20f672fa6e76e6ce78a045382ba3ad786"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "Math.mulDiv(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#204-275) performs a multiplication on the result of a division:\n\t- denominator = denominator / twos (node_modules/@openzeppelin/contracts/utils/math/Math.sol#242)\n\t- inverse *= 2 - denominator * inverse (node_modules/@openzeppelin/contracts/utils/math/Math.sol#266)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 204,
+    "fingerprint": "60ad34e4eeaf9be8431735326a047c2e4f456879271036cbffc3479b329b7c16"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "FeePool.claimRewards() (contracts/v2/FeePool.sol#346-366) performs a multiplication on the result of a division:\n\t- boosted = (stake * pct) / 100 (contracts/v2/FeePool.sol#360)\n\t- cumulative = (boosted * cumulativePerToken) / ACCUMULATOR_SCALE (contracts/v2/FeePool.sol#361)\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 346,
+    "fingerprint": "6da3f9108bff6f3a73eb1c363b339b6f3d788e60afa29a0201854d584f935cc6"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "RewardEngineMB._distribute(RewardEngineMB.Role,uint256,RewardEngineMB.RoleData,uint256[],uint256) (contracts/v2/RewardEngineMB.sol#382-401) performs a multiplication on the result of a division:\n\t- bucket = budget * roleShare[r] / uint256(WAD) (contracts/v2/RewardEngineMB.sol#389)\n\t- amt = (bucket * gw) / sum (contracts/v2/RewardEngineMB.sol#395)\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 382,
+    "fingerprint": "75dd5a0f8f5a02c66a39f424183e0924cd6cd791cd610b7ffead2112b1667358"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "KernelJobRegistry._finalize(uint256,bool,address[]) (contracts/v2/kernel/JobRegistry.sol#301-351) performs a multiplication on the result of a division:\n\t- base = split.validatorAmount / validatorCount (contracts/v2/kernel/JobRegistry.sol#320)\n\t- remainder = split.validatorAmount - (base * validatorCount) (contracts/v2/kernel/JobRegistry.sol#321)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 301,
+    "fingerprint": "7a3be43b84ed71bb60908c34aa6bb7cf743c6e0d9cfa182af2e528bae7506e3d"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "ValidationModule._finalize(uint256) (contracts/v2/ValidationModule.sol#1658-1787) performs a multiplication on the result of a division:\n\t- agentAmount = (rewardAfterValidator * agentPct) / 100 (contracts/v2/ValidationModule.sol#1726)\n\t- payout = agentAmount * 1e12 (contracts/v2/ValidationModule.sol#1727)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1658,
+    "fingerprint": "8429f7845962bc4976b2b4833ec41d314a1100ce933c3c2f35843e5e06125bcb"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "Math.invMod(uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#315-361) performs a multiplication on the result of a division:\n\t- quotient = gcd / remainder (node_modules/@openzeppelin/contracts/utils/math/Math.sol#337)\n\t- (gcd,remainder) = (remainder,gcd - remainder * quotient) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#339-346)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 315,
+    "fingerprint": "8942d09312126f44013988cc108ac45ba34577923cb67635312b8c71c04f4fe7"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "ReputationEngine.calculateReputationPoints(uint256,uint256) (contracts/v2/ReputationEngine.sol#321-327) performs a multiplication on the result of a division:\n\t- payoutPoints = (scaledPayout ** PAYOUT_EXPONENT) / PAYOUT_SCALE (contracts/v2/ReputationEngine.sol#325)\n\t- log2(1 + payoutPoints * LOG_FACTOR) + duration / DURATION_SCALE (contracts/v2/ReputationEngine.sol#326)\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 321,
+    "fingerprint": "9b1bd18fa1d10212613be1a48a2b5fd08e297db0572fbc80124daf43a4c1f667"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "StakeManager._finalizeJobFunds(bytes32,address,address,uint256,uint256,uint256,uint256,IFeePool) (contracts/v2/StakeManager.sol#2453-2518) performs a multiplication on the result of a division:\n\t- modified = (rewardSpent * pct) / 100 (contracts/v2/StakeManager.sol#2480)\n\t- burnAmount = (modified * burnPct) / 100 (contracts/v2/StakeManager.sol#2481)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2453,
+    "fingerprint": "bb30c2b681ccc7af6c0ef19548562d2f783601b136183d511895d61aa56a870e"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "Math.mulDiv(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#204-275) performs a multiplication on the result of a division:\n\t- denominator = denominator / twos (node_modules/@openzeppelin/contracts/utils/math/Math.sol#242)\n\t- inverse *= 2 - denominator * inverse (node_modules/@openzeppelin/contracts/utils/math/Math.sol#262)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 204,
+    "fingerprint": "c441bddd6a4f9b67a2832342503f73b68a124a376c8a3703246526f3efba6261"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "Math.mulDiv(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#204-275) performs a multiplication on the result of a division:\n\t- denominator = denominator / twos (node_modules/@openzeppelin/contracts/utils/math/Math.sol#242)\n\t- inverse = (3 * denominator) ^ 2 (node_modules/@openzeppelin/contracts/utils/math/Math.sol#257)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 204,
+    "fingerprint": "cbf56b3b7d31837c4f3943e7e8415e9bdbfbfd12e6233ab5aaef7bc041b1a8cb"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "Math.mulDiv(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#204-275) performs a multiplication on the result of a division:\n\t- denominator = denominator / twos (node_modules/@openzeppelin/contracts/utils/math/Math.sol#242)\n\t- inverse *= 2 - denominator * inverse (node_modules/@openzeppelin/contracts/utils/math/Math.sol#263)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 204,
+    "fingerprint": "d5bd28d0e83d49dc7bb8cfab1f39fb57d25a1bc4fa100e68e948ec895b2ff827"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "Math.mulDiv(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#204-275) performs a multiplication on the result of a division:\n\t- low = low / twos (node_modules/@openzeppelin/contracts/utils/math/Math.sol#245)\n\t- result = low * inverse (node_modules/@openzeppelin/contracts/utils/math/Math.sol#272)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 204,
+    "fingerprint": "d5d38534b31e47c09beab2a0538b7455f1cadbe95c1ed3c895652ff6a78f0e87"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "StakeManager.release(address,address,uint256,bool) (contracts/v2/StakeManager.sol#2380-2413) performs a multiplication on the result of a division:\n\t- modified = (amount * pct) / 100 (contracts/v2/StakeManager.sol#2388)\n\t- feeAmount = (modified * feePct) / 100 (contracts/v2/StakeManager.sol#2391)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2380,
+    "fingerprint": "dedfe15bccd8b0d7d922161841fde76e5d6f87b730b1254cf2fbd4d2b05383ac"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "FeePool._distributeFees() (contracts/v2/FeePool.sol#299-326) performs a multiplication on the result of a division:\n\t- perToken = (amount * ACCUMULATOR_SCALE) / total (contracts/v2/FeePool.sol#314)\n\t- accounted = (perToken * total) / ACCUMULATOR_SCALE (contracts/v2/FeePool.sol#316)\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 299,
+    "fingerprint": "edd8654511a50721face6c37e18877111f17a6055f18663eba6eb22261954245"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495) performs a multiplication on the result of a division:\n\t- agentAmount = (rewardAfterValidator * agentPct) / 100 (contracts/v2/JobRegistry.sol#2347)\n\t- expectedBurn = (agentAmount * burnRate) / 100 (contracts/v2/JobRegistry.sol#2398)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "f7f42193d0ad18cff2cda57c008fd52947c7ecd8dbb32b67d1259a6e73da4015"
+  },
+  {
+    "ruleId": "1-1-divide-before-multiply",
+    "message": "StakeManager.releaseReward(bytes32,address,address,uint256,bool) (contracts/v2/StakeManager.sol#2260-2310) performs a multiplication on the result of a division:\n\t- modified = (amount * pct) / 100 (contracts/v2/StakeManager.sol#2273)\n\t- burnAmount = (modified * burnPct) / 100 (contracts/v2/StakeManager.sol#2275)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2260,
+    "fingerprint": "ffec5ce4ba3a7fb0a99d83b73ab42539aaaaa4ec2f0048c504d837912eb8118d"
+  },
+  {
+    "ruleId": "1-0-incorrect-equality",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) uses a dangerous strict equality:\n\t- bhash == bytes32(0) (contracts/v2/ValidationModule.sol#919)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "0add85da290b9b6590342fb3fb26963b6c89fc32c10598725037a8e9adda495a"
+  },
+  {
+    "ruleId": "1-0-incorrect-equality",
+    "message": "GovernanceReward.finalizeEpoch(uint256) (contracts/v2/GovernanceReward.sol#142-155) uses a dangerous strict equality:\n\t- require(bool,string)(rewardAmount == expected,reward) (contracts/v2/GovernanceReward.sol#149)\n",
+    "uri": "contracts/v2/GovernanceReward.sol",
+    "startLine": 142,
+    "fingerprint": "1056c1a9a94b2e7a76e0c61ae6de05522175cc4a624eaf13a1224350c8503e7a"
+  },
+  {
+    "ruleId": "1-0-incorrect-equality",
+    "message": "TimelockController.getOperationState(bytes32) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#206-217) uses a dangerous strict equality:\n\t- timestamp == _DONE_TIMESTAMP (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#210)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/TimelockController.sol",
+    "startLine": 206,
+    "fingerprint": "37c707b73324e52223d71f34096b99968436a7c54d9941859088859236204a01"
+  },
+  {
+    "ruleId": "1-0-incorrect-equality",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) uses a dangerous strict equality:\n\t- selectionBlock[jobId] == 0 && r.commitDeadline == 0 (contracts/v2/ValidationModule.sol#859)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "63a2c8e01d981642cdcea34d53fdbd1469cf2b764b8269e65ecf5728a6f3dda6"
+  },
+  {
+    "ruleId": "1-0-incorrect-equality",
+    "message": "TimelockController.getOperationState(bytes32) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#206-217) uses a dangerous strict equality:\n\t- timestamp == 0 (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#208)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/TimelockController.sol",
+    "startLine": 206,
+    "fingerprint": "94e8addfa086f63793f262b7150f16fa2b6e75e122a93e1d63c20d13eb8102d8"
+  },
+  {
+    "ruleId": "1-0-incorrect-equality",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) uses a dangerous strict equality:\n\t- selectionBlock[jobId] == 0 (contracts/v2/ValidationModule.sol#864)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "9a8779e5f0ca0242427c9e6cce9dce29f8acb670f0aa4db77535cf21b343d406"
+  },
+  {
+    "ruleId": "1-0-incorrect-equality",
+    "message": "RoutingModule.selectOperator(bytes32,bytes32) (contracts/v2/modules/RoutingModule.sol#124-187) uses a dangerous strict equality:\n\t- bh == bytes32(0) (contracts/v2/modules/RoutingModule.sol#138)\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 124,
+    "fingerprint": "b0209d54dad3206037a26b41ed781eb8eef0e4156862740d0da45b7c469e8f42"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract GovernanceReward (contracts/v2/GovernanceReward.sol#18-180) has payable functions:\n\t - GovernanceReward.receive() (contracts/v2/GovernanceReward.sol#173-175)\n\t - GovernanceReward.fallback() (contracts/v2/GovernanceReward.sol#177-179)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/GovernanceReward.sol",
+    "startLine": 18,
+    "fingerprint": "0ff6329edb9cef19f84aaa981994585090895aa23181a0ba748e361e1b16bdac"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract IdentityRegistry (contracts/v2/IdentityRegistry.sol#22-1389) has payable functions:\n\t - IdentityRegistry.receive() (contracts/v2/IdentityRegistry.sol#1381-1383)\n\t - IdentityRegistry.fallback() (contracts/v2/IdentityRegistry.sol#1386-1388)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 22,
+    "fingerprint": "1e85b0071d847df8091973214cdb6c2b8c45bfed7c9368339e34a487ec329549"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract JobRegistry (contracts/v2/JobRegistry.sol#26-2680) has payable functions:\n\t - JobRegistry.receive() (contracts/v2/JobRegistry.sol#2672-2674)\n\t - JobRegistry.fallback() (contracts/v2/JobRegistry.sol#2677-2679)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 26,
+    "fingerprint": "485df4b2f4b937b89769993e3aab8f2260323ae66d934f15c582d24eb1fd463c"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract DisputeRegistryStub (contracts/legacy/DisputeRegistryStub.sol#16-48) has payable functions:\n\t - DisputeRegistryStub.appeal(address,uint256,bytes32) (contracts/legacy/DisputeRegistryStub.sol#41-47)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/legacy/DisputeRegistryStub.sol",
+    "startLine": 16,
+    "fingerprint": "4d2fc1fced7eb53a8da19d7388b5a1f1247199fba052d58708597571c42b9566"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract RoutingModule (contracts/v2/modules/RoutingModule.sol#10-226) has payable functions:\n\t - RoutingModule.receive() (contracts/v2/modules/RoutingModule.sol#202-204)\n\t - RoutingModule.fallback() (contracts/v2/modules/RoutingModule.sol#207-209)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 10,
+    "fingerprint": "4fb350750c00661652f2a840186975c6206ae4d3165567a1f083aab406f3a9d8"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract DiscoveryModule (contracts/v2/modules/DiscoveryModule.sol#11-163) has payable functions:\n\t - DiscoveryModule.receive() (contracts/v2/modules/DiscoveryModule.sol#155-157)\n\t - DiscoveryModule.fallback() (contracts/v2/modules/DiscoveryModule.sol#160-162)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 11,
+    "fingerprint": "51230041b3d3ac0645e48871250a8e4fb2c354d872b7be9d1b881a5ad61981cc"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract PlatformIncentives (contracts/v2/PlatformIncentives.sol#16-184) has payable functions:\n\t - PlatformIncentives.receive() (contracts/v2/PlatformIncentives.sol#176-178)\n\t - PlatformIncentives.fallback() (contracts/v2/PlatformIncentives.sol#181-183)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/PlatformIncentives.sol",
+    "startLine": 16,
+    "fingerprint": "5eb2b180b719226da26436d05f9658d7005e64f5fabceb6115525052cf8e970b"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract DisputeModule (contracts/v2/modules/DisputeModule.sol#21-600) has payable functions:\n\t - DisputeModule.receive() (contracts/v2/modules/DisputeModule.sol#592-594)\n\t - DisputeModule.fallback() (contracts/v2/modules/DisputeModule.sol#597-599)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 21,
+    "fingerprint": "68d939504b2cb5932db7e7218cb403660f160546453c511872cd9ace11ffe5a0"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract PlatformRegistry (contracts/v2/PlatformRegistry.sol#24-526) has payable functions:\n\t - PlatformRegistry.receive() (contracts/v2/PlatformRegistry.sol#485-487)\n\t - PlatformRegistry.fallback() (contracts/v2/PlatformRegistry.sol#489-491)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 24,
+    "fingerprint": "6cf3122ab0a016dfacae0dafbbb975f93f0b26b3d73d72c052b13d007d931924"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract ValidationModuleFailoverHarness (contracts/v2/mocks/ValidationModuleFailoverHarness.sol#6-36) has payable functions:\n\t - ValidationModule.receive() (contracts/v2/ValidationModule.sol#1868-1870)\n\t - ValidationModule.fallback() (contracts/v2/ValidationModule.sol#1873-1875)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/mocks/ValidationModuleFailoverHarness.sol",
+    "startLine": 6,
+    "fingerprint": "6daf53f4bcc7c326740eaadea917b6f6e9eacb58f21149f1e49ddf64d9164381"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract FeePool (contracts/v2/FeePool.sol#45-627) has payable functions:\n\t - FeePool.receive() (contracts/v2/FeePool.sol#619-621)\n\t - FeePool.fallback() (contracts/v2/FeePool.sol#624-626)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 45,
+    "fingerprint": "714e70cc6e031f26375b13879b0be76689375463be87efd360a7e28b9d4d5373"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract RevenueDistributor (contracts/v2/modules/RevenueDistributor.sol#13-136) has payable functions:\n\t - RevenueDistributor.receive() (contracts/v2/modules/RevenueDistributor.sol#128-130)\n\t - RevenueDistributor.fallback() (contracts/v2/modules/RevenueDistributor.sol#133-135)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/modules/RevenueDistributor.sol",
+    "startLine": 13,
+    "fingerprint": "83f331410eaf3cf00a2a1f313935d34614c8dd6ccec8c503a215438f698ecf75"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract NoValidationModule (contracts/v2/modules/NoValidationModule.sol#11-213) has payable functions:\n\t - NoValidationModule.receive() (contracts/v2/modules/NoValidationModule.sol#205-207)\n\t - NoValidationModule.fallback() (contracts/v2/modules/NoValidationModule.sol#210-212)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/modules/NoValidationModule.sol",
+    "startLine": 11,
+    "fingerprint": "87bceefc4faec86d8c19fb474b684ee2aee31c04b75f2d976ef783df33096505"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract JobEscrow (contracts/v2/modules/JobEscrow.sol#32-211) has payable functions:\n\t - JobEscrow.receive() (contracts/v2/modules/JobEscrow.sol#203-205)\n\t - JobEscrow.fallback() (contracts/v2/modules/JobEscrow.sol#208-210)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/modules/JobEscrow.sol",
+    "startLine": 32,
+    "fingerprint": "8e40d439770743370b706d01a4bff4695cc9df5ea7e6c5e68b3cc3104e46cb5a"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract OracleValidationModule (contracts/v2/modules/OracleValidationModule.sol#19-236) has payable functions:\n\t - OracleValidationModule.receive() (contracts/v2/modules/OracleValidationModule.sol#228-230)\n\t - OracleValidationModule.fallback() (contracts/v2/modules/OracleValidationModule.sol#233-235)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/modules/OracleValidationModule.sol",
+    "startLine": 19,
+    "fingerprint": "97b697fd74995851a904000da86f1d01e5d53177df0e9794e9aee04f65fdf5b3"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract CertificateNFT (contracts/v2/CertificateNFT.sol#19-232) has payable functions:\n\t - CertificateNFT.receive() (contracts/v2/CertificateNFT.sol#224-226)\n\t - CertificateNFT.fallback() (contracts/v2/CertificateNFT.sol#229-231)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/CertificateNFT.sol",
+    "startLine": 19,
+    "fingerprint": "a7ced91b267b13b3f116027144d5e091d87901e91f224092d8264507f2301a47"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract StakeManager (contracts/v2/StakeManager.sol#72-2939) has payable functions:\n\t - StakeManager.receive() (contracts/v2/StakeManager.sol#2931-2933)\n\t - StakeManager.fallback() (contracts/v2/StakeManager.sol#2936-2938)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 72,
+    "fingerprint": "aaee609dee851183876243c585cf1eea3594fd75f9241690f6f7998f710adb8e"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract JobRouter (contracts/v2/modules/JobRouter.sol#11-174) has payable functions:\n\t - JobRouter.receive() (contracts/v2/modules/JobRouter.sol#166-168)\n\t - JobRouter.fallback() (contracts/v2/modules/JobRouter.sol#171-173)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 11,
+    "fingerprint": "ad631c2b4127e1bba456c177c65ec1462630e742dcd10493531f62faab648bba"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract TaxPolicy (contracts/v2/TaxPolicy.sol#15-292) has payable functions:\n\t - TaxPolicy.receive() (contracts/v2/TaxPolicy.sol#284-286)\n\t - TaxPolicy.fallback() (contracts/v2/TaxPolicy.sol#289-291)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/TaxPolicy.sol",
+    "startLine": 15,
+    "fingerprint": "ba81688df147787b965233e9035a4b7d9c2f6f1cfe6c98e3a1ac2b86622704b9"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract ReputationEngine (contracts/v2/ReputationEngine.sol#15-455) has payable functions:\n\t - ReputationEngine.receive() (contracts/v2/ReputationEngine.sol#447-449)\n\t - ReputationEngine.fallback() (contracts/v2/ReputationEngine.sol#452-454)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 15,
+    "fingerprint": "ca656d786b43fc4c04583d78864e4b9a6d9d04ee5bb961c52741f3ea6b07b81a"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract RandaoCoordinator (contracts/v2/RandaoCoordinator.sol#17-267) has payable functions:\n\t - RandaoCoordinator.receive() (contracts/v2/RandaoCoordinator.sol#259-261)\n\t - RandaoCoordinator.fallback() (contracts/v2/RandaoCoordinator.sol#264-266)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/RandaoCoordinator.sol",
+    "startLine": 17,
+    "fingerprint": "d30d40f8d6550720d4b7de5178032c309814d1db9d743eb272ce7e94d37c2930"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract AGIALPHAToken (contracts/test/AGIALPHAToken.sol#14-101) has payable functions:\n\t - AGIALPHAToken.receive() (contracts/test/AGIALPHAToken.sol#93-95)\n\t - AGIALPHAToken.fallback() (contracts/test/AGIALPHAToken.sol#98-100)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/test/AGIALPHAToken.sol",
+    "startLine": 14,
+    "fingerprint": "e1dc522e706ada45fa6752a163f1bdad397f6c88b6f5bf0fad50370a1217912c"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract ENSOwnershipVerifier (contracts/v2/modules/ENSOwnershipVerifier.sol#11-179) has payable functions:\n\t - ENSOwnershipVerifier.receive() (contracts/v2/modules/ENSOwnershipVerifier.sol#171-173)\n\t - ENSOwnershipVerifier.fallback() (contracts/v2/modules/ENSOwnershipVerifier.sol#176-178)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/modules/ENSOwnershipVerifier.sol",
+    "startLine": 11,
+    "fingerprint": "e338e2c0eef465b02f3106af85b5b5b1a0eea0533950b88f529262345d1277d3"
+  },
+  {
+    "ruleId": "1-0-locked-ether",
+    "message": "Contract locking ether found:\n\tContract KlerosDisputeModule (contracts/v2/modules/KlerosDisputeModule.sol#12-214) has payable functions:\n\t - KlerosDisputeModule.receive() (contracts/v2/modules/KlerosDisputeModule.sol#206-208)\n\t - KlerosDisputeModule.fallback() (contracts/v2/modules/KlerosDisputeModule.sol#211-213)\n\tBut does not have a function to withdraw the ether\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 12,
+    "fingerprint": "ea2340c7c79a3b8e94e7ead8626f85e092f49ce9e37502f3779a1e326970827c"
+  },
+  {
+    "ruleId": "1-0-mapping-deletion",
+    "message": "ArbitratorCommittee.finalize(uint256) (contracts/v2/ArbitratorCommittee.sol#149-170) deletes ArbitratorCommittee.Case (contracts/v2/ArbitratorCommittee.sol#21-31) which contains a mapping:\n\t-delete cases[jobId] (contracts/v2/ArbitratorCommittee.sol#169)\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 149,
+    "fingerprint": "1c13fbd9da830dae3968a774df85cbd70ac26ca9d31c00e04bd296cc2638e52a"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in RewardEngineMB.settleEpoch(uint256,RewardEngineMB.EpochData) (contracts/v2/RewardEngineMB.sol#236-311):\n\tExternal calls:\n\t- (agents,v,pre,post) = _aggregate(data.agents,epoch,Role.Agent) (contracts/v2/RewardEngineMB.sol#253)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\t- (validators,v,pre,post) = _aggregate(data.validators,epoch,Role.Validator) (contracts/v2/RewardEngineMB.sol#257)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\t- (operators,v,pre,post) = _aggregate(data.operators,epoch,Role.Operator) (contracts/v2/RewardEngineMB.sol#261)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\tState variables written after the call(s):\n\t- (operators,v,pre,post) = _aggregate(data.operators,epoch,Role.Operator) (contracts/v2/RewardEngineMB.sol#261)\n\t\t- usedNonces[att.user][epoch] = att.nonce (contracts/v2/RewardEngineMB.sol#330)\n\tRewardEngineMB.usedNonces (contracts/v2/RewardEngineMB.sol#168) can be used in cross function reentrancies:\n\t- RewardEngineMB.usedNonces (contracts/v2/RewardEngineMB.sol#168)\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 236,
+    "fingerprint": "075dbb0f753770c6f7356a7d60e74f727588679dc45743fe19772694ff6176da"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n\t\t- identityRegistry.setAgentRootNode(node) (contracts/v2/JobRegistry.sol#633)\n\t- _setAgentMerkleRoot(config.agentMerkleRoot) (contracts/v2/JobRegistry.sol#1545)\n\t\t- identityRegistry.setAgentMerkleRoot(root) (contracts/v2/JobRegistry.sol#640)\n\t- _setValidatorRootNode(config.validatorRootNode) (contracts/v2/JobRegistry.sol#1551)\n\t\t- identityRegistry.setClubRootNode(node) (contracts/v2/JobRegistry.sol#648)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#649)\n\t- _setValidatorMerkleRoot(config.validatorMerkleRoot) (contracts/v2/JobRegistry.sol#1556)\n\t\t- identityRegistry.setValidatorMerkleRoot(root) (contracts/v2/JobRegistry.sol#656)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#657)\n\tState variables written after the call(s):\n\t- _bumpAgentAuthCacheVersionInternal() (contracts/v2/JobRegistry.sol#1566)\n\t\t- ++ agentAuthCacheVersion (contracts/v2/JobRegistry.sol#668)\n\tJobRegistry.agentAuthCacheVersion (contracts/v2/JobRegistry.sol#732) can be used in cross function reentrancies:\n\t- JobRegistry._bumpAgentAuthCacheVersionInternal() (contracts/v2/JobRegistry.sol#666-671)\n\t- JobRegistry.agentAuthCacheVersion (contracts/v2/JobRegistry.sol#732)\n\t- JobRegistry.updateAgentAuthCache(address,bool) (contracts/v2/JobRegistry.sol#1203-1212)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "13b9fd5e480a3b98f1a034164d1820795d223ccce7a5231dcca462e203f976d7"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in StakeManager._slashBatched(address,StakeManager.Role,uint256,address,address[]) (contracts/v2/StakeManager.sol#2756-2799):\n\tExternal calls:\n\t- _slash(user,role,chunkAmount,recipient,slice) (contracts/v2/StakeManager.sol#2790)\n\t\t- IERC20Burnable(address(token)).burn(amount) (contracts/v2/StakeManager.sol#1091-1095)\n\t\t- feePool.depositFee(employerShare) (contracts/v2/StakeManager.sol#2716)\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- IERC20Burnable(address(token)).burn(amount) (contracts/v2/StakeManager.sol#1091-1095)\n\t\t- feePool.depositFee(employerShare) (contracts/v2/StakeManager.sol#2716)\n\tState variables written after the call(s):\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- boostedStake[user][role] = newBoosted (contracts/v2/StakeManager.sol#2679)\n\tStakeManager.boostedStake (contracts/v2/StakeManager.sol#161) can be used in cross function reentrancies:\n\t- StakeManager.syncBoostedStake(address,StakeManager.Role) (contracts/v2/StakeManager.sol#2902-2911)\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- jobRegistryLockedStake[user] = registryLocked - reduction_scope_0 (contracts/v2/StakeManager.sol#1928)\n\t\t- jobRegistryLockedStake[user] = registryLocked_scope_1 - reduction_scope_2 (contracts/v2/StakeManager.sol#1941)\n\t\t- jobRegistryLockedStake[user] = 0 (contracts/v2/StakeManager.sol#2690)\n\tStakeManager.jobRegistryLockedStake (contracts/v2/StakeManager.sol#170) can be used in cross function reentrancies:\n\t- StakeManager.jobRegistryLockedStake (contracts/v2/StakeManager.sol#170)\n\t- StakeManager.lockStake(address,uint256,uint64) (contracts/v2/StakeManager.sol#1823-1826)\n\t- StakeManager.releaseStake(address,uint256) (contracts/v2/StakeManager.sol#1831-1836)\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- lockedStakes[user] = 0 (contracts/v2/StakeManager.sol#2687)\n\t\t- lockedStakes[user] = locked - amount (contracts/v2/StakeManager.sol#2697)\n\tStakeManager.lockedStakes (contracts/v2/StakeManager.sol#164) can be used in cross function reentrancies:\n\t- StakeManager._lockStake(address,uint256,uint64) (contracts/v2/StakeManager.sol#1875-1892)\n\t- StakeManager._unlockStake(address,uint256) (contracts/v2/StakeManager.sol#1894-1906)\n\t- StakeManager.lockedStakes (contracts/v2/StakeManager.sol#164)\n\t- StakeManager.requestWithdraw(StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2082-2110)\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- operatorRewardPool += operatorShare (contracts/v2/StakeManager.sol#2730)\n\tStakeManager.operatorRewardPool (contracts/v2/StakeManager.sol#191) can be used in cross function reentrancies:\n\t- StakeManager.operatorRewardPool (contracts/v2/StakeManager.sol#191)\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- stakes[user][role] = newStake (contracts/v2/StakeManager.sol#2681)\n\tStakeManager.stakes (contracts/v2/StakeManager.sol#152) can be used in cross function reentrancies:\n\t- StakeManager._lockStake(address,uint256,uint64) (contracts/v2/StakeManager.sol#1875-1892)\n\t- StakeManager.requestWithdraw(StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2082-2110)\n\t- StakeManager.stakeOf(address,StakeManager.Role) (contracts/v2/StakeManager.sol#2889-2891)\n\t- StakeManager.stakes (contracts/v2/StakeManager.sol#152)\n\t- StakeManager.syncBoostedStake(address,StakeManager.Role) (contracts/v2/StakeManager.sol#2902-2911)\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- totalBoostedStakes[role] = totalBoostedStakes[role] + newBoosted - oldBoosted (contracts/v2/StakeManager.sol#2680)\n\tStakeManager.totalBoostedStakes (contracts/v2/StakeManager.sol#158) can be used in cross function reentrancies:\n\t- StakeManager.syncBoostedStake(address,StakeManager.Role) (contracts/v2/StakeManager.sol#2902-2911)\n\t- StakeManager.totalBoostedStake(StakeManager.Role) (contracts/v2/StakeManager.sol#2916-2918)\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- totalStakes[role] -= amount (contracts/v2/StakeManager.sol#2682)\n\tStakeManager.totalStakes (contracts/v2/StakeManager.sol#155) can be used in cross function reentrancies:\n\t- StakeManager.totalStake(StakeManager.Role) (contracts/v2/StakeManager.sol#2895-2897)\n\t- StakeManager.totalStakes (contracts/v2/StakeManager.sol#155)\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- delete unbonds[user] (contracts/v2/StakeManager.sol#2668)\n\t\t- u.amt = updated (contracts/v2/StakeManager.sol#2670)\n\t\t- u.unlockAt = uint64(block.timestamp + unbondingPeriod) (contracts/v2/StakeManager.sol#2671)\n\t\t- u.jailed = false (contracts/v2/StakeManager.sol#2672)\n\tStakeManager.unbonds (contracts/v2/StakeManager.sol#182) can be used in cross function reentrancies:\n\t- StakeManager.requestWithdraw(StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2082-2110)\n\t- StakeManager.unbonds (contracts/v2/StakeManager.sol#182)\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- validatorModuleLockedStake[user] = validatorLocked - reduction (contracts/v2/StakeManager.sol#1921)\n\t\t- validatorModuleLockedStake[user] = validatorLocked_scope_3 - reduction_scope_4 (contracts/v2/StakeManager.sol#1947)\n\t\t- validatorModuleLockedStake[user] = 0 (contracts/v2/StakeManager.sol#2693)\n\tStakeManager.validatorModuleLockedStake (contracts/v2/StakeManager.sol#173) can be used in cross function reentrancies:\n\t- StakeManager.lockValidatorStake(uint256,address,uint256,uint64) (contracts/v2/StakeManager.sol#1843-1851)\n\t- StakeManager.unlockValidatorStake(uint256,address,uint256) (contracts/v2/StakeManager.sol#1857-1867)\n\t- StakeManager.validatorModuleLockedStake (contracts/v2/StakeManager.sol#173)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2756,
+    "fingerprint": "153c5e21e6738c7062dd3b1c7eb290d413a20fd63720f64984cfd9b5da9a7cf4"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in RandaoCoordinator.commit(bytes32,bytes32) (contracts/v2/RandaoCoordinator.sol#199-214):\n\tExternal calls:\n\t- ! token.transferFrom(msg.sender,address(this),currentDeposit) (contracts/v2/RandaoCoordinator.sol#208)\n\tState variables written after the call(s):\n\t- commitments[tag][msg.sender] = commitment (contracts/v2/RandaoCoordinator.sol#210)\n\tRandaoCoordinator.commitments (contracts/v2/RandaoCoordinator.sol#78) can be used in cross function reentrancies:\n\t- RandaoCoordinator.commit(bytes32,bytes32) (contracts/v2/RandaoCoordinator.sol#199-214)\n\t- RandaoCoordinator.commitments (contracts/v2/RandaoCoordinator.sol#78)\n\t- RandaoCoordinator.reveal(bytes32,uint256) (contracts/v2/RandaoCoordinator.sol#217-236)\n\t- r.deposits[msg.sender] = currentDeposit (contracts/v2/RandaoCoordinator.sol#211)\n\tRandaoCoordinator.rounds (contracts/v2/RandaoCoordinator.sol#77) can be used in cross function reentrancies:\n\t- RandaoCoordinator.commit(bytes32,bytes32) (contracts/v2/RandaoCoordinator.sol#199-214)\n\t- RandaoCoordinator.forfeit(bytes32,address) (contracts/v2/RandaoCoordinator.sol#248-256)\n\t- RandaoCoordinator.random(bytes32) (contracts/v2/RandaoCoordinator.sol#240-245)\n\t- RandaoCoordinator.reveal(bytes32,uint256) (contracts/v2/RandaoCoordinator.sol#217-236)\n\t- r.commits += 1 (contracts/v2/RandaoCoordinator.sol#212)\n\tRandaoCoordinator.rounds (contracts/v2/RandaoCoordinator.sol#77) can be used in cross function reentrancies:\n\t- RandaoCoordinator.commit(bytes32,bytes32) (contracts/v2/RandaoCoordinator.sol#199-214)\n\t- RandaoCoordinator.forfeit(bytes32,address) (contracts/v2/RandaoCoordinator.sol#248-256)\n\t- RandaoCoordinator.random(bytes32) (contracts/v2/RandaoCoordinator.sol#240-245)\n\t- RandaoCoordinator.reveal(bytes32,uint256) (contracts/v2/RandaoCoordinator.sol#217-236)\n",
+    "uri": "contracts/v2/RandaoCoordinator.sol",
+    "startLine": 199,
+    "fingerprint": "1ae2d04fb683797d5dd4ad1b44cd3ca2e1f0d828ed2f5c245407687d87689cc7"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362):\n\tExternal calls:\n\t- jobRegistry.escalateToDispute(jobId,rationale) (contracts/v2/ValidationModule.sol#355)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#356)\n\t\t- stakeManager.unlockValidatorStake(jobId,val,lockAmount) (contracts/v2/ValidationModule.sol#1817)\n\tState variables written after the call(s):\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#356)\n\t\t- r.revealedCount = 0 (contracts/v2/ValidationModule.sol#1826)\n\t\t- delete rounds[jobId] (contracts/v2/ValidationModule.sol#1827)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 317,
+    "fingerprint": "2614eeeafa095433cca2b83ea3fc78e93daabcdb0c8d664a9cd36af5270b98dd"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in KernelJobRegistry.onValidationQuorumFailure(uint256,address[]) (contracts/v2/kernel/JobRegistry.sol#271-279):\n\tExternal calls:\n\t- _handleNonRevealers(jobId,nonRevealers) (contracts/v2/kernel/JobRegistry.sol#277)\n\t\t- stakeManager.slash(offender,bps,beneficiary,reason) (contracts/v2/kernel/JobRegistry.sol#297)\n\t- _finalize(jobId,false,new address[](0)) (contracts/v2/kernel/JobRegistry.sol#278)\n\t\t- stakeManager.unlockAll(job.agent,jobId) (contracts/v2/kernel/JobRegistry.sol#363)\n\t\t- stakeManager.unlockAll(validators[i],jobId) (contracts/v2/kernel/JobRegistry.sol#367)\n\t\t- split = rewardEngine.split(jobId,job.reward) (contracts/v2/kernel/JobRegistry.sol#312)\n\t\t- escrowVault.release(jobId,job.agent,split.agentAmount) (contracts/v2/kernel/JobRegistry.sol#315)\n\t\t- escrowVault.release(jobId,rewardedValidators[i],payout) (contracts/v2/kernel/JobRegistry.sol#325)\n\t\t- escrowVault.release(jobId,opsTreasury,split.opsAmount) (contracts/v2/kernel/JobRegistry.sol#330)\n\t\t- escrowVault.release(jobId,job.employer,split.employerRebateAmount) (contracts/v2/kernel/JobRegistry.sol#334)\n\t\t- escrowVault.burn(jobId,split.burnAmount) (contracts/v2/kernel/JobRegistry.sol#338)\n\t\t- escrowVault.refund(jobId,job.employer) (contracts/v2/kernel/JobRegistry.sol#343)\n\t\t- escrowVault.refund(jobId,job.employer) (contracts/v2/kernel/JobRegistry.sol#346)\n\tState variables written after the call(s):\n\t- _finalize(jobId,false,new address[](0)) (contracts/v2/kernel/JobRegistry.sol#278)\n\t\t- job.finalized = true (contracts/v2/kernel/JobRegistry.sol#305)\n\t\t- job.success = success (contracts/v2/kernel/JobRegistry.sol#306)\n\tKernelJobRegistry.jobs (contracts/v2/kernel/JobRegistry.sol#38) can be used in cross function reentrancies:\n\t- KernelJobRegistry.jobs (contracts/v2/kernel/JobRegistry.sol#38)\n\t- KernelJobRegistry.submitResult(uint256) (contracts/v2/kernel/JobRegistry.sol#216-229)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 271,
+    "fingerprint": "2800793784b60a19f676cc9a94f6fcb700f36a412c0cf38257d809142a6d5f58"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in RewardEngineMB.settleEpoch(uint256,RewardEngineMB.EpochData) (contracts/v2/RewardEngineMB.sol#236-311):\n\tExternal calls:\n\t- (agents,v,pre,post) = _aggregate(data.agents,epoch,Role.Agent) (contracts/v2/RewardEngineMB.sol#253)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\t- (validators,v,pre,post) = _aggregate(data.validators,epoch,Role.Validator) (contracts/v2/RewardEngineMB.sol#257)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\tState variables written after the call(s):\n\t- (validators,v,pre,post) = _aggregate(data.validators,epoch,Role.Validator) (contracts/v2/RewardEngineMB.sol#257)\n\t\t- usedNonces[att.user][epoch] = att.nonce (contracts/v2/RewardEngineMB.sol#330)\n\tRewardEngineMB.usedNonces (contracts/v2/RewardEngineMB.sol#168) can be used in cross function reentrancies:\n\t- RewardEngineMB.usedNonces (contracts/v2/RewardEngineMB.sol#168)\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 236,
+    "fingerprint": "29b0331b491a31fa7d047e8dfba18b38365fb0e6cf919217bcfc067b12ce346c"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in RewardEngineMB.settleEpoch(uint256,RewardEngineMB.EpochData) (contracts/v2/RewardEngineMB.sol#236-311):\n\tExternal calls:\n\t- (agents,v,pre,post) = _aggregate(data.agents,epoch,Role.Agent) (contracts/v2/RewardEngineMB.sol#253)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\t- (validators,v,pre,post) = _aggregate(data.validators,epoch,Role.Validator) (contracts/v2/RewardEngineMB.sol#257)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\t- (operators,v,pre,post) = _aggregate(data.operators,epoch,Role.Operator) (contracts/v2/RewardEngineMB.sol#261)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\t- (employers,v,pre,post) = _aggregate(data.employers,epoch,Role.Employer) (contracts/v2/RewardEngineMB.sol#265)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\tState variables written after the call(s):\n\t- (employers,v,pre,post) = _aggregate(data.employers,epoch,Role.Employer) (contracts/v2/RewardEngineMB.sol#265)\n\t\t- usedNonces[att.user][epoch] = att.nonce (contracts/v2/RewardEngineMB.sol#330)\n\tRewardEngineMB.usedNonces (contracts/v2/RewardEngineMB.sol#168) can be used in cross function reentrancies:\n\t- RewardEngineMB.usedNonces (contracts/v2/RewardEngineMB.sol#168)\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 236,
+    "fingerprint": "2bc42cc9d7000a08fe29308cd213862f82a112be4ac956ab231f1942eb65e90e"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule._finalize(uint256) (contracts/v2/ValidationModule.sol#1658-1787):\n\tExternal calls:\n\t- reputationEngine.updateScores(jobId,job.agent,committee,success,revealedStates,voteStates,payout,duration) (contracts/v2/ValidationModule.sol#1733-1742)\n\t- jobRegistry.markReputationProcessed(jobId) (contracts/v2/ValidationModule.sol#1743)\n\t- stakeManager.slash(val,IStakeManager.Role.Validator,penalty,job.employer) (contracts/v2/ValidationModule.sol#1753-1758)\n\t- stakeManager.slash(val,IStakeManager.Role.Validator,slashAmount,job.employer) (contracts/v2/ValidationModule.sol#1768-1773)\n\tState variables written after the call(s):\n\t- r.tallied = true (contracts/v2/ValidationModule.sol#1780)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- _reduceValidatorLock(jobId,val,penalty) (contracts/v2/ValidationModule.sol#1759)\n\t\t- validatorStakeLocks[jobId][val] = 0 (contracts/v2/ValidationModule.sol#1798)\n\t\t- validatorStakeLocks[jobId][val] = locked - amount (contracts/v2/ValidationModule.sol#1800)\n\tValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178)\n\t- _reduceValidatorLock(jobId,val,slashAmount) (contracts/v2/ValidationModule.sol#1774)\n\t\t- validatorStakeLocks[jobId][val] = 0 (contracts/v2/ValidationModule.sol#1798)\n\t\t- validatorStakeLocks[jobId][val] = locked - amount (contracts/v2/ValidationModule.sol#1800)\n\tValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1658,
+    "fingerprint": "30461cd23266e5bf3414cf48ba5f7b901b236d5711fcaff40a4d4211bc0b9606"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in RewardEngineMB.settleEpoch(uint256,RewardEngineMB.EpochData) (contracts/v2/RewardEngineMB.sol#236-311):\n\tExternal calls:\n\t- (agents,v,pre,post) = _aggregate(data.agents,epoch,Role.Agent) (contracts/v2/RewardEngineMB.sol#253)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\t- (validators,v,pre,post) = _aggregate(data.validators,epoch,Role.Validator) (contracts/v2/RewardEngineMB.sol#257)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\t- (operators,v,pre,post) = _aggregate(data.operators,epoch,Role.Operator) (contracts/v2/RewardEngineMB.sol#261)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\t- (employers,v,pre,post) = _aggregate(data.employers,epoch,Role.Employer) (contracts/v2/RewardEngineMB.sol#265)\n\t\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\t- token.mint(address(feePool),budget) (contracts/v2/RewardEngineMB.sol#287)\n\t- redistributed += _distribute(Role.Agent,budget,agents,wA,sumA) (contracts/v2/RewardEngineMB.sol#298)\n\t\t- feePool.reward(rd.users[i],amt) (contracts/v2/RewardEngineMB.sol#396)\n\t\t- reputation.update(rd.users[i],baseline - rd.energies[i]) (contracts/v2/RewardEngineMB.sol#397)\n\t- redistributed += _distribute(Role.Validator,budget,validators,wV,sumV) (contracts/v2/RewardEngineMB.sol#299)\n\t\t- feePool.reward(rd.users[i],amt) (contracts/v2/RewardEngineMB.sol#396)\n\t\t- reputation.update(rd.users[i],baseline - rd.energies[i]) (contracts/v2/RewardEngineMB.sol#397)\n\t- redistributed += _distribute(Role.Operator,budget,operators,wO,sumO) (contracts/v2/RewardEngineMB.sol#300)\n\t\t- feePool.reward(rd.users[i],amt) (contracts/v2/RewardEngineMB.sol#396)\n\t\t- reputation.update(rd.users[i],baseline - rd.energies[i]) (contracts/v2/RewardEngineMB.sol#397)\n\t- redistributed += _distribute(Role.Employer,budget,employers,wE,sumE) (contracts/v2/RewardEngineMB.sol#301)\n\t\t- feePool.reward(rd.users[i],amt) (contracts/v2/RewardEngineMB.sol#396)\n\t\t- reputation.update(rd.users[i],baseline - rd.energies[i]) (contracts/v2/RewardEngineMB.sol#397)\n\t- feePool.reward(treasury,dust) (contracts/v2/RewardEngineMB.sol#305)\n\tState variables written after the call(s):\n\t- epochSettled[epoch] = true (contracts/v2/RewardEngineMB.sol#308)\n\tRewardEngineMB.epochSettled (contracts/v2/RewardEngineMB.sol#57) can be used in cross function reentrancies:\n\t- RewardEngineMB.epochSettled (contracts/v2/RewardEngineMB.sol#57)\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 236,
+    "fingerprint": "3738bc95dd4d2b47e048d3cbfc236c76ad77f54c3660797d45e42b88eeb67353"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule._finalize(uint256) (contracts/v2/ValidationModule.sol#1658-1787):\n\tExternal calls:\n\t- reputationEngine.updateScores(jobId,job.agent,committee,success,revealedStates,voteStates,payout,duration) (contracts/v2/ValidationModule.sol#1733-1742)\n\t- jobRegistry.markReputationProcessed(jobId) (contracts/v2/ValidationModule.sol#1743)\n\t- stakeManager.slash(val,IStakeManager.Role.Validator,penalty,job.employer) (contracts/v2/ValidationModule.sol#1753-1758)\n\t- stakeManager.slash(val,IStakeManager.Role.Validator,slashAmount,job.employer) (contracts/v2/ValidationModule.sol#1768-1773)\n\t- jobRegistry.onValidationResult(jobId,success,r.validators) (contracts/v2/ValidationModule.sol#1784)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1785)\n\t\t- stakeManager.unlockValidatorStake(jobId,val,lockAmount) (contracts/v2/ValidationModule.sol#1817)\n\tState variables written after the call(s):\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1785)\n\t\t- delete revealed[jobId][val] (contracts/v2/ValidationModule.sol#1813)\n\tValidationModule.revealed (contracts/v2/ValidationModule.sol#175) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealed (contracts/v2/ValidationModule.sol#175)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1785)\n\t\t- r.revealedCount = 0 (contracts/v2/ValidationModule.sol#1826)\n\t\t- delete rounds[jobId] (contracts/v2/ValidationModule.sol#1827)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1785)\n\t\t- delete validatorStakeLocks[jobId][val] (contracts/v2/ValidationModule.sol#1819)\n\tValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1785)\n\t\t- delete validatorStakes[jobId][val] (contracts/v2/ValidationModule.sol#1820)\n\tValidationModule.validatorStakes (contracts/v2/ValidationModule.sol#177) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorStakes (contracts/v2/ValidationModule.sol#177)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1785)\n\t\t- delete votes[jobId][val] (contracts/v2/ValidationModule.sol#1814)\n\tValidationModule.votes (contracts/v2/ValidationModule.sol#176) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.votes (contracts/v2/ValidationModule.sol#176)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1658,
+    "fingerprint": "3aa0e767f136ae0e3a52cc94f147c6dd03e7068d8615ff0206fa9cb7d30402d9"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in KernelJobRegistry.onValidationRejected(uint256,address[],address[]) (contracts/v2/kernel/JobRegistry.sol#261-269):\n\tExternal calls:\n\t- _handleNonRevealers(jobId,nonRevealers) (contracts/v2/kernel/JobRegistry.sol#266)\n\t\t- stakeManager.slash(offender,bps,beneficiary,reason) (contracts/v2/kernel/JobRegistry.sol#297)\n\t- _slashParticipant(jobId,jobs[jobId].agent,config.maliciousSlashBps(),validation_rejected) (contracts/v2/kernel/JobRegistry.sol#267)\n\t\t- stakeManager.slash(offender,bps,beneficiary,reason) (contracts/v2/kernel/JobRegistry.sol#297)\n\t- _finalize(jobId,false,validators) (contracts/v2/kernel/JobRegistry.sol#268)\n\t\t- stakeManager.unlockAll(job.agent,jobId) (contracts/v2/kernel/JobRegistry.sol#363)\n\t\t- stakeManager.unlockAll(validators[i],jobId) (contracts/v2/kernel/JobRegistry.sol#367)\n\t\t- split = rewardEngine.split(jobId,job.reward) (contracts/v2/kernel/JobRegistry.sol#312)\n\t\t- escrowVault.release(jobId,job.agent,split.agentAmount) (contracts/v2/kernel/JobRegistry.sol#315)\n\t\t- escrowVault.release(jobId,rewardedValidators[i],payout) (contracts/v2/kernel/JobRegistry.sol#325)\n\t\t- escrowVault.release(jobId,opsTreasury,split.opsAmount) (contracts/v2/kernel/JobRegistry.sol#330)\n\t\t- escrowVault.release(jobId,job.employer,split.employerRebateAmount) (contracts/v2/kernel/JobRegistry.sol#334)\n\t\t- escrowVault.burn(jobId,split.burnAmount) (contracts/v2/kernel/JobRegistry.sol#338)\n\t\t- escrowVault.refund(jobId,job.employer) (contracts/v2/kernel/JobRegistry.sol#343)\n\t\t- escrowVault.refund(jobId,job.employer) (contracts/v2/kernel/JobRegistry.sol#346)\n\tState variables written after the call(s):\n\t- _finalize(jobId,false,validators) (contracts/v2/kernel/JobRegistry.sol#268)\n\t\t- job.finalized = true (contracts/v2/kernel/JobRegistry.sol#305)\n\t\t- job.success = success (contracts/v2/kernel/JobRegistry.sol#306)\n\tKernelJobRegistry.jobs (contracts/v2/kernel/JobRegistry.sol#38) can be used in cross function reentrancies:\n\t- KernelJobRegistry.jobs (contracts/v2/kernel/JobRegistry.sol#38)\n\t- KernelJobRegistry.submitResult(uint256) (contracts/v2/kernel/JobRegistry.sol#216-229)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 261,
+    "fingerprint": "466bae8b73ff3c5f4d9e09a626633705dcaaeefc2a89ff7d906eaad6865c2cfc"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in PlatformRegistry.acknowledgeStakeAndRegister(uint256) (contracts/v2/PlatformRegistry.sol#211-226):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/PlatformRegistry.sol#217)\n\t- manager.depositStakeFor(msg.sender,IStakeManager.Role.Platform,amount) (contracts/v2/PlatformRegistry.sol#219-223)\n\tState variables written after the call(s):\n\t- _register(msg.sender) (contracts/v2/PlatformRegistry.sol#224)\n\t\t- registered[operator] = true (contracts/v2/PlatformRegistry.sol#151)\n\tPlatformRegistry.registered (contracts/v2/PlatformRegistry.sol#31) can be used in cross function reentrancies:\n\t- PlatformRegistry.getOperatorStatus(address) (contracts/v2/PlatformRegistry.sol#335-362)\n\t- PlatformRegistry.registered (contracts/v2/PlatformRegistry.sol#31)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 211,
+    "fingerprint": "4c29de8ac6eaacabc438c7e00bdb6294b8b85e808944f131746e54911078c13a"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n\t\t- identityRegistry.setAgentRootNode(node) (contracts/v2/JobRegistry.sol#633)\n\tState variables written after the call(s):\n\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n\t\t- ++ agentAuthCacheVersion (contracts/v2/JobRegistry.sol#668)\n\tJobRegistry.agentAuthCacheVersion (contracts/v2/JobRegistry.sol#732) can be used in cross function reentrancies:\n\t- JobRegistry._bumpAgentAuthCacheVersionInternal() (contracts/v2/JobRegistry.sol#666-671)\n\t- JobRegistry.agentAuthCacheVersion (contracts/v2/JobRegistry.sol#732)\n\t- JobRegistry.updateAgentAuthCache(address,bool) (contracts/v2/JobRegistry.sol#1203-1212)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "4cfe56976f9d149fc7a95b280ee27b4f1981011339d48ffd9243f54d2fcc5685"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in PlatformRegistry.acknowledgeStakeAndRegisterFor(address,uint256) (contracts/v2/PlatformRegistry.sol#282-303):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(operator) (contracts/v2/PlatformRegistry.sol#294)\n\t- manager.depositStakeFor(operator,IStakeManager.Role.Platform,amount) (contracts/v2/PlatformRegistry.sol#296-300)\n\tState variables written after the call(s):\n\t- _register(operator) (contracts/v2/PlatformRegistry.sol#301)\n\t\t- registered[operator] = true (contracts/v2/PlatformRegistry.sol#151)\n\tPlatformRegistry.registered (contracts/v2/PlatformRegistry.sol#31) can be used in cross function reentrancies:\n\t- PlatformRegistry.getOperatorStatus(address) (contracts/v2/PlatformRegistry.sol#335-362)\n\t- PlatformRegistry.registered (contracts/v2/PlatformRegistry.sol#31)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 282,
+    "fingerprint": "4fe968c593069e218dec11aca79435491db542d13889b833046d598578c49011"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250):\n\tExternal calls:\n\t- (authorized,None,None,None) = identityRegistry.verifyValidator(candidate,subdomain,proof) (contracts/v2/ValidationModule.sol#1052-1056)\n\t- (authorized_scope_3,None,None,None) = identityRegistry.verifyValidator(candidate_scope_1,subdomain_scope_4,proof_scope_6) (contracts/v2/ValidationModule.sol#1135-1139)\n\tState variables written after the call(s):\n\t- r.validators = selected (contracts/v2/ValidationModule.sol#1227)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- r.commitDeadline = block.timestamp + commitWindow (contracts/v2/ValidationModule.sol#1228)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- r.revealDeadline = r.commitDeadline + revealWindow (contracts/v2/ValidationModule.sol#1229)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "5e5ea9c210a3bdd5728f26d2ddd5656d582631590dc685053320df064cdd3e51"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in JobRegistry.claimTimeout(uint256) (contracts/v2/JobRegistry.sol#2568-2638):\n\tExternal calls:\n\t- stakeManager.redistributeEscrow(jobKey,employer,totalRefund,validators) (contracts/v2/JobRegistry.sol#2604)\n\t- stakeManager.slash(agent,IStakeManager.Role.Agent,uint256(stakeAmount),employer) (contracts/v2/JobRegistry.sol#2607-2612)\n\tState variables written after the call(s):\n\t- job.agent = address(0) (contracts/v2/JobRegistry.sol#2618)\n\tJobRegistry.jobs (contracts/v2/JobRegistry.sol#244) can be used in cross function reentrancies:\n\t- JobRegistry._cancelJob(uint256) (contracts/v2/JobRegistry.sol#2521-2539)\n\t- JobRegistry._createJob(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1621-1700)\n\t- JobRegistry._dispute(uint256,bytes32,string) (contracts/v2/JobRegistry.sol#2225-2252)\n\t- JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495)\n\t- JobRegistry._finalizeByEmployer(uint256) (contracts/v2/JobRegistry.sol#2296-2302)\n\t- JobRegistry.burnEvidenceStatus(uint256) (contracts/v2/JobRegistry.sol#313-324)\n\t- JobRegistry.cancelJob(uint256) (contracts/v2/JobRegistry.sol#2541-2558)\n\t- JobRegistry.confirmEmployerBurn(uint256,bytes32) (contracts/v2/JobRegistry.sol#427-446)\n\t- JobRegistry.getSpecHash(uint256) (contracts/v2/JobRegistry.sol#309-311)\n\t- JobRegistry.jobs (contracts/v2/JobRegistry.sol#244)\n\t- JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001)\n\t- JobRegistry.submitBurnReceipt(uint256,bytes32,uint256,uint256) (contracts/v2/JobRegistry.sol#364-387)\n\t- job.reward = 0 (contracts/v2/JobRegistry.sol#2621)\n\tJobRegistry.jobs (contracts/v2/JobRegistry.sol#244) can be used in cross function reentrancies:\n\t- JobRegistry._cancelJob(uint256) (contracts/v2/JobRegistry.sol#2521-2539)\n\t- JobRegistry._createJob(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1621-1700)\n\t- JobRegistry._dispute(uint256,bytes32,string) (contracts/v2/JobRegistry.sol#2225-2252)\n\t- JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495)\n\t- JobRegistry._finalizeByEmployer(uint256) (contracts/v2/JobRegistry.sol#2296-2302)\n\t- JobRegistry.burnEvidenceStatus(uint256) (contracts/v2/JobRegistry.sol#313-324)\n\t- JobRegistry.cancelJob(uint256) (contracts/v2/JobRegistry.sol#2541-2558)\n\t- JobRegistry.confirmEmployerBurn(uint256,bytes32) (contracts/v2/JobRegistry.sol#427-446)\n\t- JobRegistry.getSpecHash(uint256) (contracts/v2/JobRegistry.sol#309-311)\n\t- JobRegistry.jobs (contracts/v2/JobRegistry.sol#244)\n\t- JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001)\n\t- JobRegistry.submitBurnReceipt(uint256,bytes32,uint256,uint256) (contracts/v2/JobRegistry.sol#364-387)\n\t- job.stake = 0 (contracts/v2/JobRegistry.sol#2622)\n\tJobRegistry.jobs (contracts/v2/JobRegistry.sol#244) can be used in cross function reentrancies:\n\t- JobRegistry._cancelJob(uint256) (contracts/v2/JobRegistry.sol#2521-2539)\n\t- JobRegistry._createJob(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1621-1700)\n\t- JobRegistry._dispute(uint256,bytes32,string) (contracts/v2/JobRegistry.sol#2225-2252)\n\t- JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495)\n\t- JobRegistry._finalizeByEmployer(uint256) (contracts/v2/JobRegistry.sol#2296-2302)\n\t- JobRegistry.burnEvidenceStatus(uint256) (contracts/v2/JobRegistry.sol#313-324)\n\t- JobRegistry.cancelJob(uint256) (contracts/v2/JobRegistry.sol#2541-2558)\n\t- JobRegistry.confirmEmployerBurn(uint256,bytes32) (contracts/v2/JobRegistry.sol#427-446)\n\t- JobRegistry.getSpecHash(uint256) (contracts/v2/JobRegistry.sol#309-311)\n\t- JobRegistry.jobs (contracts/v2/JobRegistry.sol#244)\n\t- JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001)\n\t- JobRegistry.submitBurnReceipt(uint256,bytes32,uint256,uint256) (contracts/v2/JobRegistry.sol#364-387)\n\t- job.burnReceiptAmount = 0 (contracts/v2/JobRegistry.sol#2624)\n\tJobRegistry.jobs (contracts/v2/JobRegistry.sol#244) can be used in cross function reentrancies:\n\t- JobRegistry._cancelJob(uint256) (contracts/v2/JobRegistry.sol#2521-2539)\n\t- JobRegistry._createJob(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1621-1700)\n\t- JobRegistry._dispute(uint256,bytes32,string) (contracts/v2/JobRegistry.sol#2225-2252)\n\t- JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495)\n\t- JobRegistry._finalizeByEmployer(uint256) (contracts/v2/JobRegistry.sol#2296-2302)\n\t- JobRegistry.burnEvidenceStatus(uint256) (contracts/v2/JobRegistry.sol#313-324)\n\t- JobRegistry.cancelJob(uint256) (contracts/v2/JobRegistry.sol#2541-2558)\n\t- JobRegistry.confirmEmployerBurn(uint256,bytes32) (contracts/v2/JobRegistry.sol#427-446)\n\t- JobRegistry.getSpecHash(uint256) (contracts/v2/JobRegistry.sol#309-311)\n\t- JobRegistry.jobs (contracts/v2/JobRegistry.sol#244)\n\t- JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001)\n\t- JobRegistry.submitBurnReceipt(uint256,bytes32,uint256,uint256) (contracts/v2/JobRegistry.sol#364-387)\n\t- job.resultHash = bytes32(0) (contracts/v2/JobRegistry.sol#2625)\n\tJobRegistry.jobs (contracts/v2/JobRegistry.sol#244) can be used in cross function reentrancies:\n\t- JobRegistry._cancelJob(uint256) (contracts/v2/JobRegistry.sol#2521-2539)\n\t- JobRegistry._createJob(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1621-1700)\n\t- JobRegistry._dispute(uint256,bytes32,string) (contracts/v2/JobRegistry.sol#2225-2252)\n\t- JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495)\n\t- JobRegistry._finalizeByEmployer(uint256) (contracts/v2/JobRegistry.sol#2296-2302)\n\t- JobRegistry.burnEvidenceStatus(uint256) (contracts/v2/JobRegistry.sol#313-324)\n\t- JobRegistry.cancelJob(uint256) (contracts/v2/JobRegistry.sol#2541-2558)\n\t- JobRegistry.confirmEmployerBurn(uint256,bytes32) (contracts/v2/JobRegistry.sol#427-446)\n\t- JobRegistry.getSpecHash(uint256) (contracts/v2/JobRegistry.sol#309-311)\n\t- JobRegistry.jobs (contracts/v2/JobRegistry.sol#244)\n\t- JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001)\n\t- JobRegistry.submitBurnReceipt(uint256,bytes32,uint256,uint256) (contracts/v2/JobRegistry.sol#364-387)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2568,
+    "fingerprint": "63314bd94e652b4c416e78d4a0e0fba31e4bdaa0dd3635df7126bf46d4eb1430"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250):\n\tExternal calls:\n\t- (authorized,None,None,None) = identityRegistry.verifyValidator(candidate,subdomain,proof) (contracts/v2/ValidationModule.sol#1052-1056)\n\tState variables written after the call(s):\n\t- validatorAuthCache[candidate] = true (contracts/v2/ValidationModule.sol#1059)\n\tValidationModule.validatorAuthCache (contracts/v2/ValidationModule.sol#144) can be used in cross function reentrancies:\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorAuthCache (contracts/v2/ValidationModule.sol#144)\n\t- validatorAuthExpiry[candidate] = block.timestamp + validatorAuthCacheDuration (contracts/v2/ValidationModule.sol#1060-1061)\n\tValidationModule.validatorAuthExpiry (contracts/v2/ValidationModule.sol#145) can be used in cross function reentrancies:\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorAuthExpiry (contracts/v2/ValidationModule.sol#145)\n\t- validatorAuthVersion[candidate] = validatorAuthCacheVersion (contracts/v2/ValidationModule.sol#1062-1063)\n\tValidationModule.validatorAuthVersion (contracts/v2/ValidationModule.sol#146) can be used in cross function reentrancies:\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorAuthVersion (contracts/v2/ValidationModule.sol#146)\n\t- validatorPoolRotation = (rotationStart + i) % n (contracts/v2/ValidationModule.sol#1081)\n\tValidationModule.validatorPoolRotation (contracts/v2/ValidationModule.sol#138) can be used in cross function reentrancies:\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorPoolRotation (contracts/v2/ValidationModule.sol#138)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "66c8d7342ceca25f3c21864cc8e9b79613a69cb2464922775dc17b4cb3f57c2b"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n\t\t- identityRegistry.setAgentRootNode(node) (contracts/v2/JobRegistry.sol#633)\n\t- _setAgentMerkleRoot(config.agentMerkleRoot) (contracts/v2/JobRegistry.sol#1545)\n\t\t- identityRegistry.setAgentMerkleRoot(root) (contracts/v2/JobRegistry.sol#640)\n\tState variables written after the call(s):\n\t- _setAgentMerkleRoot(config.agentMerkleRoot) (contracts/v2/JobRegistry.sol#1545)\n\t\t- ++ agentAuthCacheVersion (contracts/v2/JobRegistry.sol#668)\n\tJobRegistry.agentAuthCacheVersion (contracts/v2/JobRegistry.sol#732) can be used in cross function reentrancies:\n\t- JobRegistry._bumpAgentAuthCacheVersionInternal() (contracts/v2/JobRegistry.sol#666-671)\n\t- JobRegistry.agentAuthCacheVersion (contracts/v2/JobRegistry.sol#732)\n\t- JobRegistry.updateAgentAuthCache(address,bool) (contracts/v2/JobRegistry.sol#1203-1212)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "6f7144a8a0368f6ea031f0a9f42177f0b4f189c49251a976806d31acf1bc879b"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in DisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/DisputeModule.sol#303-342):\n\tExternal calls:\n\t- sm.lockDisputeFee(claimant,disputeFee) (contracts/v2/modules/DisputeModule.sol#325)\n\t- sm.recordDispute() (contracts/v2/modules/DisputeModule.sol#327)\n\tState variables written after the call(s):\n\t- d.claimant = claimant (contracts/v2/modules/DisputeModule.sol#330)\n\tDisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68) can be used in cross function reentrancies:\n\t- DisputeModule._resolve(uint256,bool,address) (contracts/v2/modules/DisputeModule.sol#515-567)\n\t- DisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68)\n\t- DisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/DisputeModule.sol#303-342)\n\t- DisputeModule.raiseGovernanceDispute(uint256,string) (contracts/v2/modules/DisputeModule.sol#347-375)\n\t- DisputeModule.resolveWithSignatures(uint256,bool,bytes[]) (contracts/v2/modules/DisputeModule.sol#395-429)\n\t- DisputeModule.submitEvidence(uint256,bytes32,string) (contracts/v2/modules/DisputeModule.sol#437-467)\n\t- d.raisedAt = block.timestamp (contracts/v2/modules/DisputeModule.sol#331)\n\tDisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68) can be used in cross function reentrancies:\n\t- DisputeModule._resolve(uint256,bool,address) (contracts/v2/modules/DisputeModule.sol#515-567)\n\t- DisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68)\n\t- DisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/DisputeModule.sol#303-342)\n\t- DisputeModule.raiseGovernanceDispute(uint256,string) (contracts/v2/modules/DisputeModule.sol#347-375)\n\t- DisputeModule.resolveWithSignatures(uint256,bool,bytes[]) (contracts/v2/modules/DisputeModule.sol#395-429)\n\t- DisputeModule.submitEvidence(uint256,bytes32,string) (contracts/v2/modules/DisputeModule.sol#437-467)\n\t- d.resolved = false (contracts/v2/modules/DisputeModule.sol#332)\n\tDisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68) can be used in cross function reentrancies:\n\t- DisputeModule._resolve(uint256,bool,address) (contracts/v2/modules/DisputeModule.sol#515-567)\n\t- DisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68)\n\t- DisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/DisputeModule.sol#303-342)\n\t- DisputeModule.raiseGovernanceDispute(uint256,string) (contracts/v2/modules/DisputeModule.sol#347-375)\n\t- DisputeModule.resolveWithSignatures(uint256,bool,bytes[]) (contracts/v2/modules/DisputeModule.sol#395-429)\n\t- DisputeModule.submitEvidence(uint256,bytes32,string) (contracts/v2/modules/DisputeModule.sol#437-467)\n\t- d.fee = disputeFee (contracts/v2/modules/DisputeModule.sol#333)\n\tDisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68) can be used in cross function reentrancies:\n\t- DisputeModule._resolve(uint256,bool,address) (contracts/v2/modules/DisputeModule.sol#515-567)\n\t- DisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68)\n\t- DisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/DisputeModule.sol#303-342)\n\t- DisputeModule.raiseGovernanceDispute(uint256,string) (contracts/v2/modules/DisputeModule.sol#347-375)\n\t- DisputeModule.resolveWithSignatures(uint256,bool,bytes[]) (contracts/v2/modules/DisputeModule.sol#395-429)\n\t- DisputeModule.submitEvidence(uint256,bytes32,string) (contracts/v2/modules/DisputeModule.sol#437-467)\n\t- d.evidenceHash = evidenceHash (contracts/v2/modules/DisputeModule.sol#334)\n\tDisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68) can be used in cross function reentrancies:\n\t- DisputeModule._resolve(uint256,bool,address) (contracts/v2/modules/DisputeModule.sol#515-567)\n\t- DisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68)\n\t- DisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/DisputeModule.sol#303-342)\n\t- DisputeModule.raiseGovernanceDispute(uint256,string) (contracts/v2/modules/DisputeModule.sol#347-375)\n\t- DisputeModule.resolveWithSignatures(uint256,bool,bytes[]) (contracts/v2/modules/DisputeModule.sol#395-429)\n\t- DisputeModule.submitEvidence(uint256,bytes32,string) (contracts/v2/modules/DisputeModule.sol#437-467)\n\t- d.reason = reason (contracts/v2/modules/DisputeModule.sol#335)\n\tDisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68) can be used in cross function reentrancies:\n\t- DisputeModule._resolve(uint256,bool,address) (contracts/v2/modules/DisputeModule.sol#515-567)\n\t- DisputeModule.disputes (contracts/v2/modules/DisputeModule.sol#68)\n\t- DisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/DisputeModule.sol#303-342)\n\t- DisputeModule.raiseGovernanceDispute(uint256,string) (contracts/v2/modules/DisputeModule.sol#347-375)\n\t- DisputeModule.resolveWithSignatures(uint256,bool,bytes[]) (contracts/v2/modules/DisputeModule.sol#395-429)\n\t- DisputeModule.submitEvidence(uint256,bytes32,string) (contracts/v2/modules/DisputeModule.sol#437-467)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 303,
+    "fingerprint": "7831478f347f52fbfe2abce7bbedcc3a2ae674b6a78747684985dbac74826f46"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in PlatformRegistry.acknowledgeAndDeregister() (contracts/v2/PlatformRegistry.sol#233-242):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/PlatformRegistry.sol#238)\n\tState variables written after the call(s):\n\t- registered[msg.sender] = false (contracts/v2/PlatformRegistry.sol#240)\n\tPlatformRegistry.registered (contracts/v2/PlatformRegistry.sol#31) can be used in cross function reentrancies:\n\t- PlatformRegistry.getOperatorStatus(address) (contracts/v2/PlatformRegistry.sol#335-362)\n\t- PlatformRegistry.registered (contracts/v2/PlatformRegistry.sol#31)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 233,
+    "fingerprint": "78928ca5aed8a94b4c51f435a74b8ce37bc7fd86ad43e808fc6bdc15c063e6dd"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495):\n\tExternal calls:\n\t- stakeManager.finalizeJobFundsWithPct(jobKey,employerParam,payee,agentPct,rewardAfterValidator,validatorReward,fee,pool,isGov) (contracts/v2/JobRegistry.sol#2356-2366)\n\t- stakeManager.distributeValidatorRewards(jobKey,validatorReward) (contracts/v2/JobRegistry.sol#2370-2373)\n\t- stakeManager.releaseReward(jobKey,job.employer,payee,validatorReward,true) (contracts/v2/JobRegistry.sol#2375-2381)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),treasury,validators) (contracts/v2/JobRegistry.sol#2386-2392)\n\t- stakeManager.releaseStake(job.agent,uint256(job.stake)) (contracts/v2/JobRegistry.sol#2394)\n\t- reputationEngine.onFinalize(job.agent,true,payout,completionTime) (contracts/v2/JobRegistry.sol#2416-2421)\n\t- reputationEngine.rewardValidator(val,agentGain) (contracts/v2/JobRegistry.sol#2426)\n\t- certificateNFT.mint(job.agent,jobId,job.uriHash) (contracts/v2/JobRegistry.sol#2435)\n\t- stakeManager.redistributeEscrow(jobKey,recipient,uint256(job.reward) + fee_scope_0,validators) (contracts/v2/JobRegistry.sol#2448-2453)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),recipient,validators) (contracts/v2/JobRegistry.sol#2456-2462)\n\t- reputationEngine.onFinalize(job.agent,false,0,0) (contracts/v2/JobRegistry.sol#2466)\n\t- auditModule.onJobFinalized(jobId,job.agent,success,job.resultHash) (contracts/v2/JobRegistry.sol#2476-2479)\n\tState variables written after the call(s):\n\t- _clearValidatorData(jobId) (contracts/v2/JobRegistry.sol#2491)\n\t\t- delete jobValidatorVotes[jobId][validators[i]] (contracts/v2/JobRegistry.sol#338)\n\tJobRegistry.jobValidatorVotes (contracts/v2/JobRegistry.sol#256) can be used in cross function reentrancies:\n\t- JobRegistry._clearValidatorData(uint256) (contracts/v2/JobRegistry.sol#331-344)\n\t- JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495)\n\t- JobRegistry.getJobValidatorVote(uint256,address) (contracts/v2/JobRegistry.sol#282-288)\n\t- JobRegistry.validatorCommittee(uint256) (contracts/v2/JobRegistry.sol#290-307)\n\t- _clearValidatorData(jobId) (contracts/v2/JobRegistry.sol#2491)\n\t\t- delete jobValidators[jobId] (contracts/v2/JobRegistry.sol#343)\n\tJobRegistry.jobValidators (contracts/v2/JobRegistry.sol#255) can be used in cross function reentrancies:\n\t- JobRegistry._clearValidatorData(uint256) (contracts/v2/JobRegistry.sol#331-344)\n\t- JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495)\n\t- JobRegistry.getJobValidators(uint256) (contracts/v2/JobRegistry.sol#274-280)\n\t- JobRegistry.validatorCommittee(uint256) (contracts/v2/JobRegistry.sol#290-307)\n\t- delete reputationProcessed[jobId] (contracts/v2/JobRegistry.sol#2493)\n\tJobRegistry.reputationProcessed (contracts/v2/JobRegistry.sol#257) can be used in cross function reentrancies:\n\t- JobRegistry._cancelJob(uint256) (contracts/v2/JobRegistry.sol#2521-2539)\n\t- JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495)\n\t- JobRegistry.markReputationProcessed(uint256) (contracts/v2/JobRegistry.sol#2034-2038)\n\t- JobRegistry.reputationProcessed (contracts/v2/JobRegistry.sol#257)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "79619adadf513bc17fc2afa5f83ef8c7fa0f690001cc38a3925430a1319ffd1a"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250):\n\tExternal calls:\n\t- (authorized,None,None,None) = identityRegistry.verifyValidator(candidate,subdomain,proof) (contracts/v2/ValidationModule.sol#1052-1056)\n\t- (authorized_scope_3,None,None,None) = identityRegistry.verifyValidator(candidate_scope_1,subdomain_scope_4,proof_scope_6) (contracts/v2/ValidationModule.sol#1135-1139)\n\t- stakeManager.lockValidatorStake(jobId,val_scope_12,stakeAmount_scope_13,lockTime) (contracts/v2/ValidationModule.sol#1238)\n\tState variables written after the call(s):\n\t- delete pendingEntropy[jobId] (contracts/v2/ValidationModule.sol#1245)\n\tValidationModule.pendingEntropy (contracts/v2/ValidationModule.sol#185) can be used in cross function reentrancies:\n\t- ValidationModule.pendingEntropy (contracts/v2/ValidationModule.sol#185)\n\t- ValidationModule.resetSelection(uint256) (contracts/v2/ValidationModule.sol#1843-1847)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- delete selectionBlock[jobId] (contracts/v2/ValidationModule.sol#1246)\n\tValidationModule.selectionBlock (contracts/v2/ValidationModule.sol#187) can be used in cross function reentrancies:\n\t- ValidationModule.resetSelection(uint256) (contracts/v2/ValidationModule.sol#1843-1847)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.selectionBlock (contracts/v2/ValidationModule.sol#187)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "7a3d2948713e753ba9c3687afe73bc338eea3791fb8dd5903428ea46f2b6619f"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250):\n\tExternal calls:\n\t- (authorized_scope_3,None,None,None) = identityRegistry.verifyValidator(candidate_scope_1,subdomain_scope_4,proof_scope_6) (contracts/v2/ValidationModule.sol#1135-1139)\n\tState variables written after the call(s):\n\t- validatorAuthCache[candidate_scope_1] = true (contracts/v2/ValidationModule.sol#1142)\n\tValidationModule.validatorAuthCache (contracts/v2/ValidationModule.sol#144) can be used in cross function reentrancies:\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorAuthCache (contracts/v2/ValidationModule.sol#144)\n\t- validatorAuthExpiry[candidate_scope_1] = block.timestamp + validatorAuthCacheDuration (contracts/v2/ValidationModule.sol#1143-1144)\n\tValidationModule.validatorAuthExpiry (contracts/v2/ValidationModule.sol#145) can be used in cross function reentrancies:\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorAuthExpiry (contracts/v2/ValidationModule.sol#145)\n\t- validatorAuthVersion[candidate_scope_1] = validatorAuthCacheVersion (contracts/v2/ValidationModule.sol#1145-1146)\n\tValidationModule.validatorAuthVersion (contracts/v2/ValidationModule.sol#146) can be used in cross function reentrancies:\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorAuthVersion (contracts/v2/ValidationModule.sol#146)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "7fb43eaa566f513d58346c0b799c5b18987fcc60f9b744a5d6b3ce201b57c3fb"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in PlatformRegistry.stakeAndRegister(uint256) (contracts/v2/PlatformRegistry.sol#173-184):\n\tExternal calls:\n\t- manager.depositStakeFor(msg.sender,IStakeManager.Role.Platform,amount) (contracts/v2/PlatformRegistry.sol#177-181)\n\tState variables written after the call(s):\n\t- _register(msg.sender) (contracts/v2/PlatformRegistry.sol#182)\n\t\t- registered[operator] = true (contracts/v2/PlatformRegistry.sol#151)\n\tPlatformRegistry.registered (contracts/v2/PlatformRegistry.sol#31) can be used in cross function reentrancies:\n\t- PlatformRegistry.getOperatorStatus(address) (contracts/v2/PlatformRegistry.sol#335-362)\n\t- PlatformRegistry.registered (contracts/v2/PlatformRegistry.sol#31)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 173,
+    "fingerprint": "82198feb68875fe5874ecf5d398dedde56c722c428255c7d02f7bbfe4fc0d8bc"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\tState variables written after the call(s):\n\t- _setValidationModule(IValidationModule(config.validationModule)) (contracts/v2/JobRegistry.sol#1463)\n\t\t- validationModule = module (contracts/v2/JobRegistry.sol#513)\n\tJobRegistry.validationModule (contracts/v2/JobRegistry.sol#448) can be used in cross function reentrancies:\n\t- JobRegistry._createJob(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1621-1700)\n\t- JobRegistry._setIdentityRegistry(IIdentityRegistry) (contracts/v2/JobRegistry.sol#490-500)\n\t- JobRegistry._setValidationModule(IValidationModule) (contracts/v2/JobRegistry.sol#510-516)\n\t- JobRegistry._setValidatorMerkleRoot(bytes32) (contracts/v2/JobRegistry.sol#653-659)\n\t- JobRegistry._setValidatorRootNode(bytes32) (contracts/v2/JobRegistry.sol#645-651)\n\t- JobRegistry._startValidation(uint256,uint256) (contracts/v2/JobRegistry.sol#353-360)\n\t- JobRegistry.cancelJob(uint256) (contracts/v2/JobRegistry.sol#2541-2558)\n\t- JobRegistry.confirmEmployerBurn(uint256,bytes32) (contracts/v2/JobRegistry.sol#427-446)\n\t- JobRegistry.constructor(IValidationModule,IStakeManager,IReputationEngine,IDisputeModule,ICertificateNFT,IFeePool,ITaxPolicy,uint256,uint96,address[],address) (contracts/v2/JobRegistry.sol#1036-1103)\n\t- JobRegistry.finalize(uint256) (contracts/v2/JobRegistry.sol#2281-2294)\n\t- JobRegistry.markReputationProcessed(uint256) (contracts/v2/JobRegistry.sol#2034-2038)\n\t- JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001)\n\t- JobRegistry.submitBurnReceipt(uint256,bytes32,uint256,uint256) (contracts/v2/JobRegistry.sol#364-387)\n\t- JobRegistry.validationModule (contracts/v2/JobRegistry.sol#448)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "8ba99e025a740ed788b0abceb5498a6da7e97efeed2c5d2af1cd171dd90f073b"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in RewardEngineMB._aggregate(RewardEngineMB.Proof[],uint256,RewardEngineMB.Role) (contracts/v2/RewardEngineMB.sol#313-357):\n\tExternal calls:\n\t- signer = energyOracle.verify(att,proofs[i].sig) (contracts/v2/RewardEngineMB.sol#327)\n\tState variables written after the call(s):\n\t- usedNonces[att.user][epoch] = att.nonce (contracts/v2/RewardEngineMB.sol#330)\n\tRewardEngineMB.usedNonces (contracts/v2/RewardEngineMB.sol#168) can be used in cross function reentrancies:\n\t- RewardEngineMB.usedNonces (contracts/v2/RewardEngineMB.sol#168)\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 313,
+    "fingerprint": "976072d3cdcc39233a6dc1931d5469864c0db674f75c77f8b33cffbdeaf3ce40"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ReentrantERC20._reenter() (contracts/legacy/ReentrantERC20.sol#29-36):\n\tExternal calls:\n\t- manager.resolveDispute(jobId,IJobManager.DisputeOutcome.AgentWin) (contracts/legacy/ReentrantERC20.sol#33)\n\tState variables written after the call(s):\n\t- attack = false (contracts/legacy/ReentrantERC20.sol#34)\n\tReentrantERC20.attack (contracts/legacy/ReentrantERC20.sol#16) can be used in cross function reentrancies:\n\t- ReentrantERC20._reenter() (contracts/legacy/ReentrantERC20.sol#29-36)\n",
+    "uri": "contracts/legacy/ReentrantERC20.sol",
+    "startLine": 29,
+    "fingerprint": "992f5ebb558172fb9e0207857945e183f23e62f16f1545d90da0d89864c8a5b8"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in KernelJobRegistry._unlockJob(uint256) (contracts/v2/kernel/JobRegistry.sol#361-371):\n\tExternal calls:\n\t- stakeManager.unlockAll(job.agent,jobId) (contracts/v2/kernel/JobRegistry.sol#363)\n\t- stakeManager.unlockAll(validators[i],jobId) (contracts/v2/kernel/JobRegistry.sol#367)\n\tState variables written after the call(s):\n\t- delete jobValidators[jobId] (contracts/v2/kernel/JobRegistry.sol#370)\n\tKernelJobRegistry.jobValidators (contracts/v2/kernel/JobRegistry.sol#40) can be used in cross function reentrancies:\n\t- KernelJobRegistry._lockValidators(uint256) (contracts/v2/kernel/JobRegistry.sol#353-359)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 361,
+    "fingerprint": "9f12387f4577900823ed5972228d2d79826fecfa6698263ffdc4e1c9bf33bbfd"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in JobRegistry._applyForJob(uint256,string,bytes32[]) (contracts/v2/JobRegistry.sol#1750-1861):\n\tExternal calls:\n\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyAgent(msg.sender,subdomain,proof) (contracts/v2/JobRegistry.sol#1791-1792)\n\t- stakeManager.lockStake(msg.sender,uint256(job.stake),lockTime) (contracts/v2/JobRegistry.sol#1842)\n\tState variables written after the call(s):\n\t- job.agent = msg.sender (contracts/v2/JobRegistry.sol#1854)\n\tJobRegistry.jobs (contracts/v2/JobRegistry.sol#244) can be used in cross function reentrancies:\n\t- JobRegistry._cancelJob(uint256) (contracts/v2/JobRegistry.sol#2521-2539)\n\t- JobRegistry._createJob(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1621-1700)\n\t- JobRegistry._dispute(uint256,bytes32,string) (contracts/v2/JobRegistry.sol#2225-2252)\n\t- JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495)\n\t- JobRegistry._finalizeByEmployer(uint256) (contracts/v2/JobRegistry.sol#2296-2302)\n\t- JobRegistry.burnEvidenceStatus(uint256) (contracts/v2/JobRegistry.sol#313-324)\n\t- JobRegistry.cancelJob(uint256) (contracts/v2/JobRegistry.sol#2541-2558)\n\t- JobRegistry.confirmEmployerBurn(uint256,bytes32) (contracts/v2/JobRegistry.sol#427-446)\n\t- JobRegistry.getSpecHash(uint256) (contracts/v2/JobRegistry.sol#309-311)\n\t- JobRegistry.jobs (contracts/v2/JobRegistry.sol#244)\n\t- JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001)\n\t- JobRegistry.submitBurnReceipt(uint256,bytes32,uint256,uint256) (contracts/v2/JobRegistry.sol#364-387)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1750,
+    "fingerprint": "9f3f0cd53c31f7c4e358fa20f9e086cff525ea751aebdb757947344a94002c7b"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ArbitratorCommittee.finalize(uint256) (contracts/v2/ArbitratorCommittee.sol#149-170):\n\tExternal calls:\n\t- disputeModule.resolveDispute(jobId,employerWins) (contracts/v2/ArbitratorCommittee.sol#159)\n\t- disputeModule.slashValidator(juror,absenteeSlash,employer) (contracts/v2/ArbitratorCommittee.sol#164)\n\tState variables written after the call(s):\n\t- delete cases[jobId] (contracts/v2/ArbitratorCommittee.sol#169)\n\tArbitratorCommittee.cases (contracts/v2/ArbitratorCommittee.sol#33) can be used in cross function reentrancies:\n\t- ArbitratorCommittee.commit(uint256,bytes32) (contracts/v2/ArbitratorCommittee.sol#121-129)\n\t- ArbitratorCommittee.finalize(uint256) (contracts/v2/ArbitratorCommittee.sol#149-170)\n\t- ArbitratorCommittee.openCase(uint256) (contracts/v2/ArbitratorCommittee.sol#105-118)\n\t- ArbitratorCommittee.reveal(uint256,bool,uint256) (contracts/v2/ArbitratorCommittee.sol#132-146)\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 149,
+    "fingerprint": "a8678d903dbc435aa0cbddfcd49aa8e7336c36e1010c01ac7fd11eb1c716e769"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001):\n\tExternal calls:\n\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyAgent(msg.sender,subdomain,proof) (contracts/v2/JobRegistry.sol#1953-1954)\n\tState variables written after the call(s):\n\t- agentSubdomains[msg.sender] = subdomain (contracts/v2/JobRegistry.sol#1964)\n\tJobRegistry.agentSubdomains (contracts/v2/JobRegistry.sol#734) can be used in cross function reentrancies:\n\t- JobRegistry.agentSubdomains (contracts/v2/JobRegistry.sol#734)\n\t- JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001)\n\t- job.resultHash = resultHash (contracts/v2/JobRegistry.sol#1975)\n\tJobRegistry.jobs (contracts/v2/JobRegistry.sol#244) can be used in cross function reentrancies:\n\t- JobRegistry._cancelJob(uint256) (contracts/v2/JobRegistry.sol#2521-2539)\n\t- JobRegistry._createJob(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1621-1700)\n\t- JobRegistry._dispute(uint256,bytes32,string) (contracts/v2/JobRegistry.sol#2225-2252)\n\t- JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495)\n\t- JobRegistry._finalizeByEmployer(uint256) (contracts/v2/JobRegistry.sol#2296-2302)\n\t- JobRegistry.burnEvidenceStatus(uint256) (contracts/v2/JobRegistry.sol#313-324)\n\t- JobRegistry.cancelJob(uint256) (contracts/v2/JobRegistry.sol#2541-2558)\n\t- JobRegistry.confirmEmployerBurn(uint256,bytes32) (contracts/v2/JobRegistry.sol#427-446)\n\t- JobRegistry.getSpecHash(uint256) (contracts/v2/JobRegistry.sol#309-311)\n\t- JobRegistry.jobs (contracts/v2/JobRegistry.sol#244)\n\t- JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001)\n\t- JobRegistry.submitBurnReceipt(uint256,bytes32,uint256,uint256) (contracts/v2/JobRegistry.sol#364-387)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1917,
+    "fingerprint": "a9de75d24b0b7d3af1ee16cc6591d86fe8fb9931f7bbe0ff88d79d12f5763e5b"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830):\n\tExternal calls:\n\t- stakeManager.unlockValidatorStake(jobId,val,lockAmount) (contracts/v2/ValidationModule.sol#1817)\n\tState variables written after the call(s):\n\t- delete _validatorLookup[jobId][val] (contracts/v2/ValidationModule.sol#1821)\n\tValidationModule._validatorLookup (contracts/v2/ValidationModule.sol#179) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- delete commitments[jobId][val][nonce] (contracts/v2/ValidationModule.sol#1812)\n\tValidationModule.commitments (contracts/v2/ValidationModule.sol#174) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.commitments (contracts/v2/ValidationModule.sol#174)\n\t- delete jobNonce[jobId] (contracts/v2/ValidationModule.sol#1828)\n\tValidationModule.jobNonce (contracts/v2/ValidationModule.sol#180) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.jobNonce (contracts/v2/ValidationModule.sol#180)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- delete revealed[jobId][val] (contracts/v2/ValidationModule.sol#1813)\n\tValidationModule.revealed (contracts/v2/ValidationModule.sol#175) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealed (contracts/v2/ValidationModule.sol#175)\n\t- r.revealedCount = 0 (contracts/v2/ValidationModule.sol#1826)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- delete rounds[jobId] (contracts/v2/ValidationModule.sol#1827)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- delete validatorStakeLocks[jobId][val] (contracts/v2/ValidationModule.sol#1819)\n\tValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178)\n\t- delete validatorStakes[jobId][val] (contracts/v2/ValidationModule.sol#1820)\n\tValidationModule.validatorStakes (contracts/v2/ValidationModule.sol#177) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorStakes (contracts/v2/ValidationModule.sol#177)\n\t- delete votes[jobId][val] (contracts/v2/ValidationModule.sol#1814)\n\tValidationModule.votes (contracts/v2/ValidationModule.sol#176) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.votes (contracts/v2/ValidationModule.sol#176)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1804,
+    "fingerprint": "abe9a7ee1d8e45da9cc21fc1daa891b3b64ee596d4f8d2ed4d15486388990e59"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in JobRegistry._applyForJob(uint256,string,bytes32[]) (contracts/v2/JobRegistry.sol#1750-1861):\n\tExternal calls:\n\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyAgent(msg.sender,subdomain,proof) (contracts/v2/JobRegistry.sol#1791-1792)\n\tState variables written after the call(s):\n\t- agentAuthCache[msg.sender] = true (contracts/v2/JobRegistry.sol#1801)\n\tJobRegistry.agentAuthCache (contracts/v2/JobRegistry.sol#729) can be used in cross function reentrancies:\n\t- JobRegistry.agentAuthCache (contracts/v2/JobRegistry.sol#729)\n\t- JobRegistry.updateAgentAuthCache(address,bool) (contracts/v2/JobRegistry.sol#1203-1212)\n\t- agentAuthExpiry[msg.sender] = block.timestamp + agentAuthCacheDuration (contracts/v2/JobRegistry.sol#1802-1803)\n\tJobRegistry.agentAuthExpiry (contracts/v2/JobRegistry.sol#730) can be used in cross function reentrancies:\n\t- JobRegistry.agentAuthExpiry (contracts/v2/JobRegistry.sol#730)\n\t- JobRegistry.updateAgentAuthCache(address,bool) (contracts/v2/JobRegistry.sol#1203-1212)\n\t- agentAuthVersion[msg.sender] = agentAuthCacheVersion (contracts/v2/JobRegistry.sol#1804)\n\tJobRegistry.agentAuthVersion (contracts/v2/JobRegistry.sol#731) can be used in cross function reentrancies:\n\t- JobRegistry.agentAuthVersion (contracts/v2/JobRegistry.sol#731)\n\t- JobRegistry.updateAgentAuthCache(address,bool) (contracts/v2/JobRegistry.sol#1203-1212)\n\t- agentSubdomains[msg.sender] = subdomain (contracts/v2/JobRegistry.sol#1806)\n\tJobRegistry.agentSubdomains (contracts/v2/JobRegistry.sol#734) can be used in cross function reentrancies:\n\t- JobRegistry.agentSubdomains (contracts/v2/JobRegistry.sol#734)\n\t- JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1750,
+    "fingerprint": "b2e6f89fd059eb41ffb0c506d7ddd09bffbf2537834d9579a2e61e8ddef854d9"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule._revealValidation(uint256,bool,bytes32,bytes32,string,bytes32[]) (contracts/v2/ValidationModule.sol#1364-1474):\n\tExternal calls:\n\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyValidator(msg.sender,subdomain,proof) (contracts/v2/ValidationModule.sol#1382-1387)\n\tState variables written after the call(s):\n\t- r.participants.push(msg.sender) (contracts/v2/ValidationModule.sol#1455)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- r.revealedCount += 1 (contracts/v2/ValidationModule.sol#1456)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- r.approvals += stake (contracts/v2/ValidationModule.sol#1457)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- r.rejections += stake (contracts/v2/ValidationModule.sol#1457)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1364,
+    "fingerprint": "be7a1208f3b368547e44f078304c7ddf7d1c9faae22689437bc3de09702bc36e"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule.forceFinalize(uint256) (contracts/v2/ValidationModule.sol#1570-1629):\n\tExternal calls:\n\t- stakeManager.slash(val,IStakeManager.Role.Validator,penalty,job.employer) (contracts/v2/ValidationModule.sol#1602-1607)\n\t- reputationEngine.subtract(val,1) (contracts/v2/ValidationModule.sol#1616)\n\t- jobRegistry.forceFinalize(jobId) (contracts/v2/ValidationModule.sol#1626)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1627)\n\t\t- stakeManager.unlockValidatorStake(jobId,val,lockAmount) (contracts/v2/ValidationModule.sol#1817)\n\tState variables written after the call(s):\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1627)\n\t\t- delete revealed[jobId][val] (contracts/v2/ValidationModule.sol#1813)\n\tValidationModule.revealed (contracts/v2/ValidationModule.sol#175) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealed (contracts/v2/ValidationModule.sol#175)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1627)\n\t\t- r.revealedCount = 0 (contracts/v2/ValidationModule.sol#1826)\n\t\t- delete rounds[jobId] (contracts/v2/ValidationModule.sol#1827)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1627)\n\t\t- delete validatorStakeLocks[jobId][val] (contracts/v2/ValidationModule.sol#1819)\n\tValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1627)\n\t\t- delete validatorStakes[jobId][val] (contracts/v2/ValidationModule.sol#1820)\n\tValidationModule.validatorStakes (contracts/v2/ValidationModule.sol#177) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorStakes (contracts/v2/ValidationModule.sol#177)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1570,
+    "fingerprint": "bea31058af9618a269e6a9c11fb8a64702ec62ba5db01b84e48089b235e930c1"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in KernelJobRegistry.onValidationApproved(uint256,address[],address[]) (contracts/v2/kernel/JobRegistry.sol#252-259):\n\tExternal calls:\n\t- _handleNonRevealers(jobId,nonRevealers) (contracts/v2/kernel/JobRegistry.sol#257)\n\t\t- stakeManager.slash(offender,bps,beneficiary,reason) (contracts/v2/kernel/JobRegistry.sol#297)\n\t- _finalize(jobId,true,validators) (contracts/v2/kernel/JobRegistry.sol#258)\n\t\t- stakeManager.unlockAll(job.agent,jobId) (contracts/v2/kernel/JobRegistry.sol#363)\n\t\t- stakeManager.unlockAll(validators[i],jobId) (contracts/v2/kernel/JobRegistry.sol#367)\n\t\t- split = rewardEngine.split(jobId,job.reward) (contracts/v2/kernel/JobRegistry.sol#312)\n\t\t- escrowVault.release(jobId,job.agent,split.agentAmount) (contracts/v2/kernel/JobRegistry.sol#315)\n\t\t- escrowVault.release(jobId,rewardedValidators[i],payout) (contracts/v2/kernel/JobRegistry.sol#325)\n\t\t- escrowVault.release(jobId,opsTreasury,split.opsAmount) (contracts/v2/kernel/JobRegistry.sol#330)\n\t\t- escrowVault.release(jobId,job.employer,split.employerRebateAmount) (contracts/v2/kernel/JobRegistry.sol#334)\n\t\t- escrowVault.burn(jobId,split.burnAmount) (contracts/v2/kernel/JobRegistry.sol#338)\n\t\t- escrowVault.refund(jobId,job.employer) (contracts/v2/kernel/JobRegistry.sol#343)\n\t\t- escrowVault.refund(jobId,job.employer) (contracts/v2/kernel/JobRegistry.sol#346)\n\tState variables written after the call(s):\n\t- _finalize(jobId,true,validators) (contracts/v2/kernel/JobRegistry.sol#258)\n\t\t- job.finalized = true (contracts/v2/kernel/JobRegistry.sol#305)\n\t\t- job.success = success (contracts/v2/kernel/JobRegistry.sol#306)\n\tKernelJobRegistry.jobs (contracts/v2/kernel/JobRegistry.sol#38) can be used in cross function reentrancies:\n\t- KernelJobRegistry.jobs (contracts/v2/kernel/JobRegistry.sol#38)\n\t- KernelJobRegistry.submitResult(uint256) (contracts/v2/kernel/JobRegistry.sol#216-229)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 252,
+    "fingerprint": "d4112cdaf8e09acab7c414a1a4fb382e61c4202e90ff330d4468da291a1cafe2"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in JobEscrow.postJob(uint256,string,bytes32) (contracts/v2/modules/JobEscrow.sol#118-138):\n\tExternal calls:\n\t- operator = routingModule.selectOperator(bytes32(nextJobId),seed) (contracts/v2/modules/JobEscrow.sol#124)\n\tState variables written after the call(s):\n\t- jobId = nextJobId ++ (contracts/v2/modules/JobEscrow.sol#126)\n\tJobEscrow.nextJobId (contracts/v2/modules/JobEscrow.sol#54) can be used in cross function reentrancies:\n\t- JobEscrow.nextJobId (contracts/v2/modules/JobEscrow.sol#54)\n",
+    "uri": "contracts/v2/modules/JobEscrow.sol",
+    "startLine": 118,
+    "fingerprint": "daa1749484ca5984827cad0baa83cc16a731584cfdca5b2419694d279ad89956"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in ValidationModule.forceFinalize(uint256) (contracts/v2/ValidationModule.sol#1570-1629):\n\tExternal calls:\n\t- stakeManager.slash(val,IStakeManager.Role.Validator,penalty,job.employer) (contracts/v2/ValidationModule.sol#1602-1607)\n\t- reputationEngine.subtract(val,1) (contracts/v2/ValidationModule.sol#1616)\n\tState variables written after the call(s):\n\t- r.tallied = true (contracts/v2/ValidationModule.sol#1623)\n\tValidationModule.rounds (contracts/v2/ValidationModule.sol#172) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634)\n\t- ValidationModule.rounds (contracts/v2/ValidationModule.sol#172)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362)\n\t- ValidationModule.validators(uint256) (contracts/v2/ValidationModule.sol#624-627)\n\t- _reduceValidatorLock(jobId,val,penalty) (contracts/v2/ValidationModule.sol#1608)\n\t\t- validatorStakeLocks[jobId][val] = 0 (contracts/v2/ValidationModule.sol#1798)\n\t\t- validatorStakeLocks[jobId][val] = locked - amount (contracts/v2/ValidationModule.sol#1800)\n\tValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178) can be used in cross function reentrancies:\n\t- ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830)\n\t- ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250)\n\t- ValidationModule.validatorStakeLocks (contracts/v2/ValidationModule.sol#178)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1570,
+    "fingerprint": "e6478b351b72510fde66580731ae6f31728fdd59d82d299accc5469bc2328a61"
+  },
+  {
+    "ruleId": "1-1-reentrancy-no-eth",
+    "message": "Reentrancy in StakeManager._redistributeEscrowBatched(bytes32,address,uint256,address[]) (contracts/v2/StakeManager.sol#971-1028):\n\tExternal calls:\n\t- part = _distributeEscrowPenalty(jobId,recipient,chunkAmount,slice,true) (contracts/v2/StakeManager.sol#1008)\n\t\t- IERC20Burnable(address(token)).burn(amount) (contracts/v2/StakeManager.sol#1091-1095)\n\t- remainder = _distributeEscrowPenalty(jobId,recipient,amount - allocated,empty_scope_2,true) (contracts/v2/StakeManager.sol#1020-1021)\n\t\t- IERC20Burnable(address(token)).burn(amount) (contracts/v2/StakeManager.sol#1091-1095)\n\tState variables written after the call(s):\n\t- remainder = _distributeEscrowPenalty(jobId,recipient,amount - allocated,empty_scope_2,true) (contracts/v2/StakeManager.sol#1020-1021)\n\t\t- jobEscrows[jobId] = escrow - amount (contracts/v2/StakeManager.sol#922)\n\tStakeManager.jobEscrows (contracts/v2/StakeManager.sol#188) can be used in cross function reentrancies:\n\t- StakeManager.jobEscrows (contracts/v2/StakeManager.sol#188)\n\t- StakeManager.lockReward(bytes32,address,uint256) (contracts/v2/StakeManager.sol#2234-2238)\n\t- remainder = _distributeEscrowPenalty(jobId,recipient,amount - allocated,empty_scope_2,true) (contracts/v2/StakeManager.sol#1020-1021)\n\t\t- operatorRewardPool += operatorShare (contracts/v2/StakeManager.sol#959)\n\tStakeManager.operatorRewardPool (contracts/v2/StakeManager.sol#191) can be used in cross function reentrancies:\n\t- StakeManager.operatorRewardPool (contracts/v2/StakeManager.sol#191)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 971,
+    "fingerprint": "f2868b677de0930f4d246af8de4c484454c555d22c120831df0e4b2d01ecbf43"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "RewardEngineMB.settleEpoch(uint256,RewardEngineMB.EpochData).totalValue (contracts/v2/RewardEngineMB.sol#241) is a local variable never initialized\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 241,
+    "fingerprint": "023acee7be62e3fd3b9e10a26183e0466b78335e6e598517a5a7d2e70af37767"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).feePctChanged (contracts/v2/StakeManager.sol#1489) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1489,
+    "fingerprint": "05c231f5b72b9afe0759224ed6dbc1cc34b24c976d750570fbe33b2a95062d97"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).operatorSlashPctChanged (contracts/v2/StakeManager.sol#1500) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1500,
+    "fingerprint": "08f6be3a82f7a175b91705d6e58de8c253db6f468a54cc5d88f1f8ab50fd70b4"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "RewardEngineMB.settleEpoch(uint256,RewardEngineMB.EpochData).sumUpre (contracts/v2/RewardEngineMB.sol#242) is a local variable never initialized\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 242,
+    "fingerprint": "091fd2efb4e11ce434eb5677202262a4ddf2674134e94a0d4e32506385b96a4f"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRouter.routingWeight(address).total (contracts/v2/modules/JobRouter.sol#98) is a local variable never initialized\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 98,
+    "fingerprint": "09ce31fe349956d31c7fee7dab642caa30559c5fd3b7a79f1fcae7cced748382"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).maxJobDurationUpdated (contracts/v2/JobRegistry.sol#1396) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1396,
+    "fingerprint": "0bf77996b403634bb1080de7798f2cc0cb84d376c7e7cb5a5c697800bddf6437"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "PlatformRegistry.applyConfiguration(PlatformRegistry.ConfigUpdate,PlatformRegistry.RegistrarConfig[],PlatformRegistry.BlacklistConfig[]).pauserManagerChanged (contracts/v2/PlatformRegistry.sol#412) is a local variable never initialized\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 412,
+    "fingerprint": "0c93156d9c1e0f14ebed24d3dfa4b43030bd8aff701878995f278933a333ca6c"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).agentAuthCacheDurationUpdated (contracts/v2/JobRegistry.sol#1403) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1403,
+    "fingerprint": "0f224a1e0f40f1ec7718f3b56d6fe12efbdd3f09e6299c43b6be92223fbefe01"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).modulesUpdated (contracts/v2/JobRegistry.sol#1379) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1379,
+    "fingerprint": "127e247fd3267c8003c19ef04c34aba529d4ef20bd35abfe80591bd86cb680c9"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "Deployer.deployDefaultsWithoutTaxPolicy(Deployer.IdentityParams,address).econ (contracts/v2/Deployer.sol#233) is a local variable never initialized\n",
+    "uri": "contracts/v2/Deployer.sol",
+    "startLine": 233,
+    "fingerprint": "12cecf7449048d0627973c4e1ed5274d0967583369a8364a737dc586e775d001"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.finalize(uint256).revealIdx (contracts/v2/kernel/ValidationModule.sol#148) is a local variable never initialized\n",
+    "uri": "contracts/v2/kernel/ValidationModule.sol",
+    "startLine": 148,
+    "fingerprint": "1a2fb9cd9edbe977b63bddc868022117da1502a58db0051776bda05fdc3c666e"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "FeePool.applyConfiguration(FeePool.ConfigUpdate,FeePool.AllowlistUpdate[],FeePool.RewarderConfig[]).governanceChanged (contracts/v2/FeePool.sol#544) is a local variable never initialized\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 544,
+    "fingerprint": "1a4ed2cee00e41497971afb1a3f0d4912faf741f47ba5c127c48dc5d325d1986"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "Deployer._deploy(bool,Deployer.EconParams,Deployer.IdentityParams,address).policy (contracts/v2/Deployer.sol#340) is a local variable never initialized\n",
+    "uri": "contracts/v2/Deployer.sol",
+    "startLine": 340,
+    "fingerprint": "1b5c1328177c2e45ce0d6601b98777ba069ad4d4b53a02085510f7dc8e4d8a54"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).validatorRewardPctChanged (contracts/v2/StakeManager.sol#1492) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1492,
+    "fingerprint": "1b6c888d3c8b6fe3456d1aedeb5b8d7ba4ade1dd205a6d986be7535a71b40d58"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager._redistributeEscrowBatched(bytes32,address,uint256,address[]).empty (contracts/v2/StakeManager.sol#986) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 986,
+    "fingerprint": "1d1e6cf57575033aa34b1eb9244ebdf176eb31c823d3f0463b2abf938752671c"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.selectValidators(uint256,uint256).proof (contracts/v2/ValidationModule.sol#1051) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1051,
+    "fingerprint": "1d79f1b7579765ead31b77b2a5eea309d67157be535d04f4bbecd5c532b6cd2c"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.slash(address,uint256,address).validators (contracts/v2/StakeManager.sol#2839) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2839,
+    "fingerprint": "208af3974fd9c268b16ca37f0dfe9a0bf842e492b0520bc9dfedcc5f09665c7a"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).feePctUpdated (contracts/v2/JobRegistry.sol#1393) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1393,
+    "fingerprint": "2894c37d4e60fcca990580cc5197a9695228edd7ef270aec366dfda03372e814"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).disputeModuleUpdated (contracts/v2/JobRegistry.sol#1382) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1382,
+    "fingerprint": "296f21a162da7b67c5570c6f52a6236c11eca092b456e9195ef3b75076509150"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry._finalize(uint256).agentBlacklisted (contracts/v2/JobRegistry.sol#2312) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2312,
+    "fingerprint": "2c41edea884d3ab18c979ed6bb91c576d09674376f6a62da22345fec80fe1d31"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.selectValidators(uint256,uint256).candidateCount (contracts/v2/ValidationModule.sol#991) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 991,
+    "fingerprint": "2c4d992ff83cf57e6d278be88f0387bdbd197b85b9ddf4fcb703bc61cec617cf"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.distributeValidatorRewards(bytes32,uint256).maxIndex (contracts/v2/StakeManager.sol#2571) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2571,
+    "fingerprint": "2e5662da987a6384ab1f1eed95c4b2613cde622d3233a37cf3088312fc88b150"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "PlatformRegistry.applyConfiguration(PlatformRegistry.ConfigUpdate,PlatformRegistry.RegistrarConfig[],PlatformRegistry.BlacklistConfig[]).pauserChanged (contracts/v2/PlatformRegistry.sol#411) is a local variable never initialized\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 411,
+    "fingerprint": "2ef82076549488a5f45573d0b8b081167898427376f0c8431a9f82cf38f01e56"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).autoStakeTuningChanged (contracts/v2/StakeManager.sol#1479) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1479,
+    "fingerprint": "304ba39e09b1d86b3be70cf3921c9daa6f8635ec3ba72a112be1d5edeff07fd8"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).roleMinimumsChanged (contracts/v2/StakeManager.sol#1482) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1482,
+    "fingerprint": "307396d52179deead88d6302af5ae87ab83e1ffd0b11b0e7e22620e82db56e28"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).maxStakePerAddressChanged (contracts/v2/StakeManager.sol#1494) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1494,
+    "fingerprint": "31b064142a8ae6649aeeb192b3b830b40fb889a0c816d45f9357d15b4c918a4a"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).agentMerkleUpdated (contracts/v2/JobRegistry.sol#1400) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1400,
+    "fingerprint": "34fc8b9a20fb9d27b96c4ef76c46acc61de6abf16bf514755a06417b9104b3d5"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).pauserChanged (contracts/v2/StakeManager.sol#1475) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1475,
+    "fingerprint": "3b0702e3f20de5f52d748958ec164d85c2f4759205bbebe44e1414df00572603"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "RewardEngineMB.settleEpoch(uint256,RewardEngineMB.EpochData).sumUpost (contracts/v2/RewardEngineMB.sol#243) is a local variable never initialized\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 243,
+    "fingerprint": "3b17620e7e141b24fcd6b04cd18e575919ff0c4a04566c41185b96e124b3d9c1"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).maxActiveJobsUpdated (contracts/v2/JobRegistry.sol#1397) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1397,
+    "fingerprint": "423000638e7f002f633a0d4d76481e242db217dde0c3d43adaef9520cdbf1a53"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).treasuryUpdated (contracts/v2/JobRegistry.sol#1390) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1390,
+    "fingerprint": "429d769eeae41f35f3cfc8bbb6fb703e90b657a57f3246959dd657b061a82da1"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).certificateNFTUpdated (contracts/v2/JobRegistry.sol#1386) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1386,
+    "fingerprint": "42ddc876eaaa41024d6b3d5858a6a1ca0c6d5526fb333be8bbc6507038d15ec3"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).stakeManagerUpdated (contracts/v2/JobRegistry.sol#1384) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1384,
+    "fingerprint": "42f28db027b75c00f01fdd25d753e942a1f1d7a08cd3e0384cfda0e678880314"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.redistributeEscrow(bytes32,address,uint256).validators (contracts/v2/StakeManager.sol#2341) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2341,
+    "fingerprint": "4e184a79abc09a11e64ab245b2f6e5c3faa3511a455a584d258bbbffd98b1a9e"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).agentRootUpdated (contracts/v2/JobRegistry.sol#1399) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1399,
+    "fingerprint": "4fe7f4673fda2bf3d5dfd373e171a33b93d6d25549d0630c97c3e8740f8ffb62"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).expirationGracePeriodUpdated (contracts/v2/JobRegistry.sol#1398) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1398,
+    "fingerprint": "53e6f8a3ab9c7f2df61935164288ccad4c3fe63e34540df9530b366169e23e9d"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).taxPolicyUpdated (contracts/v2/JobRegistry.sol#1389) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1389,
+    "fingerprint": "550c9f273b2f073142ae3851bffe5a521c795a4aa303cc30b681c2d5035109e6"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ReputationEngine.getOperatorScore(address).stake (contracts/v2/ReputationEngine.sol#420) is a local variable never initialized\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 420,
+    "fingerprint": "5673ab03021ffca2279a2f7b7c17d004321984892aa4eb29f225192d20d1fe0d"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "IdentityRegistry.applyConfiguration(IdentityRegistry.ConfigUpdate,IdentityRegistry.AdditionalAgentConfig[],IdentityRegistry.AdditionalValidatorConfig[],IdentityRegistry.AdditionalNodeOperatorConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.AgentTypeConfig[]).nameWrapperUpdated (contracts/v2/IdentityRegistry.sol#364) is a local variable never initialized\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 364,
+    "fingerprint": "5862b44ae7eb68a2b6111e004b23122737d3c590403cbffa9649b9546270cc54"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.selectValidators(uint256,uint256).skipVerification_scope_5 (contracts/v2/ValidationModule.sol#1122) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1122,
+    "fingerprint": "5bc1ac002d81929077228f5edc8446b0a1bbd14b42bb9a456844013b2e48aab4"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.selectValidators(uint256,uint256).chosen (contracts/v2/ValidationModule.sol#1190) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1190,
+    "fingerprint": "5c216b07158bf7f0af4289bc0632f1b70345769de5d3304ff1d2898ce0468231"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).slashBurnPctChanged (contracts/v2/StakeManager.sol#1501) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1501,
+    "fingerprint": "5e2e7887959d79eba40801c93f5fdaf5781d5b710dc9e43d8f1e4cd745a8752e"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "IdentityRegistry.applyConfiguration(IdentityRegistry.ConfigUpdate,IdentityRegistry.AdditionalAgentConfig[],IdentityRegistry.AdditionalValidatorConfig[],IdentityRegistry.AdditionalNodeOperatorConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.AgentTypeConfig[]).agentMerkleUpdated (contracts/v2/IdentityRegistry.sol#370) is a local variable never initialized\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 370,
+    "fingerprint": "605ee5643c651172016dce459e31f5ef42cc66bdfafbb221c4ccf34386176d40"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).maxJobRewardUpdated (contracts/v2/JobRegistry.sol#1395) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1395,
+    "fingerprint": "62791477606247bc14743f0bd015465ab8b29c196990bef66963fe7d49d087f1"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).validationModuleChanged (contracts/v2/StakeManager.sol#1487) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1487,
+    "fingerprint": "64518ab4fb86beee1d043ffb9d5bb6dfffdfc10513f9c31c484772a3318accf3"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).unpausedChanged (contracts/v2/StakeManager.sol#1499) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1499,
+    "fingerprint": "650cbcf3e139960666bdb6cc9cd2c873a5932b3cbbcc4ca60c2d233367263eaa"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).reputationModuleUpdated (contracts/v2/JobRegistry.sol#1385) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1385,
+    "fingerprint": "66391a72b56f4de800e6dd9cc1083938686caa19061eb137ba02db8b4267286a"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).validationModuleUpdated (contracts/v2/JobRegistry.sol#1383) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1383,
+    "fingerprint": "675245914bede51ba0f4a4cfb0fed9184bcc57669cbffabfd6ce44ea81d08a5c"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "DisputeModule._resolve(uint256,bool,address).index (contracts/v2/modules/DisputeModule.sol#552) is a local variable never initialized\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 552,
+    "fingerprint": "684b881fb3ff8baceb4f375033c3519e044515a4896df1d7c2f81a7fde548896"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).maxAGITypesChanged (contracts/v2/StakeManager.sol#1496) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1496,
+    "fingerprint": "6c700a7f4f635dbe2861359864509a6cc761636160d8cb9088e91620336cd6e0"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).stakeRecommendationsChanged (contracts/v2/StakeManager.sol#1495) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1495,
+    "fingerprint": "6d296c18a3aac30855eb830809aa2d567d676684d779d96dbf5243279f21df7c"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "FeePool.applyConfiguration(FeePool.ConfigUpdate,FeePool.AllowlistUpdate[],FeePool.RewarderConfig[]).stakeManagerChanged (contracts/v2/FeePool.sol#540) is a local variable never initialized\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 540,
+    "fingerprint": "7514c6f69d130612265593064a18cb321a904602f109ba01fb1deade021bc33e"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "RewardEngineMB.settleEpoch(uint256,RewardEngineMB.EpochData).minted (contracts/v2/RewardEngineMB.sol#284) is a local variable never initialized\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 284,
+    "fingerprint": "77098550d8a3ff697b775ef2b3f8cd1f2778e27261b7f2c62ba5e1f435bd59f5"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "RoutingModule.selectOperator(bytes32,bytes32).totalWeight (contracts/v2/modules/RoutingModule.sol#144) is a local variable never initialized\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 144,
+    "fingerprint": "774d667ca330aa4286e52c64814769d8cce633b846276b2a258b1c8540a86522"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry._finalize(uint256).fee (contracts/v2/JobRegistry.sol#2339) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2339,
+    "fingerprint": "780abc8501736c602c6f465a8a9d17641847e9de75c7a499935eaba125178585"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).feePoolChanged (contracts/v2/StakeManager.sol#1490) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1490,
+    "fingerprint": "78a3c9202625f2811b5a9c7b9cef1d50d3c3bb75689eb46a16447e50a9341690"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).unbondingPeriodChanged (contracts/v2/StakeManager.sol#1493) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1493,
+    "fingerprint": "7a4b6c01231c9ea040a7762266ff14b477150ee12763d8e39dde68e5d71b6ca0"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "IdentityRegistry.applyConfiguration(IdentityRegistry.ConfigUpdate,IdentityRegistry.AdditionalAgentConfig[],IdentityRegistry.AdditionalValidatorConfig[],IdentityRegistry.AdditionalNodeOperatorConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.AgentTypeConfig[]).validatorMerkleUpdated (contracts/v2/IdentityRegistry.sol#371) is a local variable never initialized\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 371,
+    "fingerprint": "7b75f14390964d3023a04ff94ba997c74f60be4ab4b42d2b0535ce8336f2c1c8"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).feePoolUpdated (contracts/v2/JobRegistry.sol#1388) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1388,
+    "fingerprint": "7b856a237adcfff7d4b481830fe6c0abb5b4ccb3211cbc328bcea7692297e6d4"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry._createJob(uint256,uint64,uint8,bytes32,string).fee (contracts/v2/JobRegistry.sol#1684) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1684,
+    "fingerprint": "7cbdaf6ee26efa35cb65657aa24f66fce2d096ecf900167fd37081f544c5c815"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.distributeValidatorRewards(bytes32,uint256).maxWeight (contracts/v2/StakeManager.sol#2570) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2570,
+    "fingerprint": "7e91dee9314864463745c50a7759e7b33a45c5896aee4fd6e0e3d39550c588d7"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.selectValidators(uint256,uint256).rcRand (contracts/v2/ValidationModule.sol#949) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 949,
+    "fingerprint": "80c103d5a5c5ad9ee99d15f4627ce8c46fa56d94dc77bf28548061cc273353ab"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).jobRegistryChanged (contracts/v2/StakeManager.sol#1485) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1485,
+    "fingerprint": "84164a8dbf2b6a6035067b745fb3bf43179c39b822a082d142d78417d8e406ff"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.selectValidators(uint256,uint256).eligible (contracts/v2/ValidationModule.sol#1084) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1084,
+    "fingerprint": "847ec118c163ece77659c12ba729273a8313613865846e2c609bd0172ec2771d"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).disputeModuleChanged (contracts/v2/StakeManager.sol#1486) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1486,
+    "fingerprint": "8a6fa081e415af45886f2643d9d6cd4e79562b1a69ed13104c30aed9246f91e7"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRouter.selectPlatform(bytes32).cumulative (contracts/v2/modules/JobRouter.sol#135) is a local variable never initialized\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 135,
+    "fingerprint": "8ad6ea2adf25b4eacd793ddddd6658d55a77412353081167e65a4b6a1fa6a0fe"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "FeePool.applyConfiguration(FeePool.ConfigUpdate,FeePool.AllowlistUpdate[],FeePool.RewarderConfig[]).pauserManagerChanged (contracts/v2/FeePool.sol#547) is a local variable never initialized\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 547,
+    "fingerprint": "8dd419acdc4a4c3871cfef4b3137e3b8fcc7ec222c266b85097ed02997af3d6c"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "RevenueDistributor.distribute(uint256).totalStake (contracts/v2/modules/RevenueDistributor.sol#94) is a local variable never initialized\n",
+    "uri": "contracts/v2/modules/RevenueDistributor.sol",
+    "startLine": 94,
+    "fingerprint": "8ec97cb61dcb7688f087610c3cc205a211196daf499dac899bbcbc20bd37d78a"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).ackModulesAdded (contracts/v2/JobRegistry.sol#1406) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1406,
+    "fingerprint": "90b20a77a873292fea166f17ef46f17f364807eda3523ef9133c032ce83f25a1"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).thermostatChanged (contracts/v2/StakeManager.sol#1477) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1477,
+    "fingerprint": "937967332c9957f8d8ab2be2176bb601fe3f5f0e3249bb6d3cd5260a96c635b2"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.selectValidators(uint256,uint256).totalStake (contracts/v2/ValidationModule.sol#992) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 992,
+    "fingerprint": "9590e68ce363a39c1e72fdae1ce24bb11f8049b29100fdabb9e458c46ec9392d"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager._slashBatched(address,StakeManager.Role,uint256,address,address[]).empty (contracts/v2/StakeManager.sol#2768) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2768,
+    "fingerprint": "97a4c5d13c4abdb9e61537a1225da20fb90a4044c172e7923b920eb82b0b33a6"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRouter.selectPlatform(bytes32).total (contracts/v2/modules/JobRouter.sol#116) is a local variable never initialized\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 116,
+    "fingerprint": "98d09c811ddd8b28f897c29052add85b09a6f8284d617e4aaf02878cd4e81e5a"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "IdentityRegistry.applyConfiguration(IdentityRegistry.ConfigUpdate,IdentityRegistry.AdditionalAgentConfig[],IdentityRegistry.AdditionalValidatorConfig[],IdentityRegistry.AdditionalNodeOperatorConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.AgentTypeConfig[]).reputationUpdated (contracts/v2/IdentityRegistry.sol#365) is a local variable never initialized\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 365,
+    "fingerprint": "9aeecc1399346481e0b5163e4030f3261e4557f81b8ed7d9dbcad90d388ae48e"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry._finalize(uint256).validatorReward (contracts/v2/JobRegistry.sol#2331) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2331,
+    "fingerprint": "9c7b4f0b299848354901b516ac50d1ef298d2185d52b3e5f3eac717a438bdef4"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).maxTotalPayoutPctChanged (contracts/v2/StakeManager.sol#1497) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1497,
+    "fingerprint": "9ddee5885aa1cb454d04320a5757ce027e9aff5e9de760b91e1c6b7656b52b69"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "DiscoveryModule.getPlatforms(uint256,uint256).count (contracts/v2/modules/DiscoveryModule.sol#89) is a local variable never initialized\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 89,
+    "fingerprint": "a51552e74b4967a313a5a0e89a34fb9d35aee19eaf4af3957cc47472896ff725"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "FeePool.applyConfiguration(FeePool.ConfigUpdate,FeePool.AllowlistUpdate[],FeePool.RewarderConfig[]).pauserChanged (contracts/v2/FeePool.sol#546) is a local variable never initialized\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 546,
+    "fingerprint": "a5d03966c9611aac6073411e0469e4c17b71bd0929f4d92094147ff0b233539b"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.submit(uint256,bytes32,string,string,bytes32[]).cachedHash (contracts/v2/JobRegistry.sol#1947) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1947,
+    "fingerprint": "a7b6458e5c3c3078c3c4fba5def3cee0d3df9904adfdf7bf3a8b06a1f0ab2e3f"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).minAgentStakeUpdated (contracts/v2/JobRegistry.sol#1392) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1392,
+    "fingerprint": "a8a1ff7b0efdb5efaf0f330262af397b3ebb0e01a73298b26016a167df369a89"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager._slashBatched(address,StakeManager.Role,uint256,address,address[]).empty_scope_2 (contracts/v2/StakeManager.sol#2796) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2796,
+    "fingerprint": "ac0a335bfc87ae4593540c4a37ca713f3c22372cede67083318d532202030ea8"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "Deployer.deployDefaults(Deployer.IdentityParams,address).econ (contracts/v2/Deployer.sol#197) is a local variable never initialized\n",
+    "uri": "contracts/v2/Deployer.sol",
+    "startLine": 197,
+    "fingerprint": "af06dd4497db60cdae2df59b4a3ce6a7286c993e78f715797f83135f48ef9284"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).jobStakeUpdated (contracts/v2/JobRegistry.sol#1391) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1391,
+    "fingerprint": "b082cddd807b8082742e805379419b1ab6a389b00ed73d333dc3405c71174f63"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "DisputeModule._resolve(uint256,bool,address).correctCount (contracts/v2/modules/DisputeModule.sol#544) is a local variable never initialized\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 544,
+    "fingerprint": "b16f3c93ca9be813936f31e6934d9718063187ffb273830af01b65248f168f08"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "FeePool.applyConfiguration(FeePool.ConfigUpdate,FeePool.AllowlistUpdate[],FeePool.RewarderConfig[]).rewardRoleChanged (contracts/v2/FeePool.sol#541) is a local variable never initialized\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 541,
+    "fingerprint": "b1ef8e666dcfcf8e68528664ae77cde96f6c03243f98293e17b145a3e6e24ccf"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "IdentityRegistry.applyConfiguration(IdentityRegistry.ConfigUpdate,IdentityRegistry.AdditionalAgentConfig[],IdentityRegistry.AdditionalValidatorConfig[],IdentityRegistry.AdditionalNodeOperatorConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.AgentTypeConfig[]).ensUpdated (contracts/v2/IdentityRegistry.sol#363) is a local variable never initialized\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 363,
+    "fingerprint": "b60e49e4631f9543fde347be3d14a88476ffb389163b2ff097712892a1884e26"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.slash(address,StakeManager.Role,uint256,address).validators (contracts/v2/StakeManager.sol#2812) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2812,
+    "fingerprint": "b8ad1ccb86a9862d40f395025a1a2964e2a48301f497e17578fb7460cfc7355c"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule._finalize(uint256).approvalCount (contracts/v2/ValidationModule.sol#1676) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1676,
+    "fingerprint": "b8d8f743ff0ce7b5c8d6a60782f3ac170fdb39d33bab8b37d69edf0df4c24c0b"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "IdentityRegistry.applyConfiguration(IdentityRegistry.ConfigUpdate,IdentityRegistry.AdditionalAgentConfig[],IdentityRegistry.AdditionalValidatorConfig[],IdentityRegistry.AdditionalNodeOperatorConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.AgentTypeConfig[]).attestationUpdated (contracts/v2/IdentityRegistry.sol#366) is a local variable never initialized\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 366,
+    "fingerprint": "ba14cd49086ccea74930818bbf09e02d0ca9a4b7a729657c297f30e344f86382"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule._finalize(uint256).duration (contracts/v2/ValidationModule.sol#1713) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1713,
+    "fingerprint": "bcc019ca2a2a1adb99e20f114912bfd0617b9ef19868283c1efcf0551744abda"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).hamiltonianChanged (contracts/v2/StakeManager.sol#1478) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1478,
+    "fingerprint": "bcf8ce73f62c288713997b66d026a58cce7933db9b09a27f39c0844689b2d939"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "IdentityRegistry.applyConfiguration(IdentityRegistry.ConfigUpdate,IdentityRegistry.AdditionalAgentConfig[],IdentityRegistry.AdditionalValidatorConfig[],IdentityRegistry.AdditionalNodeOperatorConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.AgentTypeConfig[]).agentRootUpdated (contracts/v2/IdentityRegistry.sol#367) is a local variable never initialized\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 367,
+    "fingerprint": "be0fe665e4c5c2fb65459ed8b71ffce6c13495691bf19ad65fdea0f58805170b"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "FeePool.applyConfiguration(FeePool.ConfigUpdate,FeePool.AllowlistUpdate[],FeePool.RewarderConfig[]).treasuryChanged (contracts/v2/FeePool.sol#543) is a local variable never initialized\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 543,
+    "fingerprint": "be9968749a317f1c6ad3508b3a9440d638bbaf102d81368e3989e7b17d973da8"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.finalize(uint256).approved (contracts/v2/kernel/ValidationModule.sol#159) is a local variable never initialized\n",
+    "uri": "contracts/v2/kernel/ValidationModule.sol",
+    "startLine": 159,
+    "fingerprint": "beee2185ad3fe241fa14180cd82f9ede64f6fc2929623f2d6f8b7131332b951f"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry._finalize(uint256).employerBlacklisted (contracts/v2/JobRegistry.sol#2313) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2313,
+    "fingerprint": "bf3e7d05acdf46ad9ccf63084e062b9a01c886a844666435079d1dce3b9c835e"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "FeePool.applyConfiguration(FeePool.ConfigUpdate,FeePool.AllowlistUpdate[],FeePool.RewarderConfig[]).taxPolicyChanged (contracts/v2/FeePool.sol#545) is a local variable never initialized\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 545,
+    "fingerprint": "bf601e518b505d5b52fffaff69a1ec9a54213fc93730e6209eb10c05adf8abda"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.selectValidators(uint256,uint256).skipVerification (contracts/v2/ValidationModule.sol#1039) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1039,
+    "fingerprint": "c09c4035a8ddfa4ecc843b1d0c146da6f41f3af219a7aab18beab203bf63fda7"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.finalize(uint256).nonRevealIdx (contracts/v2/kernel/ValidationModule.sol#147) is a local variable never initialized\n",
+    "uri": "contracts/v2/kernel/ValidationModule.sol",
+    "startLine": 147,
+    "fingerprint": "c1815e2ff658ad7ab527175e38efb0244850e9d3e589fc7ff1e4c02582ac72a5"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).pauserManagerChanged (contracts/v2/StakeManager.sol#1476) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1476,
+    "fingerprint": "c557c8e1a46491727df8b511ae4ef783ecc13b427935c1249145349959033aa3"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).autoStakeConfigChanged (contracts/v2/StakeManager.sol#1480) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1480,
+    "fingerprint": "c8a98c6046d6368394cf4fb5238033a5e6663543bd440202e4d92ec51c01abc4"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "RoutingModule.selectOperator(bytes32,bytes32).cumulative (contracts/v2/modules/RoutingModule.sol#166) is a local variable never initialized\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 166,
+    "fingerprint": "c9d807141148d34e005aa74130a0b1d9a2029048dc3625e9068fa8d42c3cd9c3"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule.selectValidators(uint256,uint256).proof_scope_6 (contracts/v2/ValidationModule.sol#1134) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1134,
+    "fingerprint": "cb99f7fd3ddb97285c6a91164d6ea487dce900c035d8108df6ad8284cd5ea8a7"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "ValidationModule._finalize(uint256).payout (contracts/v2/ValidationModule.sol#1712) is a local variable never initialized\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1712,
+    "fingerprint": "cbebc194ef7f47469bbe611974623f2b14df660e0a819650dccd2607dc3280a5"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry._finalize(uint256).fundsRedirected (contracts/v2/JobRegistry.sol#2325) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2325,
+    "fingerprint": "cf04171aa132780988921de5912ec5cb8dd56d7236cf3b0f993cc80affa7d046"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "RevenueDistributor.distribute(uint256).distributed (contracts/v2/modules/RevenueDistributor.sol#105) is a local variable never initialized\n",
+    "uri": "contracts/v2/modules/RevenueDistributor.sol",
+    "startLine": 105,
+    "fingerprint": "d2bce8b8c02a1245429c0f60ea9b6d52a6772d497295f63be933d1c5d15e35a9"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "FeePool.applyConfiguration(FeePool.ConfigUpdate,FeePool.AllowlistUpdate[],FeePool.RewarderConfig[]).burnPctChanged (contracts/v2/FeePool.sol#542) is a local variable never initialized\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 542,
+    "fingerprint": "d3058cd8a4a93ebd8b0648258cdc3c441a7fa010149fa73bff310c74185eb6f9"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "IdentityRegistry.applyConfiguration(IdentityRegistry.ConfigUpdate,IdentityRegistry.AdditionalAgentConfig[],IdentityRegistry.AdditionalValidatorConfig[],IdentityRegistry.AdditionalNodeOperatorConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.AgentTypeConfig[]).nodeRootUpdated (contracts/v2/IdentityRegistry.sol#369) is a local variable never initialized\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 369,
+    "fingerprint": "d3c27227c6539c782d9e8d796be6f6c6033949118151189ee5c268e714850e9a"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry._applyForJob(uint256,string,bytes32[]).lockTime (contracts/v2/JobRegistry.sol#1837) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1837,
+    "fingerprint": "d424e61c43828051164b3af7fff43137e18509130892b4186e948ac10d277537"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry._applyForJob(uint256,string,bytes32[]).cachedHash (contracts/v2/JobRegistry.sol#1779) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1779,
+    "fingerprint": "d6984e6582d9d6453ff2cb2531fc21146ab2513de7a296662b6fa828afee259a"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).pausedChanged (contracts/v2/StakeManager.sol#1498) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1498,
+    "fingerprint": "d762efedd79988efbfaa2852fce782118f8386f4c3f47059e7c2f6cdaa9fbaa9"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "PlatformRegistry.applyConfiguration(PlatformRegistry.ConfigUpdate,PlatformRegistry.RegistrarConfig[],PlatformRegistry.BlacklistConfig[]).reputationEngineChanged (contracts/v2/PlatformRegistry.sol#409) is a local variable never initialized\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 409,
+    "fingerprint": "d9c70cfef8ac35ea65df6a0d7ea6b32f1c86752da8a4b731017a5c9dd1ccb4dc"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "IdentityRegistry.applyConfiguration(IdentityRegistry.ConfigUpdate,IdentityRegistry.AdditionalAgentConfig[],IdentityRegistry.AdditionalValidatorConfig[],IdentityRegistry.AdditionalNodeOperatorConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.AgentTypeConfig[]).clubRootUpdated (contracts/v2/IdentityRegistry.sol#368) is a local variable never initialized\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 368,
+    "fingerprint": "dbaf2f2991cc9c16f8b55a43b17086159cb78a945e21357fcc83ba422a3b6ba0"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).burnPctChanged (contracts/v2/StakeManager.sol#1491) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1491,
+    "fingerprint": "dc091ba4fc38a1beddc15cf05d874715a4db19dd99f93a3521e3d29557ee6130"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "PlatformRegistry.applyConfiguration(PlatformRegistry.ConfigUpdate,PlatformRegistry.RegistrarConfig[],PlatformRegistry.BlacklistConfig[]).minStakeChanged (contracts/v2/PlatformRegistry.sol#410) is a local variable never initialized\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 410,
+    "fingerprint": "ddb74c98d429584ec26506821f244b8e06983054aa3ab3372e0c46b3a5806e61"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "RewardEngineMB.settleEpoch(uint256,RewardEngineMB.EpochData).Tsys (contracts/v2/RewardEngineMB.sol#272) is a local variable never initialized\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 272,
+    "fingerprint": "e13330c44a7d4d5a5e4ad4a922b8dd5b97ae94fea53f5db5f5fc5347c232cede"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).pauserUpdated (contracts/v2/JobRegistry.sol#1378) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1378,
+    "fingerprint": "e5c133e68ea52b9ca3d62dddfac8555193e62adef98abef11e844266c32da47e"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).validatorRootUpdated (contracts/v2/JobRegistry.sol#1401) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1401,
+    "fingerprint": "e62a4c184ae9befe3d3bd02521bf8da8eec9c996098fae8c1638a9ef3eb60d15"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "PlatformRegistry.applyConfiguration(PlatformRegistry.ConfigUpdate,PlatformRegistry.RegistrarConfig[],PlatformRegistry.BlacklistConfig[]).stakeManagerChanged (contracts/v2/PlatformRegistry.sol#408) is a local variable never initialized\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 408,
+    "fingerprint": "ea6e89eafe842e3256b21867995509ec36cb486f7e44fe9d662efa4a48979ebf"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).minStakeChanged (contracts/v2/StakeManager.sol#1481) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1481,
+    "fingerprint": "ebb5eb661024072db2171a0d918ceb7d23784bc092bb4844f2b26048fcec191e"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).validatorMerkleUpdated (contracts/v2/JobRegistry.sol#1402) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1402,
+    "fingerprint": "ed4971f474504536a466d228221ec7c0affd133f77eead3fb1c46dc568e4bee7"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).treasuryChanged (contracts/v2/StakeManager.sol#1484) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1484,
+    "fingerprint": "f25855f833d91cd089a8b0574085743632769d213185a80253effbf1e8e6698c"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).auditModuleUpdated (contracts/v2/JobRegistry.sol#1387) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1387,
+    "fingerprint": "f2f9842b3ef5b2fb35c56fac777a453304c136a65b14655eb4f0905cb3fb79aa"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).identityRegistryUpdated (contracts/v2/JobRegistry.sol#1381) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1381,
+    "fingerprint": "f4e5a47f171554a5aa82e461c98aec1f61b7950e95cbe78fe3e8315783397b2d"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.governanceSlash(address,StakeManager.Role,uint256,address).empty (contracts/v2/StakeManager.sol#2880) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2880,
+    "fingerprint": "f5f48bd7d4bd84fed3c726f3a67a3b2d2b96ad1fffadf5b7b94a8763917ff1b9"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).agentAuthCacheVersionBumped (contracts/v2/JobRegistry.sol#1404) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1404,
+    "fingerprint": "f652850eb4c7da79a2d8e60ca6a5ab606b2b3631680f29eef34cdad2e3309f35"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager._redistributeEscrowBatched(bytes32,address,uint256,address[]).empty_scope_2 (contracts/v2/StakeManager.sol#1019) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1019,
+    "fingerprint": "f70a6b1d64fb95343f8a7a89cde70bbbc17bdb996e3cccdc3b3978ed80502397"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).slashingChanged (contracts/v2/StakeManager.sol#1483) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1483,
+    "fingerprint": "f8c97513ccc72cd0515713dfc33101a87db8bb5ddfb31d17bf576049940939a6"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).pauserManagerUpdated (contracts/v2/JobRegistry.sol#1380) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1380,
+    "fingerprint": "fb1459e8dc24982ac4937be471c9554db89f3db0273e55a9d3f87f20376d7c97"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]).modulesChanged (contracts/v2/StakeManager.sol#1488) is a local variable never initialized\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1488,
+    "fingerprint": "fc508a88f7992911e49bbfc7bcc15e526168dec8225e0d07b2f917ef804b26c7"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "RewardEngineMB.settleEpoch(uint256,RewardEngineMB.EpochData).redistributed (contracts/v2/RewardEngineMB.sol#297) is a local variable never initialized\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 297,
+    "fingerprint": "fd28a967b34dc9d5d1fdba0ec0409b178589fb326457f198336b2a1498962f0a"
+  },
+  {
+    "ruleId": "1-1-uninitialized-local",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]).validatorRewardPctUpdated (contracts/v2/JobRegistry.sol#1394) is a local variable never initialized\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1394,
+    "fingerprint": "febac7e29e9db12797c17c91a620ab45e0ec15993dba31fb69e9cc2a8c2e1048"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "GovernorVotesQuorumFraction._optimisticUpperLookupRecent(Checkpoints.Trace208,uint256) (node_modules/@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol#104-112) ignores return value by (None,key,value) = ckpts.latestCheckpoint() (node_modules/@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol#110)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol",
+    "startLine": 104,
+    "fingerprint": "0299443cb25422cb28c34790f77f514f8fdf38389bc743380331f2a84083d9e2"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "MockJobRegistry.acknowledgeTaxPolicy() (contracts/legacy/MockV2.sol#473-478) ignores return value by taxPolicy.acknowledge() (contracts/legacy/MockV2.sol#475)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 473,
+    "fingerprint": "08517d3b811ed6fa4e3b163014044944d488a9609481a212e8d534e4e9a340e8"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "PlatformRegistry.acknowledgeAndRegisterFor(address) (contracts/v2/PlatformRegistry.sol#261-271) ignores return value by IJobRegistryAck(registry).acknowledgeFor(operator) (contracts/v2/PlatformRegistry.sol#268)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 261,
+    "fingerprint": "0bdb9036739fbed4cfd26bbde50ec961065ed2f39377bacba204ee47488ff950"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "IdentityRegistry._checkValidatorENSOwnership(address,string,bytes32[]) (contracts/v2/IdentityRegistry.sol#760-798) ignores return value by (ok,None,None,None) = ENSIdentityVerifier.checkOwnership(ens,nameWrapper,clubRootNodeAliases[i],validatorMerkleRoot,claimant,subdomain,proof) (contracts/v2/IdentityRegistry.sol#783-791)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 760,
+    "fingerprint": "1119f2f08edea714d4831214784b9fcba7912b0a3c9e3e2774ee85621fa58d61"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "PlatformRegistry.acknowledgeStakeAndRegisterFor(address,uint256) (contracts/v2/PlatformRegistry.sol#282-303) ignores return value by IJobRegistryAck(registry).acknowledgeFor(operator) (contracts/v2/PlatformRegistry.sol#294)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 282,
+    "fingerprint": "26316f59fed5664c02a0a8d2ae3646fb65a32cb5da6d5ea14b32bba956ce0c7e"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "CommitRevealEchidnaHarness.fuzzCommitAndReveal(uint256,bool,bytes32,bytes32) (contracts/test/CommitRevealEchidna.sol#24-46) ignores return value by commitReveal.reveal(jobId,approve,salt,specHash) (contracts/test/CommitRevealEchidna.sol#42)\n",
+    "uri": "contracts/test/CommitRevealEchidna.sol",
+    "startLine": 24,
+    "fingerprint": "2703311e2c41c8e444b7bc5c19d1d372d4b96518827b62bc70766e8f644065e1"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "StakeManager.acknowledgeAndDepositFor(address,StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2070-2076) ignores return value by IJobRegistryAck(registry).acknowledgeFor(user) (contracts/v2/StakeManager.sol#2074)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2070,
+    "fingerprint": "2f3ad71ee29ba6353084a4c4185a8adb01939f69280c2299d9849bc2b04c0349"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "GovernorVotesQuorumFraction._updateQuorumNumerator(uint256) (node_modules/@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol#89-99) ignores return value by _quorumNumeratorHistory.push(clock(),SafeCast.toUint208(newQuorumNumerator)) (node_modules/@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol#96)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol",
+    "startLine": 89,
+    "fingerprint": "2faf60f09f969967c7b1853bb47918e816991172ce7e9cf179ce3b1ffbe71536"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "SignatureChecker.isValidSignatureNow(address,bytes32,bytes) (node_modules/@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol#32-39) ignores return value by (recovered,err,None) = ECDSA.tryRecover(hash,signature) (node_modules/@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol#34)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol",
+    "startLine": 32,
+    "fingerprint": "3a8257197f2d20db0ad9b6cd5b789b91f3713672d5f1faab3681b5a2a4e51f43"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "JobEscrow.acknowledgeAndAcceptResult(uint256) (contracts/v2/modules/JobEscrow.sol#189-195) ignores return value by IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/modules/JobEscrow.sol#192)\n",
+    "uri": "contracts/v2/modules/JobEscrow.sol",
+    "startLine": 189,
+    "fingerprint": "3b38f0cea51dfc722d56a3860024deb26799720d682336c93cb8b0d5c97e09c7"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "QuadraticVotingAttack.vote() (contracts/test/QuadraticVotingAttack.sol#42-45) ignores return value by token.approve(address(qv),type()(uint256).max) (contracts/test/QuadraticVotingAttack.sol#43)\n",
+    "uri": "contracts/test/QuadraticVotingAttack.sol",
+    "startLine": 42,
+    "fingerprint": "42bb184fd196f05cf56024320667396493296ba7a9525b4c079dcbd967f7bbf7"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "EnergyOracle.setSigners(address[],bool[]) (contracts/v2/EnergyOracle.sol#54-73) ignores return value by signerSet.remove(signer) (contracts/v2/EnergyOracle.sol#69)\n",
+    "uri": "contracts/v2/EnergyOracle.sol",
+    "startLine": 54,
+    "fingerprint": "4459216c7d2749b7c99cf9538b98490c3d08ac9758c18502c9de74f6a3837499"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "PlatformIncentives.acknowledgeStakeAndActivate(uint256) (contracts/v2/PlatformIncentives.sol#126-144) ignores return value by IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/PlatformIncentives.sol#129)\n",
+    "uri": "contracts/v2/PlatformIncentives.sol",
+    "startLine": 126,
+    "fingerprint": "4643a954b6d10cb8b774e2710143999c1c4cdbd8e9c194db6cf12e4f9f15a9b3"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "PlatformRegistry.acknowledgeAndRegister() (contracts/v2/PlatformRegistry.sol#194-201) ignores return value by IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/PlatformRegistry.sol#198)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 194,
+    "fingerprint": "490f34ad8ff681835a3a2a822e63259b73c0025e57807ee5f97a9b7750afdbca"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "KlerosDisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/KlerosDisputeModule.sol#106-120) ignores return value by IArbitrationService(arbitrator).createDispute(jobId,claimant,payload) (contracts/v2/modules/KlerosDisputeModule.sol#117)\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 106,
+    "fingerprint": "4d6853365b86b758f8ff223abc34134eb84ccefd125c711dbcb28d715c2e6c97"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "Governor._executeOperations(uint256,address[],uint256[],bytes[],bytes32) (node_modules/@openzeppelin/contracts/governance/Governor.sol#434-445) ignores return value by Address.verifyCallResult(success,returndata) (node_modules/@openzeppelin/contracts/governance/Governor.sol#443)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 434,
+    "fingerprint": "5004460602411869cfbab4e78a5addf81a84afc63979ffb7a717f259e755d271"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495) ignores return value by certificateNFT.mint(job.agent,jobId,job.uriHash) (contracts/v2/JobRegistry.sol#2435)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "54b40c91417498013b0c1e86aad4c0bb2c29bd6781299d7337a5988e874dba65"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "StakeManager.acknowledgeAndWithdrawFor(address,StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2212-2223) ignores return value by IJobRegistryAck(registry).acknowledgeFor(user) (contracts/v2/StakeManager.sol#2221)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2212,
+    "fingerprint": "5a5739264dc5f73970581c34b94de686a700a6457ea9b9e9d310de0b18c764eb"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "QuadraticVotingAttack.attackCast() (contracts/test/QuadraticVotingAttack.sol#27-33) ignores return value by token.approve(address(qv),type()(uint256).max) (contracts/test/QuadraticVotingAttack.sol#29)\n",
+    "uri": "contracts/test/QuadraticVotingAttack.sol",
+    "startLine": 27,
+    "fingerprint": "5ca0cbcacc61ac0929b379fbdf67fba498d9c15d0decfd84e2c22907fa1e36b8"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "StakeManager.acknowledgeAndDeposit(StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2034-2039) ignores return value by IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/StakeManager.sol#2037)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2034,
+    "fingerprint": "60c463e3f874ac95879c450a6be663d4d0a7e62f8ee8cf6b5cbd409b58c03592"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "Votes._push(Checkpoints.Trace208,function(uint208,uint208) returns(uint208),uint208) (node_modules/@openzeppelin/contracts/governance/utils/Votes.sol#232-238) ignores return value by store.push(clock(),op(store.latest(),delta)) (node_modules/@openzeppelin/contracts/governance/utils/Votes.sol#237)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/utils/Votes.sol",
+    "startLine": 232,
+    "fingerprint": "657d6349d4645417dd0b5b266e9e33ebca26bf54c614b091b673c9d99db2009e"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "JobRegistry._startValidation(uint256,uint256) (contracts/v2/JobRegistry.sol#353-360) ignores return value by validationModule.start(jobId,entropy) (contracts/v2/JobRegistry.sol#357)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 353,
+    "fingerprint": "658452aa7fd0ba1ebf9ec4f300b88eef4d540e46187c6d8023910392333d25e4"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "PlatformRegistry.acknowledgeStakeAndRegister(uint256) (contracts/v2/PlatformRegistry.sol#211-226) ignores return value by IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/PlatformRegistry.sol#217)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 211,
+    "fingerprint": "67da1515aecac75cafc4568248697105f7537ccf5def13dd72c5b95faed5ea4e"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "TimelockController._execute(address,uint256,bytes) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#411-414) ignores return value by Address.verifyCallResult(success,returndata) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#413)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/TimelockController.sol",
+    "startLine": 411,
+    "fingerprint": "696e593783c7bf360d51a24331e5e975698353a82c85fcecac48886b9c59f4ab"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "IdentityRegistry._checkAgentENSOwnership(address,string,bytes32[]) (contracts/v2/IdentityRegistry.sol#720-758) ignores return value by (ok,None,None,None) = ENSIdentityVerifier.checkOwnership(ens,nameWrapper,agentRootNode,agentMerkleRoot,claimant,subdomain,proof) (contracts/v2/IdentityRegistry.sol#727-735)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 720,
+    "fingerprint": "72eb3d28dc0848e7e1b7d9748c016eabff1dcf068789cb7732e264533a35b85e"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "IdentityRegistry._checkValidatorENSOwnership(address,string,bytes32[]) (contracts/v2/IdentityRegistry.sol#760-798) ignores return value by (ok,None,None,None) = ENSIdentityVerifier.checkOwnership(ens,nameWrapper,clubRootNode,validatorMerkleRoot,claimant,subdomain,proof) (contracts/v2/IdentityRegistry.sol#767-775)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 760,
+    "fingerprint": "73a3b24d571d4e8dddf869589cabd7dda0af554df29f73311809cb23e4a910ae"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "EnergyOracle.setSigner(address,bool) (contracts/v2/EnergyOracle.sol#40-49) ignores return value by signerSet.add(signer) (contracts/v2/EnergyOracle.sol#44)\n",
+    "uri": "contracts/v2/EnergyOracle.sol",
+    "startLine": 40,
+    "fingerprint": "7549783d06cb41c421a2a08cce67b3cef6e94d722da79163fb22fcd308151834"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "EmployerContract.approveToken(address,address,uint256) (contracts/test/EmployerContract.sol#11-13) ignores return value by IERC20(token).approve(spender,amount) (contracts/test/EmployerContract.sol#12)\n",
+    "uri": "contracts/test/EmployerContract.sol",
+    "startLine": 11,
+    "fingerprint": "7643ef8b522a3daef371c40b39dc3a6fc922bb2e5b53ffa6c49e14cd4ab9ce12"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "IdentityRegistry._checkNodeENSOwnership(address,string,bytes32[]) (contracts/v2/IdentityRegistry.sol#800-838) ignores return value by (ok,None,None,None) = ENSIdentityVerifier.checkOwnership(ens,nameWrapper,nodeRootNodeAliases[i],validatorMerkleRoot,claimant,subdomain,proof) (contracts/v2/IdentityRegistry.sol#823-831)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 800,
+    "fingerprint": "782b3de52fed95e5b17617b26e0f9426ee1700e446c4a583174f4d6e6c55cd77"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "MockJobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/legacy/MockV2.sol#638-656) ignores return value by IValidationModule(validationModule).start(jobId,0) (contracts/legacy/MockV2.sol#654)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 638,
+    "fingerprint": "8c4ad6fc46f476280e91a0afb1ffdd47bb91f4d71d2575340b852be7b049b2e6"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "ReentrantBuyer.approveToken(address,uint256) (contracts/legacy/ReentrantBuyer.sol#22-24) ignores return value by IERC20(token).approve(address(nft),amount) (contracts/legacy/ReentrantBuyer.sol#23)\n",
+    "uri": "contracts/legacy/ReentrantBuyer.sol",
+    "startLine": 22,
+    "fingerprint": "8c857f8d62da73d11e941a064e71ea7e33df873134756bd7d734e35f44607f4c"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "IdentityRegistry._checkAgentENSOwnership(address,string,bytes32[]) (contracts/v2/IdentityRegistry.sol#720-758) ignores return value by (ok,None,None,None) = ENSIdentityVerifier.checkOwnership(ens,nameWrapper,agentRootNodeAliases[i],agentMerkleRoot,claimant,subdomain,proof) (contracts/v2/IdentityRegistry.sol#743-751)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 720,
+    "fingerprint": "989a23d3478d68e021ccc42b8c65bc62949886b46fd221bebec08d975eae2fd6"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) ignores return value by (authorized_scope_3,None,None,None) = identityRegistry.verifyValidator(candidate_scope_1,subdomain_scope_4,proof_scope_6) (contracts/v2/ValidationModule.sol#1135-1139)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "a71ed9b7606d4f2bd28986f60fd39fb357aa7b49f21abbecd97c7c73d35a4d1b"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "EnergyOracle.setSigner(address,bool) (contracts/v2/EnergyOracle.sol#40-49) ignores return value by signerSet.remove(signer) (contracts/v2/EnergyOracle.sol#46)\n",
+    "uri": "contracts/v2/EnergyOracle.sol",
+    "startLine": 40,
+    "fingerprint": "b416cdb55be7610fd128c78444662037e400bf372122295c081fe475141b3b60"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "Time.get(Time.Delay) (node_modules/@openzeppelin/contracts/utils/types/Time.sol#93-96) ignores return value by (delay,None,None) = self.getFull() (node_modules/@openzeppelin/contracts/utils/types/Time.sol#94)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/types/Time.sol",
+    "startLine": 93,
+    "fingerprint": "b63df2d2ac450a96e8440d4a4124ab3f52df5c55d5114777f581c5f18f12357a"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "EnergyOracle.setSigners(address[],bool[]) (contracts/v2/EnergyOracle.sol#54-73) ignores return value by signerSet.add(signer) (contracts/v2/EnergyOracle.sol#67)\n",
+    "uri": "contracts/v2/EnergyOracle.sol",
+    "startLine": 54,
+    "fingerprint": "bd5e610bebc20b1ad550a52b3ece2ba280f2f9e0e73426d8327b3a5828e80a62"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) ignores return value by (authorized,None,None,None) = identityRegistry.verifyValidator(candidate,subdomain,proof) (contracts/v2/ValidationModule.sol#1052-1056)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "d90fa8d099339c4e9a10ba5ea90af255394c84e9094ea364b296cd166098cc2d"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "PlatformRegistry.acknowledgeAndDeregister() (contracts/v2/PlatformRegistry.sol#233-242) ignores return value by IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/PlatformRegistry.sol#238)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 233,
+    "fingerprint": "e8175e4867c7fa49226efe23baa2a0b2cefa8553eb0112184dffbde82cc77b46"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "IdentityRegistry._checkNodeENSOwnership(address,string,bytes32[]) (contracts/v2/IdentityRegistry.sol#800-838) ignores return value by (ok,None,None,None) = ENSIdentityVerifier.checkOwnership(ens,nameWrapper,nodeRootNode,validatorMerkleRoot,claimant,subdomain,proof) (contracts/v2/IdentityRegistry.sol#807-815)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 800,
+    "fingerprint": "e9aa9639cc56ee7fd53059cb58df433bf2a157777b70f208c8c377962b9397a2"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "StakeManager.acknowledgeAndWithdraw(StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2195-2200) ignores return value by IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/StakeManager.sol#2198)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2195,
+    "fingerprint": "ea06b5a06f70e58c0e8c059aa6f77a35fba03179fc554398a1cbb33b1316f17b"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "KlerosDisputeModule.raiseGovernanceDispute(uint256,string) (contracts/v2/modules/KlerosDisputeModule.sol#123-134) ignores return value by IArbitrationService(arbitrator).createDispute(jobId,address(this),payload) (contracts/v2/modules/KlerosDisputeModule.sol#131)\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 123,
+    "fingerprint": "f45927d1fd20c1297aae99c378c43512eeee4b230e924f7da5e7303552051ae2"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "Governor.relay(address,uint256,bytes) (node_modules/@openzeppelin/contracts/governance/Governor.sol#656-659) ignores return value by Address.verifyCallResult(success,returndata) (node_modules/@openzeppelin/contracts/governance/Governor.sol#658)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 656,
+    "fingerprint": "f601cd96ab85271b8372c7685f0656c03beafd4136efc6a5966cdf5d3e2f9135"
+  },
+  {
+    "ruleId": "1-1-unused-return",
+    "message": "MockJobRegistry.finalize(uint256) (contracts/legacy/MockV2.sol#762-785) ignores return value by certificateNFT.mint(job.agent,jobId,job.uriHash) (contracts/legacy/MockV2.sol#782)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 762,
+    "fingerprint": "f8278f77033bf6b81dfc7287b605d984838ea007054157f698dee3bcf00bdf96"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "GovernableMock.constructor(address).governance (contracts/v2/mocks/GovernableMock.sol#10) shadows:\n\t- Governable.governance (contracts/v2/Governable.sol#13) (state variable)\n",
+    "uri": "contracts/v2/mocks/GovernableMock.sol",
+    "startLine": 10,
+    "fingerprint": "05eeb7dd400dbdc53b8a7697fc5b4d3e32df4dbfb5340fac08e8b8bc1e7fa978"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "ValidationModuleFailoverHarness.seedRound(uint256,uint256,uint256).revealDeadline (contracts/v2/mocks/ValidationModuleFailoverHarness.sol#26) shadows:\n\t- ValidationModule.revealDeadline(uint256) (contracts/v2/ValidationModule.sol#632-634) (function)\n",
+    "uri": "contracts/v2/mocks/ValidationModuleFailoverHarness.sol",
+    "startLine": 26,
+    "fingerprint": "168786d79dd1c9ab242e03f422f15e500182a5f6e97381c702e0b1b86d9b21d1"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "ERC20Permit.constructor(string).name (node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol#39) shadows:\n\t- ERC20.name() (node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol#52-54) (function)\n\t- IERC20Metadata.name() (node_modules/@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol#15) (function)\n",
+    "uri": "node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol",
+    "startLine": 39,
+    "fingerprint": "1f85c0fac855acf8d2d6992ee89e0b0ee24104b934a28808f04d68e95041b471"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "SimpleJobRegistry.finalizeJob(uint256,string).job (contracts/test/SimpleJobRegistry.sol#145) shadows:\n\t- SimpleJobRegistry.job(uint256) (contracts/test/SimpleJobRegistry.sol#154-156) (function)\n",
+    "uri": "contracts/test/SimpleJobRegistry.sol",
+    "startLine": 145,
+    "fingerprint": "2561b7f91a13afbc7094d1dce5b1c8bd602b97d88a2b11a93134a74ce9ae6c1f"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "IValidationModule.validators(uint256).validators (contracts/v2/interfaces/IValidationModule.sol#208) shadows:\n\t- IValidationModule.validators(uint256) (contracts/v2/interfaces/IValidationModule.sol#208) (function)\n",
+    "uri": "contracts/v2/interfaces/IValidationModule.sol",
+    "startLine": 208,
+    "fingerprint": "2b3b49d3e25cac422dfce789880a9021e2dee1907368db762d96ee8b1d58ad1d"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "SimpleJobRegistry.applyForJob(uint256,string,bytes).job (contracts/test/SimpleJobRegistry.sol#121) shadows:\n\t- SimpleJobRegistry.job(uint256) (contracts/test/SimpleJobRegistry.sol#154-156) (function)\n",
+    "uri": "contracts/test/SimpleJobRegistry.sol",
+    "startLine": 121,
+    "fingerprint": "423fa8900bc176e30f1440b0ed182d5af3bb3515f7bee7542e756e8561f9964a"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "DeterministicValidationModule.rounds(uint256).validators (contracts/test/DeterministicValidationModule.sol#171) shadows:\n\t- DeterministicValidationModule.validators(uint256) (contracts/test/DeterministicValidationModule.sol#192-194) (function)\n",
+    "uri": "contracts/test/DeterministicValidationModule.sol",
+    "startLine": 171,
+    "fingerprint": "6904f4b930f2548760d3a5e4f0989cd2bc619a857dfc8da69aeb04ccc1cf3463"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "GovernorHarness.constructor(IVotes,TimelockController,uint48,uint32,uint256,uint256).timelock (contracts/coverage/GovernorHarness.sol#11) shadows:\n\t- GovernorTimelockControl.timelock() (node_modules/@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol#65-67) (function)\n",
+    "uri": "contracts/coverage/GovernorHarness.sol",
+    "startLine": 11,
+    "fingerprint": "8c2d2a22d24bf48594ef21da6130ff5e8e5e70e75dd4d585f8e91eec90dd8ba7"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "IValidationModule.start(uint256,uint256).validators (contracts/v2/interfaces/IValidationModule.sol#77) shadows:\n\t- IValidationModule.validators(uint256) (contracts/v2/interfaces/IValidationModule.sol#208) (function)\n",
+    "uri": "contracts/v2/interfaces/IValidationModule.sol",
+    "startLine": 77,
+    "fingerprint": "8fa64cef69184bf29e0cd503212bfb742c6df3cef715463c3bbaea5a5c260632"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "AttestationRegistry._ownerOf(bytes32).owner (contracts/v2/AttestationRegistry.sol#62) shadows:\n\t- Ownable.owner() (node_modules/@openzeppelin/contracts/access/Ownable.sol#56-58) (function)\n",
+    "uri": "contracts/v2/AttestationRegistry.sol",
+    "startLine": 62,
+    "fingerprint": "97f7cdd5a886ab0ca18f458493c5565836bf810ea4916da0afd9809dc1ca05d9"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "SimpleJobRegistry.jobs(uint256).job (contracts/test/SimpleJobRegistry.sol#73) shadows:\n\t- SimpleJobRegistry.job(uint256) (contracts/test/SimpleJobRegistry.sol#154-156) (function)\n",
+    "uri": "contracts/test/SimpleJobRegistry.sol",
+    "startLine": 73,
+    "fingerprint": "9939efe2a549febc7a586631a86449c75f358a1606163f91a699cdc74bec519c"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "SimpleJobRegistry.submit(uint256,bytes32,string,string,bytes).job (contracts/test/SimpleJobRegistry.sol#136) shadows:\n\t- SimpleJobRegistry.job(uint256) (contracts/test/SimpleJobRegistry.sol#154-156) (function)\n",
+    "uri": "contracts/test/SimpleJobRegistry.sol",
+    "startLine": 136,
+    "fingerprint": "9ba7a5a8b78a3e8eece61708636d650bf11da77d4d957168ed1b036f45676e77"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "DeterministicValidationModule.setValidators(address[]).validators (contracts/test/DeterministicValidationModule.sol#60) shadows:\n\t- DeterministicValidationModule.validators(uint256) (contracts/test/DeterministicValidationModule.sol#192-194) (function)\n",
+    "uri": "contracts/test/DeterministicValidationModule.sol",
+    "startLine": 60,
+    "fingerprint": "9d7ff8a5f8a96cd4c860d01fae448d563bd399910259c0d15c9b6df5b7a87b75"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "AGIGovernor.constructor(IVotes,TimelockController,uint48,uint32,uint256,uint256).timelock (contracts/v2/governance/AGIGovernor.sol#27) shadows:\n\t- GovernorTimelockControl.timelock() (node_modules/@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol#65-67) (function)\n",
+    "uri": "contracts/v2/governance/AGIGovernor.sol",
+    "startLine": 27,
+    "fingerprint": "aed89dfea08580dfbd51b28ed3dd60d89ce081cdf5c7920877d14673c72e6aed"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "GovernanceTarget.constructor(address).governance (contracts/test/GovernanceTarget.sol#13) shadows:\n\t- Governable.governance (contracts/v2/Governable.sol#13) (state variable)\n",
+    "uri": "contracts/test/GovernanceTarget.sol",
+    "startLine": 13,
+    "fingerprint": "bc2dc9c08c4142cf409fc813d479e0965a8c858f75ceb4f3dde59107d57e0072"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "MockVotesToken.nonces(address).owner (contracts/test/MockVotesToken.sol#34) shadows:\n\t- Ownable.owner() (node_modules/@openzeppelin/contracts/access/Ownable.sol#56-58) (function)\n",
+    "uri": "contracts/test/MockVotesToken.sol",
+    "startLine": 34,
+    "fingerprint": "c81762cbcda7d2eca22b1f593d763db952d29e7a04327a457fa26faac7c2a45b"
+  },
+  {
+    "ruleId": "2-0-shadowing-local",
+    "message": "CoverageVotesToken.nonces(address).owner (contracts/coverage/CoverageVotesToken.sol#24) shadows:\n\t- Ownable.owner() (node_modules/@openzeppelin/contracts/access/Ownable.sol#56-58) (function)\n",
+    "uri": "contracts/coverage/CoverageVotesToken.sol",
+    "startLine": 24,
+    "fingerprint": "df4578b703c45d6fe0a5f763e100ad4eef7e7c2ddece08a272e4207f5b615b4a"
+  },
+  {
+    "ruleId": "2-1-events-access",
+    "message": "KlerosDisputeModule.setArbitrator(address) (contracts/v2/modules/KlerosDisputeModule.sol#96-98) should emit an event for: \n\t- arbitrator = _arbitrator (contracts/v2/modules/KlerosDisputeModule.sol#97) \n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 96,
+    "fingerprint": "13ff1d461d4290f82fd75047a4094787ae8a34652462719364273ddd84bacbfb"
+  },
+  {
+    "ruleId": "2-1-events-maths",
+    "message": "RewardEngineMB.setMaxProofs(uint256) (contracts/v2/RewardEngineMB.sol#192-194) should emit an event for: \n\t- maxProofs = max (contracts/v2/RewardEngineMB.sol#193) \n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 192,
+    "fingerprint": "4432547241d87e13b1c5390c8956c1a1e3526f54fb85af5ce1cfae0a489b0d4c"
+  },
+  {
+    "ruleId": "2-1-events-maths",
+    "message": "RewardEngineMB.setTemperature(int256) (contracts/v2/RewardEngineMB.sol#204-207) should emit an event for: \n\t- temperature = temp (contracts/v2/RewardEngineMB.sol#206) \n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 204,
+    "fingerprint": "c4c7b8e12dcd5a2b40f03a17dc8c3dc5f62ed06a59992136fea1b68fd8568580"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "MockArbitrator.setDisputeModule(address).module (contracts/v2/mocks/MockArbitrator.sol#16) lacks a zero-check on :\n\t\t- disputeModule = module (contracts/v2/mocks/MockArbitrator.sol#17)\n",
+    "uri": "contracts/v2/mocks/MockArbitrator.sol",
+    "startLine": 16,
+    "fingerprint": "04c0a9dcfd93af051dc6afd56c16bca8963624e149e57056ae61f02746e5b86c"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "KlerosDisputeModule.setArbitrator(address)._arbitrator (contracts/v2/modules/KlerosDisputeModule.sol#96) lacks a zero-check on :\n\t\t- arbitrator = _arbitrator (contracts/v2/modules/KlerosDisputeModule.sol#97)\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 96,
+    "fingerprint": "06d70c1c36087b79a36b067347fb2006f8b73e6d07fed5f7cd3bfa755c6a9efd"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "MockStakeManager.setJobRegistry(address).j (contracts/legacy/MockV2.sol#28) lacks a zero-check on :\n\t\t- jobRegistry = j (contracts/legacy/MockV2.sol#28)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 28,
+    "fingerprint": "06e1214798ac21019263c8d2a55e163f0ea5eb57814406479e50a98c932fe050"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "StakeManager.setPauserManager(address).manager (contracts/v2/StakeManager.sol#506) lacks a zero-check on :\n\t\t- pauserManager = manager (contracts/v2/StakeManager.sol#507)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 506,
+    "fingerprint": "099a87bc518f5ae22f5a8c1082aeb5f4ddfd2f27d5df6a2e84aef40150356aa0"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "KlerosDisputeModule.constructor(IJobRegistry,address,address)._governance (contracts/v2/modules/KlerosDisputeModule.sol#82) lacks a zero-check on :\n\t\t- governance = _governance (contracts/v2/modules/KlerosDisputeModule.sol#86)\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 82,
+    "fingerprint": "0d12029248fe9505ca43b820096cc994a40e41a85fe1524a81e13fe038836f99"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "DisputeModule.setCommittee(address).newCommittee (contracts/v2/modules/DisputeModule.sol#187) lacks a zero-check on :\n\t\t- committee = newCommittee (contracts/v2/modules/DisputeModule.sol#192)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 187,
+    "fingerprint": "107e8142ae6bf86c029a9ed34097c84b1c8f242841cfeca1341a405fd580caf5"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "QuadraticVoting.constructor(address,address)._executor (contracts/v2/QuadraticVoting.sol#57) lacks a zero-check on :\n\t\t- proposalExecutor = _executor (contracts/v2/QuadraticVoting.sol#59)\n",
+    "uri": "contracts/v2/QuadraticVoting.sol",
+    "startLine": 57,
+    "fingerprint": "11f271eb149892137a36a1a2be6f60c2d7724331c75f8e1b7e8b2aa0f94d95f9"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "AuditModule.constructor(address,IReputationEngine)._jobRegistry (contracts/v2/AuditModule.sol#59) lacks a zero-check on :\n\t\t- jobRegistry = _jobRegistry (contracts/v2/AuditModule.sol#60)\n",
+    "uri": "contracts/v2/AuditModule.sol",
+    "startLine": 59,
+    "fingerprint": "196c48a4f806c3fb0de2d5c756e14e70cf775ab167b23c7acadde4a61137bf40"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "CertificateNFT.setJobRegistry(address).registry (contracts/v2/modules/CertificateNFT.sol#48) lacks a zero-check on :\n\t\t- jobRegistry = registry (contracts/v2/modules/CertificateNFT.sol#49)\n",
+    "uri": "contracts/v2/modules/CertificateNFT.sol",
+    "startLine": 48,
+    "fingerprint": "19d8def7da5607abeb877b50984728d7ca55e151577b217de948409300352327"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "DisputeModule.setPauser(address)._pauser (contracts/v2/modules/DisputeModule.sol#259) lacks a zero-check on :\n\t\t- pauser = _pauser (contracts/v2/modules/DisputeModule.sol#263)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 259,
+    "fingerprint": "230d899b278a045f4cf0f7d9c04dbe4a68e001fb690bd825487bc85b886c4cd2"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "RevenueDistributor.setTreasury(address)._treasury (contracts/v2/modules/RevenueDistributor.sol#74) lacks a zero-check on :\n\t\t- treasury = _treasury (contracts/v2/modules/RevenueDistributor.sol#75)\n",
+    "uri": "contracts/v2/modules/RevenueDistributor.sol",
+    "startLine": 74,
+    "fingerprint": "2bfa6db2101530d027266d952b02dafaccd470c9c222b7047133f391e931ea5f"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "QuadraticVoting.setProposalExecutor(address).executor (contracts/v2/QuadraticVoting.sol#70) lacks a zero-check on :\n\t\t- proposalExecutor = executor (contracts/v2/QuadraticVoting.sol#71)\n",
+    "uri": "contracts/v2/QuadraticVoting.sol",
+    "startLine": 70,
+    "fingerprint": "31785566d37ebf8113bcd14b9396ed332d58b5107a325d472ae2448e750c20da"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "KernelJobRegistry.setOpsTreasury(address).treasury (contracts/v2/kernel/JobRegistry.sol#147) lacks a zero-check on :\n\t\t- opsTreasury = treasury (contracts/v2/kernel/JobRegistry.sol#148)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 147,
+    "fingerprint": "31b2ab100352190562f3025d7ccff9d7e07eb2dbf1b6a343399d0dcca00d1544"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "ValidationModule.setPauserManager(address).manager (contracts/v2/ValidationModule.sol#265) lacks a zero-check on :\n\t\t- pauserManager = manager (contracts/v2/ValidationModule.sol#266)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 265,
+    "fingerprint": "3c62c4e61bbbb73749567f92b2eaa87b9069789751d662df5534efa0690d2388"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "ArbitratorCommittee.setPauserManager(address).manager (contracts/v2/ArbitratorCommittee.sol#65) lacks a zero-check on :\n\t\t- pauserManager = manager (contracts/v2/ArbitratorCommittee.sol#66)\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 65,
+    "fingerprint": "40d0b0c3783095441e8a6df0ddba309e494aeadf1613a59ceb54cf5ba1013d46"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "FeePool.setPauserManager(address).manager (contracts/v2/FeePool.sol#167) lacks a zero-check on :\n\t\t- pauserManager = manager (contracts/v2/FeePool.sol#168)\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 167,
+    "fingerprint": "50e6e4fbde95734872d8e9912680c49337a1963a09bafd9678299cb6b5afa48a"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "DisputeModule.constructor(IJobRegistry,uint256,uint256,address,address)._committee (contracts/v2/modules/DisputeModule.sol#132) lacks a zero-check on :\n\t\t- committee = _committee (contracts/v2/modules/DisputeModule.sol#147)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 132,
+    "fingerprint": "6307f8114cc8cbcb2830a91fc0a31ecfe3ecd40b508fbabb1dfa93bcc48b4788"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "IdentityRegistryMock.setReputationEngine(address).engine (contracts/v2/mocks/IdentityRegistryMock.sol#52) lacks a zero-check on :\n\t\t- reputationEngine = engine (contracts/v2/mocks/IdentityRegistryMock.sol#53)\n",
+    "uri": "contracts/v2/mocks/IdentityRegistryMock.sol",
+    "startLine": 52,
+    "fingerprint": "631ebeff94b683c8a78a4d1c9959453dc716af62ea1c02dc4dd101bc3644b22c"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "ReentrantStakeManager.setJobRegistry(address).j (contracts/v2/mocks/ReentrantStakeManager.sol#22) lacks a zero-check on :\n\t\t- jobRegistry = j (contracts/v2/mocks/ReentrantStakeManager.sol#22)\n",
+    "uri": "contracts/v2/mocks/ReentrantStakeManager.sol",
+    "startLine": 22,
+    "fingerprint": "670d65ee07186f37f46f38b74ab5aa598ad013594d92eeff4dc377be97481b2f"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "MockRoutingModule.constructor(address)._operator (contracts/legacy/MockRoutingModule.sol#9) lacks a zero-check on :\n\t\t- operator = _operator (contracts/legacy/MockRoutingModule.sol#10)\n",
+    "uri": "contracts/legacy/MockRoutingModule.sol",
+    "startLine": 9,
+    "fingerprint": "69e5a8c87551dfdd2fe3e18ae0936c447dda04a58aefaaa7e7de121503653818"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "ArbitratorCommittee.setPauser(address)._pauser (contracts/v2/ArbitratorCommittee.sol#57) lacks a zero-check on :\n\t\t- pauser = _pauser (contracts/v2/ArbitratorCommittee.sol#61)\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 57,
+    "fingerprint": "6f7d9fe2e55cdf8c6019e6b3cfd81b66d2840bd830552d8a956850d39cb54436"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "IdentityRegistryMock.setNameWrapper(address)._wrapper (contracts/v2/mocks/IdentityRegistryMock.sol#48) lacks a zero-check on :\n\t\t- nameWrapper = _wrapper (contracts/v2/mocks/IdentityRegistryMock.sol#49)\n",
+    "uri": "contracts/v2/mocks/IdentityRegistryMock.sol",
+    "startLine": 48,
+    "fingerprint": "6fa6a0bece7439fe705b747b86b45602e4f6627512947e4a5b168d9e691549ca"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "TimelockMock.execute(address,bytes).target (contracts/legacy/TimelockMock.sol#12) lacks a zero-check on :\n\t\t- (ok,None) = target.call(data) (contracts/legacy/TimelockMock.sol#13)\n",
+    "uri": "contracts/legacy/TimelockMock.sol",
+    "startLine": 12,
+    "fingerprint": "82745d78a955a6c4782cae6e99a3b9fc40c83718b25c3f7f1d46aa2c044cb208"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "KernelJobRegistry.constructor(KernelStakeManager,EscrowVault,RewardEngine,KernelConfig,ValidationModule,address,address).opsTreasury_ (contracts/v2/kernel/JobRegistry.sol#96) lacks a zero-check on :\n\t\t- opsTreasury = opsTreasury_ (contracts/v2/kernel/JobRegistry.sol#110)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 96,
+    "fingerprint": "8a2d3c5b90332fa5a59d87dbbeef1cf8ce41a1af176efac51b4338e2626851a4"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "ReentrantJobRegistry.attackFinalize(bytes32,address,uint256)._agent (contracts/v2/mocks/ReentrantJobRegistry.sol#56) lacks a zero-check on :\n\t\t- agent = _agent (contracts/v2/mocks/ReentrantJobRegistry.sol#58)\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 56,
+    "fingerprint": "939b9ccfefeab2e70e2d51069959a47e9762bc4b6f4ff9041f88cd78982c9ca6"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "AuditModule.setJobRegistry(address).registry (contracts/v2/AuditModule.sol#65) lacks a zero-check on :\n\t\t- jobRegistry = registry (contracts/v2/AuditModule.sol#66)\n",
+    "uri": "contracts/v2/AuditModule.sol",
+    "startLine": 65,
+    "fingerprint": "9dae2d939b7398eae7bb97aa89670345a076ffe2dabaed60b92fe8478c8f299a"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "DisputeModule.setPauserManager(address).manager (contracts/v2/modules/DisputeModule.sol#267) lacks a zero-check on :\n\t\t- pauserManager = manager (contracts/v2/modules/DisputeModule.sol#268)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 267,
+    "fingerprint": "9f10a507b3879b59fb0bec3ca520135ebce2971142f8a4eaf2f6875bebe01eb5"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "MockArbitrator.createDispute(uint256,address,bytes32).claimant (contracts/v2/mocks/MockArbitrator.sol#20) lacks a zero-check on :\n\t\t- lastClaimant = claimant (contracts/v2/mocks/MockArbitrator.sol#22)\n",
+    "uri": "contracts/v2/mocks/MockArbitrator.sol",
+    "startLine": 20,
+    "fingerprint": "a34ddd2355564122b19cc0443eec6be5d000ebe729cc856f7b345202174d7d91"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "JobEscrow.setJobRegistry(address).registry (contracts/v2/modules/JobEscrow.sol#100) lacks a zero-check on :\n\t\t- jobRegistry = registry (contracts/v2/modules/JobEscrow.sol#101)\n",
+    "uri": "contracts/v2/modules/JobEscrow.sol",
+    "startLine": 100,
+    "fingerprint": "ac261fd2d79c99130a6cece56c332e6f9288c15091d825ec3c684fc006cd17e9"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "ValidationModule.setPauser(address)._pauser (contracts/v2/ValidationModule.sol#257) lacks a zero-check on :\n\t\t- pauser = _pauser (contracts/v2/ValidationModule.sol#261)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 257,
+    "fingerprint": "b9921f0428d770e21411bb5584a3fa5724eb06260b0cd32378fd9cff4d6d8177"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "JobRegistry.setPauserManager(address).manager (contracts/v2/JobRegistry.sol#485) lacks a zero-check on :\n\t\t- pauserManager = manager (contracts/v2/JobRegistry.sol#486)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 485,
+    "fingerprint": "be1bc37eab078f603fb856a38cbd5e71c8f9251dcaf5822af547d40c2d92cbda"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "ReputationEngine.setPauser(address)._pauser (contracts/v2/ReputationEngine.sol#79) lacks a zero-check on :\n\t\t- pauser = _pauser (contracts/v2/ReputationEngine.sol#83)\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 79,
+    "fingerprint": "bea47dc49f486c5998a6118856ceec8362fb1f5aa8f02f6cdc59c9f4bd69d37c"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "RandaoCoordinator.constructor(uint256,uint256,uint256,address).treasury_ (contracts/v2/RandaoCoordinator.sol#89) lacks a zero-check on :\n\t\t- _treasury = treasury_ (contracts/v2/RandaoCoordinator.sol#96)\n",
+    "uri": "contracts/v2/RandaoCoordinator.sol",
+    "startLine": 89,
+    "fingerprint": "bf4b0328a0c192fb69fffd0d27fdbd80814fdeaf0eb321c47f54bd68cbc16d3e"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "KlerosDisputeModule.setGovernance(address)._governance (contracts/v2/modules/KlerosDisputeModule.sol#90) lacks a zero-check on :\n\t\t- governance = _governance (contracts/v2/modules/KlerosDisputeModule.sol#91)\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 90,
+    "fingerprint": "c5d30936164dca93ab08d95d433ffe93326df168377f08667698f771b4a1bd51"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "MockStakeManager.setDisputeModule(address).module (contracts/legacy/MockV2.sol#76) lacks a zero-check on :\n\t\t- disputeModule = module (contracts/legacy/MockV2.sol#77)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 76,
+    "fingerprint": "d25b416e028269862b18183051c1b49a4af19a30629b40f326c1162ca5419a24"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "KlerosDisputeModule.constructor(IJobRegistry,address,address)._arbitrator (contracts/v2/modules/KlerosDisputeModule.sol#81) lacks a zero-check on :\n\t\t- arbitrator = _arbitrator (contracts/v2/modules/KlerosDisputeModule.sol#85)\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 81,
+    "fingerprint": "d8d572d242e85c8f090b87f9fc03dc4f4acbf0d0d2f5870b53fb6e89bf4c6ddc"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "Governor.relay(address,uint256,bytes).target (node_modules/@openzeppelin/contracts/governance/Governor.sol#656) lacks a zero-check on :\n\t\t- (success,returndata) = target.call{value: value}(data) (node_modules/@openzeppelin/contracts/governance/Governor.sol#657)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 656,
+    "fingerprint": "d95406bd4e7e26caef32bf6f3dabae5567000bdafdbd25c497e081e2d4e80736"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "Ownable2Step.transferOwnership(address).newOwner (node_modules/@openzeppelin/contracts/access/Ownable2Step.sol#43) lacks a zero-check on :\n\t\t- _pendingOwner = newOwner (node_modules/@openzeppelin/contracts/access/Ownable2Step.sol#44)\n",
+    "uri": "node_modules/@openzeppelin/contracts/access/Ownable2Step.sol",
+    "startLine": 43,
+    "fingerprint": "df32211a2051406553fe733e8e83af14d4955bfa6ac4010e6ac368c14b53ee70"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "PlatformRegistry.setPauserManager(address).manager (contracts/v2/PlatformRegistry.sol#98) lacks a zero-check on :\n\t\t- pauserManager = manager (contracts/v2/PlatformRegistry.sol#99)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 98,
+    "fingerprint": "e153bd9da62363ade26de57e63889ba3f404382761ffd4bb1d40375487d6b7f8"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "ReputationEngine.setPauserManager(address).manager (contracts/v2/ReputationEngine.sol#87) lacks a zero-check on :\n\t\t- pauserManager = manager (contracts/v2/ReputationEngine.sol#88)\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 87,
+    "fingerprint": "e1744944bceb1268b52a946d43efe7b83d351370dbb38c1e52c1da5d49a4e6fd"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "MockJobRegistry.setValidationModule(address).module (contracts/legacy/MockV2.sol#488) lacks a zero-check on :\n\t\t- validationModule = module (contracts/legacy/MockV2.sol#489)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 488,
+    "fingerprint": "fb6c97ab44db9452fe620796aac04424b7d9963836185237e0a0d8e626d1e71b"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "ValidationStub.setJobRegistry(address).registry (contracts/v2/mocks/ValidationStub.sol#16) lacks a zero-check on :\n\t\t- jobRegistry = registry (contracts/v2/mocks/ValidationStub.sol#17)\n",
+    "uri": "contracts/v2/mocks/ValidationStub.sol",
+    "startLine": 16,
+    "fingerprint": "fef4c582e3c6230a30950f67bf3f10e4560900a579ce6ab786462cd0332f455b"
+  },
+  {
+    "ruleId": "2-1-missing-zero-check",
+    "message": "IdentityRegistryMock.setENS(address)._ens (contracts/v2/mocks/IdentityRegistryMock.sol#44) lacks a zero-check on :\n\t\t- ens = _ens (contracts/v2/mocks/IdentityRegistryMock.sol#45)\n",
+    "uri": "contracts/v2/mocks/IdentityRegistryMock.sol",
+    "startLine": 44,
+    "fingerprint": "ffd8b37553ddaaca652dc68c9dc63c0317680821c4aea0b58ba6fa57781aaa7e"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "DiscoveryModule.getPlatforms(uint256,uint256) (contracts/v2/modules/DiscoveryModule.sol#81-129) has external calls inside a loop: reputationEngine.isBlacklisted(p) (contracts/v2/modules/DiscoveryModule.sol#94)\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 81,
+    "fingerprint": "02433bee7567bb415c7b9142e64a7b110f34df572086798bb67e92588d175ddc"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) has external calls inside a loop: (authorized_scope_3,None,None,None) = identityRegistry.verifyValidator(candidate_scope_1,subdomain_scope_4,proof_scope_6) (contracts/v2/ValidationModule.sol#1135-1139)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "02f5a53d91bc59553d2fca8f5ef3d53dca51e63684781d8eff2f031c6d738d5e"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "CommitRevealEchidnaHarness.echidna_nonce_matches_successful_reveals() (contracts/test/CommitRevealEchidna.sol#51-59) has external calls inside a loop: commitReveal.nonces(jobId) != successfulReveals[jobId] (contracts/test/CommitRevealEchidna.sol#53)\n",
+    "uri": "contracts/test/CommitRevealEchidna.sol",
+    "startLine": 51,
+    "fingerprint": "075a9ffceeb034b9b9873ab6a01727ed4fb4e28145632802900c12a579ecd03e"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) has external calls inside a loop: ! identityRegistry.additionalValidators(candidate) (contracts/v2/ValidationModule.sol#1041)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "0b340c378261086872edc55dac7b3433b41feeb52fe01016b9745c598511ff5f"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) has external calls inside a loop: reputationEngine.isBlacklisted(candidate_scope_1) (contracts/v2/ValidationModule.sol#1107)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "0cce6918ff9927d7c346f88ca621ac413f9af5120773aad11e7ed1ed101eca4c"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "JobRouter.selectPlatform(bytes32) (contracts/v2/modules/JobRouter.sol#114-152) has external calls inside a loop: score = platformRegistry.getScore(op) (contracts/v2/modules/JobRouter.sol#124)\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 114,
+    "fingerprint": "125e6394284fc1057592279e7e189852d067175b13aae99f3b00bfa7746e9551"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "JobRouter.selectPlatform(bytes32) (contracts/v2/modules/JobRouter.sol#114-152) has external calls inside a loop: ! platformRegistry.registered(op_scope_1) (contracts/v2/modules/JobRouter.sol#139)\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 114,
+    "fingerprint": "14a0dafb7de225d3b4b87dedcc9fcb3f9df373b2a2636840094975bcdff1c66b"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "RoutingModule.selectOperator(bytes32,bytes32) (contracts/v2/modules/RoutingModule.sol#124-187) has external calls inside a loop: rep = reputationEngine.getReputation(op) (contracts/v2/modules/RoutingModule.sol#153)\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 124,
+    "fingerprint": "23686fb263b45aea7089fe40109e24b4cbb84bd9befeca483ce75f695764001e"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) has external calls inside a loop: stakeManager.lockValidatorStake(jobId,val_scope_12,stakeAmount_scope_13,lockTime) (contracts/v2/ValidationModule.sol#1238)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "2619af3c3be2906ad067e2992eccafef67b3014e72a9848b16aac4a7e24bb8e0"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.forceFinalize(uint256) (contracts/v2/ValidationModule.sol#1570-1629) has external calls inside a loop: reputationEngine.subtract(val,1) (contracts/v2/ValidationModule.sol#1616)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1570,
+    "fingerprint": "2811c03adb0a055d67885cdaf3ecafe33abfbd70db95ce4d541413067939821a"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "JobRouter.routingWeight(address) (contracts/v2/modules/JobRouter.sol#94-109) has external calls inside a loop: s = platformRegistry.getScore(p) (contracts/v2/modules/JobRouter.sol#103)\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 94,
+    "fingerprint": "2835fe1a6b56b63939192f485869080380d8e39242fa11935e95af061572d249"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) has external calls inside a loop: ! identityRegistry.additionalValidators(candidate_scope_1) (contracts/v2/ValidationModule.sol#1124)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "29ace66f03cc59767a1b31a02b95261637d6ccfa9717c392e9937e92f6990792"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "JobRouter.selectPlatform(bytes32) (contracts/v2/modules/JobRouter.sol#114-152) has external calls inside a loop: ! platformRegistry.registered(op) (contracts/v2/modules/JobRouter.sol#120)\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 114,
+    "fingerprint": "2c5a7af4cab674cd812627b9cf4db899d8d974b72ea134cf42e2c828c24bd7a7"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "IdentityRegistry.verifyValidator(address,string,bytes32[]) (contracts/v2/IdentityRegistry.sol#1250-1342) has external calls inside a loop: attestationRegistry.isAttested(aliasNode,AttestationRegistry.Role.Validator,claimant) (contracts/v2/IdentityRegistry.sol#1296-1300)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 1250,
+    "fingerprint": "35abc3179d6ba849dd43f84b76c8610f0cf15aadddef09102290c15e7f60e088"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) has external calls inside a loop: stake_scope_2 = stakeManager.stakeOf(candidate_scope_1,IStakeManager.Role.Validator) (contracts/v2/ValidationModule.sol#1095-1098)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "3a696947f4dd021cc5fc4fb44c93a380e25e5aa1c222c84f7049412d25a940a4"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "RoutingModule.selectOperator(bytes32,bytes32) (contracts/v2/modules/RoutingModule.sol#124-187) has external calls inside a loop: stake = stakeManager.stakeOf(op,IStakeManager.Role.Platform) (contracts/v2/modules/RoutingModule.sol#149)\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 124,
+    "fingerprint": "3b4c439e74c2fbcf7cf5e6a58ddf019065c2dbd85d9f5b1ece5cab46b6d6a87f"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "JobRouter.selectPlatform(bytes32) (contracts/v2/modules/JobRouter.sol#114-152) has external calls inside a loop: score_scope_2 = platformRegistry.getScore(op_scope_1) (contracts/v2/modules/JobRouter.sol#143)\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 114,
+    "fingerprint": "3e1d08c1d146bfea8eff79c28cf289b453a9de21accc99fe7c548f0a20a1db4a"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) has external calls inside a loop: (authorized,None,None,None) = identityRegistry.verifyValidator(candidate,subdomain,proof) (contracts/v2/ValidationModule.sol#1052-1056)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "3e59090946bb23f2151b86b488ffe4ba1cc37a2f5222d5a983f0ba2225361192"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "RoutingModule.selectOperator(bytes32,bytes32) (contracts/v2/modules/RoutingModule.sol#124-187) has external calls inside a loop: stake_scope_2 = stakeManager.stakeOf(op_scope_1,IStakeManager.Role.Platform) (contracts/v2/modules/RoutingModule.sol#170)\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 124,
+    "fingerprint": "4a0a0a630443972ce5aaf7992f2b7d972002af8338df1be710c4079a765c68fa"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "JobRouter.routingWeight(address) (contracts/v2/modules/JobRouter.sol#94-109) has external calls inside a loop: ! registered[p] || ! platformRegistry.registered(p) (contracts/v2/modules/JobRouter.sol#102)\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 94,
+    "fingerprint": "4f9ecb556c2963084a7f3dc936caab4dc9be958e411953a527675344560e256f"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) has external calls inside a loop: reputationEngine.isBlacklisted(candidate) (contracts/v2/ValidationModule.sol#1024)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "611401e08907d98ff8939376a0d7f5627b40dd7e157e20c5b3c4fc724ac008b7"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) has external calls inside a loop: stake = stakeManager.stakeOf(candidate,IStakeManager.Role.Validator) (contracts/v2/ValidationModule.sol#1012-1015)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "64be24c51e453903dc6b37e9e07255a4796be638231cef1f720eb654d428f834"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "RoutingModule.selectOperator(bytes32,bytes32) (contracts/v2/modules/RoutingModule.sol#124-187) has external calls inside a loop: rep_scope_3 = reputationEngine.getReputation(op_scope_1) (contracts/v2/modules/RoutingModule.sol#174)\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 124,
+    "fingerprint": "6642374e45c0ed1a8012c81f301bc85b48c6e93b6c181cd5c6d631034ca10979"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "DiscoveryModule.getPlatforms(uint256,uint256) (contracts/v2/modules/DiscoveryModule.sol#81-129) has external calls inside a loop: rep = reputationEngine.getReputation(p) (contracts/v2/modules/DiscoveryModule.sol#97)\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 81,
+    "fingerprint": "6f6b50958326472620eb355a5851d121efffa19b8d052c027e56115315e4eaf5"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "JobRegistry._enableAckModule(address) (contracts/v2/JobRegistry.sol#679-686) has external calls inside a loop: (ok,data) = module.staticcall(abi.encodeWithSelector(IJobRegistryAck.acknowledgeFor.selector,address(0))) (contracts/v2/JobRegistry.sol#680-682)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 679,
+    "fingerprint": "76153cab064d406a8e6bc00426310e837451f6ef556275f2350df74641bdd1ee"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ValidationModule.forceFinalize(uint256) (contracts/v2/ValidationModule.sol#1570-1629) has external calls inside a loop: stakeManager.slash(val,IStakeManager.Role.Validator,penalty,job.employer) (contracts/v2/ValidationModule.sol#1602-1607)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1570,
+    "fingerprint": "78f8b551d9ac1db84c8f2d43621a3bbd13c91cca7583843ee8c8bf8af6bf204c"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "Address.functionCallWithValue(address,bytes,uint256) (node_modules/@openzeppelin/contracts/utils/Address.sol#75-81) has external calls inside a loop: (success,returndata) = target.call{value: value}(data) (node_modules/@openzeppelin/contracts/utils/Address.sol#79)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Address.sol",
+    "startLine": 75,
+    "fingerprint": "7a8dfb54d4e91a16dee0da085ce6a209a0a0300fe33585126b7e66a22562865c"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "IdentityRegistry.isAuthorizedValidator(address,string,bytes32[]) (contracts/v2/IdentityRegistry.sol#994-1077) has external calls inside a loop: attestationRegistry.isAttested(aliasNode_scope_2,AttestationRegistry.Role.Node,claimant) (contracts/v2/IdentityRegistry.sol#1063-1067)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 994,
+    "fingerprint": "83be96efafdbd84b8fc9cea72c2d5b175d02562c18446766cda478ae49982c64"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "DiscoveryModule.getPlatforms(uint256,uint256) (contracts/v2/modules/DiscoveryModule.sol#81-129) has external calls inside a loop: stake = stakeManager.stakeOf(p,IStakeManager.Role.Platform) (contracts/v2/modules/DiscoveryModule.sol#95)\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 81,
+    "fingerprint": "8f57b69b4d456b30768b01dd185f2ef2573360e2dabd12d5dbf7380c190d933a"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "JobRegistry.onValidationResult(uint256,bool,address[]) (contracts/v2/JobRegistry.sol#2102-2134) has external calls inside a loop: jobValidatorVotes[jobId][validator] = validationModule.votes(jobId,validator) (contracts/v2/JobRegistry.sol#2124-2127)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2102,
+    "fingerprint": "a37d4656296ae8bef6d16b21351dc9dd16ee294efbe3e940dc020f8576fcecd4"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "TimelockController._execute(address,uint256,bytes) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#411-414) has external calls inside a loop: (success,returndata) = target.call{value: value}(data) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#412)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/TimelockController.sol",
+    "startLine": 411,
+    "fingerprint": "ab22ea866c31308009b70669867eb1f44d85d81dd1d91e1af89b54fbbeb94086"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "ArbitratorCommittee.finalize(uint256) (contracts/v2/ArbitratorCommittee.sol#149-170) has external calls inside a loop: disputeModule.slashValidator(juror,absenteeSlash,employer) (contracts/v2/ArbitratorCommittee.sol#164)\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 149,
+    "fingerprint": "ad07c3492c34851caad2c962710f6a1a9e7aca1de3a8dc98f68c685638836ed1"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "RevenueDistributor.distribute(uint256) (contracts/v2/modules/RevenueDistributor.sol#88-120) has external calls inside a loop: stake = stakeManager.stakeOf(op,IStakeManager.Role.Platform) (contracts/v2/modules/RevenueDistributor.sol#98)\n",
+    "uri": "contracts/v2/modules/RevenueDistributor.sol",
+    "startLine": 88,
+    "fingerprint": "ad6da95ff9d28b69681bc5e50b3817475d7fde902c791920cd311b32d67facd2"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "IdentityRegistry.isAuthorizedValidator(address,string,bytes32[]) (contracts/v2/IdentityRegistry.sol#994-1077) has external calls inside a loop: attestationRegistry.isAttested(aliasNode,AttestationRegistry.Role.Validator,claimant) (contracts/v2/IdentityRegistry.sol#1034-1038)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 994,
+    "fingerprint": "b914ead7f15b8cc4ffac4961a751e48f94fe307163d0172e9abf8cef9a8b6c96"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "KernelJobRegistry.createJob(address,address[],uint256,uint64,bytes32) (contracts/v2/kernel/JobRegistry.sol#156-214) has external calls inside a loop: stakeManager.availableStakeOf(validator) < minValidatorStake (contracts/v2/kernel/JobRegistry.sol#180)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 156,
+    "fingerprint": "cad5b28c7165d42dc5338a0bd2ca6be2ac8f9c1a5fd282b064f88c5c83b99220"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "GovernanceReward.recordVoters(address[]) (contracts/v2/GovernanceReward.sol#122-134) has external calls inside a loop: stake = stakeManager.stakeOf(v,rewardRole) (contracts/v2/GovernanceReward.sol#128)\n",
+    "uri": "contracts/v2/GovernanceReward.sol",
+    "startLine": 122,
+    "fingerprint": "e78254dc1dd759912cccc38e63afe7724620208bee5f5fa39fb383c0b0e58877"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "IdentityRegistry.isAuthorizedAgent(address,string,bytes32[]) (contracts/v2/IdentityRegistry.sol#944-992) has external calls inside a loop: attestationRegistry.isAttested(aliasNode,AttestationRegistry.Role.Agent,claimant) (contracts/v2/IdentityRegistry.sol#981-985)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 944,
+    "fingerprint": "e93c6fad290faa1744effc5066b0ca16759094e6a8145eca4a35d9abd41d601a"
+  },
+  {
+    "ruleId": "2-1-calls-loop",
+    "message": "StakeManager.getTotalPayoutPct(address) (contracts/v2/StakeManager.sol#1757-1777) has external calls inside a loop: bal = IERC721(t.nft).balanceOf(user) (contracts/v2/StakeManager.sol#1762-1768)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1757,
+    "fingerprint": "f7217d98a26fd73fc1c39287cd0bfe1e30b10b2cef7d96cba9e5c10f937be833"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ReentrantStakeManager.slash(address,IStakeManager.Role,uint256,address) (contracts/v2/mocks/ReentrantStakeManager.sol#169-185):\n\tExternal calls:\n\t- (ok,err) = address(validation).call(abi.encodeWithSelector(IValidationModule.finalize.selector,attackJobId)) (contracts/v2/mocks/ReentrantStakeManager.sol#172-174)\n\tState variables written after the call(s):\n\t- _stakes[user][role] = st - amount (contracts/v2/mocks/ReentrantStakeManager.sol#183)\n\t- totalStakes[role] -= amount (contracts/v2/mocks/ReentrantStakeManager.sol#184)\n",
+    "uri": "contracts/v2/mocks/ReentrantStakeManager.sol",
+    "startLine": 169,
+    "fingerprint": "083d8c6569ce6e2dbeac9f0e1f0474b5e6a9b68d6e1933e2428970d639a06b58"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\tState variables written after the call(s):\n\t- _setStakeManager(IStakeManager(config.stakeManager)) (contracts/v2/JobRegistry.sol#1475)\n\t\t- acknowledgers[address(_stakeMgr)] = true (contracts/v2/JobRegistry.sol#535)\n\t- _setAuditModule(IAuditModule(config.auditModule)) (contracts/v2/JobRegistry.sol#1469)\n\t\t- auditModule = module (contracts/v2/JobRegistry.sol#520)\n\t\t- auditModule = module (contracts/v2/JobRegistry.sol#526)\n\t- _setCertificateNFT(ICertificateNFT(config.certificateNFT)) (contracts/v2/JobRegistry.sol#1487)\n\t\t- certificateNFT = _certNFT (contracts/v2/JobRegistry.sol#552)\n\t- _setDisputeModule(IDisputeModule(config.disputeModule)) (contracts/v2/JobRegistry.sol#1457)\n\t\t- disputeModule = module (contracts/v2/JobRegistry.sol#505)\n\t- _setExpirationGracePeriod(config.expirationGracePeriod) (contracts/v2/JobRegistry.sol#1534)\n\t\t- expirationGracePeriod = period (contracts/v2/JobRegistry.sol#627)\n\t- _setFeePool(IFeePool(config.feePool)) (contracts/v2/JobRegistry.sol#1493)\n\t\t- feePool = _feePool (contracts/v2/JobRegistry.sol#561)\n\t- _setJobStake(config.jobStake) (contracts/v2/JobRegistry.sol#1509)\n\t\t- jobStake = stake (contracts/v2/JobRegistry.sol#581)\n\t- _setMaxActiveJobsPerAgent(config.maxActiveJobsPerAgent) (contracts/v2/JobRegistry.sol#1529)\n\t\t- maxActiveJobsPerAgent = limit (contracts/v2/JobRegistry.sol#622)\n\t- _setJobDurationLimit(config.jobDurationLimit) (contracts/v2/JobRegistry.sol#1524)\n\t\t- maxJobDuration = limit (contracts/v2/JobRegistry.sol#617)\n\t- _setMaxJobReward(config.maxJobReward) (contracts/v2/JobRegistry.sol#1519)\n\t\t- maxJobReward = maxReward (contracts/v2/JobRegistry.sol#612)\n\t- _setMinAgentStake(config.minAgentStake) (contracts/v2/JobRegistry.sol#1514)\n\t\t- minAgentStake = uint96(stake) (contracts/v2/JobRegistry.sol#587)\n\t- _setReputationEngine(IReputationEngine(config.reputationModule)) (contracts/v2/JobRegistry.sol#1481)\n\t\t- reputationEngine = _reputation (contracts/v2/JobRegistry.sol#544)\n\t- _setStakeManager(IStakeManager(config.stakeManager)) (contracts/v2/JobRegistry.sol#1475)\n\t\t- stakeManager = _stakeMgr (contracts/v2/JobRegistry.sol#534)\n\t- _setTaxPolicy(ITaxPolicy(config.taxPolicy)) (contracts/v2/JobRegistry.sol#1499)\n\t\t- taxPolicy = _policy (contracts/v2/JobRegistry.sol#569)\n\t- _setTreasury(config.treasury) (contracts/v2/JobRegistry.sol#1504)\n\t\t- treasury = _treasury (contracts/v2/JobRegistry.sol#576)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "092334d314ab79aedf4ea43194fff119104ae83143f8c6d04b34896d381ee8a3"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in StakeManager.acknowledgeAndWithdrawFor(address,StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2212-2223):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(user) (contracts/v2/StakeManager.sol#2221)\n\tState variables written after the call(s):\n\t- _withdraw(user,role,amount) (contracts/v2/StakeManager.sol#2222)\n\t\t- boostedStake[user][role] = newBoosted (contracts/v2/StakeManager.sol#2163)\n\t- _withdraw(user,role,amount) (contracts/v2/StakeManager.sol#2222)\n\t\t- jobRegistryLockedStake[user] = 0 (contracts/v2/StakeManager.sol#2151)\n\t- _withdraw(user,role,amount) (contracts/v2/StakeManager.sol#2222)\n\t\t- lockedStakes[user] = 0 (contracts/v2/StakeManager.sol#2148)\n\t- _withdraw(user,role,amount) (contracts/v2/StakeManager.sol#2222)\n\t\t- stakes[user][role] = newStake (contracts/v2/StakeManager.sol#2165)\n\t- _withdraw(user,role,amount) (contracts/v2/StakeManager.sol#2222)\n\t\t- totalBoostedStakes[role] = totalBoostedStakes[role] + newBoosted - oldBoosted (contracts/v2/StakeManager.sol#2164)\n\t- _withdraw(user,role,amount) (contracts/v2/StakeManager.sol#2222)\n\t\t- totalStakes[role] -= amount (contracts/v2/StakeManager.sol#2166)\n\t- _withdraw(user,role,amount) (contracts/v2/StakeManager.sol#2222)\n\t\t- unlockTime[user] = 0 (contracts/v2/StakeManager.sol#2149)\n\t- _withdraw(user,role,amount) (contracts/v2/StakeManager.sol#2222)\n\t\t- validatorModuleLockedStake[user] = 0 (contracts/v2/StakeManager.sol#2154)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2212,
+    "fingerprint": "13bf126203d2b8ccb8bcdaf720731e69584311b9e799e82d17745d72de7e70db"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ValidationModule._finalize(uint256) (contracts/v2/ValidationModule.sol#1658-1787):\n\tExternal calls:\n\t- reputationEngine.updateScores(jobId,job.agent,committee,success,revealedStates,voteStates,payout,duration) (contracts/v2/ValidationModule.sol#1733-1742)\n\t- jobRegistry.markReputationProcessed(jobId) (contracts/v2/ValidationModule.sol#1743)\n\t- stakeManager.slash(val,IStakeManager.Role.Validator,penalty,job.employer) (contracts/v2/ValidationModule.sol#1753-1758)\n\t- stakeManager.slash(val,IStakeManager.Role.Validator,slashAmount,job.employer) (contracts/v2/ValidationModule.sol#1768-1773)\n\tState variables written after the call(s):\n\t- validatorBanUntil[val] = untilBlock (contracts/v2/ValidationModule.sol#1763)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1658,
+    "fingerprint": "1788876b69c1a460c0205300fe7068545e17767be9a4a837f93eed289e576810"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry.acknowledgeAndSubmit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#2004-2013):\n\tExternal calls:\n\t- _acknowledge(msg.sender) (contracts/v2/JobRegistry.sol#2011)\n\t\t- ack = taxPolicy.acknowledgeFor(user) (contracts/v2/JobRegistry.sol#1332)\n\t- submit(jobId,resultHash,resultURI,subdomain,proof) (contracts/v2/JobRegistry.sol#2012)\n\t\t- validationModule.start(jobId,entropy) (contracts/v2/JobRegistry.sol#357)\n\t\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyAgent(msg.sender,subdomain,proof) (contracts/v2/JobRegistry.sol#1953-1954)\n\tState variables written after the call(s):\n\t- submit(jobId,resultHash,resultURI,subdomain,proof) (contracts/v2/JobRegistry.sol#2012)\n\t\t- validationStartPending[jobId] = false (contracts/v2/JobRegistry.sol#354)\n\t\t- validationStartPending[jobId] = true (contracts/v2/JobRegistry.sol#1995)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2004,
+    "fingerprint": "18bf01930cbaab29a6d49eecc8d639fcad351e641624875b729add06fda764e2"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ValidationModule._commitValidation(uint256,bytes32,string,bytes32[]) (contracts/v2/ValidationModule.sol#1286-1332):\n\tExternal calls:\n\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyValidator(msg.sender,subdomain,proof) (contracts/v2/ValidationModule.sol#1307-1312)\n\tState variables written after the call(s):\n\t- commitments[jobId][msg.sender][nonce] = commitHash (contracts/v2/ValidationModule.sol#1330)\n\t- validatorAuthCache[msg.sender] = true (contracts/v2/ValidationModule.sol#1321)\n\t- validatorAuthExpiry[msg.sender] = block.timestamp + validatorAuthCacheDuration (contracts/v2/ValidationModule.sol#1323-1324)\n\t- validatorAuthVersion[msg.sender] = validatorAuthCacheVersion (contracts/v2/ValidationModule.sol#1322)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1286,
+    "fingerprint": "18d702735b81d4db128ef5ed7c8927bdf88a74c825f25ecd638746fa18b3a53d"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in StakeManager._slashBatched(address,StakeManager.Role,uint256,address,address[]) (contracts/v2/StakeManager.sol#2756-2799):\n\tExternal calls:\n\t- _slash(user,role,chunkAmount,recipient,slice) (contracts/v2/StakeManager.sol#2790)\n\t\t- IERC20Burnable(address(token)).burn(amount) (contracts/v2/StakeManager.sol#1091-1095)\n\t\t- feePool.depositFee(employerShare) (contracts/v2/StakeManager.sol#2716)\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- IERC20Burnable(address(token)).burn(amount) (contracts/v2/StakeManager.sol#1091-1095)\n\t\t- feePool.depositFee(employerShare) (contracts/v2/StakeManager.sol#2716)\n\tState variables written after the call(s):\n\t- _slash(user,role,amount - allocated,recipient,empty_scope_2) (contracts/v2/StakeManager.sol#2797)\n\t\t- unlockTime[user] = 0 (contracts/v2/StakeManager.sol#2688)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2756,
+    "fingerprint": "1ff78d0ef52fbbc48ff8f945906d5befe478641a13076ebcf793c0dc4dee451b"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobEscrow.postJob(uint256,string,bytes32) (contracts/v2/modules/JobEscrow.sol#118-138):\n\tExternal calls:\n\t- operator = routingModule.selectOperator(bytes32(nextJobId),seed) (contracts/v2/modules/JobEscrow.sol#124)\n\tState variables written after the call(s):\n\t- jobs[jobId] = Job({employer:msg.sender,operator:operator,reward:reward,state:State.Posted,submittedAt:0,data:data,result:}) (contracts/v2/modules/JobEscrow.sol#128-136)\n",
+    "uri": "contracts/v2/modules/JobEscrow.sol",
+    "startLine": 118,
+    "fingerprint": "2490701756c6b4d93847af18964ba068b5b82976d83993e732873b00acfda63b"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in FeePool.claimRewards() (contracts/v2/FeePool.sol#346-366):\n\tExternal calls:\n\t- stakeManager.syncBoostedStake(msg.sender,rewardRole) (contracts/v2/FeePool.sol#351)\n\t- _distributeFees() (contracts/v2/FeePool.sol#352)\n\t\t- IERC20Burnable(address(token)).burn(amt) (contracts/v2/FeePool.sol#330-334)\n\tState variables written after the call(s):\n\t- userCheckpoint[msg.sender] = cumulative (contracts/v2/FeePool.sol#363)\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 346,
+    "fingerprint": "2ba4e1d0ce0f59c3266921b4c7f287a8764d09ce25cf99309f250ced75d61f32"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in CertificateNFT.mint(address,uint256,bytes32) (contracts/v2/modules/CertificateNFT.sol#90-100):\n\tExternal calls:\n\t- _safeMint(to,tokenId) (contracts/v2/modules/CertificateNFT.sol#97)\n\t\t- retval = IERC721Receiver(to).onERC721Received(operator,from,tokenId,data) (node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol#33-47)\n\t\t- ERC721Utils.checkOnERC721Received(_msgSender(),address(0),to,tokenId,data) (node_modules/@openzeppelin/contracts/token/ERC721/ERC721.sol#289)\n\tState variables written after the call(s):\n\t- tokenHashes[tokenId] = uriHash (contracts/v2/modules/CertificateNFT.sol#98)\n",
+    "uri": "contracts/v2/modules/CertificateNFT.sol",
+    "startLine": 90,
+    "fingerprint": "30184345a8a6bf72eed1a372672e581a71b5cd7017a29c6d485d041e3cf0f1d0"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in StakeManager.acknowledgeAndWithdraw(StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2195-2200):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/StakeManager.sol#2198)\n\tState variables written after the call(s):\n\t- _withdraw(msg.sender,role,amount) (contracts/v2/StakeManager.sol#2199)\n\t\t- boostedStake[user][role] = newBoosted (contracts/v2/StakeManager.sol#2163)\n\t- _withdraw(msg.sender,role,amount) (contracts/v2/StakeManager.sol#2199)\n\t\t- jobRegistryLockedStake[user] = 0 (contracts/v2/StakeManager.sol#2151)\n\t- _withdraw(msg.sender,role,amount) (contracts/v2/StakeManager.sol#2199)\n\t\t- lockedStakes[user] = 0 (contracts/v2/StakeManager.sol#2148)\n\t- _withdraw(msg.sender,role,amount) (contracts/v2/StakeManager.sol#2199)\n\t\t- stakes[user][role] = newStake (contracts/v2/StakeManager.sol#2165)\n\t- _withdraw(msg.sender,role,amount) (contracts/v2/StakeManager.sol#2199)\n\t\t- totalBoostedStakes[role] = totalBoostedStakes[role] + newBoosted - oldBoosted (contracts/v2/StakeManager.sol#2164)\n\t- _withdraw(msg.sender,role,amount) (contracts/v2/StakeManager.sol#2199)\n\t\t- totalStakes[role] -= amount (contracts/v2/StakeManager.sol#2166)\n\t- _withdraw(msg.sender,role,amount) (contracts/v2/StakeManager.sol#2199)\n\t\t- unlockTime[user] = 0 (contracts/v2/StakeManager.sol#2149)\n\t- _withdraw(msg.sender,role,amount) (contracts/v2/StakeManager.sol#2199)\n\t\t- validatorModuleLockedStake[user] = 0 (contracts/v2/StakeManager.sol#2154)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2195,
+    "fingerprint": "32649c1d6d8f13e12bbf07a7d90cb910ab44c6a947f3cf0607db28098d735d1a"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in StakeManager.acknowledgeAndDepositFor(address,StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2070-2076):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(user) (contracts/v2/StakeManager.sol#2074)\n\tState variables written after the call(s):\n\t- _acknowledgedDepositFor(user,role,amount) (contracts/v2/StakeManager.sol#2075)\n\t\t- boostedStake[user][role] = newBoosted (contracts/v2/StakeManager.sol#1964)\n\t- _acknowledgedDepositFor(user,role,amount) (contracts/v2/StakeManager.sol#2075)\n\t\t- stakes[user][role] = newStake (contracts/v2/StakeManager.sol#1966)\n\t- _acknowledgedDepositFor(user,role,amount) (contracts/v2/StakeManager.sol#2075)\n\t\t- totalBoostedStakes[role] = totalBoostedStakes[role] + newBoosted - oldBoosted (contracts/v2/StakeManager.sol#1965)\n\t- _acknowledgedDepositFor(user,role,amount) (contracts/v2/StakeManager.sol#2075)\n\t\t- totalStakes[role] += amount (contracts/v2/StakeManager.sol#1967)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2070,
+    "fingerprint": "3881b789ad458d30bf3ca7de18d5fbed6c316bf04b0f1f65634996fe0c71558c"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobEscrow.acknowledgeAndAcceptResult(uint256) (contracts/v2/modules/JobEscrow.sol#189-195):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/modules/JobEscrow.sol#192)\n\tState variables written after the call(s):\n\t- _accept(jobId) (contracts/v2/modules/JobEscrow.sol#194)\n\t\t- job.state = State.Accepted (contracts/v2/modules/JobEscrow.sol#174)\n",
+    "uri": "contracts/v2/modules/JobEscrow.sol",
+    "startLine": 189,
+    "fingerprint": "3e2aa51e6a0c932e29a2a51ae21e9dfffa25bb44455681fa76e35ac0a1dd7ea6"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495):\n\tExternal calls:\n\t- stakeManager.finalizeJobFundsWithPct(jobKey,employerParam,payee,agentPct,rewardAfterValidator,validatorReward,fee,pool,isGov) (contracts/v2/JobRegistry.sol#2356-2366)\n\t- stakeManager.distributeValidatorRewards(jobKey,validatorReward) (contracts/v2/JobRegistry.sol#2370-2373)\n\t- stakeManager.releaseReward(jobKey,job.employer,payee,validatorReward,true) (contracts/v2/JobRegistry.sol#2375-2381)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),treasury,validators) (contracts/v2/JobRegistry.sol#2386-2392)\n\t- stakeManager.releaseStake(job.agent,uint256(job.stake)) (contracts/v2/JobRegistry.sol#2394)\n\t- reputationEngine.onFinalize(job.agent,true,payout,completionTime) (contracts/v2/JobRegistry.sol#2416-2421)\n\t- reputationEngine.rewardValidator(val,agentGain) (contracts/v2/JobRegistry.sol#2426)\n\t- certificateNFT.mint(job.agent,jobId,job.uriHash) (contracts/v2/JobRegistry.sol#2435)\n\t- stakeManager.redistributeEscrow(jobKey,recipient,uint256(job.reward) + fee_scope_0,validators) (contracts/v2/JobRegistry.sol#2448-2453)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),recipient,validators) (contracts/v2/JobRegistry.sol#2456-2462)\n\t- reputationEngine.onFinalize(job.agent,false,0,0) (contracts/v2/JobRegistry.sol#2466)\n\tState variables written after the call(s):\n\t- employerStats[job.employer].successful ++ (contracts/v2/JobRegistry.sol#2470)\n\t- employerStats[job.employer].failed ++ (contracts/v2/JobRegistry.sol#2472)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "43502124129f06082af5f85065c810e67d5cecb20d5988654c3d72873b698e34"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in GovernorTimelockControl._executeOperations(uint256,address[],uint256[],bytes[],bytes32) (node_modules/@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol#97-108):\n\tExternal calls:\n\t- _timelock.executeBatch{value: msg.value}(targets,values,calldatas,0,_timelockSalt(descriptionHash)) (node_modules/@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol#105)\n\tState variables written after the call(s):\n\t- delete _timelockIds[proposalId] (node_modules/@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol#107)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol",
+    "startLine": 97,
+    "fingerprint": "447292e212bfebc9a97cdf93b1c3c1d3f6bb7c8cc2ec55ab8f583f6bcdeccce0"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495):\n\tExternal calls:\n\t- stakeManager.finalizeJobFundsWithPct(jobKey,employerParam,payee,agentPct,rewardAfterValidator,validatorReward,fee,pool,isGov) (contracts/v2/JobRegistry.sol#2356-2366)\n\t- stakeManager.distributeValidatorRewards(jobKey,validatorReward) (contracts/v2/JobRegistry.sol#2370-2373)\n\t- stakeManager.releaseReward(jobKey,job.employer,payee,validatorReward,true) (contracts/v2/JobRegistry.sol#2375-2381)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),treasury,validators) (contracts/v2/JobRegistry.sol#2386-2392)\n\t- stakeManager.releaseStake(job.agent,uint256(job.stake)) (contracts/v2/JobRegistry.sol#2394)\n\t- reputationEngine.onFinalize(job.agent,true,payout,completionTime) (contracts/v2/JobRegistry.sol#2416-2421)\n\t- reputationEngine.rewardValidator(val,agentGain) (contracts/v2/JobRegistry.sol#2426)\n\t- certificateNFT.mint(job.agent,jobId,job.uriHash) (contracts/v2/JobRegistry.sol#2435)\n\t- stakeManager.redistributeEscrow(jobKey,recipient,uint256(job.reward) + fee_scope_0,validators) (contracts/v2/JobRegistry.sol#2448-2453)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),recipient,validators) (contracts/v2/JobRegistry.sol#2456-2462)\n\t- reputationEngine.onFinalize(job.agent,false,0,0) (contracts/v2/JobRegistry.sol#2466)\n\t- auditModule.onJobFinalized(jobId,job.agent,success,job.resultHash) (contracts/v2/JobRegistry.sol#2476-2479)\n\tState variables written after the call(s):\n\t- activeJobs[agentAddr] = activeCount - 1 (contracts/v2/JobRegistry.sol#2488)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "4c6152a4c7610d75c422c25c40fde96685087f44ba16699050cb7f3c4ac41191"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in FeePool.depositFee(uint256) (contracts/v2/FeePool.sol#239-250):\n\tExternal calls:\n\t- _burnFees(msg.sender,burnAmount) (contracts/v2/FeePool.sol#243)\n\t\t- IERC20Burnable(address(token)).burn(amt) (contracts/v2/FeePool.sol#330-334)\n\tState variables written after the call(s):\n\t- pendingFees += netAmount (contracts/v2/FeePool.sol#247)\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 239,
+    "fingerprint": "55cf93261e77360a90eaa14d4aca36882e3968f2526e1e3c8a2fce825c507211"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ReentrantJobRegistry.attackFinalize(bytes32,address,uint256) (contracts/v2/mocks/ReentrantJobRegistry.sol#56-65):\n\tExternal calls:\n\t- token.setAttack(true) (contracts/v2/mocks/ReentrantJobRegistry.sol#62)\n\t- stakeManager.finalizeJobFunds(jobId,employer,agent,reward,0,0,IFeePool(address(0)),false) (contracts/v2/mocks/ReentrantJobRegistry.sol#63)\n\tState variables written after the call(s):\n\t- attackType = AttackType.None (contracts/v2/mocks/ReentrantJobRegistry.sol#64)\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 56,
+    "fingerprint": "5fc9541319869c62a7d220fe9d74de8f2708d22f09e1e9f3e6ad8f47c7bf8eed"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry._cancelJob(uint256) (contracts/v2/JobRegistry.sol#2521-2539):\n\tExternal calls:\n\t- stakeManager.refundEscrow(bytes32(jobId),job.employer,uint256(job.reward) + fee) (contracts/v2/JobRegistry.sol#2528-2532)\n\tState variables written after the call(s):\n\t- _clearValidatorData(jobId) (contracts/v2/JobRegistry.sol#2534)\n\t\t- delete jobValidatorVotes[jobId][validators[i]] (contracts/v2/JobRegistry.sol#338)\n\t- _clearValidatorData(jobId) (contracts/v2/JobRegistry.sol#2534)\n\t\t- delete jobValidators[jobId] (contracts/v2/JobRegistry.sol#343)\n\t- delete reputationProcessed[jobId] (contracts/v2/JobRegistry.sol#2536)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2521,
+    "fingerprint": "64900915a00c51195fb662595f5d82ed8b0272521a85d320959c1c322f190876"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in MockJobRegistry.acknowledgeTaxPolicy() (contracts/legacy/MockV2.sol#473-478):\n\tExternal calls:\n\t- taxPolicy.acknowledge() (contracts/legacy/MockV2.sol#475)\n\tState variables written after the call(s):\n\t- taxAcknowledgedVersion[msg.sender] = taxPolicyVersion (contracts/legacy/MockV2.sol#477)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 473,
+    "fingerprint": "6b3a764952fb10fee677a5cc93bb05dadcd55d83b76b6aead5fb72f04ce40519"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in PlatformRegistry.acknowledgeAndRegisterFor(address) (contracts/v2/PlatformRegistry.sol#261-271):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(operator) (contracts/v2/PlatformRegistry.sol#268)\n\tState variables written after the call(s):\n\t- _register(operator) (contracts/v2/PlatformRegistry.sol#270)\n\t\t- registered[operator] = true (contracts/v2/PlatformRegistry.sol#151)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 261,
+    "fingerprint": "7daabc9c133db101ec1546d731975f3a1336356a5c62022ded9d230f38285f0c"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ValidationModule._cleanup(uint256) (contracts/v2/ValidationModule.sol#1804-1830):\n\tExternal calls:\n\t- stakeManager.unlockValidatorStake(jobId,val,lockAmount) (contracts/v2/ValidationModule.sol#1817)\n\tState variables written after the call(s):\n\t- delete selectionSeeds[jobId] (contracts/v2/ValidationModule.sol#1829)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1804,
+    "fingerprint": "7f9d4b9663b09e93caed237c4b690681939359cc495db5df639ed67a358efdc3"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in StakeManager.acknowledgeAndDeposit(StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2034-2039):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/StakeManager.sol#2037)\n\tState variables written after the call(s):\n\t- _acknowledgedDeposit(role,amount) (contracts/v2/StakeManager.sol#2038)\n\t\t- boostedStake[user][role] = newBoosted (contracts/v2/StakeManager.sol#1964)\n\t- _acknowledgedDeposit(role,amount) (contracts/v2/StakeManager.sol#2038)\n\t\t- stakes[user][role] = newStake (contracts/v2/StakeManager.sol#1966)\n\t- _acknowledgedDeposit(role,amount) (contracts/v2/StakeManager.sol#2038)\n\t\t- totalBoostedStakes[role] = totalBoostedStakes[role] + newBoosted - oldBoosted (contracts/v2/StakeManager.sol#1965)\n\t- _acknowledgedDeposit(role,amount) (contracts/v2/StakeManager.sol#2038)\n\t\t- totalStakes[role] += amount (contracts/v2/StakeManager.sol#1967)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2034,
+    "fingerprint": "87c8243edaf0864910cae115f925f408ba10fee1f4f896faaf61bb45db877804"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001):\n\tExternal calls:\n\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyAgent(msg.sender,subdomain,proof) (contracts/v2/JobRegistry.sol#1953-1954)\n\t- _startValidation(jobId,entropy) (contracts/v2/JobRegistry.sol#1998)\n\t\t- validationModule.start(jobId,entropy) (contracts/v2/JobRegistry.sol#357)\n\tState variables written after the call(s):\n\t- _startValidation(jobId,entropy) (contracts/v2/JobRegistry.sol#1998)\n\t\t- validationStartPending[jobId] = false (contracts/v2/JobRegistry.sol#354)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1917,
+    "fingerprint": "8f8bbcb7a79e4a5b77d70f5f9e3f0f06aa605cf68ffa952245ad6d689f757d31"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001):\n\tExternal calls:\n\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyAgent(msg.sender,subdomain,proof) (contracts/v2/JobRegistry.sol#1953-1954)\n\tState variables written after the call(s):\n\t- pendingValidationEntropy[jobId] = entropy (contracts/v2/JobRegistry.sol#1994)\n\t- validationStartPending[jobId] = true (contracts/v2/JobRegistry.sol#1995)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1917,
+    "fingerprint": "93ae2d39cef2ceaceead38bdc2802ae5ee2c1012a5eae485d49d21d8d67c36b2"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry.acknowledgeAndCreateJobWithAgentTypes(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1739-1748):\n\tExternal calls:\n\t- _acknowledge(msg.sender) (contracts/v2/JobRegistry.sol#1746)\n\t\t- ack = taxPolicy.acknowledgeFor(user) (contracts/v2/JobRegistry.sol#1332)\n\t- jobId = _createJob(reward,deadline,agentTypes,specHash,uri) (contracts/v2/JobRegistry.sol#1747)\n\t\t- stakeManager.lockReward(bytes32(jobId),msg.sender,reward + fee) (contracts/v2/JobRegistry.sol#1687)\n\tState variables written after the call(s):\n\t- jobId = _createJob(reward,deadline,agentTypes,specHash,uri) (contracts/v2/JobRegistry.sol#1747)\n\t\t- jobs[jobId] = Job({employer:msg.sender,agent:address(0),reward:uint128(reward),stake:jobStake,burnReceiptAmount:0,uriHash:uriHash,resultHash:bytes32(0),specHash:specHash,packedMetadata:_encodeMetadata(metadata)}) (contracts/v2/JobRegistry.sol#1673-1683)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1739,
+    "fingerprint": "99e0cc7d2dec7840b98d4cc73132b5d2ffe26a140f3e7a7abf676c44b9895190"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry.claimTimeout(uint256) (contracts/v2/JobRegistry.sol#2568-2638):\n\tExternal calls:\n\t- stakeManager.redistributeEscrow(jobKey,employer,totalRefund,validators) (contracts/v2/JobRegistry.sol#2604)\n\t- stakeManager.slash(agent,IStakeManager.Role.Agent,uint256(stakeAmount),employer) (contracts/v2/JobRegistry.sol#2607-2612)\n\tState variables written after the call(s):\n\t- activeJobs[agent] = activeCount - 1 (contracts/v2/JobRegistry.sol#2630)\n\t- employerStats[employer].failed ++ (contracts/v2/JobRegistry.sol#2616)\n\t- _clearValidatorData(jobId) (contracts/v2/JobRegistry.sol#2633)\n\t\t- delete jobValidatorVotes[jobId][validators[i]] (contracts/v2/JobRegistry.sol#338)\n\t- _clearValidatorData(jobId) (contracts/v2/JobRegistry.sol#2633)\n\t\t- delete jobValidators[jobId] (contracts/v2/JobRegistry.sol#343)\n\t- delete reputationProcessed[jobId] (contracts/v2/JobRegistry.sol#2635)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2568,
+    "fingerprint": "9d942657b91f7ee66de8ac7f6f4d03467972700fa4a6de96d25d3a338c54f9c2"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry._applyForJob(uint256,string,bytes32[]) (contracts/v2/JobRegistry.sol#1750-1861):\n\tExternal calls:\n\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyAgent(msg.sender,subdomain,proof) (contracts/v2/JobRegistry.sol#1791-1792)\n\t- stakeManager.lockStake(msg.sender,uint256(job.stake),lockTime) (contracts/v2/JobRegistry.sol#1842)\n\tState variables written after the call(s):\n\t- activeJobs[msg.sender] = active + 1 (contracts/v2/JobRegistry.sol#1858)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1750,
+    "fingerprint": "a5a3281687283520603e4f2f4c9af2f29c5702c08c70b0f4b87f8a63aeec9d62"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in PlatformRegistry.acknowledgeAndRegister() (contracts/v2/PlatformRegistry.sol#194-201):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/PlatformRegistry.sol#198)\n\tState variables written after the call(s):\n\t- _register(msg.sender) (contracts/v2/PlatformRegistry.sol#200)\n\t\t- registered[operator] = true (contracts/v2/PlatformRegistry.sol#151)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 194,
+    "fingerprint": "a5e2f2c0c7bc4684bfe7e1448eaa8ba97a68180a8762a90c889786484525fb26"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ValidationModule.forceFinalize(uint256) (contracts/v2/ValidationModule.sol#1570-1629):\n\tExternal calls:\n\t- stakeManager.slash(val,IStakeManager.Role.Validator,penalty,job.employer) (contracts/v2/ValidationModule.sol#1602-1607)\n\t- reputationEngine.subtract(val,1) (contracts/v2/ValidationModule.sol#1616)\n\tState variables written after the call(s):\n\t- validatorBanUntil[val] = untilBlock (contracts/v2/ValidationModule.sol#1612)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1570,
+    "fingerprint": "a661446950625d4d015bd3b3d8f868b9fd42acd9a3e6ee852fc19e014015e9a6"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ValidationModule._revealValidation(uint256,bool,bytes32,bytes32,string,bytes32[]) (contracts/v2/ValidationModule.sol#1364-1474):\n\tExternal calls:\n\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyValidator(msg.sender,subdomain,proof) (contracts/v2/ValidationModule.sol#1382-1387)\n\tState variables written after the call(s):\n\t- revealed[jobId][msg.sender] = true (contracts/v2/ValidationModule.sol#1453)\n\t- validatorAuthCache[msg.sender] = true (contracts/v2/ValidationModule.sol#1396)\n\t- validatorAuthExpiry[msg.sender] = block.timestamp + validatorAuthCacheDuration (contracts/v2/ValidationModule.sol#1398-1399)\n\t- validatorAuthVersion[msg.sender] = validatorAuthCacheVersion (contracts/v2/ValidationModule.sol#1397)\n\t- votes[jobId][msg.sender] = approve (contracts/v2/ValidationModule.sol#1454)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1364,
+    "fingerprint": "a860ebe663a12fd80a11bf798ff839d532a4237b03d83d136120fd8dd90fb399"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250):\n\tExternal calls:\n\t- (authorized,None,None,None) = identityRegistry.verifyValidator(candidate,subdomain,proof) (contracts/v2/ValidationModule.sol#1052-1056)\n\t- (authorized_scope_3,None,None,None) = identityRegistry.verifyValidator(candidate_scope_1,subdomain_scope_4,proof_scope_6) (contracts/v2/ValidationModule.sol#1135-1139)\n\tState variables written after the call(s):\n\t- _validatorLookup[jobId][val_scope_10] = true (contracts/v2/ValidationModule.sol#1221)\n\t- validatorStakeLocks[jobId][val_scope_10] = stakeAmount (contracts/v2/ValidationModule.sol#1220)\n\t- validatorStakes[jobId][val_scope_10] = stakeAmount (contracts/v2/ValidationModule.sol#1219)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "a9e431c43c12a352909891678855169d5493704d64f02f177e73f59b4f64208a"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in SimpleJobRegistry.createJob(uint256,uint64,bytes32,string) (contracts/test/SimpleJobRegistry.sol#92-114):\n\tExternal calls:\n\t- token.transferFrom(msg.sender,address(this),reward) (contracts/test/SimpleJobRegistry.sol#99)\n\tState variables written after the call(s):\n\t- jobStore[jobId] = Job({employer:msg.sender,agent:address(0),reward:reward,deadline:deadline,specHash:specHash,uri:uri,subdomain:,submitted:false,finalized:false,resultHash:bytes32(0),resultURI:}) (contracts/test/SimpleJobRegistry.sol#100-112)\n",
+    "uri": "contracts/test/SimpleJobRegistry.sol",
+    "startLine": 92,
+    "fingerprint": "ae4a20573d9db3601d9363d3ee88ee6dba7e786d5ac29ba06e3fc5ca7c365134"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ReentrantJobRegistry.attackValidator(bytes32,uint256) (contracts/v2/mocks/ReentrantJobRegistry.sol#67-74):\n\tExternal calls:\n\t- token.setAttack(true) (contracts/v2/mocks/ReentrantJobRegistry.sol#71)\n\t- stakeManager.distributeValidatorRewards(jobId,amount) (contracts/v2/mocks/ReentrantJobRegistry.sol#72)\n\tState variables written after the call(s):\n\t- attackType = AttackType.None (contracts/v2/mocks/ReentrantJobRegistry.sol#73)\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 67,
+    "fingerprint": "ae760de515c48d09c2d88c2f3f6c92df7959b26ebbe850867cd858159d52e97b"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n\t\t- identityRegistry.setAgentRootNode(node) (contracts/v2/JobRegistry.sol#633)\n\t- _setAgentMerkleRoot(config.agentMerkleRoot) (contracts/v2/JobRegistry.sol#1545)\n\t\t- identityRegistry.setAgentMerkleRoot(root) (contracts/v2/JobRegistry.sol#640)\n\t- _setValidatorRootNode(config.validatorRootNode) (contracts/v2/JobRegistry.sol#1551)\n\t\t- identityRegistry.setClubRootNode(node) (contracts/v2/JobRegistry.sol#648)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#649)\n\t- _setValidatorMerkleRoot(config.validatorMerkleRoot) (contracts/v2/JobRegistry.sol#1556)\n\t\t- identityRegistry.setValidatorMerkleRoot(root) (contracts/v2/JobRegistry.sol#656)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#657)\n\tState variables written after the call(s):\n\t- _setAgentAuthCacheDuration(config.agentAuthCacheDuration) (contracts/v2/JobRegistry.sol#1561)\n\t\t- agentAuthCacheDuration = duration (contracts/v2/JobRegistry.sol#662)\n\t- (feeChanged_scope_1,validatorChanged) = _applyFeeConfiguration(newFee,newValidator,config.setFeePct,config.setValidatorRewardPct) (contracts/v2/JobRegistry.sol#1574-1579)\n\t\t- feePct = newFeePct (contracts/v2/JobRegistry.sol#600)\n\t- (feeChanged_scope_1,validatorChanged) = _applyFeeConfiguration(newFee,newValidator,config.setFeePct,config.setValidatorRewardPct) (contracts/v2/JobRegistry.sol#1574-1579)\n\t\t- validatorRewardPct = newValidatorRewardPct (contracts/v2/JobRegistry.sol#605)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "ae910fd5986b12393611004818cbb19daaf506befdd8f7778ee20b7eaeeb597b"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry._setAgentMerkleRoot(bytes32) (contracts/v2/JobRegistry.sol#638-643):\n\tExternal calls:\n\t- identityRegistry.setAgentMerkleRoot(root) (contracts/v2/JobRegistry.sol#640)\n\tState variables written after the call(s):\n\t- _bumpAgentAuthCacheVersionInternal() (contracts/v2/JobRegistry.sol#641)\n\t\t- ++ agentAuthCacheVersion (contracts/v2/JobRegistry.sol#668)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 638,
+    "fingerprint": "b6280b550f50d2e9f534bf29828925831e6b6945ece3495c89a422f181b40bea"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in StakeManager._slash(address,StakeManager.Role,uint256,address,address[]) (contracts/v2/StakeManager.sol#2633-2753):\n\tExternal calls:\n\t- feePool.depositFee(employerShare) (contracts/v2/StakeManager.sol#2716)\n\tState variables written after the call(s):\n\t- operatorRewardPool += operatorShare (contracts/v2/StakeManager.sol#2730)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2633,
+    "fingerprint": "c0226a116188e6d1833ef96c12e2373b30ac5f4da836ab1789cf8fd6b5471d14"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ReentrantERC20.transfer(address,uint256) (contracts/legacy/ReentrantERC20.sol#38-41):\n\tExternal calls:\n\t- _reenter() (contracts/legacy/ReentrantERC20.sol#39)\n\t\t- manager.resolveDispute(jobId,IJobManager.DisputeOutcome.AgentWin) (contracts/legacy/ReentrantERC20.sol#33)\n\tState variables written after the call(s):\n\t- super.transfer(to,amount) (contracts/legacy/ReentrantERC20.sol#40)\n\t\t- _balances[from] = fromBalance - value (node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol#187)\n\t\t- _balances[to] += value (node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol#199)\n\t- super.transfer(to,amount) (contracts/legacy/ReentrantERC20.sol#40)\n\t\t- _totalSupply += value (node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol#179)\n\t\t- _totalSupply -= value (node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol#194)\n",
+    "uri": "contracts/legacy/ReentrantERC20.sol",
+    "startLine": 38,
+    "fingerprint": "c4078365af38b0f8535b6c9bc93f604a4a1696cef4be596456c05a0ccb873e03"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in CommitRevealEchidnaHarness.fuzzCommitAndReveal(uint256,bool,bytes32,bytes32) (contracts/test/CommitRevealEchidna.sol#24-46):\n\tExternal calls:\n\t- commitReveal.commit(jobId,commitHash) (contracts/test/CommitRevealEchidna.sol#36)\n\t- commitReveal.reveal(jobId,approve,salt,specHash) (contracts/test/CommitRevealEchidna.sol#42)\n\tState variables written after the call(s):\n\t- successfulReveals[jobId] += 1 (contracts/test/CommitRevealEchidna.sol#44)\n",
+    "uri": "contracts/test/CommitRevealEchidna.sol",
+    "startLine": 24,
+    "fingerprint": "e4b1d8667ec4134d0591c797adf0029b11c1fff130a99e31bc5216a3c1ebb140"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in ReentrantStakeManager.slash(address,uint256,address) (contracts/v2/mocks/ReentrantStakeManager.sol#200-216):\n\tExternal calls:\n\t- (ok,err) = address(validation).call(abi.encodeWithSelector(IValidationModule.finalize.selector,attackJobId)) (contracts/v2/mocks/ReentrantStakeManager.sol#203-205)\n\tState variables written after the call(s):\n\t- _stakes[user][Role.Validator] = st - amount (contracts/v2/mocks/ReentrantStakeManager.sol#214)\n\t- totalStakes[Role.Validator] -= amount (contracts/v2/mocks/ReentrantStakeManager.sol#215)\n",
+    "uri": "contracts/v2/mocks/ReentrantStakeManager.sol",
+    "startLine": 200,
+    "fingerprint": "e908c0763b218770f1805a513dc172cda2ff343ea4ae213884914bb11ccec6e5"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in CertificateNFT.mint(address,uint256,bytes32) (contracts/v2/CertificateNFT.sol#152-164):\n\tExternal calls:\n\t- _safeMint(to,tokenId) (contracts/v2/CertificateNFT.sol#161)\n\t\t- ERC721Utils.checkOnERC721Received(_msgSender(),address(0),to,tokenId,data) (node_modules/@openzeppelin/contracts/token/ERC721/ERC721.sol#289)\n\t\t- retval = IERC721Receiver(to).onERC721Received(operator,from,tokenId,data) (node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol#33-47)\n\tState variables written after the call(s):\n\t- tokenHashes[tokenId] = uriHash (contracts/v2/CertificateNFT.sol#162)\n",
+    "uri": "contracts/v2/CertificateNFT.sol",
+    "startLine": 152,
+    "fingerprint": "f155e15623341e7299e9b714caad68a5e66f16d7095d42010b7e3f4614b839ba"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry._setAgentRootNode(bytes32) (contracts/v2/JobRegistry.sol#631-636):\n\tExternal calls:\n\t- identityRegistry.setAgentRootNode(node) (contracts/v2/JobRegistry.sol#633)\n\tState variables written after the call(s):\n\t- _bumpAgentAuthCacheVersionInternal() (contracts/v2/JobRegistry.sol#634)\n\t\t- ++ agentAuthCacheVersion (contracts/v2/JobRegistry.sol#668)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 631,
+    "fingerprint": "f42ec1ea3d013799be288c15c5f248ae48d6297516f941dd33452d9afb79ac1a"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in SystemPause._setPausers(address) (contracts/v2/SystemPause.sol#313-378):\n\tExternal calls:\n\t- jobRegistry.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#318)\n\t- stakeManager.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#324)\n\t- validationModule.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#330)\n\t- disputeModule.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#336)\n\t- platformRegistry.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#342)\n\t- feePool.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#348)\n\t- reputationEngine.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#354)\n\t- arbitratorCommittee.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#360)\n\t- jobRegistry.setPauser(pauser) (contracts/v2/SystemPause.sol#366)\n\t- stakeManager.setPauser(pauser) (contracts/v2/SystemPause.sol#367)\n\t- validationModule.setPauser(pauser) (contracts/v2/SystemPause.sol#368)\n\t- disputeModule.setPauser(pauser) (contracts/v2/SystemPause.sol#369)\n\t- platformRegistry.setPauser(pauser) (contracts/v2/SystemPause.sol#370)\n\t- feePool.setPauser(pauser) (contracts/v2/SystemPause.sol#371)\n\t- reputationEngine.setPauser(pauser) (contracts/v2/SystemPause.sol#372)\n\t- arbitratorCommittee.setPauser(pauser) (contracts/v2/SystemPause.sol#373)\n\tState variables written after the call(s):\n\t- activePauser = pauser (contracts/v2/SystemPause.sol#375)\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 313,
+    "fingerprint": "fad741cab6bb8b4b0f1a45c7554b030945867793252cdcc88da88575f72ed32d"
+  },
+  {
+    "ruleId": "2-1-reentrancy-benign",
+    "message": "Reentrancy in JobRegistry.acknowledgeAndCreateJob(uint256,uint64,bytes32,string) (contracts/v2/JobRegistry.sol#1729-1737):\n\tExternal calls:\n\t- _acknowledge(msg.sender) (contracts/v2/JobRegistry.sol#1735)\n\t\t- ack = taxPolicy.acknowledgeFor(user) (contracts/v2/JobRegistry.sol#1332)\n\t- jobId = _createJob(reward,deadline,3,specHash,uri) (contracts/v2/JobRegistry.sol#1736)\n\t\t- stakeManager.lockReward(bytes32(jobId),msg.sender,reward + fee) (contracts/v2/JobRegistry.sol#1687)\n\tState variables written after the call(s):\n\t- jobId = _createJob(reward,deadline,3,specHash,uri) (contracts/v2/JobRegistry.sol#1736)\n\t\t- jobs[jobId] = Job({employer:msg.sender,agent:address(0),reward:uint128(reward),stake:jobStake,burnReceiptAmount:0,uriHash:uriHash,resultHash:bytes32(0),specHash:specHash,packedMetadata:_encodeMetadata(metadata)}) (contracts/v2/JobRegistry.sol#1673-1683)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1729,
+    "fingerprint": "fcf326870fb558fdeeb7c2f9a9d10e031e54649959bb8347c24abb2d815a9b4d"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in TimelockController.executeBatch(address[],uint256[],bytes[],bytes32,bytes32) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#384-406):\n\tExternal calls:\n\t- _execute(target,value,payload) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#402)\n\t\t- (success,returndata) = target.call{value: value}(data) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#412)\n\tEvent emitted after the call(s):\n\t- CallExecuted(id,i,target,value,payload) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#403)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/TimelockController.sol",
+    "startLine": 384,
+    "fingerprint": "019422b56006d5053ab318a9a536a37caf89b28c19ebda9636ec264f9976d17e"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in SimpleJobRegistry.finalizeJob(uint256,string) (contracts/test/SimpleJobRegistry.sol#144-152):\n\tExternal calls:\n\t- token.transfer(job.agent,job.reward) (contracts/test/SimpleJobRegistry.sol#150)\n\tEvent emitted after the call(s):\n\t- JobFinalized(jobId,resultRef) (contracts/test/SimpleJobRegistry.sol#151)\n",
+    "uri": "contracts/test/SimpleJobRegistry.sol",
+    "startLine": 144,
+    "fingerprint": "01f9da30b7262dc7b961c06b469bde10fc769e0b268311d505157bd550b2dd21"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in DisputeModule.slashValidator(address,uint256,address) (contracts/v2/modules/DisputeModule.sol#474-485):\n\tExternal calls:\n\t- sm.slash(juror,amount,employer) (contracts/v2/modules/DisputeModule.sol#482)\n\tEvent emitted after the call(s):\n\t- JurorSlashed(juror,amount,employer) (contracts/v2/modules/DisputeModule.sol#484)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 474,
+    "fingerprint": "05e55d25e6ac5341a7c455b0c25a45c366bf34d3af26bc1d5796db60ad5416ac"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in RandaoCoordinator.commit(bytes32,bytes32) (contracts/v2/RandaoCoordinator.sol#199-214):\n\tExternal calls:\n\t- ! token.transferFrom(msg.sender,address(this),currentDeposit) (contracts/v2/RandaoCoordinator.sol#208)\n\tEvent emitted after the call(s):\n\t- Committed(tag,msg.sender,commitment) (contracts/v2/RandaoCoordinator.sol#213)\n",
+    "uri": "contracts/v2/RandaoCoordinator.sol",
+    "startLine": 199,
+    "fingerprint": "062436fa28b20014d8d284a13e9d8c93ab10b78a9a33310a7aaad53cbb45babf"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.acknowledgeAndCancel(uint256) (contracts/v2/JobRegistry.sol#2506-2509):\n\tExternal calls:\n\t- _acknowledge(msg.sender) (contracts/v2/JobRegistry.sol#2507)\n\t\t- ack = taxPolicy.acknowledgeFor(user) (contracts/v2/JobRegistry.sol#1332)\n\t- cancelJob(jobId) (contracts/v2/JobRegistry.sol#2508)\n\t\t- stakeManager.refundEscrow(bytes32(jobId),job.employer,uint256(job.reward) + fee) (contracts/v2/JobRegistry.sol#2528-2532)\n\tEvent emitted after the call(s):\n\t- JobCancelled(jobId) (contracts/v2/JobRegistry.sol#2538)\n\t\t- cancelJob(jobId) (contracts/v2/JobRegistry.sol#2508)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2506,
+    "fingerprint": "166ddd591ee3aa0af9389e35b82bb678c117dd46b47a7423e48bccd0ee1e6086"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495):\n\tExternal calls:\n\t- stakeManager.finalizeJobFundsWithPct(jobKey,employerParam,payee,agentPct,rewardAfterValidator,validatorReward,fee,pool,isGov) (contracts/v2/JobRegistry.sol#2356-2366)\n\t- stakeManager.distributeValidatorRewards(jobKey,validatorReward) (contracts/v2/JobRegistry.sol#2370-2373)\n\t- stakeManager.releaseReward(jobKey,job.employer,payee,validatorReward,true) (contracts/v2/JobRegistry.sol#2375-2381)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),treasury,validators) (contracts/v2/JobRegistry.sol#2386-2392)\n\t- stakeManager.releaseStake(job.agent,uint256(job.stake)) (contracts/v2/JobRegistry.sol#2394)\n\t- reputationEngine.onFinalize(job.agent,true,payout,completionTime) (contracts/v2/JobRegistry.sol#2416-2421)\n\t- reputationEngine.rewardValidator(val,agentGain) (contracts/v2/JobRegistry.sol#2426)\n\t- certificateNFT.mint(job.agent,jobId,job.uriHash) (contracts/v2/JobRegistry.sol#2435)\n\t- stakeManager.redistributeEscrow(jobKey,recipient,uint256(job.reward) + fee_scope_0,validators) (contracts/v2/JobRegistry.sol#2448-2453)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),recipient,validators) (contracts/v2/JobRegistry.sol#2456-2462)\n\t- reputationEngine.onFinalize(job.agent,false,0,0) (contracts/v2/JobRegistry.sol#2466)\n\t- auditModule.onJobFinalized(jobId,job.agent,success,job.resultHash) (contracts/v2/JobRegistry.sol#2476-2479)\n\tEvent emitted after the call(s):\n\t- AuditModuleCallbackFailed(jobId,err) (contracts/v2/JobRegistry.sol#2478)\n\t- GovernanceFinalized(jobId,msg.sender,fundsRedirected) (contracts/v2/JobRegistry.sol#2482)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "1f087b8d5edeb71784467c13ab6bbcd501a5b92746a6370a7fdc46c6d223ff4e"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in PlatformIncentives.acknowledgeStakeAndActivate(uint256) (contracts/v2/PlatformIncentives.sol#126-144):\n\tExternal calls:\n\t- IJobRegistryAck(registry).acknowledgeFor(msg.sender) (contracts/v2/PlatformIncentives.sol#129)\n\t- stakeManager.depositStakeFor(msg.sender,IStakeManager.Role.Platform,amount) (contracts/v2/PlatformIncentives.sol#133-137)\n\t- platformRegistry.registerFor(msg.sender) (contracts/v2/PlatformIncentives.sol#141)\n\t- jobRouter.registerFor(msg.sender) (contracts/v2/PlatformIncentives.sol#142)\n\tEvent emitted after the call(s):\n\t- Activated(msg.sender,amount) (contracts/v2/PlatformIncentives.sol#143)\n",
+    "uri": "contracts/v2/PlatformIncentives.sol",
+    "startLine": 126,
+    "fingerprint": "224744d7f3c86fc7409d402f56b349756b82496980e9c8dd26aad4a4ed35317f"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n\t\t- identityRegistry.setAgentRootNode(node) (contracts/v2/JobRegistry.sol#633)\n\t- _setAgentMerkleRoot(config.agentMerkleRoot) (contracts/v2/JobRegistry.sol#1545)\n\t\t- identityRegistry.setAgentMerkleRoot(root) (contracts/v2/JobRegistry.sol#640)\n\t- _setValidatorRootNode(config.validatorRootNode) (contracts/v2/JobRegistry.sol#1551)\n\t\t- identityRegistry.setClubRootNode(node) (contracts/v2/JobRegistry.sol#648)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#649)\n\tEvent emitted after the call(s):\n\t- ValidatorRootNodeUpdated(node) (contracts/v2/JobRegistry.sol#650)\n\t\t- _setValidatorRootNode(config.validatorRootNode) (contracts/v2/JobRegistry.sol#1551)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "243c6d54fddf4e61e8c1f71abd7093fd1d0c388978fb794d5ec42059c58fb352"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.acknowledgeAndSubmit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#2004-2013):\n\tExternal calls:\n\t- _acknowledge(msg.sender) (contracts/v2/JobRegistry.sol#2011)\n\t\t- ack = taxPolicy.acknowledgeFor(user) (contracts/v2/JobRegistry.sol#1332)\n\t- submit(jobId,resultHash,resultURI,subdomain,proof) (contracts/v2/JobRegistry.sol#2012)\n\t\t- validationModule.start(jobId,entropy) (contracts/v2/JobRegistry.sol#357)\n\t\t- (authorized,node,viaWrapper,viaMerkle) = identityRegistry.verifyAgent(msg.sender,subdomain,proof) (contracts/v2/JobRegistry.sol#1953-1954)\n\tEvent emitted after the call(s):\n\t- AgentIdentityVerified(msg.sender,node,subdomain,viaWrapper,viaMerkle) (contracts/v2/JobRegistry.sol#1956-1962)\n\t\t- submit(jobId,resultHash,resultURI,subdomain,proof) (contracts/v2/JobRegistry.sol#2012)\n\t- AgentSubdomainUpdated(msg.sender,subdomain) (contracts/v2/JobRegistry.sol#1965)\n\t\t- submit(jobId,resultHash,resultURI,subdomain,proof) (contracts/v2/JobRegistry.sol#2012)\n\t- JobSubmitted(jobId,msg.sender,resultHash,resultURI,subdomain) (contracts/v2/JobRegistry.sol#1978)\n\t\t- submit(jobId,resultHash,resultURI,subdomain,proof) (contracts/v2/JobRegistry.sol#2012)\n\t- ResultSubmitted(jobId,msg.sender,resultHash,resultURI,subdomain) (contracts/v2/JobRegistry.sol#1977)\n\t\t- submit(jobId,resultHash,resultURI,subdomain,proof) (contracts/v2/JobRegistry.sol#2012)\n\t- ValidationStartPending(jobId) (contracts/v2/JobRegistry.sol#1996)\n\t\t- submit(jobId,resultHash,resultURI,subdomain,proof) (contracts/v2/JobRegistry.sol#2012)\n\t- ValidationStartTriggered(jobId) (contracts/v2/JobRegistry.sol#358)\n\t\t- submit(jobId,resultHash,resultURI,subdomain,proof) (contracts/v2/JobRegistry.sol#2012)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2004,
+    "fingerprint": "289d8b2564efd60712b639521ad5b0efb78f1edd074a1b389f08105b6dabd56a"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._setIdentityRegistry(IIdentityRegistry) (contracts/v2/JobRegistry.sol#490-500):\n\tExternal calls:\n\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\tEvent emitted after the call(s):\n\t- IdentityRegistryUpdated(address(registry)) (contracts/v2/JobRegistry.sol#498)\n\t- ModuleUpdated(IdentityRegistry,address(registry)) (contracts/v2/JobRegistry.sol#499)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 490,
+    "fingerprint": "2c14894bdbf55e01bca9bf3426d11edea4ac49bd424ecffd8cf86927e034a85e"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.acknowledgeAndFinalize(uint256) (contracts/v2/JobRegistry.sol#2499-2502):\n\tExternal calls:\n\t- _acknowledge(msg.sender) (contracts/v2/JobRegistry.sol#2500)\n\t\t- ack = taxPolicy.acknowledgeFor(user) (contracts/v2/JobRegistry.sol#1332)\n\t- finalize(jobId) (contracts/v2/JobRegistry.sol#2501)\n\t\t- stakeManager.finalizeJobFundsWithPct(jobKey,employerParam,payee,agentPct,rewardAfterValidator,validatorReward,fee,pool,isGov) (contracts/v2/JobRegistry.sol#2356-2366)\n\t\t- stakeManager.distributeValidatorRewards(jobKey,validatorReward) (contracts/v2/JobRegistry.sol#2370-2373)\n\t\t- stakeManager.releaseReward(jobKey,job.employer,payee,validatorReward,true) (contracts/v2/JobRegistry.sol#2375-2381)\n\t\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),treasury,validators) (contracts/v2/JobRegistry.sol#2386-2392)\n\t\t- stakeManager.releaseStake(job.agent,uint256(job.stake)) (contracts/v2/JobRegistry.sol#2394)\n\t\t- reputationEngine.onFinalize(job.agent,true,payout,completionTime) (contracts/v2/JobRegistry.sol#2416-2421)\n\t\t- reputationEngine.rewardValidator(val,agentGain) (contracts/v2/JobRegistry.sol#2426)\n\t\t- certificateNFT.mint(job.agent,jobId,job.uriHash) (contracts/v2/JobRegistry.sol#2435)\n\t\t- stakeManager.redistributeEscrow(jobKey,recipient,uint256(job.reward) + fee_scope_0,validators) (contracts/v2/JobRegistry.sol#2448-2453)\n\t\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),recipient,validators) (contracts/v2/JobRegistry.sol#2456-2462)\n\t\t- reputationEngine.onFinalize(job.agent,false,0,0) (contracts/v2/JobRegistry.sol#2466)\n\t\t- auditModule.onJobFinalized(jobId,job.agent,success,job.resultHash) (contracts/v2/JobRegistry.sol#2476-2479)\n\tEvent emitted after the call(s):\n\t- AuditModuleCallbackFailed(jobId,err) (contracts/v2/JobRegistry.sol#2478)\n\t\t- finalize(jobId) (contracts/v2/JobRegistry.sol#2501)\n\t- BurnDiscrepancy(jobId,job.burnReceiptAmount,expectedBurn) (contracts/v2/JobRegistry.sol#2400-2404)\n\t\t- finalize(jobId) (contracts/v2/JobRegistry.sol#2501)\n\t- GovernanceFinalized(jobId,msg.sender,fundsRedirected) (contracts/v2/JobRegistry.sol#2482)\n\t\t- finalize(jobId) (contracts/v2/JobRegistry.sol#2501)\n\t- JobFinalized(jobId,job.agent) (contracts/v2/JobRegistry.sol#2474)\n\t\t- finalize(jobId) (contracts/v2/JobRegistry.sol#2501)\n\t- JobPayout(jobId,job.agent,rewardAfterValidator,bonus,fee) (contracts/v2/JobRegistry.sol#2438)\n\t\t- finalize(jobId) (contracts/v2/JobRegistry.sol#2501)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2499,
+    "fingerprint": "2d7e8a83b87e421c06fce9168dc098ac7a4826f9f709b662d92002f0914833a4"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in DisputeModule._resolve(uint256,bool,address) (contracts/v2/modules/DisputeModule.sol#515-567):\n\tExternal calls:\n\t- jobRegistry.resolveDispute(jobId,employerWins) (contracts/v2/modules/DisputeModule.sol#531)\n\t- sm.payDisputeFee(recipient,fee) (contracts/v2/modules/DisputeModule.sol#535)\n\t- sm.slash(validators[i_scope_1],fee,employer,participants) (contracts/v2/modules/DisputeModule.sol#561)\n\tEvent emitted after the call(s):\n\t- DisputeResolved(jobId,resolver,employerWins) (contracts/v2/modules/DisputeModule.sol#566)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 515,
+    "fingerprint": "2e3ca853267d37a3326afa22a9d02acf3cbfb57965037e230ea5d21ea717f48b"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._setValidatorMerkleRoot(bytes32) (contracts/v2/JobRegistry.sol#653-659):\n\tExternal calls:\n\t- identityRegistry.setValidatorMerkleRoot(root) (contracts/v2/JobRegistry.sol#656)\n\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#657)\n\tEvent emitted after the call(s):\n\t- ValidatorMerkleRootUpdated(root) (contracts/v2/JobRegistry.sol#658)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 653,
+    "fingerprint": "31ae9b4cc5be347deca42f0a07af31baee59b4723db932ba18544d5f4de23f42"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.acknowledgeAndDispute(uint256,bytes32,string) (contracts/v2/JobRegistry.sol#2206-2218):\n\tExternal calls:\n\t- _acknowledge(msg.sender) (contracts/v2/JobRegistry.sol#2215)\n\t\t- ack = taxPolicy.acknowledgeFor(user) (contracts/v2/JobRegistry.sol#1332)\n\t- _dispute(jobId,evidenceHash,reason) (contracts/v2/JobRegistry.sol#2217)\n\t\t- disputeModule.raiseDispute(jobId,msg.sender,evidenceHash,reason) (contracts/v2/JobRegistry.sol#2249)\n\tEvent emitted after the call(s):\n\t- JobDisputed(jobId,msg.sender) (contracts/v2/JobRegistry.sol#2251)\n\t\t- _dispute(jobId,evidenceHash,reason) (contracts/v2/JobRegistry.sol#2217)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2206,
+    "fingerprint": "3f6a5feaa44c486e0b53c03df64040991816221e8c2ce79345eaab07039eeade"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in DisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/DisputeModule.sol#303-342):\n\tExternal calls:\n\t- sm.lockDisputeFee(claimant,disputeFee) (contracts/v2/modules/DisputeModule.sol#325)\n\t- sm.recordDispute() (contracts/v2/modules/DisputeModule.sol#327)\n\tEvent emitted after the call(s):\n\t- DisputeRaised(jobId,claimant,evidenceHash,reason) (contracts/v2/modules/DisputeModule.sol#337)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 303,
+    "fingerprint": "42abc7f6c29dbd169d04f38042408614242d9a300fc7dffdb0b4e7a8500b184e"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.acknowledgeAndCreateJob(uint256,uint64,bytes32,string) (contracts/v2/JobRegistry.sol#1729-1737):\n\tExternal calls:\n\t- _acknowledge(msg.sender) (contracts/v2/JobRegistry.sol#1735)\n\t\t- ack = taxPolicy.acknowledgeFor(user) (contracts/v2/JobRegistry.sol#1332)\n\t- jobId = _createJob(reward,deadline,3,specHash,uri) (contracts/v2/JobRegistry.sol#1736)\n\t\t- stakeManager.lockReward(bytes32(jobId),msg.sender,reward + fee) (contracts/v2/JobRegistry.sol#1687)\n\tEvent emitted after the call(s):\n\t- JobCreated(jobId,msg.sender,address(0),reward,uint256(jobStake),fee,specHash,uri) (contracts/v2/JobRegistry.sol#1690-1699)\n\t\t- jobId = _createJob(reward,deadline,3,specHash,uri) (contracts/v2/JobRegistry.sol#1736)\n\t- JobFunded(jobId,msg.sender,reward,fee) (contracts/v2/JobRegistry.sol#1688)\n\t\t- jobId = _createJob(reward,deadline,3,specHash,uri) (contracts/v2/JobRegistry.sol#1736)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1729,
+    "fingerprint": "4fdad5812d240aa9713619548cc938b4e43eb1192bd06dcf5f155e39380f5591"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250):\n\tExternal calls:\n\t- (authorized,None,None,None) = identityRegistry.verifyValidator(candidate,subdomain,proof) (contracts/v2/ValidationModule.sol#1052-1056)\n\t- (authorized_scope_3,None,None,None) = identityRegistry.verifyValidator(candidate_scope_1,subdomain_scope_4,proof_scope_6) (contracts/v2/ValidationModule.sol#1135-1139)\n\t- stakeManager.lockValidatorStake(jobId,val_scope_12,stakeAmount_scope_13,lockTime) (contracts/v2/ValidationModule.sol#1238)\n\tEvent emitted after the call(s):\n\t- ValidatorsSelected(jobId,selected) (contracts/v2/ValidationModule.sol#1248)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "5018f6fb65a6c209862d6a4628d799fa5f8adddee4d5b409105d1432db1e3502"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.acknowledgeAndCreateJobWithAgentTypes(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1739-1748):\n\tExternal calls:\n\t- _acknowledge(msg.sender) (contracts/v2/JobRegistry.sol#1746)\n\t\t- ack = taxPolicy.acknowledgeFor(user) (contracts/v2/JobRegistry.sol#1332)\n\t- jobId = _createJob(reward,deadline,agentTypes,specHash,uri) (contracts/v2/JobRegistry.sol#1747)\n\t\t- stakeManager.lockReward(bytes32(jobId),msg.sender,reward + fee) (contracts/v2/JobRegistry.sol#1687)\n\tEvent emitted after the call(s):\n\t- JobCreated(jobId,msg.sender,address(0),reward,uint256(jobStake),fee,specHash,uri) (contracts/v2/JobRegistry.sol#1690-1699)\n\t\t- jobId = _createJob(reward,deadline,agentTypes,specHash,uri) (contracts/v2/JobRegistry.sol#1747)\n\t- JobFunded(jobId,msg.sender,reward,fee) (contracts/v2/JobRegistry.sol#1688)\n\t\t- jobId = _createJob(reward,deadline,agentTypes,specHash,uri) (contracts/v2/JobRegistry.sol#1747)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1739,
+    "fingerprint": "576f666950b05cbedf8ababa738ffb677993aae814f3ceb9873130455e2515aa"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\tEvent emitted after the call(s):\n\t- AcknowledgerUpdated(address(_stakeMgr),true) (contracts/v2/JobRegistry.sol#536)\n\t\t- _setStakeManager(IStakeManager(config.stakeManager)) (contracts/v2/JobRegistry.sol#1475)\n\t- AuditModuleUpdated(address(module)) (contracts/v2/JobRegistry.sol#521)\n\t\t- _setAuditModule(IAuditModule(config.auditModule)) (contracts/v2/JobRegistry.sol#1469)\n\t- AuditModuleUpdated(address(module)) (contracts/v2/JobRegistry.sol#527)\n\t\t- _setAuditModule(IAuditModule(config.auditModule)) (contracts/v2/JobRegistry.sol#1469)\n\t- CertificateNFTUpdated(address(_certNFT)) (contracts/v2/JobRegistry.sol#553)\n\t\t- _setCertificateNFT(ICertificateNFT(config.certificateNFT)) (contracts/v2/JobRegistry.sol#1487)\n\t- DisputeModuleUpdated(address(module)) (contracts/v2/JobRegistry.sol#506)\n\t\t- _setDisputeModule(IDisputeModule(config.disputeModule)) (contracts/v2/JobRegistry.sol#1457)\n\t- ExpirationGracePeriodUpdated(period) (contracts/v2/JobRegistry.sol#628)\n\t\t- _setExpirationGracePeriod(config.expirationGracePeriod) (contracts/v2/JobRegistry.sol#1534)\n\t- FeePoolUpdated(address(_feePool)) (contracts/v2/JobRegistry.sol#562)\n\t\t- _setFeePool(IFeePool(config.feePool)) (contracts/v2/JobRegistry.sol#1493)\n\t- JobParametersUpdated(0,jobStake,maxReward,maxJobDuration,minAgentStake) (contracts/v2/JobRegistry.sol#613)\n\t\t- _setMaxJobReward(config.maxJobReward) (contracts/v2/JobRegistry.sol#1519)\n\t- JobParametersUpdated(0,stake,maxJobReward,maxJobDuration,minAgentStake) (contracts/v2/JobRegistry.sol#582)\n\t\t- _setJobStake(config.jobStake) (contracts/v2/JobRegistry.sol#1509)\n\t- JobParametersUpdated(0,jobStake,maxJobReward,limit,minAgentStake) (contracts/v2/JobRegistry.sol#618)\n\t\t- _setJobDurationLimit(config.jobDurationLimit) (contracts/v2/JobRegistry.sol#1524)\n\t- JobParametersUpdated(0,jobStake,maxJobReward,maxJobDuration,stake) (contracts/v2/JobRegistry.sol#588)\n\t\t- _setMinAgentStake(config.minAgentStake) (contracts/v2/JobRegistry.sol#1514)\n\t- MaxActiveJobsPerAgentUpdated(limit) (contracts/v2/JobRegistry.sol#623)\n\t\t- _setMaxActiveJobsPerAgent(config.maxActiveJobsPerAgent) (contracts/v2/JobRegistry.sol#1529)\n\t- ModuleUpdated(AuditModule,address(module)) (contracts/v2/JobRegistry.sol#522)\n\t\t- _setAuditModule(IAuditModule(config.auditModule)) (contracts/v2/JobRegistry.sol#1469)\n\t- ModuleUpdated(FeePool,address(_feePool)) (contracts/v2/JobRegistry.sol#563)\n\t\t- _setFeePool(IFeePool(config.feePool)) (contracts/v2/JobRegistry.sol#1493)\n\t- ModuleUpdated(DisputeModule,address(module)) (contracts/v2/JobRegistry.sol#507)\n\t\t- _setDisputeModule(IDisputeModule(config.disputeModule)) (contracts/v2/JobRegistry.sol#1457)\n\t- ModuleUpdated(ReputationEngine,address(_reputation)) (contracts/v2/JobRegistry.sol#546)\n\t\t- _setReputationEngine(IReputationEngine(config.reputationModule)) (contracts/v2/JobRegistry.sol#1481)\n\t- ModuleUpdated(TaxPolicy,address(_policy)) (contracts/v2/JobRegistry.sol#571)\n\t\t- _setTaxPolicy(ITaxPolicy(config.taxPolicy)) (contracts/v2/JobRegistry.sol#1499)\n\t- ModuleUpdated(CertificateNFT,address(_certNFT)) (contracts/v2/JobRegistry.sol#554)\n\t\t- _setCertificateNFT(ICertificateNFT(config.certificateNFT)) (contracts/v2/JobRegistry.sol#1487)\n\t- ModuleUpdated(ValidationModule,address(module)) (contracts/v2/JobRegistry.sol#515)\n\t\t- _setValidationModule(IValidationModule(config.validationModule)) (contracts/v2/JobRegistry.sol#1463)\n\t- ModuleUpdated(StakeManager,address(_stakeMgr)) (contracts/v2/JobRegistry.sol#538)\n\t\t- _setStakeManager(IStakeManager(config.stakeManager)) (contracts/v2/JobRegistry.sol#1475)\n\t- ModuleUpdated(AuditModule,address(module)) (contracts/v2/JobRegistry.sol#528)\n\t\t- _setAuditModule(IAuditModule(config.auditModule)) (contracts/v2/JobRegistry.sol#1469)\n\t- ReputationEngineUpdated(address(_reputation)) (contracts/v2/JobRegistry.sol#545)\n\t\t- _setReputationEngine(IReputationEngine(config.reputationModule)) (contracts/v2/JobRegistry.sol#1481)\n\t- StakeManagerUpdated(address(_stakeMgr)) (contracts/v2/JobRegistry.sol#537)\n\t\t- _setStakeManager(IStakeManager(config.stakeManager)) (contracts/v2/JobRegistry.sol#1475)\n\t- TaxPolicyUpdated(address(_policy),_policy.policyVersion()) (contracts/v2/JobRegistry.sol#570)\n\t\t- _setTaxPolicy(ITaxPolicy(config.taxPolicy)) (contracts/v2/JobRegistry.sol#1499)\n\t- TreasuryUpdated(_treasury) (contracts/v2/JobRegistry.sol#577)\n\t\t- _setTreasury(config.treasury) (contracts/v2/JobRegistry.sol#1504)\n\t- ValidationModuleUpdated(address(module)) (contracts/v2/JobRegistry.sol#514)\n\t\t- _setValidationModule(IValidationModule(config.validationModule)) (contracts/v2/JobRegistry.sol#1463)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "59301bc651088286f9a4dba1ba5d00256f422c7d2cfbe70ee446ec705e95b3c7"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in ModuleInstaller.replaceValidationModule(JobRegistry,address,address[]) (contracts/v2/ModuleInstaller.sol#160-226):\n\tExternal calls:\n\t- jobRegistry.setModules(IValidationModule(newValidation),stake,rep,dispute,nft,feePool,ackModules) (contracts/v2/ModuleInstaller.sol#173-181)\n\t- _callOptional(newValidation,abi.encodeWithSignature(setJobRegistry(address),address(jobRegistry))) (contracts/v2/ModuleInstaller.sol#184-190)\n\t\t- (ok,None) = target.call(data) (contracts/v2/ModuleInstaller.sol#229)\n\t- _callOptional(newValidation,abi.encodeWithSignature(setStakeManager(address),address(stake))) (contracts/v2/ModuleInstaller.sol#191-197)\n\t\t- (ok,None) = target.call(data) (contracts/v2/ModuleInstaller.sol#229)\n\t- _callOptional(newValidation,abi.encodeWithSignature(setReputationEngine(address),address(rep))) (contracts/v2/ModuleInstaller.sol#198-204)\n\t\t- (ok,None) = target.call(data) (contracts/v2/ModuleInstaller.sol#229)\n\t- _callOptional(newValidation,abi.encodeWithSignature(setIdentityRegistry(address),address(identity))) (contracts/v2/ModuleInstaller.sol#206-212)\n\t\t- (ok,None) = target.call(data) (contracts/v2/ModuleInstaller.sol#229)\n\t- _callOptional(newValidation,abi.encodeWithSignature(transferOwnership(address),moduleOwner)) (contracts/v2/ModuleInstaller.sol#216-222)\n\t\t- (ok,None) = target.call(data) (contracts/v2/ModuleInstaller.sol#229)\n\t- jobRegistry.setGovernance(moduleOwner) (contracts/v2/ModuleInstaller.sol#224)\n\tEvent emitted after the call(s):\n\t- ValidationModuleMigrated(newValidation) (contracts/v2/ModuleInstaller.sol#225)\n",
+    "uri": "contracts/v2/ModuleInstaller.sol",
+    "startLine": 160,
+    "fingerprint": "5d8ffc9407024d4c8f332f4ed81faa998804d2904a75ddf59803c7aafe28dd67"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in MockJobRegistry._dispute(uint256,bytes32,string) (contracts/legacy/MockV2.sol#737-752):\n\tExternal calls:\n\t- disputeModule.raiseDispute(jobId,msg.sender,evidenceHash,reason) (contracts/legacy/MockV2.sol#749)\n\tEvent emitted after the call(s):\n\t- JobDisputed(jobId,msg.sender) (contracts/legacy/MockV2.sol#751)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 737,
+    "fingerprint": "61cac028747e2b9685d4a500c6f9110309993b82345dec7552e580d2b329ff54"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._setValidatorRootNode(bytes32) (contracts/v2/JobRegistry.sol#645-651):\n\tExternal calls:\n\t- identityRegistry.setClubRootNode(node) (contracts/v2/JobRegistry.sol#648)\n\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#649)\n\tEvent emitted after the call(s):\n\t- ValidatorRootNodeUpdated(node) (contracts/v2/JobRegistry.sol#650)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 645,
+    "fingerprint": "6747bd316c26129cd05417965c200178a1cee99d559c409d6960341ed693f58b"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in AuditModule.recordAudit(uint256,bool,string) (contracts/v2/AuditModule.sol#133-152):\n\tExternal calls:\n\t- reputationEngine.subtract(record.agent,auditPenalty) (contracts/v2/AuditModule.sol#149)\n\tEvent emitted after the call(s):\n\t- AuditPenaltyApplied(jobId,record.agent,auditPenalty) (contracts/v2/AuditModule.sol#150)\n",
+    "uri": "contracts/v2/AuditModule.sol",
+    "startLine": 133,
+    "fingerprint": "6abc032054ca025b902348494516b7200870e9ea2b23c585cdf5279e8e7e679a"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495):\n\tExternal calls:\n\t- stakeManager.finalizeJobFundsWithPct(jobKey,employerParam,payee,agentPct,rewardAfterValidator,validatorReward,fee,pool,isGov) (contracts/v2/JobRegistry.sol#2356-2366)\n\t- stakeManager.distributeValidatorRewards(jobKey,validatorReward) (contracts/v2/JobRegistry.sol#2370-2373)\n\t- stakeManager.releaseReward(jobKey,job.employer,payee,validatorReward,true) (contracts/v2/JobRegistry.sol#2375-2381)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),treasury,validators) (contracts/v2/JobRegistry.sol#2386-2392)\n\t- stakeManager.releaseStake(job.agent,uint256(job.stake)) (contracts/v2/JobRegistry.sol#2394)\n\tEvent emitted after the call(s):\n\t- BurnDiscrepancy(jobId,job.burnReceiptAmount,expectedBurn) (contracts/v2/JobRegistry.sol#2400-2404)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "6b372d2572741184dd76740b086e1eb6b7fe91aa5f34d126641c5c887c298b89"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in KlerosDisputeModule.raiseGovernanceDispute(uint256,string) (contracts/v2/modules/KlerosDisputeModule.sol#123-134):\n\tExternal calls:\n\t- IArbitrationService(arbitrator).createDispute(jobId,address(this),payload) (contracts/v2/modules/KlerosDisputeModule.sol#131)\n\tEvent emitted after the call(s):\n\t- DisputeRaised(jobId,address(this),payload,reason) (contracts/v2/modules/KlerosDisputeModule.sol#133)\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 123,
+    "fingerprint": "6faf19dd31949f9b80392e70b7e173ef0567efd1156ff651d3238de055a3cd00"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in MockFeePool.reward(address,uint256) (contracts/v2/mocks/RewardEngineMBMocks.sol#29-34):\n\tExternal calls:\n\t- require(bool,string)(token.transfer(to,amount),MockFeePool: transfer failed) (contracts/v2/mocks/RewardEngineMBMocks.sol#32)\n\tEvent emitted after the call(s):\n\t- Rewarded(to,amount) (contracts/v2/mocks/RewardEngineMBMocks.sol#33)\n",
+    "uri": "contracts/v2/mocks/RewardEngineMBMocks.sol",
+    "startLine": 29,
+    "fingerprint": "6fe5f8c2e830e8eb9e76d2767715cc0124bd52a60ba459a2512c4b08c6e41b18"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n\t\t- identityRegistry.setAgentRootNode(node) (contracts/v2/JobRegistry.sol#633)\n\tEvent emitted after the call(s):\n\t- AgentAuthCacheVersionBumped(agentAuthCacheVersion) (contracts/v2/JobRegistry.sol#670)\n\t\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n\t- AgentRootNodeUpdated(node) (contracts/v2/JobRegistry.sol#635)\n\t\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "7005a941565a658a9ee88dddb2cf3966fb8882efe4ff6709bebbd46d6e6330af"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in KlerosDisputeModule.resolveDispute(uint256,bool) (contracts/v2/modules/KlerosDisputeModule.sol#137-144):\n\tExternal calls:\n\t- jobRegistry.resolveDispute(jobId,employerWins) (contracts/v2/modules/KlerosDisputeModule.sol#142)\n\tEvent emitted after the call(s):\n\t- DisputeResolved(jobId,employerWins) (contracts/v2/modules/KlerosDisputeModule.sol#143)\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 137,
+    "fingerprint": "719621f182d0963eb5be8d3ee819357617c3dede1538832afbfc89acef647091"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in SimpleJobRegistry.createJob(uint256,uint64,bytes32,string) (contracts/test/SimpleJobRegistry.sol#92-114):\n\tExternal calls:\n\t- token.transferFrom(msg.sender,address(this),reward) (contracts/test/SimpleJobRegistry.sol#99)\n\tEvent emitted after the call(s):\n\t- JobCreated(jobId,msg.sender,address(0),reward,0,0,specHash,uri) (contracts/test/SimpleJobRegistry.sol#113)\n",
+    "uri": "contracts/test/SimpleJobRegistry.sol",
+    "startLine": 92,
+    "fingerprint": "7529ca80e5640ea2a6aa9106ffcc9a54b2d7fc9438277a78cf640ffac5d7bcbc"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in ModuleInstaller.initialize(JobRegistry,StakeManager,ValidationModule,IReputationEngine,IDisputeModule,ICertificateNFT,PlatformIncentives,IPlatformRegistryFull,IJobRouter,IFeePool,ITaxPolicy,IIdentityRegistry,bytes32,bytes32,bytes32,bytes32,address[]) (contracts/v2/ModuleInstaller.sol#72-152):\n\tExternal calls:\n\t- jobRegistry.setModules(validationModule,IStakeManager(address(stakeManager)),reputationEngine,disputeModule,certificateNFT,feePool,_ackModules) (contracts/v2/ModuleInstaller.sol#94-102)\n\t- jobRegistry.setTaxPolicy(taxPolicy) (contracts/v2/ModuleInstaller.sol#104)\n\t- disputeModule.setTaxPolicy(taxPolicy) (contracts/v2/ModuleInstaller.sol#105)\n\t- jobRegistry.setIdentityRegistry(identityRegistry) (contracts/v2/ModuleInstaller.sol#107)\n\t- validationModule.setIdentityRegistry(identityRegistry) (contracts/v2/ModuleInstaller.sol#108)\n\t- identityRegistry.setAgentRootNode(agentRootNode) (contracts/v2/ModuleInstaller.sol#109)\n\t- identityRegistry.setClubRootNode(clubRootNode) (contracts/v2/ModuleInstaller.sol#110)\n\t- identityRegistry.setAgentMerkleRoot(agentMerkleRoot) (contracts/v2/ModuleInstaller.sol#111)\n\t- identityRegistry.setValidatorMerkleRoot(validatorMerkleRoot) (contracts/v2/ModuleInstaller.sol#112)\n\t- stakeManager.setModules(address(jobRegistry),address(disputeModule)) (contracts/v2/ModuleInstaller.sol#113)\n\t- platformIncentives.setModules(IStakeManager(address(stakeManager)),platformRegistry,jobRouter) (contracts/v2/ModuleInstaller.sol#114-118)\n\t- platformRegistry.setRegistrar(address(platformIncentives),true) (contracts/v2/ModuleInstaller.sol#119)\n\t- jobRouter.setRegistrar(address(platformIncentives),true) (contracts/v2/ModuleInstaller.sol#120)\n\t- jobRegistry.setGovernance(moduleOwner) (contracts/v2/ModuleInstaller.sol#123)\n\t- stakeManager.setGovernance(moduleOwner) (contracts/v2/ModuleInstaller.sol#124)\n\t- IOwnable(address(validationModule)).transferOwnership(moduleOwner) (contracts/v2/ModuleInstaller.sol#125)\n\t- IOwnable(address(reputationEngine)).transferOwnership(moduleOwner) (contracts/v2/ModuleInstaller.sol#126)\n\t- IOwnable(address(disputeModule)).transferOwnership(moduleOwner) (contracts/v2/ModuleInstaller.sol#127)\n\t- IOwnable(address(certificateNFT)).transferOwnership(moduleOwner) (contracts/v2/ModuleInstaller.sol#128)\n\t- platformIncentives.transferOwnership(moduleOwner) (contracts/v2/ModuleInstaller.sol#129)\n\t- IOwnable(address(platformRegistry)).transferOwnership(moduleOwner) (contracts/v2/ModuleInstaller.sol#130)\n\t- IOwnable(address(jobRouter)).transferOwnership(moduleOwner) (contracts/v2/ModuleInstaller.sol#131)\n\t- IOwnable(address(feePool)).transferOwnership(moduleOwner) (contracts/v2/ModuleInstaller.sol#132)\n\t- IOwnable(address(taxPolicy)).transferOwnership(moduleOwner) (contracts/v2/ModuleInstaller.sol#134)\n\t- IOwnable(address(identityRegistry)).transferOwnership(moduleOwner) (contracts/v2/ModuleInstaller.sol#136)\n\tEvent emitted after the call(s):\n\t- ModulesInstalled(address(jobRegistry),address(stakeManager),address(validationModule),address(reputationEngine),address(disputeModule),address(certificateNFT),address(platformIncentives),address(platformRegistry),address(jobRouter),address(feePool),address(taxPolicy),address(identityRegistry)) (contracts/v2/ModuleInstaller.sol#138-151)\n",
+    "uri": "contracts/v2/ModuleInstaller.sol",
+    "startLine": 72,
+    "fingerprint": "78e663afffbdb71feedf052cfc507c7fcf4f714ac9acf9d6aad288ad5e23a7b1"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n\t\t- identityRegistry.setAgentRootNode(node) (contracts/v2/JobRegistry.sol#633)\n\t- _setAgentMerkleRoot(config.agentMerkleRoot) (contracts/v2/JobRegistry.sol#1545)\n\t\t- identityRegistry.setAgentMerkleRoot(root) (contracts/v2/JobRegistry.sol#640)\n\tEvent emitted after the call(s):\n\t- AgentAuthCacheVersionBumped(agentAuthCacheVersion) (contracts/v2/JobRegistry.sol#670)\n\t\t- _setAgentMerkleRoot(config.agentMerkleRoot) (contracts/v2/JobRegistry.sol#1545)\n\t- AgentMerkleRootUpdated(root) (contracts/v2/JobRegistry.sol#642)\n\t\t- _setAgentMerkleRoot(config.agentMerkleRoot) (contracts/v2/JobRegistry.sol#1545)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "79418057b20d30e0ff5036ab5c46acff3f95b37bc0da37e0f0afaa26908077b1"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._dispute(uint256,bytes32,string) (contracts/v2/JobRegistry.sol#2225-2252):\n\tExternal calls:\n\t- disputeModule.raiseDispute(jobId,msg.sender,evidenceHash,reason) (contracts/v2/JobRegistry.sol#2249)\n\tEvent emitted after the call(s):\n\t- JobDisputed(jobId,msg.sender) (contracts/v2/JobRegistry.sol#2251)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2225,
+    "fingerprint": "802c1efae3126d1147583b1c993ac92a127d0ab15f547a7ec4f8158dabc96ede"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._setAgentRootNode(bytes32) (contracts/v2/JobRegistry.sol#631-636):\n\tExternal calls:\n\t- identityRegistry.setAgentRootNode(node) (contracts/v2/JobRegistry.sol#633)\n\tEvent emitted after the call(s):\n\t- AgentAuthCacheVersionBumped(agentAuthCacheVersion) (contracts/v2/JobRegistry.sol#670)\n\t\t- _bumpAgentAuthCacheVersionInternal() (contracts/v2/JobRegistry.sol#634)\n\t- AgentRootNodeUpdated(node) (contracts/v2/JobRegistry.sol#635)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 631,
+    "fingerprint": "85bb7623b2029f8b7846b3625b73adc9194e09139ca9c40205f69065ea1ead04"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in ReentrantERC20.transfer(address,uint256) (contracts/legacy/ReentrantERC20.sol#38-41):\n\tExternal calls:\n\t- _reenter() (contracts/legacy/ReentrantERC20.sol#39)\n\t\t- manager.resolveDispute(jobId,IJobManager.DisputeOutcome.AgentWin) (contracts/legacy/ReentrantERC20.sol#33)\n\tEvent emitted after the call(s):\n\t- Transfer(from,to,value) (node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol#203)\n\t\t- super.transfer(to,amount) (contracts/legacy/ReentrantERC20.sol#40)\n",
+    "uri": "contracts/legacy/ReentrantERC20.sol",
+    "startLine": 38,
+    "fingerprint": "874f42567fe9856465a483f7877ad4fbe3c6631c65c271e000d727fbdb6e07e1"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in TimelockController.execute(address,uint256,bytes,bytes32,bytes32) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#357-370):\n\tExternal calls:\n\t- _execute(target,value,payload) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#367)\n\t\t- (success,returndata) = target.call{value: value}(data) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#412)\n\tEvent emitted after the call(s):\n\t- CallExecuted(id,0,target,value,payload) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#368)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/TimelockController.sol",
+    "startLine": 357,
+    "fingerprint": "8e1dcc9181fa0b9004860ba648990f6b82e6f72573ac0c261d023769bc9f4eeb"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in ValidationModule.triggerFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/ValidationModule.sol#317-362):\n\tExternal calls:\n\t- jobRegistry.escalateToDispute(jobId,rationale) (contracts/v2/ValidationModule.sol#355)\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#356)\n\t\t- stakeManager.unlockValidatorStake(jobId,val,lockAmount) (contracts/v2/ValidationModule.sol#1817)\n\tEvent emitted after the call(s):\n\t- ValidationFailover(jobId,action,deadline,rationale) (contracts/v2/ValidationModule.sol#357)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 317,
+    "fingerprint": "8e999481e50fc6f4ef3df695c947a6013f684606aa47c180762a45e05fa08c72"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in KernelJobRegistry.submitResult(uint256) (contracts/v2/kernel/JobRegistry.sol#216-229):\n\tExternal calls:\n\t- _lockValidators(jobId) (contracts/v2/kernel/JobRegistry.sol#226)\n\t\t- stakeManager.lockStake(validators[i],jobId,minStake) (contracts/v2/kernel/JobRegistry.sol#357)\n\t- validationModule.startRound(jobId) (contracts/v2/kernel/JobRegistry.sol#227)\n\tEvent emitted after the call(s):\n\t- JobSubmitted(jobId) (contracts/v2/kernel/JobRegistry.sol#228)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 216,
+    "fingerprint": "973dd77b2aab21fd60ee3b449251b7a5eb1eb3e3b9ecaa54dfb98225323bbe0a"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._acknowledge(address) (contracts/v2/JobRegistry.sol#1330-1334):\n\tExternal calls:\n\t- ack = taxPolicy.acknowledgeFor(user) (contracts/v2/JobRegistry.sol#1332)\n\tEvent emitted after the call(s):\n\t- TaxAcknowledged(user,taxPolicy.policyVersion(),ack) (contracts/v2/JobRegistry.sol#1333)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1330,
+    "fingerprint": "97fb2019e25d2e1e591daeeea0d0f5157ae3fc1c73dd724a14b4b465e1f98497"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in MockJobRegistry.createJob(uint256,uint64,bytes32,string) (contracts/legacy/MockV2.sol#551-601):\n\tExternal calls:\n\t- _stakeManager.lock(msg.sender,reward) (contracts/legacy/MockV2.sol#598)\n\tEvent emitted after the call(s):\n\t- JobCreated(jobId,msg.sender,reward,deadline) (contracts/legacy/MockV2.sol#600)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 551,
+    "fingerprint": "9e81168a2c9cdefb8c6a3173b6db95fb2f0bb14e2d0af3395c3316d18e8eb607"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in Deployer._deploy(bool,Deployer.EconParams,Deployer.IdentityParams,address) (contracts/v2/Deployer.sol#237-475):\n\tExternal calls:\n\t- stake.setValidatorSlashRewardPct(validatorSlashPct) (contracts/v2/Deployer.sol#289)\n\t- stake.setTreasuryAllowlist(governance,true) (contracts/v2/Deployer.sol#292)\n\t- committee.setDisputeModule(IDisputeModule(address(dispute))) (contracts/v2/Deployer.sol#335)\n\t- certificate.setJobRegistry(address(registry)) (contracts/v2/Deployer.sol#338)\n\t- registry.setModules(validation,IStakeManager(address(stake)),IReputationEngine(address(reputation)),IDisputeModule(address(dispute)),ICertificateNFT(address(certificate)),IFeePool(address(pool)),acks) (contracts/v2/Deployer.sol#380-388)\n\t- registry.setTaxPolicy(ITaxPolicy(address(policy))) (contracts/v2/Deployer.sol#390)\n\t- registry.setIdentityRegistry(IIdentityRegistry(address(identity))) (contracts/v2/Deployer.sol#393)\n\t- validation.setIdentityRegistry(IIdentityRegistry(address(identity))) (contracts/v2/Deployer.sol#394)\n\t- identity.setAgentMerkleRoot(ids.agentMerkleRoot) (contracts/v2/Deployer.sol#396)\n\t- identity.setValidatorMerkleRoot(ids.validatorMerkleRoot) (contracts/v2/Deployer.sol#399)\n\t- validation.setReputationEngine(repInterface) (contracts/v2/Deployer.sol#402)\n\t- stake.setModules(address(registry),address(dispute)) (contracts/v2/Deployer.sol#403)\n\t- incentives.setModules(IStakeManager(address(stake)),IPlatformRegistryFull(address(pRegistry)),IJobRouter(address(router))) (contracts/v2/Deployer.sol#404-408)\n\t- pRegistry.setRegistrar(address(incentives),true) (contracts/v2/Deployer.sol#409)\n\t- router.setRegistrar(address(incentives),true) (contracts/v2/Deployer.sol#410)\n\t- reputation.setAuthorizedCaller(address(registry),true) (contracts/v2/Deployer.sol#411)\n\t- reputation.setAuthorizedCaller(address(validation),true) (contracts/v2/Deployer.sol#412)\n\t- stake.setGovernance(address(pause)) (contracts/v2/Deployer.sol#426)\n\t- registry.setGovernance(address(pause)) (contracts/v2/Deployer.sol#427)\n\t- dispute.setGovernance(address(pause)) (contracts/v2/Deployer.sol#428)\n\t- validation.transferOwnership(address(pause)) (contracts/v2/Deployer.sol#431)\n\t- reputation.transferOwnership(address(pause)) (contracts/v2/Deployer.sol#432)\n\t- committee.transferOwnership(address(pause)) (contracts/v2/Deployer.sol#433)\n\t- certificate.transferOwnership(governance) (contracts/v2/Deployer.sol#434)\n\t- pRegistry.transferOwnership(address(pause)) (contracts/v2/Deployer.sol#435)\n\t- router.transferOwnership(governance) (contracts/v2/Deployer.sol#436)\n\t- incentives.transferOwnership(governance) (contracts/v2/Deployer.sol#437)\n\t- pool.transferOwnership(address(pause)) (contracts/v2/Deployer.sol#438)\n\t- policy.transferOwnership(governance) (contracts/v2/Deployer.sol#440)\n\t- identity.transferOwnership(governance) (contracts/v2/Deployer.sol#442)\n\tEvent emitted after the call(s):\n\t- Deployed(address(stake),address(registry),address(validation),address(reputation),address(dispute),address(certificate),address(pRegistry),address(router),address(incentives),address(pool),address(policy),address(identity),address(pause)) (contracts/v2/Deployer.sol#444-458)\n",
+    "uri": "contracts/v2/Deployer.sol",
+    "startLine": 237,
+    "fingerprint": "a0dd67bba3e964e680f1562d86346c34cd1dad5138eb3172473fa64d01a369af"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in SystemPause._setPausers(address) (contracts/v2/SystemPause.sol#313-378):\n\tExternal calls:\n\t- jobRegistry.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#318)\n\t- stakeManager.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#324)\n\t- validationModule.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#330)\n\t- disputeModule.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#336)\n\t- platformRegistry.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#342)\n\t- feePool.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#348)\n\t- reputationEngine.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#354)\n\t- arbitratorCommittee.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#360)\n\t- jobRegistry.setPauser(pauser) (contracts/v2/SystemPause.sol#366)\n\t- stakeManager.setPauser(pauser) (contracts/v2/SystemPause.sol#367)\n\t- validationModule.setPauser(pauser) (contracts/v2/SystemPause.sol#368)\n\t- disputeModule.setPauser(pauser) (contracts/v2/SystemPause.sol#369)\n\t- platformRegistry.setPauser(pauser) (contracts/v2/SystemPause.sol#370)\n\t- feePool.setPauser(pauser) (contracts/v2/SystemPause.sol#371)\n\t- reputationEngine.setPauser(pauser) (contracts/v2/SystemPause.sol#372)\n\t- arbitratorCommittee.setPauser(pauser) (contracts/v2/SystemPause.sol#373)\n\tEvent emitted after the call(s):\n\t- PausersUpdated(pauser) (contracts/v2/SystemPause.sol#377)\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 313,
+    "fingerprint": "a55c0f4fd869a84fdf1af79166b7931d9eccdaeb3207d467bfd7a2d7adc97300"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in Governor.execute(address[],uint256[],bytes[],bytes32) (node_modules/@openzeppelin/contracts/governance/Governor.sol#390-425):\n\tExternal calls:\n\t- _executeOperations(proposalId,targets,values,calldatas,descriptionHash) (node_modules/@openzeppelin/contracts/governance/Governor.sol#415)\n\t\t- (success,returndata) = targets[i].call{value: values[i]}(calldatas[i]) (node_modules/@openzeppelin/contracts/governance/Governor.sol#442)\n\tEvent emitted after the call(s):\n\t- ProposalExecuted(proposalId) (node_modules/@openzeppelin/contracts/governance/Governor.sol#422)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 390,
+    "fingerprint": "b48a38e619a2de7fe67d84d85be0014e09650d0446685045af615cda316cd872"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in SystemPause.setModules(JobRegistry,StakeManager,ValidationModule,DisputeModule,PlatformRegistry,FeePool,ReputationEngine,ArbitratorCommittee) (contracts/v2/SystemPause.sol#125-198):\n\tExternal calls:\n\t- _setPausers(address(this)) (contracts/v2/SystemPause.sol#186)\n\t\t- jobRegistry.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#318)\n\t\t- stakeManager.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#324)\n\t\t- validationModule.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#330)\n\t\t- disputeModule.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#336)\n\t\t- platformRegistry.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#342)\n\t\t- feePool.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#348)\n\t\t- reputationEngine.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#354)\n\t\t- arbitratorCommittee.setPauserManager(address(this)) (contracts/v2/SystemPause.sol#360)\n\t\t- jobRegistry.setPauser(pauser) (contracts/v2/SystemPause.sol#366)\n\t\t- stakeManager.setPauser(pauser) (contracts/v2/SystemPause.sol#367)\n\t\t- validationModule.setPauser(pauser) (contracts/v2/SystemPause.sol#368)\n\t\t- disputeModule.setPauser(pauser) (contracts/v2/SystemPause.sol#369)\n\t\t- platformRegistry.setPauser(pauser) (contracts/v2/SystemPause.sol#370)\n\t\t- feePool.setPauser(pauser) (contracts/v2/SystemPause.sol#371)\n\t\t- reputationEngine.setPauser(pauser) (contracts/v2/SystemPause.sol#372)\n\t\t- arbitratorCommittee.setPauser(pauser) (contracts/v2/SystemPause.sol#373)\n\tEvent emitted after the call(s):\n\t- ModulesUpdated(address(_jobRegistry),address(_stakeManager),address(_validationModule),address(_disputeModule),address(_platformRegistry),address(_feePool),address(_reputationEngine),address(_arbitratorCommittee)) (contracts/v2/SystemPause.sol#188-197)\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 125,
+    "fingerprint": "bb391bad2cbafecde369251346af0ccd110e35580d35a77746ec5b3c9dfe9f42"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in MockJobRegistry.escalateToDispute(uint256,string) (contracts/legacy/MockV2.sol#715-720):\n\tExternal calls:\n\t- disputeModule.raiseGovernanceDispute(jobId,reason) (contracts/legacy/MockV2.sol#717)\n\t- _dispute(jobId,bytes32(0),reason) (contracts/legacy/MockV2.sol#719)\n\t\t- disputeModule.raiseDispute(jobId,msg.sender,evidenceHash,reason) (contracts/legacy/MockV2.sol#749)\n\tEvent emitted after the call(s):\n\t- JobDisputed(jobId,msg.sender) (contracts/legacy/MockV2.sol#751)\n\t\t- _dispute(jobId,bytes32(0),reason) (contracts/legacy/MockV2.sol#719)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 715,
+    "fingerprint": "bd12cc94b3636f966cc3093f1cb682853bfe470c4202a27d61ff4575da01a72e"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._cancelJob(uint256) (contracts/v2/JobRegistry.sol#2521-2539):\n\tExternal calls:\n\t- stakeManager.refundEscrow(bytes32(jobId),job.employer,uint256(job.reward) + fee) (contracts/v2/JobRegistry.sol#2528-2532)\n\tEvent emitted after the call(s):\n\t- JobCancelled(jobId) (contracts/v2/JobRegistry.sol#2538)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2521,
+    "fingerprint": "c249413b5934ff2d5dae911f479d53f40269b6c216234d329fb1a8049739ceec"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495):\n\tExternal calls:\n\t- stakeManager.finalizeJobFundsWithPct(jobKey,employerParam,payee,agentPct,rewardAfterValidator,validatorReward,fee,pool,isGov) (contracts/v2/JobRegistry.sol#2356-2366)\n\t- stakeManager.distributeValidatorRewards(jobKey,validatorReward) (contracts/v2/JobRegistry.sol#2370-2373)\n\t- stakeManager.releaseReward(jobKey,job.employer,payee,validatorReward,true) (contracts/v2/JobRegistry.sol#2375-2381)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),treasury,validators) (contracts/v2/JobRegistry.sol#2386-2392)\n\t- stakeManager.releaseStake(job.agent,uint256(job.stake)) (contracts/v2/JobRegistry.sol#2394)\n\t- reputationEngine.onFinalize(job.agent,true,payout,completionTime) (contracts/v2/JobRegistry.sol#2416-2421)\n\t- reputationEngine.rewardValidator(val,agentGain) (contracts/v2/JobRegistry.sol#2426)\n\t- certificateNFT.mint(job.agent,jobId,job.uriHash) (contracts/v2/JobRegistry.sol#2435)\n\tEvent emitted after the call(s):\n\t- JobPayout(jobId,job.agent,rewardAfterValidator,bonus,fee) (contracts/v2/JobRegistry.sol#2438)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "c2f0a93dd794977316c35b48ee486e50eaf7605560cf085a8fa7f669d1132e79"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in RandaoCoordinator.forfeit(bytes32,address) (contracts/v2/RandaoCoordinator.sol#248-256):\n\tExternal calls:\n\t- ! token.transfer(_treasury,dep) (contracts/v2/RandaoCoordinator.sol#254)\n\tEvent emitted after the call(s):\n\t- DepositForfeited(tag,user,dep) (contracts/v2/RandaoCoordinator.sol#255)\n",
+    "uri": "contracts/v2/RandaoCoordinator.sol",
+    "startLine": 248,
+    "fingerprint": "cbdf32a8e4cb6da34b495e74fcf2a5cf03eeb04e5cbca2c9c39a15cd3e86ad17"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in ArbitratorCommittee.finalize(uint256) (contracts/v2/ArbitratorCommittee.sol#149-170):\n\tExternal calls:\n\t- disputeModule.resolveDispute(jobId,employerWins) (contracts/v2/ArbitratorCommittee.sol#159)\n\t- disputeModule.slashValidator(juror,absenteeSlash,employer) (contracts/v2/ArbitratorCommittee.sol#164)\n\tEvent emitted after the call(s):\n\t- CaseFinalized(jobId,employerWins) (contracts/v2/ArbitratorCommittee.sol#168)\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 149,
+    "fingerprint": "d4f4f0e3d2f87db8d557cf0e9fcedadbb79e1aa952e68ab63cbeaeb108313d16"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in PlatformIncentives.stakeAndActivate(uint256) (contracts/v2/PlatformIncentives.sol#103-116):\n\tExternal calls:\n\t- stakeManager.depositStakeFor(msg.sender,IStakeManager.Role.Platform,amount) (contracts/v2/PlatformIncentives.sol#105-109)\n\t- platformRegistry.registerFor(msg.sender) (contracts/v2/PlatformIncentives.sol#113)\n\t- jobRouter.registerFor(msg.sender) (contracts/v2/PlatformIncentives.sol#114)\n\tEvent emitted after the call(s):\n\t- Activated(msg.sender,amount) (contracts/v2/PlatformIncentives.sol#115)\n",
+    "uri": "contracts/v2/PlatformIncentives.sol",
+    "startLine": 103,
+    "fingerprint": "d8d2de20fcb491e6ac31b341e441c7d91a781468ff2ebfea8555fbc5407c7520"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in ValidationModule.resetJobNonce(uint256) (contracts/v2/ValidationModule.sol#1834-1839):\n\tExternal calls:\n\t- _cleanup(jobId) (contracts/v2/ValidationModule.sol#1837)\n\t\t- stakeManager.unlockValidatorStake(jobId,val,lockAmount) (contracts/v2/ValidationModule.sol#1817)\n\tEvent emitted after the call(s):\n\t- JobNonceReset(jobId) (contracts/v2/ValidationModule.sol#1838)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1834,
+    "fingerprint": "dad74600f772cc916698c967c3f74eede2934f676b3547ecfb01b7bdac4e20c2"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616):\n\tExternal calls:\n\t- _setIdentityRegistry(IIdentityRegistry(config.identityRegistry)) (contracts/v2/JobRegistry.sol#1450)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#496)\n\t- _setAgentRootNode(config.agentRootNode) (contracts/v2/JobRegistry.sol#1539)\n\t\t- identityRegistry.setAgentRootNode(node) (contracts/v2/JobRegistry.sol#633)\n\t- _setAgentMerkleRoot(config.agentMerkleRoot) (contracts/v2/JobRegistry.sol#1545)\n\t\t- identityRegistry.setAgentMerkleRoot(root) (contracts/v2/JobRegistry.sol#640)\n\t- _setValidatorRootNode(config.validatorRootNode) (contracts/v2/JobRegistry.sol#1551)\n\t\t- identityRegistry.setClubRootNode(node) (contracts/v2/JobRegistry.sol#648)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#649)\n\t- _setValidatorMerkleRoot(config.validatorMerkleRoot) (contracts/v2/JobRegistry.sol#1556)\n\t\t- identityRegistry.setValidatorMerkleRoot(root) (contracts/v2/JobRegistry.sol#656)\n\t\t- validationModule.bumpValidatorAuthCacheVersion() (contracts/v2/JobRegistry.sol#657)\n\tEvent emitted after the call(s):\n\t- AgentAuthCacheDurationUpdated(duration) (contracts/v2/JobRegistry.sol#663)\n\t\t- _setAgentAuthCacheDuration(config.agentAuthCacheDuration) (contracts/v2/JobRegistry.sol#1561)\n\t- AgentAuthCacheVersionBumped(agentAuthCacheVersion) (contracts/v2/JobRegistry.sol#670)\n\t\t- _bumpAgentAuthCacheVersionInternal() (contracts/v2/JobRegistry.sol#1566)\n\t- ConfigurationApplied(msg.sender,pauserUpdated,pauserManagerUpdated,modulesUpdated,identityRegistryUpdated,disputeModuleUpdated,validationModuleUpdated,stakeManagerUpdated,reputationModuleUpdated,certificateNFTUpdated,auditModuleUpdated,feePoolUpdated,taxPolicyUpdated,treasuryUpdated,jobStakeUpdated,minAgentStakeUpdated,feePctUpdated,validatorRewardPctUpdated,maxJobRewardUpdated,maxJobDurationUpdated,maxActiveJobsUpdated,expirationGracePeriodUpdated,agentRootUpdated,agentMerkleUpdated,validatorRootUpdated,validatorMerkleUpdated,agentAuthCacheDurationUpdated,agentAuthCacheVersionBumped,ackUpdateLen,ackModulesAdded) (contracts/v2/JobRegistry.sol#1584-1615)\n\t- FeePctUpdated(newFeePct) (contracts/v2/JobRegistry.sol#601)\n\t\t- (feeChanged_scope_1,validatorChanged) = _applyFeeConfiguration(newFee,newValidator,config.setFeePct,config.setValidatorRewardPct) (contracts/v2/JobRegistry.sol#1574-1579)\n\t- ValidatorMerkleRootUpdated(root) (contracts/v2/JobRegistry.sol#658)\n\t\t- _setValidatorMerkleRoot(config.validatorMerkleRoot) (contracts/v2/JobRegistry.sol#1556)\n\t- ValidatorRewardPctUpdated(newValidatorRewardPct) (contracts/v2/JobRegistry.sol#606)\n\t\t- (feeChanged_scope_1,validatorChanged) = _applyFeeConfiguration(newFee,newValidator,config.setFeePct,config.setValidatorRewardPct) (contracts/v2/JobRegistry.sol#1574-1579)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "dcff2ce0321266711d0a52ddb392ebfc636126a1bc346afdbd82ab18ff9b30c8"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in SystemPause.triggerValidationFailover(uint256,IValidationModule.FailoverAction,uint64,string) (contracts/v2/SystemPause.sol#303-311):\n\tExternal calls:\n\t- validationModule.triggerFailover(jobId,action,extension,reason) (contracts/v2/SystemPause.sol#309)\n\tEvent emitted after the call(s):\n\t- ValidationFailoverForwarded(jobId,action,extension,reason) (contracts/v2/SystemPause.sol#310)\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 303,
+    "fingerprint": "dd7b926bb6a77ca661073c92645b835e05dbb404a6a5ea6e167759b9e1b82386"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in KlerosDisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/KlerosDisputeModule.sol#106-120):\n\tExternal calls:\n\t- IArbitrationService(arbitrator).createDispute(jobId,claimant,payload) (contracts/v2/modules/KlerosDisputeModule.sol#117)\n\tEvent emitted after the call(s):\n\t- DisputeRaised(jobId,claimant,payload,reason) (contracts/v2/modules/KlerosDisputeModule.sol#119)\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 106,
+    "fingerprint": "e0877a434c865180002966d709a7c11712160e4b5173d71a2d5e0378929b33d1"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in MockJobRegistry.finalize(uint256) (contracts/legacy/MockV2.sol#762-785):\n\tExternal calls:\n\t- _stakeManager.release(job.employer,recipient,job.reward,success) (contracts/legacy/MockV2.sol#769)\n\t- _stakeManager.slash(job.agent,IStakeManager.Role.Agent,job.stake,recipient) (contracts/legacy/MockV2.sol#771)\n\t- reputationEngine.add(job.agent,1) (contracts/legacy/MockV2.sol#776)\n\t- reputationEngine.subtract(job.agent,1) (contracts/legacy/MockV2.sol#778)\n\t- certificateNFT.mint(job.agent,jobId,job.uriHash) (contracts/legacy/MockV2.sol#782)\n\tEvent emitted after the call(s):\n\t- JobFinalized(jobId,job.agent) (contracts/legacy/MockV2.sol#784)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 762,
+    "fingerprint": "e603d4af4030b16c446e45c3fcdeca4e7f25c1ace9e2101bf6de3d719cc9d39c"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in ValidationModule.finalize(uint256) (contracts/v2/kernel/ValidationModule.sol#134-173):\n\tExternal calls:\n\t- jobRegistry.onValidationApproved(jobId,revealedValidators,nonRevealers) (contracts/v2/kernel/ValidationModule.sol#164)\n\t- jobRegistry.onValidationRejected(jobId,revealedValidators,nonRevealers) (contracts/v2/kernel/ValidationModule.sol#166)\n\t- jobRegistry.onValidationQuorumFailure(jobId,nonRevealers) (contracts/v2/kernel/ValidationModule.sol#169)\n\tEvent emitted after the call(s):\n\t- RoundFinalized(jobId,approved,quorumMet) (contracts/v2/kernel/ValidationModule.sol#172)\n",
+    "uri": "contracts/v2/kernel/ValidationModule.sol",
+    "startLine": 134,
+    "fingerprint": "e67d1ebd3f471f43084f20b987d8af66229db918cc5e07c5d552ac8ab871a4e6"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._setAgentMerkleRoot(bytes32) (contracts/v2/JobRegistry.sol#638-643):\n\tExternal calls:\n\t- identityRegistry.setAgentMerkleRoot(root) (contracts/v2/JobRegistry.sol#640)\n\tEvent emitted after the call(s):\n\t- AgentAuthCacheVersionBumped(agentAuthCacheVersion) (contracts/v2/JobRegistry.sol#670)\n\t\t- _bumpAgentAuthCacheVersionInternal() (contracts/v2/JobRegistry.sol#641)\n\t- AgentMerkleRootUpdated(root) (contracts/v2/JobRegistry.sol#642)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 638,
+    "fingerprint": "ef719d0f145ac71dc22039830cdbe3213174d28d6ab5ac55e5664bfe0eec9a13"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in CertificateNFT.mint(address,uint256,bytes32) (contracts/v2/CertificateNFT.sol#152-164):\n\tExternal calls:\n\t- _safeMint(to,tokenId) (contracts/v2/CertificateNFT.sol#161)\n\t\t- ERC721Utils.checkOnERC721Received(_msgSender(),address(0),to,tokenId,data) (node_modules/@openzeppelin/contracts/token/ERC721/ERC721.sol#289)\n\t\t- retval = IERC721Receiver(to).onERC721Received(operator,from,tokenId,data) (node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol#33-47)\n\tEvent emitted after the call(s):\n\t- CertificateMinted(to,jobId,uriHash) (contracts/v2/CertificateNFT.sol#163)\n",
+    "uri": "contracts/v2/CertificateNFT.sol",
+    "startLine": 152,
+    "fingerprint": "efa6967fb599a369b1b46547de41583095a92cab00c32bfb55692e88742255e4"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in MockJobRegistry.cancelJob(uint256) (contracts/legacy/MockV2.sol#791-800):\n\tExternal calls:\n\t- _stakeManager.release(job.employer,job.employer,job.reward,false) (contracts/legacy/MockV2.sol#797)\n\tEvent emitted after the call(s):\n\t- JobCancelled(jobId) (contracts/legacy/MockV2.sol#799)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 791,
+    "fingerprint": "f13fc14b32729f65f6e2f4e453ea5f8b16e81d385d22395cbe9d5ee5f93513f1"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in OwnerConfigurator._applyConfiguration(OwnerConfigurator.ConfigurationCall) (contracts/v2/admin/OwnerConfigurator.sol#50-66):\n\tExternal calls:\n\t- returnData = call.target.functionCall(call.callData) (contracts/v2/admin/OwnerConfigurator.sol#58)\n\tEvent emitted after the call(s):\n\t- ParameterUpdated(call.moduleKey,call.parameterKey,call.oldValue,call.newValue,_msgSender()) (contracts/v2/admin/OwnerConfigurator.sol#59-65)\n",
+    "uri": "contracts/v2/admin/OwnerConfigurator.sol",
+    "startLine": 50,
+    "fingerprint": "f2c7234dbc1f66c892f6c0967911b1dd1fc737a7649393206f4b7ed2da27d805"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in CertificateNFT.mint(address,uint256,bytes32) (contracts/v2/modules/CertificateNFT.sol#90-100):\n\tExternal calls:\n\t- _safeMint(to,tokenId) (contracts/v2/modules/CertificateNFT.sol#97)\n\t\t- retval = IERC721Receiver(to).onERC721Received(operator,from,tokenId,data) (node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol#33-47)\n\t\t- ERC721Utils.checkOnERC721Received(_msgSender(),address(0),to,tokenId,data) (node_modules/@openzeppelin/contracts/token/ERC721/ERC721.sol#289)\n\tEvent emitted after the call(s):\n\t- CertificateMinted(to,jobId,uriHash) (contracts/v2/modules/CertificateNFT.sol#99)\n",
+    "uri": "contracts/v2/modules/CertificateNFT.sol",
+    "startLine": 90,
+    "fingerprint": "f3535d57e02f2ff7d98656f79a7efa6b395b52cac6c1bd304ac3cf0b31aa75b9"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250):\n\tExternal calls:\n\t- (authorized,None,None,None) = identityRegistry.verifyValidator(candidate,subdomain,proof) (contracts/v2/ValidationModule.sol#1052-1056)\n\tEvent emitted after the call(s):\n\t- ValidatorPoolRotationUpdated(validatorPoolRotation) (contracts/v2/ValidationModule.sol#1082)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "f4722cae5b751db6ddab0b42ec4324ca1f7a291a1921cdaf56f3b96c8715f588"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495):\n\tExternal calls:\n\t- stakeManager.finalizeJobFundsWithPct(jobKey,employerParam,payee,agentPct,rewardAfterValidator,validatorReward,fee,pool,isGov) (contracts/v2/JobRegistry.sol#2356-2366)\n\t- stakeManager.distributeValidatorRewards(jobKey,validatorReward) (contracts/v2/JobRegistry.sol#2370-2373)\n\t- stakeManager.releaseReward(jobKey,job.employer,payee,validatorReward,true) (contracts/v2/JobRegistry.sol#2375-2381)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),treasury,validators) (contracts/v2/JobRegistry.sol#2386-2392)\n\t- stakeManager.releaseStake(job.agent,uint256(job.stake)) (contracts/v2/JobRegistry.sol#2394)\n\t- reputationEngine.onFinalize(job.agent,true,payout,completionTime) (contracts/v2/JobRegistry.sol#2416-2421)\n\t- reputationEngine.rewardValidator(val,agentGain) (contracts/v2/JobRegistry.sol#2426)\n\t- certificateNFT.mint(job.agent,jobId,job.uriHash) (contracts/v2/JobRegistry.sol#2435)\n\t- stakeManager.redistributeEscrow(jobKey,recipient,uint256(job.reward) + fee_scope_0,validators) (contracts/v2/JobRegistry.sol#2448-2453)\n\t- stakeManager.slash(job.agent,IStakeManager.Role.Agent,uint256(job.stake),recipient,validators) (contracts/v2/JobRegistry.sol#2456-2462)\n\t- reputationEngine.onFinalize(job.agent,false,0,0) (contracts/v2/JobRegistry.sol#2466)\n\tEvent emitted after the call(s):\n\t- JobFinalized(jobId,job.agent) (contracts/v2/JobRegistry.sol#2474)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "f92702fd31ab340ddcb198358382d4fd52a1ee14884576dbeef08442f378151c"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in RandaoCoordinator.reveal(bytes32,uint256) (contracts/v2/RandaoCoordinator.sol#217-236):\n\tExternal calls:\n\t- ! token.transfer(msg.sender,dep) (contracts/v2/RandaoCoordinator.sol#233)\n\tEvent emitted after the call(s):\n\t- Revealed(tag,msg.sender,secret) (contracts/v2/RandaoCoordinator.sol#235)\n",
+    "uri": "contracts/v2/RandaoCoordinator.sol",
+    "startLine": 217,
+    "fingerprint": "fc0bf85c424bc312066fd879d4577a4c8ebc82c08b29d13b6db8cc263d9cfa25"
+  },
+  {
+    "ruleId": "2-1-reentrancy-events",
+    "message": "Reentrancy in JobRegistry._startValidation(uint256,uint256) (contracts/v2/JobRegistry.sol#353-360):\n\tExternal calls:\n\t- validationModule.start(jobId,entropy) (contracts/v2/JobRegistry.sol#357)\n\tEvent emitted after the call(s):\n\t- ValidationStartTriggered(jobId) (contracts/v2/JobRegistry.sol#358)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 353,
+    "fingerprint": "fe0a18d60e834a31901600f90e183b8fee15f7921db82fb440f7a0d2c3718948"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "MockJobRegistry.createJob(uint256,uint64,bytes32,string) (contracts/legacy/MockV2.sol#551-601) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(deadline > block.timestamp,deadline) (contracts/legacy/MockV2.sol#568)\n\t- require(bool,string)(uint256(deadline) - block.timestamp <= maxJobDuration,duration) (contracts/legacy/MockV2.sol#569-572)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 551,
+    "fingerprint": "037829c8628e821d58c3d143feee1f2203bd8852389fd60f6ed1fd6b5ca0040d"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp > _getDeadline(job) (contracts/v2/JobRegistry.sol#1938)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1917,
+    "fingerprint": "09ad6679dccb61a66141110d65472d9b3af045375b672d5f3dfcd51d1d6990dd"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ArbitratorCommittee.finalize(uint256) (contracts/v2/ArbitratorCommittee.sol#149-170) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(block.timestamp > c.revealDeadline,active) (contracts/v2/ArbitratorCommittee.sol#154)\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 149,
+    "fingerprint": "0a5eb9c6261674272d28fc41404bfe956907174445d5a4981fee44864accf054"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "TimelockController.getOperationState(bytes32) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#206-217) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- timestamp == 0 (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#208)\n\t- timestamp == _DONE_TIMESTAMP (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#210)\n\t- timestamp > block.timestamp (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#212)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/TimelockController.sol",
+    "startLine": 206,
+    "fingerprint": "0ef84387bd7fb7d268effc04c941964f117fe8707381f1f5bb96e91c663dc120"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "JobEscrow._accept(uint256) (contracts/v2/modules/JobEscrow.sol#164-178) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp < job.submittedAt + resultTimeout (contracts/v2/modules/JobEscrow.sol#170)\n",
+    "uri": "contracts/v2/modules/JobEscrow.sol",
+    "startLine": 164,
+    "fingerprint": "14efa8e0e2731aed1cf381a0d60b0ead78705c9a2890d3e67430dbcda26ca5a2"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ERC20Permit.permit(address,address,uint256,uint256,uint8,bytes32,bytes32) (node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol#42-65) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp > deadline (node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol#51)\n",
+    "uri": "node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol",
+    "startLine": 42,
+    "fingerprint": "23849fe0810f2634b7306bc1891eb425ea2e480e9df1b27e168f4d73e7021c2c"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "DisputeModule.raiseDispute(uint256,address,bytes32,string) (contracts/v2/modules/DisputeModule.sol#303-342) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(d.raisedAt == 0,disputed) (contracts/v2/modules/DisputeModule.sol#314)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 303,
+    "fingerprint": "32cd574f4108894ac4d3ffb4209814ccd865590940d35d4cf98109c1215d4085"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ValidationModule.finalize(uint256) (contracts/v2/kernel/ValidationModule.sol#134-173) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp <= round.revealDeadline && round.totalReveals < round.validators.length (contracts/v2/kernel/ValidationModule.sol#138)\n",
+    "uri": "contracts/v2/kernel/ValidationModule.sol",
+    "startLine": 134,
+    "fingerprint": "369784c1e332e8cc3ba7c804a6e7e85524faa2c424fa18c7980144b353500ac3"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ArbitratorCommittee.reveal(uint256,bool,uint256) (contracts/v2/ArbitratorCommittee.sol#132-146) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(block.timestamp > c.commitDeadline,commit phase) (contracts/v2/ArbitratorCommittee.sol#135)\n\t- require(bool,string)(block.timestamp <= c.revealDeadline,reveal over) (contracts/v2/ArbitratorCommittee.sol#136)\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 132,
+    "fingerprint": "3bde75b14ff8202d7e8bd04cb48205ebd77c5584498e39ee383154a3801c0d4f"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ArbitratorCommittee.openCase(uint256) (contracts/v2/ArbitratorCommittee.sol#105-118) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(c.jurors.length == 0,exists) (contracts/v2/ArbitratorCommittee.sol#107)\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 105,
+    "fingerprint": "3dd06372413cba3e170f90f89bccb4854ed38e71e693b08ede1cb0effeb7c586"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- authorized = validatorAuthCache[candidate] && validatorAuthVersion[candidate] == validatorAuthCacheVersion && validatorAuthExpiry[candidate] > block.timestamp (contracts/v2/ValidationModule.sol#1032-1036)\n\t- authorized_scope_3 = validatorAuthCache[candidate_scope_1] && validatorAuthVersion[candidate_scope_1] == validatorAuthCacheVersion && validatorAuthExpiry[candidate_scope_1] > block.timestamp (contracts/v2/ValidationModule.sol#1115-1119)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "3fd69661409634ae9ecc607c23b27d7872f2679650dee227e2ae9d3bfea38273"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "DisputeModule.resolveWithSignatures(uint256,bool,bytes[]) (contracts/v2/modules/DisputeModule.sol#395-429) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(block.timestamp >= d.raisedAt + disputeWindow,window) (contracts/v2/modules/DisputeModule.sol#403)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 395,
+    "fingerprint": "49c1022d46176b024d753e4b35c5321a07499c89186818479f3e9f2802ee9471"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "StakeManager.finalizeWithdraw(StakeManager.Role) (contracts/v2/StakeManager.sol#2115-2129) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp < u.unlockAt (contracts/v2/StakeManager.sol#2125)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2115,
+    "fingerprint": "49d8db2a29dc94da7486e607f908fcacf7c910ac9b3d150bb372c363a48ad242"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "DisputeModule._resolve(uint256,bool,address) (contracts/v2/modules/DisputeModule.sol#515-567) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(block.timestamp >= d.raisedAt + disputeWindow,window) (contracts/v2/modules/DisputeModule.sol#518)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 515,
+    "fingerprint": "4db73700d026f58bbaedf5e29bd3f8cf64f166b21c0981be1cbbd4c727cace45"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "RandaoCoordinator.reveal(bytes32,uint256) (contracts/v2/RandaoCoordinator.sol#217-236) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp <= r.commitDeadline (contracts/v2/RandaoCoordinator.sol#219)\n\t- block.timestamp > r.revealDeadline (contracts/v2/RandaoCoordinator.sol#220)\n",
+    "uri": "contracts/v2/RandaoCoordinator.sol",
+    "startLine": 217,
+    "fingerprint": "6309aa77a66e8d798541adff1cb49e53a0df29b4103ea2650eb5d796c3ce1871"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "JobRegistry.claimTimeout(uint256) (contracts/v2/JobRegistry.sol#2568-2638) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp <= expiry (contracts/v2/JobRegistry.sol#2587)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2568,
+    "fingerprint": "6346b9638fe3f4420575795e0f89020f07586d0e55e3def808350fe8fbe9529c"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ValidationModule.commit(uint256,bytes32) (contracts/v2/kernel/ValidationModule.sol#103-112) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp > round.commitDeadline (contracts/v2/kernel/ValidationModule.sol#106)\n",
+    "uri": "contracts/v2/kernel/ValidationModule.sol",
+    "startLine": 103,
+    "fingerprint": "663dfdbf8b32acfdb62d46b4ac064a781df1b0ec0736ef6faab0adc07f28d067"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "DisputeModule.raiseGovernanceDispute(uint256,string) (contracts/v2/modules/DisputeModule.sol#347-375) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(d.raisedAt == 0,disputed) (contracts/v2/modules/DisputeModule.sol#354)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 347,
+    "fingerprint": "69659878ab4490ceb834c652ae02af84888d67805b7fe07de1334d8232543d7d"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "StakeManager._lockStake(address,uint256,uint64) (contracts/v2/StakeManager.sol#1875-1892) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- newUnlock > unlockTime[user] (contracts/v2/StakeManager.sol#1886)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1875,
+    "fingerprint": "7aef5bb4912a03badee023a0ef9713081944f78ff357e34ebd350f3553ad7d21"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "StakeManager._maybeAdjustStake() (contracts/v2/StakeManager.sol#627-655) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp < lastStakeTune + stakeTuneWindow (contracts/v2/StakeManager.sol#628)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 627,
+    "fingerprint": "807140cb3187ae8e1d4a40491af532b4287115f7cef3e4904a7694a4b5525b1e"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ArbitratorCommittee.commit(uint256,bytes32) (contracts/v2/ArbitratorCommittee.sol#121-129) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(block.timestamp <= c.commitDeadline,commit over) (contracts/v2/ArbitratorCommittee.sol#124)\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 121,
+    "fingerprint": "858b4426017f461010f7b6f4c18a57742c09a2efe54f819fb6bc5f07c401793c"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "KernelJobRegistry.submitResult(uint256) (contracts/v2/kernel/JobRegistry.sol#216-229) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp > job.deadline (contracts/v2/kernel/JobRegistry.sol#222)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 216,
+    "fingerprint": "8af54235caa0459a9557392a8ec855e19f016f39b8d359cbb2c4d90974b93513"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ValidationModule._revealValidation(uint256,bool,bytes32,bytes32,string,bytes32[]) (contracts/v2/ValidationModule.sol#1364-1474) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp <= r.commitDeadline (contracts/v2/ValidationModule.sol#1373)\n\t- block.timestamp > r.revealDeadline (contracts/v2/ValidationModule.sol#1374)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1364,
+    "fingerprint": "8e4481cf3b6f7081d35768238e19224f888570178799c105c450f6dd8c71d55b"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "MockJobRegistry.decodeJobMetadata(uint256) (contracts/legacy/MockV2.sol#362-376) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- metadata.success = (packed & _SUCCESS_MASK) != 0 (contracts/legacy/MockV2.sol#369)\n\t- metadata.burnConfirmed = (packed & _BURN_CONFIRMED_MASK) != 0 (contracts/legacy/MockV2.sol#370)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 362,
+    "fingerprint": "93133c61d3d7851f3471ec771cf488c2a37af43a3e7ae62be9c4248e97c54a07"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "KernelJobRegistry.createJob(address,address[],uint256,uint64,bytes32) (contracts/v2/kernel/JobRegistry.sol#156-214) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- deadline <= block.timestamp (contracts/v2/kernel/JobRegistry.sol#165)\n\t- deadline - block.timestamp > maxDuration (contracts/v2/kernel/JobRegistry.sol#167)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 156,
+    "fingerprint": "a108b4e37ec4632afdfb37e44e8ba7e0ec5c90b28f15c732411a3525093d1d01"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "RandaoCoordinator.forfeit(bytes32,address) (contracts/v2/RandaoCoordinator.sol#248-256) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp <= r.revealDeadline (contracts/v2/RandaoCoordinator.sol#250)\n",
+    "uri": "contracts/v2/RandaoCoordinator.sol",
+    "startLine": 248,
+    "fingerprint": "a61e955e1bd3684b8701685614dd76afcec90733496d9d7c87423d199f530d2b"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ValidationModule._finalize(uint256) (contracts/v2/ValidationModule.sol#1658-1787) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- earlyWindowReached = r.earlyFinalizeEligibleAt != 0 && block.timestamp >= r.earlyFinalizeEligibleAt (contracts/v2/ValidationModule.sol#1661-1663)\n\t- ! earlyWindowReached && block.timestamp <= r.revealDeadline (contracts/v2/ValidationModule.sol#1665)\n\t- metadata.assignedAt != 0 && block.timestamp > metadata.assignedAt (contracts/v2/ValidationModule.sol#1728)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1658,
+    "fingerprint": "a9f98bceb032e3068511ca7e9c34f9666ebaf4f9334c6789e8108aa7c4431fda"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "JobRegistry._applyForJob(uint256,string,bytes32[]) (contracts/v2/JobRegistry.sol#1750-1861) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- authorized = agentAuthCache[msg.sender] && agentAuthExpiry[msg.sender] > block.timestamp && agentAuthVersion[msg.sender] == agentAuthCacheVersion (contracts/v2/JobRegistry.sol#1772-1775)\n\t- authorized && ! cachedMatches (contracts/v2/JobRegistry.sol#1784)\n\t- uint256(deadline) > block.timestamp (contracts/v2/JobRegistry.sol#1839)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1750,
+    "fingerprint": "aa1d63db973bd4d9e76a8b0c2e98807d89c659a854a21a9c9d5ab259cc4f226e"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ValidationModule._commitValidation(uint256,bytes32,string,bytes32[]) (contracts/v2/ValidationModule.sol#1286-1332) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- r.commitDeadline == 0 || block.timestamp > r.commitDeadline (contracts/v2/ValidationModule.sol#1298)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1286,
+    "fingerprint": "acc6eeb6c1c8c73c1500acaab9b0d67809ced8f8c8a2aaaa7ae328a956f001c5"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "Time._getFullAt(Time.Delay,uint48) (node_modules/@openzeppelin/contracts/utils/types/Time.sol#74-80) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- effect <= timepoint (node_modules/@openzeppelin/contracts/utils/types/Time.sol#79)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/types/Time.sol",
+    "startLine": 74,
+    "fingerprint": "b63b079ff0fdab3c21643b3fadb210941da4285b1735b4a3d5da8fb677e0c0bd"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "AuditModule.onJobFinalized(uint256,address,bool,bytes32) (contracts/v2/AuditModule.sol#97-127) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- uint256(seed) % MAX_BPS >= auditProbabilityBps (contracts/v2/AuditModule.sol#113)\n",
+    "uri": "contracts/v2/AuditModule.sol",
+    "startLine": 97,
+    "fingerprint": "bcc0f678acb8aa6c0c6ec045613468adbef0384cc88de6973ec5bd7da240436c"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "MockJobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/legacy/MockV2.sol#638-656) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(block.timestamp <= deadlines[jobId],deadline) (contracts/legacy/MockV2.sol#648)\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 638,
+    "fingerprint": "bd7aed23c484abfbef56d0f04c2f587f03d76eb7d152ea5f06aefc9f2ba01212"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "StakeManager.requestWithdraw(StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2082-2110) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- locked > 0 && block.timestamp < unlock && remaining < locked (contracts/v2/StakeManager.sol#2100)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2082,
+    "fingerprint": "c0b84c14a24f481112a72805319b8b3eacf81da507302e940263c5fc436a412a"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ValidationModule.reveal(uint256,bool,bytes32) (contracts/v2/kernel/ValidationModule.sol#114-132) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp <= round.commitDeadline (contracts/v2/kernel/ValidationModule.sol#118)\n\t- block.timestamp > round.revealDeadline (contracts/v2/kernel/ValidationModule.sol#119)\n",
+    "uri": "contracts/v2/kernel/ValidationModule.sol",
+    "startLine": 114,
+    "fingerprint": "c5626b7acea74521b94d8a2190d6b3187a9cf429520a31d1c2dc50dc171f8599"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "RandaoCoordinator.random(bytes32) (contracts/v2/RandaoCoordinator.sol#240-245) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- r.revealDeadline == 0 || block.timestamp <= r.revealDeadline (contracts/v2/RandaoCoordinator.sol#242)\n",
+    "uri": "contracts/v2/RandaoCoordinator.sol",
+    "startLine": 240,
+    "fingerprint": "c882cee765cff61f653b6e1bc8e7427eba8465cb1af22b31d8dcc8429812336e"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "RandaoCoordinator.commit(bytes32,bytes32) (contracts/v2/RandaoCoordinator.sol#199-214) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp > r.commitDeadline (contracts/v2/RandaoCoordinator.sol#205)\n",
+    "uri": "contracts/v2/RandaoCoordinator.sol",
+    "startLine": 199,
+    "fingerprint": "d73eae837a9436a13eeaa5f515a71c3b39eaf3a4816f3ece4f202178a4ef05a0"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "EnergyOracle.verify(IEnergyOracle.Attestation,bytes) (contracts/v2/EnergyOracle.sol#92-120) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- att.deadline < block.timestamp (contracts/v2/EnergyOracle.sol#97)\n",
+    "uri": "contracts/v2/EnergyOracle.sol",
+    "startLine": 92,
+    "fingerprint": "d9913cd8b14be7d78dbfdf2e8325044c772fa2742ac4bf99e088a153538bc014"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "ValidationModule.forceFinalize(uint256) (contracts/v2/ValidationModule.sol#1570-1629) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp <= r.revealDeadline + forceFinalizeGrace (contracts/v2/ValidationModule.sol#1579)\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1570,
+    "fingerprint": "e9db6dbd5b86ee688e03784e3f887c6b7545c6add4c4872543edd7c7274c1ce4"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "JobRegistry._createJob(uint256,uint64,uint8,bytes32,string) (contracts/v2/JobRegistry.sol#1621-1700) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- deadline <= block.timestamp (contracts/v2/JobRegistry.sol#1643)\n\t- maxJobDuration > 0 && uint256(deadline) - block.timestamp > maxJobDuration (contracts/v2/JobRegistry.sol#1647-1648)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1621,
+    "fingerprint": "ef46acd5bc8475070785d0e759496a5c9eea6014330dd838962f41a16cf45439"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "GovernanceReward.finalizeEpoch(uint256) (contracts/v2/GovernanceReward.sol#142-155) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(block.timestamp >= lastEpochTime + epochLength,early) (contracts/v2/GovernanceReward.sol#143)\n",
+    "uri": "contracts/v2/GovernanceReward.sol",
+    "startLine": 142,
+    "fingerprint": "f219d9706f730294d901f376b96c250a4c9e5c2b2ebe875de064b65d98d861f5"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "Votes.delegateBySig(address,uint256,uint256,uint8,bytes32,bytes32) (node_modules/@openzeppelin/contracts/governance/utils/Votes.sol#143-162) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp > expiry (node_modules/@openzeppelin/contracts/governance/utils/Votes.sol#151)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/utils/Votes.sol",
+    "startLine": 143,
+    "fingerprint": "f2e5e8901e27c1f9e2a37d5d61514aeda61870e41619e83e3ad0e11a90a68496"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "KernelJobRegistry.cancelExpiredJob(uint256) (contracts/v2/kernel/JobRegistry.sol#231-246) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp <= job.deadline (contracts/v2/kernel/JobRegistry.sol#235)\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 231,
+    "fingerprint": "f2fab385fa3f9ef5b7e254460230ab75d9388caa58b1d210b4d720fbbc71ffc8"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "StakeManager._withdraw(address,StakeManager.Role,uint256) (contracts/v2/StakeManager.sol#2132-2169) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp < unlock (contracts/v2/StakeManager.sol#2145)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2132,
+    "fingerprint": "fe941c1c475f0501e93aef05e706b99bab50a015fb8680edfb3158315a8eaeff"
+  },
+  {
+    "ruleId": "2-1-timestamp",
+    "message": "QuadraticVoting.castVote(uint256,uint256,uint256) (contracts/v2/QuadraticVoting.sol#83-109) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool,string)(deadline > block.timestamp,deadline) (contracts/v2/QuadraticVoting.sol#88)\n\t- require(bool,string)(block.timestamp <= d,expired) (contracts/v2/QuadraticVoting.sol#91)\n",
+    "uri": "contracts/v2/QuadraticVoting.sol",
+    "startLine": 83,
+    "fingerprint": "ff756c8376a151dbd74ee88a945816531f5df52dfba3160cd81e45b88bdc3a91"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SafeCast.toUint(bool) (node_modules/@openzeppelin/contracts/utils/math/SafeCast.sol#1157-1161) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/SafeCast.sol#1158-1160)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/SafeCast.sol",
+    "startLine": 1157,
+    "fingerprint": "02f5259e080856d63e5545d201ae538dd6b493b8f5a09e4287364c8b9a650872"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "StorageSlot.getAddressSlot(bytes32) (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#66-70) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#67-69)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/StorageSlot.sol",
+    "startLine": 66,
+    "fingerprint": "054be2726c041e3fb58c31a34494cdcecaeaee608fbdb1976c6606f26d6559fd"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SlotDerivation.erc7201Slot(string) (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#45-50) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#46-49)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol",
+    "startLine": 45,
+    "fingerprint": "0cc36b90c9760d55d81b04c479bd3447d5e01b27194e594d684ac050c6fba2eb"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeAccess(address[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#383-389) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#385-387)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 383,
+    "fingerprint": "0d596a39e1a8062605ec62b673b01f7543fa38187283e1a764f124d759072937"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "RewardEngineMB._aggregate(RewardEngineMB.Proof[],uint256,RewardEngineMB.Role) (contracts/v2/RewardEngineMB.sol#313-357) uses assembly\n\t- INLINE ASM (contracts/v2/RewardEngineMB.sol#349-356)\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 313,
+    "fingerprint": "1d5b9285656a7f387a99c37ecf25eb3dd25a2a7f3538851b823c8b350fb026dc"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "ShortStrings.toString(ShortString) (node_modules/@openzeppelin/contracts/utils/ShortStrings.sol#63-72) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/ShortStrings.sol#67-70)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/ShortStrings.sol",
+    "startLine": 63,
+    "fingerprint": "21684b209ba0488d2402f71bd0b02a0cd89e3aa4816931bf48baed9a68f039b0"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "StorageSlot.getUint256Slot(bytes32) (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#93-97) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#94-96)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/StorageSlot.sol",
+    "startLine": 93,
+    "fingerprint": "264c3ea2ec5f81f48f40bc32de2e71f4534bc537579c0899d8e1bc23ed94c652"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeAccess(string[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#435-441) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#437-439)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 435,
+    "fingerprint": "26c820a5bb1d8fa3dc1efbedc51bb0416221f66c649ab5da8ea32fd870c5cca5"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SafeERC20._callOptionalReturnBool(IERC20,bytes) (node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol#201-211) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol#205-209)\n",
+    "uri": "node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol",
+    "startLine": 201,
+    "fingerprint": "2d1928acc36ad4243b0ab5c5517e9d6f6fd6ac46675a53bbe016b31ae8035cc2"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Strings.escapeJSON(string) (node_modules/@openzeppelin/contracts/utils/Strings.sol#446-476) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Strings.sol#470-473)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Strings.sol",
+    "startLine": 446,
+    "fingerprint": "2de8274c65027cb4e372cfa16f2661e7fd433edf778ec2cf1bb5e22917e98e88"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Checkpoints._unsafeAccess(Checkpoints.Checkpoint208[],uint256) (node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol#418-426) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol#422-425)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol",
+    "startLine": 418,
+    "fingerprint": "2f0c56af3d468fdf0ac11eb1166fb2fbd59fca3a8213148b364ba3c05bf67879"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Bytes._unsafeReadBytesOffset(bytes,uint256) (node_modules/@openzeppelin/contracts/utils/Bytes.sol#107-112) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Bytes.sol#109-111)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Bytes.sol",
+    "startLine": 107,
+    "fingerprint": "3099691cc951200ea9788195eef63fa0cc57c1256c46b3b354a98d4cbc2960d5"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "ERC721Utils.checkOnERC721Received(address,address,address,uint256,bytes) (node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol#25-49) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol#43-45)\n",
+    "uri": "node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol",
+    "startLine": 25,
+    "fingerprint": "330737915edee699a915eef57855ae3af84bc48ee0b9fb37aa9abc91e7ad8ac1"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "EnumerableSet.values(EnumerableSet.UintSet,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#498-507) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#502-504)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol",
+    "startLine": 498,
+    "fingerprint": "375f8630dd3e1b2fcda6e2b70da01d8cd1b7494d28b7e13b8816a5ee5db070d0"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "EnumerableSet.values(EnumerableSet.Bytes32Set,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#294-303) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#298-300)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol",
+    "startLine": 294,
+    "fingerprint": "37bf1038f7cec34d7a48e31fb247d6c3d4c7f9ec8889750caa9e92bbe94eab6d"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Math.tryModExp(bytes,bytes,bytes) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#449-471) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/Math.sol#461-470)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 449,
+    "fingerprint": "3eb2bdc28e6c136822fd1d75045a31216595acdd47b75327d329c4a089f46ad6"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeAccess(uint256[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#409-415) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#411-413)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 409,
+    "fingerprint": "459b38699aab3616afd86ee1678ff0adc978b6a51c4a8abac09ee024e956b7a9"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SlotDerivation.deriveMapping(bytes32,bool) (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#85-91) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#86-90)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol",
+    "startLine": 85,
+    "fingerprint": "4aaa23470099551a0a42dcdbb357259a194c4f3e6c997bdf4e917930c4931418"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SlotDerivation.deriveMapping(bytes32,bytes) (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#144-154) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#145-153)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol",
+    "startLine": 144,
+    "fingerprint": "4d15b18e25664353eb1557913389e6fc04a9a1a6ff0d5d9c6c91a0055f48dfe9"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "EnumerableSet.values(EnumerableSet.Bytes32Set) (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#275-284) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#279-281)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol",
+    "startLine": 275,
+    "fingerprint": "4e03e0700188d300875c1e2089db7673cef7e99e445c9af123cec4b4d46ea0cf"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "StorageSlot.getBooleanSlot(bytes32) (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#75-79) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#76-78)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/StorageSlot.sol",
+    "startLine": 75,
+    "fingerprint": "4ffcc4bc56133512f291e0c8f23819ab8446934f704bebe05592aa8eea731e00"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeMemoryAccess(string[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#492-496) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#493-495)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 492,
+    "fingerprint": "50ba910c6a57cf8f2235ff74545620007d319431f5c943121c8ce002b061fa62"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Bytes.slice(bytes,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/Bytes.sol#86-99) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Bytes.sol#94-96)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Bytes.sol",
+    "startLine": 86,
+    "fingerprint": "51edfd862ea2213ddf6349e4741b7f9bb4d619a1b3566220178b02dfbb863148"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "StorageSlot.getBytes32Slot(bytes32) (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#84-88) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#85-87)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/StorageSlot.sol",
+    "startLine": 84,
+    "fingerprint": "612a9dc8c9c1dbfe7add1f8af0f4900582be8dddb47a4de76e5fa917021b0b88"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Math.mulDiv(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#204-275) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/Math.sol#227-234)\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/Math.sol#240-249)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 204,
+    "fingerprint": "65f44c3b86accfa132c68b07bb21be2f91c79e87197596cdb86d7ef037deed90"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeSetLength(bytes32[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#514-518) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#515-517)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 514,
+    "fingerprint": "66ce461297ef6ab0d610cd68af29f6079f0c304dc66f67d1f13e7b6a2353bced"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeMemoryAccess(bytes[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#481-485) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#482-484)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 481,
+    "fingerprint": "670354cc568562532afd42180e9c35b6a0f9c2a23faf9e696c8c888e1a0871fd"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "EnumerableSet.values(EnumerableSet.AddressSet) (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#377-386) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#381-383)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol",
+    "startLine": 377,
+    "fingerprint": "68b4bf6c672b0afb99d039a9a64fdc9f5f7831d124d16648063893b48ae26063"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Panic.panic(uint256) (node_modules/@openzeppelin/contracts/utils/Panic.sol#50-56) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Panic.sol#51-55)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Panic.sol",
+    "startLine": 50,
+    "fingerprint": "6b9e67291c502e0170fe7e856173b7dfdc60a14ed74cc695b43324c0047fff70"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "ReentrantJobRegistry._bubble(bytes) (contracts/v2/mocks/ReentrantJobRegistry.sol#102-109) uses assembly\n\t- INLINE ASM (contracts/v2/mocks/ReentrantJobRegistry.sol#106-108)\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 102,
+    "fingerprint": "6cb94e1afb60d52dec1e94c7885ec9ae4bde66ae4cce8213e4075c336d2d31ec"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SlotDerivation.deriveMapping(bytes32,address) (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#74-80) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#75-79)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol",
+    "startLine": 74,
+    "fingerprint": "6dc6e7a6f5845e65aa7908d2272874c501c48c63332fd5bfc194bce712a295be"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeAccess(bytes[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#422-428) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#424-426)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 422,
+    "fingerprint": "71534ce16db9be6c988323595979d6438131a6ce4a69feaa0503206e91074d27"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "ReentrantStakeManager.slash(address,uint256,address) (contracts/v2/mocks/ReentrantStakeManager.sol#200-216) uses assembly\n\t- INLINE ASM (contracts/v2/mocks/ReentrantStakeManager.sol#207-209)\n",
+    "uri": "contracts/v2/mocks/ReentrantStakeManager.sol",
+    "startLine": 200,
+    "fingerprint": "7257b0208c75099089b287b5a073d905a1e34b528023c540449c4133226b06ba"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeAccess(bytes32[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#396-402) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#398-400)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 396,
+    "fingerprint": "7614c864a716a6d04514ce5de39b68f8e78ea26a2c5de8ef59a47e703db292b5"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "StorageSlot.getInt256Slot(bytes32) (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#102-106) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#103-105)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/StorageSlot.sol",
+    "startLine": 102,
+    "fingerprint": "76502d1be4f6d19cafe0691c0f0f12ee6bd060f0d2e31208ded3c04716e69dd3"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Strings.toChecksumHexString(address) (node_modules/@openzeppelin/contracts/utils/Strings.sol#111-129) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Strings.sol#116-118)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Strings.sol",
+    "startLine": 111,
+    "fingerprint": "76956479693ac724c4a2f2ae32c1a3a870f8b948f32c68915d344d7d2c7bbee8"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "ReputationEngine.log2(uint256) (contracts/v2/ReputationEngine.sol#335-357) uses assembly\n\t- INLINE ASM (contracts/v2/ReputationEngine.sol#336-356)\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 335,
+    "fingerprint": "78cdb5b8ade5fbc52ae797e038c08fc658f6fc1f874f9b50d5f5775a07963a41"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeMemoryAccess(bytes32[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#459-463) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#460-462)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 459,
+    "fingerprint": "806037ea436187eb916c26d073ccdaac631622a1de8d25364a5094a350f617d6"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Address._revert(bytes) (node_modules/@openzeppelin/contracts/utils/Address.sol#138-148) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Address.sol#142-144)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Address.sol",
+    "startLine": 138,
+    "fingerprint": "8595d00e73efb47c217c3e53b5a9a9d95de4df79d2407b253f5240492ed20621"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "EnumerableSet.values(EnumerableSet.AddressSet,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#396-405) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#400-402)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol",
+    "startLine": 396,
+    "fingerprint": "8cfd724507338e6f543e3672f5c1ce39816fb3ae3e94960050090423d29cd841"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Strings.toString(uint256) (node_modules/@openzeppelin/contracts/utils/Strings.sol#45-63) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Strings.sol#50-52)\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Strings.sol#55-57)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Strings.sol",
+    "startLine": 45,
+    "fingerprint": "8e13a29075f76f838f94ede98eaafc706d80076d031bd00f37d573f1a04b4f3c"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "StorageSlot.getBytesSlot(bytes) (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#138-142) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#139-141)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/StorageSlot.sol",
+    "startLine": 138,
+    "fingerprint": "8fc877a96d4067319b343c0d9bd2cdbf0f95fd84f867bf804c0023402d21d0a3"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SlotDerivation.deriveArray(bytes32) (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#64-69) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#65-68)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol",
+    "startLine": 64,
+    "fingerprint": "9171ad9399845f8dc5cf057bd9778ea3766c115d08f6b1a56c9c87998d56be02"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays._castToUint256Array(address[]) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#180-184) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#181-183)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 180,
+    "fingerprint": "9753502b457038467f3e8efc34d439bafbd183f4937df47ea3f6ab2e4e5f76cc"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Math.mul512(uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#37-46) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/Math.sol#41-45)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 37,
+    "fingerprint": "98a38daf187a050903d837022e875b739edc787fbc4a7747baf53e811ba118d5"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeSetLength(address[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#503-507) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#504-506)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 503,
+    "fingerprint": "9a7ee79bac0e518b792d064e4d681a892f35f513f3ef01a0e2e52710b6be4d48"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "StorageSlot.getStringSlot(bytes32) (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#111-115) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#112-114)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/StorageSlot.sol",
+    "startLine": 111,
+    "fingerprint": "9afc2c43f065cf3fe1452981a6b55dc27c6bc95642e598da45fa226493eac6cb"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Checkpoints._unsafeAccess(Checkpoints.Checkpoint160[],uint256) (node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol#621-629) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol#625-628)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol",
+    "startLine": 621,
+    "fingerprint": "9b6ce6316e7d9c8209b867099305efe297c1b51460f5d52076615af6fb700965"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "EnumerableSet.values(EnumerableSet.UintSet) (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#479-488) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#483-485)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol",
+    "startLine": 479,
+    "fingerprint": "9fe05754dc9ed1b7303897cc8e6ea5953420424546c5a67a255e5b6d5a4430e1"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "MessageHashUtils.toEthSignedMessageHash(bytes32) (node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol#30-36) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol#31-35)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol",
+    "startLine": 30,
+    "fingerprint": "a1466dfc9a9ab8077e66ed79f05b199aed652c2d738560bd3a71d19ad02fc831"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "ReentrantStakeManager.slash(address,IStakeManager.Role,uint256,address) (contracts/v2/mocks/ReentrantStakeManager.sol#169-185) uses assembly\n\t- INLINE ASM (contracts/v2/mocks/ReentrantStakeManager.sol#176-178)\n",
+    "uri": "contracts/v2/mocks/ReentrantStakeManager.sol",
+    "startLine": 169,
+    "fingerprint": "a96fc4630d3829fdb277a0d53d3a0d17dca7cbcefee059edb86576baf2a1f952"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeSetLength(string[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#547-551) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#548-550)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 547,
+    "fingerprint": "aba394584ae6e4b92b0bbda3daa2b440703bd4b106f7e1402f5b41b16f4898d4"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Strings._unsafeReadBytesOffset(bytes,uint256) (node_modules/@openzeppelin/contracts/utils/Strings.sol#484-489) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Strings.sol#486-488)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Strings.sol",
+    "startLine": 484,
+    "fingerprint": "af562e08a99713c27f4d15dceb1d0171c647169b24ea8937170f6883fe5f7d48"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Governor._unsafeReadBytesOffset(bytes,uint256) (node_modules/@openzeppelin/contracts/governance/Governor.sol#812-817) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/governance/Governor.sol#814-816)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 812,
+    "fingerprint": "b4c3f147e34be3479835c0cc558515afe5264779c6e194c411c4c0427c6e2c1c"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays._swap(uint256,uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#170-177) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#171-176)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 170,
+    "fingerprint": "b61edd35b44510b90f6464c2b78e550012540b8df4632db85792e4bceed785e6"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SlotDerivation.deriveMapping(bytes32,string) (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#129-139) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#130-138)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol",
+    "startLine": 129,
+    "fingerprint": "b94b12995e1c69b74910033b8f8c4727c3f1b58578480c43843a761cb2ba4d21"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "ECDSA.tryRecover(bytes32,bytes) (node_modules/@openzeppelin/contracts/utils/cryptography/ECDSA.sol#56-75) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/cryptography/ECDSA.sol#66-70)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/cryptography/ECDSA.sol",
+    "startLine": 56,
+    "fingerprint": "b9d20c63bae19d995ced3db08a1fa3f210fc69fe013d0bbb66ac19c7f22c42a8"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays._mload(uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#161-165) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#162-164)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 161,
+    "fingerprint": "bca962b5da286d5ccd550fc9c25576c1c4413bec5924b44777fe82e9011856ce"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Math.log2(uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#612-651) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/Math.sol#648-650)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 612,
+    "fingerprint": "bcf77543398db6517f671d5853fc727bac283727a7180b3084f18a05ad072d90"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeSetLength(uint256[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#525-529) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#526-528)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 525,
+    "fingerprint": "bd0f4864634e0acd6ddad0affbf7dfd3b3e44ca17c4c8eb4f951bf130dc6b8ae"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SlotDerivation.deriveMapping(bytes32,bytes32) (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#96-102) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#97-101)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol",
+    "startLine": 96,
+    "fingerprint": "beef93b7a62dc9fb31f18b0b17aa689678d48b7e54eaf489571a7cb00fd39ac8"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "StorageSlot.getStringSlot(string) (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#120-124) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#121-123)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/StorageSlot.sol",
+    "startLine": 120,
+    "fingerprint": "c242b16f9d7ba2c0f8be576b5fc71ae1951eea16908028f4cd35e032f919a8e5"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays._begin(uint256[]) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#142-146) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#143-145)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 142,
+    "fingerprint": "c3da5508380e35399d98e8fc26e9f4c54da3e62bd36717fa8923a0735953c6a5"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Math.tryMul(uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#73-84) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/Math.sol#76-80)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 73,
+    "fingerprint": "c9b577be3ced93f22739fffdb6412c478ac11ba4fbfb832a24f271848789988b"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays._castToUint256Comp(function(address,address) returns(bool)) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#194-200) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#197-199)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 194,
+    "fingerprint": "ccf5c6ed74f1c74e62bfcfd131c7d8cb43fed6c7311ecc6df4793dab2821f915"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Math.tryMod(uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#102-110) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/Math.sol#105-108)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 102,
+    "fingerprint": "d157c527fb903d6284db1c35ee7cf183db1be54b3e53913f3390c37f30279328"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Math.tryModExp(uint256,uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#409-433) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/Math.sol#411-432)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 409,
+    "fingerprint": "d4318b56c437eeba9d6e9e029d17fbb0f2a9df441b46ce99a9a041213a6b7091"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Math.tryDiv(uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#89-97) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/Math.sol#92-95)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 89,
+    "fingerprint": "d4fee22f13e59a3fe9db6750252db29a47d4fdb32128fb1942827c0910e4a97e"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "StorageSlot.getBytesSlot(bytes32) (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#129-133) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#130-132)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/StorageSlot.sol",
+    "startLine": 129,
+    "fingerprint": "d78e7e85e12d6bdb74bebffb61bcb33e173d4336ea4af18ae3bd87951c3eef33"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeMemoryAccess(address[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#448-452) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#449-451)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 448,
+    "fingerprint": "d84a6adbece158298ff323c62592820670f922614365aab1030a46fe819af7b4"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SlotDerivation.deriveMapping(bytes32,uint256) (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#107-113) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#108-112)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol",
+    "startLine": 107,
+    "fingerprint": "e0c01184cd0f973029b5ffb3c7d6c3654d89bb577dec5adeea6d8a72a7419783"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "MessageHashUtils.toTypedDataHash(bytes32,bytes32) (node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol#90-98) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol#91-97)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol",
+    "startLine": 90,
+    "fingerprint": "e1be57b10ea95484c4174068a983268996aa621fbb63969c3d27fda31dc97307"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SystemPause.executeGovernanceCall(address,bytes) (contracts/v2/SystemPause.sol#239-272) uses assembly\n\t- INLINE ASM (contracts/v2/SystemPause.sol#256-258)\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 239,
+    "fingerprint": "e31b84c4c6460590a424230cd5619a479b440d13058fbb42b691ea12fd17e621"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SafeERC20._callOptionalReturn(IERC20,bytes) (node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol#173-191) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol#176-186)\n",
+    "uri": "node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol",
+    "startLine": 173,
+    "fingerprint": "e33f785d9aba7249e9ee500ebca265dd99dc07b707a45bc02b2097d7f4cae1df"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Hashes.efficientKeccak256(bytes32,bytes32) (node_modules/@openzeppelin/contracts/utils/cryptography/Hashes.sol#24-30) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/cryptography/Hashes.sol#25-29)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/cryptography/Hashes.sol",
+    "startLine": 24,
+    "fingerprint": "e6bfbf18c4bab7a3412cd4de16ff8b4476414fee1ad78c1d33cd80ff642283eb"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeMemoryAccess(uint256[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#470-474) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#471-473)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 470,
+    "fingerprint": "e9571a20df2361fbd18bc01ecfc0fa26f2de255110fd64f57c99564bd559d84c"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays.unsafeSetLength(bytes[],uint256) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#536-540) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#537-539)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 536,
+    "fingerprint": "e9a4a56b0b60c07c6c41982899c7fbdb235cb9f930acb7564b7487245dca4eeb"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "MessageHashUtils.toDataWithIntendedValidatorHash(address,bytes32) (node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol#69-79) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol#73-78)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol",
+    "startLine": 69,
+    "fingerprint": "eb159f0e6e8b422fce15e51a0d8e0d9044094a48bd35afc3b2c176cc1ba1dfb2"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "SlotDerivation.deriveMapping(bytes32,int256) (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#118-124) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#119-123)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol",
+    "startLine": 118,
+    "fingerprint": "eef1873b7c0c8bf657b5d83e205a6a8a3ae41447af3ea4cab0c54f0cd620111e"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays._castToUint256Comp(function(bytes32,bytes32) returns(bool)) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#203-209) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#206-208)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 203,
+    "fingerprint": "f025e70799e79ea2829b8c65b6f8347ad6485edf56519fa840628dc1e1d8573c"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Math.add512(uint256,uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#25-30) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/math/Math.sol#26-29)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 25,
+    "fingerprint": "f2906f6dc51a3ca6ec6db0c163e036667be25739e938918f805dd4954be968d7"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Checkpoints._unsafeAccess(Checkpoints.Checkpoint224[],uint256) (node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol#215-223) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol#219-222)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol",
+    "startLine": 215,
+    "fingerprint": "f3dfc544e065618fe375e9a98e3a480aa9d0ef95a80fb95828ae8f06a5763686"
+  },
+  {
+    "ruleId": "3-0-assembly",
+    "message": "Arrays._castToUint256Array(bytes32[]) (node_modules/@openzeppelin/contracts/utils/Arrays.sol#187-191) uses assembly\n\t- INLINE ASM (node_modules/@openzeppelin/contracts/utils/Arrays.sol#188-190)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Arrays.sol",
+    "startLine": 187,
+    "fingerprint": "f4f738b0cde59ef8b1cab287f9b8d1ac1337448bf28d9f9978670ed0cbc3ebc9"
+  },
+  {
+    "ruleId": "3-0-pragma",
+    "message": "10 different versions of Solidity are used:\n\t- Version constraint ^0.8.20 is used by:\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/access/AccessControl.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/access/Ownable.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/access/Ownable2Step.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/governance/utils/Votes.sol#3)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC721/ERC721.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/Address.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/Arrays.sol#5)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/Comparators.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/Context.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/Errors.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/Nonces.sol#3)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/Panic.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/Pausable.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/ReentrancyGuard.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/ShortStrings.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#5)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#5)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/Strings.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/cryptography/ECDSA.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/cryptography/EIP712.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/cryptography/Hashes.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/cryptography/MerkleProof.sol#5)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/introspection/ERC165.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/math/Math.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/math/SafeCast.sol#5)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/math/SignedMath.sol#4)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol#5)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/structs/DoubleEndedQueue.sol#3)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#5)\n\t\t-^0.8.20 (node_modules/@openzeppelin/contracts/utils/types/Time.sol#4)\n\t\t-^0.8.20 (contracts/test/EchidnaHarness.sol#2)\n\t- Version constraint >=0.8.4 is used by:\n\t\t->=0.8.4 (node_modules/@openzeppelin/contracts/access/IAccessControl.sol#4)\n\t\t->=0.8.4 (node_modules/@openzeppelin/contracts/governance/IGovernor.sol#4)\n\t\t->=0.8.4 (node_modules/@openzeppelin/contracts/governance/utils/IVotes.sol#3)\n\t\t->=0.8.4 (node_modules/@openzeppelin/contracts/interfaces/IERC5805.sol#4)\n\t\t->=0.8.4 (node_modules/@openzeppelin/contracts/interfaces/draft-IERC6093.sol#3)\n\t- Version constraint ^0.8.24 is used by:\n\t\t-^0.8.24 (node_modules/@openzeppelin/contracts/governance/Governor.sol#4)\n\t\t-^0.8.24 (node_modules/@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol#4)\n\t\t-^0.8.24 (node_modules/@openzeppelin/contracts/governance/extensions/GovernorSettings.sol#4)\n\t\t-^0.8.24 (node_modules/@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol#4)\n\t\t-^0.8.24 (node_modules/@openzeppelin/contracts/governance/extensions/GovernorVotes.sol#4)\n\t\t-^0.8.24 (node_modules/@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol#4)\n\t\t-^0.8.24 (node_modules/@openzeppelin/contracts/utils/Bytes.sol#4)\n\t\t-^0.8.24 (node_modules/@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol#4)\n\t- Version constraint >=0.5.0 is used by:\n\t\t->=0.5.0 (node_modules/@openzeppelin/contracts/interfaces/IERC1271.sol#4)\n\t\t->=0.5.0 (node_modules/@openzeppelin/contracts/interfaces/IERC7913.sol#4)\n\t\t->=0.5.0 (node_modules/@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol#4)\n\t- Version constraint >=0.6.2 is used by:\n\t\t->=0.6.2 (node_modules/@openzeppelin/contracts/interfaces/IERC1363.sol#4)\n\t\t->=0.6.2 (node_modules/@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol#4)\n\t\t->=0.6.2 (node_modules/@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol#4)\n\t\t->=0.6.2 (node_modules/@openzeppelin/contracts/token/ERC721/IERC721.sol#4)\n\t\t->=0.6.2 (node_modules/@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol#4)\n\t- Version constraint >=0.4.16 is used by:\n\t\t->=0.4.16 (node_modules/@openzeppelin/contracts/interfaces/IERC165.sol#4)\n\t\t->=0.4.16 (node_modules/@openzeppelin/contracts/interfaces/IERC20.sol#4)\n\t\t->=0.4.16 (node_modules/@openzeppelin/contracts/interfaces/IERC5267.sol#4)\n\t\t->=0.4.16 (node_modules/@openzeppelin/contracts/interfaces/IERC6372.sol#4)\n\t\t->=0.4.16 (node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol#4)\n\t\t->=0.4.16 (node_modules/@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol#4)\n\t\t->=0.4.16 (node_modules/@openzeppelin/contracts/utils/introspection/IERC165.sol#4)\n\t- Version constraint >=0.8.19 is used by:\n\t\t->=0.8.19 (node_modules/@prb/math/src/Common.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/sd1x18/Casting.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/sd1x18/Constants.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/sd1x18/Errors.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/sd1x18/ValueType.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/sd59x18/Casting.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/sd59x18/Constants.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/sd59x18/Errors.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/sd59x18/Helpers.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/sd59x18/Math.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/sd59x18/ValueType.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/ud2x18/Casting.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/ud2x18/Constants.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/ud2x18/Errors.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/ud2x18/ValueType.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/ud60x18/Casting.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/ud60x18/Constants.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/ud60x18/Errors.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/ud60x18/Helpers.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/ud60x18/Math.sol#2)\n\t\t->=0.8.19 (node_modules/@prb/math/src/ud60x18/ValueType.sol#2)\n\t- Version constraint ^0.8.25 is used by:\n\t\t-^0.8.25 (contracts/CommitRevealMock.sol#2)\n\t\t-^0.8.25 (contracts/Migrations.sol#2)\n\t\t-^0.8.25 (contracts/coverage/CommitRevealCoverage.sol#2)\n\t\t-^0.8.25 (contracts/coverage/ConfiguratorTarget.sol#2)\n\t\t-^0.8.25 (contracts/coverage/CoverageGovernanceTarget.sol#2)\n\t\t-^0.8.25 (contracts/coverage/CoverageVotesToken.sol#2)\n\t\t-^0.8.25 (contracts/coverage/GovernorHarness.sol#2)\n\t\t-^0.8.25 (contracts/coverage/OwnerConfiguratorHarness.sol#2)\n\t\t-^0.8.25 (contracts/coverage/TestSupport.sol#2)\n\t\t-^0.8.25 (contracts/coverage/TimelockHarness.sol#2)\n\t\t-^0.8.25 (contracts/gas/CommitRevealImports.sol#2)\n\t\t-^0.8.25 (contracts/legacy/BadTaxPolicy.sol#2)\n\t\t-^0.8.25 (contracts/legacy/MockENS.sol#2)\n\t\t-^0.8.25 (contracts/legacy/MockNameWrapper.sol#2)\n\t\t-^0.8.25 (contracts/legacy/MockRoutingModule.sol#2)\n\t\t-^0.8.25 (contracts/legacy/ReentrantBuyer.sol#2)\n\t\t-^0.8.25 (contracts/legacy/ReentrantERC206.sol#2)\n\t\t-^0.8.25 (contracts/legacy/RevertingNameWrapper.sol#2)\n\t\t-^0.8.25 (contracts/legacy/TaxExemptHelper.sol#2)\n\t\t-^0.8.25 (contracts/legacy/TimelockControllerHarness.sol#2)\n\t\t-^0.8.25 (contracts/legacy/TimelockMock.sol#2)\n\t\t-^0.8.25 (contracts/mocks/TestAGIALPHA.sol#2)\n\t\t-^0.8.25 (contracts/test/AGIALPHAToken.sol#2)\n\t\t-^0.8.25 (contracts/test/BadStakeManager.sol#2)\n\t\t-^0.8.25 (contracts/test/CommitRevealEchidna.sol#2)\n\t\t-^0.8.25 (contracts/test/ConfigurableModuleMock.sol#2)\n\t\t-^0.8.25 (contracts/test/DeterministicValidationModule.sol#2)\n\t\t-^0.8.25 (contracts/test/EmployerContract.sol#2)\n\t\t-^0.8.25 (contracts/test/GovernanceRewardMock.sol#2)\n\t\t-^0.8.25 (contracts/test/GovernanceTarget.sol#2)\n\t\t-^0.8.25 (contracts/test/MockERC20.sol#2)\n\t\t-^0.8.25 (contracts/test/MockERC206Decimals.sol#2)\n\t\t-^0.8.25 (contracts/test/MockERC20NoMetadata.sol#2)\n\t\t-^0.8.25 (contracts/test/MockHamiltonianFeed.sol#2)\n\t\t-^0.8.25 (contracts/test/MockVotesToken.sol#2)\n\t\t-^0.8.25 (contracts/test/QuadraticVotingAttack.sol#2)\n\t\t-^0.8.25 (contracts/test/ReentrantERC20.sol#2)\n\t\t-^0.8.25 (contracts/test/SimpleJobRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/ArbitratorCommittee.sol#2)\n\t\t-^0.8.25 (contracts/v2/AttestationRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/AuditModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/CertificateNFT.sol#2)\n\t\t-^0.8.25 (contracts/v2/Constants.sol#2)\n\t\t-^0.8.25 (contracts/v2/Deployer.sol#2)\n\t\t-^0.8.25 (contracts/v2/ENSIdentityVerifier.sol#2)\n\t\t-^0.8.25 (contracts/v2/EnergyOracle.sol#2)\n\t\t-^0.8.25 (contracts/v2/FeePool.sol#2)\n\t\t-^0.8.25 (contracts/v2/Governable.sol#2)\n\t\t-^0.8.25 (contracts/v2/GovernanceReward.sol#2)\n\t\t-^0.8.25 (contracts/v2/HamiltonianMonitor.sol#2)\n\t\t-^0.8.25 (contracts/v2/IdentityRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/JobRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/ModuleInstaller.sol#2)\n\t\t-^0.8.25 (contracts/v2/PlatformIncentives.sol#2)\n\t\t-^0.8.25 (contracts/v2/PlatformRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/QuadraticVoting.sol#2)\n\t\t-^0.8.25 (contracts/v2/RandaoCoordinator.sol#2)\n\t\t-^0.8.25 (contracts/v2/ReputationEngine.sol#2)\n\t\t-^0.8.25 (contracts/v2/RewardEngineMB.sol#2)\n\t\t-^0.8.25 (contracts/v2/StakeManager.sol#2)\n\t\t-^0.8.25 (contracts/v2/SystemPause.sol#2)\n\t\t-^0.8.25 (contracts/v2/TaxPolicy.sol#2)\n\t\t-^0.8.25 (contracts/v2/Thermostat.sol#2)\n\t\t-^0.8.25 (contracts/v2/ValidationModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/admin/OwnerConfigurator.sol#2)\n\t\t-^0.8.25 (contracts/v2/governance/AGIGovernor.sol#2)\n\t\t-^0.8.25 (contracts/v2/governance/AGITimelock.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IAddrResolver.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IAuditModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/ICertificateNFT.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IDisputeModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IENS.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IERC20Burnable.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IERC20Mintable.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IEnergyOracle.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IFeePool.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IHamiltonian.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IIdentityRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IJobEscrow.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IJobRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IJobRegistryAck.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IJobRegistryTax.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IJobRouter.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/INameWrapper.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IPlatformRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IPlatformRegistryFull.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IRandaoCoordinator.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IReputationEngine.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IReputationEngineV2.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IStakeManager.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/ITaxPolicy.sol#2)\n\t\t-^0.8.25 (contracts/v2/interfaces/IValidationModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/kernel/Config.sol#2)\n\t\t-^0.8.25 (contracts/v2/kernel/EscrowVault.sol#2)\n\t\t-^0.8.25 (contracts/v2/kernel/JobRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/kernel/RewardEngine.sol#2)\n\t\t-^0.8.25 (contracts/v2/kernel/StakeManager.sol#2)\n\t\t-^0.8.25 (contracts/v2/kernel/ValidationModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/kernel/interfaces/IJobRegistryKernel.sol#2)\n\t\t-^0.8.25 (contracts/v2/libraries/TaxAcknowledgement.sol#2)\n\t\t-^0.8.25 (contracts/v2/libraries/ThermoMath.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/GovernableMock.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/IdentityRegistryMock.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/IdentityRegistryToggle.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/JobRegistryAckRecorder.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/JobRegistryAckRevert.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/JobRegistryAckStub.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/MockArbitrator.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/ReentrantIdentityRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/ReentrantJobRegistry.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/ReentrantStakeManager.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/RewardEngineMBMocks.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/TaxPolicyNonExempt.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/ValidationModuleFailoverHarness.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/ValidationStub.sol#2)\n\t\t-^0.8.25 (contracts/v2/mocks/VersionMock.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/CertificateNFT.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/DiscoveryModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/DisputeModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/ENSOwnershipVerifier.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/JobEscrow.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/JobRouter.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/KlerosDisputeModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/NoValidationModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/OracleValidationModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/RevenueDistributor.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/RoutingModule.sol#2)\n\t\t-^0.8.25 (contracts/v2/modules/VerifyOwnership.sol#2)\n\t\t-^0.8.25 (contracts/v2/utils/Ownable2Step.sol#2)\n\t- Version constraint ^0.8.23 is used by:\n\t\t-^0.8.23 (contracts/legacy/DisputeRegistryStub.sol#2)\n\t\t-^0.8.23 (contracts/legacy/MockV2.sol#2)\n\t- Version constraint ^0.8.21 is used by:\n\t\t-^0.8.21 (contracts/legacy/MaliciousERC721.sol#2)\n\t\t-^0.8.21 (contracts/legacy/MockERC721.sol#2)\n\t\t-^0.8.21 (contracts/legacy/MockResolver.sol#2)\n\t\t-^0.8.21 (contracts/legacy/ReentrantERC20.sol#2)\n\t\t-^0.8.21 (contracts/legacy/StubReputationEngine.sol#2)\n\t\t-^0.8.21 (contracts/legacy/StubStakeManager.sol#2)\n",
+    "uri": "node_modules/@openzeppelin/contracts/access/AccessControl.sol",
+    "startLine": 4,
+    "fingerprint": "fde6de6a98d7b0799704846e12032b3849e69a248f6ad3e96731089c6bf8ef8b"
+  },
+  {
+    "ruleId": "3-1-costly-loop",
+    "message": "DiscoveryModule.deregisterPlatform(address) (contracts/v2/modules/DiscoveryModule.sol#64-76) has costly operations inside a loop:\n\t- platforms.pop() (contracts/v2/modules/DiscoveryModule.sol#71)\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 64,
+    "fingerprint": "0a842bb616dd5b01c4e6bf8ddd168d0fd712a70ce301594a951a2c646147c9ed"
+  },
+  {
+    "ruleId": "3-1-costly-loop",
+    "message": "RoutingModule.deregister(address) (contracts/v2/modules/RoutingModule.sol#65-77) has costly operations inside a loop:\n\t- operators.pop() (contracts/v2/modules/RoutingModule.sol#72)\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 65,
+    "fingerprint": "47b760ea9fbd1e54cd5a4222bd219c5f937f02eed1f94f574351e238e4e0c622"
+  },
+  {
+    "ruleId": "3-1-costly-loop",
+    "message": "IdentityRegistry._removeNodeRootNodeAlias(bytes32) (contracts/v2/IdentityRegistry.sol#652-671) has costly operations inside a loop:\n\t- nodeRootNodeAliases.pop() (contracts/v2/IdentityRegistry.sol#666)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 652,
+    "fingerprint": "6e402aa31d05a7e6327eac4b190ac16fb21dd15d94ec3e7c24ff502f6671a387"
+  },
+  {
+    "ruleId": "3-1-costly-loop",
+    "message": "TaxPolicy._revokeAcknowledgement(address) (contracts/v2/TaxPolicy.sol#123-128) has costly operations inside a loop:\n\t- delete _acknowledgedVersion[user] (contracts/v2/TaxPolicy.sol#126)\n",
+    "uri": "contracts/v2/TaxPolicy.sol",
+    "startLine": 123,
+    "fingerprint": "839a361cba6dd76a287c817351d04f71aef2cb40e450f7229887609fbce6a48d"
+  },
+  {
+    "ruleId": "3-1-costly-loop",
+    "message": "StakeManager.removeAGIType(address) (contracts/v2/StakeManager.sol#1730-1744) has costly operations inside a loop:\n\t- agiTypes.pop() (contracts/v2/StakeManager.sol#1735)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1730,
+    "fingerprint": "85fd784326c615ea6df663a7f6374481fd7943cce114aad821ecf8fa3bbde273"
+  },
+  {
+    "ruleId": "3-1-costly-loop",
+    "message": "RevenueDistributor.deregister(address) (contracts/v2/modules/RevenueDistributor.sol#59-71) has costly operations inside a loop:\n\t- operators.pop() (contracts/v2/modules/RevenueDistributor.sol#66)\n",
+    "uri": "contracts/v2/modules/RevenueDistributor.sol",
+    "startLine": 59,
+    "fingerprint": "95f6e9a30c73bd6fed3f8f12d39de036bfc8b5d876c964638fcdfa8b9f9c0f42"
+  },
+  {
+    "ruleId": "3-1-costly-loop",
+    "message": "IdentityRegistry._removeClubRootNodeAlias(bytes32) (contracts/v2/IdentityRegistry.sol#619-638) has costly operations inside a loop:\n\t- clubRootNodeAliases.pop() (contracts/v2/IdentityRegistry.sol#633)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 619,
+    "fingerprint": "f0c0a79f4e6eecaa226fcab4b9f40241c3899c0305436527eb6dc7a109fc543a"
+  },
+  {
+    "ruleId": "3-1-costly-loop",
+    "message": "IdentityRegistry._removeAgentRootNodeAlias(bytes32) (contracts/v2/IdentityRegistry.sol#586-605) has costly operations inside a loop:\n\t- agentRootNodeAliases.pop() (contracts/v2/IdentityRegistry.sol#600)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 586,
+    "fingerprint": "feaf2214d4c7185ff5072bedbdc38e6c224334ae66530d50dc155f447829718d"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "JobRegistry.applyConfiguration(JobRegistry.ConfigUpdate,JobRegistry.AcknowledgerUpdate[],address[]) (contracts/v2/JobRegistry.sol#1364-1616) has a high cyclomatic complexity (34).\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1364,
+    "fingerprint": "10df20b5a0759aa662d13b40cf7287617ddd318ac0be733fad47a296e14f5b54"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "JobRegistry._finalize(uint256) (contracts/v2/JobRegistry.sol#2304-2495) has a high cyclomatic complexity (40).\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 2304,
+    "fingerprint": "264beec899ddc331cc642469a0ca41a52fe4c20a2e99e9dde9fe2865be83fcb4"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "JobRegistry.submit(uint256,bytes32,string,string,bytes32[]) (contracts/v2/JobRegistry.sol#1917-2001) has a high cyclomatic complexity (16).\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1917,
+    "fingerprint": "3653f4f8b3b2f080c53a07911e7045a0db39aace87ea20c8f79ca4f132b6bb8d"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "log10(SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#363-459) has a high cyclomatic complexity (80).\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 363,
+    "fingerprint": "3e6d46774af25ed9dfc8f53a2ed66972ab747bbeb84fe6e9958833fce4526fe3"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "IdentityRegistry.applyConfiguration(IdentityRegistry.ConfigUpdate,IdentityRegistry.AdditionalAgentConfig[],IdentityRegistry.AdditionalValidatorConfig[],IdentityRegistry.AdditionalNodeOperatorConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.RootNodeAliasConfig[],IdentityRegistry.AgentTypeConfig[]) (contracts/v2/IdentityRegistry.sol#353-488) has a high cyclomatic complexity (20).\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 353,
+    "fingerprint": "43b7e18d889456f810b5a2f95b566fb14254e956f80314d1facc6a1192135c4e"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "DiscoveryModule.getPlatforms(uint256,uint256) (contracts/v2/modules/DiscoveryModule.sol#81-129) has a high cyclomatic complexity (12).\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 81,
+    "fingerprint": "45699d68256388fb9d6f1fc2beb7ae1ee9afd99be1e97fe15870a575fb7b2422"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "StakeManager._maybeAdjustStake() (contracts/v2/StakeManager.sol#627-655) has a high cyclomatic complexity (12).\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 627,
+    "fingerprint": "4da255e732d711cb2419a47951850d54958c7c0f6581dea1002f275184a7c3e7"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "log10(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#270-367) has a high cyclomatic complexity (81).\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 270,
+    "fingerprint": "688c71e83c66472469e5a4a0413a32d873f884c400014736ae6d98f2001b66b3"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "StakeManager._slash(address,StakeManager.Role,uint256,address,address[]) (contracts/v2/StakeManager.sol#2633-2753) has a high cyclomatic complexity (23).\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2633,
+    "fingerprint": "7345747b4f3df54a063ebb17eea67e418689e6b08aac7d6bc8f88789d832db47"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "JobRegistry._applyForJob(uint256,string,bytes32[]) (contracts/v2/JobRegistry.sol#1750-1861) has a high cyclomatic complexity (22).\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1750,
+    "fingerprint": "7ed5a08f3b1709f9248b8101d53909826a991c12086feea09e6d0580d10d1ae5"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "Deployer._deploy(bool,Deployer.EconParams,Deployer.IdentityParams,address) (contracts/v2/Deployer.sol#237-475) has a high cyclomatic complexity (13).\n",
+    "uri": "contracts/v2/Deployer.sol",
+    "startLine": 237,
+    "fingerprint": "8cbae3293b6c7ce90cebe5129d78986503468bcb689fde9f499612c86c0cb3cd"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "RoutingModule.selectOperator(bytes32,bytes32) (contracts/v2/modules/RoutingModule.sol#124-187) has a high cyclomatic complexity (12).\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 124,
+    "fingerprint": "93eca372bb010dd9e374ad8bd835bc2109c624c1e706d7b4109c5458981f8ece"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "JobRegistry.constructor(IValidationModule,IStakeManager,IReputationEngine,IDisputeModule,ICertificateNFT,IFeePool,ITaxPolicy,uint256,uint96,address[],address) (contracts/v2/JobRegistry.sol#1036-1103) has a high cyclomatic complexity (18).\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1036,
+    "fingerprint": "9466632152b54628291e4b506c79b96b7cf7b164a3f35aba69f751755be63aa3"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "StakeManager._finalizeJobFunds(bytes32,address,address,uint256,uint256,uint256,uint256,IFeePool) (contracts/v2/StakeManager.sol#2453-2518) has a high cyclomatic complexity (13).\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2453,
+    "fingerprint": "b2700cd80ec6de118989e2c5688445bf452ebca30d166f2078a3f01e38b3f8b8"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "KernelJobRegistry.createJob(address,address[],uint256,uint64,bytes32) (contracts/v2/kernel/JobRegistry.sol#156-214) has a high cyclomatic complexity (14).\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 156,
+    "fingerprint": "bee80447f1bf785578d5ff4febe7033f896384a53ab3e6e6e073886be3936471"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "ValidationModule.constructor(IJobRegistry,IStakeManager,uint256,uint256,uint256,uint256,address[]) (contracts/v2/ValidationModule.sol#372-435) has a high cyclomatic complexity (12).\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 372,
+    "fingerprint": "c83272f415ae137961db811fdf3fc75f1a79136943bae80f6c3dbb4962106163"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "StakeManager.applyConfiguration(StakeManager.ConfigUpdate,StakeManager.TreasuryAllowlistUpdate[]) (contracts/v2/StakeManager.sol#1461-1703) has a high cyclomatic complexity (40).\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1461,
+    "fingerprint": "ca492cd5aeabd86e989b149faf35671441840ccae030c26650550870bfd7dc74"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "ValidationModule.selectValidators(uint256,uint256) (contracts/v2/ValidationModule.sol#837-1250) has a high cyclomatic complexity (48).\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 837,
+    "fingerprint": "d01aa33d17f591586424371628066f91389b1e175d01ed4f261091983753cb29"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "ENSIdentityVerifier.verifyOwnership(IENS,INameWrapper,bytes32,bytes32,address,string,bytes32[]) (contracts/v2/ENSIdentityVerifier.sol#57-132) has a high cyclomatic complexity (12).\n",
+    "uri": "contracts/v2/ENSIdentityVerifier.sol",
+    "startLine": 57,
+    "fingerprint": "d49803a6d91e2239f1fadf409a6ae4591d31ddca05bb719a4d51aab2b9b52871"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "SystemPause._setPausers(address) (contracts/v2/SystemPause.sol#313-378) has a high cyclomatic complexity (34).\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 313,
+    "fingerprint": "e171e2e9ca5cedfb33ecdb2dd22b6e48573be6a55d696a832bcd4f60cc93a279"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "exp2(uint256) (node_modules/@prb/math/src/Common.sol#54-292) has a high cyclomatic complexity (73).\n",
+    "uri": "node_modules/@prb/math/src/Common.sol",
+    "startLine": 54,
+    "fingerprint": "e8022933ca229ba2a8624aa244bf31859176931047632a4f6b573fdbd43e06b8"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "KernelJobRegistry._finalize(uint256,bool,address[]) (contracts/v2/kernel/JobRegistry.sol#301-351) has a high cyclomatic complexity (13).\n",
+    "uri": "contracts/v2/kernel/JobRegistry.sol",
+    "startLine": 301,
+    "fingerprint": "f79d18ff81e88c7ab17e0d613b1332ff37b3ed69139a1f45560e5434d1c6c01c"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "ValidationModule._revealValidation(uint256,bool,bytes32,bytes32,string,bytes32[]) (contracts/v2/ValidationModule.sol#1364-1474) has a high cyclomatic complexity (27).\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1364,
+    "fingerprint": "fc09f7963c113f66f7fb4315589d9038ba18f1df0715dbd051549b133aa8e7b0"
+  },
+  {
+    "ruleId": "3-0-cyclomatic-complexity",
+    "message": "ValidationModule._finalize(uint256) (contracts/v2/ValidationModule.sol#1658-1787) has a high cyclomatic complexity (22).\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 1658,
+    "fingerprint": "ff3e4348895f74e597b4e088774afdc9dd11aee5662dddd18f6b207521c945a1"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "and(UD60x18,uint256) (node_modules/@prb/math/src/ud60x18/Helpers.sol#13-15) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 13,
+    "fingerprint": "0086ac77c0f3a2c3634571ef6dcbddc47b660c19386c2844fe51347ecf8ea699"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "wrap(uint64) (node_modules/@prb/math/src/ud2x18/Casting.sol#69-71) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud2x18/Casting.sol",
+    "startLine": 69,
+    "fingerprint": "043de91c3a2d3ba1cbfc1beb18901ccabdbee15a9132e548e92aef13f6582b33"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint256(UD60x18) (node_modules/@prb/math/src/ud60x18/Casting.sol#49-51) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Casting.sol",
+    "startLine": 49,
+    "fingerprint": "0640f894517cdcb8761ffae2cfd9686d7d6490652e748bf44bd13a3b513459b0"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "and(SD59x18,int256) (node_modules/@prb/math/src/sd59x18/Helpers.sol#13-15) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 13,
+    "fingerprint": "06f9561a4f1321397325e07eee1cdf33ff64b1ea3b7bed7bc8cecf0769c27e9a"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUD60x18(UD2x18) (node_modules/@prb/math/src/ud2x18/Casting.sol#31-33) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud2x18/Casting.sol",
+    "startLine": 31,
+    "fingerprint": "0765dcb4c1623b039706f3dac9aa99de83b23460ae187b03c5644d1f706b7360"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint40(SD59x18) (node_modules/@prb/math/src/sd59x18/Casting.sol#90-99) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Casting.sol",
+    "startLine": 90,
+    "fingerprint": "08f68af0f99d45e22c62484b29e021d24054a9b731173e087257d02ed9704b97"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "isZero(UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#38-41) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 38,
+    "fingerprint": "094b4d6991c1b3b07da2df97d8f44b4acfcaf38d15cc2e541f771d9dc7228d1c"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "powu(SD59x18,uint256) (node_modules/@prb/math/src/sd59x18/Math.sol#640-671) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 640,
+    "fingerprint": "0bf8e49a699fc4ed0726091882b404d39158676df80b274bc467cca2895cede5"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint40(UD60x18) (node_modules/@prb/math/src/ud60x18/Casting.sol#67-73) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Casting.sol",
+    "startLine": 67,
+    "fingerprint": "0dfda18f6ecb537ba97d479f5db969b8a344ad2765220724cb8bbf3abc91e122"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "inv(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#223-227) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 223,
+    "fingerprint": "13ad4c21a26429473b501ab4ed3a971ff71a047ae505f05680a4e8efd26c3be2"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint40(UD2x18) (node_modules/@prb/math/src/ud2x18/Casting.sol#50-56) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud2x18/Casting.sol",
+    "startLine": 50,
+    "fingerprint": "18954096b23dff80a9995caeecc390a28871e8c9793c3c11ec85cc1729a4550f"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "sd(int256) (node_modules/@prb/math/src/sd59x18/Casting.sol#102-104) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Casting.sol",
+    "startLine": 102,
+    "fingerprint": "1ab86507b9362a6704ed752ad812e2567ca09c7c2c96a5956dd69534720d1043"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "gte(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#33-35) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 33,
+    "fingerprint": "1b95a13141883b155b5ca8f5e16da6d9ccad7c5a8ee0f07722bd810ec75718f1"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "ceil(SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#81-100) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 81,
+    "fingerprint": "1f20b0663116224c842003568f56adbd9cfeebc4cd7396c4fcb4328f268cd2a0"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "eq(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#23-25) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 23,
+    "fingerprint": "24dc75082905b0505b093ff2db7a71aa32c86c263770a14681517b3d23828a16"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint128(SD59x18) (node_modules/@prb/math/src/sd59x18/Casting.sol#75-84) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Casting.sol",
+    "startLine": 75,
+    "fingerprint": "25f7741d26791e8eff86c7ce59ee7393f472bc176fee03d3f464b406307ecb6b"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoSD59x18(UD2x18) (node_modules/@prb/math/src/ud2x18/Casting.sol#25-27) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud2x18/Casting.sol",
+    "startLine": 25,
+    "fingerprint": "268d2ed4c9af933128f6e8480268a33478e927e36b3f0098e440ba0ca99160fd"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "isZero(SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#38-40) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 38,
+    "fingerprint": "26aee1390e049efd0bbd3ead14011af28f0d5175737f8bc115ad7548df797c62"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "and2(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#18-20) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 18,
+    "fingerprint": "27f3c65b3fbd865ba80710180e2e993b4c9afd30ca87b11e79516aa58a80d153"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "lte(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#54-56) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 54,
+    "fingerprint": "282e6f7c413e416eb8354ef98b443fd3e9cb8b99e2045ecaf5499be167bf2bcc"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "mod(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#59-61) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 59,
+    "fingerprint": "283dc8eedeb8eba5f4d4c4f2bca6791f2fde9b911b4743b755d9391b13c7e50f"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUD2x18(UD60x18) (node_modules/@prb/math/src/ud60x18/Casting.sol#28-34) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Casting.sol",
+    "startLine": 28,
+    "fingerprint": "2b1a02a1f3ce8b2d89f433ca24315462a78b9b707cd81bdad74fe9dcf86f0349"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoSD1x18(SD59x18) (node_modules/@prb/math/src/sd59x18/Casting.sol#23-32) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Casting.sol",
+    "startLine": 23,
+    "fingerprint": "2b4417e158ebf7685626901429984de1cb2d0a7e6770544d806a663ab1954366"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "uncheckedAdd(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#89-93) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 89,
+    "fingerprint": "2c66fc7b6233af6f978c8e58ff2152abb78fce39a9da89a799a43cf240edc5a1"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint40(SD1x18) (node_modules/@prb/math/src/sd1x18/Casting.sol#64-73) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd1x18/Casting.sol",
+    "startLine": 64,
+    "fingerprint": "2f8d8ad303bfdbc69fdb42c6df3b0b49130047ceadc303f54763d26913acff32"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint256(SD1x18) (node_modules/@prb/math/src/sd1x18/Casting.sol#41-47) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd1x18/Casting.sol",
+    "startLine": 41,
+    "fingerprint": "30650dcedaadf1912783c8f07b99b32254e30880f50a53b3047574cbee33d826"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "sd59x18(int256) (node_modules/@prb/math/src/sd59x18/Casting.sol#107-109) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Casting.sol",
+    "startLine": 107,
+    "fingerprint": "3457e49ad0105fa9286851054e78d6908a81aa5d1c5b9eb0d73c43ad6f7da5bb"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "or(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#74-76) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 74,
+    "fingerprint": "3761874cb11b4cc22b75f1a4b315a5725f156c804862d0f3cd4768790d70f937"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "ud(uint256) (node_modules/@prb/math/src/ud60x18/Casting.sol#76-78) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Casting.sol",
+    "startLine": 76,
+    "fingerprint": "412d5dd910c578848b380c26dd45bf694a6a14a38ef2a7eeccc6845927382345"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoSD59x18(UD60x18) (node_modules/@prb/math/src/ud60x18/Casting.sol#39-45) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Casting.sol",
+    "startLine": 39,
+    "fingerprint": "42351a0aed17342cf9c8e8f1565288256f6e9c813071162774cb7ac4f9522078"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "xor(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#114-116) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 114,
+    "fingerprint": "43681fc3118e4abcbe713099991361be366acbc57967245b31f8d3923eeb517b"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUD2x18(SD59x18) (node_modules/@prb/math/src/sd59x18/Casting.sol#38-47) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Casting.sol",
+    "startLine": 38,
+    "fingerprint": "46134fff56234262f705257152b468351a4209d8f3d0f2d2e95851db9b8017d8"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUD60x18(SD1x18) (node_modules/@prb/math/src/sd1x18/Casting.sol#30-36) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd1x18/Casting.sol",
+    "startLine": 30,
+    "fingerprint": "462d97208b54477ec9b7e400b170473b7758bbf5fb6a3752efeae139f28b453c"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "sqrt(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#561-572) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 561,
+    "fingerprint": "46300a7490404e503e280486a522ae83b7a7dafd0800d360f6240391a2bfd47d"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "uncheckedSub(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#96-100) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 96,
+    "fingerprint": "475cc684b4afe10c7de9529e91f01f536116ff19ef0d00ec7f494ebc1e3dc8de"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "div(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#121-150) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 121,
+    "fingerprint": "479cc9c613e6caaaee0fb72b12c60d9f34f8eafd62aa218476283b38dd031300"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint128(UD2x18) (node_modules/@prb/math/src/ud2x18/Casting.sol#37-39) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud2x18/Casting.sol",
+    "startLine": 37,
+    "fingerprint": "47a1e735a4de3aa0dc6a9a40eb2a26e614064db5e1b95beb4b0d984f4bac0353"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "uncheckedSub(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#100-104) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 100,
+    "fingerprint": "4939366054d3382ba7718a788ace74a63bf3c68df984676236b4de6a6299581f"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUD60x18(SD59x18) (node_modules/@prb/math/src/sd59x18/Casting.sol#52-58) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Casting.sol",
+    "startLine": 52,
+    "fingerprint": "49e35d596d02f3ec277ee09e092e7a490d7bbd3f80e8a5dad384cb5341ee1489"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "mod(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#58-60) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 58,
+    "fingerprint": "4abb0ebcce148ac1c0f3dd97c1bbe43002e453638670612a89ce7e733c5a157f"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "wrap(int64) (node_modules/@prb/math/src/sd1x18/Casting.sol#86-88) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd1x18/Casting.sol",
+    "startLine": 86,
+    "fingerprint": "4f99c0ab195f918c5e2f21b1e088c16f09d7a02d4ef3702bdafff8172f506aee"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "lshift(UD60x18,uint256) (node_modules/@prb/math/src/ud60x18/Helpers.sol#44-46) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 44,
+    "fingerprint": "51215e25845762e9e0c6510637b256d9426ec3da15b9ebd8f34d9d1c04650b27"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "rshift(UD60x18,uint256) (node_modules/@prb/math/src/ud60x18/Helpers.sol#79-81) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 79,
+    "fingerprint": "51e7a516236925196b4bfe5be2e97363ca3b66a0418cb9ee7fc364c6f540dc34"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "sd1x18(int64) (node_modules/@prb/math/src/sd1x18/Casting.sol#76-78) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd1x18/Casting.sol",
+    "startLine": 76,
+    "fingerprint": "545686c5661567edd677b3584bba41a8afb19bcc2200c49008d80d69f528da0b"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "gm(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#283-307) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 283,
+    "fingerprint": "58eb58eb348e602b23e22beed70895f77347f8bfa9b99de6a32efdabce8bff79"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "mul(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#449-451) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 449,
+    "fingerprint": "594c4ce030924c38b4d24a4601c8eefc7dc744127518833d8415d8b8a49dc3cb"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "uncheckedAdd(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#93-97) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 93,
+    "fingerprint": "5b5aad0e180fc16ec9b0ab860398ab945331dffc113350f16174a7b4ecd8fff8"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "StakeManager._setSlashingPercentages(uint256,uint256) (contracts/v2/StakeManager.sol#1046-1054) is never used and should be removed\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1046,
+    "fingerprint": "609e3742d7c267118a4d0c883cb5fb086a81573a2de366f3521c857d8ea5fdf1"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoSD1x18(UD60x18) (node_modules/@prb/math/src/ud60x18/Casting.sol#17-23) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Casting.sol",
+    "startLine": 17,
+    "fingerprint": "60b6c74d938082155e8853d89c4678e01ee1ec5b0b4384d3ff566b2f8a73f80e"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "unwrap(UD60x18) (node_modules/@prb/math/src/ud60x18/Casting.sol#86-88) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Casting.sol",
+    "startLine": 86,
+    "fingerprint": "6676497985554eda5c1da292f96a111cd5a9e9e9e943732ae603f65590af4f70"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "unwrap(UD2x18) (node_modules/@prb/math/src/ud2x18/Casting.sol#64-66) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud2x18/Casting.sol",
+    "startLine": 64,
+    "fingerprint": "6835acfc5e8ac70569e80e584090addd58a260289aaca387dfa16719abd3a0dd"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "ud60x18(uint256) (node_modules/@prb/math/src/ud60x18/Casting.sol#81-83) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Casting.sol",
+    "startLine": 81,
+    "fingerprint": "6a76869f7a4306a553b9a5bc25677b438e96a3b3019870d4492b70934659fd89"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "pow(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#597-621) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 597,
+    "fingerprint": "6f9ee2849a285e3d906c945478b2888de67dd5cd0f7ddc4a709564aa05bf5098"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint128(UD60x18) (node_modules/@prb/math/src/ud60x18/Casting.sol#56-62) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Casting.sol",
+    "startLine": 56,
+    "fingerprint": "71153175d49a5226674b8adf277ceae643c7c82f39dad90ccfef11e9f244a4ea"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUD2x18(SD1x18) (node_modules/@prb/math/src/sd1x18/Casting.sol#19-25) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd1x18/Casting.sol",
+    "startLine": 19,
+    "fingerprint": "76e816caddc9a5cffb24c3043e8e63ea2220e2bba25bf1b15b44547a9bd205a1"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "mulDiv(uint256,uint256,uint256) (node_modules/@prb/math/src/Common.sol#387-469) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/Common.sol",
+    "startLine": 387,
+    "fingerprint": "77dec07ead06eb1feb6adea5bb6059174e17ab1e9289614dd4b91c69f212f2d7"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "log2(SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#484-533) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 484,
+    "fingerprint": "7925267cfac1ed9e44364e64e4fea5640e964ef2873c4de0d2b1ef0f16175380"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "powu(UD60x18,uint256) (node_modules/@prb/math/src/ud60x18/Math.sol#531-546) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 531,
+    "fingerprint": "7e703044e3870ebad8ebddc579b8a9b58c1489b0c8a4c6dcfa9960ea310e4ebc"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "ln(SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#340-344) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 340,
+    "fingerprint": "805fbd547184f72053280cf3618947158c142a7e3336f18acdc4bf94fd3caf53"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "gt(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#28-30) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 28,
+    "fingerprint": "824faf01a0c2e454ae4534d96adc821a88f4aa9af94dd9b5a20ba6a8bcacb581"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "lshift(SD59x18,uint256) (node_modules/@prb/math/src/sd59x18/Helpers.sol#43-45) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 43,
+    "fingerprint": "848093e54a54b128cb95fa60bd7c4751c1f835099fa57a63d5e44ce7c8493858"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "eq(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#23-25) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 23,
+    "fingerprint": "895f85676f4ec50b396abd07d5179407a0fd13795c1ec37a1130e76988835e5f"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "xor(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#103-105) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 103,
+    "fingerprint": "8b80f5e8a6dea49e17fceb5bddcc4c14ecb528ec91a208350166056463dda5bd"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoSD59x18(SD1x18) (node_modules/@prb/math/src/sd1x18/Casting.sol#13-15) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd1x18/Casting.sol",
+    "startLine": 13,
+    "fingerprint": "8bc41da242398b534025ee6f0669f1136c89883e6522099d258055479c7d2b50"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "lt(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#49-51) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 49,
+    "fingerprint": "8d1d1ffe9d42e7080a5677a5b91d6225dd6ade605a7ebad673802cac7e97a04f"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint128(SD1x18) (node_modules/@prb/math/src/sd1x18/Casting.sol#52-58) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd1x18/Casting.sol",
+    "startLine": 52,
+    "fingerprint": "8d59e1a8ed1165ba9ad9ab9c4676467d7d2593c98190a887cc6d5f2982365b33"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "avg(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#48-54) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 48,
+    "fingerprint": "910cecb94a7653932d1ecf213e80b4d917a7eae390257cba38953f0caa6e9568"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoSD1x18(UD2x18) (node_modules/@prb/math/src/ud2x18/Casting.sol#15-21) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud2x18/Casting.sol",
+    "startLine": 15,
+    "fingerprint": "91e49c1198a5f4cf49e74e55a0976e08c5afb40972389bf8328fc35ca073bc01"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "sqrt(SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#688-703) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 688,
+    "fingerprint": "9240173d8cf65c7cf8b6be4d1f486112a304afabe4356a0cf64140b49a024807"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "mul(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#549-578) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 549,
+    "fingerprint": "92a435e32e5e48e8d1f7dc08f221f1ec3ccbaba1d90fd8b07ca7ee6d54a98f5f"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "msb(uint256) (node_modules/@prb/math/src/Common.sol#320-369) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/Common.sol",
+    "startLine": 320,
+    "fingerprint": "962a62635c1b4b17df48473b59131985eaa253874c10645d58ebd10254eb0846"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint256(SD59x18) (node_modules/@prb/math/src/sd59x18/Casting.sol#63-69) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Casting.sol",
+    "startLine": 63,
+    "fingerprint": "97276c4d6c77fcf20116cb95de7a19e468e8992cad285dc4fafa5723afff8974"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "uncheckedUnary(SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#107-111) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 107,
+    "fingerprint": "9c85be97b9f53cd3e8e306e41136baf7401bbc632e8e7ca9aeaf7bd5d9bb1aac"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoUint256(UD2x18) (node_modules/@prb/math/src/ud2x18/Casting.sol#43-45) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud2x18/Casting.sol",
+    "startLine": 43,
+    "fingerprint": "9df08845feffa610e968075bd2744341f44a385f86db1e1c15f595e5420b109f"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "sub(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#84-86) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 84,
+    "fingerprint": "9e516f9dfe71fb624ef58aae955ce87047d501de2d347ea628265abd93da719c"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "log10(SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#363-459) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 363,
+    "fingerprint": "a1203f3229f44512461110042265c536714d2b7e914e31409076747113e79ad4"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "and2(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#18-20) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 18,
+    "fingerprint": "a3bc6809297ad8df2bdaa8ad31ac618f4d154f7939ba0f7bc1a50d458a4d9212"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "neq(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#64-66) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 64,
+    "fingerprint": "a616c58a73da8fe7e4d402c722b3ba0abe2e270157dff4ea720b0fbb64046496"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "mulDivSigned(int256,int256,int256) (node_modules/@prb/math/src/Common.sol#545-582) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/Common.sol",
+    "startLine": 545,
+    "fingerprint": "a83029d6864dcb60e264aba5aebf444730812c2e6419f55b69dbde728e412ef4"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "frac(SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#266-268) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 266,
+    "fingerprint": "aab14d1f64be91e54a21ff57ca225ba08aa8049e1a4e39b74c1284f7cd195512"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "exp2(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#141-154) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 141,
+    "fingerprint": "abcafec21d54f40f43c23202b90f15c304fd21dd0ff5d699486b80760edd503f"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "gt(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#28-30) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 28,
+    "fingerprint": "afdb519ddbe58b6b64bd210b421de3109d2e1a7a0e12e2b92d3e21be4a1098d1"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "StakeManager._setSlashingDistribution(uint256,uint256,uint256) (contracts/v2/StakeManager.sol#1031-1043) is never used and should be removed\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1031,
+    "fingerprint": "b36a5e52ad8ab034f6197e82acad63e40e4bc11b1e056fe4090d304878d37715"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "floor(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#162-170) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 162,
+    "fingerprint": "b4565997c4fe8b1d917da18b359f387858f9621b710461d8c8e7e66d7cb8f4ff"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "add(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#8-10) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 8,
+    "fingerprint": "b6aac29829ead4a27b46b695770c282638027b1cd6d1002fe35e01136cda6146"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "unwrap(SD1x18) (node_modules/@prb/math/src/sd1x18/Casting.sol#81-83) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd1x18/Casting.sol",
+    "startLine": 81,
+    "fingerprint": "b8c634165b0f769df5d29f8fe92751c5c328845b90ed22e3204aea2bda4a2539"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "abs(SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#32-38) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 32,
+    "fingerprint": "bb81a87da7ef185ec1abb680fa409c1ba5118b6537efc40f4b1d7d82e9a34281"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "inv(SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#320-322) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 320,
+    "fingerprint": "be8f63ec15027b54ed82a82de7871953596a86be438bf21a2ba767c79fa8d410"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "frac(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#177-181) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 177,
+    "fingerprint": "bfa639f0a2dcb794ad038cbde6582576cae725d4777b476927efe9f9dfa525ee"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "lte(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#53-55) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 53,
+    "fingerprint": "c1ca18d6da9c306a306db9a1aee68b626dcf622f722b2235a0bf87e3fd913a46"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "add(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#8-10) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 8,
+    "fingerprint": "c4c8718f235ba4089c4089992edc4377b8f0744f8c829d30e298ea276d1d4f30"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "pow(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#481-513) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 481,
+    "fingerprint": "c5933565f9a6930b117927c59bf1006d939c93e06813d37058ee14ce631f3d2d"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "sub(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#83-85) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 83,
+    "fingerprint": "cb31745fec696610128bf5fd392999e5d2129c3d1810e42bb30741e353e2dd14"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "wrap(uint256) (node_modules/@prb/math/src/ud60x18/Casting.sol#91-93) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Casting.sol",
+    "startLine": 91,
+    "fingerprint": "ce0389bcd655d87a60b01848dba4467d026451c70faf711bc618eefac45de8d1"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "lt(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#48-50) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 48,
+    "fingerprint": "cf006e9d248dbbb13adb33663db7f3bb937bf8b7117ba8be8ab79930b67803d0"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "div(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#99-101) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 99,
+    "fingerprint": "d2de54e636ffb0f880e3aeb9a3cd01bcb04ea14f7867f27d48ac4cc512c82f4f"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "neq(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#63-65) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 63,
+    "fingerprint": "d3450b74aae6b485038b09ead89940177918d205c5e8cead03ccd00a15fcbfc0"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "rshift(SD59x18,uint256) (node_modules/@prb/math/src/sd59x18/Helpers.sol#78-80) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 78,
+    "fingerprint": "d6242c47b5f42bfde96905c7561b46d49d1a61ddd4075b00958391d523475323"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "log10(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#270-367) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 270,
+    "fingerprint": "d6a4d8ff71979cf24d374498711f3d94236c744db45c8534a6a3798166b4d010"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "ceil(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#67-83) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 67,
+    "fingerprint": "d75bf8e19474f99791b71983446164953821da1f656736e2bfeeaa3dc199e792"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "ln(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#245-251) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 245,
+    "fingerprint": "d7cebd3ecd137c64ea7d6cfd5f6fd947633110147190cca7fce3fe84fad759aa"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "exp(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#115-128) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 115,
+    "fingerprint": "d8b6ea0db1e0e58c8e1b1912d69dea1d45c9b863ead1711e923e864e66a1ccc1"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "log2(UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#392-432) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 392,
+    "fingerprint": "dd7c74fe1d232cc239fa286df1ae5704d66eb1d27c205bbc5266e7705ae80606"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "or(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#73-75) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 73,
+    "fingerprint": "e27baf2bc6bde4a89239486b39fde3285d3497b53ac379a85129f9a45f19c773"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "mulDiv18(uint256,uint256) (node_modules/@prb/math/src/Common.sol#495-526) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/Common.sol",
+    "startLine": 495,
+    "fingerprint": "e439c0845d1cf6a2163b342fbe2307b1f55eae89447f8844ed6e0610b082ed99"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "unary(SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#88-90) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 88,
+    "fingerprint": "e485dc239cd81baeb34eef3a196586c6d4290199fe4b8e3bac0ec48820b7db7e"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "floor(SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#240-259) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 240,
+    "fingerprint": "e76a023aea08d4fbcfed4ec2e02abbab0dcb5e6b8688735b03d3307463838981"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "gm(UD60x18,UD60x18) (node_modules/@prb/math/src/ud60x18/Math.sol#192-210) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Math.sol",
+    "startLine": 192,
+    "fingerprint": "f18ff55299c74e507fb602fb326686b83b091af7e2d4fb04bef478a4ca4576d3"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "sqrt(uint256) (node_modules/@prb/math/src/Common.sol#595-672) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/Common.sol",
+    "startLine": 595,
+    "fingerprint": "f3fd56f47bb4a800501ed2102e4c038329d26ee036e2d6c0f859e59e91d8d3e8"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "not(UD60x18) (node_modules/@prb/math/src/ud60x18/Helpers.sol#69-71) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud60x18/Helpers.sol",
+    "startLine": 69,
+    "fingerprint": "f69e88641b7f278a260b4fdee114cef7fe4a16ba9b5b2826ce40a57cf7443ed6"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "intoInt256(SD59x18) (node_modules/@prb/math/src/sd59x18/Casting.sol#15-17) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Casting.sol",
+    "startLine": 15,
+    "fingerprint": "f6df097bbbb34d9e2fa1e81a65ca0de994ee2a795f9b8bd88f47bd476720738d"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "avg(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Math.sol#49-68) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Math.sol",
+    "startLine": 49,
+    "fingerprint": "f74182aadbec89ad5297c1f3bc14d794b28f4d5cb4c3c72ae86cc96895f6f816"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "not(SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#68-70) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 68,
+    "fingerprint": "f75f7bc40c6cc314775a132a2d5bb5ec13a4d9d21ccdd50a035e725bb4355b5b"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "gte(SD59x18,SD59x18) (node_modules/@prb/math/src/sd59x18/Helpers.sol#33-35) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/sd59x18/Helpers.sol",
+    "startLine": 33,
+    "fingerprint": "fdc6ffc5878b44a00b31b5f833c6fc2957f5c6b930d98a8817b4a722de7b4ea3"
+  },
+  {
+    "ruleId": "3-1-dead-code",
+    "message": "ud2x18(uint64) (node_modules/@prb/math/src/ud2x18/Casting.sol#59-61) is never used and should be removed\n",
+    "uri": "node_modules/@prb/math/src/ud2x18/Casting.sol",
+    "startLine": 59,
+    "fingerprint": "feec3988cf71c09476563f0d37828da8ca84d054f0ad75936338f64de5a49079"
+  },
+  {
+    "ruleId": "3-0-solc-version",
+    "message": "Version constraint >=0.4.16 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)\n\t- DirtyBytesArrayToStorage\n\t- ABIDecodeTwoDimensionalArrayMemory\n\t- KeccakCaching\n\t- EmptyByteArrayCopy\n\t- DynamicArrayCleanup\n\t- ImplicitConstructorCallvalueCheck\n\t- TupleAssignmentMultiStackSlotComponents\n\t- MemoryArrayCreationOverflow\n\t- privateCanBeOverridden\n\t- SignedArrayStorageCopy\n\t- ABIEncoderV2StorageArrayWithMultiSlotElement\n\t- DynamicConstructorArgumentsClippedABIV2\n\t- UninitializedFunctionPointerInConstructor_0.4.x\n\t- IncorrectEventSignatureInLibraries_0.4.x\n\t- ExpExponentCleanup\n\t- NestedArrayFunctionCallDecoder\n\t- ZeroFunctionSelector.\nIt is used by:\n\t- >=0.4.16 (node_modules/@openzeppelin/contracts/interfaces/IERC165.sol#4)\n\t- >=0.4.16 (node_modules/@openzeppelin/contracts/interfaces/IERC20.sol#4)\n\t- >=0.4.16 (node_modules/@openzeppelin/contracts/interfaces/IERC5267.sol#4)\n\t- >=0.4.16 (node_modules/@openzeppelin/contracts/interfaces/IERC6372.sol#4)\n\t- >=0.4.16 (node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol#4)\n\t- >=0.4.16 (node_modules/@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol#4)\n\t- >=0.4.16 (node_modules/@openzeppelin/contracts/utils/introspection/IERC165.sol#4)\n",
+    "uri": "node_modules/@openzeppelin/contracts/interfaces/IERC165.sol",
+    "startLine": 4,
+    "fingerprint": "2608dc9a812ee8a6b7d12eef70537526bcbe83b08d430d110b62b8c8494d947d"
+  },
+  {
+    "ruleId": "3-0-solc-version",
+    "message": "Version constraint ^0.8.21 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)\n\t- VerbatimInvalidDeduplication.\nIt is used by:\n\t- ^0.8.21 (contracts/legacy/MaliciousERC721.sol#2)\n\t- ^0.8.21 (contracts/legacy/MockERC721.sol#2)\n\t- ^0.8.21 (contracts/legacy/MockResolver.sol#2)\n\t- ^0.8.21 (contracts/legacy/ReentrantERC20.sol#2)\n\t- ^0.8.21 (contracts/legacy/StubReputationEngine.sol#2)\n\t- ^0.8.21 (contracts/legacy/StubStakeManager.sol#2)\n",
+    "uri": "contracts/legacy/MaliciousERC721.sol",
+    "startLine": 2,
+    "fingerprint": "2673623a76ec7205096cd8ef8c0301814b5255abf3ba2114f1f6170340575395"
+  },
+  {
+    "ruleId": "3-0-solc-version",
+    "message": "Version constraint ^0.8.20 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)\n\t- VerbatimInvalidDeduplication\n\t- FullInlinerNonExpressionSplitArgumentEvaluationOrder\n\t- MissingSideEffectsOnSelectorAccess.\nIt is used by:\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/access/AccessControl.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/access/Ownable.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/access/Ownable2Step.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/governance/utils/Votes.sol#3)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC721/ERC721.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/Address.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/Arrays.sol#5)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/Comparators.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/Context.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/Errors.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/Nonces.sol#3)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/Panic.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/Pausable.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/ReentrancyGuard.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/ShortStrings.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/SlotDerivation.sol#5)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/StorageSlot.sol#5)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/Strings.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/cryptography/ECDSA.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/cryptography/EIP712.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/cryptography/Hashes.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/cryptography/MerkleProof.sol#5)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/introspection/ERC165.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/math/Math.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/math/SafeCast.sol#5)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/math/SignedMath.sol#4)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/structs/Checkpoints.sol#5)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/structs/DoubleEndedQueue.sol#3)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/structs/EnumerableSet.sol#5)\n\t- ^0.8.20 (node_modules/@openzeppelin/contracts/utils/types/Time.sol#4)\n\t- ^0.8.20 (contracts/test/EchidnaHarness.sol#2)\n",
+    "uri": "node_modules/@openzeppelin/contracts/access/AccessControl.sol",
+    "startLine": 4,
+    "fingerprint": "506b2d2698a2402c873fae74e2c10a1a7a127b615dd64ecf5f9931366219e991"
+  },
+  {
+    "ruleId": "3-0-solc-version",
+    "message": "Version constraint >=0.8.4 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)\n\t- FullInlinerNonExpressionSplitArgumentEvaluationOrder\n\t- MissingSideEffectsOnSelectorAccess\n\t- AbiReencodingHeadOverflowWithStaticArrayCleanup\n\t- DirtyBytesArrayToStorage\n\t- DataLocationChangeInInternalOverride\n\t- NestedCalldataArrayAbiReencodingSizeValidation\n\t- SignedImmutables.\nIt is used by:\n\t- >=0.8.4 (node_modules/@openzeppelin/contracts/access/IAccessControl.sol#4)\n\t- >=0.8.4 (node_modules/@openzeppelin/contracts/governance/IGovernor.sol#4)\n\t- >=0.8.4 (node_modules/@openzeppelin/contracts/governance/utils/IVotes.sol#3)\n\t- >=0.8.4 (node_modules/@openzeppelin/contracts/interfaces/IERC5805.sol#4)\n\t- >=0.8.4 (node_modules/@openzeppelin/contracts/interfaces/draft-IERC6093.sol#3)\n",
+    "uri": "node_modules/@openzeppelin/contracts/access/IAccessControl.sol",
+    "startLine": 4,
+    "fingerprint": "87002271c3b063369b958c9e5c6e1aa96bf3596194a82f02410119749b932f82"
+  },
+  {
+    "ruleId": "3-0-solc-version",
+    "message": "Version constraint >=0.5.0 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)\n\t- DirtyBytesArrayToStorage\n\t- ABIDecodeTwoDimensionalArrayMemory\n\t- KeccakCaching\n\t- EmptyByteArrayCopy\n\t- DynamicArrayCleanup\n\t- ImplicitConstructorCallvalueCheck\n\t- TupleAssignmentMultiStackSlotComponents\n\t- MemoryArrayCreationOverflow\n\t- privateCanBeOverridden\n\t- SignedArrayStorageCopy\n\t- ABIEncoderV2StorageArrayWithMultiSlotElement\n\t- DynamicConstructorArgumentsClippedABIV2\n\t- UninitializedFunctionPointerInConstructor\n\t- IncorrectEventSignatureInLibraries\n\t- ABIEncoderV2PackedStorage.\nIt is used by:\n\t- >=0.5.0 (node_modules/@openzeppelin/contracts/interfaces/IERC1271.sol#4)\n\t- >=0.5.0 (node_modules/@openzeppelin/contracts/interfaces/IERC7913.sol#4)\n\t- >=0.5.0 (node_modules/@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol#4)\n",
+    "uri": "node_modules/@openzeppelin/contracts/interfaces/IERC1271.sol",
+    "startLine": 4,
+    "fingerprint": "9644103732698fcf78ec0813c85f1392d26ba3223fc42e574b15773e7188774a"
+  },
+  {
+    "ruleId": "3-0-solc-version",
+    "message": "Version constraint >=0.8.19 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)\n\t- VerbatimInvalidDeduplication\n\t- FullInlinerNonExpressionSplitArgumentEvaluationOrder\n\t- MissingSideEffectsOnSelectorAccess.\nIt is used by:\n\t- >=0.8.19 (node_modules/@prb/math/src/Common.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/sd1x18/Casting.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/sd1x18/Constants.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/sd1x18/Errors.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/sd1x18/ValueType.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/sd59x18/Casting.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/sd59x18/Constants.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/sd59x18/Errors.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/sd59x18/Helpers.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/sd59x18/Math.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/sd59x18/ValueType.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/ud2x18/Casting.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/ud2x18/Constants.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/ud2x18/Errors.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/ud2x18/ValueType.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/ud60x18/Casting.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/ud60x18/Constants.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/ud60x18/Errors.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/ud60x18/Helpers.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/ud60x18/Math.sol#2)\n\t- >=0.8.19 (node_modules/@prb/math/src/ud60x18/ValueType.sol#2)\n",
+    "uri": "node_modules/@prb/math/src/Common.sol",
+    "startLine": 2,
+    "fingerprint": "a9fe77259815354db58fca8d0a923bd5498cca0a12c85046b37fefe47603d785"
+  },
+  {
+    "ruleId": "3-0-solc-version",
+    "message": "Version constraint >=0.6.2 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)\n\t- MissingSideEffectsOnSelectorAccess\n\t- AbiReencodingHeadOverflowWithStaticArrayCleanup\n\t- DirtyBytesArrayToStorage\n\t- NestedCalldataArrayAbiReencodingSizeValidation\n\t- ABIDecodeTwoDimensionalArrayMemory\n\t- KeccakCaching\n\t- EmptyByteArrayCopy\n\t- DynamicArrayCleanup\n\t- MissingEscapingInFormatting\n\t- ArraySliceDynamicallyEncodedBaseType\n\t- ImplicitConstructorCallvalueCheck\n\t- TupleAssignmentMultiStackSlotComponents\n\t- MemoryArrayCreationOverflow.\nIt is used by:\n\t- >=0.6.2 (node_modules/@openzeppelin/contracts/interfaces/IERC1363.sol#4)\n\t- >=0.6.2 (node_modules/@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol#4)\n\t- >=0.6.2 (node_modules/@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol#4)\n\t- >=0.6.2 (node_modules/@openzeppelin/contracts/token/ERC721/IERC721.sol#4)\n\t- >=0.6.2 (node_modules/@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol#4)\n",
+    "uri": "node_modules/@openzeppelin/contracts/interfaces/IERC1363.sol",
+    "startLine": 4,
+    "fingerprint": "e45744ebf80fc2e330bc44575866f33d11c218b4b71bd1c6c26cd192ad20db3a"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in ModuleInstaller._callOptional(address,bytes) (contracts/v2/ModuleInstaller.sol#228-231):\n\t- (ok,None) = target.call(data) (contracts/v2/ModuleInstaller.sol#229)\n",
+    "uri": "contracts/v2/ModuleInstaller.sol",
+    "startLine": 228,
+    "fingerprint": "063b78aedcfb08f127526844c3a59b7f6fedb845dee5ebd1dccd810908bc353a"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in Address.functionStaticCall(address,bytes) (node_modules/@openzeppelin/contracts/utils/Address.sol#87-90):\n\t- (success,returndata) = target.staticcall(data) (node_modules/@openzeppelin/contracts/utils/Address.sol#88)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Address.sol",
+    "startLine": 87,
+    "fingerprint": "247d32f8415b82d5c23ed6a41efcfcaf895e7c922154258f9f9a615461fbe29a"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in Governor._executeOperations(uint256,address[],uint256[],bytes[],bytes32) (node_modules/@openzeppelin/contracts/governance/Governor.sol#434-445):\n\t- (success,returndata) = targets[i].call{value: values[i]}(calldatas[i]) (node_modules/@openzeppelin/contracts/governance/Governor.sol#442)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 434,
+    "fingerprint": "3a17b110776f1dcf79a7a925184e3e9c8b91090d553b246fb4117028e25f7092"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in TimelockMock.execute(address,bytes) (contracts/legacy/TimelockMock.sol#12-15):\n\t- (ok,None) = target.call(data) (contracts/legacy/TimelockMock.sol#13)\n",
+    "uri": "contracts/legacy/TimelockMock.sol",
+    "startLine": 12,
+    "fingerprint": "3b65f517f19444ac2ad37b9894327c2dde947978d9183f2ce3aa62d3136e199d"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in Address.functionDelegateCall(address,bytes) (node_modules/@openzeppelin/contracts/utils/Address.sol#96-99):\n\t- (success,returndata) = target.delegatecall(data) (node_modules/@openzeppelin/contracts/utils/Address.sol#97)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Address.sol",
+    "startLine": 96,
+    "fingerprint": "433da96c86e01861fa69e008bc0fa0f29707486963ae85d1642a3caa97fa6485"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in JobRegistry._enableAckModule(address) (contracts/v2/JobRegistry.sol#679-686):\n\t- (ok,data) = module.staticcall(abi.encodeWithSelector(IJobRegistryAck.acknowledgeFor.selector,address(0))) (contracts/v2/JobRegistry.sol#680-682)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 679,
+    "fingerprint": "43965fe323e7b6c779aba576366d209ef0103f151180cb9c0d6ee8cd33397e7f"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in ReentrantStakeManager.slash(address,IStakeManager.Role,uint256,address) (contracts/v2/mocks/ReentrantStakeManager.sol#169-185):\n\t- (ok,err) = address(validation).call(abi.encodeWithSelector(IValidationModule.finalize.selector,attackJobId)) (contracts/v2/mocks/ReentrantStakeManager.sol#172-174)\n",
+    "uri": "contracts/v2/mocks/ReentrantStakeManager.sol",
+    "startLine": 169,
+    "fingerprint": "5097035f575f41ceb3195a3d568420ef6cb8c76d90859736e380d601804b83be"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in Governor.relay(address,uint256,bytes) (node_modules/@openzeppelin/contracts/governance/Governor.sol#656-659):\n\t- (success,returndata) = target.call{value: value}(data) (node_modules/@openzeppelin/contracts/governance/Governor.sol#657)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 656,
+    "fingerprint": "7243749ed31f8fdca4cd919dca41f5480f90eb61d6c59754feea0f9e788b41ec"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in SystemPause.executeGovernanceCall(address,bytes) (contracts/v2/SystemPause.sol#239-272):\n\t- (success,response) = target.call(data) (contracts/v2/SystemPause.sol#253)\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 239,
+    "fingerprint": "8acd4c9a54fe9a19ae022a9e11302ecfb383a5e6d9bd90e9ac6c7650e6f0be7e"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in Address.functionCallWithValue(address,bytes,uint256) (node_modules/@openzeppelin/contracts/utils/Address.sol#75-81):\n\t- (success,returndata) = target.call{value: value}(data) (node_modules/@openzeppelin/contracts/utils/Address.sol#79)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Address.sol",
+    "startLine": 75,
+    "fingerprint": "9d21a0d332acca394c80ac4b5f3704fa12498d04758e35edc563916aa5962904"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in Address.sendValue(address,uint256) (node_modules/@openzeppelin/contracts/utils/Address.sol#33-42):\n\t- (success,returndata) = recipient.call{value: amount}() (node_modules/@openzeppelin/contracts/utils/Address.sol#38)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/Address.sol",
+    "startLine": 33,
+    "fingerprint": "9f7e597b41909f45a10f7c9d4c603a28e1b78bd17d0fda8426b817fdc2576796"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in SignatureChecker.isValidERC1271SignatureNow(address,bytes32,bytes) (node_modules/@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol#48-59):\n\t- (success,result) = signer.staticcall(abi.encodeCall(IERC1271.isValidSignature,(hash,signature))) (node_modules/@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol#53-55)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol",
+    "startLine": 48,
+    "fingerprint": "afaec223bb642e1407ddb23d3bf8cfd52dfb7fe90fb3f6c8b779216cfec76d72"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in ReentrantStakeManager.slash(address,uint256,address) (contracts/v2/mocks/ReentrantStakeManager.sol#200-216):\n\t- (ok,err) = address(validation).call(abi.encodeWithSelector(IValidationModule.finalize.selector,attackJobId)) (contracts/v2/mocks/ReentrantStakeManager.sol#203-205)\n",
+    "uri": "contracts/v2/mocks/ReentrantStakeManager.sol",
+    "startLine": 200,
+    "fingerprint": "d6fa39f27dd57a68919f9e0b36f9840e65444e30e161de032d3e55a3a60cef26"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in SignatureChecker.isValidSignatureNow(bytes,bytes32,bytes) (node_modules/@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol#76-93):\n\t- (success,result) = address(bytes20(signer)).staticcall(abi.encodeCall(IERC7913SignatureVerifier.verify,(signer.slice(20),hash,signature))) (node_modules/@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol#86-88)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol",
+    "startLine": 76,
+    "fingerprint": "ef27273725529eb3a0a72e15e7fc29c1e2d5d64b3b3efdad8ea1aeddb8749fcd"
+  },
+  {
+    "ruleId": "3-0-low-level-calls",
+    "message": "Low level call in TimelockController._execute(address,uint256,bytes) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#411-414):\n\t- (success,returndata) = target.call{value: value}(data) (node_modules/@openzeppelin/contracts/governance/TimelockController.sol#412)\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/TimelockController.sol",
+    "startLine": 411,
+    "fingerprint": "f920d0d2dac2b7eda121e7b4537b85f02d345fbe0aeb9299cb354fdab9db54f0"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "MockArbitrator (contracts/v2/mocks/MockArbitrator.sol#8-31) should inherit from IArbitrationService (contracts/v2/modules/KlerosDisputeModule.sol#217-223)\n",
+    "uri": "contracts/v2/mocks/MockArbitrator.sol",
+    "startLine": 8,
+    "fingerprint": "022b04c9b3e40645f9c112c4bf158435ff1e50b2e5df00b8efe8775663dbcdb7"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "PlatformRegistry (contracts/v2/PlatformRegistry.sol#24-526) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 24,
+    "fingerprint": "07537e2eda77c8b8badce6c792cd4c038e31bb81d3dd7082fee5a3f09fd7978e"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "DisputeModule (contracts/v2/modules/DisputeModule.sol#21-600) should inherit from IKlerosModule (contracts/v2/mocks/MockArbitrator.sol#33-35)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 21,
+    "fingerprint": "077632802f2acfa821374612d1641f7a113abd1b0c7b91040dbc90172f3d1b72"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "ReentrantERC206 (contracts/legacy/ReentrantERC206.sol#13-43) should inherit from IReentrantToken (contracts/v2/mocks/ReentrantJobRegistry.sol#23-25)\n",
+    "uri": "contracts/legacy/ReentrantERC206.sol",
+    "startLine": 13,
+    "fingerprint": "0a21c2633a4f51a85ac899dcbe7b7f0b2bed10e4ac20c54b5700d873ed78dfa8"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "DisputeModule (contracts/v2/modules/DisputeModule.sol#21-600) should inherit from IDisputeModule (contracts/legacy/DisputeRegistryStub.sol#6-13)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 21,
+    "fingerprint": "181e203b07eaff260ae601224c613ba8cce188d515e8d8bc833dcb457754cd7d"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "RevenueDistributor (contracts/v2/modules/RevenueDistributor.sol#13-136) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/modules/RevenueDistributor.sol",
+    "startLine": 13,
+    "fingerprint": "1f85e430daca78ff016cff751378a3f2f0c48c97d1b3beb10cac6eb1dc1f8de9"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "GovernanceRewardMock (contracts/test/GovernanceRewardMock.sol#4-16) should inherit from IGovernanceReward (contracts/v2/QuadraticVoting.sol#11-13)\n",
+    "uri": "contracts/test/GovernanceRewardMock.sol",
+    "startLine": 4,
+    "fingerprint": "1ff2c4e803c707c503e6b921aa75d376e680a72a9524c30fc988b4e0ff56b383"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "DisputeModule (contracts/v2/modules/DisputeModule.sol#21-600) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 21,
+    "fingerprint": "2196f0c45557bdcc41bfbc6a5630e93d9374f377d414564bbbfe924a64ad01a9"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "FeePool (contracts/v2/FeePool.sol#45-627) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 45,
+    "fingerprint": "30177e2d7dacab65636ab082553a3ec5b9fda4db3dcb9bbe448a75a4337d1efc"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "JobEscrow (contracts/v2/modules/JobEscrow.sol#32-211) should inherit from IJobEscrow (contracts/v2/interfaces/IJobEscrow.sol#6-26)\n",
+    "uri": "contracts/v2/modules/JobEscrow.sol",
+    "startLine": 32,
+    "fingerprint": "347dabf0090ccde07c7c3968ea9ad97baf6f73f529efcd04f173ed19ed8ed29e"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "RevertingNameWrapper (contracts/legacy/RevertingNameWrapper.sol#8-12) should inherit from INameWrapper (contracts/v2/interfaces/INameWrapper.sol#6-11)\n",
+    "uri": "contracts/legacy/RevertingNameWrapper.sol",
+    "startLine": 8,
+    "fingerprint": "368cb97dab9415536f26377b63d896f6f2aa925effe8931e4f04448cdf61b325"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "GovernanceReward (contracts/v2/GovernanceReward.sol#18-180) should inherit from IGovernanceReward (contracts/v2/QuadraticVoting.sol#11-13)\n",
+    "uri": "contracts/v2/GovernanceReward.sol",
+    "startLine": 18,
+    "fingerprint": "3b7c3cee7c4e54b5507d1e886ed3461d386cbeebc7a3439791f14a3bb5858b5b"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "RoutingModule (contracts/v2/modules/RoutingModule.sol#10-226) should inherit from IRoutingModule (contracts/v2/modules/JobEscrow.sol#12-14)\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 10,
+    "fingerprint": "41ca99dad72d9763200cbc33905f66ed24437b00d86716ca10d07694a033f88a"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "AGIALPHAToken (contracts/test/AGIALPHAToken.sol#14-101) should inherit from IERC20Burnable (contracts/v2/interfaces/IERC20Burnable.sol#6-15)\n",
+    "uri": "contracts/test/AGIALPHAToken.sol",
+    "startLine": 14,
+    "fingerprint": "447fb8c2198b1e40508809ed5a14e9e89381930c641b5d6e36dcd67a400d7ae3"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "ModuleInstaller (contracts/v2/ModuleInstaller.sol#35-237) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/ModuleInstaller.sol",
+    "startLine": 35,
+    "fingerprint": "469905bed4f7ad97b11507acaa99f38fe9733a2703560add74962e2f92e87fe3"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "StakeManager (contracts/v2/StakeManager.sol#72-2939) should inherit from IStakeManager (contracts/v2/mocks/ReentrantJobRegistry.sol#6-21)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 72,
+    "fingerprint": "4d51e91d0537b12981886ce90c6831d9c32a8fa4e7a28087bd6edeb7f0ff805b"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "StakeManager (contracts/v2/StakeManager.sol#72-2939) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 72,
+    "fingerprint": "4eef5a13562c5adc1e7585bfc15a469bb4373ccbdb0e98125976c6649731a7bb"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "PlatformIncentives (contracts/v2/PlatformIncentives.sol#16-184) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/PlatformIncentives.sol",
+    "startLine": 16,
+    "fingerprint": "56a40a293592da24b940bd9fe2ce2127fc739b2096cadd9a7617fdd2bebb8c05"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "KlerosDisputeModule (contracts/v2/modules/KlerosDisputeModule.sol#12-214) should inherit from IKlerosModule (contracts/v2/mocks/MockArbitrator.sol#33-35)\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 12,
+    "fingerprint": "6390740972ab7f54a85179120a63597bc7a11176e48a379c2978b84b3ff58021"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "GovernanceReward (contracts/v2/GovernanceReward.sol#18-180) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/GovernanceReward.sol",
+    "startLine": 18,
+    "fingerprint": "63edc25901bbf617e9da4475947cf202a17483526c069489d00bb93b4d0c53a1"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "JobRegistry (contracts/v2/JobRegistry.sol#26-2680) should inherit from IJobRegistryAck (contracts/v2/interfaces/IJobRegistryAck.sol#4-7)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 26,
+    "fingerprint": "73f9f884e80833ac60416fde0eeb3e928712bb1a557bf8cf4887fc1baaf6dfe5"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "ReentrantERC20 (contracts/test/ReentrantERC20.sol#11-46) should inherit from IReentrantToken (contracts/v2/mocks/ReentrantJobRegistry.sol#23-25)\n",
+    "uri": "contracts/test/ReentrantERC20.sol",
+    "startLine": 11,
+    "fingerprint": "751ec85458eb1f784073e5ce04fb2e5533c3529842f86bf784e46e839ee94763"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "MockHamiltonianFeed (contracts/test/MockHamiltonianFeed.sol#4-14) should inherit from IHamiltonian (contracts/v2/interfaces/IHamiltonian.sol#4-6)\n",
+    "uri": "contracts/test/MockHamiltonianFeed.sol",
+    "startLine": 4,
+    "fingerprint": "890650024b5ee246b0921a5d58b6c427c08536e4c074045bf2275c6e6c62b0d7"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "IdentityRegistry (contracts/v2/IdentityRegistry.sol#22-1389) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/IdentityRegistry.sol",
+    "startLine": 22,
+    "fingerprint": "93fd69fc7195ac041684989a6ba1eaee6d6f0158c736f60d11416779ef295e13"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "ReentrantJobRegistry (contracts/v2/mocks/ReentrantJobRegistry.sol#28-110) should inherit from IReentrantCaller (contracts/legacy/ReentrantERC206.sol#8-10)\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 28,
+    "fingerprint": "9ccec378320ad71944cba30a775b6c1ed67bf78d6092d73cb4012facf4058894"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "CertificateNFT (contracts/v2/CertificateNFT.sol#19-232) should inherit from IMarketplaceNFT (contracts/legacy/ReentrantBuyer.sol#9-11)\n",
+    "uri": "contracts/v2/CertificateNFT.sol",
+    "startLine": 19,
+    "fingerprint": "9f4a3ade73523a59456891d58b6320cddde31dd1f3ccc25b6f490daeaeb1f290"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "CertificateNFT (contracts/v2/CertificateNFT.sol#19-232) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/CertificateNFT.sol",
+    "startLine": 19,
+    "fingerprint": "9fe138da77e9c8a9c9ebe80791cba24565f31d6d5072b848364471663d0a1d6c"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "AGIALPHAToken (contracts/test/AGIALPHAToken.sol#14-101) should inherit from IERC20Mintable (contracts/v2/interfaces/IERC20Mintable.sol#6-16)\n",
+    "uri": "contracts/test/AGIALPHAToken.sol",
+    "startLine": 14,
+    "fingerprint": "a875a6ed7b8a4d829efa92fb82f17f0ff1b17e15b4c2ea198bcf078eb167754d"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "JobRouter (contracts/v2/modules/JobRouter.sol#11-174) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/modules/JobRouter.sol",
+    "startLine": 11,
+    "fingerprint": "b26dd93100cfc53fd1d5b1164998f2ba38ae33ace404d2094a7c84822b21d667"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "RoutingModule (contracts/v2/modules/RoutingModule.sol#10-226) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/modules/RoutingModule.sol",
+    "startLine": 10,
+    "fingerprint": "b3ba160a17c004db61233dbd14be47aea96e578637bd7a2131e18c21930efb2e"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "MockResolver (contracts/legacy/MockResolver.sol#8-18) should inherit from IAddrResolver (contracts/v2/interfaces/IAddrResolver.sol#4-6)\n",
+    "uri": "contracts/legacy/MockResolver.sol",
+    "startLine": 8,
+    "fingerprint": "b707deb7b5e9a57c64b58ec6a3573623a4924d93360b2433d4f6d3df894d01ac"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "SimpleJobRegistry (contracts/test/SimpleJobRegistry.sol#8-157) should inherit from IJobRegistryTax (contracts/v2/interfaces/IJobRegistryTax.sol#8-11)\n",
+    "uri": "contracts/test/SimpleJobRegistry.sol",
+    "startLine": 8,
+    "fingerprint": "bf2deca7189a83f0c84dc3bb8cfb132805170aaa6913224b9d82d6b3f2404e86"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "JobEscrow (contracts/v2/modules/JobEscrow.sol#32-211) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/modules/JobEscrow.sol",
+    "startLine": 32,
+    "fingerprint": "ca851ebae47d4e86dcbeb1ebf6c3242b629389e01c801680392b334ec2354a7c"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "ReputationEngine (contracts/v2/ReputationEngine.sol#15-455) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 15,
+    "fingerprint": "d141e974fd1135e91186e43ff5826ac0f163abe8faf46720c69de3456940cad1"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "JobRegistry (contracts/v2/JobRegistry.sol#26-2680) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 26,
+    "fingerprint": "dc30a1d86a831323ac4a5e1f3ab396ce02ca72e06944f54f3aa36703d0dc395b"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "DiscoveryModule (contracts/v2/modules/DiscoveryModule.sol#11-163) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 11,
+    "fingerprint": "dee6ca43fe7c90066822b95bd55009dd1156e197839ec1228fea0bb12d51d98e"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "MockRoutingModule (contracts/legacy/MockRoutingModule.sol#6-16) should inherit from IRoutingModule (contracts/v2/modules/JobEscrow.sol#12-14)\n",
+    "uri": "contracts/legacy/MockRoutingModule.sol",
+    "startLine": 6,
+    "fingerprint": "e0ac8bd050b158035b8714065cdc4b6c6decd73400d0f2e17f5664c54437ed3e"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "MockNameWrapper (contracts/legacy/MockNameWrapper.sol#8-18) should inherit from INameWrapper (contracts/v2/interfaces/INameWrapper.sol#6-11)\n",
+    "uri": "contracts/legacy/MockNameWrapper.sol",
+    "startLine": 8,
+    "fingerprint": "e8dc4401fc3a4f6a08e208f63dbef1c40173a8cd94647ecda9e23e0461f37e95"
+  },
+  {
+    "ruleId": "3-0-missing-inheritance",
+    "message": "ENSOwnershipVerifier (contracts/v2/modules/ENSOwnershipVerifier.sol#11-179) should inherit from ITaxExempt (contracts/legacy/TaxExemptHelper.sol#6-8)\n",
+    "uri": "contracts/v2/modules/ENSOwnershipVerifier.sol",
+    "startLine": 11,
+    "fingerprint": "f33e5ac1f620efd0b5aab4aebd317b67d3fcaabcae08be84fa848afdf8874daf"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setPauser(address)._pauser (contracts/v2/JobRegistry.sol#478) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 478,
+    "fingerprint": "002d01d9afbbce653e6fa3f4a09ab2c9e444fcb471db7056c6797c3230a6d766"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter PlatformIncentives.setModules(IStakeManager,IPlatformRegistryFull,IJobRouter)._jobRouter (contracts/v2/PlatformIncentives.sol#76) is not in mixedCase\n",
+    "uri": "contracts/v2/PlatformIncentives.sol",
+    "startLine": 76,
+    "fingerprint": "01eda1b22deab5c96b9dd3e85f8effeda27b30321ea0754b46e9433b5ca9b764"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Thermostat.setTemperatureBounds(int256,int256)._max (contracts/v2/Thermostat.sol#84) is not in mixedCase\n",
+    "uri": "contracts/v2/Thermostat.sol",
+    "startLine": 84,
+    "fingerprint": "0322c377dd8b7aec00bd7a2a80a091ac4f2608857d9ab63270f41c2ecffa433c"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantJobRegistry.attackFinalize(bytes32,address,uint256)._reward (contracts/v2/mocks/ReentrantJobRegistry.sol#56) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 56,
+    "fingerprint": "039cb66ae49c58160f4b292ea677db04f15564b4163dc0d90366b6bc2922f5b0"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setJobRegistry(address)._jobRegistry (contracts/v2/StakeManager.sol#1247) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1247,
+    "fingerprint": "041e76e1355157c9f00862f05d39fbd47a647a90bdaedc03c119bb22fd25edbf"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setTaxPolicy(ITaxPolicy)._policy (contracts/v2/JobRegistry.sol#1275) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1275,
+    "fingerprint": "056b43acac1d0995430a6e69dee0709ae69717f972d3a0a85b70de08919ccd3b"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashDistribution(uint256,uint256,uint256,uint256)._validatorSlashPct (contracts/v2/StakeManager.sol#1186) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1186,
+    "fingerprint": "088187a04fe57d7b78b609003e219f0e919a1e0b088165855532acc01f9c0b89"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ThermoMath.mbWeights(int256[],uint256[],int256,int256).T (contracts/v2/libraries/ThermoMath.sol#40) is not in mixedCase\n",
+    "uri": "contracts/v2/libraries/ThermoMath.sol",
+    "startLine": 40,
+    "fingerprint": "091a9756b20e7a53bdd6702e81568a8d8856261af9a7962f4452e3383917bdb4"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setThermostat(address)._thermostat (contracts/v2/StakeManager.sol#517) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 517,
+    "fingerprint": "0b8c7a746128a3363ff664e03181a92c57636e2e92197f9dd06af055593bbed2"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Governable.setGovernance(address)._governance (contracts/v2/Governable.sol#46) is not in mixedCase\n",
+    "uri": "contracts/v2/Governable.sol",
+    "startLine": 46,
+    "fingerprint": "0ba1ba184682a7103319fc58d023a07e612b028ffebade9b53a37678fe50b36c"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantERC206.setCaller(address)._caller (contracts/legacy/ReentrantERC206.sol#27) is not in mixedCase\n",
+    "uri": "contracts/legacy/ReentrantERC206.sol",
+    "startLine": 27,
+    "fingerprint": "0c81c7a20bf9cb04d876334a10b2ad6ce19e02ea0f5d37eeb535243c38a8d55d"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter MockJobRegistry.setTaxPolicyVersion(uint256)._version (contracts/legacy/MockV2.sol#484) is not in mixedCase\n",
+    "uri": "contracts/legacy/MockV2.sol",
+    "startLine": 484,
+    "fingerprint": "0d67057c50d08ad053d9bfa566889ee39d480b9d8b5f8eff91eb7b66128e3f2c"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter RewardEngineMB.setKappa(uint256)._kappa (contracts/v2/RewardEngineMB.sol#159) is not in mixedCase\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 159,
+    "fingerprint": "0dc4960dc0631a589e157b1655807daba0e8a3b8cbb46949c8803dc012a97861"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashingParameters(uint256,uint256)._employerSlashPct (contracts/v2/StakeManager.sol#1118) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1118,
+    "fingerprint": "0f780812ebc028fbaf57bcdf7eb873fa7f79d670ab548a112a7d8067210ab93d"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setFeePool(IFeePool)._feePool (contracts/v2/JobRegistry.sol#1221) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1221,
+    "fingerprint": "131c1266c41ae1ffe0477ba44b003f8a3352e9c2fbb5d1d88f42ceaec94f62e4"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter DiscoveryModule.setReputationEngine(IReputationEngine)._reputationEngine (contracts/v2/modules/DiscoveryModule.sol#144) is not in mixedCase\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 144,
+    "fingerprint": "139f618db9335f308a884e5f86849f56cc80825da7c9b9427e9f8743a9051f78"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantIdentityRegistry.attackCommit(uint256,bytes32)._commitHash (contracts/v2/mocks/ReentrantIdentityRegistry.sol#26) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantIdentityRegistry.sol",
+    "startLine": 26,
+    "fingerprint": "1908bb20d92462ae03ae0b4123ad1568fcab0f036070653825d964cc26f484d7"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Variable ValidationModule.DOMAIN_SEPARATOR (contracts/v2/ValidationModule.sol#77) is not in mixedCase\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 77,
+    "fingerprint": "1947cbd763e2eb302f0e88c7b052e8d94b38a0a219cb7ba4502e8189e0e887e4"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter DisputeModule.setPauser(address)._pauser (contracts/v2/modules/DisputeModule.sol#259) is not in mixedCase\n",
+    "uri": "contracts/v2/modules/DisputeModule.sol",
+    "startLine": 259,
+    "fingerprint": "1a03d65b0938ba5a120998b32f081fd710218dca51605fc37ff6dd146d540b70"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Thermostat.setKPIWeights(int256,int256,int256)._wSla (contracts/v2/Thermostat.sol#63) is not in mixedCase\n",
+    "uri": "contracts/v2/Thermostat.sol",
+    "startLine": 63,
+    "fingerprint": "1e35fe0474bc7b77b123eca62c6c150fd77d8c306134bd3b295b8acf917d509a"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ValidationModule.setPauser(address)._pauser (contracts/v2/ValidationModule.sol#257) is not in mixedCase\n",
+    "uri": "contracts/v2/ValidationModule.sol",
+    "startLine": 257,
+    "fingerprint": "1fae5ca89c7a5d9520508e643ee96d9b9433520a273ee6f0ca607e6311544579"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter DiscoveryModule.setMinStake(uint256)._minStake (contracts/v2/modules/DiscoveryModule.sol#132) is not in mixedCase\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 132,
+    "fingerprint": "22b54624b96d529c47bf6bda413d5279e673d3b4a329e4394646be1a2ce60761"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter SystemPause.setModules(JobRegistry,StakeManager,ValidationModule,DisputeModule,PlatformRegistry,FeePool,ReputationEngine,ArbitratorCommittee)._jobRegistry (contracts/v2/SystemPause.sol#126) is not in mixedCase\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 126,
+    "fingerprint": "25facf71fa6db205ffd89def8a2bfe05080150be1a5f0843c1cae448af4b2d22"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter DiscoveryModule.setStakeManager(IStakeManager)._stakeManager (contracts/v2/modules/DiscoveryModule.sol#138) is not in mixedCase\n",
+    "uri": "contracts/v2/modules/DiscoveryModule.sol",
+    "startLine": 138,
+    "fingerprint": "2aeb89b34a67f9dd54cfbb1fb579eb274ceba87199df87001a503261e6d32faa"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.finalizeJobFundsWithPct(bytes32,address,address,uint256,uint256,uint256,uint256,IFeePool,bool)._feePool (contracts/v2/StakeManager.sol#2446) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2446,
+    "fingerprint": "2cbf742581b79e68ef5027b70948fc0c9bfc9dda4dcd37555ede9829e70d7304"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Function GovernorVotes.CLOCK_MODE() (node_modules/@openzeppelin/contracts/governance/extensions/GovernorVotes.sol#45-51) is not in mixedCase\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/extensions/GovernorVotes.sol",
+    "startLine": 45,
+    "fingerprint": "2d79b9e3916fe3e1ed4d8c9ba353070fe2821031f1e30ff65bb68ebe9b52c23b"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setModules(IValidationModule,IStakeManager,IReputationEngine,IDisputeModule,ICertificateNFT,IFeePool,address[])._disputeModule (contracts/v2/JobRegistry.sol#1114) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1114,
+    "fingerprint": "337605120839b1f4b3f75355cfec776aff895973dc0a28443890b06c468a80c0"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setModules(address,address)._disputeModule (contracts/v2/StakeManager.sol#1304) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1304,
+    "fingerprint": "3394d2ee88a08b4eb4eb099f4df00c8a769a14069bc3b164b3741e2d012345ff"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Thermostat.setPID(int256,int256,int256)._kd (contracts/v2/Thermostat.sol#52) is not in mixedCase\n",
+    "uri": "contracts/v2/Thermostat.sol",
+    "startLine": 52,
+    "fingerprint": "3711db0555741a491db490e78d711cb9d4a5c5cd4f1c59da78fde068ce8955c7"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setOperatorSlashPct(uint256)._operatorSlashPct (contracts/v2/StakeManager.sol#1167) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1167,
+    "fingerprint": "3864e6cecf42444a17da8cf1053e87c8b670d93a72b4feaafbd8c7c05d02e73b"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter SystemPause.setModules(JobRegistry,StakeManager,ValidationModule,DisputeModule,PlatformRegistry,FeePool,ReputationEngine,ArbitratorCommittee)._validationModule (contracts/v2/SystemPause.sol#128) is not in mixedCase\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 128,
+    "fingerprint": "3bf8d72946f064809fa83382620686e79e446342c39b83d37af1d3f1aeae1095"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Function IERC6372.CLOCK_MODE() (node_modules/@openzeppelin/contracts/interfaces/IERC6372.sol#16) is not in mixedCase\n",
+    "uri": "node_modules/@openzeppelin/contracts/interfaces/IERC6372.sol",
+    "startLine": 16,
+    "fingerprint": "3c6579b79ed27f97c3788555e43262cc32f29f77636170a1fcabac06b58d2589"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantJobRegistry.lockReward(bytes32,address,uint256)._jobId (contracts/v2/mocks/ReentrantJobRegistry.sol#52) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 52,
+    "fingerprint": "3d7e9a8269448a597e25ff05972b5729c5c7465f804343a9faaa7097400c448a"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashingDistribution(uint256,uint256,uint256)._validatorSlashPct (contracts/v2/StakeManager.sol#1147) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1147,
+    "fingerprint": "41bfe164db8f8ce598b0f038acbcee9aabf10c6c506b6e9731c97925c3a35bbf"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantERC20.setAttack(address,uint256)._manager (contracts/legacy/ReentrantERC20.sol#24) is not in mixedCase\n",
+    "uri": "contracts/legacy/ReentrantERC20.sol",
+    "startLine": 24,
+    "fingerprint": "4366ca1e57d651dfb523b1207ac1d104b18e8570d020df7ca96b7d79f83d766d"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashingPercentages(uint256,uint256)._treasurySlashPct (contracts/v2/StakeManager.sol#1105) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1105,
+    "fingerprint": "4ba7dba48e2c0ab8b7b51cd3c90f56f57b301cf09be32f6bc923791314773a0b"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter RevenueDistributor.setTreasury(address)._treasury (contracts/v2/modules/RevenueDistributor.sol#74) is not in mixedCase\n",
+    "uri": "contracts/v2/modules/RevenueDistributor.sol",
+    "startLine": 74,
+    "fingerprint": "4d232ca9c43bc1eb6253ab66f85d12aade8cfbc6f2244508b0437dd61b7bd383"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setMinStake(uint256)._minStake (contracts/v2/StakeManager.sol#750) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 750,
+    "fingerprint": "4e8becd9c25796656bb8a52f19e46392bdc7859f5e674961b169ef8657ca4ac2"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter SystemPause.setModules(JobRegistry,StakeManager,ValidationModule,DisputeModule,PlatformRegistry,FeePool,ReputationEngine,ArbitratorCommittee)._stakeManager (contracts/v2/SystemPause.sol#127) is not in mixedCase\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 127,
+    "fingerprint": "5099ee78cfa37907643343b3254cf4c36d673e7805830f8fcafdb5de0d6b54b6"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter PlatformIncentives.setModules(IStakeManager,IPlatformRegistryFull,IJobRouter)._platformRegistry (contracts/v2/PlatformIncentives.sol#75) is not in mixedCase\n",
+    "uri": "contracts/v2/PlatformIncentives.sol",
+    "startLine": 75,
+    "fingerprint": "50ac548b6a58baca16dd2c449977cb9e8102db3fd2625e439128da62352eb2b8"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Thermostat.setPID(int256,int256,int256)._kp (contracts/v2/Thermostat.sol#52) is not in mixedCase\n",
+    "uri": "contracts/v2/Thermostat.sol",
+    "startLine": 52,
+    "fingerprint": "5167e444a82e99a21d94757e39ce06ac38847ec48b9e3a40a9928c22ccf22b49"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ModuleInstaller.initialize(JobRegistry,StakeManager,ValidationModule,IReputationEngine,IDisputeModule,ICertificateNFT,PlatformIncentives,IPlatformRegistryFull,IJobRouter,IFeePool,ITaxPolicy,IIdentityRegistry,bytes32,bytes32,bytes32,bytes32,address[])._ackModules (contracts/v2/ModuleInstaller.sol#89) is not in mixedCase\n",
+    "uri": "contracts/v2/ModuleInstaller.sol",
+    "startLine": 89,
+    "fingerprint": "53653a519b4640ebb3a316ad32e13d9af74978f1f930443a8b132158e83e895b"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter RewardEngineMB.setTreasury(address)._treasury (contracts/v2/RewardEngineMB.sol#184) is not in mixedCase\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 184,
+    "fingerprint": "5636c1921622bab5356ff18f2887d034b02d50efe22b0b981451d8dd407cb572"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setModules(IValidationModule,IStakeManager,IReputationEngine,IDisputeModule,ICertificateNFT,IFeePool,address[])._validation (contracts/v2/JobRegistry.sol#1111) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1111,
+    "fingerprint": "5a0f9af2d3716984429c64e59471716f8bf28c4d1f18ac5e5edcf2221ff307b8"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Function EIP712._EIP712Version() (node_modules/@openzeppelin/contracts/utils/cryptography/EIP712.sol#157-159) is not in mixedCase\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/cryptography/EIP712.sol",
+    "startLine": 157,
+    "fingerprint": "5b08301e8648d88e4cc740cc85995aa02917ecb8ccef3ef89d067cf5d80e4685"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter FeePool.setTreasuryAllowlist(address,bool)._treasury (contracts/v2/FeePool.sol#449) is not in mixedCase\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 449,
+    "fingerprint": "5fc01b6a0d3dc94a29e5c48ee08aa356e2e21efda7fc5bb2b0a4e59f90fc8577"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setTreasuryAllowlist(address,bool)._treasury (contracts/v2/StakeManager.sol#1231) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1231,
+    "fingerprint": "635b7705a06ee881f300a23cd373d198acfc576e3ff3e103ec558dcb855e471b"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Variable StubReputationEngine._blacklist (contracts/legacy/StubReputationEngine.sol#8) is not in mixedCase\n",
+    "uri": "contracts/legacy/StubReputationEngine.sol",
+    "startLine": 8,
+    "fingerprint": "6812b795c745ee4bba861f8924797efb9b4b43e5b693a95697fecdb1ce7bdac0"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ThermoMath.mbWeights(int256[],uint256[],int256,int256).E (contracts/v2/libraries/ThermoMath.sol#38) is not in mixedCase\n",
+    "uri": "contracts/v2/libraries/ThermoMath.sol",
+    "startLine": 38,
+    "fingerprint": "686de646a656d022a8038c4b75960871a68ab5f92518fa0e95d08e08a2ed8ba4"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setTreasury(address)._treasury (contracts/v2/JobRegistry.sol#1227) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1227,
+    "fingerprint": "68c9d0db7d94a82d9f6210d8ab5524ae497b14e86b05708cc4f92c6d8cfc6392"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Thermostat.setIntegralBounds(int256,int256)._max (contracts/v2/Thermostat.sol#97) is not in mixedCase\n",
+    "uri": "contracts/v2/Thermostat.sol",
+    "startLine": 97,
+    "fingerprint": "6d3adb0dab39e95e7c95168371732df1e58ccf65aa0edfcdb0d90540097da820"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter QuadraticVoting.setTreasury(address)._treasury (contracts/v2/QuadraticVoting.sol#76) is not in mixedCase\n",
+    "uri": "contracts/v2/QuadraticVoting.sol",
+    "startLine": 76,
+    "fingerprint": "6e30ef1568017e8502631b80bd6a76ef541845c9bd12894eb5dcba0007be4083"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Function Governor.CLOCK_MODE() (node_modules/@openzeppelin/contracts/governance/Governor.sol#795) is not in mixedCase\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/Governor.sol",
+    "startLine": 795,
+    "fingerprint": "6efc2bb8ddf3ff0fdfd76280cc39c8f038bce96c0fccba32ce773530add341a8"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setFeePct(uint256)._feePct (contracts/v2/JobRegistry.sol#1242) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1242,
+    "fingerprint": "73d0a8c8079ade72dd90d8d54f0e97af68adea948dc821497eacce0cb38f1577"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setModules(IValidationModule,IStakeManager,IReputationEngine,IDisputeModule,ICertificateNFT,IFeePool,address[])._certNFT (contracts/v2/JobRegistry.sol#1115) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1115,
+    "fingerprint": "772257d2850e141daa7ba28df1c50499c8cb26f36c1671c6d6bf2f7aa3bc5ef6"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter IdentityRegistryMock.setNameWrapper(address)._wrapper (contracts/v2/mocks/IdentityRegistryMock.sol#48) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/IdentityRegistryMock.sol",
+    "startLine": 48,
+    "fingerprint": "77c16d70a08dddc46b6d436c2a9a2035aa2b647fdc14e5e1f1e4e93ad55ff1da"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter SystemPause.setModules(JobRegistry,StakeManager,ValidationModule,DisputeModule,PlatformRegistry,FeePool,ReputationEngine,ArbitratorCommittee)._feePool (contracts/v2/SystemPause.sol#131) is not in mixedCase\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 131,
+    "fingerprint": "78cc82a1ae6dff544b52c4bb290f1256ff5eeadd88809ab8d532549340c1d3a6"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Thermostat.setTemperatureBounds(int256,int256)._min (contracts/v2/Thermostat.sol#84) is not in mixedCase\n",
+    "uri": "contracts/v2/Thermostat.sol",
+    "startLine": 84,
+    "fingerprint": "79a24ad857c1d600e38e966caf6056898ba1eb53d807de6e94613f5a3165cf85"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setPauser(address)._pauser (contracts/v2/StakeManager.sol#499) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 499,
+    "fingerprint": "7aac055c42dc1180218de432108b26b799fe3e253555aa3090a972ef0eef16c6"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter MockHamiltonianFeed.setHamiltonian(int256)._h (contracts/test/MockHamiltonianFeed.sol#7) is not in mixedCase\n",
+    "uri": "contracts/test/MockHamiltonianFeed.sol",
+    "startLine": 7,
+    "fingerprint": "7fa520883e116c3f1ed4fd2f0f282529d3e8af10c79f516cfb6727bd91d41245"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter KlerosDisputeModule.setArbitrator(address)._arbitrator (contracts/v2/modules/KlerosDisputeModule.sol#96) is not in mixedCase\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 96,
+    "fingerprint": "813dd7457e2a1a3c5aca41afd10551ffc75ddc9bee242cbe5e8abd6785c94b00"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantERC206.setAttack(bool)._attack (contracts/legacy/ReentrantERC206.sol#31) is not in mixedCase\n",
+    "uri": "contracts/legacy/ReentrantERC206.sol",
+    "startLine": 31,
+    "fingerprint": "84f54fed882e0cd04049b0f4fe8df114278e6137f31a4364f78545f387241285"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantJobRegistry.lockReward(bytes32,address,uint256)._amount (contracts/v2/mocks/ReentrantJobRegistry.sol#52) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 52,
+    "fingerprint": "851e1a55098ed212017b834b8df57e78d96fc50d2aeea01f35ca344079856504"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter FeePool.setGovernance(address)._governance (contracts/v2/FeePool.sol#384) is not in mixedCase\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 384,
+    "fingerprint": "87dfcc6cd2f22665a6ac7a6889c1f5cdf3fea36ff0e29af77ae7b255b2983d6a"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashingPercentages(uint256,uint256)._employerSlashPct (contracts/v2/StakeManager.sol#1105) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1105,
+    "fingerprint": "8a9d701f6081aba045e99572d9ed71fd202d4ee553e00f5998b2b2c64a1f065c"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.finalizeJobFunds(bytes32,address,address,uint256,uint256,uint256,IFeePool,bool)._feePool (contracts/v2/StakeManager.sol#2430) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2430,
+    "fingerprint": "8c62ea02dc811cd004258747bc025090882d955d51b1d2c8e484a06b02870f5a"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setHamiltonianFeed(address)._feed (contracts/v2/StakeManager.sol#526) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 526,
+    "fingerprint": "8c6fe4284de117b123db0fc56bdb58708b9bde54ebef7457bf72c5a7b91388d2"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setTreasury(address)._treasury (contracts/v2/StakeManager.sol#1219) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1219,
+    "fingerprint": "939be1b52318ac4e4405a754b76ef25a82c29a6a9076ecf0832ff268aca08a4c"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter IdentityRegistryMock.setENS(address)._ens (contracts/v2/mocks/IdentityRegistryMock.sol#44) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/IdentityRegistryMock.sol",
+    "startLine": 44,
+    "fingerprint": "95c19398f57ed035a6554d50074f424260bfecf479a0efdf658f955b45ea22fc"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setModules(address,address)._jobRegistry (contracts/v2/StakeManager.sol#1304) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1304,
+    "fingerprint": "9808c950a7ab2ae33ca676c3a48692ea026e65513e27efbd3f0b805ce80640bf"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantIdentityRegistry.attackCommit(uint256,bytes32)._jobId (contracts/v2/mocks/ReentrantIdentityRegistry.sol#26) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantIdentityRegistry.sol",
+    "startLine": 26,
+    "fingerprint": "98cc259bbd208d8816b6d921a7aa0d5c3db278e29ebf322a225fd5b4e27c2aa9"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter RewardEngineMB.setReputationEngine(IReputationEngineV2)._reputation (contracts/v2/RewardEngineMB.sol#219) is not in mixedCase\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 219,
+    "fingerprint": "99d170a63a7b4f5b7658d4c0076e3e06d530166f3a0dadbc83d9cb8c04037da3"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Function IERC20Permit.DOMAIN_SEPARATOR() (node_modules/@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol#89) is not in mixedCase\n",
+    "uri": "node_modules/@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol",
+    "startLine": 89,
+    "fingerprint": "9a77c79a6cf40e2f151723e49ba63d30100a56d0f72688e58cdf4a550a6ff843"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ValidationStub.setResult(bool)._result (contracts/v2/mocks/ValidationStub.sol#20) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ValidationStub.sol",
+    "startLine": 20,
+    "fingerprint": "9e7bd7837e4fcac2398cc6049e94fde61893d54f70b5d2e16e24429038bc9b48"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter SystemPause.setModules(JobRegistry,StakeManager,ValidationModule,DisputeModule,PlatformRegistry,FeePool,ReputationEngine,ArbitratorCommittee)._reputationEngine (contracts/v2/SystemPause.sol#132) is not in mixedCase\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 132,
+    "fingerprint": "9f772f6174bc506afa7ada9ba756bd283feae70b1de97002c89d4af2a4c6fe2e"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantIdentityRegistry.attackReveal(uint256,bool,bytes32,bytes32)._approve (contracts/v2/mocks/ReentrantIdentityRegistry.sol#34) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantIdentityRegistry.sol",
+    "startLine": 34,
+    "fingerprint": "a0e3a35cc9621f1d9d76362727f5cfd28a5f21cdfc347f636f872dcc7e774e42"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter SystemPause.setModules(JobRegistry,StakeManager,ValidationModule,DisputeModule,PlatformRegistry,FeePool,ReputationEngine,ArbitratorCommittee)._arbitratorCommittee (contracts/v2/SystemPause.sol#133) is not in mixedCase\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 133,
+    "fingerprint": "a1729550cbeaec6061105248571eedf14fb62cb420e99929957ac5a0cdd97d99"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter SystemPause.setModules(JobRegistry,StakeManager,ValidationModule,DisputeModule,PlatformRegistry,FeePool,ReputationEngine,ArbitratorCommittee)._disputeModule (contracts/v2/SystemPause.sol#129) is not in mixedCase\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 129,
+    "fingerprint": "a389108f851473d651e920e022909a81e44632ad7a2227801b8476291cb51edf"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantIdentityRegistry.attackReveal(uint256,bool,bytes32,bytes32)._jobId (contracts/v2/mocks/ReentrantIdentityRegistry.sol#33) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantIdentityRegistry.sol",
+    "startLine": 33,
+    "fingerprint": "a483bc60a086454061bc30cd53adda4baaf297e1db3b4d053f223dde0cfd69d0"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashDistribution(uint256,uint256,uint256,uint256)._employerSlashPct (contracts/v2/StakeManager.sol#1183) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1183,
+    "fingerprint": "a49087d02427b9406ff74ea119c70b62988a49b2d19af8440d74aa4ff0434b48"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantJobRegistry.attackValidator(bytes32,uint256)._amount (contracts/v2/mocks/ReentrantJobRegistry.sol#67) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 67,
+    "fingerprint": "a6b20399a3bbdf71f29cfdc44008f428877a396952c228d370ce44cfedcee3f4"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter OracleValidationModule.setOracle(IValidationOracle)._oracle (contracts/v2/modules/OracleValidationModule.sol#49) is not in mixedCase\n",
+    "uri": "contracts/v2/modules/OracleValidationModule.sol",
+    "startLine": 49,
+    "fingerprint": "a7d8071375d4008dbcbd47a855125cf4b689c630d760cfd43ce311a41f38f1b9"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Function ERC20Permit.DOMAIN_SEPARATOR() (node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol#74-76) is not in mixedCase\n",
+    "uri": "node_modules/@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol",
+    "startLine": 74,
+    "fingerprint": "ae3f36aabe9ce571b2d0bac868aa8ddd745117bd041ef8300b9798601ba580ca"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter RewardEngineMB.setFeePool(IFeePool)._feePool (contracts/v2/RewardEngineMB.sol#211) is not in mixedCase\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 211,
+    "fingerprint": "b03cb9ad2a2f7812b664f7065bd1e7b9e78537bba2eee13305666aab94f3d158"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter FeePool.setTaxPolicy(ITaxPolicy)._policy (contracts/v2/FeePool.sol#455) is not in mixedCase\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 455,
+    "fingerprint": "b61120a70e267fc70ddb33ec2db734747ff822943e8068138ec03864d842c61b"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter RewardEngineMB.setMu(RewardEngineMB.Role,int256)._mu (contracts/v2/RewardEngineMB.sol#144) is not in mixedCase\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 144,
+    "fingerprint": "b639ff9b6b90604d86b64cc02ea8d76c6e0f6ab1b7a3e8d7c41800573a13dea6"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter PlatformIncentives.setModules(IStakeManager,IPlatformRegistryFull,IJobRouter)._stakeManager (contracts/v2/PlatformIncentives.sol#74) is not in mixedCase\n",
+    "uri": "contracts/v2/PlatformIncentives.sol",
+    "startLine": 74,
+    "fingerprint": "b9ef161348e39eb2ce458c875a04b4bc2d9b6066383aebb6e9224254f2434894"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantERC20.setAttack(address,uint256)._jobId (contracts/legacy/ReentrantERC20.sol#24) is not in mixedCase\n",
+    "uri": "contracts/legacy/ReentrantERC20.sol",
+    "startLine": 24,
+    "fingerprint": "be010dcf56e4aed440a83350a5be1b4a14958a164fd153070797f8b05ef3db4e"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantJobRegistry.attackFinalize(bytes32,address,uint256)._agent (contracts/v2/mocks/ReentrantJobRegistry.sol#56) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 56,
+    "fingerprint": "bf6a2cd90a9b90c1698dc589342e7fa6d4bd6f1d3ea1116b68e5d2db9e7a0727"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setModules(IValidationModule,IStakeManager,IReputationEngine,IDisputeModule,ICertificateNFT,IFeePool,address[])._ackModules (contracts/v2/JobRegistry.sol#1117) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1117,
+    "fingerprint": "c28eb3a202525c6249475f6e1dc2eacb7a0eb253f904fe2fa6cbfc8d051e5f92"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantJobRegistry.attackValidator(bytes32,uint256)._jobId (contracts/v2/mocks/ReentrantJobRegistry.sol#67) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 67,
+    "fingerprint": "c29711b43d9b355d7f33e7b94cc3c35bbf2adecd6ab1a9c8d28defa33bf884d1"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantERC20.setAttack(bool)._attack (contracts/test/ReentrantERC20.sol#25) is not in mixedCase\n",
+    "uri": "contracts/test/ReentrantERC20.sol",
+    "startLine": 25,
+    "fingerprint": "c44f8995d9f063b819a822fbd36d5499553f6f085273994557a1594ae3b6cf30"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setModules(IValidationModule,IStakeManager,IReputationEngine,IDisputeModule,ICertificateNFT,IFeePool,address[])._feePool (contracts/v2/JobRegistry.sol#1116) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1116,
+    "fingerprint": "c4fd305bbe22fdfd62445af3f7ddc72120dbe189f07f6dad91a607d95ce402d0"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter GovernableMock.setValue(uint256)._value (contracts/v2/mocks/GovernableMock.sol#12) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/GovernableMock.sol",
+    "startLine": 12,
+    "fingerprint": "c6151d188e8dda69a7501fa40f0a40ddb0845e5eb994f5350138854f67936710"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Thermostat.setIntegralBounds(int256,int256)._min (contracts/v2/Thermostat.sol#97) is not in mixedCase\n",
+    "uri": "contracts/v2/Thermostat.sol",
+    "startLine": 97,
+    "fingerprint": "c856782e0ac1619b73d36f39fef77e9d72322fdeda60ee18e5952f19c1ae8e9c"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setModules(IValidationModule,IStakeManager,IReputationEngine,IDisputeModule,ICertificateNFT,IFeePool,address[])._stakeMgr (contracts/v2/JobRegistry.sol#1112) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1112,
+    "fingerprint": "c8b6ccab1993f1451690be25b5ac7926477276b0b33ee7071bc4b7b488dc2355"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Thermostat.setKPIWeights(int256,int256,int256)._wEmission (contracts/v2/Thermostat.sol#63) is not in mixedCase\n",
+    "uri": "contracts/v2/Thermostat.sol",
+    "startLine": 63,
+    "fingerprint": "c954963293c17ddce4ea269e676a808c3b6924028467c2509781fa390bc215fa"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Function Votes.CLOCK_MODE() (node_modules/@openzeppelin/contracts/governance/utils/Votes.sol#66-72) is not in mixedCase\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/utils/Votes.sol",
+    "startLine": 66,
+    "fingerprint": "c9a99ff34d28f3a1335a6dd9353cc7ab3c8120915e4107bea7bc97230ade7e38"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter FeePool.setPauser(address)._pauser (contracts/v2/FeePool.sol#160) is not in mixedCase\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 160,
+    "fingerprint": "caf334a783ddc5134e54ac4a643496e1201fb55dd706fec2b7fc45bced26bfd8"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashingDistribution(uint256,uint256,uint256)._treasurySlashPct (contracts/v2/StakeManager.sol#1146) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1146,
+    "fingerprint": "cf0707c4a5911e97b050b3be94e7441c0e7cda871bfeabf4f83eccbda178f6e4"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setValidatorSlashRewardPct(uint256)._validatorSlashPct (contracts/v2/StakeManager.sol#1130) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1130,
+    "fingerprint": "d0f868f161376ccf0cfc5e15411cc8563a493135c3d0d0aa446be6397462b9b8"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashingParameters(uint256,uint256)._treasurySlashPct (contracts/v2/StakeManager.sol#1118) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1118,
+    "fingerprint": "d117343978182657ffcfd975f2950e840f4bad5268c7036fbbdaf3e2b0654b91"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReputationEngine.setPauser(address)._pauser (contracts/v2/ReputationEngine.sol#79) is not in mixedCase\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 79,
+    "fingerprint": "d260d252de1b3e6f31e815507fc925e79726efe72c5ebda2b8965728aab1c0f1"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Thermostat.setKPIWeights(int256,int256,int256)._wBacklog (contracts/v2/Thermostat.sol#63) is not in mixedCase\n",
+    "uri": "contracts/v2/Thermostat.sol",
+    "startLine": 63,
+    "fingerprint": "d49518c34b63d00d7fbfad1c1e9a892294c5c6dd794890572ee601d653a9b739"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashingDistribution(uint256,uint256,uint256)._employerSlashPct (contracts/v2/StakeManager.sol#1145) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1145,
+    "fingerprint": "d54d23ac998be1db69bd3f7f4b1e8323f8b01d7b272bef1c8f5d193052ea9148"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantJobRegistry.attackFinalize(bytes32,address,uint256)._jobId (contracts/v2/mocks/ReentrantJobRegistry.sol#56) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 56,
+    "fingerprint": "d6bed9da4f0c60a4216e3b0e253f8ea57f1a3db878a588e5cc30925277f281f9"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ArbitratorCommittee.setPauser(address)._pauser (contracts/v2/ArbitratorCommittee.sol#57) is not in mixedCase\n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 57,
+    "fingerprint": "d83a35d6dce8a9db7b05b97b88fe4f60d1b473da5d1caef534ecdada40d50ff8"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashDistribution(uint256,uint256,uint256,uint256)._operatorSlashPct (contracts/v2/StakeManager.sol#1185) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1185,
+    "fingerprint": "d95172e10f9b5d64955433eb98352725c3a2929a5f8d4f5707b9e5ff310a7362"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Function EIP712._EIP712Name() (node_modules/@openzeppelin/contracts/utils/cryptography/EIP712.sol#146-148) is not in mixedCase\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/cryptography/EIP712.sol",
+    "startLine": 146,
+    "fingerprint": "db96ea04e6546eb3d22674155940655c8a832e0e60c564b72e5f02f0c4ebf387"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantIdentityRegistry.attackReveal(uint256,bool,bytes32,bytes32)._burnTxHash (contracts/v2/mocks/ReentrantIdentityRegistry.sol#35) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantIdentityRegistry.sol",
+    "startLine": 35,
+    "fingerprint": "dbfdc521ae4e76afb66327a65b0c86f8556e125c1167e01609ce80b11e8c40ec"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter RewardEngineMB.setThermostat(Thermostat)._thermostat (contracts/v2/RewardEngineMB.sol#198) is not in mixedCase\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 198,
+    "fingerprint": "de40dd2bc62bd5df39b514d16173bea6082609f06ac9453eafa25129ea0c5234"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantERC20.setCaller(address)._caller (contracts/test/ReentrantERC20.sol#21) is not in mixedCase\n",
+    "uri": "contracts/test/ReentrantERC20.sol",
+    "startLine": 21,
+    "fingerprint": "e1dd331ce369d7f0a1a67ceb47fed5b7e7661dcf2942a6c6b2f6b25972ec059c"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter KlerosDisputeModule.setGovernance(address)._governance (contracts/v2/modules/KlerosDisputeModule.sol#90) is not in mixedCase\n",
+    "uri": "contracts/v2/modules/KlerosDisputeModule.sol",
+    "startLine": 90,
+    "fingerprint": "e9f4d46b3dd4f59b18c4e7501c059922750d676312911939e95c2b31c195f903"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter ReentrantIdentityRegistry.attackReveal(uint256,bool,bytes32,bytes32)._salt (contracts/v2/mocks/ReentrantIdentityRegistry.sol#36) is not in mixedCase\n",
+    "uri": "contracts/v2/mocks/ReentrantIdentityRegistry.sol",
+    "startLine": 36,
+    "fingerprint": "ed6619cce34516efb104adbc238b5195d5961ba2af6f42f679124a1e9b0c4629"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter RewardEngineMB.setEnergyOracle(IEnergyOracle)._energyOracle (contracts/v2/RewardEngineMB.sol#227) is not in mixedCase\n",
+    "uri": "contracts/v2/RewardEngineMB.sol",
+    "startLine": 227,
+    "fingerprint": "ef412991cbb7244535b442a0563680b48eff6a51333e7c43900dacf46e912989"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Function IGovernor.COUNTING_MODE() (node_modules/@openzeppelin/contracts/governance/IGovernor.sol#202) is not in mixedCase\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/IGovernor.sol",
+    "startLine": 202,
+    "fingerprint": "f2604d6263f4ab225f8c8010916cf5f3a7539fb1965fc9a27b05b6ff2da9f7ae"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter JobRegistry.setModules(IValidationModule,IStakeManager,IReputationEngine,IDisputeModule,ICertificateNFT,IFeePool,address[])._reputation (contracts/v2/JobRegistry.sol#1113) is not in mixedCase\n",
+    "uri": "contracts/v2/JobRegistry.sol",
+    "startLine": 1113,
+    "fingerprint": "f5e915a9a61f0d83a02eac273211e63b33d1aec5c4411100fa250baf1e6ed5b6"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter FeePool.setTreasury(address)._treasury (contracts/v2/FeePool.sol#442) is not in mixedCase\n",
+    "uri": "contracts/v2/FeePool.sol",
+    "startLine": 442,
+    "fingerprint": "f63a25daa9df634b78381378fbfbac7284c4088434f96eeb9d2bbd00b273900b"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter Thermostat.setPID(int256,int256,int256)._ki (contracts/v2/Thermostat.sol#52) is not in mixedCase\n",
+    "uri": "contracts/v2/Thermostat.sol",
+    "startLine": 52,
+    "fingerprint": "f6849477146c022aa20cfbda93b956147c30c3ccefd64f4e6dcb663c82d0a6c0"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter PlatformRegistry.setPauser(address)._pauser (contracts/v2/PlatformRegistry.sol#91) is not in mixedCase\n",
+    "uri": "contracts/v2/PlatformRegistry.sol",
+    "startLine": 91,
+    "fingerprint": "f6da6a7367a2ece2a1f8d8ad4aa9b403f23d62780fb19d5753e15fda384d74fc"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter SystemPause.setModules(JobRegistry,StakeManager,ValidationModule,DisputeModule,PlatformRegistry,FeePool,ReputationEngine,ArbitratorCommittee)._platformRegistry (contracts/v2/SystemPause.sol#130) is not in mixedCase\n",
+    "uri": "contracts/v2/SystemPause.sol",
+    "startLine": 130,
+    "fingerprint": "f78a89005c4f4abc0e958c0540fa4af4eca4194809e5bc04358ae3cbe22f437d"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Function GovernorCountingSimple.COUNTING_MODE() (node_modules/@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol#32-34) is not in mixedCase\n",
+    "uri": "node_modules/@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol",
+    "startLine": 32,
+    "fingerprint": "f8455f97078fe956b2db5ed384d45a5d4d064ec4206822fd13e9f5f02c606734"
+  },
+  {
+    "ruleId": "3-0-naming-convention",
+    "message": "Parameter StakeManager.setSlashDistribution(uint256,uint256,uint256,uint256)._treasurySlashPct (contracts/v2/StakeManager.sol#1184) is not in mixedCase\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 1184,
+    "fingerprint": "f8cbed48cdf9da71e04fefe8fe5e6463cd904cfed13ed496829978e3607d3848"
+  },
+  {
+    "ruleId": "3-0-redundant-statements",
+    "message": "Redundant expression \"ok (contracts/v2/ModuleInstaller.sol#230)\" inModuleInstaller (contracts/v2/ModuleInstaller.sol#35-237)\n",
+    "uri": "contracts/v2/ModuleInstaller.sol",
+    "startLine": 230,
+    "fingerprint": "04034a14dd3d43b8aee4383ffa1a90c9d8289d45252ea563194e65a3ec5fe622"
+  },
+  {
+    "ruleId": "3-0-redundant-statements",
+    "message": "Redundant expression \"byGovernance (contracts/v2/StakeManager.sol#2449)\" inStakeManager (contracts/v2/StakeManager.sol#72-2939)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2449,
+    "fingerprint": "321ab10b91f85c2cd4b1b8564fd6ccde6c3b17b0f327e645601a6357d7058bcb"
+  },
+  {
+    "ruleId": "3-0-redundant-statements",
+    "message": "Redundant expression \"byGovernance (contracts/v2/StakeManager.sol#2433)\" inStakeManager (contracts/v2/StakeManager.sol#72-2939)\n",
+    "uri": "contracts/v2/StakeManager.sol",
+    "startLine": 2433,
+    "fingerprint": "99ae666f5c5c020002ba43f4e511138a829cc838ce55efced30f50f662f01e1e"
+  },
+  {
+    "ruleId": "3-1-too-many-digits",
+    "message": "ReputationEngine.log2(uint256) (contracts/v2/ReputationEngine.sol#335-357) uses literals with too many digits:\n\t- x = x | x / 0x100000000 (contracts/v2/ReputationEngine.sol#344)\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 335,
+    "fingerprint": "0b72df8351cad8d492d1d054bf3de85e26220672da81c15e17c91962ff4b97d3"
+  },
+  {
+    "ruleId": "3-1-too-many-digits",
+    "message": "ShortStrings.slitherConstructorConstantVariables() (node_modules/@openzeppelin/contracts/utils/ShortStrings.sol#40-122) uses literals with too many digits:\n\t- FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF (node_modules/@openzeppelin/contracts/utils/ShortStrings.sol#42)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/ShortStrings.sol",
+    "startLine": 40,
+    "fingerprint": "5c0b598507d1697674c5e292672c23f09d1df755babcec8746c61b4644eb380a"
+  },
+  {
+    "ruleId": "3-1-too-many-digits",
+    "message": "ReputationEngine.log2(uint256) (contracts/v2/ReputationEngine.sol#335-357) uses literals with too many digits:\n\t- x = x | x / 0x10000000000000000 (contracts/v2/ReputationEngine.sol#345)\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 335,
+    "fingerprint": "65283e8d51074a50b567949239af50c7479a5045360acaab46e04578af3c26dd"
+  },
+  {
+    "ruleId": "3-1-too-many-digits",
+    "message": "Math.log2(uint256) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#612-651) uses literals with too many digits:\n\t- r = r | byte(uint256,uint256)(x >> r,0x0000010102020202030303030303030300000000000000000000000000000000) (node_modules/@openzeppelin/contracts/utils/math/Math.sol#649)\n",
+    "uri": "node_modules/@openzeppelin/contracts/utils/math/Math.sol",
+    "startLine": 612,
+    "fingerprint": "9c0058e8e0ebe9a88b5c491139a8d4df04b051acd8fe32b27078947f548e7c7d"
+  },
+  {
+    "ruleId": "3-1-too-many-digits",
+    "message": "ReputationEngine.log2(uint256) (contracts/v2/ReputationEngine.sol#335-357) uses literals with too many digits:\n\t- x = x | x / 0x100000000000000000000000000000000 (contracts/v2/ReputationEngine.sol#346)\n",
+    "uri": "contracts/v2/ReputationEngine.sol",
+    "startLine": 335,
+    "fingerprint": "c34f7cd870514edf609f9f8fd2129bc94b7091f9eda709b588ba26efd86cadc5"
+  },
+  {
+    "ruleId": "4-0-constable-states",
+    "message": "DisputeRegistryStub.taxPolicyVersion (contracts/legacy/DisputeRegistryStub.sol#26) should be constant \n",
+    "uri": "contracts/legacy/DisputeRegistryStub.sol",
+    "startLine": 26,
+    "fingerprint": "87c36423b67ea9090ab214fa89e7710b8b2287b7f07b9aa3bb6a8c7c79e2a851"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "Migrations.owner (contracts/Migrations.sol#7) should be immutable \n",
+    "uri": "contracts/Migrations.sol",
+    "startLine": 7,
+    "fingerprint": "39a2c78a5e5032e587a3e47cc0a2ecfffe650b3f00ce5e9d5cb59fa01ee7ce63"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "QuadraticVotingAttack.deadline (contracts/test/QuadraticVotingAttack.sol#17) should be immutable \n",
+    "uri": "contracts/test/QuadraticVotingAttack.sol",
+    "startLine": 17,
+    "fingerprint": "44dc4b7c3df050657267b2408c763227382ca7cbe04e5a33631247174252bb0b"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "ArbitratorCommittee.jobRegistry (contracts/v2/ArbitratorCommittee.sol#16) should be immutable \n",
+    "uri": "contracts/v2/ArbitratorCommittee.sol",
+    "startLine": 16,
+    "fingerprint": "5a1b064002166ffa4a23b0f200501cb157a12e98ccc672ececb47e5bac4805af"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "JobRegistryAckStub.policy (contracts/v2/mocks/JobRegistryAckStub.sol#10) should be immutable \n",
+    "uri": "contracts/v2/mocks/JobRegistryAckStub.sol",
+    "startLine": 10,
+    "fingerprint": "5a657af4604bbe9e0dd34c6ea61909a03c0a28723c23a7ff0527e10cba79b99b"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "JobRegistryAckRecorder.policy (contracts/v2/mocks/JobRegistryAckRecorder.sol#12) should be immutable \n",
+    "uri": "contracts/v2/mocks/JobRegistryAckRecorder.sol",
+    "startLine": 12,
+    "fingerprint": "9975cc5d85e81fc149e1c946969c7df2ba6520b086d1223da84d961812066ab1"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "QuadraticVotingAttack.token (contracts/test/QuadraticVotingAttack.sol#15) should be immutable \n",
+    "uri": "contracts/test/QuadraticVotingAttack.sol",
+    "startLine": 15,
+    "fingerprint": "9e34c5a7a44894ad5e45c0159c08128663bc494b07b14a5c6f6f82cdb707c2a7"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "ReentrantJobRegistry.stakeManager (contracts/v2/mocks/ReentrantJobRegistry.sol#29) should be immutable \n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 29,
+    "fingerprint": "a5a7f6a4629149d55042231ced016c0b5ac219292ff1c929a90ef9a39960c6de"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "ReentrantJobRegistry.token (contracts/v2/mocks/ReentrantJobRegistry.sol#30) should be immutable \n",
+    "uri": "contracts/v2/mocks/ReentrantJobRegistry.sol",
+    "startLine": 30,
+    "fingerprint": "c00f8f7632bc295b69adde031c09f812f34adb2525dc2ffe359dca3028cde168"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "QuadraticVotingAttack.proposalId (contracts/test/QuadraticVotingAttack.sol#16) should be immutable \n",
+    "uri": "contracts/test/QuadraticVotingAttack.sol",
+    "startLine": 16,
+    "fingerprint": "c7a7db48ab533f35b9a589d5d3657dab93b59c8639576eddfa6f3bfe72f2ef5c"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "MockRoutingModule.operator (contracts/legacy/MockRoutingModule.sol#7) should be immutable \n",
+    "uri": "contracts/legacy/MockRoutingModule.sol",
+    "startLine": 7,
+    "fingerprint": "c836f5dbe92f7108d7f7d3471f5508d3e796c08bc61f28dcedb8af4c70678b8a"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "VersionMock.version (contracts/v2/mocks/VersionMock.sol#6) should be immutable \n",
+    "uri": "contracts/v2/mocks/VersionMock.sol",
+    "startLine": 6,
+    "fingerprint": "dd1006bc46f9906a555c38bab9c87f07433cc614c0398cc25e43c276f6ab484e"
+  },
+  {
+    "ruleId": "4-0-immutable-states",
+    "message": "QuadraticVotingAttack.qv (contracts/test/QuadraticVotingAttack.sol#14) should be immutable \n",
+    "uri": "contracts/test/QuadraticVotingAttack.sol",
+    "startLine": 14,
+    "fingerprint": "df32df8f2564195f9cc36810adc3606a862ce15f6ed15b7922667c4f9b9f6458"
+  }
+]

--- a/tools/ci/check-slither-baseline.mjs
+++ b/tools/ci/check-slither-baseline.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { exit } from 'node:process';
+
+const sarifPath = process.argv[2] ?? 'reports/security/slither.sarif';
+const baselinePath = process.argv[3] ?? 'reports/security/slither-baseline.json';
+
+function readJson(path) {
+  try {
+    const data = readFileSync(path, 'utf8');
+    return JSON.parse(data);
+  } catch (error) {
+    console.error(`Failed to read JSON from ${path}:`, error);
+    exit(1);
+  }
+}
+
+function normaliseText(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function buildKey(entry) {
+  if (entry?.fingerprint) {
+    return `fp:${entry.fingerprint}`;
+  }
+  const { ruleId = '', uri = '', startLine = 0, message = '' } = entry ?? {};
+  return `legacy:${[ruleId, uri, startLine, normaliseText(message)].join('|')}`;
+}
+
+function extractResults(sarif) {
+  const runs = Array.isArray(sarif?.runs) ? sarif.runs : [];
+  const results = [];
+  for (const run of runs) {
+    if (!Array.isArray(run?.results)) continue;
+    for (const result of run.results) {
+      const loc = Array.isArray(result?.locations) ? result.locations[0] : undefined;
+      const physical = loc?.physicalLocation ?? {};
+      const artifact = physical.artifactLocation ?? {};
+      const region = physical.region ?? {};
+      const fingerprint =
+        result?.partialFingerprints?.id ??
+        result?.partialFingerprints?.primaryLocationLineHash ??
+        '';
+      results.push({
+        ruleId: result?.ruleId ?? '',
+        message: result?.message?.text ?? '',
+        uri: artifact?.uri ?? '',
+        startLine: typeof region?.startLine === 'number' ? region.startLine : 0,
+        fingerprint: fingerprint || undefined,
+      });
+    }
+  }
+  return results;
+}
+
+const sarif = readJson(sarifPath);
+const baselineEntries = readJson(baselinePath);
+
+if (!Array.isArray(baselineEntries)) {
+  console.error(`Baseline at ${baselinePath} is not an array`);
+  exit(1);
+}
+
+const baselineSet = new Set(baselineEntries.map(buildKey));
+const findings = extractResults(sarif);
+
+const newFindings = [];
+const keyCounts = new Map();
+
+for (const finding of findings) {
+  const key = buildKey(finding);
+  keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1);
+  if (!baselineSet.has(key)) {
+    newFindings.push(finding);
+  }
+}
+
+const duplicateKeys = [...keyCounts.entries()].filter(([, count]) => count > 1);
+if (duplicateKeys.length > 0) {
+  console.warn('Detected duplicate findings in SARIF output:');
+  for (const [key, count] of duplicateKeys) {
+    console.warn(`  ${key} (x${count})`);
+  }
+}
+
+if (newFindings.length > 0) {
+  console.error('New Slither findings detected that are not in the baseline:');
+  for (const finding of newFindings) {
+    console.error(`  [${finding.ruleId}] ${finding.uri}:${finding.startLine} :: ${normaliseText(finding.message)}`);
+  }
+  exit(1);
+}
+
+console.log(`Slither findings match baseline (${baselineEntries.length} entries).`);


### PR DESCRIPTION
## Summary
- add a fingerprint-aware baseline check to the static-analysis workflow so Slither results gate on committed findings
- ignore transient SARIF artefacts and version the `reports/security/slither-baseline.json` snapshot used by CI
- document the baseline process in the README and tabletop incident-response guide for operator awareness

## Testing
- node tools/ci/check-slither-baseline.mjs reports/security/slither.sarif reports/security/slither-baseline.json

------
https://chatgpt.com/codex/tasks/task_e_68e996286160833380ac9150810cf9c0