### PR TITLE
Add lifecycle governance diagram to α-AGI Insight MARK demo

### DIFF
--- a/.github/workflows/demo-alpha-agi-insight-mark.yml
+++ b/.github/workflows/demo-alpha-agi-insight-mark.yml
@@ -198,5 +198,6 @@ jobs:
             demo/alpha-agi-insight-mark/reports/insight-control-matrix.json
             demo/alpha-agi-insight-mark/reports/insight-control-map.mmd
             demo/alpha-agi-insight-mark/reports/insight-superintelligence.mmd
+            demo/alpha-agi-insight-mark/reports/insight-lifecycle.mmd
             demo/alpha-agi-insight-mark/reports/insight-manifest.json
             demo/alpha-agi-insight-mark/reports/insight-telemetry.log

--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -81,6 +81,7 @@ Running the demo produces:
 - `insight-owner-brief.md` – rapid-response owner command checklist with custody overview.
 - `insight-market-matrix.csv` – CSV dataset for financial modelling and downstream analytics.
 - `insight-constellation.mmd` – mermaid constellation showing live custody, market, and sentinel linkages.
+- `insight-lifecycle.mmd` – end-to-end sequence diagram proving owner-dominated lifecycle control from swarm genesis to market settlement.
 - `insight-manifest.json` – SHA-256 hashes of every generated artefact and the scenario dataset that produced them.
 
 All outputs are designed for direct inclusion in boardroom briefings and investor packets.

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -41,6 +41,7 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 - `insight-owner-brief.md` – executive command sheet summarising pause hooks and custody.
 - `insight-market-matrix.csv` – spreadsheet-ready dataset for analysts and treasury.
 - `insight-constellation.mmd` – constellation mermaid capturing live custody and sentinel edges.
+- `insight-lifecycle.mmd` – sequence diagram evidencing owner command authority across the full deployment-to-market cycle.
 - `insight-manifest.json` – SHA-256 hashes; re-run the demo and confirm hashes change only when artefacts change. The manifest now fingerprints the scenario dataset too, so provenance can be attested.
 - `insight-recap.json` – network metadata, contract addresses, minted ledger, telemetry, and a stats block validating owner/delegate mints, market state, confidence bands, capability index, and forecast value against generated artefacts.
 - `insight-telemetry.log` – chronological agent conversation for audit trails.

--- a/demo/alpha-agi-insight-mark/scripts/runDemo.ts
+++ b/demo/alpha-agi-insight-mark/scripts/runDemo.ts
@@ -428,6 +428,7 @@ async function main() {
   const ownerBriefPath = path.join(reportsDir, "insight-owner-brief.md");
   const csvPath = path.join(reportsDir, "insight-market-matrix.csv");
   const constellationPath = path.join(reportsDir, "insight-constellation.mmd");
+  const lifecyclePath = path.join(reportsDir, "insight-lifecycle.mmd");
   const manifestPath = path.join(reportsDir, "insight-manifest.json");
 
   const scenarioRelativePath = path
@@ -1292,6 +1293,30 @@ ${htmlRows}
     `    classDef sealed fill:#343a55,stroke:#7a8bbd,color:#f1f5ff;\n` +
     `    classDef revealed fill:#214d6d,stroke:#7fe6ff,color:#ecfbff;\n`;
 
+  const lifecycleMermaid =
+    `sequenceDiagram\n` +
+    `    autonumber\n` +
+    `    participant Operator as Owner / Operator\n` +
+    `    participant MetaSwarm as Meta-Agentic Swarm\n` +
+    `    participant Forge as α-AGI Nova-Seed Forge\n` +
+    `    participant Exchange as α-AGI MARK Exchange\n` +
+    `    participant Sentinel as System Pause Sentinel\n` +
+    `    participant Treasury as Treasury Governance\n` +
+    `    Operator->>MetaSwarm: Define disruption mandate + guardrails\n` +
+    `    MetaSwarm-->>MetaSwarm: Thermodynamic rupture exploration\n` +
+    `    MetaSwarm->>Forge: Submit cryptosealed Nova-Seed blueprint\n` +
+    `    Forge-->>Operator: Mint #seedId + notarise provenance hash\n` +
+    `    Operator->>Exchange: Configure listing, fees, oracle policy\n` +
+    `    Exchange-->>Treasury: Route settlement fees (${(Number(await exchange.feeBps()) / 100).toFixed(2)}%)\n` +
+    `    Exchange-)Operator: Emit trade + custody attestations\n` +
+    `    Sentinel-->>Forge: Pause / resume custody lattice\n` +
+    `    Sentinel-->>Exchange: Trigger market circuit-break\n` +
+    `    Operator->>Forge: Reveal FusionPlan when strategic window opens\n` +
+    `    Operator->>Exchange: Resolve prediction via oracle rotation\n` +
+    `    Exchange-->>MetaSwarm: Feed confirmed rupture telemetry\n` +
+    `    MetaSwarm-->>Operator: Update capability index + executive dossier\n` +
+    `    note over Operator,Exchange: Owner retains unilateral pause, repricing, oracle and treasury authority.\n`;
+
   const telemetryLog = telemetry.map((entry) => `${entry.timestamp} [${entry.agent}] ${entry.message}`).join("\n");
 
   await writeFile(recapPath, JSON.stringify(recap, null, 2));
@@ -1305,6 +1330,7 @@ ${htmlRows}
   await writeFile(ownerBriefPath, ownerBrief);
   await writeFile(csvPath, csvContent);
   await writeFile(constellationPath, constellationMermaid);
+  await writeFile(lifecyclePath, lifecycleMermaid);
 
   const manifestEntries: { path: string; sha256: string }[] = [];
   for (const file of [
@@ -1319,6 +1345,7 @@ ${htmlRows}
     ownerBriefPath,
     csvPath,
     constellationPath,
+    lifecyclePath,
   ]) {
     const content = await readFile(file);
     const relativePath = path.relative(path.join(__dirname, ".."), file);

--- a/demo/alpha-agi-insight-mark/scripts/verifyReports.ts
+++ b/demo/alpha-agi-insight-mark/scripts/verifyReports.ts
@@ -101,6 +101,7 @@ const mermaidSuperintelligencePath = path.join(reportsDir, "insight-superintelli
 const mermaidControlMapPath = path.join(reportsDir, "insight-control-map.mmd");
 const mermaidGovernancePath = path.join(reportsDir, "insight-governance.mmd");
 const mermaidConstellationPath = path.join(reportsDir, "insight-constellation.mmd");
+const mermaidLifecyclePath = path.join(reportsDir, "insight-lifecycle.mmd");
 const telemetryPath = path.join(reportsDir, "insight-telemetry.log");
 const ownerBriefPath = path.join(reportsDir, "insight-owner-brief.md");
 const csvPath = path.join(reportsDir, "insight-market-matrix.csv");
@@ -216,6 +217,7 @@ async function verifyManifest(manifest: Manifest) {
     path.relative(baseDir, matrixPath).replace(/\\/g, "/"),
     path.relative(baseDir, mermaidSuperintelligencePath).replace(/\\/g, "/"),
     path.relative(baseDir, mermaidControlMapPath).replace(/\\/g, "/"),
+    path.relative(baseDir, mermaidLifecyclePath).replace(/\\/g, "/"),
     path.relative(baseDir, telemetryPath).replace(/\\/g, "/"),
     path.relative(baseDir, ownerBriefPath).replace(/\\/g, "/"),
     path.relative(baseDir, csvPath).replace(/\\/g, "/"),
@@ -552,11 +554,13 @@ async function verifyMermaidFiles(minted: RecapMintedEntry[]) {
   await ensureExists(mermaidGovernancePath, "Governance mermaid");
   await ensureExists(mermaidConstellationPath, "Constellation mermaid");
   await ensureExists(mermaidControlMapPath, "Control map mermaid");
+  await ensureExists(mermaidLifecyclePath, "Lifecycle mermaid");
 
   const superintelligence = await readFile(mermaidSuperintelligencePath, "utf8");
   const governance = await readFile(mermaidGovernancePath, "utf8");
   const constellation = await readFile(mermaidConstellationPath, "utf8");
   const controlMap = await readFile(mermaidControlMapPath, "utf8");
+  const lifecycle = await readFile(mermaidLifecyclePath, "utf8");
 
   const superTokens = ["Meta-Agentic Tree Search", "Thermodynamic Rupture Trigger", "AGI Capability Index"];
   for (const token of superTokens) {
@@ -582,6 +586,18 @@ async function verifyMermaidFiles(minted: RecapMintedEntry[]) {
   }
   if (!constellation.includes("pause sweep")) {
     throw new Error("Constellation mermaid missing pause sweep annotations.");
+  }
+  const lifecycleTokens = [
+    "Meta-Agentic Swarm",
+    "α-AGI Nova-Seed Forge",
+    "α-AGI MARK Exchange",
+    "System Pause Sentinel",
+    "Treasury Governance",
+  ];
+  for (const token of lifecycleTokens) {
+    if (!lifecycle.includes(token)) {
+      throw new Error(`Lifecycle mermaid missing ${token} participant.`);
+    }
   }
   for (const entry of minted) {
     const tokenNode = `token${entry.tokenId}`;


### PR DESCRIPTION
## Summary
- generate a new `insight-lifecycle.mmd` sequence diagram during the α-AGI Insight MARK demo run and fingerprint it in the manifest bundle
- extend the dossier verifier to require and validate the lifecycle diagram alongside existing mermaid schematics
- document the additional artefact in the README, operator runbook, and CI workflow uploads so operators and automation capture it automatically

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci
- npm run verify:alpha-agi-insight-mark

------
https://chatgpt.com/codex/tasks/task_e_68f389a09ac883338e02a9e89cab8fcf