### PR TITLE
Add Hypernova governance demo and CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,59 @@ jobs:
             reports/localhost/zenith-sapience/**
           if-no-files-found: warn
 
+  hypernova_demo:
+    name: Hypernova Governance Demonstration
+    needs: tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            **/package-lock.json
+      - name: Cache Hardhat compilers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/hardhat-nodejs
+          key: hardhat-${{ runner.os }}-${{ hashFiles('hardhat.config.js', 'package-lock.json') }}
+          restore-keys: |
+            hardhat-${{ runner.os }}-
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline --progress=false
+      - name: Run Hypernova deterministic kit
+        run: npm run demo:zenith-hypernova
+      - name: Run Hypernova local rehearsal
+        env:
+          PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
+          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
+          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          RPC_URL: http://127.0.0.1:8545
+          CHAIN_ID: '31337'
+        run: npm run demo:zenith-hypernova:local
+      - name: Upload Hypernova artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: zenith-hypernova-reports
+          path: |
+            reports/zenith-hypernova/**
+            reports/localhost/zenith-hypernova/**
+          if-no-files-found: warn
+
   summary:
     name: CI summary
     runs-on: ubuntu-24.04
@@ -310,6 +363,7 @@ jobs:
       - coverage
       - asi_takeoff_demo
       - zenith_demo
+      - hypernova_demo
       - invariants
     steps:
       - name: Harden runner
@@ -330,6 +384,7 @@ jobs:
             coverage: 'Coverage thresholds',
             asi_takeoff_demo: 'ASI Take-Off Demo',
             zenith_demo: 'Zenith Sapience Demo',
+            hypernova_demo: 'Hypernova Governance Demo',
             invariants: 'Invariant tests'
           };
           const lines = ['# AGI Jobs v0 — CI v2 status', '', '| Job | Result |', '| --- | --- |'];

--- a/.github/workflows/demo-zenith-hypernova.yml
+++ b/.github/workflows/demo-zenith-hypernova.yml
@@ -1,0 +1,80 @@
+name: demo-zenith-hypernova
+
+on:
+  pull_request:
+    paths:
+      - 'demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/**'
+      - 'scripts/v2/asiGlobalDemo.ts'
+      - 'scripts/v2/asiGlobalKit.ts'
+      - 'scripts/v2/lib/asiTakeoffKit.ts'
+      - 'package.json'
+      - '.github/workflows/demo-zenith-hypernova.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/**'
+      - 'scripts/v2/asiGlobalDemo.ts'
+      - 'scripts/v2/asiGlobalKit.ts'
+      - 'scripts/v2/lib/asiTakeoffKit.ts'
+      - 'package.json'
+      - '.github/workflows/demo-zenith-hypernova.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  hypernova:
+    name: Hypernova Governance Demo
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Harden runner
+        uses: step-security/harden-runner@v2.13.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com
+            github.com
+            objects.githubusercontent.com
+            raw.githubusercontent.com
+            registry.npmjs.org
+            nodejs.org
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: '1.4.0'
+
+      - name: Run Hypernova deterministic kit
+        run: npm run demo:zenith-hypernova
+
+      - name: Run Hypernova local rehearsal
+        env:
+          PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
+          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
+          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          RPC_URL: http://127.0.0.1:8545
+          CHAIN_ID: '31337'
+        run: npm run demo:zenith-hypernova:local
+
+      - name: Upload Hypernova artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: zenith-hypernova-reports
+          path: |
+            reports/zenith-hypernova/**
+            reports/localhost/zenith-hypernova/**

--- a/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/OWNER-CONTROL.md
+++ b/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/OWNER-CONTROL.md
@@ -1,0 +1,123 @@
+# Hypernova Owner Control Matrix
+
+This dossier catalogues every adjustable parameter surfaced during the Supra-Sovereign
+Hypernova drill. All commands rely on existing repository scripts; no new code paths are
+introduced.
+
+## 1. Governance Topology
+
+- **Verify wiring**
+  ```bash
+  npm run owner:verify-control -- --network hardhat
+  ```
+- **Render topology diagram**
+  ```bash
+  ASI_GLOBAL_MERMAID_TITLE="Hypernova Governance Topology" \
+  ASI_GLOBAL_MERMAID_PATH="reports/zenith-hypernova/governance.mmd" \
+  npm run owner:diagram -- --network hardhat --format markdown --out reports/zenith-hypernova/governance.md
+  ```
+
+## 2. System Pause Circuit Breaker
+
+- **Dry-run pause/resume instructions**
+  ```bash
+  npm run owner:command-center -- --network hardhat --format markdown --out reports/zenith-hypernova/command-center.md
+  ```
+  Follow the generated Safe transaction plan to execute `SystemPause.pause()` or resume.
+
+## 3. Thermodynamic Steering
+
+- **Inspect current parameters**
+  ```bash
+  npm run owner:parameters -- --network hardhat --format markdown --out reports/zenith-hypernova/parameter-matrix.md
+  ```
+- **Preview emergency temperature increase**
+  ```bash
+  npx hardhat run --no-compile scripts/v2/updateThermodynamics.ts \
+    --network hardhat \
+    --temperature 0.45 \
+    --preview
+  ```
+- **Execute temperature change (requires explicit confirmation)**
+  ```bash
+  npx hardhat run --no-compile scripts/v2/updateThermodynamics.ts \
+    --network hardhat \
+    --temperature 0.45 \
+    --execute
+  ```
+- **Restore baseline configuration**
+  ```bash
+  npx hardhat run --no-compile scripts/v2/updateThermodynamics.ts \
+    --network hardhat \
+    --load config/thermodynamics.json \
+    --execute
+  ```
+
+## 4. Treasury & Rewards
+
+- **Review fee splits and recipients**
+  ```bash
+  npx hardhat run --no-compile scripts/v2/owner-dashboard.ts --network hardhat
+  ```
+- **Preview fee redirect**
+  ```bash
+  npx hardhat run --no-compile scripts/v2/updateFeePool.ts \
+    --network hardhat \
+    --treasury 0xTREASURY-NEW \
+    --preview
+  ```
+- **Execute redirect after governance approval**
+  ```bash
+  npx hardhat run --no-compile scripts/v2/updateFeePool.ts \
+    --network hardhat \
+    --treasury 0xTREASURY-NEW \
+    --execute
+  ```
+
+## 5. Identity & Access
+
+- **Update ENS allowlist snapshot**
+  ```bash
+  npm run identity:update -- --plan reports/zenith-hypernova/identity-plan.json
+  ```
+  Inspect the generated diff before applying with `--execute`.
+
+## 6. Validator Operations
+
+- **Rotate validator delegates**
+  ```bash
+  npm run owner:rotate -- --network hardhat --plan demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/project-plan.json
+  ```
+- **Trigger dispute rehearsal**
+  ```bash
+  npm run disputes:sim -- --network hardhat
+  ```
+
+## 7. Upgrade Planning
+
+- **Generate Safe transaction bundle**
+  ```bash
+  npm run owner:plan:safe -- --output reports/zenith-hypernova/upgrade-plan.json
+  ```
+- **Blueprint review**
+  ```bash
+  npm run owner:blueprint -- --network hardhat --out reports/zenith-hypernova/blueprint.md
+  ```
+
+## 8. Continuous Assurance
+
+- **Mission Control dashboard refresh**
+  ```bash
+  npm run owner:mission-control -- --network hardhat --format markdown \
+    --out reports/zenith-hypernova/mission-control.md \
+    --bundle reports/zenith-hypernova/mission-bundle \
+    --bundle-name zenith-hypernova
+  ```
+- **Pulse telemetry snapshot**
+  ```bash
+  npm run owner:pulse -- --network hardhat --out reports/zenith-hypernova/pulse.json
+  ```
+
+> **Reminder:** Every state-changing command demands explicit confirmation (`--execute`).
+> Without it, scripts run in preview mode and output Safe transaction data for multisig
+> review, keeping the owner in full control.

--- a/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/README.md
+++ b/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/README.md
@@ -1,0 +1,117 @@
+# Zenith Sapience Initiative – Supra-Sovereign Hypernova Governance Demonstration
+
+The **Supra-Sovereign Hypernova** rehearsal pushes the repository's ASI governance stack
+into a high-energy, multi-epoch stress test without introducing any new contracts or
+custom executors. It is engineered as a turnkey experience for non-technical owners:
+every command delegates to battle-tested scripts that already ship with AGI Jobs v0 (v2),
+wrapping them in mission-specific configuration, diagrams, and audit bundles.
+
+> **Prime directive:** Orchestrate a five-continent resilience surge, exercising every
+> owner override (pause, thermostat, treasury, validator rotation) while proving that the
+> canonical `npm run demo:asi-global` tooling can sustain repeated thermodynamic shock
+> adjustments under continuous CI enforcement.
+
+## Scenario Snapshot
+
+- **Mission frame** – A coalition of nation blocs funds the Hypernova Transition Grid,
+  demanding verifiable delivery of climate, infrastructure, and humanitarian milestones
+  across synchronized epochs.
+- **Governance spine** – Multisig + timelock authority confirmed through Mission Control
+  dossiers, mermaid topology renders, and owner command matrices generated directly from
+  repository scripts.
+- **Economic kernel** – RewardEngineMB, StakeManager, and Dispute workflows handle
+  incentives, slashing, and treasury routing with thermodynamic steering toggled live.
+- **Automation loop** – Plan → simulate → dry-run → reporting executed through the
+  existing `scripts/v2/asiGlobalDemo.ts` harness; this demo only adjusts environment
+  variables.
+- **Audit surface** – Deterministic governance kit, SHA-256 manifests, Mission Control
+  briefings, and thermodynamic reports stored under `reports/zenith-hypernova/`.
+
+## Operator Quickstart
+
+1. **Install prerequisites** – Node.js 20+, npm, Hardhat/Foundry toolchain as documented
+   in [docs/setup.md](../../docs/setup.md).
+2. **Generate the deterministic kit**:
+
+   ```bash
+   npm run demo:zenith-hypernova
+   ```
+
+   This wrapper sets Hypernova-specific environment overrides for
+   `scripts/v2/asiGlobalDemo.ts`, emitting artefacts to
+   `reports/zenith-hypernova/` and packaging a governance kit named
+   `zenith-hypernova-governance-kit`.
+3. **(Optional) Execute the local rehearsal loop** – spins up an ephemeral Hardhat node
+   with scripted agents and validators:
+
+   ```bash
+   npm run demo:zenith-hypernova:local
+   ```
+
+4. **Inspect the artefacts** under `reports/zenith-hypernova/`:
+   - `summary.md` – executive KPI brief.
+   - `mission-control.md` – pause status, treasury wiring, multisig authorities.
+   - `command-center.md` – owner command cheat sheet.
+   - `governance.mmd` / `governance.md` – mermaid topology and rendered view.
+   - `zenith-hypernova-governance-kit.*` – hashed manifest and markdown bundle for
+     auditors.
+
+All owner scripts default to preview/dry-run behaviour. Adding `--execute` is a deliberate
+act requiring multisig approval and is captured in the Mission Control output.
+
+## Assets Included
+
+| File | Purpose |
+| --- | --- |
+| [`project-plan.json`](./project-plan.json) | Structured orchestration brief consumed by `scripts/v2/asiGlobalDemo.ts`. |
+| [`RUNBOOK.md`](./RUNBOOK.md) | End-to-end operator drill, covering dry-runs, pauses, disputes, and thermodynamic swings. |
+| [`OWNER-CONTROL.md`](./OWNER-CONTROL.md) | Owner authority matrix with ready-to-execute CLI commands. |
+| [`bin/zenith-hypernova.sh`](./bin/zenith-hypernova.sh) | Deterministic kit wrapper for CI and manual runs. |
+| [`bin/zenith-hypernova-local.sh`](./bin/zenith-hypernova-local.sh) | Local rehearsal harness targeting an Anvil/Hardhat fork. |
+
+## Configuration Strategy
+
+The wrapper scripts only export environment variables already supported by the global
+demo pipeline:
+
+- `ASI_GLOBAL_PLAN_PATH` → points at this folder's `project-plan.json`.
+- `ASI_GLOBAL_REPORT_ROOT` → relocates artefacts to `reports/zenith-hypernova/`.
+- `ASI_GLOBAL_OUTPUT_BASENAME` → renames the governance kit to
+  `zenith-hypernova-governance-kit`.
+- `ASI_GLOBAL_BUNDLE_NAME` & `ASI_GLOBAL_MERMAID_TITLE` → retitle the bundle and
+  diagrams without touching rendering logic.
+- `ASI_GLOBAL_REFERENCE_DOCS_APPEND` & `ASI_GLOBAL_ADDITIONAL_ARTIFACTS_APPEND` → inject
+  this runbook and owner dossier into the generated kit.
+
+No contracts, migrations, or novel code paths are introduced – we strictly parameterise
+existing automation to maintain production parity.
+
+## Governance & Safety
+
+`OWNER-CONTROL.md` enumerates every owner-facing toggle (system pause, thermostat,
+reward splits, identity registry updates, validator rotation, quadratic governance tools)
+with explicit CLI usage. Mission Control outputs confirm the multisig + timelock
+hierarchy, ensuring human governors retain absolute authority over automation at all
+moments.
+
+## Continuous Integration
+
+`.github/workflows/demo-zenith-hypernova.yml` runs both Hypernova wrappers on pull
+requests touching this demo or the shared ASI tooling. The job uploads artefacts for
+reviewers and feeds into the main `ci (v2)` workflow, which now blocks merges until the
+Hypernova rehearsal is green. Branch protection guidance in
+[docs/ci-v2-branch-protection-checklist.md](../../docs/ci-v2-branch-protection-checklist.md)
+has been updated accordingly so non-technical owners can verify enforcement.
+
+## Follow-on Actions
+
+- Execute `npm run demo:zenith-hypernova` whenever plan, governance docs, or owner
+  guidance changes.
+- Embed `reports/zenith-hypernova/governance.md` into dashboards so executives can review
+  live topology diagrams.
+- Run `npm run owner:verify-control -- --network hardhat` after deployments to confirm the
+  wiring still matches the Hypernova specification.
+
+The Supra-Sovereign Hypernova drill therefore delivers a spectacular yet controlled
+planetary governance showcase, staying inside the repo's existing battle-tested surfaces
+while maximising auditability and owner supremacy.

--- a/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/RUNBOOK.md
+++ b/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/RUNBOOK.md
@@ -1,0 +1,124 @@
+# Hypernova Mission Runbook
+
+This runbook mirrors the deterministic `npm run demo:zenith-hypernova` wrapper while
+surfacing each stage for inspection. Every command delegates to existing scripts in this
+repository; no bespoke automation is introduced.
+
+## 1. Pre-Flight Checks
+
+- Ensure **Node.js 20.x** and **npm** are installed.
+- (Optional) Install **Foundry** if you plan to run the local rehearsal via Anvil.
+- Confirm contract health and owner wiring:
+
+  ```bash
+  npm run owner:health
+  npm run owner:verify-control -- --network hardhat
+  ```
+
+  These verify SystemPause, multisig ownership, treasury custody, and parameter access.
+
+## 2. Deterministic Governance Kit
+
+1. Execute the Hypernova wrapper (exports environment overrides only):
+
+   ```bash
+   npm run demo:zenith-hypernova
+   ```
+
+   Behind the scenes this performs:
+
+   - `scripts/generate-constants.ts` – regenerates protocol constants.
+   - `hardhat compile` – re-compiles contracts to match generated artefacts.
+   - `scripts/v2/testnetDryRun.ts --json` – simulates the complete job lifecycle with
+     thermodynamic adjustments.
+   - `scripts/v2/thermodynamicsReport.ts` – records entropy/temperature telemetry.
+   - `scripts/v2/ownerMissionControl.ts` – emits the governance dossier.
+   - `scripts/v2/ownerCommandCenter.ts` / `ownerParameterMatrix.ts` – enumerates owner
+     controls.
+   - `scripts/v2/renderOwnerMermaid.ts` – renders governance topology diagrams.
+   - `scripts/v2/verifyOwnerControl.ts` – reconfirms owner supremacy.
+   - `scripts/v2/lib/asiTakeoffKit.ts` – bundles the governance kit with SHA-256 hashes.
+
+2. Inspect the output:
+
+   ```bash
+   tree reports/zenith-hypernova -L 1
+   cat reports/zenith-hypernova/summary.md
+   ```
+
+3. Archive the governance kit for auditors (optional):
+
+   ```bash
+   cp reports/zenith-hypernova/zenith-hypernova-governance-kit.* ~/Desktop/
+   ```
+
+## 3. Local Rehearsal (Optional)
+
+1. Launch the local harness:
+
+   ```bash
+   npm run demo:zenith-hypernova:local
+   ```
+
+   This spins up Hardhat/Anvil, deploys defaults via `scripts/v2/deployDefaults.ts`, and
+   runs the aurora agent pipeline with Hypernova scope (`AURORA_REPORT_SCOPE=zenith-hypernova`).
+
+2. Examine receipts:
+
+   ```bash
+   tree reports/localhost/zenith-hypernova -L 2
+   ```
+
+## 4. Parameter & Control Drills
+
+All owner commands run in **dry-run mode** unless `--execute` is supplied. Capture the
+resulting artefacts in `reports/zenith-hypernova/` for audit evidence.
+
+| Objective | Command |
+| --- | --- |
+| Pause/resume the entire system | `npm run owner:command-center -- --network hardhat --format markdown --out reports/zenith-hypernova/command-center.md` (follow the generated instructions to pause or resume). |
+| Raise global temperature in an emergency | `npx hardhat run --no-compile scripts/v2/updateThermodynamics.ts --network hardhat --temperature 0.45 --preview` |
+| Apply the change on-chain after approval | `npx hardhat run --no-compile scripts/v2/updateThermodynamics.ts --network hardhat --temperature 0.45 --execute` |
+| Redirect treasury fees | `npx hardhat run --no-compile scripts/v2/updateFeePool.ts --network hardhat --preview` |
+| Rotate governor delegates | `npm run owner:rotate -- --network hardhat --plan demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/project-plan.json` |
+| Refresh identity snapshot | `npm run identity:update -- --plan reports/zenith-hypernova/identity-plan.json` |
+
+## 5. Incident & Recovery Drills
+
+1. **Emergency Pause** – trigger via `npm run owner:command-center`; confirm
+   `mission-control.md` shows `paused: true`.
+2. **Dispute Simulation** – exercise the built-in dispute harness:
+
+   ```bash
+   npm run disputes:sim -- --network hardhat
+   ```
+
+   Demonstrates validator slashing and job reissue.
+3. **Thermostat Reset** – restore baseline thermodynamics after a drill:
+
+   ```bash
+   npx hardhat run --no-compile scripts/v2/updateThermodynamics.ts --network hardhat --load config/thermodynamics.json
+   ```
+4. **Governance Upgrade Rehearsal** – generate a Safe transaction bundle:
+
+   ```bash
+   npm run owner:plan:safe -- --output reports/zenith-hypernova/upgrade-plan.json
+   ```
+
+   Review with signers before submission.
+
+## 6. Post-Run Verification
+
+- Re-run `npm run owner:verify-control -- --network hardhat`.
+- Hash the kit for immutable archival:
+
+  ```bash
+  shasum -a 256 reports/zenith-hypernova/zenith-hypernova-governance-kit.json
+  ```
+
+- Document governance actions in `reports/zenith-hypernova/mission-control.md`.
+
+---
+
+Following this runbook keeps the Hypernova demo deterministic, auditable, and deployable
+by non-technical stewards with minimal effort.

--- a/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/bin/zenith-hypernova-local.sh
+++ b/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/bin/zenith-hypernova-local.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+NETWORK_NAME="${NETWORK:-localhost}"
+LOCAL_REPORT_ROOT="reports/${NETWORK_NAME}/zenith-hypernova"
+
+export ASI_GLOBAL_PLAN_PATH="demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/project-plan.json"
+export ASI_GLOBAL_REPORT_ROOT="$LOCAL_REPORT_ROOT"
+export ASI_GLOBAL_OUTPUT_BASENAME="zenith-hypernova-governance-kit"
+export ASI_GLOBAL_BUNDLE_NAME="zenith-hypernova"
+export ASI_GLOBAL_MERMAID_TITLE="Hypernova Governance Topology"
+export ASI_GLOBAL_REFERENCE_DOCS_APPEND='[
+  {"path":"demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/RUNBOOK.md","description":"Hypernova operator runbook."},
+  {"path":"demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/OWNER-CONTROL.md","description":"Owner control matrix for the Hypernova initiative."}
+]'
+export ASI_GLOBAL_ADDITIONAL_ARTIFACTS_APPEND='[
+  {"key":"hypernovaRunbook","path":"demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/RUNBOOK.md","description":"Mission runbook for the Hypernova initiative."},
+  {"key":"hypernovaOwnerControl","path":"demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/OWNER-CONTROL.md","description":"Owner control dossier for the Hypernova initiative."}
+]'
+
+export AURORA_REPORT_SCOPE="zenith-hypernova"
+export AURORA_REPORT_TITLE="Hypernova Initiative — Mission Report"
+
+rm -rf "$LOCAL_REPORT_ROOT"
+mkdir -p "$LOCAL_REPORT_ROOT"
+
+NETWORK="$NETWORK_NAME" npm run demo:asi-global -- "$@"

--- a/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/bin/zenith-hypernova.sh
+++ b/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/bin/zenith-hypernova.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+REPORT_ROOT="reports/zenith-hypernova"
+
+export ASI_GLOBAL_PLAN_PATH="demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/project-plan.json"
+export ASI_GLOBAL_REPORT_ROOT="$REPORT_ROOT"
+export ASI_GLOBAL_OUTPUT_BASENAME="zenith-hypernova-governance-kit"
+export ASI_GLOBAL_BUNDLE_NAME="zenith-hypernova"
+export ASI_GLOBAL_MERMAID_TITLE="Hypernova Governance Topology"
+export ASI_GLOBAL_REFERENCE_DOCS_APPEND='[
+  {"path":"demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/RUNBOOK.md","description":"Hypernova operator runbook."},
+  {"path":"demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/OWNER-CONTROL.md","description":"Owner control matrix for the Hypernova initiative."}
+]'
+export ASI_GLOBAL_ADDITIONAL_ARTIFACTS_APPEND='[
+  {"key":"hypernovaRunbook","path":"demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/RUNBOOK.md","description":"Mission runbook for the Hypernova initiative."},
+  {"key":"hypernovaOwnerControl","path":"demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/OWNER-CONTROL.md","description":"Owner control dossier for the Hypernova initiative."}
+]'
+
+rm -rf "$REPORT_ROOT"
+mkdir -p "$REPORT_ROOT"
+
+npm run demo:asi-global -- "$@"

--- a/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/project-plan.json
+++ b/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/project-plan.json
@@ -1,0 +1,393 @@
+{
+  "initiative": "Zenith Sapience Initiative – Supra-Sovereign Hypernova Governance Demonstration",
+  "objective": "Stage a supra-sovereign Hypernova surge that steers thermodynamic incentives, executes continental programmes, and proves every owner override remains effective under stress.",
+  "budget": {
+    "currency": "AGIALPHA",
+    "total": "1250000000",
+    "allocations": {
+      "Pan-African Coalition": "210000000",
+      "Americas Alliance": "250000000",
+      "Asia-Pacific Compact": "260000000",
+      "European Union Grid": "210000000",
+      "MENA Hydrogen Bloc": "160000000",
+      "Global Governance Reserve": "62000000",
+      "Earth Systems Observatory": "21000000"
+    }
+  },
+  "governance": {
+    "owner": "0xZENITH-MULTISIG",
+    "pauseAuthority": "SystemPause",
+    "treasury": "0xZENITH-TREASURY",
+    "quadraticVoting": {
+      "contract": "AGIGovernor",
+      "timelock": "0xZENITH-TIMELOCK",
+      "executionDelayDays": 7,
+      "proposalThreshold": "1500000",
+      "quorumFraction": "0.21"
+    },
+    "thermostat": {
+      "initialTemperature": "0.22",
+      "emergencyTemperature": "0.45",
+      "updateScript": "scripts/v2/updateThermodynamics.ts",
+      "ownerGuide": "demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/OWNER-CONTROL.md"
+    },
+    "controlScripts": {
+      "commandCenter": "npm run owner:command-center -- --network hardhat --format markdown --out reports/zenith-hypernova/command-center.md",
+      "parameterMatrix": "npm run owner:parameters -- --network hardhat --format markdown --out reports/zenith-hypernova/parameter-matrix.md",
+      "missionControl": "npm run owner:mission-control -- --network hardhat --format markdown --out reports/zenith-hypernova/mission-control.md --bundle reports/zenith-hypernova/mission-bundle",
+      "mermaid": "npx hardhat run --no-compile scripts/v2/renderOwnerMermaid.ts --format markdown --out reports/zenith-hypernova/governance.md --title 'Hypernova Governance Topology'"
+    }
+  },
+  "regions": [
+    {
+      "id": "AFRICA",
+      "name": "Pan-African Coalition",
+      "goal": "Deploy adaptive microgrid corridors linking 18 member nations with autonomous validation loops.",
+      "kpis": [
+        "5.2 GW incremental capacity commissioned",
+        ">=97% validator concurrence on safety attestations",
+        "Thermostat variance kept within ±1.5%"
+      ]
+    },
+    {
+      "id": "AMERICAS",
+      "name": "Americas Alliance",
+      "goal": "Reinforce continental coastal resilience grids and automated climate offset exchanges.",
+      "kpis": [
+        "9 sovereign logistics hubs activated",
+        "Dual-governor quorum for every capital expenditure",
+        "Validator-driven disputes resolved < 36h"
+      ]
+    },
+    {
+      "id": "APAC",
+      "name": "Asia-Pacific Compact",
+      "goal": "Construct floating wind megastructures and real-time demand response bridges.",
+      "kpis": [
+        "18 floating assemblies online",
+        "Dynamic validator share balancing (±2% of target)",
+        "Cross-border energy treaty compliance events published"
+      ]
+    },
+    {
+      "id": "EU",
+      "name": "European Union Grid",
+      "goal": "Upgrade high-voltage corridors and digital twin arbitration across 30 operators.",
+      "kpis": [
+        "HVDC congestion reduced by 45%",
+        "Quadratic governance turnout above 75%",
+        "SystemPause exercised in quarterly drill"
+      ]
+    },
+    {
+      "id": "MENA",
+      "name": "MENA Hydrogen Bloc",
+      "goal": "Close the desalination-to-hydrogen supply loop with carbon auditing and validator enforced compliance.",
+      "kpis": [
+        "Hydrogen yield >= 720 kt/year",
+        "Validator incentive clawbacks under 0.4%",
+        "RewardEngineMB validator share between 19-23%"
+      ]
+    },
+    {
+      "id": "EARTH",
+      "name": "Earth Systems Observatory",
+      "goal": "Synthesize cross-regional telemetry, climate feedbacks, and mission-level incentive adjustments.",
+      "kpis": [
+        "Telemetry latency under 45 seconds",
+        "Mission summary auto-published within 5 minutes of closure",
+        "All governance actions hashed into audit kit"
+      ]
+    }
+  ],
+  "participants": {
+    "metaOrchestrator": {
+      "handle": "zenith.orchestrator.world.agi.eth",
+      "role": "Planetary coordination cortex",
+      "capabilities": [
+        "Plan→Simulate→Execute loops",
+        "Governance-safe thermostat modulation",
+        "Automatic command-center briefings"
+      ]
+    },
+    "council": [
+      {
+        "handle": "zenith.council.sustainability.agi.eth",
+        "role": "Sustainability ombudscouncil",
+        "stake": "8800000"
+      },
+      {
+        "handle": "zenith.council.infrastructure.agi.eth",
+        "role": "Infrastructure arbitration trust",
+        "stake": "9600000"
+      },
+      {
+        "handle": "zenith.council.humanitarian.agi.eth",
+        "role": "Humanitarian resilience board",
+        "stake": "7200000"
+      }
+    ],
+    "agents": [
+      {
+        "handle": "africa.microgrid.sovereign.agent.agi.eth",
+        "role": "Sovereign microgrid integrator",
+        "regions": ["AFRICA"],
+        "capabilities": [
+          "On-chain job orchestration",
+          "Thermostat telemetry streaming",
+          "Validator co-signing"
+        ]
+      },
+      {
+        "handle": "americas.resilience.collective.agent.agi.eth",
+        "role": "Pan-continental coastal reinforcement guild",
+        "regions": ["AMERICAS"],
+        "capabilities": [
+          "Bonding curve treasury management",
+          "Cross-border logistics verification",
+          "Stake slashing recovery"
+        ]
+      },
+      {
+        "handle": "apac.wind-nexus.agent.agi.eth",
+        "role": "Floating wind superstructure federation",
+        "regions": ["APAC"],
+        "capabilities": [
+          "Mission-phase demand shaping",
+          "Validator rotation automation",
+          "IPFS deliverable attestation"
+        ]
+      },
+      {
+        "handle": "eu.intertie.digitaltwin.agent.agi.eth",
+        "role": "Digital twin arbitration consortium",
+        "regions": ["EU"],
+        "capabilities": [
+          "Simulation-first compliance",
+          "Mermaid topology verification",
+          "Pause drill rehearsals"
+        ]
+      },
+      {
+        "handle": "mena.hydrogen.loop.agent.agi.eth",
+        "role": "Hydrogen compliance and export lattice",
+        "regions": ["MENA"],
+        "capabilities": [
+          "Zero-knowledge emission attestations",
+          "Validator staking balancer",
+          "Thermostat rescue trigger"
+        ]
+      },
+      {
+        "handle": "earth.observatory.agent.agi.eth",
+        "role": "Earth systems observatory",
+        "regions": ["EARTH"],
+        "capabilities": [
+          "Cross-region telemetry synthesis",
+          "Governance kit publishing",
+          "Owner intervention alerts"
+        ]
+      }
+    ],
+    "validators": [
+      {
+        "handle": "zenith.validators.audit.club.agi.eth",
+        "role": "Global audit club",
+        "regions": ["AFRICA", "AMERICAS", "APAC", "EU", "MENA", "EARTH"],
+        "capabilities": [
+          "Dual quorum attestation",
+          "Dispute arbitration",
+          "Mission-control delta analysis"
+        ]
+      },
+      {
+        "handle": "zenith.validators.ecology.club.agi.eth",
+        "role": "Planetary ecology council",
+        "regions": ["AFRICA", "APAC", "MENA", "EARTH"],
+        "capabilities": [
+          "Climate KPI audit",
+          "Thermostat oversight",
+          "Emergency pause recommendation"
+        ]
+      },
+      {
+        "handle": "zenith.validators.finance.club.agi.eth",
+        "role": "Global finance controls syndicate",
+        "regions": ["AMERICAS", "EU", "MENA", "EARTH"],
+        "capabilities": [
+          "Treasury flow verification",
+          "Stake recovery workflows",
+          "Quadratic vote supervision"
+        ]
+      }
+    ]
+  },
+  "jobs": [
+    {
+      "id": "AFRICA-MICROGRID-CORRIDOR",
+      "region": "AFRICA",
+      "title": "Deploy adaptive microgrid corridors",
+      "reward": "185000000",
+      "deadlineDays": 165,
+      "dependencies": [],
+      "energyBudget": "132000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.23",
+        "adjustmentOnDelay": "increase-validator-share"
+      }
+    },
+    {
+      "id": "AFRICA-AUDIT-HARMONISATION",
+      "region": "AFRICA",
+      "title": "Harmonise microgrid audit frameworks",
+      "reward": "32000000",
+      "deadlineDays": 45,
+      "dependencies": ["AFRICA-MICROGRID-CORRIDOR"],
+      "energyBudget": "12000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.07",
+        "adjustmentOnDelay": "trigger-pause-check"
+      }
+    },
+    {
+      "id": "AMERICAS-COASTAL-RESILIENCE",
+      "region": "AMERICAS",
+      "title": "Fortify coastal resilience grids",
+      "reward": "205000000",
+      "deadlineDays": 150,
+      "dependencies": [],
+      "energyBudget": "150000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.25",
+        "adjustmentOnDelay": "raise-temperature"
+      }
+    },
+    {
+      "id": "AMERICAS-OFFSET-EXCHANGE",
+      "region": "AMERICAS",
+      "title": "Launch automated climate offset exchange",
+      "reward": "35000000",
+      "deadlineDays": 42,
+      "dependencies": ["AMERICAS-COASTAL-RESILIENCE"],
+      "energyBudget": "14000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.08",
+        "adjustmentOnDelay": "increase-agent-share"
+      }
+    },
+    {
+      "id": "APAC-FLOATING-WIND-ARRAYS",
+      "region": "APAC",
+      "title": "Construct floating wind megastructures",
+      "reward": "190000000",
+      "deadlineDays": 180,
+      "dependencies": [],
+      "energyBudget": "135000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.27",
+        "adjustmentOnDelay": "raise-temperature"
+      }
+    },
+    {
+      "id": "APAC-DEMAND-BRIDGES",
+      "region": "APAC",
+      "title": "Bridge demand response markets",
+      "reward": "36000000",
+      "deadlineDays": 48,
+      "dependencies": ["APAC-FLOATING-WIND-ARRAYS"],
+      "energyBudget": "12000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.09",
+        "adjustmentOnDelay": "increase-validator-share"
+      }
+    },
+    {
+      "id": "EU-HVDC-EXPANSION",
+      "region": "EU",
+      "title": "Expand HVDC corridors",
+      "reward": "168000000",
+      "deadlineDays": 160,
+      "dependencies": [],
+      "energyBudget": "118000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.19",
+        "adjustmentOnDelay": "raise-temperature"
+      }
+    },
+    {
+      "id": "EU-DIGITAL-TWIN-ARBITRATION",
+      "region": "EU",
+      "title": "Deploy digital twin arbitration",
+      "reward": "42000000",
+      "deadlineDays": 55,
+      "dependencies": ["EU-HVDC-EXPANSION"],
+      "energyBudget": "15000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.08",
+        "adjustmentOnDelay": "trigger-pause-check"
+      }
+    },
+    {
+      "id": "MENA-HYDROGEN-LOOP",
+      "region": "MENA",
+      "title": "Close desalination-to-hydrogen loop",
+      "reward": "150000000",
+      "deadlineDays": 170,
+      "dependencies": [],
+      "energyBudget": "104000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.24",
+        "adjustmentOnDelay": "raise-temperature"
+      }
+    },
+    {
+      "id": "MENA-EXPORT-COMPLIANCE",
+      "region": "MENA",
+      "title": "Institute hydrogen export compliance",
+      "reward": "38000000",
+      "deadlineDays": 46,
+      "dependencies": ["MENA-HYDROGEN-LOOP"],
+      "energyBudget": "15000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.1",
+        "adjustmentOnDelay": "double-validator-bonus"
+      }
+    },
+    {
+      "id": "EARTH-SYSTEMS-INTEGRATION",
+      "region": "EARTH",
+      "title": "Integrate telemetry & incentive steering",
+      "reward": "47000000",
+      "deadlineDays": 58,
+      "dependencies": [
+        "AFRICA-AUDIT-HARMONISATION",
+        "AMERICAS-OFFSET-EXCHANGE",
+        "APAC-DEMAND-BRIDGES",
+        "EU-DIGITAL-TWIN-ARBITRATION",
+        "MENA-EXPORT-COMPLIANCE"
+      ],
+      "energyBudget": "18000000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.06",
+        "adjustmentOnDelay": "trigger-pause-check"
+      }
+    }
+  ],
+  "reporting": {
+    "artifacts": {
+      "dryRun": "reports/zenith-hypernova/dry-run.json",
+      "thermodynamics": "reports/zenith-hypernova/thermodynamics.json",
+      "missionControl": "reports/zenith-hypernova/mission-control.md",
+      "commandCenter": "reports/zenith-hypernova/command-center.md",
+      "parameterMatrix": "reports/zenith-hypernova/parameter-matrix.md",
+      "summary": "reports/zenith-hypernova/summary.md",
+      "mermaid": "reports/zenith-hypernova/governance.mmd",
+      "kit": "reports/zenith-hypernova/zenith-hypernova-governance-kit.json"
+    },
+    "dashboards": [
+      "reports/zenith-hypernova/mission-control.md",
+      "reports/zenith-hypernova/parameter-matrix.md",
+      "reports/zenith-hypernova/thermodynamics.json"
+    ]
+  }
+}

--- a/docs/ci-v2-branch-protection-checklist.md
+++ b/docs/ci-v2-branch-protection-checklist.md
@@ -14,7 +14,10 @@
 | `ci (v2) / Tests` | [`tests`](../.github/workflows/ci.yml) | Runs Hardhat compilation, the unit test suite, ABI drift detection, and constants regeneration.【F:.github/workflows/ci.yml†L62-L116】 |
 | `ci (v2) / Foundry` | [`foundry`](../.github/workflows/ci.yml) | Executes fuzz tests after unit tests, even when they fail, to expose property violations.【F:.github/workflows/ci.yml†L118-L165】 |
 | `ci (v2) / Coverage thresholds` | [`coverage`](../.github/workflows/ci.yml) | Enforces ≥90 % coverage and access-control reporting while publishing LCOV artifacts.【F:.github/workflows/ci.yml†L167-L216】 |
-| `ci (v2) / CI summary` | [`summary`](../.github/workflows/ci.yml) | Aggregates upstream job results into a single ✅/❌ indicator required by branch protection.【F:.github/workflows/ci.yml†L218-L233】 |
+| `ci (v2) / ASI Take-Off Demo` | [`asi_takeoff_demo`](../.github/workflows/ci.yml) | Exercises the ASI take-off rehearsal so mission automation never regresses.【F:.github/workflows/ci.yml†L208-L248】 |
+| `ci (v2) / Zenith Sapience Demonstration` | [`zenith_demo`](../.github/workflows/ci.yml) | Validates the flagship Zenith parameterisation with deterministic kit + local rehearsal.【F:.github/workflows/ci.yml†L249-L300】 |
+| `ci (v2) / Hypernova Governance Demonstration` | [`hypernova_demo`](../.github/workflows/ci.yml) | Runs the Supra-Sovereign Hypernova drill, proving the new governance configuration stays green end-to-end.【F:.github/workflows/ci.yml†L302-L353】 |
+| `ci (v2) / CI summary` | [`summary`](../.github/workflows/ci.yml) | Aggregates upstream job results into a single ✅/❌ indicator required by branch protection.【F:.github/workflows/ci.yml†L355-L401】 |
 | `static-analysis / Slither static analysis` | [`slither`](../.github/workflows/static-analysis.yml) | Fails the merge if Slither reports unapproved high-severity findings and uploads SARIF to the security tab.【F:.github/workflows/static-analysis.yml†L20-L106】 |
 | `static-analysis / CodeQL analysis` | [`codeql`](../.github/workflows/static-analysis.yml) | Ensures CodeQL JavaScript/TypeScript scans succeed with the hardened config and SARIF upload before merges land.【F:.github/workflows/static-analysis.yml†L108-L157】 |
 
@@ -28,7 +31,7 @@ The job display names in GitHub Actions must stay in sync with these contexts. A
 
 1. Navigate to **Settings → Branches**.
 2. Edit the rule that applies to `main`.
-3. Under **Require status checks to pass before merging**, verify the seven contexts above appear in the list, in order.
+3. Under **Require status checks to pass before merging**, verify the eight contexts above appear in the list, in order.
 4. Confirm **Require branches to be up to date before merging** and **Include administrators** are enabled. Both are required for audit compliance.
 5. Capture a screenshot or export the configuration for your change-control records.
 
@@ -52,7 +55,7 @@ gh api repos/:owner/:repo/branches/main/protection --jq '{required_status_checks
 gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled'
 ```
 
-- The first command must output the seven contexts exactly as listed in the table above.
+- The first command must output the eight contexts exactly as listed in the table above.
 - The second must print `true`, proving administrators cannot bypass the checks.
 - Record the command output (copy/paste or redirect to a dated text file) for auditors.
 

--- a/docs/v2-ci-operations.md
+++ b/docs/v2-ci-operations.md
@@ -122,6 +122,7 @@ Any change to those values inside `config/` or environment overrides forces the 
 - **Incident response:** When a CI job fails on `main`, triage by inspecting the job logs, then open an incident ticket using the `owner-control-change-ticket.md` template.
 - **Temporarily skipping jobs:** Use GitHub's `workflow_dispatch` trigger to run a targeted branch with fixes instead of editing the workflow file.
 - **Infrastructure updates:** Record any changes to cache keys or environment variables in `docs/release-checklist.md` and attach a PR link for traceability.
+- **Hypernova drill:** If the `hypernova_demo` job regresses, rerun `npm run demo:zenith-hypernova` locally to reproduce, capture the reports in `reports/zenith-hypernova/`, and attach them to the incident ticket for non-technical owners.
 
 ## Audit checkpoints
 

--- a/package.json
+++ b/package.json
@@ -136,7 +136,9 @@
     "audit:freeze": "node scripts/audit/check-freeze.js",
     "audit:final": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/audit/final-readiness.ts",
     "audit:dossier": "bash scripts/audit/export-dossier.sh",
-    "audit:package": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/audit/package-kit.ts"
+    "audit:package": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/audit/package-kit.ts",
+    "demo:zenith-hypernova": "bash demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/bin/zenith-hypernova.sh",
+    "demo:zenith-hypernova:local": "bash demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/bin/zenith-hypernova-local.sh"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- introduce the Supra-Sovereign Hypernova governance drill with full runbook, owner control dossier, and orchestration plan
- wire npm entry points plus a dedicated GitHub Actions workflow to package and rehearse the Hypernova scenario
- extend the v2 CI pipeline, branch-protection checklist, and operations guide so the new demo is enforced as a required green check

## Testing
- ❌ `npm run lint:check` *(fails because solhint reports existing Natspec warnings in upstream contracts)*

------
https://chatgpt.com/codex/tasks/task_e_68edc4ad34f0833389eaf2ab07b4d6b3