### PR TITLE
Add ASI systems matrix for Sovereign Constellation

### DIFF
--- a/demo/sovereign-constellation/README.md
+++ b/demo/sovereign-constellation/README.md
@@ -104,6 +104,9 @@ sequenceDiagram
 - **ASI control deck** – `config/asiTakesOffMatrix.json` powers the `/constellation/asi-takes-off` API, the console's new
   control deck, and the `npm run demo:sovereign-constellation:asi-takes-off` CLI briefing so stakeholders can rehearse the
   entire deployment with zero manual coding.
+- **ASI systems matrix** – `config/asiTakesOffSystems.json` documents the five flagship pillars with operator workflows,
+  owner levers, automation commands, and verification artefacts. The server exposes `/constellation/asi-takes-off/systems`
+  and the console renders the dataset so every mission assurance remains transparent.
 
 ## Flagship mission — ASI Takes Off
 
@@ -133,6 +136,7 @@ demo/sovereign-constellation/
 │   ├── playbooks.json
 │   ├── missionProfiles.json
 │   ├── autotune.telemetry.json
+│   ├── asiTakesOffSystems.json
 │   └── actors.json
 ├── server/
 │   ├── package.json

--- a/demo/sovereign-constellation/app/src/App.tsx
+++ b/demo/sovereign-constellation/app/src/App.tsx
@@ -172,6 +172,34 @@ type AsiDeck = {
   };
 };
 
+type AsiSystemControl = {
+  module: string;
+  action: string;
+  description: string;
+};
+
+type AsiSystemAutomation = {
+  label: string;
+  command: string;
+  impact: string;
+};
+
+type AsiSystemVerification = {
+  artifact: string;
+  description: string;
+};
+
+type AsiSystem = {
+  id: string;
+  title: string;
+  summary: string;
+  operatorWorkflow: string[];
+  ownerControls: AsiSystemControl[];
+  automation: AsiSystemAutomation[];
+  verification: AsiSystemVerification[];
+  assurance: string;
+};
+
 type LaunchCommand = {
   label: string;
   run: string;
@@ -246,6 +274,7 @@ export default function App() {
   const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
   const [missionProfiles, setMissionProfiles] = useState<MissionProfile[]>([]);
   const [asiDeck, setAsiDeck] = useState<AsiDeck>();
+  const [asiSystems, setAsiSystems] = useState<AsiSystem[]>([]);
   const [launchSequence, setLaunchSequence] = useState<LaunchStep[]>([]);
   const [selectedHub, setSelectedHub] = useState<string>("");
   const [jobs, setJobs] = useState<any[]>([]);
@@ -367,6 +396,16 @@ export default function App() {
           if ((payload as any).autotunePlan) {
             setAutotunePlan((payload as any).autotunePlan as AutotunePlan);
           }
+          if (Array.isArray((payload as any).systems)) {
+            setAsiSystems((payload as any).systems as AsiSystem[]);
+          }
+        }
+      })
+      .catch((err) => console.error(err));
+    fetchJson("/constellation/asi-takes-off/systems", undefined, orchestratorBase)
+      .then((payload) => {
+        if (payload && typeof payload === "object" && Array.isArray((payload as any).systems)) {
+          setAsiSystems((payload as any).systems as AsiSystem[]);
         }
       })
       .catch((err) => console.error(err));
@@ -971,6 +1010,96 @@ export default function App() {
               </p>
               <code style={{ ...codeStyle, marginTop: 8 }}>npm run demo:sovereign-constellation:asi-takes-off</code>
             </div>
+          </div>
+        </section>
+      ) : null}
+
+      {asiSystems.length > 0 ? (
+        <section data-testid="asi-takes-off-systems" style={{ marginBottom: 32 }}>
+          <h2 style={{ marginTop: 0 }}>ASI Takes Off Systems Matrix</h2>
+          <p style={{ maxWidth: 860 }}>
+            Each pillar of the flagship objective is grounded in live code, deterministic automation, and owner-only
+            controls. Review the matrix to understand exactly how non-technical directors and governance owners co-pilot
+            the superintelligent launch.
+          </p>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
+              gap: 18
+            }}
+          >
+            {asiSystems.map((system) => (
+              <div key={system.id} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 12 }}>
+                <div>
+                  <h3 style={{ marginTop: 0, marginBottom: 4 }}>{system.title}</h3>
+                  <p style={{ marginTop: 0 }}>{system.summary}</p>
+                </div>
+                {Array.isArray(system.operatorWorkflow) && system.operatorWorkflow.length > 0 ? (
+                  <div>
+                    <strong style={{ fontSize: 13 }}>Operator workflow</strong>
+                    <ul style={{ paddingLeft: 18, marginTop: 6 }}>
+                      {system.operatorWorkflow.map((item, idx) => (
+                        <li key={`${system.id}-operator-${idx}`} style={{ fontSize: 13, marginBottom: 4 }}>
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+                {Array.isArray(system.ownerControls) && system.ownerControls.length > 0 ? (
+                  <div>
+                    <strong style={{ fontSize: 13 }}>Owner levers</strong>
+                    <ul style={{ paddingLeft: 18, marginTop: 6 }}>
+                      {system.ownerControls.map((control, idx) => (
+                        <li key={`${system.id}-owner-${idx}`} style={{ fontSize: 13, marginBottom: 4 }}>
+                          <span style={{ fontWeight: 600 }}>{control.module}</span> · {control.action}
+                          <div style={{ fontSize: 12, color: "#334155" }}>{control.description}</div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+                {Array.isArray(system.automation) && system.automation.length > 0 ? (
+                  <div>
+                    <strong style={{ fontSize: 13 }}>Automation spine</strong>
+                    <ul style={{ paddingLeft: 18, marginTop: 6 }}>
+                      {system.automation.map((entry, idx) => (
+                        <li key={`${system.id}-automation-${idx}`} style={{ fontSize: 13, marginBottom: 6 }}>
+                          <div style={{ fontWeight: 600 }}>{entry.label}</div>
+                          <code style={codeStyle}>{entry.command}</code>
+                          <div style={{ fontSize: 12, color: "#334155" }}>{entry.impact}</div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+                {Array.isArray(system.verification) && system.verification.length > 0 ? (
+                  <div>
+                    <strong style={{ fontSize: 13 }}>Proof points</strong>
+                    <ul style={{ paddingLeft: 18, marginTop: 6 }}>
+                      {system.verification.map((item, idx) => (
+                        <li key={`${system.id}-verification-${idx}`} style={{ fontSize: 13, marginBottom: 4 }}>
+                          <span style={{ fontWeight: 600 }}>{item.artifact}</span>
+                          <div style={{ fontSize: 12, color: "#334155" }}>{item.description}</div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+                <div
+                  style={{
+                    fontSize: 13,
+                    background: "rgba(22, 163, 74, 0.12)",
+                    padding: 12,
+                    borderRadius: 12,
+                    marginTop: "auto"
+                  }}
+                >
+                  <strong>Assurance:</strong> {system.assurance}
+                </div>
+              </div>
+            ))}
           </div>
         </section>
       ) : null}

--- a/demo/sovereign-constellation/bin/asi-takes-off.mjs
+++ b/demo/sovereign-constellation/bin/asi-takes-off.mjs
@@ -19,6 +19,7 @@ async function main() {
   const hubs = loadJson("config/constellation.hubs.json");
   const uiConfig = loadJson("config/constellation.ui.config.json");
   const telemetry = loadJson("config/autotune.telemetry.json");
+  const systems = loadJson("config/asiTakesOffSystems.json");
 
   const [{ buildOwnerAtlas }, { computeAutotunePlan }] = await Promise.all([
     import("../shared/ownerAtlas.mjs"),
@@ -43,6 +44,35 @@ async function main() {
     console.log(`   Owner supremacy: ${pillar.ownerLever}`);
   }
   console.log("");
+
+  if (Array.isArray(systems) && systems.length > 0) {
+    console.log("Systems matrix:");
+    for (const system of systems) {
+      console.log(` • ${system.title}`);
+      console.log(`   ${system.summary}`);
+      if (Array.isArray(system.operatorWorkflow) && system.operatorWorkflow.length > 0) {
+        console.log("   Operator workflow:");
+        for (const step of system.operatorWorkflow) {
+          console.log(`     - ${step}`);
+        }
+      }
+      if (Array.isArray(system.ownerControls) && system.ownerControls.length > 0) {
+        console.log("   Owner levers:");
+        for (const control of system.ownerControls) {
+          console.log(`     - ${control.module} :: ${control.action} — ${control.description}`);
+        }
+      }
+      if (Array.isArray(system.automation) && system.automation.length > 0) {
+        console.log("   Automation spine:");
+        for (const entry of system.automation) {
+          console.log(`     - ${entry.label}: ${entry.command}`);
+          console.log(`       ${entry.impact}`);
+        }
+      }
+      console.log(`   Assurance: ${system.assurance}`);
+    }
+    console.log("");
+  }
 
   console.log("Owner assurances:");
   console.log(` • Pausing: ${deck.ownerAssurances.pausing}`);

--- a/demo/sovereign-constellation/config/asiTakesOffSystems.json
+++ b/demo/sovereign-constellation/config/asiTakesOffSystems.json
@@ -1,0 +1,230 @@
+[
+  {
+    "id": "meta-agentic-alpha-agi-orchestration",
+    "title": "Meta-Agentic α-AGI Orchestration",
+    "summary": "The Constellation Orchestrator decomposes a single intent into coordinated research, industrial, and governance jobs across Helios, Triton, and Athena.",
+    "operatorWorkflow": [
+      "Select the Flagship Mission: ASI Takes Off in the console mission selector to autoload the cross-hub plan.",
+      "Use the mission preview to inspect every unsigned transaction, then sign each prompt from the wallet to dispatch jobs to their target networks.",
+      "Monitor the jobs table; each hub streams confirmations once the orchestrator finalizes createJob calls."],
+    "ownerControls": [
+      {
+        "module": "SystemPause",
+        "action": "pause() / unpause()",
+        "description": "Freeze or resume every orchestrated hub at once using the shared SystemPause helper wired in deployConstellation.ts."
+      },
+      {
+        "module": "JobRegistry",
+        "action": "setDisputeModule(address)",
+        "description": "Swap dispute logic for any hub to escalate arbitration when orchestrated missions surface anomalies."
+      }
+    ],
+    "automation": [
+      {
+        "label": "Bootstrap orchestrator and console",
+        "command": "npm run demo:sovereign-constellation",
+        "impact": "Spawns the orchestrator server, wallet-first console, and local RPC so a non-technical operator can coordinate hubs in minutes."
+      },
+      {
+        "label": "Seed cross-network jobs",
+        "command": "npm run demo:sovereign-constellation:seed",
+        "impact": "Primes each hub with sample telemetry so the orchestrator showcases deterministic cross-chain job finalisation."
+      }
+    ],
+    "verification": [
+      {
+        "artifact": "config/playbooks.json#asi-takes-off",
+        "description": "Defines the exact createJob payloads for all hubs proving orchestration is scripted rather than aspirational."
+      },
+      {
+        "artifact": "test/SovereignConstellation.t.ts",
+        "description": "Integration test executes the flagship playbook end-to-end to guarantee orchestration never regresses."
+      }
+    ],
+    "assurance": "A single wallet operator can span networks with one plan while the owner retains a global kill-switch."
+  },
+  {
+    "id": "alpha-agi-governance",
+    "title": "α-AGI Governance",
+    "summary": "Every module across the constellation is owner-configurable, surfacing direct writeContract links and Safe payloads so governance never leaves human control.",
+    "operatorWorkflow": [
+      "Open the Owner Governance Atlas from the console to inspect each module's actionable controls.",
+      "Use the \"Apply thermostat plan\" button after reviewing recommendations to push validated parameter updates.",
+      "If escalation is needed, trigger the SystemPause card and resume once validators complete dispute review."],
+    "ownerControls": [
+      {
+        "module": "ValidationModule",
+        "action": "setCommitRevealWindows(uint256,uint256)",
+        "description": "Rebalance cadence instantly whenever validator participation drifts." 
+      },
+      {
+        "module": "StakeManager",
+        "action": "setMinStake(uint256)",
+        "description": "Adjust risk exposure and validator skin-in-the-game without redeploying contracts."
+      },
+      {
+        "module": "IdentityRegistry",
+        "action": "addAdditionalValidator(address)",
+        "description": "Onboard or rotate trusted validators as the mission footprint expands."
+      }
+    ],
+    "automation": [
+      {
+        "label": "Generate owner atlas",
+        "command": "npm run demo:sovereign-constellation:atlas",
+        "impact": "Outputs a JSON control matrix enumerating every owner-only method so governance coverage is auditable."
+      },
+      {
+        "label": "Rotate governance",
+        "command": "npm run demo:sovereign-constellation:ci",
+        "impact": "Runs the complete CI, builds app/server artefacts, and ensures governance rotation scripts remain functional."
+      }
+    ],
+    "verification": [
+      {
+        "artifact": "scripts/rotateConstellationGovernance.ts",
+        "description": "Transfers ownership to a Safe and validates that only the owner address can mutate configuration."
+      },
+      {
+        "artifact": "config/asiTakesOffMatrix.json",
+        "description": "Documents pausing, upgrades, and emergency levers guaranteeing ownership assurances remain explicit."
+      }
+    ],
+    "assurance": "Owner-first controls are provably wired across every hub, letting leadership pause, upgrade, or expand participation on demand."
+  },
+  {
+    "id": "making-the-chain-disappear",
+    "title": "Making the Chain Disappear",
+    "summary": "Wallet-first UX abstracts all RPC plumbing so directors simply sign prompts while the orchestrator tags chain metadata automatically.",
+    "operatorWorkflow": [
+      "Launch the console and connect a wallet; the interface auto-detects hubs and networks from constellation.hubs.json.",
+      "Preview the flagship playbook to review chain IDs and required signatures with human-readable annotations.",
+      "Approve the orchestrator-prepared transactions in sequence; MetaMask routes each signature to the correct network."
+    ],
+    "ownerControls": [
+      {
+        "module": "Console",
+        "action": "orchestratorBase override",
+        "description": "Operators can point the UI at staging or production orchestrators without touching code, guaranteeing safe rollouts."
+      },
+      {
+        "module": "Orchestrator",
+        "action": "POST /constellation/:hub/tx/*",
+        "description": "Endpoints emit unsigned payloads so the owner never delegates key custody to infrastructure."
+      }
+    ],
+    "automation": [
+      {
+        "label": "Console build",
+        "command": "npm run demo:sovereign-constellation:app:build",
+        "impact": "Produces a static production bundle for immediate hosting with prewired API targets."
+      },
+      {
+        "label": "Server build",
+        "command": "npm run demo:sovereign-constellation:server:build",
+        "impact": "Generates the orchestrator server artefact exposing the wallet-first API catalogue."
+      }
+    ],
+    "verification": [
+      {
+        "artifact": "cypress/e2e/sovereign-constellation.cy.ts",
+        "description": "UI smoke test asserts that non-technical flows render the launch sequence and control deck without manual setup."
+      },
+      {
+        "artifact": "server/index.ts",
+        "description": "Express routes serialize transactions with chainId and rpcUrl fields proving the wallet can route prompts automatically."
+      }
+    ],
+    "assurance": "All blockchain interaction remains invisible to the operator—security and simplicity move in lockstep."
+  },
+  {
+    "id": "recursive-self-improvement",
+    "title": "Recursive Self-Improvement",
+    "summary": "Telemetry-driven thermostat logic continuously recommends staking, cadence, and pausing adjustments so the constellation self-optimises under owner supervision.",
+    "operatorWorkflow": [
+      "Run npm run demo:sovereign-constellation:plan to compute recommendations from autotune.telemetry.json.",
+      "Review suggested actions inside the console, then dispatch supported updates directly from the owner control panel.",
+      "Re-run the plan after missions settle to confirm entropy and participation have rebounded."
+    ],
+    "ownerControls": [
+      {
+        "module": "Autotune",
+        "action": "computeAutotunePlan(telemetry)",
+        "description": "Shared library cross-checks mission telemetry and surfaces actions in both CLI and API surfaces."
+      },
+      {
+        "module": "StakeManager",
+        "action": "setMinStake(uint256)",
+        "description": "Owner applies thermostat recommendations to harden validator incentives immediately."
+      }
+    ],
+    "automation": [
+      {
+        "label": "Thermostat planning",
+        "command": "npm run demo:sovereign-constellation:plan",
+        "impact": "Deterministically recomputes the self-improvement plan and stores receipts under reports/ for auditability."
+      },
+      {
+        "label": "Server plan endpoint",
+        "command": "GET /constellation/thermostat/plan",
+        "impact": "Exposes the same plan to the UI ensuring humans and agents share one feedback loop."
+      }
+    ],
+    "verification": [
+      {
+        "artifact": "shared/autotune.mjs",
+        "description": "Implements PID-inspired tuning logic used by both CLI scripts and server routes."
+      },
+      {
+        "artifact": "test/AutotunePlan.t.ts",
+        "description": "Hardhat test asserts thermostat recommendations are stable across releases."
+      }
+    ],
+    "assurance": "Feedback loops remain explainable—owners choose when to apply them, yet the system keeps learning."
+  },
+  {
+    "id": "winning-the-ai-race",
+    "title": "Winning the AI Race",
+    "summary": "Sovereign Constellation composes audited AGI Jobs v2 modules, deterministic CI, and wallet-first UX so a single organisation wields civilisation-scale leverage immediately.",
+    "operatorWorkflow": [
+      "Execute the ASI launch sequence from the console to deploy hubs, preview missions, and apply owner assurances end-to-end.",
+      "Keep the CI workflow demo-asi-takeoff.yml green to guarantee every push retains production readiness.",
+      "Broadcast the CLI briefing (npm run demo:sovereign-constellation:asi-takes-off) to align stakeholders on the operating doctrine."
+    ],
+    "ownerControls": [
+      {
+        "module": "CI",
+        "action": "demo-asi-takeoff.yml",
+        "description": "Workflow enforces full-stack validation so ownership can demand evidence that the superintelligent platform remains trustworthy."
+      },
+      {
+        "module": "Deploy scripts",
+        "action": "deployConstellation.ts",
+        "description": "Mainnet-ready script deploys hubs, wires pause circuits, and hands control to the owner-defined Safe."
+      }
+    ],
+    "automation": [
+      {
+        "label": "Full CI",
+        "command": "npm run demo:sovereign-constellation:ci",
+        "impact": "Runs contract tests, server/app builds, and thermostat planning so releases stay production-ready."
+      },
+      {
+        "label": "ASI Take-Off workflow",
+        "command": ".github/workflows/demo-asi-takeoff.yml",
+        "impact": "Public GitHub check publishes artefacts proving the demo passed across deterministic and local environments."
+      }
+    ],
+    "verification": [
+      {
+        "artifact": ".github/workflows/demo-asi-takeoff.yml",
+        "description": "Workflow log shows both deterministic kit and local launch succeed before merges."
+      },
+      {
+        "artifact": "reports/asi-takeoff",
+        "description": "Receipts archived on each run capture job IDs, telemetry, and governance state for executive review."
+      }
+    ],
+    "assurance": "Production-critical checks stay enforced on PRs and main, proving AGI Jobs v0 (v2) is the decisive advantage."
+  }
+]

--- a/demo/sovereign-constellation/cypress/e2e/sovereign-constellation.cy.ts
+++ b/demo/sovereign-constellation/cypress/e2e/sovereign-constellation.cy.ts
@@ -13,6 +13,11 @@ describe("Sovereign Constellation UI", () => {
       cy.contains("Automation Spine");
       cy.contains("npm run demo:sovereign-constellation:asi-takes-off");
     });
+    cy.get('[data-testid="asi-takes-off-systems"]').within(() => {
+      cy.contains("Systems Matrix");
+      cy.contains("Owner levers");
+      cy.contains("Automation spine");
+    });
     cy.get('[data-testid="mission-profiles"]').within(() => {
       cy.contains("ASI Takes Off Mission Profiles");
       cy.contains("Load mission plan").first().click();

--- a/demo/sovereign-constellation/server/index.ts
+++ b/demo/sovereign-constellation/server/index.ts
@@ -111,6 +111,34 @@ type AsiDeck = {
   ownerAssurances: AsiOwnerAssurances;
 };
 
+type AsiSystemControl = {
+  module: string;
+  action: string;
+  description: string;
+};
+
+type AsiSystemAutomation = {
+  label: string;
+  command: string;
+  impact: string;
+};
+
+type AsiSystemVerification = {
+  artifact: string;
+  description: string;
+};
+
+type AsiSystem = {
+  id: string;
+  title: string;
+  summary: string;
+  operatorWorkflow: string[];
+  ownerControls: AsiSystemControl[];
+  automation: AsiSystemAutomation[];
+  verification: AsiSystemVerification[];
+  assurance: string;
+};
+
 const buildOwnerAtlas = untypedBuildOwnerAtlas as OwnerAtlasLib["buildOwnerAtlas"];
 const computeAutotunePlan = untypedComputeAutotunePlan as AutotuneLib["computeAutotunePlan"];
 type AutotuneTelemetry = Parameters<AutotuneLib["computeAutotunePlan"]>[0];
@@ -131,6 +159,7 @@ const playbooks = loadJson<any[]>("config/playbooks.json");
 const actors = loadJson<any[]>("config/actors.json");
 const missionProfiles = loadJson<MissionProfile[]>("config/missionProfiles.json");
 const asiDeck = loadJson<AsiDeck>("config/asiTakesOffMatrix.json");
+const asiSystems = loadJson<AsiSystem[]>("config/asiTakesOffSystems.json");
 
 type ConstellationContext = {
   uiConfig: UiConfig;
@@ -139,6 +168,7 @@ type ConstellationContext = {
   actors: any[];
   missionProfiles: MissionProfile[];
   asiDeck: AsiDeck;
+  asiSystems: AsiSystem[];
 };
 
 const defaultContext: ConstellationContext = {
@@ -147,7 +177,8 @@ const defaultContext: ConstellationContext = {
   playbooks,
   actors,
   missionProfiles,
-  asiDeck
+  asiDeck,
+  asiSystems
 };
 
 const jobAbi = [
@@ -221,9 +252,13 @@ export function createServer(ctx: ConstellationContext = defaultContext) {
     return res.json({
       deck: ctx.asiDeck,
       ownerAtlas: atlas,
-      autotunePlan: plan
+      autotunePlan: plan,
+      systems: ctx.asiSystems
     });
   });
+  app.get("/constellation/asi-takes-off/systems", (_req, res) =>
+    res.json({ systems: ctx.asiSystems })
+  );
 
   app.post("/constellation/:hub/tx/create", (req, res) => {
     const hub = getHub(ctx, req.params.hub);

--- a/demo/sovereign-constellation/test/server/asiTakesOffDeck.spec.js
+++ b/demo/sovereign-constellation/test/server/asiTakesOffDeck.spec.js
@@ -6,6 +6,8 @@ const { spawnSync } = require("child_process");
 const root = path.join(__dirname, "..", "..");
 const matrixFile = path.join(root, "config/asiTakesOffMatrix.json");
 const payload = JSON.parse(fs.readFileSync(matrixFile, "utf8"));
+const systemsFile = path.join(root, "config/asiTakesOffSystems.json");
+const systems = JSON.parse(fs.readFileSync(systemsFile, "utf8"));
 
 assert.equal(payload.mission.id, "asi-takes-off", "ASI deck must describe the flagship mission");
 assert.ok(Array.isArray(payload.pillars) && payload.pillars.length === 5, "All five mission pillars must be listed");
@@ -34,9 +36,24 @@ assert.ok(payload.ownerAssurances?.pausing, "Owner assurances should describe pa
 assert.ok(payload.ownerAssurances?.upgrades, "Owner assurances should document upgrade control");
 assert.ok(payload.ownerAssurances?.emergencyResponse, "Owner assurances should surface emergency response levers");
 
+assert.ok(Array.isArray(systems) && systems.length === 5, "Systems matrix must enumerate all five pillars");
+systems.forEach((system) => {
+  assert.ok(system.id && system.title, "Every system entry needs an id and title");
+  assert.ok(Array.isArray(system.operatorWorkflow) && system.operatorWorkflow.length >= 1, "System entries require operator workflow guidance");
+  assert.ok(Array.isArray(system.ownerControls) && system.ownerControls.length >= 1, "System entries must reference owner controls");
+  system.ownerControls.forEach((control) => {
+    assert.ok(control.module && control.action, "Owner control entries require module and action");
+    assert.ok(control.description, "Owner control entries must include descriptions");
+  });
+  assert.ok(Array.isArray(system.automation) && system.automation.length >= 1, "System entries document automation commands");
+  assert.ok(Array.isArray(system.verification) && system.verification.length >= 1, "System entries must cite proof artefacts");
+  assert.ok(system.assurance, "System entries must state the assurance statement");
+});
+
 const cliPath = path.join(root, "bin/asi-takes-off.mjs");
 const result = spawnSync("node", [cliPath], { encoding: "utf8" });
 assert.equal(result.status, 0, `ASI Takes Off CLI should exit cleanly. stderr: ${result.stderr}`);
 assert.ok(result.stdout.includes("ASI Takes Off"), "CLI briefing should mention ASI Takes Off");
 assert.ok(result.stdout.includes("Automation spine"), "CLI output should enumerate automation spine instructions");
+assert.ok(result.stdout.includes("Systems matrix"), "CLI output should highlight the systems matrix overview");
 console.log("✅ asiTakesOffMatrix.json schema validated and CLI briefing renders");


### PR DESCRIPTION
## Summary
- add an asiTakesOffSystems.json dataset that codifies the five ASI Takes Off pillars with workflows, owner controls, automation, and proofs
- surface the systems matrix through a new orchestrator API, CLI briefing output, and a dedicated console section for non-technical operators
- expand automated coverage with updated server assertions and Cypress checks referencing the new systems matrix

## Testing
- npm run demo:sovereign-constellation:test:server
- npm run demo:sovereign-constellation:app:install
- npm run demo:sovereign-constellation:app:build

------
https://chatgpt.com/codex/tasks/task_e_68f3e8cde9308333a2d9ca1de156daf5