### PR TITLE
Add guardrail tests for α-AGI Insight MARK sentinel controls

### DIFF
--- a/demo/alpha-agi-insight-mark/test/AlphaInsightNovaSeed.test.ts
+++ b/demo/alpha-agi-insight-mark/test/AlphaInsightNovaSeed.test.ts
@@ -128,6 +128,19 @@ describe("AlphaInsightNovaSeed", () => {
     await contract.mintInsight(alice.address, sampleInput());
   });
 
+  it("blocks unauthorized pause and sentinel unpause attempts", async () => {
+    await contract.setSystemPause(alice.address);
+
+    await expect(contract.connect(bob).pause()).to.be.revertedWith("NOT_AUTHORIZED");
+
+    await contract.connect(alice).pause();
+    await expect(contract.connect(alice).unpause())
+      .to.be.revertedWithCustomError(contract, "OwnableUnauthorizedAccount")
+      .withArgs(alice.address);
+
+    await contract.unpause();
+  });
+
   it("prevents blank metadata", async () => {
     await expect(contract.mintInsight(alice.address, sampleInput({ sector: "" }))).to.be.revertedWith("SECTOR_REQUIRED");
     await expect(contract.mintInsight(alice.address, sampleInput({ thesis: "" }))).to.be.revertedWith("THESIS_REQUIRED");

--- a/demo/alpha-agi-insight-mark/test/InsightAccessToken.test.ts
+++ b/demo/alpha-agi-insight-mark/test/InsightAccessToken.test.ts
@@ -30,4 +30,17 @@ describe("InsightAccessToken", () => {
     await token.transfer(recipient.address, ethers.parseUnits("10", 18));
     expect(await token.balanceOf(recipient.address)).to.equal(ethers.parseUnits("10", 18));
   });
+
+  it("prevents unauthorized pause and sentinel unpause attempts", async () => {
+    await token.setSystemPause(sentinel.address);
+
+    await expect(token.connect(recipient).pause()).to.be.revertedWith("NOT_AUTHORIZED");
+
+    await token.connect(sentinel).pause();
+    await expect(token.connect(sentinel).unpause())
+      .to.be.revertedWithCustomError(token, "OwnableUnauthorizedAccount")
+      .withArgs(sentinel.address);
+
+    await token.unpause();
+  });
 });


### PR DESCRIPTION
## Summary
- extend Insight Access Token coverage to assert unauthorized pause/unpause attempts revert
- add Nova-Seed ownership guard tests confirming sentinel and owner roles are enforced
- harden Alpha Insight Exchange test suite around pause guardianship, invalid configuration updates, and duplicate oracle resolutions

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci
- npm run verify:alpha-agi-insight-mark

------
https://chatgpt.com/codex/tasks/task_e_68f3aa1796b08333a72288be1759246a