### PR TITLE
Fix AURORA demo staking amount scaling

### DIFF
--- a/.github/workflows/demo-aurora.yml
+++ b/.github/workflows/demo-aurora.yml
@@ -3,8 +3,8 @@ name: demo-aurora
 on:
   pull_request:
     paths:
-      - "demo/**"
-      - ".github/workflows/demo-aurora.yml"
+      - 'demo/**'
+      - '.github/workflows/demo-aurora.yml'
   workflow_dispatch:
 
 permissions:
@@ -28,11 +28,13 @@ jobs:
             raw.githubusercontent.com
             registry.npmjs.org
             nodejs.org
+            download.cypress.io
+            cdn.cypress.io
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install
@@ -45,11 +47,11 @@ jobs:
 
       - name: Run AURORA (local)
         env:
-          PRIVATE_KEY: "0x59c6995e998f97a5a004497e5d6a897bcf7a20a0aa2a0b3f1d0ad6bdfb9c0001"
-          WORKER_PRIVATE_KEY: "0x8b3a350cf5c34c9194ca8afc2a0eae2b2aeeafce0c12cf5f8f1b2e7ab6fce201"
-          VALIDATOR_PRIVATE_KEY: "0x0f4b9bf3efb59c0a8b6dfa8172932d03cd4b16ba29cf15f9272972d4d8f90b02"
-          RPC_URL: "http://127.0.0.1:8545"
-          CHAIN_ID: "31337"
+          PRIVATE_KEY: '0x59c6995e998f97a5a004497e5d6a897bcf7a20a0aa2a0b3f1d0ad6bdfb9c0001'
+          WORKER_PRIVATE_KEY: '0x8b3a350cf5c34c9194ca8afc2a0eae2b2aeeafce0c12cf5f8f1b2e7ab6fce201'
+          VALIDATOR_PRIVATE_KEY: '0x0f4b9bf3efb59c0a8b6dfa8172932d03cd4b16ba29cf15f9272972d4d8f90b02'
+          RPC_URL: 'http://127.0.0.1:8545'
+          CHAIN_ID: '31337'
         run: bash demo/aurora/bin/aurora-local.sh
 
       - name: Upload demo receipts

--- a/demo/aurora/aurora.demo.ts
+++ b/demo/aurora/aurora.demo.ts
@@ -121,9 +121,10 @@ async function main(): Promise<void> {
   const workerStakeRaw = toBigInt(spec.stake?.worker, 20_000_000n);
   const validatorStakeRaw = toBigInt(spec.stake?.validator, 50_000_000n);
 
-  const reward = rewardRaw;
-  const workerStake = workerStakeRaw;
-  const validatorStake = validatorStakeRaw;
+  const sixToEighteenDecimals = 10n ** 12n;
+  const reward = rewardRaw * sixToEighteenDecimals;
+  const workerStake = workerStakeRaw * sixToEighteenDecimals;
+  const validatorStake = validatorStakeRaw * sixToEighteenDecimals;
   const allowanceBuffer = reward * 4n;
 
   const receipts: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- refresh the AURORA README and runbook with quickstart instructions and diagrams
- overhaul the demo orchestrator to mint local AGIALPHA liquidity, capture receipts, and tolerate partial validation flows
- add deterministic environment samples, wrapper scripts, and CI wiring for the demo entrypoints
- restore 18-decimal scaling for reward and stake amounts in the AURORA demo orchestrator to satisfy minimum stake requirements
- ensure the demo AURORA workflow pins Node.js via `.nvmrc` so toolchain verification passes
- normalize quoting in the demo AURORA workflow YAML to satisfy Prettier formatting checks
- permit Cypress download endpoints during the hardened install step so `npm ci` succeeds under egress restrictions

## Testing
- npm run format:check
- npm ci

------
https://chatgpt.com/codex/tasks/task_e_68ecf25f8c2883339e058c24917b7da4