### PR TITLE
Manage Aurora demo signer nonces

### DIFF
--- a/demo/aurora/aurora.demo.ts
+++ b/demo/aurora/aurora.demo.ts
@@ -218,8 +218,8 @@ function writeReceipt(net: string, name: string, data: unknown) {
   const dir = path.join(baseDir, 'receipts');
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, name), JSON.stringify(data, null, 2));
-  const baseDir = path.join('reports', net, REPORT_SCOPE, 'receipts');
-  const outputPath = path.join(baseDir, name);
+  const legacyDir = path.join('reports', net, REPORT_SCOPE, 'receipts');
+  const outputPath = path.join(legacyDir, name);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, JSON.stringify(data, null, 2));
 }
@@ -228,9 +228,8 @@ function resolveDeploySummaryPath(net: string): string {
   if (process.env.AURORA_DEPLOY_OUTPUT) {
     return path.resolve(process.env.AURORA_DEPLOY_OUTPUT);
   }
-  const baseDir = resolveReportBaseDir(net);
-  return path.resolve(baseDir, 'receipts', 'deploy.json');
-  return path.resolve('reports', net, REPORT_SCOPE, 'receipts', 'deploy.json');
+  const namespace = resolveReportNamespace();
+  return path.resolve('reports', net, namespace, 'receipts', 'deploy.json');
 }
 
 function specAmountToWei(


### PR DESCRIPTION
## Summary
- add nonce-managed signers and impersonation helpers to the Aurora demo script
- wire in mission/report path resolvers and environment overrides for spec/result metadata
- adjust validation committee governance calls and add acknowledger safety checks

## Testing
- npm run demo:aurora:local *(fails: NotAcknowledger during StakeManager deposit)*

------
https://chatgpt.com/codex/tasks/task_e_68ed38ed906c83339b5bf3889d871639