### PR TITLE
Capture Hardhat compiler metadata in release manifests

### DIFF
--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -28,7 +28,7 @@ containing:
 
 - `reports/abis/head/` – Final ABI exports (used for Etherscan verification).
 - `reports/sbom/` – SPDX SBOM (`.spdx.json`) plus CycloneDX manifest.
-- `reports/release/manifest.json` – Contract names ↔ addresses ↔ bytecode hashes, plus network metadata (chain ID, explorer URL, deployment-config reference).
+- `reports/release/manifest.json` – Contract names ↔ addresses ↔ bytecode hashes, toolchain fingerprint (Node, npm, Hardhat, Foundry, full Solidity compiler matrix), and network metadata (chain ID, explorer URL, deployment-config reference).
 - `reports/release/notes.md` – Human-readable release notes with change log.
 - `typechain-types/` – TypeScript bindings (must match ABIs).
 - `deployment-config/` – Verification configs and deterministic deployment params.

--- a/scripts/release/generate-release-notes.js
+++ b/scripts/release/generate-release-notes.js
@@ -122,11 +122,49 @@ function buildToolchainSection(toolchain = {}) {
   if (toolchain.hardhatToolbox) {
     entries.push(`- @nomicfoundation/hardhat-toolbox: \`${toolchain.hardhatToolbox}\``);
   }
+  if (toolchain.npm) {
+    entries.push(`- npm: \`${toolchain.npm}\``);
+  }
   if (toolchain.solc) {
     entries.push(`- solc: \`${toolchain.solc}\``);
   }
   if (toolchain.forge) {
     entries.push(`- forge: \`${toolchain.forge}\``);
+  }
+  if (Array.isArray(toolchain.solidityCompilers) && toolchain.solidityCompilers.length > 0) {
+    entries.push('- Solidity compiler matrix:');
+    for (const compiler of toolchain.solidityCompilers) {
+      if (!compiler || typeof compiler !== 'object') {
+        continue;
+      }
+      const descriptor = [];
+      if (compiler.longVersion && compiler.longVersion !== compiler.version) {
+        descriptor.push(`long ${compiler.longVersion}`);
+      }
+      if (compiler.optimizer && typeof compiler.optimizer === 'object') {
+        const enabled = compiler.optimizer.enabled === undefined
+          ? 'unspecified'
+          : compiler.optimizer.enabled
+            ? 'enabled'
+            : 'disabled';
+        if (Number.isFinite(compiler.optimizer.runs)) {
+          descriptor.push(`optimizer ${enabled} (runs ${compiler.optimizer.runs})`);
+        } else {
+          descriptor.push(`optimizer ${enabled}`);
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(compiler, 'viaIR')) {
+        descriptor.push(`viaIR ${compiler.viaIR ? 'enabled' : 'disabled'}`);
+      }
+      if (compiler.evmVersion) {
+        descriptor.push(`evm ${compiler.evmVersion}`);
+      }
+      if (Array.isArray(compiler.sources) && compiler.sources.length > 0) {
+        descriptor.push(`sources: ${compiler.sources.join(', ')}`);
+      }
+      const suffix = descriptor.length > 0 ? ` (${descriptor.join('; ')})` : '';
+      entries.push(`  - ${compiler.version}${suffix}`);
+    }
   }
   return entries.length > 0 ? entries.join('\n') : '_Toolchain metadata unavailable._';
 }

--- a/scripts/release/validate-manifest.js
+++ b/scripts/release/validate-manifest.js
@@ -105,10 +105,26 @@ function ensureToolchain(toolchain, errors) {
     hardhat: 'Hardhat version',
     solc: 'solc version',
     forge: 'forge version',
+    npm: 'npm version',
   };
   for (const [key, label] of Object.entries(required)) {
     if (!isNonEmptyString(toolchain[key])) {
       errors.push(`Manifest missing ${label.toLowerCase()}.`);
+    }
+  }
+
+  if (!Array.isArray(toolchain.solidityCompilers) || toolchain.solidityCompilers.length === 0) {
+    errors.push('Manifest missing Hardhat solidity compiler matrix.');
+    return;
+  }
+
+  for (const compiler of toolchain.solidityCompilers) {
+    if (!compiler || typeof compiler !== 'object') {
+      errors.push('Manifest contains invalid solidity compiler metadata entry.');
+      continue;
+    }
+    if (!isNonEmptyString(compiler.version)) {
+      errors.push('Solidity compiler entry missing version.');
     }
   }
 }


### PR DESCRIPTION
## Summary
- capture npm version and the Hardhat compiler matrix from build-info when generating the release manifest
- surface the richer toolchain fingerprint inside automated release notes for auditors and operators
- harden manifest validation and documentation so releases must include the compiler matrix metadata

## Testing
- npm run release:manifest -- --network sepolia --deployment-config deployment-config/sepolia.json
- npm run release:notes -- --manifest reports/release/manifest.json --out reports/release/notes.md --network sepolia --version 0.0.0-test
- npm run release:manifest:validate -- --manifest reports/release/manifest.json --no-git-check


------
https://chatgpt.com/codex/tasks/task_e_68eacddf7ed08333a4f86ac77eb0c14c