### PR TITLE
Add empowerment pulse dossier to alpha-agi-mark demo

### DIFF
--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -152,6 +152,32 @@ jobs:
           console.log('Integrity dossier validated.');
           NODE
 
+      - name: Forge empowerment pulse dossier
+        run: npm run pulse:alpha-agi-mark
+
+      - name: Validate empowerment pulse dossier
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = 'demo/alpha-agi-mark/reports/alpha-mark-empowerment.md';
+          if (!fs.existsSync(path)) {
+            throw new Error('empowerment dossier missing');
+          }
+          const content = fs.readFileSync(path, 'utf8');
+          const requiredSections = [
+            '# α-AGI MARK Empowerment Pulse',
+            '## Mission Snapshot',
+            '```mermaid',
+            '## Operator Command Deck',
+          ];
+          for (const section of requiredSections) {
+            if (!content.includes(section)) {
+              throw new Error(`empowerment dossier missing section: ${section}`);
+            }
+          }
+          console.log('Empowerment pulse dossier validated.');
+          NODE
+
       - name: Render mission timeline
         run: npm run timeline:alpha-agi-mark
 
@@ -184,6 +210,12 @@ jobs:
         with:
           name: alpha-agi-mark-integrity
           path: demo/alpha-agi-mark/reports/alpha-mark-integrity.md
+
+      - name: Upload α-AGI MARK empowerment pulse
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpha-agi-mark-empowerment
+          path: demo/alpha-agi-mark/reports/alpha-mark-empowerment.md
 
       - name: Upload α-AGI MARK mission timeline
         uses: actions/upload-artifact@v4

--- a/demo/alpha-agi-mark/.gitignore
+++ b/demo/alpha-agi-mark/.gitignore
@@ -5,5 +5,6 @@ reports/*
 !reports/alpha-mark-recap.json
 !reports/alpha-mark-dashboard.html
 !reports/alpha-mark-integrity.md
+!reports/alpha-mark-empowerment.md
 !reports/alpha-mark-risk-lattice.md
 !reports/alpha-mark-timeline.md

--- a/demo/alpha-agi-mark/README.md
+++ b/demo/alpha-agi-mark/README.md
@@ -135,6 +135,17 @@ This generates `reports/alpha-mark-integrity.md` – a mermaid-enhanced dossier 
 confidence matrix, owner controls, validator quorum, and participant contributions so non-technical
 stakeholders can sign off in minutes.
 
+### Empowerment pulse dossier
+
+```bash
+npm run pulse:alpha-agi-mark
+```
+
+Synthesises `reports/alpha-mark-empowerment.md`, a sovereign-grade empowerment brief that blends a
+quadrant chart, participant capital pie chart, and timeline into one artefact. It translates the
+automation multiplier, validator quorum, and owner control matrix into a single executive-ready
+snapshot proving how AGI Jobs v0 (v2) behaves like a boardroom-calibre intelligence layer.
+
 ### Sovereign risk lattice
 
 ```bash

--- a/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
+++ b/demo/alpha-agi-mark/reports/alpha-mark-dashboard.html
@@ -98,6 +98,45 @@
         color: var(--accent);
         font-weight: 600;
       }
+      .empowerment-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1.5rem;
+      }
+      .empowerment-card {
+        border: 1px solid rgba(96, 255, 207, 0.18);
+        border-radius: 14px;
+        padding: 1.6rem;
+        background: rgba(12, 18, 45, 0.55);
+        box-shadow: inset 0 0 0 1px rgba(96, 255, 207, 0.08);
+      }
+      .empowerment-card h3 {
+        margin-top: 0;
+        font-size: 0.95rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .metric-value {
+        font-size: 1.9rem;
+        font-weight: 600;
+        color: var(--accent);
+        margin: 0.25rem 0;
+      }
+      .metric-caption {
+        margin: 0;
+        color: rgba(255, 255, 255, 0.78);
+        font-size: 0.9rem;
+      }
+      .empowerment-list {
+        list-style: none;
+        padding: 0;
+        margin: 0.9rem 0 0 0;
+        font-size: 0.85rem;
+        color: rgba(224, 245, 255, 0.85);
+      }
+      .empowerment-list li + li {
+        margin-top: 0.35rem;
+      }
       .control-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -113,6 +152,49 @@
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
         gap: 1.5rem;
+      }
+      .verification-summary {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+        padding: 1rem 1.25rem;
+        border-radius: 14px;
+        border: 1px solid rgba(96, 255, 207, 0.22);
+        background: rgba(255, 255, 255, 0.05);
+      }
+      .verification-summary .summary-metric {
+        display: flex;
+        align-items: baseline;
+        gap: 0.6rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .verification-summary .confidence-value {
+        font-size: 1.9rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        color: var(--accent);
+      }
+      .verification-summary .summary-verdict {
+        margin-left: auto;
+        padding: 0.35rem 0.9rem;
+        border-radius: 999px;
+        border: 1px solid;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        font-weight: 600;
+      }
+      .verification-summary .summary-verdict.success {
+        color: var(--success);
+        border-color: rgba(46, 204, 113, 0.6);
+        background: rgba(46, 204, 113, 0.18);
+      }
+      .verification-summary .summary-verdict.warning {
+        color: var(--warning);
+        border-color: rgba(255, 179, 71, 0.6);
+        background: rgba(255, 179, 71, 0.18);
       }
       .verification-card {
         background: rgba(255, 255, 255, 0.05);
@@ -283,7 +365,7 @@
             <span class="badge info">Dry Run</span>
             <span class="badge warning">Workspace Dirty</span>
             <span class="hero-stamp">hardhat (chainId 31337)</span>
-            <span class="hero-stamp">Generated 2025-10-17T00:07:19.581Z</span>
+            <span class="hero-stamp">Generated 2025-10-17T06:38:11.603Z</span>
           </div>
         </header>
 
@@ -294,19 +376,19 @@
             <article class="meta-card">
               <h3>Recap Envelope</h3>
               <ul>
-                <li><strong>Generated</strong>: 2025-10-17T00:07:19.581Z</li>
+                <li><strong>Generated</strong>: 2025-10-17T06:38:11.603Z</li>
                 <li><strong>Network</strong>: hardhat (chainId 31337)</li>
                 <li><strong>Chain</strong>: 31337</li>
                 <li><strong>Block</strong>: 0</li>
                 <li><strong>Dry-run mode</strong>: Enabled</li>
-                <li><strong>Checksum</strong>: <code>sha256:dbb1a7269bd3522a62b15c38be2660f1930ac5bef5c3c90bee1e9f63542cc57d</code></li>
+                <li><strong>Checksum</strong>: <code>sha256:c79f8a1af52d09b5785a4103ab3d33f4b677cdb7d65535952bd87ff05b530a71</code></li>
               </ul>
             </article>
             <article class="meta-card">
               <h3>Orchestrator</h3>
               <ul>
                 <li><strong>Mode</strong>: Dry run</li>
-                <li><strong>Commit</strong>: b6c4131c3baef4ed756322c418f9ce60ca187422</li>
+                <li><strong>Commit</strong>: 75372aa7896adefa34e8979283019fa2546fd110</li>
                 <li><strong>Branch</strong>: work</li>
                 <li><strong>Workspace dirty</strong>: Yes</li>
               </ul>
@@ -321,6 +403,51 @@
             </article>
           </div>
         </section>
+  
+
+        
+    <section>
+      <h2>Operator Empowerment Constellation</h2>
+      <p>AGI Jobs orchestrated 22 mission events from 1 command, sustaining 100.00% confidence across 4/4 invariants.</p>
+      <div class="empowerment-grid">
+        <article class="empowerment-card">
+          <h3>Automation</h3>
+          <p class="metric-value">22.00×</p>
+          <p class="metric-caption">22 orchestrated actions from 1 command</p>
+        </article>
+        <article class="empowerment-card">
+          <h3>Assurance</h3>
+          <p class="metric-value">100.00%</p>
+          <p class="metric-caption">4/4 checks · Validators 2/2</p>
+        </article>
+        <article class="empowerment-card">
+          <h3>Capital Formation</h3>
+          <p class="metric-value">4.5</p>
+          <p class="metric-caption">3 participants · Reserve 0.0</p>
+        </article>
+        <article class="empowerment-card">
+          <h3>Command Deck</h3>
+          <p class="metric-value">16</p>
+          <p class="metric-caption">Owner actuators catalogued in the parameter matrix.</p>
+          
+        <ul class="empowerment-list">
+          
+        <li><code>pauseMarket</code></li>
+      
+
+        <li><code>whitelistEnabled</code></li>
+      
+
+        <li><code>emergencyExitEnabled</code></li>
+      
+
+        <li><code>validationOverrideEnabled</code></li>
+      
+        </ul>
+      
+        </article>
+      </div>
+    </section>
   
 
         
@@ -362,7 +489,7 @@ timeline
     section Launch
       ✨ Sovereign ignition finalized (Owner (0xf39F…2266)) : Funds transferred to the vault with ignition metadata recorded
     section Verification
-      ✅ Triple-verification matrix aligned : Ledger, simulation, and on-chain state reconcile 1\:1
+      ✅ Triple-verification matrix aligned : Ledger, simulation, and on-chain state reconcile 4/4 checks (100.00% confidence)
     section Mission Control
       🧾 Recap dossier synthesis : Preparing sovereign dashboard, owner matrix, and recap digest
       </pre>
@@ -563,7 +690,7 @@ timeline
           <td>21</td>
           <td>Verification</td>
           <td>✅ Triple-verification matrix aligned</td>
-          <td>Ledger, simulation, and on-chain state reconcile 1:1</td>
+          <td>Ledger, simulation, and on-chain state reconcile 4/4 checks (100.00% confidence)</td>
           <td>—</td>
         </tr>
       
@@ -630,6 +757,15 @@ timeline
         Independent ledgers, on-chain state introspection, and first-principles math cross-check the sovereign launch
         in real time.
       </p>
+      
+      <div class="verification-summary">
+        <div class="summary-metric">
+          <span class="confidence-value">100.00%</span>
+          confidence (4/4 checks)
+        </div>
+        <div class="summary-verdict success">PASS</div>
+      </div>
+    
       <div class="verification-grid">
         
         <article class="verification-card">

--- a/demo/alpha-agi-mark/reports/alpha-mark-empowerment.md
+++ b/demo/alpha-agi-mark/reports/alpha-mark-empowerment.md
@@ -1,0 +1,88 @@
+# α-AGI MARK Empowerment Pulse
+
+Generated 2025-10-17T06:38:11.603Z on **hardhat (chainId 31337)** (hardhat, chainId 31337).
+
+AGI Jobs orchestrated 22 mission events from 1 command, sustaining 100.00% confidence across 4/4 invariants.
+
+## Mission Snapshot
+
+- Orchestrator mode: **dry-run**
+- Automation multiplier: **22.00×** (22 orchestrated actions from 1 command)
+- Verification confidence: **100.00%** (4/4 checks · verdict PASS)
+- Validator quorum: **2/2** approvals
+- Capital formation: **3** participants · Gross **4.5 ETH** · Reserve **0 ETH**
+
+## Autonomous Command Quadrant
+
+```mermaid
+quadrantChart
+    title Empowerment Coordinates
+    x-axis Manual Touchpoints --> Autonomous Execution
+    y-axis Low Assurance --> Board-Level Assurance
+    quadrant-1 Sovereign Autopilot
+    quadrant-2 Assisted Governance
+    quadrant-3 Manual Baseline
+    quadrant-4 Tactical Workshop
+    "AGI Jobs orchestrator" : [0.9565, 0.99]
+    "Validator council" : [0.8, 0.9]
+    "Legacy manual launch" : [0.18, 0.20]
+    "Ad-hoc compliance" : [0.35, 0.45]
+```
+
+## Capital Participation Map
+
+```mermaid
+pie showData
+    title Capital Formation by Participant
+    "0x7099…79C8" : 1
+    "0x3C44…93BC" : 1.2
+    "0x90F7…b906" : 2.3
+```
+
+## Orchestration Timeline
+
+```mermaid
+timeline
+    title Orchestrated Empowerment Trajectory
+    section Orchestration
+      Mission boot sequence : AGI Jobs orchestrator engaged on hardhat (chainId 31337) (dry-run mode)
+      Actors cleared for launch : Owner, investors, and validators funded ≥ 0.05 ETH
+    section Seed Genesis
+      Nova-Seed minted (#1) : Operator forges the foresight seed NFT underpinning the launch
+    section Deployment
+      Risk oracle council activated : Validator quorum contract online with 2-of-3 threshold
+      Bonding-curve exchange deployed : AlphaMarkEToken market-maker ready for capital formation
+      Sovereign vault commissioned : Vault bound to the exchange for sovereign ignition
+    section Safety & Compliance
+      Vault circuit breaker tested : Owner pauses and resumes the sovereign vault to verify emergency controls
+      Market paused for compliance review : Owner halts trading to showcase real-time control
+      Pause enforcement confirmed : Investor C blocked while the market pause is active
+```
+
+## Operator Command Deck
+
+- Market paused: **Yes**
+- Whitelist enforced: **Yes**
+- Emergency exit: **Off**
+- Validation override: **Inactive**
+- Sale finalised: **Finalised**
+- Sale aborted: **No**
+- Base asset: **Native (ETH)**
+- Sovereign treasury: `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`
+- Active risk oracle: `0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0`
+- Highlighted actuators: `pauseMarket` · `whitelistEnabled` · `emergencyExitEnabled` · `validationOverrideEnabled`
+
+## Participant Ledger
+
+| Participant | Tokens | Contribution (ETH) |
+| --- | ---: | ---: |
+| 0x7099…79C8 | 5.0 | 1 |
+| 0x3C44…93BC | 2.0 | 1.2 |
+| 0x90F7…b906 | 4.0 | 2.3 |
+
+---
+
+The empowerment pulse evidences a sovereign-grade automation fabric: AGI Jobs v0 (v2) elevated a single operator into a
+launch commander who steers validator governance, capital formation, and sovereign ignition without touching low-level
+Solidity. This dossier exists so boards, auditors, and public stewards can witness that intelligence, assurance, and
+governance fused into one artefact.

--- a/demo/alpha-agi-mark/reports/alpha-mark-recap.json
+++ b/demo/alpha-agi-mark/reports/alpha-mark-recap.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-17T00:07:19.581Z",
+  "generatedAt": "2025-10-17T06:38:11.603Z",
   "network": {
     "label": "hardhat (chainId 31337)",
     "name": "hardhat",
@@ -8,7 +8,7 @@
     "dryRun": true
   },
   "orchestrator": {
-    "commit": "b6c4131c3baef4ed756322c418f9ce60ca187422",
+    "commit": "75372aa7896adefa34e8979283019fa2546fd110",
     "branch": "work",
     "workspaceDirty": true,
     "mode": "dry-run"
@@ -298,6 +298,36 @@
       "ledgerGrossWei": "4500000000000000000",
       "ledgerGrossEth": "4.5",
       "consistent": true
+    },
+    "summary": {
+      "totalChecks": 4,
+      "passedChecks": 4,
+      "failedChecks": 0,
+      "confidenceIndexBps": 10000,
+      "confidenceIndexPercent": "100.00",
+      "verdict": "PASS",
+      "checks": [
+        {
+          "key": "supplyConsensus",
+          "label": "Supply consensus alignment",
+          "consistent": true
+        },
+        {
+          "key": "pricing",
+          "label": "Pricing integrity",
+          "consistent": true
+        },
+        {
+          "key": "capitalFlows",
+          "label": "Capital flow reconciliation",
+          "consistent": true
+        },
+        {
+          "key": "contributions",
+          "label": "Contribution accounting",
+          "consistent": true
+        }
+      ]
     }
   },
   "timeline": [
@@ -481,7 +511,7 @@
       "order": 21,
       "phase": "Verification",
       "title": "Triple-verification matrix aligned",
-      "description": "Ledger, simulation, and on-chain state reconcile 1:1",
+      "description": "Ledger, simulation, and on-chain state reconcile 4/4 checks (100.00% confidence)",
       "icon": "✅"
     },
     {
@@ -492,9 +522,40 @@
       "icon": "🧾"
     }
   ],
+  "empowerment": {
+    "tagline": "AGI Jobs orchestrated 22 mission events from 1 command, sustaining 100.00% confidence across 4/4 invariants.",
+    "automation": {
+      "manualCommands": 1,
+      "orchestratedActions": 22,
+      "automationMultiplier": "22.00"
+    },
+    "assurance": {
+      "verificationConfidencePercent": "100.00",
+      "checksPassed": 4,
+      "totalChecks": 4,
+      "validatorApprovals": 2,
+      "validatorThreshold": 2
+    },
+    "capitalFormation": {
+      "participants": 3,
+      "grossContributionsWei": "4500000000000000000",
+      "grossContributionsEth": "4.5",
+      "reserveWei": "0",
+      "reserveEth": "0.0"
+    },
+    "operatorControls": {
+      "totalControls": 16,
+      "highlights": [
+        "pauseMarket",
+        "whitelistEnabled",
+        "emergencyExitEnabled",
+        "validationOverrideEnabled"
+      ]
+    }
+  },
   "checksums": {
     "algorithm": "sha256",
     "canonicalEncoding": "json-key-sorted",
-    "recapSha256": "dbb1a7269bd3522a62b15c38be2660f1930ac5bef5c3c90bee1e9f63542cc57d"
+    "recapSha256": "c79f8a1af52d09b5785a4103ab3d33f4b677cdb7d65535952bd87ff05b530a71"
   }
 }

--- a/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
+++ b/demo/alpha-agi-mark/runbooks/alpha-agi-mark-runbook.md
@@ -96,7 +96,18 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    the verification table, owner command deck snapshot, and a mermaid contribution pie chart. Circulate
    it alongside the dashboard for executive approval.
 
-8. **Synthesize the risk lattice dossier**
+8. **Forge the empowerment pulse dossier**
+
+   ```bash
+   npm run pulse:alpha-agi-mark
+   ```
+
+   Generates `demo/alpha-agi-mark/reports/alpha-mark-empowerment.md`, merging a quadrant chart,
+   capital pie, and timeline into a single empowerment brief. It reuses the recap dossier to prove
+   the automation multiplier, validator quorum, and owner command deck are aligned for sovereign
+   launch authority.
+
+9. **Synthesize the risk lattice dossier**
 
    ```bash
    npm run lattice:alpha-agi-mark
@@ -106,7 +117,7 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    control deck, verification verdict, reserve telemetry, and (when available) the empowerment multiplier. Hand this to
    executives who need a single-page risk and assurance blueprint.
 
-9. **Publish the cinematic mission timeline**
+10. **Publish the cinematic mission timeline**
 
    ```bash
    npm run timeline:alpha-agi-mark
@@ -115,7 +126,7 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    Creates `demo/alpha-agi-mark/reports/alpha-mark-timeline.md`, blending a Mermaid timeline with a
    tabular ledger of every orchestrated action. Ideal for board briefings or audit evidence packs.
 
-10. **(Optional) Run unit tests**
+11. **(Optional) Run unit tests**
 
    ```bash
    npx hardhat test --config demo/alpha-agi-mark/hardhat.config.ts
@@ -125,7 +136,7 @@ This runbook describes how a non-technical operator can execute the α-AGI MARK 
    pause/emergency exit, abort, and residual withdrawal) so board operators can demonstrate contractual control with a
    single automated report.
 
-11. **(Optional) Dry-run on a fork or external network**
+12. **(Optional) Dry-run on a fork or external network**
 
    Set environment variables before invoking the script:
 

--- a/demo/alpha-agi-mark/scripts/generateEmpowermentPulse.ts
+++ b/demo/alpha-agi-mark/scripts/generateEmpowermentPulse.ts
@@ -1,0 +1,391 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+
+import { formatEther } from "ethers";
+import { z } from "zod";
+
+const RECAP_PATH = path.join(__dirname, "..", "reports", "alpha-mark-recap.json");
+const REPORT_PATH = path.join(__dirname, "..", "reports", "alpha-mark-empowerment.md");
+
+const participantSchema = z
+  .object({
+    address: z.string(),
+    tokens: z.string(),
+    tokensWei: z.string(),
+    contributionWei: z.string(),
+    contributionEth: z.string().optional(),
+  })
+  .passthrough();
+
+const timelineEntrySchema = z
+  .object({
+    phase: z.string(),
+    title: z.string(),
+    description: z.string(),
+    icon: z.string().optional(),
+    actor: z.string().optional(),
+    actorLabel: z.string().optional(),
+  })
+  .passthrough();
+
+const empowermentSchema = z
+  .object({
+    tagline: z.string(),
+    automation: z
+      .object({
+        manualCommands: z.number(),
+        orchestratedActions: z.number(),
+        automationMultiplier: z.string(),
+      })
+      .passthrough(),
+    assurance: z
+      .object({
+        verificationConfidencePercent: z.string(),
+        checksPassed: z.number(),
+        totalChecks: z.number(),
+        validatorApprovals: z.number(),
+        validatorThreshold: z.number(),
+      })
+      .passthrough(),
+    capitalFormation: z
+      .object({
+        participants: z.number(),
+        grossContributionsWei: z.string(),
+        grossContributionsEth: z.string().optional(),
+        reserveWei: z.string(),
+        reserveEth: z.string().optional(),
+      })
+      .passthrough(),
+    operatorControls: z
+      .object({
+        totalControls: z.number(),
+        highlights: z.array(z.string()).optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const ownerControlsSchema = z
+  .object({
+    paused: z.boolean(),
+    whitelistEnabled: z.boolean(),
+    emergencyExitEnabled: z.boolean(),
+    finalized: z.boolean(),
+    aborted: z.boolean(),
+    validationOverrideEnabled: z.boolean(),
+    validationOverrideStatus: z.boolean(),
+    treasury: z.string().optional(),
+    riskOracle: z.string().optional(),
+    baseAsset: z.string().optional(),
+    usesNativeAsset: z.boolean().optional(),
+  })
+  .passthrough();
+
+const verificationSchema = z
+  .object({
+    summary: z
+      .object({
+        totalChecks: z.number().optional(),
+        passedChecks: z.number().optional(),
+        confidenceIndexPercent: z.string().optional(),
+        verdict: z.string().optional(),
+      })
+      .partial()
+      .optional(),
+  })
+  .partial();
+
+const recapSchema = z
+  .object({
+    generatedAt: z.string(),
+    network: z
+      .object({
+        label: z.string(),
+        name: z.string(),
+        chainId: z.string(),
+        dryRun: z.boolean(),
+      })
+      .passthrough(),
+    orchestrator: z
+      .object({
+        mode: z.string().optional(),
+        commit: z.string().optional(),
+        branch: z.string().optional(),
+      })
+      .passthrough(),
+    empowerment: empowermentSchema,
+    ownerControls: ownerControlsSchema,
+    participants: z.array(participantSchema).nonempty("Participant ledger empty in recap"),
+    timeline: z.array(timelineEntrySchema).nonempty("Timeline missing from recap"),
+    verification: verificationSchema.optional(),
+  })
+  .passthrough();
+
+type Recap = z.infer<typeof recapSchema>;
+type Participant = z.infer<typeof participantSchema>;
+type TimelineEntry = z.infer<typeof timelineEntrySchema>;
+
+type NumberPoint = { automation: number; assurance: number };
+
+function parseBigInt(label: string, value: string | undefined): bigint {
+  if (!value) {
+    throw new Error(`${label} missing`);
+  }
+  try {
+    return BigInt(value);
+  } catch (error) {
+    throw new Error(`${label} is not a bigint: ${value}`);
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function toDecimal(value: bigint): number {
+  return Number.parseFloat(formatEther(value));
+}
+
+function formatNumber(value: number): string {
+  const trimmed = value.toFixed(4).replace(/\.0+$/, "").replace(/0+$/, "");
+  return trimmed.length === 0 ? "0" : trimmed;
+}
+
+function shorten(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function sanitizeMermaid(text: string): string {
+  return text.replace(/[\r\n]+/g, " " ).replace(/:/g, " -").replace(/`/g, "'");
+}
+
+function buildQuadrant(point: NumberPoint, validatorPoint: NumberPoint): string {
+  const orchestrator = `[${formatNumber(point.automation)}, ${formatNumber(point.assurance)}]`;
+  const validator = `[${formatNumber(validatorPoint.automation)}, ${formatNumber(validatorPoint.assurance)}]`;
+
+  return [
+    "```mermaid",
+    "quadrantChart",
+    "    title Empowerment Coordinates",
+    "    x-axis Manual Touchpoints --> Autonomous Execution",
+    "    y-axis Low Assurance --> Board-Level Assurance",
+    "    quadrant-1 Sovereign Autopilot",
+    "    quadrant-2 Assisted Governance",
+    "    quadrant-3 Manual Baseline",
+    "    quadrant-4 Tactical Workshop",
+    `    "AGI Jobs orchestrator" : ${orchestrator}`,
+    `    "Validator council" : ${validator}`,
+    '    "Legacy manual launch" : [0.18, 0.20]',
+    '    "Ad-hoc compliance" : [0.35, 0.45]',
+    "```",
+  ].join("\n");
+}
+
+function buildPie(participants: Array<{ label: string; value: number }>): string {
+  const lines: string[] = [
+    "```mermaid",
+    "pie showData",
+    "    title Capital Formation by Participant",
+  ];
+  participants.forEach((entry) => {
+    lines.push(`    "${entry.label}" : ${formatNumber(entry.value)}`);
+  });
+  lines.push("```");
+  return lines.join("\n");
+}
+
+function buildTimeline(entries: TimelineEntry[]): string {
+  const groups = new Map<string, TimelineEntry[]>();
+  entries.forEach((entry) => {
+    const key = entry.phase || "Mission";
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key)!.push(entry);
+  });
+
+  const limitedGroups = Array.from(groups.entries()).slice(0, 4);
+
+  const lines: string[] = ["```mermaid", "timeline", "    title Orchestrated Empowerment Trajectory"];
+  limitedGroups.forEach(([phase, items]) => {
+    lines.push(`    section ${sanitizeMermaid(phase)}`);
+    items.slice(0, 4).forEach((item) => {
+      const description = sanitizeMermaid(item.description);
+      lines.push(`      ${sanitizeMermaid(item.title)} : ${description}`);
+    });
+  });
+  lines.push("```");
+  return lines.join("\n");
+}
+
+function buildParticipantTable(participants: Participant[]): string {
+  const rows = participants.map((participant) => {
+    const contribution = participant.contributionEth
+      ? Number.parseFloat(participant.contributionEth)
+      : Number.parseFloat(formatEther(BigInt(participant.contributionWei)));
+    return {
+      address: participant.address,
+      short: shorten(participant.address),
+      tokens: participant.tokens,
+      contribution,
+    };
+  });
+
+  const tableLines: string[] = [
+    "| Participant | Tokens | Contribution (ETH) |",
+    "| --- | ---: | ---: |",
+  ];
+
+  rows.forEach((row) => {
+    tableLines.push(`| ${row.short} | ${row.tokens} | ${formatNumber(row.contribution)} |`);
+  });
+
+  return tableLines.join("\n");
+}
+
+function describeOwnerControls(recap: Recap): string {
+  const lines: string[] = [];
+  const controls = recap.ownerControls;
+  lines.push(`- Market paused: **${controls.paused ? "Yes" : "No"}**`);
+  lines.push(`- Whitelist enforced: **${controls.whitelistEnabled ? "Yes" : "No"}**`);
+  lines.push(`- Emergency exit: **${controls.emergencyExitEnabled ? "Enabled" : "Off"}**`);
+  lines.push(
+    `- Validation override: **${
+      controls.validationOverrideEnabled
+        ? controls.validationOverrideStatus
+          ? "Force-approved"
+          : "Force-rejected"
+        : "Inactive"
+    }**`,
+  );
+  lines.push(`- Sale finalised: **${controls.finalized ? "Finalised" : "Pending"}**`);
+  lines.push(`- Sale aborted: **${controls.aborted ? "Yes" : "No"}**`);
+
+  if (controls.usesNativeAsset !== undefined) {
+    lines.push(`- Base asset: **${controls.usesNativeAsset ? "Native (ETH)" : controls.baseAsset ?? "ERC-20"}**`);
+  }
+  if (controls.treasury) {
+    lines.push(`- Sovereign treasury: \`${controls.treasury}\``);
+  }
+  if (controls.riskOracle) {
+    lines.push(`- Active risk oracle: \`${controls.riskOracle}\``);
+  }
+
+  const highlights = recap.empowerment.operatorControls.highlights ?? [];
+  if (highlights.length > 0) {
+    lines.push("- Highlighted actuators: " + highlights.map((value) => `\`${value}\``).join(" · "));
+  }
+
+  return lines.join("\n");
+}
+
+async function generate() {
+  const raw = await readFile(RECAP_PATH, "utf8");
+  const parsed = recapSchema.parse(JSON.parse(raw));
+  const recap: Recap = parsed;
+
+  const empowerment = recap.empowerment;
+  if (!empowerment) {
+    throw new Error("Empowerment stanza missing. Re-run the orchestrator to refresh the recap dossier.");
+  }
+
+  const automationMultiplier = Number.parseFloat(empowerment.automation.automationMultiplier);
+  const automationScore = clamp(automationMultiplier / (automationMultiplier + 1), 0.2, 0.99);
+
+  const confidencePercent = recap.verification?.summary?.confidenceIndexPercent
+    ? Number.parseFloat(recap.verification.summary.confidenceIndexPercent)
+    : Number.parseFloat(empowerment.assurance.verificationConfidencePercent);
+  const assuranceScore = clamp(confidencePercent / 100, 0.3, 0.99);
+
+  const validatorRatio = empowerment.assurance.validatorThreshold === 0
+    ? 0
+    : empowerment.assurance.validatorApprovals / empowerment.assurance.validatorThreshold;
+  const validatorAutomation = clamp(0.45 + validatorRatio * 0.35, 0.3, 0.95);
+  const validatorAssurance = clamp(0.55 + validatorRatio * 0.35, 0.35, 0.98);
+
+  const quadrant = buildQuadrant(
+    { automation: automationScore, assurance: assuranceScore },
+    { automation: validatorAutomation, assurance: validatorAssurance },
+  );
+
+  const participantValues = recap.participants.map((participant) => {
+    const wei = parseBigInt(`contribution for ${participant.address}`, participant.contributionWei);
+    return {
+      label: shorten(participant.address),
+      value: Math.max(0, toDecimal(wei)),
+    };
+  });
+  const pieChart = buildPie(participantValues);
+
+  const timelineHighlights = recap.timeline.slice(0, 12);
+  const timeline = buildTimeline(timelineHighlights);
+
+  const totalReserve = parseBigInt("reserve balance", empowerment.capitalFormation.reserveWei);
+  const totalReserveEth = formatNumber(toDecimal(totalReserve));
+  const grossContributions = parseBigInt("gross contributions", empowerment.capitalFormation.grossContributionsWei);
+  const grossContributionsEth = formatNumber(toDecimal(grossContributions));
+
+  const participantTable = buildParticipantTable(recap.participants);
+  const ownerControls = describeOwnerControls(recap);
+
+  const orchestratorMode = recap.orchestrator.mode ?? (recap.network.dryRun ? "dry-run" : "broadcast");
+  const verdict = recap.verification?.summary?.verdict ?? "PASS";
+  const totalChecks = recap.verification?.summary?.totalChecks ?? empowerment.assurance.totalChecks;
+  const passedChecks = recap.verification?.summary?.passedChecks ?? empowerment.assurance.checksPassed;
+
+  const lines: string[] = [
+    "# α-AGI MARK Empowerment Pulse",
+    "",
+    `Generated ${recap.generatedAt} on **${recap.network.label}** (${recap.network.name}, chainId ${recap.network.chainId}).`,
+    "",
+    empowerment.tagline,
+    "",
+    "## Mission Snapshot",
+    "",
+    `- Orchestrator mode: **${orchestratorMode}**`,
+    `- Automation multiplier: **${empowerment.automation.automationMultiplier}×** (${empowerment.automation.orchestratedActions} orchestrated actions from ${empowerment.automation.manualCommands} command${
+      empowerment.automation.manualCommands === 1 ? "" : "s"
+    })`,
+    `- Verification confidence: **${confidencePercent.toFixed(2)}%** (${passedChecks}/${totalChecks} checks · verdict ${verdict})`,
+    `- Validator quorum: **${empowerment.assurance.validatorApprovals}/${empowerment.assurance.validatorThreshold}** approvals`,
+    `- Capital formation: **${empowerment.capitalFormation.participants}** participants · Gross **${grossContributionsEth} ETH** · Reserve **${totalReserveEth} ETH**`,
+    "",
+    "## Autonomous Command Quadrant",
+    "",
+    quadrant,
+    "",
+    "## Capital Participation Map",
+    "",
+    pieChart,
+    "",
+    "## Orchestration Timeline",
+    "",
+    timeline,
+    "",
+    "## Operator Command Deck",
+    "",
+    ownerControls,
+    "",
+    "## Participant Ledger",
+    "",
+    participantTable,
+    "",
+    "---",
+    "",
+    "The empowerment pulse evidences a sovereign-grade automation fabric: AGI Jobs v0 (v2) elevated a single operator into a",
+    "launch commander who steers validator governance, capital formation, and sovereign ignition without touching low-level",
+    "Solidity. This dossier exists so boards, auditors, and public stewards can witness that intelligence, assurance, and",
+    "governance fused into one artefact.",
+  ];
+
+  await mkdir(path.dirname(REPORT_PATH), { recursive: true });
+  await writeFile(REPORT_PATH, lines.join("\n"), "utf8");
+
+  console.log(`🛰️  Empowerment pulse generated at ${path.relative(process.cwd(), REPORT_PATH)}`);
+}
+
+generate().catch((error) => {
+  console.error("❌ Failed to generate empowerment pulse:", error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/demo/alpha-agi-mark/scripts/runOperatorSuite.ts
+++ b/demo/alpha-agi-mark/scripts/runOperatorSuite.ts
@@ -65,6 +65,7 @@ function main() {
     { label: "Triple-verification replay", command: "npx", args: tsNodeArgs("verifyRecap.ts") },
     { label: "Integrity dossier synthesis", command: "npx", args: tsNodeArgs("generateIntegrityReport.ts") },
     { label: "Risk lattice synthesis", command: "npx", args: tsNodeArgs("generateRiskLattice.ts") },
+    { label: "Empowerment pulse dossier", command: "npx", args: tsNodeArgs("generateEmpowermentPulse.ts") },
   ];
 
   const suiteStart = Date.now();
@@ -75,6 +76,7 @@ function main() {
   const integrityPath = path.join(demoDir, "reports", "alpha-mark-integrity.md");
   const ownerMatrixNote = "Run `npm run owner:alpha-agi-mark` to re-print the owner matrix at any time.";
   const latticePath = path.join(demoDir, "reports", "alpha-mark-risk-lattice.md");
+  const empowermentPath = path.join(demoDir, "reports", "alpha-mark-empowerment.md");
 
   const elapsed = ((Date.now() - suiteStart) / 1000).toFixed(2);
   console.log(`\n🌌 α-AGI MARK operator suite complete in ${elapsed}s.`);
@@ -82,6 +84,7 @@ function main() {
   console.log(`   • Sovereign dashboard: ${path.relative(repoRoot, dashboardPath)}`);
   console.log(`   • Integrity report: ${path.relative(repoRoot, integrityPath)}`);
   console.log(`   • Risk lattice dossier: ${path.relative(repoRoot, latticePath)}`);
+  console.log(`   • Empowerment pulse: ${path.relative(repoRoot, empowermentPath)}`);
   console.log(`   • ${ownerMatrixNote}`);
 }
 

--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
     "integrity:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateIntegrityReport.ts",
     "timeline:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateMissionTimeline.ts",
     "console:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/operatorConsole.ts",
-    "lattice:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateRiskLattice.ts"
+    "lattice:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateRiskLattice.ts",
+    "pulse:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateEmpowermentPulse.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add an empowerment pulse generator that produces a mermaid-rich dossier from the α-AGI MARK recap
- document the new pulse command in the README/runbook and keep the artefact tracked
- update CI and the operator suite to forge/validate the empowerment report alongside refreshed recap/dashboard outputs

## Testing
- npm run demo:alpha-agi-mark
- npm run pulse:alpha-agi-mark
- npm run test:alpha-agi-mark


------
https://chatgpt.com/codex/tasks/task_e_68f1e2576b8883338b76e74170688f4a