### PR TITLE
Add mission timeline orchestration to α-AGI MARK demo

### DIFF
--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -87,6 +87,9 @@ jobs:
           if (!Array.isArray(data.participants) || data.participants.length === 0) {
             throw new Error('participants missing');
           }
+          if (!Array.isArray(data.timeline) || data.timeline.length === 0) {
+            throw new Error('timeline missing');
+          }
           if (!data.launch || !data.launch.finalized) {
             throw new Error('launch did not finalize');
           }
@@ -108,6 +111,7 @@ jobs:
           const requiredSnippets = [
             'MARK Launch Telemetry',
             'Mission Control Metrics',
+            'Mission Timeline',
             'class="mermaid"',
             'Owner Control Deck',
           ];
@@ -148,6 +152,27 @@ jobs:
           console.log('Integrity dossier validated.');
           NODE
 
+      - name: Render mission timeline
+        run: npm run timeline:alpha-agi-mark
+
+      - name: Validate mission timeline
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = 'demo/alpha-agi-mark/reports/alpha-mark-timeline.md';
+          if (!fs.existsSync(path)) {
+            throw new Error('mission timeline dossier missing');
+          }
+          const content = fs.readFileSync(path, 'utf8');
+          const required = ['# α-AGI MARK Mission Timeline', '```mermaid', '| # | Phase | Event | Details | Actor |'];
+          for (const needle of required) {
+            if (!content.includes(needle)) {
+              throw new Error(`timeline dossier missing section: ${needle}`);
+            }
+          }
+          console.log('Mission timeline dossier validated.');
+          NODE
+
       - name: Upload α-AGI MARK recap
         uses: actions/upload-artifact@v4
         with:
@@ -159,3 +184,9 @@ jobs:
         with:
           name: alpha-agi-mark-integrity
           path: demo/alpha-agi-mark/reports/alpha-mark-integrity.md
+
+      - name: Upload α-AGI MARK mission timeline
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpha-agi-mark-timeline
+          path: demo/alpha-agi-mark/reports/alpha-mark-timeline.md

--- a/demo/alpha-agi-mark/.gitignore
+++ b/demo/alpha-agi-mark/.gitignore
@@ -5,3 +5,4 @@ reports/*
 !reports/alpha-mark-recap.json
 !reports/alpha-mark-dashboard.html
 !reports/alpha-mark-integrity.md
+!reports/alpha-mark-timeline.md

--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -134,6 +134,35 @@ npm run dashboard:alpha-agi-mark
 
 ## Triple-Verification Matrix
 
+## Mission Timeline
+
+Every orchestrated action is now captured in a cinematic mission timeline so non-technical stakeholders can replay the entire
+launch sequence at a glance. Generate the Markdown dossier at `demo/alpha-agi-mark/reports/alpha-mark-timeline.md`:
+
+```bash
+npm run timeline:alpha-agi-mark
+```
+
+The report embeds a Mermaid timeline plus a detailed event ledger. Use it to brief councils, auditors, or investors without
+re-running the demo.
+
+```mermaid
+timeline
+    title α-AGI MARK Operator Journey
+    section Orchestration
+      🚀 Boot sequence : Orchestrator primes Hardhat dry-run environment
+      💠 Actors cleared : Wallets funded above 0.05 ETH
+    section Market Activation
+      🟢 Investor A acquires SeedShares : 5 SeedShares committed to the bonding curve
+      ⏸️ Compliance pause : Owner halts trading to showcase safety controls
+    section Governance
+      🗳️ Validator approvals : Council reaches consensus for launch
+    section Launch
+      ✨ Sovereign ignition : Funds dispatched to the α-AGI Sovereign vault
+```
+
+## Triple-Verification Matrix
+
 α-AGI MARK now triangulates its state through three independent vantage points—on-chain contract reads, a deterministic
 trade ledger, and a first-principles bonding-curve simulator. Every run prints a "Triple-Verification Matrix" confirming that
 all three perspectives agree on supply, pricing, capital flows, and participant contributions. The recap dossier exposes the

--- a/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
+++ b/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
@@ -203,6 +203,20 @@
         padding: 0.8rem 1rem;
         text-align: left;
       }
+      .timeline-table-wrapper {
+        margin-top: 1.5rem;
+        overflow-x: auto;
+      }
+      .timeline-table td:first-child {
+        width: 3.5rem;
+      }
+      .timeline-table td:nth-child(5) {
+        white-space: nowrap;
+      }
+      .timeline-table td,
+      .timeline-table th {
+        vertical-align: top;
+      }
       .meta-grid {
         display: grid;
         gap: 1.5rem;
@@ -269,7 +283,7 @@
             <span class="badge info">Dry Run</span>
             <span class="badge warning">Workspace Dirty</span>
             <span class="hero-stamp">hardhat (chainId 31337)</span>
-            <span class="hero-stamp">Generated 2025-10-16T21:18:44.346Z</span>
+            <span class="hero-stamp">Generated 2025-10-16T22:28:58.620Z</span>
           </div>
         </header>
 
@@ -280,19 +294,19 @@
             <article class="meta-card">
               <h3>Recap Envelope</h3>
               <ul>
-                <li><strong>Generated</strong>: 2025-10-16T21:18:44.346Z</li>
+                <li><strong>Generated</strong>: 2025-10-16T22:28:58.620Z</li>
                 <li><strong>Network</strong>: hardhat (chainId 31337)</li>
                 <li><strong>Chain</strong>: 31337</li>
                 <li><strong>Block</strong>: 0</li>
                 <li><strong>Dry-run mode</strong>: Enabled</li>
-                <li><strong>Checksum</strong>: <code>sha256:03bed5b0e77f3148972204e0e07a1df196de416021d4114cd69ef9eb2221a6ab</code></li>
+                <li><strong>Checksum</strong>: <code>sha256:fd9fa6cf56c3f3e497c5ce72aafebcba39b660c1344eff89646e7ac659fb194b</code></li>
               </ul>
             </article>
             <article class="meta-card">
               <h3>Orchestrator</h3>
               <ul>
                 <li><strong>Mode</strong>: Dry run</li>
-                <li><strong>Commit</strong>: a4afab5557e2be3afa4dca6e9532732aa30ca080</li>
+                <li><strong>Commit</strong>: c7f11d9aec96ad3de7103c89aaa8f517bbc9040c</li>
                 <li><strong>Branch</strong>: work</li>
                 <li><strong>Workspace dirty</strong>: Yes</li>
               </ul>
@@ -307,6 +321,265 @@
             </article>
           </div>
         </section>
+  
+
+        
+    <section>
+      <h2>Mission Timeline</h2>
+      <p>The orchestrator chronicles every decisive action for auditors and operators alike.</p>
+      <pre class="mermaid">
+timeline
+    title α-AGI MARK Operator Timeline
+    section Orchestration
+      🚀 Mission boot sequence : AGI Jobs orchestrator engaged on hardhat (chainId 31337) (dry-run mode)
+      💠 Actors cleared for launch : Owner, investors, and validators funded ≥ 0.05 ETH
+    section Seed Genesis
+      🌱 Nova-Seed minted (#1) (Owner (0xf39F…2266)) : Operator forges the foresight seed NFT underpinning the launch
+    section Deployment
+      🛡️ Risk oracle council activated (Owner (0xf39F…2266)) : Validator quorum contract online with 2-of-3 threshold
+      🏛️ Bonding-curve exchange deployed (Owner (0xf39F…2266)) : AlphaMarkEToken market-maker ready for capital formation
+      👑 Sovereign vault commissioned (Owner (0xf39F…2266)) : Vault bound to the exchange for sovereign ignition
+    section Safety &amp; Compliance
+      🛡️ Vault circuit breaker tested (Owner (0xf39F…2266)) : Owner pauses and resumes the sovereign vault to verify emergency controls
+    section Configuration
+      🪙 Base asset retargeted (Owner (0xf39F…2266)) : Funding rail toggled from ETH to stablecoin and back before launch
+      🛠️ Owner governance levers calibrated (Owner (0xf39F…2266)) : Treasury, funding cap, and whitelist configured for sovereign launch
+    section Market Activation
+      🟢 Investor A acquires 5 SeedShares (Investor A (0x7099…79C8)) : 1.0 ETH committed to the reserve
+    section Safety &amp; Compliance
+      ⏸️ Market paused for compliance review (Owner (0xf39F…2266)) : Owner halts trading to showcase real-time control
+      🛑 Pause enforcement confirmed (Investor C (0x90F7…b906)) : Investor C blocked while the market pause is active
+      ▶️ Market resumed (Owner (0xf39F…2266)) : Owner reopens trading after compliance check
+    section Market Activation
+      🟢 Investor B acquires 3 SeedShares (Investor B (0x3C44…93BC)) : 1.2 ETH committed to the reserve
+      🟢 Investor C acquires 4 SeedShares (Investor C (0x90F7…b906)) : 2.3 ETH committed to the reserve
+    section Governance
+      🗳️ Validator A casts approval (Validator A (0x15d3…6A65)) : Consensus progress\: 1/3
+      ⚖️ Launch guard rejected premature finalize (Owner (0xf39F…2266)) : Owner cannot finalize before oracle quorum
+      🗳️ Validator B casts approval (Validator B (0x9965…A4dc)) : Consensus secured (2/2)
+    section Liquidity
+      🔄 Investor B redeems 1 SeedShares (Investor B (0x3C44…93BC)) : 0.65 ETH released from the reserve
+    section Launch
+      ✨ Sovereign ignition finalized (Owner (0xf39F…2266)) : Funds transferred to the vault with ignition metadata recorded
+    section Verification
+      ✅ Triple-verification matrix aligned : Ledger, simulation, and on-chain state reconcile 1\:1
+    section Mission Control
+      🧾 Recap dossier synthesis : Preparing sovereign dashboard, owner matrix, and recap digest
+      </pre>
+      <div class="timeline-table-wrapper">
+        <table class="timeline-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Phase</th>
+              <th>Event</th>
+              <th>Details</th>
+              <th>Actor</th>
+            </tr>
+          </thead>
+          <tbody>
+            
+        <tr>
+          <td>1</td>
+          <td>Orchestration</td>
+          <td>🚀 Mission boot sequence</td>
+          <td>AGI Jobs orchestrator engaged on hardhat (chainId 31337) (dry-run mode)</td>
+          <td>—</td>
+        </tr>
+      
+
+        <tr>
+          <td>2</td>
+          <td>Orchestration</td>
+          <td>💠 Actors cleared for launch</td>
+          <td>Owner, investors, and validators funded ≥ 0.05 ETH</td>
+          <td>—</td>
+        </tr>
+      
+
+        <tr>
+          <td>3</td>
+          <td>Seed Genesis</td>
+          <td>🌱 Nova-Seed minted (#1)</td>
+          <td>Operator forges the foresight seed NFT underpinning the launch</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>4</td>
+          <td>Deployment</td>
+          <td>🛡️ Risk oracle council activated</td>
+          <td>Validator quorum contract online with 2-of-3 threshold</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>5</td>
+          <td>Deployment</td>
+          <td>🏛️ Bonding-curve exchange deployed</td>
+          <td>AlphaMarkEToken market-maker ready for capital formation</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>6</td>
+          <td>Deployment</td>
+          <td>👑 Sovereign vault commissioned</td>
+          <td>Vault bound to the exchange for sovereign ignition</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>7</td>
+          <td>Safety &amp; Compliance</td>
+          <td>🛡️ Vault circuit breaker tested</td>
+          <td>Owner pauses and resumes the sovereign vault to verify emergency controls</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>8</td>
+          <td>Configuration</td>
+          <td>🪙 Base asset retargeted</td>
+          <td>Funding rail toggled from ETH to stablecoin and back before launch</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>9</td>
+          <td>Configuration</td>
+          <td>🛠️ Owner governance levers calibrated</td>
+          <td>Treasury, funding cap, and whitelist configured for sovereign launch</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>10</td>
+          <td>Market Activation</td>
+          <td>🟢 Investor A acquires 5 SeedShares</td>
+          <td>1.0 ETH committed to the reserve</td>
+          <td>Investor A (0x7099…79C8)</td>
+        </tr>
+      
+
+        <tr>
+          <td>11</td>
+          <td>Safety &amp; Compliance</td>
+          <td>⏸️ Market paused for compliance review</td>
+          <td>Owner halts trading to showcase real-time control</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>12</td>
+          <td>Safety &amp; Compliance</td>
+          <td>🛑 Pause enforcement confirmed</td>
+          <td>Investor C blocked while the market pause is active</td>
+          <td>Investor C (0x90F7…b906)</td>
+        </tr>
+      
+
+        <tr>
+          <td>13</td>
+          <td>Safety &amp; Compliance</td>
+          <td>▶️ Market resumed</td>
+          <td>Owner reopens trading after compliance check</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>14</td>
+          <td>Market Activation</td>
+          <td>🟢 Investor B acquires 3 SeedShares</td>
+          <td>1.2 ETH committed to the reserve</td>
+          <td>Investor B (0x3C44…93BC)</td>
+        </tr>
+      
+
+        <tr>
+          <td>15</td>
+          <td>Market Activation</td>
+          <td>🟢 Investor C acquires 4 SeedShares</td>
+          <td>2.3 ETH committed to the reserve</td>
+          <td>Investor C (0x90F7…b906)</td>
+        </tr>
+      
+
+        <tr>
+          <td>16</td>
+          <td>Governance</td>
+          <td>🗳️ Validator A casts approval</td>
+          <td>Consensus progress: 1/3</td>
+          <td>Validator A (0x15d3…6A65)</td>
+        </tr>
+      
+
+        <tr>
+          <td>17</td>
+          <td>Governance</td>
+          <td>⚖️ Launch guard rejected premature finalize</td>
+          <td>Owner cannot finalize before oracle quorum</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>18</td>
+          <td>Governance</td>
+          <td>🗳️ Validator B casts approval</td>
+          <td>Consensus secured (2/2)</td>
+          <td>Validator B (0x9965…A4dc)</td>
+        </tr>
+      
+
+        <tr>
+          <td>19</td>
+          <td>Liquidity</td>
+          <td>🔄 Investor B redeems 1 SeedShares</td>
+          <td>0.65 ETH released from the reserve</td>
+          <td>Investor B (0x3C44…93BC)</td>
+        </tr>
+      
+
+        <tr>
+          <td>20</td>
+          <td>Launch</td>
+          <td>✨ Sovereign ignition finalized</td>
+          <td>Funds transferred to the vault with ignition metadata recorded</td>
+          <td>Owner (0xf39F…2266)</td>
+        </tr>
+      
+
+        <tr>
+          <td>21</td>
+          <td>Verification</td>
+          <td>✅ Triple-verification matrix aligned</td>
+          <td>Ledger, simulation, and on-chain state reconcile 1:1</td>
+          <td>—</td>
+        </tr>
+      
+
+        <tr>
+          <td>22</td>
+          <td>Mission Control</td>
+          <td>🧾 Recap dossier synthesis</td>
+          <td>Preparing sovereign dashboard, owner matrix, and recap digest</td>
+          <td>—</td>
+        </tr>
+      
+          </tbody>
+        </table>
+      </div>
+    </section>
   
 
         <section>

--- a/demo/alpha-agi-mark/reports/alpha-mark-integrity.md
+++ b/demo/alpha-agi-mark/reports/alpha-mark-integrity.md
@@ -1,17 +1,17 @@
 # α-AGI MARK Integrity Report
 
-Generated: 2025-10-16T21:18:44.346Z
+Generated: 2025-10-16T22:28:58.620Z
 
 ## Recap Envelope
 
 - Network: hardhat (chainId 31337) (chain 31337, block 0)
 - Dry-run mode: enabled
-- Checksum (sha256/json-key-sorted): 03bed5b0e77f3148972204e0e07a1df196de416021d4114cd69ef9eb2221a6ab
+- Checksum (sha256/json-key-sorted): fd9fa6cf56c3f3e497c5ce72aafebcba39b660c1344eff89646e7ac659fb194b
 
 ### Orchestrator Telemetry
 
 - Mode: dry-run
-- Git commit: a4afab5557e2be3afa4dca6e9532732aa30ca080
+- Git commit: c7f11d9aec96ad3de7103c89aaa8f517bbc9040c
 - Git branch: work
 - Workspace dirty: yes
 

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.json
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-16T21:18:44.346Z",
+  "generatedAt": "2025-10-16T22:28:58.620Z",
   "network": {
     "label": "hardhat (chainId 31337)",
     "name": "hardhat",
@@ -8,7 +8,7 @@
     "dryRun": true
   },
   "orchestrator": {
-    "commit": "a4afab5557e2be3afa4dca6e9532732aa30ca080",
+    "commit": "c7f11d9aec96ad3de7103c89aaa8f517bbc9040c",
     "branch": "work",
     "workspaceDirty": true,
     "mode": "dry-run"
@@ -295,9 +295,201 @@
       "consistent": true
     }
   },
+  "timeline": [
+    {
+      "order": 1,
+      "phase": "Orchestration",
+      "title": "Mission boot sequence",
+      "description": "AGI Jobs orchestrator engaged on hardhat (chainId 31337) (dry-run mode)",
+      "icon": "🚀"
+    },
+    {
+      "order": 2,
+      "phase": "Orchestration",
+      "title": "Actors cleared for launch",
+      "description": "Owner, investors, and validators funded ≥ 0.05 ETH",
+      "icon": "💠"
+    },
+    {
+      "order": 3,
+      "phase": "Seed Genesis",
+      "title": "Nova-Seed minted (#1)",
+      "description": "Operator forges the foresight seed NFT underpinning the launch",
+      "icon": "🌱",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 4,
+      "phase": "Deployment",
+      "title": "Risk oracle council activated",
+      "description": "Validator quorum contract online with 2-of-3 threshold",
+      "icon": "🛡️",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 5,
+      "phase": "Deployment",
+      "title": "Bonding-curve exchange deployed",
+      "description": "AlphaMarkEToken market-maker ready for capital formation",
+      "icon": "🏛️",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 6,
+      "phase": "Deployment",
+      "title": "Sovereign vault commissioned",
+      "description": "Vault bound to the exchange for sovereign ignition",
+      "icon": "👑",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 7,
+      "phase": "Safety & Compliance",
+      "title": "Vault circuit breaker tested",
+      "description": "Owner pauses and resumes the sovereign vault to verify emergency controls",
+      "icon": "🛡️",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 8,
+      "phase": "Configuration",
+      "title": "Base asset retargeted",
+      "description": "Funding rail toggled from ETH to stablecoin and back before launch",
+      "icon": "🪙",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 9,
+      "phase": "Configuration",
+      "title": "Owner governance levers calibrated",
+      "description": "Treasury, funding cap, and whitelist configured for sovereign launch",
+      "icon": "🛠️",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 10,
+      "phase": "Market Activation",
+      "title": "Investor A acquires 5 SeedShares",
+      "description": "1.0 ETH committed to the reserve",
+      "icon": "🟢",
+      "actor": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+      "actorLabel": "Investor A"
+    },
+    {
+      "order": 11,
+      "phase": "Safety & Compliance",
+      "title": "Market paused for compliance review",
+      "description": "Owner halts trading to showcase real-time control",
+      "icon": "⏸️",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 12,
+      "phase": "Safety & Compliance",
+      "title": "Pause enforcement confirmed",
+      "description": "Investor C blocked while the market pause is active",
+      "icon": "🛑",
+      "actor": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+      "actorLabel": "Investor C"
+    },
+    {
+      "order": 13,
+      "phase": "Safety & Compliance",
+      "title": "Market resumed",
+      "description": "Owner reopens trading after compliance check",
+      "icon": "▶️",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 14,
+      "phase": "Market Activation",
+      "title": "Investor B acquires 3 SeedShares",
+      "description": "1.2 ETH committed to the reserve",
+      "icon": "🟢",
+      "actor": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+      "actorLabel": "Investor B"
+    },
+    {
+      "order": 15,
+      "phase": "Market Activation",
+      "title": "Investor C acquires 4 SeedShares",
+      "description": "2.3 ETH committed to the reserve",
+      "icon": "🟢",
+      "actor": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+      "actorLabel": "Investor C"
+    },
+    {
+      "order": 16,
+      "phase": "Governance",
+      "title": "Validator A casts approval",
+      "description": "Consensus progress: 1/3",
+      "icon": "🗳️",
+      "actor": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+      "actorLabel": "Validator A"
+    },
+    {
+      "order": 17,
+      "phase": "Governance",
+      "title": "Launch guard rejected premature finalize",
+      "description": "Owner cannot finalize before oracle quorum",
+      "icon": "⚖️",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 18,
+      "phase": "Governance",
+      "title": "Validator B casts approval",
+      "description": "Consensus secured (2/2)",
+      "icon": "🗳️",
+      "actor": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+      "actorLabel": "Validator B"
+    },
+    {
+      "order": 19,
+      "phase": "Liquidity",
+      "title": "Investor B redeems 1 SeedShares",
+      "description": "0.65 ETH released from the reserve",
+      "icon": "🔄",
+      "actor": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+      "actorLabel": "Investor B"
+    },
+    {
+      "order": 20,
+      "phase": "Launch",
+      "title": "Sovereign ignition finalized",
+      "description": "Funds transferred to the vault with ignition metadata recorded",
+      "icon": "✨",
+      "actor": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "actorLabel": "Owner"
+    },
+    {
+      "order": 21,
+      "phase": "Verification",
+      "title": "Triple-verification matrix aligned",
+      "description": "Ledger, simulation, and on-chain state reconcile 1:1",
+      "icon": "✅"
+    },
+    {
+      "order": 22,
+      "phase": "Mission Control",
+      "title": "Recap dossier synthesis",
+      "description": "Preparing sovereign dashboard, owner matrix, and recap digest",
+      "icon": "🧾"
+    }
+  ],
   "checksums": {
     "algorithm": "sha256",
     "canonicalEncoding": "json-key-sorted",
-    "recapSha256": "03bed5b0e77f3148972204e0e07a1df196de416021d4114cd69ef9eb2221a6ab"
+    "recapSha256": "fd9fa6cf56c3f3e497c5ce72aafebcba39b660c1344eff89646e7ac659fb194b"
   }
 }

--- a/demo/alpha-agi-mark/reports/alpha-mark-timeline.md
+++ b/demo/alpha-agi-mark/reports/alpha-mark-timeline.md
@@ -1,0 +1,76 @@
+# α-AGI MARK Mission Timeline
+
+Generated 2025-10-16T22:28:58.620Z on hardhat (chainId 31337).
+
+- **Orchestrator mode:** dry-run
+- **Commit:** c7f11d9aec96ad3de7103c89aaa8f517bbc9040c
+- **Branch:** work
+
+## Cinematic Timeline
+
+```mermaid
+timeline
+    title α-AGI MARK Mission Timeline
+    section Orchestration
+      🚀 Mission boot sequence : AGI Jobs orchestrator engaged on hardhat (chainId 31337) (dry-run mode)
+      💠 Actors cleared for launch : Owner, investors, and validators funded ≥ 0.05 ETH
+    section Seed Genesis
+      🌱 Nova-Seed minted (#1) (Owner) : Operator forges the foresight seed NFT underpinning the launch
+    section Deployment
+      🛡️ Risk oracle council activated (Owner) : Validator quorum contract online with 2-of-3 threshold
+      🏛️ Bonding-curve exchange deployed (Owner) : AlphaMarkEToken market-maker ready for capital formation
+      👑 Sovereign vault commissioned (Owner) : Vault bound to the exchange for sovereign ignition
+    section Safety & Compliance
+      🛡️ Vault circuit breaker tested (Owner) : Owner pauses and resumes the sovereign vault to verify emergency controls
+    section Configuration
+      🪙 Base asset retargeted (Owner) : Funding rail toggled from ETH to stablecoin and back before launch
+      🛠️ Owner governance levers calibrated (Owner) : Treasury, funding cap, and whitelist configured for sovereign launch
+    section Market Activation
+      🟢 Investor A acquires 5 SeedShares (Investor A) : 1.0 ETH committed to the reserve
+    section Safety & Compliance
+      ⏸️ Market paused for compliance review (Owner) : Owner halts trading to showcase real-time control
+      🛑 Pause enforcement confirmed (Investor C) : Investor C blocked while the market pause is active
+      ▶️ Market resumed (Owner) : Owner reopens trading after compliance check
+    section Market Activation
+      🟢 Investor B acquires 3 SeedShares (Investor B) : 1.2 ETH committed to the reserve
+      🟢 Investor C acquires 4 SeedShares (Investor C) : 2.3 ETH committed to the reserve
+    section Governance
+      🗳️ Validator A casts approval (Validator A) : Consensus progress\: 1/3
+      ⚖️ Launch guard rejected premature finalize (Owner) : Owner cannot finalize before oracle quorum
+      🗳️ Validator B casts approval (Validator B) : Consensus secured (2/2)
+    section Liquidity
+      🔄 Investor B redeems 1 SeedShares (Investor B) : 0.65 ETH released from the reserve
+    section Launch
+      ✨ Sovereign ignition finalized (Owner) : Funds transferred to the vault with ignition metadata recorded
+    section Verification
+      ✅ Triple-verification matrix aligned : Ledger, simulation, and on-chain state reconcile 1\:1
+    section Mission Control
+      🧾 Recap dossier synthesis : Preparing sovereign dashboard, owner matrix, and recap digest
+```
+
+## Event Ledger
+
+| # | Phase | Event | Details | Actor |
+|:-:|:------|:------|:--------|:------|
+| 1 | Orchestration | 🚀 Mission boot sequence | AGI Jobs orchestrator engaged on hardhat (chainId 31337) (dry-run mode) | — |
+| 2 | Orchestration | 💠 Actors cleared for launch | Owner, investors, and validators funded ≥ 0.05 ETH | — |
+| 3 | Seed Genesis | 🌱 Nova-Seed minted (#1) | Operator forges the foresight seed NFT underpinning the launch | Owner |
+| 4 | Deployment | 🛡️ Risk oracle council activated | Validator quorum contract online with 2-of-3 threshold | Owner |
+| 5 | Deployment | 🏛️ Bonding-curve exchange deployed | AlphaMarkEToken market-maker ready for capital formation | Owner |
+| 6 | Deployment | 👑 Sovereign vault commissioned | Vault bound to the exchange for sovereign ignition | Owner |
+| 7 | Safety & Compliance | 🛡️ Vault circuit breaker tested | Owner pauses and resumes the sovereign vault to verify emergency controls | Owner |
+| 8 | Configuration | 🪙 Base asset retargeted | Funding rail toggled from ETH to stablecoin and back before launch | Owner |
+| 9 | Configuration | 🛠️ Owner governance levers calibrated | Treasury, funding cap, and whitelist configured for sovereign launch | Owner |
+| 10 | Market Activation | 🟢 Investor A acquires 5 SeedShares | 1.0 ETH committed to the reserve | Investor A |
+| 11 | Safety & Compliance | ⏸️ Market paused for compliance review | Owner halts trading to showcase real-time control | Owner |
+| 12 | Safety & Compliance | 🛑 Pause enforcement confirmed | Investor C blocked while the market pause is active | Investor C |
+| 13 | Safety & Compliance | ▶️ Market resumed | Owner reopens trading after compliance check | Owner |
+| 14 | Market Activation | 🟢 Investor B acquires 3 SeedShares | 1.2 ETH committed to the reserve | Investor B |
+| 15 | Market Activation | 🟢 Investor C acquires 4 SeedShares | 2.3 ETH committed to the reserve | Investor C |
+| 16 | Governance | 🗳️ Validator A casts approval | Consensus progress: 1/3 | Validator A |
+| 17 | Governance | ⚖️ Launch guard rejected premature finalize | Owner cannot finalize before oracle quorum | Owner |
+| 18 | Governance | 🗳️ Validator B casts approval | Consensus secured (2/2) | Validator B |
+| 19 | Liquidity | 🔄 Investor B redeems 1 SeedShares | 0.65 ETH released from the reserve | Investor B |
+| 20 | Launch | ✨ Sovereign ignition finalized | Funds transferred to the vault with ignition metadata recorded | Owner |
+| 21 | Verification | ✅ Triple-verification matrix aligned | Ledger, simulation, and on-chain state reconcile 1:1 | — |
+| 22 | Mission Control | 🧾 Recap dossier synthesis | Preparing sovereign dashboard, owner matrix, and recap digest | — |

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -83,13 +83,22 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    the verification table, owner command deck snapshot, and a mermaid contribution pie chart. Circulate
    it alongside the dashboard for executive approval.
 
-7. **(Optional) Run unit tests**
+7. **Publish the cinematic mission timeline**
+
+   ```bash
+   npm run timeline:alpha-agi-mark
+   ```
+
+   Creates `demo/alpha-agi-mark/reports/alpha-mark-timeline.md`, blending a Mermaid timeline with a
+   tabular ledger of every orchestrated action. Ideal for board briefings or audit evidence packs.
+
+8. **(Optional) Run unit tests**
 
    ```bash
    npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts
    ```
 
-8. **(Optional) Dry-run on a fork or external network**
+9. **(Optional) Dry-run on a fork or external network**
 
    Set environment variables before invoking the script:
 

--- a/demo/alpha-agi-mark/scripts/generateMissionTimeline.ts
+++ b/demo/alpha-agi-mark/scripts/generateMissionTimeline.ts
@@ -1,0 +1,117 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+
+import { z } from "zod";
+
+const REPORT_DIR = path.join(__dirname, "..", "reports");
+const RECAP_PATH = path.join(REPORT_DIR, "alpha-mark-recap.json");
+const TIMELINE_PATH = path.join(REPORT_DIR, "alpha-mark-timeline.md");
+
+const timelineEntrySchema = z
+  .object({
+    order: z.number(),
+    phase: z.string(),
+    title: z.string(),
+    description: z.string(),
+    icon: z.string().optional(),
+    actor: z.string().optional(),
+    actorLabel: z.string().optional(),
+  })
+  .passthrough();
+
+const recapSchema = z
+  .object({
+    generatedAt: z.string(),
+    network: z
+      .object({
+        label: z.string(),
+        name: z.string(),
+        chainId: z.string(),
+      })
+      .passthrough(),
+    orchestrator: z
+      .object({
+        commit: z.string().optional(),
+        branch: z.string().optional(),
+        mode: z.enum(["dry-run", "broadcast"]),
+      })
+      .passthrough(),
+    timeline: z.array(timelineEntrySchema).nonempty("Timeline is empty – run the demo first."),
+  })
+  .passthrough();
+
+type TimelineEntry = z.infer<typeof timelineEntrySchema>;
+
+function sanitizeMermaid(value: string): string {
+  return value.replace(/\r?\n/g, " ").replace(/:/g, "\\:");
+}
+
+function shortenAddress(address: string | undefined): string | undefined {
+  if (!address) return undefined;
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function buildMermaid(entries: TimelineEntry[]): string {
+  const lines = ["timeline", "    title α-AGI MARK Mission Timeline"];
+  let currentPhase: string | undefined;
+
+  for (const entry of entries) {
+    const phase = entry.phase || "Mission";
+    if (phase !== currentPhase) {
+      lines.push(`    section ${phase}`);
+      currentPhase = phase;
+    }
+    const icon = entry.icon ? `${entry.icon} ` : "";
+    const actor = entry.actorLabel || shortenAddress(entry.actor);
+    const actorSuffix = actor ? ` (${actor})` : "";
+    lines.push(`      ${sanitizeMermaid(`${icon}${entry.title}${actorSuffix}`)} : ${sanitizeMermaid(entry.description)}`);
+  }
+
+  return lines.join("\n");
+}
+
+function buildTable(entries: TimelineEntry[]): string {
+  const header = `| # | Phase | Event | Details | Actor |\n|:-:|:------|:------|:--------|:------|`;
+  const rows = entries
+    .map((entry) => {
+      const label = entry.icon ? `${entry.icon} ${entry.title}` : entry.title;
+      const actor = entry.actorLabel || shortenAddress(entry.actor) || "—";
+      return `| ${entry.order} | ${entry.phase} | ${label} | ${entry.description} | ${actor} |`;
+    })
+    .join("\n");
+  return `${header}\n${rows}`;
+}
+
+async function main() {
+  const raw = await readFile(RECAP_PATH, "utf8");
+  const recap = recapSchema.parse(JSON.parse(raw));
+
+  const mermaid = buildMermaid(recap.timeline);
+  const table = buildTable(recap.timeline);
+  const generatedAt = new Date(recap.generatedAt).toISOString();
+  const networkLabel = recap.network.label;
+  const commitLabel = recap.orchestrator.commit ?? "(unavailable)";
+  const branchLabel = recap.orchestrator.branch ?? "(unavailable)";
+
+  const markdown = `# α-AGI MARK Mission Timeline\n\n` +
+    `Generated ${generatedAt} on ${networkLabel}.\n\n` +
+    `- **Orchestrator mode:** ${recap.orchestrator.mode}\n` +
+    `- **Commit:** ${commitLabel}\n` +
+    `- **Branch:** ${branchLabel}\n\n` +
+    `## Cinematic Timeline\n\n` +
+    "```mermaid\n" +
+    `${mermaid}\n` +
+    "```\n\n" +
+    `## Event Ledger\n\n${table}\n`;
+
+  await mkdir(REPORT_DIR, { recursive: true });
+  await writeFile(TIMELINE_PATH, markdown, "utf8");
+
+  console.log(`Mission timeline written to ${TIMELINE_PATH}`);
+}
+
+main().catch((error) => {
+  console.error("Failed to generate mission timeline:", error);
+  process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -164,7 +164,8 @@
     "owner:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/exportOwnerMatrix.ts",
     "dashboard:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateDashboard.ts",
     "verify:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/verifyRecap.ts",
-    "integrity:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateIntegrityReport.ts"
+    "integrity:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateIntegrityReport.ts",
+    "timeline:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateMissionTimeline.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- instrument the demo orchestrator to capture timeline events and persist them into the recap and dashboard
- surface the mission timeline across docs, dashboards, CI, and add a markdown generator for the cinematic log
- regenerate the demo outputs to include the new timeline artefacts and tighten .gitignore exceptions

## Testing
- npm run demo:alpha-agi-mark:full
- npm run timeline:alpha-agi-mark
- npm run test:alpha-agi-mark

------
https://chatgpt.com/codex/tasks/task_e_68f16f507554833388edda315c4cb273