### PR TITLE
Add owner control snapshot export for AGI labor market demo

### DIFF
--- a/demo/agi-labor-market-grand-demo/README.md
+++ b/demo/agi-labor-market-grand-demo/README.md
@@ -118,6 +118,10 @@ environment variable before running the script.
      reputation.
    - Owner action logs highlighting every governance lever exercised during the
      simulation.
+   - A **sovereign control snapshot** comparing baseline configuration, live
+     drill adjustments, and restored settings, including pauser delegation and
+     emergency pause outcomes so non-technical owners can verify authority at a
+     glance.
    - Scenario timelines for the cooperative and disputed job lifecycles.
    - Certificate issuance, burn telemetry, and fee economics derived from the
      Hardhat run.

--- a/demo/agi-labor-market-grand-demo/ui/app.js
+++ b/demo/agi-labor-market-grand-demo/ui/app.js
@@ -181,6 +181,183 @@ function renderOwnerActions(container, ownerActions) {
   container.appendChild(wrapper);
 }
 
+function renderOwnerControlSnapshot(container, ownerControl) {
+  if (!ownerControl) {
+    const notice = document.createElement('div');
+    notice.className = 'notice';
+    notice.textContent =
+      'Run the latest grand demo export to populate the owner command snapshot. The Hardhat script records every governance lever exercised.';
+    container.appendChild(notice);
+    return;
+  }
+
+  const addressesSection = document.createElement('div');
+  addressesSection.className = 'owner-control-section';
+  const addressesTitle = document.createElement('h3');
+  addressesTitle.textContent = 'Command identities';
+  addressesSection.appendChild(addressesTitle);
+
+  const addressList = document.createElement('dl');
+  addressList.className = 'owner-control-dl';
+  const addressEntries = [
+    { label: 'Owner', value: ownerControl.ownerAddress },
+    { label: 'Moderator', value: ownerControl.moderatorAddress },
+    { label: 'Registry', value: ownerControl.modules.registry },
+    { label: 'Stake manager', value: ownerControl.modules.stake },
+    { label: 'Validation module', value: ownerControl.modules.validation },
+    { label: 'Fee pool', value: ownerControl.modules.feePool },
+    { label: 'Dispute module', value: ownerControl.modules.dispute },
+    { label: 'Certificate NFT', value: ownerControl.modules.certificate },
+    { label: 'Reputation engine', value: ownerControl.modules.reputation },
+    { label: 'Identity registry', value: ownerControl.modules.identity },
+  ];
+  for (const entry of addressEntries) {
+    const dt = document.createElement('dt');
+    dt.textContent = entry.label;
+    const dd = document.createElement('dd');
+    dd.className = 'parameters';
+    dd.textContent = entry.value;
+    addressList.appendChild(dt);
+    addressList.appendChild(dd);
+  }
+  addressesSection.appendChild(addressList);
+  container.appendChild(addressesSection);
+
+  const tableSection = document.createElement('div');
+  tableSection.className = 'owner-control-section';
+  const tableTitle = document.createElement('h3');
+  tableTitle.textContent = 'Parameter authority – baseline vs live adjustments';
+  tableSection.appendChild(tableTitle);
+
+  const table = document.createElement('table');
+  table.className = 'owner-control-table';
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  ['Setting', 'Baseline', 'During drill', 'Restored'].forEach((label) => {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const rows = [
+    {
+      label: 'Protocol fee',
+      render: (state) => `${state.feePct}%`,
+    },
+    {
+      label: 'Validator reward share',
+      render: (state) => `${state.validatorRewardPct}%`,
+    },
+    {
+      label: 'Fee burn',
+      render: (state) => `${state.burnPct}%`,
+    },
+    {
+      label: 'Commit window',
+      render: (state) => state.commitWindowFormatted,
+    },
+    {
+      label: 'Reveal window',
+      render: (state) => state.revealWindowFormatted,
+    },
+    {
+      label: 'Reveal quorum',
+      render: (state) => `${state.revealQuorumPct}%`,
+    },
+    {
+      label: 'Minimum revealers',
+      render: (state) => state.minRevealers.toString(),
+    },
+    {
+      label: 'Non-reveal penalty',
+      render: (state) => `${state.nonRevealPenaltyBps} bps`,
+    },
+    {
+      label: 'Non-reveal ban',
+      render: (state) => `${state.nonRevealBanBlocks} blocks`,
+    },
+    {
+      label: 'Registry pauser',
+      render: (state) => state.registryPauser,
+      className: 'parameters',
+    },
+    {
+      label: 'Stake manager pauser',
+      render: (state) => state.stakePauser,
+      className: 'parameters',
+    },
+    {
+      label: 'Validation pauser',
+      render: (state) => state.validationPauser,
+      className: 'parameters',
+    },
+  ];
+
+  const tbody = document.createElement('tbody');
+  for (const row of rows) {
+    const tr = document.createElement('tr');
+    const labelCell = document.createElement('th');
+    labelCell.textContent = row.label;
+    tr.appendChild(labelCell);
+
+    const states = [ownerControl.baseline, ownerControl.upgraded, ownerControl.restored];
+    for (const state of states) {
+      const td = document.createElement('td');
+      const value = row.render(state);
+      td.textContent = value;
+      if (row.className) {
+        td.className = row.className;
+      }
+      tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  tableSection.appendChild(table);
+  container.appendChild(tableSection);
+
+  const pauseSection = document.createElement('div');
+  pauseSection.className = 'owner-control-section';
+  const pauseTitle = document.createElement('h3');
+  pauseTitle.textContent = 'Emergency pause drill outcomes';
+  pauseSection.appendChild(pauseTitle);
+
+  const pauseTable = document.createElement('table');
+  pauseTable.className = 'owner-control-table';
+  const pauseHead = document.createElement('thead');
+  const pauseHeadRow = document.createElement('tr');
+  ['', 'Registry', 'Stake manager', 'Validation'].forEach((label) => {
+    const th = document.createElement('th');
+    th.textContent = label;
+    pauseHeadRow.appendChild(th);
+  });
+  pauseHead.appendChild(pauseHeadRow);
+  pauseTable.appendChild(pauseHead);
+
+  const pauseBody = document.createElement('tbody');
+  const pauseRows = [
+    { label: 'Owner drill', status: ownerControl.pauseDrill.owner },
+    { label: 'Moderator drill', status: ownerControl.pauseDrill.moderator },
+  ];
+  for (const entry of pauseRows) {
+    const tr = document.createElement('tr');
+    const labelCell = document.createElement('th');
+    labelCell.textContent = entry.label;
+    tr.appendChild(labelCell);
+    ['registry', 'stake', 'validation'].forEach((key) => {
+      const td = document.createElement('td');
+      td.textContent = entry.status[key] ? 'Paused + resumed' : 'Not exercised';
+      tr.appendChild(td);
+    });
+    pauseBody.appendChild(tr);
+  }
+  pauseTable.appendChild(pauseBody);
+  pauseSection.appendChild(pauseTable);
+  container.appendChild(pauseSection);
+}
+
 function renderScenarios(container, scenarios, data) {
   const timelineOptions = document.createElement('div');
   timelineOptions.className = 'timeline-controls';
@@ -283,6 +460,13 @@ function renderApp(data) {
   const ownerCard = createCard('Owner command log', 'Every configuration call executed during the run.');
   renderOwnerActions(ownerCard, data.ownerActions);
   app.appendChild(ownerCard);
+
+  const controlCard = createCard(
+    'Owner sovereign control snapshot',
+    'Baseline safeguards, live adjustments, and delegated emergency drills captured from the run.'
+  );
+  renderOwnerControlSnapshot(controlCard, data.ownerControl);
+  app.appendChild(controlCard);
 
   const scenariosCard = createCard('Scenario narratives', 'Select a view to focus the timeline on a specific lifecycle.');
   renderScenarios(scenariosCard, data.scenarios, data);

--- a/demo/agi-labor-market-grand-demo/ui/export/latest.json
+++ b/demo/agi-labor-market-grand-demo/ui/export/latest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-16T00:10:13.264Z",
+  "generatedAt": "2025-10-16T00:40:12.441Z",
   "network": "hardhat (chainId 31337)",
   "actors": [
     {
@@ -65,7 +65,7 @@
       "parameters": {
         "registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
       },
-      "at": "2025-10-16T00:10:12.282Z"
+      "at": "2025-10-16T00:40:11.673Z"
     },
     {
       "label": "Linked certificate to stake manager",
@@ -74,7 +74,7 @@
       "parameters": {
         "stake": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
       },
-      "at": "2025-10-16T00:10:12.289Z"
+      "at": "2025-10-16T00:40:11.677Z"
     },
     {
       "label": "Connected stake manager fee pool",
@@ -83,7 +83,7 @@
       "parameters": {
         "feePool": "0x0B306BF915C4d645ff596e518fAf3F9669b97016"
       },
-      "at": "2025-10-16T00:10:12.312Z"
+      "at": "2025-10-16T00:40:11.688Z"
     },
     {
       "label": "Connected stake modules",
@@ -93,7 +93,7 @@
         "registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "dispute": "0x9A676e781A523b5d0C0e43731313A708CB607508"
       },
-      "at": "2025-10-16T00:10:12.317Z"
+      "at": "2025-10-16T00:40:11.692Z"
     },
     {
       "label": "Linked stake to validation module",
@@ -102,7 +102,7 @@
       "parameters": {
         "validation": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
       },
-      "at": "2025-10-16T00:10:12.321Z"
+      "at": "2025-10-16T00:40:11.694Z"
     },
     {
       "label": "Validation module registry link",
@@ -111,7 +111,7 @@
       "parameters": {
         "registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
       },
-      "at": "2025-10-16T00:10:12.324Z"
+      "at": "2025-10-16T00:40:11.698Z"
     },
     {
       "label": "Validation module identity link",
@@ -120,7 +120,7 @@
       "parameters": {
         "identity": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788"
       },
-      "at": "2025-10-16T00:10:12.327Z"
+      "at": "2025-10-16T00:40:11.704Z"
     },
     {
       "label": "Validation module reputation link",
@@ -129,7 +129,7 @@
       "parameters": {
         "reputation": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318"
       },
-      "at": "2025-10-16T00:10:12.329Z"
+      "at": "2025-10-16T00:40:11.706Z"
     },
     {
       "label": "Validation module stake link",
@@ -138,7 +138,7 @@
       "parameters": {
         "stake": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
       },
-      "at": "2025-10-16T00:10:12.332Z"
+      "at": "2025-10-16T00:40:11.708Z"
     },
     {
       "label": "Registry module wiring finalised",
@@ -152,7 +152,7 @@
         "certificate": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "feePool": "0x0B306BF915C4d645ff596e518fAf3F9669b97016"
       },
-      "at": "2025-10-16T00:10:12.342Z"
+      "at": "2025-10-16T00:40:11.713Z"
     },
     {
       "label": "Registry identity registry set",
@@ -161,7 +161,7 @@
       "parameters": {
         "identity": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788"
       },
-      "at": "2025-10-16T00:10:12.345Z"
+      "at": "2025-10-16T00:40:11.715Z"
     },
     {
       "label": "Validator reward percentage configured",
@@ -170,7 +170,7 @@
       "parameters": {
         "pct": 20
       },
-      "at": "2025-10-16T00:10:12.348Z"
+      "at": "2025-10-16T00:40:11.717Z"
     },
     {
       "label": "Registry authorised to update reputation",
@@ -180,7 +180,7 @@
         "caller": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "allowed": true
       },
-      "at": "2025-10-16T00:10:12.351Z"
+      "at": "2025-10-16T00:40:11.719Z"
     },
     {
       "label": "Validation authorised to update reputation",
@@ -190,7 +190,7 @@
         "caller": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "allowed": true
       },
-      "at": "2025-10-16T00:10:12.355Z"
+      "at": "2025-10-16T00:40:11.721Z"
     },
     {
       "label": "Dispute module stake link",
@@ -199,7 +199,7 @@
       "parameters": {
         "stake": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
       },
-      "at": "2025-10-16T00:10:12.357Z"
+      "at": "2025-10-16T00:40:11.723Z"
     },
     {
       "label": "Commit/reveal windows tuned",
@@ -209,7 +209,7 @@
         "commitWindow": 60,
         "revealWindow": 60
       },
-      "at": "2025-10-16T00:10:12.361Z"
+      "at": "2025-10-16T00:40:11.725Z"
     },
     {
       "label": "Validator quorum set",
@@ -218,7 +218,7 @@
       "parameters": {
         "count": 3
       },
-      "at": "2025-10-16T00:10:12.363Z"
+      "at": "2025-10-16T00:40:11.726Z"
     },
     {
       "label": "Validator pool curated",
@@ -231,7 +231,7 @@
           "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
         ]
       },
-      "at": "2025-10-16T00:10:12.369Z"
+      "at": "2025-10-16T00:40:11.729Z"
     },
     {
       "label": "Reveal quorum configured",
@@ -241,7 +241,7 @@
         "minYesVotes": 0,
         "minRevealers": 2
       },
-      "at": "2025-10-16T00:10:12.372Z"
+      "at": "2025-10-16T00:40:11.730Z"
     },
     {
       "label": "Non-reveal penalty set",
@@ -251,7 +251,7 @@
         "penaltyBps": 100,
         "penaltyDivisor": 1
       },
-      "at": "2025-10-16T00:10:12.376Z"
+      "at": "2025-10-16T00:40:11.732Z"
     },
     {
       "label": "Fee pool burn percentage adjusted",
@@ -260,7 +260,7 @@
       "parameters": {
         "burnPct": 5
       },
-      "at": "2025-10-16T00:10:12.379Z"
+      "at": "2025-10-16T00:40:11.733Z"
     },
     {
       "label": "Certificate base URI set",
@@ -269,7 +269,7 @@
       "parameters": {
         "baseURI": "ipfs://agi-jobs/demo/certificates/"
       },
-      "at": "2025-10-16T00:10:12.382Z"
+      "at": "2025-10-16T00:40:11.735Z"
     },
     {
       "label": "Emergency AI agent allowlisted",
@@ -278,7 +278,7 @@
       "parameters": {
         "agent": "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
       },
-      "at": "2025-10-16T00:10:12.387Z"
+      "at": "2025-10-16T00:40:11.737Z"
     },
     {
       "label": "Agent type annotated",
@@ -288,7 +288,7 @@
         "agent": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
         "agentType": 1
       },
-      "at": "2025-10-16T00:10:12.390Z"
+      "at": "2025-10-16T00:40:11.739Z"
     },
     {
       "label": "Emergency AI agent allowlisted",
@@ -297,7 +297,7 @@
       "parameters": {
         "agent": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
       },
-      "at": "2025-10-16T00:10:12.393Z"
+      "at": "2025-10-16T00:40:11.740Z"
     },
     {
       "label": "Agent type annotated",
@@ -307,7 +307,7 @@
         "agent": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
         "agentType": 1
       },
-      "at": "2025-10-16T00:10:12.396Z"
+      "at": "2025-10-16T00:40:11.743Z"
     },
     {
       "label": "Validator council seat granted",
@@ -316,7 +316,7 @@
       "parameters": {
         "validator": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"
       },
-      "at": "2025-10-16T00:10:12.400Z"
+      "at": "2025-10-16T00:40:11.744Z"
     },
     {
       "label": "Validator council seat granted",
@@ -325,7 +325,7 @@
       "parameters": {
         "validator": "0x976EA74026E726554dB657fA54763abd0C3a0aa9"
       },
-      "at": "2025-10-16T00:10:12.406Z"
+      "at": "2025-10-16T00:40:11.748Z"
     },
     {
       "label": "Validator council seat granted",
@@ -334,7 +334,7 @@
       "parameters": {
         "validator": "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
       },
-      "at": "2025-10-16T00:10:12.409Z"
+      "at": "2025-10-16T00:40:11.749Z"
     },
     {
       "label": "Protocol fee temporarily increased",
@@ -344,7 +344,7 @@
         "previous": 5,
         "pct": 9
       },
-      "at": "2025-10-16T00:10:12.512Z"
+      "at": "2025-10-16T00:40:11.814Z"
     },
     {
       "label": "Validator rewards boosted",
@@ -354,7 +354,7 @@
         "previous": 20,
         "pct": 25
       },
-      "at": "2025-10-16T00:10:12.514Z"
+      "at": "2025-10-16T00:40:11.816Z"
     },
     {
       "label": "Fee pool burn widened",
@@ -364,7 +364,7 @@
         "previous": 5,
         "burnPct": 6
       },
-      "at": "2025-10-16T00:10:12.516Z"
+      "at": "2025-10-16T00:40:11.819Z"
     },
     {
       "label": "Commit/reveal windows extended",
@@ -376,7 +376,7 @@
         "commitWindow": "90s",
         "revealWindow": "90s"
       },
-      "at": "2025-10-16T00:10:12.525Z"
+      "at": "2025-10-16T00:40:11.826Z"
     },
     {
       "label": "Reveal quorum tightened",
@@ -388,7 +388,7 @@
         "pct": 50,
         "minRevealers": 2
       },
-      "at": "2025-10-16T00:10:12.528Z"
+      "at": "2025-10-16T00:40:11.829Z"
     },
     {
       "label": "Non-reveal penalty escalated",
@@ -400,7 +400,7 @@
         "bps": 150,
         "banBlocks": 12
       },
-      "at": "2025-10-16T00:10:12.531Z"
+      "at": "2025-10-16T00:40:11.831Z"
     },
     {
       "label": "Registry pauser delegated",
@@ -409,7 +409,7 @@
       "parameters": {
         "newPauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.542Z"
+      "at": "2025-10-16T00:40:11.840Z"
     },
     {
       "label": "Stake manager pauser delegated",
@@ -418,7 +418,7 @@
       "parameters": {
         "newPauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.545Z"
+      "at": "2025-10-16T00:40:11.843Z"
     },
     {
       "label": "Validation module pauser delegated",
@@ -427,7 +427,7 @@
       "parameters": {
         "newPauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.548Z"
+      "at": "2025-10-16T00:40:11.845Z"
     },
     {
       "label": "Registry paused for drill",
@@ -436,7 +436,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.551Z"
+      "at": "2025-10-16T00:40:11.847Z"
     },
     {
       "label": "Stake manager paused for drill",
@@ -445,7 +445,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.554Z"
+      "at": "2025-10-16T00:40:11.850Z"
     },
     {
       "label": "Validation module paused for drill",
@@ -454,7 +454,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.557Z"
+      "at": "2025-10-16T00:40:11.852Z"
     },
     {
       "label": "Registry unpaused after drill",
@@ -463,7 +463,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.568Z"
+      "at": "2025-10-16T00:40:11.859Z"
     },
     {
       "label": "Stake manager unpaused after drill",
@@ -472,7 +472,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.571Z"
+      "at": "2025-10-16T00:40:11.860Z"
     },
     {
       "label": "Validation module unpaused after drill",
@@ -481,7 +481,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.572Z"
+      "at": "2025-10-16T00:40:11.863Z"
     },
     {
       "label": "Registry paused by delegated moderator",
@@ -490,7 +490,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.575Z"
+      "at": "2025-10-16T00:40:11.865Z"
     },
     {
       "label": "Stake manager paused by delegated moderator",
@@ -499,7 +499,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.577Z"
+      "at": "2025-10-16T00:40:11.871Z"
     },
     {
       "label": "Validation module paused by delegated moderator",
@@ -508,7 +508,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.580Z"
+      "at": "2025-10-16T00:40:11.873Z"
     },
     {
       "label": "Registry unpaused by delegated moderator",
@@ -517,7 +517,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.586Z"
+      "at": "2025-10-16T00:40:11.879Z"
     },
     {
       "label": "Stake manager unpaused by delegated moderator",
@@ -526,7 +526,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.589Z"
+      "at": "2025-10-16T00:40:11.882Z"
     },
     {
       "label": "Validation module unpaused by delegated moderator",
@@ -535,7 +535,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.590Z"
+      "at": "2025-10-16T00:40:11.883Z"
     },
     {
       "label": "Protocol fee restored",
@@ -544,7 +544,7 @@
       "parameters": {
         "pct": 5
       },
-      "at": "2025-10-16T00:10:12.595Z"
+      "at": "2025-10-16T00:40:11.896Z"
     },
     {
       "label": "Validator reward restored",
@@ -553,7 +553,7 @@
       "parameters": {
         "pct": 20
       },
-      "at": "2025-10-16T00:10:12.597Z"
+      "at": "2025-10-16T00:40:11.898Z"
     },
     {
       "label": "Fee pool burn restored",
@@ -562,7 +562,7 @@
       "parameters": {
         "burnPct": 5
       },
-      "at": "2025-10-16T00:10:12.601Z"
+      "at": "2025-10-16T00:40:11.900Z"
     },
     {
       "label": "Commit/reveal cadence restored",
@@ -572,7 +572,7 @@
         "commitWindow": "60s",
         "revealWindow": "60s"
       },
-      "at": "2025-10-16T00:10:12.604Z"
+      "at": "2025-10-16T00:40:11.902Z"
     },
     {
       "label": "Reveal quorum restored",
@@ -582,7 +582,7 @@
         "pct": 0,
         "minRevealers": 2
       },
-      "at": "2025-10-16T00:10:12.606Z"
+      "at": "2025-10-16T00:40:11.903Z"
     },
     {
       "label": "Non-reveal penalty restored",
@@ -592,7 +592,7 @@
         "bps": 100,
         "banBlocks": 1
       },
-      "at": "2025-10-16T00:10:12.608Z"
+      "at": "2025-10-16T00:40:11.905Z"
     },
     {
       "label": "Registry pauser returned to owner",
@@ -601,7 +601,7 @@
       "parameters": {
         "newPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.611Z"
+      "at": "2025-10-16T00:40:11.907Z"
     },
     {
       "label": "Stake manager pauser returned to owner",
@@ -610,7 +610,7 @@
       "parameters": {
         "newPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.613Z"
+      "at": "2025-10-16T00:40:11.908Z"
     },
     {
       "label": "Validation module pauser returned to owner",
@@ -619,7 +619,7 @@
       "parameters": {
         "newPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.615Z"
+      "at": "2025-10-16T00:40:11.909Z"
     },
     {
       "label": "Dispute fee waived for demonstration",
@@ -628,7 +628,7 @@
       "parameters": {
         "fee": 0
       },
-      "at": "2025-10-16T00:10:13.114Z"
+      "at": "2025-10-16T00:40:12.322Z"
     },
     {
       "label": "Dispute window accelerated",
@@ -637,7 +637,7 @@
       "parameters": {
         "window": 0
       },
-      "at": "2025-10-16T00:10:13.123Z"
+      "at": "2025-10-16T00:40:12.332Z"
     },
     {
       "label": "Owner enrolled as dispute moderator",
@@ -647,7 +647,7 @@
         "moderator": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
         "enabled": 1
       },
-      "at": "2025-10-16T00:10:13.125Z"
+      "at": "2025-10-16T00:40:12.334Z"
     },
     {
       "label": "External moderator empowered",
@@ -657,19 +657,19 @@
         "moderator": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
         "enabled": 1
       },
-      "at": "2025-10-16T00:10:13.128Z"
+      "at": "2025-10-16T00:40:12.336Z"
     }
   ],
   "timeline": [
     {
       "kind": "section",
       "label": "Bootstrapping AGI Jobs v2 grand demo environment",
-      "at": "2025-10-16T00:10:11.268Z"
+      "at": "2025-10-16T00:40:11.001Z"
     },
     {
       "kind": "summary",
       "label": "Demo actor roster initialised",
-      "at": "2025-10-16T00:10:11.961Z",
+      "at": "2025-10-16T00:40:11.462Z",
       "meta": {
         "actors": [
           {
@@ -732,7 +732,7 @@
     {
       "kind": "summary",
       "label": "Initial AGIα liquidity minted to actors",
-      "at": "2025-10-16T00:10:12.037Z",
+      "at": "2025-10-16T00:40:11.510Z",
       "meta": {
         "amount": "2000.0 AGIα",
         "recipients": [
@@ -749,12 +749,12 @@
     {
       "kind": "step",
       "label": "Deploying core contracts",
-      "at": "2025-10-16T00:10:12.037Z"
+      "at": "2025-10-16T00:40:11.510Z"
     },
     {
       "kind": "summary",
       "label": "StakeManager deployed",
-      "at": "2025-10-16T00:10:12.091Z",
+      "at": "2025-10-16T00:40:11.543Z",
       "meta": {
         "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "args": [
@@ -771,7 +771,7 @@
     {
       "kind": "summary",
       "label": "ReputationEngine deployed",
-      "at": "2025-10-16T00:10:12.120Z",
+      "at": "2025-10-16T00:40:11.556Z",
       "meta": {
         "address": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
         "args": [
@@ -782,7 +782,7 @@
     {
       "kind": "summary",
       "label": "IdentityRegistry deployed",
-      "at": "2025-10-16T00:10:12.143Z",
+      "at": "2025-10-16T00:40:11.578Z",
       "meta": {
         "address": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "args": [
@@ -797,7 +797,7 @@
     {
       "kind": "summary",
       "label": "ValidationModule deployed",
-      "at": "2025-10-16T00:10:12.179Z",
+      "at": "2025-10-16T00:40:11.601Z",
       "meta": {
         "address": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "args": [
@@ -814,7 +814,7 @@
     {
       "kind": "summary",
       "label": "CertificateNFT deployed",
-      "at": "2025-10-16T00:10:12.194Z",
+      "at": "2025-10-16T00:40:11.615Z",
       "meta": {
         "address": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "args": [
@@ -826,7 +826,7 @@
     {
       "kind": "summary",
       "label": "JobRegistry deployed",
-      "at": "2025-10-16T00:10:12.245Z",
+      "at": "2025-10-16T00:40:11.648Z",
       "meta": {
         "address": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "args": [
@@ -847,7 +847,7 @@
     {
       "kind": "summary",
       "label": "DisputeModule deployed",
-      "at": "2025-10-16T00:10:12.261Z",
+      "at": "2025-10-16T00:40:11.659Z",
       "meta": {
         "address": "0x9A676e781A523b5d0C0e43731313A708CB607508",
         "args": [
@@ -862,7 +862,7 @@
     {
       "kind": "summary",
       "label": "FeePool deployed",
-      "at": "2025-10-16T00:10:12.274Z",
+      "at": "2025-10-16T00:40:11.669Z",
       "meta": {
         "address": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
         "args": [
@@ -876,12 +876,12 @@
     {
       "kind": "step",
       "label": "Wiring governance relationships and module cross-links",
-      "at": "2025-10-16T00:10:12.278Z"
+      "at": "2025-10-16T00:40:11.671Z"
     },
     {
       "kind": "owner-action",
       "label": "Linked certificate to job registry",
-      "at": "2025-10-16T00:10:12.282Z",
+      "at": "2025-10-16T00:40:11.673Z",
       "meta": {
         "contract": "CertificateNFT@0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "method": "setJobRegistry",
@@ -893,7 +893,7 @@
     {
       "kind": "owner-action",
       "label": "Linked certificate to stake manager",
-      "at": "2025-10-16T00:10:12.289Z",
+      "at": "2025-10-16T00:40:11.677Z",
       "meta": {
         "contract": "CertificateNFT@0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "method": "setStakeManager",
@@ -905,7 +905,7 @@
     {
       "kind": "owner-action",
       "label": "Connected stake manager fee pool",
-      "at": "2025-10-16T00:10:12.312Z",
+      "at": "2025-10-16T00:40:11.688Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "setFeePool",
@@ -917,7 +917,7 @@
     {
       "kind": "owner-action",
       "label": "Connected stake modules",
-      "at": "2025-10-16T00:10:12.317Z",
+      "at": "2025-10-16T00:40:11.692Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "setModules",
@@ -930,7 +930,7 @@
     {
       "kind": "owner-action",
       "label": "Linked stake to validation module",
-      "at": "2025-10-16T00:10:12.321Z",
+      "at": "2025-10-16T00:40:11.694Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "setValidationModule",
@@ -942,7 +942,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module registry link",
-      "at": "2025-10-16T00:10:12.324Z",
+      "at": "2025-10-16T00:40:11.698Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setJobRegistry",
@@ -954,7 +954,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module identity link",
-      "at": "2025-10-16T00:10:12.327Z",
+      "at": "2025-10-16T00:40:11.704Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setIdentityRegistry",
@@ -966,7 +966,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module reputation link",
-      "at": "2025-10-16T00:10:12.329Z",
+      "at": "2025-10-16T00:40:11.706Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setReputationEngine",
@@ -978,7 +978,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module stake link",
-      "at": "2025-10-16T00:10:12.332Z",
+      "at": "2025-10-16T00:40:11.708Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setStakeManager",
@@ -990,7 +990,7 @@
     {
       "kind": "owner-action",
       "label": "Registry module wiring finalised",
-      "at": "2025-10-16T00:10:12.342Z",
+      "at": "2025-10-16T00:40:11.713Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setModules",
@@ -1007,7 +1007,7 @@
     {
       "kind": "owner-action",
       "label": "Registry identity registry set",
-      "at": "2025-10-16T00:10:12.345Z",
+      "at": "2025-10-16T00:40:11.715Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setIdentityRegistry",
@@ -1019,7 +1019,7 @@
     {
       "kind": "owner-action",
       "label": "Validator reward percentage configured",
-      "at": "2025-10-16T00:10:12.348Z",
+      "at": "2025-10-16T00:40:11.717Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setValidatorRewardPct",
@@ -1031,7 +1031,7 @@
     {
       "kind": "owner-action",
       "label": "Registry authorised to update reputation",
-      "at": "2025-10-16T00:10:12.351Z",
+      "at": "2025-10-16T00:40:11.719Z",
       "meta": {
         "contract": "ReputationEngine@0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
         "method": "setCaller",
@@ -1044,7 +1044,7 @@
     {
       "kind": "owner-action",
       "label": "Validation authorised to update reputation",
-      "at": "2025-10-16T00:10:12.355Z",
+      "at": "2025-10-16T00:40:11.721Z",
       "meta": {
         "contract": "ReputationEngine@0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
         "method": "setCaller",
@@ -1057,7 +1057,7 @@
     {
       "kind": "owner-action",
       "label": "Dispute module stake link",
-      "at": "2025-10-16T00:10:12.357Z",
+      "at": "2025-10-16T00:40:11.723Z",
       "meta": {
         "contract": "DisputeModule@0x9A676e781A523b5d0C0e43731313A708CB607508",
         "method": "setStakeManager",
@@ -1069,12 +1069,12 @@
     {
       "kind": "step",
       "label": "Configuring policy parameters for rapid local simulation",
-      "at": "2025-10-16T00:10:12.358Z"
+      "at": "2025-10-16T00:40:11.723Z"
     },
     {
       "kind": "owner-action",
       "label": "Commit/reveal windows tuned",
-      "at": "2025-10-16T00:10:12.361Z",
+      "at": "2025-10-16T00:40:11.725Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setCommitRevealWindows",
@@ -1087,7 +1087,7 @@
     {
       "kind": "owner-action",
       "label": "Validator quorum set",
-      "at": "2025-10-16T00:10:12.363Z",
+      "at": "2025-10-16T00:40:11.726Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setValidatorsPerJob",
@@ -1099,7 +1099,7 @@
     {
       "kind": "owner-action",
       "label": "Validator pool curated",
-      "at": "2025-10-16T00:10:12.369Z",
+      "at": "2025-10-16T00:40:11.729Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setValidatorPool",
@@ -1115,7 +1115,7 @@
     {
       "kind": "owner-action",
       "label": "Reveal quorum configured",
-      "at": "2025-10-16T00:10:12.372Z",
+      "at": "2025-10-16T00:40:11.730Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setRevealQuorum",
@@ -1128,7 +1128,7 @@
     {
       "kind": "owner-action",
       "label": "Non-reveal penalty set",
-      "at": "2025-10-16T00:10:12.376Z",
+      "at": "2025-10-16T00:40:11.732Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setNonRevealPenalty",
@@ -1141,7 +1141,7 @@
     {
       "kind": "owner-action",
       "label": "Fee pool burn percentage adjusted",
-      "at": "2025-10-16T00:10:12.379Z",
+      "at": "2025-10-16T00:40:11.733Z",
       "meta": {
         "contract": "FeePool@0x0B306BF915C4d645ff596e518fAf3F9669b97016",
         "method": "setBurnPct",
@@ -1153,7 +1153,7 @@
     {
       "kind": "owner-action",
       "label": "Certificate base URI set",
-      "at": "2025-10-16T00:10:12.382Z",
+      "at": "2025-10-16T00:40:11.735Z",
       "meta": {
         "contract": "CertificateNFT@0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "method": "setBaseURI",
@@ -1165,12 +1165,12 @@
     {
       "kind": "step",
       "label": "Seeding IdentityRegistry with emergency allowlists",
-      "at": "2025-10-16T00:10:12.382Z"
+      "at": "2025-10-16T00:40:11.735Z"
     },
     {
       "kind": "owner-action",
       "label": "Emergency AI agent allowlisted",
-      "at": "2025-10-16T00:10:12.387Z",
+      "at": "2025-10-16T00:40:11.737Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "addAdditionalAgent",
@@ -1182,7 +1182,7 @@
     {
       "kind": "owner-action",
       "label": "Agent type annotated",
-      "at": "2025-10-16T00:10:12.390Z",
+      "at": "2025-10-16T00:40:11.739Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "setAgentType",
@@ -1195,7 +1195,7 @@
     {
       "kind": "owner-action",
       "label": "Emergency AI agent allowlisted",
-      "at": "2025-10-16T00:10:12.393Z",
+      "at": "2025-10-16T00:40:11.740Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "addAdditionalAgent",
@@ -1207,7 +1207,7 @@
     {
       "kind": "owner-action",
       "label": "Agent type annotated",
-      "at": "2025-10-16T00:10:12.396Z",
+      "at": "2025-10-16T00:40:11.743Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "setAgentType",
@@ -1220,7 +1220,7 @@
     {
       "kind": "owner-action",
       "label": "Validator council seat granted",
-      "at": "2025-10-16T00:10:12.400Z",
+      "at": "2025-10-16T00:40:11.744Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "addAdditionalValidator",
@@ -1232,7 +1232,7 @@
     {
       "kind": "owner-action",
       "label": "Validator council seat granted",
-      "at": "2025-10-16T00:10:12.406Z",
+      "at": "2025-10-16T00:40:11.748Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "addAdditionalValidator",
@@ -1244,7 +1244,7 @@
     {
       "kind": "owner-action",
       "label": "Validator council seat granted",
-      "at": "2025-10-16T00:10:12.409Z",
+      "at": "2025-10-16T00:40:11.749Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "addAdditionalValidator",
@@ -1256,12 +1256,12 @@
     {
       "kind": "step",
       "label": "Initial token approvals and staking for actors",
-      "at": "2025-10-16T00:10:12.410Z"
+      "at": "2025-10-16T00:40:11.749Z"
     },
     {
       "kind": "balance",
       "label": "Initial treasury state",
-      "at": "2025-10-16T00:10:12.491Z",
+      "at": "2025-10-16T00:40:11.787Z",
       "meta": {
         "participants": [
           {
@@ -1305,17 +1305,17 @@
     {
       "kind": "section",
       "label": "Owner mission control – unstoppable command authority demonstration",
-      "at": "2025-10-16T00:10:12.492Z"
+      "at": "2025-10-16T00:40:11.788Z"
     },
     {
       "kind": "step",
       "label": "Owner calibrates market economics and validator incentives",
-      "at": "2025-10-16T00:10:12.508Z"
+      "at": "2025-10-16T00:40:11.811Z"
     },
     {
       "kind": "owner-action",
       "label": "Protocol fee temporarily increased",
-      "at": "2025-10-16T00:10:12.512Z",
+      "at": "2025-10-16T00:40:11.814Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setFeePct",
@@ -1328,7 +1328,7 @@
     {
       "kind": "owner-action",
       "label": "Validator rewards boosted",
-      "at": "2025-10-16T00:10:12.514Z",
+      "at": "2025-10-16T00:40:11.816Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setValidatorRewardPct",
@@ -1341,7 +1341,7 @@
     {
       "kind": "owner-action",
       "label": "Fee pool burn widened",
-      "at": "2025-10-16T00:10:12.516Z",
+      "at": "2025-10-16T00:40:11.819Z",
       "meta": {
         "contract": "FeePool@0x0B306BF915C4d645ff596e518fAf3F9669b97016",
         "method": "setBurnPct",
@@ -1354,12 +1354,12 @@
     {
       "kind": "step",
       "label": "Owner updates validation committee cadence and accountability levers",
-      "at": "2025-10-16T00:10:12.522Z"
+      "at": "2025-10-16T00:40:11.823Z"
     },
     {
       "kind": "owner-action",
       "label": "Commit/reveal windows extended",
-      "at": "2025-10-16T00:10:12.525Z",
+      "at": "2025-10-16T00:40:11.826Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setCommitRevealWindows",
@@ -1374,7 +1374,7 @@
     {
       "kind": "owner-action",
       "label": "Reveal quorum tightened",
-      "at": "2025-10-16T00:10:12.528Z",
+      "at": "2025-10-16T00:40:11.829Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setRevealQuorum",
@@ -1389,7 +1389,7 @@
     {
       "kind": "owner-action",
       "label": "Non-reveal penalty escalated",
-      "at": "2025-10-16T00:10:12.531Z",
+      "at": "2025-10-16T00:40:11.831Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setNonRevealPenalty",
@@ -1404,12 +1404,12 @@
     {
       "kind": "step",
       "label": "Owner delegates emergency pauser powers and performs a live drill",
-      "at": "2025-10-16T00:10:12.539Z"
+      "at": "2025-10-16T00:40:11.838Z"
     },
     {
       "kind": "owner-action",
       "label": "Registry pauser delegated",
-      "at": "2025-10-16T00:10:12.542Z",
+      "at": "2025-10-16T00:40:11.840Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setPauser",
@@ -1421,7 +1421,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager pauser delegated",
-      "at": "2025-10-16T00:10:12.545Z",
+      "at": "2025-10-16T00:40:11.843Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "setPauser",
@@ -1433,7 +1433,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module pauser delegated",
-      "at": "2025-10-16T00:10:12.548Z",
+      "at": "2025-10-16T00:40:11.845Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setPauser",
@@ -1445,7 +1445,7 @@
     {
       "kind": "owner-action",
       "label": "Registry paused for drill",
-      "at": "2025-10-16T00:10:12.551Z",
+      "at": "2025-10-16T00:40:11.847Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "pause",
@@ -1457,7 +1457,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager paused for drill",
-      "at": "2025-10-16T00:10:12.554Z",
+      "at": "2025-10-16T00:40:11.850Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "pause",
@@ -1469,7 +1469,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module paused for drill",
-      "at": "2025-10-16T00:10:12.557Z",
+      "at": "2025-10-16T00:40:11.852Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "pause",
@@ -1481,7 +1481,7 @@
     {
       "kind": "owner-action",
       "label": "Registry unpaused after drill",
-      "at": "2025-10-16T00:10:12.568Z",
+      "at": "2025-10-16T00:40:11.859Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "unpause",
@@ -1493,7 +1493,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager unpaused after drill",
-      "at": "2025-10-16T00:10:12.571Z",
+      "at": "2025-10-16T00:40:11.860Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "unpause",
@@ -1505,7 +1505,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module unpaused after drill",
-      "at": "2025-10-16T00:10:12.572Z",
+      "at": "2025-10-16T00:40:11.863Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "unpause",
@@ -1517,7 +1517,7 @@
     {
       "kind": "owner-action",
       "label": "Registry paused by delegated moderator",
-      "at": "2025-10-16T00:10:12.575Z",
+      "at": "2025-10-16T00:40:11.865Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "pause",
@@ -1529,7 +1529,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager paused by delegated moderator",
-      "at": "2025-10-16T00:10:12.577Z",
+      "at": "2025-10-16T00:40:11.871Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "pause",
@@ -1541,7 +1541,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module paused by delegated moderator",
-      "at": "2025-10-16T00:10:12.580Z",
+      "at": "2025-10-16T00:40:11.873Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "pause",
@@ -1553,7 +1553,7 @@
     {
       "kind": "owner-action",
       "label": "Registry unpaused by delegated moderator",
-      "at": "2025-10-16T00:10:12.586Z",
+      "at": "2025-10-16T00:40:11.879Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "unpause",
@@ -1565,7 +1565,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager unpaused by delegated moderator",
-      "at": "2025-10-16T00:10:12.589Z",
+      "at": "2025-10-16T00:40:11.882Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "unpause",
@@ -1577,7 +1577,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module unpaused by delegated moderator",
-      "at": "2025-10-16T00:10:12.590Z",
+      "at": "2025-10-16T00:40:11.883Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "unpause",
@@ -1589,12 +1589,12 @@
     {
       "kind": "step",
       "label": "Owner restores baseline configuration to prepare live scenarios",
-      "at": "2025-10-16T00:10:12.592Z"
+      "at": "2025-10-16T00:40:11.894Z"
     },
     {
       "kind": "owner-action",
       "label": "Protocol fee restored",
-      "at": "2025-10-16T00:10:12.595Z",
+      "at": "2025-10-16T00:40:11.896Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setFeePct",
@@ -1606,7 +1606,7 @@
     {
       "kind": "owner-action",
       "label": "Validator reward restored",
-      "at": "2025-10-16T00:10:12.597Z",
+      "at": "2025-10-16T00:40:11.898Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setValidatorRewardPct",
@@ -1618,7 +1618,7 @@
     {
       "kind": "owner-action",
       "label": "Fee pool burn restored",
-      "at": "2025-10-16T00:10:12.601Z",
+      "at": "2025-10-16T00:40:11.900Z",
       "meta": {
         "contract": "FeePool@0x0B306BF915C4d645ff596e518fAf3F9669b97016",
         "method": "setBurnPct",
@@ -1630,7 +1630,7 @@
     {
       "kind": "owner-action",
       "label": "Commit/reveal cadence restored",
-      "at": "2025-10-16T00:10:12.604Z",
+      "at": "2025-10-16T00:40:11.902Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setCommitRevealWindows",
@@ -1643,7 +1643,7 @@
     {
       "kind": "owner-action",
       "label": "Reveal quorum restored",
-      "at": "2025-10-16T00:10:12.606Z",
+      "at": "2025-10-16T00:40:11.903Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setRevealQuorum",
@@ -1656,7 +1656,7 @@
     {
       "kind": "owner-action",
       "label": "Non-reveal penalty restored",
-      "at": "2025-10-16T00:10:12.608Z",
+      "at": "2025-10-16T00:40:11.905Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setNonRevealPenalty",
@@ -1669,7 +1669,7 @@
     {
       "kind": "owner-action",
       "label": "Registry pauser returned to owner",
-      "at": "2025-10-16T00:10:12.611Z",
+      "at": "2025-10-16T00:40:11.907Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setPauser",
@@ -1681,7 +1681,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager pauser returned to owner",
-      "at": "2025-10-16T00:10:12.613Z",
+      "at": "2025-10-16T00:40:11.908Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "setPauser",
@@ -1693,7 +1693,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module pauser returned to owner",
-      "at": "2025-10-16T00:10:12.615Z",
+      "at": "2025-10-16T00:40:11.909Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setPauser",
@@ -1705,37 +1705,41 @@
     {
       "kind": "summary",
       "label": "Owner mission control baseline restored",
-      "at": "2025-10-16T00:10:12.630Z",
+      "at": "2025-10-16T00:40:11.918Z",
       "meta": {
         "feePct": 5,
         "validatorRewardPct": 20,
         "burnPct": 5,
-        "commitWindow": "60s",
-        "revealWindow": "60s",
+        "commitWindowSeconds": 60,
+        "revealWindowSeconds": 60,
+        "commitWindowFormatted": "60s",
+        "revealWindowFormatted": "60s",
         "revealQuorumPct": 0,
         "minRevealers": 2,
         "nonRevealPenaltyBps": 100,
         "nonRevealBanBlocks": 1,
         "registryPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
         "stakePauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        "validationPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        "validationPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "commitWindow": "60s",
+        "revealWindow": "60s"
       }
     },
     {
       "kind": "section",
       "label": "Scenario 1 – Cooperative intergovernmental AI labour success",
-      "at": "2025-10-16T00:10:12.631Z"
+      "at": "2025-10-16T00:40:11.919Z"
     },
     {
       "kind": "step",
       "label": "Nation A approves escrow and posts a climate-coordination job",
-      "at": "2025-10-16T00:10:12.633Z",
+      "at": "2025-10-16T00:40:11.921Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "job-summary",
       "label": "Job 1 (after posting)",
-      "at": "2025-10-16T00:10:12.653Z",
+      "at": "2025-10-16T00:40:11.937Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "jobId": "1",
@@ -1751,13 +1755,13 @@
     {
       "kind": "step",
       "label": "Alice stakes identity and applies through the emergency allowlist",
-      "at": "2025-10-16T00:10:12.653Z",
+      "at": "2025-10-16T00:40:11.937Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "job-summary",
       "label": "Job 1 (after agent assignment)",
-      "at": "2025-10-16T00:10:12.671Z",
+      "at": "2025-10-16T00:40:11.950Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "jobId": "1",
@@ -1773,13 +1777,13 @@
     {
       "kind": "step",
       "label": "Alice submits validated deliverables with provable IPFS evidence",
-      "at": "2025-10-16T00:10:12.671Z",
+      "at": "2025-10-16T00:40:11.950Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "job-summary",
       "label": "Job 1 (after submission)",
-      "at": "2025-10-16T00:10:12.684Z",
+      "at": "2025-10-16T00:40:11.968Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "jobId": "1",
@@ -1795,25 +1799,25 @@
     {
       "kind": "step",
       "label": "Nation A records burn proof and primes the validation committee selection",
-      "at": "2025-10-16T00:10:12.684Z",
+      "at": "2025-10-16T00:40:11.968Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "step",
       "label": "Validators commit to their assessments under commit–reveal secrecy",
-      "at": "2025-10-16T00:10:12.745Z",
+      "at": "2025-10-16T00:40:12.014Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "step",
       "label": "Validators reveal unanimous approval, meeting the quorum instantly",
-      "at": "2025-10-16T00:10:12.811Z",
+      "at": "2025-10-16T00:40:12.045Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "job-summary",
       "label": "Job 1 (after validator finalize)",
-      "at": "2025-10-16T00:10:12.907Z",
+      "at": "2025-10-16T00:40:12.115Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "jobId": "1",
@@ -1829,13 +1833,13 @@
     {
       "kind": "step",
       "label": "Nation A finalizes payment, rewarding Alice and the validator cohort",
-      "at": "2025-10-16T00:10:12.907Z",
+      "at": "2025-10-16T00:40:12.115Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "job-summary",
       "label": "Job 1 (after treasury settlement)",
-      "at": "2025-10-16T00:10:12.928Z",
+      "at": "2025-10-16T00:40:12.141Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "jobId": "1",
@@ -1851,7 +1855,7 @@
     {
       "kind": "balance",
       "label": "Post-job token balances",
-      "at": "2025-10-16T00:10:12.939Z",
+      "at": "2025-10-16T00:40:12.150Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "participants": [
@@ -1886,19 +1890,19 @@
     {
       "kind": "section",
       "label": "Scenario 2 – Cross-border dispute resolved by owner governance",
-      "at": "2025-10-16T00:10:12.942Z",
+      "at": "2025-10-16T00:40:12.151Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "step",
       "label": "Nation B funds a frontier language translation initiative",
-      "at": "2025-10-16T00:10:12.943Z",
+      "at": "2025-10-16T00:40:12.153Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "job-summary",
       "label": "Job 2 (after posting)",
-      "at": "2025-10-16T00:10:12.955Z",
+      "at": "2025-10-16T00:40:12.167Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "jobId": "2",
@@ -1914,25 +1918,25 @@
     {
       "kind": "step",
       "label": "Bob applies, contributes work, and submits contested deliverables",
-      "at": "2025-10-16T00:10:12.955Z",
+      "at": "2025-10-16T00:40:12.168Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "step",
       "label": "Validators disagree; one plans to approve, another to reject, one will abstain",
-      "at": "2025-10-16T00:10:13.015Z",
+      "at": "2025-10-16T00:40:12.227Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "step",
       "label": "Partial reveals occur – one validator abstains, triggering penalties",
-      "at": "2025-10-16T00:10:13.046Z",
+      "at": "2025-10-16T00:40:12.263Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "job-summary",
       "label": "Job 2 (after partial quorum)",
-      "at": "2025-10-16T00:10:13.111Z",
+      "at": "2025-10-16T00:40:12.320Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "jobId": "2",
@@ -1948,13 +1952,13 @@
     {
       "kind": "step",
       "label": "Bob leverages dispute rights; governance moderates and sides with the agent",
-      "at": "2025-10-16T00:10:13.111Z",
+      "at": "2025-10-16T00:40:12.320Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "owner-action",
       "label": "Dispute fee waived for demonstration",
-      "at": "2025-10-16T00:10:13.114Z",
+      "at": "2025-10-16T00:40:12.322Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "contract": "DisputeModule@0x9A676e781A523b5d0C0e43731313A708CB607508",
@@ -1967,7 +1971,7 @@
     {
       "kind": "owner-action",
       "label": "Dispute window accelerated",
-      "at": "2025-10-16T00:10:13.123Z",
+      "at": "2025-10-16T00:40:12.332Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "contract": "DisputeModule@0x9A676e781A523b5d0C0e43731313A708CB607508",
@@ -1980,7 +1984,7 @@
     {
       "kind": "owner-action",
       "label": "Owner enrolled as dispute moderator",
-      "at": "2025-10-16T00:10:13.125Z",
+      "at": "2025-10-16T00:40:12.334Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "contract": "DisputeModule@0x9A676e781A523b5d0C0e43731313A708CB607508",
@@ -1994,7 +1998,7 @@
     {
       "kind": "owner-action",
       "label": "External moderator empowered",
-      "at": "2025-10-16T00:10:13.128Z",
+      "at": "2025-10-16T00:40:12.336Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "contract": "DisputeModule@0x9A676e781A523b5d0C0e43731313A708CB607508",
@@ -2008,13 +2012,13 @@
     {
       "kind": "step",
       "label": "Nation B finalizes, distributing escrow and validator rewards post-dispute",
-      "at": "2025-10-16T00:10:13.149Z",
+      "at": "2025-10-16T00:40:12.350Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "job-summary",
       "label": "Job 2 (after dispute resolution)",
-      "at": "2025-10-16T00:10:13.180Z",
+      "at": "2025-10-16T00:40:12.374Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "jobId": "2",
@@ -2030,7 +2034,7 @@
     {
       "kind": "balance",
       "label": "Post-dispute token balances",
-      "at": "2025-10-16T00:10:13.190Z",
+      "at": "2025-10-16T00:40:12.381Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "participants": [
@@ -2065,13 +2069,13 @@
     {
       "kind": "section",
       "label": "Sovereign labour market telemetry dashboard",
-      "at": "2025-10-16T00:10:13.190Z",
+      "at": "2025-10-16T00:40:12.381Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "summary",
       "label": "Agent portfolios",
-      "at": "2025-10-16T00:10:13.239Z",
+      "at": "2025-10-16T00:40:12.423Z",
       "meta": {
         "agents": [
           {
@@ -2108,7 +2112,7 @@
     {
       "kind": "summary",
       "label": "Validator council status",
-      "at": "2025-10-16T00:10:13.262Z",
+      "at": "2025-10-16T00:40:12.440Z",
       "meta": {
         "validators": [
           {
@@ -2141,7 +2145,7 @@
     {
       "kind": "summary",
       "label": "Market telemetry dashboard",
-      "at": "2025-10-16T00:10:13.263Z",
+      "at": "2025-10-16T00:40:12.441Z",
       "meta": {
         "totalJobs": "2",
         "totalBurned": "6.175 AGIα",
@@ -2168,7 +2172,7 @@
     {
       "kind": "section",
       "label": "Demo complete – AGI Jobs v2 sovereignty market simulation finished",
-      "at": "2025-10-16T00:10:13.263Z"
+      "at": "2025-10-16T00:40:12.441Z"
     }
   ],
   "scenarios": [
@@ -2233,5 +2237,79 @@
         "uri": "ipfs://agi-jobs/demo/certificates/2"
       }
     ]
+  },
+  "ownerControl": {
+    "ownerAddress": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "moderatorAddress": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
+    "modules": {
+      "registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+      "stake": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
+      "validation": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
+      "feePool": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
+      "dispute": "0x9A676e781A523b5d0C0e43731313A708CB607508",
+      "certificate": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
+      "reputation": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
+      "identity": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788"
+    },
+    "baseline": {
+      "feePct": 5,
+      "validatorRewardPct": 20,
+      "burnPct": 5,
+      "commitWindowSeconds": 60,
+      "revealWindowSeconds": 60,
+      "commitWindowFormatted": "60s",
+      "revealWindowFormatted": "60s",
+      "revealQuorumPct": 0,
+      "minRevealers": 2,
+      "nonRevealPenaltyBps": 100,
+      "nonRevealBanBlocks": 1,
+      "registryPauser": "0x0000000000000000000000000000000000000000",
+      "stakePauser": "0x0000000000000000000000000000000000000000",
+      "validationPauser": "0x0000000000000000000000000000000000000000"
+    },
+    "upgraded": {
+      "feePct": 9,
+      "validatorRewardPct": 25,
+      "burnPct": 6,
+      "commitWindowSeconds": 90,
+      "revealWindowSeconds": 90,
+      "commitWindowFormatted": "90s",
+      "revealWindowFormatted": "90s",
+      "revealQuorumPct": 50,
+      "minRevealers": 2,
+      "nonRevealPenaltyBps": 150,
+      "nonRevealBanBlocks": 12,
+      "registryPauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
+      "stakePauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
+      "validationPauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
+    },
+    "restored": {
+      "feePct": 5,
+      "validatorRewardPct": 20,
+      "burnPct": 5,
+      "commitWindowSeconds": 60,
+      "revealWindowSeconds": 60,
+      "commitWindowFormatted": "60s",
+      "revealWindowFormatted": "60s",
+      "revealQuorumPct": 0,
+      "minRevealers": 2,
+      "nonRevealPenaltyBps": 100,
+      "nonRevealBanBlocks": 1,
+      "registryPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "stakePauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "validationPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    },
+    "pauseDrill": {
+      "owner": {
+        "registry": true,
+        "stake": true,
+        "validation": true
+      },
+      "moderator": {
+        "registry": true,
+        "stake": true,
+        "validation": true
+      }
+    }
   }
 }

--- a/demo/agi-labor-market-grand-demo/ui/sample.json
+++ b/demo/agi-labor-market-grand-demo/ui/sample.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-16T00:10:13.264Z",
+  "generatedAt": "2025-10-16T00:40:12.441Z",
   "network": "hardhat (chainId 31337)",
   "actors": [
     {
@@ -65,7 +65,7 @@
       "parameters": {
         "registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
       },
-      "at": "2025-10-16T00:10:12.282Z"
+      "at": "2025-10-16T00:40:11.673Z"
     },
     {
       "label": "Linked certificate to stake manager",
@@ -74,7 +74,7 @@
       "parameters": {
         "stake": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
       },
-      "at": "2025-10-16T00:10:12.289Z"
+      "at": "2025-10-16T00:40:11.677Z"
     },
     {
       "label": "Connected stake manager fee pool",
@@ -83,7 +83,7 @@
       "parameters": {
         "feePool": "0x0B306BF915C4d645ff596e518fAf3F9669b97016"
       },
-      "at": "2025-10-16T00:10:12.312Z"
+      "at": "2025-10-16T00:40:11.688Z"
     },
     {
       "label": "Connected stake modules",
@@ -93,7 +93,7 @@
         "registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "dispute": "0x9A676e781A523b5d0C0e43731313A708CB607508"
       },
-      "at": "2025-10-16T00:10:12.317Z"
+      "at": "2025-10-16T00:40:11.692Z"
     },
     {
       "label": "Linked stake to validation module",
@@ -102,7 +102,7 @@
       "parameters": {
         "validation": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
       },
-      "at": "2025-10-16T00:10:12.321Z"
+      "at": "2025-10-16T00:40:11.694Z"
     },
     {
       "label": "Validation module registry link",
@@ -111,7 +111,7 @@
       "parameters": {
         "registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
       },
-      "at": "2025-10-16T00:10:12.324Z"
+      "at": "2025-10-16T00:40:11.698Z"
     },
     {
       "label": "Validation module identity link",
@@ -120,7 +120,7 @@
       "parameters": {
         "identity": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788"
       },
-      "at": "2025-10-16T00:10:12.327Z"
+      "at": "2025-10-16T00:40:11.704Z"
     },
     {
       "label": "Validation module reputation link",
@@ -129,7 +129,7 @@
       "parameters": {
         "reputation": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318"
       },
-      "at": "2025-10-16T00:10:12.329Z"
+      "at": "2025-10-16T00:40:11.706Z"
     },
     {
       "label": "Validation module stake link",
@@ -138,7 +138,7 @@
       "parameters": {
         "stake": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
       },
-      "at": "2025-10-16T00:10:12.332Z"
+      "at": "2025-10-16T00:40:11.708Z"
     },
     {
       "label": "Registry module wiring finalised",
@@ -152,7 +152,7 @@
         "certificate": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "feePool": "0x0B306BF915C4d645ff596e518fAf3F9669b97016"
       },
-      "at": "2025-10-16T00:10:12.342Z"
+      "at": "2025-10-16T00:40:11.713Z"
     },
     {
       "label": "Registry identity registry set",
@@ -161,7 +161,7 @@
       "parameters": {
         "identity": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788"
       },
-      "at": "2025-10-16T00:10:12.345Z"
+      "at": "2025-10-16T00:40:11.715Z"
     },
     {
       "label": "Validator reward percentage configured",
@@ -170,7 +170,7 @@
       "parameters": {
         "pct": 20
       },
-      "at": "2025-10-16T00:10:12.348Z"
+      "at": "2025-10-16T00:40:11.717Z"
     },
     {
       "label": "Registry authorised to update reputation",
@@ -180,7 +180,7 @@
         "caller": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "allowed": true
       },
-      "at": "2025-10-16T00:10:12.351Z"
+      "at": "2025-10-16T00:40:11.719Z"
     },
     {
       "label": "Validation authorised to update reputation",
@@ -190,7 +190,7 @@
         "caller": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "allowed": true
       },
-      "at": "2025-10-16T00:10:12.355Z"
+      "at": "2025-10-16T00:40:11.721Z"
     },
     {
       "label": "Dispute module stake link",
@@ -199,7 +199,7 @@
       "parameters": {
         "stake": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
       },
-      "at": "2025-10-16T00:10:12.357Z"
+      "at": "2025-10-16T00:40:11.723Z"
     },
     {
       "label": "Commit/reveal windows tuned",
@@ -209,7 +209,7 @@
         "commitWindow": 60,
         "revealWindow": 60
       },
-      "at": "2025-10-16T00:10:12.361Z"
+      "at": "2025-10-16T00:40:11.725Z"
     },
     {
       "label": "Validator quorum set",
@@ -218,7 +218,7 @@
       "parameters": {
         "count": 3
       },
-      "at": "2025-10-16T00:10:12.363Z"
+      "at": "2025-10-16T00:40:11.726Z"
     },
     {
       "label": "Validator pool curated",
@@ -231,7 +231,7 @@
           "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
         ]
       },
-      "at": "2025-10-16T00:10:12.369Z"
+      "at": "2025-10-16T00:40:11.729Z"
     },
     {
       "label": "Reveal quorum configured",
@@ -241,7 +241,7 @@
         "minYesVotes": 0,
         "minRevealers": 2
       },
-      "at": "2025-10-16T00:10:12.372Z"
+      "at": "2025-10-16T00:40:11.730Z"
     },
     {
       "label": "Non-reveal penalty set",
@@ -251,7 +251,7 @@
         "penaltyBps": 100,
         "penaltyDivisor": 1
       },
-      "at": "2025-10-16T00:10:12.376Z"
+      "at": "2025-10-16T00:40:11.732Z"
     },
     {
       "label": "Fee pool burn percentage adjusted",
@@ -260,7 +260,7 @@
       "parameters": {
         "burnPct": 5
       },
-      "at": "2025-10-16T00:10:12.379Z"
+      "at": "2025-10-16T00:40:11.733Z"
     },
     {
       "label": "Certificate base URI set",
@@ -269,7 +269,7 @@
       "parameters": {
         "baseURI": "ipfs://agi-jobs/demo/certificates/"
       },
-      "at": "2025-10-16T00:10:12.382Z"
+      "at": "2025-10-16T00:40:11.735Z"
     },
     {
       "label": "Emergency AI agent allowlisted",
@@ -278,7 +278,7 @@
       "parameters": {
         "agent": "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
       },
-      "at": "2025-10-16T00:10:12.387Z"
+      "at": "2025-10-16T00:40:11.737Z"
     },
     {
       "label": "Agent type annotated",
@@ -288,7 +288,7 @@
         "agent": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
         "agentType": 1
       },
-      "at": "2025-10-16T00:10:12.390Z"
+      "at": "2025-10-16T00:40:11.739Z"
     },
     {
       "label": "Emergency AI agent allowlisted",
@@ -297,7 +297,7 @@
       "parameters": {
         "agent": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
       },
-      "at": "2025-10-16T00:10:12.393Z"
+      "at": "2025-10-16T00:40:11.740Z"
     },
     {
       "label": "Agent type annotated",
@@ -307,7 +307,7 @@
         "agent": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
         "agentType": 1
       },
-      "at": "2025-10-16T00:10:12.396Z"
+      "at": "2025-10-16T00:40:11.743Z"
     },
     {
       "label": "Validator council seat granted",
@@ -316,7 +316,7 @@
       "parameters": {
         "validator": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"
       },
-      "at": "2025-10-16T00:10:12.400Z"
+      "at": "2025-10-16T00:40:11.744Z"
     },
     {
       "label": "Validator council seat granted",
@@ -325,7 +325,7 @@
       "parameters": {
         "validator": "0x976EA74026E726554dB657fA54763abd0C3a0aa9"
       },
-      "at": "2025-10-16T00:10:12.406Z"
+      "at": "2025-10-16T00:40:11.748Z"
     },
     {
       "label": "Validator council seat granted",
@@ -334,7 +334,7 @@
       "parameters": {
         "validator": "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
       },
-      "at": "2025-10-16T00:10:12.409Z"
+      "at": "2025-10-16T00:40:11.749Z"
     },
     {
       "label": "Protocol fee temporarily increased",
@@ -344,7 +344,7 @@
         "previous": 5,
         "pct": 9
       },
-      "at": "2025-10-16T00:10:12.512Z"
+      "at": "2025-10-16T00:40:11.814Z"
     },
     {
       "label": "Validator rewards boosted",
@@ -354,7 +354,7 @@
         "previous": 20,
         "pct": 25
       },
-      "at": "2025-10-16T00:10:12.514Z"
+      "at": "2025-10-16T00:40:11.816Z"
     },
     {
       "label": "Fee pool burn widened",
@@ -364,7 +364,7 @@
         "previous": 5,
         "burnPct": 6
       },
-      "at": "2025-10-16T00:10:12.516Z"
+      "at": "2025-10-16T00:40:11.819Z"
     },
     {
       "label": "Commit/reveal windows extended",
@@ -376,7 +376,7 @@
         "commitWindow": "90s",
         "revealWindow": "90s"
       },
-      "at": "2025-10-16T00:10:12.525Z"
+      "at": "2025-10-16T00:40:11.826Z"
     },
     {
       "label": "Reveal quorum tightened",
@@ -388,7 +388,7 @@
         "pct": 50,
         "minRevealers": 2
       },
-      "at": "2025-10-16T00:10:12.528Z"
+      "at": "2025-10-16T00:40:11.829Z"
     },
     {
       "label": "Non-reveal penalty escalated",
@@ -400,7 +400,7 @@
         "bps": 150,
         "banBlocks": 12
       },
-      "at": "2025-10-16T00:10:12.531Z"
+      "at": "2025-10-16T00:40:11.831Z"
     },
     {
       "label": "Registry pauser delegated",
@@ -409,7 +409,7 @@
       "parameters": {
         "newPauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.542Z"
+      "at": "2025-10-16T00:40:11.840Z"
     },
     {
       "label": "Stake manager pauser delegated",
@@ -418,7 +418,7 @@
       "parameters": {
         "newPauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.545Z"
+      "at": "2025-10-16T00:40:11.843Z"
     },
     {
       "label": "Validation module pauser delegated",
@@ -427,7 +427,7 @@
       "parameters": {
         "newPauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.548Z"
+      "at": "2025-10-16T00:40:11.845Z"
     },
     {
       "label": "Registry paused for drill",
@@ -436,7 +436,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.551Z"
+      "at": "2025-10-16T00:40:11.847Z"
     },
     {
       "label": "Stake manager paused for drill",
@@ -445,7 +445,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.554Z"
+      "at": "2025-10-16T00:40:11.850Z"
     },
     {
       "label": "Validation module paused for drill",
@@ -454,7 +454,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.557Z"
+      "at": "2025-10-16T00:40:11.852Z"
     },
     {
       "label": "Registry unpaused after drill",
@@ -463,7 +463,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.568Z"
+      "at": "2025-10-16T00:40:11.859Z"
     },
     {
       "label": "Stake manager unpaused after drill",
@@ -472,7 +472,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.571Z"
+      "at": "2025-10-16T00:40:11.860Z"
     },
     {
       "label": "Validation module unpaused after drill",
@@ -481,7 +481,7 @@
       "parameters": {
         "by": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.572Z"
+      "at": "2025-10-16T00:40:11.863Z"
     },
     {
       "label": "Registry paused by delegated moderator",
@@ -490,7 +490,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.575Z"
+      "at": "2025-10-16T00:40:11.865Z"
     },
     {
       "label": "Stake manager paused by delegated moderator",
@@ -499,7 +499,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.577Z"
+      "at": "2025-10-16T00:40:11.871Z"
     },
     {
       "label": "Validation module paused by delegated moderator",
@@ -508,7 +508,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.580Z"
+      "at": "2025-10-16T00:40:11.873Z"
     },
     {
       "label": "Registry unpaused by delegated moderator",
@@ -517,7 +517,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.586Z"
+      "at": "2025-10-16T00:40:11.879Z"
     },
     {
       "label": "Stake manager unpaused by delegated moderator",
@@ -526,7 +526,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.589Z"
+      "at": "2025-10-16T00:40:11.882Z"
     },
     {
       "label": "Validation module unpaused by delegated moderator",
@@ -535,7 +535,7 @@
       "parameters": {
         "by": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
       },
-      "at": "2025-10-16T00:10:12.590Z"
+      "at": "2025-10-16T00:40:11.883Z"
     },
     {
       "label": "Protocol fee restored",
@@ -544,7 +544,7 @@
       "parameters": {
         "pct": 5
       },
-      "at": "2025-10-16T00:10:12.595Z"
+      "at": "2025-10-16T00:40:11.896Z"
     },
     {
       "label": "Validator reward restored",
@@ -553,7 +553,7 @@
       "parameters": {
         "pct": 20
       },
-      "at": "2025-10-16T00:10:12.597Z"
+      "at": "2025-10-16T00:40:11.898Z"
     },
     {
       "label": "Fee pool burn restored",
@@ -562,7 +562,7 @@
       "parameters": {
         "burnPct": 5
       },
-      "at": "2025-10-16T00:10:12.601Z"
+      "at": "2025-10-16T00:40:11.900Z"
     },
     {
       "label": "Commit/reveal cadence restored",
@@ -572,7 +572,7 @@
         "commitWindow": "60s",
         "revealWindow": "60s"
       },
-      "at": "2025-10-16T00:10:12.604Z"
+      "at": "2025-10-16T00:40:11.902Z"
     },
     {
       "label": "Reveal quorum restored",
@@ -582,7 +582,7 @@
         "pct": 0,
         "minRevealers": 2
       },
-      "at": "2025-10-16T00:10:12.606Z"
+      "at": "2025-10-16T00:40:11.903Z"
     },
     {
       "label": "Non-reveal penalty restored",
@@ -592,7 +592,7 @@
         "bps": 100,
         "banBlocks": 1
       },
-      "at": "2025-10-16T00:10:12.608Z"
+      "at": "2025-10-16T00:40:11.905Z"
     },
     {
       "label": "Registry pauser returned to owner",
@@ -601,7 +601,7 @@
       "parameters": {
         "newPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.611Z"
+      "at": "2025-10-16T00:40:11.907Z"
     },
     {
       "label": "Stake manager pauser returned to owner",
@@ -610,7 +610,7 @@
       "parameters": {
         "newPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.613Z"
+      "at": "2025-10-16T00:40:11.908Z"
     },
     {
       "label": "Validation module pauser returned to owner",
@@ -619,7 +619,7 @@
       "parameters": {
         "newPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
       },
-      "at": "2025-10-16T00:10:12.615Z"
+      "at": "2025-10-16T00:40:11.909Z"
     },
     {
       "label": "Dispute fee waived for demonstration",
@@ -628,7 +628,7 @@
       "parameters": {
         "fee": 0
       },
-      "at": "2025-10-16T00:10:13.114Z"
+      "at": "2025-10-16T00:40:12.322Z"
     },
     {
       "label": "Dispute window accelerated",
@@ -637,7 +637,7 @@
       "parameters": {
         "window": 0
       },
-      "at": "2025-10-16T00:10:13.123Z"
+      "at": "2025-10-16T00:40:12.332Z"
     },
     {
       "label": "Owner enrolled as dispute moderator",
@@ -647,7 +647,7 @@
         "moderator": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
         "enabled": 1
       },
-      "at": "2025-10-16T00:10:13.125Z"
+      "at": "2025-10-16T00:40:12.334Z"
     },
     {
       "label": "External moderator empowered",
@@ -657,19 +657,19 @@
         "moderator": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
         "enabled": 1
       },
-      "at": "2025-10-16T00:10:13.128Z"
+      "at": "2025-10-16T00:40:12.336Z"
     }
   ],
   "timeline": [
     {
       "kind": "section",
       "label": "Bootstrapping AGI Jobs v2 grand demo environment",
-      "at": "2025-10-16T00:10:11.268Z"
+      "at": "2025-10-16T00:40:11.001Z"
     },
     {
       "kind": "summary",
       "label": "Demo actor roster initialised",
-      "at": "2025-10-16T00:10:11.961Z",
+      "at": "2025-10-16T00:40:11.462Z",
       "meta": {
         "actors": [
           {
@@ -732,7 +732,7 @@
     {
       "kind": "summary",
       "label": "Initial AGIα liquidity minted to actors",
-      "at": "2025-10-16T00:10:12.037Z",
+      "at": "2025-10-16T00:40:11.510Z",
       "meta": {
         "amount": "2000.0 AGIα",
         "recipients": [
@@ -749,12 +749,12 @@
     {
       "kind": "step",
       "label": "Deploying core contracts",
-      "at": "2025-10-16T00:10:12.037Z"
+      "at": "2025-10-16T00:40:11.510Z"
     },
     {
       "kind": "summary",
       "label": "StakeManager deployed",
-      "at": "2025-10-16T00:10:12.091Z",
+      "at": "2025-10-16T00:40:11.543Z",
       "meta": {
         "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "args": [
@@ -771,7 +771,7 @@
     {
       "kind": "summary",
       "label": "ReputationEngine deployed",
-      "at": "2025-10-16T00:10:12.120Z",
+      "at": "2025-10-16T00:40:11.556Z",
       "meta": {
         "address": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
         "args": [
@@ -782,7 +782,7 @@
     {
       "kind": "summary",
       "label": "IdentityRegistry deployed",
-      "at": "2025-10-16T00:10:12.143Z",
+      "at": "2025-10-16T00:40:11.578Z",
       "meta": {
         "address": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "args": [
@@ -797,7 +797,7 @@
     {
       "kind": "summary",
       "label": "ValidationModule deployed",
-      "at": "2025-10-16T00:10:12.179Z",
+      "at": "2025-10-16T00:40:11.601Z",
       "meta": {
         "address": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "args": [
@@ -814,7 +814,7 @@
     {
       "kind": "summary",
       "label": "CertificateNFT deployed",
-      "at": "2025-10-16T00:10:12.194Z",
+      "at": "2025-10-16T00:40:11.615Z",
       "meta": {
         "address": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "args": [
@@ -826,7 +826,7 @@
     {
       "kind": "summary",
       "label": "JobRegistry deployed",
-      "at": "2025-10-16T00:10:12.245Z",
+      "at": "2025-10-16T00:40:11.648Z",
       "meta": {
         "address": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "args": [
@@ -847,7 +847,7 @@
     {
       "kind": "summary",
       "label": "DisputeModule deployed",
-      "at": "2025-10-16T00:10:12.261Z",
+      "at": "2025-10-16T00:40:11.659Z",
       "meta": {
         "address": "0x9A676e781A523b5d0C0e43731313A708CB607508",
         "args": [
@@ -862,7 +862,7 @@
     {
       "kind": "summary",
       "label": "FeePool deployed",
-      "at": "2025-10-16T00:10:12.274Z",
+      "at": "2025-10-16T00:40:11.669Z",
       "meta": {
         "address": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
         "args": [
@@ -876,12 +876,12 @@
     {
       "kind": "step",
       "label": "Wiring governance relationships and module cross-links",
-      "at": "2025-10-16T00:10:12.278Z"
+      "at": "2025-10-16T00:40:11.671Z"
     },
     {
       "kind": "owner-action",
       "label": "Linked certificate to job registry",
-      "at": "2025-10-16T00:10:12.282Z",
+      "at": "2025-10-16T00:40:11.673Z",
       "meta": {
         "contract": "CertificateNFT@0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "method": "setJobRegistry",
@@ -893,7 +893,7 @@
     {
       "kind": "owner-action",
       "label": "Linked certificate to stake manager",
-      "at": "2025-10-16T00:10:12.289Z",
+      "at": "2025-10-16T00:40:11.677Z",
       "meta": {
         "contract": "CertificateNFT@0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "method": "setStakeManager",
@@ -905,7 +905,7 @@
     {
       "kind": "owner-action",
       "label": "Connected stake manager fee pool",
-      "at": "2025-10-16T00:10:12.312Z",
+      "at": "2025-10-16T00:40:11.688Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "setFeePool",
@@ -917,7 +917,7 @@
     {
       "kind": "owner-action",
       "label": "Connected stake modules",
-      "at": "2025-10-16T00:10:12.317Z",
+      "at": "2025-10-16T00:40:11.692Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "setModules",
@@ -930,7 +930,7 @@
     {
       "kind": "owner-action",
       "label": "Linked stake to validation module",
-      "at": "2025-10-16T00:10:12.321Z",
+      "at": "2025-10-16T00:40:11.694Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "setValidationModule",
@@ -942,7 +942,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module registry link",
-      "at": "2025-10-16T00:10:12.324Z",
+      "at": "2025-10-16T00:40:11.698Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setJobRegistry",
@@ -954,7 +954,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module identity link",
-      "at": "2025-10-16T00:10:12.327Z",
+      "at": "2025-10-16T00:40:11.704Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setIdentityRegistry",
@@ -966,7 +966,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module reputation link",
-      "at": "2025-10-16T00:10:12.329Z",
+      "at": "2025-10-16T00:40:11.706Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setReputationEngine",
@@ -978,7 +978,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module stake link",
-      "at": "2025-10-16T00:10:12.332Z",
+      "at": "2025-10-16T00:40:11.708Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setStakeManager",
@@ -990,7 +990,7 @@
     {
       "kind": "owner-action",
       "label": "Registry module wiring finalised",
-      "at": "2025-10-16T00:10:12.342Z",
+      "at": "2025-10-16T00:40:11.713Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setModules",
@@ -1007,7 +1007,7 @@
     {
       "kind": "owner-action",
       "label": "Registry identity registry set",
-      "at": "2025-10-16T00:10:12.345Z",
+      "at": "2025-10-16T00:40:11.715Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setIdentityRegistry",
@@ -1019,7 +1019,7 @@
     {
       "kind": "owner-action",
       "label": "Validator reward percentage configured",
-      "at": "2025-10-16T00:10:12.348Z",
+      "at": "2025-10-16T00:40:11.717Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setValidatorRewardPct",
@@ -1031,7 +1031,7 @@
     {
       "kind": "owner-action",
       "label": "Registry authorised to update reputation",
-      "at": "2025-10-16T00:10:12.351Z",
+      "at": "2025-10-16T00:40:11.719Z",
       "meta": {
         "contract": "ReputationEngine@0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
         "method": "setCaller",
@@ -1044,7 +1044,7 @@
     {
       "kind": "owner-action",
       "label": "Validation authorised to update reputation",
-      "at": "2025-10-16T00:10:12.355Z",
+      "at": "2025-10-16T00:40:11.721Z",
       "meta": {
         "contract": "ReputationEngine@0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
         "method": "setCaller",
@@ -1057,7 +1057,7 @@
     {
       "kind": "owner-action",
       "label": "Dispute module stake link",
-      "at": "2025-10-16T00:10:12.357Z",
+      "at": "2025-10-16T00:40:11.723Z",
       "meta": {
         "contract": "DisputeModule@0x9A676e781A523b5d0C0e43731313A708CB607508",
         "method": "setStakeManager",
@@ -1069,12 +1069,12 @@
     {
       "kind": "step",
       "label": "Configuring policy parameters for rapid local simulation",
-      "at": "2025-10-16T00:10:12.358Z"
+      "at": "2025-10-16T00:40:11.723Z"
     },
     {
       "kind": "owner-action",
       "label": "Commit/reveal windows tuned",
-      "at": "2025-10-16T00:10:12.361Z",
+      "at": "2025-10-16T00:40:11.725Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setCommitRevealWindows",
@@ -1087,7 +1087,7 @@
     {
       "kind": "owner-action",
       "label": "Validator quorum set",
-      "at": "2025-10-16T00:10:12.363Z",
+      "at": "2025-10-16T00:40:11.726Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setValidatorsPerJob",
@@ -1099,7 +1099,7 @@
     {
       "kind": "owner-action",
       "label": "Validator pool curated",
-      "at": "2025-10-16T00:10:12.369Z",
+      "at": "2025-10-16T00:40:11.729Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setValidatorPool",
@@ -1115,7 +1115,7 @@
     {
       "kind": "owner-action",
       "label": "Reveal quorum configured",
-      "at": "2025-10-16T00:10:12.372Z",
+      "at": "2025-10-16T00:40:11.730Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setRevealQuorum",
@@ -1128,7 +1128,7 @@
     {
       "kind": "owner-action",
       "label": "Non-reveal penalty set",
-      "at": "2025-10-16T00:10:12.376Z",
+      "at": "2025-10-16T00:40:11.732Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setNonRevealPenalty",
@@ -1141,7 +1141,7 @@
     {
       "kind": "owner-action",
       "label": "Fee pool burn percentage adjusted",
-      "at": "2025-10-16T00:10:12.379Z",
+      "at": "2025-10-16T00:40:11.733Z",
       "meta": {
         "contract": "FeePool@0x0B306BF915C4d645ff596e518fAf3F9669b97016",
         "method": "setBurnPct",
@@ -1153,7 +1153,7 @@
     {
       "kind": "owner-action",
       "label": "Certificate base URI set",
-      "at": "2025-10-16T00:10:12.382Z",
+      "at": "2025-10-16T00:40:11.735Z",
       "meta": {
         "contract": "CertificateNFT@0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "method": "setBaseURI",
@@ -1165,12 +1165,12 @@
     {
       "kind": "step",
       "label": "Seeding IdentityRegistry with emergency allowlists",
-      "at": "2025-10-16T00:10:12.382Z"
+      "at": "2025-10-16T00:40:11.735Z"
     },
     {
       "kind": "owner-action",
       "label": "Emergency AI agent allowlisted",
-      "at": "2025-10-16T00:10:12.387Z",
+      "at": "2025-10-16T00:40:11.737Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "addAdditionalAgent",
@@ -1182,7 +1182,7 @@
     {
       "kind": "owner-action",
       "label": "Agent type annotated",
-      "at": "2025-10-16T00:10:12.390Z",
+      "at": "2025-10-16T00:40:11.739Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "setAgentType",
@@ -1195,7 +1195,7 @@
     {
       "kind": "owner-action",
       "label": "Emergency AI agent allowlisted",
-      "at": "2025-10-16T00:10:12.393Z",
+      "at": "2025-10-16T00:40:11.740Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "addAdditionalAgent",
@@ -1207,7 +1207,7 @@
     {
       "kind": "owner-action",
       "label": "Agent type annotated",
-      "at": "2025-10-16T00:10:12.396Z",
+      "at": "2025-10-16T00:40:11.743Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "setAgentType",
@@ -1220,7 +1220,7 @@
     {
       "kind": "owner-action",
       "label": "Validator council seat granted",
-      "at": "2025-10-16T00:10:12.400Z",
+      "at": "2025-10-16T00:40:11.744Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "addAdditionalValidator",
@@ -1232,7 +1232,7 @@
     {
       "kind": "owner-action",
       "label": "Validator council seat granted",
-      "at": "2025-10-16T00:10:12.406Z",
+      "at": "2025-10-16T00:40:11.748Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "addAdditionalValidator",
@@ -1244,7 +1244,7 @@
     {
       "kind": "owner-action",
       "label": "Validator council seat granted",
-      "at": "2025-10-16T00:10:12.409Z",
+      "at": "2025-10-16T00:40:11.749Z",
       "meta": {
         "contract": "IdentityRegistry@0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
         "method": "addAdditionalValidator",
@@ -1256,12 +1256,12 @@
     {
       "kind": "step",
       "label": "Initial token approvals and staking for actors",
-      "at": "2025-10-16T00:10:12.410Z"
+      "at": "2025-10-16T00:40:11.749Z"
     },
     {
       "kind": "balance",
       "label": "Initial treasury state",
-      "at": "2025-10-16T00:10:12.491Z",
+      "at": "2025-10-16T00:40:11.787Z",
       "meta": {
         "participants": [
           {
@@ -1305,17 +1305,17 @@
     {
       "kind": "section",
       "label": "Owner mission control – unstoppable command authority demonstration",
-      "at": "2025-10-16T00:10:12.492Z"
+      "at": "2025-10-16T00:40:11.788Z"
     },
     {
       "kind": "step",
       "label": "Owner calibrates market economics and validator incentives",
-      "at": "2025-10-16T00:10:12.508Z"
+      "at": "2025-10-16T00:40:11.811Z"
     },
     {
       "kind": "owner-action",
       "label": "Protocol fee temporarily increased",
-      "at": "2025-10-16T00:10:12.512Z",
+      "at": "2025-10-16T00:40:11.814Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setFeePct",
@@ -1328,7 +1328,7 @@
     {
       "kind": "owner-action",
       "label": "Validator rewards boosted",
-      "at": "2025-10-16T00:10:12.514Z",
+      "at": "2025-10-16T00:40:11.816Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setValidatorRewardPct",
@@ -1341,7 +1341,7 @@
     {
       "kind": "owner-action",
       "label": "Fee pool burn widened",
-      "at": "2025-10-16T00:10:12.516Z",
+      "at": "2025-10-16T00:40:11.819Z",
       "meta": {
         "contract": "FeePool@0x0B306BF915C4d645ff596e518fAf3F9669b97016",
         "method": "setBurnPct",
@@ -1354,12 +1354,12 @@
     {
       "kind": "step",
       "label": "Owner updates validation committee cadence and accountability levers",
-      "at": "2025-10-16T00:10:12.522Z"
+      "at": "2025-10-16T00:40:11.823Z"
     },
     {
       "kind": "owner-action",
       "label": "Commit/reveal windows extended",
-      "at": "2025-10-16T00:10:12.525Z",
+      "at": "2025-10-16T00:40:11.826Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setCommitRevealWindows",
@@ -1374,7 +1374,7 @@
     {
       "kind": "owner-action",
       "label": "Reveal quorum tightened",
-      "at": "2025-10-16T00:10:12.528Z",
+      "at": "2025-10-16T00:40:11.829Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setRevealQuorum",
@@ -1389,7 +1389,7 @@
     {
       "kind": "owner-action",
       "label": "Non-reveal penalty escalated",
-      "at": "2025-10-16T00:10:12.531Z",
+      "at": "2025-10-16T00:40:11.831Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setNonRevealPenalty",
@@ -1404,12 +1404,12 @@
     {
       "kind": "step",
       "label": "Owner delegates emergency pauser powers and performs a live drill",
-      "at": "2025-10-16T00:10:12.539Z"
+      "at": "2025-10-16T00:40:11.838Z"
     },
     {
       "kind": "owner-action",
       "label": "Registry pauser delegated",
-      "at": "2025-10-16T00:10:12.542Z",
+      "at": "2025-10-16T00:40:11.840Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setPauser",
@@ -1421,7 +1421,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager pauser delegated",
-      "at": "2025-10-16T00:10:12.545Z",
+      "at": "2025-10-16T00:40:11.843Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "setPauser",
@@ -1433,7 +1433,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module pauser delegated",
-      "at": "2025-10-16T00:10:12.548Z",
+      "at": "2025-10-16T00:40:11.845Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setPauser",
@@ -1445,7 +1445,7 @@
     {
       "kind": "owner-action",
       "label": "Registry paused for drill",
-      "at": "2025-10-16T00:10:12.551Z",
+      "at": "2025-10-16T00:40:11.847Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "pause",
@@ -1457,7 +1457,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager paused for drill",
-      "at": "2025-10-16T00:10:12.554Z",
+      "at": "2025-10-16T00:40:11.850Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "pause",
@@ -1469,7 +1469,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module paused for drill",
-      "at": "2025-10-16T00:10:12.557Z",
+      "at": "2025-10-16T00:40:11.852Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "pause",
@@ -1481,7 +1481,7 @@
     {
       "kind": "owner-action",
       "label": "Registry unpaused after drill",
-      "at": "2025-10-16T00:10:12.568Z",
+      "at": "2025-10-16T00:40:11.859Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "unpause",
@@ -1493,7 +1493,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager unpaused after drill",
-      "at": "2025-10-16T00:10:12.571Z",
+      "at": "2025-10-16T00:40:11.860Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "unpause",
@@ -1505,7 +1505,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module unpaused after drill",
-      "at": "2025-10-16T00:10:12.572Z",
+      "at": "2025-10-16T00:40:11.863Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "unpause",
@@ -1517,7 +1517,7 @@
     {
       "kind": "owner-action",
       "label": "Registry paused by delegated moderator",
-      "at": "2025-10-16T00:10:12.575Z",
+      "at": "2025-10-16T00:40:11.865Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "pause",
@@ -1529,7 +1529,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager paused by delegated moderator",
-      "at": "2025-10-16T00:10:12.577Z",
+      "at": "2025-10-16T00:40:11.871Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "pause",
@@ -1541,7 +1541,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module paused by delegated moderator",
-      "at": "2025-10-16T00:10:12.580Z",
+      "at": "2025-10-16T00:40:11.873Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "pause",
@@ -1553,7 +1553,7 @@
     {
       "kind": "owner-action",
       "label": "Registry unpaused by delegated moderator",
-      "at": "2025-10-16T00:10:12.586Z",
+      "at": "2025-10-16T00:40:11.879Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "unpause",
@@ -1565,7 +1565,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager unpaused by delegated moderator",
-      "at": "2025-10-16T00:10:12.589Z",
+      "at": "2025-10-16T00:40:11.882Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "unpause",
@@ -1577,7 +1577,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module unpaused by delegated moderator",
-      "at": "2025-10-16T00:10:12.590Z",
+      "at": "2025-10-16T00:40:11.883Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "unpause",
@@ -1589,12 +1589,12 @@
     {
       "kind": "step",
       "label": "Owner restores baseline configuration to prepare live scenarios",
-      "at": "2025-10-16T00:10:12.592Z"
+      "at": "2025-10-16T00:40:11.894Z"
     },
     {
       "kind": "owner-action",
       "label": "Protocol fee restored",
-      "at": "2025-10-16T00:10:12.595Z",
+      "at": "2025-10-16T00:40:11.896Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setFeePct",
@@ -1606,7 +1606,7 @@
     {
       "kind": "owner-action",
       "label": "Validator reward restored",
-      "at": "2025-10-16T00:10:12.597Z",
+      "at": "2025-10-16T00:40:11.898Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setValidatorRewardPct",
@@ -1618,7 +1618,7 @@
     {
       "kind": "owner-action",
       "label": "Fee pool burn restored",
-      "at": "2025-10-16T00:10:12.601Z",
+      "at": "2025-10-16T00:40:11.900Z",
       "meta": {
         "contract": "FeePool@0x0B306BF915C4d645ff596e518fAf3F9669b97016",
         "method": "setBurnPct",
@@ -1630,7 +1630,7 @@
     {
       "kind": "owner-action",
       "label": "Commit/reveal cadence restored",
-      "at": "2025-10-16T00:10:12.604Z",
+      "at": "2025-10-16T00:40:11.902Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setCommitRevealWindows",
@@ -1643,7 +1643,7 @@
     {
       "kind": "owner-action",
       "label": "Reveal quorum restored",
-      "at": "2025-10-16T00:10:12.606Z",
+      "at": "2025-10-16T00:40:11.903Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setRevealQuorum",
@@ -1656,7 +1656,7 @@
     {
       "kind": "owner-action",
       "label": "Non-reveal penalty restored",
-      "at": "2025-10-16T00:10:12.608Z",
+      "at": "2025-10-16T00:40:11.905Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setNonRevealPenalty",
@@ -1669,7 +1669,7 @@
     {
       "kind": "owner-action",
       "label": "Registry pauser returned to owner",
-      "at": "2025-10-16T00:10:12.611Z",
+      "at": "2025-10-16T00:40:11.907Z",
       "meta": {
         "contract": "JobRegistry@0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
         "method": "setPauser",
@@ -1681,7 +1681,7 @@
     {
       "kind": "owner-action",
       "label": "Stake manager pauser returned to owner",
-      "at": "2025-10-16T00:10:12.613Z",
+      "at": "2025-10-16T00:40:11.908Z",
       "meta": {
         "contract": "StakeManager@0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
         "method": "setPauser",
@@ -1693,7 +1693,7 @@
     {
       "kind": "owner-action",
       "label": "Validation module pauser returned to owner",
-      "at": "2025-10-16T00:10:12.615Z",
+      "at": "2025-10-16T00:40:11.909Z",
       "meta": {
         "contract": "ValidationModule@0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
         "method": "setPauser",
@@ -1705,37 +1705,41 @@
     {
       "kind": "summary",
       "label": "Owner mission control baseline restored",
-      "at": "2025-10-16T00:10:12.630Z",
+      "at": "2025-10-16T00:40:11.918Z",
       "meta": {
         "feePct": 5,
         "validatorRewardPct": 20,
         "burnPct": 5,
-        "commitWindow": "60s",
-        "revealWindow": "60s",
+        "commitWindowSeconds": 60,
+        "revealWindowSeconds": 60,
+        "commitWindowFormatted": "60s",
+        "revealWindowFormatted": "60s",
         "revealQuorumPct": 0,
         "minRevealers": 2,
         "nonRevealPenaltyBps": 100,
         "nonRevealBanBlocks": 1,
         "registryPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
         "stakePauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        "validationPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        "validationPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "commitWindow": "60s",
+        "revealWindow": "60s"
       }
     },
     {
       "kind": "section",
       "label": "Scenario 1 – Cooperative intergovernmental AI labour success",
-      "at": "2025-10-16T00:10:12.631Z"
+      "at": "2025-10-16T00:40:11.919Z"
     },
     {
       "kind": "step",
       "label": "Nation A approves escrow and posts a climate-coordination job",
-      "at": "2025-10-16T00:10:12.633Z",
+      "at": "2025-10-16T00:40:11.921Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "job-summary",
       "label": "Job 1 (after posting)",
-      "at": "2025-10-16T00:10:12.653Z",
+      "at": "2025-10-16T00:40:11.937Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "jobId": "1",
@@ -1751,13 +1755,13 @@
     {
       "kind": "step",
       "label": "Alice stakes identity and applies through the emergency allowlist",
-      "at": "2025-10-16T00:10:12.653Z",
+      "at": "2025-10-16T00:40:11.937Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "job-summary",
       "label": "Job 1 (after agent assignment)",
-      "at": "2025-10-16T00:10:12.671Z",
+      "at": "2025-10-16T00:40:11.950Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "jobId": "1",
@@ -1773,13 +1777,13 @@
     {
       "kind": "step",
       "label": "Alice submits validated deliverables with provable IPFS evidence",
-      "at": "2025-10-16T00:10:12.671Z",
+      "at": "2025-10-16T00:40:11.950Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "job-summary",
       "label": "Job 1 (after submission)",
-      "at": "2025-10-16T00:10:12.684Z",
+      "at": "2025-10-16T00:40:11.968Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "jobId": "1",
@@ -1795,25 +1799,25 @@
     {
       "kind": "step",
       "label": "Nation A records burn proof and primes the validation committee selection",
-      "at": "2025-10-16T00:10:12.684Z",
+      "at": "2025-10-16T00:40:11.968Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "step",
       "label": "Validators commit to their assessments under commit–reveal secrecy",
-      "at": "2025-10-16T00:10:12.745Z",
+      "at": "2025-10-16T00:40:12.014Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "step",
       "label": "Validators reveal unanimous approval, meeting the quorum instantly",
-      "at": "2025-10-16T00:10:12.811Z",
+      "at": "2025-10-16T00:40:12.045Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "job-summary",
       "label": "Job 1 (after validator finalize)",
-      "at": "2025-10-16T00:10:12.907Z",
+      "at": "2025-10-16T00:40:12.115Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "jobId": "1",
@@ -1829,13 +1833,13 @@
     {
       "kind": "step",
       "label": "Nation A finalizes payment, rewarding Alice and the validator cohort",
-      "at": "2025-10-16T00:10:12.907Z",
+      "at": "2025-10-16T00:40:12.115Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "job-summary",
       "label": "Job 1 (after treasury settlement)",
-      "at": "2025-10-16T00:10:12.928Z",
+      "at": "2025-10-16T00:40:12.141Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "jobId": "1",
@@ -1851,7 +1855,7 @@
     {
       "kind": "balance",
       "label": "Post-job token balances",
-      "at": "2025-10-16T00:10:12.939Z",
+      "at": "2025-10-16T00:40:12.150Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success",
       "meta": {
         "participants": [
@@ -1886,19 +1890,19 @@
     {
       "kind": "section",
       "label": "Scenario 2 – Cross-border dispute resolved by owner governance",
-      "at": "2025-10-16T00:10:12.942Z",
+      "at": "2025-10-16T00:40:12.151Z",
       "scenario": "Scenario 1 – Cooperative intergovernmental AI labour success"
     },
     {
       "kind": "step",
       "label": "Nation B funds a frontier language translation initiative",
-      "at": "2025-10-16T00:10:12.943Z",
+      "at": "2025-10-16T00:40:12.153Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "job-summary",
       "label": "Job 2 (after posting)",
-      "at": "2025-10-16T00:10:12.955Z",
+      "at": "2025-10-16T00:40:12.167Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "jobId": "2",
@@ -1914,25 +1918,25 @@
     {
       "kind": "step",
       "label": "Bob applies, contributes work, and submits contested deliverables",
-      "at": "2025-10-16T00:10:12.955Z",
+      "at": "2025-10-16T00:40:12.168Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "step",
       "label": "Validators disagree; one plans to approve, another to reject, one will abstain",
-      "at": "2025-10-16T00:10:13.015Z",
+      "at": "2025-10-16T00:40:12.227Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "step",
       "label": "Partial reveals occur – one validator abstains, triggering penalties",
-      "at": "2025-10-16T00:10:13.046Z",
+      "at": "2025-10-16T00:40:12.263Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "job-summary",
       "label": "Job 2 (after partial quorum)",
-      "at": "2025-10-16T00:10:13.111Z",
+      "at": "2025-10-16T00:40:12.320Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "jobId": "2",
@@ -1948,13 +1952,13 @@
     {
       "kind": "step",
       "label": "Bob leverages dispute rights; governance moderates and sides with the agent",
-      "at": "2025-10-16T00:10:13.111Z",
+      "at": "2025-10-16T00:40:12.320Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "owner-action",
       "label": "Dispute fee waived for demonstration",
-      "at": "2025-10-16T00:10:13.114Z",
+      "at": "2025-10-16T00:40:12.322Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "contract": "DisputeModule@0x9A676e781A523b5d0C0e43731313A708CB607508",
@@ -1967,7 +1971,7 @@
     {
       "kind": "owner-action",
       "label": "Dispute window accelerated",
-      "at": "2025-10-16T00:10:13.123Z",
+      "at": "2025-10-16T00:40:12.332Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "contract": "DisputeModule@0x9A676e781A523b5d0C0e43731313A708CB607508",
@@ -1980,7 +1984,7 @@
     {
       "kind": "owner-action",
       "label": "Owner enrolled as dispute moderator",
-      "at": "2025-10-16T00:10:13.125Z",
+      "at": "2025-10-16T00:40:12.334Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "contract": "DisputeModule@0x9A676e781A523b5d0C0e43731313A708CB607508",
@@ -1994,7 +1998,7 @@
     {
       "kind": "owner-action",
       "label": "External moderator empowered",
-      "at": "2025-10-16T00:10:13.128Z",
+      "at": "2025-10-16T00:40:12.336Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "contract": "DisputeModule@0x9A676e781A523b5d0C0e43731313A708CB607508",
@@ -2008,13 +2012,13 @@
     {
       "kind": "step",
       "label": "Nation B finalizes, distributing escrow and validator rewards post-dispute",
-      "at": "2025-10-16T00:10:13.149Z",
+      "at": "2025-10-16T00:40:12.350Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "job-summary",
       "label": "Job 2 (after dispute resolution)",
-      "at": "2025-10-16T00:10:13.180Z",
+      "at": "2025-10-16T00:40:12.374Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "jobId": "2",
@@ -2030,7 +2034,7 @@
     {
       "kind": "balance",
       "label": "Post-dispute token balances",
-      "at": "2025-10-16T00:10:13.190Z",
+      "at": "2025-10-16T00:40:12.381Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance",
       "meta": {
         "participants": [
@@ -2065,13 +2069,13 @@
     {
       "kind": "section",
       "label": "Sovereign labour market telemetry dashboard",
-      "at": "2025-10-16T00:10:13.190Z",
+      "at": "2025-10-16T00:40:12.381Z",
       "scenario": "Scenario 2 – Cross-border dispute resolved by owner governance"
     },
     {
       "kind": "summary",
       "label": "Agent portfolios",
-      "at": "2025-10-16T00:10:13.239Z",
+      "at": "2025-10-16T00:40:12.423Z",
       "meta": {
         "agents": [
           {
@@ -2108,7 +2112,7 @@
     {
       "kind": "summary",
       "label": "Validator council status",
-      "at": "2025-10-16T00:10:13.262Z",
+      "at": "2025-10-16T00:40:12.440Z",
       "meta": {
         "validators": [
           {
@@ -2141,7 +2145,7 @@
     {
       "kind": "summary",
       "label": "Market telemetry dashboard",
-      "at": "2025-10-16T00:10:13.263Z",
+      "at": "2025-10-16T00:40:12.441Z",
       "meta": {
         "totalJobs": "2",
         "totalBurned": "6.175 AGIα",
@@ -2168,7 +2172,7 @@
     {
       "kind": "section",
       "label": "Demo complete – AGI Jobs v2 sovereignty market simulation finished",
-      "at": "2025-10-16T00:10:13.263Z"
+      "at": "2025-10-16T00:40:12.441Z"
     }
   ],
   "scenarios": [
@@ -2233,5 +2237,79 @@
         "uri": "ipfs://agi-jobs/demo/certificates/2"
       }
     ]
+  },
+  "ownerControl": {
+    "ownerAddress": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "moderatorAddress": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
+    "modules": {
+      "registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+      "stake": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
+      "validation": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
+      "feePool": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
+      "dispute": "0x9A676e781A523b5d0C0e43731313A708CB607508",
+      "certificate": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
+      "reputation": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
+      "identity": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788"
+    },
+    "baseline": {
+      "feePct": 5,
+      "validatorRewardPct": 20,
+      "burnPct": 5,
+      "commitWindowSeconds": 60,
+      "revealWindowSeconds": 60,
+      "commitWindowFormatted": "60s",
+      "revealWindowFormatted": "60s",
+      "revealQuorumPct": 0,
+      "minRevealers": 2,
+      "nonRevealPenaltyBps": 100,
+      "nonRevealBanBlocks": 1,
+      "registryPauser": "0x0000000000000000000000000000000000000000",
+      "stakePauser": "0x0000000000000000000000000000000000000000",
+      "validationPauser": "0x0000000000000000000000000000000000000000"
+    },
+    "upgraded": {
+      "feePct": 9,
+      "validatorRewardPct": 25,
+      "burnPct": 6,
+      "commitWindowSeconds": 90,
+      "revealWindowSeconds": 90,
+      "commitWindowFormatted": "90s",
+      "revealWindowFormatted": "90s",
+      "revealQuorumPct": 50,
+      "minRevealers": 2,
+      "nonRevealPenaltyBps": 150,
+      "nonRevealBanBlocks": 12,
+      "registryPauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
+      "stakePauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
+      "validationPauser": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
+    },
+    "restored": {
+      "feePct": 5,
+      "validatorRewardPct": 20,
+      "burnPct": 5,
+      "commitWindowSeconds": 60,
+      "revealWindowSeconds": 60,
+      "commitWindowFormatted": "60s",
+      "revealWindowFormatted": "60s",
+      "revealQuorumPct": 0,
+      "minRevealers": 2,
+      "nonRevealPenaltyBps": 100,
+      "nonRevealBanBlocks": 1,
+      "registryPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "stakePauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "validationPauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    },
+    "pauseDrill": {
+      "owner": {
+        "registry": true,
+        "stake": true,
+        "validation": true
+      },
+      "moderator": {
+        "registry": true,
+        "stake": true,
+        "validation": true
+      }
+    }
   }
 }

--- a/demo/agi-labor-market-grand-demo/ui/styles.css
+++ b/demo/agi-labor-market-grand-demo/ui/styles.css
@@ -166,6 +166,59 @@ main {
   color: var(--muted);
 }
 
+.owner-control-section {
+  margin-top: 1.5rem;
+}
+
+.owner-control-section:first-of-type {
+  margin-top: 1rem;
+}
+
+.owner-control-dl {
+  display: grid;
+  grid-template-columns: minmax(180px, 220px) 1fr;
+  gap: 0.45rem 1rem;
+  margin: 1rem 0 0;
+}
+
+.owner-control-dl dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.owner-control-dl dd {
+  margin: 0;
+}
+
+.owner-control-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  font-size: 0.85rem;
+}
+
+.owner-control-table th,
+.owner-control-table td {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 0.55rem 0.65rem;
+  vertical-align: top;
+}
+
+.owner-control-table th {
+  text-align: left;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  background: rgba(30, 41, 59, 0.72);
+}
+
+.owner-control-table td {
+  background: rgba(15, 23, 42, 0.7);
+}
+
 .parameters {
   font-family: 'SFMono-Regular', 'Roboto Mono', ui-monospace, monospace;
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- extend the grand demo script to capture an owner-control snapshot and pause drill telemetry alongside the existing transcript
- surface the new snapshot in the UI with dedicated cards, tables, and styling that walk non-technical operators through addresses, parameter deltas, and emergency drills
- refresh the bundled transcript/README so the demo highlights the new sovereign control view by default

## Testing
- npm run demo:agi-labor-market:export

------
https://chatgpt.com/codex/tasks/task_e_68f03d678c6c8333a634e38e2fa29a24