### PR TITLE
chore: adjust scorecard workflow permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,11 +8,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
-  id-token: write
+permissions: read-all
 
 concurrency:
   group: scorecard-${{ github.ref }}
@@ -21,6 +17,11 @@ concurrency:
 jobs:
   analyze:
     name: OpenSSF Scorecard
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      id-token: write
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## Summary
- scope the scorecard workflow's default permissions to read-only
- grant the job-specific permissions required to upload SARIF and publish results

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68eb007bbac48333bdd04aa7c0c78f36