### PR TITLE
Harden CI egress and codify security enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,36 @@ env:
   REQUIRED_APPROVALS: '3'
   COMMIT_WINDOW: '30m'
   REVEAL_WINDOW: '30m'
+  HARDEN_RUNNER_EGRESS_POLICY: block
+  HARDEN_RUNNER_ALLOWED_ENDPOINTS: |
+    api.github.com:443
+    github.com:443
+    raw.githubusercontent.com:443
+    objects.githubusercontent.com:443
+    codeload.github.com:443
+    pkg-containers.githubusercontent.com:443
+    uploads.github.com:443
+    gist.githubusercontent.com:443
+    ghcr.io:443
+    registry.npmjs.org:443
+    registry.yarnpkg.com:443
+    nodejs.org:443
+    objects-origin.githubusercontent.com:443
+    files.pythonhosted.org:443
+    pypi.org:443
+    pypi.python.org:443
+    pythonhosted.org:443
+    binaries.soliditylang.org:443
+    storage.googleapis.com:443
+    dl.google.com:443
+    registry-1.docker.io:443
+    auth.docker.io:443
+    production.cloudflare.docker.com:443
+    fulcio.sigstore.dev:443
+    rekor.sigstore.dev:443
+    tuf-repo-cdn.sigstore.dev:443
+    oauth2.sigstore.dev:443
+    amazonaws.com:443
 
 jobs:
   lint:
@@ -39,7 +69,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
@@ -72,7 +103,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
@@ -115,7 +147,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
@@ -165,7 +198,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
@@ -219,7 +253,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - name: Publish pipeline summary
         env:
           NEEDS_CONTEXT: ${{ toJson(needs) }}
@@ -231,7 +266,8 @@ jobs:
             lint: 'Lint & static checks',
             tests: 'Tests',
             foundry: 'Foundry',
-            coverage: 'Coverage thresholds'
+            coverage: 'Coverage thresholds',
+            invariants: 'Invariant tests'
           };
           const lines = ['# AGI Jobs v0 — CI v2 status', '', '| Job | Result |', '| --- | --- |'];
           let failed = false;
@@ -260,7 +296,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -41,12 +41,43 @@ jobs:
       REQUIRED_APPROVALS: '3'
       COMMIT_WINDOW: '30m'
       REVEAL_WINDOW: '30m'
+      HARDEN_RUNNER_EGRESS_POLICY: block
+      HARDEN_RUNNER_ALLOWED_ENDPOINTS: |
+        api.github.com:443
+        github.com:443
+        raw.githubusercontent.com:443
+        objects.githubusercontent.com:443
+        codeload.github.com:443
+        pkg-containers.githubusercontent.com:443
+        uploads.github.com:443
+        gist.githubusercontent.com:443
+        ghcr.io:443
+        registry.npmjs.org:443
+        registry.yarnpkg.com:443
+        nodejs.org:443
+        objects-origin.githubusercontent.com:443
+        files.pythonhosted.org:443
+        pypi.org:443
+        pypi.python.org:443
+        pythonhosted.org:443
+        binaries.soliditylang.org:443
+        storage.googleapis.com:443
+        dl.google.com:443
+        registry-1.docker.io:443
+        auth.docker.io:443
+        production.cloudflare.docker.com:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        oauth2.sigstore.dev:443
+        amazonaws.com:443
 
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/.github/workflows/release-mainnet.yml
+++ b/.github/workflows/release-mainnet.yml
@@ -18,6 +18,38 @@ permissions:
   id-token: write
   packages: read
 
+env:
+  HARDEN_RUNNER_EGRESS_POLICY: block
+  HARDEN_RUNNER_ALLOWED_ENDPOINTS: |
+    api.github.com:443
+    github.com:443
+    raw.githubusercontent.com:443
+    objects.githubusercontent.com:443
+    codeload.github.com:443
+    pkg-containers.githubusercontent.com:443
+    uploads.github.com:443
+    gist.githubusercontent.com:443
+    ghcr.io:443
+    registry.npmjs.org:443
+    registry.yarnpkg.com:443
+    nodejs.org:443
+    objects-origin.githubusercontent.com:443
+    files.pythonhosted.org:443
+    pypi.org:443
+    pypi.python.org:443
+    pythonhosted.org:443
+    binaries.soliditylang.org:443
+    storage.googleapis.com:443
+    dl.google.com:443
+    registry-1.docker.io:443
+    auth.docker.io:443
+    production.cloudflare.docker.com:443
+    fulcio.sigstore.dev:443
+    rekor.sigstore.dev:443
+    tuf-repo-cdn.sigstore.dev:443
+    oauth2.sigstore.dev:443
+    amazonaws.com:443
+
 jobs:
   guardrails:
     runs-on: ubuntu-24.04
@@ -25,7 +57,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - name: Confirm
         run: |
           test "${{ inputs.confirm }}" = "YES" || { echo "Deployment not confirmed"; exit 1; }
@@ -45,7 +78,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,38 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  HARDEN_RUNNER_EGRESS_POLICY: block
+  HARDEN_RUNNER_ALLOWED_ENDPOINTS: |
+    api.github.com:443
+    github.com:443
+    raw.githubusercontent.com:443
+    objects.githubusercontent.com:443
+    codeload.github.com:443
+    pkg-containers.githubusercontent.com:443
+    uploads.github.com:443
+    gist.githubusercontent.com:443
+    ghcr.io:443
+    registry.npmjs.org:443
+    registry.yarnpkg.com:443
+    nodejs.org:443
+    objects-origin.githubusercontent.com:443
+    files.pythonhosted.org:443
+    pypi.org:443
+    pypi.python.org:443
+    pythonhosted.org:443
+    binaries.soliditylang.org:443
+    storage.googleapis.com:443
+    dl.google.com:443
+    registry-1.docker.io:443
+    auth.docker.io:443
+    production.cloudflare.docker.com:443
+    fulcio.sigstore.dev:443
+    rekor.sigstore.dev:443
+    tuf-repo-cdn.sigstore.dev:443
+    oauth2.sigstore.dev:443
+    amazonaws.com:443
+
 jobs:
   prepare:
     runs-on: ubuntu-24.04
@@ -39,7 +71,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
@@ -166,7 +199,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -314,7 +348,8 @@ jobs:
         if: ${{ steps.npm-token.outputs.publish == 'true' }}
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - name: Checkout
         if: ${{ steps.npm-token.outputs.publish == 'true' }}
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -378,7 +413,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
@@ -453,7 +489,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,38 @@ concurrency:
   group: scorecard-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  HARDEN_RUNNER_EGRESS_POLICY: block
+  HARDEN_RUNNER_ALLOWED_ENDPOINTS: |
+    api.github.com:443
+    github.com:443
+    raw.githubusercontent.com:443
+    objects.githubusercontent.com:443
+    codeload.github.com:443
+    pkg-containers.githubusercontent.com:443
+    uploads.github.com:443
+    gist.githubusercontent.com:443
+    ghcr.io:443
+    registry.npmjs.org:443
+    registry.yarnpkg.com:443
+    nodejs.org:443
+    objects-origin.githubusercontent.com:443
+    files.pythonhosted.org:443
+    pypi.org:443
+    pypi.python.org:443
+    pythonhosted.org:443
+    binaries.soliditylang.org:443
+    storage.googleapis.com:443
+    dl.google.com:443
+    registry-1.docker.io:443
+    auth.docker.io:443
+    production.cloudflare.docker.com:443
+    fulcio.sigstore.dev:443
+    rekor.sigstore.dev:443
+    tuf-repo-cdn.sigstore.dev:443
+    oauth2.sigstore.dev:443
+    amazonaws.com:443
+
 jobs:
   analyze:
     name: OpenSSF Scorecard
@@ -28,7 +60,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,6 +17,38 @@ concurrency:
   group: static-analysis-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  HARDEN_RUNNER_EGRESS_POLICY: block
+  HARDEN_RUNNER_ALLOWED_ENDPOINTS: |
+    api.github.com:443
+    github.com:443
+    raw.githubusercontent.com:443
+    objects.githubusercontent.com:443
+    codeload.github.com:443
+    pkg-containers.githubusercontent.com:443
+    uploads.github.com:443
+    gist.githubusercontent.com:443
+    ghcr.io:443
+    registry.npmjs.org:443
+    registry.yarnpkg.com:443
+    nodejs.org:443
+    objects-origin.githubusercontent.com:443
+    files.pythonhosted.org:443
+    pypi.org:443
+    pypi.python.org:443
+    pythonhosted.org:443
+    binaries.soliditylang.org:443
+    storage.googleapis.com:443
+    dl.google.com:443
+    registry-1.docker.io:443
+    auth.docker.io:443
+    production.cloudflare.docker.com:443
+    fulcio.sigstore.dev:443
+    rekor.sigstore.dev:443
+    tuf-repo-cdn.sigstore.dev:443
+    oauth2.sigstore.dev:443
+    amazonaws.com:443
+
 jobs:
   slither:
     name: Slither static analysis
@@ -26,7 +58,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -118,7 +151,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          allowed-endpoints: ${{ env.HARDEN_RUNNER_ALLOWED_ENDPOINTS }}
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -149,6 +183,11 @@ jobs:
         uses: github/codeql-action/analyze@7dccf72e419e51b915f40df725d7c2e766b51b44
         with:
           output: reports/security/codeql
+
+      - name: Upload CodeQL SARIF to security tab
+        uses: github/codeql-action/upload-sarif@755f44910c12a3d7ca0d8c6e42c048b3362f7cec
+        with:
+          sarif_file: reports/security/codeql/*.sarif
 
       - name: Upload CodeQL artefacts
         if: ${{ always() }}

--- a/docs/ci-v2-branch-protection-checklist.md
+++ b/docs/ci-v2-branch-protection-checklist.md
@@ -29,8 +29,15 @@ The job display names in GitHub Actions must stay in sync with these contexts. A
 1. Navigate to **Settings → Branches**.
 2. Edit the rule that applies to `main`.
 3. Under **Require status checks to pass before merging**, verify the seven contexts above appear in the list, in order.
-4. Confirm **Require branches to be up to date before merging** and **Include administrators** are enabled. Both are required for audit compliance.
-5. Capture a screenshot or export the configuration for your change-control records.
+4. Confirm the following toggles are enabled:
+   - **Require branches to be up to date before merging**
+   - **Require linear history**
+   - **Dismiss stale pull request approvals when new commits are pushed**
+   - **Require approvals** with at least one **Code owner review**
+   - **Require conversation resolution before merging**
+   - **Include administrators**
+5. In the **Rules applied to everyone** section, ensure **Restrict who can push to matching branches** only allows GitHub Actions (via the merge queue) and automated service accounts. Human pushes must remain blocked.
+6. Capture a screenshot or export the configuration for your change-control records.
 
 ### 2. Confirm enforcement with the GitHub CLI
 
@@ -64,6 +71,13 @@ gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled
 ### 4. Double-check companion workflows
 
 If your governance policy also requires `e2e`, `fuzz`, `webapp`, or `containers` workflows, repeat the UI and CLI verification to ensure their contexts are enforced. Document any optional workflows in the change ticket associated with the release.
+
+### 5. Validate secret scanning & push protection
+
+1. Navigate to **Settings → Code security and analysis**.
+2. Confirm both **Secret scanning** and **Secret scanning → Push protection** display the "Enabled" badge (green check icon).
+3. If either control is disabled, open a Sev2 governance ticket and enable the feature immediately. Production releases must block commits that expose credentials.
+4. Record screenshots of the enabled state and attach them to the same change ticket that stores the branch protection audit.
 
 ---
 

--- a/docs/security/harden-runner-allowlist.md
+++ b/docs/security/harden-runner-allowlist.md
@@ -1,0 +1,65 @@
+# Harden Runner Egress Allow-List
+
+> **Audience:** Security and DevOps stewards who maintain the GitHub Actions hardening policy for AGI Jobs v0 (v2).
+>
+> **Purpose:** Document the canonical egress domains required for the repository's CI/CD workflows so auditors can verify that the `step-security/harden-runner` allow-list blocks unexpected network traffic without disrupting deterministic builds.
+
+---
+
+## Policy overview
+
+All workflows pin `step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a` and enforce `egress-policy: block`. Every job receives the same allow-list via the `HARDEN_RUNNER_ALLOWED_ENDPOINTS` environment variable. When a new dependency or deployment target is added, update the list in the workflow **and** reflect the change in this document.
+
+The current allow-list covers four categories:
+
+1. **GitHub infrastructure** – required for fetching repository contents, actions, artifacts, and container registries.
+2. **Package registries and toolchains** – Node.js, npm, Foundry, Python, Hardhat, and Solidity binaries.
+3. **Container ecosystem** – Docker Hub, GHCR, and Buildx/QEMU setup.
+4. **Security tooling** – Sigstore (Cosign), OpenSSF Scorecard, and AWS APIs used for explorer credential retrieval.
+
+---
+
+## Approved endpoints
+
+| Category | Endpoint | Justification |
+| --- | --- | --- |
+| GitHub core | `api.github.com:443` | Required for checkout, GitHub API usage, and artifact uploads.【F:.github/workflows/ci.yml†L20-L56】【F:.github/workflows/static-analysis.yml†L1-L111】 |
+| GitHub core | `github.com:443` | Used by `actions/checkout`, Foundry, and git submodules.【F:.github/workflows/ci.yml†L69-L165】 |
+| GitHub content | `raw.githubusercontent.com:443` | Fetches action metadata and Foundry installer scripts.【F:.github/workflows/ci.yml†L132-L165】 |
+| GitHub content | `objects.githubusercontent.com:443` | Provides LFS-backed objects and cached action blobs.【F:.github/workflows/static-analysis.yml†L35-L84】 |
+| GitHub downloads | `codeload.github.com:443` | Needed by `actions/checkout` to download archives.【F:.github/workflows/release.yml†L68-L154】 |
+| GitHub packages | `pkg-containers.githubusercontent.com:443` | Authenticates GHCR pulls for Docker-based jobs.【F:.github/workflows/release.yml†L361-L427】 |
+| GitHub uploads | `uploads.github.com:443` | Enables artifact uploads and release asset publishing.【F:.github/workflows/release.yml†L408-L492】 |
+| GitHub gist | `gist.githubusercontent.com:443` | Required for certain third-party actions that host assets on gists.【F:.github/workflows/scorecard.yml†L20-L52】 |
+| GHCR | `ghcr.io:443` | Pushes signed images for orchestrator, gateway, and webapp deployments.【F:.github/workflows/release.yml†L352-L427】 |
+| npm | `registry.npmjs.org:443` | Supplies all JavaScript dependencies across CI jobs.【F:.github/workflows/ci.yml†L82-L142】 |
+| npm | `registry.yarnpkg.com:443` | Backup domain occasionally used by npm registry CDN.【F:.github/workflows/ci.yml†L82-L142】 |
+| Node.js | `nodejs.org:443` | Provides Node.js binaries when `actions/setup-node` downloads versions from `.nvmrc`.【F:.github/workflows/static-analysis.yml†L31-L47】 |
+| GitHub objects | `objects-origin.githubusercontent.com:443` | Supports fallback downloads for cached action assets.【F:.github/workflows/static-analysis.yml†L31-L47】 |
+| Python | `files.pythonhosted.org:443` | Hosts Python wheels for Slither and tooling installations.【F:.github/workflows/static-analysis.yml†L43-L84】 |
+| Python | `pypi.org:443` | Required for PyPI API queries during pip installs.【F:.github/workflows/static-analysis.yml†L43-L84】 |
+| Python | `pypi.python.org:443` | Legacy alias resolved during some pip transactions.【F:.github/workflows/static-analysis.yml†L43-L84】 |
+| Python | `pythonhosted.org:443` | CDN domain for Python package downloads.【F:.github/workflows/static-analysis.yml†L43-L84】 |
+| Solidity | `binaries.soliditylang.org:443` | Supplies Hardhat and Slither-managed solc binaries.【F:.github/workflows/static-analysis.yml†L47-L80】 |
+| Google CDN | `storage.googleapis.com:443` | Hosts cached Node.js and Foundry assets referenced by GitHub Actions.【F:.github/workflows/ci.yml†L82-L142】 |
+| Google CDN | `dl.google.com:443` | Fallback CDN for Node.js binary downloads.【F:.github/workflows/static-analysis.yml†L31-L47】 |
+| Docker Hub | `registry-1.docker.io:443` | Pulls Trivy scanner images and Buildx base layers.【F:.github/workflows/release.yml†L352-L427】 |
+| Docker Auth | `auth.docker.io:443` | Authenticates Docker Hub requests during image pulls.【F:.github/workflows/release.yml†L352-L427】 |
+| Docker CDN | `production.cloudflare.docker.com:443` | Transfers layer blobs for Docker Hub images.【F:.github/workflows/release.yml†L352-L427】 |
+| Sigstore | `fulcio.sigstore.dev:443` | OIDC certificate authority for Cosign keyless signatures.【F:.github/workflows/release.yml†L408-L472】 |
+| Sigstore | `rekor.sigstore.dev:443` | Transparency log for Cosign keyless signatures.【F:.github/workflows/release.yml†L408-L472】 |
+| Sigstore | `tuf-repo-cdn.sigstore.dev:443` | Hosts Cosign/TUF metadata required for signature verification.【F:.github/workflows/release.yml†L408-L472】 |
+| Sigstore | `oauth2.sigstore.dev:443` | Handles OAuth flows for Sigstore federated identity.【F:.github/workflows/release.yml†L408-L472】 |
+| AWS | `amazonaws.com:443` | Covers AWS APIs (Secrets Manager, STS, S3) used for explorer credential retrieval and provenance storage.【F:.github/workflows/release.yml†L180-L260】 |
+
+> **Important:** If a workflow fails because a new trusted endpoint is blocked, update the allow-list in the workflow and in this table within the same pull request. Security reviewers will reject changes that diverge from this document.
+
+---
+
+## Change control
+
+1. Document any modifications to the allow-list in the pull request description and link to the change ticket in the owner control registry.
+2. Run `npm run ci:verify-toolchain` locally to ensure no unintended network calls are introduced. Pair this with the `--policy block` mode in a dry-run to replicate CI conditions.
+3. Capture the `step-security` summary from the workflow run to prove that only approved endpoints were contacted.
+
+Keeping the egress policy strict and well documented is a critical component of the "best-in-class" institutional deployment posture for AGI Jobs v0 (v2).


### PR DESCRIPTION
## Summary
- enforce block-mode hardened runner allowlists across CI, release, static analysis, contracts, and scorecard workflows
- upload CodeQL SARIF reports to GitHub code scanning and label the CI summary for invariant coverage clarity
- document branch protection prerequisites and the shared hardened runner egress allow-list for auditors

## Testing
- not run (workflow and documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68eb6ec691d083339e701d907637b1fc