### PR TITLE
Document branch protection verification for α-AGI Insight MARK

### DIFF
--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -71,8 +71,12 @@ Green CI is contractually enforced for this demo. After running the tests and de
 workflow before merges:
 
 ```bash
-GITHUB_TOKEN=<repo_scope_token> npm run ci:verify-branch-protection -- --branch main
+# Recommended: capture the token without echoing it or storing it in history
+read -s GITHUB_TOKEN && export GITHUB_TOKEN
+npm run ci:verify-branch-protection -- --branch main
 ```
+
+Run `unset GITHUB_TOKEN` when the verification completes so the shell session no longer holds the secret.
 
 The command prints a ✅/❌ table verifying that linting, tests, Foundry fuzzing, coverage, and the dedicated α-AGI Insight MARK
 workflow are all marked as required contexts on `main` and on pull requests. Non-technical operators can paste the transcript

--- a/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
+++ b/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
@@ -49,7 +49,7 @@ Evidence Links: insight-manifest.json, transaction hashes
 - [ ] `insight-owner-brief.md` countersigned for rapid-response command authority.
 - [ ] Oracle address verified via `owner:verify-control` tooling.
 - [ ] `insight-superintelligence.mmd` reviewed to confirm Meta-Agentic Tree Search + thermodynamic trigger topology matches governance expectations.
-- [ ] Branch protection attested via `GITHUB_TOKEN=<repo_scope_token> npm run ci:verify-branch-protection -- --branch main`.
+- [ ] Branch protection attested via `npm run ci:verify-branch-protection -- --branch main` after seeding `GITHUB_TOKEN` with `read -s GITHUB_TOKEN && export GITHUB_TOKEN` and clearing it via `unset GITHUB_TOKEN` when finished.
 
 ## 5. Future Extensions
 

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -66,7 +66,7 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 3. Execute `npm run verify:alpha-agi-insight-mark` – the verifier performs the same manifest, telemetry, and mermaid integrity checks enforced in CI so non-technical operators can certify the dossier bundle locally.
 4. Compare the new `insight-manifest.json` to the previous run to ensure reproducibility.
 5. Store artefacts in your evidence vault alongside transaction hashes for board reviews.
-6. Audit GitHub branch protections with `GITHUB_TOKEN=<repo_scope_token> npm run ci:verify-branch-protection -- --branch main` and archive the ✅/❌ transcript.
+6. Audit GitHub branch protections. Run `read -s GITHUB_TOKEN && export GITHUB_TOKEN` before `npm run ci:verify-branch-protection -- --branch main` so the token is never echoed into logs, then archive the ✅/❌ transcript. Finish with `unset GITHUB_TOKEN`.
 
 ## 6. Live Network Launch (Advanced)
 


### PR DESCRIPTION
## Summary
- document the CI and branch protection verification step for the α-AGI Insight MARK demo runbook and owner control briefing
- add README guidance so operators confirm GitHub enforces the full V2 workflow contract before merging

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci

------
https://chatgpt.com/codex/tasks/task_e_68f3a4b2b49c83338eeb21c0bc30b949