### PR TITLE
Strengthen AGI labour market grand demo guarantees

### DIFF
--- a/.github/workflows/demo-agi-labor-market.yml
+++ b/.github/workflows/demo-agi-labor-market.yml
@@ -1,0 +1,81 @@
+name: demo-agi-labor-market
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/v2/agiLaborMarketGrandDemo.ts'
+      - 'scripts/v2/launchAgiLaborMarketControlRoom.ts'
+      - 'demo/agi-labor-market-grand-demo/**'
+      - '.github/workflows/demo-agi-labor-market.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  agi-labor-market-demo:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: |
+            api.github.com
+            github.com
+            objects.githubusercontent.com
+            raw.githubusercontent.com
+            registry.npmjs.org
+            nodejs.org
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            **/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline --progress=false
+
+      - name: Run AGI Jobs v2 labour market export
+        run: npm run demo:agi-labor-market:export
+
+      - name: Validate sovereign control transcript
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = 'demo/agi-labor-market-grand-demo/ui/export/latest.json';
+          const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+          const requiredArrays = [
+            ['timeline', data.timeline],
+            ['ownerActions', data.ownerActions],
+            ['scenarios', data.scenarios],
+          ];
+          for (const [label, value] of requiredArrays) {
+            if (!Array.isArray(value) || value.length === 0) {
+              throw new Error(`${label} missing from transcript`);
+            }
+          }
+          if (!data.market || !Array.isArray(data.market.agentPortfolios) || data.market.agentPortfolios.length === 0) {
+            throw new Error('market agentPortfolios missing from transcript');
+          }
+          if (!data.ownerControl || !data.ownerControl.baseline) {
+            throw new Error('ownerControl snapshot missing from transcript');
+          }
+          console.log(`Validated transcript with ${data.timeline.length} timeline entries and ${data.ownerActions.length} owner actions.`);
+          NODE
+
+      - name: Upload transcript artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agi-labor-market-transcript
+          path: demo/agi-labor-market-grand-demo/ui/export/latest.json

--- a/demo/agi-labor-market-grand-demo/README.md
+++ b/demo/agi-labor-market-grand-demo/README.md
@@ -74,17 +74,35 @@ The script:
 2. Demonstrates **owner mission control** — live updates to protocol fees,
    validator incentives, non-reveal penalties, and emergency pause delegation to
    a trusted operator — proving that the platform owner can steer every
-   parameter in real time.
+   parameter in real time. Every configuration change is immediately asserted,
+   so the script halts if any module fails to reflect the owner’s command.
 3. Walks through the happy-path job where all validators approve.
 4. Runs a contested job where governance resolves a dispute in favour of the
    agent.
-5. Prints a full telemetry dashboard – validator/agent stakes, fee pool state,
+5. Verifies that each agent receives exactly one credential NFT, that burn
+   accounting reconciles against total supply, and that the dispute flow mints
+   credentials even when moderation is required.
+6. Prints a full telemetry dashboard – validator/agent stakes, fee pool state,
    burn totals, reputation scores, and certificate ownership – so a
    non-technical operator sees the market outcome at a glance.
 
 The output is intentionally narrative, providing contextual breadcrumbs (job
 state transitions, committee selections, dispute escalations) so a non-technical
 operator can follow the on-chain flow without reading contract code.
+
+### Continuous verification for non-technical operators
+
+The repository ships a dedicated GitHub Actions workflow,
+[`demo-agi-labor-market.yml`](../../.github/workflows/demo-agi-labor-market.yml),
+that replays the export on every pull request touching this demo. The job
+produces an artefact containing `export/latest.json` and fails if:
+
+- the Hardhat script does not emit a transcript,
+- owner actions, scenarios, or timeline events are missing, or
+- the sovereign control snapshot omits baseline parameters.
+
+This guarantees that the showcased workflow remains fully functional and
+accessible without requiring local manual testing.
 
 ### One-command sovereign control room (non-technical friendly)
 


### PR DESCRIPTION
## Summary
- add runtime assertions to the AGI labour market grand demo to prove owner command authority, job lifecycle state transitions, and credential issuance
- harden the telemetry summary with supply and certificate consistency checks
- document the new guarantees and wire a dedicated demo-agi-labor-market CI workflow that exports and validates transcripts on every PR

## Testing
- npm run demo:agi-labor-market --silent
- npm run demo:agi-labor-market:export --silent
- node - <<'NODE' … (transcript validation)


------
https://chatgpt.com/codex/tasks/task_e_68f05b26b44c83338dd18d070eb3047a