### PR TITLE
Track sovereign intake breakdown in alpha-agi-mark demo

### DIFF
--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -140,6 +140,8 @@ Every demo run now emits a cinematic HTML dossier at `demo/alpha-agi-mark/report
 any browser to explore:
 
 - Mission control metrics capturing validator consensus, reserve power, and sovereign vault status
+- Dedicated gauges for native vs. external sovereign intake with ignition-mode badges so compliance teams instantly know which
+  asset underwrote the launch
 - A telemetry envelope showing network, orchestrator git metadata, actor registries, and the live recap checksum badge
 - A control-deck grid showing every owner actuator with live status badges
 - Full participant ledger plus the operator parameter matrix rendered as responsive tables

--- a/demo/alpha-agi-mark/contracts/AlphaMarkEToken.sol
+++ b/demo/alpha-agi-mark/contracts/AlphaMarkEToken.sol
@@ -15,7 +15,7 @@ interface IAlphaMarkRiskOracle {
 }
 
 interface IAlphaSovereignVault {
-    function notifyLaunch(uint256 amount, bytes calldata metadata) external returns (bool);
+    function notifyLaunch(uint256 amount, bool usedNativeAsset, bytes calldata metadata) external returns (bool);
 }
 
 error LaunchAcknowledgementFailed(address recipient);
@@ -447,7 +447,7 @@ contract AlphaMarkEToken is ERC20, Ownable, Pausable, ReentrancyGuard {
             return;
         }
 
-        try IAlphaSovereignVault(recipient).notifyLaunch(amount, metadata) returns (bool acknowledged) {
+        try IAlphaSovereignVault(recipient).notifyLaunch(amount, usesNativeAsset, metadata) returns (bool acknowledged) {
             if (!acknowledged) {
                 revert LaunchAcknowledgementRejected(recipient);
             }

--- a/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
+++ b/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
@@ -283,7 +283,7 @@
             <span class="badge info">Dry Run</span>
             <span class="badge warning">Workspace Dirty</span>
             <span class="hero-stamp">hardhat (chainId 31337)</span>
-            <span class="hero-stamp">Generated 2025-10-16T22:28:58.620Z</span>
+            <span class="hero-stamp">Generated 2025-10-17T00:07:19.581Z</span>
           </div>
         </header>
 
@@ -294,19 +294,19 @@
             <article class="meta-card">
               <h3>Recap Envelope</h3>
               <ul>
-                <li><strong>Generated</strong>: 2025-10-16T22:28:58.620Z</li>
+                <li><strong>Generated</strong>: 2025-10-17T00:07:19.581Z</li>
                 <li><strong>Network</strong>: hardhat (chainId 31337)</li>
                 <li><strong>Chain</strong>: 31337</li>
                 <li><strong>Block</strong>: 0</li>
                 <li><strong>Dry-run mode</strong>: Enabled</li>
-                <li><strong>Checksum</strong>: <code>sha256:fd9fa6cf56c3f3e497c5ce72aafebcba39b660c1344eff89646e7ac659fb194b</code></li>
+                <li><strong>Checksum</strong>: <code>sha256:dbb1a7269bd3522a62b15c38be2660f1930ac5bef5c3c90bee1e9f63542cc57d</code></li>
               </ul>
             </article>
             <article class="meta-card">
               <h3>Orchestrator</h3>
               <ul>
                 <li><strong>Mode</strong>: Dry run</li>
-                <li><strong>Commit</strong>: c7f11d9aec96ad3de7103c89aaa8f517bbc9040c</li>
+                <li><strong>Commit</strong>: b6c4131c3baef4ed756322c418f9ce60ca187422</li>
                 <li><strong>Branch</strong>: work</li>
                 <li><strong>Workspace dirty</strong>: Yes</li>
               </ul>
@@ -608,7 +608,12 @@ timeline
           <article class="metric">
             <h3>Sovereign Vault</h3>
             <strong>3.85</strong>
-            <p>Manifest URI: ipfs://alpha-mark/sovereign/genesis<br />Last ignition: 3.85</p>
+            <p>
+              Manifest URI: ipfs://alpha-mark/sovereign/genesis<br />
+              Native intake: 3.85<br />
+              External intake: 0.0<br />
+              Last ignition: 3.85 · Native asset
+            </p>
           </article>
           <article class="metric">
             <h3>Participants</h3>

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.json
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-16T22:28:58.620Z",
+  "generatedAt": "2025-10-17T00:07:19.581Z",
   "network": {
     "label": "hardhat (chainId 31337)",
     "name": "hardhat",
@@ -8,7 +8,7 @@
     "dryRun": true
   },
   "orchestrator": {
-    "commit": "c7f11d9aec96ad3de7103c89aaa8f517bbc9040c",
+    "commit": "b6c4131c3baef4ed756322c418f9ce60ca187422",
     "branch": "work",
     "workspaceDirty": true,
     "mode": "dry-run"
@@ -122,12 +122,17 @@
       "manifestUri": "ipfs://alpha-mark/sovereign/genesis",
       "totalReceivedWei": "3850000000000000000",
       "totalReceivedEth": "3.85",
+      "totalReceivedNativeWei": "3850000000000000000",
+      "totalReceivedNativeEth": "3.85",
+      "totalReceivedExternalWei": "0",
+      "totalReceivedExternalEth": "0.0",
       "lastAcknowledgedAmountWei": "3850000000000000000",
       "lastAcknowledgedAmountEth": "3.85",
       "lastAcknowledgedMetadataHex": "0xceb12d41474920536f7665726569676e2069676e6974696f6e3a204e6f76612d5365656420617363656e6473",
       "decodedMetadata": "α-AGI Sovereign ignition: Nova-Seed ascends",
       "vaultBalanceWei": "3850000000000000000",
-      "vaultBalanceEth": "3.85"
+      "vaultBalanceEth": "3.85",
+      "lastAcknowledgedUsedNative": true
     }
   },
   "trades": [
@@ -490,6 +495,6 @@
   "checksums": {
     "algorithm": "sha256",
     "canonicalEncoding": "json-key-sorted",
-    "recapSha256": "fd9fa6cf56c3f3e497c5ce72aafebcba39b660c1344eff89646e7ac659fb194b"
+    "recapSha256": "dbb1a7269bd3522a62b15c38be2660f1930ac5bef5c3c90bee1e9f63542cc57d"
   }
 }

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -42,6 +42,7 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    - validator council roster and votes
    - bonding curve statistics (supply, reserve balance, pricing)
    - launch outcome summary, including sovereign vault manifest, acknowledgement metadata, and treasury balance
+   - breakdown of native vs. external sovereign intake plus the ignition-mode badge captured in the recap
    - `ownerParameterMatrix` providing a full owner control matrix with descriptions
    - cross-reference visuals from the [`Operator Empowerment Atlas`](../docs/operator-empowerment-atlas.md) and
      [`Operator Command Console`](../docs/operator-command-console.md) for stakeholder briefings

--- a/demo/alpha-agi-mark/scripts/operatorConsole.ts
+++ b/demo/alpha-agi-mark/scripts/operatorConsole.ts
@@ -166,8 +166,14 @@ const recapSchema = z
           .object({
             manifestUri: z.string().optional(),
             totalReceivedWei: z.string().optional(),
+            totalReceivedNativeWei: z.string().optional(),
+            totalReceivedExternalWei: z.string().optional(),
             lastAcknowledgedAmountWei: z.string().optional(),
             decodedMetadata: z.string().optional(),
+            totalReceivedEth: z.string().optional(),
+            totalReceivedNativeEth: z.string().optional(),
+            totalReceivedExternalEth: z.string().optional(),
+            lastAcknowledgedUsedNative: z.boolean().optional(),
           })
           .passthrough()
           .optional(),
@@ -227,6 +233,7 @@ const styles = {
   accent: (text: string) => colour(text, "38;2;224;245;255"),
   muted: (text: string) => colour(text, "2;38;2;180;200;215"),
   success: (text: string) => colour(text, "1;38;2;110;255;180"),
+  info: (text: string) => colour(text, "1;38;2;130;200;255"),
   warning: (text: string) => colour(text, "1;38;2;255;210;110"),
   danger: (text: string) => colour(text, "1;38;2;255;120;120"),
 };
@@ -350,10 +357,20 @@ function renderSummary(recap: Recap): void {
     ["Launch status", launchStatus],
     ["Treasury", formatAddress(treasury)],
     [
-      "Vault received",
+      "Vault intake",
       sovereign?.totalReceivedWei
-        ? `${weiToEth(sovereign.totalReceivedWei)} ETH`
+        ? `${weiToEth(sovereign.totalReceivedWei)} units (native ${weiToEth(
+            sovereign.totalReceivedNativeWei,
+          )} | external ${weiToEth(sovereign.totalReceivedExternalWei)})`
         : "—",
+    ],
+    [
+      "Ignition mode",
+      sovereign?.lastAcknowledgedUsedNative === undefined
+        ? "—"
+        : sovereign.lastAcknowledgedUsedNative
+          ? styles.success("Native asset")
+          : styles.info("External asset"),
     ],
     ["Seed holder", formatAddress(recap.seed?.holder ?? recap.actors.owner)],
     ["Supply", recap.bondingCurve?.supplyWholeTokens ?? "n/a"],

--- a/demo/alpha-agi-mark/scripts/renderDashboard.ts
+++ b/demo/alpha-agi-mark/scripts/renderDashboard.ts
@@ -148,13 +148,18 @@ type RecapData = {
     sovereignVault: {
       manifestUri: string;
       totalReceivedWei: string;
+      totalReceivedNativeWei: string;
+      totalReceivedExternalWei: string;
       lastAcknowledgedAmountWei: string;
       lastAcknowledgedMetadataHex: string;
       decodedMetadata: string;
       vaultBalanceWei: string;
       totalReceivedEth?: string;
+      totalReceivedNativeEth?: string;
+      totalReceivedExternalEth?: string;
       lastAcknowledgedAmountEth?: string;
       vaultBalanceEth?: string;
+      lastAcknowledgedUsedNative?: boolean;
     };
   };
   ownerParameterMatrix?: Array<{ parameter: string; value: unknown; description: string }>;
@@ -570,10 +575,21 @@ function buildDashboardHtml(recap: RecapData): string {
     recap.launch.sovereignVault.totalReceivedEth,
     `${recap.launch.sovereignVault.totalReceivedWei} wei`,
   );
+  const sovereignNative = formatNumber(
+    recap.launch.sovereignVault.totalReceivedNativeEth,
+    `${recap.launch.sovereignVault.totalReceivedNativeWei} wei`,
+  );
+  const sovereignToken = formatNumber(
+    recap.launch.sovereignVault.totalReceivedExternalEth,
+    `${recap.launch.sovereignVault.totalReceivedExternalWei} wei`,
+  );
   const lastIgnition = formatNumber(
     recap.launch.sovereignVault.lastAcknowledgedAmountEth,
     `${recap.launch.sovereignVault.lastAcknowledgedAmountWei} wei`,
   );
+  const lastIgnitionMode = recap.launch.sovereignVault.lastAcknowledgedUsedNative
+    ? "Native asset"
+    : "External asset";
 
   const ownerMatrix = buildOwnerMatrixTable(recap.ownerParameterMatrix ?? []);
   const timelineSection = buildTimelineSection(recap.timeline ?? []);
@@ -947,9 +963,12 @@ function buildDashboardHtml(recap: RecapData): string {
           <article class="metric">
             <h3>Sovereign Vault</h3>
             <strong>${escapeHtml(sovereignBalance)}</strong>
-            <p>Manifest URI: ${escapeHtml(recap.launch.sovereignVault.manifestUri)}<br />Last ignition: ${escapeHtml(
-              lastIgnition,
-            )}</p>
+            <p>
+              Manifest URI: ${escapeHtml(recap.launch.sovereignVault.manifestUri)}<br />
+              Native intake: ${escapeHtml(sovereignNative)}<br />
+              External intake: ${escapeHtml(sovereignToken)}<br />
+              Last ignition: ${escapeHtml(lastIgnition)} · ${escapeHtml(lastIgnitionMode)}
+            </p>
           </article>
           <article class="metric">
             <h3>Participants</h3>

--- a/demo/alpha-agi-mark/scripts/runDemo.ts
+++ b/demo/alpha-agi-mark/scripts/runDemo.ts
@@ -596,6 +596,9 @@ async function main() {
 
   const sovereignMetadata = await sovereignVault.lastAcknowledgedMetadata();
   const sovereignTotalReceived = await sovereignVault.totalReceived();
+  const sovereignNativeReceived = await sovereignVault.totalReceivedNative();
+  const sovereignTokenReceived = await sovereignVault.totalReceivedExternal();
+  const lastAcknowledgedUsedNative = await sovereignVault.lastAcknowledgedUsedNative();
   const lastAcknowledgedAmount = await sovereignVault.lastAcknowledgedAmount();
   const vaultBalance = await sovereignVault.vaultBalance();
   const combinedReserve = reserve + sovereignTotalReceived;
@@ -679,12 +682,17 @@ async function main() {
         manifestUri: await sovereignVault.manifestUri(),
         totalReceivedWei: sovereignTotalReceived.toString(),
         totalReceivedEth: ethers.formatEther(sovereignTotalReceived),
+        totalReceivedNativeWei: sovereignNativeReceived.toString(),
+        totalReceivedNativeEth: ethers.formatEther(sovereignNativeReceived),
+        totalReceivedExternalWei: sovereignTokenReceived.toString(),
+        totalReceivedExternalEth: ethers.formatEther(sovereignTokenReceived),
         lastAcknowledgedAmountWei: lastAcknowledgedAmount.toString(),
         lastAcknowledgedAmountEth: ethers.formatEther(lastAcknowledgedAmount),
         lastAcknowledgedMetadataHex: sovereignMetadata,
         decodedMetadata: ethers.toUtf8String(sovereignMetadata),
         vaultBalanceWei: vaultBalance.toString(),
         vaultBalanceEth: ethers.formatEther(vaultBalance),
+        lastAcknowledgedUsedNative,
       },
     },
   };

--- a/demo/alpha-agi-mark/scripts/verifyRecap.ts
+++ b/demo/alpha-agi-mark/scripts/verifyRecap.ts
@@ -107,12 +107,15 @@ const recapSchema = z.object({
     .object({
       sovereignVault: z
         .object({
-        totalReceivedWei: z.string(),
-        totalReceivedEth: z.string().optional(),
-        lastAcknowledgedAmountWei: z.string().optional(),
-        lastAcknowledgedAmountEth: z.string().optional(),
-        vaultBalanceWei: z.string().optional(),
-      })
+          totalReceivedWei: z.string(),
+          totalReceivedNativeWei: z.string().optional(),
+          totalReceivedExternalWei: z.string().optional(),
+          totalReceivedEth: z.string().optional(),
+          lastAcknowledgedAmountWei: z.string().optional(),
+          lastAcknowledgedAmountEth: z.string().optional(),
+          vaultBalanceWei: z.string().optional(),
+          lastAcknowledgedUsedNative: z.boolean().optional(),
+        })
         .passthrough(),
     })
     .passthrough(),
@@ -164,6 +167,14 @@ function main() {
       const vaultReceived = parseBigInt(
         recap.launch.sovereignVault.totalReceivedWei,
         "sovereign vault receipts",
+      );
+      const vaultNative = parseBigInt(
+        recap.launch.sovereignVault.totalReceivedNativeWei ?? "0",
+        "sovereign vault native intake",
+      );
+      const vaultExternal = parseBigInt(
+        recap.launch.sovereignVault.totalReceivedExternalWei ?? "0",
+        "sovereign vault external intake",
       );
 
       let ledgerSupply = 0n;
@@ -241,6 +252,13 @@ function main() {
         reserveWei + vaultReceived === ledgerNetWei,
         formatWei(ledgerNetWei),
         formatWei(reserveWei + vaultReceived),
+      );
+
+      appendCheck(
+        "Vault intake splits match aggregate",
+        vaultNative + vaultExternal === vaultReceived,
+        formatWei(vaultReceived),
+        formatWei(vaultNative + vaultExternal),
       );
 
       appendCheck(


### PR DESCRIPTION
## Summary
- track native vs external sovereign vault intake and expose new launch metadata controls
- update demo scripts, dashboards, and console to surface intake breakdowns and ignition mode
- extend tests and recap verification to validate the new accounting paths

## Testing
- `npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts`
- `npm run demo:alpha-agi-mark`
- `npm run verify:alpha-agi-mark`


------
https://chatgpt.com/codex/tasks/task_e_68f186b466d48333a400b9d3c634f949