### PR TITLE
Add verification confidence summary to alpha-agi-mark demo

### DIFF
--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -188,7 +188,16 @@ timeline
 α-AGI MARK now triangulates its state through three independent vantage points—on-chain contract reads, a deterministic
 trade ledger, and a first-principles bonding-curve simulator. Every run prints a "Triple-Verification Matrix" confirming that
 all three perspectives agree on supply, pricing, capital flows, and participant contributions. The recap dossier exposes the
-results under a new `verification` section and the dashboard renders the matrix as a dedicated integrity panel.
+results under a new `verification` section and the dashboard renders the matrix as a dedicated integrity panel. The orchestrator
+also records a `summary` object with:
+
+- `confidenceIndexPercent` / `confidenceIndexBps` – mathematically derived confidence index from the core checks (basis points and human-readable %)
+- `passedChecks` / `totalChecks` – the authoritative ledger of how many invariants aligned
+- `verdict` – `PASS` when every invariant reconciles, `REVIEW` if any discrepancy surfaces
+- `checks[]` – canonical labels and booleans for each pillar so downstream tools can display consistent messaging
+
+All downstream surfaces (console, dashboard, integrity dossier, verifier) consume the same summary so a non-technical operator
+sees identical confidence numbers everywhere.
 
 ```mermaid
 flowchart LR

--- a/demo/alpha-agi-mark/docs/operator-verification-compendium.md
+++ b/demo/alpha-agi-mark/docs/operator-verification-compendium.md
@@ -34,7 +34,10 @@ mindmap
 
 The orchestrator captures every signal into artefacts that a non-technical user can open in their browser. The
 triangulation engine cross-references three independent perspectives so that no single ledger can be tampered with
-without detection.
+without detection. Every recap now emits a `verification.summary` bundle containing the canonical confidence index
+(basis points + human readable percentage), the exact number of invariants that passed, the launch verdict, and a
+machine-readable list of each check. Because the summary is embedded in the recap, console, dashboard, integrity report,
+and verifier all display identical confidence numbers without manual reconciliation.
 
 ## Operator flow – five minute audit
 

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -82,7 +82,9 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    ```
 
    The script replays the trade ledger from the recap, recomputes the bonding-curve math independently, and
-   prints a confidence index table that must read 100% before green-lighting any external announcement.
+   prints a confidence index table that must read 100% before green-lighting any external announcement. The recap now
+   carries a `verification.summary` payload (confidence index, passed/total counts, verdict, labelled checks) so the
+   console, dashboard, and integrity dossier all present the exact same confidence score.
 
 7. **Emit the integrity dossier for stakeholder sign-off**
 


### PR DESCRIPTION
## Summary
- capture bonding-curve verification results with a summary object that records confidence, pass counts, and verdicts in the recap
- surface the shared confidence summary across the dashboard, operator console, integrity dossier, and verification script while cross-checking the recorded data
- document the new operator-facing confidence signals in the README, verification compendium, and runbook

## Testing
- npm run demo:alpha-agi-mark:ci
- npm run verify:alpha-agi-mark
- npm run integrity:alpha-agi-mark

------
https://chatgpt.com/codex/tasks/task_e_68f19294031883339d9c753b4a0e366b