### PR TITLE
Add audit freeze guardrail and external verification playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ scripts/**/*.js
 !scripts/subgraph-e2e.js
 !scripts/docs/check-links.js
 !scripts/observability-smoke-check.js
+!scripts/audit/check-freeze.js
 !scripts/release/generate-manifest.js
 !scripts/release/generate-release-notes.js
 !scripts/release/render-manifest-summary.js

--- a/docs/AUDIT_DOSSIER.md
+++ b/docs/AUDIT_DOSSIER.md
@@ -1,6 +1,6 @@
 # AGI Jobs v0 Audit Dossier
 
-This guide packages the exact evidence bundle requested for the "Recommended Next Coding Sprint: External Audit & Final Verification" milestone. It is written for third-party security auditors and internal reviewers that need to recreate the full verification state of the protocol without hunting through the repository.
+This guide packages the exact evidence bundle requested for the "Recommended Next Coding Sprint: External Audit & Final Verification" milestone. It is written for third-party security auditors and internal reviewers that need to recreate the full verification state of the protocol without hunting through the repository. Pair this dossier with the [External Audit & Final Verification Playbook](audit/final-verification-playbook.md) and the `npm run audit:freeze` guardrail to ensure the repository is code-frozen before artefacts are minted.【F:scripts/audit/check-freeze.js†L1-L86】【F:package.json†L10-L101】
 
 The repository already enforces a **green v2 CI** pipeline (`.github/workflows/ci.yml`) that executes linting, tests, coverage validation, ABI checks, and Foundry fuzzing. The instructions below mirror that workflow locally while also capturing artefacts (logs, JSON reports) in a single export directory suitable for hand-off.
 

--- a/docs/audit/final-verification-playbook.md
+++ b/docs/audit/final-verification-playbook.md
@@ -1,0 +1,39 @@
+# External Audit & Final Verification Playbook
+
+> **Audience.** Release managers, security leads, and contract owners preparing AGI Jobs v2 for external audit certification and production deployment.
+>
+> **Outcome.** Every checklist item from the "Recommended Next Coding Sprint: External Audit & Final Verification" mandate is executable with one command or referenced runbook, producing audit-grade artefacts for non-technical reviewers.
+
+## 1. Audit Preparation & Code Freeze
+
+1. **Lock the freeze branch.** Run `npm run audit:freeze` from a clean checkout of `main` to enforce branch parity, clean working tree, and upstream synchronisation. Configure a different branch with `AUDIT_FREEZE_BRANCH=<branch>` or bypass branch enforcement only when mirroring the audit staging branch (`AUDIT_FREEZE_ALLOW_BRANCH=1`).【F:scripts/audit/check-freeze.js†L1-L86】【F:package.json†L10-L101】
+2. **Capture the dossier.** Execute `npm run audit:dossier` to export the Slither report, coverage snapshots, dependency audits, and structured logs into `reports/audit` for hand-off to auditors.【F:docs/AUDIT_DOSSIER.md†L3-L92】【F:package.json†L10-L101】
+3. **Freeze documentation pointers.** Update the change ticket with the dossier hash and link to the owner audit evidence (`npm run owner:audit -- --network <net>`). Follow the archival flow in the owner audit guide to prevent drift.【F:docs/owner-control-audit.md†L26-L114】
+4. **Pause new feature work.** Announce a code-freeze window referencing this playbook. Only emergency fixes with accompanying audit artefacts may merge until auditors sign off.
+
+## 2. Support Auditors & Issue Remediation
+
+* **On-call triage.** Keep the security & governance team on a shared channel with the auditors. Provide the [audit dossier](../AUDIT_DOSSIER.md) and the owner control atlas for protocol architecture context.【F:docs/AUDIT_DOSSIER.md†L3-L206】【F:docs/owner-control-atlas.md†L1-L210】
+* **Fast-turn patches.** Treat every audit finding as high severity. Patch using small, reviewable PRs, regenerate the dossier, and attach owner audit outputs to the remediation ticket for a tamper-evident trail.【F:docs/owner-control-change-ticket.md†L1-L119】
+* **Regression coverage.** Extend Foundry/Hardhat property tests or add targeted unit tests for each remediation. Re-run `npm run coverage:report` to prove no invariant regressions.【F:test/README.md†L1-L120】【F:package.json†L10-L101】
+
+## 3. Formal Verification of Critical Invariants (Optional)
+
+* **Instrument invariants.** Apply Scribble or Verx annotations around staking, treasury, and pause flows. The invariants documented in the property-based testing suite offer the baseline specification.【F:contracts/v2/StakeManager.sol†L1-L400】【F:contracts/v2/SystemPause.sol†L1-L250】
+* **Traceability.** Archive the verification proofs beside the audit dossier. Cross-reference the invariant IDs in the change ticket to make the assurance evidence easy to audit.【F:docs/owner-control-audit.md†L92-L114】
+
+## 4. Testnet Deployment & Dry-Run
+
+1. **Deploy the audited artefacts.** Follow the mainnet deployment runbook on Sepolia/Goerli using the documented scripts (`npm run deploy:oneclick` or `npm run migrate:sepolia`). Capture emitted addresses in the deployment manifest.【F:docs/RUNBOOK.md†L4-L83】【F:docs/deployment-production-guide.md†L118-L158】【F:package.json†L10-L101】
+2. **Exercise owner control.** Walk through the owner command centre (`npm run owner:command-center -- --network <net>`), pause/unpause flows (`npm run pause:test`), and parameter updates to demonstrate complete owner authority with audit trails.【F:docs/owner-control-parameter-playbook.md†L1-L86】【F:package.json†L10-L101】【F:contracts/v2/SystemPause.sol†L1-L250】
+3. **Scenario validation.** Reproduce the dispute, validation, and staking flows using the orchestrator and CLI scripts. Log results in `reports/<network>/` and attach them to the release verification summary.【F:docs/release-explorer-verification.md†L21-L110】【F:docs/production-deployment-handbook.md†L204-L208】
+
+## 5. Post-Audit Hardening & Sign-Off
+
+* **Configuration parity.** Compare multisig, timelock, and treasury addresses against the governance manifests before mainnet promotion. Use `npm run owner:verify-control` to confirm on-chain state matches the approved configuration.【F:package.json†L10-L101】【F:docs/owner-control-verification.md†L3-L88】
+* **Monitoring updates.** Run `npm run monitoring:validate` and refresh the sentinel dashboards to ensure alerts cover any new runtime checks recommended by auditors.【F:package.json†L10-L101】【F:monitoring/prometheus/rules.yaml†L1-L33】
+* **Final approval.** Once auditors clear all findings, lift the code freeze via a signed change-ticket entry and tag the release with the manifest, dossier, and verification outputs bundled for institutional compliance.【F:docs/release-manifest.md†L3-L86】【F:docs/owner-control-zero-downtime-guide.md†L47-L206】
+
+---
+
+By following this playbook the protocol team guarantees an auditable, repeatable pathway from code-freeze to post-audit hardening, matching institutional expectations for production readiness.

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "alpha-bridge:test": "node --test services/alpha-bridge/test/alpha-bridge.test.js",
     "validator:cli": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/validator/cli.ts",
     "hamiltonian:report": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/hamiltonian-tracker.ts",
+    "audit:freeze": "node scripts/audit/check-freeze.js",
     "audit:dossier": "bash scripts/audit/export-dossier.sh"
   },
   "keywords": [],

--- a/scripts/audit/check-freeze.js
+++ b/scripts/audit/check-freeze.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+
+function run(command) {
+  return execSync(command, { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' }).trim();
+}
+
+function fail(message, extra = {}) {
+  const payload = { status: 'failed', reason: message, ...extra };
+  console.error(`\n❌  audit:freeze check failed\n${JSON.stringify(payload, null, 2)}\n`);
+  process.exit(1);
+}
+
+function ok(summary) {
+  console.log(`\n✅  audit:freeze ready\n${JSON.stringify(summary, null, 2)}\n`);
+}
+
+function main() {
+  const expectedBranch = process.env.AUDIT_FREEZE_BRANCH || 'main';
+  const allowBranchOverride = process.env.AUDIT_FREEZE_ALLOW_BRANCH === '1';
+  const allowDirty = process.env.AUDIT_FREEZE_ALLOW_DIRTY === '1';
+
+  let branch;
+  try {
+    branch = run('git rev-parse --abbrev-ref HEAD');
+  } catch (error) {
+    fail('Unable to determine current branch. Ensure git is installed and repository is accessible.');
+  }
+
+  if (!allowBranchOverride && branch !== expectedBranch) {
+    fail('Current branch does not match expected freeze branch.', { branch, expectedBranch });
+  }
+
+  let status;
+  try {
+    status = run('git status --porcelain --untracked-files=all');
+  } catch (error) {
+    fail('Unable to read git status. Ensure repository is not in the middle of a merge/rebase.');
+  }
+
+  if (!allowDirty && status.length > 0) {
+    const files = status.split('\n').filter(Boolean).slice(0, 20);
+    fail('Working tree must be clean before initiating the audit freeze.', { dirtyFiles: files });
+  }
+
+  let upstream = null;
+  try {
+    upstream = run('git rev-parse --abbrev-ref --symbolic-full-name @{u}');
+  } catch (error) {
+    upstream = null;
+  }
+
+  if (upstream) {
+    try {
+      run('git remote update --prune');
+    } catch (error) {
+      if (process.env.AUDIT_FREEZE_IGNORE_FETCH !== '1') {
+        fail('Failed to fetch remote updates. Set AUDIT_FREEZE_IGNORE_FETCH=1 to skip this check in air-gapped environments.');
+      }
+    }
+
+    if (process.env.AUDIT_FREEZE_IGNORE_FETCH !== '1') {
+      const divergence = run(`git rev-list --left-right --count ${upstream}...HEAD`);
+      const [behindStr, aheadStr] = divergence.split('\t');
+      const behind = Number.parseInt(behindStr, 10);
+      const ahead = Number.parseInt(aheadStr, 10);
+      if (Number.isFinite(behind) && behind > 0) {
+        fail('Local branch is behind upstream. Pull the latest audited commit before freezing.', { upstream, behind, ahead });
+      }
+      if (Number.isFinite(ahead) && ahead > 0) {
+        fail('Local branch has unpushed commits. Push or archive them before the audit freeze.', { upstream, ahead, behind });
+      }
+    }
+  }
+
+  ok({
+    branch,
+    expectedBranch,
+    upstream: upstream || 'none',
+    fetched: process.env.AUDIT_FREEZE_IGNORE_FETCH === '1' ? 'skipped' : Boolean(upstream),
+    clean: status.length === 0,
+  });
+}
+
+main();


### PR DESCRIPTION
## Summary
- add an explicit audit freeze CLI guardrail and expose it via npm scripts for auditors
- document the full external audit and final verification runbook aligned with the sprint brief
- cross-link the dossier guide to the new playbook and whitelist the helper script in version control

## Testing
- AUDIT_FREEZE_ALLOW_BRANCH=1 AUDIT_FREEZE_ALLOW_DIRTY=1 AUDIT_FREEZE_IGNORE_FETCH=1 node scripts/audit/check-freeze.js

------
https://chatgpt.com/codex/tasks/task_e_68ebb94a934083338d4bff77e2084f15