### PR TITLE
chore: enforce signed release tags

### DIFF
--- a/.github/signers/README.md
+++ b/.github/signers/README.md
@@ -1,0 +1,16 @@
+# Maintainer Signing Keys
+
+This directory stores the SSH allowed signers file used by CI to verify tag signatures.
+
+1. Export the SSH or hardware-backed key you registered with GitHub:
+   ```bash
+   ssh-keygen -Y export -f ~/.ssh/id_ed25519.pub
+   ```
+2. Append the exported key to `allowed_signers` in this directory using the following format:
+   ```
+   maintainer@example.com namespaces="git" ssh-ed25519 AAAAC3...
+   ```
+3. Commit the updated `allowed_signers` file. The release workflow reads it automatically
+   and runs `git tag -v` during tag builds.
+
+If you rotate keys, update this file and rerun the release workflow to keep the provenance checks green.

--- a/.github/signers/allowed_signers
+++ b/.github/signers/allowed_signers
@@ -1,0 +1,6 @@
+# Populate this file with maintainer SSH signing keys in the format:
+# maintainer@example.com namespaces="git" ssh-ed25519 AAAAC3...
+#
+# The release workflow uses the keys listed here to run `git tag -v` on
+# release tags. Keep the keys hardware-backed when possible (e.g. YubiKey)
+# and rotate them if compromised.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
 
+      - name: Enforce signed release tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          node scripts/ci/ensure-tag-signature.js "${GITHUB_REF}"
+
       - name: Install dependencies
         run: npm ci
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ scripts/**/*.js
 !scripts/ci/abi-targets.js
 !scripts/ci/remap-coverage-paths.js
 !scripts/ci/check-toolchain-locks.js
+!scripts/ci/ensure-tag-signature.js
 !scripts/verify-wiring.js
 !scripts/run-wire-verify.js
 !scripts/subgraph-e2e.js

--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ The wizard validates `.env` secrets, highlights ENS configuration drift, prints 
 - [docs/burn-receipts.md](docs/burn-receipts.md) – employer-side token burn process and validator verification.
 - [docs/expired-unclaimed-handling.md](docs/expired-unclaimed-handling.md) – guidance for expired stakes and unclaimed fees.
 - [docs/release-checklist.md](docs/release-checklist.md) – steps to compile, test and prepare an Etherscan call plan.
+- [docs/release-provenance.md](docs/release-provenance.md) – hardware-backed tag signing, CI enforcement, and owner control sign-off for verifiable releases.
 
 ## Migrating from legacy
 

--- a/docs/deployment-readiness-checklist.md
+++ b/docs/deployment-readiness-checklist.md
@@ -42,8 +42,10 @@ This checklist condenses the operational knowledge required to take the AGI Jobs
 
 ## 4. CI & Release Gates
 
-- Align pipeline jobs (lint, tests, coverage, security, gas, docs) with GitHub branch protection so that merges to `main` mirror the local commands below.  
+- Align pipeline jobs (lint, tests, coverage, security, gas, docs) with GitHub branch protection so that merges to `main` mirror the local commands below.
   _Key Scripts:_ `npm run lint:check`, `npm test`, `npm run coverage:check`, `npm run security:audit`, `npm run gas:check`, `npm run docs:verify`. 【F:package.json†L8-L131】
+- Require hardware-backed signed release tags and verify them in CI before publishing artefacts.
+  _Reference:_ `scripts/ci/ensure-tag-signature.js` and the [Release Provenance & Tag Signing](release-provenance.md) playbook. 【F:scripts/ci/ensure-tag-signature.js†L1-L70】【F:docs/release-provenance.md†L1-L98】
 - Require green runs of planner→simulator→runner integration tests on every PR, plus manual owner checklist sign-off for production rollouts.
 
 ✅ **Action:** Mirror the above commands in CI (GitHub Actions or equivalent) and enforce mandatory status checks plus review requirements on both PR and default branches.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -63,4 +63,13 @@ Use this list before tagging a new production release.
     - Confirm mainnet deployment dry-run (`npm run migrate:wizard -- --network mainnet`) succeeded at least once with pinned block numbers.
     - Package audit artefacts (coverage HTML, Slither SARIF, Echidna logs, fork drill outputs) for hand-off.
 
+11. **Sign and verify the release tag**
+    ```bash
+    git tag -s vX.Y.Z -m "vX.Y.Z"
+    git tag -v vX.Y.Z
+    git push origin vX.Y.Z
+    ```
+    - Ensure the hardware-backed key used above appears in `.github/signers/allowed_signers`.
+    - Confirm the release workflow reports “git tag -v succeeded” to guarantee provenance. 【F:scripts/ci/ensure-tag-signature.js†L1-L70】
+
 Tick each item to ensure deployments remain reproducible and auditable.

--- a/docs/release-provenance.md
+++ b/docs/release-provenance.md
@@ -1,0 +1,83 @@
+# Release Provenance & Tag Signing
+
+This playbook codifies how to produce verifiable AGI Jobs v0 releases so
+operations, auditors, and downstream integrators can trust the build
+artefacts.
+
+## 1. Generate a Hardware-Backed Signing Key
+
+1. Provision a YubiKey (or similar hardware token) and enable either
+   [SSH signatures](https://docs.github.com/en/authentication/connected-accounts/about-ssh-signature-verification)
+   or [GPG signatures](https://docs.github.com/en/authentication/connected-accounts/about-commit-signature-verification).
+2. Export the public half of the key and register it with the repository
+   owner’s GitHub account so the `Verified` badge appears on signed tags.
+3. Export the allowed signers entry and append it to
+   `.github/signers/allowed_signers` (commit the change):
+   ```bash
+   ssh-keygen -Y export -f ~/.ssh/id_ed25519.pub >> .github/signers/allowed_signers
+   ```
+
+## 2. Configure Git for Tag Signing
+
+Either configure SSH-based signing:
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global tag.gpgsign true
+```
+
+Or configure GPG signing:
+```bash
+git config --global user.signingkey <GPG_KEY_ID>
+git config --global tag.gpgsign true
+```
+
+## 3. Create and Verify a Signed Tag
+
+1. Cut the release tag:
+   ```bash
+   git tag -s vX.Y.Z -m "vX.Y.Z"
+   ```
+2. Verify locally before pushing:
+   ```bash
+   git tag -v vX.Y.Z
+   ```
+3. Push the tag and confirm GitHub shows a **Verified** badge:
+   ```bash
+   git push origin vX.Y.Z
+   ```
+
+## 4. CI Enforcement
+
+- The release workflow executes `scripts/ci/ensure-tag-signature.js`. It
+  halts the pipeline if the tag lacks a cryptographic signature.
+- When `.github/signers/allowed_signers` is populated, CI also runs
+  `git tag -v` to verify the signature against the committed maintainer
+  keys. Rotate the keys and update the file whenever maintainers change
+  tokens.
+
+## 5. Provenance & Artifact Attestations
+
+- Use the signed tag as the trust anchor for SBOMs, contract ABIs, NPM
+  packages, Docker images, and any other release artefact.
+- Consider enabling GitHub’s
+  [Artifact Attestations](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#artifact-attestations)
+  in conjunction with the signed tag to provide verifiable build
+  provenance downstream.
+
+## 6. Owner Control Sign-off
+
+Before attaching the signed release to production, run the owner control
+stack to prove the governance knobs remain adjustable:
+```bash
+npm run owner:doctor -- --network <network>
+npm run owner:dashboard -- --network <network>
+npm run owner:parameters -- --network <network>
+```
+Archive the generated markdown reports with the release record so the
+contract owner can demonstrate end-to-end authority over fees, burn
+rates, and pause/timelock circuits.
+
+Maintaining the signed tag workflow plus owner control artefacts ensures
+releases are both cryptographically authentic and operationally
+actionable for the contract owner.

--- a/scripts/ci/ensure-tag-signature.js
+++ b/scripts/ci/ensure-tag-signature.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/*
+ * Enforce that release tags carry a cryptographic signature before
+ * the release workflow proceeds. The script verifies that the tag
+ * contains a signature block and, when an allowed signers file is
+ * present, validates the signature using `git tag -v`.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+function run(command, options = {}) {
+  return execSync(command, {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    ...options,
+  }).trim();
+}
+
+const ref = process.argv[2];
+if (!ref) {
+  fail('Tag reference argument is required.');
+}
+
+const tagName = ref.startsWith('refs/tags/')
+  ? ref.slice('refs/tags/'.length)
+  : ref;
+
+try {
+  run(`git rev-parse --verify refs/tags/${tagName}`);
+} catch (error) {
+  fail(`Tag ${tagName} not found in checkout: ${error.message}`);
+}
+
+let signatureBlock = '';
+try {
+  signatureBlock = run(
+    `git for-each-ref --format='%(contents:signature)' refs/tags/${tagName}`
+  );
+} catch (error) {
+  fail(`Unable to inspect tag signature metadata: ${error.message}`);
+}
+
+if (!signatureBlock) {
+  fail(`Tag ${tagName} is missing a cryptographic signature.`);
+}
+
+console.log(`✅ Detected signature payload on tag ${tagName}.`);
+
+const allowedSignersFromEnv = process.env.GIT_ALLOWED_SIGNERS;
+const defaultAllowedSigners = path.join(
+  '.github',
+  'signers',
+  'allowed_signers'
+);
+const allowedSignersPath = allowedSignersFromEnv || defaultAllowedSigners;
+
+if (fs.existsSync(allowedSignersPath)) {
+  try {
+    run(`git config gpg.ssh.allowedSignersFile "${allowedSignersPath}"`);
+    execSync(`git tag -v ${tagName}`, { stdio: 'inherit' });
+    console.log(`✅ git tag -v succeeded using ${allowedSignersPath}.`);
+  } catch (error) {
+    fail(`Signature verification failed for tag ${tagName}: ${error.message}`);
+  }
+} else {
+  console.warn(
+    `::warning::Skipping git tag -v verification because ${allowedSignersPath} was not found. ` +
+      'Add maintainer signing keys to enable strict validation.'
+  );
+}


### PR DESCRIPTION
## Summary
- add a release workflow guard that halts unsigned tag builds and verifies signatures against committed maintainer keys
- document the signing key process via a release provenance playbook, checklist updates, and README links for owner control sign-off
- ship the ensure-tag-signature CI helper and gitignore exception so the hardware-backed tag requirement is enforced consistently

## Testing
- npm run format:check
- node --check scripts/ci/ensure-tag-signature.js

------
https://chatgpt.com/codex/tasks/task_e_68e9b4ea5c908333bded2de5870a4e1a