### PR TITLE
Add owner brief and constellation artefacts to Insight MARK demo

### DIFF
--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -63,6 +63,9 @@ Running the demo produces:
 - `insight-control-map.mmd` – mermaid diagram for governance briefings.
 - `insight-governance.mmd` – meta-agent swarm and sentinel orchestration schematic.
 - `insight-telemetry.log` – time-stamped agent dialogue.
+- `insight-owner-brief.md` – rapid-response owner command checklist with custody overview.
+- `insight-market-matrix.csv` – CSV dataset for financial modelling and downstream analytics.
+- `insight-constellation.mmd` – mermaid constellation showing live custody, market, and sentinel linkages.
 - `insight-manifest.json` – SHA-256 hashes of every generated artefact and the scenario dataset that produced them.
 
 All outputs are designed for direct inclusion in boardroom briefings and investor packets.

--- a/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
+++ b/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
@@ -45,6 +45,7 @@ Evidence Links: insight-manifest.json, transaction hashes
 - [ ] Telemetry log reviewed for anomalies.
 - [ ] `insight-control-matrix.json` imported into owner dashboard.
 - [ ] `insight-report.html` rendered and archived with the board briefing packet.
+- [ ] `insight-owner-brief.md` countersigned for rapid-response command authority.
 - [ ] Oracle address verified via `owner:verify-control` tooling.
 
 ## 5. Future Extensions

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -37,6 +37,9 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 - `insight-control-matrix.json` – machine-readable owner control inventory.
 - `insight-control-map.mmd` – mermaid diagram (render via https://mermaid.live/).
 - `insight-governance.mmd` – insight swarm + sentinel orchestration schematic.
+- `insight-owner-brief.md` – executive command sheet summarising pause hooks and custody.
+- `insight-market-matrix.csv` – spreadsheet-ready dataset for analysts and treasury.
+- `insight-constellation.mmd` – constellation mermaid capturing live custody and sentinel edges.
 - `insight-manifest.json` – SHA-256 hashes; re-run the demo and confirm hashes change only when artefacts change. The manifest now fingerprints the scenario dataset too, so provenance can be attested.
 - `insight-telemetry.log` – chronological agent conversation for audit trails.
 


### PR DESCRIPTION
## Summary
- document the new owner brief, market matrix, and constellation artefacts across demo guides
- extend the demo script to generate CSV, owner briefing markdown, and constellation mermaid outputs with manifest hashing
- add CSV formatting helpers and ensure manifest path normalisation works on all platforms

## Testing
- npm run demo:alpha-agi-insight-mark:ci
- npm run test:alpha-agi-insight-mark
- npm run lint -- --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68f2700db85c8333a613240d0266f078