### PR TITLE
Add α-AGI MARK executive dossier renderer

### DIFF
--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -96,8 +96,13 @@ jobs:
           console.log(`Validated α-AGI MARK recap for ${data.participants.length} participants.`);
           NODE
 
+      - name: Render executive dossier
+        run: npm run demo:alpha-agi-mark:report
+
       - name: Upload α-AGI MARK recap
         uses: actions/upload-artifact@v4
         with:
           name: alpha-agi-mark-recap
-          path: demo/alpha-agi-mark/reports/alpha-mark-recap.json
+          path: |
+            demo/alpha-agi-mark/reports/alpha-mark-recap.json
+            demo/alpha-agi-mark/reports/alpha-mark-recap.md

--- a/demo/alpha-agi-mark/.gitignore
+++ b/demo/alpha-agi-mark/.gitignore
@@ -3,3 +3,4 @@ cache/
 typechain-types/
 reports/*
 !reports/alpha-mark-recap.json
+!reports/alpha-mark-recap.md

--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -20,6 +20,16 @@ The demo deploys four core contracts:
 
 ![α-AGI MARK flow diagram](runbooks/alpha-agi-mark-flow.mmd)
 
+### Operator Dossier Rendering
+
+After the demo run, convert the JSON recap into a narrative briefing and rich diagram by executing:
+
+```bash
+npm run demo:alpha-agi-mark:report
+```
+
+The script produces `reports/alpha-mark-recap.md`, weaving in a dynamic Mermaid diagram, owner-control matrix, validator ledger, and participant capitalization tables so non-technical operators can share or archive the launch proof with zero manual formatting.
+
 ## Quickstart
 
 ```bash

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.md
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.md
@@ -1,0 +1,88 @@
+# α-AGI MARK Power Dossier
+
+> Non-technical operators receive a sovereign-grade audit trail rendered directly from the AGI Jobs v0 (v2) run. The dossier fuses cryptoeconomic telemetry, validator consensus, and owner controls into a single launch brief.
+
+## Hypergraph Overview
+
+```mermaid
+flowchart LR
+    classDef owner fill:#0f172a,color:#f8fafc,stroke:#38bdf8,stroke-width:2px;
+    classDef contract fill:#1e293b,color:#e0f2fe,stroke:#22d3ee,stroke-width:2px;
+    classDef control fill:#172554,color:#fef3c7,stroke:#fbbf24,stroke-width:2px;
+    classDef data fill:#082f49,color:#bbf7d0,stroke:#34d399,stroke-width:2px;
+    owner((Operator Key\n0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)):::owner --> seed[(NovaSeedNFT\n0x5FbDB2315678afecb367f032d93F642f64180aa3\nToken #1)]:::contract
+    seed --> oracle{AlphaMarkRiskOracle\nValidators: 2/2}:::contract
+    oracle -- approvals --> approvals[[Consensus Layer]]:::control
+    approvals --> mark[(AlphaMarkEToken\n0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9\nSupply: 11)]:::contract
+    investors[[Investors A/B/C]]:::owner --> mark
+    mark --> reserve[[Bonding Curve Reserve\n3.85 ETH]]:::data
+    mark -. compliance levers .-> controls[Pause / Whitelist / Funding Cap]:::control
+    controls -. owner authority .-> owner
+    mark --> |Finalize| vault[(AlphaSovereignVault\n0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9)]:::contract
+    vault --> manifest{{Launch Manifest\nipfs://alpha-mark/sovereign/genesis}}:::data
+    vault --> owner
+```
+
+## System Snapshot
+
+| Component | Address |
+| --- | --- |
+| NovaSeedNFT | 0x5FbDB2315678afecb367f032d93F642f64180aa3 |
+| Risk Oracle | 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0 |
+| Bonding Curve Exchange | 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9 |
+| Sovereign Vault | 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9 |
+
+## Owner Command Matrix
+
+| Control Lever | Status | Details |
+| --- | --- | --- |
+| Market paused | ✅ | Exchange trading switch
+| Whitelist enforced | ✅ | Compliance gate
+| Emergency exit | ⬜️ | Enables redemptions during pauses
+| Launch finalized | ✅ | Sale locked and reserves transferred
+| Launch aborted | ⬜️ | Funds returned scenario
+| Validation override | ⬜️ | Forced decision -> false
+| Treasury address | ✅ | 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+| Base asset | ✅ | Native ETH
+| Funding cap | ✅ | 1000 ETH
+| Max supply | ✅ | 100 SeedShares
+| Sale deadline | ✅ | —
+| Curve base price | ✅ | 0.1 ETH
+| Curve slope | ✅ | 0.05 ETH
+
+## Validator Council Ledger
+
+| # | Validator Address |
+| --- | --- |
+| 1 | 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65 |
+| 2 | 0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc |
+| 3 | 0x976EA74026E726554dB657fA54763abd0C3a0aa9 |
+| ✅ Consensus | 2/2 approvals |
+
+## Participant Capitalization
+
+| Investor | SeedShares | Contribution | Raw Wei |
+| --- | ---: | ---: | --- |
+| 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 | 5.0 | 1 ETH | 1000000000000000000 |
+| 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC | 2.0 | 1.2 ETH | 1200000000000000000 |
+| 0x90F79bf6EB2c4f870365E785982E1f101E93b906 | 4.0 | 2.3 ETH | 2300000000000000000 |
+
+## Sovereign Vault State
+
+| Field | Value |
+| --- | --- |
+| Manifest URI | ipfs://alpha-mark/sovereign/genesis |
+| Vault balance | 3.85 ETH |
+| Total received | 3.85 ETH |
+| Last acknowledged amount | 3.85 ETH |
+| Launch metadata | α-AGI Sovereign ignition: Nova-Seed ascends |
+
+### Launch Verdict
+
+- Finalized: ✅
+- Aborted: ✅ No abort triggered (flag=false confirms sovereign ascent succeeded).
+- Treasury receiving address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+- Sovereign vault manifest confirms ignition metadata: “α-AGI Sovereign ignition: Nova-Seed ascends”
+- Bonding curve supply closed at 11 SeedShares with next price 0.65 ETH.
+
+AGI Jobs v0 (v2) transforms the on-chain market choreography into a narrated briefing so the operator can execute audits, investor updates, or regulatory submissions without touching Solidity or CLI minutiae.

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-flow.mmd
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-flow.mmd
@@ -1,14 +1,34 @@
 ```mermaid
-graph TD
-    A[Owner launches demo] --> B[NovaSeedNFT deployed]
-    B --> C[AlphaMarkRiskOracle deployed]
-    C --> D[AlphaMarkEToken deployed]
-    D --> E[Investors buy SeedShares via bonding curve]
-    E --> F[Owner toggles whitelist & pause controls]
-    F --> G[Validators submit approvals]
-    G --> H{Approval threshold met?}
-    H -- No --> I[Owner may override or abort]
-    H -- Yes --> J[Owner finalizes launch]
-    J --> K[Sovereign funds released]
-    K --> L[Recap generated for operator]
+flowchart LR
+    classDef owner fill:#0f172a,color:#f8fafc,stroke:#38bdf8,stroke-width:2px;
+    classDef contract fill:#1e293b,color:#e0f2fe,stroke:#22d3ee,stroke-width:2px;
+    classDef control fill:#172554,color:#fef3c7,stroke:#fbbf24,stroke-width:2px;
+    classDef data fill:#082f49,color:#bbf7d0,stroke:#34d399,stroke-width:2px;
+
+    subgraph Ignition["Nova-Seed Ignition"]
+        owner((Operator Key)):::owner --> seed[(NovaSeedNFT<br/>Genesis Seed)]:::contract
+        seed --> seedMeta{{Manifest & Metadata}}:::data
+    end
+
+    subgraph Governance["Validator Council"]
+        seed --> oracle{AlphaMarkRiskOracle}:::contract
+        oracle --> tally[[Consensus Threshold]]:::control
+        owner -. override authority .-> oracle
+    end
+
+    subgraph MarketDesk["Bonding-Curve Exchange"]
+        tally --> mark[(AlphaMarkEToken<br/>Bonding Curve Desk)]:::contract
+        investors[[Investors A/B/C]]:::owner --> mark
+        mark --> reserve[[Reserve Pool]]:::data
+        mark -. whitelist / pause / cap .-> controls[Compliance Matrix]:::control
+        controls -. owner command .-> owner
+    end
+
+    subgraph Sovereign["α-AGI Sovereign Launch"]
+        mark -->|Finalize| vault[(AlphaSovereignVault<br/>Sovereign Treasury)]:::contract
+        vault --> launchMeta{{Ignition Metadata}}:::data
+        vault --> owner
+    end
+
+    owner -->|Recap + Dossier| dossier[[Mermaid + Markdown Hyper-Report]]:::data
 ```

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -23,7 +23,7 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
   - pauses and resumes trading to verify safety controls
   - demonstrates pre-launch base asset retargeting (ETH -> ERC-20 stablecoin)
   - proves the sovereign vault pause/unpause circuit breaker
-  - finalizes the launch with ignition metadata and prints a comprehensive recap
+ - finalizes the launch with ignition metadata and prints a comprehensive recap
 
 2. **Inspect recap artifacts**
 
@@ -36,13 +36,21 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    - bonding curve statistics (supply, reserve balance, pricing)
    - launch outcome summary, including sovereign vault manifest, acknowledgement metadata, and treasury balance
 
-3. **(Optional) Run unit tests**
+3. **Render the operator dossier**
+
+   ```bash
+   npm run demo:alpha-agi-mark:report
+   ```
+
+   This command transforms the JSON recap into `reports/alpha-mark-recap.md`, layering rich Mermaid system maps, owner-control matrices, validator rosters, and participant capitalization tables for executive-ready sharing.
+
+4. **(Optional) Run unit tests**
 
    ```bash
    npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts
    ```
 
-4. **(Optional) Dry-run on a fork or external network**
+5. **(Optional) Dry-run on a fork or external network**
 
    Set environment variables before invoking the script:
 

--- a/demo/alpha-agi-mark/scripts/renderRecap.ts
+++ b/demo/alpha-agi-mark/scripts/renderRecap.ts
@@ -1,0 +1,236 @@
+import { readFile, writeFile, mkdir } from "fs/promises";
+import path from "path";
+import { format } from "util";
+import { ethers } from "ethers";
+
+const REPORT_DIR = path.join(__dirname, "..", "reports");
+const JSON_PATH = path.join(REPORT_DIR, "alpha-mark-recap.json");
+const MARKDOWN_PATH = path.join(REPORT_DIR, "alpha-mark-recap.md");
+
+interface RecapParticipant {
+  address: string;
+  tokens: string;
+  contributionWei: string;
+}
+
+interface RecapData {
+  contracts: {
+    novaSeed: string;
+    riskOracle: string;
+    markExchange: string;
+    sovereignVault: string;
+  };
+  seed: {
+    tokenId: string;
+    holder: string;
+  };
+  validators: {
+    approvalCount: string;
+    approvalThreshold: string;
+    members: string[];
+  };
+  bondingCurve: {
+    supplyWholeTokens: string;
+    reserveWei: string;
+    nextPriceWei: string;
+    basePriceWei: string;
+    slopeWei: string;
+  };
+  ownerControls: {
+    paused: boolean;
+    whitelistEnabled: boolean;
+    emergencyExitEnabled: boolean;
+    finalized: boolean;
+    aborted: boolean;
+    validationOverrideEnabled: boolean;
+    validationOverrideStatus: boolean;
+    treasury: string;
+    riskOracle: string;
+    baseAsset: string;
+    usesNativeAsset: boolean;
+    fundingCapWei: string;
+    maxSupplyWholeTokens: string;
+    saleDeadlineTimestamp: string;
+    basePriceWei: string;
+    slopeWei: string;
+  };
+  participants: RecapParticipant[];
+  launch: {
+    finalized: boolean;
+    aborted: boolean;
+    treasury: string;
+    sovereignVault: {
+      manifestUri: string;
+      totalReceivedWei: string;
+      lastAcknowledgedAmountWei: string;
+      lastAcknowledgedMetadataHex: string;
+      decodedMetadata: string;
+      vaultBalanceWei: string;
+    };
+  };
+}
+
+function formatEtherAbbreviated(value: bigint): string {
+  const etherString = ethers.formatEther(value);
+  const [integerPart, fractionalRaw = "0"] = etherString.split(".");
+  const fractional = fractionalRaw.slice(0, 4).replace(/0+$/, "");
+  return fractional.length > 0 ? `${integerPart}.${fractional}` : integerPart;
+}
+
+function formatWei(value: string, currencyLabel: string): string {
+  const bigValue = BigInt(value || "0");
+  return `${formatEtherAbbreviated(bigValue)} ${currencyLabel}`;
+}
+
+function formatTimestamp(ts: string): string {
+  const numeric = Number(ts);
+  if (!numeric) {
+    return "—";
+  }
+  const date = new Date(numeric * 1000);
+  return `${date.toISOString()} (${numeric})`;
+}
+
+function boolToStatus(value: boolean): string {
+  return value ? "✅" : "⬜️";
+}
+
+async function main(): Promise<void> {
+  const raw = await readFile(JSON_PATH, "utf8").catch((error) => {
+    throw new Error(`Unable to read recap dossier at ${JSON_PATH}: ${(error as Error).message}`);
+  });
+
+  const recap = JSON.parse(raw) as RecapData;
+  const currencyLabel = recap.ownerControls.usesNativeAsset ? "ETH" : "base units";
+  const baseAssetDescriptor = recap.ownerControls.usesNativeAsset
+    ? "Native ETH"
+    : recap.ownerControls.baseAsset;
+
+  const mermaidDiagram = [
+    "```mermaid",
+    "flowchart LR",
+    "    classDef owner fill:#0f172a,color:#f8fafc,stroke:#38bdf8,stroke-width:2px;",
+    "    classDef contract fill:#1e293b,color:#e0f2fe,stroke:#22d3ee,stroke-width:2px;",
+    "    classDef control fill:#172554,color:#fef3c7,stroke:#fbbf24,stroke-width:2px;",
+    "    classDef data fill:#082f49,color:#bbf7d0,stroke:#34d399,stroke-width:2px;",
+    format(
+      "    owner((Operator Key\\n%s)):::owner --> seed[(NovaSeedNFT\\n%s\\nToken #%s)]:::contract",
+      recap.seed.holder,
+      recap.contracts.novaSeed,
+      recap.seed.tokenId,
+    ),
+    "    seed --> oracle{AlphaMarkRiskOracle\\nValidators: " +
+      `${recap.validators.approvalCount}/${recap.validators.approvalThreshold}` +
+      "}:::contract",
+    "    oracle -- approvals --> approvals[[Consensus Layer]]:::control",
+    "    approvals --> mark[(AlphaMarkEToken\\n" +
+      `${recap.contracts.markExchange}\\nSupply: ${recap.bondingCurve.supplyWholeTokens}` +
+      ")]:::contract",
+    "    investors[[Investors A/B/C]]:::owner --> mark",
+    "    mark --> reserve[[Bonding Curve Reserve\\n" +
+      `${formatWei(recap.launch.sovereignVault.lastAcknowledgedAmountWei, currencyLabel)}` +
+      "]]:::data",
+    "    mark -. compliance levers .-> controls[Pause / Whitelist / Funding Cap]:::control",
+    "    controls -. owner authority .-> owner",
+    "    mark --> |Finalize| vault[(AlphaSovereignVault\\n" +
+      `${recap.contracts.sovereignVault}` +
+      ")]:::contract",
+    "    vault --> manifest{{Launch Manifest\\n" +
+      `${recap.launch.sovereignVault.manifestUri}` +
+      "}}:::data",
+    "    vault --> owner",
+    "```",
+  ].join("\n");
+
+  const ownerControlsTable = [
+    "| Control Lever | Status | Details |",
+    "| --- | --- | --- |",
+    `| Market paused | ${boolToStatus(recap.ownerControls.paused)} | Exchange trading switch`,
+    `| Whitelist enforced | ${boolToStatus(recap.ownerControls.whitelistEnabled)} | Compliance gate`,
+    `| Emergency exit | ${boolToStatus(recap.ownerControls.emergencyExitEnabled)} | Enables redemptions during pauses`,
+    `| Launch finalized | ${boolToStatus(recap.ownerControls.finalized)} | Sale locked and reserves transferred`,
+    `| Launch aborted | ${boolToStatus(recap.ownerControls.aborted)} | Funds returned scenario`,
+    `| Validation override | ${boolToStatus(recap.ownerControls.validationOverrideEnabled)} | Forced decision -> ${recap.ownerControls.validationOverrideStatus}`,
+    `| Treasury address | ✅ | ${recap.ownerControls.treasury}`,
+    `| Base asset | ✅ | ${baseAssetDescriptor}`,
+    `| Funding cap | ✅ | ${formatWei(recap.ownerControls.fundingCapWei, currencyLabel)}`,
+    `| Max supply | ✅ | ${recap.ownerControls.maxSupplyWholeTokens} SeedShares`,
+    `| Sale deadline | ✅ | ${formatTimestamp(recap.ownerControls.saleDeadlineTimestamp)}`,
+    `| Curve base price | ✅ | ${formatWei(recap.ownerControls.basePriceWei, currencyLabel)}`,
+    `| Curve slope | ✅ | ${formatWei(recap.ownerControls.slopeWei, currencyLabel)}`,
+  ].join("\n");
+
+  const contractTable = [
+    "| Component | Address |",
+    "| --- | --- |",
+    `| NovaSeedNFT | ${recap.contracts.novaSeed} |`,
+    `| Risk Oracle | ${recap.contracts.riskOracle} |`,
+    `| Bonding Curve Exchange | ${recap.contracts.markExchange} |`,
+    `| Sovereign Vault | ${recap.contracts.sovereignVault} |`,
+  ].join("\n");
+
+  const validatorList = recap.validators.members
+    .map((member, index) => `| ${index + 1} | ${member} |`)
+    .join("\n");
+
+  const validatorTable = [
+    "| # | Validator Address |",
+    "| --- | --- |",
+    validatorList,
+    `| ✅ Consensus | ${recap.validators.approvalCount}/${recap.validators.approvalThreshold} approvals |`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const participantsTable = [
+    "| Investor | SeedShares | Contribution | Raw Wei |",
+    "| --- | ---: | ---: | --- |",
+    ...recap.participants.map((participant) => {
+      const contribution = formatWei(participant.contributionWei, currencyLabel);
+      return `| ${participant.address} | ${participant.tokens} | ${contribution} | ${participant.contributionWei} |`;
+    }),
+  ].join("\n");
+
+  const vaultTable = [
+    "| Field | Value |",
+    "| --- | --- |",
+    `| Manifest URI | ${recap.launch.sovereignVault.manifestUri} |`,
+    `| Vault balance | ${formatWei(recap.launch.sovereignVault.vaultBalanceWei, currencyLabel)} |`,
+    `| Total received | ${formatWei(recap.launch.sovereignVault.totalReceivedWei, currencyLabel)} |`,
+    `| Last acknowledged amount | ${formatWei(recap.launch.sovereignVault.lastAcknowledgedAmountWei, currencyLabel)} |`,
+    `| Launch metadata | ${recap.launch.sovereignVault.decodedMetadata} |`,
+  ].join("\n");
+
+  const markdown = `# α-AGI MARK Power Dossier\n\n` +
+    `> Non-technical operators receive a sovereign-grade audit trail rendered directly from the AGI Jobs v0 (v2) run.` +
+    ` The dossier fuses cryptoeconomic telemetry, validator consensus, and owner controls into a single launch brief.\n\n` +
+    `## Hypergraph Overview\n\n${mermaidDiagram}\n\n` +
+    `## System Snapshot\n\n${contractTable}\n\n` +
+    `## Owner Command Matrix\n\n${ownerControlsTable}\n\n` +
+    `## Validator Council Ledger\n\n${validatorTable}\n\n` +
+    `## Participant Capitalization\n\n${participantsTable}\n\n` +
+    `## Sovereign Vault State\n\n${vaultTable}\n\n` +
+    `### Launch Verdict\n\n` +
+    `- Finalized: ${recap.launch.finalized ? "✅" : "❌"}\n` +
+    `- Aborted: ${
+      recap.launch.aborted
+        ? "⚠️ Abort triggered — review emergency exit timeline."
+        : "✅ No abort triggered (flag=false confirms sovereign ascent succeeded)."
+    }\n` +
+    `- Treasury receiving address: ${recap.launch.treasury}\n` +
+    `- Sovereign vault manifest confirms ignition metadata: “${recap.launch.sovereignVault.decodedMetadata}”\n` +
+    `- Bonding curve supply closed at ${recap.bondingCurve.supplyWholeTokens} SeedShares with next price ` +
+    `${formatWei(recap.bondingCurve.nextPriceWei, currencyLabel)}.\n\n` +
+    `AGI Jobs v0 (v2) transforms the on-chain market choreography into a narrated briefing so the operator can execute ` +
+    `audits, investor updates, or regulatory submissions without touching Solidity or CLI minutiae.\n`;
+
+  await mkdir(REPORT_DIR, { recursive: true });
+  await writeFile(MARKDOWN_PATH, markdown, "utf8");
+
+  console.log(`📄 Rendered α-AGI MARK dossier to ${MARKDOWN_PATH}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "demo:agi-labor-market:control-room": "ts-node --transpile-only scripts/v2/launchAgiLaborMarketControlRoom.ts",
     "demo:alpha-agi-mark": "npx hardhat run --config demo/alpha-agi-mark/hardhat.config.ts demo/alpha-agi-mark/scripts/runDemo.ts",
     "demo:alpha-agi-mark:ci": "AGIJOBS_DEMO_DRY_RUN=true npm run demo:alpha-agi-mark",
+    "demo:alpha-agi-mark:report": "npx ts-node --transpile-only demo/alpha-agi-mark/scripts/renderRecap.ts",
     "test:alpha-agi-mark": "npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add a renderRecap TypeScript utility and npm script that transforms the demo recap JSON into a shareable markdown/mermaid dossier for non-technical operators
- refresh the α-AGI MARK documentation and flowchart to highlight the new reporting workflow and upgraded system diagram
- teach the demo workflow to generate and publish both JSON and markdown recap artefacts for CI visibility

## Testing
- npm run test:alpha-agi-mark
- npm run demo:alpha-agi-mark:report

------
https://chatgpt.com/codex/tasks/task_e_68f131fe79548333a943e92c46091c4d