### PR TITLE
Add planetary mesh intelligence summary

### DIFF
--- a/demo/sovereign-mesh/README.md
+++ b/demo/sovereign-mesh/README.md
@@ -136,6 +136,7 @@ sequenceDiagram
 
 | Section | What it delivers |
 | --- | --- |
+| **Mesh Intelligence Dashboard** | Planetary-scale KPIs (hubs, missions, reward budgets) sourced from `/mesh/summary`. |
 | **Connect & Select Hub** | Wallet-first connect button + hub selector that hydrates live jobs via The Graph. |
 | **Create Job** | Reward + URI form that composes a `createJob` transaction with sensible deadlines and spec hash. |
 | **Participate** | Validators stake, commit, reveal, and finalize in a human-friendly workflow (salts handled automatically). |
@@ -153,6 +154,7 @@ sequenceDiagram
 - **CI enforced** — `.github/workflows/ci.yml` includes the Sovereign Mesh build job so every PR keeps the demo green.
 - **Owner-safe orchestration** — the console’s Owner Control Center composes pause/unpause and parameter tuning transactions directly for the governance wallet.
 - **Operability hooks** — `GET /mesh/health` provides a ready probe for load balancers and observability stacks.
+- **Planetary telemetry** — `GET /mesh/summary` aggregates mission rewards, hub coverage, and sponsor counts for dashboards.
 
 ## Mission blueprint editing
 

--- a/demo/sovereign-mesh/cypress/e2e/sovereign-mesh.cy.ts
+++ b/demo/sovereign-mesh/cypress/e2e/sovereign-mesh.cy.ts
@@ -2,6 +2,7 @@ describe("Sovereign Mesh UI", () => {
   it("renders hub selector and mission menu", () => {
     cy.visit("http://localhost:5178");
     cy.contains("Sovereign Mesh");
+    cy.contains("Mesh Intelligence Dashboard");
     cy.get("select").first().select("Public Research Hub");
     cy.contains("Mission Playbooks");
   });


### PR DESCRIPTION
## Summary
- add a /mesh/summary orchestrator endpoint that aggregates hubs, missions, and reward budgets
- surface the Mesh Intelligence Dashboard in the console with planetary KPIs and per-hub reward share visuals
- document the telemetry endpoint and update the Cypress smoke test for the new dashboard

## Testing
- npm run build (demo/sovereign-mesh/server)
- npm run build (demo/sovereign-mesh/app)


------
https://chatgpt.com/codex/tasks/task_e_68f2edb89e3c8333addbff5aa2991d95