### PR TITLE
Add meta-agentic analytics to α-AGI Insight MARK demo

### DIFF
--- a/.github/workflows/demo-alpha-agi-insight-mark.yml
+++ b/.github/workflows/demo-alpha-agi-insight-mark.yml
@@ -89,7 +89,13 @@ jobs:
             throw new Error('insight report missing');
           }
           const content = fs.readFileSync(reportPath, 'utf8');
-          const required = ['# α-AGI Insight MARK Recap', '## Owner Command Hooks', '## Telemetry Snapshot'];
+          const required = [
+            '# α-AGI Insight MARK Recap',
+            '## Owner Command Hooks',
+            '## Meta-Agentic Pareto Frontier',
+            '## Thermodynamic Signal Inventory',
+            '## Telemetry Snapshot',
+          ];
           for (const token of required) {
             if (!content.includes(token)) {
               throw new Error(`missing section: ${token}`);
@@ -110,13 +116,42 @@ jobs:
           if (!content.includes('α-AGI Insight MARK Executive Report')) {
             throw new Error('executive report title missing');
           }
-          const requiredSnippets = ['Disruption Timeline', 'Nova-Seed Market Matrix', 'Owner Command Hooks'];
+          const requiredSnippets = [
+            'Disruption Timeline',
+            'Nova-Seed Market Matrix',
+            'Meta-Agentic Pareto Frontier',
+            'Thermodynamic Signal Inventory',
+            'Owner Command Hooks',
+          ];
           for (const snippet of requiredSnippets) {
             if (!content.includes(snippet)) {
               throw new Error(`expected section not found in HTML report: ${snippet}`);
             }
           }
           console.log('Executive HTML dossier validated.');
+          NODE
+
+      - name: Validate meta-agentic schematics
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const evolutionPath = 'demo/alpha-agi-insight-mark/reports/insight-evolution.mmd';
+          const thermoPath = 'demo/alpha-agi-insight-mark/reports/insight-thermodynamics.mmd';
+          if (!fs.existsSync(evolutionPath)) {
+            throw new Error('insight-evolution.mmd missing');
+          }
+          if (!fs.existsSync(thermoPath)) {
+            throw new Error('insight-thermodynamics.mmd missing');
+          }
+          const evolution = fs.readFileSync(evolutionPath, 'utf8');
+          const thermo = fs.readFileSync(thermoPath, 'utf8');
+          if (!evolution.includes('Pareto Frontier')) {
+            throw new Error('evolution mermaid missing Pareto Frontier node');
+          }
+          if (!thermo.includes('Phase Transition Gate')) {
+            throw new Error('thermodynamics mermaid missing phase transition gate');
+          }
+          console.log('Meta-agentic schematics validated.');
           NODE
 
       - name: Validate control matrix

--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -10,6 +10,7 @@
 - **Tokenised disruption** – Each α-AGI Nova-Seed is minted from the meta-agent scenarios, sealed until the owner reveals it, and can be listed or traded through α-AGI MARK with automated manifest hashing for integrity proofs.
 - **Production rigor** – The Hardhat project includes unit tests covering minting, pausing, delegated minters, fixed-price trading, fee distribution, and oracle resolution. The GitHub workflow executes the tests, runs the demo end-to-end, and verifies the generated dossiers.
 - **Regulatory superpowers** – Live repricing (`updateListingPrice`) and instant custody evacuation (`forceDelist`) ensure the owner can reshape liquidity or quarantine an asset mid-flight without downtime.
+- **Meta-agentic analytics** – The demo now exports a MATS Pareto frontier, thermodynamic signal inventory, and dual mermaid schematics (`insight-evolution.mmd`, `insight-thermodynamics.mmd`) that visualise NSGA-II objective vectors and T<sub>AGI</sub> phase transitions for every minted seed.
 
 ## Quickstart
 
@@ -62,6 +63,8 @@ Running the demo produces:
 - `insight-control-matrix.json` – machine-readable owner control registry.
 - `insight-control-map.mmd` – mermaid diagram for governance briefings.
 - `insight-governance.mmd` – meta-agent swarm and sentinel orchestration schematic.
+- `insight-evolution.mmd` – Meta-Agentic Tree Search (NSGA-II) pipeline feeding the Nova-Seed forge and α-AGI MARK.
+- `insight-thermodynamics.mmd` – Thermodynamic capability ladder showing when each rupture activates as T<sub>AGI</sub> heats up.
 - `insight-telemetry.log` – time-stamped agent dialogue.
 - `insight-owner-brief.md` – rapid-response owner command checklist with custody overview.
 - `insight-market-matrix.csv` – CSV dataset for financial modelling and downstream analytics.

--- a/demo/alpha-agi-insight-mark/data/insight-scenarios.json
+++ b/demo/alpha-agi-insight-mark/data/insight-scenarios.json
@@ -18,7 +18,18 @@
       "sealedURI": "ipfs://alpha-agi-insight/finance/seed.json",
       "fusionURI": "ipfs://alpha-agi-insight/finance/fusion.json",
       "confidence": 0.91,
-      "forecastValue": "42T"
+      "forecastValue": "42T",
+      "capabilityIndex": 0.84,
+      "phaseShift": "T_AGI crosses 0.82 – liquidity equilibria collapse into singular market mesh.",
+      "objectives": {
+        "impact": 0.94,
+        "resilience": 0.88,
+        "velocity": 0.91
+      },
+      "signals": [
+        "Quantum Liquidity Mesh online in Singapore",
+        "Regulated AGI treasuries approved across EU bloc"
+      ]
     },
     {
       "sector": "Healthcare",
@@ -27,7 +38,18 @@
       "sealedURI": "ipfs://alpha-agi-insight/healthcare/seed.json",
       "fusionURI": "ipfs://alpha-agi-insight/healthcare/fusion.json",
       "confidence": 0.88,
-      "forecastValue": "17T"
+      "forecastValue": "17T",
+      "capabilityIndex": 0.8,
+      "phaseShift": "Bio-AGI synergy surpasses FDA adaptive governance threshold at T_AGI 0.79.",
+      "objectives": {
+        "impact": 0.89,
+        "resilience": 0.93,
+        "velocity": 0.87
+      },
+      "signals": [
+        "Self-validating clinical trial networks activated",
+        "AGI wetlab co-pilot reduces synthesis cycles to minutes"
+      ]
     },
     {
       "sector": "Energy",
@@ -36,7 +58,18 @@
       "sealedURI": "ipfs://alpha-agi-insight/energy/seed.json",
       "fusionURI": "ipfs://alpha-agi-insight/energy/fusion.json",
       "confidence": 0.86,
-      "forecastValue": "11T"
+      "forecastValue": "11T",
+      "capabilityIndex": 0.77,
+      "phaseShift": "Thermodynamic twins stabilize fusion microgrids once T_AGI exceeds 0.75.",
+      "objectives": {
+        "impact": 0.92,
+        "resilience": 0.9,
+        "velocity": 0.83
+      },
+      "signals": [
+        "Autonomous fusion pilot hits persistent positive Q",
+        "Continental grid telemetry shows AGI corrective reflexes"
+      ]
     }
   ]
 }

--- a/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
+++ b/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
@@ -46,6 +46,7 @@ Evidence Links: insight-manifest.json, transaction hashes
 - [ ] `insight-control-matrix.json` imported into owner dashboard.
 - [ ] `insight-report.html` rendered and archived with the board briefing packet.
 - [ ] `insight-owner-brief.md` countersigned for rapid-response command authority.
+- [ ] `insight-evolution.mmd` and `insight-thermodynamics.mmd` rendered to confirm Pareto vectors and phase shifts align with governance policy.
 - [ ] Oracle address verified via `owner:verify-control` tooling.
 
 ## 5. Future Extensions
@@ -53,5 +54,6 @@ Evidence Links: insight-manifest.json, transaction hashes
 - Swap the settlement token by calling `setPaymentToken(newToken)` once the new ERC-20 is deployed.
 - Route fees to a multisig or treasury module using `setTreasury(multisigAddress)`.
 - Chainlink or in-house AI oracle integrations can be layered by configuring `setOracle(oracleContract)`.
+- Plug advanced thermodynamic models into the demo by regenerating `insight-thermodynamics.mmd` with real capability telemetry for audit committees.
 
 Maintaining this briefing ensures every production launch or change adheres to auditable, repeatable owner governance procedures.

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -37,6 +37,8 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 - `insight-control-matrix.json` – machine-readable owner control inventory.
 - `insight-control-map.mmd` – mermaid diagram (render via https://mermaid.live/).
 - `insight-governance.mmd` – insight swarm + sentinel orchestration schematic.
+- `insight-evolution.mmd` – NSGA-II Meta-Agentic Tree Search pipeline showing how the Pareto frontier feeds Nova-Seed forging.
+- `insight-thermodynamics.mmd` – Thermodynamic capability ladder mapping each sector’s phase shift against the T_AGI index.
 - `insight-owner-brief.md` – executive command sheet summarising pause hooks and custody.
 - `insight-market-matrix.csv` – spreadsheet-ready dataset for analysts and treasury.
 - `insight-constellation.mmd` – constellation mermaid capturing live custody and sentinel edges.
@@ -49,9 +51,9 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 2. **Pause/Resume** – From the Hardhat console or Owner Console UI, call `pause()` on each contract to halt trading, then `unpause()`.
 3. **Rotate Oracle** – Use `setOracle(<new address>)` on the exchange. The new oracle can immediately call `resolvePrediction`.
 4. **Retarget Treasury** – Call `setTreasury(<new address>)`. Validate the change via `insight-recap.json` and on-chain logs.
-5. **Dynamic Pricing** – Reprice an active listing via `updateListingPrice(tokenId, price)`; confirm the markdown reflects the new amount.
+5. **Dynamic Pricing** – Reprice an active listing via `updateListingPrice(tokenId, price)`; confirm the markdown and HTML dashboards update the live pricing and capability gauges.
 6. **Custody Override** – Call `forceDelist(tokenId, <custodian>)` to evacuate a seed into a safe wallet, then re-list when cleared.
-7. **Reveal & Revise FusionPlan** – Trigger `revealFusionPlan(tokenId, uri)` to expose the cryptosealed FusionPlan, then `updateFusionPlan(tokenId, uri)` if revisions are needed.
+7. **Reveal & Revise FusionPlan** – Trigger `revealFusionPlan(tokenId, uri)` to expose the cryptosealed FusionPlan, then `updateFusionPlan(tokenId, uri)` if revisions are needed. Check `insight-evolution.mmd` and `insight-thermodynamics.mmd` to ensure the governance diagrams reflect the updated frontier and phase shift.
 
 ## 5. Verification Loop
 


### PR DESCRIPTION
## Summary
- extend the α-AGI Insight MARK scenario dataset and orchestrator to track capability indices, phase shifts, objective vectors, and thermodynamic signals
- generate meta-agentic Pareto frontier and thermodynamic inventory sections across markdown, HTML, CSV, owner brief, and new Mermaid schematics
- document the new artefacts in the README/runbook/owner briefing and enforce them in the dedicated CI workflow validation step

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci


------
https://chatgpt.com/codex/tasks/task_e_68f27a4eb4408333b57f5acc611d623f