### PR TITLE
Enhance alpha-agi-mark sovereign telemetry

### DIFF
--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -51,6 +51,7 @@ The demo enumerates all tunable controls in the final recap:
 - Validator roster resets and approval clearing
 - Launch, abort, and override controls
 - Full owner control snapshot exported under `ownerControls` in the recap dossier
+- Sovereign vault telemetry capturing launch asset type (native or ERC-20) and acknowledged totals per asset
 
 ## Runbook
 

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -34,7 +34,7 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    - consolidated `ownerControls` snapshot of every pause/whitelist/override lever
    - validator council roster and votes
    - bonding curve statistics (supply, reserve balance, pricing)
-   - launch outcome summary, including sovereign vault manifest, acknowledgement metadata, and treasury balance
+   - launch outcome summary, including sovereign vault manifest, acknowledgement metadata, treasury balance, and per-asset acknowledgement tallies
 
 3. **(Optional) Run unit tests**
 

--- a/demo/alpha-agi-mark/scripts/runDemo.ts
+++ b/demo/alpha-agi-mark/scripts/runDemo.ts
@@ -172,6 +172,17 @@ async function main() {
 
   const sovereignMetadata = await sovereignVault.lastAcknowledgedMetadata();
   const sovereignTotalReceived = await sovereignVault.totalReceived();
+  const sovereignTotalAcknowledged = await sovereignVault.totalAcknowledged();
+  const sovereignLastAsset = await sovereignVault.lastAcknowledgedAsset();
+  const sovereignAssetIsNative = await sovereignVault.lastAcknowledgedAssetIsNative();
+
+  const acknowledgedBreakdown: Record<string, string> = {};
+  const nativeAcknowledged = await sovereignVault.totalAcknowledgedByAsset(ethers.ZeroAddress);
+  acknowledgedBreakdown["native"] = nativeAcknowledged.toString();
+  if (!sovereignAssetIsNative) {
+    const assetAcknowledged = await sovereignVault.totalAcknowledgedByAsset(sovereignLastAsset);
+    acknowledgedBreakdown[sovereignLastAsset] = assetAcknowledged.toString();
+  }
   const recap = {
     contracts: {
       novaSeed: novaSeed.target,
@@ -204,10 +215,14 @@ async function main() {
       sovereignVault: {
         manifestUri: await sovereignVault.manifestUri(),
         totalReceivedWei: sovereignTotalReceived.toString(),
+        totalAcknowledgedWei: sovereignTotalAcknowledged.toString(),
         lastAcknowledgedAmountWei: (await sovereignVault.lastAcknowledgedAmount()).toString(),
         lastAcknowledgedMetadataHex: sovereignMetadata,
         decodedMetadata: ethers.toUtf8String(sovereignMetadata),
         vaultBalanceWei: (await sovereignVault.vaultBalance()).toString(),
+        lastAcknowledgedAsset: sovereignLastAsset,
+        lastAcknowledgedIsNative: sovereignAssetIsNative,
+        acknowledgedByAssetWei: acknowledgedBreakdown,
       },
     },
   };


### PR DESCRIPTION
## Summary
- extend AlphaMark exchange to prefer the new sovereign acknowledgement interface while keeping legacy compatibility
- expand the sovereign vault with per-asset acknowledgement accounting and expose the telemetry in the demo recap
- update tests, runbook, and README to cover the richer launch reporting

## Testing
- npm run test:alpha-agi-mark
- npm run demo:alpha-agi-mark:ci

------
https://chatgpt.com/codex/tasks/task_e_68f12a7cddb88333bf23ee2e82a9fa55