### PR TITLE
Add alpha-agi-mark recap verifier and trade ledger surfaces

### DIFF
--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -119,6 +119,9 @@ jobs:
           console.log('Dashboard dossier structure validated.');
           NODE
 
+      - name: Offline recap triangulation
+        run: npm run verify:alpha-agi-mark
+
       - name: Upload α-AGI MARK recap
         uses: actions/upload-artifact@v4
         with:

--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -76,6 +76,17 @@ To run the Hardhat unit tests for the demo:
 npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts
 ```
 
+### Offline verification
+
+After the demo run completes you can re-validate every figure using an independent triangulation script:
+
+```bash
+npm run verify:alpha-agi-mark
+```
+
+The verifier consumes the recap dossier, replays the trade ledger, recomputes bonding-curve pricing from first
+principles, and prints a "confidence index" table that must reach 100% before sign-off.
+
 ## Sovereign Dashboard
 
 Every demo run now emits a cinematic HTML dossier at `demo/alpha-agi-mark/reports/alpha-mark-dashboard.html`. Open the file in
@@ -84,6 +95,7 @@ any browser to explore:
 - Mission control metrics capturing validator consensus, reserve power, and sovereign vault status
 - A control-deck grid showing every owner actuator with live status badges
 - Full participant ledger plus the operator parameter matrix rendered as responsive tables
+- A trade resonance log charting every buy/sell action and its capital impact
 - An auto-generated Mermaid diagram visualising the launch topology and emergency fail-safes
 
 Regenerate the dashboard at any time from the latest recap JSON:

--- a/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
+++ b/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
@@ -149,6 +149,16 @@
         background: rgba(255, 107, 107, 0.18);
         border-color: rgba(255, 107, 107, 0.6);
       }
+      .badge.buy {
+        color: #5ac8fa;
+        background: rgba(90, 200, 250, 0.18);
+        border-color: rgba(90, 200, 250, 0.6);
+      }
+      .badge.sell {
+        color: #ffaf5f;
+        background: rgba(255, 175, 95, 0.18);
+        border-color: rgba(255, 175, 95, 0.6);
+      }
       table {
         width: 100%;
         border-collapse: collapse;
@@ -356,6 +366,64 @@
       
         </div>
       </section>
+
+      
+      <section>
+        <h2>Trade Resonance Log</h2>
+        <p>Every bonding curve action captured chronologically to prove deterministic capital flows.</p>
+        
+    <table class="ledger-table">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Kind</th>
+          <th>Actor</th>
+          <th>Tokens</th>
+          <th>Value (ETH)</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        <tr>
+          <td>1</td>
+          <td><span class="badge buy">BUY</span></td>
+          <td>Investor A<br /><span class="mono">0x7099…79C8</span></td>
+          <td>5</td>
+          <td>1.0</td>
+        </tr>
+      
+
+        <tr>
+          <td>2</td>
+          <td><span class="badge buy">BUY</span></td>
+          <td>Investor B<br /><span class="mono">0x3C44…93BC</span></td>
+          <td>3</td>
+          <td>1.2</td>
+        </tr>
+      
+
+        <tr>
+          <td>3</td>
+          <td><span class="badge buy">BUY</span></td>
+          <td>Investor C<br /><span class="mono">0x90F7…b906</span></td>
+          <td>4</td>
+          <td>2.3</td>
+        </tr>
+      
+
+        <tr>
+          <td>4</td>
+          <td><span class="badge sell">SELL</span></td>
+          <td>Investor B<br /><span class="mono">0x3C44…93BC</span></td>
+          <td>1</td>
+          <td>0.65</td>
+        </tr>
+      
+      </tbody>
+    </table>
+  
+      </section>
+      
 
       <section>
         <h2>Participant Ledger</h2>

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.json
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.json
@@ -68,18 +68,21 @@
     {
       "address": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
       "tokens": "5.0",
+      "tokensWei": "5000000000000000000",
       "contributionWei": "1000000000000000000",
       "contributionEth": "1.0"
     },
     {
       "address": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
       "tokens": "2.0",
+      "tokensWei": "2000000000000000000",
       "contributionWei": "1200000000000000000",
       "contributionEth": "1.2"
     },
     {
       "address": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
       "tokens": "4.0",
+      "tokensWei": "4000000000000000000",
       "contributionWei": "2300000000000000000",
       "contributionEth": "2.3"
     }
@@ -100,6 +103,40 @@
       "vaultBalanceEth": "3.85"
     }
   },
+  "trades": [
+    {
+      "kind": "BUY",
+      "actor": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+      "label": "Investor A",
+      "tokensWhole": "5",
+      "valueWei": "1000000000000000000",
+      "valueEth": "1.0"
+    },
+    {
+      "kind": "BUY",
+      "actor": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+      "label": "Investor B",
+      "tokensWhole": "3",
+      "valueWei": "1200000000000000000",
+      "valueEth": "1.2"
+    },
+    {
+      "kind": "BUY",
+      "actor": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+      "label": "Investor C",
+      "tokensWhole": "4",
+      "valueWei": "2300000000000000000",
+      "valueEth": "2.3"
+    },
+    {
+      "kind": "SELL",
+      "actor": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+      "label": "Investor B",
+      "tokensWhole": "1",
+      "valueWei": "650000000000000000",
+      "valueEth": "0.65"
+    }
+  ],
   "ownerParameterMatrix": [
     {
       "parameter": "pauseMarket",

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -61,13 +61,22 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
 
    This regenerates the HTML dossier using the latest recap JSON, useful after manual parameter tweaks.
 
-5. **(Optional) Run unit tests**
+5. **Run the offline triangulation verifier**
+
+   ```bash
+   npm run verify:alpha-agi-mark
+   ```
+
+   The script replays the trade ledger from the recap, recomputes the bonding-curve math independently, and
+   prints a confidence index table that must read 100% before green-lighting any external announcement.
+
+6. **(Optional) Run unit tests**
 
    ```bash
    npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts
    ```
 
-6. **(Optional) Dry-run on a fork or external network**
+7. **(Optional) Dry-run on a fork or external network**
 
    Set environment variables before invoking the script:
 

--- a/demo/alpha-agi-mark/scripts/runDemo.ts
+++ b/demo/alpha-agi-mark/scripts/runDemo.ts
@@ -11,6 +11,7 @@ type Address = string;
 interface ParticipantSnapshot {
   address: Address;
   tokens: string;
+  tokensWei: string;
   contributionWei: string;
   contributionEth?: string;
 }
@@ -402,6 +403,7 @@ async function main() {
     participants.push({
       address,
       tokens: ethers.formatEther(balance),
+      tokensWei: balance.toString(),
       contributionWei: contribution.toString(),
       contributionEth: ethers.formatEther(contribution),
     });
@@ -654,6 +656,14 @@ async function main() {
 
   const enrichedRecap = {
     ...recap,
+    trades: tradeLedger.map((entry) => ({
+      kind: entry.kind,
+      actor: entry.actor,
+      label: entry.label,
+      tokensWhole: entry.tokensWhole.toString(),
+      valueWei: entry.valueWei.toString(),
+      valueEth: ethers.formatEther(entry.valueWei),
+    })),
     ownerParameterMatrix,
     verification,
   };

--- a/demo/alpha-agi-mark/scripts/verifyRecap.ts
+++ b/demo/alpha-agi-mark/scripts/verifyRecap.ts
@@ -1,0 +1,218 @@
+import { readFile } from "fs/promises";
+import path from "path";
+
+import { z } from "zod";
+import { formatEther } from "ethers";
+
+const RECAP_PATH = path.join(__dirname, "..", "reports", "alpha-mark-recap.json");
+const WHOLE_TOKEN = 10n ** 18n;
+
+type CheckResult = {
+  label: string;
+  ok: boolean;
+  expected?: string;
+  actual?: string;
+};
+
+const tradeSchema = z.object({
+  kind: z.enum(["BUY", "SELL"]),
+  actor: z.string(),
+  label: z.string(),
+  tokensWhole: z.string(),
+  valueWei: z.string(),
+  valueEth: z.string().optional(),
+});
+
+const participantSchema = z.object({
+  address: z.string(),
+  tokens: z.string(),
+  tokensWei: z.string(),
+  contributionWei: z.string(),
+  contributionEth: z.string().optional(),
+});
+
+const recapSchema = z.object({
+  bondingCurve: z.object({
+    supplyWholeTokens: z.string(),
+    reserveWei: z.string(),
+    nextPriceWei: z.string(),
+    basePriceWei: z.string(),
+    slopeWei: z.string(),
+  }),
+  ownerControls: z.object({
+    basePriceWei: z.string(),
+    slopeWei: z.string(),
+    fundingCapWei: z.string(),
+    finalized: z.boolean(),
+    aborted: z.boolean(),
+  }),
+  launch: z.object({
+    sovereignVault: z.object({
+      totalReceivedWei: z.string(),
+    }),
+  }),
+  participants: z.array(participantSchema).nonempty("Participant ledger is empty"),
+  trades: z.array(tradeSchema).nonempty("Trade ledger is empty"),
+  verification: z
+    .object({
+      supplyConsensus: z.object({ consistent: z.boolean() }),
+      pricing: z.object({ consistent: z.boolean() }),
+      capitalFlows: z.object({ consistent: z.boolean() }),
+      contributions: z.object({ consistent: z.boolean() }),
+    })
+    .optional(),
+});
+
+function parseBigInt(value: string, label: string): bigint {
+  try {
+    return BigInt(value);
+  } catch (error) {
+    throw new Error(`Failed to parse ${label} as bigint (value: ${value})`);
+  }
+}
+
+function formatWei(value: bigint): string {
+  return `${value.toString()} wei (${formatEther(value)} ETH)`;
+}
+
+function main() {
+  return readFile(RECAP_PATH, "utf8")
+    .then((raw) => recapSchema.parse(JSON.parse(raw)))
+    .then((recap) => {
+      const checks: CheckResult[] = [];
+
+      const supply = parseBigInt(recap.bondingCurve.supplyWholeTokens, "bonding curve supply");
+      const reserveWei = parseBigInt(recap.bondingCurve.reserveWei, "reserve balance");
+      const nextPrice = parseBigInt(recap.bondingCurve.nextPriceWei, "next price");
+      const basePrice = parseBigInt(recap.ownerControls.basePriceWei, "base price");
+      const slope = parseBigInt(recap.ownerControls.slopeWei, "slope");
+      const fundingCap = parseBigInt(recap.ownerControls.fundingCapWei, "funding cap");
+      const vaultReceived = parseBigInt(
+        recap.launch.sovereignVault.totalReceivedWei,
+        "sovereign vault receipts",
+      );
+
+      let ledgerSupply = 0n;
+      let ledgerGrossWei = 0n;
+      let ledgerSellWei = 0n;
+      recap.trades.forEach((trade, index) => {
+        const tokens = parseBigInt(trade.tokensWhole, `trade[${index}].tokensWhole`);
+        const value = parseBigInt(trade.valueWei, `trade[${index}].valueWei`);
+        if (trade.kind === "BUY") {
+          ledgerSupply += tokens;
+          ledgerGrossWei += value;
+        } else {
+          ledgerSupply -= tokens;
+          ledgerSellWei += value;
+        }
+        if (ledgerSupply < 0n) {
+          throw new Error(
+            `Trade ledger became negative after processing index ${index} (${trade.kind}).`,
+          );
+        }
+      });
+      const ledgerNetWei = ledgerGrossWei - ledgerSellWei;
+
+      const participantContributionSum = recap.participants.reduce((acc, participant) => {
+        return acc + parseBigInt(participant.contributionWei, `participant ${participant.address} contribution`);
+      }, 0n);
+
+      const participantTokenWeiSum = recap.participants.reduce((acc, participant) => {
+        return acc + parseBigInt(participant.tokensWei, `participant ${participant.address} token balance`);
+      }, 0n);
+
+      const expectedNextPrice = basePrice + slope * supply;
+
+      const appendCheck = (label: string, ok: boolean, expected?: string, actual?: string) => {
+        checks.push({ label, ok, expected, actual });
+      };
+
+      appendCheck(
+        "Trade ledger supply equals recorded supply",
+        ledgerSupply === supply,
+        supply.toString(),
+        ledgerSupply.toString(),
+      );
+
+      appendCheck(
+        "Participant balances equal supply (wei)",
+        participantTokenWeiSum === supply * WHOLE_TOKEN,
+        (supply * WHOLE_TOKEN).toString(),
+        participantTokenWeiSum.toString(),
+      );
+
+      appendCheck(
+        "Next price matches base + slope * supply",
+        expectedNextPrice === nextPrice,
+        formatWei(expectedNextPrice),
+        formatWei(nextPrice),
+      );
+
+      appendCheck(
+        "Vault receipts + reserve equal net capital",
+        reserveWei + vaultReceived === ledgerNetWei,
+        formatWei(ledgerNetWei),
+        formatWei(reserveWei + vaultReceived),
+      );
+
+      appendCheck(
+        "Participant contributions equal gross capital",
+        participantContributionSum === ledgerGrossWei,
+        formatWei(ledgerGrossWei),
+        formatWei(participantContributionSum),
+      );
+
+      appendCheck(
+        "Funding cap respected",
+        fundingCap === 0n || ledgerGrossWei <= fundingCap,
+        fundingCap === 0n ? "Unlimited" : formatWei(fundingCap),
+        formatWei(ledgerGrossWei),
+      );
+
+      if (recap.verification) {
+        appendCheck(
+          "Embedded verification flag: supply",
+          recap.verification.supplyConsensus.consistent,
+        );
+        appendCheck(
+          "Embedded verification flag: pricing",
+          recap.verification.pricing.consistent,
+        );
+        appendCheck(
+          "Embedded verification flag: capital flows",
+          recap.verification.capitalFlows.consistent,
+        );
+        appendCheck(
+          "Embedded verification flag: contributions",
+          recap.verification.contributions.consistent,
+        );
+      }
+
+      const passCount = checks.filter((check) => check.ok).length;
+      const confidence = (passCount / checks.length) * 100;
+
+      console.log("\nα-AGI MARK recap verification (independent triangulation)");
+      console.table(
+        checks.map((check) => ({
+          Check: check.label,
+          Pass: check.ok ? "✅" : "❌",
+          Expected: check.expected ?? "-",
+          Actual: check.actual ?? "-",
+        })),
+      );
+
+      console.log(
+        `\nConfidence index: ${confidence.toFixed(2)}% (${passCount}/${checks.length} checks passed).`,
+      );
+
+      if (checks.some((check) => !check.ok)) {
+        throw new Error("Recap verification failed – inspect the table above for discrepancies.");
+      }
+    })
+    .catch((error) => {
+      console.error("Verification failed:", error.message ?? error);
+      process.exitCode = 1;
+    });
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -161,7 +161,8 @@
     "demo:alpha-agi-mark:ci": "AGIJOBS_DEMO_DRY_RUN=true npm run demo:alpha-agi-mark",
     "test:alpha-agi-mark": "npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts",
     "owner:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/exportOwnerMatrix.ts",
-    "dashboard:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateDashboard.ts"
+    "dashboard:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateDashboard.ts",
+    "verify:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/verifyRecap.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add an offline recap verification script that rebuilds ledger math and reports a confidence index, wiring it into the CI workflow
- expose detailed trade ledger entries and raw token balances in the demo recap and dashboard so non-technical operators can audit flows visually
- document the new verification flow and npm script in the alpha-agi-mark README and runbook

## Testing
- npm run test:alpha-agi-mark
- npm run demo:alpha-agi-mark:ci
- npm run verify:alpha-agi-mark

------
https://chatgpt.com/codex/tasks/task_e_68f148067c8c8333b5852bce2b9f8731