### PR TITLE
Add governance kit manifest for ASI take-off demo

### DIFF
--- a/.github/workflows/demo-asi-takeoff.yml
+++ b/.github/workflows/demo-asi-takeoff.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           version: '1.4.0'
 
+      - name: Run ASI Take-Off demo (deterministic kit)
+        run: npm run demo:asi-takeoff
+
       - name: Run ASI Take-Off demo (local)
         env:
           PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
@@ -58,4 +61,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: asi-takeoff-receipts
-          path: reports/localhost/asi-takeoff/**
+          path: |
+            reports/asi-takeoff/**
+            reports/localhost/asi-takeoff/**

--- a/demo/asi-takeoff/README.md
+++ b/demo/asi-takeoff/README.md
@@ -36,6 +36,9 @@ Local (Anvil / Hardhat):
 ```bash
 cp demo/asi-takeoff/env.example .env
 npm run demo:asi-takeoff:local
+
+# Optional: generate a governance kit for the deterministic artefacts
+npm run demo:asi-takeoff:kit -- --report-root reports/localhost/asi-takeoff --summary-md reports/localhost/asi-takeoff/asi-takeoff-report.md --bundle reports/localhost/asi-takeoff/receipts --logs reports/localhost/asi-takeoff/receipts
 ```
 
 Generate the Markdown mission report:
@@ -49,6 +52,10 @@ Artifacts:
 - `reports/<network>/asi-takeoff/receipts/mission.json`
 - `reports/<network>/asi-takeoff/receipts/jobs/<slug>/*.json`
 - `reports/<network>/asi-takeoff/asi-takeoff-report.md`
+- `reports/<network>/asi-takeoff/governance-kit.json`
+- `reports/<network>/asi-takeoff/governance-kit.md`
+
+The governance kit consolidates the plan of record, dry-run harness output, thermodynamic telemetry, mission-control dossier, and integrity hashes for auditors.  The kit is generated automatically by `npm run demo:asi-takeoff` and can be reproduced for any report root with `npm run demo:asi-takeoff:kit`.
 
 ---
 

--- a/demo/asi-takeoff/RUNBOOK.md
+++ b/demo/asi-takeoff/RUNBOOK.md
@@ -40,6 +40,13 @@ The script performs:
 - `reports/localhost/asi-takeoff/receipts/stake.json` – stake acknowledgements.
 - `reports/localhost/asi-takeoff/receipts/governance.json` – pause drills, stake minimum adjustments, validator pool updates.
 - `reports/localhost/asi-takeoff/asi-takeoff-report.md` – Markdown mission dossier.
+- `reports/asi-takeoff/governance-kit.{json,md}` – deterministic control-plane manifest with SHA-256 hashes.
+
+Rebuild the governance kit for the local receipts if necessary:
+
+```bash
+npm run demo:asi-takeoff:kit -- --report-root reports/localhost/asi-takeoff --plan demo/asi-takeoff/project-plan.json --summary-md reports/localhost/asi-takeoff/asi-takeoff-report.md --bundle reports/localhost/asi-takeoff/receipts
+```
 
 ## 4. Owner Control Validations
 

--- a/docs/asi-national-governance-demo.md
+++ b/docs/asi-national-governance-demo.md
@@ -209,12 +209,23 @@ entire flow runs inside CI.
    The output enumerates every governance command executed and their
    resulting contract hashes.【F:scripts/v2/ownerMissionControl.ts†L35-L276】
 
-3. **Branch protection evidence.** Attach the latest
+3. **Governance kit manifest.** Combine the plan of record with dry-run,
+   thermodynamic, and mission-control artefacts into a hashed dossier:
+
+   ```bash
+   npm run demo:asi-takeoff:kit -- --report-root reports/localhost/asi-takeoff --summary-md reports/localhost/asi-takeoff/asi-takeoff-report.md --bundle reports/localhost/asi-takeoff/receipts
+   ```
+
+   The generated `governance-kit.{json,md}` files provide a turnkey audit
+   bundle for non-technical owners, showing integrity hashes and control
+   checklist entries produced by `scripts/v2/lib/asiTakeoffKit.ts`.【F:scripts/v2/lib/asiTakeoffKit.ts†L1-L340】
+
+4. **Branch protection evidence.** Attach the latest
    `npm run ci:verify-branch-protection` transcript and test matrix from
    `.github/workflows/` to the release dossier to prove CI gating is
    enforced as part of the demo acceptance.
 
-4. **Continuous observability.** Collect Prometheus metrics from
+5. **Continuous observability.** Collect Prometheus metrics from
    `/onebox/metrics` and structured logs keyed by the `planHash` so the
    audit trail ties API activity to blockchain receipts.【F:routes/onebox.py†L209-L237】【F:routes/onebox.py†L1765-L1905】
 

--- a/docs/asi-takeoff-demo.md
+++ b/docs/asi-takeoff-demo.md
@@ -27,6 +27,9 @@ Outputs are persisted to `reports/asi-takeoff` and include:
 - `mission-control.md` – governance report with diagrams and checklists.
 - `summary.md` / `summary.json` – curated view binding technical telemetry to business goals.
 - `logs/*.log` – per-step console output, timestamped for audit replay.
+- `governance-kit.json` / `governance-kit.md` – consolidated owner-control manifest with SHA-256 hashes for each artefact.
+
+The governance kit is generated automatically at the end of the pipeline via `scripts/v2/lib/asiTakeoffKit.ts`.  It cross-links the national initiative plan, dry-run receipts, thermodynamic report, mission-control dossier, and receipt directories, giving non-technical owners a single bundle to verify before approving deployments.
 
 ## How to Run
 
@@ -37,6 +40,12 @@ npm run demo:asi-takeoff
 
 The command may take several minutes on the first run because it compiles the entire contract suite.  The dry-run harness expects
 an ephemeral Hardhat network (the default when the script is executed with no `--network` flag).
+
+To regenerate the kit for alternate report directories (for example, artefacts produced by `npm run demo:asi-takeoff:local`), use:
+
+```bash
+npm run demo:asi-takeoff:kit -- --report-root reports/localhost/asi-takeoff --summary-md reports/localhost/asi-takeoff/asi-takeoff-report.md --bundle reports/localhost/asi-takeoff/receipts
+```
 
 ## CI Integration
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "demo:aurora:sepolia": "npx hardhat run demo/aurora/aurora.demo.ts --network sepolia",
     "demo:asi-takeoff": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/asiTakeoffDemo.ts",
     "demo:asi-takeoff:local": "bash demo/asi-takeoff/bin/asi-takeoff-local.sh",
+    "demo:asi-takeoff:kit": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/asiTakeoffKit.ts",
     "demo:asi-takeoff:report": "AURORA_REPORT_SCOPE=asi-takeoff AURORA_REPORT_TITLE='ASI Take-Off — Mission Report' ts-node --transpile-only demo/aurora/bin/aurora-report.ts",
     "subgraph:e2e": "node scripts/subgraph-e2e.js",
     "migrate:mainnet": "TRUFFLE_NETWORK=mainnet npm run compile:mainnet && npx truffle migrate --network mainnet --reset && TRUFFLE_NETWORK=mainnet npm run wire:verify",

--- a/scripts/v2/asiTakeoffDemo.ts
+++ b/scripts/v2/asiTakeoffDemo.ts
@@ -4,6 +4,8 @@ import { spawn } from 'child_process';
 import { promises as fs } from 'fs';
 import path from 'path';
 
+import { generateAsiTakeoffKit } from './lib/asiTakeoffKit';
+
 interface CommandStep {
   key: string;
   title: string;
@@ -282,6 +284,18 @@ async function main(): Promise<void> {
   const dryRunReport = JSON.parse(dryRunRaw) as DryRunReport;
   const plan = await loadPlan();
   await writeSummary(plan, dryRunReport);
+
+  await generateAsiTakeoffKit({
+    planPath: PLAN_PATH,
+    reportRoot: REPORT_ROOT,
+    dryRunPath: DRY_RUN_PATH,
+    thermodynamicsPath: THERMODYNAMICS_PATH,
+    missionControlPath: MISSION_CONTROL_PATH,
+    summaryJsonPath: SUMMARY_JSON_PATH,
+    summaryMarkdownPath: SUMMARY_MD_PATH,
+    bundleDir: BUNDLE_ROOT,
+    logDir: LOG_ROOT,
+  });
 
   process.stdout.write('\nDemo artefacts generated at reports/asi-takeoff.\n');
 }

--- a/scripts/v2/asiTakeoffKit.ts
+++ b/scripts/v2/asiTakeoffKit.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env ts-node
+
+import path from 'path';
+
+import { generateAsiTakeoffKit } from './lib/asiTakeoffKit';
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+interface CliOptions {
+  reportRoot: string;
+  planPath: string;
+  dryRunPath?: string;
+  thermodynamicsPath?: string;
+  missionControlPath?: string;
+  summaryJsonPath?: string;
+  summaryMarkdownPath?: string;
+  bundleDir?: string;
+  logDir?: string;
+  outputBasename?: string;
+  networkHint?: string;
+}
+
+function resolveFromRoot(target: string | undefined): string | undefined {
+  if (!target) {
+    return undefined;
+  }
+  return path.isAbsolute(target) ? target : path.join(ROOT, target);
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    reportRoot: path.join(ROOT, 'reports', 'asi-takeoff'),
+    planPath: path.join(ROOT, 'demo', 'asi-takeoff', 'project-plan.json'),
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    switch (arg) {
+      case '--report-root':
+        if (!next) throw new Error('Missing value for --report-root');
+        options.reportRoot = resolveFromRoot(next)!;
+        i += 1;
+        break;
+      case '--plan':
+        if (!next) throw new Error('Missing value for --plan');
+        options.planPath = resolveFromRoot(next)!;
+        i += 1;
+        break;
+      case '--dry-run':
+        if (!next) throw new Error('Missing value for --dry-run');
+        options.dryRunPath = resolveFromRoot(next);
+        i += 1;
+        break;
+      case '--thermodynamics':
+        if (!next) throw new Error('Missing value for --thermodynamics');
+        options.thermodynamicsPath = resolveFromRoot(next);
+        i += 1;
+        break;
+      case '--mission-control':
+        if (!next) throw new Error('Missing value for --mission-control');
+        options.missionControlPath = resolveFromRoot(next);
+        i += 1;
+        break;
+      case '--summary-json':
+        if (!next) throw new Error('Missing value for --summary-json');
+        options.summaryJsonPath = resolveFromRoot(next);
+        i += 1;
+        break;
+      case '--summary-md':
+        if (!next) throw new Error('Missing value for --summary-md');
+        options.summaryMarkdownPath = resolveFromRoot(next);
+        i += 1;
+        break;
+      case '--bundle':
+        if (!next) throw new Error('Missing value for --bundle');
+        options.bundleDir = resolveFromRoot(next);
+        i += 1;
+        break;
+      case '--logs':
+        if (!next) throw new Error('Missing value for --logs');
+        options.logDir = resolveFromRoot(next);
+        i += 1;
+        break;
+      case '--output-name':
+        if (!next) throw new Error('Missing value for --output-name');
+        options.outputBasename = next;
+        i += 1;
+        break;
+      case '--network':
+        if (!next) throw new Error('Missing value for --network');
+        options.networkHint = next;
+        i += 1;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const result = await generateAsiTakeoffKit({
+    planPath: options.planPath,
+    reportRoot: options.reportRoot,
+    dryRunPath: options.dryRunPath,
+    thermodynamicsPath: options.thermodynamicsPath,
+    missionControlPath: options.missionControlPath,
+    summaryJsonPath: options.summaryJsonPath,
+    summaryMarkdownPath: options.summaryMarkdownPath,
+    bundleDir: options.bundleDir,
+    logDir: options.logDir,
+    outputBasename: options.outputBasename,
+    networkHint: options.networkHint,
+  });
+
+  process.stdout.write(
+    `Governance kit generated:\n- ${result.manifestPath}\n- ${result.markdownPath}\n`,
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`ASI take-off governance kit failed: ${(error as Error).message}\n`);
+  process.exitCode = 1;
+});
+

--- a/scripts/v2/lib/asiTakeoffKit.ts
+++ b/scripts/v2/lib/asiTakeoffKit.ts
@@ -1,0 +1,358 @@
+import crypto from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+
+export interface AsiTakeoffKitOptions {
+  planPath: string;
+  reportRoot: string;
+  dryRunPath?: string;
+  thermodynamicsPath?: string;
+  missionControlPath?: string;
+  summaryJsonPath?: string;
+  summaryMarkdownPath?: string;
+  bundleDir?: string;
+  logDir?: string;
+  outputBasename?: string;
+  networkHint?: string;
+  additionalArtifacts?: Array<ArtifactInput>;
+}
+
+export interface ArtifactInput {
+  key: string;
+  path: string;
+  description: string;
+  optional?: boolean;
+}
+
+export interface DirectoryDescriptor {
+  key: string;
+  path: string;
+  entries: string[];
+}
+
+export interface KitArtifactRecord {
+  key: string;
+  path: string;
+  description: string;
+  sha256: string;
+  size: number;
+}
+
+export interface AsiTakeoffKitResult {
+  manifestPath: string;
+  markdownPath: string;
+  manifest: Record<string, unknown>;
+  markdown: string;
+}
+
+function ensureAbsolute(targetPath: string): string {
+  if (path.isAbsolute(targetPath)) {
+    return targetPath;
+  }
+  return path.join(ROOT, targetPath);
+}
+
+function relativeToRoot(targetPath: string): string {
+  return path.relative(ROOT, targetPath);
+}
+
+async function ensureFileExists(filePath: string, label: string): Promise<void> {
+  try {
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) {
+      throw new Error(`Expected ${label} to be a file: ${relativeToRoot(filePath)}`);
+    }
+  } catch (error) {
+    throw new Error(
+      `Missing required ${label}: ${relativeToRoot(filePath)} (${(error as Error).message})`,
+    );
+  }
+}
+
+async function computeSha256(filePath: string): Promise<string> {
+  const buffer = await fs.readFile(filePath);
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+async function collectDirectoryDescriptor(
+  key: string,
+  directoryPath: string,
+): Promise<DirectoryDescriptor | undefined> {
+  try {
+    const stat = await fs.stat(directoryPath);
+    if (!stat.isDirectory()) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+
+  const entries = await fs.readdir(directoryPath);
+  entries.sort();
+  return {
+    key,
+    path: relativeToRoot(directoryPath),
+    entries,
+  };
+}
+
+async function addArtifact(
+  artifacts: KitArtifactRecord[],
+  input: ArtifactInput,
+): Promise<void> {
+  const absolute = ensureAbsolute(input.path);
+  try {
+    await ensureFileExists(absolute, input.key);
+  } catch (error) {
+    if (input.optional) {
+      return;
+    }
+    throw error;
+  }
+
+  const stat = await fs.stat(absolute);
+  const sha256 = await computeSha256(absolute);
+  artifacts.push({
+    key: input.key,
+    path: relativeToRoot(absolute),
+    description: input.description,
+    sha256,
+    size: stat.size,
+  });
+}
+
+export async function generateAsiTakeoffKit(
+  options: AsiTakeoffKitOptions,
+): Promise<AsiTakeoffKitResult> {
+  const reportRoot = ensureAbsolute(options.reportRoot);
+  const planPath = ensureAbsolute(options.planPath);
+  await fs.mkdir(reportRoot, { recursive: true });
+
+  await ensureFileExists(planPath, 'project plan');
+  const planRaw = await fs.readFile(planPath, 'utf8');
+  let plan: Record<string, any>;
+  try {
+    plan = JSON.parse(planRaw) as Record<string, any>;
+  } catch (error) {
+    throw new Error(
+      `Unable to parse project plan JSON at ${relativeToRoot(planPath)}: ${(error as Error).message}`,
+    );
+  }
+
+  const artifacts: KitArtifactRecord[] = [];
+
+  const dryRunPath = options.dryRunPath
+    ? ensureAbsolute(options.dryRunPath)
+    : path.join(reportRoot, 'dry-run.json');
+  const thermodynamicsPath = options.thermodynamicsPath
+    ? ensureAbsolute(options.thermodynamicsPath)
+    : path.join(reportRoot, 'thermodynamics.json');
+  const missionControlPath = options.missionControlPath
+    ? ensureAbsolute(options.missionControlPath)
+    : path.join(reportRoot, 'mission-control.md');
+  const summaryJsonPath = options.summaryJsonPath
+    ? ensureAbsolute(options.summaryJsonPath)
+    : path.join(reportRoot, 'summary.json');
+  const summaryMarkdownPath = options.summaryMarkdownPath
+    ? ensureAbsolute(options.summaryMarkdownPath)
+    : path.join(reportRoot, 'summary.md');
+
+  const requiredArtifacts: ArtifactInput[] = [
+    {
+      key: 'plan',
+      path: planPath,
+      description: 'Canonical national initiative plan used for orchestration.',
+    },
+    {
+      key: 'dryRun',
+      path: dryRunPath,
+      description: 'Owner dry-run harness output capturing job lifecycle replay.',
+    },
+    {
+      key: 'thermodynamics',
+      path: thermodynamicsPath,
+      description: 'Thermodynamic telemetry snapshot for incentive levers.',
+    },
+    {
+      key: 'missionControl',
+      path: missionControlPath,
+      description: 'Owner mission-control dossier including governance diagram.',
+    },
+  ];
+
+  if (summaryJsonPath) {
+    requiredArtifacts.push({
+      key: 'summaryJson',
+      path: summaryJsonPath,
+      description: 'Structured summary linking artefacts to mission goals.',
+      optional: true,
+    });
+  }
+
+  if (summaryMarkdownPath) {
+    requiredArtifacts.push({
+      key: 'summaryMarkdown',
+      path: summaryMarkdownPath,
+      description: 'Human-readable mission summary for reviewers.',
+      optional: true,
+    });
+  }
+
+  if (options.additionalArtifacts) {
+    requiredArtifacts.push(...options.additionalArtifacts);
+  }
+
+  for (const artifact of requiredArtifacts) {
+    await addArtifact(artifacts, artifact);
+  }
+
+  const bundleDescriptor = options.bundleDir
+    ? await collectDirectoryDescriptor('missionBundle', ensureAbsolute(options.bundleDir))
+    : undefined;
+  const logDescriptor = options.logDir
+    ? await collectDirectoryDescriptor('logs', ensureAbsolute(options.logDir))
+    : undefined;
+
+  const outputBasename = options.outputBasename ?? 'governance-kit';
+  const manifestPath = path.join(reportRoot, `${outputBasename}.json`);
+  const markdownPath = path.join(reportRoot, `${outputBasename}.md`);
+
+  const governance = plan.governance ?? {};
+  const thermostat = governance.thermostat ?? {};
+  const network = options.networkHint ?? 'hardhat';
+  const thermostatScript = thermostat.updateScript ?? 'scripts/v2/updateThermodynamics.ts';
+
+  const checklist = [
+    {
+      title: 'Verify owner control wiring',
+      command: `npm run owner:verify-control -- --network ${network}`,
+      purpose: 'Confirms SystemPause, treasury, and thermostat governance match hardened defaults.',
+    },
+    {
+      title: 'Exercise pause and resume drill',
+      command: 'npm run pause:test',
+      purpose: 'Demonstrates the owner can halt and restore job execution paths instantly.',
+    },
+    {
+      title: 'Thermostat parameter dry-run',
+      command: `npx hardhat run ${thermostatScript} --network ${network}`,
+      purpose: 'Simulates temperature adjustments before committing to the chain.',
+    },
+    {
+      title: 'Thermostat parameter execute',
+      command: `npx hardhat run ${thermostatScript} --network ${network} --execute`,
+      purpose: 'Applies incentive tuning on-chain under multisig supervision.',
+    },
+    {
+      title: 'Audit CI branch protection',
+      command: 'npm run ci:verify-branch-protection',
+      purpose: 'Proves pull requests and main remain blocked on the green CI suite.',
+    },
+  ];
+
+  const manifest = {
+    version: 'v1',
+    generatedAt: new Date().toISOString(),
+    reportRoot: relativeToRoot(reportRoot),
+    ownerControls: {
+      owner: governance.owner ?? null,
+      pauseAuthority: governance.pauseAuthority ?? null,
+      treasury: governance.treasury ?? null,
+      thermostat,
+    },
+    initiative: plan.initiative ?? plan.title ?? null,
+    objective: plan.objective ?? null,
+    budget: plan.budget ?? null,
+    jobs: Array.isArray(plan.jobs)
+      ? plan.jobs.map((job: any) => ({
+          id: job.id ?? job.name ?? 'job',
+          title: job.title ?? job.name ?? null,
+          reward: job.reward ?? null,
+          deadlineDays: job.deadlineDays ?? null,
+          dependencies: job.dependencies ?? [],
+          thermodynamicProfile: job.thermodynamicProfile ?? null,
+        }))
+      : [],
+    participants: plan.participants ?? {},
+    artifacts,
+    directories: [bundleDescriptor, logDescriptor].filter(
+      (descriptor): descriptor is DirectoryDescriptor => Boolean(descriptor),
+    ),
+    checklist,
+  };
+
+  const mdLines: string[] = [];
+  mdLines.push('# ASI Take-Off Governance Kit');
+  mdLines.push('');
+  mdLines.push(`- Generated: ${manifest.generatedAt}`);
+  if (manifest.initiative) {
+    mdLines.push(`- Initiative: ${manifest.initiative}`);
+  }
+  if (manifest.objective) {
+    mdLines.push(`- Objective: ${manifest.objective}`);
+  }
+  if (manifest.ownerControls.owner) {
+    mdLines.push(`- Owner multisig: \`${manifest.ownerControls.owner}\``);
+  }
+  if (manifest.ownerControls.pauseAuthority) {
+    mdLines.push(`- Pause authority: \`${manifest.ownerControls.pauseAuthority}\``);
+  }
+  if (manifest.ownerControls.treasury) {
+    mdLines.push(`- Treasury: \`${manifest.ownerControls.treasury}\``);
+  }
+  if (manifest.ownerControls.thermostat?.initialTemperature) {
+    mdLines.push(
+      `- Thermostat baseline temperature: ${manifest.ownerControls.thermostat.initialTemperature}`,
+    );
+  }
+  mdLines.push('');
+  mdLines.push('## Operational Checklist');
+  mdLines.push('');
+  for (const item of checklist) {
+    mdLines.push(`- **${item.title}.** ${item.purpose} Command: \`${item.command}\`.`);
+  }
+  mdLines.push('');
+  mdLines.push('## Artifact Integrity');
+  mdLines.push('');
+  mdLines.push('| Key | Path | SHA-256 | Size (bytes) |');
+  mdLines.push('| --- | --- | --- | ---: |');
+  for (const artifact of artifacts) {
+    mdLines.push(
+      `| ${artifact.key} | ${artifact.path} | \`${artifact.sha256}\` | ${artifact.size} |`,
+    );
+  }
+  mdLines.push('');
+  if (manifest.directories.length > 0) {
+    mdLines.push('## Directory Artefacts');
+    mdLines.push('');
+    for (const directory of manifest.directories) {
+      mdLines.push(`- **${directory.key}** (\`${directory.path}\`)`);
+      if (directory.entries.length === 0) {
+        mdLines.push('  - (empty directory)');
+      } else {
+        for (const entry of directory.entries) {
+          mdLines.push(`  - ${entry}`);
+        }
+      }
+    }
+    mdLines.push('');
+  }
+  mdLines.push('## Owner Control References');
+  mdLines.push('');
+  mdLines.push('- `docs/asi-national-governance-demo.md` – end-to-end governance drill.');
+  mdLines.push('- `demo/asi-takeoff/RUNBOOK.md` – operator procedures and verifications.');
+  mdLines.push('- `docs/thermodynamic-incentives.md` – incentive tuning rationale.');
+
+  await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  await fs.writeFile(markdownPath, `${mdLines.join('\n')}\n`);
+
+  return {
+    manifestPath,
+    markdownPath,
+    manifest,
+    markdown: mdLines.join('\n'),
+  };
+}
+


### PR DESCRIPTION
## Summary
- add a reusable governance kit generator that consolidates mission artefacts with integrity hashes
- expose a CLI wrapper and wire the kit into the existing asi take-off demo pipeline and CI workflow
- document the kit usage across demo quickstarts and governance playbooks for non-technical operators

## Testing
- `npm run demo:asi-takeoff` *(fails: solc download stalled, see logs)*
- `npm run lint:check` *(fails: command interrupted due to duration)*

------
https://chatgpt.com/codex/tasks/task_e_68ed38ed906c83339b5bf3889d871639