### PR TITLE
Add transaction ledger verification to α-AGI Insight MARK demo

### DIFF
--- a/demo/alpha-agi-insight-mark/README.md
+++ b/demo/alpha-agi-insight-mark/README.md
@@ -102,6 +102,7 @@ Running the demo produces:
 - `insight-agency-orbit.mmd` – mermaid orbit of the meta-agent swarm mapping mint, custody, and market routing authority.
 - `insight-lifecycle.mmd` – end-to-end sequence diagram proving owner-dominated lifecycle control from swarm genesis to market settlement.
 - `insight-manifest.json` – SHA-256 hashes of every generated artefact and the scenario dataset that produced them.
+- `insight-ledger.json` – transaction-certified ledger binding each Nova-Seed to mint/list/reprice/settlement tx hashes plus sentinel pause drills.
 
 All outputs are designed for direct inclusion in boardroom briefings and investor packets.
 

--- a/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
+++ b/demo/alpha-agi-insight-mark/docs/owner-control-briefing.md
@@ -42,6 +42,7 @@ Evidence Links: insight-manifest.json, transaction hashes
 ## 4. Verification Checklist
 
 - [ ] `insight-manifest.json` hashes verified and stored in evidence vault.
+- [ ] `insight-ledger.json` reviewed – mint/list/reprice/settlement hashes reconciled with pause drill receipts.
 - [ ] `npm run verify:alpha-agi-insight-mark` executed and archived (mirrors CI dossier validation locally).
 - [ ] Telemetry log reviewed for anomalies.
 - [ ] `insight-control-matrix.json` imported into owner dashboard.

--- a/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
+++ b/demo/alpha-agi-insight-mark/runbooks/operator-runbook.md
@@ -45,6 +45,7 @@ Navigate to `demo/alpha-agi-insight-mark/reports/` and review:
 - `insight-agency-orbit.mmd` – orbit schematic linking each meta-agent to its minted seeds and custody paths.
 - `insight-lifecycle.mmd` – sequence diagram evidencing owner command authority across the full deployment-to-market cycle.
 - `insight-manifest.json` – SHA-256 hashes; re-run the demo and confirm hashes change only when artefacts change. The manifest now fingerprints the scenario dataset too, so provenance can be attested.
+- `insight-ledger.json` – structured ledger of every mint/list/reprice/sale hash plus sentinel pause + owner resume drill receipts.
 - `insight-recap.json` – network metadata, contract addresses, minted ledger, telemetry, and a stats block validating owner/delegate mints, market state, confidence bands, capability index, and forecast value against generated artefacts.
 - `insight-telemetry.log` – chronological agent conversation for audit trails.
 


### PR DESCRIPTION
## Summary
- capture mint, listing, repricing, trade, resolution, and pause transaction hashes during the α-AGI Insight MARK run and persist them in a new `insight-ledger.json`
- extend the dossier verifier to require the ledger artefact and reconcile it with recap data, scenario fingerprints, and sentinel drill transactions
- document the ledger output in the README, operator runbook, and owner-control briefing checklists

## Testing
- npm run test:alpha-agi-insight-mark
- npm run demo:alpha-agi-insight-mark:ci
- npm run verify:alpha-agi-insight-mark

------
https://chatgpt.com/codex/tasks/task_e_68f3bba0408c8333b04f5eea1138b72c