### PR TITLE
Add owner control center to Sovereign Mesh demo

### DIFF
--- a/demo/sovereign-mesh/README.md
+++ b/demo/sovereign-mesh/README.md
@@ -120,6 +120,7 @@ graph TD
 | **Connect & Select Hub** | Wallet-first connect button + hub selector that hydrates live jobs via The Graph. |
 | **Create Job** | Reward + URI form that composes a `createJob` transaction with sensible deadlines and spec hash. |
 | **Participate** | Validators stake, commit, reveal, and finalize in a human-friendly workflow (salts handled automatically). |
+| **Owner Control Center** | Governance wallet can pause/unpause hubs, retune validation cadence, and update staking economics from the console. |
 | **Mission Playbooks** | Dynamic preview of sponsors, total rewards, and cross-hub deliverables with one-click instantiation. |
 | **Mesh Sponsors & Actors** | Configurable roster of planetary sponsors with mission-ready taglines to humanize the mesh. |
 | **Owner Panels** | Direct links to every hub contract write interface on Etherscan for immediate governance actions. |
@@ -130,6 +131,7 @@ graph TD
 - **Config-driven** — missions, hubs, actors, RPC endpoints, and presentation can be updated by editing JSON files.
 - **Typed + tested** — Hardhat scenario covers dual-hub lifecycle, Cypress assures the UI boots, TypeScript builds enforced in CI.
 - **CI enforced** — `.github/workflows/ci.yml` includes the Sovereign Mesh build job so every PR keeps the demo green.
+- **Owner-safe orchestration** — the console’s Owner Control Center composes pause/unpause and parameter tuning transactions directly for the governance wallet.
 
 ## Mission blueprint editing
 


### PR DESCRIPTION
## Summary
- extend the Sovereign Mesh orchestrator API with governance transaction composers for pausing, validation tuning, and stake configuration
- expand the console with an Owner Control Center, reusable transaction planner, and richer error messaging
- document the new governance tooling inside the demo README

## Testing
- npm run build (demo/sovereign-mesh/server)
- npm run build (demo/sovereign-mesh/app)
- npm test -- --grep "Sovereign Mesh"


------
https://chatgpt.com/codex/tasks/task_e_68f2c72c94ec8333ac378056d8e11d81