### PR TITLE
Add external audit launch kit generator

### DIFF
--- a/docs/AUDIT_DOSSIER.md
+++ b/docs/AUDIT_DOSSIER.md
@@ -11,6 +11,8 @@ The repository already enforces a **green v2 CI** pipeline (`.github/workflows/c
 * Optional but recommended: [Foundry](https://book.getfoundry.sh/getting-started/installation) (`forge` on the `PATH`) and [Slither](https://github.com/crytic/slither) for extended static analysis. The export script gracefully skips these steps if the tools are not present, while logging the omission.
 * Docker is **not** required for the base dossier export. Echidna and other heavy fuzzers are already covered via the existing CI workflows and can be run separately if an auditor requests them.
 
+For a frozen snapshot of the overall launch plan, run `npm run audit:kit` (documented in [docs/audit/external-audit-launch-kit.md](audit/external-audit-launch-kit.md)) to generate a Markdown checklist before minting the dossier. The launch kit references every command below and keeps auditors aligned on scope.
+
 ## 2. Running the automated export
 
 Execute the helper script to generate a complete dossier (or invoke the orchestrator with `npm run audit:final -- --with-dossier` to run branch-protection and owner-control checks first):

--- a/docs/audit/external-audit-launch-kit.md
+++ b/docs/audit/external-audit-launch-kit.md
@@ -1,0 +1,50 @@
+# External Audit Launch Kit
+
+This document complements the [External Audit & Final Verification Playbook](final-verification-playbook.md) by providing a single command that emits the entire checklist in ready-to-share Markdown. It is targeted at non-technical release managers who need to freeze the repository, brief auditors, and ship artefacts without editing code.
+
+## Quickstart
+
+```bash
+npm run audit:kit -- --output reports/audit/launch-kit.md
+```
+
+The command:
+
+1. Generates a timestamped launch kit covering every stage of the "Recommended Next Coding Sprint: External Audit & Final Verification" mandate.
+2. Produces Markdown with checkbox lists, command references, and artefact expectations so coordinators can track completion at a glance.
+3. Accepts `--format json` for automation pipelines that want to ingest the same structure programmatically.
+4. Refuses to overwrite existing files unless you pass `--force`, preventing accidental loss of annotated launch kits.
+
+The generated Markdown references:
+
+- `npm run audit:freeze` and `npm run audit:final -- --full` to guarantee the repository is frozen and the CI v2 guardrails are green.
+- `npm run audit:dossier` to capture the auditor hand-off bundle described in [docs/AUDIT_DOSSIER.md](../AUDIT_DOSSIER.md).
+- `npm run owner:verify-control` and `npm run monitoring:validate` to prove the contract owner retains full control and that monitoring hooks are live.
+
+## Regeneration workflow
+
+Run the command every time you:
+
+- Enter or exit a freeze window.
+- Address an audit finding.
+- Update branch protection, owner control manifests, or monitoring dashboards.
+
+Store the rendered Markdown beside the dossier summary (`reports/audit/summary.json`) so auditors can diff successive launch kits. The JSON format is safe to ingest into ticketing systems for automated sign-off gates.
+
+## Parameters
+
+| Flag | Description |
+| --- | --- |
+| `--output <file>` | Write the launch kit to a file instead of stdout. |
+| `--format json` | Emit structured JSON (default is Markdown). |
+| `--force` | Overwrite an existing file specified by `--output`. |
+
+If you omit `--output`, the script prints the kit to stdout so you can preview the content or pipe it into other tooling.
+
+## Operational notes
+
+- Always run `npm run audit:freeze` immediately before generating the launch kit to ensure branch parity and a clean worktree.
+- Capture the git commit hash in your change ticket alongside the generated Markdown for immutable traceability.
+- Attach the launch kit to the shared audit folder so third-party reviewers can follow the exact state transitions you executed.
+
+By pairing this launch kit generator with the playbook, the team achieves repeatable, auditable readiness for an external security review while keeping the contract owner firmly in control of every parameter.

--- a/docs/audit/final-verification-playbook.md
+++ b/docs/audit/final-verification-playbook.md
@@ -4,6 +4,8 @@
 >
 > **Outcome.** Every checklist item from the "Recommended Next Coding Sprint: External Audit & Final Verification" mandate is executable with one command or referenced runbook, producing audit-grade artefacts for non-technical reviewers.
 
+Before starting, generate a launch kit with `npm run audit:kit -- --output reports/audit/launch-kit.md` so coordinators and auditors share the same checklist snapshot. The generator wraps the steps below into ready-to-share Markdown with checkboxes, references, and artefact expectations.
+
 ## 1. Audit Preparation & Code Freeze
 
 1. **Automated readiness sweep.** Launch `npm run audit:final -- --full` to chain the freeze guard, branch-protection verification, owner control proof, and dossier export into a single, auditable run. Use `npm run audit:final -- --with-owner-check` or `npm run audit:final -- --with-dossier` to run individual heavy steps, and `npm run audit:final -- --dry-run` to preview commands without executing them.【F:scripts/audit/final-readiness.ts†L1-L214】【F:package.json†L10-L101】

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
     "hamiltonian:report": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/hamiltonian-tracker.ts",
     "audit:freeze": "node scripts/audit/check-freeze.js",
     "audit:final": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/audit/final-readiness.ts",
-    "audit:dossier": "bash scripts/audit/export-dossier.sh"
+    "audit:dossier": "bash scripts/audit/export-dossier.sh",
+    "audit:kit": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/audit/generate-audit-kit.ts"
   },
   "keywords": [],
   "author": "",

--- a/scripts/audit/generate-audit-kit.ts
+++ b/scripts/audit/generate-audit-kit.ts
@@ -1,0 +1,304 @@
+#!/usr/bin/env ts-node
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+type OutputFormat = "markdown" | "json";
+
+type Section = {
+  title: string;
+  description?: string;
+  checklist: string[];
+};
+
+type CommandEntry = {
+  label: string;
+  command: string;
+  reference: string;
+};
+
+type AuditKit = {
+  generatedAt: string;
+  repository: string;
+  format: OutputFormat;
+  sections: Section[];
+  commands: CommandEntry[];
+  artefacts: string[];
+};
+
+function printHelp(): void {
+  console.log(
+    "Usage: npm run audit:kit [--output <file>] [--format markdown|json] [--force]\n\n" +
+      "Generates a consolidated External Audit Launch Kit that packages the critical\n" +
+      "checklists, commands, and artefact expectations demanded by the\n" +
+      '"Recommended Next Coding Sprint: External Audit & Final Verification" brief.'
+  );
+}
+
+function parseArgs(): {
+  outputPath?: string;
+  format: OutputFormat;
+  force: boolean;
+} {
+  const args = process.argv.slice(2);
+  const result: { outputPath?: string; format: OutputFormat; force: boolean } = {
+    format: "markdown",
+    force: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    switch (arg) {
+      case "--output": {
+        const value = args[i + 1];
+        if (!value) {
+          throw new Error("--output requires a value");
+        }
+        result.outputPath = value;
+        i += 1;
+        break;
+      }
+      case "--format": {
+        const value = args[i + 1];
+        if (value !== "markdown" && value !== "json") {
+          throw new Error("--format must be 'markdown' or 'json'");
+        }
+        result.format = value;
+        i += 1;
+        break;
+      }
+      case "--force":
+        result.force = true;
+        break;
+      case "-h":
+      case "--help":
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return result;
+}
+
+function resolveRepo(): string {
+  const envRepo = process.env.GITHUB_REPOSITORY;
+  if (envRepo) {
+    return envRepo;
+  }
+
+  try {
+    const { execSync } = require("node:child_process");
+    const origin = execSync("git config --get remote.origin.url", {
+      encoding: "utf8",
+    })
+      .trim()
+      .replace(/\.git$/, "");
+
+    if (origin.includes("github.com")) {
+      const cleaned = origin
+        .replace(/^git@github.com:/, "")
+        .replace(/^https:\/\/github.com\//, "");
+      return cleaned;
+    }
+  } catch (error) {
+    console.warn(
+      `Warning: unable to determine repository from git remote (${(error as Error).message}).`
+    );
+  }
+
+  return "MontrealAI/AGIJobsv0";
+}
+
+function buildKit(format: OutputFormat): AuditKit {
+  const generatedAt = new Date().toISOString();
+  const repository = resolveRepo();
+
+  const sections: Section[] = [
+    {
+      title: "Audit Preparation & Code Freeze",
+      description:
+        "Execute the freeze guardrails and capture the dossier before auditors begin.",
+      checklist: [
+        "Run `npm run audit:freeze` from a clean `main` checkout to assert branch parity and cleanliness.",
+        "Execute `npm run audit:final -- --full` to chain the freeze guard, branch protection verification, owner control proof, and dossier export.",
+        "Record the generated dossier hash and attach it to the owner control change ticket for tamper-evident traceability.",
+        "Announce the code-freeze window. Only ship emergency fixes with regenerated dossier artefacts until the audit concludes.",
+      ],
+    },
+    {
+      title: "Support Auditors & Issue Remediation",
+      description:
+        "Keep remediation loops short and auditable when findings arrive.",
+      checklist: [
+        "Share `docs/AUDIT_DOSSIER.md` and `docs/owner-control-atlas.md` with auditors for architecture context.",
+        "For every finding, ship a focused PR with reproducing tests and rerun `npm run audit:dossier` before merging.",
+        "Attach owner-control verification output to remediation tickets so governance retains full visibility.",
+      ],
+    },
+    {
+      title: "Optional Formal Verification",
+      description:
+        "Supplement property tests with formal proofs on the pause, staking, and treasury invariants.",
+      checklist: [
+        "Instrument Scribble or Verx specifications around `StakeManager`, `FeePool`, and `SystemPause`.",
+        "Archive generated proofs alongside the audit dossier and reference them from the change ticket.",
+      ],
+    },
+    {
+      title: "Testnet Deployment & Dry-Run",
+      description:
+        "Rehearse the production deployment on Sepolia/Goerli with the audited artefacts.",
+      checklist: [
+        "Deploy using `npm run deploy:oneclick` or `npm run migrate:sepolia` and capture manifests in `reports/<network>/`.",
+        "Exercise pause/unpause and parameter edits via `npm run owner:command-center -- --network <net>` and `npm run pause:test`.",
+        "Validate orchestrator workflows end-to-end and archive CLI outputs for later comparison with mainnet runs.",
+      ],
+    },
+    {
+      title: "Post-Audit Hardening & Sign-Off",
+      description:
+        "Reconfirm production configuration and monitoring before lifting the freeze.",
+      checklist: [
+        "Compare governance addresses against manifests using `npm run owner:verify-control`.",
+        "Refresh monitoring hooks with `npm run monitoring:validate` and propagate any new alerts.",
+        "Lift the freeze only after tagging the release with dossier, manifest, and verification artefacts attached.",
+      ],
+    },
+  ];
+
+  const commands: CommandEntry[] = [
+    {
+      label: "Freeze guardrail",
+      command: "npm run audit:freeze",
+      reference: "docs/audit/final-verification-playbook.md#1-audit-preparation--code-freeze",
+    },
+    {
+      label: "End-to-end readiness sweep",
+      command: "npm run audit:final -- --full",
+      reference: "scripts/audit/final-readiness.ts",
+    },
+    {
+      label: "Export dossier",
+      command: "npm run audit:dossier",
+      reference: "docs/AUDIT_DOSSIER.md",
+    },
+    {
+      label: "Verify owner control",
+      command: "npm run owner:verify-control",
+      reference: "docs/owner-control-parameter-playbook.md",
+    },
+    {
+      label: "Validate monitoring",
+      command: "npm run monitoring:validate",
+      reference: "monitoring/prometheus/rules.yaml",
+    },
+  ];
+
+  const artefacts = [
+    "`reports/audit/` — Logs, summary.json, and optional Slither output from the dossier export.",
+    "`reports/release-manifest.json` — Deterministic manifest for the audited deployment.",
+    "`coverage/` & gas snapshots — Coverage HTML, access-control metrics, and gas baselines for diffing.",
+    "`docs/` selections — Especially the owner-control suite, deployment runbooks, and monitoring guides for non-technical reviewers.",
+  ];
+
+  return { generatedAt, repository, format, sections, commands, artefacts };
+}
+
+function renderMarkdown(kit: AuditKit): string {
+  const lines: string[] = [];
+  lines.push("# AGI Jobs v0 — External Audit Launch Kit");
+  lines.push("");
+  lines.push(`Generated: ${kit.generatedAt}`);
+  lines.push(`Repository: ${kit.repository}`);
+  lines.push("");
+  lines.push(
+    "> This launch kit distils the external audit sprint requirements into an actionable" +
+      " checklist for non-technical coordinators. Follow it alongside the detailed" +
+      " [External Audit & Final Verification Playbook](docs/audit/final-verification-playbook.md) to keep the codebase frozen," +
+      " prove owner control, and ship audit artefacts without drift."
+  );
+  lines.push("");
+
+  for (const section of kit.sections) {
+    lines.push(`## ${section.title}`);
+    if (section.description) {
+      lines.push("");
+      lines.push(section.description);
+    }
+    lines.push("");
+    for (const item of section.checklist) {
+      lines.push(`- [ ] ${item}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Command Reference");
+  lines.push("");
+  lines.push("| Task | Command | Reference |");
+  lines.push("| --- | --- | --- |");
+  for (const entry of kit.commands) {
+    lines.push(`| ${entry.label} | \`$ ${entry.command}\` | ${entry.reference} |`);
+  }
+  lines.push("");
+
+  lines.push("## Artefact Bundle Checklist");
+  lines.push("");
+  for (const artefact of kit.artefacts) {
+    lines.push(`- [ ] ${artefact}`);
+  }
+  lines.push("");
+
+  lines.push(
+    "Once the checkboxes above are marked complete, capture the rendered Markdown, bundle the artefacts, and hand the package to the external auditors along with the CI v2 status page."
+  );
+
+  return lines.join("\n");
+}
+
+function main(): void {
+  let options;
+  try {
+    options = parseArgs();
+  } catch (error) {
+    console.error((error as Error).message);
+    printHelp();
+    process.exit(1);
+    return;
+  }
+
+  const kit = buildKit(options.format);
+  let output = "";
+
+  if (options.format === "markdown") {
+    output = renderMarkdown(kit);
+  } else {
+    output = JSON.stringify(kit, null, 2);
+  }
+
+  if (options.outputPath) {
+    const resolved = path.resolve(process.cwd(), options.outputPath);
+    if (!options.force) {
+      try {
+        const { accessSync, constants } = require("node:fs");
+        accessSync(resolved, constants.F_OK);
+        console.error(
+          `Refusing to overwrite existing file ${resolved}. Pass --force to replace it.`
+        );
+        process.exit(1);
+        return;
+      } catch {
+        // File does not exist; safe to write.
+      }
+    }
+
+    writeFileSync(resolved, output, { encoding: "utf8" });
+    console.log(`Audit launch kit written to ${resolved}`);
+  } else {
+    console.log(output);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a TypeScript generator that assembles the external audit launch kit into Markdown or JSON for auditors
- surface the launch kit in the audit dossier and final verification playbook documentation and ship a dedicated how-to guide
- expose the helper through a new npm script so release managers can produce the artefact with one command

## Testing
- npm run audit:kit -- --format json --output /tmp/launch-kit.json --force
- npm run lint:ci

------
https://chatgpt.com/codex/tasks/task_e_68ebd09a42288333a98b792faf0ccc27