### PR TITLE
Add audit dossier export tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ For a printable walkthrough (including remediation steps when a context drifts),
 - [Owner control index](#owner-control-index)
 - [Owner control doctor](#owner-control-doctor)
 - [Owner control audit](#owner-control-audit)
+- [Audit dossier export](#audit-dossier-export)
 - [Owner control systems map](#owner-control-systems-map)
 - [Owner control quick reference CLI](#owner-control-quick-reference-cli)
 - [Owner control snapshot kit](#owner-control-snapshot-kit)
@@ -344,6 +345,16 @@ npm run owner:audit -- --network <network> --out reports/<network>-owner-audit.m
 ```
 
 The CLI loads every module loader used by `owner:update-all`, verifies the JSON manifests parse cleanly, records SHA-256 hashes for `config/agialpha*.json` and `config/owner-control*.json`, and prints a table of owner/governance/token targets with ✅/⚠️/❌ statuses. Each row links to the dedicated Hardhat helper and the relevant operations handbook so the contract owner can adjust parameters without touching Solidity. The Markdown output embeds Mermaid diagrams, actionable remediation notes and copy/paste commands, while `--format human` and `--format json` support chat summaries and automation pipelines respectively. Full usage guidance lives in [docs/owner-control-audit.md](docs/owner-control-audit.md).
+
+### Audit dossier export
+
+Preparing for an external security review? Generate the complete verifier package mirrored by the CI v2 workflow with a single command:
+
+```bash
+npm run audit:dossier
+```
+
+The helper wraps linting, unit tests, coverage, dependency audits, ABI diffing, owner-control validation, and optional Foundry/Slither checks into timestamped logs under `reports/audit`. The process is documented in [docs/AUDIT_DOSSIER.md](docs/AUDIT_DOSSIER.md) so auditors receive a deterministic bundle of artefacts alongside reproducible commands.
 
 ### Owner control systems map
 

--- a/docs/AUDIT_DOSSIER.md
+++ b/docs/AUDIT_DOSSIER.md
@@ -1,0 +1,100 @@
+# AGI Jobs v0 Audit Dossier
+
+This guide packages the exact evidence bundle requested for the "Recommended Next Coding Sprint: External Audit & Final Verification" milestone. It is written for third-party security auditors and internal reviewers that need to recreate the full verification state of the protocol without hunting through the repository.
+
+The repository already enforces a **green v2 CI** pipeline (`.github/workflows/ci.yml`) that executes linting, tests, coverage validation, ABI checks, and Foundry fuzzing. The instructions below mirror that workflow locally while also capturing artefacts (logs, JSON reports) in a single export directory suitable for hand-off.
+
+## 1. Prerequisites
+
+* Node.js 20.18.1 (automatically checked by the export script).
+* `npm` (comes with Node.js).
+* Optional but recommended: [Foundry](https://book.getfoundry.sh/getting-started/installation) (`forge` on the `PATH`) and [Slither](https://github.com/crytic/slither) for extended static analysis. The export script gracefully skips these steps if the tools are not present, while logging the omission.
+* Docker is **not** required for the base dossier export. Echidna and other heavy fuzzers are already covered via the existing CI workflows and can be run separately if an auditor requests them.
+
+## 2. Running the automated export
+
+Execute the helper script to generate a complete dossier:
+
+```bash
+npm run audit:dossier
+```
+
+The script performs the following actions in a hardened order and stores the logs in `reports/audit/logs`:
+
+1. Capture toolchain fingerprints (`node -v`, `npm -v`).
+2. Install reproducible dependencies (`npm ci`).
+3. Run Solidity + TypeScript linting (`npm run lint:ci`).
+4. Regenerate protocol constants and compile the contracts (Hardhat).
+5. Execute the Hardhat unit-test suite (`npm test`).
+6. Check ABI compatibility drift (`npm run abi:diff`).
+7. Produce coverage and access-control reports (`npm run coverage`, `npm run check:access-control`).
+8. Perform dependency vulnerability scanning (`npm run security:audit`).
+9. Prove the contract owner retains full operational control (`npm run owner:verify-control`).
+10. Optionally run Foundry-based fuzz/property tests and Slither analysis when available.
+
+Each step writes a structured log file and contributes to `reports/audit/summary.json`, which lists the status (`passed`, `failed`, or `skipped`) alongside the command that was executed. A failure aborts the export immediately and makes the failing log trivial to locate.
+
+## 3. Artefacts produced
+
+* `reports/audit/logs/*.log` &mdash; raw execution logs for every step, prepended with timestamps and commands for forensic traceability.
+* `reports/audit/summary.json` &mdash; machine-readable overview containing commit hash, branch, generation timestamp, and step status entries.
+* `reports/audit/slither.json` (optional) &mdash; emitted when Slither is installed to capture high/medium/low findings using Crytic's JSON schema.
+
+These files, combined with the existing coverage HTML output (`coverage/`), provide auditors with an immutable snapshot of the repository state.
+
+## 4. Manual validation checklist
+
+In addition to the automated export, auditors should review the following manual artefacts:
+
+| Area | Evidence | Location |
+| ---- | -------- | -------- |
+| Governance & owner controls | Runbooks and CLI automation demonstrating parameter changes, pausing, emergency workflows | `scripts/v2/owner*` commands (see Section 5) |
+| Deployment manifests | Deterministic contract manifests and post-deploy diffing utilities | `reports/`, `scripts/release/*` |
+| Monitoring & observability | Sentinel templates, validation scripts, tabletop incident drills | `monitoring/`, `scripts/observability-smoke-check.js`, `scripts/security/run-tabletop.ts` |
+| Formal safety nets | Property-based tests (`foundry` profiles), Echidna harnesses (`echidna/`), access-control coverage gates | `fuzz/`, `test/`, `.github/workflows/fuzz.yml` |
+
+## 5. Owner control capabilities (audit focus)
+
+The AGI Jobs v0 contracts expose a comprehensive owner/governance interface. The following commands demonstrate key invariants requested by the project owner:
+
+```bash
+# Summarise all governance-controlled parameters and their mutability
+npm run owner:parameters
+
+# Produce a machine-readable owner control matrix for audit sign-off
+npm run owner:verify-control
+
+# Emit the emergency pause runbook (pausing/unpausing, failover paths)
+npm run owner:emergency
+
+# Visualise module ownership and delegation graph for the committee/multisig
+npm run owner:diagram
+
+# Run an automated health check that fails if any module cannot be updated
+npm run owner:health
+```
+
+These scripts run without requiring private keys and verify, via call-static simulations, that governance retains the ability to adjust fees, validator requirements, thermodynamic thresholds, and pause/unpause the protocol. They also assert that control is **not** delegated to unknown addresses, satisfying the requirement that the contract owner can modify every relevant parameter.
+
+## 6. CI & branch protection enforcement
+
+The `ci (v2)` workflow (`.github/workflows/ci.yml`) is required on both `main` and pull requests. The branch protection check is verified by `npm run ci:verify-branch-protection`, ensuring external contributors cannot merge code that bypasses the audit gate. The audit dossier export mirrors this configuration locally so auditors can pre-validate changes before raising PRs.
+
+## 7. Suggested audit hand-off package
+
+When freezing the code for audit:
+
+1. Run `npm run audit:dossier` and archive the generated `reports/audit` directory together with the coverage HTML and gas snapshots.
+2. Include the latest `reports/release-manifest.json` and `reports/sbom/cyclonedx.json` if supply-chain review is requested.
+3. Attach the `docs/` folder, especially this dossier and the existing deployment & runbook documentation.
+4. Share the `README.md` sections covering architecture, monitoring, and incident response with auditors.
+
+This package, plus the automated logs, satisfies the "External Audit & Final Verification" readiness checklist.
+
+## 8. Continuous improvement hooks
+
+* Any audit finding should result in a failing unit test or invariant that reproduces the issue. Add it to the repository before shipping the fix.
+* Update `reports/audit/summary.json` whenever re-running the dossier so auditors can diff successive exports.
+* Extend the export script with additional steps (e.g., `npm run gas:check`, testnet dry-run scripts) as the deployment team finalises the release rehearsal.
+
+By following this guide, teams can present auditors with a deterministic, reproducible dossier that demonstrates production readiness at institutional scale.

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "alpha-bridge:start": "node services/alpha-bridge/src/server.js",
     "alpha-bridge:test": "node --test services/alpha-bridge/test/alpha-bridge.test.js",
     "validator:cli": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/validator/cli.ts",
-    "hamiltonian:report": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/hamiltonian-tracker.ts"
+    "hamiltonian:report": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/hamiltonian-tracker.ts",
+    "audit:dossier": "bash scripts/audit/export-dossier.sh"
   },
   "keywords": [],
   "author": "",

--- a/scripts/audit/export-dossier.sh
+++ b/scripts/audit/export-dossier.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+OUTPUT_DIR="$ROOT_DIR/reports/audit"
+LOG_DIR="$OUTPUT_DIR/logs"
+SUMMARY_FILE="$OUTPUT_DIR/summary.json"
+
+mkdir -p "$LOG_DIR"
+
+echo "=== AGI Jobs v0 Audit Dossier Export ==="
+echo "Root directory: $ROOT_DIR"
+echo "Artifacts directory: $OUTPUT_DIR"
+echo "Timestamp: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+declare -a SUMMARY_ENTRIES
+
+log_step() {
+  local step_name="$1"
+  shift
+  local log_path="$LOG_DIR/${step_name// /_}.log"
+
+  echo "\n--- Running: $step_name ---"
+  echo "Command: $*"
+  {
+    echo "# $step_name"
+    echo "# Command: $*"
+    echo "# Started: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  } >"$log_path"
+
+  if "$@" | tee -a "$log_path"; then
+    echo "# Completed: $(date -u '+%Y-%m-%dT%H:%M:%SZ')" >>"$log_path"
+    SUMMARY_ENTRIES+=("{\"step\":\"$step_name\",\"status\":\"passed\",\"log\":\"logs/${step_name// /_}.log\"}")
+  else
+    status=$?
+    echo "# Failed: $(date -u '+%Y-%m-%dT%H:%M:%SZ')" >>"$log_path"
+    SUMMARY_ENTRIES+=("{\"step\":\"$step_name\",\"status\":\"failed\",\"code\":$status,\"log\":\"logs/${step_name// /_}.log\"}")
+    echo "Step '$step_name' failed with exit code $status. See $log_path for details." >&2
+    exit $status
+  fi
+}
+
+pushd "$ROOT_DIR" >/dev/null
+
+log_step "Node toolchain fingerprint" node -v
+log_step "NPM toolchain fingerprint" npm -v
+
+log_step "Install dependencies" npm ci --no-audit --prefer-offline --progress=false
+
+log_step "Static analysis" npm run lint:ci
+
+log_step "Contracts compile" npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
+log_step "Hardhat compile" npx hardhat compile
+
+log_step "Unit tests" npm test
+
+log_step "ABI diff" npm run abi:diff
+
+log_step "Coverage" npm run coverage
+log_step "Access control coverage" npm run check:access-control
+
+log_step "Security audit-ci" npm run security:audit
+
+log_step "Owner control verification" npm run owner:verify-control
+
+if command -v forge >/dev/null 2>&1; then
+  log_step "Foundry tests" forge test -vvvv --ffi --fuzz-runs 256
+else
+  echo "Forge not found on PATH, skipping Foundry tests step." | tee "$LOG_DIR/Foundry_tests.log"
+  SUMMARY_ENTRIES+=("{\"step\":\"Foundry tests\",\"status\":\"skipped\",\"log\":\"logs/Foundry_tests.log\",\"note\":\"forge not installed\"}")
+fi
+
+if command -v slither >/dev/null 2>&1; then
+  log_step "Slither static analysis" slither . --fail-high --checklist --json "$OUTPUT_DIR/slither.json"
+else
+  echo "Slither not found on PATH, skipping Slither step." | tee "$LOG_DIR/Slither_static_analysis.log"
+  SUMMARY_ENTRIES+=("{\"step\":\"Slither static analysis\",\"status\":\"skipped\",\"log\":\"logs/Slither_static_analysis.log\",\"note\":\"slither not installed\"}")
+fi
+
+cat >"$SUMMARY_FILE" <<JSON
+{
+  "generatedAt": "$(date -u '+%Y-%m-%dT%H:%M:%SZ')",
+  "commit": "$(git rev-parse HEAD)",
+  "branch": "$(git rev-parse --abbrev-ref HEAD)",
+  "steps": [
+    $(IFS=,; echo "${SUMMARY_ENTRIES[*]}")
+  ]
+}
+JSON
+
+echo "\nDossier summary written to $SUMMARY_FILE"
+echo "Logs available in $LOG_DIR"
+
+popd >/dev/null


### PR DESCRIPTION
## Summary
- add an audit dossier export script that reproduces the v2 CI checks, captures logs, and builds a structured summary
- document the export workflow and owner-control verification focus for external auditors
- expose the helper via npm scripts and surface it in the README navigation

## Testing
- npm run lint:ci
- bash -n scripts/audit/export-dossier.sh

------
https://chatgpt.com/codex/tasks/task_e_68ebab6978488333ae199b73c810c41e