### PR TITLE
Add executive HTML report to alpha AGI insight demo

### DIFF
--- a/.github/workflows/demo-alpha-agi-insight-mark.yml
+++ b/.github/workflows/demo-alpha-agi-insight-mark.yml
@@ -98,6 +98,27 @@ jobs:
           console.log('Markdown dossier validated.');
           NODE
 
+      - name: Validate executive HTML dashboard
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = 'demo/alpha-agi-insight-mark/reports/insight-report.html';
+          if (!fs.existsSync(path)) {
+            throw new Error('executive report HTML missing');
+          }
+          const content = fs.readFileSync(path, 'utf8');
+          if (!content.includes('α-AGI Insight MARK Executive Report')) {
+            throw new Error('executive report title missing');
+          }
+          const requiredSnippets = ['Disruption Timeline', 'Nova-Seed Market Matrix', 'Owner Command Hooks'];
+          for (const snippet of requiredSnippets) {
+            if (!content.includes(snippet)) {
+              throw new Error(`expected section not found in HTML report: ${snippet}`);
+            }
+          }
+          console.log('Executive HTML dossier validated.');
+          NODE
+
       - name: Validate control matrix
         run: |
           node - <<'NODE'
@@ -152,6 +173,7 @@ jobs:
           path: |
             demo/alpha-agi-insight-mark/reports/insight-recap.json
             demo/alpha-agi-insight-mark/reports/insight-report.md
+            demo/alpha-agi-insight-mark/reports/insight-report.html
             demo/alpha-agi-insight-mark/reports/insight-control-matrix.json
             demo/alpha-agi-insight-mark/reports/insight-control-map.mmd
             demo/alpha-agi-insight-mark/reports/insight-manifest.json

--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -51,6 +51,7 @@ Running the demo produces:
 
 - `insight-recap.json` – network, contract addresses, minted seed states, and telemetry.
 - `insight-report.md` – executive summary with tables and owner command hooks.
+- `insight-report.html` – shareable executive dashboard with disruption timeline visualisation.
 - `insight-control-matrix.json` – machine-readable owner control registry.
 - `insight-control-map.mmd` – mermaid diagram for governance briefings.
 - `insight-telemetry.log` – time-stamped agent dialogue.

--- a/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
+++ b/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
@@ -42,6 +42,7 @@ Evidence Links: insight-manifest.json, transaction hashes
 - [ ] `insight-manifest.json` hashes verified and stored in evidence vault.
 - [ ] Telemetry log reviewed for anomalies.
 - [ ] `insight-control-matrix.json` imported into owner dashboard.
+- [ ] `insight-report.html` rendered and archived with the board briefing packet.
 - [ ] Oracle address verified via `owner:verify-control` tooling.
 
 ## 5. Future Extensions

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -33,6 +33,7 @@ Watch the console for emoji-tagged telemetry such as:
 Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 
 - `insight-report.md` – executive summary (ready to paste into investor decks).
+- `insight-report.html` – polished executive dashboard with timeline and confidence bars for board briefings.
 - `insight-control-matrix.json` – machine-readable owner control inventory.
 - `insight-control-map.mmd` – mermaid diagram (render via https://mermaid.live/).
 - `insight-manifest.json` – SHA-256 hashes; re-run the demo and confirm hashes change only when artefacts change.


### PR DESCRIPTION
## Summary
- generate an HTML executive dashboard from the alpha AGI Insight MARK demo run, including confidence visuals and disruption timeline data baked into the manifest
- document the new deliverable across the demo README, operator runbook, and owner control briefing to keep board-ready artefact guidance aligned
- extend the dedicated CI workflow to assert the HTML dossier and publish it with the other demo artefacts

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci

------
https://chatgpt.com/codex/tasks/task_e_68f259f34f10833396cad76a31122c4e