### PR TITLE
feat(demo/alpha-agi-mark): support ERC20 base assets

### DIFF
--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -15,7 +15,7 @@ The demo deploys three core contracts:
 
 1. **NovaSeedNFT** – ERC-721 token representing a foresight seed.
 2. **AlphaMarkRiskOracle** – validator-governed approval oracle with owner override controls.
-3. **AlphaMarkEToken** – ERC-20 bonding-curve market with programmable compliance gates, pause switches, and launch finalization mechanics.
+3. **AlphaMarkEToken** – ERC-20 bonding-curve market with programmable compliance gates, pause switches, base asset retargeting (ETH or ERC-20 stablecoins), and launch finalization mechanics.
 
 ![α-AGI MARK flow diagram](runbooks/alpha-agi-mark-flow.mmd)
 
@@ -43,6 +43,7 @@ npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts
 The demo enumerates all tunable controls in the final recap:
 
 - Curve parameters (base price, slope, supply caps)
+- Base asset retargeting between native ETH and ERC-20 stablecoins
 - Compliance whitelist toggles
 - Pause / emergency exit switches
 - Validator council membership and approval thresholds

--- a/demo/alpha-agi-mark/contracts/TestStablecoin.sol
+++ b/demo/alpha-agi-mark/contracts/TestStablecoin.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title TestStablecoin
+/// @notice Minimal ERC20 used for exercising ERC20-based financing flows in tests.
+contract TestStablecoin is ERC20 {
+    constructor() ERC20("Test Stablecoin", "TST") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/demo/alpha-agi-mark/hardhat.config.ts
+++ b/demo/alpha-agi-mark/hardhat.config.ts
@@ -5,6 +5,7 @@ const config: HardhatUserConfig = {
   solidity: {
     version: "0.8.26",
     settings: {
+      viaIR: true,
       optimizer: {
         enabled: true,
         runs: 500,

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.json
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.json
@@ -34,6 +34,8 @@
     "validationOverrideStatus": false,
     "treasury": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
     "riskOracle": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+    "baseAsset": "0x0000000000000000000000000000000000000000",
+    "usesNativeAsset": true,
     "fundingCapWei": "1000000000000000000000",
     "maxSupplyWholeTokens": "100",
     "saleDeadlineTimestamp": "0",

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -21,7 +21,8 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    - deploys the NovaSeedNFT, AlphaMarkRiskOracle, and AlphaMarkEToken contracts
    - performs investor buys and validator approvals
    - pauses and resumes trading to verify safety controls
-   - finalizes the launch and prints a comprehensive recap
+  - demonstrates pre-launch base asset retargeting (ETH -> ERC-20 stablecoin)
+  - finalizes the launch and prints a comprehensive recap
 
 2. **Inspect recap artifacts**
 


### PR DESCRIPTION
## Summary
- add ERC20-compatible reserve flows to AlphaMarkEToken with owner retarget controls and reporting updates
- extend demo script, documentation, and recap to showcase pre-launch base-asset switching
- add dedicated stablecoin test contract and new test coverage for ERC20 purchase/sell/finalize flows

## Testing
- npm run test:alpha-agi-mark
- npm run demo:alpha-agi-mark


------
https://chatgpt.com/codex/tasks/task_e_68f119b752ac8333aeaedf1ec17be6c2