### PR TITLE
Enhance alpha-agi-mark demo with sovereign vault launch stage

### DIFF
--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -75,6 +75,9 @@ jobs:
               throw new Error(`contract address missing for ${key}`);
             }
           }
+          if (!data.contracts.sovereignVault) {
+            throw new Error('contract address missing for sovereignVault');
+          }
           if (!data.validators || data.validators.approvalCount === undefined) {
             throw new Error('validator consensus details missing');
           }
@@ -86,6 +89,9 @@ jobs:
           }
           if (!data.launch || !data.launch.finalized) {
             throw new Error('launch did not finalize');
+          }
+          if (!data.launch.sovereignVault || !data.launch.sovereignVault.decodedMetadata) {
+            throw new Error('sovereign vault details missing');
           }
           console.log(`Validated α-AGI MARK recap for ${data.participants.length} participants.`);
           NODE

--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -11,11 +11,12 @@ The α-AGI MARK demo showcases how a non-technical operator can launch a foresig
 
 ## Architecture
 
-The demo deploys three core contracts:
+The demo deploys four core contracts:
 
 1. **NovaSeedNFT** – ERC-721 token representing a foresight seed.
 2. **AlphaMarkRiskOracle** – validator-governed approval oracle with owner override controls.
-3. **AlphaMarkEToken** – ERC-20 bonding-curve market with programmable compliance gates, pause switches, base asset retargeting (ETH or ERC-20 stablecoins), and launch finalization mechanics.
+3. **AlphaMarkEToken** – ERC-20 bonding-curve market with programmable compliance gates, pause switches, base asset retargeting (ETH or ERC-20 stablecoins), launch finalization metadata, and sovereign callbacks.
+4. **AlphaSovereignVault** – launch treasury that acknowledges the ignition metadata, tracks received capital, and gives the owner pause/withdraw controls for the sovereign stage.
 
 ![α-AGI MARK flow diagram](runbooks/alpha-agi-mark-flow.mmd)
 

--- a/demo/alpha-agi-mark/contracts/AlphaSovereignVault.sol
+++ b/demo/alpha-agi-mark/contracts/AlphaSovereignVault.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title AlphaSovereignVault
+/// @notice Minimal sovereign treasury that receives α-AGI MARK launch proceeds and
+///         gives the operator full post-launch control.
+contract AlphaSovereignVault is Ownable, Pausable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    event LaunchManifestUpdated(string manifestUri);
+    event MarkExchangeDesignated(address indexed markExchange);
+    event LaunchAcknowledged(address indexed markExchange, uint256 amount, bytes metadata, uint256 timestamp);
+    event TreasuryWithdrawal(address indexed to, uint256 amount);
+    event TreasuryTokenWithdrawal(address indexed asset, address indexed to, uint256 amount);
+
+    string public manifestUri;
+    address public markExchange;
+
+    uint256 public totalReceived;
+    uint256 public lastAcknowledgedAmount;
+    bytes public lastAcknowledgedMetadata;
+
+    constructor(address owner_, string memory manifestUri_) Ownable(owner_) {
+        require(owner_ != address(0), "Owner required");
+        manifestUri = manifestUri_;
+    }
+
+    function setManifestUri(string calldata newManifestUri) external onlyOwner {
+        manifestUri = newManifestUri;
+        emit LaunchManifestUpdated(newManifestUri);
+    }
+
+    function designateMarkExchange(address newMarkExchange) external onlyOwner {
+        require(newMarkExchange != address(0), "Mark required");
+        markExchange = newMarkExchange;
+        emit MarkExchangeDesignated(newMarkExchange);
+    }
+
+    function pauseVault() external onlyOwner {
+        _pause();
+    }
+
+    function unpauseVault() external onlyOwner {
+        _unpause();
+    }
+
+    function notifyLaunch(uint256 amount, bytes calldata metadata) external whenNotPaused returns (bool) {
+        require(msg.sender == markExchange, "Unauthorized sender");
+        lastAcknowledgedAmount = amount;
+        lastAcknowledgedMetadata = metadata;
+        emit LaunchAcknowledged(msg.sender, amount, metadata, block.timestamp);
+        return true;
+    }
+
+    function withdraw(address payable to, uint256 amount) external onlyOwner nonReentrant {
+        require(to != address(0), "Recipient required");
+        require(amount <= address(this).balance, "Insufficient balance");
+        (bool success, ) = to.call{value: amount}("");
+        require(success, "Withdrawal failed");
+        emit TreasuryWithdrawal(to, amount);
+    }
+
+    function withdrawToken(address asset, address to, uint256 amount) external onlyOwner nonReentrant {
+        require(to != address(0), "Recipient required");
+        IERC20(asset).safeTransfer(to, amount);
+        emit TreasuryTokenWithdrawal(asset, to, amount);
+    }
+
+    function vaultBalance() external view returns (uint256) {
+        return address(this).balance;
+    }
+
+    receive() external payable {
+        totalReceived += msg.value;
+    }
+}

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.json
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.json
@@ -2,7 +2,8 @@
   "contracts": {
     "novaSeed": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
     "riskOracle": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
-    "markExchange": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+    "markExchange": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
+    "sovereignVault": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"
   },
   "seed": {
     "tokenId": "1",
@@ -62,6 +63,14 @@
   "launch": {
     "finalized": true,
     "aborted": false,
-    "treasury": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    "treasury": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "sovereignVault": {
+      "manifestUri": "ipfs://alpha-mark/sovereign/genesis",
+      "totalReceivedWei": "3850000000000000000",
+      "lastAcknowledgedAmountWei": "3850000000000000000",
+      "lastAcknowledgedMetadataHex": "0xceb12d41474920536f7665726569676e2069676e6974696f6e3a204e6f76612d5365656420617363656e6473",
+      "decodedMetadata": "α-AGI Sovereign ignition: Nova-Seed ascends",
+      "vaultBalanceWei": "3850000000000000000"
+    }
   }
 }

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -18,11 +18,12 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    The orchestrator automatically:
 
    - boots a Hardhat chain
-   - deploys the NovaSeedNFT, AlphaMarkRiskOracle, and AlphaMarkEToken contracts
-   - performs investor buys and validator approvals
-   - pauses and resumes trading to verify safety controls
+  - deploys the NovaSeedNFT, AlphaMarkRiskOracle, AlphaMarkEToken, and AlphaSovereignVault contracts
+  - performs investor buys and validator approvals
+  - pauses and resumes trading to verify safety controls
   - demonstrates pre-launch base asset retargeting (ETH -> ERC-20 stablecoin)
-  - finalizes the launch and prints a comprehensive recap
+  - proves the sovereign vault pause/unpause circuit breaker
+  - finalizes the launch with ignition metadata and prints a comprehensive recap
 
 2. **Inspect recap artifacts**
 
@@ -33,7 +34,7 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    - consolidated `ownerControls` snapshot of every pause/whitelist/override lever
    - validator council roster and votes
    - bonding curve statistics (supply, reserve balance, pricing)
-   - launch outcome summary
+   - launch outcome summary, including sovereign vault manifest, acknowledgement metadata, and treasury balance
 
 3. **(Optional) Run unit tests**
 


### PR DESCRIPTION
## Summary
- add an AlphaSovereignVault treasury so launches acknowledge ignition metadata and the owner keeps sovereign-stage controls
- update AlphaMarkEToken to require sovereign acknowledgements and refresh the demo script/docs to showcase the new flow and recap fields
- expand Hardhat tests and CI recap validation to cover the sovereign vault happy path and failure scenarios

## Testing
- npm run test:alpha-agi-mark
- npm run demo:alpha-agi-mark > /tmp/demo.log && tail -n 40 /tmp/demo.log
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68f11f44f8f483338867156bbf60ff5c