### PR TITLE
feat: render alpha-agi-mark sovereign dashboard

### DIFF
--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -96,6 +96,29 @@ jobs:
           console.log(`Validated α-AGI MARK recap for ${data.participants.length} participants.`);
           NODE
 
+      - name: Validate sovereign dashboard
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = 'demo/alpha-agi-mark/reports/alpha-mark-dashboard.html';
+          if (!fs.existsSync(path)) {
+            throw new Error('dashboard file missing');
+          }
+          const html = fs.readFileSync(path, 'utf8');
+          const requiredSnippets = [
+            'MARK Launch Telemetry',
+            'Mission Control Metrics',
+            'class="mermaid"',
+            'Owner Control Deck',
+          ];
+          for (const snippet of requiredSnippets) {
+            if (!html.includes(snippet)) {
+              throw new Error(`dashboard missing snippet: ${snippet}`);
+            }
+          }
+          console.log('Dashboard dossier structure validated.');
+          NODE
+
       - name: Upload α-AGI MARK recap
         uses: actions/upload-artifact@v4
         with:

--- a/demo/alpha-agi-mark/.gitignore
+++ b/demo/alpha-agi-mark/.gitignore
@@ -3,3 +3,4 @@ cache/
 typechain-types/
 reports/*
 !reports/alpha-mark-recap.json
+!reports/alpha-mark-dashboard.html

--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -18,7 +18,24 @@ The demo deploys four core contracts:
 3. **AlphaMarkEToken** – ERC-20 bonding-curve market with programmable compliance gates, pause switches, base asset retargeting (ETH or ERC-20 stablecoins), launch finalization metadata, and sovereign callbacks.
 4. **AlphaSovereignVault** – launch treasury that acknowledges the ignition metadata, tracks received capital, and gives the owner pause/withdraw controls for the sovereign stage.
 
-![α-AGI MARK flow diagram](runbooks/alpha-agi-mark-flow.mmd)
+```mermaid
+flowchart TD
+    classDef contract fill:#1a1f4d,stroke:#60ffcf,color:#f6faff,stroke-width:2px;
+    classDef actor fill:#113322,stroke:#60ffcf,color:#e8fff6,stroke-dasharray: 5 3;
+    classDef control fill:#2f2445,stroke:#9d7bff,color:#f6f0ff;
+
+    Operator((Operator Console)):::actor -->|Mint & Configure| Seed[NovaSeedNFT — α-AGI Nova-Seed]:::contract
+    Seed -->|Launch Request| Oracle[AlphaMarkRiskOracle — Validator Council]:::contract
+    Seed -->|Enables Pricing| Exchange[AlphaMarkEToken — Bonding Curve Exchange]:::contract
+    Exchange -->|Capital Flow| Reserve((Sovereign Reserve)):::control
+    Exchange -->|Compliance, Pause, Overrides| ControlDeck{{Owner Control Deck}}:::control
+    ControlDeck -->|Gates Participation| Exchange
+    Investors((SeedShare Contributors)):::actor -->|Bonding Curve Buys/Sells| Exchange
+    Oracle -->|Consensus Signal| Launch{Launch Condition}
+    Launch -->|Finalized| Vault[AlphaSovereignVault — Treasury]:::contract
+    Launch -->|Abort Path| Emergency((Emergency Exit Corridor)):::control
+    Vault -->|Ignition Metadata| Sovereign[[α-AGI Sovereign Manifest]]:::contract
+```
 
 ## Quickstart
 
@@ -51,6 +68,22 @@ To run the Hardhat unit tests for the demo:
 
 ```bash
 npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts
+```
+
+## Sovereign Dashboard
+
+Every demo run now emits a cinematic HTML dossier at `demo/alpha-agi-mark/reports/alpha-mark-dashboard.html`. Open the file in
+any browser to explore:
+
+- Mission control metrics capturing validator consensus, reserve power, and sovereign vault status
+- A control-deck grid showing every owner actuator with live status badges
+- Full participant ledger plus the operator parameter matrix rendered as responsive tables
+- An auto-generated Mermaid diagram visualising the launch topology and emergency fail-safes
+
+Regenerate the dashboard at any time from the latest recap JSON:
+
+```bash
+npm run dashboard:alpha-agi-mark
 ```
 
 ## Owner Controls

--- a/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
+++ b/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
@@ -1,0 +1,460 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>α-AGI MARK Sovereign Launch Dashboard</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg-gradient: radial-gradient(circle at 20% 20%, #1a1f4d 0%, #05010c 65%, #000000 100%);
+        --accent: #60ffcf;
+        --accent-soft: rgba(96, 255, 207, 0.2);
+        --warning: #ffb347;
+        --danger: #ff6b6b;
+        --success: #2ecc71;
+        --card-bg: rgba(255, 255, 255, 0.04);
+        --table-header: rgba(255, 255, 255, 0.08);
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--bg-gradient);
+        color: #f6faff;
+        padding: 3rem 1rem 4rem;
+        line-height: 1.6;
+      }
+      main {
+        max-width: 1080px;
+        margin: 0 auto;
+      }
+      header.hero {
+        text-align: center;
+        margin-bottom: 3rem;
+      }
+      header.hero h1 {
+        font-size: clamp(2.5rem, 5vw, 3.8rem);
+        margin: 0;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      header.hero p {
+        max-width: 720px;
+        margin: 1rem auto 0 auto;
+        color: rgba(255, 255, 255, 0.78);
+      }
+      section {
+        margin-bottom: 3rem;
+        background: var(--card-bg);
+        border-radius: 18px;
+        padding: 2rem;
+        box-shadow: 0 18px 50px rgba(8, 11, 40, 0.45);
+        backdrop-filter: blur(12px);
+      }
+      section h2 {
+        margin-top: 0;
+        font-size: 1.6rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+      .metrics {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1.5rem;
+      }
+      .metric {
+        border: 1px solid rgba(96, 255, 207, 0.25);
+        border-radius: 14px;
+        padding: 1.5rem;
+        text-align: center;
+      }
+      .metric h3 {
+        margin: 0 0 0.5rem 0;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.9rem;
+        letter-spacing: 0.1em;
+      }
+      .metric strong {
+        font-size: 1.6rem;
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .control-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1.25rem;
+      }
+      .control-card {
+        background: rgba(255, 255, 255, 0.04);
+        border-radius: 14px;
+        padding: 1.2rem 1.3rem;
+        border: 1px solid rgba(96, 255, 207, 0.12);
+      }
+      .control-card header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.75rem;
+      }
+      .control-card h3 {
+        margin: 0;
+        font-size: 1rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .badge {
+        display: inline-block;
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.7rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        border: 1px solid currentColor;
+      }
+      .badge.on {
+        color: var(--accent);
+        background: rgba(96, 255, 207, 0.1);
+      }
+      .badge.off {
+        color: rgba(255, 255, 255, 0.56);
+        border-color: rgba(255, 255, 255, 0.4);
+      }
+      .badge.success {
+        color: var(--success);
+        background: rgba(46, 204, 113, 0.16);
+        border-color: rgba(46, 204, 113, 0.6);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+        font-size: 0.95rem;
+      }
+      table thead {
+        background: var(--table-header);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 0.8rem;
+      }
+      table th,
+      table td {
+        padding: 0.8rem 1rem;
+        text-align: left;
+      }
+      table tbody tr:nth-child(even) {
+        background: rgba(255, 255, 255, 0.04);
+      }
+      .mono {
+        font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", ui-monospace, monospace;
+      }
+      pre.mermaid {
+        background: rgba(0, 0, 0, 0.45);
+        border-radius: 12px;
+        padding: 1.5rem;
+        overflow-x: auto;
+        border: 1px solid rgba(96, 255, 207, 0.2);
+      }
+      footer {
+        text-align: center;
+        margin-top: 4rem;
+        color: rgba(255, 255, 255, 0.6);
+        font-size: 0.85rem;
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js" integrity="sha256-YBtS2OVCkXbkqVKgf/mBlC9ZwTe74MkRUyvMh35vjps=" crossorigin="anonymous"></script>
+    <script>mermaid.initialize({ startOnLoad: true, theme: 'dark' });</script>
+  </head>
+  <body>
+    <main>
+      <header class="hero">
+        <p class="mono">α-AGI Sovereign Command Console</p>
+        <h1>MARK Launch Telemetry</h1>
+        <p>
+          Autonomous foresight launch executed via AGI Jobs v0 (v2). This dossier captures every
+          actuator a non-technical steward needs to command an α-AGI Nova-Seed into sovereign reality.
+        </p>
+      </header>
+
+      <section>
+        <h2>Mission Control Metrics</h2>
+        <div class="metrics">
+          <article class="metric">
+            <h3>Validator Consensus</h3>
+            <strong>2/2</strong>
+            <p>3 guardians in council</p>
+          </article>
+          <article class="metric">
+            <h3>Live SeedShares Supply</h3>
+            <strong>11</strong>
+            <p>Dynamic bonding curve issuance</p>
+          </article>
+          <article class="metric">
+            <h3>Reserve Power</h3>
+            <strong>0.0</strong>
+            <p>Capital safeguarding the sovereign ignition</p>
+          </article>
+          <article class="metric">
+            <h3>Next Token Price</h3>
+            <strong>0.65</strong>
+            <p>Real-time quote for incremental participation</p>
+          </article>
+          <article class="metric">
+            <h3>Sovereign Vault</h3>
+            <strong>3.85</strong>
+            <p>Manifest URI: ipfs://alpha-mark/sovereign/genesis<br />Last ignition: 3.85</p>
+          </article>
+          <article class="metric">
+            <h3>Participants</h3>
+            <strong>3</strong>
+            <p>Every participant recorded with on-chain contributions</p>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2>Owner Control Deck</h2>
+        <div class="control-grid">
+          
+        <article class="control-card">
+          <header>
+            <h3>Market State</h3>
+            <span class="badge off">DISABLED</span>
+          </header>
+          <p>Paused for operator oversight</p>
+        </article>
+      
+
+        <article class="control-card">
+          <header>
+            <h3>Whitelist</h3>
+            <span class="badge on">ENABLED</span>
+          </header>
+          <p>Only approved sovereign contributors may participate</p>
+        </article>
+      
+
+        <article class="control-card">
+          <header>
+            <h3>Emergency Exit</h3>
+            <span class="badge off">DISABLED</span>
+          </header>
+          <p>Exit lever on standby</p>
+        </article>
+      
+
+        <article class="control-card">
+          <header>
+            <h3>Validation Override</h3>
+            <span class="badge off">DISABLED</span>
+          </header>
+          <p>Validator council governs launch</p>
+        </article>
+      
+        </div>
+      </section>
+
+      <section>
+        <h2>Participant Ledger</h2>
+        <p>The bonding curve ledger ensures contributions and SeedShares stay solvent in both ascent and emergency exit scenarios.</p>
+        
+    <table>
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Participant</th>
+          <th>SeedShares</th>
+          <th>Contribution</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        <tr>
+          <td>1</td>
+          <td class="mono">0x7099…79C8</td>
+          <td>5.0</td>
+          <td>1.0</td>
+        </tr>
+      
+
+        <tr>
+          <td>2</td>
+          <td class="mono">0x3C44…93BC</td>
+          <td>2.0</td>
+          <td>1.2</td>
+        </tr>
+      
+
+        <tr>
+          <td>3</td>
+          <td class="mono">0x90F7…b906</td>
+          <td>4.0</td>
+          <td>2.3</td>
+        </tr>
+      
+      </tbody>
+    </table>
+  
+      </section>
+
+      <section>
+        <h2>Operator Parameter Matrix</h2>
+        <p>Every actuator exposed to the owner is catalogued here to guarantee absolute command authority.</p>
+        
+    <table>
+      <thead>
+        <tr>
+          <th>Control Lever</th>
+          <th>Value</th>
+          <th>Purpose</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        <tr>
+          <td class="mono">pauseMarket</td>
+          <td>true</td>
+          <td>Master halt switch for all bonding-curve trades</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">whitelistEnabled</td>
+          <td>true</td>
+          <td>Compliance gate restricting participation to approved wallets</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">emergencyExitEnabled</td>
+          <td>false</td>
+          <td>Allow redemptions while paused for orderly unwinding</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">validationOverrideEnabled</td>
+          <td>false</td>
+          <td>Owner override switch for the risk oracle consensus</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">validationOverrideStatus</td>
+          <td>false</td>
+          <td>Forced validation outcome when override is enabled</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">finalized</td>
+          <td>true</td>
+          <td>Indicates whether sovereign funds have been dispatched</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">aborted</td>
+          <td>false</td>
+          <td>Emergency abort flag preserving participant capital</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">treasury</td>
+          <td>0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266</td>
+          <td>Address receiving proceeds on finalization</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">riskOracle</td>
+          <td>0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0</td>
+          <td>Validator council contract controlling launch approvals</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">baseAsset</td>
+          <td>0x0000000000000000000000000000000000000000</td>
+          <td>Current financing currency (0x0 indicates native ETH)</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">usesNativeAsset</td>
+          <td>true</td>
+          <td>True when the market accepts native ETH deposits</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">fundingCap</td>
+          <td>{&quot;wei&quot;:&quot;1000000000000000000000&quot;,&quot;eth&quot;:&quot;1000.0&quot;}</td>
+          <td>Upper bound on capital accepted before launch</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">maxSupplyWholeTokens</td>
+          <td>100</td>
+          <td>Maximum SeedShares that can ever be minted</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">saleDeadlineTimestamp</td>
+          <td>0</td>
+          <td>Timestamp after which purchases are rejected</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">basePrice</td>
+          <td>{&quot;wei&quot;:&quot;100000000000000000&quot;,&quot;eth&quot;:&quot;0.1&quot;}</td>
+          <td>Bonding curve base price component</td>
+        </tr>
+      
+
+        <tr>
+          <td class="mono">slope</td>
+          <td>{&quot;wei&quot;:&quot;50000000000000000&quot;,&quot;eth&quot;:&quot;0.05&quot;}</td>
+          <td>Bonding curve slope component</td>
+        </tr>
+      
+      </tbody>
+    </table>
+  
+      </section>
+
+      <section>
+        <h2>Launch Dynamics</h2>
+        <pre class="mermaid">
+flowchart LR
+    Operator((Operator 0xf39F…2266)) --&gt; Seed[Nova-Seed #1]
+    Seed --&gt;|Tokenizes vision| Exchange[α-AGI SeedShares Exchange]
+    Exchange --&gt;|Bonding curve capital| Reserve((Sovereign Reserve))
+    Exchange --&gt;|Validator consensus (2/2)| Oracle[Risk Oracle Council]
+    Oracle --&gt; Launch{Launch Condition}
+    Launch --&gt;|Finalized| Vault[[α-AGI Sovereign Vault]]
+    Vault --&gt;|Acknowledge| Manifest&gt;&quot;α-AGI Sovereign ignition: Nova-Seed ascends&quot;]
+    Launch -.-&gt;|Abort| Emergency((Emergency Exit))
+        </pre>
+        <p class="mono">Contracts: NovaSeed 0x5FbD…0aa3 · Oracle 0x9fE4…a6e0 · Exchange 0xCf7E…0Fc9 · Vault 0xDc64…F6C9</p>
+      </section>
+
+      <footer>
+        Crafted autonomously by AGI Jobs v0 (v2). Re-run <code>npm run demo:alpha-agi-mark</code> to regenerate this living dossier.
+      </footer>
+    </main>
+  </body>
+</html>

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.json
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.json
@@ -37,7 +37,11 @@
     "reserveWei": "0",
     "nextPriceWei": "650000000000000000",
     "basePriceWei": "100000000000000000",
-    "slopeWei": "50000000000000000"
+    "slopeWei": "50000000000000000",
+    "reserveEth": "0.0",
+    "nextPriceEth": "0.65",
+    "basePriceEth": "0.1",
+    "slopeEth": "0.05"
   },
   "ownerControls": {
     "paused": true,
@@ -52,26 +56,32 @@
     "baseAsset": "0x0000000000000000000000000000000000000000",
     "usesNativeAsset": true,
     "fundingCapWei": "1000000000000000000000",
+    "fundingCapEth": "1000.0",
     "maxSupplyWholeTokens": "100",
     "saleDeadlineTimestamp": "0",
     "basePriceWei": "100000000000000000",
-    "slopeWei": "50000000000000000"
+    "basePriceEth": "0.1",
+    "slopeWei": "50000000000000000",
+    "slopeEth": "0.05"
   },
   "participants": [
     {
       "address": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
       "tokens": "5.0",
-      "contributionWei": "1000000000000000000"
+      "contributionWei": "1000000000000000000",
+      "contributionEth": "1.0"
     },
     {
       "address": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
       "tokens": "2.0",
-      "contributionWei": "1200000000000000000"
+      "contributionWei": "1200000000000000000",
+      "contributionEth": "1.2"
     },
     {
       "address": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
       "tokens": "4.0",
-      "contributionWei": "2300000000000000000"
+      "contributionWei": "2300000000000000000",
+      "contributionEth": "2.3"
     }
   ],
   "launch": {
@@ -81,10 +91,13 @@
     "sovereignVault": {
       "manifestUri": "ipfs://alpha-mark/sovereign/genesis",
       "totalReceivedWei": "3850000000000000000",
+      "totalReceivedEth": "3.85",
       "lastAcknowledgedAmountWei": "3850000000000000000",
+      "lastAcknowledgedAmountEth": "3.85",
       "lastAcknowledgedMetadataHex": "0xceb12d41474920536f7665726569676e2069676e6974696f6e3a204e6f76612d5365656420617363656e6473",
       "decodedMetadata": "α-AGI Sovereign ignition: Nova-Seed ascends",
-      "vaultBalanceWei": "3850000000000000000"
+      "vaultBalanceWei": "3850000000000000000",
+      "vaultBalanceEth": "3.85"
     }
   },
   "ownerParameterMatrix": [
@@ -114,6 +127,16 @@
       "description": "Forced validation outcome when override is enabled"
     },
     {
+      "parameter": "finalized",
+      "value": true,
+      "description": "Indicates whether sovereign funds have been dispatched"
+    },
+    {
+      "parameter": "aborted",
+      "value": false,
+      "description": "Emergency abort flag preserving participant capital"
+    },
+    {
       "parameter": "treasury",
       "value": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       "description": "Address receiving proceeds on finalization"
@@ -129,8 +152,16 @@
       "description": "Current financing currency (0x0 indicates native ETH)"
     },
     {
-      "parameter": "fundingCapWei",
-      "value": "1000000000000000000000",
+      "parameter": "usesNativeAsset",
+      "value": true,
+      "description": "True when the market accepts native ETH deposits"
+    },
+    {
+      "parameter": "fundingCap",
+      "value": {
+        "wei": "1000000000000000000000",
+        "eth": "1000.0"
+      },
       "description": "Upper bound on capital accepted before launch"
     },
     {
@@ -144,13 +175,19 @@
       "description": "Timestamp after which purchases are rejected"
     },
     {
-      "parameter": "basePriceWei",
-      "value": "100000000000000000",
+      "parameter": "basePrice",
+      "value": {
+        "wei": "100000000000000000",
+        "eth": "0.1"
+      },
       "description": "Bonding curve base price component"
     },
     {
-      "parameter": "slopeWei",
-      "value": "50000000000000000",
+      "parameter": "slope",
+      "value": {
+        "wei": "50000000000000000",
+        "eth": "0.05"
+      },
       "description": "Bonding curve slope component"
     }
   ]

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-flow.mmd
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-flow.mmd
@@ -1,15 +1,18 @@
 ```mermaid
-graph TD
-    A[Owner launches demo] --> B[NovaSeedNFT deployed]
-    B --> C[AlphaMarkRiskOracle deployed]
-    C --> D[AlphaMarkEToken deployed]
-    D --> E[Investors buy SeedShares via bonding curve]
-    E --> F[Owner toggles whitelist & pause controls]
-    F --> G[Validators submit approvals]
-    G --> H{Approval threshold met?}
-    H -- No --> I[Owner may override or abort]
-    H -- Yes --> J[Owner finalizes launch]
-    J --> K[Sovereign funds released]
-    K --> L[Recap generated for operator]
-    L --> M[Owner parameter matrix exported]
+flowchart TD
+    classDef contract fill:#1a1f4d,stroke:#60ffcf,color:#f6faff,stroke-width:2px;
+    classDef actor fill:#113322,stroke:#60ffcf,color:#e8fff6,stroke-dasharray: 5 3;
+    classDef control fill:#2f2445,stroke:#9d7bff,color:#f6f0ff;
+
+    Operator((Operator Console)):::actor -->|Mint & Configure| Seed[NovaSeedNFT — α-AGI Nova-Seed]:::contract
+    Seed -->|Launch Request| Oracle[AlphaMarkRiskOracle — Validator Council]:::contract
+    Seed -->|Enables Pricing| Exchange[AlphaMarkEToken — Bonding Curve Exchange]:::contract
+    Exchange -->|Capital Flow| Reserve((Sovereign Reserve)):::control
+    Exchange -->|Compliance, Pause, Overrides| ControlDeck{{Owner Control Deck}}:::control
+    ControlDeck -->|Gates Participation| Exchange
+    Investors((SeedShare Contributors)):::actor -->|Bonding Curve Buys/Sells| Exchange
+    Oracle -->|Consensus Signal| Launch{Launch Condition}
+    Launch -->|Finalized| Vault[AlphaSovereignVault — Treasury]:::contract
+    Launch -->|Abort Path| Emergency((Emergency Exit Corridor)):::control
+    Vault -->|Ignition Metadata| Sovereign[[α-AGI Sovereign Manifest]]:::contract
 ```

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -28,7 +28,8 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
 
 2. **Inspect recap artifacts**
 
-   At the end of the run the script emits a JSON recap under `demo/alpha-agi-mark/reports/alpha-mark-recap.json`. It contains:
+   At the end of the run the script emits a JSON recap under `demo/alpha-agi-mark/reports/alpha-mark-recap.json` **and** a
+   cinematic HTML dashboard at `demo/alpha-agi-mark/reports/alpha-mark-dashboard.html`. The recap dossier contains:
 
    - contract addresses
    - owner governance parameters
@@ -46,13 +47,21 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
 
    The command reads the latest recap dossier and prints a tabular summary of every operator control lever.
 
-4. **(Optional) Run unit tests**
+4. **Render (or re-render) the sovereign dashboard**
+
+   ```bash
+   npm run dashboard:alpha-agi-mark
+   ```
+
+   This regenerates the HTML dossier using the latest recap JSON, useful after manual parameter tweaks.
+
+5. **(Optional) Run unit tests**
 
    ```bash
    npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts
    ```
 
-5. **(Optional) Dry-run on a fork or external network**
+6. **(Optional) Dry-run on a fork or external network**
 
    Set environment variables before invoking the script:
 

--- a/demo/alpha-agi-mark/scripts/generateDashboard.ts
+++ b/demo/alpha-agi-mark/scripts/generateDashboard.ts
@@ -1,0 +1,17 @@
+import { readFile } from "fs/promises";
+import path from "path";
+
+import { renderDashboard } from "./renderDashboard";
+
+async function main() {
+  const recapPath = path.join(__dirname, "..", "reports", "alpha-mark-recap.json");
+  const raw = await readFile(recapPath, "utf8");
+  const recap = JSON.parse(raw);
+  const output = await renderDashboard(recap);
+  console.log(`Rendered α-AGI MARK dashboard to ${output}`);
+}
+
+main().catch((error) => {
+  console.error("Failed to render α-AGI MARK dashboard:", error);
+  process.exitCode = 1;
+});

--- a/demo/alpha-agi-mark/scripts/renderDashboard.ts
+++ b/demo/alpha-agi-mark/scripts/renderDashboard.ts
@@ -1,0 +1,524 @@
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+
+const DASHBOARD_PATH = path.join(__dirname, "..", "reports", "alpha-mark-dashboard.html");
+
+type RecapParticipant = {
+  address: string;
+  tokens: string;
+  contributionWei: string;
+  contributionEth?: string;
+};
+
+type RecapData = {
+  contracts: {
+    novaSeed: string;
+    riskOracle: string;
+    markExchange: string;
+    sovereignVault: string;
+  };
+  seed: {
+    tokenId: string;
+    holder: string;
+  };
+  validators: {
+    approvalCount: string;
+    approvalThreshold: string;
+    members: string[];
+    matrix: Array<{ address: string; approved: boolean }>;
+  };
+  bondingCurve: {
+    supplyWholeTokens: string;
+    reserveWei: string;
+    nextPriceWei: string;
+    basePriceWei: string;
+    slopeWei: string;
+    reserveEth?: string;
+    nextPriceEth?: string;
+    basePriceEth?: string;
+    slopeEth?: string;
+  };
+  ownerControls: {
+    paused: boolean;
+    whitelistEnabled: boolean;
+    emergencyExitEnabled: boolean;
+    finalized: boolean;
+    aborted: boolean;
+    validationOverrideEnabled: boolean;
+    validationOverrideStatus: boolean;
+    treasury: string;
+    riskOracle: string;
+    baseAsset: string;
+    usesNativeAsset: boolean;
+    fundingCapWei: string;
+    maxSupplyWholeTokens: string;
+    saleDeadlineTimestamp: string;
+    basePriceWei: string;
+    slopeWei: string;
+    fundingCapEth?: string;
+    basePriceEth?: string;
+    slopeEth?: string;
+  };
+  participants: RecapParticipant[];
+  launch: {
+    finalized: boolean;
+    aborted: boolean;
+    treasury: string;
+    sovereignVault: {
+      manifestUri: string;
+      totalReceivedWei: string;
+      lastAcknowledgedAmountWei: string;
+      lastAcknowledgedMetadataHex: string;
+      decodedMetadata: string;
+      vaultBalanceWei: string;
+      totalReceivedEth?: string;
+      lastAcknowledgedAmountEth?: string;
+      vaultBalanceEth?: string;
+    };
+  };
+  ownerParameterMatrix?: Array<{ parameter: string; value: unknown; description: string }>;
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function shortenAddress(address: string): string {
+  if (!address || address.length < 10) {
+    return address;
+  }
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function renderBooleanBadge(value: boolean): string {
+  return `<span class="badge ${value ? "on" : "off"}">${value ? "ENABLED" : "DISABLED"}</span>`;
+}
+
+function formatNumber(value: string | undefined, fallback = "-"): string {
+  if (!value || value === "0") {
+    return fallback;
+  }
+  return value;
+}
+
+function buildControlHighlights(recap: RecapData): string {
+  const controls = [
+    {
+      label: "Market State",
+      detail: recap.ownerControls.paused ? "Paused for operator oversight" : "Live & programmable",
+      badge: recap.ownerControls.paused ? renderBooleanBadge(false) : '<span class="badge success">LIVE</span>',
+    },
+    {
+      label: "Whitelist",
+      detail: recap.ownerControls.whitelistEnabled
+        ? "Only approved sovereign contributors may participate"
+        : "Open liquidity access",
+      badge: renderBooleanBadge(recap.ownerControls.whitelistEnabled),
+    },
+    {
+      label: "Emergency Exit",
+      detail: recap.ownerControls.emergencyExitEnabled
+        ? "Participants can unwind even during a pause"
+        : "Exit lever on standby",
+      badge: renderBooleanBadge(recap.ownerControls.emergencyExitEnabled),
+    },
+    {
+      label: "Validation Override",
+      detail: recap.ownerControls.validationOverrideEnabled
+        ? `Owner override engaged (${recap.ownerControls.validationOverrideStatus ? "FORCE-GREEN" : "FORCE-RED"})`
+        : "Validator council governs launch",
+      badge: renderBooleanBadge(recap.ownerControls.validationOverrideEnabled),
+    },
+  ];
+
+  return controls
+    .map(
+      (control) => `
+        <article class="control-card">
+          <header>
+            <h3>${escapeHtml(control.label)}</h3>
+            ${control.badge}
+          </header>
+          <p>${escapeHtml(control.detail)}</p>
+        </article>
+      `,
+    )
+    .join("\n");
+}
+
+function buildParticipantsTable(participants: RecapParticipant[]): string {
+  const rows = participants
+    .map((participant, idx) => {
+      const contribution = participant.contributionEth ?? participant.contributionWei;
+      return `
+        <tr>
+          <td>${idx + 1}</td>
+          <td class="mono">${escapeHtml(shortenAddress(participant.address))}</td>
+          <td>${escapeHtml(participant.tokens)}</td>
+          <td>${escapeHtml(contribution)}</td>
+        </tr>
+      `;
+    })
+    .join("\n");
+
+  return `
+    <table>
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Participant</th>
+          <th>SeedShares</th>
+          <th>Contribution</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>
+  `;
+}
+
+function buildOwnerMatrixTable(entries: Array<{ parameter: string; value: unknown; description: string }> = []): string {
+  if (entries.length === 0) {
+    return "<p>No owner parameter matrix entries captured.</p>";
+  }
+
+  const rows = entries
+    .map((entry) => {
+      const value =
+        typeof entry.value === "object" && entry.value !== null
+          ? escapeHtml(JSON.stringify(entry.value))
+          : escapeHtml(String(entry.value));
+      return `
+        <tr>
+          <td class="mono">${escapeHtml(entry.parameter)}</td>
+          <td>${value}</td>
+          <td>${escapeHtml(entry.description)}</td>
+        </tr>
+      `;
+    })
+    .join("\n");
+
+  return `
+    <table>
+      <thead>
+        <tr>
+          <th>Control Lever</th>
+          <th>Value</th>
+          <th>Purpose</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>
+  `;
+}
+
+function buildMermaidFlow(recap: RecapData): string {
+  const metadataSnippet = recap.launch.sovereignVault.decodedMetadata
+    ? recap.launch.sovereignVault.decodedMetadata.replace(/\"/g, '\\"')
+    : "Ignition metadata";
+
+  const mermaidLines = [
+    "flowchart LR",
+    `    Operator((Operator ${shortenAddress(recap.seed.holder)})) --> Seed[Nova-Seed #${recap.seed.tokenId}]`,
+    "    Seed -->|Tokenizes vision| Exchange[α-AGI SeedShares Exchange]",
+    "    Exchange -->|Bonding curve capital| Reserve((Sovereign Reserve))",
+    `    Exchange -->|Validator consensus (${recap.validators.approvalCount}/${recap.validators.approvalThreshold})| Oracle[Risk Oracle Council]`,
+    "    Oracle --> Launch{Launch Condition}",
+    "    Launch -->|Finalized| Vault[[α-AGI Sovereign Vault]]",
+    `    Vault -->|Acknowledge| Manifest>\"${metadataSnippet}\"]`,
+    "    Launch -.->|Abort| Emergency((Emergency Exit))",
+  ];
+
+  return mermaidLines.join("\n");
+}
+
+function buildDashboardHtml(recap: RecapData): string {
+  const participantCount = recap.participants.length;
+  const reserve = formatNumber(recap.bondingCurve.reserveEth, `${recap.bondingCurve.reserveWei} wei`);
+  const nextPrice = formatNumber(recap.bondingCurve.nextPriceEth, `${recap.bondingCurve.nextPriceWei} wei`);
+  const sovereignBalance = formatNumber(
+    recap.launch.sovereignVault.totalReceivedEth,
+    `${recap.launch.sovereignVault.totalReceivedWei} wei`,
+  );
+  const lastIgnition = formatNumber(
+    recap.launch.sovereignVault.lastAcknowledgedAmountEth,
+    `${recap.launch.sovereignVault.lastAcknowledgedAmountWei} wei`,
+  );
+
+  const ownerMatrix = buildOwnerMatrixTable(recap.ownerParameterMatrix ?? []);
+  const mermaidDefinition = escapeHtml(buildMermaidFlow(recap));
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>α-AGI MARK Sovereign Launch Dashboard</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg-gradient: radial-gradient(circle at 20% 20%, #1a1f4d 0%, #05010c 65%, #000000 100%);
+        --accent: #60ffcf;
+        --accent-soft: rgba(96, 255, 207, 0.2);
+        --warning: #ffb347;
+        --danger: #ff6b6b;
+        --success: #2ecc71;
+        --card-bg: rgba(255, 255, 255, 0.04);
+        --table-header: rgba(255, 255, 255, 0.08);
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--bg-gradient);
+        color: #f6faff;
+        padding: 3rem 1rem 4rem;
+        line-height: 1.6;
+      }
+      main {
+        max-width: 1080px;
+        margin: 0 auto;
+      }
+      header.hero {
+        text-align: center;
+        margin-bottom: 3rem;
+      }
+      header.hero h1 {
+        font-size: clamp(2.5rem, 5vw, 3.8rem);
+        margin: 0;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      header.hero p {
+        max-width: 720px;
+        margin: 1rem auto 0 auto;
+        color: rgba(255, 255, 255, 0.78);
+      }
+      section {
+        margin-bottom: 3rem;
+        background: var(--card-bg);
+        border-radius: 18px;
+        padding: 2rem;
+        box-shadow: 0 18px 50px rgba(8, 11, 40, 0.45);
+        backdrop-filter: blur(12px);
+      }
+      section h2 {
+        margin-top: 0;
+        font-size: 1.6rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+      .metrics {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1.5rem;
+      }
+      .metric {
+        border: 1px solid rgba(96, 255, 207, 0.25);
+        border-radius: 14px;
+        padding: 1.5rem;
+        text-align: center;
+      }
+      .metric h3 {
+        margin: 0 0 0.5rem 0;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.9rem;
+        letter-spacing: 0.1em;
+      }
+      .metric strong {
+        font-size: 1.6rem;
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .control-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1.25rem;
+      }
+      .control-card {
+        background: rgba(255, 255, 255, 0.04);
+        border-radius: 14px;
+        padding: 1.2rem 1.3rem;
+        border: 1px solid rgba(96, 255, 207, 0.12);
+      }
+      .control-card header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.75rem;
+      }
+      .control-card h3 {
+        margin: 0;
+        font-size: 1rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .badge {
+        display: inline-block;
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.7rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        border: 1px solid currentColor;
+      }
+      .badge.on {
+        color: var(--accent);
+        background: rgba(96, 255, 207, 0.1);
+      }
+      .badge.off {
+        color: rgba(255, 255, 255, 0.56);
+        border-color: rgba(255, 255, 255, 0.4);
+      }
+      .badge.success {
+        color: var(--success);
+        background: rgba(46, 204, 113, 0.16);
+        border-color: rgba(46, 204, 113, 0.6);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+        font-size: 0.95rem;
+      }
+      table thead {
+        background: var(--table-header);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 0.8rem;
+      }
+      table th,
+      table td {
+        padding: 0.8rem 1rem;
+        text-align: left;
+      }
+      table tbody tr:nth-child(even) {
+        background: rgba(255, 255, 255, 0.04);
+      }
+      .mono {
+        font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", ui-monospace, monospace;
+      }
+      pre.mermaid {
+        background: rgba(0, 0, 0, 0.45);
+        border-radius: 12px;
+        padding: 1.5rem;
+        overflow-x: auto;
+        border: 1px solid rgba(96, 255, 207, 0.2);
+      }
+      footer {
+        text-align: center;
+        margin-top: 4rem;
+        color: rgba(255, 255, 255, 0.6);
+        font-size: 0.85rem;
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js" integrity="sha256-YBtS2OVCkXbkqVKgf/mBlC9ZwTe74MkRUyvMh35vjps=" crossorigin="anonymous"></script>
+    <script>mermaid.initialize({ startOnLoad: true, theme: 'dark' });</script>
+  </head>
+  <body>
+    <main>
+      <header class="hero">
+        <p class="mono">α-AGI Sovereign Command Console</p>
+        <h1>MARK Launch Telemetry</h1>
+        <p>
+          Autonomous foresight launch executed via AGI Jobs v0 (v2). This dossier captures every
+          actuator a non-technical steward needs to command an α-AGI Nova-Seed into sovereign reality.
+        </p>
+      </header>
+
+      <section>
+        <h2>Mission Control Metrics</h2>
+        <div class="metrics">
+          <article class="metric">
+            <h3>Validator Consensus</h3>
+            <strong>${escapeHtml(`${recap.validators.approvalCount}/${recap.validators.approvalThreshold}`)}</strong>
+            <p>${escapeHtml(recap.validators.members.length.toString())} guardians in council</p>
+          </article>
+          <article class="metric">
+            <h3>Live SeedShares Supply</h3>
+            <strong>${escapeHtml(recap.bondingCurve.supplyWholeTokens)}</strong>
+            <p>Dynamic bonding curve issuance</p>
+          </article>
+          <article class="metric">
+            <h3>Reserve Power</h3>
+            <strong>${escapeHtml(reserve)}</strong>
+            <p>Capital safeguarding the sovereign ignition</p>
+          </article>
+          <article class="metric">
+            <h3>Next Token Price</h3>
+            <strong>${escapeHtml(nextPrice)}</strong>
+            <p>Real-time quote for incremental participation</p>
+          </article>
+          <article class="metric">
+            <h3>Sovereign Vault</h3>
+            <strong>${escapeHtml(sovereignBalance)}</strong>
+            <p>Manifest URI: ${escapeHtml(recap.launch.sovereignVault.manifestUri)}<br />Last ignition: ${escapeHtml(
+              lastIgnition,
+            )}</p>
+          </article>
+          <article class="metric">
+            <h3>Participants</h3>
+            <strong>${participantCount}</strong>
+            <p>Every participant recorded with on-chain contributions</p>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2>Owner Control Deck</h2>
+        <div class="control-grid">
+          ${buildControlHighlights(recap)}
+        </div>
+      </section>
+
+      <section>
+        <h2>Participant Ledger</h2>
+        <p>The bonding curve ledger ensures contributions and SeedShares stay solvent in both ascent and emergency exit scenarios.</p>
+        ${buildParticipantsTable(recap.participants)}
+      </section>
+
+      <section>
+        <h2>Operator Parameter Matrix</h2>
+        <p>Every actuator exposed to the owner is catalogued here to guarantee absolute command authority.</p>
+        ${ownerMatrix}
+      </section>
+
+      <section>
+        <h2>Launch Dynamics</h2>
+        <pre class="mermaid">
+${mermaidDefinition}
+        </pre>
+        <p class="mono">Contracts: NovaSeed ${escapeHtml(shortenAddress(recap.contracts.novaSeed))} · Oracle ${escapeHtml(shortenAddress(recap.contracts.riskOracle))} · Exchange ${escapeHtml(shortenAddress(recap.contracts.markExchange))} · Vault ${escapeHtml(shortenAddress(recap.contracts.sovereignVault))}</p>
+      </section>
+
+      <footer>
+        Crafted autonomously by AGI Jobs v0 (v2). Re-run <code>npm run demo:alpha-agi-mark</code> to regenerate this living dossier.
+      </footer>
+    </main>
+  </body>
+</html>`;
+}
+
+export async function renderDashboard(recap: RecapData, outputPath = DASHBOARD_PATH): Promise<string> {
+  const html = buildDashboardHtml(recap);
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, html, "utf8");
+  return outputPath;
+}

--- a/package.json
+++ b/package.json
@@ -160,7 +160,8 @@
     "demo:alpha-agi-mark": "npx hardhat run --config demo/alpha-agi-mark/hardhat.config.ts demo/alpha-agi-mark/scripts/runDemo.ts",
     "demo:alpha-agi-mark:ci": "AGIJOBS_DEMO_DRY_RUN=true npm run demo:alpha-agi-mark",
     "test:alpha-agi-mark": "npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts",
-    "owner:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/exportOwnerMatrix.ts"
+    "owner:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/exportOwnerMatrix.ts",
+    "dashboard:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateDashboard.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a renderDashboard helper that builds a cinematic HTML dossier for the α-AGI MARK recap
- extend the demo script and documentation so every run emits the dashboard plus richer metrics
- wire CI to validate the generated dashboard artefact and expose a helper command to rebuild it

## Testing
- npm run demo:alpha-agi-mark
- npm run dashboard:alpha-agi-mark
- npm run owner:alpha-agi-mark
- npm run test:alpha-agi-mark

------
https://chatgpt.com/codex/tasks/task_e_68f134b57b988333a1360972473b4c05