### PR TITLE
Add incident response tabletop generator and catalog

### DIFF
--- a/docs/security/incident-response-scenarios.json
+++ b/docs/security/incident-response-scenarios.json
@@ -1,0 +1,324 @@
+{
+  "version": "2025.02.18",
+  "lastUpdated": "2025-02-18T00:00:00Z",
+  "scenarios": [
+    {
+      "id": "validator-compromise",
+      "title": "Malicious validator double-signing on StakeManager",
+      "severity": "SEV-1",
+      "description": "Forta signals a validator performing double-signing to steal escrowed rewards while attempting to bypass slash enforcement.",
+      "triggers": [
+        "Forta bot `agi-jobs-validator-slasher` emits CRITICAL alert",
+        "Prometheus alert `stake_manager_double_signing` fires in Alertmanager",
+        "Operator paging channel receives automated SEV-1 notification"
+      ],
+      "objectives": [
+        "Pause StakeManager and JobRouter within 15 minutes",
+        "Slash compromised validator(s) and quarantine pending payouts",
+        "Capture on-chain evidence bundle for external forensic firm"
+      ],
+      "tabletopFocus": [
+        "Exercise pause pipeline with Safe signer quorum",
+        "Validate validator registry snapshot tooling",
+        "Confirm Forta + Defender Sentinel correlation"
+      ],
+      "communicationsPlan": [
+        "Incident Commander posts acknowledgement in #incident-bridge",
+        "Communications drafts SEV-1 holding statement referencing pause",
+        "Treasury notifies custodial partners about payout freeze"
+      ],
+      "dependencies": [
+        "`monitoring/onchain/pause-governance-sentinel.json` deployed",
+        "Safe signer roster current in `docs/owner-control-snapshot.md`",
+        "Forta subscription active with webhook to paging channel"
+      ],
+      "metrics": {
+        "detectionSloMinutes": 5,
+        "responseSloMinutes": 30,
+        "restorationSloMinutes": 180,
+        "notes": [
+          "Record actual detection latency in tabletop summary",
+          "Document Safe confirmation timestamps for compliance"
+        ]
+      },
+      "evidence": [
+        "`reports/incidents/<date>/forta-alert.json`",
+        "`reports/incidents/<date>/owner-emergency.md`",
+        "`reports/incidents/<date>/stake-manager-state.json`"
+      ],
+      "steps": [
+        {
+          "title": "Validate alert authenticity",
+          "owner": "Technical Lead",
+          "actions": [
+            "Open Defender Sentinel event linked in the Forta alert and confirm contract address matches StakeManager.",
+            "Run `npm run owner:pulse` to capture module heartbeat and append results to the incident log."
+          ],
+          "evidence": [
+            "Screenshot of Sentinel event detail",
+            "Console output from `owner:pulse` saved to `reports/incidents/<date>/owner-pulse.txt`"
+          ],
+          "communications": [
+            "Notify Incident Commander with recommended severity"
+          ],
+          "durationMinutes": 10
+        },
+        {
+          "title": "Enter safe mode",
+          "owner": "Technical Lead",
+          "actions": [
+            "Execute `npm run owner:emergency -- --dry-run` to generate Safe transaction bundle.",
+            "Submit production pause transaction via Safe after TL and Treasury approvals.",
+            "Run `npm run owner:snapshot` once pause is confirmed on-chain."
+          ],
+          "evidence": [
+            "Safe transaction hash recorded in incident log",
+            "Paused module list exported to compliance drive"
+          ],
+          "communications": [
+            "Treasury confirms signer quorum availability",
+            "IC informs community that protocol is paused"
+          ],
+          "durationMinutes": 20
+        },
+        {
+          "title": "Quarantine validator and document impact",
+          "owner": "Forensics",
+          "actions": [
+            "Run `npm run owner:doctor -- --validators <address>` to inspect validator health and slash status.",
+            "Collect Forta alert payload, relevant on-chain transactions, and validator stake balances for the forensic bundle.",
+            "Open Jira ticket to track slashing remediation tasks."
+          ],
+          "evidence": [
+            "Validator report saved as `reports/incidents/<date>/validator-<address>.json`",
+            "Jira incident ticket ID recorded"
+          ],
+          "communications": [
+            "FORENSICS syncs with legal counsel on disclosure requirements"
+          ],
+          "durationMinutes": 30
+        },
+        {
+          "title": "Stabilise payouts",
+          "owner": "Treasury",
+          "actions": [
+            "Review pending job settlements and suspend payouts to the compromised validator account.",
+            "If impacted jobs exist, coordinate manual settlement through paymaster fallback scripts (`scripts/v2/manual-settlement.ts`)."
+          ],
+          "evidence": [
+            "Treasury ledger entry referencing incident number",
+            "Paymaster fallback execution log (if used)"
+          ],
+          "communications": [
+            "COMMS updates partners on payout status"
+          ],
+          "durationMinutes": 45
+        }
+      ],
+      "postExerciseQuestions": [
+        "Were detection alerts correlated fast enough to inform severity decision?",
+        "Did Safe signer availability impact response time?",
+        "Were manual settlement tools understood by Treasury?"
+      ]
+    },
+    {
+      "id": "governance-key-rotation",
+      "title": "Emergency multisig rotation after hardware loss",
+      "severity": "SEV-2",
+      "description": "Owner multisig signer reports lost hardware wallet; incident tests ability to rotate keys without disrupting operations.",
+      "triggers": [
+        "Signer reports loss via secure channel",
+        "Safe health monitor detects missing signature for >2 hours",
+        "Branch protection check indicates upcoming release requiring approval"
+      ],
+      "objectives": [
+        "Rotate affected Safe signer within 24 hours",
+        "Re-issue owner command suite credentials to new signer",
+        "Validate monitoring rules recognise new signer set"
+      ],
+      "tabletopFocus": [
+        "Run owner control audit to verify signer diff",
+        "Exercise documentation updates for governance roster",
+        "Confirm EIP-712 signing instructions for new hardware"
+      ],
+      "communicationsPlan": [
+        "IC logs event as SEV-2 in compliance register",
+        "COMMS drafts internal-only advisory for engineering org",
+        "Security lead notifies custodians reliant on multisig auth"
+      ],
+      "dependencies": [
+        "`owner-safe-bundle.json` stored in secure vault",
+        "Replacement signer identity pre-vetted in `docs/owner-control-index.md`",
+        "Access to `npm run owner:rotate` with up-to-date config"
+      ],
+      "metrics": {
+        "detectionSloMinutes": 30,
+        "responseSloMinutes": 120,
+        "notes": [
+          "Measure time between incident logging and Safe rotation completion",
+          "Ensure branch protection remains enforced during rotation"
+        ]
+      },
+      "evidence": [
+        "Updated Safe signer list exported from Gnosis Safe UI",
+        "`reports/incidents/<date>/owner-config-audit.json`",
+        "Screenshot of updated branch protection settings"
+      ],
+      "steps": [
+        {
+          "title": "Capture incident context",
+          "owner": "Incident Commander",
+          "actions": [
+            "Open change ticket using `docs/owner-control-change-ticket.md` template and assign TL + Treasury reviewers.",
+            "Verify lost device revocation procedures executed (disable Passkeys, revoke API tokens)."
+          ],
+          "evidence": [
+            "Completed change ticket stored in compliance drive",
+            "Security checklist for device revocation"
+          ],
+          "communications": [
+            "IC alerts governance chat with summary and next checkpoint time"
+          ],
+          "durationMinutes": 20
+        },
+        {
+          "title": "Generate rotation bundle",
+          "owner": "Technical Lead",
+          "actions": [
+            "Execute `npm run owner:rotate -- --target owner` to prepare Safe transaction JSON for signer replacement.",
+            "Validate output with `npm run owner:audit` to ensure new signer set matches roster."
+          ],
+          "evidence": [
+            "Rotation bundle stored at `reports/owner/rotation/<date>.json`",
+            "Owner audit diff exported to incident folder"
+          ],
+          "communications": [
+            "TL briefs Treasury on signing order and timeline"
+          ],
+          "durationMinutes": 40
+        },
+        {
+          "title": "Execute rotation and verify controls",
+          "owner": "Treasury",
+          "actions": [
+            "Collect signatures from remaining quorum using Safe UI or CLI.",
+            "Run `npm run owner:verify-control` to confirm new signer set active on-chain.",
+            "Trigger `npm run monitoring:sentinels -- --network mainnet` to render updated monitoring config with new addresses."
+          ],
+          "evidence": [
+            "Safe execution transaction hash",
+            "Updated sentinel templates archived"
+          ],
+          "communications": [
+            "COMMS sends internal announcement confirming rotation complete"
+          ],
+          "durationMinutes": 60
+        }
+      ],
+      "postExerciseQuestions": [
+        "Did Safe rotation tooling surface any stale configuration?",
+        "Were new signers able to complete hardware setup quickly?",
+        "Are monitoring templates easy to regenerate after rotations?"
+      ]
+    },
+    {
+      "id": "oracle-outage",
+      "title": "Energy oracle liveness degradation",
+      "severity": "SEV-3",
+      "description": "Thermostat module detects stale energy oracle updates; tabletop checks fallback data path and communication cadence.",
+      "triggers": [
+        "Prometheus alert `thermostat_oracle_stale` fires",
+        "`npm run owner:pulse` indicates oracle heartbeat older than SLA",
+        "Operator receives partner escalation about delayed settlements"
+      ],
+      "objectives": [
+        "Fail over to backup oracle feed within 60 minutes",
+        "Keep job settlements flowing via manual data entry if needed",
+        "Broadcast status update to validators and employers"
+      ],
+      "tabletopFocus": [
+        "Exercise thermostat fallback configuration",
+        "Validate operator documentation for manual energy price entry",
+        "Ensure comms handles SEV-3 status updates"
+      ],
+      "communicationsPlan": [
+        "IC publishes SEV-3 notice in status page",
+        "COMMS notifies validators of manual fallback operations",
+        "Partner manager informs enterprise customers of SLA impact"
+      ],
+      "dependencies": [
+        "Backup oracle credentials stored in vault",
+        "`scripts/v2/updateEnergyOracle.ts` reviewed in last quarter",
+        "Manual settlement SOP in `docs/token-operations.md`"
+      ],
+      "metrics": {
+        "detectionSloMinutes": 15,
+        "responseSloMinutes": 60,
+        "notes": [
+          "Track time to execute fallback update script",
+          "Record validator feedback in retrospective"
+        ]
+      },
+      "evidence": [
+        "Thermostat metrics export pre/post failover",
+        "Fallback script execution log",
+        "Status page update screenshot"
+      ],
+      "steps": [
+        {
+          "title": "Confirm outage and assess scope",
+          "owner": "Technical Lead",
+          "actions": [
+            "Run `npm run owner:surface` to inspect oracle heartbeat timestamps.",
+            "Check Grafana dashboard `Thermostat / Oracle` to quantify drift." 
+          ],
+          "evidence": [
+            "Owner surface report saved to `reports/incidents/<date>/oracle-surface.json`",
+            "Grafana screenshot archived"
+          ],
+          "communications": [
+            "IC receives summary with recommended SEV-3 classification"
+          ],
+          "durationMinutes": 15
+        },
+        {
+          "title": "Activate fallback feed",
+          "owner": "Technical Lead",
+          "actions": [
+            "Execute `npx hardhat run --network mainnet scripts/v2/updateEnergyOracle.ts --fallback` in dry-run mode.",
+            "After validation, perform production execution via Safe with multi-sig approvals."
+          ],
+          "evidence": [
+            "Dry-run log stored in incident folder",
+            "Safe transaction hash and gas receipt"
+          ],
+          "communications": [
+            "COMMS updates validators on fallback activation"
+          ],
+          "durationMinutes": 30
+        },
+        {
+          "title": "Maintain service and record metrics",
+          "owner": "Operations",
+          "actions": [
+            "Coordinate manual settlement cadence every 30 minutes until oracle restored.",
+            "Track validator acknowledgements using `scripts/v2/ownerControlPulse.ts`."
+          ],
+          "evidence": [
+            "Manual settlement log appended to incident doc",
+            "Owner control pulse output archived"
+          ],
+          "communications": [
+            "Status page updated hourly with current state"
+          ],
+          "durationMinutes": 90
+        }
+      ],
+      "postExerciseQuestions": [
+        "Were fallback credentials accessible without delay?",
+        "Did manual settlements meet validator expectations?",
+        "Were stakeholders satisfied with communication frequency?"
+      ]
+    }
+  ]
+}

--- a/docs/security/incident-tabletop.md
+++ b/docs/security/incident-tabletop.md
@@ -59,6 +59,33 @@ controls after every tagged release.
 - Post-exercise report stored in the compliance archive alongside the release
   provenance attestation.
 
+## Automated evidence capture (new)
+
+Use the catalogued scenarios in
+`docs/security/incident-response-scenarios.json` to generate a fully
+templated tabletop packet before every rehearsal:
+
+```bash
+# Discover available exercises
+npm run incident:tabletop -- --list
+
+# Generate a markdown plan and evidence checklist for the validator scenario
+npm run incident:tabletop -- --scenario validator-compromise \
+  --out reports/incident-tabletop/$(date +%Y%m%d)-validator.md
+```
+
+The generator validates the scenario schema, resolves the latest catalog
+version, and writes an auditable plan containing:
+
+- Step-by-step action flow with target durations and command references.
+- Evidence artefact checklist aligned with compliance expectations.
+- Post-exercise reflection prompts for the retrospective meeting.
+
+Save the rendered file in the incident exercise archive together with
+screenshots, Safe transaction hashes, and monitoring exports. This produces
+objective proof that the quarterly drills executed against the exact
+institutional requirements captured in the readiness rubric.
+
 ## Follow-up (T+7 days)
 
 - [ ] Close or track remediation tickets spawned during the exercise.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "monitoring:sentinels": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/monitoring/render-sentinels.ts",
     "monitoring:validate": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/monitoring/validate-sentinels.ts",
     "docs:verify": "node scripts/docs/check-links.js",
+    "incident:tabletop": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/security/run-tabletop.ts",
     "ci:verify-branch-protection": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/ci/verify-branch-protection.ts",
     "ci:verify-toolchain": "node scripts/ci/check-toolchain-locks.js",
     "ci:verify-signers": "node scripts/ci/check-signers.js",

--- a/scripts/security/run-tabletop.ts
+++ b/scripts/security/run-tabletop.ts
@@ -1,0 +1,421 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { z } from 'zod';
+
+type OutputFormat = 'markdown' | 'human' | 'json';
+
+interface CliOptions {
+  scenarioIds: string[];
+  format: OutputFormat;
+  catalogPath?: string;
+  outPath?: string;
+  listOnly: boolean;
+  help: boolean;
+}
+
+interface RenderContext {
+  generatedAt: string;
+  catalogVersion?: string;
+  catalogLastUpdated?: string;
+}
+
+const StepSchema = z.object({
+  title: z.string().min(1, 'Step title is required'),
+  owner: z.string().min(1, 'Step owner is required'),
+  actions: z.array(z.string().min(1)).min(1, 'Each step must contain at least one action'),
+  evidence: z.array(z.string().min(1)).default([]),
+  communications: z.array(z.string().min(1)).default([]),
+  durationMinutes: z.number().int().nonnegative().optional(),
+});
+
+type ScenarioStep = z.infer<typeof StepSchema>;
+
+const MetricsSchema = z
+  .object({
+    detectionSloMinutes: z.number().int().nonnegative().optional(),
+    responseSloMinutes: z.number().int().nonnegative().optional(),
+    restorationSloMinutes: z.number().int().nonnegative().optional(),
+    notes: z.array(z.string().min(1)).default([]),
+  })
+  .default({ notes: [] });
+
+const ScenarioSchema = z.object({
+  id: z.string().min(1, 'Scenario id is required'),
+  title: z.string().min(1, 'Scenario title is required'),
+  severity: z.enum(['SEV-1', 'SEV-2', 'SEV-3', 'SEV-4']),
+  description: z.string().min(1),
+  triggers: z.array(z.string().min(1)).min(1),
+  objectives: z.array(z.string().min(1)).min(1),
+  steps: z.array(StepSchema).min(1, 'Scenario must define at least one step'),
+  metrics: MetricsSchema,
+  evidence: z.array(z.string().min(1)).default([]),
+  tabletopFocus: z.array(z.string().min(1)).default([]),
+  communicationsPlan: z.array(z.string().min(1)).default([]),
+  dependencies: z.array(z.string().min(1)).default([]),
+  postExerciseQuestions: z.array(z.string().min(1)).default([]),
+});
+
+type Scenario = z.infer<typeof ScenarioSchema>;
+
+const CatalogSchema = z.object({
+  version: z.string().optional(),
+  lastUpdated: z.string().optional(),
+  scenarios: z.array(ScenarioSchema).min(1, 'At least one scenario must be defined'),
+});
+
+type Catalog = z.infer<typeof CatalogSchema>;
+
+const DEFAULT_CATALOG_PATH = path.resolve(process.cwd(), 'docs', 'security', 'incident-response-scenarios.json');
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    scenarioIds: [],
+    format: 'markdown',
+    listOnly: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const current = argv[i];
+    if ((current === '--scenario' || current === '-s') && argv[i + 1]) {
+      options.scenarioIds.push(argv[i + 1]);
+      i += 1;
+    } else if (current === '--format' && argv[i + 1]) {
+      const candidate = argv[i + 1];
+      if (candidate === 'markdown' || candidate === 'human' || candidate === 'json') {
+        options.format = candidate;
+      } else {
+        throw new Error(`Unsupported format "${candidate}". Use markdown|human|json.`);
+      }
+      i += 1;
+    } else if (current === '--catalog' && argv[i + 1]) {
+      options.catalogPath = argv[i + 1];
+      i += 1;
+    } else if (current === '--out' && argv[i + 1]) {
+      options.outPath = argv[i + 1];
+      i += 1;
+    } else if (current === '--list') {
+      options.listOnly = true;
+    } else if (current === '--help' || current === '-h') {
+      options.help = true;
+    } else if (current === '--all') {
+      options.scenarioIds = [];
+    }
+  }
+
+  return options;
+}
+
+function usage(): string {
+  return `Usage: ts-node scripts/security/run-tabletop.ts [options]\n\n` +
+    'Options:\n' +
+    '  --scenario <id>   Generate output for a specific scenario (repeatable).\n' +
+    '  --all             Include every scenario in the catalog (default behaviour).\n' +
+    '  --format <type>   Output format: markdown (default), human, json.\n' +
+    '  --catalog <path>  Path to scenario catalog JSON (default docs/security/incident-response-scenarios.json).\n' +
+    '  --out <path>      Write output to file (directories will be created).\n' +
+    '  --list            List available scenarios and exit.\n' +
+    '  --help            Show this message.\n';
+}
+
+async function loadCatalog(catalogPath?: string): Promise<{ catalog: Catalog; filePath: string }> {
+  const resolvedPath = path.resolve(process.cwd(), catalogPath ?? DEFAULT_CATALOG_PATH);
+  const buffer = await fs.readFile(resolvedPath, 'utf8');
+  const parsedJson = JSON.parse(buffer);
+  const catalog = CatalogSchema.parse(parsedJson);
+  return { catalog, filePath: resolvedPath };
+}
+
+function selectScenarios(catalog: Catalog, scenarioIds: string[]): { selected: Scenario[]; missing: string[] } {
+  if (scenarioIds.length === 0) {
+    return { selected: catalog.scenarios, missing: [] };
+  }
+
+  const idSet = new Set(scenarioIds);
+  const selected = catalog.scenarios.filter((scenario) => idSet.has(scenario.id));
+  const missing = scenarioIds.filter((id) => !selected.some((scenario) => scenario.id === id));
+  return { selected, missing };
+}
+
+function renderMarkdown(context: RenderContext, scenarios: Scenario[]): string {
+  const lines: string[] = [];
+  lines.push('# Incident Tabletop Exercise Plan');
+  lines.push('');
+  lines.push(`Generated: ${context.generatedAt}`);
+  if (context.catalogVersion) {
+    lines.push(`Catalog version: ${context.catalogVersion}`);
+  }
+  if (context.catalogLastUpdated) {
+    lines.push(`Catalog last updated: ${context.catalogLastUpdated}`);
+  }
+  lines.push('');
+
+  scenarios.forEach((scenario, index) => {
+    lines.push(`## Scenario: ${scenario.title}`);
+    lines.push('');
+    lines.push(`- **ID:** ${scenario.id}`);
+    lines.push(`- **Severity:** ${scenario.severity}`);
+    lines.push(`- **Purpose:** ${scenario.description}`);
+    if (scenario.tabletopFocus.length > 0) {
+      lines.push(`- **Focus areas:** ${scenario.tabletopFocus.join('; ')}`);
+    }
+    if (scenario.dependencies.length > 0) {
+      lines.push(`- **Dependencies:** ${scenario.dependencies.join('; ')}`);
+    }
+    lines.push('');
+
+    lines.push('### Activation triggers');
+    scenario.triggers.forEach((trigger) => {
+      lines.push(`- ${trigger}`);
+    });
+    lines.push('');
+
+    lines.push('### Objectives');
+    scenario.objectives.forEach((objective) => {
+      lines.push(`- ${objective}`);
+    });
+    lines.push('');
+
+    if (scenario.communicationsPlan.length > 0) {
+      lines.push('### Communications plan');
+      scenario.communicationsPlan.forEach((entry) => {
+        lines.push(`- ${entry}`);
+      });
+      lines.push('');
+    }
+
+    lines.push('### Step-by-step flow');
+    scenario.steps.forEach((step, stepIndex) => {
+      lines.push(`#### Step ${stepIndex + 1}: ${step.title}`);
+      lines.push(`*Owner:* ${step.owner}`);
+      if (typeof step.durationMinutes === 'number') {
+        lines.push(`*Target duration:* ${step.durationMinutes} minutes`);
+      }
+      lines.push('**Actions**');
+      step.actions.forEach((action) => {
+        lines.push(`- ${action}`);
+      });
+      if (step.evidence.length > 0) {
+        lines.push('**Evidence**');
+        step.evidence.forEach((evidence) => {
+          lines.push(`- ${evidence}`);
+        });
+      }
+      if (step.communications.length > 0) {
+        lines.push('**Communications**');
+        step.communications.forEach((communication) => {
+          lines.push(`- ${communication}`);
+        });
+      }
+      lines.push('');
+    });
+
+    if (scenario.metrics.detectionSloMinutes || scenario.metrics.responseSloMinutes || scenario.metrics.restorationSloMinutes) {
+      lines.push('### Service level objectives');
+      if (typeof scenario.metrics.detectionSloMinutes === 'number') {
+        lines.push(`- Detection SLO: ${scenario.metrics.detectionSloMinutes} minutes`);
+      }
+      if (typeof scenario.metrics.responseSloMinutes === 'number') {
+        lines.push(`- Response SLO: ${scenario.metrics.responseSloMinutes} minutes`);
+      }
+      if (typeof scenario.metrics.restorationSloMinutes === 'number') {
+        lines.push(`- Restoration SLO: ${scenario.metrics.restorationSloMinutes} minutes`);
+      }
+      scenario.metrics.notes.forEach((note) => {
+        lines.push(`- Note: ${note}`);
+      });
+      lines.push('');
+    }
+
+    if (scenario.evidence.length > 0) {
+      lines.push('### Artefacts to capture');
+      scenario.evidence.forEach((entry) => {
+        lines.push(`- ${entry}`);
+      });
+      lines.push('');
+    }
+
+    if (scenario.postExerciseQuestions.length > 0) {
+      lines.push('### Post-exercise reflection');
+      scenario.postExerciseQuestions.forEach((question) => {
+        lines.push(`- ${question}`);
+      });
+      lines.push('');
+    }
+
+    if (index < scenarios.length - 1) {
+      lines.push('---');
+      lines.push('');
+    }
+  });
+
+  return lines.join('\n');
+}
+
+function renderHuman(context: RenderContext, scenarios: Scenario[]): string {
+  const sections: string[] = [];
+  sections.push(`Incident Tabletop Exercise Plan (generated ${context.generatedAt})`);
+  if (context.catalogVersion) {
+    sections.push(`Catalog version ${context.catalogVersion}`);
+  }
+  if (context.catalogLastUpdated) {
+    sections.push(`Catalog last updated ${context.catalogLastUpdated}`);
+  }
+  sections.push('');
+
+  scenarios.forEach((scenario, index) => {
+    sections.push(`${index + 1}. ${scenario.title} [${scenario.id} – ${scenario.severity}]`);
+    sections.push(`Purpose: ${scenario.description}`);
+    if (scenario.tabletopFocus.length > 0) {
+      sections.push(`Focus areas: ${scenario.tabletopFocus.join('; ')}`);
+    }
+    if (scenario.dependencies.length > 0) {
+      sections.push(`Dependencies: ${scenario.dependencies.join('; ')}`);
+    }
+    sections.push('Triggers:');
+    scenario.triggers.forEach((trigger, triggerIndex) => {
+      sections.push(`  ${triggerIndex + 1}) ${trigger}`);
+    });
+    sections.push('Objectives:');
+    scenario.objectives.forEach((objective, objectiveIndex) => {
+      sections.push(`  ${objectiveIndex + 1}) ${objective}`);
+    });
+    if (scenario.communicationsPlan.length > 0) {
+      sections.push('Communications:');
+      scenario.communicationsPlan.forEach((entry, commIndex) => {
+        sections.push(`  ${commIndex + 1}) ${entry}`);
+      });
+    }
+    sections.push('Steps:');
+    scenario.steps.forEach((step, stepIndex) => {
+      const duration = typeof step.durationMinutes === 'number' ? ` (~${step.durationMinutes}m)` : '';
+      sections.push(`  ${stepIndex + 1}. ${step.title}${duration} — Owner: ${step.owner}`);
+      step.actions.forEach((action, actionIndex) => {
+        sections.push(`     - Action ${actionIndex + 1}: ${action}`);
+      });
+      if (step.evidence.length > 0) {
+        step.evidence.forEach((evidence) => {
+          sections.push(`     - Evidence: ${evidence}`);
+        });
+      }
+      if (step.communications.length > 0) {
+        step.communications.forEach((communication) => {
+          sections.push(`     - Comms: ${communication}`);
+        });
+      }
+    });
+    const sloParts: string[] = [];
+    if (typeof scenario.metrics.detectionSloMinutes === 'number') {
+      sloParts.push(`detection ${scenario.metrics.detectionSloMinutes}m`);
+    }
+    if (typeof scenario.metrics.responseSloMinutes === 'number') {
+      sloParts.push(`response ${scenario.metrics.responseSloMinutes}m`);
+    }
+    if (typeof scenario.metrics.restorationSloMinutes === 'number') {
+      sloParts.push(`restoration ${scenario.metrics.restorationSloMinutes}m`);
+    }
+    if (sloParts.length > 0 || scenario.metrics.notes.length > 0) {
+      sections.push(`SLOs: ${sloParts.join(', ') || 'n/a'}`);
+      scenario.metrics.notes.forEach((note) => {
+        sections.push(`  - Note: ${note}`);
+      });
+    }
+    if (scenario.evidence.length > 0) {
+      sections.push('Capture the following artefacts:');
+      scenario.evidence.forEach((entry) => {
+        sections.push(`  - ${entry}`);
+      });
+    }
+    if (scenario.postExerciseQuestions.length > 0) {
+      sections.push('Reflection prompts:');
+      scenario.postExerciseQuestions.forEach((question) => {
+        sections.push(`  - ${question}`);
+      });
+    }
+    sections.push('');
+  });
+
+  return sections.join('\n');
+}
+
+function renderJson(context: RenderContext, scenarios: Scenario[]): string {
+  const payload = {
+    generatedAt: context.generatedAt,
+    catalogVersion: context.catalogVersion ?? null,
+    catalogLastUpdated: context.catalogLastUpdated ?? null,
+    scenarios,
+  };
+  return `${JSON.stringify(payload, null, 2)}\n`;
+}
+
+async function writeOutput(content: string, outPath?: string): Promise<void> {
+  if (!outPath) {
+    process.stdout.write(content);
+    if (!content.endsWith('\n')) {
+      process.stdout.write('\n');
+    }
+    return;
+  }
+
+  const resolved = path.resolve(process.cwd(), outPath);
+  const directory = path.dirname(resolved);
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(resolved, content, 'utf8');
+  process.stderr.write(`✅ Wrote tabletop plan to ${resolved}\n`);
+}
+
+async function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+
+    if (options.help) {
+      await writeOutput(`${usage()}\n`);
+      return;
+    }
+
+    const { catalog, filePath } = await loadCatalog(options.catalogPath);
+    const context: RenderContext = {
+      generatedAt: new Date().toISOString(),
+      catalogVersion: catalog.version,
+      catalogLastUpdated: catalog.lastUpdated,
+    };
+
+    if (options.listOnly) {
+      const lines = catalog.scenarios.map((scenario) => `${scenario.id}\t${scenario.title} (${scenario.severity})`);
+      await writeOutput(`${lines.join('\n')}\n`);
+      return;
+    }
+
+    const { selected, missing } = selectScenarios(catalog, options.scenarioIds);
+
+    if (missing.length > 0) {
+      throw new Error(`Unknown scenario id(s): ${missing.join(', ')}`);
+    }
+
+    if (selected.length === 0) {
+      throw new Error('No scenarios selected. Use --scenario <id> or ensure catalog defines scenarios.');
+    }
+
+    const relativeCatalog = path.relative(process.cwd(), filePath);
+    context.catalogVersion = context.catalogVersion ?? `@${relativeCatalog}`;
+
+    let output = '';
+    if (options.format === 'json') {
+      output = renderJson(context, selected);
+    } else if (options.format === 'human') {
+      output = `${renderHuman(context, selected)}\n`;
+    } else {
+      output = `${renderMarkdown(context, selected)}\n`;
+    }
+
+    await writeOutput(output, options.outPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`❌ ${message}\n`);
+    process.stderr.write(`${usage()}\n`);
+    process.exitCode = 1;
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary
- add a structured incident-response scenario catalog aligned with the institutional readiness rubric
- implement a ts-node tabletop generator that renders markdown, human, or JSON plans and writes evidence packets
- expose the generator through npm scripts and document the workflow for audit-grade exercise evidence

## Testing
- npm run incident:tabletop -- --list
- npm run incident:tabletop -- --scenario validator-compromise --format markdown

------
https://chatgpt.com/codex/tasks/task_e_68ea8cde9e408333b2c65ebf63cb4d0e