### PR TITLE
Enhance alpha-agi-mark telemetry and verification

### DIFF
--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -130,6 +130,17 @@ flowchart LR
     Verifier --> Recap[(alpha-mark-recap.json)]
 ```
 
+## Execution Telemetry & Confidence Index
+
+Each demo export now carries an `execution` telemetry block with the operator address, target network, broadcast mode
+(dry-run sentinel vs. live), and the exact AGI Jobs command that orchestrated the launch. The recap, dashboard, and integrity
+dossier surface this context so non-technical reviewers can trace every decision back to a timestamped operator session.
+
+The triple-verification output also publishes a numerical confidence index derived from the supply, pricing, capital flow, and
+contribution checks. Both the recap verifier (`npm run verify:alpha-agi-mark`) and the integrity dossier generation tool
+recompute the index independently and refuse to pass if the recorded percentage or check counts drift from the raw ledger.
+This closes the loop between automation, documentation, and owner oversight.
+
 ## Owner Controls
 
 The demo enumerates all tunable controls in the final recap:

--- a/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
+++ b/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
@@ -58,6 +58,57 @@
         letter-spacing: 0.06em;
         text-transform: uppercase;
       }
+      .telemetry-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1.5rem;
+      }
+      .telemetry-grid article {
+        background: rgba(255, 255, 255, 0.03);
+        border-radius: 14px;
+        padding: 1.2rem;
+        border: 1px solid rgba(96, 255, 207, 0.16);
+        box-shadow: inset 0 0 25px rgba(96, 255, 207, 0.08);
+      }
+      .telemetry-grid h3 {
+        margin-top: 0;
+        font-size: 1rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(255, 255, 255, 0.72);
+      }
+      .telemetry-grid ul {
+        list-style: none;
+        padding-left: 0;
+        margin: 0;
+        display: grid;
+        gap: 0.35rem;
+      }
+      .telemetry-grid li {
+        background: rgba(255, 255, 255, 0.05);
+        border-radius: 999px;
+        padding: 0.3rem 0.8rem;
+        display: inline-flex;
+        align-items: center;
+        width: fit-content;
+        border: 1px solid rgba(96, 255, 207, 0.15);
+      }
+      .timestamp {
+        margin-top: 1.5rem;
+        color: rgba(255, 255, 255, 0.7);
+      }
+      .confidence-indicator {
+        background: rgba(96, 255, 207, 0.1);
+        border: 1px solid rgba(96, 255, 207, 0.35);
+        border-radius: 12px;
+        padding: 0.85rem 1rem;
+        font-weight: 600;
+        max-width: 420px;
+      }
+      .confidence-indicator span {
+        color: var(--accent);
+        font-weight: 700;
+      }
       .metrics {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -217,6 +268,35 @@
         </p>
       </header>
 
+      
+    <section>
+      <h2>Execution Telemetry</h2>
+      <div class="telemetry-grid">
+        <article>
+          <h3>Network</h3>
+          <p class="mono">hardhat (chainId 31337)</p>
+          <p class="mono">Chain ID: 31337</p>
+          <p>Dry-run sentinel active</p>
+        </article>
+        <article>
+          <h3>Operator</h3>
+          <p class="mono">0xf39F…2266</p>
+          <p>AGI Jobs v0 (v2)</p>
+          <p class="mono">npm run demo:alpha-agi-mark</p>
+        </article>
+        <article>
+          <h3>Investors</h3>
+          <ul><li class="mono">0x7099…79C8</li><li class="mono">0x3C44…93BC</li><li class="mono">0x90F7…b906</li></ul>
+        </article>
+        <article>
+          <h3>Validators</h3>
+          <ul><li class="mono">0x15d3…6A65</li><li class="mono">0x9965…A4dc</li><li class="mono">0x976E…0aa9</li></ul>
+        </article>
+      </div>
+      <p class="timestamp">Telemetry generated at <span class="mono">2025-10-16T21:10:18.031Z</span></p>
+    </section>
+  
+
       <section>
         <h2>Mission Control Metrics</h2>
         <div class="metrics">
@@ -260,6 +340,12 @@
         Independent ledgers, on-chain state introspection, and first-principles math cross-check the sovereign launch
         in real time.
       </p>
+      
+      <p class="confidence-indicator">
+        Confidence Index: <span>100.00%</span>
+        (4/4 core checks aligned)
+      </p>
+    
       <div class="verification-grid">
         
         <article class="verification-card">

--- a/demo/alpha-agi-mark/reports/alpha-mark-integrity.md
+++ b/demo/alpha-agi-mark/reports/alpha-mark-integrity.md
@@ -1,10 +1,10 @@
 # α-AGI MARK Integrity Report
 
-Generated: 2025-10-16T20:09:48.930Z
+Generated: 2025-10-16T21:10:18.031Z
 
 ## Confidence Summary
 
-- Confidence index: 100.00% (10/10 checks passed)
+- Confidence index: 100.00% (11/11 checks passed)
 - Validator quorum: 2/2
 - Ledger supply processed: 11 whole tokens
 - Gross capital processed: 4500000000000000000 wei (4.5 ETH)
@@ -22,6 +22,19 @@ Generated: 2025-10-16T20:09:48.930Z
 | Embedded verification: pricing | ✅ | - | - |
 | Embedded verification: capital flows | ✅ | - | - |
 | Embedded verification: contributions | ✅ | - | - |
+| Recorded confidence index matches recomputed value | ✅ | 100.00% (4/4) | 100.00% (4/4) |
+
+## Execution Telemetry
+
+| Signal | Value |
+|---|---|
+| Network | hardhat (chainId 31337) (chain 31337) |
+| Mode | Dry-run sentinel |
+| Operator | 0xf39F…2266 |
+| Toolchain | AGI Jobs v0 (v2) |
+| Command | npm run demo:alpha-agi-mark |
+| Investors | 0x7099…79C8, 0x3C44…93BC, 0x90F7…b906 |
+| Validators | 0x15d3…6A65, 0x9965…A4dc, 0x976E…0aa9 |
 
 ## Participant Contribution Constellation
 

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.json
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.json
@@ -1,4 +1,5 @@
 {
+  "generatedAt": "2025-10-16T21:10:18.031Z",
   "contracts": {
     "novaSeed": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
     "riskOracle": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
@@ -266,6 +267,30 @@
       "ledgerGrossWei": "4500000000000000000",
       "ledgerGrossEth": "4.5",
       "consistent": true
+    },
+    "confidenceIndex": {
+      "percentage": "100.00",
+      "consistentChecks": 4,
+      "totalChecks": 4
     }
+  },
+  "execution": {
+    "generatedAt": "2025-10-16T21:10:18.031Z",
+    "network": "hardhat (chainId 31337)",
+    "chainId": "31337",
+    "dryRun": true,
+    "operator": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "investors": [
+      "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+      "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+      "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
+    ],
+    "validators": [
+      "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+      "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+      "0x976EA74026E726554dB657fA54763abd0C3a0aa9"
+    ],
+    "toolchain": "AGI Jobs v0 (v2)",
+    "job": "npm run demo:alpha-agi-mark"
   }
 }

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -36,6 +36,7 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    - contract addresses
    - owner governance parameters
    - consolidated `ownerControls` snapshot of every pause/whitelist/override lever
+   - `execution` telemetry showing network, operator wallet, broadcast mode, and command used
    - validator council roster and votes
    - bonding curve statistics (supply, reserve balance, pricing)
    - launch outcome summary, including sovereign vault manifest, acknowledgement metadata, and treasury balance
@@ -43,7 +44,7 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    - cross-reference visuals from the [`Operator Empowerment Atlas`](../docs/operator-empowerment-atlas.md) and
      [`Operator Command Console`](../docs/operator-command-console.md) for stakeholder briefings
    - `verification` snapshot documenting the triple-check consensus across supply, pricing, capital flows, and contribution
-     tallies
+     tallies plus the recorded confidence index and raw check counts
 
 3. **Render the owner control matrix at any time**
 
@@ -68,7 +69,9 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    ```
 
    The script replays the trade ledger from the recap, recomputes the bonding-curve math independently, and
-   prints a confidence index table that must read 100% before green-lighting any external announcement.
+   prints a confidence index table that must read 100% before green-lighting any external announcement. The verifier now
+   rejects any recap whose embedded confidence percentage or check counts differ from the recomputed figure, ensuring the
+   telemetry in `alpha-mark-recap.json` stays tamper-evident.
 
 6. **Emit the integrity dossier for stakeholder sign-off**
 


### PR DESCRIPTION
## Summary
- add execution telemetry and confidence index metadata to the α-AGI MARK recap
- render the new telemetry panel and verification badge across the dashboard and integrity dossier
- harden the recap verifier and documentation to cross-check the stored confidence metrics for non-technical operators

## Testing
- npm run demo:alpha-agi-mark
- npm run verify:alpha-agi-mark
- npm run integrity:alpha-agi-mark
- npm run test:alpha-agi-mark
- npm run owner:alpha-agi-mark

------
https://chatgpt.com/codex/tasks/task_e_68f15d68fda083339198de715896c0c0