### PR TITLE
Add alpha-agi-mark operator suite runner

### DIFF
--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -56,6 +56,18 @@ This command:
 3. Simulates investor participation, validator approvals, pause/unpause sequences, and the sovereign launch transition.
 4. Prints a full state recap that a non-technical operator can read to verify success.
 
+### End-to-end operator suite
+
+```bash
+npm run demo:alpha-agi-mark:full
+```
+
+Runs the orchestrator above and immediately:
+
+1. Prints the owner control matrix so governance levers are visible without extra commands.
+2. Replays the trade ledger through the independent verifier, ensuring the recap dossier is internally consistent.
+3. Generates the integrity dossier that fuses verification output, owner controls, and mission telemetry for stakeholder sign-off.
+
 ### Network & safety controls
 
 - `AGIJOBS_DEMO_DRY_RUN` (default `true`) keeps the run in simulation mode. When set to `false` the script prompts for an explicit

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -25,8 +25,11 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    - proves the sovereign vault pause/unpause circuit breaker
    - finalizes the launch with ignition metadata and prints a comprehensive recap
    - emits an owner parameter matrix table in the console and inside the recap dossier
-   - runs the triple-verification matrix to confirm supply, pricing, capital flows, and participant ledgers agree across all
-     independent checks
+     - runs the triple-verification matrix to confirm supply, pricing, capital flows, and participant ledgers agree across all
+       independent checks
+
+   > **Need everything in one keystroke?** Run `npm run demo:alpha-agi-mark:full` to execute the demo, replay the verification,
+   > emit the owner matrix, and synthesise the integrity dossier without running additional commands.
 
 2. **Inspect recap artifacts**
 

--- a/demo/alpha-agi-mark/scripts/runOperatorSuite.ts
+++ b/demo/alpha-agi-mark/scripts/runOperatorSuite.ts
@@ -1,0 +1,90 @@
+import { spawnSync, SpawnSyncReturns } from "child_process";
+import path from "path";
+
+interface Step {
+  label: string;
+  command: string;
+  args: string[];
+}
+
+function runStep(index: number, total: number, step: Step, env: NodeJS.ProcessEnv, cwd: string) {
+  const banner = `[${index + 1}/${total}] ${step.label}`;
+  console.log(`\n${banner}`);
+  const start = Date.now();
+  const result: SpawnSyncReturns<Buffer> = spawnSync(step.command, step.args, {
+    cwd,
+    stdio: "inherit",
+    env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${step.label} failed with exit code ${result.status ?? "unknown"}`);
+  }
+
+  const elapsedMs = Date.now() - start;
+  console.log(`   ✅ Completed ${step.label} in ${(elapsedMs / 1000).toFixed(2)}s`);
+}
+
+function main() {
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  const demoDir = path.resolve(__dirname, "..");
+
+  const network = process.env.ALPHA_MARK_NETWORK?.trim();
+  const suiteEnv: NodeJS.ProcessEnv = { ...process.env };
+  if (network && network.length > 0 && network !== "hardhat" && !suiteEnv.HARDHAT_NETWORK) {
+    suiteEnv.HARDHAT_NETWORK = network;
+    console.log(`ℹ️  Detected ALPHA_MARK_NETWORK=${network}; setting HARDHAT_NETWORK to match.`);
+  }
+
+  const hardhatArgs = [
+    "hardhat",
+    "run",
+    "--config",
+    path.join(demoDir, "hardhat.config.ts"),
+  ];
+
+  if (network && network.length > 0 && network !== "hardhat") {
+    hardhatArgs.push("--network", network);
+  }
+
+  hardhatArgs.push(path.join(demoDir, "scripts", "runDemo.ts"));
+
+  const tsNodeArgs = (script: string): string[] => [
+    "ts-node",
+    "--compiler-options",
+    '{"module":"commonjs"}',
+    path.join(demoDir, "scripts", script),
+  ];
+
+  const steps: Step[] = [
+    { label: "α-AGI MARK orchestrator", command: "npx", args: hardhatArgs },
+    { label: "Owner parameter matrix", command: "npx", args: tsNodeArgs("exportOwnerMatrix.ts") },
+    { label: "Triple-verification replay", command: "npx", args: tsNodeArgs("verifyRecap.ts") },
+    { label: "Integrity dossier synthesis", command: "npx", args: tsNodeArgs("generateIntegrityReport.ts") },
+  ];
+
+  const suiteStart = Date.now();
+  steps.forEach((step, index) => runStep(index, steps.length, step, suiteEnv, repoRoot));
+
+  const recapPath = path.join(demoDir, "reports", "alpha-mark-recap.json");
+  const dashboardPath = path.join(demoDir, "reports", "alpha-mark-dashboard.html");
+  const integrityPath = path.join(demoDir, "reports", "alpha-mark-integrity.md");
+  const ownerMatrixNote = "Run `npm run owner:alpha-agi-mark` to re-print the owner matrix at any time.";
+
+  const elapsed = ((Date.now() - suiteStart) / 1000).toFixed(2);
+  console.log(`\n🌌 α-AGI MARK operator suite complete in ${elapsed}s.`);
+  console.log(`   • Recap dossier: ${path.relative(repoRoot, recapPath)}`);
+  console.log(`   • Sovereign dashboard: ${path.relative(repoRoot, dashboardPath)}`);
+  console.log(`   • Integrity report: ${path.relative(repoRoot, integrityPath)}`);
+  console.log(`   • ${ownerMatrixNote}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error("❌ α-AGI MARK operator suite aborted:", (error as Error).message ?? error);
+  process.exitCode = 1;
+}

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "demo:agi-labor-market:control-room": "ts-node --transpile-only scripts/v2/launchAgiLaborMarketControlRoom.ts",
     "demo:alpha-agi-mark": "npx hardhat run --config demo/alpha-agi-mark/hardhat.config.ts demo/alpha-agi-mark/scripts/runDemo.ts",
     "demo:alpha-agi-mark:ci": "AGIJOBS_DEMO_DRY_RUN=true npm run demo:alpha-agi-mark",
+    "demo:alpha-agi-mark:full": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/runOperatorSuite.ts",
     "test:alpha-agi-mark": "npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts",
     "owner:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/exportOwnerMatrix.ts",
     "dashboard:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateDashboard.ts",


### PR DESCRIPTION
## Summary
- add a TypeScript operator suite script that runs the α-AGI MARK demo, owner matrix, verifier, and integrity report in one pass
- expose the suite through a new npm script and document the single-command workflow in the demo README and runbook

## Testing
- npm run demo:alpha-agi-mark:full
- npm run test:alpha-agi-mark

------
https://chatgpt.com/codex/tasks/task_e_68f16583a23c83339ed19d523ec5e6da