### PR TITLE
feat: harden alpha-agi-insight-mark governance

### DIFF
--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -6,6 +6,7 @@
 
 - **Push-button foresight** – `npm run demo:alpha-agi-insight-mark` deploys the Nova-Seed NFT, Insight Access Token, and Insight Exchange, executes the simulated meta-agent swarm, and exports recap dossiers, telemetry logs, mermaid diagrams, and owner control matrices.
 - **Absolute owner command** – The contract owner can pause every module, rotate the oracle, retarget the treasury, retune trading fees, and update or reveal FusionPlans at any time.
+- **Sentinel-grade emergency controls** – Owners can delegate a cross-contract SystemPause sentinel that can freeze the Nova-Seed, exchange, and settlement token instantly while the owner retains sole authority to resume operations.
 - **Tokenised disruption** – Each α-AGI Nova-Seed is minted from the meta-agent scenarios, sealed until the owner reveals it, and can be listed or traded through α-AGI MARK with automated manifest hashing for integrity proofs.
 - **Production rigor** – The Hardhat project includes unit tests covering minting, pausing, delegated minters, fixed-price trading, fee distribution, and oracle resolution. The GitHub workflow executes the tests, runs the demo end-to-end, and verifies the generated dossiers.
 
@@ -20,7 +21,7 @@ The script:
 1. Boots a Hardhat in-memory chain (unless custom RPC details are provided).
 2. Deploys the Insight Access Token (settlement token), Alpha Insight Nova-Seed, and Alpha Insight Exchange.
 3. Simulates the meta-agent pipeline, forging three Nova-Seeds with disruption forecasts.
-4. Lists the first two seeds on α-AGI MARK, processes a trade, resolves a prediction, and logs telemetry.
+4. Lists the first two seeds on α-AGI MARK, processes a trade, resolves a prediction, drills the delegated sentinel pause/unpause flow, and logs telemetry.
 5. Generates Markdown/JSON dossiers under `demo/alpha-agi-insight-mark/reports/` with SHA-256 manifests for audit trails.
 
 Set `AGIJOBS_DEMO_DRY_RUN=false` to enable the explicit launch confirmation prompt before broadcasting to a live network. Custom networks can be targeted via:
@@ -44,10 +45,11 @@ npm run test:alpha-agi-insight-mark
 
 The suite covers:
 
-- Owner and delegated minter flows, metadata updates, and fusion-plan reveals.
-- Pause guards on the NFT contract.
+- Owner and delegated minter flows, metadata updates, and fusion-plan reveals and revisions.
+- Pause guards on the NFT contract including delegated sentinel authority.
 - Fixed-price listing, purchase execution, fee routing, and cancellation.
-- Oracle resolution governance on the exchange.
+- Oracle resolution governance on the exchange plus sentinel-driven pause drills.
+- Settlement token sentinel controls.
 
 ## Reports & Dossiers
 
@@ -58,6 +60,7 @@ Running the demo produces:
 - `insight-report.html` – shareable executive dashboard with disruption timeline visualisation.
 - `insight-control-matrix.json` – machine-readable owner control registry.
 - `insight-control-map.mmd` – mermaid diagram for governance briefings.
+- `insight-governance.mmd` – meta-agent swarm and sentinel orchestration schematic.
 - `insight-telemetry.log` – time-stamped agent dialogue.
 - `insight-manifest.json` – SHA-256 hashes of every generated artefact and the scenario dataset that produced them.
 

--- a/demo/alpha-agi-insight-mark/contracts/InsightAccessToken.sol
+++ b/demo/alpha-agi-insight-mark/contracts/InsightAccessToken.sol
@@ -8,13 +8,33 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 /// @title InsightAccessToken
 /// @notice Owner mintable ERC-20 token used for settling foresight trades in the demo marketplace.
 contract InsightAccessToken is ERC20, ERC20Pausable, Ownable {
+    address private _systemPause;
+
+    event SystemPauseUpdated(address indexed systemPause);
+
     constructor(address owner_) ERC20(unicode"α-AGI Insight Credit", "AIC") Ownable(owner_) {}
 
     function mint(address to, uint256 amount) external onlyOwner {
         _mint(to, amount);
     }
 
-    function pause() external onlyOwner {
+    function systemPause() external view returns (address) {
+        return _systemPause;
+    }
+
+    function setSystemPause(address newSystemPause) external onlyOwner {
+        _systemPause = newSystemPause;
+        emit SystemPauseUpdated(newSystemPause);
+    }
+
+    modifier onlyOwnerOrSystemPause() {
+        if (msg.sender != owner() && msg.sender != _systemPause) {
+            revert("NOT_AUTHORIZED");
+        }
+        _;
+    }
+
+    function pause() external onlyOwnerOrSystemPause {
         _pause();
     }
 

--- a/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
+++ b/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
@@ -4,16 +4,17 @@
 
 | Contract | Address | Governance Handles |
 | --- | --- | --- |
-| Insight Access Token (`InsightAccessToken`) | Populate from `insight-recap.json` | `mint`, `pause`, `unpause` |
-| Nova-Seed (`AlphaInsightNovaSeed`) | Populate from `insight-recap.json` | `setMinter`, `updateInsightDetails`, `updateSealedURI`, `revealFusionPlan`, `pause`, `unpause` |
-| Foresight Exchange (`AlphaInsightExchange`) | Populate from `insight-recap.json` | `setOracle`, `setTreasury`, `setPaymentToken`, `setFeeBps`, `pause`, `unpause`, `resolvePrediction` |
+| Insight Access Token (`InsightAccessToken`) | Populate from `insight-recap.json` | `mint`, `pause`, `unpause`, `setSystemPause` |
+| Nova-Seed (`AlphaInsightNovaSeed`) | Populate from `insight-recap.json` | `setMinter`, `updateInsightDetails`, `updateSealedURI`, `revealFusionPlan`, `updateFusionPlan`, `pause`, `unpause`, `setSystemPause` |
+| Foresight Exchange (`AlphaInsightExchange`) | Populate from `insight-recap.json` | `setOracle`, `setTreasury`, `setPaymentToken`, `setFeeBps`, `pause`, `unpause`, `resolvePrediction`, `setSystemPause` |
 
 ## 2. Emergency Procedures
 
-1. **Market Halt** – Call `pause()` on the exchange. This blocks new listings and purchases immediately.
-2. **Asset Freeze** – Call `pause()` on the Nova-Seed to prevent transfers/minting. Use `setMinter(address, false)` to revoke agent minters.
-3. **Liquidity Freeze** – Call `pause()` on the settlement token to suspend token transfers if treasury risk is detected.
-4. **Oracle Override** – Use `setOracle(owner)` to take direct control of prediction resolution during an incident.
+1. **Delegate Sentinel** – Rotate or confirm the SystemPause sentinel via `setSystemPause(address)` on each contract. The sentinel can execute `pause()` during emergencies even if the owner is offline.
+2. **Market Halt** – Call `pause()` on the exchange (or instruct the sentinel). This blocks new listings and purchases immediately.
+3. **Asset Freeze** – Call `pause()` on the Nova-Seed to prevent transfers/minting. Use `setMinter(address, false)` to revoke agent minters.
+4. **Liquidity Freeze** – Call `pause()` on the settlement token to suspend token transfers if treasury risk is detected.
+5. **Oracle Override** – Use `setOracle(owner)` to take direct control of prediction resolution during an incident.
 
 ## 3. Change Management Template
 

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -18,8 +18,8 @@ The orchestrator:
 
 - Deploys the Insight Access Token, Nova-Seed NFT, and Foresight Exchange.
 - Spins up the synthetic meta-agent swarm (Meta-Sentinel, Thermodynamic Oracle, FusionSmith, Venture Cartographer, Guardian Auditor).
-- Mints three disruption insights, reveals the first FusionPlan, lists two tokens, and executes a sale.
-- Resolves the traded prediction and exports integrity artefacts.
+- Mints three disruption insights, reveals and revises the first FusionPlan, lists two tokens, and executes a sale.
+- Resolves the traded prediction, drills the delegated SystemPause sentinel, and exports integrity artefacts.
 
 Watch the console for emoji-tagged telemetry such as:
 
@@ -36,15 +36,17 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 - `insight-report.html` – polished executive dashboard with timeline and confidence bars for board briefings.
 - `insight-control-matrix.json` – machine-readable owner control inventory.
 - `insight-control-map.mmd` – mermaid diagram (render via https://mermaid.live/).
+- `insight-governance.mmd` – insight swarm + sentinel orchestration schematic.
 - `insight-manifest.json` – SHA-256 hashes; re-run the demo and confirm hashes change only when artefacts change. The manifest now fingerprints the scenario dataset too, so provenance can be attested.
 - `insight-telemetry.log` – chronological agent conversation for audit trails.
 
 ## 4. Owner Control Drills
 
-1. **Pause/Resume** – From the Hardhat console or Owner Console UI, call `pause()` on each contract to halt trading, then `unpause()`.
-2. **Rotate Oracle** – Use `setOracle(<new address>)` on the exchange. The new oracle can immediately call `resolvePrediction`.
-3. **Retarget Treasury** – Call `setTreasury(<new address>)`. Validate the change via `insight-recap.json` and on-chain logs.
-4. **Reveal FusionPlan** – Trigger `revealFusionPlan(tokenId, uri)` to expose the cryptosealed FusionPlan at your chosen time.
+1. **Delegate Sentinel** – Call `setSystemPause(<sentinel address>)` on all three contracts, then have the sentinel trigger `pause()`. Only the owner can `unpause()`.
+2. **Pause/Resume** – From the Hardhat console or Owner Console UI, call `pause()` on each contract to halt trading, then `unpause()`.
+3. **Rotate Oracle** – Use `setOracle(<new address>)` on the exchange. The new oracle can immediately call `resolvePrediction`.
+4. **Retarget Treasury** – Call `setTreasury(<new address>)`. Validate the change via `insight-recap.json` and on-chain logs.
+5. **Reveal & Revise FusionPlan** – Trigger `revealFusionPlan(tokenId, uri)` to expose the cryptosealed FusionPlan, then `updateFusionPlan(tokenId, uri)` if revisions are needed.
 
 ## 5. Verification Loop
 
@@ -61,7 +63,7 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 4. (Recommended) Set `INSIGHT_MARK_CHAIN_ID` and `INSIGHT_MARK_EXPECTED_OWNER` to enforce that the connected network and signer match your deployment plan.
 5. After deployment, import contract addresses from `insight-recap.json` into the Owner Console to manage pause/upgrade levers.
 
-> **Emergency** – Invoke `pause()` on the exchange first (halts trading), then `pause()` on the Nova-Seed and settlement token. Use the owner change ticket from `docs/owner-control-briefing.md` for the incident log.
+> **Emergency** – Have the delegated sentinel issue `pause()` on all contracts, then coordinate owner-led `unpause()` once investigations complete. Record the action using the owner change ticket from `docs/owner-control-briefing.md`.
 
 ## 7. Clean-up
 

--- a/demo/alpha-agi-insight-mark/test/AlphaInsightExchange.test.ts
+++ b/demo/alpha-agi-insight-mark/test/AlphaInsightExchange.test.ts
@@ -72,6 +72,18 @@ describe("AlphaInsightExchange", () => {
     expect(await nova.ownerOf(1n)).to.equal(seller.address);
   });
 
+  it("permits delegated sentinel pausing", async () => {
+    await exchange.setSystemPause(seller.address);
+    await nova.connect(seller).approve(await exchange.getAddress(), 1n);
+    await exchange.connect(seller).listInsight(1n, ethers.parseUnits("200", 18));
+
+    await exchange.connect(seller).pause();
+    await expect(exchange.connect(buyer).buyInsight(1n)).to.be.revertedWithCustomError(exchange, "EnforcedPause");
+
+    await exchange.unpause();
+    await exchange.connect(seller).cancelListing(1n);
+  });
+
   it("records oracle resolution", async () => {
     await exchange.setOracle(oracle.address);
     await exchange.connect(oracle).resolvePrediction(1n, true, "Finance rupture confirmed");

--- a/demo/alpha-agi-insight-mark/test/InsightAccessToken.test.ts
+++ b/demo/alpha-agi-insight-mark/test/InsightAccessToken.test.ts
@@ -1,0 +1,33 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import type { InsightAccessToken } from "../typechain-types";
+
+describe("InsightAccessToken", () => {
+  let owner: any;
+  let sentinel: any;
+  let recipient: any;
+  let token: InsightAccessToken;
+
+  beforeEach(async () => {
+    [owner, sentinel, recipient] = await ethers.getSigners();
+    const factory = await ethers.getContractFactory("InsightAccessToken");
+    token = (await factory.deploy(owner.address)) as unknown as InsightAccessToken;
+    await token.waitForDeployment();
+  });
+
+  it("supports owner minting and sentinel pause", async () => {
+    await token.mint(owner.address, ethers.parseUnits("100", 18));
+    await token.setSystemPause(sentinel.address);
+
+    await token.connect(sentinel).pause();
+    await expect(token.transfer(recipient.address, ethers.parseUnits("1", 18))).to.be.revertedWithCustomError(
+      token,
+      "EnforcedPause"
+    );
+
+    await token.unpause();
+    await token.transfer(recipient.address, ethers.parseUnits("10", 18));
+    expect(await token.balanceOf(recipient.address)).to.equal(ethers.parseUnits("10", 18));
+  });
+});


### PR DESCRIPTION
## Summary
- add delegated SystemPause controls and fusion plan revision support to the α-AGI Insight MARK contracts
- expand the demo run to document sentinel drills, produce enriched governance artefacts, and render a second mermaid schematic
- extend README/runbooks plus unit tests to cover sentinel pausing and the updated workflow, including a new settlement token spec

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci

------
https://chatgpt.com/codex/tasks/task_e_68f264f315d083338c55cc6518c03aca