### PR TITLE
Enhance Sovereign Mesh mission intelligence

### DIFF
--- a/demo/sovereign-mesh/README.md
+++ b/demo/sovereign-mesh/README.md
@@ -8,6 +8,7 @@
 - **Owner governed** — the hub owner retains full control (pause, rotate governance, tune parameters) through documented, linked controls.
 - **Wallet-first empowerment** — non-technical users launch, fund, validate, and settle missions entirely from their Ethereum wallet.
 - **Production discipline** — TypeScript/React orchestrator, fully typed Node backend, Hardhat scenarios, Cypress smoke test, and CI integration keep the demo enterprise grade.
+- **Mesh intelligence** — an always-on dashboard exposes hub coverage, mission counts, and cumulative rewards so decision-makers see the scale of their orchestration at a glance.
 
 ## Directory layout
 
@@ -78,6 +79,23 @@ graph TD
   E3 -.-> C
 ```
 
+```mermaid
+sequenceDiagram
+  participant User as Mission Owner
+  participant Console as Sovereign Mesh Console
+  participant Orchestrator as Orchestrator API
+  participant Hub as Target Hub(s)
+  participant Validators as Validator Mesh
+
+  User->>Console: Choose playbook & review mission preview
+  Console->>Orchestrator: Request mission plan & intelligence summary
+  Orchestrator-->>Console: Return tx bundle + mesh metrics
+  Console->>User: Display step timeline, hub routing, rewards
+  User->>Hub: Sign createJob transactions (per mission step)
+  Validators->>Hub: Stake → Commit → Reveal → Finalize
+  Hub-->>User: Emit completion events & reward distribution
+```
+
 ## Quickstart (non-technical operator)
 
 1. **Clone + install**
@@ -118,6 +136,7 @@ graph TD
 | Section | What it delivers |
 | --- | --- |
 | **Connect & Select Hub** | Wallet-first connect button + hub selector that hydrates live jobs via The Graph. |
+| **Mission Intelligence Feed** | Planetary mesh overview (hub count, mission inventory, incentive totals) streamed from `/mesh/summary`. |
 | **Create Job** | Reward + URI form that composes a `createJob` transaction with sensible deadlines and spec hash. |
 | **Participate** | Validators stake, commit, reveal, and finalize in a human-friendly workflow (salts handled automatically). |
 | **Mission Playbooks** | One-click instantiation of multi-hub missions (jobs across hubs queued sequentially for signature). |
@@ -125,6 +144,7 @@ graph TD
 
 ## Production-grade guarantees
 
+- **Mission intelligence API** — the orchestrator now exposes `GET /mesh/summary`, aggregating hub metadata, mission totals, and reward sums (both in wei and formatted) for dashboards and monitoring pipelines.
 - **No private keys on the server** — the Express orchestrator only returns unsigned transactions; the wallet signs everything.
 - **Config-driven** — missions, hubs, actors, RPC endpoints, and presentation can be updated by editing JSON files.
 - **Typed + tested** — Hardhat scenario covers dual-hub lifecycle, Cypress assures the UI boots, TypeScript builds enforced in CI.
@@ -163,3 +183,4 @@ npx cypress run --spec demo/sovereign-mesh/cypress/e2e/sovereign-mesh.cy.ts
 - Extend playbooks with branching logic and automated dispute escalation triggers.
 
 Sovereign Mesh shows how AGI Jobs v0 (v2) becomes the command deck for planetary coordination — a non-technical user orchestrates superintelligent capabilities with clarity, safety, and unstoppable scale.
+- Fetch real-time mesh telemetry from [`GET /mesh/summary`](server/index.ts) to power analytics overlays, dashboards, and mission readiness reports.

--- a/demo/sovereign-mesh/app/src/App.tsx
+++ b/demo/sovereign-mesh/app/src/App.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ethers } from "ethers";
 import { getSigner } from "./lib/ethers";
 import { makeClient, qJobs } from "./lib/subgraph";
 import { computeCommit } from "./lib/commit";
-import { short } from "./lib/format";
+import { formatToken, short, titleCase } from "./lib/format";
 
 type MeshConfig = {
   network: string;
@@ -27,6 +27,38 @@ type Job = {
   uri: string;
   status: string;
   validators?: { account: string }[];
+};
+
+type PlaybookStep = {
+  hub: string;
+  rewardWei: string;
+  uri: string;
+};
+
+type Playbook = {
+  id: string;
+  name: string;
+  steps: PlaybookStep[];
+};
+
+type MissionSummary = {
+  network: string;
+  hubCount: number;
+  missionCount: number;
+  totalRewardWei: string;
+  totalRewardEther: string;
+  updatedAt: string;
+  missions: {
+    id: string;
+    name: string;
+    stepCount: number;
+    hubCount: number;
+    stageCount: number;
+    totalRewardWei: string;
+    totalRewardEther: string;
+    hubs: string[];
+    stages: string[];
+  }[];
 };
 
 const DEFAULT_MESH_API_BASE = "http://localhost:8084";
@@ -73,7 +105,7 @@ const useMeshConfig = () => {
   const [cfg, setCfg] = useState<MeshConfig>();
   const [hubs, setHubs] = useState<Record<string, HubConfig>>({});
   const [actors, setActors] = useState<any[]>([]);
-  const [playbooks, setPlaybooks] = useState<any[]>([]);
+  const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
 
   useEffect(() => {
     fetchJson("/mesh/config").then(setCfg).catch(console.error);
@@ -81,19 +113,24 @@ const useMeshConfig = () => {
       .then((data) => setHubs(data.hubs ?? {}))
       .catch(console.error);
     fetchJson("/mesh/actors").then(setActors).catch(console.error);
-    fetchJson("/mesh/playbooks").then(setPlaybooks).catch(console.error);
+    fetchJson("/mesh/playbooks")
+      .then((pb) => setPlaybooks(pb as Playbook[]))
+      .catch(console.error);
   }, []);
 
   return { cfg, hubs, actors, playbooks };
 };
 
-const Table: React.FC<{ jobs: Job[] }> = ({ jobs }) => (
+const Table: React.FC<{ jobs: Job[]; toToken: (wei: string | bigint) => string }> = ({
+  jobs,
+  toToken
+}) => (
   <table className="mesh-table">
     <thead>
       <tr>
         <th>ID</th>
         <th>Proposer</th>
-        <th>Reward (wei)</th>
+        <th>Reward (AGIA)</th>
         <th>URI</th>
         <th>Status</th>
         <th>#Validators</th>
@@ -104,7 +141,7 @@ const Table: React.FC<{ jobs: Job[] }> = ({ jobs }) => (
         <tr key={job.id}>
           <td>{job.id}</td>
           <td>{short(job.employer)}</td>
-          <td>{job.reward}</td>
+          <td title={`${job.reward} wei`}>{toToken(job.reward)}</td>
           <td>
             <a href={job.uri} target="_blank" rel="noreferrer">
               {job.uri}
@@ -117,6 +154,71 @@ const Table: React.FC<{ jobs: Job[] }> = ({ jobs }) => (
     </tbody>
   </table>
 );
+
+const MissionPreview: React.FC<{
+  playbook?: Playbook;
+  resolveHubLabel: (hubId: string) => string;
+}> = ({ playbook, resolveHubLabel }) => {
+  if (!playbook) {
+    return (
+      <p className="mesh-muted">
+        Choose a mission to preview step sequencing, hub routing, and total rewards.
+      </p>
+    );
+  }
+
+  const stepDetails = playbook.steps.map((step) => {
+    const parts = String(step.hub).split("@");
+    const stage = titleCase(parts.length > 1 ? parts[0] : "Mission");
+    const hubId = parts.length > 1 ? parts[1] : parts[0];
+    return {
+      stage,
+      hubId,
+      uri: step.uri,
+      rewardWei: step.rewardWei
+    };
+  });
+
+  const totalReward = stepDetails.reduce(
+    (acc, step) => acc + BigInt(step.rewardWei || "0"),
+    0n
+  );
+  const uniqueHubs = Array.from(new Set(stepDetails.map((step) => step.hubId))).filter(
+    Boolean
+  );
+
+  return (
+    <div className="mesh-preview">
+      <div className="mesh-preview-summary">
+        <span className="mesh-chip">{stepDetails.length} steps</span>
+        <span className="mesh-chip">{uniqueHubs.length} hubs</span>
+        <span className="mesh-chip">{formatToken(totalReward)} total</span>
+      </div>
+      <ol className="mesh-timeline">
+        {stepDetails.map((step, index) => (
+          <li key={`${step.stage}-${index}`}>
+            <div className="mesh-step-index">{index + 1}</div>
+            <div className="mesh-step-body">
+              <div className="mesh-step-meta">{step.stage}</div>
+              <div className="mesh-step-heading">
+                {resolveHubLabel(step.hubId || "")} ·
+                <span className="mesh-step-amount"> {formatToken(step.rewardWei)}</span>
+              </div>
+              <a
+                className="mesh-step-uri"
+                href={step.uri}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {step.uri}
+              </a>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
 
 const ensureStyles = () => {
   if (document.getElementById("sovereign-mesh-styles")) return;
@@ -134,6 +236,23 @@ const ensureStyles = () => {
     .mesh-table { width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 14px; }
     .mesh-table th, .mesh-table td { border-bottom: 1px solid rgba(148,163,184,0.25); padding: 8px 12px; text-align: left; }
     .mesh-table a { color: #38bdf8; }
+    .mesh-muted { color: rgba(226,232,240,0.7); font-size: 14px; margin-top: 8px; }
+    .mesh-chip { display: inline-flex; align-items: center; padding: 6px 12px; border-radius: 999px; background: rgba(56,189,248,0.15); border: 1px solid rgba(56,189,248,0.35); font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; }
+    .mesh-preview { margin-top: 16px; }
+    .mesh-preview-summary { display: flex; flex-wrap: wrap; gap: 12px; }
+    .mesh-timeline { list-style: none; margin: 20px 0 0; padding: 0; position: relative; }
+    .mesh-timeline::before { content: ""; position: absolute; left: 15px; top: 0; bottom: 0; width: 2px; background: linear-gradient(180deg, rgba(94,234,212,0.5), rgba(56,189,248,0)); }
+    .mesh-timeline li { display: flex; gap: 12px; margin-bottom: 18px; position: relative; }
+    .mesh-step-index { width: 32px; height: 32px; background: radial-gradient(circle, rgba(34,211,238,0.9), rgba(14,165,233,0.7)); border-radius: 50%; color: #020617; font-weight: 700; display: flex; align-items: center; justify-content: center; box-shadow: 0 0 16px rgba(34,211,238,0.5); }
+    .mesh-step-body { flex: 1; background: rgba(15,23,42,0.82); border: 1px solid rgba(94,234,212,0.25); border-radius: 16px; padding: 12px 16px; }
+    .mesh-step-meta { font-size: 11px; text-transform: uppercase; letter-spacing: 0.18em; color: rgba(148,163,184,0.7); margin-bottom: 4px; }
+    .mesh-step-heading { font-weight: 600; font-size: 16px; display: flex; align-items: baseline; gap: 6px; color: #e2e8f0; }
+    .mesh-step-amount { color: #5eead4; font-size: 14px; }
+    .mesh-step-uri { font-size: 12px; color: #38bdf8; word-break: break-all; display: inline-block; margin-top: 6px; }
+    .mesh-stat-grid { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 12px; }
+    .mesh-stat { background: rgba(15,23,42,0.85); border: 1px solid rgba(148,163,184,0.25); border-radius: 16px; padding: 16px 20px; min-width: 160px; }
+    .mesh-stat-value { font-size: 28px; font-weight: 700; color: #5eead4; display: block; }
+    .mesh-stat-label { text-transform: uppercase; font-size: 11px; letter-spacing: 0.18em; color: rgba(148,163,184,0.7); }
     details { margin-top: 16px; }
     details summary { cursor: pointer; }
   `;
@@ -151,21 +270,60 @@ const App: React.FC = () => {
   const [jobId, setJobId] = useState("1");
   const [approve, setApprove] = useState(true);
   const [selectedPlaybook, setSelectedPlaybook] = useState("");
+  const [summary, setSummary] = useState<MissionSummary>();
+
+  const selectedPlaybookData = useMemo(
+    () => playbooks.find((pb) => pb.id === selectedPlaybook),
+    [playbooks, selectedPlaybook]
+  );
+  const resolveHubLabel = useCallback(
+    (hubId: string) => hubs[hubId]?.label ?? titleCase(hubId),
+    [hubs]
+  );
+  const toToken = useCallback((value: string | bigint) => formatToken(value), []);
 
   useEffect(() => {
     ensureStyles();
   }, []);
 
-  useEffect(() => {
-    if (!cfg || !selectedHub) return;
+  const loadJobs = useCallback(() => {
+    if (!cfg || !selectedHub) {
+      setJobs([]);
+      return;
+    }
     const hub = hubs[selectedHub];
-    if (!hub) return;
+    if (!hub) {
+      setJobs([]);
+      return;
+    }
     const subgraphUrl = hub.subgraphUrl || cfg.defaultSubgraphUrl;
     makeClient(subgraphUrl)
       .request<{ jobs: Job[] }>(qJobs)
       .then((data) => setJobs(data.jobs ?? []))
-      .catch((err) => console.error("Subgraph error", err));
+      .catch((err) => {
+        console.error("Subgraph error", err);
+        setJobs([]);
+      });
   }, [cfg, hubs, selectedHub]);
+
+  const loadSummary = useCallback(() => {
+    fetchJson("/mesh/summary")
+      .then((data) => setSummary(data as MissionSummary))
+      .catch((err) => console.error("Mesh summary error", err));
+  }, []);
+
+  useEffect(() => {
+    loadJobs();
+    if (!selectedHub) return;
+    const interval = window.setInterval(loadJobs, 30000);
+    return () => window.clearInterval(interval);
+  }, [loadJobs, selectedHub]);
+
+  useEffect(() => {
+    loadSummary();
+    const interval = window.setInterval(loadSummary, 60000);
+    return () => window.clearInterval(interval);
+  }, [loadSummary]);
 
   const orchestratorBase = cfg?.orchestratorBase || meshApiBase;
 
@@ -194,6 +352,8 @@ const App: React.FC = () => {
       uri
     });
     alert(`✅ Job created on ${selectedHub}\n${hash}`);
+    loadJobs();
+    loadSummary();
   };
 
   const stake = async (role: number, amountWei: string) => {
@@ -216,6 +376,7 @@ const App: React.FC = () => {
       proof: []
     });
     alert(`🌀 Commit broadcasted\n${hash}`);
+    loadJobs();
   };
 
   const reveal = async () => {
@@ -228,6 +389,7 @@ const App: React.FC = () => {
       salt
     });
     alert(`🌈 Reveal confirmed\n${hash}`);
+    loadJobs();
   };
 
   const finalize = async () => {
@@ -236,6 +398,7 @@ const App: React.FC = () => {
       jobId: Number(jobId)
     });
     alert(`🏁 Finalization submitted\n${hash}`);
+    loadJobs();
   };
 
   const dispute = async () => {
@@ -246,6 +409,7 @@ const App: React.FC = () => {
       evidence
     });
     alert(`⚖️ Dispute raised\n${hash}`);
+    loadJobs();
   };
 
   const instantiate = async () => {
@@ -261,6 +425,8 @@ const App: React.FC = () => {
       await sent.wait();
     }
     alert(`🚀 Mission instantiated across ${response.txs.length} jobs`);
+    loadJobs();
+    loadSummary();
   };
 
   const allowlistDev = async (role: number) => {
@@ -311,7 +477,61 @@ const App: React.FC = () => {
 
       <div className="mesh-card">
         <h3>Live Jobs — {selectedHub || "Select a hub"}</h3>
-        <Table jobs={jobs} />
+        <Table jobs={jobs} toToken={toToken} />
+      </div>
+
+      <div className="mesh-card">
+        <h3>Mission Intelligence Feed</h3>
+        {summary ? (
+          <>
+            <div className="mesh-stat-grid">
+              <div className="mesh-stat">
+                <span className="mesh-stat-value">{summary.hubCount}</span>
+                <span className="mesh-stat-label">Hubs Online</span>
+              </div>
+              <div className="mesh-stat">
+                <span className="mesh-stat-value">{summary.missionCount}</span>
+                <span className="mesh-stat-label">Mission Blueprints</span>
+              </div>
+              <div className="mesh-stat">
+                <span className="mesh-stat-value">{toToken(summary.totalRewardWei)}</span>
+                <span className="mesh-stat-label">Total Incentives</span>
+              </div>
+            </div>
+            <p className="mesh-muted">
+              Network: {summary.network} · Updated {" "}
+              {new Date(summary.updatedAt).toLocaleTimeString()}
+            </p>
+            <table className="mesh-table mesh-missions">
+              <thead>
+                <tr>
+                  <th>Mission</th>
+                  <th>Steps</th>
+                  <th>Hubs</th>
+                  <th>Stages</th>
+                  <th>Total Reward</th>
+                  <th>Hub Routing</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.missions.map((mission) => (
+                  <tr key={mission.id}>
+                    <td>{mission.name}</td>
+                    <td>{mission.stepCount}</td>
+                    <td>{mission.hubCount}</td>
+                    <td title={mission.stages.map((stage) => titleCase(stage)).join(", ")}>
+                      {mission.stageCount}
+                    </td>
+                    <td>{toToken(mission.totalRewardWei)}</td>
+                    <td>{mission.hubs.map((hub) => resolveHubLabel(hub)).join(", ")}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        ) : (
+          <p className="mesh-muted">Loading mission intelligence…</p>
+        )}
       </div>
 
       <div className="mesh-card">
@@ -353,6 +573,10 @@ const App: React.FC = () => {
           </select>
           <button onClick={instantiate}>Instantiate Mission</button>
         </div>
+        <MissionPreview
+          playbook={selectedPlaybookData}
+          resolveHubLabel={resolveHubLabel}
+        />
       </div>
 
       <div className="mesh-card">

--- a/demo/sovereign-mesh/app/src/lib/format.ts
+++ b/demo/sovereign-mesh/app/src/lib/format.ts
@@ -1,5 +1,35 @@
+import { ethers } from "ethers";
+
 export const short = (value?: string | null) => {
   if (!value) return "";
   if (value.length <= 10) return value;
   return `${value.slice(0, 6)}…${value.slice(-4)}`;
 };
+
+export const formatToken = (
+  value: string | bigint,
+  decimals = 2,
+  symbol = "AGIA"
+) => {
+  try {
+    const formatted = ethers.formatEther(value ?? 0);
+    const [wholeRaw, fractionalRaw = ""] = formatted.split(".");
+    const whole = BigInt(wholeRaw || "0").toLocaleString();
+    if (decimals <= 0) {
+      return `${whole} ${symbol}`;
+    }
+    const fractional = fractionalRaw.padEnd(decimals, "0").slice(0, decimals);
+    return `${whole}.${fractional} ${symbol}`;
+  } catch (err) {
+    console.warn("[Sovereign Mesh] Unable to format token", value, err);
+    return `${value} ${symbol}`;
+  }
+};
+
+export const titleCase = (value: string) =>
+  value
+    ? value
+        .replace(/[-_]/g, " ")
+        .replace(/\b\w/g, (c) => c.toUpperCase())
+        .trim()
+    : "";


### PR DESCRIPTION
## Summary
- add a /mesh/summary intelligence endpoint that aggregates hub metadata, mission coverage, and reward totals for Sovereign Mesh
- expand the React console with real-time mission analytics, formatted token display, and a mission preview timeline for non-technical users
- update documentation with the new intelligence workflow, diagrams, and guidance on the summary API

## Testing
- npm --prefix demo/sovereign-mesh/server run build
- npm --prefix demo/sovereign-mesh/app run build
- npm test -- --grep "Sovereign Mesh" *(no matching tests were executed)*

------
https://chatgpt.com/codex/tasks/task_e_68f2bebd0fcc8333882fdfdd009f2783