### PR TITLE
Add health endpoint and governance diagram to Sovereign Mesh demo

### DIFF
--- a/demo/sovereign-mesh/README.md
+++ b/demo/sovereign-mesh/README.md
@@ -78,6 +78,25 @@ graph TD
   E3 -.-> C
 ```
 
+### Validation & governance nerve center
+
+```mermaid
+sequenceDiagram
+  participant Owner as Hub Owner Wallet
+  participant Console as Sovereign Mesh Console
+  participant API as Orchestrator API
+  participant Modules as Validation/Stake Modules
+
+  Owner->>Console: Tune validation & staking inputs
+  Console->>API: /mesh/{hub}/owner/* requests
+  API->>Modules: Encoded governance transactions
+  Modules-->>Owner: Emit events confirming parameter shifts
+  Owner->>Console: Pause/Resume hub if needed
+  Console->>API: /mesh/{hub}/owner/pause or /unpause
+  API->>Modules: Dispatch pause/unpause calls
+  Modules-->>Owner: Confirm hub state change
+```
+
 ## Quickstart (non-technical operator)
 
 1. **Clone + install**
@@ -124,6 +143,7 @@ graph TD
 | **Mission Playbooks** | Dynamic preview of sponsors, total rewards, and cross-hub deliverables with one-click instantiation. |
 | **Mesh Sponsors & Actors** | Configurable roster of planetary sponsors with mission-ready taglines to humanize the mesh. |
 | **Owner Panels** | Direct links to every hub contract write interface on Etherscan for immediate governance actions. |
+| **Health API** | `GET /mesh/health` exposes a machine-readable heartbeat (network, hub count, uptime) for monitoring. |
 
 ## Production-grade guarantees
 
@@ -132,6 +152,7 @@ graph TD
 - **Typed + tested** — Hardhat scenario covers dual-hub lifecycle, Cypress assures the UI boots, TypeScript builds enforced in CI.
 - **CI enforced** — `.github/workflows/ci.yml` includes the Sovereign Mesh build job so every PR keeps the demo green.
 - **Owner-safe orchestration** — the console’s Owner Control Center composes pause/unpause and parameter tuning transactions directly for the governance wallet.
+- **Operability hooks** — `GET /mesh/health` provides a ready probe for load balancers and observability stacks.
 
 ## Mission blueprint editing
 

--- a/demo/sovereign-mesh/server/index.ts
+++ b/demo/sovereign-mesh/server/index.ts
@@ -21,6 +21,8 @@ const actors = JSON.parse(
   readFileSync(path.join(root, "config/actors.json"), "utf8")
 );
 
+const startedAt = Date.now();
+
 const jobAbi = [
   "function createJob(uint256 reward, uint64 deadline, bytes32 specHash, string uri) returns (uint256)"
 ];
@@ -143,6 +145,14 @@ app.get("/mesh/hubs", (_req, res) => res.json({ hubs }));
 app.get("/mesh/actors", (_req, res) => res.json(actors));
 app.get("/mesh/playbooks", (_req, res) => res.json(playbooks));
 app.get("/mesh/config", (_req, res) => res.json(meshCfg));
+app.get("/mesh/health", (_req, res) => {
+  res.json({
+    status: "ok",
+    network: meshCfg.network,
+    hubs: Object.keys(hubs).length,
+    uptimeSeconds: Math.floor((Date.now() - startedAt) / 1000)
+  });
+});
 
 app.post("/mesh/:hub/tx/create", (req, res) => {
   const hub = getHub(req.params.hub);


### PR DESCRIPTION
## Summary
- add a machine-readable `/mesh/health` heartbeat with uptime and hub count for Sovereign Mesh
- document the new operability hook and governance flow with a mermaid sequence diagram in the demo README

## Testing
- npm run lint:ci
- (cd demo/sovereign-mesh/server && npm ci && npm run build)
- (cd demo/sovereign-mesh/app && npm ci && npm run build)
- npx hardhat test demo/sovereign-mesh/test/SovereignMesh.t.ts


------
https://chatgpt.com/codex/tasks/task_e_68f2e64092a48333831c295bada55429