### PR TITLE
Add ASI Takes Off control deck briefing experience

### DIFF
--- a/demo/sovereign-constellation/README.md
+++ b/demo/sovereign-constellation/README.md
@@ -101,6 +101,9 @@ sequenceDiagram
 - **ASI launch sequence** – `config/constellation.ui.config.json` enumerates a four-step "ASI Takes Off" ritual that the
   console renders into step cards. Non-technical directors simply follow the instructions, run the provided commands, and
   confirm the success signals and owner levers highlighted in the UI.
+- **ASI control deck** – `config/asiTakesOffMatrix.json` powers the `/constellation/asi-takes-off` API, the console's new
+  control deck, and the `npm run demo:sovereign-constellation:asi-takes-off` CLI briefing so stakeholders can rehearse the
+  entire deployment with zero manual coding.
 
 ## Flagship mission — ASI Takes Off
 
@@ -111,6 +114,13 @@ sequenceDiagram
   cards so the flagship plan can be loaded with a single click by any non-technical operator.
 - The Node test suite (`npm run demo:sovereign-constellation:test:server`) asserts the endpoint stays wired, while the
   Cypress smoke test verifies the UI autoloads the flagship mission.
+
+### Zero-code ASI Takes Off briefing
+
+- `npm run demo:sovereign-constellation:asi-takes-off` prints a mission briefing sourced from repository config, summarising
+  the pillars, automation spine, thermostat recommendations, and owner atlas synopsis for rapid stakeholder alignment.
+- The `/constellation/asi-takes-off` endpoint returns the same dataset (deck, owner atlas, autotune plan) so the React console
+  can render a control deck for non-technical operators.
 
 ## Directory layout
 

--- a/demo/sovereign-constellation/bin/asi-takes-off.mjs
+++ b/demo/sovereign-constellation/bin/asi-takes-off.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { ethers } from "ethers";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const demoRoot = path.join(__dirname, "..", "");
+
+function loadJson(relPath) {
+  const fullPath = path.join(demoRoot, relPath);
+  return JSON.parse(fs.readFileSync(fullPath, "utf8"));
+}
+
+async function main() {
+  console.log("\n🎖️  ASI Takes Off — Sovereign Constellation Mission Briefing\n");
+  const deck = loadJson("config/asiTakesOffMatrix.json");
+  const hubs = loadJson("config/constellation.hubs.json");
+  const uiConfig = loadJson("config/constellation.ui.config.json");
+  const telemetry = loadJson("config/autotune.telemetry.json");
+
+  const [{ buildOwnerAtlas }, { computeAutotunePlan }] = await Promise.all([
+    import("../shared/ownerAtlas.mjs"),
+    import("../shared/autotune.mjs")
+  ]);
+
+  const atlas = buildOwnerAtlas(hubs, uiConfig);
+  const plan = computeAutotunePlan(telemetry, { mission: deck?.mission?.id ?? "asi-takes-off" });
+
+  console.log(`Mission: ${deck.mission.title}`);
+  console.log(deck.mission.tagline);
+  console.log("");
+  console.log(`Constellation: ${deck.constellation.label}`);
+  console.log(deck.constellation.summary);
+  console.log(`Promise: ${deck.constellation.operatorPromise}`);
+  console.log("");
+
+  console.log("Pillars of deployment:");
+  for (const pillar of deck.pillars ?? []) {
+    console.log(` • ${pillar.title}: ${pillar.headline}`);
+    console.log(`   Operator focus: ${pillar.operatorAction}`);
+    console.log(`   Owner supremacy: ${pillar.ownerLever}`);
+  }
+  console.log("");
+
+  console.log("Owner assurances:");
+  console.log(` • Pausing: ${deck.ownerAssurances.pausing}`);
+  console.log(` • Upgrades: ${deck.ownerAssurances.upgrades}`);
+  console.log(` • Emergency response: ${deck.ownerAssurances.emergencyResponse}`);
+  console.log("");
+
+  console.log("Automation spine (run in order):");
+  for (const command of deck.automation.launchCommands ?? []) {
+    console.log(` • ${command.label}`);
+    console.log(`   ${command.run}`);
+  }
+  console.log("");
+  console.log(`CI guardrail: ${deck.automation.ci.description}`);
+  console.log(`Owner visibility: ${deck.automation.ci.ownerVisibility}`);
+  console.log("");
+
+  console.log("Thermostat recommendations:");
+  if (plan?.summary) {
+    console.log(
+      ` • Avg participation ${(plan.summary.averageParticipation * 100).toFixed(2)}% with commit/reveal ` +
+        `${plan.summary.commitWindowSeconds}s/${plan.summary.revealWindowSeconds}s`
+    );
+    const minStakeDisplay = plan.summary.minStakeWei
+      ? `${ethers.formatEther(plan.summary.minStakeWei)} AGIA`
+      : String(plan.summary.minStakeWei);
+    console.log(` • Minimum stake: ${minStakeDisplay}`);
+    if (Array.isArray(plan.summary.notes) && plan.summary.notes.length > 0) {
+      for (const note of plan.summary.notes) {
+        console.log(`   - ${note}`);
+      }
+    }
+  } else {
+    console.log(" • Telemetry not available. Run npm run demo:sovereign-constellation:plan first.");
+  }
+  console.log("");
+
+  console.log("Owner atlas synopsis:");
+  for (const hub of atlas.atlas ?? []) {
+    console.log(` • ${hub.label} (${hub.networkName}) owner ${hub.owner} governance ${hub.governance}`);
+    for (const module of hub.modules ?? []) {
+      console.log(`   - ${module.module}: ${module.actions.length} actionable controls`);
+    }
+  }
+  console.log("");
+
+  console.log("To open the full console:");
+  console.log(" • npm run demo:sovereign-constellation:local");
+  console.log("");
+  console.log("All instructions above are sourced from repository config. Non-technical directors can hand this briefing to a wallet operator and launch immediately.\n");
+}
+
+main().catch((error) => {
+  console.error("Failed to generate ASI Takes Off briefing:");
+  console.error(error);
+  process.exit(1);
+});

--- a/demo/sovereign-constellation/config/asiTakesOffMatrix.json
+++ b/demo/sovereign-constellation/config/asiTakesOffMatrix.json
@@ -1,0 +1,79 @@
+{
+  "mission": {
+    "id": "asi-takes-off",
+    "title": "ASI Takes Off",
+    "tagline": "Precision meets destiny as Sovereign Constellation deploys a civilization-scale workforce for a single director."
+  },
+  "constellation": {
+    "label": "Sovereign Constellation",
+    "summary": "Three autonomous AGI hubs span research, industrial execution, and civic governance while staying under the owner's wallet control.",
+    "operatorPromise": "Launch a planetary AGI workforce without writing code; every signature and override lives in your wallet."
+  },
+  "pillars": [
+    {
+      "id": "meta-agentic-alpha-agi-orchestration",
+      "title": "Meta-Agentic α-AGI Orchestration",
+      "headline": "One click ignites Helios, Triton, and Athena under a single mission intent.",
+      "operatorAction": "Load the flagship playbook and sign each prepared transaction from the orchestrator console.",
+      "ownerLever": "Pause or resume any hub instantly via the SystemPause atlas entry.",
+      "proof": "playbooks.json › asi-takes-off"
+    },
+    {
+      "id": "alpha-agi-governance",
+      "title": "α-AGI Governance",
+      "headline": "All mutable parameters route through owner-only controls surfaced in the atlas UI.",
+      "operatorAction": "Use the Owner Console to adjust commit/reveal windows and minimum stake live.",
+      "ownerLever": "Rotate governance to a Safe or pause contracts directly from owner atlas links.",
+      "proof": "generateOwnerAtlas.mjs"
+    },
+    {
+      "id": "making-the-chain-disappear",
+      "title": "Making the Chain Disappear",
+      "headline": "Wallet prompts arrive with the correct chain metadata so no manual RPC juggling is required.",
+      "operatorAction": "Accept orchestrator-prepared prompts; the console alerts if a network switch is needed.",
+      "ownerLever": "Grant temporary validator access by adding addresses through the IdentityRegistry write link.",
+      "proof": "server/index.ts › serializeTx"
+    },
+    {
+      "id": "recursive-self-improvement",
+      "title": "Recursive Self-Improvement",
+      "headline": "Telemetry feeds an autotune plan that rebalances incentives and timing for future missions.",
+      "operatorAction": "Review the Thermostat plan and apply the recommended parameters with one click.",
+      "ownerLever": "Adopt the suggested dispute module rotation to iterate governance safely.",
+      "proof": "autotune.mjs"
+    },
+    {
+      "id": "winning-the-ai-race",
+      "title": "Winning the AI Race",
+      "headline": "CI, mission automation, and owner supremacy collapse time-to-deploy to minutes.",
+      "operatorAction": "Run the ASI Takes Off CLI or launch sequence to reproduce the constellation end-to-end.",
+      "ownerLever": "Audit the Owner Control Matrix export to verify every control remains under your key.",
+      "proof": "scripts/generateOwnerAtlas.mjs"
+    }
+  ],
+  "automation": {
+    "launchCommands": [
+      {
+        "label": "Spin up the full constellation",
+        "run": "npm run demo:sovereign-constellation:local"
+      },
+      {
+        "label": "Compute owner atlas and thermostat plan",
+        "run": "npm run demo:sovereign-constellation:plan"
+      },
+      {
+        "label": "Execute CI-quality smoke",
+        "run": "npm run demo:sovereign-constellation:ci"
+      }
+    ],
+    "ci": {
+      "description": "Root CI enforces tests, builds, and autotune computation on every commit via demo:sovereign-constellation:ci.",
+      "ownerVisibility": "Branch protections require all constellation checks green before merge." 
+    }
+  },
+  "ownerAssurances": {
+    "pausing": "SystemPause addresses broadcast owner-triggered halts to every hub simultaneously.",
+    "upgrades": "Each module exposes transferOwnership and upgrade hooks guarded by owner-only modifiers.",
+    "emergencyResponse": "Owner atlas callouts reference the exact explorer URLs for critical overrides."
+  }
+}

--- a/demo/sovereign-constellation/cypress/e2e/sovereign-constellation.cy.ts
+++ b/demo/sovereign-constellation/cypress/e2e/sovereign-constellation.cy.ts
@@ -8,6 +8,11 @@ describe("Sovereign Constellation UI", () => {
       cy.contains("Launch constellation");
     });
     cy.get('[data-testid="constellation-hero"]').should("exist");
+    cy.get('[data-testid="asi-takes-off-deck"]').within(() => {
+      cy.contains("ASI Takes Off Control Deck");
+      cy.contains("Automation Spine");
+      cy.contains("npm run demo:sovereign-constellation:asi-takes-off");
+    });
     cy.get('[data-testid="mission-profiles"]').within(() => {
       cy.contains("ASI Takes Off Mission Profiles");
       cy.contains("Load mission plan").first().click();

--- a/demo/sovereign-constellation/test/server/asiTakesOffDeck.spec.js
+++ b/demo/sovereign-constellation/test/server/asiTakesOffDeck.spec.js
@@ -1,0 +1,42 @@
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const root = path.join(__dirname, "..", "..");
+const matrixFile = path.join(root, "config/asiTakesOffMatrix.json");
+const payload = JSON.parse(fs.readFileSync(matrixFile, "utf8"));
+
+assert.equal(payload.mission.id, "asi-takes-off", "ASI deck must describe the flagship mission");
+assert.ok(Array.isArray(payload.pillars) && payload.pillars.length === 5, "All five mission pillars must be listed");
+payload.pillars.forEach((pillar) => {
+  assert.ok(pillar.headline, `Pillar ${pillar.id} requires a headline`);
+  assert.ok(pillar.operatorAction, `Pillar ${pillar.id} requires an operator action narrative`);
+  assert.ok(pillar.ownerLever, `Pillar ${pillar.id} must highlight owner supremacy`);
+});
+
+assert.ok(payload.automation?.launchCommands?.length >= 3, "Automation spine should include all launch commands");
+const commandRuns = payload.automation.launchCommands.map((item) => item.run);
+assert.ok(
+  commandRuns.includes("npm run demo:sovereign-constellation:local"),
+  "Launch commands should reference the local constellation bootstrap"
+);
+assert.ok(
+  commandRuns.includes("npm run demo:sovereign-constellation:ci"),
+  "Launch commands must cover the CI enforcement script"
+);
+assert.ok(
+  commandRuns.includes("npm run demo:sovereign-constellation:plan"),
+  "Launch commands must include the thermostat planning step"
+);
+
+assert.ok(payload.ownerAssurances?.pausing, "Owner assurances should describe pausing guarantees");
+assert.ok(payload.ownerAssurances?.upgrades, "Owner assurances should document upgrade control");
+assert.ok(payload.ownerAssurances?.emergencyResponse, "Owner assurances should surface emergency response levers");
+
+const cliPath = path.join(root, "bin/asi-takes-off.mjs");
+const result = spawnSync("node", [cliPath], { encoding: "utf8" });
+assert.equal(result.status, 0, `ASI Takes Off CLI should exit cleanly. stderr: ${result.stderr}`);
+assert.ok(result.stdout.includes("ASI Takes Off"), "CLI briefing should mention ASI Takes Off");
+assert.ok(result.stdout.includes("Automation spine"), "CLI output should enumerate automation spine instructions");
+console.log("✅ asiTakesOffMatrix.json schema validated and CLI briefing renders");

--- a/package.json
+++ b/package.json
@@ -184,10 +184,11 @@
     "demo:sovereign-constellation:app:install": "npm ci --prefix demo/sovereign-constellation/app",
     "demo:sovereign-constellation:app:build": "npm run build --prefix demo/sovereign-constellation/app",
     "demo:sovereign-constellation:test:contracts": "npx hardhat test demo/sovereign-constellation/test/*.t.ts",
-    "demo:sovereign-constellation:test:server": "node demo/sovereign-constellation/test/server/missionProfiles.spec.js",
+    "demo:sovereign-constellation:test:server": "node demo/sovereign-constellation/test/server/missionProfiles.spec.js && node demo/sovereign-constellation/test/server/asiTakesOffDeck.spec.js",
     "demo:sovereign-constellation:test": "npm run demo:sovereign-constellation:test:contracts && npm run demo:sovereign-constellation:test:server",
     "demo:sovereign-constellation:ci": "npm run demo:sovereign-constellation:test && npm run demo:sovereign-constellation:server:install && npm run demo:sovereign-constellation:server:build && npm run demo:sovereign-constellation:app:install && npm run demo:sovereign-constellation:app:build && npm run demo:sovereign-constellation:plan",
-    "demo:sovereign-constellation:local": "node demo/sovereign-constellation/bin/sovereign-constellation-local.mjs"
+    "demo:sovereign-constellation:local": "node demo/sovereign-constellation/bin/sovereign-constellation-local.mjs",
+    "demo:sovereign-constellation:asi-takes-off": "node demo/sovereign-constellation/bin/asi-takes-off.mjs"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a config-driven ASI Takes Off control deck surfaced via the orchestrator API and React console
- provide an asi-takes-off CLI briefing that assembles owner atlas, telemetry, and mission pillars for non-technical users
- expand tests and Cypress smoke coverage to enforce the new dataset and scripts

## Testing
- npm run demo:sovereign-constellation:test:server

------
https://chatgpt.com/codex/tasks/task_e_68f3d9c5a96883339c7583d5d9f7fa0a