### PR TITLE
Add Omni Concord Ascension Atlas demonstration

### DIFF
--- a/demo/OMNI-CONCORD-ASCENSION-ATLAS/MISSION-PLAYBOOK.md
+++ b/demo/OMNI-CONCORD-ASCENSION-ATLAS/MISSION-PLAYBOOK.md
@@ -1,0 +1,74 @@
+# Omni Concord Ascension Atlas — Mission Playbook
+
+## Stage Alignment
+
+```mermaid
+gantt
+    title Mission Cadence
+    dateFormat  HH:mm
+    axisFormat  %H:%M
+    section Preparation
+    ENS + identity hardening            :done,    p1, 00:00, 00:30
+    Owner atlas + mission control       :active,  p2, after p1, 00:45
+    section Execution
+    Planner → simulator reconciliation  :crit,    e1, after p2, 01:15
+    Runner receipts + IPFS pinning      :crit,    e2, after e1, 00:45
+    Thermodynamics & Hamiltonian sync   :milestone, e3, after e2, 00:10
+    section Assurance
+    Change-ticket emission              :a1,      after e3, 00:20
+    Governance kit publication          :a2,      after a1, 00:25
+    CI summary + coverage upload        :a3,      after a2, 00:15
+```
+
+The cadence above reuses existing deterministic harnesses to guarantee each stage emits immutable artefacts and can be rerun under CI without manual intervention.【F:demo/asi-takeoff/README.md†L23-L82】【F:README.md†L17-L45】
+
+## Module Lever Index
+
+| Lever | Existing Capability | Command | Artefact |
+| ----- | ------------------- | ------- | -------- |
+| Identity sealing | Audit the registry for orphaned agents and validators | `npx hardhat run --no-compile scripts/v2/auditIdentityRegistry.ts --network mainnet` | `reports/mainnet/identity-audit.json` |
+| Thermodynamic steering | Apply updated role enthalpy budgets via Hardhat | `npx hardhat run --no-compile scripts/v2/updateThermodynamics.ts --network mainnet` | `reports/mainnet/thermodynamics-update.json` |
+| Hamiltonian guardrails | Update energy gradients & monitoring thresholds | `npm run hamiltonian:update -- --network mainnet --config config/hamiltonian-monitor.json` | `reports/mainnet/hamiltonian-update.json` |
+| Treasury routing | Tune FeePool treasury/burn shares in place | `npx hardhat run --no-compile scripts/v2/updateFeePool.ts --network mainnet --treasury <address>` | `reports/mainnet/fee-pool-update.json` |
+| Mission dossier | Compile deterministic evidence bundle | `npm run demo:asi-takeoff:kit -- --report-root reports/mainnet/omni-concord-ascension-atlas` | `reports/mainnet/omni-concord-ascension-atlas/governance-kit.md` |
+
+## Assurance Mesh
+
+```mermaid
+flowchart LR
+  classDef doc fill:#f8fafc,stroke:#7c3aed,color:#1e293b;
+  classDef cmd fill:#eef2ff,stroke:#6366f1,color:#312e81;
+  classDef artefact fill:#ecfeff,stroke:#0ea5e9,color:#0f172a;
+
+  PolicyDocs[Org Policies\n`storage/org-policies.json`]:::doc --> IdentityAudit[`auditIdentityRegistry.ts`]:::cmd
+  IdentityAudit --> IdentityArtefact[Identity Audit JSON]:::artefact
+
+  ThermoPlan[`config/thermodynamics.json`]:::doc --> ThermoUpdate[`updateThermodynamics.ts`]:::cmd
+  ThermoUpdate --> ThermoReport[Thermodynamics Report]:::artefact
+
+  HamiltonianConfig[`config/hamiltonian-monitor.json`]:::doc --> HamiltonianUpdate[`hamiltonian:update`]:::cmd
+  HamiltonianUpdate --> HamiltonianSnapshot[Hamiltonian Snapshot]:::artefact
+
+  FeePolicy[`config/owner-control.json`]:::doc --> FeeUpdate[`updateFeePool.ts`]:::cmd
+  FeeUpdate --> FeeArtefact[Treasury Adjustment Receipt]:::artefact
+
+  MissionPlan[`demo/asi-global/project-plan.json`]:::doc --> MissionDrill[`demo:asi-takeoff`]:::cmd
+  MissionDrill --> GovernanceKit[Governance Kit]:::artefact
+```
+
+All assurance pathways terminate in deterministic artefacts under `reports/<network>/`, matching the expectations laid out in the owner control verification suite and change-ticket playbook.【F:docs/owner-control-verification.md†L50-L120】【F:docs/owner-control-change-ticket.md†L1-L140】
+
+## Change Ticket Checklist
+
+1. Run `npm run owner:atlas -- --network mainnet --report-root reports/mainnet/atlas` and attach the resulting atlas summary to the mission folder.【F:scripts/v2/ownerControlAtlas.ts†L1-L170】
+2. Capture pre-change policy surfaces with `npm run owner:snapshot -- --network mainnet --out reports/mainnet/omni-concord-ascension-atlas/pre-change.md` before executing parameter updates.【F:scripts/v2/ownerControlSnapshot.ts†L1-L180】
+3. Execute `npm run owner:change-ticket -- --network mainnet --format markdown --out reports/mainnet/omni-concord-ascension-atlas/change-ticket.md` to bind the atlas, snapshot, and verification outputs in one tamper-evident manifest.【F:docs/owner-control-change-ticket.md†L1-L140】
+4. Append CI logs (`npm run ci:verify-branch-protection`, `npm run coverage:report`) to the change-ticket archive to demonstrate branch protection and test discipline at the time of execution.【F:README.md†L23-L45】
+
+## Mainnet Safety Valves
+
+- **Emergency pause drill.** Execute `npm run owner:emergency -- --network mainnet --out reports/mainnet/omni-concord-ascension-atlas/emergency.md` to verify all pause/resume runbooks remain executable.【F:scripts/v2/ownerEmergencyRunbook.ts†L1-L210】
+- **Thermostat sanity.** After thermodynamic updates, run `npx hardhat run --no-compile scripts/v2/updateThermostat.ts --network mainnet` (without `--execute`) to confirm role temperatures remain within pre-approved envelopes before publishing receipts.【F:scripts/v2/updateThermostat.ts†L1-L160】
+- **Stake reconciliation.** Call `npm run owner:parameters -- --network mainnet --out reports/mainnet/omni-concord-ascension-atlas/parameters.md` to reconcile stake minima with the mission loadout.【F:scripts/v2/ownerParameterMatrix.ts†L1-L200】
+
+By chaining these safety valves with the mission blueprint, the Atlas demonstration exhibits a continuously verifiable, economically transformative machine that remains bounded by rigorous governance controls already living inside AGI Jobs v2.

--- a/demo/OMNI-CONCORD-ASCENSION-ATLAS/README.md
+++ b/demo/OMNI-CONCORD-ASCENSION-ATLAS/README.md
@@ -1,0 +1,200 @@
+# OMNI CONCORD ASCENSION ATLAS — CI-Ready Take-Off Demonstration
+
+> A mission-grade synthesis of the AGI Jobs v2 stack that choreographs global coordination, decentralized governance, and macroeconomic planning across mainnet infrastructure while remaining fully automatable from the existing repository.
+
+---
+
+## Mission Thesis
+
+- **Singular coordination layer.** Elevate the `apps/orchestrator` one-box planner→simulator→runner chain into a planetary command surface that allocates labour, capital, and telemetry across every `contracts/v2` subsystem without introducing net-new code paths.【F:routes/onebox.py†L1503-L2215】【F:docs/orchestration.md†L1-L196】
+- **End-to-end deterministic outputs.** Reuse the `demo/asi-takeoff` pipelines, `scripts/v2/asiTakeoffDemo.ts`, and governance kit generators so every drill yields reproducible receipts, IPFS attestations, and mission dossiers consumable by regulators and partners.【F:demo/asi-takeoff/README.md†L5-L68】【F:scripts/v2/asiTakeoffDemo.ts†L1-L120】
+- **Economic command economy.** Drive thermodynamic incentives, Hamiltonian monitoring, and treasury levers by chaining the `scripts/v2/updateThermodynamics.ts`, `updateHamiltonianMonitor.ts`, and `updateFeePool.ts` automation hooks into orchestrated change windows governed through owner control kits.【F:scripts/v2/updateThermodynamics.ts†L1-L120】【F:scripts/v2/updateHamiltonianMonitor.ts†L1-L118】【F:scripts/v2/updateFeePool.ts†L1-L90】
+- **Human-aligned, machine-paced governance.** Anchor all authority proofs in the owner-control suite (`docs/owner-control-*.md`, `scripts/v2/owner*.ts`) so every decision point is demonstrably auditable without pausing the pipeline.【F:docs/owner-control-command-center.md†L1-L160】【F:scripts/v2/ownerCommandCenter.ts†L1-L180】
+
+---
+
+## Architecture Field Guide
+
+```mermaid
+flowchart TD
+  classDef orchestrator fill:#0f172a,color:#e0f2fe,stroke:#38bdf8;
+  classDef contract fill:#082f49,color:#f0f9ff,stroke:#0ea5e9;
+  classDef ops fill:#f1f5f9,color:#0f172a,stroke:#cbd5f5;
+  classDef telemetry fill:#04122b,color:#f8fafc,stroke:#7dd3fc;
+
+  subgraph CommandMesh
+    Planner[/Planner API\n`/onebox/plan`/]:::orchestrator
+    Simulator[/Simulator API\n`/onebox/simulate`/]:::orchestrator
+    Runner[/Runner API\n`/onebox/execute`/]:::orchestrator
+    Status[/Mission status\n`/onebox/status`/]:::orchestrator
+  end
+
+  subgraph ProtocolCore
+    JR[JobRegistry]:::contract
+    SM[StakeManager]:::contract
+    VM[ValidationModule]:::contract
+    DM[DisputeModule]:::contract
+    MB[RewardEngineMB]:::contract
+    TH[Thermostat]:::contract
+    EO[EnergyOracle]:::contract
+    SP[SystemPause]:::contract
+  end
+
+  subgraph SovereignOps
+    MissionKit[[ASI Take-Off Kit\n`npm run demo:asi-takeoff`]]:::ops
+    OwnerAtlas[[Owner Control Atlas\n`scripts/v2/ownerControlAtlas.ts`]]:::ops
+    ThermoSync[[Thermodynamics Sync\n`scripts/v2/updateThermodynamics.ts`]]:::ops
+    Hamiltonian[[Hamiltonian Monitor Update\n`scripts/v2/updateHamiltonianMonitor.ts`]]:::ops
+    Treasury[[FeePool Calibration\n`scripts/v2/updateFeePool.ts`]]:::ops
+  end
+
+  subgraph Observability
+    Receipts[(IPFS Receipts)]:::telemetry
+    Governance[(Governance Kits)]:::telemetry
+    Metrics[(Prometheus Metrics)]:::telemetry
+    Audit[(Audit Dossiers)]:::telemetry
+  end
+
+  Planner --> Simulator --> Runner --> Status
+  Runner --> JR
+  JR --> VM --> DM --> JR
+  JR --> SM --> MB --> ThermoSync
+  TH --> MB
+  EO --> MB
+  MB --> Treasury
+  SP --> Runner
+  Runner --> Receipts
+  MissionKit --> Receipts
+  MissionKit --> Governance
+  OwnerAtlas --> Governance
+  ThermoSync --> JR
+  Hamiltonian --> Metrics
+  Treasury --> Audit
+  Status --> Metrics
+  Receipts --> Audit
+```
+
+### Execution Narrative
+
+1. **Mission planning** — The orchestrator planner parses cross-sector intents, enforces policy caps, and emits canonical plan hashes binding the demonstration’s macroeconomic portfolio.【F:docs/orchestration.md†L11-L65】
+2. **Simulation intelligence** — The simulator applies organisational policy, budget projections, and thermodynamic forecasts before any value moves on-chain.【F:docs/orchestration.md†L66-L133】
+3. **Runner ignition** — Execution pins receipts to IPFS, routes rewards through `RewardEngineMB`, and surfaces status telemetry for institutional dashboards.【F:docs/orchestration.md†L134-L196】
+4. **Owner cadence** — Owner control kits validate SystemPause, treasury, thermostat, and registry settings so automation cannot drift outside hardened envelopes.【F:docs/owner-control-operations.md†L1-L160】
+5. **Audit-grade closure** — Mission kits produce deterministic artefacts, change tickets, and attestation bundles to hand regulators a verifiable macro-coordination dossier.【F:demo/asi-takeoff/README.md†L23-L68】
+
+---
+
+## Sequence of Operations
+
+```mermaid
+sequenceDiagram
+  participant StratOps as Strategic Operator
+  participant Planner as Planner API
+  participant Simulator as Simulator API
+  participant Runner as Runner API
+  participant Contracts as V2 Contracts
+  participant Kits as Demo & Owner Kits
+  participant Observers as Observability Fabric
+
+  StratOps->>Planner: Submit planetary mission narrative
+  Planner-->>StratOps: Plan hash + structured intent
+  StratOps->>Simulator: Submit intent + plan hash
+  Simulator-->>StratOps: Policy clearance + risk lattice
+  StratOps->>Runner: Authorise execution (relayer or wallet)
+  Runner->>Contracts: Dispatch post/assign/finalise calls
+  Contracts-->>Runner: Emit receipts + thermodynamic state
+  Runner->>Kits: Persist mission receipts & governance kit
+  Kits->>Observers: Publish IPFS CIDs, Prometheus metrics
+  Observers-->>StratOps: Render dashboards, change tickets
+```
+
+---
+
+## Implementation Blueprint
+
+### 1. Launch the planetary mission plan
+
+- Copy the deterministic environment template: `cp demo/asi-takeoff/env.example .env`.
+- Populate mainnet RPC endpoints, relayer credentials, and ENS roots following the [AGI Jobs v2 Mainnet Guide](../../docs/AGIJobs-v2-Mainnet-Guide.md).【F:docs/AGIJobs-v2-Mainnet-Guide.md†L1-L200】
+- Feed scenario prompts through the console or `npm run demo:asi-takeoff:local -- --report-root <root>` to generate baseline artefacts aligned with the existing energy orchestration drills.【F:demo/asi-takeoff/README.md†L41-L65】
+
+### 2. Elevate to global coordination
+
+- Chain additional mission plans via `ASI_GLOBAL_PLAN_PATH=demo/asi-global/project-plan.json npm run demo:asi-takeoff:local` to merge national-scale governance drills with the new macroeconomic lattice.【F:demo/asi-takeoff/README.md†L59-L65】【F:demo/asi-global/README.md†L1-L160】
+- Use `npm run demo:asi-global` to synthesise inter-regional labour sharing while remaining within the deterministic harness.【F:scripts/v2/asiGlobalDemo.ts†L1-L160】
+
+### 3. Bind economic planning levers
+
+- Execute thermodynamic recalibration: `npx hardhat run --no-compile scripts/v2/updateThermodynamics.ts --network mainnet`.
+- Refresh Hamiltonian monitoring thresholds via `npm run hamiltonian:update -- --network mainnet --config config/hamiltonian-monitor.json` to align energy entropy with macro forecasts.【F:docs/hamiltonian-monitor.md†L1-L160】
+- Align treasury parameters by running `npx hardhat run --no-compile scripts/v2/updateFeePool.ts --network mainnet --treasury <address> --burnPct <bps>` ensuring owner control receipts capture the change.【F:docs/owner-control-command-center.md†L90-L160】
+
+### 4. Codify governance cadence
+
+- Generate the Owner Control Atlas: `npm run owner:atlas -- --network mainnet --report-root reports/mainnet/atlas` to snapshot permissions, signers, and emergency runbooks.【F:scripts/v2/ownerControlAtlas.ts†L1-L170】
+- Issue change tickets before each parameter adjustment: `npm run owner:change-ticket -- --network mainnet --format json --out reports/mainnet/omni-concord-ascension-atlas/change-ticket.json`.
+- Validate emergency pause authority with `npm run owner:verify-control -- --network mainnet --check system-pause`.【F:scripts/v2/verifyOwnerControl.ts†L1-L160】
+
+### 5. Publish artefacts & attestations
+
+- Upload mission kits, change tickets, and receipts to IPFS using the built-in pinning inside the runner (`/onebox/execute`) and replicate CIDs within the governance kit markdown for institutional archives.【F:routes/onebox.py†L2116-L2215】
+- Feed the generated `reports/<network>/asi-takeoff/governance-kit.json` into executive dashboards so leadership consumes identical deterministic evidence already produced by the harness.【F:demo/asi-takeoff/README.md†L59-L82】
+
+---
+
+## CI & Automation Envelope
+
+| Capability | Command | Purpose |
+| ---------- | ------- | ------- |
+| Deterministic take-off drill | `npm run demo:asi-takeoff` | Replays mission against local or mainnet forks generating artefacts for audit. |
+| Global orchestration test | `npm run demo:asi-global` | Exercises cross-region coordination using existing deterministic scripts. |
+| Contract integrity | `npm run lint && npm run test` | Mirrors CI v2 gating with lint, Hardhat compilation, and test execution.【F:README.md†L17-L45】 |
+| Foundry fuzzing | `npm run test:foundry` | Reinforces smart-contract safety nets before new macroeconomic cadences. |
+| Owner verification | `npm run owner:verify-control` | Confirms pause/treasury/thermostat wiring stays within hardened policy. |
+| Thermodynamic regression | `npm run thermodynamics:report` | Compares energy profiles before/after macroeconomic updates.【F:scripts/v2/thermodynamicsReport.ts†L1-L160】 |
+
+Integrate the matrix above into `.github/workflows/ci.yml` by wiring composite actions or job dependencies to prove the demonstration always deploys cleanly under CI v2’s summary gate.
+
+---
+
+## Observability & Assurance
+
+- **Prometheus / Grafana.** Forward `/onebox/metrics` counters (`plan_total`, `simulate_total`, `time_to_outcome_seconds`) into institutional dashboards for live mission oversight.【F:docs/orchestration.md†L97-L133】
+- **Hamiltonian Monitor.** Couple the `monitoring/hamiltonian` package with `scripts/v2/updateHamiltonianMonitor.ts` to adapt energy allowances as macroeconomic demands shift.【F:docs/hamiltonian-monitor.md†L60-L140】
+- **Evidence of Execution.** Archive every CID, transaction hash, and proof-of-policy outcome using `docs/Evidence_of_Execution.md` as the compliance baseline.【F:docs/Evidence_of_Execution.md†L1-L200】
+- **Owner mission control.** Embed `npm run owner:mission-control` outputs into the governance kit so stakeholders read a single canonical mission feed.【F:scripts/v2/ownerMissionControl.ts†L1-L200】
+
+---
+
+## Mainnet-Scale Readiness Checklist
+
+1. **Identity discipline.** Validate ENS roots via `npx hardhat run --no-compile scripts/v2/auditIdentityRegistry.ts --network mainnet` before each drill to prevent orphan agents.【F:scripts/v2/auditIdentityRegistry.ts†L1-L200】
+2. **Treasury custody.** Confirm multisig and emergency signers with the Owner Control Blueprint before reconfiguring fee flows.【F:docs/owner-control-blueprint.md†L1-L160】
+3. **Disaster rehearsal.** Run `npm run owner:emergency -- --network mainnet` to rehearse pause/resume sequences and guarantee macroeconomic safety valves remain responsive.【F:scripts/v2/ownerEmergencyRunbook.ts†L1-L210】
+4. **Policy synchronicity.** Keep `storage/org-policies.json` aligned with mission requirements; use `npm run identity:update -- --network mainnet` as a guardrail for policy drift.【F:routes/onebox.py†L1758-L1774】
+5. **CI evidence.** Attach CI summary artefacts and coverage reports to each governance kit to prove the build that executed the drill passed all enforceable gates.【F:README.md†L17-L45】
+
+---
+
+## Deliverable Bundle
+
+All assets produced by the demonstration are deterministic and reproducible:
+
+- `reports/<network>/omni-concord-ascension-atlas/mission.json` — macroeconomic execution ledger derived from the existing ASI take-off harness.
+- `reports/<network>/omni-concord-ascension-atlas/governance-kit.md` — consolidated owner control, thermodynamics, Hamiltonian, and treasury updates.
+- `reports/<network>/omni-concord-ascension-atlas/change-tickets/*.json` — auditable change manifests signed by the owner control toolkit.
+- `reports/<network>/omni-concord-ascension-atlas/metrics/*.prom` — exportable Prometheus snapshots captured during the drill.
+
+Leverage these artefacts to demonstrate a machine-intelligence economic conductor capable of realigning market structures while remaining anchored in verifiable, reproducible automation.
+
+---
+
+## Reflective Extension
+
+To extend the demonstration without altering core code paths:
+
+- Layer regional federations by feeding separate plan files through the same deterministic pipeline; merge governance kits using `npm run demo:asi-global:kit`.
+- Plug external data sources into the planner by enriching prompt templates while keeping policy enforcement within the simulator for zero-risk testing.
+- Activate one-click deployment (`npm run deploy:oneclick:auto`) to spin up fresh environments that inherit the same mission choreography for new coalitions.【F:scripts/v2/oneclick-stack.ts†L1-L200】
+
+The OMNI CONCORD ASCENSION ATLAS positions AGI Jobs v2 as the machine-grade orchestrator that concentrates global coordination, economic planning, and governance into one continuously verified command surface.


### PR DESCRIPTION
## Summary
- add the Omni Concord Ascension Atlas folder that choreographs a CI-ready take-off demonstration using existing AGI Jobs v2 tooling
- document the mission architecture, runbook, and global coordination flows with detailed Mermaid diagrams and operational playbooks
- capture governance, thermodynamics, and observability procedures so teams can replay the scenario on mainnet infrastructure without new code

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eec9cf2fe48333b85007cff037a559