### PR TITLE
Strengthen α-AGI Insight MARK demo provenance controls

### DIFF
--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -31,6 +31,10 @@ Set `AGIJOBS_DEMO_DRY_RUN=false` to enable the explicit launch confirmation prom
 - `INSIGHT_MARK_OWNER_KEY`
 - `INSIGHT_MARK_PARTICIPANT_KEYS`
 - `INSIGHT_MARK_ORACLE_KEYS`
+- `INSIGHT_MARK_SCENARIO_FILE`
+- `INSIGHT_MARK_EXPECTED_OWNER`
+
+When a custom scenario file is supplied via `INSIGHT_MARK_SCENARIO_FILE`, the demo validates the JSON exists, records its SHA-256 fingerprint, and embeds both the path and hash in the recap/manifest so operators can prove the data provenance. `INSIGHT_MARK_EXPECTED_OWNER` and `INSIGHT_MARK_CHAIN_ID` are enforced against the live Hardhat signer and connected network to prevent misconfigured mainnet deployments.
 
 ## Tests
 
@@ -55,7 +59,7 @@ Running the demo produces:
 - `insight-control-matrix.json` – machine-readable owner control registry.
 - `insight-control-map.mmd` – mermaid diagram for governance briefings.
 - `insight-telemetry.log` – time-stamped agent dialogue.
-- `insight-manifest.json` – SHA-256 hashes of every generated artefact.
+- `insight-manifest.json` – SHA-256 hashes of every generated artefact and the scenario dataset that produced them.
 
 All outputs are designed for direct inclusion in boardroom briefings and investor packets.
 

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -36,7 +36,7 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 - `insight-report.html` – polished executive dashboard with timeline and confidence bars for board briefings.
 - `insight-control-matrix.json` – machine-readable owner control inventory.
 - `insight-control-map.mmd` – mermaid diagram (render via https://mermaid.live/).
-- `insight-manifest.json` – SHA-256 hashes; re-run the demo and confirm hashes change only when artefacts change.
+- `insight-manifest.json` – SHA-256 hashes; re-run the demo and confirm hashes change only when artefacts change. The manifest now fingerprints the scenario dataset too, so provenance can be attested.
 - `insight-telemetry.log` – chronological agent conversation for audit trails.
 
 ## 4. Owner Control Drills
@@ -56,8 +56,10 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 ## 6. Live Network Launch (Advanced)
 
 1. Export the required environment variables (RPC URL, private keys).
-2. Set `AGIJOBS_DEMO_DRY_RUN=false` so the script prompts for `launch` confirmation.
-3. After deployment, import contract addresses from `insight-recap.json` into the Owner Console to manage pause/upgrade levers.
+2. Optionally set `INSIGHT_MARK_SCENARIO_FILE` to your curated foresight dataset – the script will refuse to run if the file is missing and will embed the SHA-256 fingerprint in every recap.
+3. Set `AGIJOBS_DEMO_DRY_RUN=false` so the script prompts for `launch` confirmation. Confirm the prompt by typing `LAUNCH`.
+4. (Recommended) Set `INSIGHT_MARK_CHAIN_ID` and `INSIGHT_MARK_EXPECTED_OWNER` to enforce that the connected network and signer match your deployment plan.
+5. After deployment, import contract addresses from `insight-recap.json` into the Owner Console to manage pause/upgrade levers.
 
 > **Emergency** – Invoke `pause()` on the exchange first (halts trading), then `pause()` on the Nova-Seed and settlement token. Use the owner change ticket from `docs/owner-control-briefing.md` for the incident log.
 


### PR DESCRIPTION
## Summary
- add configurable scenario source loading with launch confirmation and network/signer validation to the α-AGI Insight MARK demo orchestrator
- embed on-chain verification of minted foresight and record scenario fingerprints in recap/manifest artefacts with updated HTML/Markdown outputs
- document the new safeguards and environment variables for operators in the README and runbook

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci

------
https://chatgpt.com/codex/tasks/task_e_68f25f08a8588333ac1cabae2595afd6