### PR TITLE
chore: validate release manifest before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,13 @@ jobs:
             --network "${{ steps.network.outputs.network }}" \
             --deployment-config "deployment-config/${{ steps.network.outputs.network }}.json"
 
+      - name: Validate release manifest
+        run: |
+          node scripts/release/validate-manifest.js \
+            --manifest reports/release/manifest.json \
+            --fail-on-warnings \
+            --require-addresses
+
       - name: Generate release notes
         run: |
           npm run release:notes -- \

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ scripts/**/*.js
 !scripts/release/generate-manifest.js
 !scripts/release/generate-release-notes.js
 !scripts/release/run-etherscan-verification.js
+!scripts/release/validate-manifest.js
 !scripts/utils/parseDuration.js
 build/
 lib/*

--- a/docs/institutional-readiness-status.md
+++ b/docs/institutional-readiness-status.md
@@ -24,7 +24,7 @@ This status dossier records how the repository satisfies the "Institutional Depl
 - **Owner runbooks for non-technical operators.** The owner handbook suite (for example, `docs/owner-control-handbook.md`, `docs/owner-control-command-center.md`) and `npm run owner:quickstart` cover zero-code operations end-to-end.
 
 ## Deployment transparency
-- **Release manifest & SBOM.** `npm run release:manifest`, `npm run release:notes`, and `npm run sbom:generate` produce the artefacts enumerated in `docs/release-artifacts.md`.
+- **Release manifest & SBOM.** `npm run release:manifest`, `npm run release:manifest:validate -- --fail-on-warnings --require-addresses`, `npm run release:notes`, and `npm run sbom:generate` produce the artefacts enumerated in `docs/release-artifacts.md` with validation that fails if metadata or addresses drift.
 - **Contract address registry.** `docs/DEPLOYED_ADDRESSES.md` and machine-readable JSON snapshots (`docs/deployment-addresses.json`) stay in sync via the deployment guides.
 - **Operator telemetry.** `monitoring/` houses Prometheus/Grafana/Alertmanager configs, with the high-level orientation in `docs/operator-telemetry.md` and `docs/institutional-observability.md`.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -49,9 +49,12 @@ Use this list before tagging a new production release.
    ```bash
    npm run sbom:generate
    npm run release:manifest
+   npm run release:manifest:validate -- --fail-on-warnings --require-addresses
    npm run release:notes -- --network mainnet --version X.Y.Z
    jq '.warnings' reports/release/manifest.json
    ```
+   - The validator enforces clean git/toolchain metadata and non-zero contract
+     addresses before release artefacts are published.
    - Ensure the warnings array is empty before publishing the release.
    - Inspect `reports/release/notes.md` for the generated contract inventory and toolchain summary. This file is published as the release body.
    - Attach the manifest, release notes, and SBOM JSON files to the signed tag artefacts.

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -74,7 +74,9 @@ Add the manifest to the artefact bundle referenced in
 
 1. Run the owner control doctors and snapshot scripts.
 2. Regenerate the SBOM and ABI exports.
-3. Run `npm run release:manifest` and review the warnings section.
+3. Run `npm run release:manifest` followed by `npm run release:manifest:validate -- --fail-on-warnings`.
+   The validator fails fast if toolchain metadata, contract hashes, or deployment
+   addresses are missing so you never publish an incomplete manifest.
 4. Attach the resulting JSON to the signed release alongside coverage,
    Slither/Echidna logs, and the owner sign-off packages.
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "owner:command-center": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerCommandCenter.ts",
     "sbom:generate": "mkdir -p reports/sbom && npm exec -- @cyclonedx/cyclonedx-npm --output-format json --output-file reports/sbom/cyclonedx.json",
     "release:manifest": "node scripts/release/generate-manifest.js",
+    "release:manifest:validate": "node scripts/release/validate-manifest.js",
     "release:notes": "node scripts/release/generate-release-notes.js",
     "release:verify": "node scripts/release/run-etherscan-verification.js",
     "owner:mission-control": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/ownerMissionControl.ts",

--- a/scripts/release/validate-manifest.js
+++ b/scripts/release/validate-manifest.js
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function usage() {
+  return `Usage: node scripts/release/validate-manifest.js [options]\n\n` +
+    `Options:\n` +
+    `  --manifest <path>          Path to the manifest JSON (default reports/release/manifest.json)\n` +
+    `  --fail-on-warnings         Treat manifest warnings as errors\n` +
+    `  --allow-warning <message>  Allow a specific warning string (can be repeated)\n` +
+    `  --require-addresses        Require non-zero config addresses for all contracts\n` +
+    `  --optional-contract <name> Allow a contract to skip address requirements (repeatable)\n` +
+    `  --no-toolchain-check       Do not enforce toolchain metadata\n` +
+    `  --no-git-check             Do not enforce git metadata\n` +
+    `  --help                     Show this message`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    manifestPath: path.resolve(process.cwd(), 'reports/release/manifest.json'),
+    failOnWarnings: false,
+    allowedWarnings: new Set(),
+    requireAddresses: false,
+    optionalContracts: new Set(),
+    enforceToolchain: true,
+    enforceGit: true,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const current = argv[i];
+    switch (current) {
+      case '--manifest':
+        if (typeof argv[i + 1] !== 'string') {
+          throw new Error('--manifest requires a path argument');
+        }
+        options.manifestPath = path.resolve(process.cwd(), argv[i + 1]);
+        i += 1;
+        break;
+      case '--fail-on-warnings':
+        options.failOnWarnings = true;
+        break;
+      case '--allow-warning':
+        if (typeof argv[i + 1] !== 'string') {
+          throw new Error('--allow-warning requires a warning message');
+        }
+        options.allowedWarnings.add(argv[i + 1]);
+        i += 1;
+        break;
+      case '--require-addresses':
+        options.requireAddresses = true;
+        break;
+      case '--optional-contract':
+        if (typeof argv[i + 1] !== 'string') {
+          throw new Error('--optional-contract requires a contract name');
+        }
+        options.optionalContracts.add(argv[i + 1]);
+        i += 1;
+        break;
+      case '--no-toolchain-check':
+        options.enforceToolchain = false;
+        break;
+      case '--no-git-check':
+        options.enforceGit = false;
+        break;
+      case '--help':
+        console.log(usage());
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${current}`);
+    }
+  }
+
+  return options;
+}
+
+function readManifest(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Manifest not found: ${path.relative(process.cwd(), filePath)}`);
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isZeroAddress(value) {
+  if (!isNonEmptyString(value)) {
+    return true;
+  }
+  const normalised = value.trim().toLowerCase();
+  return normalised === '0x0000000000000000000000000000000000000000';
+}
+
+function ensureToolchain(toolchain, errors) {
+  if (!toolchain || typeof toolchain !== 'object') {
+    errors.push('Manifest missing toolchain metadata.');
+    return;
+  }
+  const required = {
+    node: 'Node.js version',
+    hardhat: 'Hardhat version',
+    solc: 'solc version',
+    forge: 'forge version',
+  };
+  for (const [key, label] of Object.entries(required)) {
+    if (!isNonEmptyString(toolchain[key])) {
+      errors.push(`Manifest missing ${label.toLowerCase()}.`);
+    }
+  }
+}
+
+function ensureGitInfo(gitInfo, errors) {
+  if (!gitInfo || typeof gitInfo !== 'object') {
+    errors.push('Manifest missing git metadata.');
+    return;
+  }
+  if (!isNonEmptyString(gitInfo.commit)) {
+    errors.push('Manifest git.commit is empty.');
+  }
+  if (gitInfo.dirty === true) {
+    errors.push('Manifest recorded dirty git tree; release must run from a clean commit.');
+  }
+}
+
+function ensureContracts(manifest, options, errors) {
+  if (!manifest.contracts || typeof manifest.contracts !== 'object') {
+    errors.push('Manifest has no contracts section.');
+    return;
+  }
+  const names = Object.keys(manifest.contracts);
+  if (names.length === 0) {
+    errors.push('Manifest contract inventory is empty.');
+    return;
+  }
+  for (const name of names.sort()) {
+    const entry = manifest.contracts[name];
+    if (!entry || typeof entry !== 'object') {
+      errors.push(`Manifest entry for ${name} is invalid.`);
+      continue;
+    }
+    if (!isNonEmptyString(entry.artifact)) {
+      errors.push(`Manifest missing artifact path for ${name}.`);
+    }
+    if (!isNonEmptyString(entry.bytecodeHash)) {
+      errors.push(`Manifest missing bytecode hash for ${name}.`);
+    }
+    if (!Number.isFinite(entry.deployedBytecodeLength) || entry.deployedBytecodeLength <= 0) {
+      errors.push(`Manifest missing deployed bytecode length for ${name}.`);
+    }
+    if (!isNonEmptyString(entry.abiHash)) {
+      errors.push(`Manifest missing ABI hash for ${name}.`);
+    }
+
+    if (options.requireAddresses && !options.optionalContracts.has(name)) {
+      if (!entry.addresses || typeof entry.addresses !== 'object') {
+        errors.push(`Manifest missing address records for ${name}.`);
+      } else if (!isNonEmptyString(entry.addresses.config) || isZeroAddress(entry.addresses.config)) {
+        errors.push(`Manifest config address for ${name} is missing or zero.`);
+      }
+    }
+  }
+}
+
+function collectBlockingWarnings(manifest, options) {
+  const warnings = Array.isArray(manifest.warnings) ? manifest.warnings : [];
+  if (!options.failOnWarnings) {
+    return [];
+  }
+  const blocking = warnings.filter((warning) => !options.allowedWarnings.has(warning));
+  if (blocking.length > 0) {
+    return [`Manifest emitted warnings:\n- ${blocking.join('\n- ')}`];
+  }
+  return [];
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const manifest = readManifest(options.manifestPath);
+    const errors = [];
+
+    errors.push(...collectBlockingWarnings(manifest, options));
+
+    if (options.enforceToolchain) {
+      ensureToolchain(manifest.toolchain, errors);
+    }
+    if (options.enforceGit) {
+      ensureGitInfo(manifest.git, errors);
+    }
+    ensureContracts(manifest, options, errors);
+
+    if (errors.length > 0) {
+      console.error('Manifest validation failed:\n');
+      for (const error of errors) {
+        console.error(`- ${error}`);
+      }
+      console.error(`\nSee ${path.relative(process.cwd(), options.manifestPath)} for details.`);
+      process.exit(1);
+    }
+
+    console.log(`Manifest validation succeeded for ${path.relative(process.cwd(), options.manifestPath)}.`);
+  } catch (error) {
+    if (error && error.message) {
+      console.error(error.message);
+    } else {
+      console.error(error);
+    }
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a hardened release manifest validator that enforces toolchain metadata, contract hashes, and non-zero addresses
- wire the validator into the release workflow and expose it via `npm run release:manifest:validate`
- document the new validation gate in the release checklist and institutional readiness dossier

## Testing
- node scripts/release/validate-manifest.js --fail-on-warnings --require-addresses

------
https://chatgpt.com/codex/tasks/task_e_68eac264a0988333a5e34c5c0e12a50f