### PR TITLE
chore(ci): enforce signed release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,9 @@ jobs:
             echo "::error::Version must follow semver."; exit 1; fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Require signed release tag
+        run: node scripts/ci/ensure-tag-signed.js
+
       - name: Verify changelog contains version
         run: |
           VERSION="${{ steps.version.outputs.version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ scripts/**/*.js
 !scripts/ci/abi-targets.js
 !scripts/ci/remap-coverage-paths.js
 !scripts/ci/check-toolchain-locks.js
+!scripts/ci/ensure-tag-signed.js
 !scripts/verify-wiring.js
 !scripts/run-wire-verify.js
 !scripts/subgraph-e2e.js

--- a/docs/production-launch-blueprint.md
+++ b/docs/production-launch-blueprint.md
@@ -68,7 +68,9 @@ sequenceDiagram
 ```
 
 1. **Clone at the release tag** you intend to deploy. Rebase your configuration branch on
-   top of the latest hotfix or security patch before executing.
+   top of the latest hotfix or security patch before executing. Ensure the tag follows the
+   [release tag signing playbook](release-tag-signing.md) so provenance checks remain valid
+   throughout the launch.
 2. **Review security notices** in `SECURITY.md` and the latest release notes in
    `CHANGELOG.md` to understand mandatory mitigations.
 3. **Export credentials** from an encrypted secret manager. Populate:

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -63,4 +63,9 @@ Use this list before tagging a new production release.
     - Confirm mainnet deployment dry-run (`npm run migrate:wizard -- --network mainnet`) succeeded at least once with pinned block numbers.
     - Package audit artefacts (coverage HTML, Slither SARIF, Echidna logs, fork drill outputs) for hand-off.
 
+11. **Sign and verify the release tag**
+    - Follow the [release tag signing playbook](release-tag-signing.md) to create an annotated, signed `vX.Y.Z` tag.
+    - Run `git tag -v vX.Y.Z` (SSH: configure `ssh-keygen -Y import`; GPG: import the ASCII-armored key) and capture the output in the release ticket.
+    - Confirm the release workflow's **Require signed release tag** step succeeded and that GitHub shows the **Verified** badge on the tag page.
+
 Tick each item to ensure deployments remain reproducible and auditable.

--- a/docs/release-tag-signing.md
+++ b/docs/release-tag-signing.md
@@ -1,0 +1,102 @@
+# Release tag signing playbook
+
+This playbook makes the "Sign your Git release tags" requirement auditable. It covers
+both SSH- and GPG-backed signing so that every production tag shows the **Verified**
+badge on GitHub and passes the `Require signed release tag` job in the
+[release workflow](../.github/workflows/release.yml).
+
+## Why it matters
+
+- **Supply-chain integrity** – Annotated, signed tags provide cryptographic proof of
+  origin. Operators and external auditors can independently verify provenance with
+  `git tag -v <tag>`.
+- **CI provenance** – Signed tags unlock attestation workflows such as
+  `npm publish --provenance` and GitHub's artifact attestations, satisfying the
+  production readiness requirement for verifiable builds.
+- **Operational clarity** – The release workflow now fails if a tag is missing a
+  signature, preventing unsigned releases from progressing unnoticed.
+
+## Prerequisites
+
+1. Generate or import a signing key:
+   - **SSH** – Reuse a hardened signing key (for example a YubiKey-backed
+     `id_ed25519_sk`). Upload the public key under "Settings → SSH and GPG keys →
+     New SSH key" with the **Signing** purpose selected.
+   - **GPG** – Import your hardware-backed OpenPGP key (recommended: YubiKey) using
+     `gpg --import` or create one with `gpg --full-generate-key`.
+2. Configure Git to use the key for tag signing:
+   - SSH signing:
+     ```bash
+     git config --global gpg.format ssh
+     git config --global user.signingkey ~/.ssh/id_ed25519.pub
+     git config --global tag.gpgsign true
+     ```
+   - GPG signing:
+     ```bash
+     git config --global user.signingkey YOUR_GPG_KEY_ID
+     git config --global tag.gpgsign true
+     ```
+
+> **Tip:** Keep the signing key on hardware (YubiKey, smartcard) and require a
+> touch confirmation. This blocks malware from silently issuing a release tag.
+
+## Creating a signed release tag
+
+1. Make sure `CHANGELOG.md` and release notes are finalised.
+2. Create an annotated tag with signing enabled:
+   ```bash
+   VERSION=2.3.0
+   git tag -s "v$VERSION" -m "v$VERSION"
+   ```
+   - When using SSH signing the same command works because Git reads
+     `gpg.format=ssh` from the config.
+3. Push the tag and branch:
+   ```bash
+   git push origin main --follow-tags
+   git push origin "v$VERSION"
+   ```
+
+GitHub should display a green **Verified** badge next to the tag. If the badge is
+missing, expand the dropdown for troubleshooting guidance.
+
+## Verifying a tag locally
+
+Operators must verify the signature before approving the deployment:
+
+```bash
+# Imports the release manager's public key for verification
+ssh-keygen -Y import -f ~/.ssh/allowed_signers <<'KEY'
+release-manager@example.com namespaces="git" <ssh-public-key>
+KEY
+
+git tag -v v2.3.0
+```
+
+For GPG keys, exchange the ASCII-armored public key (`gpg --armor --export`) and
+import it with `gpg --import`. Verification must exit with status `0`. The command
+prints the key fingerprint so auditors can match it against their records.
+
+## Integrating with CI and attestations
+
+- The release workflow runs `node scripts/ci/ensure-tag-signed.js` to ensure every
+  tag pushed to `main` is annotated and contains either an OpenPGP or SSH signature.
+- When `npm publish` executes with `--provenance`, GitHub automatically links the
+  published artefacts to the signed tag, providing an immutable supply-chain trail.
+- Enable [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-artifacts)
+  on the repository to emit provenance statements after publishing.
+
+## Incident response
+
+If a tag was pushed without a signature:
+
+1. **Delete the remote tag** immediately:
+   ```bash
+   git push --delete origin v2.3.0
+   ```
+2. **Retag the release** using the signed flow above.
+3. **Re-run the release workflow** so the signed tag propagates through CI.
+4. **Document the correction** inside the incident log, including screenshots of the
+   Verified badge and the `git tag -v` output.
+
+Maintaining these steps keeps production releases verifiable by non-technical
+stakeholders and meets the institutional deployment standard.

--- a/scripts/ci/ensure-tag-signed.js
+++ b/scripts/ci/ensure-tag-signed.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+
+function run(command) {
+  const result = spawnSync(command, {
+    shell: true,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  if (result.status !== 0) {
+    const errorOutput = (result.stderr || result.stdout || '').trim();
+    throw new Error(errorOutput ? `Command failed (${command}): ${errorOutput}` : `Command failed (${command})`);
+  }
+
+  return result.stdout.trim();
+}
+
+function main() {
+  const ref = process.env.GITHUB_REF || '';
+  let tagName = '';
+
+  if (ref.startsWith('refs/tags/')) {
+    tagName = ref.substring('refs/tags/'.length);
+  } else {
+    try {
+      tagName = run('git describe --exact-match --tags');
+    } catch (error) {
+      console.log('ℹ️ No Git tag detected for this workflow run; skipping signature verification.');
+      return;
+    }
+  }
+
+  if (!tagName) {
+    console.log('ℹ️ No Git tag detected for this workflow run; skipping signature verification.');
+    return;
+  }
+
+  const tagType = run(`git cat-file -t ${tagName}`);
+  if (tagType !== 'tag') {
+    console.error(`❌ Tag "${tagName}" is lightweight (${tagType}). Create an annotated, signed tag.`);
+    process.exit(1);
+  }
+
+  const payloadResult = spawnSync(`git cat-file -p ${tagName}`, {
+    shell: true,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  if (payloadResult.status !== 0) {
+    const errorOutput = (payloadResult.stderr || payloadResult.stdout || '').trim();
+    console.error(`❌ Unable to inspect tag "${tagName}": ${errorOutput}`);
+    process.exit(1);
+  }
+
+  const payload = payloadResult.stdout;
+  const signatureMarkers = [
+    '-----BEGIN PGP SIGNATURE-----',
+    '-----BEGIN SSH SIGNATURE-----',
+    '-----BEGIN OPENSSH SIGNATURE-----'
+  ];
+
+  const hasSignature = signatureMarkers.some((marker) => payload.includes(marker));
+  if (!hasSignature) {
+    console.error(
+      `❌ Tag "${tagName}" is annotated but not signed. Use \`git tag -s\` (GPG) or configure \`gpg.format=ssh\` for SSH signing.`
+    );
+    process.exit(1);
+  }
+
+  console.log(`✅ Verified that tag "${tagName}" contains a cryptographic signature.`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a release workflow gate that refuses unsigned tags and allowlist the helper script in gitignore
- document the end-to-end release tag signing process for operators and link it into launch playbooks
- update the release checklist to require `git tag -v` evidence before deployment approval

## Testing
- node scripts/ci/ensure-tag-signed.js
- npm run docs:verify

------
https://chatgpt.com/codex/tasks/task_e_68e9b4ea5c908333bded2de5870a4e1a