### PR TITLE
Enhance Alpha Insight MARK owner interventions

### DIFF
--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -9,6 +9,7 @@
 - **Sentinel-grade emergency controls** – Owners can delegate a cross-contract SystemPause sentinel that can freeze the Nova-Seed, exchange, and settlement token instantly while the owner retains sole authority to resume operations.
 - **Tokenised disruption** – Each α-AGI Nova-Seed is minted from the meta-agent scenarios, sealed until the owner reveals it, and can be listed or traded through α-AGI MARK with automated manifest hashing for integrity proofs.
 - **Production rigor** – The Hardhat project includes unit tests covering minting, pausing, delegated minters, fixed-price trading, fee distribution, and oracle resolution. The GitHub workflow executes the tests, runs the demo end-to-end, and verifies the generated dossiers.
+- **Regulatory superpowers** – Live repricing (`updateListingPrice`) and instant custody evacuation (`forceDelist`) ensure the owner can reshape liquidity or quarantine an asset mid-flight without downtime.
 
 ## Quickstart
 
@@ -21,7 +22,7 @@ The script:
 1. Boots a Hardhat in-memory chain (unless custom RPC details are provided).
 2. Deploys the Insight Access Token (settlement token), Alpha Insight Nova-Seed, and Alpha Insight Exchange.
 3. Simulates the meta-agent pipeline, forging three Nova-Seeds with disruption forecasts.
-4. Lists the first two seeds on α-AGI MARK, processes a trade, resolves a prediction, drills the delegated sentinel pause/unpause flow, and logs telemetry.
+4. Lists the first two seeds on α-AGI MARK, reprices them live, processes a trade, force-delists the second to sentinel custody, resolves a prediction, drills the delegated sentinel pause/unpause flow, and logs telemetry.
 5. Generates Markdown/JSON dossiers under `demo/alpha-agi-insight-mark/reports/` with SHA-256 manifests for audit trails.
 
 Set `AGIJOBS_DEMO_DRY_RUN=false` to enable the explicit launch confirmation prompt before broadcasting to a live network. Custom networks can be targeted via:

--- a/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
+++ b/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
@@ -6,7 +6,7 @@
 | --- | --- | --- |
 | Insight Access Token (`InsightAccessToken`) | Populate from `insight-recap.json` | `mint`, `pause`, `unpause`, `setSystemPause` |
 | Nova-Seed (`AlphaInsightNovaSeed`) | Populate from `insight-recap.json` | `setMinter`, `updateInsightDetails`, `updateSealedURI`, `revealFusionPlan`, `updateFusionPlan`, `pause`, `unpause`, `setSystemPause` |
-| Foresight Exchange (`AlphaInsightExchange`) | Populate from `insight-recap.json` | `setOracle`, `setTreasury`, `setPaymentToken`, `setFeeBps`, `pause`, `unpause`, `resolvePrediction`, `setSystemPause` |
+| Foresight Exchange (`AlphaInsightExchange`) | Populate from `insight-recap.json` | `setOracle`, `setTreasury`, `setPaymentToken`, `setFeeBps`, `updateListingPrice`, `forceDelist`, `pause`, `unpause`, `resolvePrediction`, `setSystemPause` |
 
 ## 2. Emergency Procedures
 
@@ -15,6 +15,7 @@
 3. **Asset Freeze** – Call `pause()` on the Nova-Seed to prevent transfers/minting. Use `setMinter(address, false)` to revoke agent minters.
 4. **Liquidity Freeze** – Call `pause()` on the settlement token to suspend token transfers if treasury risk is detected.
 5. **Oracle Override** – Use `setOracle(owner)` to take direct control of prediction resolution during an incident.
+6. **Force Custody Transfer** – If a listing must be evacuated (e.g., legal hold), invoke `forceDelist(tokenId, custody)` to move it to a secure wallet while keeping ledger integrity.
 
 ## 3. Change Management Template
 

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -18,7 +18,7 @@ The orchestrator:
 
 - Deploys the Insight Access Token, Nova-Seed NFT, and Foresight Exchange.
 - Spins up the synthetic meta-agent swarm (Meta-Sentinel, Thermodynamic Oracle, FusionSmith, Venture Cartographer, Guardian Auditor).
-- Mints three disruption insights, reveals and revises the first FusionPlan, lists two tokens, and executes a sale.
+- Mints three disruption insights, reveals and revises the first FusionPlan, lists two tokens, reprices live, executes a sale, and force-delists a listing to sentinel custody.
 - Resolves the traded prediction, drills the delegated SystemPause sentinel, and exports integrity artefacts.
 
 Watch the console for emoji-tagged telemetry such as:
@@ -46,7 +46,9 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 2. **Pause/Resume** – From the Hardhat console or Owner Console UI, call `pause()` on each contract to halt trading, then `unpause()`.
 3. **Rotate Oracle** – Use `setOracle(<new address>)` on the exchange. The new oracle can immediately call `resolvePrediction`.
 4. **Retarget Treasury** – Call `setTreasury(<new address>)`. Validate the change via `insight-recap.json` and on-chain logs.
-5. **Reveal & Revise FusionPlan** – Trigger `revealFusionPlan(tokenId, uri)` to expose the cryptosealed FusionPlan, then `updateFusionPlan(tokenId, uri)` if revisions are needed.
+5. **Dynamic Pricing** – Reprice an active listing via `updateListingPrice(tokenId, price)`; confirm the markdown reflects the new amount.
+6. **Custody Override** – Call `forceDelist(tokenId, <custodian>)` to evacuate a seed into a safe wallet, then re-list when cleared.
+7. **Reveal & Revise FusionPlan** – Trigger `revealFusionPlan(tokenId, uri)` to expose the cryptosealed FusionPlan, then `updateFusionPlan(tokenId, uri)` if revisions are needed.
 
 ## 5. Verification Loop
 


### PR DESCRIPTION
## Summary
- add owner-governed listing repricing and force-delist capabilities to the α-AGI Insight MARK exchange with supporting tests
- extend the demo orchestration to surface repricing/custody actions across markdown, HTML dashboards, and control matrices
- update operator and governance docs to coach dynamic pricing drills and emergency custody evacuations

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci

------
https://chatgpt.com/codex/tasks/task_e_68f26a9c3884833381dd889dd29db1b7