### PR TITLE
Add interactive AGI Jobs grand demo UI and reporting

### DIFF
--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -4,6 +4,7 @@ import PoliciesPanel from './components/PoliciesPanel';
 import GovernanceActionForm from './components/GovernanceActionForm';
 import GasPanel from './components/GasPanel';
 import ReceiptsViewer from './components/ReceiptsViewer';
+import GrandDemoPanel from './components/GrandDemoPanel';
 import { ApiProvider, useApi } from './context/ApiContext';
 import { GovernanceSnapshot } from './types';
 
@@ -46,6 +47,7 @@ function AppShell() {
     <div className="app-shell">
       <h1>AGI Jobs Owner Console</h1>
       <div className="panel-grid">
+        <GrandDemoPanel />
         <ConnectionPanel onConfigSaved={() => setSnapshot(null)} />
         <PoliciesPanel
           snapshot={snapshot}

--- a/apps/console/src/components/GrandDemoPanel.tsx
+++ b/apps/console/src/components/GrandDemoPanel.tsx
@@ -1,0 +1,313 @@
+import { useMemo, useState } from 'react';
+import rawReport from '../data/grand-demo-report.json';
+import {
+  DemoBalanceSnapshot,
+  DemoSectionRecord,
+  GrandDemoReport,
+} from '../types';
+
+const reportData = rawReport as GrandDemoReport;
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function shortenAddress(address: string, chars = 4): string {
+  if (!address || address.length <= chars * 2 + 2) {
+    return address;
+  }
+  return `${address.slice(0, chars + 2)}…${address.slice(-chars)}`;
+}
+
+function SnapshotTable({ snapshot }: { snapshot: DemoBalanceSnapshot }) {
+  return (
+    <div className="demo-snapshot">
+      <div className="demo-snapshot-header">
+        <h4>{snapshot.label}</h4>
+        {snapshot.notes && <p className="helper-text">{snapshot.notes}</p>}
+      </div>
+      <table className="demo-snapshot-table">
+        <thead>
+          <tr>
+            <th scope="col">Participant</th>
+            <th scope="col">Role</th>
+            <th scope="col">Balance</th>
+            <th scope="col">Address</th>
+          </tr>
+        </thead>
+        <tbody>
+          {snapshot.entries.map((entry) => (
+            <tr key={`${snapshot.id}-${entry.address}`}>
+              <td>{entry.name}</td>
+              <td>{entry.role ?? '—'}</td>
+              <td>{entry.balance.formatted}</td>
+              <td className="address-cell" title={entry.address}>
+                {shortenAddress(entry.address)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface ScenarioViewerProps {
+  scenario: DemoSectionRecord | undefined;
+}
+
+function ScenarioViewer({ scenario }: ScenarioViewerProps) {
+  if (!scenario) {
+    return (
+      <p className="helper-text" role="status">
+        Select a scenario to review the sovereign labour market timeline.
+      </p>
+    );
+  }
+
+  return (
+    <div className="demo-scenario-view">
+      {scenario.outcome && (
+        <p className="scenario-outcome" role="status">
+          {scenario.outcome}
+        </p>
+      )}
+      <ol className="demo-step-list">
+        {scenario.steps.map((step, index) => (
+          <li key={`${scenario.id}-step-${index}`} className="demo-step">
+            <div className="demo-step-header">
+              <span className="demo-step-index" aria-hidden="true">
+                {index + 1}
+              </span>
+              <h4>{step.title}</h4>
+            </div>
+            <div className="demo-step-events">
+              {step.events.map((event, eventIndex) => (
+                <article
+                  key={`${scenario.id}-step-${index}-event-${eventIndex}`}
+                  className="demo-event-card"
+                >
+                  <h5>{event.label}</h5>
+                  {event.details && <p>{event.details}</p>}
+                  {event.metrics && (
+                    <dl className="demo-metric-grid">
+                      {Object.entries(event.metrics).map(([key, value]) => (
+                        <div key={`${scenario.id}-${index}-${key}`}>
+                          <dt>{key}</dt>
+                          <dd>{value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+                  )}
+                </article>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ol>
+      {scenario.snapshots.length > 0 && (
+        <div className="demo-snapshot-grid">
+          {scenario.snapshots.map((snapshot) => (
+            <SnapshotTable key={snapshot.id} snapshot={snapshot} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function GrandDemoPanel() {
+  const report = reportData;
+  const scenarios = useMemo(
+    () => report.sections.filter((section) => section.kind === 'scenario'),
+    [report.sections]
+  );
+  const [selectedScenarioId, setSelectedScenarioId] = useState<string>(
+    scenarios[0]?.id ?? ''
+  );
+  const selectedScenario = useMemo(
+    () => scenarios.find((section) => section.id === selectedScenarioId) ?? scenarios[0],
+    [scenarios, selectedScenarioId]
+  );
+
+  const telemetry = report.telemetry;
+
+  return (
+    <div className="panel panel-wide grand-demo-panel">
+      <header className="grand-demo-header">
+        <div>
+          <h2>AGI Jobs v2 – Sovereign Labour Market Grand Demo</h2>
+          <p className="helper-text">
+            Fully sovereign AI labour orchestration with nation-state employers,
+            validator councils, dispute governance, and certificate minting –
+            powered entirely by the production contracts in this repository.
+          </p>
+        </div>
+        <div className="demo-meta-block">
+          <dl>
+            <div>
+              <dt>Network</dt>
+              <dd>
+                {report.metadata.network.name} (chain ID {report.metadata.network.chainId})
+              </dd>
+            </div>
+            <div>
+              <dt>Generated</dt>
+              <dd>{formatTimestamp(report.metadata.generatedAt)}</dd>
+            </div>
+            <div>
+              <dt>Owner control</dt>
+              <dd className="address-cell" title={report.owner.address}>
+                {shortenAddress(report.owner.address)}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </header>
+
+      <section className="grand-demo-overview">
+        <h3>Mission ledger</h3>
+        <div className="demo-token-stats">
+          <div>
+            <span className="stat-label">Token</span>
+            <span className="stat-value">
+              {report.token.symbol} · {report.token.decimals} decimals
+            </span>
+          </div>
+          <div>
+            <span className="stat-label">Initial supply</span>
+            <span className="stat-value">{report.token.initialSupply.formatted}</span>
+          </div>
+          {telemetry && (
+            <div>
+              <span className="stat-label">Current burn</span>
+              <span className="stat-value">{telemetry.totalBurned.formatted}</span>
+            </div>
+          )}
+        </div>
+        <p className="helper-text">
+          Use <code>npm run demo:agi-labor-market:report</code> to regenerate this
+          transcript with live wallet addresses and balances from your own
+          simulation run.
+        </p>
+      </section>
+
+      <section className="grand-demo-actors">
+        <h3>Actors &amp; sovereign roles</h3>
+        <div className="actor-grid">
+          {report.actors.map((actor) => (
+            <article key={actor.id} className="actor-card">
+              <h4>{actor.name}</h4>
+              <p className="actor-role">{actor.role}</p>
+              <p className="address-cell" title={actor.address}>
+                {shortenAddress(actor.address, 6)}
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="grand-demo-scenarios">
+        <div className="scenario-header">
+          <h3>Interactive scenarios</h3>
+          <div className="scenario-tabs" role="tablist">
+            {scenarios.map((scenario) => (
+              <button
+                key={scenario.id}
+                type="button"
+                className={
+                  selectedScenario?.id === scenario.id
+                    ? 'scenario-tab active'
+                    : 'scenario-tab'
+                }
+                onClick={() => setSelectedScenarioId(scenario.id)}
+                role="tab"
+                aria-selected={selectedScenario?.id === scenario.id}
+              >
+                {scenario.title}
+              </button>
+            ))}
+          </div>
+        </div>
+        <ScenarioViewer scenario={selectedScenario} />
+      </section>
+
+      {telemetry && (
+        <section className="grand-demo-telemetry">
+          <h3>Owner telemetry console</h3>
+          <div className="telemetry-grid">
+            <div>
+              <span className="stat-label">Jobs completed</span>
+              <span className="stat-value">{telemetry.totalJobs}</span>
+            </div>
+            <div>
+              <span className="stat-label">Protocol fee</span>
+              <span className="stat-value">{telemetry.feePct}%</span>
+            </div>
+            <div>
+              <span className="stat-label">Validator reward</span>
+              <span className="stat-value">{telemetry.validatorRewardPct}%</span>
+            </div>
+            <div>
+              <span className="stat-label">Pending fees</span>
+              <span className="stat-value">{telemetry.feePoolPending.formatted}</span>
+            </div>
+            <div>
+              <span className="stat-label">Agent stake</span>
+              <span className="stat-value">{telemetry.totalAgentStake.formatted}</span>
+            </div>
+            <div>
+              <span className="stat-label">Validator stake</span>
+              <span className="stat-value">{telemetry.totalValidatorStake.formatted}</span>
+            </div>
+          </div>
+          <div className="telemetry-subgrid">
+            <div>
+              <h4>Agent credentials</h4>
+              {telemetry.certificates.length === 0 ? (
+                <p className="helper-text">No credentials minted yet.</p>
+              ) : (
+                <ul>
+                  {telemetry.certificates.map((cert) => (
+                    <li key={cert.jobId}>
+                      Job #{cert.jobId} → {shortenAddress(cert.owner, 6)}
+                      {cert.uri && (
+                        <span className="helper-text"> · {cert.uri}</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <div>
+              <h4>Agent portfolios</h4>
+              <ul>
+                {telemetry.agentPortfolios.map((actor) => (
+                  <li key={actor.id}>
+                    <strong>{actor.name}</strong> — liquid {actor.liquid?.formatted}
+                    , stake {actor.staked?.formatted}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h4>Validator council</h4>
+              <ul>
+                {telemetry.validatorPortfolios.map((actor) => (
+                  <li key={actor.id}>
+                    <strong>{actor.name}</strong> — stake {actor.staked?.formatted}
+                    , reputation {actor.reputation}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/console/src/data/grand-demo-report.json
+++ b/apps/console/src/data/grand-demo-report.json
@@ -1,0 +1,732 @@
+{
+  "metadata": {
+    "generatedAt": "2025-10-15T20:54:46.952Z",
+    "network": {
+      "chainId": 31337,
+      "name": "hardhat"
+    }
+  },
+  "token": {
+    "symbol": "AGIα",
+    "decimals": 18,
+    "initialSupply": {
+      "raw": "14000000000000000000000",
+      "formatted": "14000.0 AGIα"
+    }
+  },
+  "owner": {
+    "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+  },
+  "actors": [
+    {
+      "id": "owner",
+      "name": "Sovereign Operator",
+      "role": "Owner",
+      "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    },
+    {
+      "id": "nation-a",
+      "name": "Nation A – Climate Coalition",
+      "role": "Employer Nation",
+      "address": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+    },
+    {
+      "id": "nation-b",
+      "name": "Nation B – Linguistic Alliance",
+      "role": "Employer Nation",
+      "address": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+    },
+    {
+      "id": "alice",
+      "name": "Alice – Climate Response Agent",
+      "role": "Agent",
+      "address": "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
+    },
+    {
+      "id": "bob",
+      "name": "Bob – Translation Agent",
+      "role": "Agent",
+      "address": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
+    },
+    {
+      "id": "charlie",
+      "name": "Charlie – Validator",
+      "role": "Validator",
+      "address": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"
+    },
+    {
+      "id": "dora",
+      "name": "Dora – Validator",
+      "role": "Validator",
+      "address": "0x976EA74026E726554dB657fA54763abd0C3a0aa9"
+    },
+    {
+      "id": "evan",
+      "name": "Evan – Validator",
+      "role": "Validator",
+      "address": "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
+    },
+    {
+      "id": "moderator",
+      "name": "Global Moderator",
+      "role": "Moderator",
+      "address": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
+    }
+  ],
+  "sections": [
+    {
+      "id": "bootstrapping-agi-jobs-v2-grand-demo-environment",
+      "title": "Bootstrapping AGI Jobs v2 grand demo environment",
+      "kind": "setup",
+      "steps": [
+        {
+          "title": "Deploying core contracts",
+          "events": []
+        },
+        {
+          "title": "Wiring governance relationships and module cross-links",
+          "events": []
+        },
+        {
+          "title": "Configuring policy parameters for rapid local simulation",
+          "events": []
+        },
+        {
+          "title": "Seeding IdentityRegistry with emergency allowlists",
+          "events": []
+        },
+        {
+          "title": "Initial token approvals and staking for actors",
+          "events": []
+        }
+      ],
+      "snapshots": [
+        {
+          "id": "initial-treasury-state",
+          "label": "Initial treasury state",
+          "entries": [
+            {
+              "name": "Owner treasury",
+              "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+              "role": "Owner",
+              "balance": {
+                "raw": "0",
+                "formatted": "0.0 AGIα"
+              }
+            },
+            {
+              "name": "Nation A",
+              "address": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+              "role": "Employer nation",
+              "balance": {
+                "raw": "2000000000000000000000",
+                "formatted": "2000.0 AGIα"
+              }
+            },
+            {
+              "name": "Nation B",
+              "address": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+              "role": "Employer nation",
+              "balance": {
+                "raw": "2000000000000000000000",
+                "formatted": "2000.0 AGIα"
+              }
+            },
+            {
+              "name": "Alice (agent)",
+              "address": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+              "role": "Agent",
+              "balance": {
+                "raw": "1990000000000000000000",
+                "formatted": "1990.0 AGIα"
+              }
+            },
+            {
+              "name": "Bob (agent)",
+              "address": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+              "role": "Agent",
+              "balance": {
+                "raw": "1990000000000000000000",
+                "formatted": "1990.0 AGIα"
+              }
+            },
+            {
+              "name": "Charlie (validator)",
+              "address": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+              "role": "Validator",
+              "balance": {
+                "raw": "1990000000000000000000",
+                "formatted": "1990.0 AGIα"
+              }
+            },
+            {
+              "name": "Dora (validator)",
+              "address": "0x976EA74026E726554dB657fA54763abd0C3a0aa9",
+              "role": "Validator",
+              "balance": {
+                "raw": "1990000000000000000000",
+                "formatted": "1990.0 AGIα"
+              }
+            },
+            {
+              "name": "Evan (validator)",
+              "address": "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
+              "role": "Validator",
+              "balance": {
+                "raw": "1990000000000000000000",
+                "formatted": "1990.0 AGIα"
+              }
+            },
+            {
+              "name": "Moderator reserve",
+              "address": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
+              "role": "Moderator",
+              "balance": {
+                "raw": "0",
+                "formatted": "0.0 AGIα"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "scenario-1-cooperative-intergovernmental-ai-labour-success",
+      "title": "Scenario 1 – Cooperative intergovernmental AI labour success",
+      "kind": "scenario",
+      "steps": [
+        {
+          "title": "Nation A approves escrow and posts a climate-coordination job",
+          "events": [
+            {
+              "label": "Escrow funded and job created",
+              "details": "Nation A locks 250 AGIα with a 5% protocol fee and publishes a coordinated climate action brief.",
+              "metrics": {
+                "reward": "250.0 AGIα",
+                "protocolFee": "12.5 AGIα",
+                "jobId": "1",
+                "employer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Alice stakes identity and applies through the emergency allowlist",
+          "events": [
+            {
+              "label": "Agent onboarded instantly",
+              "details": "Alice claims the mission slot via the sovereign emergency queue.",
+              "metrics": {
+                "agent": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+                "jobState": "Applied"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Alice submits validated deliverables with provable IPFS evidence",
+          "events": [
+            {
+              "label": "Deliverables anchored on-chain",
+              "details": "Alice ships verifiable climate intelligence with pinned IPFS evidence and cryptographic result hashes.",
+              "metrics": {
+                "jobState": "Submitted",
+                "resultUri": "ipfs://results/climate-success"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Nation A records burn proof and primes the validation committee selection",
+          "events": [
+            {
+              "label": "Treasury burn attested",
+              "details": "Nation A registers their burn receipt, proving escrow deflation before rewards flow.",
+              "metrics": {
+                "burnHash": "0x1832a411ce28b731b97d02089d55f01fdcf79a962b77ef1341c6058c4767f19c"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Validators commit to their assessments under commit–reveal secrecy",
+          "events": [
+            {
+              "label": "Validator council commits",
+              "details": "Three sovereign validators seal their votes, guaranteeing Sybil-resistant due process.",
+              "metrics": {
+                "quorum": "3",
+                "commitDeadline": "2025-10-15T20:56:49.000Z"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Validators reveal unanimous approval, meeting the quorum instantly",
+          "events": [
+            {
+              "label": "All validators approve",
+              "details": "Commit–reveal finality completes with unanimous alignment, clearing settlement without delay.",
+              "metrics": {
+                "revealDeadline": "2025-10-15T20:57:49.000Z"
+              }
+            },
+            {
+              "label": "Validation round finalized",
+              "details": "Consensus recorded on-chain with success flag true.",
+              "metrics": {
+                "success": "true",
+                "state": "Completed"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Nation A finalizes payment, rewarding Alice and the validator cohort",
+          "events": [
+            {
+              "label": "Escrow distributed",
+              "details": "The employer triggers sovereign settlement – Alice receives the treasury reward and validators earn protocol fees.",
+              "metrics": {
+                "success": "true"
+              }
+            },
+            {
+              "label": "Treasury telemetry",
+              "details": "Post-settlement balances illustrate value flow across nations, agents, and validators.",
+              "metrics": {
+                "agentBalance": "2190.0 AGIα",
+                "employerBalance": "1737.5 AGIα"
+              }
+            },
+            {
+              "label": "Credential minted",
+              "details": "Completion mints an AGI Jobs credential NFT for Alice – portable proof of sovereign-grade delivery.",
+              "metrics": {
+                "certificates": "1"
+              }
+            }
+          ]
+        }
+      ],
+      "snapshots": [
+        {
+          "id": "post-job-token-balances",
+          "label": "Post-job token balances",
+          "entries": [
+            {
+              "name": "Nation A",
+              "address": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+              "role": "Employer nation",
+              "balance": {
+                "raw": "1737500000000000000000",
+                "formatted": "1737.5 AGIα"
+              }
+            },
+            {
+              "name": "Alice (agent)",
+              "address": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+              "role": "Agent",
+              "balance": {
+                "raw": "2190000000000000000000",
+                "formatted": "2190.0 AGIα"
+              }
+            },
+            {
+              "name": "Charlie (validator)",
+              "address": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+              "role": "Validator",
+              "balance": {
+                "raw": "2006666666666666666666",
+                "formatted": "2006.666666666666666666 AGIα"
+              }
+            },
+            {
+              "name": "Dora (validator)",
+              "address": "0x976EA74026E726554dB657fA54763abd0C3a0aa9",
+              "role": "Validator",
+              "balance": {
+                "raw": "2006666666666666666666",
+                "formatted": "2006.666666666666666666 AGIα"
+              }
+            },
+            {
+              "name": "Evan (validator)",
+              "address": "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
+              "role": "Validator",
+              "balance": {
+                "raw": "2006666666666666666668",
+                "formatted": "2006.666666666666666668 AGIα"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": "Climate coalition mission finalized with unanimous validator approval and credential issuance."
+    },
+    {
+      "id": "scenario-2-cross-border-dispute-resolved-by-owner-governance",
+      "title": "Scenario 2 – Cross-border dispute resolved by owner governance",
+      "kind": "scenario",
+      "steps": [
+        {
+          "title": "Nation B funds a frontier language translation initiative",
+          "events": [
+            {
+              "label": "Nation B launches translation bid",
+              "details": "A multilingual diplomacy mission is posted with validator fees primed for oversight.",
+              "metrics": {
+                "reward": "180.0 AGIα",
+                "jobId": "2"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Bob applies, contributes work, and submits contested deliverables",
+          "events": [
+            {
+              "label": "Agent Bob delivers",
+              "details": "Bob provides translation drafts yet signals the need for moderator attention.",
+              "metrics": {
+                "jobState": "Submitted",
+                "agent": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
+              }
+            },
+            {
+              "label": "Employer records burn checkpoint",
+              "details": "Nation B attests to partial budget burn before dispute escalates.",
+              "metrics": {
+                "burnHash": "0xc2af6c4f51497826f2c5f1ad43c4a2f3d58ddfdb09e40d9aff69addabc6f1818"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Validators disagree; one plans to approve, another to reject, one will abstain",
+          "events": [
+            {
+              "label": "Split validator commits",
+              "details": "Validator council telegraphs contention – one support vote, one dissent, one undecided.",
+              "metrics": {
+                "commitDeadline": "2025-10-15T20:58:59.000Z"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Partial reveals occur – one validator abstains, triggering penalties",
+          "events": [
+            {
+              "label": "Reveal quorum missed",
+              "details": "Only two validators reveal – the abstaining validator will be penalised under slashing policy.",
+              "metrics": {
+                "revealed": "2"
+              }
+            },
+            {
+              "label": "Validation flags dispute",
+              "details": "The module records a failed quorum, routing governance authority to the owner.",
+              "metrics": {
+                "state": "Disputed"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Bob leverages dispute rights; governance moderates and sides with the agent",
+          "events": [
+            {
+              "label": "Owner configures emergency council",
+              "details": "The sovereign owner waives dispute fees, sets zero windows, and fast-tracks moderator appointments.",
+              "metrics": {
+                "owner": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                "moderator": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
+              }
+            },
+            {
+              "label": "Dispute resolved for the agent",
+              "details": "Owner + moderator multisig resolves in favour of Bob, restoring escrow with sovereign accountability.",
+              "metrics": {
+                "employerWins": "false"
+              }
+            }
+          ]
+        },
+        {
+          "title": "Nation B finalizes, distributing escrow and validator rewards post-dispute",
+          "events": [
+            {
+              "label": "Escrow finalised post-dispute",
+              "details": "Nation B honours the dispute verdict; Bob is paid and the abstaining validator forfeits rewards.",
+              "metrics": {
+                "success": "true"
+              }
+            },
+            {
+              "label": "Post-dispute balances",
+              "details": "Liquidity snapshot exhibits Bob’s win and the abstaining validator’s slashed position.",
+              "metrics": {
+                "agentBalance": "2170.0 AGIα",
+                "slashedValidator": "2006.666666666666666668 AGIα"
+              }
+            }
+          ]
+        }
+      ],
+      "snapshots": [
+        {
+          "id": "post-dispute-token-balances",
+          "label": "Post-dispute token balances",
+          "entries": [
+            {
+              "name": "Nation B",
+              "address": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+              "role": "Employer nation",
+              "balance": {
+                "raw": "1811000000000000000000",
+                "formatted": "1811.0 AGIα"
+              }
+            },
+            {
+              "name": "Bob (agent)",
+              "address": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+              "role": "Agent",
+              "balance": {
+                "raw": "2170000000000000000000",
+                "formatted": "2170.0 AGIα"
+              }
+            },
+            {
+              "name": "Charlie (validator)",
+              "address": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+              "role": "Validator",
+              "balance": {
+                "raw": "2006666666666666666666",
+                "formatted": "2006.666666666666666666 AGIα"
+              }
+            },
+            {
+              "name": "Dora (validator)",
+              "address": "0x976EA74026E726554dB657fA54763abd0C3a0aa9",
+              "role": "Validator",
+              "balance": {
+                "raw": "2006666666666666666666",
+                "formatted": "2006.666666666666666666 AGIα"
+              }
+            },
+            {
+              "name": "Evan (validator)",
+              "address": "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
+              "role": "Validator",
+              "balance": {
+                "raw": "2006666666666666666668",
+                "formatted": "2006.666666666666666668 AGIα"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": "Owner-controlled dispute resolution restored agent rewards while enforcing validator accountability."
+    },
+    {
+      "id": "sovereign-labour-market-telemetry-dashboard",
+      "title": "Sovereign labour market telemetry dashboard",
+      "kind": "telemetry",
+      "steps": [
+        {
+          "title": "Aggregating sovereign telemetry for the owner command center",
+          "events": [
+            {
+              "label": "Jobs orchestrated",
+              "details": "Total engagements mediated during the demo session.",
+              "metrics": {
+                "totalJobs": "2"
+              }
+            },
+            {
+              "label": "Supply shift",
+              "details": "Net AGIα burn recorded against circulating supply.",
+              "metrics": {
+                "burned": "6.175 AGIα",
+                "finalSupply": "13993.825 AGIα"
+              }
+            },
+            {
+              "label": "Protocol economics",
+              "details": "Fee levers and pending distributions surfaced for governance.",
+              "metrics": {
+                "feePct": "5%",
+                "validatorRewardPct": "20%",
+                "pendingFees": "20.425 AGIα"
+              }
+            },
+            {
+              "label": "Capital committed",
+              "details": "Stake and slashing collateral currently protecting the market.",
+              "metrics": {
+                "agents": "20.0 AGIα",
+                "validators": "24.9 AGIα"
+              }
+            },
+            {
+              "label": "Credentials minted",
+              "details": "Credential NFTs issued to trusted agents after sovereign verification.",
+              "metrics": {
+                "certificates": "#1 → 0x90F79bf6EB2c4f870365E785982E1f101E93b906, #2 → 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
+              }
+            }
+          ]
+        }
+      ],
+      "snapshots": [],
+      "outcome": "Telemetry captured – download the structured JSON report for archival or UI replay."
+    },
+    {
+      "id": "demo-complete-agi-jobs-v2-sovereignty-market-simulation-finished",
+      "title": "Demo complete – AGI Jobs v2 sovereignty market simulation finished",
+      "kind": "wrapup",
+      "steps": [],
+      "snapshots": [],
+      "outcome": "Demonstration complete – the JSON transcript captures the full market simulation."
+    }
+  ],
+  "telemetry": {
+    "totalJobs": 2,
+    "totalBurned": {
+      "raw": "6175000000000000000",
+      "formatted": "6.175 AGIα"
+    },
+    "feePct": "5",
+    "validatorRewardPct": "20",
+    "feePoolPending": {
+      "raw": "20425000000000000000",
+      "formatted": "20.425 AGIα"
+    },
+    "totalAgentStake": {
+      "raw": "20000000000000000000",
+      "formatted": "20.0 AGIα"
+    },
+    "totalValidatorStake": {
+      "raw": "24900000000000000000",
+      "formatted": "24.9 AGIα"
+    },
+    "agentPortfolios": [
+      {
+        "id": "alice",
+        "name": "Alice (agent)",
+        "role": "Agent",
+        "address": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+        "liquid": {
+          "raw": "2190000000000000000000",
+          "formatted": "2190.0 AGIα"
+        },
+        "staked": {
+          "raw": "10000000000000000000",
+          "formatted": "10.0 AGIα"
+        },
+        "locked": {
+          "raw": "0",
+          "formatted": "0.0 AGIα"
+        },
+        "reputation": "145",
+        "certificates": [
+          "#1 ← ipfs://agi-jobs/demo/certificates/1"
+        ]
+      },
+      {
+        "id": "bob",
+        "name": "Bob (agent)",
+        "role": "Agent",
+        "address": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+        "liquid": {
+          "raw": "2170000000000000000000",
+          "formatted": "2170.0 AGIα"
+        },
+        "staked": {
+          "raw": "10000000000000000000",
+          "formatted": "10.0 AGIα"
+        },
+        "locked": {
+          "raw": "0",
+          "formatted": "0.0 AGIα"
+        },
+        "reputation": "145",
+        "certificates": [
+          "#2 ← ipfs://agi-jobs/demo/certificates/2"
+        ]
+      }
+    ],
+    "validatorPortfolios": [
+      {
+        "id": "charlie",
+        "name": "Charlie (validator)",
+        "role": "Validator",
+        "address": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+        "liquid": {
+          "raw": "2006666666666666666666",
+          "formatted": "2006.666666666666666666 AGIα"
+        },
+        "staked": {
+          "raw": "5000000000000000000",
+          "formatted": "5.0 AGIα"
+        },
+        "locked": {
+          "raw": "0",
+          "formatted": "0.0 AGIα"
+        },
+        "reputation": "9"
+      },
+      {
+        "id": "dora",
+        "name": "Dora (validator)",
+        "role": "Validator",
+        "address": "0x976EA74026E726554dB657fA54763abd0C3a0aa9",
+        "liquid": {
+          "raw": "2006666666666666666666",
+          "formatted": "2006.666666666666666666 AGIα"
+        },
+        "staked": {
+          "raw": "10000000000000000000",
+          "formatted": "10.0 AGIα"
+        },
+        "locked": {
+          "raw": "0",
+          "formatted": "0.0 AGIα"
+        },
+        "reputation": "10"
+      },
+      {
+        "id": "evan",
+        "name": "Evan (validator)",
+        "role": "Validator",
+        "address": "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
+        "liquid": {
+          "raw": "2006666666666666666668",
+          "formatted": "2006.666666666666666668 AGIα"
+        },
+        "staked": {
+          "raw": "9900000000000000000",
+          "formatted": "9.9 AGIα"
+        },
+        "locked": {
+          "raw": "0",
+          "formatted": "0.0 AGIα"
+        },
+        "reputation": "9"
+      }
+    ],
+    "certificates": [
+      {
+        "jobId": "1",
+        "owner": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+        "uri": "ipfs://agi-jobs/demo/certificates/1"
+      },
+      {
+        "jobId": "2",
+        "owner": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+        "uri": "ipfs://agi-jobs/demo/certificates/2"
+      }
+    ]
+  }
+}

--- a/apps/console/src/styles.css
+++ b/apps/console/src/styles.css
@@ -63,6 +63,10 @@ h1 {
   margin-top: 1.25rem;
 }
 
+.panel-wide {
+  grid-column: 1 / -1;
+}
+
 label {
   display: block;
   font-size: 0.85rem;
@@ -116,6 +120,285 @@ button.secondary {
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.18);
   color: rgba(242, 245, 248, 0.9);
+}
+
+.grand-demo-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.grand-demo-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.demo-meta-block {
+  min-width: 260px;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  background: rgba(14, 18, 24, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.demo-meta-block dl {
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.demo-meta-block dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.demo-meta-block dd {
+  margin: 0.15rem 0 0;
+  font-weight: 600;
+}
+
+.grand-demo-overview .demo-token-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.stat-value {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.grand-demo-actors .actor-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.actor-card {
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  background: rgba(17, 20, 28, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.25);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.actor-card h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.actor-role {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.address-cell {
+  font-family: 'JetBrains Mono', 'Fira Code', 'Source Code Pro', monospace;
+  font-size: 0.8rem;
+  color: rgba(197, 223, 255, 0.95);
+}
+
+.grand-demo-scenarios .scenario-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.scenario-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.scenario-tab {
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid transparent;
+  color: rgba(242, 245, 248, 0.85);
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease, transform 0.2s ease;
+}
+
+.scenario-tab:hover {
+  border-color: rgba(122, 184, 255, 0.4);
+}
+
+.scenario-tab.active {
+  background: linear-gradient(120deg, #4481ff 0%, #8a5bff 100%);
+  color: #fff;
+  transform: translateY(-2px);
+}
+
+.demo-step-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.demo-step {
+  padding: 1.25rem 1.5rem;
+  border-radius: 18px;
+  background: rgba(13, 16, 24, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.35);
+}
+
+.demo-step-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.demo-step-header h4 {
+  margin: 0;
+}
+
+.demo-step-index {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(68, 129, 255, 0.9), rgba(138, 91, 255, 0.9));
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+}
+
+.demo-step-events {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.demo-event-card {
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  background: rgba(21, 26, 36, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.demo-event-card h5 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.demo-event-card p {
+  margin: 0 0 0.75rem;
+  color: rgba(242, 245, 248, 0.85);
+}
+
+.demo-metric-grid {
+  display: grid;
+  gap: 0.35rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  margin: 0;
+}
+
+.demo-metric-grid dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.demo-metric-grid dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.demo-snapshot-grid {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.demo-snapshot {
+  border-radius: 14px;
+  background: rgba(14, 18, 26, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.demo-snapshot-header {
+  padding: 1rem 1.25rem 0.75rem;
+}
+
+.demo-snapshot-header h4 {
+  margin: 0;
+}
+
+.demo-snapshot-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.demo-snapshot-table th,
+.demo-snapshot-table td {
+  padding: 0.6rem 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.scenario-outcome {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  background: rgba(68, 129, 255, 0.2);
+  border: 1px solid rgba(122, 184, 255, 0.35);
+  font-weight: 600;
+}
+
+.grand-demo-telemetry {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.telemetry-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.telemetry-grid > div,
+.telemetry-subgrid > div {
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  background: rgba(18, 22, 30, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.telemetry-subgrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.telemetry-subgrid h4 {
+  margin-top: 0;
+}
+
+.telemetry-subgrid ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+  font-size: 0.9rem;
 }
 
 button:disabled {

--- a/apps/console/src/types.ts
+++ b/apps/console/src/types.ts
@@ -80,3 +80,100 @@ export interface StoredReceiptRecord {
   payload?: Record<string, unknown> | null;
   metadata?: Record<string, unknown> | null;
 }
+
+export interface DemoTokenAmount {
+  raw: string;
+  formatted: string;
+}
+
+export interface DemoBalanceEntry {
+  name: string;
+  address: string;
+  role?: string;
+  balance: DemoTokenAmount;
+}
+
+export interface DemoBalanceSnapshot {
+  id: string;
+  label: string;
+  notes?: string;
+  entries: DemoBalanceEntry[];
+}
+
+export interface DemoStepEvent {
+  label: string;
+  details?: string;
+  metrics?: Record<string, string>;
+}
+
+export interface DemoStepRecord {
+  title: string;
+  events: DemoStepEvent[];
+}
+
+export type DemoSectionKind = 'setup' | 'scenario' | 'telemetry' | 'wrapup';
+
+export interface DemoSectionRecord {
+  id: string;
+  title: string;
+  kind: DemoSectionKind;
+  summary?: string;
+  outcome?: string;
+  steps: DemoStepRecord[];
+  snapshots: DemoBalanceSnapshot[];
+}
+
+export interface DemoActorProfile {
+  id: string;
+  name: string;
+  role: string;
+  address: string;
+}
+
+export interface DemoActorState extends DemoActorProfile {
+  liquid?: DemoTokenAmount;
+  staked?: DemoTokenAmount;
+  locked?: DemoTokenAmount;
+  reputation?: string;
+  certificates?: string[];
+}
+
+export interface MintedCertificateRecord {
+  jobId: string;
+  owner: string;
+  uri?: string;
+}
+
+export interface DemoTelemetry {
+  totalJobs: number;
+  totalBurned: DemoTokenAmount;
+  feePct: string;
+  validatorRewardPct: string;
+  feePoolPending: DemoTokenAmount;
+  totalAgentStake: DemoTokenAmount;
+  totalValidatorStake: DemoTokenAmount;
+  agentPortfolios: DemoActorState[];
+  validatorPortfolios: DemoActorState[];
+  certificates: MintedCertificateRecord[];
+}
+
+export interface GrandDemoReport {
+  metadata: {
+    generatedAt: string;
+    network: {
+      chainId: number;
+      name: string;
+    };
+  };
+  token: {
+    symbol: string;
+    decimals: number;
+    initialSupply: DemoTokenAmount;
+  };
+  owner: {
+    address: string;
+  };
+  actors: DemoActorProfile[];
+  sections: DemoSectionRecord[];
+  telemetry: DemoTelemetry | null;
+}

--- a/apps/console/tsconfig.json
+++ b/apps/console/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "target": "ES2020",
     "moduleResolution": "Node",
+    "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,

--- a/demo/agi-labor-market-grand-demo/README.md
+++ b/demo/agi-labor-market-grand-demo/README.md
@@ -66,6 +66,20 @@ From the repository root run:
 npx hardhat run --no-compile scripts/v2/agiLaborMarketGrandDemo.ts --network hardhat
 ```
 
+Once the automation completes you can export a structured JSON transcript and
+drive the interactive owner console demo:
+
+```bash
+npm run demo:agi-labor-market:report
+npm --prefix apps/console run dev
+```
+
+Open the console (default http://localhost:5173) to explore the “AGI Jobs v2 –
+Sovereign Labour Market Grand Demo” panel. Non-technical operators can replay
+the entire story – participating actors, validator steps, dispute escalations,
+balance snapshots, and owner governance actions – without running any CLI
+commands.
+
 The script:
 
 1. Boots the entire v2 module suite and displays initial balances.

--- a/package.json
+++ b/package.json
@@ -154,7 +154,8 @@
     "demo:omega-business-3": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/LARGE-SCALE-OMEGA-BUSINESS-3/orchestrator.ts",
     "demo:omega-business-3:mainnet": "demo/LARGE-SCALE-OMEGA-BUSINESS-3/bin/omega-mainnet.sh",
     "demo:omega-business-3:ui": "demo/LARGE-SCALE-OMEGA-BUSINESS-3/bin/omega-ui.sh",
-    "demo:agi-labor-market": "npx hardhat run --no-compile scripts/v2/agiLaborMarketGrandDemo.ts --network hardhat"
+    "demo:agi-labor-market": "npx hardhat run --no-compile scripts/v2/agiLaborMarketGrandDemo.ts --network hardhat",
+    "demo:agi-labor-market:report": "npx hardhat run --no-compile scripts/v2/agiLaborMarketGrandDemo.ts --network hardhat -- --report apps/console/src/data/grand-demo-report.json"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- capture detailed telemetry from the AGI Jobs grand demo run, including actors, events, balance snapshots, and JSON export support with CLI and env options
- surface the new data in the owner console via a full-width grand demo panel with scenario timelines, actor directory, and owner telemetry widgets
- document the workflow for exporting the JSON report and replaying the experience in the UI

## Testing
- npm --prefix apps/console run typecheck
- AGI_JOBS_DEMO_REPORT=apps/console/src/data/grand-demo-report.json npm run demo:agi-labor-market

------
https://chatgpt.com/codex/tasks/task_e_68f006e41aa48333bdcfae57aade492a