### PR TITLE
Update Scorecard GitHub Action pin

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@e4c423540e964e15ccadc56558705ba15136265c
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
         with:
           results_file: scorecard.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- update the security-scorecard workflow to pin ossf/scorecard-action to commit 4eaacf0543bb3f2c246792bd56e8cdeffafb205a
- ensure the workflow uses a commit recognized by the Scorecard workflow restrictions

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68eb0da01c888333bd2765ac566b05ae