### PR TITLE
Add integrity dossier automation to alpha-agi-mark demo

### DIFF
--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -122,8 +122,40 @@ jobs:
       - name: Offline recap triangulation
         run: npm run verify:alpha-agi-mark
 
+      - name: Build integrity dossier
+        run: npm run integrity:alpha-agi-mark
+
+      - name: Validate integrity dossier
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = 'demo/alpha-agi-mark/reports/alpha-mark-integrity.md';
+          if (!fs.existsSync(path)) {
+            throw new Error('integrity dossier missing');
+          }
+          const content = fs.readFileSync(path, 'utf8');
+          const requiredSections = [
+            '# α-AGI MARK Integrity Report',
+            '## Confidence Summary',
+            '```mermaid',
+            'Owner Command Deck Snapshot',
+          ];
+          for (const section of requiredSections) {
+            if (!content.includes(section)) {
+              throw new Error(`integrity dossier missing section: ${section}`);
+            }
+          }
+          console.log('Integrity dossier validated.');
+          NODE
+
       - name: Upload α-AGI MARK recap
         uses: actions/upload-artifact@v4
         with:
           name: alpha-agi-mark-recap
           path: demo/alpha-agi-mark/reports/alpha-mark-recap.json
+
+      - name: Upload α-AGI MARK integrity dossier
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpha-agi-mark-integrity
+          path: demo/alpha-agi-mark/reports/alpha-mark-integrity.md

--- a/demo/alpha-agi-mark/.gitignore
+++ b/demo/alpha-agi-mark/.gitignore
@@ -4,3 +4,4 @@ typechain-types/
 reports/*
 !reports/alpha-mark-recap.json
 !reports/alpha-mark-dashboard.html
+!reports/alpha-mark-integrity.md

--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -87,6 +87,16 @@ npm run verify:alpha-agi-mark
 The verifier consumes the recap dossier, replays the trade ledger, recomputes bonding-curve pricing from first
 principles, and prints a "confidence index" table that must reach 100% before sign-off.
 
+For a presentation-ready briefing, render the integrity report:
+
+```bash
+npm run integrity:alpha-agi-mark
+```
+
+This generates `reports/alpha-mark-integrity.md` – a mermaid-enhanced dossier that summarises the
+confidence matrix, owner controls, validator quorum, and participant contributions so non-technical
+stakeholders can sign off in minutes.
+
 ## Sovereign Dashboard
 
 Every demo run now emits a cinematic HTML dossier at `demo/alpha-agi-mark/reports/alpha-mark-dashboard.html`. Open the file in

--- a/demo/alpha-agi-mark/reports/alpha-mark-integrity.md
+++ b/demo/alpha-agi-mark/reports/alpha-mark-integrity.md
@@ -1,0 +1,72 @@
+# α-AGI MARK Integrity Report
+
+Generated: 2025-10-16T20:09:48.930Z
+
+## Confidence Summary
+
+- Confidence index: 100.00% (10/10 checks passed)
+- Validator quorum: 2/2
+- Ledger supply processed: 11 whole tokens
+- Gross capital processed: 4500000000000000000 wei (4.5 ETH)
+- Net capital secured in sovereign reserve: 3850000000000000000 wei (3.85 ETH)
+
+| Check | Status | Expected | Observed |
+|---|:---:|---|---|
+| Ledger supply equals recorded supply | ✅ | 11 | 11 |
+| Participant balances equal supply | ✅ | 11000000000000000000 | 11000000000000000000 |
+| Next price matches base + slope * supply | ✅ | 650000000000000000 wei (0.65 ETH) | 650000000000000000 wei (0.65 ETH) |
+| Vault receipts + reserve equal net capital | ✅ | 3850000000000000000 wei (3.85 ETH) | 3850000000000000000 wei (3.85 ETH) |
+| Participant contributions equal gross capital | ✅ | 4500000000000000000 wei (4.5 ETH) | 4500000000000000000 wei (4.5 ETH) |
+| Funding cap respected | ✅ | 1000000000000000000000 wei (1000.0 ETH) | 4500000000000000000 wei (4.5 ETH) |
+| Embedded verification: supply | ✅ | - | - |
+| Embedded verification: pricing | ✅ | - | - |
+| Embedded verification: capital flows | ✅ | - | - |
+| Embedded verification: contributions | ✅ | - | - |
+
+## Participant Contribution Constellation
+
+```mermaid
+pie title Contribution resonance (ETH)
+    "0x7099…79C8" : 1.0000
+    "0x3C44…93BC" : 1.2000
+    "0x90F7…b906" : 2.3000
+```
+
+## Launch Telemetry
+
+| Metric | Value |
+|---|---|
+| Supply | 11 SeedShares |
+| Next price | 650000000000000000 wei (0.65 ETH) |
+| Base price | 100000000000000000 wei (0.1 ETH) |
+| Slope | 50000000000000000 wei (0.05 ETH) |
+| Reserve balance | 0 wei (0.0 ETH) |
+| Sovereign vault receipts | 3850000000000000000 wei (3.85 ETH) |
+| Last acknowledged amount | 3850000000000000000 wei (3.85 ETH) |
+| Vault balance | 3850000000000000000 wei (3.85 ETH) |
+| Treasury address | 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 |
+| Sovereign vault | ipfs://alpha-mark/sovereign/genesis |
+| Sovereign metadata | α-AGI Sovereign ignition: Nova-Seed ascends |
+
+## Owner Command Deck Snapshot
+
+- ✅ Market paused
+- ✅ Whitelist enforced
+- ❌ Emergency exit armed
+- ✅ Launch finalized
+- ❌ Launch aborted
+- ❌ Validation override enabled
+
+### Control Parameters
+
+| Parameter | Value |
+|---|---|
+| Funding cap | 1000.0 |
+| Max supply | 100 SeedShares |
+| Sale deadline | 0 |
+| Treasury | 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 |
+| Risk oracle | 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0 |
+| Base asset | 0x0000000000000000000000000000000000000000 |
+| Uses native asset | Yes (native ETH) |
+| Base price (wei) | 100000000000000000 |
+| Slope (wei) | 50000000000000000 |

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -70,13 +70,23 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    The script replays the trade ledger from the recap, recomputes the bonding-curve math independently, and
    prints a confidence index table that must read 100% before green-lighting any external announcement.
 
-6. **(Optional) Run unit tests**
+6. **Emit the integrity dossier for stakeholder sign-off**
+
+   ```bash
+   npm run integrity:alpha-agi-mark
+   ```
+
+   Produces `demo/alpha-agi-mark/reports/alpha-mark-integrity.md`, a Markdown control-room report with
+   the verification table, owner command deck snapshot, and a mermaid contribution pie chart. Circulate
+   it alongside the dashboard for executive approval.
+
+7. **(Optional) Run unit tests**
 
    ```bash
    npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts
    ```
 
-7. **(Optional) Dry-run on a fork or external network**
+8. **(Optional) Dry-run on a fork or external network**
 
    Set environment variables before invoking the script:
 

--- a/demo/alpha-agi-mark/scripts/generateIntegrityReport.ts
+++ b/demo/alpha-agi-mark/scripts/generateIntegrityReport.ts
@@ -1,0 +1,372 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+
+import { formatEther } from "ethers";
+import { z } from "zod";
+
+const REPORT_DIR = path.join(__dirname, "..", "reports");
+const RECAP_PATH = path.join(REPORT_DIR, "alpha-mark-recap.json");
+const REPORT_PATH = path.join(REPORT_DIR, "alpha-mark-integrity.md");
+
+const tradeSchema = z.object({
+  kind: z.enum(["BUY", "SELL"]),
+  actor: z.string(),
+  label: z.string(),
+  tokensWhole: z.string(),
+  valueWei: z.string(),
+});
+
+const participantSchema = z.object({
+  address: z.string(),
+  tokens: z.string(),
+  tokensWei: z.string(),
+  contributionWei: z.string(),
+  contributionEth: z.string().optional(),
+});
+
+const recapSchema = z.object({
+  generatedAt: z.string().optional(),
+  bondingCurve: z.object({
+    supplyWholeTokens: z.string(),
+    reserveWei: z.string(),
+    nextPriceWei: z.string(),
+    basePriceWei: z.string(),
+    slopeWei: z.string(),
+    reserveEth: z.string().optional(),
+    nextPriceEth: z.string().optional(),
+  }),
+  ownerControls: z.object({
+    paused: z.boolean(),
+    whitelistEnabled: z.boolean(),
+    emergencyExitEnabled: z.boolean(),
+    finalized: z.boolean(),
+    aborted: z.boolean(),
+    validationOverrideEnabled: z.boolean(),
+    validationOverrideStatus: z.boolean(),
+    treasury: z.string(),
+    riskOracle: z.string(),
+    baseAsset: z.string(),
+    usesNativeAsset: z.boolean(),
+    fundingCapWei: z.string(),
+    fundingCapEth: z.string().optional(),
+    maxSupplyWholeTokens: z.string(),
+    saleDeadlineTimestamp: z.string(),
+    basePriceWei: z.string(),
+    basePriceEth: z.string().optional(),
+    slopeWei: z.string(),
+    slopeEth: z.string().optional(),
+  }),
+  validators: z
+    .object({
+      approvalCount: z.string(),
+      approvalThreshold: z.string(),
+      members: z.array(z.string()),
+    })
+    .optional(),
+  participants: z.array(participantSchema),
+  trades: z.array(tradeSchema),
+  launch: z.object({
+    finalized: z.boolean(),
+    aborted: z.boolean(),
+    treasury: z.string(),
+    sovereignVault: z.object({
+      manifestUri: z.string(),
+      totalReceivedWei: z.string(),
+      totalReceivedEth: z.string().optional(),
+      lastAcknowledgedAmountWei: z.string(),
+      lastAcknowledgedAmountEth: z.string().optional(),
+      lastAcknowledgedMetadataHex: z.string().optional(),
+      decodedMetadata: z.string().optional(),
+      vaultBalanceWei: z.string().optional(),
+      vaultBalanceEth: z.string().optional(),
+    }),
+  }),
+  verification: z
+    .object({
+      supplyConsensus: z.object({
+        ledgerWholeTokens: z.string(),
+        contractWholeTokens: z.string(),
+        simulationWholeTokens: z.string(),
+        participantAggregateWholeTokens: z.string(),
+        consistent: z.boolean(),
+      }),
+      pricing: z.object({
+        contractNextPriceWei: z.string(),
+        simulatedNextPriceWei: z.string(),
+        consistent: z.boolean(),
+      }),
+      capitalFlows: z.object({
+        ledgerGrossWei: z.string(),
+        ledgerRedemptionsWei: z.string(),
+        ledgerNetWei: z.string(),
+        simulatedReserveWei: z.string(),
+        contractReserveWei: z.string(),
+        vaultReceivedWei: z.string(),
+        combinedReserveWei: z.string(),
+        consistent: z.boolean(),
+      }),
+      contributions: z.object({
+        participantAggregateWei: z.string(),
+        ledgerGrossWei: z.string(),
+        consistent: z.boolean(),
+      }),
+    })
+    .optional(),
+});
+
+type Recap = z.infer<typeof recapSchema>;
+
+type CheckResult = {
+  label: string;
+  ok: boolean;
+  expected?: string;
+  observed?: string;
+};
+
+function parseBigInt(label: string, value: string): bigint {
+  try {
+    return BigInt(value);
+  } catch (error) {
+    throw new Error(`Failed to parse ${label} (${value}) as bigint`);
+  }
+}
+
+function asEth(value: bigint): string {
+  return `${value.toString()} wei (${formatEther(value)} ETH)`;
+}
+
+function badge(flag: boolean): string {
+  return flag ? "✅" : "❌";
+}
+
+function shortAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function buildChecks(recap: Recap) {
+  const checks: CheckResult[] = [];
+
+  const supply = parseBigInt("recorded supply", recap.bondingCurve.supplyWholeTokens);
+  const reserve = parseBigInt("reserve balance", recap.bondingCurve.reserveWei);
+  const nextPrice = parseBigInt("next price", recap.bondingCurve.nextPriceWei);
+  const basePrice = parseBigInt("base price", recap.bondingCurve.basePriceWei);
+  const slope = parseBigInt("slope", recap.bondingCurve.slopeWei);
+  const fundingCap = parseBigInt("funding cap", recap.ownerControls.fundingCapWei);
+  const vaultReceived = parseBigInt(
+    "sovereign vault receipts",
+    recap.launch.sovereignVault.totalReceivedWei,
+  );
+
+  let ledgerSupply = 0n;
+  let ledgerGross = 0n;
+  let ledgerRedemptions = 0n;
+  for (const trade of recap.trades) {
+    const tokens = parseBigInt(`trade tokens (${trade.label})`, trade.tokensWhole);
+    const value = parseBigInt(`trade value (${trade.label})`, trade.valueWei);
+    if (trade.kind === "BUY") {
+      ledgerSupply += tokens;
+      ledgerGross += value;
+    } else {
+      ledgerSupply -= tokens;
+      ledgerRedemptions += value;
+    }
+  }
+  if (ledgerSupply < 0n) {
+    throw new Error("Trade ledger yields negative supply");
+  }
+  const ledgerNet = ledgerGross - ledgerRedemptions;
+  const expectedNextPrice = basePrice + slope * supply;
+
+  const participantTokenSum = recap.participants.reduce((acc, participant) => {
+    return acc + parseBigInt(`participant token balance (${participant.address})`, participant.tokensWei);
+  }, 0n);
+
+  const participantContributionSum = recap.participants.reduce((acc, participant) => {
+    return acc + parseBigInt(`participant contribution (${participant.address})`, participant.contributionWei);
+  }, 0n);
+
+  checks.push({
+    label: "Ledger supply equals recorded supply",
+    ok: ledgerSupply === supply,
+    expected: supply.toString(),
+    observed: ledgerSupply.toString(),
+  });
+
+  checks.push({
+    label: "Participant balances equal supply",
+    ok: participantTokenSum === supply * 10n ** 18n,
+    expected: (supply * 10n ** 18n).toString(),
+    observed: participantTokenSum.toString(),
+  });
+
+  checks.push({
+    label: "Next price matches base + slope * supply",
+    ok: expectedNextPrice === nextPrice,
+    expected: asEth(expectedNextPrice),
+    observed: asEth(nextPrice),
+  });
+
+  checks.push({
+    label: "Vault receipts + reserve equal net capital",
+    ok: reserve + vaultReceived === ledgerNet,
+    expected: asEth(ledgerNet),
+    observed: asEth(reserve + vaultReceived),
+  });
+
+  checks.push({
+    label: "Participant contributions equal gross capital",
+    ok: participantContributionSum === ledgerGross,
+    expected: asEth(ledgerGross),
+    observed: asEth(participantContributionSum),
+  });
+
+  checks.push({
+    label: "Funding cap respected",
+    ok: fundingCap === 0n || ledgerGross <= fundingCap,
+    expected: fundingCap === 0n ? "Unlimited" : asEth(fundingCap),
+    observed: asEth(ledgerGross),
+  });
+
+  if (recap.verification) {
+    checks.push({
+      label: "Embedded verification: supply",
+      ok: recap.verification.supplyConsensus.consistent,
+    });
+    checks.push({
+      label: "Embedded verification: pricing",
+      ok: recap.verification.pricing.consistent,
+    });
+    checks.push({
+      label: "Embedded verification: capital flows",
+      ok: recap.verification.capitalFlows.consistent,
+    });
+    checks.push({
+      label: "Embedded verification: contributions",
+      ok: recap.verification.contributions.consistent,
+    });
+  }
+
+  return {
+    checks,
+    ledgerGross,
+    ledgerNet,
+    ledgerSupply,
+    ledgerRedemptions,
+  };
+}
+
+function renderChecksTable(checks: CheckResult[]): string {
+  const header = "| Check | Status | Expected | Observed |";
+  const separator = "|---|:---:|---|---|";
+  const rows = checks.map((check) => {
+    const status = check.ok ? "✅" : "❌";
+    const expected = check.expected ?? "-";
+    const observed = check.observed ?? "-";
+    return `| ${check.label} | ${status} | ${expected} | ${observed} |`;
+  });
+  return [header, separator, ...rows].join("\n");
+}
+
+function renderOwnerControls(controls: Recap["ownerControls"]): string {
+  const items = [
+    { label: "Market paused", flag: controls.paused },
+    { label: "Whitelist enforced", flag: controls.whitelistEnabled },
+    { label: "Emergency exit armed", flag: controls.emergencyExitEnabled },
+    { label: "Launch finalized", flag: controls.finalized },
+    { label: "Launch aborted", flag: controls.aborted },
+    { label: "Validation override enabled", flag: controls.validationOverrideEnabled },
+  ];
+  return items
+    .map((item) => `- ${badge(item.flag)} ${item.label}`)
+    .join("\n");
+}
+
+function renderContributionPie(participants: Recap["participants"]): string {
+  const lines = participants.map((participant) => {
+    const contributionValue = parseBigInt(
+      `participant contribution (${participant.address})`,
+      participant.contributionWei,
+    );
+    const contribution = parseFloat(participant.contributionEth ?? formatEther(contributionValue));
+    return `    \"${shortAddress(participant.address)}\" : ${contribution.toFixed(4)}`;
+  });
+  return ["```mermaid", "pie title Contribution resonance (ETH)", ...lines, "```"].join("\n");
+}
+
+async function main() {
+  await mkdir(REPORT_DIR, { recursive: true });
+  const raw = await readFile(RECAP_PATH, "utf8");
+  const recap = recapSchema.parse(JSON.parse(raw));
+
+  const { checks, ledgerGross, ledgerNet, ledgerSupply } = buildChecks(recap);
+  const passCount = checks.filter((check) => check.ok).length;
+  const confidence = (passCount / checks.length) * 100;
+
+  const generatedAt = recap.generatedAt
+    ? new Date(recap.generatedAt).toISOString()
+    : new Date().toISOString();
+
+  const contributionPie = renderContributionPie(recap.participants);
+  const ownerControls = renderOwnerControls(recap.ownerControls);
+  const validatorSummary = recap.validators
+    ? `Validator quorum: ${recap.validators.approvalCount}/${recap.validators.approvalThreshold}`
+    : "Validator quorum: (not available in recap)";
+  const metadataDisplay =
+    recap.launch.sovereignVault.decodedMetadata ??
+    recap.launch.sovereignVault.lastAcknowledgedMetadataHex ??
+    "Unavailable";
+  const vaultBalanceDisplay = recap.launch.sovereignVault.vaultBalanceWei
+    ? asEth(parseBigInt("vault balance", recap.launch.sovereignVault.vaultBalanceWei))
+    : "Unavailable";
+  const lastAcknowledgedAmountDisplay = asEth(
+    parseBigInt("last acknowledged amount", recap.launch.sovereignVault.lastAcknowledgedAmountWei),
+  );
+
+  const markdown = `# α-AGI MARK Integrity Report\n\n` +
+    `Generated: ${generatedAt}\n\n` +
+    `## Confidence Summary\n\n` +
+    `- Confidence index: ${confidence.toFixed(2)}% (${passCount}/${checks.length} checks passed)\n` +
+    `- ${validatorSummary}\n` +
+    `- Ledger supply processed: ${ledgerSupply.toString()} whole tokens\n` +
+    `- Gross capital processed: ${asEth(ledgerGross)}\n` +
+    `- Net capital secured in sovereign reserve: ${asEth(ledgerNet)}\n\n` +
+    `${renderChecksTable(checks)}\n\n` +
+    `## Participant Contribution Constellation\n\n` +
+    `${contributionPie}\n\n` +
+    `## Launch Telemetry\n\n` +
+    `| Metric | Value |\n|---|---|\n` +
+    `| Supply | ${recap.bondingCurve.supplyWholeTokens} SeedShares |\n` +
+    `| Next price | ${asEth(parseBigInt("next price", recap.bondingCurve.nextPriceWei))} |\n` +
+    `| Base price | ${asEth(parseBigInt("base price", recap.bondingCurve.basePriceWei))} |\n` +
+    `| Slope | ${asEth(parseBigInt("slope", recap.bondingCurve.slopeWei))} |\n` +
+    `| Reserve balance | ${asEth(parseBigInt("reserve", recap.bondingCurve.reserveWei))} |\n` +
+    `| Sovereign vault receipts | ${asEth(parseBigInt("vault", recap.launch.sovereignVault.totalReceivedWei))} |\n` +
+    `| Last acknowledged amount | ${lastAcknowledgedAmountDisplay} |\n` +
+    `| Vault balance | ${vaultBalanceDisplay} |\n` +
+    `| Treasury address | ${recap.launch.treasury} |\n` +
+    `| Sovereign vault | ${recap.launch.sovereignVault.manifestUri} |\n` +
+    `| Sovereign metadata | ${metadataDisplay} |\n\n` +
+    `## Owner Command Deck Snapshot\n\n` +
+    `${ownerControls}\n\n` +
+    `### Control Parameters\n\n` +
+    `| Parameter | Value |\n|---|---|\n` +
+    `| Funding cap | ${recap.ownerControls.fundingCapEth ?? asEth(parseBigInt("funding cap", recap.ownerControls.fundingCapWei))} |\n` +
+    `| Max supply | ${recap.ownerControls.maxSupplyWholeTokens} SeedShares |\n` +
+    `| Sale deadline | ${recap.ownerControls.saleDeadlineTimestamp} |\n` +
+    `| Treasury | ${recap.ownerControls.treasury} |\n` +
+    `| Risk oracle | ${recap.ownerControls.riskOracle} |\n` +
+    `| Base asset | ${recap.ownerControls.baseAsset} |\n` +
+    `| Uses native asset | ${recap.ownerControls.usesNativeAsset ? 'Yes (native ETH)' : 'No (ERC-20 base asset)'} |\n` +
+    `| Base price (wei) | ${recap.ownerControls.basePriceWei} |\n` +
+    `| Slope (wei) | ${recap.ownerControls.slopeWei} |\n`;
+
+  await writeFile(REPORT_PATH, markdown, "utf8");
+  console.log(`📝 α-AGI MARK integrity report generated at ${REPORT_PATH}`);
+  console.log(`Confidence index ${confidence.toFixed(2)}% (${passCount}/${checks.length}).`);
+}
+
+main().catch((error) => {
+  console.error("Failed to generate integrity report:", error);
+  process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -162,7 +162,8 @@
     "test:alpha-agi-mark": "npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts",
     "owner:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/exportOwnerMatrix.ts",
     "dashboard:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateDashboard.ts",
-    "verify:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/verifyRecap.ts"
+    "verify:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/verifyRecap.ts",
+    "integrity:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateIntegrityReport.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a TypeScript integrity report generator that turns the recap JSON into a markdown dossier with mermaid visuals and full verification tables
- document the new `npm run integrity:alpha-agi-mark` workflow in the README and runbook so non-technical operators can publish the report
- extend the α-AGI MARK demo CI to build, validate, and upload the integrity dossier alongside the recap

## Testing
- npm run integrity:alpha-agi-mark
- npm run verify:alpha-agi-mark
- npm run test:alpha-agi-mark

------
https://chatgpt.com/codex/tasks/task_e_68f14fd4b2b48333986def1506976f60