### PR TITLE
Enhance Sovereign Mesh mission orchestration UX

### DIFF
--- a/demo/sovereign-mesh/README.md
+++ b/demo/sovereign-mesh/README.md
@@ -120,7 +120,8 @@ graph TD
 | **Connect & Select Hub** | Wallet-first connect button + hub selector that hydrates live jobs via The Graph. |
 | **Create Job** | Reward + URI form that composes a `createJob` transaction with sensible deadlines and spec hash. |
 | **Participate** | Validators stake, commit, reveal, and finalize in a human-friendly workflow (salts handled automatically). |
-| **Mission Playbooks** | One-click instantiation of multi-hub missions (jobs across hubs queued sequentially for signature). |
+| **Mission Playbooks** | Dynamic preview of sponsors, total rewards, and cross-hub deliverables with one-click instantiation. |
+| **Mesh Sponsors & Actors** | Configurable roster of planetary sponsors with mission-ready taglines to humanize the mesh. |
 | **Owner Panels** | Direct links to every hub contract write interface on Etherscan for immediate governance actions. |
 
 ## Production-grade guarantees
@@ -132,7 +133,9 @@ graph TD
 
 ## Mission blueprint editing
 
-Playbooks live in [`config/playbooks.json`](config/playbooks.json). Add new missions or adjust rewards by editing JSON — no code changes required. Each step uses the format `"stage@hub"` to map actions to hubs.
+Playbooks live in [`config/playbooks.json`](config/playbooks.json). Add new missions or adjust rewards by editing JSON — no code changes required. Each step uses the format `"stage@hub"` to map actions to hubs, supports rich `description` fields, and can declare a `sponsor` referencing an entry in [`config/actors.json`](config/actors.json).
+
+`actors.json` accepts `flag`, `name`, and optional `tagline` strings so the interface can introduce sponsors and mission owners in a narrative, human-readable way.
 
 ## Identity and governance
 

--- a/demo/sovereign-mesh/app/src/lib/format.ts
+++ b/demo/sovereign-mesh/app/src/lib/format.ts
@@ -1,5 +1,20 @@
+import { ethers } from "ethers";
+
 export const short = (value?: string | null) => {
   if (!value) return "";
   if (value.length <= 10) return value;
   return `${value.slice(0, 6)}…${value.slice(-4)}`;
+};
+
+export const formatAgi = (value: string | bigint | number) => {
+  try {
+    const formatted = Number(ethers.formatEther(value)).toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 4
+    });
+    return `${formatted} AGIA`;
+  } catch (err) {
+    console.warn("Unable to format value as AGIA", err);
+    return String(value);
+  }
 };

--- a/demo/sovereign-mesh/config/actors.json
+++ b/demo/sovereign-mesh/config/actors.json
@@ -1,7 +1,32 @@
 [
-  { "id": "usa", "flag": "🇺🇸", "name": "United States" },
-  { "id": "jpn", "flag": "🇯🇵", "name": "Japan" },
-  { "id": "deu", "flag": "🇩🇪", "name": "Germany" },
-  { "id": "ngo", "flag": "🌍", "name": "Global NGO" },
-  { "id": "city", "flag": "🏙️", "name": "Smart City DAO" }
+  {
+    "id": "usa",
+    "flag": "🇺🇸",
+    "name": "United States",
+    "tagline": "Federal climate coalition funding planetary decarbonization."
+  },
+  {
+    "id": "jpn",
+    "flag": "🇯🇵",
+    "name": "Japan",
+    "tagline": "Moonshot foresight ministry advancing resilience missions."
+  },
+  {
+    "id": "deu",
+    "flag": "🇩🇪",
+    "name": "Germany",
+    "tagline": "Industry 5.0 consortium stewarding sovereign supply meshes."
+  },
+  {
+    "id": "ngo",
+    "flag": "🌍",
+    "name": "Global NGO",
+    "tagline": "Planetary commons alliance orchestrating civic knowledge hubs."
+  },
+  {
+    "id": "city",
+    "flag": "🏙️",
+    "name": "Smart City DAO",
+    "tagline": "Metropolitan DAO pioneering climate-positive urbanism."
+  }
 ]

--- a/demo/sovereign-mesh/config/playbooks.json
+++ b/demo/sovereign-mesh/config/playbooks.json
@@ -3,6 +3,7 @@
     "id": "decarbonize-port-city",
     "name": "Mission: Decarbonize Port City",
     "summary": "Mobilize foresight, research, optimization, and knowledge hubs to drive a whole-of-city clean transition.",
+    "sponsor": "city",
     "steps": [
       {
         "hub": "foresight@civic-governance",
@@ -34,6 +35,7 @@
     "id": "pandemic-watch",
     "name": "Mission: Pandemic Watch",
     "summary": "Global sentinel network aligning public foresight, research, and operational readiness.",
+    "sponsor": "ngo",
     "steps": [
       {
         "hub": "foresight@civic-governance",


### PR DESCRIPTION
## Summary
- surface mission sponsor intelligence and total incentives directly in the console with a new preview card, including formatted AGIA rewards and deliverable details
- extend the shared configuration to describe playbook sponsors and rich actor taglines, and document the additions in the Sovereign Mesh README

## Testing
- npm run build (demo/sovereign-mesh/app)
- npm run build (demo/sovereign-mesh/server)

------
https://chatgpt.com/codex/tasks/task_e_68f2bebd0fcc8333882fdfdd009f2783