### PR TITLE
Enhance AGI labor market demo telemetry and deployment

### DIFF
--- a/demo/agi-labor-market-grand-demo/README.md
+++ b/demo/agi-labor-market-grand-demo/README.md
@@ -72,7 +72,9 @@ The script:
 2. Walks through the happy-path job where all validators approve.
 3. Runs a contested job where governance resolves a dispute in favour of the
    agent.
-4. Prints the final balances, validator rewards, burn metrics and NFT counts.
+4. Prints a full telemetry dashboard – validator/agent stakes, fee pool state,
+   burn totals, reputation scores, and certificate ownership – so a non-technical
+   operator sees the market outcome at a glance.
 
 The output is intentionally narrative, providing contextual breadcrumbs (job
 state transitions, committee selections, dispute escalations) so a non-technical


### PR DESCRIPTION
## Summary
- add helper utilities for manual module deployment, validator selection retries, and market telemetry summarisation in the AGI labor market grand demo script
- seed required governance wiring, reputation caller permissions, and token term acknowledgements to ensure the automated scenario completes successfully
- expand the CLI README to highlight the new telemetry dashboard presented at the end of the demo run

## Testing
- npm run demo:agi-labor-market

------
https://chatgpt.com/codex/tasks/task_e_68efefc888988333b4c103992b470413