### PR TITLE
Add agency orbit mermaid dossier to α-AGI Insight MARK demo

### DIFF
--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -81,6 +81,7 @@ Running the demo produces:
 - `insight-owner-brief.md` – rapid-response owner command checklist with custody overview.
 - `insight-market-matrix.csv` – CSV dataset for financial modelling and downstream analytics.
 - `insight-constellation.mmd` – mermaid constellation showing live custody, market, and sentinel linkages.
+- `insight-agency-orbit.mmd` – mermaid orbit of the meta-agent swarm mapping mint, custody, and market routing authority.
 - `insight-lifecycle.mmd` – end-to-end sequence diagram proving owner-dominated lifecycle control from swarm genesis to market settlement.
 - `insight-manifest.json` – SHA-256 hashes of every generated artefact and the scenario dataset that produced them.
 

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -41,6 +41,7 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 - `insight-owner-brief.md` – executive command sheet summarising pause hooks and custody.
 - `insight-market-matrix.csv` – spreadsheet-ready dataset for analysts and treasury.
 - `insight-constellation.mmd` – constellation mermaid capturing live custody and sentinel edges.
+- `insight-agency-orbit.mmd` – orbit schematic linking each meta-agent to its minted seeds and custody paths.
 - `insight-lifecycle.mmd` – sequence diagram evidencing owner command authority across the full deployment-to-market cycle.
 - `insight-manifest.json` – SHA-256 hashes; re-run the demo and confirm hashes change only when artefacts change. The manifest now fingerprints the scenario dataset too, so provenance can be attested.
 - `insight-recap.json` – network metadata, contract addresses, minted ledger, telemetry, and a stats block validating owner/delegate mints, market state, confidence bands, capability index, and forecast value against generated artefacts.

--- a/demo/alpha-agi-insight-mark/scripts/verifyReports.ts
+++ b/demo/alpha-agi-insight-mark/scripts/verifyReports.ts
@@ -101,6 +101,7 @@ const mermaidSuperintelligencePath = path.join(reportsDir, "insight-superintelli
 const mermaidControlMapPath = path.join(reportsDir, "insight-control-map.mmd");
 const mermaidGovernancePath = path.join(reportsDir, "insight-governance.mmd");
 const mermaidConstellationPath = path.join(reportsDir, "insight-constellation.mmd");
+const mermaidAgencyOrbitPath = path.join(reportsDir, "insight-agency-orbit.mmd");
 const mermaidLifecyclePath = path.join(reportsDir, "insight-lifecycle.mmd");
 const telemetryPath = path.join(reportsDir, "insight-telemetry.log");
 const ownerBriefPath = path.join(reportsDir, "insight-owner-brief.md");
@@ -217,6 +218,7 @@ async function verifyManifest(manifest: Manifest) {
     path.relative(baseDir, matrixPath).replace(/\\/g, "/"),
     path.relative(baseDir, mermaidSuperintelligencePath).replace(/\\/g, "/"),
     path.relative(baseDir, mermaidControlMapPath).replace(/\\/g, "/"),
+    path.relative(baseDir, mermaidAgencyOrbitPath).replace(/\\/g, "/"),
     path.relative(baseDir, mermaidLifecyclePath).replace(/\\/g, "/"),
     path.relative(baseDir, telemetryPath).replace(/\\/g, "/"),
     path.relative(baseDir, ownerBriefPath).replace(/\\/g, "/"),
@@ -554,12 +556,14 @@ async function verifyMermaidFiles(minted: RecapMintedEntry[]) {
   await ensureExists(mermaidGovernancePath, "Governance mermaid");
   await ensureExists(mermaidConstellationPath, "Constellation mermaid");
   await ensureExists(mermaidControlMapPath, "Control map mermaid");
+  await ensureExists(mermaidAgencyOrbitPath, "Agency orbit mermaid");
   await ensureExists(mermaidLifecyclePath, "Lifecycle mermaid");
 
   const superintelligence = await readFile(mermaidSuperintelligencePath, "utf8");
   const governance = await readFile(mermaidGovernancePath, "utf8");
   const constellation = await readFile(mermaidConstellationPath, "utf8");
   const controlMap = await readFile(mermaidControlMapPath, "utf8");
+  const agencyOrbit = await readFile(mermaidAgencyOrbitPath, "utf8");
   const lifecycle = await readFile(mermaidLifecyclePath, "utf8");
 
   const superTokens = ["Meta-Agentic Tree Search", "Thermodynamic Rupture Trigger", "AGI Capability Index"];
@@ -587,6 +591,22 @@ async function verifyMermaidFiles(minted: RecapMintedEntry[]) {
   if (!constellation.includes("pause sweep")) {
     throw new Error("Constellation mermaid missing pause sweep annotations.");
   }
+  const agentOrbitLabels = [
+    "Meta-Agent Constellation",
+    "Meta-Sentinel",
+    "MATS Engine",
+    "Thermodynamic Oracle",
+    "FusionSmith",
+    "Guardian Auditor",
+    "Venture Cartographer",
+    "System Sentinel",
+    "α-AGI MARK Market Grid",
+  ];
+  for (const label of agentOrbitLabels) {
+    if (!agencyOrbit.includes(label)) {
+      throw new Error(`Agency orbit mermaid missing ${label} annotation.`);
+    }
+  }
   const lifecycleTokens = [
     "Meta-Agentic Swarm",
     "α-AGI Nova-Seed Forge",
@@ -597,6 +617,15 @@ async function verifyMermaidFiles(minted: RecapMintedEntry[]) {
   for (const token of lifecycleTokens) {
     if (!lifecycle.includes(token)) {
       throw new Error(`Lifecycle mermaid missing ${token} participant.`);
+    }
+  }
+  for (const entry of minted) {
+    const nodeId = `seed${entry.tokenId}`;
+    if (!agencyOrbit.includes(nodeId)) {
+      throw new Error(`Agency orbit mermaid missing node ${nodeId}.`);
+    }
+    if (!agencyOrbit.includes(entry.scenario.sector)) {
+      throw new Error(`Agency orbit mermaid missing sector label ${entry.scenario.sector}.`);
     }
   }
   for (const entry of minted) {


### PR DESCRIPTION
## Summary
- generate a new insight-agency-orbit.mmd dossier that maps the meta-agent constellation to minted seeds and custody flows
- include the agency orbit artefact in the manifest, documentation, and dry-run outputs so operators and CI verify it automatically

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci
- npm run verify:alpha-agi-insight-mark


------
https://chatgpt.com/codex/tasks/task_e_68f38ee6f4a08333b4ab9b599f4a5d3a