### PR TITLE
Add canonical digest telemetry to alpha-agi-mark recap

### DIFF
--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -87,6 +87,11 @@ npm run verify:alpha-agi-mark
 The verifier consumes the recap dossier, replays the trade ledger, recomputes bonding-curve pricing from first
 principles, and prints a "confidence index" table that must reach 100% before sign-off.
 
+Every recap is now wrapped in a tamper-evident envelope. The demo encodes network metadata, actor registries,
+the orchestrator commit/branch, and a canonical JSON SHA-256 digest inside the recap file. The verifier recomputes
+the digest with a key-sorted canonicalisation pass and fails if the checksum diverges, guaranteeing that stakeholders
+review precisely the state emitted by the orchestrator.
+
 For a presentation-ready briefing, render the integrity report:
 
 ```bash
@@ -103,6 +108,7 @@ Every demo run now emits a cinematic HTML dossier at `demo/alpha-agi-mark/report
 any browser to explore:
 
 - Mission control metrics capturing validator consensus, reserve power, and sovereign vault status
+- A telemetry envelope showing network, orchestrator git metadata, actor registries, and the live recap checksum badge
 - A control-deck grid showing every owner actuator with live status badges
 - Full participant ledger plus the operator parameter matrix rendered as responsive tables
 - A trade resonance log charting every buy/sell action and its capital impact

--- a/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
+++ b/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
@@ -44,6 +44,23 @@
         margin: 1rem auto 0 auto;
         color: rgba(255, 255, 255, 0.78);
       }
+      header.hero .hero-meta {
+        margin-top: 1.5rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+        justify-content: center;
+      }
+      .hero-stamp {
+        padding: 0.45rem 1rem;
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.4);
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        background: rgba(255, 255, 255, 0.08);
+      }
       section {
         margin-bottom: 3rem;
         background: var(--card-bg);
@@ -144,10 +161,20 @@
         background: rgba(46, 204, 113, 0.16);
         border-color: rgba(46, 204, 113, 0.6);
       }
+      .badge.info {
+        color: #5ac8fa;
+        background: rgba(90, 200, 250, 0.18);
+        border-color: rgba(90, 200, 250, 0.6);
+      }
       .badge.danger {
         color: var(--danger);
         background: rgba(255, 107, 107, 0.18);
         border-color: rgba(255, 107, 107, 0.6);
+      }
+      .badge.warning {
+        color: var(--warning);
+        background: rgba(255, 179, 71, 0.18);
+        border-color: rgba(255, 179, 71, 0.6);
       }
       .badge.buy {
         color: #5ac8fa;
@@ -175,6 +202,29 @@
       table td {
         padding: 0.8rem 1rem;
         text-align: left;
+      }
+      .meta-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+      .meta-card {
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid rgba(96, 255, 207, 0.16);
+        border-radius: 16px;
+        padding: 1.4rem;
+      }
+      .meta-card ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        font-size: 0.9rem;
+      }
+      .meta-card li + li {
+        margin-top: 0.4rem;
+      }
+      .meta-card strong {
+        color: var(--accent);
       }
       table tbody tr:nth-child(even) {
         background: rgba(255, 255, 255, 0.04);
@@ -207,17 +257,59 @@
     <script>mermaid.initialize({ startOnLoad: true, theme: 'dark' });</script>
   </head>
   <body>
-    <main>
-      <header class="hero">
-        <p class="mono">α-AGI Sovereign Command Console</p>
-        <h1>MARK Launch Telemetry</h1>
-        <p>
-          Autonomous foresight launch executed via AGI Jobs v0 (v2). This dossier captures every
-          actuator a non-technical steward needs to command an α-AGI Nova-Seed into sovereign reality.
-        </p>
-      </header>
+      <main>
+        <header class="hero">
+          <p class="mono">α-AGI Sovereign Command Console</p>
+          <h1>MARK Launch Telemetry</h1>
+          <p>
+            Autonomous foresight launch executed via AGI Jobs v0 (v2). This dossier captures every
+            actuator a non-technical steward needs to command an α-AGI Nova-Seed into sovereign reality.
+          </p>
+          <div class="hero-meta">
+            <span class="badge info">Dry Run</span>
+            <span class="badge warning">Workspace Dirty</span>
+            <span class="hero-stamp">hardhat (chainId 31337)</span>
+            <span class="hero-stamp">Generated 2025-10-16T21:18:44.346Z</span>
+          </div>
+        </header>
 
-      <section>
+        
+        <section>
+          <h2>Mission Telemetry</h2>
+          <div class="meta-grid">
+            <article class="meta-card">
+              <h3>Recap Envelope</h3>
+              <ul>
+                <li><strong>Generated</strong>: 2025-10-16T21:18:44.346Z</li>
+                <li><strong>Network</strong>: hardhat (chainId 31337)</li>
+                <li><strong>Chain</strong>: 31337</li>
+                <li><strong>Block</strong>: 0</li>
+                <li><strong>Dry-run mode</strong>: Enabled</li>
+                <li><strong>Checksum</strong>: <code>sha256:03bed5b0e77f3148972204e0e07a1df196de416021d4114cd69ef9eb2221a6ab</code></li>
+              </ul>
+            </article>
+            <article class="meta-card">
+              <h3>Orchestrator</h3>
+              <ul>
+                <li><strong>Mode</strong>: Dry run</li>
+                <li><strong>Commit</strong>: a4afab5557e2be3afa4dca6e9532732aa30ca080</li>
+                <li><strong>Branch</strong>: work</li>
+                <li><strong>Workspace dirty</strong>: Yes</li>
+              </ul>
+            </article>
+            <article class="meta-card">
+              <h3>Actors</h3>
+              <ul>
+                <li><strong>Owner</strong>: 0xf39F…2266</li>
+                <li><strong>Investors</strong>: 0x7099…79C8, 0x3C44…93BC, 0x90F7…b906</li>
+                <li><strong>Validators</strong>: 0x15d3…6A65, 0x9965…A4dc, 0x976E…0aa9</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+  
+
+        <section>
         <h2>Mission Control Metrics</h2>
         <div class="metrics">
           <article class="metric">

--- a/demo/alpha-agi-mark/reports/alpha-mark-integrity.md
+++ b/demo/alpha-agi-mark/reports/alpha-mark-integrity.md
@@ -1,6 +1,25 @@
 # α-AGI MARK Integrity Report
 
-Generated: 2025-10-16T20:09:48.930Z
+Generated: 2025-10-16T21:18:44.346Z
+
+## Recap Envelope
+
+- Network: hardhat (chainId 31337) (chain 31337, block 0)
+- Dry-run mode: enabled
+- Checksum (sha256/json-key-sorted): 03bed5b0e77f3148972204e0e07a1df196de416021d4114cd69ef9eb2221a6ab
+
+### Orchestrator Telemetry
+
+- Mode: dry-run
+- Git commit: a4afab5557e2be3afa4dca6e9532732aa30ca080
+- Git branch: work
+- Workspace dirty: yes
+
+### Actor Registry
+
+- Owner: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+- Investors: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8, 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC, 0x90F79bf6EB2c4f870365E785982E1f101E93b906
+- Validators: 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65, 0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc, 0x976EA74026E726554dB657fA54763abd0C3a0aa9
 
 ## Confidence Summary
 

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.json
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.json
@@ -1,4 +1,31 @@
 {
+  "generatedAt": "2025-10-16T21:18:44.346Z",
+  "network": {
+    "label": "hardhat (chainId 31337)",
+    "name": "hardhat",
+    "chainId": "31337",
+    "blockNumber": "0",
+    "dryRun": true
+  },
+  "orchestrator": {
+    "commit": "a4afab5557e2be3afa4dca6e9532732aa30ca080",
+    "branch": "work",
+    "workspaceDirty": true,
+    "mode": "dry-run"
+  },
+  "actors": {
+    "owner": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "investors": [
+      "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+      "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+      "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
+    ],
+    "validators": [
+      "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+      "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+      "0x976EA74026E726554dB657fA54763abd0C3a0aa9"
+    ]
+  },
   "contracts": {
     "novaSeed": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
     "riskOracle": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
@@ -267,5 +294,10 @@
       "ledgerGrossEth": "4.5",
       "consistent": true
     }
+  },
+  "checksums": {
+    "algorithm": "sha256",
+    "canonicalEncoding": "json-key-sorted",
+    "recapSha256": "03bed5b0e77f3148972204e0e07a1df196de416021d4114cd69ef9eb2221a6ab"
   }
 }

--- a/demo/alpha-agi-mark/scripts/utils/canonical.ts
+++ b/demo/alpha-agi-mark/scripts/utils/canonical.ts
@@ -1,0 +1,25 @@
+export function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => {
+      if (a < b) return -1;
+      if (a > b) return 1;
+      return 0;
+    });
+
+    const normalized: Record<string, unknown> = {};
+    for (const [key, val] of entries) {
+      normalized[key] = canonicalize(val);
+    }
+    return normalized;
+  }
+
+  return value;
+}
+
+export function canonicalStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}


### PR DESCRIPTION
## Summary
- capture network, orchestrator, and actor metadata in the alpha-mark recap and seal it with a canonical JSON sha256 digest
- add shared canonical JSON helpers and teach the demo verifier, integrity reporter, and dashboard renderer about the expanded recap envelope
- refresh documentation and generated demo artifacts to spotlight the new telemetry and checksum guarantees

## Testing
- npm run demo:alpha-agi-mark
- npm run verify:alpha-agi-mark
- npm run integrity:alpha-agi-mark
- npm run test:alpha-agi-mark

------
https://chatgpt.com/codex/tasks/task_e_68f15d68fda083339198de715896c0c0