### PR TITLE
Enforce OpenSSF Scorecard gate in CI

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,66 @@
+name: security-scorecard
+
+on:
+  schedule:
+    - cron: '45 3 * * 1'
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  analysis:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      issues: read
+      pull-requests: read
+      checks: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          persist-credentials: false
+
+      - name: Prepare security reports directory
+        run: mkdir -p reports/security
+
+      - name: Run OpenSSF Scorecard (JSON)
+        id: scorecard_json
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+        with:
+          results_file: reports/security/scorecard.json
+          results_format: json
+          publish_results: true
+
+      - name: Enforce Scorecard policy
+        run: node tools/security/validate-scorecard.mjs reports/security/scorecard.json
+
+      - name: Run OpenSSF Scorecard (SARIF)
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+        with:
+          results_file: reports/security/scorecard.sarif
+          results_format: sarif
+          publish_results: false
+
+      - name: Upload Scorecard SARIF
+        uses: github/codeql-action/upload-sarif@7dccf72e419e51b915f40df725d7c2e766b51b44
+        with:
+          sarif_file: reports/security/scorecard.sarif
+
+      - name: Upload Scorecard artefacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: openssf-scorecard
+          path: |
+            reports/security/scorecard.json
+            reports/security/scorecard.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,10 @@ validator dispute flows that demonstrate slashing behaviour.
 - **Foundry:**
   - `forge build`
   - `forge test`
+- **OpenSSF Scorecard:** runs automatically via [security-scorecard](docs/security/scorecard.md)
+  and fails the pipeline if key checks fall below enforced thresholds (Binary-Artifacts,
+  Code-Review, Maintained, Signed-Releases, Token-Permissions, Vulnerabilities,
+  Dependency-Update-Tool, Security-Policy, and the overall score).
 
 ## Dependency Vulnerability Allowlist
 

--- a/docs/deployment-readiness-checklist.md
+++ b/docs/deployment-readiness-checklist.md
@@ -44,7 +44,8 @@ This checklist condenses the operational knowledge required to take the AGI Jobs
 
 - Align pipeline jobs (lint, tests, coverage, security, gas, docs) with GitHub branch protection so that merges to `main` mirror the local commands below.
   _Key Scripts:_ `npm run lint:check`, `npm test`, `npm run coverage:check`, `npm run security:audit`, `npm run gas:check`, `npm run docs:verify`. 【F:package.json†L8-L131】
- - Require hardware-backed signed release tags and verify them in CI before publishing artefacts. Run
+- Guard Scorecard health by keeping the security-scorecard workflow green. Any regression in Binary-Artifacts, Code-Review, Maintained, Signed-Releases, Token-Permissions, Vulnerabilities, Dependency-Update-Tool, Security-Policy, or the overall score below the enforced thresholds will block the build. Follow the [Scorecard enforcement guide](security/scorecard.md) to triage and recover.
+- Require hardware-backed signed release tags and verify them in CI before publishing artefacts. Run
    `npm run ci:verify-signers` during release prep to catch format issues before the workflow executes.
    _Reference:_ `scripts/ci/ensure-tag-signature.js`, `scripts/ci/check-signers.js`, and the [Release Provenance & Tag Signing](release-provenance.md) playbook. 【F:scripts/ci/ensure-tag-signature.js†L1-L70】【F:scripts/ci/check-signers.js†L1-L103】【F:docs/release-provenance.md†L1-L104】
 - Require green runs of planner→simulator→runner integration tests on every PR, plus manual owner checklist sign-off for production rollouts.

--- a/docs/security/scorecard.md
+++ b/docs/security/scorecard.md
@@ -1,0 +1,66 @@
+# OpenSSF Scorecard Enforcement
+
+The security-scorecard workflow (`.github/workflows/scorecard.yml`) runs on every
+pull request, on pushes to `main`, and weekly on Mondays at 03:45 UTC. It
+executes two passes of the OpenSSF Scorecard scanner:
+
+1. **JSON run (publish + policy):** Uploads the latest metrics to
+   [scorecard.dev](https://scorecard.dev/viewer/?uri=github.com/MontrealAI/AGIJobsv0)
+   using GitHub OIDC credentials and writes the raw JSON report to
+   `reports/security/scorecard.json`.
+2. **SARIF run (code scanning):** Produces `reports/security/scorecard.sarif`
+   so the repository's Security tab surfaces Scorecard findings alongside
+   CodeQL and Slither results.
+
+The JSON output is fed to `tools/security/validate-scorecard.mjs`, which hard
+fails the workflow if any of the following conditions regress:
+
+| Check | Minimum score |
+| --- | --- |
+| Binary-Artifacts | 8 |
+| Code-Review | 8 |
+| Maintained | 8 |
+| Signed-Releases | 8 |
+| Token-Permissions | 7 |
+| Vulnerabilities | 7 |
+| Dependency-Update-Tool | 7 |
+| Security-Policy | 7 |
+| Overall repository score | 8 |
+
+A failing check surfaces in the workflow logs and in the GitHub job summary so
+contributors can remediate issues before merging.
+
+## Local verification
+
+To mirror the CI gate locally:
+
+```bash
+npm install
+mkdir -p reports/security
+npx scorecard --repo=github.com/MontrealAI/AGIJobsv0 --format=json > reports/security/scorecard.json
+npm run security:scorecard:check
+```
+
+If you lack the native Scorecard binary, the official container image works as
+well:
+
+```bash
+docker run --rm ghcr.io/ossf/scorecard:stable \
+  --repo=github.com/MontrealAI/AGIJobsv0 \
+  --commit=$(git rev-parse HEAD) \
+  --format=json > reports/security/scorecard.json
+npm run security:scorecard:check
+```
+
+## Operational guidance
+
+- Attach the generated JSON and SARIF artefacts to any compliance evidence
+  bundle so risk reviewers can confirm the repository meets the enforced
+  thresholds.
+- If the workflow fails on a non-default branch because the checks cannot be
+  computed (e.g., missing release tags during feature development), regenerate
+  the report from `main`, archive it under `reports/security/scorecard.json`,
+  and rerun the job to demonstrate compliance while you address the root cause.
+- The Scorecard badge is automatically updated by the workflow. If the public
+  badge ever drops below the thresholds above, block releases until the issues
+  are resolved and a passing run is recorded.

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "webapp:typecheck": "npm run typecheck --prefix apps/console",
     "webapp:e2e": "start-server-and-test \"npm --prefix apps/console run preview -- --host 0.0.0.0 --port 4173\" http://127.0.0.1:4173 \"cypress run --config-file cypress.config.ts\"",
     "security:audit": "audit-ci --config ./audit-ci.json",
+    "security:scorecard:check": "node tools/security/validate-scorecard.mjs reports/security/scorecard.json",
     "gas:check": "FOUNDRY_PROFILE=gas forge snapshot --match-contract CommitRevealGas --snap gas-snapshots/.gas-snapshot --check",
     "gas:report": "REPORT_GAS=true npx hardhat test --no-compile",
     "gas:snapshot": "FOUNDRY_PROFILE=gas forge snapshot --match-contract CommitRevealGas --snap gas-snapshots/.gas-snapshot",

--- a/tools/security/validate-scorecard.mjs
+++ b/tools/security/validate-scorecard.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import process from 'process';
+
+function loadScorecard(filePath) {
+  const resolvedPath = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Scorecard results not found at ${resolvedPath}`);
+  }
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Unable to parse Scorecard JSON: ${error.message}`);
+  }
+}
+
+function formatStatus(passed) {
+  return passed ? '✅' : '❌';
+}
+
+function appendSummary(lines) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) {
+    return;
+  }
+  fs.appendFileSync(summaryPath, `${lines.join('\n')}\n`);
+}
+
+function main() {
+  const [, , inputFile = 'reports/security/scorecard.json'] = process.argv;
+  const data = loadScorecard(inputFile);
+
+  if (!data || typeof data !== 'object') {
+    throw new Error('Scorecard payload is empty.');
+  }
+
+  const overallScore = Number.isFinite(Number(data.score)) ? Number(data.score) : NaN;
+  const thresholds = [
+    { name: 'Binary-Artifacts', minimum: 8 },
+    { name: 'Code-Review', minimum: 8 },
+    { name: 'Maintained', minimum: 8 },
+    { name: 'Signed-Releases', minimum: 8 },
+    { name: 'Token-Permissions', minimum: 7 },
+    { name: 'Vulnerabilities', minimum: 7 },
+    { name: 'Dependency-Update-Tool', minimum: 7 },
+    { name: 'Security-Policy', minimum: 7 },
+  ];
+
+  const checks = Array.isArray(data.checks) ? data.checks : [];
+  const checkMap = new Map(checks.map((entry) => [entry.name, entry]));
+
+  const summaryLines = [
+    '## OpenSSF Scorecard policy results',
+    '',
+    '| Check | Score | Threshold | Status |',
+    '| --- | --- | --- | --- |',
+  ];
+  const failures = [];
+
+  for (const { name, minimum } of thresholds) {
+    const details = checkMap.get(name);
+    const score = details && Number.isFinite(Number(details.score)) ? Number(details.score) : NaN;
+    const passed = Number.isFinite(score) && score >= minimum;
+    summaryLines.push(`| ${name} | ${Number.isFinite(score) ? score.toFixed(1) : 'n/a'} | ${minimum.toFixed(1)} | ${formatStatus(passed)} |`);
+    if (!passed) {
+      failures.push(`Scorecard check "${name}" scored ${Number.isFinite(score) ? score.toFixed(1) : 'n/a'}, below minimum ${minimum.toFixed(1)}.`);
+    }
+  }
+
+  if (!Number.isFinite(overallScore)) {
+    failures.push('Overall Scorecard score is missing or invalid.');
+  } else {
+    summaryLines.push(`| Overall | ${overallScore.toFixed(1)} | 8.0 | ${formatStatus(overallScore >= 8)} |`);
+    if (overallScore < 8) {
+      failures.push(`Overall Scorecard score ${overallScore.toFixed(1)} fell below minimum 8.0.`);
+    }
+  }
+
+  if (checkMap.size === 0) {
+    failures.push('Scorecard report did not include any individual checks.');
+  }
+
+  appendSummary(summaryLines);
+
+  if (failures.length > 0) {
+    const message = failures.join('\n');
+    console.error(message);
+    process.exit(1);
+  }
+
+  console.log('Scorecard policy checks passed.');
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a dedicated security-scorecard workflow that publishes Scorecard results, enforces score thresholds, and uploads SARIF artefacts
- ship a reusable validator plus local script entry point for checking Scorecard baselines and document the operational process
- update security and deployment readiness guides to reference the new Scorecard gate and remediation guidance

## Testing
- npm run format:check
- npm run lint:ci

------
https://chatgpt.com/codex/tasks/task_e_68eaad1d41e88333b2b289d4ca1d47e2