### PR TITLE
Add governance capture to Aurora demo run

### DIFF
--- a/demo/aurora/README.md
+++ b/demo/aurora/README.md
@@ -23,6 +23,7 @@ npm run demo:aurora:sepolia
 **Outputs**
 
 * `reports/<network>/aurora/receipts/*.json`
+  * Includes `governance.json` capturing every forwarded + direct control action executed during the run
 * `reports/<network>/aurora/aurora-report.md`
 * Governance/owner snapshots can be generated via the existing owner tooling
 

--- a/demo/aurora/RUNBOOK.md
+++ b/demo/aurora/RUNBOOK.md
@@ -13,8 +13,9 @@ This:
 1. Boots `anvil`.
 2. Deploys v2 defaults (`scripts/v2/deployDefaults.ts`) with verification disabled for speed and writes a deployment summary.
 3. Mints mock `$AGIALPHA`, configures validator bounds, and runs the full job lifecycle end‑to‑end.
-4. Captures receipts + owner snapshots, and
-5. Writes `aurora-report.md` summarising the mission.
+4. Exercises governance controls (system-wide pause drill, stake minimum tuning, job stake retuning) with every action logged to `governance.json`.
+5. Captures receipts + owner snapshots, and
+6. Writes `aurora-report.md` summarising the mission.
 
 ## Target network
 

--- a/demo/aurora/aurora.demo.ts
+++ b/demo/aurora/aurora.demo.ts
@@ -19,6 +19,17 @@ type Spec = {
   notes?: string;
 };
 
+type GovernanceAction = {
+  target: string;
+  method: string;
+  txHash: string;
+  type: 'forwarded' | 'direct';
+  params?: unknown;
+  notes?: string;
+  before?: Record<string, string>;
+  after?: Record<string, string>;
+};
+
 const DEFAULT_KEYS = [
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
   '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
@@ -78,6 +89,23 @@ function formatUnits(value: bigint, decimals: number): string {
   return ethers.formatUnits(value, decimals);
 }
 
+function normaliseArg(value: unknown): unknown {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normaliseArg(item));
+  }
+  if (typeof value === 'object' && value !== null) {
+    const entries = Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+      k,
+      normaliseArg(v),
+    ]);
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
 async function ensureAgialpha(
   provider: ethers.JsonRpcProvider,
   owner: ethers.Wallet
@@ -118,8 +146,8 @@ async function executeGovernanceCall(
 ) {
   const data = iface.encodeFunctionData(method, args);
   const tx = await pause.executeGovernanceCall(target, data);
-  await tx.wait();
-  return tx.hash;
+  const receipt = await tx.wait();
+  return receipt?.hash || tx.hash;
 }
 
 function deriveCommitPlan(
@@ -153,6 +181,8 @@ async function main() {
   const chain = await provider.getNetwork();
   const decimals = Number(AGIALPHA_CONFIG.decimals || 18);
 
+  const governanceActions: GovernanceAction[] = [];
+
   const employerKey = process.env.PRIVATE_KEY || DEFAULT_KEYS[0];
   const workerKey = process.env.AURORA_WORKER_KEY || DEFAULT_KEYS[1];
   const validatorKeys = [
@@ -175,6 +205,9 @@ async function main() {
     throw new Error('Insufficient validator keys configured for the selected quorum.');
   }
   const validators = selectedValidatorKeys.map((key) => new ethers.Wallet(key, provider));
+  const agentRole = 0;
+  const validatorRole = 1;
+  const platformRole = 2;
 
   const summaryPath = resolveDeploySummaryPath(networkName);
   const deploySummary = readJsonFile<DeploySummary>(summaryPath);
@@ -224,6 +257,41 @@ async function main() {
     employer
   );
 
+  const recordForwardGovernanceCall = async (
+    targetName: string,
+    targetAddress: string,
+    iface: ethers.Interface,
+    method: string,
+    args: unknown[],
+    options?: { notes?: string; before?: Record<string, string>; after?: Record<string, string> }
+  ) => {
+    const txHash = await executeGovernanceCall(systemPause, targetAddress, iface, method, args);
+    governanceActions.push({
+      target: targetName,
+      method,
+      txHash,
+      type: 'forwarded',
+      params: normaliseArg(args),
+      notes: options?.notes,
+      before: options?.before,
+      after: options?.after,
+    });
+    return txHash;
+  };
+
+  const recordDirectGovernanceCall = async (
+    targetName: string,
+    method: string,
+    action: () => Promise<ethers.ContractTransactionResponse>,
+    notes?: string
+  ) => {
+    const tx = await action();
+    const receipt = await tx.wait();
+    const txHash = receipt?.hash || tx.hash;
+    governanceActions.push({ target: targetName, method, txHash, type: 'direct', notes });
+    return txHash;
+  };
+
   const token = await ensureAgialpha(provider, employer);
 
   const mintAmount = ethers.parseUnits('1000', decimals);
@@ -249,58 +317,145 @@ async function main() {
     }
   }
 
+  await recordDirectGovernanceCall(
+    'SystemPause',
+    'pauseAll',
+    () => systemPause.pauseAll(),
+    'Emergency drill: pause every core module'
+  );
+  await recordDirectGovernanceCall(
+    'SystemPause',
+    'unpauseAll',
+    () => systemPause.unpauseAll(),
+    'Resume operations after pause drill'
+  );
+
+  const originalAgentMinimum = await stakeManager.roleMinimumStake(agentRole);
+  const originalValidatorMinimum = await stakeManager.roleMinimumStake(validatorRole);
+  const originalPlatformMinimum = await stakeManager.roleMinimumStake(platformRole);
+  const stakeMinimumBaseline = {
+    agent: originalAgentMinimum,
+    validator: originalValidatorMinimum,
+    platform: originalPlatformMinimum,
+  };
+
+  const adjustedAgentMinimum = workerStakeAmount / 2n > 0n ? workerStakeAmount / 2n : 1n;
+  const adjustedValidatorMinimum =
+    validatorStakeAmount / 2n > 0n ? validatorStakeAmount / 2n : 1n;
+  const adjustedPlatformMinimum = validatorStakeAmount / 4n > 0n ? validatorStakeAmount / 4n : 1n;
+  const stakeMinimumAdjusted = {
+    agent: adjustedAgentMinimum,
+    validator: adjustedValidatorMinimum,
+    platform: adjustedPlatformMinimum,
+  };
+
+  await recordForwardGovernanceCall(
+    'StakeManager',
+    addresses.StakeManager,
+    stakeManager.interface,
+    'setRoleMinimums',
+    [adjustedAgentMinimum, adjustedValidatorMinimum, adjustedPlatformMinimum],
+    {
+      notes: 'Lower minimum stakes so demo identities can onboard quickly',
+      before: {
+        agent: formatUnits(stakeMinimumBaseline.agent, decimals),
+        validator: formatUnits(stakeMinimumBaseline.validator, decimals),
+        platform: formatUnits(stakeMinimumBaseline.platform, decimals),
+      },
+      after: {
+        agent: formatUnits(stakeMinimumAdjusted.agent, decimals),
+        validator: formatUnits(stakeMinimumAdjusted.validator, decimals),
+        platform: formatUnits(stakeMinimumAdjusted.platform, decimals),
+      },
+    }
+  );
+
+  const originalJobStake = await jobRegistry.jobStake();
+  const fallbackJobStake = rewardAmount / 10n > 0n ? rewardAmount / 10n : 1n;
+  const adjustedJobStake =
+    originalJobStake === 0n
+      ? fallbackJobStake
+      : originalJobStake + (fallbackJobStake > 0n ? fallbackJobStake : 1n);
+
+  await recordForwardGovernanceCall(
+    'JobRegistry',
+    addresses.JobRegistry,
+    jobRegistry.interface,
+    'setJobStake',
+    [adjustedJobStake],
+    {
+      notes: 'Tune employer escrow requirements for the flagship mission',
+      before: { stake: formatUnits(originalJobStake, decimals) },
+      after: { stake: formatUnits(adjustedJobStake, decimals) },
+    }
+  );
+
   await identityRegistry.addAdditionalAgent(worker.address);
   for (const validator of validators) {
     await identityRegistry.addAdditionalValidator(validator.address);
   }
 
   const validationInterface = new ethers.Interface(validationModuleArtifact.abi);
-  await executeGovernanceCall(
-    systemPause,
+  await recordForwardGovernanceCall(
+    'ValidationModule',
     addresses.ValidationModule,
     validationInterface,
     'setValidatorPool',
-    [validators.map((v) => v.address)]
+    [validators.map((v) => v.address)],
+    { notes: 'Populate validator committee pool for demo mission' }
   );
-  await executeGovernanceCall(
-    systemPause,
+  await recordForwardGovernanceCall(
+    'ValidationModule',
     addresses.ValidationModule,
     validationInterface,
     'setValidatorBounds',
-    [quorum, validatorCount]
+    [quorum, validatorCount],
+    { notes: `Require ${quorum} approvals from a pool of ${validatorCount}` }
   );
-  await executeGovernanceCall(
-    systemPause,
+  await recordForwardGovernanceCall(
+    'ValidationModule',
     addresses.ValidationModule,
     validationInterface,
     'setValidatorsPerJob',
-    [validatorCount]
+    [validatorCount],
+    { notes: 'All validators in pool review the flagship job' }
   );
-  await executeGovernanceCall(
-    systemPause,
+  await recordForwardGovernanceCall(
+    'ValidationModule',
     addresses.ValidationModule,
     validationInterface,
     'setRequiredValidatorApprovals',
-    [quorum]
+    [quorum],
+    { notes: 'Set quorum for validation success' }
   );
-  await executeGovernanceCall(
-    systemPause,
+  const previousCommitWindow = await validationModule.commitWindow();
+  await recordForwardGovernanceCall(
+    'ValidationModule',
     addresses.ValidationModule,
     validationInterface,
     'setCommitWindow',
-    [3600]
+    [3600],
+    {
+      notes: 'Tighten commit window to one hour for the drill',
+      before: { commitWindow: previousCommitWindow.toString() },
+      after: { commitWindow: '3600' },
+    }
   );
-  await executeGovernanceCall(
-    systemPause,
+  const previousRevealWindow = await validationModule.revealWindow();
+  await recordForwardGovernanceCall(
+    'ValidationModule',
     addresses.ValidationModule,
     validationInterface,
     'setRevealWindow',
-    [3600]
+    [3600],
+    {
+      notes: 'Match reveal window with the commit horizon',
+      before: { revealWindow: previousRevealWindow.toString() },
+      after: { revealWindow: '3600' },
+    }
   );
 
   const stakeEntries: Array<{ role: string; address: string; amount: string; txHash: string }> = [];
-  const agentRole = 0;
-  const validatorRole = 1;
 
   const workerStakeTx = await stakeManager
     .connect(worker)
@@ -457,6 +612,42 @@ async function main() {
     txHash: finalizeReceipt?.hash || finalizeTx.hash,
     payouts,
   });
+
+  await recordForwardGovernanceCall(
+    'StakeManager',
+    addresses.StakeManager,
+    stakeManager.interface,
+    'setRoleMinimums',
+    [stakeMinimumBaseline.agent, stakeMinimumBaseline.validator, stakeMinimumBaseline.platform],
+    {
+      notes: 'Restore production minimum stake thresholds',
+      before: {
+        agent: formatUnits(stakeMinimumAdjusted.agent, decimals),
+        validator: formatUnits(stakeMinimumAdjusted.validator, decimals),
+        platform: formatUnits(stakeMinimumAdjusted.platform, decimals),
+      },
+      after: {
+        agent: formatUnits(stakeMinimumBaseline.agent, decimals),
+        validator: formatUnits(stakeMinimumBaseline.validator, decimals),
+        platform: formatUnits(stakeMinimumBaseline.platform, decimals),
+      },
+    }
+  );
+
+  await recordForwardGovernanceCall(
+    'JobRegistry',
+    addresses.JobRegistry,
+    jobRegistry.interface,
+    'setJobStake',
+    [originalJobStake],
+    {
+      notes: 'Return job stake policy to its baseline value',
+      before: { stake: formatUnits(adjustedJobStake, decimals) },
+      after: { stake: formatUnits(originalJobStake, decimals) },
+    }
+  );
+
+  writeReceipt(networkName, 'governance.json', { actions: governanceActions });
 
   console.log('✅ AURORA demo completed.');
 }

--- a/demo/aurora/bin/aurora-local.sh
+++ b/demo/aurora/bin/aurora-local.sh
@@ -56,8 +56,9 @@ done
 
 dep_env() {
   DEPLOY_DEFAULTS_SKIP_VERIFY=1 \
+  DEPLOY_DEFAULTS_CONFIG="demo/aurora/config/deployer.hardhat.json" \
   DEPLOY_DEFAULTS_OUTPUT="$DEPLOY_OUTPUT" \
-  npx hardhat run scripts/v2/deployDefaults.ts --network localhost
+  npx hardhat run --network localhost scripts/v2/deployDefaults.ts
 }
 
 run_demo() {

--- a/demo/aurora/bin/aurora-report.ts
+++ b/demo/aurora/bin/aurora-report.ts
@@ -15,6 +15,12 @@ function section(title: string): string {
   return '\n## ' + title + '\n';
 }
 
+function renderKeyValues(record: Record<string, string>): string {
+  return Object.entries(record)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(', ');
+}
+
 (async () => {
   fs.mkdirSync(path.dirname(mdFile), { recursive: true });
   const parts: string[] = [];
@@ -27,6 +33,7 @@ function section(title: string): string {
   const validate = load('validate.json');
   const finalize = load('finalize.json');
   const stake = load('stake.json');
+  const governance = load('governance.json');
 
   if (deploy && deploy.contracts) {
     parts.push(section('Deployment Summary'));
@@ -102,6 +109,35 @@ function section(title: string): string {
           payout.delta +
           ')'
       );
+    }
+  }
+
+  if (governance && Array.isArray(governance.actions)) {
+    parts.push(section('Governance & Controls'));
+    for (const action of governance.actions as Array<Record<string, any>>) {
+      const header =
+        '- **' +
+        action.target +
+        '.' +
+        action.method +
+        '** (' +
+        action.type +
+        ') — tx `' +
+        action.txHash +
+        '`';
+      parts.push(header);
+      if (action.notes) {
+        parts.push('  - Notes: ' + action.notes);
+      }
+      if (action.params) {
+        parts.push('  - Params: ' + JSON.stringify(action.params));
+      }
+      if (action.before) {
+        parts.push('  - Before: ' + renderKeyValues(action.before as Record<string, string>));
+      }
+      if (action.after) {
+        parts.push('  - After: ' + renderKeyValues(action.after as Record<string, string>));
+      }
     }
   }
 

--- a/demo/aurora/config/deployer.hardhat.json
+++ b/demo/aurora/config/deployer.hardhat.json
@@ -1,0 +1,36 @@
+{
+  "network": "localhost",
+  "governance": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  "tax": {
+    "enabled": true,
+    "uri": "ipfs://QmExamplePolicyHash",
+    "description": "All taxes on participants; contract and owner exempt"
+  },
+  "econ": {
+    "feePct": 5,
+    "burnPct": 1,
+    "employerSlashPct": 10,
+    "treasurySlashPct": 90,
+    "validatorSlashRewardPct": 0,
+    "commitWindow": "1d",
+    "revealWindow": "1d",
+    "minStake": "1000",
+    "jobStake": "500"
+  },
+  "identity": {
+    "ens": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+    "nameWrapper": "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401",
+    "clubRootNode": "club.agi.eth",
+    "agentRootNode": "agent.agi.eth",
+    "validatorMerkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "agentMerkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "secureDefaults": {
+    "pauseOnLaunch": true,
+    "maxJobRewardAgia": 25,
+    "maxJobDurationSeconds": 86400,
+    "validatorCommitWindowSeconds": 60,
+    "validatorRevealWindowSeconds": 60
+  },
+  "output": "deployment-config/latest-deployment.json"
+}

--- a/scripts/v2/deployDefaults.ts
+++ b/scripts/v2/deployDefaults.ts
@@ -309,8 +309,10 @@ async function main() {
     cli['skip-verify'] === true ||
     skipVerifyEnv === '1' ||
     skipVerifyEnv === 'true';
+  const envConfig = toStringOrUndefined(process.env.DEPLOY_DEFAULTS_CONFIG);
   const configPath =
-    cli.config && typeof cli.config === 'string' ? cli.config : undefined;
+    (cli.config && typeof cli.config === 'string' ? cli.config : undefined) ||
+    envConfig;
   const config = configPath
     ? readJsonConfig(configPath)
     : ({} as DeployerConfig);


### PR DESCRIPTION
## Summary
- log every governance operation during the Aurora walkthrough and write a `governance.json` receipt for later auditing
- surface the new control actions in the generated mission report, README, and runbook so operators know what is captured
- provide a hardhat deployer config for the demo pipeline and allow `deployDefaults.ts` to read the config path from an environment variable

## Testing
- `npm run demo:aurora:local` *(fails: deployDefaults still reverts on this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed1864674c8333bfec795bc0125824