### PR TITLE
Add sovereign blueprint export to alpha-agi-mark demo

### DIFF
--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -69,6 +69,8 @@ Runs the orchestrator above and immediately:
 1. Prints the owner control matrix so governance levers are visible without extra commands.
 2. Replays the trade ledger through the independent verifier, ensuring the recap dossier is internally consistent.
 3. Generates the integrity dossier that fuses verification output, owner controls, and mission telemetry for stakeholder sign-off.
+4. Renders the mission timeline into Mermaid + markdown so every phase has an auditable checkpoint.
+5. Emits the sovereign blueprint, a cinematic markdown brief combining flowcharts, sequence diagrams, and deterministic cross-checks.
 
 ### Network & safety controls
 
@@ -133,6 +135,19 @@ npm run integrity:alpha-agi-mark
 This generates `reports/alpha-mark-integrity.md` – a mermaid-enhanced dossier that summarises the
 confidence matrix, owner controls, validator quorum, and participant contributions so non-technical
 stakeholders can sign off in minutes.
+
+### Timeline & blueprint exports
+
+Generate artefacts individually whenever you need refreshed visuals for investors or auditors:
+
+```bash
+npm run timeline:alpha-agi-mark
+npm run blueprint:alpha-agi-mark
+```
+
+The timeline export provides both a Mermaid cinematic timeline and a tabular event ledger. The sovereign
+blueprint replays cross-checks, lists owner levers, and embeds dual Mermaid diagrams (flowchart + sequence)
+so a non-technical operator can prove the system's trajectory at a glance.
 
 ## Sovereign Dashboard
 

--- a/demo/alpha-agi-mark/docs/operator-empowerment-atlas.md
+++ b/demo/alpha-agi-mark/docs/operator-empowerment-atlas.md
@@ -74,3 +74,24 @@ sequenceDiagram
 ```
 
 These visual systems can be printed, embedded in investor decks, or referenced in due diligence reports so the operator can demonstrate total command over α-AGI MARK without touching raw contract code.
+
+## Sovereign Blueprint Snapshot
+
+```mermaid
+graph TD
+    classDef node fill:#111533,stroke:#60ffcf,stroke-width:2px,color:#f7faff;
+    Operator[[Operator Console]]:::node -->|Runs| Orchestrator((AGI Jobs v0 (v2))):::node
+    Orchestrator -->|Synthesises| Recap[[Recap JSON]]:::node
+    Orchestrator -->|Feeds| Timeline[[Mission Timeline]]:::node
+    Orchestrator -->|Feeds| Blueprint[[Sovereign Blueprint]]:::node
+    Recap -->|Verifies| Verifier[[Triple Verification Matrix]]:::node
+    Timeline -->|Renders| Atlas[[Operator Atlas]]:::node
+    Blueprint -->|Briefs| Boardroom((Stakeholders)):::node
+    Verifier -->|Confidence Index| Integrity[[Integrity Dossier]]:::node
+    Integrity -->|Evidence| Boardroom
+```
+
+The new sovereign blueprint export (`npm run blueprint:alpha-agi-mark`) packages these artefacts into a
+single markdown dossier featuring dual Mermaid diagrams, an owner command lattice, and deterministic
+cross-check results. Pair it with the timeline export to give non-technical reviewers a cinematic audit trail
+that proves every lever, quorum, and capital flow at a glance.

--- a/demo/alpha-agi-mark/docs/operator-verification-compendium.md
+++ b/demo/alpha-agi-mark/docs/operator-verification-compendium.md
@@ -112,10 +112,12 @@ flowchart LR
     Console{{Operator Command Console}}
     Compendium[[Verification Compendium]]
     Dashboard[[Sovereign Dashboard]]
+    Blueprint[[Sovereign Blueprint]]
     Integrity[[Integrity Dossier]]
   end
   Console --> Compendium
   Console --> Dashboard
+  Console --> Blueprint
   Console --> Integrity
   Compendium --> Execs
   Compendium --> Aud

--- a/demo/alpha-agi-mark/scripts/generateSovereignBlueprint.ts
+++ b/demo/alpha-agi-mark/scripts/generateSovereignBlueprint.ts
@@ -1,0 +1,467 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+
+import { formatEther } from "ethers";
+import { z } from "zod";
+
+const REPORT_DIR = path.join(__dirname, "..", "reports");
+const RECAP_PATH = path.join(REPORT_DIR, "alpha-mark-recap.json");
+const BLUEPRINT_PATH = path.join(REPORT_DIR, "alpha-mark-blueprint.md");
+
+const WHOLE_TOKEN = 10n ** 18n;
+
+const participantSchema = z
+  .object({
+    address: z.string(),
+    tokens: z.string(),
+    tokensWei: z.string(),
+    contributionWei: z.string(),
+    contributionEth: z.string().optional(),
+  })
+  .passthrough();
+
+const tradeSchema = z
+  .object({
+    kind: z.enum(["BUY", "SELL"]),
+    actor: z.string(),
+    label: z.string(),
+    tokensWhole: z.string(),
+    valueWei: z.string(),
+    valueEth: z.string().optional(),
+  })
+  .passthrough();
+
+const ownerParameterSchema = z.object({
+  parameter: z.string(),
+  value: z.unknown(),
+  description: z.string(),
+});
+
+const timelineEntrySchema = z
+  .object({
+    order: z.number().int(),
+    phase: z.string(),
+    title: z.string(),
+    description: z.string(),
+    icon: z.string().optional(),
+    actor: z.string().optional(),
+    actorLabel: z.string().optional(),
+  })
+  .passthrough();
+
+const recapSchema = z
+  .object({
+    generatedAt: z.string(),
+    network: z
+      .object({
+        label: z.string(),
+        name: z.string(),
+        chainId: z.string(),
+        dryRun: z.boolean(),
+      })
+      .passthrough(),
+    orchestrator: z
+      .object({
+        commit: z.string().optional(),
+        branch: z.string().optional(),
+        mode: z.enum(["dry-run", "broadcast"]),
+      })
+      .passthrough(),
+    actors: z.object({
+      owner: z.string(),
+      investors: z.array(z.string()).min(3),
+      validators: z.array(z.string()).min(3),
+    }),
+    contracts: z.object({
+      novaSeed: z.string(),
+      riskOracle: z.string(),
+      markExchange: z.string(),
+      sovereignVault: z.string(),
+    }),
+    bondingCurve: z
+      .object({
+        supplyWholeTokens: z.string(),
+        reserveWei: z.string(),
+        nextPriceWei: z.string(),
+        basePriceWei: z.string(),
+        slopeWei: z.string(),
+        reserveEth: z.string().optional(),
+        nextPriceEth: z.string().optional(),
+        basePriceEth: z.string().optional(),
+        slopeEth: z.string().optional(),
+      })
+      .passthrough(),
+    ownerControls: z
+      .object({
+        paused: z.boolean(),
+        whitelistEnabled: z.boolean(),
+        emergencyExitEnabled: z.boolean(),
+        finalized: z.boolean(),
+        aborted: z.boolean(),
+        validationOverrideEnabled: z.boolean(),
+        validationOverrideStatus: z.boolean(),
+        treasury: z.string(),
+        riskOracle: z.string(),
+        baseAsset: z.string(),
+        usesNativeAsset: z.boolean(),
+        fundingCapWei: z.string(),
+        fundingCapEth: z.string().optional(),
+        maxSupplyWholeTokens: z.string(),
+        saleDeadlineTimestamp: z.string(),
+        basePriceWei: z.string(),
+        basePriceEth: z.string().optional(),
+        slopeWei: z.string(),
+        slopeEth: z.string().optional(),
+      })
+      .passthrough(),
+    ownerParameterMatrix: z.array(ownerParameterSchema).nonempty(),
+    participants: z.array(participantSchema).nonempty(),
+    trades: z.array(tradeSchema).nonempty(),
+    validators: z
+      .object({
+        approvalCount: z.string(),
+        approvalThreshold: z.string(),
+        members: z.array(z.string()),
+        matrix: z.array(z.object({ address: z.string(), approved: z.boolean() })),
+      })
+      .passthrough()
+      .optional(),
+    launch: z
+      .object({
+        finalized: z.boolean(),
+        aborted: z.boolean(),
+        treasury: z.string(),
+        sovereignVault: z
+          .object({
+            manifestUri: z.string(),
+            totalReceivedWei: z.string(),
+            totalReceivedEth: z.string().optional(),
+            lastAcknowledgedAmountWei: z.string(),
+            lastAcknowledgedAmountEth: z.string().optional(),
+            decodedMetadata: z.string().optional(),
+            vaultBalanceWei: z.string().optional(),
+            vaultBalanceEth: z.string().optional(),
+          })
+          .passthrough(),
+      })
+      .passthrough(),
+    verification: z
+      .object({
+        supplyConsensus: z.object({ consistent: z.boolean() }).passthrough(),
+        pricing: z.object({ consistent: z.boolean() }).passthrough(),
+        capitalFlows: z.object({ consistent: z.boolean() }).passthrough(),
+        contributions: z.object({ consistent: z.boolean() }).passthrough(),
+      })
+      .optional(),
+    timeline: z.array(timelineEntrySchema).optional(),
+    checksums: z
+      .object({
+        algorithm: z.string(),
+        canonicalEncoding: z.string(),
+        recapSha256: z.string(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+type Recap = z.infer<typeof recapSchema>;
+
+type Check = {
+  label: string;
+  ok: boolean;
+  expected?: string;
+  observed?: string;
+};
+
+function parseBigInt(label: string, value: string): bigint {
+  try {
+    return BigInt(value);
+  } catch (error) {
+    throw new Error(`Failed to parse ${label} as bigint (value: ${value})`);
+  }
+}
+
+function shorten(address: string): string {
+  if (!address) return address;
+  return address.length <= 10 ? address : `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function sanitizeMermaid(value: string): string {
+  return value.replace(/`/g, "'").replace(/\\/g, "\\\\").replace(/\r?\n/g, " ").replace(/:/g, "\\:");
+}
+
+function renderFlowMermaid(recap: Recap): string {
+  const owner = shorten(recap.actors.owner);
+  const seed = shorten(recap.contracts.novaSeed);
+  const oracle = shorten(recap.contracts.riskOracle);
+  const exchange = shorten(recap.contracts.markExchange);
+  const vault = shorten(recap.contracts.sovereignVault);
+
+  return [
+    "flowchart TD",
+    `  Operator((Operator ${owner})) -->|Mint| NovaSeed[NovaSeedNFT\\n${seed}]`,
+    "  NovaSeed -->|Validation Request| Oracle[AlphaMarkRiskOracle\\n" + oracle + "]",
+    "  NovaSeed -->|Financing| Exchange[AlphaMarkEToken\\n" + exchange + "]",
+    "  Investors((SeedShare Contributors)) -->|Bonding Curve| Exchange",
+    "  Oracle -->|Quorum| Exchange",
+    "  Exchange -->|Reserve Dispatch| Vault[AlphaSovereignVault\\n" + vault + "]",
+    "  Exchange -->|Owner Controls| ControlDeck{{Owner Command Deck}}",
+    "  ControlDeck --> Exchange",
+    "  Vault -->|Ignition Metadata| Sovereign[[α-AGI Sovereign]]",
+  ].join("\n");
+}
+
+function renderSequenceMermaid(recap: Recap, ledgerNet: bigint): string {
+  const reserveEth = formatEther(parseBigInt("reserve", recap.bondingCurve.reserveWei));
+  const vaultEth = formatEther(parseBigInt("vault receipts", recap.launch.sovereignVault.totalReceivedWei));
+  const totalEth = formatEther(ledgerNet);
+
+  return [
+    "sequenceDiagram",
+    "  autonumber",
+    "  participant O as Operator",
+    "  participant NE as NovaSeedNFT",
+    "  participant RO as RiskOracle",
+    "  participant EX as BondingCurve",
+    "  participant SV as SovereignVault",
+    "  O->>NE: Mint Nova-Seed",
+    "  O->>RO: Install validator quorum",
+    "  O->>EX: Configure bonding curve & controls",
+    "  loop Market Lifecycle",
+    "    Investors->>EX: Buy/Sell SeedShares",
+    "    EX-->>Investors: Dynamic pricing curve",
+    "    RO-->>EX: Approval heartbeat",
+    "  end",
+    `  EX->>SV: finalizeLaunch() transfers ${vaultEth} ETH`,
+    "  SV-->>EX: notifyLaunch acknowledgement",
+    `  EX-->>O: Reserve left on exchange ${reserveEth} ETH`,
+    `  SV-->>O: Total reconciled capital ${totalEth} ETH`,
+  ].join("\n");
+}
+
+function renderOwnerMatrixTable(recap: Recap): string {
+  const header = "| Parameter | Value | Description |\n|:---------|:------|:------------|";
+  const rows = recap.ownerParameterMatrix
+    .map((item) => {
+      let value: string;
+      if (typeof item.value === "boolean") {
+        value = item.value ? "✅ Enabled" : "⛔ Disabled";
+      } else if (item.value && typeof item.value === "object") {
+        value = "```json\n" + JSON.stringify(item.value, null, 2) + "\n```";
+      } else {
+        value = String(item.value ?? "—");
+      }
+      return `| ${item.parameter} | ${value} | ${item.description} |`;
+    })
+    .join("\n");
+  return `${header}\n${rows}`;
+}
+
+function renderParticipantTable(recap: Recap): string {
+  const header = "| Address | Tokens | Contribution (wei) | Contribution (ETH) |\n|:--------|------:|-------------------:|--------------------:|";
+  const rows = recap.participants
+    .map((participant) => {
+      const eth =
+        participant.contributionEth ?? formatEther(parseBigInt("contribution", participant.contributionWei));
+      return `| ${shorten(participant.address)} | ${participant.tokens} | ${participant.contributionWei} | ${eth} |`;
+    })
+    .join("\n");
+  return `${header}\n${rows}`;
+}
+
+function renderValidatorTable(recap: Recap): string | undefined {
+  if (!recap.validators) return undefined;
+  const header = "| Validator | Approved |\n|:---------|:--------:|";
+  const rows = recap.validators.matrix
+    .map((entry) => `| ${shorten(entry.address)} | ${entry.approved ? "✅" : "⌛"} |`)
+    .join("\n");
+  return `${header}\n${rows}`;
+}
+
+function renderTimeline(recap: Recap): string | undefined {
+  if (!recap.timeline || recap.timeline.length === 0) return undefined;
+  const header = "| # | Phase | Event | Details |\n|:-:|:------|:------|:--------|";
+  const rows = recap.timeline
+    .map((entry) => {
+      const icon = entry.icon ? `${entry.icon} ` : "";
+      return `| ${entry.order} | ${entry.phase} | ${icon}${entry.title} | ${entry.description} |`;
+    })
+    .join("\n");
+  const mermaid = ["timeline", "    title Mission Arc"];
+  let currentPhase: string | undefined;
+  for (const entry of recap.timeline) {
+    if (currentPhase !== entry.phase) {
+      mermaid.push(`    section ${sanitizeMermaid(entry.phase)}`);
+      currentPhase = entry.phase;
+    }
+    const actor = entry.actorLabel || (entry.actor ? shorten(entry.actor) : undefined);
+    const title = `${entry.icon ? entry.icon + " " : ""}${entry.title}${actor ? ` (${actor})` : ""}`;
+    mermaid.push(`      ${sanitizeMermaid(title)} : ${sanitizeMermaid(entry.description)}`);
+  }
+  return "```mermaid\n" + mermaid.join("\n") + "\n```\n\n" + `${header}\n${rows}`;
+}
+
+function buildChecks(recap: Recap) {
+  const checks: Check[] = [];
+
+  const supply = parseBigInt("supply", recap.bondingCurve.supplyWholeTokens);
+  const reserve = parseBigInt("reserve", recap.bondingCurve.reserveWei);
+  const vaultReceived = parseBigInt("vault receipts", recap.launch.sovereignVault.totalReceivedWei);
+
+  let ledgerSupply = 0n;
+  let ledgerGross = 0n;
+  let ledgerRedemptions = 0n;
+  recap.trades.forEach((trade, index) => {
+    const tokens = parseBigInt(`trade[${index}] tokens`, trade.tokensWhole);
+    const value = parseBigInt(`trade[${index}] value`, trade.valueWei);
+    if (trade.kind === "BUY") {
+      ledgerSupply += tokens;
+      ledgerGross += value;
+    } else {
+      ledgerSupply -= tokens;
+      ledgerRedemptions += value;
+    }
+  });
+
+  const ledgerNet = ledgerGross - ledgerRedemptions;
+  const participantTokenWeiSum = recap.participants.reduce((acc, participant) => {
+    return acc + parseBigInt(`participant ${participant.address} tokensWei`, participant.tokensWei);
+  }, 0n);
+  const participantContributionSum = recap.participants.reduce((acc, participant) => {
+    return acc + parseBigInt(`participant ${participant.address} contribution`, participant.contributionWei);
+  }, 0n);
+
+  checks.push({
+    label: "Ledger supply equals bonding curve supply",
+    ok: ledgerSupply === supply,
+    expected: supply.toString(),
+    observed: ledgerSupply.toString(),
+  });
+
+  checks.push({
+    label: "Participant balances equal total supply",
+    ok: participantTokenWeiSum === supply * WHOLE_TOKEN,
+    expected: (supply * WHOLE_TOKEN).toString(),
+    observed: participantTokenWeiSum.toString(),
+  });
+
+  checks.push({
+    label: "Vault receipts + reserve equal ledger net",
+    ok: vaultReceived + reserve === ledgerNet,
+    expected: (vaultReceived + reserve).toString(),
+    observed: ledgerNet.toString(),
+  });
+
+  checks.push({
+    label: "Participant contributions equal ledger gross",
+    ok: participantContributionSum === ledgerGross,
+    expected: participantContributionSum.toString(),
+    observed: ledgerGross.toString(),
+  });
+
+  checks.push({
+    label: "Treasury matches owner control snapshot",
+    ok: recap.launch.treasury === recap.ownerControls.treasury,
+    expected: recap.ownerControls.treasury,
+    observed: recap.launch.treasury,
+  });
+
+  checks.push({
+    label: "Risk oracle address aligns with owner control",
+    ok: recap.ownerControls.riskOracle === recap.contracts.riskOracle,
+    expected: recap.contracts.riskOracle,
+    observed: recap.ownerControls.riskOracle,
+  });
+
+  return { checks, ledgerNet };
+}
+
+async function main() {
+  const raw = await readFile(RECAP_PATH, "utf8");
+  const recap = recapSchema.parse(JSON.parse(raw));
+
+  const { checks, ledgerNet } = buildChecks(recap);
+  const failedCheck = checks.find((check) => !check.ok);
+  if (failedCheck) {
+    throw new Error(
+      `Blueprint verification failed: ${failedCheck.label} (expected ${failedCheck.expected}, observed ${failedCheck.observed})`,
+    );
+  }
+
+  const flowMermaid = renderFlowMermaid(recap);
+  const sequenceMermaid = renderSequenceMermaid(recap, ledgerNet);
+  const ownerMatrixTable = renderOwnerMatrixTable(recap);
+  const participantTable = renderParticipantTable(recap);
+  const validatorTable = renderValidatorTable(recap);
+  const timelineSection = renderTimeline(recap);
+
+  const generatedAt = new Date(recap.generatedAt).toISOString();
+  const checksumSection = recap.checksums
+    ? `- **Checksum (${recap.checksums.algorithm}):** \`${recap.checksums.recapSha256}\`\n`
+    : "";
+
+  const verificationSummary = recap.verification
+    ? `- Supply consensus: **${recap.verification.supplyConsensus.consistent ? "✅" : "⚠️"}**\n` +
+      `- Pricing parity: **${recap.verification.pricing.consistent ? "✅" : "⚠️"}**\n` +
+      `- Capital flows: **${recap.verification.capitalFlows.consistent ? "✅" : "⚠️"}**\n` +
+      `- Contribution ledger: **${recap.verification.contributions.consistent ? "✅" : "⚠️"}**\n`
+    : "- Verification matrix not present – run `npm run verify:alpha-agi-mark`.\n";
+
+  const markdownParts: string[] = [];
+  markdownParts.push(`# α-AGI MARK Sovereign Blueprint\n`);
+  markdownParts.push(
+    `Generated ${generatedAt} on **${recap.network.label}** (mode: ${recap.orchestrator.mode}).\\\n` +
+      `Owner: \`${recap.actors.owner}\`\\\n` +
+      `Contracts: NovaSeed \`${recap.contracts.novaSeed}\`, RiskOracle \`${recap.contracts.riskOracle}\`, ` +
+      `Exchange \`${recap.contracts.markExchange}\`, SovereignVault \`${recap.contracts.sovereignVault}\`.\n` +
+      checksumSection,
+  );
+
+  markdownParts.push("## 1. Systems Constellation\n");
+  markdownParts.push("```mermaid\n" + flowMermaid + "\n```\n");
+
+  markdownParts.push("## 2. Launch Sequence Chronicle\n");
+  markdownParts.push("```mermaid\n" + sequenceMermaid + "\n```\n");
+
+  markdownParts.push("## 3. Owner Command Lattice\n");
+  markdownParts.push(ownerMatrixTable + "\n");
+
+  markdownParts.push("## 4. Participant Ledger\n");
+  markdownParts.push(participantTable + "\n");
+
+  if (validatorTable) {
+    markdownParts.push("## 5. Validator Council Snapshot\n");
+    markdownParts.push(validatorTable + "\n");
+  }
+
+  markdownParts.push("## 6. Verification Triad\n");
+  markdownParts.push(verificationSummary);
+
+  markdownParts.push("## 7. Deterministic Cross-Checks\n");
+  markdownParts.push(
+    checks
+      .map((check) => `- **${check.label}:** ${check.ok ? "✅" : "❌"} (${check.expected ?? ""})`)
+      .join("\n") + "\n",
+  );
+
+  if (timelineSection) {
+    markdownParts.push("## 8. Mission Timeline\n");
+    markdownParts.push(timelineSection + "\n");
+  }
+
+  markdownParts.push(
+    "> **Operator Tip:** Pair this blueprint with the `npm run console:alpha-agi-mark -- --snapshot` command to brief " +
+      "stakeholders using both textual and cinematic artefacts without leaving the terminal.\n",
+  );
+
+  await mkdir(REPORT_DIR, { recursive: true });
+  await writeFile(BLUEPRINT_PATH, markdownParts.join("\n"), "utf8");
+
+  console.log(`Sovereign blueprint written to ${BLUEPRINT_PATH}`);
+}
+
+main().catch((error) => {
+  console.error("Failed to generate sovereign blueprint:", error);
+  process.exitCode = 1;
+});
+

--- a/demo/alpha-agi-mark/scripts/runOperatorSuite.ts
+++ b/demo/alpha-agi-mark/scripts/runOperatorSuite.ts
@@ -64,6 +64,8 @@ function main() {
     { label: "Owner parameter matrix", command: "npx", args: tsNodeArgs("exportOwnerMatrix.ts") },
     { label: "Triple-verification replay", command: "npx", args: tsNodeArgs("verifyRecap.ts") },
     { label: "Integrity dossier synthesis", command: "npx", args: tsNodeArgs("generateIntegrityReport.ts") },
+    { label: "Mission timeline rendering", command: "npx", args: tsNodeArgs("generateMissionTimeline.ts") },
+    { label: "Sovereign blueprint emission", command: "npx", args: tsNodeArgs("generateSovereignBlueprint.ts") },
   ];
 
   const suiteStart = Date.now();
@@ -72,6 +74,8 @@ function main() {
   const recapPath = path.join(demoDir, "reports", "alpha-mark-recap.json");
   const dashboardPath = path.join(demoDir, "reports", "alpha-mark-dashboard.html");
   const integrityPath = path.join(demoDir, "reports", "alpha-mark-integrity.md");
+  const timelinePath = path.join(demoDir, "reports", "alpha-mark-timeline.md");
+  const blueprintPath = path.join(demoDir, "reports", "alpha-mark-blueprint.md");
   const ownerMatrixNote = "Run `npm run owner:alpha-agi-mark` to re-print the owner matrix at any time.";
 
   const elapsed = ((Date.now() - suiteStart) / 1000).toFixed(2);
@@ -79,6 +83,8 @@ function main() {
   console.log(`   • Recap dossier: ${path.relative(repoRoot, recapPath)}`);
   console.log(`   • Sovereign dashboard: ${path.relative(repoRoot, dashboardPath)}`);
   console.log(`   • Integrity report: ${path.relative(repoRoot, integrityPath)}`);
+  console.log(`   • Mission timeline: ${path.relative(repoRoot, timelinePath)}`);
+  console.log(`   • Sovereign blueprint: ${path.relative(repoRoot, blueprintPath)}`);
   console.log(`   • ${ownerMatrixNote}`);
 }
 

--- a/package.json
+++ b/package.json
@@ -166,7 +166,8 @@
     "verify:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/verifyRecap.ts",
     "integrity:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateIntegrityReport.ts",
     "timeline:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateMissionTimeline.ts",
-    "console:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/operatorConsole.ts"
+    "console:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/operatorConsole.ts",
+    "blueprint:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateSovereignBlueprint.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a dedicated `generateSovereignBlueprint` script that produces a cross-verified markdown blueprint from the recap dossier
- extend the operator suite to emit the new blueprint and mission timeline, and document the richer artefact flow
- expose npm scripts and documentation updates so non-technical operators can regenerate the timeline and blueprint on demand

## Testing
- npm run blueprint:alpha-agi-mark
- npm run timeline:alpha-agi-mark

------
https://chatgpt.com/codex/tasks/task_e_68f186b466d48333a400b9d3c634f949