### PR TITLE
Expand Insight MARK forecast controls and dossier checks

### DIFF
--- a/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
+++ b/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
@@ -5,7 +5,7 @@
 | Contract | Address | Governance Handles |
 | --- | --- | --- |
 | Insight Access Token (`InsightAccessToken`) | Populate from `insight-recap.json` | `mint`, `pause`, `unpause`, `setSystemPause` |
-| Nova-Seed (`AlphaInsightNovaSeed`) | Populate from `insight-recap.json` | `setMinter`, `updateInsightDetails`, `updateSealedURI`, `revealFusionPlan`, `updateFusionPlan`, `pause`, `unpause`, `setSystemPause` |
+| Nova-Seed (`AlphaInsightNovaSeed`) | Populate from `insight-recap.json` | `setMinter`, `updateInsightDetails` (sector/thesis/timestamp/confidence/forecast), `updateSealedURI`, `revealFusionPlan`, `updateFusionPlan`, `pause`, `unpause`, `setSystemPause` |
 | Foresight Exchange (`AlphaInsightExchange`) | Populate from `insight-recap.json` | `setOracle`, `setTreasury`, `setPaymentToken`, `setFeeBps`, `updateListingPrice`, `forceDelist`, `pause`, `unpause`, `resolvePrediction`, `setSystemPause` |
 
 ## 2. Emergency Procedures

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -40,7 +40,7 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 - `insight-superintelligence.mmd` – Meta-Agentic Tree Search + thermodynamic trigger constellation (render via https://mermaid.live/).
 - `insight-owner-brief.md` – executive command sheet summarising pause hooks and custody.
 - `insight-safety-checklist.md` – safety and control checklist showing contract owners, sentinels, override levers, and integrity assertions.
-- `insight-market-matrix.csv` – spreadsheet-ready dataset for analysts and treasury.
+- `insight-market-matrix.csv` – spreadsheet-ready dataset showing confidence basis points, forecast magnitude, custody and market state for each Nova-Seed.
 - `insight-constellation.mmd` – constellation mermaid capturing live custody and sentinel edges.
 - `insight-agency-orbit.mmd` – orbit schematic linking each meta-agent to its minted seeds and custody paths.
 - `insight-lifecycle.mmd` – sequence diagram evidencing owner command authority across the full deployment-to-market cycle.
@@ -57,6 +57,7 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 5. **Dynamic Pricing** – Reprice an active listing via `updateListingPrice(tokenId, price)`; confirm the markdown reflects the new amount.
 6. **Custody Override** – Call `forceDelist(tokenId, <custodian>)` to evacuate a seed into a safe wallet, then re-list when cleared.
 7. **Reveal & Revise FusionPlan** – Trigger `revealFusionPlan(tokenId, uri)` to expose the cryptosealed FusionPlan, then `updateFusionPlan(tokenId, uri)` if revisions are needed.
+8. **Retune Forecast Parameters** – Use `updateInsightDetails(tokenId, sector, thesis, timestamp, confidenceBps, forecastValue)` to refresh disruption metadata and economic magnitude under owner command.
 
 ## 5. Verification Loop
 

--- a/demo/alpha-agi-insight-mark/test/AlphaInsightExchange.test.ts
+++ b/demo/alpha-agi-insight-mark/test/AlphaInsightExchange.test.ts
@@ -33,6 +33,8 @@ describe("AlphaInsightExchange", () => {
       thesis: "Synthetic AI investors fracture market equilibrium",
       disruptionTimestamp: BigInt(Math.floor(Date.UTC(2027, 0, 1) / 1000)),
       sealedURI: "ipfs://seed/finance",
+      confidenceBps: 9000,
+      forecastValue: "40T",
     });
 
     await token.mint(buyer.address, ethers.parseUnits("1000", 18));

--- a/demo/alpha-agi-insight-mark/test/AlphaInsightNovaSeed.test.ts
+++ b/demo/alpha-agi-insight-mark/test/AlphaInsightNovaSeed.test.ts
@@ -16,12 +16,23 @@ describe("AlphaInsightNovaSeed", () => {
     await contract.waitForDeployment();
   });
 
-  function sampleInput(overrides: Partial<{ sector: string; thesis: string; disruptionTimestamp: bigint; sealedURI: string }> = {}) {
+  function sampleInput(
+    overrides: Partial<{
+      sector: string;
+      thesis: string;
+      disruptionTimestamp: bigint;
+      sealedURI: string;
+      confidenceBps: number;
+      forecastValue: string;
+    }> = {}
+  ) {
     return {
       sector: overrides.sector ?? "Finance",
       thesis: overrides.thesis ?? "Autonomous capital markets eclipse human traders.",
       disruptionTimestamp: overrides.disruptionTimestamp ?? BigInt(Math.floor(Date.UTC(2027, 0, 1) / 1000)),
       sealedURI: overrides.sealedURI ?? "ipfs://sealed",
+      confidenceBps: overrides.confidenceBps ?? 9100,
+      forecastValue: overrides.forecastValue ?? "42T",
     };
   }
 
@@ -36,17 +47,26 @@ describe("AlphaInsightNovaSeed", () => {
     expect(insight.fusionRevealed).to.equal(false);
     expect(insight.originalMinter).to.equal(owner.address);
     expect(insight.mintedAt).to.be.gt(0n);
+    expect(insight.confidenceBps).to.equal(9100);
+    expect(insight.forecastValue).to.equal("42T");
   });
 
   it("permits delegated minters and enforces authorization", async () => {
     await expect(contract.connect(alice).mintInsight(bob.address, sampleInput())).to.be.revertedWith("NOT_AUTHORIZED");
 
     await contract.setMinter(alice.address, true);
-    await contract.connect(alice).mintInsight(bob.address, sampleInput({ sector: "Energy" }));
+    await contract
+      .connect(alice)
+      .mintInsight(
+        bob.address,
+        sampleInput({ sector: "Energy", confidenceBps: 8800, forecastValue: "17T" })
+      );
 
     const stored = await contract.getInsight(1n);
     expect(stored.sector).to.equal("Energy");
     expect(stored.originalMinter).to.equal(alice.address);
+    expect(stored.confidenceBps).to.equal(8800);
+    expect(stored.forecastValue).to.equal("17T");
   });
 
   it("blocks operations while paused", async () => {
@@ -58,7 +78,14 @@ describe("AlphaInsightNovaSeed", () => {
 
   it("allows owner to update and reveal fusion plan", async () => {
     await contract.mintInsight(alice.address, sampleInput());
-    await contract.updateInsightDetails(1n, "Healthcare", "AGI cures rare diseases", BigInt(Math.floor(Date.UTC(2028, 0, 1) / 1000)));
+    await contract.updateInsightDetails(
+      1n,
+      "Healthcare",
+      "AGI cures rare diseases",
+      BigInt(Math.floor(Date.UTC(2028, 0, 1) / 1000)),
+      9400,
+      "55T"
+    );
     await contract.revealFusionPlan(1n, "ipfs://fusion");
     await contract.updateFusionPlan(1n, "ipfs://fusion?rev=2");
 
@@ -67,6 +94,8 @@ describe("AlphaInsightNovaSeed", () => {
     expect(updated.thesis).to.equal("AGI cures rare diseases");
     expect(updated.fusionRevealed).to.equal(true);
     expect(updated.fusionURI).to.equal("ipfs://fusion?rev=2");
+    expect(updated.confidenceBps).to.equal(9400);
+    expect(updated.forecastValue).to.equal("55T");
     expect(await contract.tokenURI(1n)).to.equal("ipfs://fusion?rev=2");
   });
 
@@ -85,6 +114,7 @@ describe("AlphaInsightNovaSeed", () => {
     metadata = await contract.getInsight(1n);
     expect(metadata.sealedURI).to.equal("ipfs://sealed-post-reveal");
     expect(metadata.fusionURI).to.equal("ipfs://fusion");
+    expect(metadata.confidenceBps).to.equal(9100);
   });
 
   it("allows delegated sentinel to pause", async () => {
@@ -102,5 +132,21 @@ describe("AlphaInsightNovaSeed", () => {
     await expect(contract.mintInsight(alice.address, sampleInput({ sector: "" }))).to.be.revertedWith("SECTOR_REQUIRED");
     await expect(contract.mintInsight(alice.address, sampleInput({ thesis: "" }))).to.be.revertedWith("THESIS_REQUIRED");
     await expect(contract.mintInsight(alice.address, sampleInput({ sealedURI: "" }))).to.be.revertedWith("URI_REQUIRED");
+    await expect(contract.mintInsight(alice.address, sampleInput({ forecastValue: "" }))).to.be.revertedWith("FORECAST_REQUIRED");
+    await expect(contract.mintInsight(alice.address, sampleInput({ confidenceBps: 20000 }))).to.be.revertedWith("CONFIDENCE_INVALID");
+
+    await contract.mintInsight(alice.address, sampleInput());
+    await expect(
+      contract.updateInsightDetails(1n, "", "Valid thesis", BigInt(Math.floor(Date.UTC(2028, 0, 1) / 1000)), 9000, "10T")
+    ).to.be.revertedWith("SECTOR_REQUIRED");
+    await expect(
+      contract.updateInsightDetails(1n, "Finance", "", BigInt(Math.floor(Date.UTC(2028, 0, 1) / 1000)), 9000, "10T")
+    ).to.be.revertedWith("THESIS_REQUIRED");
+    await expect(
+      contract.updateInsightDetails(1n, "Finance", "Valid", BigInt(Math.floor(Date.UTC(2028, 0, 1) / 1000)), 9000, "")
+    ).to.be.revertedWith("FORECAST_REQUIRED");
+    await expect(
+      contract.updateInsightDetails(1n, "Finance", "Valid", BigInt(Math.floor(Date.UTC(2028, 0, 1) / 1000)), 15000, "10T")
+    ).to.be.revertedWith("CONFIDENCE_INVALID");
   });
 });


### PR DESCRIPTION
## Summary
- extend the AlphaInsightNovaSeed foresight asset to capture confidence basis points and forecast value under owner control
- enrich the Insight MARK demo orchestration with confidence-aware tables, CSV data, and updated owner documentation
- tighten the verification script to validate confidence/forecast data across recap and market dossiers

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci
- npm run verify:alpha-agi-insight-mark

------
https://chatgpt.com/codex/tasks/task_e_68f39da10e6483338dc4f875a488123e