### PR TITLE
Add alpha AGI MARK foresight demo

### DIFF
--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -1,0 +1,25 @@
+name: demo-alpha-agi-mark
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  demo-alpha-agi-mark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.18.1'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Compile demo contracts
+        run: npx hardhat --config demo/alpha-agi-mark/hardhat.config.ts compile
+      - name: Run demo tests
+        run: npx hardhat --config demo/alpha-agi-mark/hardhat.config.ts test
+      - name: Execute scripted walkthrough
+        run: npx hardhat --config demo/alpha-agi-mark/hardhat.config.ts run demo/alpha-agi-mark/scripts/runDemo.ts

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ examples/agentic/runtime-agentic.jsonl
 
 apps/console/dist/
 apps/console/node_modules/
+# α-AGI MARK demo build artifacts
+/demo/alpha-agi-mark/artifacts/
+/demo/alpha-agi-mark/cache/
+/demo/alpha-agi-mark/typechain-types/

--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -1,0 +1,40 @@
+
+# α-AGI MARK – Foresight DEX & Risk Oracle Demo
+
+This demo shows how AGI Jobs v0 (v2) empowers a non-technical operator to deploy an on-chain foresight market, complete with a bonding curve treasury, validator-driven risk oracle, launchpad finalisation, and sovereign vault custody.
+
+## Quickstart
+
+```bash
+npx hardhat --config demo/alpha-agi-mark/hardhat.config.ts test
+npx hardhat --config demo/alpha-agi-mark/hardhat.config.ts run demo/alpha-agi-mark/scripts/runDemo.ts
+```
+
+The test suite verifies bonding curve math, validator gating, and owner failsafes. The demo script deploys the full stack and simulates validators and investors collaborating to green-light a Nova-Seed.
+
+## Components
+
+- **AlphaAgiMark.sol** – ERC-20 bonding curve market with pausing, whitelisting, owner overrides, and launch finalisation / abort controls.
+- **ValidatorRiskOracle.sol** – Validator council that casts approvals. Threshold, membership, and overrides remain fully owner-configurable.
+- **NovaSeedNFT.sol** – Minimal ERC-721 capturing the foresight artefact that the market finances.
+- **SovereignVault.sol** – Receives the treasury after a successful launch and allows owner-managed disbursement.
+
+## Owner Control Surface
+
+Run the Hardhat console to inspect parameters at any time:
+
+```bash
+npx hardhat --config demo/alpha-agi-mark/hardhat.config.ts console --network hardhat
+```
+
+Key capabilities:
+
+- Pause/unpause the market instantly.
+- Toggle KYC whitelist enforcement and update allowed participants.
+- Adjust validators, approval thresholds, and override validation outcomes.
+- Lock or update pricing parameters before launch.
+- Abort or finalise the launch, directing funds to a sovereign vault of choice.
+
+## Continuous Integration
+
+Add the workflow `.github/workflows/demo-alpha-agi-mark.yml` to ensure tests and the scripted walkthrough execute on every pull request.

--- a/demo/alpha-agi-mark/contracts/AlphaAgiMark.sol
+++ b/demo/alpha-agi-mark/contracts/AlphaAgiMark.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IRiskOracle} from "./IRiskOracle.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+/**
+ * @title AlphaAgiMark
+ * @notice Bonding-curve powered foresight market backing a Nova-Seed.
+ */
+contract AlphaAgiMark is ERC20, Ownable, Pausable, ReentrancyGuard {
+    event TokensPurchased(address indexed buyer, uint256 amount, uint256 cost);
+    event TokensSold(address indexed seller, uint256 amount, uint256 payout);
+    event LaunchFinalised(address indexed sovereignVault, uint256 totalRaised);
+    event LaunchAborted(address indexed caller);
+    event WhitelistStatusChanged(bool enabled);
+    event WhitelistUpdated(address indexed account, bool allowed);
+    event OracleUpdated(address indexed oracle);
+    event PricingUpdated(uint256 basePrice, uint256 slope);
+
+    error LaunchFinalisedAlready();
+    error LaunchAbortedAlready();
+    error ValidationRequired();
+    error NotWhitelisted();
+    error AmountZero();
+    error SupplyTooLow();
+    error InvalidOracle();
+    error PricingImmutable();
+
+    IRiskOracle public oracle;
+    uint256 public basePrice;
+    uint256 public slope;
+    uint256 public reserveBalance;
+    bool public launchFinalised;
+    bool public launchAborted;
+    bool public whitelistEnabled;
+    bool public pricingLocked;
+
+    mapping(address => bool) public whitelist;
+
+    constructor(
+        address owner_,
+        address oracle_,
+        uint256 basePrice_,
+        uint256 slope_
+    ) ERC20("alpha-AGI Nova-Seed Share", "NOVA-SHARE") Ownable(owner_) {
+        require(owner_ != address(0), "owner zero");
+        _setOracle(oracle_);
+        _updatePricing(basePrice_, slope_);
+    }
+
+    receive() external payable {
+        revert("direct ETH not allowed");
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 18;
+    }
+
+    function buyShares(uint256 amount) external payable whenNotPaused nonReentrant {
+        if (launchFinalised) revert LaunchFinalisedAlready();
+        if (launchAborted) revert LaunchAbortedAlready();
+        if (amount == 0) revert AmountZero();
+        if (whitelistEnabled && !whitelist[msg.sender]) revert NotWhitelisted();
+
+        uint256 cost = calculatePurchaseCost(amount);
+        require(msg.value >= cost, "insufficient payment");
+
+        _mint(msg.sender, amount);
+        reserveBalance += cost;
+
+        emit TokensPurchased(msg.sender, amount, cost);
+
+        if (msg.value > cost) {
+            (bool success, ) = msg.sender.call{value: msg.value - cost}("");
+            require(success, "refund failed");
+        }
+    }
+
+    function sellShares(uint256 amount) external whenNotPaused nonReentrant {
+        if (amount == 0) revert AmountZero();
+        uint256 supply = totalSupply();
+        if (amount > supply) revert SupplyTooLow();
+
+        uint256 payout = calculateSaleReturn(amount);
+        _burn(msg.sender, amount);
+        reserveBalance -= payout;
+
+        emit TokensSold(msg.sender, amount, payout);
+
+        (bool success, ) = msg.sender.call{value: payout}("");
+        require(success, "payout failed");
+    }
+
+    function calculatePurchaseCost(uint256 amount) public view returns (uint256) {
+        if (amount == 0) revert AmountZero();
+        uint256 start = totalSupply();
+        uint256 end = start + amount;
+        return _reserveAt(end) - _reserveAt(start);
+    }
+
+    function calculateSaleReturn(uint256 amount) public view returns (uint256) {
+        if (amount == 0) revert AmountZero();
+        uint256 supply = totalSupply();
+        if (amount > supply) revert SupplyTooLow();
+        uint256 start = supply - amount;
+        return _reserveAt(supply) - _reserveAt(start);
+    }
+
+    function finaliseLaunch(address payable sovereignVault) external onlyOwner whenNotPaused {
+        if (launchFinalised) revert LaunchFinalisedAlready();
+        if (launchAborted) revert LaunchAbortedAlready();
+        if (address(oracle) != address(0) && !oracle.seedValidated()) revert ValidationRequired();
+        require(sovereignVault != address(0), "vault zero");
+        launchFinalised = true;
+        pricingLocked = true;
+        uint256 amount = reserveBalance;
+        reserveBalance = 0;
+        (bool success, ) = sovereignVault.call{value: amount}("");
+        require(success, "transfer failed");
+        emit LaunchFinalised(sovereignVault, amount);
+    }
+
+    function abortLaunch() external onlyOwner {
+        if (launchFinalised) revert LaunchFinalisedAlready();
+        if (launchAborted) revert LaunchAbortedAlready();
+        launchAborted = true;
+        emit LaunchAborted(msg.sender);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    function setWhitelistStatus(bool enabled) external onlyOwner {
+        whitelistEnabled = enabled;
+        emit WhitelistStatusChanged(enabled);
+    }
+
+    function setWhitelist(address account, bool allowed) external onlyOwner {
+        whitelist[account] = allowed;
+        emit WhitelistUpdated(account, allowed);
+    }
+
+    function updatePricing(uint256 newBasePrice, uint256 newSlope) external onlyOwner {
+        if (pricingLocked) revert PricingImmutable();
+        _updatePricing(newBasePrice, newSlope);
+    }
+
+    function lockPricing() external onlyOwner {
+        pricingLocked = true;
+    }
+
+    function setOracle(address oracle_) external onlyOwner {
+        _setOracle(oracle_);
+    }
+
+    function _reserveAt(uint256 supply) internal view returns (uint256) {
+        if (supply == 0) {
+            return 0;
+        }
+        uint256 baseTerm = Math.mulDiv(basePrice, supply, 1e18);
+        uint256 slopeMulSupply = Math.mulDiv(slope, supply, 1e18);
+        uint256 quadraticTerm = Math.mulDiv(slopeMulSupply, supply, 2e18);
+        return baseTerm + quadraticTerm;
+    }
+
+    function _updatePricing(uint256 basePrice_, uint256 slope_) internal {
+        require(basePrice_ > 0, "base price zero");
+        require(slope_ > 0, "slope zero");
+        basePrice = basePrice_;
+        slope = slope_;
+        emit PricingUpdated(basePrice_, slope_);
+    }
+
+    function _setOracle(address oracle_) internal {
+        if (oracle_ == address(0)) revert InvalidOracle();
+        oracle = IRiskOracle(oracle_);
+        emit OracleUpdated(oracle_);
+    }
+}

--- a/demo/alpha-agi-mark/contracts/IRiskOracle.sol
+++ b/demo/alpha-agi-mark/contracts/IRiskOracle.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IRiskOracle {
+    function seedValidated() external view returns (bool);
+
+    function totalValidators() external view returns (uint256);
+
+    function approvalsRequired() external view returns (uint256);
+
+    function approvalsCount() external view returns (uint256);
+}

--- a/demo/alpha-agi-mark/contracts/NovaSeedNFT.sol
+++ b/demo/alpha-agi-mark/contracts/NovaSeedNFT.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title NovaSeedNFT
+ * @notice Minimal ERC-721 representing an α-AGI Nova-Seed foresight artifact.
+ */
+contract NovaSeedNFT is ERC721, Ownable {
+    uint256 private _nextId = 1;
+    mapping(uint256 => string) private _tokenURIs;
+
+    constructor(address owner_) ERC721("alpha-AGI Nova-Seed", "NOVA-SEED") Ownable(owner_) {
+        require(owner_ != address(0), "owner zero");
+    }
+
+    function mint(address to, string memory tokenUri) external onlyOwner returns (uint256 tokenId) {
+        tokenId = _nextId;
+        _nextId += 1;
+        _safeMint(to, tokenId);
+        _tokenURIs[tokenId] = tokenUri;
+    }
+
+    function setTokenURI(uint256 tokenId, string calldata tokenUri) external onlyOwner {
+        require(_ownerOf(tokenId) != address(0), "nonexistent token");
+        _tokenURIs[tokenId] = tokenUri;
+    }
+
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        require(_ownerOf(tokenId) != address(0), "nonexistent token");
+        return _tokenURIs[tokenId];
+    }
+}

--- a/demo/alpha-agi-mark/contracts/SovereignVault.sol
+++ b/demo/alpha-agi-mark/contracts/SovereignVault.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title SovereignVault
+ * @notice Simple vault receiving the Nova-Seed treasury once MARK finalises.
+ */
+contract SovereignVault is Ownable {
+    event FundsReceived(address indexed from, uint256 amount);
+    event FundsWithdrawn(address indexed to, uint256 amount);
+
+    constructor(address owner_) Ownable(owner_) {
+        require(owner_ != address(0), "owner zero");
+    }
+
+    receive() external payable {
+        emit FundsReceived(msg.sender, msg.value);
+    }
+
+    function withdraw(address payable to, uint256 amount) external onlyOwner {
+        require(to != address(0), "to zero");
+        require(amount <= address(this).balance, "insufficient balance");
+        (bool success, ) = to.call{value: amount}("");
+        require(success, "withdraw failed");
+        emit FundsWithdrawn(to, amount);
+    }
+}

--- a/demo/alpha-agi-mark/contracts/ValidatorRiskOracle.sol
+++ b/demo/alpha-agi-mark/contracts/ValidatorRiskOracle.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+/**
+ * @title ValidatorRiskOracle
+ * @notice Collects validator approvals for a Nova-Seed and exposes the aggregated confidence signal.
+ */
+contract ValidatorRiskOracle is Ownable, Pausable {
+    event ValidatorAdded(address indexed account);
+    event ValidatorRemoved(address indexed account);
+    event VoteCast(address indexed validator, bool approved);
+    event ApprovalsRequiredUpdated(uint256 newRequirement);
+    event ValidationOverridden(address indexed caller, bool approved);
+
+    struct VoteState {
+        bool exists;
+        bool approved;
+    }
+
+    mapping(address => bool) private _validators;
+    mapping(address => VoteState) private _votes;
+
+    uint256 private _validatorCount;
+    uint256 private _approvals;
+    uint256 private _approvalsRequired;
+    bool private _seedValidated;
+
+    constructor(address owner_, uint256 approvalsRequired_) Ownable(owner_) {
+        require(owner_ != address(0), "owner zero");
+        _setApprovalsRequired(approvalsRequired_);
+    }
+
+    modifier onlyValidator() {
+        require(_validators[msg.sender], "not validator");
+        _;
+    }
+
+    function addValidator(address account) external onlyOwner {
+        require(account != address(0), "validator zero");
+        require(!_validators[account], "already validator");
+        _validators[account] = true;
+        _validatorCount += 1;
+        emit ValidatorAdded(account);
+    }
+
+    function removeValidator(address account) external onlyOwner {
+        require(_validators[account], "not validator");
+        _validators[account] = false;
+        _validatorCount -= 1;
+        if (_votes[account].exists && _votes[account].approved) {
+            _approvals -= 1;
+        }
+        delete _votes[account];
+        emit ValidatorRemoved(account);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    function setApprovalsRequired(uint256 newRequirement) external onlyOwner {
+        _setApprovalsRequired(newRequirement);
+    }
+
+    function castVote(bool approve) external onlyValidator whenNotPaused {
+        VoteState storage vote = _votes[msg.sender];
+        if (!vote.exists) {
+            vote.exists = true;
+            if (approve) {
+                _approvals += 1;
+            }
+        } else if (vote.approved != approve) {
+            if (approve) {
+                _approvals += 1;
+            } else {
+                _approvals -= 1;
+            }
+        }
+        vote.approved = approve;
+
+        if (!_seedValidated && _approvalsRequired > 0 && _approvals >= _approvalsRequired) {
+            _seedValidated = true;
+        }
+
+        emit VoteCast(msg.sender, approve);
+    }
+
+    function overrideValidation(bool approved) external onlyOwner {
+        _seedValidated = approved;
+        emit ValidationOverridden(msg.sender, approved);
+    }
+
+    function approvalsRequired() external view returns (uint256) {
+        return _approvalsRequired;
+    }
+
+    function approvalsCount() external view returns (uint256) {
+        return _approvals;
+    }
+
+    function totalValidators() external view returns (uint256) {
+        return _validatorCount;
+    }
+
+    function seedValidated() external view returns (bool) {
+        return _seedValidated;
+    }
+
+    function validatorVote(address validator) external view returns (bool hasVoted, bool approved) {
+        VoteState memory vote = _votes[validator];
+        return (vote.exists, vote.approved);
+    }
+
+    function isValidator(address account) external view returns (bool) {
+        return _validators[account];
+    }
+
+    function _setApprovalsRequired(uint256 newRequirement) private {
+        require(newRequirement <= _validatorCount || _validatorCount == 0, "requirement too high");
+        _approvalsRequired = newRequirement;
+        emit ApprovalsRequiredUpdated(newRequirement);
+    }
+}

--- a/demo/alpha-agi-mark/hardhat.config.ts
+++ b/demo/alpha-agi-mark/hardhat.config.ts
@@ -1,0 +1,28 @@
+import { HardhatUserConfig } from 'hardhat/types';
+import '@nomicfoundation/hardhat-toolbox';
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: '0.8.25',
+    settings: {
+      optimizer: { enabled: true, runs: 200 },
+      viaIR: true,
+    },
+  },
+  paths: {
+    sources: './contracts',
+    tests: './test',
+    cache: './cache',
+    artifacts: './artifacts',
+  },
+  mocha: {
+    timeout: 120000,
+  },
+  networks: {
+    hardhat: {
+      allowUnlimitedContractSize: true,
+    },
+  },
+};
+
+export default config;

--- a/demo/alpha-agi-mark/scripts/deploy.ts
+++ b/demo/alpha-agi-mark/scripts/deploy.ts
@@ -1,0 +1,64 @@
+
+import { ethers } from 'hardhat';
+
+export interface DeploymentAddresses {
+  owner: string;
+  oracle: string;
+  market: string;
+  vault: string;
+  novaSeed: string;
+  novaSeedId: bigint;
+}
+
+export async function deployAlphaAgiMark(owner?: string): Promise<DeploymentAddresses> {
+  const [deployer, fallbackOwner, ...rest] = await ethers.getSigners();
+  const ownerAccount = owner ?? fallbackOwner.address;
+
+  const oracleFactory = await ethers.getContractFactory('ValidatorRiskOracle');
+  const oracle = await oracleFactory.deploy(ownerAccount, 0);
+  await oracle.waitForDeployment();
+
+  const novaSeedFactory = await ethers.getContractFactory('NovaSeedNFT');
+  const novaSeed = await novaSeedFactory.deploy(ownerAccount);
+  await novaSeed.waitForDeployment();
+
+  const vaultFactory = await ethers.getContractFactory('SovereignVault');
+  const vault = await vaultFactory.deploy(ownerAccount);
+  await vault.waitForDeployment();
+
+  const basePrice = ethers.parseEther('0.05');
+  const slope = ethers.parseEther('0.01');
+  const markFactory = await ethers.getContractFactory('AlphaAgiMark');
+  const mark = await markFactory.deploy(ownerAccount, await oracle.getAddress(), basePrice, slope);
+  await mark.waitForDeployment();
+
+  const ownerSigner = await ethers.getSigner(ownerAccount);
+  const mintTx = await novaSeed.connect(ownerSigner).mint(
+    ownerAccount,
+    'ipfs://alpha-agi-nova-seed'
+  );
+  const mintReceipt = await mintTx.wait();
+  const mintEvent = mintReceipt?.logs.find((log) => log instanceof ethers.EventLog) as ethers.EventLog | undefined;
+  const tokenId = mintEvent?.args?.tokenId ?? 1n;
+
+  return {
+    owner: ownerAccount,
+    oracle: await oracle.getAddress(),
+    market: await mark.getAddress(),
+    vault: await vault.getAddress(),
+    novaSeed: await novaSeed.getAddress(),
+    novaSeedId: tokenId,
+  };
+}
+
+if (require.main === module) {
+  deployAlphaAgiMark()
+    .then((deployment) => {
+      console.log('Alpha-AGI MARK deployed');
+      console.table(deployment);
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}

--- a/demo/alpha-agi-mark/scripts/runDemo.ts
+++ b/demo/alpha-agi-mark/scripts/runDemo.ts
@@ -1,0 +1,54 @@
+
+import { ethers } from 'hardhat';
+import { deployAlphaAgiMark } from './deploy';
+
+async function main() {
+  const deployment = await deployAlphaAgiMark();
+  const [deployer, owner, validator1, validator2, validator3, investor1, investor2, investor3] = await ethers.getSigners();
+
+  const oracle = await ethers.getContractAt('ValidatorRiskOracle', deployment.oracle, owner);
+  const mark = await ethers.getContractAt('AlphaAgiMark', deployment.market, owner);
+  const vault = await ethers.getContractAt('SovereignVault', deployment.vault, owner);
+
+  await oracle.addValidator(validator1.address);
+  await oracle.addValidator(validator2.address);
+  await oracle.addValidator(validator3.address);
+  await oracle.setApprovalsRequired(2);
+
+  console.log('Validators registered.');
+
+  await mark.setWhitelistStatus(true);
+  await mark.setWhitelist(investor1.address, true);
+  await mark.setWhitelist(investor2.address, true);
+  await mark.setWhitelist(investor3.address, true);
+
+  console.log('Whitelist initialised.');
+
+  const markInvestor1 = mark.connect(investor1);
+  const markInvestor2 = mark.connect(investor2);
+  const markInvestor3 = mark.connect(investor3);
+
+  await markInvestor1.buyShares(ethers.parseEther('10'), { value: ethers.parseEther('6') });
+  await markInvestor2.buyShares(ethers.parseEther('6'), { value: ethers.parseEther('4') });
+  await markInvestor3.buyShares(ethers.parseEther('4'), { value: ethers.parseEther('3') });
+
+  console.log('Initial funding complete. Total supply:', ethers.formatEther(await mark.totalSupply()));
+  console.log('Reserve balance:', ethers.formatEther(await mark.reserveBalance()));
+
+  await oracle.connect(validator1).castVote(true);
+  await oracle.connect(validator2).castVote(true);
+
+  console.log('Oracle approvals reached:', await oracle.approvalsCount());
+
+  await mark.finaliseLaunch(await vault.getAddress());
+
+  console.log('Launch finalised. Sovereign vault balance:', ethers.formatEther(await ethers.provider.getBalance(await vault.getAddress())));
+
+  await vault.withdraw(owner.address, await ethers.provider.getBalance(await vault.getAddress()));
+  console.log('Owner retrieved funds to deploy sovereign initiative.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/demo/alpha-agi-mark/test/AlphaAgiMark.test.ts
+++ b/demo/alpha-agi-mark/test/AlphaAgiMark.test.ts
@@ -1,0 +1,69 @@
+
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import type { AlphaAgiMark, ValidatorRiskOracle } from '../typechain-types';
+
+const toWei = (value: string) => ethers.parseEther(value);
+
+describe('AlphaAgiMark demo', function () {
+  let mark: AlphaAgiMark;
+  let oracle: ValidatorRiskOracle;
+  let deployer: any;
+  let owner: any;
+  const basePrice = toWei('0.05');
+  const slope = toWei('0.01');
+
+  beforeEach(async () => {
+    [deployer, owner] = await ethers.getSigners();
+    const oracleFactory = await ethers.getContractFactory('ValidatorRiskOracle');
+    oracle = (await oracleFactory.deploy(owner.address, 0)) as ValidatorRiskOracle;
+    await oracle.waitForDeployment();
+
+    const markFactory = await ethers.getContractFactory('AlphaAgiMark');
+    mark = (await markFactory.deploy(owner.address, await oracle.getAddress(), basePrice, slope)) as AlphaAgiMark;
+    await mark.waitForDeployment();
+  });
+
+  it('computes bonding curve cost and payout consistently', async () => {
+    const amount = toWei('5');
+    const cost = await mark.calculatePurchaseCost(amount);
+    await expect(mark.buyShares(amount, { value: cost }))
+      .to.emit(mark, 'TokensPurchased')
+      .withArgs(deployer.address, amount, cost);
+
+    const payout = await mark.calculateSaleReturn(amount);
+    expect(payout).to.equal(cost);
+
+    await expect(mark.sellShares(amount))
+      .to.emit(mark, 'TokensSold')
+      .withArgs(deployer.address, amount, payout);
+  });
+
+  it('enforces oracle validation before finalising', async () => {
+    const [, , validator1, validator2] = await ethers.getSigners();
+
+    await oracle.connect(owner).addValidator(validator1.address);
+    await oracle.connect(owner).addValidator(validator2.address);
+    await oracle.connect(owner).setApprovalsRequired(2);
+
+    const cost = await mark.calculatePurchaseCost(toWei('3'));
+    await mark.buyShares(toWei('3'), { value: cost });
+
+    await oracle.connect(validator1).castVote(true);
+    await expect(mark.connect(owner).finaliseLaunch(owner.address)).to.be.revertedWithCustomError(
+      mark,
+      'ValidationRequired'
+    );
+
+    await oracle.connect(validator2).castVote(true);
+    await expect(mark.connect(owner).finaliseLaunch(owner.address)).to.emit(mark, 'LaunchFinalised');
+  });
+
+  it('allows owner to abort launch', async () => {
+    const cost = await mark.calculatePurchaseCost(toWei('2'));
+    await mark.buyShares(toWei('2'), { value: cost });
+
+    await expect(mark.connect(owner).abortLaunch()).to.emit(mark, 'LaunchAborted');
+    await expect(mark.buyShares(toWei('1'), { value: toWei('1') })).to.be.revertedWithCustomError(mark, 'LaunchAbortedAlready');
+  });
+});

--- a/demo/alpha-agi-mark/tsconfig.json
+++ b/demo/alpha-agi-mark/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "hardhat"],
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "./dist"
+  },
+  "include": ["./scripts", "./test", "./typechain", "./hardhat.config.ts"],
+  "files": []
+}

--- a/package.json
+++ b/package.json
@@ -156,7 +156,9 @@
     "demo:omega-business-3:ui": "demo/LARGE-SCALE-OMEGA-BUSINESS-3/bin/omega-ui.sh",
     "demo:agi-labor-market": "npx hardhat run --no-compile --network hardhat scripts/v2/agiLaborMarketGrandDemo.ts",
     "demo:agi-labor-market:export": "AGI_JOBS_DEMO_EXPORT=demo/agi-labor-market-grand-demo/ui/export/latest.json npx hardhat run --no-compile --network hardhat scripts/v2/agiLaborMarketGrandDemo.ts",
-    "demo:agi-labor-market:control-room": "ts-node --transpile-only scripts/v2/launchAgiLaborMarketControlRoom.ts"
+    "demo:agi-labor-market:control-room": "ts-node --transpile-only scripts/v2/launchAgiLaborMarketControlRoom.ts",
+    "demo:alpha-agi-mark": "npx hardhat --config demo/alpha-agi-mark/hardhat.config.ts run demo/alpha-agi-mark/scripts/runDemo.ts",
+    "demo:alpha-agi-mark:test": "npx hardhat --config demo/alpha-agi-mark/hardhat.config.ts test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add the alpha-agi-mark Hardhat demo that deploys the Nova-Seed bonding curve market, validator oracle, and sovereign vault
- provide scripted deployment, README guidance, and CI workflow coverage for the demo
- expose npm helper scripts and ignore generated build artefacts

## Testing
- npx hardhat --config demo/alpha-agi-mark/hardhat.config.ts test
- npx hardhat --config demo/alpha-agi-mark/hardhat.config.ts run demo/alpha-agi-mark/scripts/runDemo.ts


------
https://chatgpt.com/codex/tasks/task_e_68f101c67d4083339718012991b54a41