### PR TITLE
Add safety checklist dossier for α-AGI Insight MARK

### DIFF
--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -79,6 +79,7 @@ Running the demo produces:
 - `insight-superintelligence.mmd` – Meta-Agentic Tree Search + thermodynamic trigger mermaid capturing the superintelligent foresight engine.
 - `insight-telemetry.log` – time-stamped agent dialogue.
 - `insight-owner-brief.md` – rapid-response owner command checklist with custody overview.
+- `insight-safety-checklist.md` – contract command matrix, sentinel drill recap, parameter overrides, and integrity assertions confirming owner supremacy.
 - `insight-market-matrix.csv` – CSV dataset for financial modelling and downstream analytics.
 - `insight-constellation.mmd` – mermaid constellation showing live custody, market, and sentinel linkages.
 - `insight-agency-orbit.mmd` – mermaid orbit of the meta-agent swarm mapping mint, custody, and market routing authority.

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -39,6 +39,7 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 - `insight-governance.mmd` – insight swarm + sentinel orchestration schematic.
 - `insight-superintelligence.mmd` – Meta-Agentic Tree Search + thermodynamic trigger constellation (render via https://mermaid.live/).
 - `insight-owner-brief.md` – executive command sheet summarising pause hooks and custody.
+- `insight-safety-checklist.md` – safety and control checklist showing contract owners, sentinels, override levers, and integrity assertions.
 - `insight-market-matrix.csv` – spreadsheet-ready dataset for analysts and treasury.
 - `insight-constellation.mmd` – constellation mermaid capturing live custody and sentinel edges.
 - `insight-agency-orbit.mmd` – orbit schematic linking each meta-agent to its minted seeds and custody paths.


### PR DESCRIPTION
## Summary
- generate a dedicated safety and control checklist during the α-AGI Insight MARK demo run
- extend the dossier verifier to enforce checklist contents, contract governance data, and integrity assertions
- document the new artefact in the README and operator runbook so non-technical operators can rely on it

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci
- npm run verify:alpha-agi-insight-mark

------
https://chatgpt.com/codex/tasks/task_e_68f393522de08333b1e39a349c5043f7