### PR TITLE
Add release artefact dossier guide and Forta monitoring calibration

### DIFF
--- a/docs/monitoring-onchain.md
+++ b/docs/monitoring-onchain.md
@@ -78,3 +78,35 @@ via “Create Sentinel → Advanced JSON” or point a Forta bot at the same fil
 
 Keeping these sentinels active and rehearsed closes the gap identified in the
 institutional readiness review: real-time monitoring of governance changes.
+
+## Forta Anomaly Detection Overlay
+
+While Defender Sentinels cover deterministic governance hooks, institutions also
+expect behavioural anomaly detection. Deploy (or subscribe to) Forta bots that
+emit alerts for:
+
+- Sudden spikes in `JobRouter` executions or cancellations beyond the historical
+  99th percentile baseline.
+- Transfers from treasury or reward safes to unknown recipients.
+- Large `stake`/`unstake` sequences from a single validator within a 6-block
+  window (possible validator compromise).
+
+Recommended implementation steps:
+
+1. **Select bots** – Use Forta’s curated agent registry for transaction surge
+   detection (e.g. `0x12a4... surge-detector`). Document chosen agent IDs in the
+   change ticket.
+2. **Wire alerts** – Create a Defender Sentinel of type `FORTA_ALERT` pointing to
+   the selected Forta agent IDs. Route the alerts to `pagerduty-high` and
+   `ops-slack` to align with the parameter-change escalation path.
+3. **Calibrate thresholds** – During staging, replay production traces with
+   `npm run simulation:stress -- --network mainnet --forta-export` to ensure the
+   anomaly detector fires only for meaningful deviations. Store calibration
+   notes in `docs/security/forta-calibration.md`.
+4. **Re-validate quarterly** – Include Forta alert exercises in the tabletop
+   drills so auditors have evidence that behavioural monitoring remains
+   effective.
+
+Capturing both deterministic state changes and Forta anomalies satisfies the
+monitoring requirement in the institutional readiness rubric and gives the owner
+team early warning before parameters drift out of policy bounds.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -50,5 +50,6 @@ templates in `monitoring/onchain/` to watch for:
 - Critical parameter adjustments such as `setFeePct`, `setBurnPct`, and tax policy updates.
 
 The [on-chain monitoring playbook](monitoring-onchain.md) describes how to route these alerts into PagerDuty and the
-owner command centre runbooks. Pairing real-time sentinels with the Prometheus stack closes the loop between on-chain
-incidents and traditional infrastructure alerts.
+owner command centre runbooks, and the [Forta calibration log](security/forta-calibration.md) template captures the
+behavioural tuning required for anomaly detectors. Pairing real-time sentinels with the Prometheus stack closes the
+loop between on-chain incidents and traditional infrastructure alerts.

--- a/docs/production-launch-blueprint.md
+++ b/docs/production-launch-blueprint.md
@@ -195,6 +195,8 @@ Before opening the system to external participants, confirm the following:
       matches the desired reward distribution.
 - [ ] Validate release signatures and provenance following
       `docs/release-signing.md` before distributing artefacts.
+- [ ] Assemble the compliance dossier using
+      `docs/release-artifacts.md` and store it in the release vault.
 - [ ] Incident response runbook stored in `docs/` references this blueprint and the latest
       Safe bundles.
 

--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -1,0 +1,121 @@
+# Release Artifacts & Verification Blueprint
+
+This blueprint documents every artefact produced by the **AGI Jobs v0 (v2)**
+release pipeline and the steps required to reproduce, verify, and publish a
+production-ready drop that meets institutional audit requirements.
+
+> **Scope** – Applies to Git tags `v*`, the `release.yml` GitHub workflow, and any
+> manual dry-run performed with identical container images and toolchain pins.
+
+## 1. Toolchain fingerprint
+
+| Component | Version source | Enforcement |
+| --- | --- | --- |
+| Node.js | `.nvmrc` (CI uses `actions/setup-node`) | `npm run ci:verify-toolchain` (fails if drift is detected). |
+| npm | 10.x (bundled with pinned Node) | `package-lock.json` committed; `npm ci` only. |
+| Hardhat | Declared in `package.json` | Deterministic compile via `npx hardhat compile`. |
+| Foundry | `foundry.toml` `profile.default` pins | Validated with `foundryup --version` inside CI container image. |
+| Solc | `foundry.toml` / Hardhat config | Resolved via `hardhat.config.js` version matrix. |
+| Docker | `docker/build-push-action` pinned SHA | Reused for deterministic multi-arch images. |
+
+**Action:** prior to tagging a release, run `npm run ci:verify-toolchain` locally
+and capture the JSON summary in `reports/toolchains/<date>.json` for audit logs.
+
+## 2. Artefact inventory
+
+The release workflow produces a signed tarball `agi-jobs-v<version>-artifacts.tar.gz`
+containing:
+
+- `reports/abis/head/` – Final ABI exports (used for Etherscan verification).
+- `reports/sbom/` – SPDX SBOM (`.spdx.json`) plus CycloneDX manifest.
+- `reports/release/manifest.json` – Contract names ↔ addresses ↔ bytecode hashes.
+- `reports/release/notes.md` – Human-readable release notes with change log.
+- `typechain-types/` – TypeScript bindings (must match ABIs).
+- `deployment-config/` – Verification configs and deterministic deployment params.
+
+Every archive is accompanied by:
+
+1. SHA-256 checksum file (`.sha256`).
+2. Sigstore keyless signature (`.sig`) and certificate (`.pem`).
+3. SLSA provenance bundle (from `actions/attest-build-provenance`).
+
+**Action:** attach all companion files when publishing a GitHub release; do not
+modify the archive contents post-signing.
+
+## 3. Contract verification automation
+
+The `verify-contracts` job in `release.yml` performs automated Etherscan /
+Blockscout verification by:
+
+1. Loading API keys through OIDC + AWS Secrets Manager (`configure-aws-credentials`).
+2. Reading `reports/release/manifest.json` to resolve addresses and compiler inputs.
+3. Executing `scripts/release/run-etherscan-verification.js` to submit source +
+   metadata for every contract target listed in `deployment-config/verification/<network>.json`.
+4. Uploading `reports/release/verification-summary.json` as a workflow artefact.
+
+**Operator checklist**
+
+- ✅ Confirm the `ETHERSCAN_*` secrets are scoped to the target network before
+  dispatching the workflow.
+- ✅ After workflow completion, download the verification summary and archive it
+  alongside board approvals in the release dossier.
+
+## 4. Manual attestation reproduction
+
+Institutions may require a local reproduction of the signed artefacts. Execute:
+
+```bash
+npm ci --no-audit
+npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+npx hardhat compile
+npm run abi:export -- --out reports/abis/head
+npm run release:manifest
+npm run release:notes -- --manifest reports/release/manifest.json \
+  --out reports/release/notes.md --network mainnet --version <version>
+npm run sbom:generate
+```
+
+Then package:
+
+```bash
+tar -czf dist/agi-jobs-v<version>-artifacts.tar.gz \
+  reports/abis/head reports/sbom reports/release typechain-types deployment-config
+sha256sum dist/agi-jobs-v<version>-artifacts.tar.gz > dist/agi-jobs-v<version>-artifacts.tar.gz.sha256
+```
+
+Finally, sign with Cosign (keyless mode mirrors CI):
+
+```bash
+COSIGN_EXPERIMENTAL=1 cosign sign-blob --yes --keyless \
+  --output-signature dist/agi-jobs-v<version>-artifacts.tar.gz.sig \
+  --output-certificate dist/agi-jobs-v<version>-artifacts.tar.gz.pem \
+  dist/agi-jobs-v<version>-artifacts.tar.gz
+```
+
+The resulting hashes **must** match the CI-generated files; if not, halt and
+investigate toolchain drift.
+
+## 5. Release dossier template
+
+Store the following in the compliance drive for every version:
+
+- ✅ `reports/release/manifest.json` (immutable reference for audits).
+- ✅ Downloaded SARIF reports from CodeQL/Slither/Scorecard (CI artifacts).
+- ✅ Verification summary JSON + console exports showing “Verified” status on
+  Etherscan / Blockscout.
+- ✅ Governance approval evidence (Safe transaction hashes, timelock queue IDs).
+- ✅ Incident-response sign-off confirming tabletop rehearsal within the last 90 days.
+
+## 6. Change control linkage
+
+Each release must reference a signed change ticket using
+`docs/owner-control-change-ticket.md`. Update the ticket with:
+
+- Git commit SHA used to trigger the release workflow.
+- SBOM hash and Cosign certificate URI.
+- Links to CI runs proving `ci (v2)` and `static-analysis.yml` completed
+  successfully on the tag.
+
+Maintaining this dossier ensures auditors can independently reproduce the
+deployment and provides objective evidence that AGI Jobs v0 (v2) meets the
+“best-ever” release transparency bar described in the readiness rubric.

--- a/docs/security/forta-calibration.md
+++ b/docs/security/forta-calibration.md
@@ -1,0 +1,55 @@
+# Forta Calibration Log Template
+
+Use this template whenever Forta-based anomaly detection is tuned for AGI Jobs v0 (v2).
+Filling it out produces auditable evidence for institutional reviews and ensures the
+thresholds remain aligned with protocol risk appetite.
+
+## Metadata
+
+- **Date:** <YYYY-MM-DD>
+- **Network:** <mainnet|testnet>
+- **Forta Agent IDs:** `<0x...>`, `<0x...>`
+- **Operator:** <Name / Role>
+- **Reviewer:** <Name / Role>
+- **Change Ticket:** <Link to owner-control change record>
+
+## Baseline Dataset
+
+Describe the transaction window used to calibrate the detector.
+
+- Block range: `<start>-<end>`
+- Expected steady-state TPS: `<value>`
+- Historical validator churn rate: `<value>`
+- Data source exports: `reports/forta/baseline-<date>.json`
+
+## Threshold Configuration
+
+| Metric | Previous Threshold | New Threshold | Rationale |
+| --- | --- | --- | --- |
+| Job execution surge | 99th percentile = `<value>` | `<value>` | `<why>` |
+| Treasury outflow volume | `<value>` | `<value>` | `<why>` |
+| Validator stake churn | `<value>` | `<value>` | `<why>` |
+
+Document additional metrics if your Forta agent surfaces them.
+
+## Dry-Run Evidence
+
+1. Commands executed (`npm run simulation:stress ...`, Forta CLI, etc.).
+2. Screenshots or JSON excerpts proving the alert fired when expected.
+3. Notes on any false positives and how they were mitigated.
+
+## Approval & Rollout
+
+- ✅ Reviewer approval timestamp: `<ISO-8601>`
+- ✅ Defender Sentinel (FORTA_ALERT) updated: `<Yes/No>` (link to transaction/commit)
+- ✅ Incident response team briefed: `<Yes/No>` (attach notes in `docs/incident-response.md`).
+
+## Quarterly Revalidation Checklist
+
+- [ ] Baseline dataset refreshed.
+- [ ] Thresholds compared against actual production metrics.
+- [ ] Forta agent version pinned / upgraded with justification.
+- [ ] Monitoring tabletop exercise performed with Forta injects.
+
+Store the completed log under `docs/security/forta-calibration/<YYYY-MM-DD>-<network>.md`
+and reference it in the release dossier described in `docs/release-artifacts.md`.


### PR DESCRIPTION
## Summary
- add a release artefacts blueprint documenting the signed bundle, verification flow, and compliance dossier workflow
- extend the on-chain monitoring guide with Forta anomaly detection guidance and provide a calibration log template
- integrate the new dossier checklist into the production launch blueprint and reference Forta calibration from the monitoring overview

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ea85063ce08333b6ac48ac8aa5c4e5