### PR TITLE
Fix Scorecard workflow verification by pinning CodeQL upload-sarif commit

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,7 +45,7 @@ jobs:
           repo_token: ${{ secrets.SCORECARD_READ_TOKEN || github.token }}
 
       - name: Upload Scorecard SARIF
-        uses: github/codeql-action/upload-sarif@7dccf72e419e51b915f40df725d7c2e766b51b44
+        uses: github/codeql-action/upload-sarif@755f44910c12a3d7ca0d8c6e42c048b3362f7cec
         with:
           sarif_file: scorecard.sarif
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -99,7 +99,7 @@ jobs:
             tools/security/slither-allowlist.json
 
       - name: Upload SARIF to security tab
-        uses: github/codeql-action/upload-sarif@7dccf72e419e51b915f40df725d7c2e766b51b44
+        uses: github/codeql-action/upload-sarif@755f44910c12a3d7ca0d8c6e42c048b3362f7cec
         with:
           sarif_file: reports/security/slither.sarif
 


### PR DESCRIPTION
## Summary
- update the CodeQL upload-sarif action pin in the security-scorecard workflow to a valid commit
- align the static-analysis workflow with the same verified commit hash

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb1497f9bc8333b1e9328a763b77c3