### PR TITLE
Document institutional readiness status

### DIFF
--- a/docs/institutional-readiness-status.md
+++ b/docs/institutional-readiness-status.md
@@ -8,7 +8,7 @@ This status dossier records how the repository satisfies the "Institutional Depl
 - **Artifact attestation.** `docs/release-signing.md` & `docs/release-artifacts.md` capture the Cosign/SLSA procedure and the reporting inputs emitted by CI.
 
 ## CI & supply-chain hardening
-- **Green-only merges.** Branch policy expectations are codified in `docs/ci-v2-branch-protection-checklist.md` and machine-validated by `npm run ci:verify-branch-protection` during CI.
+- **Green-only merges.** Branch policy expectations are codified in `docs/ci-v2-branch-protection-checklist.md`; reviewers can run `npm run ci:verify-branch-protection` locally to confirm GitHub settings until the script is wired into CI.
 - **Pinned GitHub Actions + hardened runners.** All workflows (see `.github/workflows/*.yml`) pin Actions to SHAs and start with `step-security/harden-runner` to restrict egress.
 - **Static analysis + SARIF uploads.** `.github/workflows/static-analysis.yml` runs Slither, validates an allowlist, and uploads SARIF results to GitHub code scanning.
 - **Toolchain immutability.** `docs/toolchain-locks.md` documents pinned versions; `.nvmrc`, `foundry.toml`, and `scripts/ci/check-toolchain-locks.js` enforce the same versions during automation.


### PR DESCRIPTION
## Summary
- add a canonical institutional readiness status dossier linking each punch-list control to in-repo automation and documentation
- outline concrete verification commands so reviewers can confirm controls without hunting across the tree

## Testing
- npm run lint:ci
- npm test *(terminated after contract compilation began to avoid exceeding interactive session limits)*

------
https://chatgpt.com/codex/tasks/task_e_68ea969c19848333ae84b7ff92e5cd37