### PR TITLE
chore: embed network metadata in release manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,10 @@ jobs:
           npm run abi:export -- --out reports/abis/head
 
       - name: Generate release manifest
-        run: npm run release:manifest
+        run: |
+          npm run release:manifest -- \
+            --network "${{ steps.network.outputs.network }}" \
+            --deployment-config "deployment-config/${{ steps.network.outputs.network }}.json"
 
       - name: Generate release notes
         run: |

--- a/deployment-config/mainnet.json
+++ b/deployment-config/mainnet.json
@@ -1,5 +1,7 @@
 {
   "network": "mainnet",
+  "chainId": 1,
+  "explorerUrl": "https://etherscan.io",
   "governance": "0x0000000000000000000000000000000000000000",
   "agialpha": "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
   "tax": {

--- a/deployment-config/sepolia.json
+++ b/deployment-config/sepolia.json
@@ -1,5 +1,7 @@
 {
   "network": "sepolia",
+  "chainId": 11155111,
+  "explorerUrl": "https://sepolia.etherscan.io",
   "governance": "0x0000000000000000000000000000000000000000",
   "agialpha": "0x0000000000000000000000000000000000000000",
   "tax": {

--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -28,7 +28,7 @@ containing:
 
 - `reports/abis/head/` – Final ABI exports (used for Etherscan verification).
 - `reports/sbom/` – SPDX SBOM (`.spdx.json`) plus CycloneDX manifest.
-- `reports/release/manifest.json` – Contract names ↔ addresses ↔ bytecode hashes.
+- `reports/release/manifest.json` – Contract names ↔ addresses ↔ bytecode hashes, plus network metadata (chain ID, explorer URL, deployment-config reference).
 - `reports/release/notes.md` – Human-readable release notes with change log.
 - `typechain-types/` – TypeScript bindings (must match ABIs).
 - `deployment-config/` – Verification configs and deterministic deployment params.

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -26,6 +26,18 @@ npm run release:manifest -- --dir dist/release-v2.0.0
 This creates `dist/release-v2.0.0/manifest.json` and ensures the directory
 exists. Use `--out <file>` when you need an explicit path instead of a folder.
 
+Provide network context so the manifest captures the chain ID, explorer, and
+configuration provenance:
+
+```bash
+npm run release:manifest -- \
+  --network mainnet \
+  --deployment-config deployment-config/mainnet.json
+```
+
+Set `--chain-id` or `--explorer-url` when preparing a manifest for a network
+without a pre-baked configuration file.
+
 ## Manifest Contents
 
 The manifest is intentionally human-readable. Each section maps back to a
@@ -38,6 +50,8 @@ specific control in the deployment readiness checklist:
   flow in [release-provenance.md](release-provenance.md).
 - **toolchain** – Captures the versions pinned via `.nvmrc`, `package.json`, and
   `foundry.toml` so another operator can reproduce bytecode deterministically.
+- **network** – Embeds the chain name, chain ID, canonical explorer URL, and the
+  deployment-config file path used for the release.
 - **contracts** – For each production contract the manifest records:
   - the Hardhat artifact location relative to the repo root,
   - a SHA-256 hash of the ABI, and of the deployed bytecode,

--- a/scripts/release/generate-release-notes.js
+++ b/scripts/release/generate-release-notes.js
@@ -83,6 +83,34 @@ function sanitise(value) {
   return '—';
 }
 
+function buildNetworkSummary(manifestNetwork, fallbackNetwork) {
+  const info = manifestNetwork && typeof manifestNetwork === 'object' ? manifestNetwork : {};
+  const name = typeof info.name === 'string' && info.name.trim().length > 0
+    ? info.name.trim()
+    : typeof fallbackNetwork === 'string' && fallbackNetwork.trim().length > 0
+      ? fallbackNetwork.trim()
+      : 'unspecified';
+
+  const extras = [];
+  if (typeof info.chainId === 'number' && Number.isFinite(info.chainId) && info.chainId > 0) {
+    extras.push(`chainId ${info.chainId}`);
+  }
+  if (typeof info.explorerUrl === 'string' && info.explorerUrl.trim().length > 0) {
+    extras.push(`explorer ${info.explorerUrl.trim()}`);
+  }
+
+  const summaryLine = extras.length > 0
+    ? `- **Network:** \`${name}\` (${extras.join(', ')})`
+    : `- **Network:** \`${name}\``;
+
+  const extraLines = [];
+  if (typeof info.deploymentConfig === 'string' && info.deploymentConfig.trim().length > 0) {
+    extraLines.push(`  - Deployment config: \`${info.deploymentConfig.trim()}\``);
+  }
+
+  return { summaryLine, extraLines };
+}
+
 function buildToolchainSection(toolchain = {}) {
   const entries = [];
   if (toolchain.node) {
@@ -134,7 +162,11 @@ function writeReleaseNotes({ manifestPath, outPath, network, version, changelogP
 
   lines.push(`# AGI Jobs v${resolvedVersion} — Release Notes`);
   lines.push('');
-  lines.push(`- **Network:** \`${network}\``);
+  const networkSummary = buildNetworkSummary(manifest.network, network);
+  lines.push(networkSummary.summaryLine);
+  for (const extraLine of networkSummary.extraLines) {
+    lines.push(extraLine);
+  }
   if (manifest.git && manifest.git.commit) {
     lines.push(`- **Git commit:** \`${manifest.git.commit}\``);
   }


### PR DESCRIPTION
## Summary
- wire the release workflow to pass network-specific configuration into the manifest generator
- extend the manifest script to embed chain IDs, explorer URLs, and deployment config provenance for known networks
- update docs, configs, and release notes generation to surface the new network metadata

## Testing
- npm run release:manifest -- --network sepolia --deployment-config deployment-config/sepolia.json --dir tmp/release-test
- npm run release:notes -- --manifest tmp/release-test/manifest.json --out tmp/release-test/notes.md --network sepolia --version 2.0.0

------
https://chatgpt.com/codex/tasks/task_e_68eaad1d41e88333b2b289d4ca1d47e2