### PR TITLE
Add Omniphoenix take-off hyperstructure demo

### DIFF
--- a/demo/OMNIPHOENIX-ASCENDANT-HYPERSTRUCTURE/README.md
+++ b/demo/OMNIPHOENIX-ASCENDANT-HYPERSTRUCTURE/README.md
@@ -1,0 +1,153 @@
+# OMNIPHOENIX ASCENDANT HYPERSTRUCTURE — PLANETARY TAKE-OFF DEMONSTRATION
+
+> **Purpose-built for AGI Jobs v0 (v2) operators who need a reproducible, CI-stamped launch kit for a polycentric economic coordination network spanning continents, currencies, and autonomous polities.**  Every artefact, command, and governance drill leverages the existing AGI Jobs v2 toolchain—no bespoke binaries required.
+
+## Mission Thesis
+
+The Omniphoenix Ascendant Hyperstructure showcases how the current repository bootstraps a deterministic, economically expressive coordination mesh that:
+
+- Synchronizes labour markets, validator quorums, and thermodynamic incentives across **global supply corridors**.
+- Routes treasury and policy updates through **decentralized, multi-sig governed change surfaces** (Owner Command Center, Mission Control, Thermostat Update suites).
+- Couples **economic planning telemetry** (RewardEngineMB, Thermostat, Hamiltonian monitor) with **global policy execution** (owner playbooks, emergency pause drills) to create a first-class take-off theatre that feels like operating a planet-scale intelligence system.
+
+All flows execute via the battle-tested `demo:asi-takeoff` pipelines, `owner:*` governance scripts, `monitoring:*` sentinels, and the CI v2 contract defined in this repository.
+
+## Quickstart (Planetary Demonstration)
+
+```bash
+# 1. Point the demo orchestrator at the Omniphoenix plan.
+export ASI_TAKEOFF_PLAN_PATH=demo/OMNIPHOENIX-ASCENDANT-HYPERSTRUCTURE/project-plan.hyperstructure.json
+
+# 2. Run the deterministic take-off drill against the one-box orchestrator (Anvil/Hardhat network auto-managed by the script).
+npm run demo:asi-takeoff:local
+
+# 3. Generate the mission bundle & governance dossier using the stock tooling.
+npm run demo:asi-takeoff:kit -- \
+  --report-root reports/asi-takeoff \
+  --summary-md reports/asi-takeoff/omniphoenix-summary.md \
+  --bundle reports/asi-takeoff/omniphoenix-bundle \
+  --logs reports/asi-takeoff/logs
+
+# 4. Render the elevated mission report with Aurora (existing CI renderer).
+AURORA_REPORT_SCOPE=asi-takeoff \
+AURORA_REPORT_TITLE="Omniphoenix Ascendant — Planetary Take-Off" \
+NETWORK=localhost \
+npm run demo:asi-takeoff:report
+
+# 5. Capture the artefacts under a scoped directory for archival/CI publishing.
+rsync -a reports/asi-takeoff/ reports/asi-takeoff-omniphoenix/
+```
+
+The entire sequence is CI-friendly—drop these steps into any workflow runner that already executes the default ASI take-off job.  The plan override, bundle scope, and rsync step keep Omniphoenix artefacts isolated while preserving compatibility with existing upload scripts.
+
+## System Topology
+
+```mermaid
+flowchart TD
+  classDef control fill:#ede9fe,stroke:#7c3aed,color:#4c1d95;
+  classDef market fill:#e0f2fe,stroke:#0284c7,color:#075985;
+  classDef econ fill:#fff7ed,stroke:#fb923c,color:#7c2d12;
+  classDef oversight fill:#fef2f2,stroke:#dc2626,color:#7f1d1d;
+
+  subgraph G1[Global Orchestration]
+    ORCH[M0 — ASI Take-Off Orchestrator]:::control
+    PLAN[Omniphoenix Mission Plan (JSON)]:::control
+    CI[CI v2 Summary Gate]:::control
+  end
+
+  subgraph G2[Decentralized Market Fabric]
+    JR[JobRegistry]:::market
+    SM[StakeManager]:::market
+    VM[ValidationModule]:::market
+    DM[DisputeModule]:::market
+    RE[RewardEngineMB]:::econ
+    TH[Thermostat]:::econ
+    HM[Hamiltonian Monitor]:::econ
+  end
+
+  subgraph G3[Oversight & Governance]
+    OC[Owner Command Center scripts]:::oversight
+    MC[Owner Mission Control dossier]:::oversight
+    SP[SystemPause drills]:::oversight
+    SENT[Monitoring Sentinels]:::oversight
+  end
+
+  PLAN --> ORCH --> JR
+  ORCH --> SM
+  ORCH --> VM
+  JR <--> SM
+  VM --> DM --> JR
+  RE --> SM
+  TH --> RE
+  HM --> RE
+  OC --> JR
+  OC --> SM
+  OC --> TH
+  MC --> SENT
+  CI --> ORCH
+  CI --> OC
+  SENT --> SP
+  SP --> JR
+```
+
+## Polycentric Economic Lanes
+
+```mermaid
+sequenceDiagram
+  participant Atlas as Atlas Coordination Desk
+  participant Orchestrator as asiTakeoffDemo.ts
+  participant Registry as JobRegistry
+  participant Thermostat as Thermostat Module
+  participant Validators as Validator Cohort
+  participant Treasury as FeePool / Treasury
+
+  Atlas->>Orchestrator: Load Omniphoenix job graph (cross-continental corridors)
+  Orchestrator->>Registry: Post multi-region labour intents
+  Registry-->>Validators: Emit validation + stake requirements
+  Orchestrator->>Thermostat: Apply entropy-sensitive temperature mix (from plan)
+  Thermostat-->>Registry: Rebalance reward curves via RewardEngineMB
+  Validators-->>Orchestrator: Submit consensus receipts & disputes
+  Orchestrator->>Treasury: Publish bundle for treasury netting + burn schedules
+  Orchestrator-->>Atlas: Mission control dossier + thermodynamic telemetry
+```
+
+## Operational Pillars (Leveraging Existing Tooling)
+
+| Pillar | Repository Primitive | How it is used in the Omniphoenix demonstration |
+| --- | --- | --- |
+| **Economic Planning Mesh** | `scripts/v2/asiTakeoffDemo.ts`, `demo:asi-takeoff:kit` | Drives the deterministic mission loop, emits receipts, produces bundle-ready outputs for downstream governance upload. |
+| **Treasury & Thermodynamics** | `scripts/v2/updateThermodynamics.ts`, `npm run thermodynamics:report` | Applies role temperature overrides defined in the plan, snapshots energy budgets and entropy gradients for the economic council. |
+| **Global Governance Surface** | `npm run owner:mission-control`, `npm run owner:command-center`, `npm run owner:verify-control` | Confirms multi-region multi-sig wiring, pause authorities, and thermostat custody align with the hyperstructure specification. |
+| **Monitoring & Assurance** | `npm run monitoring:validate`, `npm run observability:smoke`, `npm run audit:package` | Validates sentinel coverage, runs smoke tests, and packages mission artefacts for regulators and partner DAOs. |
+| **CI Enforcement** | `ci (v2)` workflow, `npm run ci:verify-branch-protection` | Ensures Omniphoenix jobs only progress when all upstream verifications succeed; the summary gate reflects every orchestrated stage. |
+
+## Artefact Layout
+
+After running the quickstart sequence, the following files are available (all generated by repo-native tooling):
+
+- `reports/asi-takeoff/dry-run.json` – deterministic scenario log.
+- `reports/asi-takeoff/thermodynamics.json` – entropy, free-energy, and role-share snapshots.
+- `reports/asi-takeoff/mission-control.md` – owner mission dossier.
+- `reports/asi-takeoff/summary.json` / `summary.md` – pipeline digest (rename/copy via rsync for Omniphoenix scope).
+- `reports/asi-takeoff/omniphoenix-bundle/` – zipped receipts + governance kit produced by `demo:asi-takeoff:kit`.
+- `reports/asi-takeoff/logs/*.log` – per-step execution traces for auditors.
+
+## Integrating with Mainnet-Grade Infrastructure
+
+1. **Use the provided plan on a fork or staging network** by exporting `HARDHAT_FORK_URL` before invoking `npm run demo:asi-takeoff:local`. The script honours Hardhat RPC overrides already supported in this repository.
+2. **Apply thermodynamic overrides** by running `npm run thermostat:update -- --config config/thermodynamics.json` after ingesting telemetry from the Omniphoenix mission, ensuring on-chain parameters match the plan.
+3. **Enforce branch protection** using `npm run ci:verify-branch-protection` so that Omniphoenix upgrades enter production only with full CI attestation.
+4. **Publish the mission bundle** to decentralised storage by pointing `@pinata/sdk` or `web3.storage` credentials in `.env` and re-running `npm run demo:asi-takeoff:kit` (both dependencies ship with this repo).
+
+## Extending the Demonstration
+
+- **Regional overlays:** Duplicate the plan file, adjust the `jobs` array per region, and rerun the pipeline—no code changes necessary.
+- **Validator rotations:** Execute `npm run owner:rotate` after the mission to rehearse guardian handoffs while preserving plan commitments.
+- **Emergency governance drills:** Trigger `npm run pause:test` post-mission to exercise the pause authority, then audit the control surface with `npm run owner:pulse`.
+
+## Folder Contents
+
+- [`project-plan.hyperstructure.json`](./project-plan.hyperstructure.json) — initiative definition consumed by `asiTakeoffDemo.ts`.
+- [`RUNBOOK.md`](./RUNBOOK.md) — operator and CI playbook for mission execution.
+
+Use this directory as the canonical reference when showcasing AGI Jobs v2 as a fully automatable, CI-ready planetary coordination engine.

--- a/demo/OMNIPHOENIX-ASCENDANT-HYPERSTRUCTURE/RUNBOOK.md
+++ b/demo/OMNIPHOENIX-ASCENDANT-HYPERSTRUCTURE/RUNBOOK.md
@@ -1,0 +1,197 @@
+# Omniphoenix Ascendant Hyperstructure — Operator Runbook
+
+## Purpose
+
+Deliver a **fully automatable CI run** that demonstrates planetary-scale economic coordination using only the stock AGI Jobs v2 pipelines.  Every step below references commands already shipped in this repository.
+
+---
+
+## Phase 0 — Readiness Triage
+
+| Check | Command | Notes |
+| --- | --- | --- |
+| Verify toolchain lockstep | `npm run ci:verify-toolchain` | Ensures the runner honours the pinned Node/Hardhat versions referenced by CI v2. |
+| Confirm branch protection | `npm run ci:verify-branch-protection` | Fails fast if required contexts drift from the CI v2 contract. |
+| Validate monitoring sentinels | `npm run monitoring:validate` | Guarantees omnipresent alerting before we engage the orchestration loop. |
+| Smoke test observability | `npm run observability:smoke` | Asserts dashboards, metrics exporters, and log fans are responsive. |
+
+> **Decision gate:** If any check fails, execute the corresponding remediation playbooks documented under `docs/` before proceeding.
+
+---
+
+## Phase 1 — Mission Initialization
+
+```bash
+export ASI_TAKEOFF_PLAN_PATH=demo/OMNIPHOENIX-ASCENDANT-HYPERSTRUCTURE/project-plan.hyperstructure.json
+
+# Optional: pin Hardhat to a mainnet fork RPC if required.
+# export HARDHAT_FORK_URL=https://mainnet.gateway/<token>
+
+npm run compile
+npm run owner:verify-control
+npm run owner:mission-control
+```
+
+- `npm run compile` regenerates protocol constants (`contracts/v2/Constants.sol`) to ensure governance scripts operate on the latest configuration.
+- `npm run owner:verify-control` validates that SystemPause, Thermostat, and Treasury controllers match the repo’s hardened defaults.
+- `npm run owner:mission-control` emits the baseline governance dossier consumed later by the Aurora renderer.
+
+```mermaid
+flowchart LR
+  subgraph Prep[Initialization]
+    compile[npm run compile]
+    verify[npm run owner:verify-control]
+    mission[npm run owner:mission-control]
+  end
+
+  compile --> verify --> mission
+  mission --> Ready{Mission ready?}
+  Ready -->|yes| Launch[Proceed to Phase 2]
+  Ready -->|no| Remediate[Run owner:doctor / owner:command-center]
+```
+
+---
+
+## Phase 2 — Deterministic Take-Off Drill
+
+```bash
+npm run demo:asi-takeoff:local
+```
+
+What happens automatically (all provided by `scripts/v2/asiTakeoffDemo.ts`):
+
+1. **Constants regeneration** — ensures configs and Solidity constants match.
+2. **Dry-run harness** — exercises the full labour lifecycle for every job in `project-plan.hyperstructure.json`.
+3. **Thermodynamic telemetry** — records entropy, role temperatures, and free-energy budgets.
+4. **Mission control synthesis** — updates the owner dossier with Omniphoenix receipts.
+5. **Bundle prep** — stages a mission bundle folder for downstream publication.
+
+**Verification hooks during execution:** Tail `reports/asi-takeoff/logs/*.log` or subscribe CI logs to watch step-by-step completion. Any failure halts the pipeline with a non-zero exit code.
+
+---
+
+## Phase 3 — Governance & Economic Packaging
+
+```bash
+npm run demo:asi-takeoff:kit -- \
+  --report-root reports/asi-takeoff \
+  --summary-md reports/asi-takeoff/omniphoenix-summary.md \
+  --bundle reports/asi-takeoff/omniphoenix-bundle \
+  --logs reports/asi-takeoff/logs
+
+npm run demo:asi-takeoff:report
+npm run thermodynamics:report -- --output reports/asi-takeoff/omniphoenix-thermo.md
+npm run owner:command-center -- --output reports/asi-takeoff/omniphoenix-command-center.md
+```
+
+- `demo:asi-takeoff:kit` assembles an audit-grade governance kit (plan, receipts, telemetry, integrity hashes).
+- `demo:asi-takeoff:report` renders the Aurora Markdown summary for executive stakeholders.
+- `thermodynamics:report` and `owner:command-center` provide additional oversight overlays using existing script outputs.
+
+**Artefact collation:**
+
+```bash
+rsync -a reports/asi-takeoff/ reports/asi-takeoff-omniphoenix/
+```
+
+This preserves compatibility with publishing jobs that already target `reports/asi-takeoff` while delivering a scoped copy for archival.
+
+---
+
+## Phase 4 — Assurance & Posture Hardening
+
+1. `npm run owner:pulse` — verifies control-surface health post-mission.
+2. `npm run owner:atlas` — captures an end-to-end topology map for regulators.
+3. `npm run audit:package` — prepares the dossier for independent reviewers.
+4. `npm run pause:test` — rehearse emergency pause/unpause while referencing the mission receipts.
+5. `npm run owner:rotate -- --dry-run` — simulate guardian rotation without executing on-chain transactions.
+
+Record all outputs inside `reports/asi-takeoff-omniphoenix/post-mission/`.
+
+---
+
+## Phase 5 — CI & Publishing Hooks
+
+### GitHub Actions Integration
+
+Add the following job snippet to any workflow already running `npm run demo:asi-takeoff:local`:
+
+```yaml
+  omniphoenix-takeoff:
+    needs: [ci-summary]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - run: npm ci
+      - name: Omniphoenix take-off drill
+        run: |
+          export ASI_TAKEOFF_PLAN_PATH=demo/OMNIPHOENIX-ASCENDANT-HYPERSTRUCTURE/project-plan.hyperstructure.json
+          npm run demo:asi-takeoff:local
+      - name: Package Omniphoenix kit
+        run: |
+          npm run demo:asi-takeoff:kit -- --report-root reports/asi-takeoff --summary-md reports/asi-takeoff/omniphoenix-summary.md --bundle reports/asi-takeoff/omniphoenix-bundle --logs reports/asi-takeoff/logs
+      - name: Upload artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: omniphoenix-bundle
+          path: |
+            reports/asi-takeoff/omniphoenix-bundle
+            reports/asi-takeoff/omniphoenix-summary.md
+            reports/asi-takeoff/thermodynamics.json
+            reports/asi-takeoff/dry-run.json
+```
+
+### Publishing to Decentralised Storage
+
+```bash
+# Configure storage credentials (web3.storage or Pinata already supported)
+export WEB3_STORAGE_TOKEN=<token>
+
+# Repackage bundle with CID metadata
+tar -czf reports/asi-takeoff-omniphoenix/omniphoenix-bundle.tar.gz -C reports/asi-takeoff omniphoenix-bundle
+node scripts/publish/bundle-to-web3-storage.js --file reports/asi-takeoff-omniphoenix/omniphoenix-bundle.tar.gz
+```
+
+*(The `scripts/publish/bundle-to-web3-storage.js` helper ships with the repo; no new binaries are required.)*
+
+---
+
+## Mermaid Assurance Map
+
+```mermaid
+flowchart TD
+  subgraph CI[CI v2 Contract]
+    lint[Lint & Static Checks]
+    tests[Hardhat + Foundry]
+    coverage[Coverage Thresholds]
+    summary[CI Summary Gate]
+  end
+
+  subgraph Demo[Omniphoenix Demo]
+    init[Phase 1 — Initialization]
+    drill[Phase 2 — Take-Off Drill]
+    package[Phase 3 — Packaging]
+    assurance[Phase 4 — Assurance]
+    publish[Phase 5 — Publishing]
+  end
+
+  lint --> summary
+  tests --> summary
+  coverage --> summary
+  summary --> init --> drill --> package --> assurance --> publish
+```
+
+---
+
+## Post-Mission Debrief Checklist
+
+- [ ] `reports/asi-takeoff-omniphoenix/omniphoenix-summary.md` reviewed and signed off by governance council.
+- [ ] Thermodynamic adjustments proposed via `config/thermodynamics.json` pull request.
+- [ ] Validator rotation dry-run archived in `reports/asi-takeoff-omniphoenix/post-mission/guardian-rotation.log`.
+- [ ] Emergency pause rehearsal recorded with timestamp and operator signature.
+- [ ] Bundle CID published to partner registries (document CID + gateway URLs).
+
+When every checkbox is marked, the Omniphoenix Ascendant Hyperstructure demonstration is considered complete and production-ready.

--- a/demo/OMNIPHOENIX-ASCENDANT-HYPERSTRUCTURE/project-plan.hyperstructure.json
+++ b/demo/OMNIPHOENIX-ASCENDANT-HYPERSTRUCTURE/project-plan.hyperstructure.json
@@ -1,0 +1,188 @@
+{
+  "initiative": "Omniphoenix Ascendant Hyperstructure",
+  "objective": "Coordinate resilient planetary supply, climate stabilisation, and knowledge labor through the AGI Jobs v2 autonomy stack without bespoke extensions.",
+  "budget": {
+    "currency": "AGIALPHA",
+    "total": "1250000"
+  },
+  "governance": {
+    "owner": "0xOMNIPHOENIX-COUNCIL",
+    "pauseAuthority": "SystemPause",
+    "treasury": "0xTREASURY-HYPERSTRUCTURE",
+    "thermostat": {
+      "initialTemperature": "0.22",
+      "emergencyTemperature": "0.38",
+      "updateScript": "scripts/v2/updateThermodynamics.ts"
+    }
+  },
+  "participants": {
+    "agents": [
+      {
+        "handle": "atlas.agent.agi.eth",
+        "role": "Atlas Coordination Desk",
+        "capabilities": [
+          "Macroeconomic modelling",
+          "Multi-region supply orchestration",
+          "Thermodynamic scenario design"
+        ]
+      },
+      {
+        "handle": "celerity.agent.agi.eth",
+        "role": "Transcontinental Logistics Collective",
+        "capabilities": [
+          "Autonomous freight routing",
+          "Port & rail integration",
+          "Disruption forecasting"
+        ]
+      },
+      {
+        "handle": "aegis.validator.agi.eth",
+        "role": "Global Assurance Cooperative",
+        "capabilities": [
+          "Validator quorum",
+          "Stake-weighted auditing",
+          "Dispute arbitration"
+        ]
+      },
+      {
+        "handle": "harmonia.agent.agi.eth",
+        "role": "Climate Resilience Guild",
+        "capabilities": [
+          "Carbon market execution",
+          "Renewable balancing",
+          "Geo-spatial sensing"
+        ]
+      },
+      {
+        "handle": "codex.agent.agi.eth",
+        "role": "Knowledge Stewardship Assembly",
+        "capabilities": [
+          "Data governance",
+          "Open research verification",
+          "Credential attestation"
+        ]
+      }
+    ],
+    "validators": [
+      {
+        "handle": "aegis.validator.agi.eth",
+        "stake": "180000",
+        "mandate": "Global compliance, integrity attestations"
+      },
+      {
+        "handle": "aurora.validator.agi.eth",
+        "stake": "150000",
+        "mandate": "Energy balancing, thermodynamic audits"
+      },
+      {
+        "handle": "civic.validator.agi.eth",
+        "stake": "120000",
+        "mandate": "Human-impact oversight across polities"
+      },
+      {
+        "handle": "safety.validator.agi.eth",
+        "stake": "110000",
+        "mandate": "Infrastructure resilience and fail-safe drills"
+      }
+    ]
+  },
+  "jobs": [
+    {
+      "id": "GLOBAL-INPUT-LEDGER",
+      "title": "Harmonised supply input registry across continental corridors",
+      "reward": "145000",
+      "deadlineDays": 21,
+      "dependencies": [],
+      "energyBudget": "52000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.14",
+        "adjustmentOnDelay": "raise-temperature"
+      }
+    },
+    {
+      "id": "CLIMATE-SWARM-DEPLOY",
+      "title": "Deploy adaptive climate stabilisation swarm",
+      "reward": "210000",
+      "deadlineDays": 45,
+      "dependencies": ["GLOBAL-INPUT-LEDGER"],
+      "energyBudget": "87000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.19",
+        "adjustmentOnDelay": "increase-agent-share"
+      }
+    },
+    {
+      "id": "PAN-PAYMENTS-NETTING",
+      "title": "Cross-currency settlement and treasury routing drill",
+      "reward": "175000",
+      "deadlineDays": 18,
+      "dependencies": ["GLOBAL-INPUT-LEDGER"],
+      "energyBudget": "46000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.09",
+        "adjustmentOnDelay": "double-validator-bonus"
+      }
+    },
+    {
+      "id": "KNOWLEDGE-SAFEGUARD",
+      "title": "Open research verification and attestation cycle",
+      "reward": "120000",
+      "deadlineDays": 30,
+      "dependencies": ["GLOBAL-INPUT-LEDGER"],
+      "energyBudget": "33000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.07",
+        "adjustmentOnDelay": "trigger-pause-check"
+      }
+    },
+    {
+      "id": "INFRA-REGEN-DEPLOY",
+      "title": "Autonomous infrastructure regeneration across megacities",
+      "reward": "245000",
+      "deadlineDays": 120,
+      "dependencies": ["CLIMATE-SWARM-DEPLOY", "PAN-PAYMENTS-NETTING"],
+      "energyBudget": "158000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.23",
+        "adjustmentOnDelay": "raise-temperature"
+      }
+    },
+    {
+      "id": "GLOBAL-AUDIT-SYNTH",
+      "title": "Planetary assurance synthesis and dispute resolution dry-run",
+      "reward": "98000",
+      "deadlineDays": 20,
+      "dependencies": ["KNOWLEDGE-SAFEGUARD", "PAN-PAYMENTS-NETTING"],
+      "energyBudget": "28000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.05",
+        "adjustmentOnDelay": "trigger-pause-check"
+      }
+    },
+    {
+      "id": "EQUILIBRIUM-REBALANCE",
+      "title": "Thermodynamic equilibrium calibration and treasury rebalance",
+      "reward": "135000",
+      "deadlineDays": 25,
+      "dependencies": ["INFRA-REGEN-DEPLOY", "GLOBAL-AUDIT-SYNTH"],
+      "energyBudget": "41000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.11",
+        "adjustmentOnDelay": "increase-agent-share"
+      }
+    }
+  ],
+  "reporting": {
+    "artifacts": {
+      "dryRun": "reports/asi-takeoff/dry-run.json",
+      "thermodynamics": "reports/asi-takeoff/thermodynamics.json",
+      "missionControl": "reports/asi-takeoff/mission-control.md",
+      "summary": "reports/asi-takeoff/summary.md"
+    },
+    "dashboards": [
+      "reports/asi-takeoff/mission-control.md",
+      "reports/asi-takeoff/thermodynamics.json",
+      "reports/asi-takeoff/summary.json"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add the Omniphoenix Ascendant Hyperstructure demo directory under `demo/`
- document planetary-scale orchestration flows with mermaid diagrams and CI guidance
- provide a hyperstructure project plan JSON that reuses the existing `demo:asi-takeoff` pipeline

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68eed7487d5c8333895d9d279dccc2eb