### PR TITLE
Add SystemPause governance regression tests

### DIFF
--- a/contracts/test/RevertsWithoutData.sol
+++ b/contracts/test/RevertsWithoutData.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title RevertsWithoutData
+/// @notice Harness contract that always reverts without returning revert data.
+/// @dev Used in tests to ensure callers handle empty revert payloads correctly.
+contract RevertsWithoutData {
+    fallback() external payable {
+        assembly {
+            revert(0, 0)
+        }
+    }
+}

--- a/contracts/test/SystemPauseFailoverSpy.sol
+++ b/contracts/test/SystemPauseFailoverSpy.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title SystemPauseFailoverSpy
+/// @notice Minimal module harness that tracks failover calls from {SystemPause}.
+/// @dev Implements the subset of the ValidationModule interface used by SystemPause
+///      so tests can assert that governance forwarding works end-to-end.
+contract SystemPauseFailoverSpy {
+    enum FailoverAction {
+        None,
+        ExtendReveal,
+        EscalateDispute
+    }
+
+    error NotAuthorised();
+
+    address private _owner;
+    address private _pauserManager;
+    address private _pauser;
+
+    bool public paused;
+    uint256 public lastJobId;
+    FailoverAction public lastAction;
+    uint64 public lastExtension;
+    string public lastReason;
+    uint256 public triggerCount;
+
+    constructor(address initialOwner) {
+        _owner = initialOwner;
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+
+    function transferOwnership(address newOwner) external {
+        if (msg.sender != _owner) revert NotAuthorised();
+        _owner = newOwner;
+    }
+
+    function pauserManager() external view returns (address) {
+        return _pauserManager;
+    }
+
+    function pauser() external view returns (address) {
+        return _pauser;
+    }
+
+    function setPauserManager(address manager) external {
+        if (msg.sender != _owner) revert NotAuthorised();
+        _pauserManager = manager;
+    }
+
+    function setPauser(address newPauser) external {
+        if (msg.sender != _owner && msg.sender != _pauserManager) {
+            revert NotAuthorised();
+        }
+        _pauser = newPauser;
+    }
+
+    function pause() external {
+        if (msg.sender != _pauser) revert NotAuthorised();
+        paused = true;
+    }
+
+    function unpause() external {
+        if (msg.sender != _pauser) revert NotAuthorised();
+        paused = false;
+    }
+
+    function triggerFailover(
+        uint256 jobId,
+        FailoverAction action,
+        uint64 extension,
+        string calldata reason
+    ) external {
+        if (msg.sender != _owner) revert NotAuthorised();
+        lastJobId = jobId;
+        lastAction = action;
+        lastExtension = extension;
+        lastReason = reason;
+        triggerCount += 1;
+    }
+
+    function lastFailover()
+        external
+        view
+        returns (
+            uint256 jobId,
+            FailoverAction action,
+            uint64 extension,
+            string memory reason,
+            uint256 count
+        )
+    {
+        return (lastJobId, lastAction, lastExtension, lastReason, triggerCount);
+    }
+}


### PR DESCRIPTION
## Summary
- add a SystemPauseFailoverSpy harness so governance-driven failovers can be asserted without the full validation stack
- add a RevertsWithoutData harness for simulating empty revert payloads in governance calls
- extend the SystemPause Hardhat suite to cover failover forwarding and empty revert handling

## Testing
- `npx hardhat test --no-compile test/v2/SystemPause.test.js --grep "forwards validation failover commands"`
- `npx hardhat test --no-compile test/v2/SystemPause.test.js --grep "surfaces governance call failures without revert data"`


------
https://chatgpt.com/codex/tasks/task_e_68ebe39337ac83338fc7cd4de456dd1c