### PR TITLE
Ensure sovereign vault accounting tracks ERC20 launches

### DIFF
--- a/demo/alpha-agi-mark/contracts/AlphaSovereignVault.sol
+++ b/demo/alpha-agi-mark/contracts/AlphaSovereignVault.sol
@@ -50,8 +50,18 @@ contract AlphaSovereignVault is Ownable, Pausable, ReentrancyGuard {
         _unpause();
     }
 
-    function notifyLaunch(uint256 amount, bytes calldata metadata) external whenNotPaused returns (bool) {
+    function notifyLaunch(uint256 amount, bytes calldata metadata)
+        external
+        payable
+        whenNotPaused
+        returns (bool)
+    {
         require(msg.sender == markExchange, "Unauthorized sender");
+        if (msg.value > 0) {
+            require(msg.value == amount, "Native amount mismatch");
+        }
+        uint256 credit = msg.value > 0 ? msg.value : amount;
+        totalReceived += credit;
         lastAcknowledgedAmount = amount;
         lastAcknowledgedMetadata = metadata;
         emit LaunchAcknowledged(msg.sender, amount, metadata, block.timestamp);

--- a/demo/alpha-agi-mark/test/AlphaMarkGovernance.test.ts
+++ b/demo/alpha-agi-mark/test/AlphaMarkGovernance.test.ts
@@ -107,6 +107,7 @@ describe("α-AGI MARK owner governance", function () {
     expect(await mark.finalized()).to.equal(true);
     expect(await mark.reserveBalance()).to.equal(0n);
     expect(await stable.balanceOf(vault.target)).to.equal(cost);
+    expect(await vault.totalReceived()).to.equal(cost);
     expect(await vault.lastAcknowledgedAmount()).to.equal(cost);
     expect(await vault.lastAcknowledgedMetadata()).to.equal(metadata);
   });
@@ -144,9 +145,11 @@ describe("α-AGI MARK owner governance", function () {
       .to.emit(vault, "LaunchAcknowledged")
       .withArgs(owner.address, 123n, metadata, anyValue);
 
+    expect(await vault.totalReceived()).to.equal(123n);
+
     const depositAmount = toWei("1");
     await owner.sendTransaction({ to: vault.target, value: depositAmount });
-    expect(await vault.totalReceived()).to.equal(depositAmount);
+    expect(await vault.totalReceived()).to.equal(depositAmount + 123n);
 
     await expect(vault.connect(other).withdraw(recipient.address, toWei("0.1")))
       .to.be.revertedWithCustomError(vault, "OwnableUnauthorizedAccount");


### PR DESCRIPTION
## Summary
- route native finalizations through the sovereign vault acknowledgement so contract recipients receive funds atomically
- make `AlphaSovereignVault.notifyLaunch` payable and track total received capital for both native and ERC-20 launches
- extend governance tests to assert vault accounting for ERC-20 settlements and manual acknowledgements

## Testing
- npm run test:alpha-agi-mark
- npm run demo:alpha-agi-mark

------
https://chatgpt.com/codex/tasks/task_e_68f15d68fda083339198de715896c0c0