### PR TITLE
Harden CI workflows with restricted egress and pinned actions

### DIFF
--- a/.github/workflows/apps-images.yml
+++ b/.github/workflows/apps-images.yml
@@ -27,11 +27,41 @@ jobs:
     outputs:
       digest: ${{ steps.get_digest.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Login to GHCR (main)
         if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -39,7 +69,7 @@ jobs:
 
       - name: Build Console image
         id: build_console
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           file: apps/console/Dockerfile
@@ -87,23 +117,53 @@ jobs:
     outputs:
       digest: ${{ steps.get_digest.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Setup Node for web build
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install root deps
-        run: npm ci
+        run: npm ci --no-audit --prefer-offline --progress=false
 
       - name: Webapp build
         run: npm --prefix apps/enterprise-portal run build
 
       - name: Login to GHCR (main)
         if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -111,7 +171,7 @@ jobs:
 
       - name: Build Portal image
         id: build_portal
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           file: apps/enterprise-portal/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
@@ -72,7 +97,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
@@ -115,7 +165,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
@@ -165,7 +240,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
@@ -219,7 +319,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Publish pipeline summary
         env:
           NEEDS_CONTEXT: ${{ toJson(needs) }}
@@ -260,7 +385,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -46,16 +46,46 @@ jobs:
             file: apps/console/Dockerfile
             tag: owner-console:latest
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
         with:
           driver-opts: network=host
 
@@ -65,7 +95,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -74,7 +104,7 @@ jobs:
       - name: Build (PR, single-arch, load)
         if: github.event_name == 'pull_request'
         id: build-pr
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.file }}
@@ -89,7 +119,7 @@ jobs:
       - name: Build & Push (main/tags, multi-arch, attestations)
         if: github.event_name != 'pull_request'
         id: build-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.file }}
@@ -133,7 +163,7 @@ jobs:
 
       - name: Publish digest artefact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ matrix.image.name }}-digest
           path: digest.txt

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -46,7 +46,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,31 +15,61 @@ concurrency:
 
 jobs:
   orchestrator-e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
       TERM: xterm
       CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-audit --prefer-offline --progress=false
 
       - name: Orchestrator tsc
         run: npx tsc -p apps/orchestrator/tsconfig.json
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
           version: 'v1.4.0'
 
@@ -85,7 +115,7 @@ jobs:
 
       - name: Upload e2e logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: e2e-logs
           path: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,16 +17,46 @@ concurrency:
 
 jobs:
   forge-fuzz:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -35,16 +65,16 @@ jobs:
             **/package-lock.json
 
       - name: Install Node dependencies
-        run: npm ci
+        run: npm ci --no-audit --prefer-offline --progress=false
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
           version: 'v1.4.0'
 
       - name: Cache forge libraries
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: lib
           key: ${{ runner.os }}-foundry-${{ hashFiles('foundry.toml') }}

--- a/.github/workflows/orchestrator-ci.yml
+++ b/.github/workflows/orchestrator-ci.yml
@@ -22,11 +22,41 @@ jobs:
   tsc:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --no-audit --prefer-offline --progress=false
       - name: Orchestrator tsc
         run: npx tsc -p apps/orchestrator/tsconfig.json

--- a/.github/workflows/release-mainnet.yml
+++ b/.github/workflows/release-mainnet.yml
@@ -25,7 +25,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Confirm
         run: |
           test "${{ inputs.confirm }}" = "YES" || { echo "Deployment not confirmed"; exit 1; }
@@ -45,7 +70,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
@@ -166,7 +191,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -314,7 +364,32 @@ jobs:
         if: ${{ steps.npm-token.outputs.publish == 'true' }}
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout
         if: ${{ steps.npm-token.outputs.publish == 'true' }}
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -378,7 +453,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
@@ -453,7 +553,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -26,7 +26,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -118,7 +143,32 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -15,28 +15,58 @@ concurrency:
 
 jobs:
   webapp-ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            index.docker.io:443
+            nodejs.org:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            storage.googleapis.com:443
+            dl.google.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            binaries.soliditylang.org:443
+            solc-bin.ethereum.org:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            oauth2.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
           cache: npm
 
       - name: Install repository dependencies
-        run: npm ci
+        run: npm ci --no-audit --prefer-offline --progress=false
 
       - name: Install console dependencies
-        run: npm ci --prefix apps/console
+        run: npm ci --no-audit --prefer-offline --progress=false --prefix apps/console
 
       - name: Install enterprise portal dependencies
-        run: npm ci --prefix apps/enterprise-portal
+        run: npm ci --no-audit --prefer-offline --progress=false --prefix apps/enterprise-portal
 
       - name: Type-check webapp
         run: npm run webapp:typecheck
@@ -58,7 +88,7 @@ jobs:
 
       - name: Upload webapp artefacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: owner-console-dist
           path: apps/console/dist


### PR DESCRIPTION
## Summary
- enforce block-mode harden-runner controls with an explicit egress allow-list across every workflow
- pin all remaining GitHub Actions (checkout, setup-node, docker helpers, artifacts, foundry, etc.) to audited commit SHAs
- align webapp, e2e, fuzz, and container jobs with production npm flags and Ubuntu 24.04 runners to match institutional deployment requirements

## Testing
- npm run lint *(fails: Solhint warnings exceed configured threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68eb6ec691d083339e701d907637b1fc