### PR TITLE
Ensure AGIALPHA term acknowledgement for core contracts

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -91,3 +91,8 @@ jobs:
 
       - name: Foundry tests
         run: forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'
+
+      - name: Foundry invariants
+        env:
+          FOUNDRY_PROFILE: default
+        run: forge test --ffi --match-path 'test/v2/invariant/*.t.sol' --match-test '^invariant_'

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,16 +17,21 @@ concurrency:
 
 jobs:
   forge-fuzz:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -35,16 +40,16 @@ jobs:
             **/package-lock.json
 
       - name: Install Node dependencies
-        run: npm ci
+        run: npm ci --no-audit --prefer-offline --progress=false
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
           version: 'v1.4.0'
 
       - name: Cache forge libraries
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: lib
           key: ${{ runner.os }}-foundry-${{ hashFiles('foundry.toml') }}
@@ -71,3 +76,9 @@ jobs:
         env:
           FOUNDRY_PROFILE: default
         run: forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'
+
+      - name: Foundry invariants (deep)
+        env:
+          FOUNDRY_PROFILE: default
+          FOUNDRY_INVARIANT_RUNS: 1024
+        run: forge test --ffi --match-path 'test/v2/invariant/*.t.sol' --match-test '^invariant_'

--- a/contracts/v2/FeePool.sol
+++ b/contracts/v2/FeePool.sol
@@ -13,6 +13,7 @@ import {AGIALPHA, AGIALPHA_DECIMALS, BURN_ADDRESS} from "./Constants.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
 import {ITaxPolicy} from "./interfaces/ITaxPolicy.sol";
 import {TaxAcknowledgement} from "./libraries/TaxAcknowledgement.sol";
+import {TokenAcknowledgement} from "./utils/TokenAcknowledgement.sol";
 
 error InvalidPercentage();
 error NotStakeManager();
@@ -188,6 +189,7 @@ contract FeePool is Ownable, Pausable, ReentrancyGuard, TaxAcknowledgement {
         if (IERC20Metadata(address(token)).decimals() != AGIALPHA_DECIMALS) {
             revert InvalidTokenDecimals();
         }
+        TokenAcknowledgement.acknowledge(address(token), address(this));
         uint256 pct = _burnPct == 0 ? DEFAULT_BURN_PCT : _burnPct;
         if (pct > 100) revert InvalidPercentage();
 

--- a/contracts/v2/GovernanceReward.sol
+++ b/contracts/v2/GovernanceReward.sol
@@ -8,6 +8,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
 import {IFeePool} from "./interfaces/IFeePool.sol";
 import {IStakeManager} from "./interfaces/IStakeManager.sol";
+import {TokenAcknowledgement} from "./utils/TokenAcknowledgement.sol";
 
 /// @title GovernanceReward
 /// @notice Distributes a portion of the FeePool to voters based on staked balance snapshots.
@@ -71,6 +72,7 @@ contract GovernanceReward is Ownable {
         if (IERC20Metadata(address(token)).decimals() != AGIALPHA_DECIMALS) {
             revert InvalidTokenDecimals();
         }
+        TokenAcknowledgement.acknowledge(address(token), address(this));
         emit FeePoolUpdated(address(_feePool));
         emit StakeManagerUpdated(address(_stakeManager));
         emit RewardRoleUpdated(_role);

--- a/contracts/v2/QuadraticVoting.sol
+++ b/contracts/v2/QuadraticVoting.sol
@@ -7,6 +7,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {AGIALPHA} from "./Constants.sol";
+import {TokenAcknowledgement} from "./utils/TokenAcknowledgement.sol";
 
 interface IGovernanceReward {
     function recordVoters(address[] calldata voters) external;
@@ -56,6 +57,7 @@ contract QuadraticVoting is Ownable, ReentrancyGuard {
 
     constructor(address _token, address _executor) Ownable(msg.sender) {
         token = _token == address(0) ? IERC20(AGIALPHA) : IERC20(_token);
+        TokenAcknowledgement.acknowledge(address(token), address(this));
         proposalExecutor = _executor;
         emit ProposalExecutorUpdated(_executor);
     }

--- a/contracts/v2/RandaoCoordinator.sol
+++ b/contracts/v2/RandaoCoordinator.sol
@@ -6,6 +6,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {IRandaoCoordinator} from "./interfaces/IRandaoCoordinator.sol";
 import {AGIALPHA, AGIALPHA_DECIMALS} from "./Constants.sol";
+import {TokenAcknowledgement} from "./utils/TokenAcknowledgement.sol";
 
 /// @title RandaoCoordinator
 /// @notice Simple commit-reveal randomness aggregator with penalties for
@@ -95,6 +96,7 @@ contract RandaoCoordinator is Ownable, IRandaoCoordinator {
         _deposit = deposit_;
         _treasury = treasury_;
         token = IERC20(AGIALPHA);
+        TokenAcknowledgement.acknowledge(address(token), address(this));
 
         emit CommitWindowUpdated(0, commitWindow_);
         emit RevealWindowUpdated(0, revealWindow_);
@@ -191,6 +193,7 @@ contract RandaoCoordinator is Ownable, IRandaoCoordinator {
         }
 
         token = IERC20(newToken);
+        TokenAcknowledgement.acknowledge(newToken, address(this));
         emit TokenUpdated(previous, newToken);
     }
 

--- a/contracts/v2/StakeManager.sol
+++ b/contracts/v2/StakeManager.sol
@@ -20,6 +20,7 @@ import {IDisputeModule} from "./interfaces/IDisputeModule.sol";
 import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
 import {Thermostat} from "./Thermostat.sol";
 import {IHamiltonian} from "./interfaces/IHamiltonian.sol";
+import {TokenAcknowledgement} from "./utils/TokenAcknowledgement.sol";
 
 error InvalidPercentage();
 error InvalidTreasury();
@@ -675,6 +676,7 @@ contract StakeManager is Governable, ReentrancyGuard, TaxAcknowledgement, Pausab
         if (IERC20Metadata(address(token)).decimals() != AGIALPHA_DECIMALS) {
             revert InvalidTokenDecimals();
         }
+        TokenAcknowledgement.acknowledge(address(token), address(this));
         minStake = _minStake == 0 ? DEFAULT_MIN_STAKE : _minStake;
         emit MinStakeUpdated(minStake);
         uint16 employerPctBps = _toBps(_employerSlashPct);

--- a/contracts/v2/kernel/EscrowVault.sol
+++ b/contracts/v2/kernel/EscrowVault.sol
@@ -5,6 +5,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {TokenAcknowledgement} from "../utils/TokenAcknowledgement.sol";
 
 /// @title EscrowVault
 /// @notice Holds job rewards until the registry resolves the job outcome.
@@ -32,6 +33,7 @@ contract EscrowVault is Ownable, ReentrancyGuard {
     constructor(IERC20 token_, address owner_) Ownable(owner_) {
         if (address(token_) == address(0)) revert ZeroAddress();
         token = token_;
+        TokenAcknowledgement.acknowledge(address(token_), address(this));
     }
 
     modifier onlyController() {

--- a/contracts/v2/kernel/StakeManager.sol
+++ b/contracts/v2/kernel/StakeManager.sol
@@ -5,6 +5,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {TokenAcknowledgement} from "../utils/TokenAcknowledgement.sol";
 
 /// @title KernelStakeManager
 /// @notice Minimal staking contract shared by agents and validators.
@@ -61,6 +62,7 @@ contract KernelStakeManager is Ownable, ReentrancyGuard {
     constructor(IERC20 token_, address owner_) Ownable(owner_) {
         if (address(token_) == address(0)) revert ZeroAddress();
         stakingToken = token_;
+        TokenAcknowledgement.acknowledge(address(token_), address(this));
     }
 
     /// @notice Allow governance to authorize or revoke operator permissions.

--- a/contracts/v2/modules/JobEscrow.sol
+++ b/contracts/v2/modules/JobEscrow.sol
@@ -8,6 +8,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {AGIALPHA, AGIALPHA_DECIMALS} from "../Constants.sol";
 import {IJobRegistryAck} from "../interfaces/IJobRegistryAck.sol";
+import {TokenAcknowledgement} from "../utils/TokenAcknowledgement.sol";
 
 interface IRoutingModule {
     function selectOperator(bytes32 jobId, bytes32 seed) external returns (address);
@@ -83,6 +84,7 @@ contract JobEscrow is Ownable, ReentrancyGuard {
         if (IERC20Metadata(address(token)).decimals() != AGIALPHA_DECIMALS) {
             revert InvalidTokenDecimals();
         }
+        TokenAcknowledgement.acknowledge(address(token), address(this));
         routingModule = _routing;
         resultTimeout = DEFAULT_TIMEOUT;
         emit ResultTimeoutUpdated(DEFAULT_TIMEOUT);

--- a/contracts/v2/modules/RevenueDistributor.sol
+++ b/contracts/v2/modules/RevenueDistributor.sol
@@ -7,6 +7,7 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IStakeManager} from "../interfaces/IStakeManager.sol";
 import {AGIALPHA} from "../Constants.sol";
+import {TokenAcknowledgement} from "../utils/TokenAcknowledgement.sol";
 
 /// @title RevenueDistributor
 /// @notice Splits incoming job fees among active operators based on stake.
@@ -39,6 +40,7 @@ contract RevenueDistributor is Ownable {
         );
         stakeManager = _stakeManager;
         emit StakeManagerUpdated(address(_stakeManager));
+        TokenAcknowledgement.acknowledge(address(token), address(this));
     }
 
     /// @notice Register the caller as an operator.

--- a/contracts/v2/utils/TokenAcknowledgement.sol
+++ b/contracts/v2/utils/TokenAcknowledgement.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title TokenAcknowledgement
+/// @notice Utility helpers to acknowledge non-standard ERC20 token terms.
+/// @dev The canonical $AGIALPHA token requires contracts to call `acceptTerms`
+///      before they can transfer tokens. This library performs a best-effort
+///      acknowledgement that tolerates tokens without this extension while
+///      reverting when acknowledgement is expected but still missing.
+library TokenAcknowledgement {
+    error TokenTermsUnacknowledged(address token, address actor);
+
+    bytes4 private constant HAS_ACK_SELECTOR = bytes4(keccak256("hasAcknowledged(address)"));
+    bytes4 private constant ACCEPT_TERMS_SELECTOR = bytes4(keccak256("acceptTerms()"));
+
+    /// @notice Attempts to ensure that `actor` acknowledged the token terms.
+    /// @param token Address of the ERC20 token contract.
+    /// @param actor Address that must be able to transfer the token.
+    function acknowledge(address token, address actor) internal {
+        if (token == address(0) || actor == address(0)) {
+            return;
+        }
+
+        if (!_supportsAcknowledgement(token)) {
+            // The token does not expose acknowledgement helpers. Nothing else to do.
+            return;
+        }
+
+        if (_hasAcknowledged(token, actor)) {
+            return;
+        }
+
+        // Attempt acknowledgement via the non-standard extension. Ignore the
+        // return value because the function does not return anything. Any
+        // revert will bubble up and be caught by the subsequent check.
+        (bool success, ) = token.call(abi.encodeWithSelector(ACCEPT_TERMS_SELECTOR));
+        if (!success) {
+            revert TokenTermsUnacknowledged(token, actor);
+        }
+
+        if (!_hasAcknowledged(token, actor)) {
+            revert TokenTermsUnacknowledged(token, actor);
+        }
+    }
+
+    function _supportsAcknowledgement(address token) private view returns (bool) {
+        if (token.code.length == 0) {
+            return false;
+        }
+        (bool ok, ) = token.staticcall(abi.encodeWithSelector(HAS_ACK_SELECTOR, address(this)));
+        return ok;
+    }
+
+    function _hasAcknowledged(address token, address actor) private view returns (bool) {
+        (bool ok, bytes memory data) = token.staticcall(abi.encodeWithSelector(HAS_ACK_SELECTOR, actor));
+        return ok && data.length >= 32 && abi.decode(data, (bool));
+    }
+}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -19,6 +19,7 @@ Use this list before tagging a new production release.
    ```bash
    npm run echidna
    npm run echidna:commit-reveal   # deterministic seed for reproducibility
+   forge test --ffi --match-path 'test/v2/invariant/*.t.sol' --match-test '^invariant_'
    ```
 4. **Static analysis**
    ```bash

--- a/docs/v2-ci-operations.md
+++ b/docs/v2-ci-operations.md
@@ -100,9 +100,10 @@ npm run lint:ci
 npm test
 npm run coverage
 forge test -vvvv --ffi --fuzz-runs 256
+forge test --ffi --match-path 'test/v2/invariant/*.t.sol' --match-test '^invariant_'
 ```
 
-Running the commands in this order matches the GitHub workflow dependencies, letting contributors catch failures before opening a pull request.
+Running the commands in this order matches the GitHub workflow dependencies, letting contributors catch failures before opening a pull request. The dedicated invariant command mirrors the `Foundry invariants` steps now enforced in both `contracts-ci` and the nightly `fuzz` workflow, so property regressions cannot sneak past local smoke tests.
 
 ### Environment guardrails enforced by CI
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,15 @@ optimizer = true
 optimizer_runs = 200
 gas_reports = ['FeePool', 'JobRouter']
 
+[profile.default.fuzz]
+runs = 256
+
+[profile.default.invariant]
+runs = 256
+depth = 128
+fail_on_revert = true
+
+
 [profile.gas]
 src = 'contracts/gas'
 test = 'test/gas'


### PR DESCRIPTION
## Summary
- add a reusable TokenAcknowledgement helper to guarantee AGIALPHA terms are accepted by contracts that move protocol funds
- invoke the acknowledgement helper across staking, fee distribution, escrow, governance, and randomness modules so withdrawals cannot revert unexpectedly

## Testing
- npm run compile -- --show-stack-traces

------
https://chatgpt.com/codex/tasks/task_e_68ea34778c208333ae4567e39a4b6703