### PR TITLE
Add triple verification matrix to alpha-agi-mark demo

### DIFF
--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -86,6 +86,22 @@ Regenerate the dashboard at any time from the latest recap JSON:
 npm run dashboard:alpha-agi-mark
 ```
 
+## Triple-Verification Matrix
+
+α-AGI MARK now triangulates its state through three independent vantage points—on-chain contract reads, a deterministic
+trade ledger, and a first-principles bonding-curve simulator. Every run prints a "Triple-Verification Matrix" confirming that
+all three perspectives agree on supply, pricing, capital flows, and participant contributions. The recap dossier exposes the
+results under a new `verification` section and the dashboard renders the matrix as a dedicated integrity panel.
+
+```mermaid
+flowchart LR
+    OnChain[(On-chain Introspection)] --> Verifier{{Triangulation Engine}}
+    Ledger[(Deterministic Trade Ledger)] --> Verifier
+    Simulation[(Bonding Curve Simulation)] --> Verifier
+    Verifier --> Dashboard[[Sovereign Dashboard]]
+    Verifier --> Recap[(alpha-mark-recap.json)]
+```
+
 ## Owner Controls
 
 The demo enumerates all tunable controls in the final recap:

--- a/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
+++ b/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
@@ -92,6 +92,23 @@
         padding: 1.2rem 1.3rem;
         border: 1px solid rgba(96, 255, 207, 0.12);
       }
+      .verification-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 1.5rem;
+      }
+      .verification-card {
+        background: rgba(255, 255, 255, 0.05);
+        border-radius: 16px;
+        padding: 1.4rem;
+        border: 1px solid rgba(96, 255, 207, 0.16);
+      }
+      .verification-card header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.9rem;
+      }
       .control-card header {
         display: flex;
         align-items: center;
@@ -126,6 +143,11 @@
         color: var(--success);
         background: rgba(46, 204, 113, 0.16);
         border-color: rgba(46, 204, 113, 0.6);
+      }
+      .badge.danger {
+        color: var(--danger);
+        background: rgba(255, 107, 107, 0.18);
+        border-color: rgba(255, 107, 107, 0.6);
       }
       table {
         width: 100%;
@@ -220,6 +242,78 @@
           </article>
         </div>
       </section>
+
+      
+    <section>
+      <h2>Triple-Verification Matrix</h2>
+      <p>
+        Independent ledgers, on-chain state introspection, and first-principles math cross-check the sovereign launch
+        in real time.
+      </p>
+      <div class="verification-grid">
+        
+        <article class="verification-card">
+          <header>
+            <h3>Supply Consensus</h3>
+            <span class="badge success">CONSISTENT</span>
+          </header>
+          
+      <p class="mono">
+        Ledger 11 ·
+        Contract 11 ·
+        Simulation 11 ·
+        Participants 11
+      </p>
+    
+        </article>
+      
+
+        <article class="verification-card">
+          <header>
+            <h3>Pricing Integrity</h3>
+            <span class="badge success">CONSISTENT</span>
+          </header>
+          
+      <p>
+        On-chain quote: <span class="mono">0.65</span><br />
+        Simulated quote: <span class="mono">0.65</span>
+      </p>
+    
+        </article>
+      
+
+        <article class="verification-card">
+          <header>
+            <h3>Capital Flow Integrity</h3>
+            <span class="badge success">CONSISTENT</span>
+          </header>
+          
+      <p>
+        Gross inflow: <span class="mono">4.5</span><br />
+        Redemptions: <span class="mono">0.65</span><br />
+        Net reserve: <span class="mono">3.85</span><br />
+        Vault received: <span class="mono">3.85</span>
+      </p>
+    
+        </article>
+      
+
+        <article class="verification-card">
+          <header>
+            <h3>Contribution Accounting</h3>
+            <span class="badge success">CONSISTENT</span>
+          </header>
+          
+      <p>
+        On-chain aggregate: <span class="mono">4.5</span><br />
+        Ledger aggregate: <span class="mono">4.5</span>
+      </p>
+    
+        </article>
+      
+      </div>
+    </section>
+  
 
       <section>
         <h2>Owner Control Deck</h2>

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.json
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.json
@@ -190,5 +190,45 @@
       },
       "description": "Bonding curve slope component"
     }
-  ]
+  ],
+  "verification": {
+    "supplyConsensus": {
+      "ledgerWholeTokens": "11",
+      "contractWholeTokens": "11",
+      "simulationWholeTokens": "11",
+      "participantAggregateWholeTokens": "11",
+      "consistent": true
+    },
+    "pricing": {
+      "contractNextPriceWei": "650000000000000000",
+      "contractNextPriceEth": "0.65",
+      "simulatedNextPriceWei": "650000000000000000",
+      "simulatedNextPriceEth": "0.65",
+      "consistent": true
+    },
+    "capitalFlows": {
+      "ledgerGrossWei": "4500000000000000000",
+      "ledgerGrossEth": "4.5",
+      "ledgerRedemptionsWei": "650000000000000000",
+      "ledgerRedemptionsEth": "0.65",
+      "ledgerNetWei": "3850000000000000000",
+      "ledgerNetEth": "3.85",
+      "simulatedReserveWei": "3850000000000000000",
+      "simulatedReserveEth": "3.85",
+      "contractReserveWei": "0",
+      "contractReserveEth": "0.0",
+      "vaultReceivedWei": "3850000000000000000",
+      "vaultReceivedEth": "3.85",
+      "combinedReserveWei": "3850000000000000000",
+      "combinedReserveEth": "3.85",
+      "consistent": true
+    },
+    "contributions": {
+      "participantAggregateWei": "4500000000000000000",
+      "participantAggregateEth": "4.5",
+      "ledgerGrossWei": "4500000000000000000",
+      "ledgerGrossEth": "4.5",
+      "consistent": true
+    }
+  }
 }

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -25,6 +25,8 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    - proves the sovereign vault pause/unpause circuit breaker
    - finalizes the launch with ignition metadata and prints a comprehensive recap
    - emits an owner parameter matrix table in the console and inside the recap dossier
+   - runs the triple-verification matrix to confirm supply, pricing, capital flows, and participant ledgers agree across all
+     independent checks
 
 2. **Inspect recap artifacts**
 
@@ -38,6 +40,8 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    - bonding curve statistics (supply, reserve balance, pricing)
    - launch outcome summary, including sovereign vault manifest, acknowledgement metadata, and treasury balance
    - `ownerParameterMatrix` providing a full owner control matrix with descriptions
+   - `verification` snapshot documenting the triple-check consensus across supply, pricing, capital flows, and contribution
+     tallies
 
 3. **Render the owner control matrix at any time**
 


### PR DESCRIPTION
## Summary
- extend the alpha-agi-mark orchestration script with a deterministic trade ledger, bonding-curve simulation, and cross-check assertions that emit a triple-verification matrix
- surface the verification results in the recap JSON and sovereign dashboard, adding a dedicated integrity panel and regenerated demo artifacts
- document the new verification workflow in the README and runbook so non-technical operators understand the integrity checks

## Testing
- npm run demo:alpha-agi-mark
- npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts


------
https://chatgpt.com/codex/tasks/task_e_68f13df9e8a88333b756e36c882d44b3