### PR TITLE
Ensure Sovereign Constellation demo exposes single-command launcher

### DIFF
--- a/demo/sovereign-constellation/README.md
+++ b/demo/sovereign-constellation/README.md
@@ -173,7 +173,7 @@ demo/sovereign-constellation/
    ```
 2. **Launch a local constellation**
    ```bash
-   npm run demo:sovereign-constellation:local
+   npm run demo:sovereign-constellation
    ```
    The helper script deploys three hubs to a local Hardhat node, seeds showcase jobs, regenerates the owner atlas, starts the orchestrator on
    `http://localhost:8090`, and serves the console on `http://localhost:5179`.
@@ -192,7 +192,7 @@ demo/sovereign-constellation/
   dependency install, constellation deployment, mission load, and governance verification flows.
 - The React console reads the launch sequence and renders it ahead of the hero metrics so directors can see exactly which
   commands to run, what success looks like, and which owner controls to exercise next.
-- Cypress smoke tests assert that the launch sequence is always visible and that it includes the `demo:sovereign-constellation:local`
+- Cypress smoke tests assert that the launch sequence is always visible and that it includes the `demo:sovereign-constellation`
   command so CI protects the non-technical onboarding story.
 
 ## Owner control matrix

--- a/demo/sovereign-constellation/bin/asi-takes-off.mjs
+++ b/demo/sovereign-constellation/bin/asi-takes-off.mjs
@@ -90,7 +90,7 @@ async function main() {
   console.log("");
 
   console.log("To open the full console:");
-  console.log(" • npm run demo:sovereign-constellation:local");
+  console.log(" • npm run demo:sovereign-constellation");
   console.log("");
   console.log("All instructions above are sourced from repository config. Non-technical directors can hand this briefing to a wallet operator and launch immediately.\n");
 }

--- a/demo/sovereign-constellation/config/asiTakesOffMatrix.json
+++ b/demo/sovereign-constellation/config/asiTakesOffMatrix.json
@@ -55,7 +55,7 @@
     "launchCommands": [
       {
         "label": "Spin up the full constellation",
-        "run": "npm run demo:sovereign-constellation:local"
+        "run": "npm run demo:sovereign-constellation"
       },
       {
         "label": "Compute owner atlas and thermostat plan",

--- a/demo/sovereign-constellation/config/constellation.ui.config.json
+++ b/demo/sovereign-constellation/config/constellation.ui.config.json
@@ -43,7 +43,7 @@
       "commands": [
         {
           "label": "Launch constellation",
-          "run": "npm run demo:sovereign-constellation:local"
+          "run": "npm run demo:sovereign-constellation"
         }
       ],
       "successSignal": "Console output shows Hardhat deployments for Helios, Triton, and Athena followed by server listening on 8090 and the console on 5179.",

--- a/demo/sovereign-constellation/test/server/asiTakesOffDeck.spec.js
+++ b/demo/sovereign-constellation/test/server/asiTakesOffDeck.spec.js
@@ -18,8 +18,8 @@ payload.pillars.forEach((pillar) => {
 assert.ok(payload.automation?.launchCommands?.length >= 3, "Automation spine should include all launch commands");
 const commandRuns = payload.automation.launchCommands.map((item) => item.run);
 assert.ok(
-  commandRuns.includes("npm run demo:sovereign-constellation:local"),
-  "Launch commands should reference the local constellation bootstrap"
+  commandRuns.includes("npm run demo:sovereign-constellation"),
+  "Launch commands should reference the single-command constellation bootstrap"
 );
 assert.ok(
   commandRuns.includes("npm run demo:sovereign-constellation:ci"),

--- a/demo/sovereign-constellation/test/server/missionProfiles.spec.js
+++ b/demo/sovereign-constellation/test/server/missionProfiles.spec.js
@@ -30,8 +30,8 @@ uiConfig.launchSequence.forEach((step) => {
 const igniteStep = uiConfig.launchSequence.find((step) => step.id === "ignite-constellation");
 assert.ok(igniteStep, "ignite-constellation step should be defined");
 assert.ok(
-  igniteStep.commands.some((command) => /demo:sovereign-constellation:local/.test(command.run)),
-  "ignite-constellation must instruct the operator to run the local constellation command"
+  igniteStep.commands.some((command) => command.run.includes("npm run demo:sovereign-constellation")),
+  "ignite-constellation must instruct the operator to run the single-command constellation launcher"
 );
 console.log("✅ missionProfiles.json contains the ASI Takes Off flagship entry");
 console.log("✅ constellation.ui.config.json documents the non-technical ASI Takes Off launch sequence");

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "lattice:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateRiskLattice.ts",
     "pulse:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateEmpowermentPulse.ts",
     "superintelligence:alpha-agi-mark": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/alpha-agi-mark/scripts/generateSuperintelligenceBrief.ts",
+    "demo:sovereign-constellation": "node demo/sovereign-constellation/bin/sovereign-constellation-local.mjs",
     "demo:sovereign-constellation:deploy": "npx hardhat run --no-compile demo/sovereign-constellation/scripts/deployConstellation.ts",
     "demo:sovereign-constellation:seed": "npx hardhat run --no-compile demo/sovereign-constellation/scripts/seedConstellation.ts",
     "demo:sovereign-constellation:atlas": "node demo/sovereign-constellation/scripts/generateOwnerAtlas.mjs",


### PR DESCRIPTION
## Summary
- add a top-level `npm run demo:sovereign-constellation` script that runs the local constellation bootstrap
- update the launch sequence, ASI deck, CLI briefing, and README to reference the single-command entrypoint
- adjust automated checks so the Sovereign Constellation tests enforce the new launcher documentation

## Testing
- npm run demo:sovereign-constellation:test:server
- node demo/sovereign-constellation/bin/asi-takes-off.mjs


------
https://chatgpt.com/codex/tasks/task_e_68f3e2cd3a4083338c7ba3220d93a349