### PR TITLE
Add ASI victory assurance dataset and CLI

### DIFF
--- a/demo/sovereign-constellation/README.md
+++ b/demo/sovereign-constellation/README.md
@@ -107,6 +107,10 @@ sequenceDiagram
 - **ASI systems matrix** – `config/asiTakesOffSystems.json` documents the five flagship pillars with operator workflows,
   owner levers, automation commands, and verification artefacts. The server exposes `/constellation/asi-takes-off/systems`
   and the console renders the dataset so every mission assurance remains transparent.
+- **Victory assurance plan** – `config/asiTakesOffVictoryPlan.json` captures the readiness gates, owner controls, and telemetry
+  metrics required for a "green across the board" launch. The server returns it from
+  `/constellation/asi-takes-off/victory-plan`, and the `npm run demo:sovereign-constellation:victory` CLI renders the playbook
+  for non-technical directors.
 
 ## Flagship mission — ASI Takes Off
 
@@ -124,6 +128,8 @@ sequenceDiagram
   the pillars, automation spine, thermostat recommendations, and owner atlas synopsis for rapid stakeholder alignment.
 - The `/constellation/asi-takes-off` endpoint returns the same dataset (deck, owner atlas, autotune plan) so the React console
   can render a control deck for non-technical operators.
+- `npm run demo:sovereign-constellation:victory` prints the readiness gates, telemetry metrics, and unstoppable assurances from
+  `asiTakesOffVictoryPlan.json`, ensuring the operator can prove the system remains battle-ready without coding.
 
 ## Directory layout
 

--- a/demo/sovereign-constellation/bin/asi-victory-plan.mjs
+++ b/demo/sovereign-constellation/bin/asi-victory-plan.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const demoRoot = path.join(__dirname, "..", "");
+
+function loadJson(relPath) {
+  const fullPath = path.join(demoRoot, relPath);
+  return JSON.parse(fs.readFileSync(fullPath, "utf8"));
+}
+
+function printSection(title) {
+  console.log(`\n${title}`);
+  console.log("".padEnd(title.length, "="));
+}
+
+function printListItem(label, value) {
+  console.log(` • ${label}`);
+  if (value) {
+    console.log(`   ${value}`);
+  }
+}
+
+function main() {
+  const plan = loadJson("config/asiTakesOffVictoryPlan.json");
+
+  console.log("\n🏆  ASI Takes Off — Victory Assurance Plan\n");
+  console.log(`${plan.title}`);
+  console.log(plan.summary);
+  console.log(`Promise: ${plan.operatorPromise}`);
+
+  printSection("Objectives");
+  for (const objective of plan.objectives ?? []) {
+    console.log(` • ${objective.title} (${objective.id})`);
+    console.log(`   Outcome: ${objective.outcome}`);
+    console.log(`   Verification: ${objective.verification}`);
+  }
+
+  printSection("Owner Controls");
+  for (const control of plan.ownerControls ?? []) {
+    console.log(` • ${control.module} :: ${control.action}`);
+    console.log(`   Command: ${control.command}`);
+    console.log(`   Verification: ${control.verification}`);
+  }
+
+  printSection("CI Gates");
+  for (const gate of plan.ciGates ?? []) {
+    printListItem(`${gate.name}`, gate.description);
+    console.log(`   Command: ${gate.command}`);
+  }
+
+  printSection("Telemetry Metrics");
+  console.log(plan.telemetry?.overview ?? "Telemetry overview unavailable.");
+  for (const metric of plan.telemetry?.metrics ?? []) {
+    console.log(` • ${metric.metric} → target ${metric.target}`);
+    console.log(`   Source: ${metric.source}`);
+    console.log(`   Verification: ${metric.verification}`);
+  }
+
+  printSection("Assurance Statements");
+  console.log(` • Unstoppable readiness: ${plan.assurance?.unstoppable}`);
+  console.log(` • Owner sovereignty: ${plan.assurance?.ownerSovereignty}`);
+  console.log(` • Readiness criteria: ${plan.assurance?.readiness}`);
+
+  console.log("\nNext steps:");
+  console.log(" • Run npm run demo:sovereign-constellation to launch the constellation.");
+  console.log(" • Execute npm run demo:sovereign-constellation:ci before merging mission changes.");
+  console.log(" • Apply thermostat recommendations with npm run demo:sovereign-constellation:plan.\n");
+}
+
+try {
+  main();
+} catch (error) {
+  console.error("Failed to render victory assurance plan:");
+  console.error(error);
+  process.exit(1);
+}

--- a/demo/sovereign-constellation/config/asiTakesOffVictoryPlan.json
+++ b/demo/sovereign-constellation/config/asiTakesOffVictoryPlan.json
@@ -1,0 +1,91 @@
+{
+  "id": "asi-takes-off-victory",
+  "title": "ASI Takes Off Victory Assurance Plan",
+  "summary": "Hardens the Sovereign Constellation launch so a single operator can command audited hubs, enforce owner supremacy, and validate telemetry without writing code.",
+  "operatorPromise": "Victory is defined as completing the ASI Takes Off playbook with all control checks, telemetry confirmations, and CI guardrails reporting green.",
+  "objectives": [
+    {
+      "id": "ignite-mission",
+      "title": "Ignite the Meta-Agentic Mission",
+      "outcome": "Helios, Triton, and Athena accept the asi-takes-off playbook transactions and emit JobCreated events per hub.",
+      "verification": "Run npm run demo:sovereign-constellation to launch the orchestrator console and sign each prepared transaction."
+    },
+    {
+      "id": "assert-governance",
+      "title": "Assert Owner Governance",
+      "outcome": "Owner atlas exports list SystemPause, ValidationModule, StakeManager, and JobRegistry controls for every hub under the operator's wallet.",
+      "verification": "Execute npm run demo:sovereign-constellation:atlas and inspect reports/sovereign-constellation/owner-atlas.json."
+    },
+    {
+      "id": "seal-telemetry",
+      "title": "Seal Telemetry Feedback",
+      "outcome": "Thermostat autotune plan recommends commit/reveal, stake, and dispute parameters that reflect latest telemetry inputs.",
+      "verification": "Run npm run demo:sovereign-constellation:plan and confirm console output lists recommended parameters." 
+    }
+  ],
+  "ownerControls": [
+    {
+      "module": "SystemPause",
+      "action": "pause",
+      "command": "curl -XPOST localhost:8090/constellation/helios/tx/pause -d '{\"action\":\"pause\"}'",
+      "verification": "Explorer shows JobRegistry pause transaction signed by owner; CLI prints \"Helios paused\" message."
+    },
+    {
+      "module": "ValidationModule",
+      "action": "setCommitRevealWindows",
+      "command": "curl -XPOST localhost:8090/constellation/triton/tx/validation/commit-window -d '{\"commitWindowSeconds\":3600,\"revealWindowSeconds\":1800}'",
+      "verification": "Hardhat console or Etherscan events show ValidationWindowUpdated with requested values."
+    },
+    {
+      "module": "StakeManager",
+      "action": "setMinStake",
+      "command": "curl -XPOST localhost:8090/constellation/athena/tx/stake/min -d '{\"minStakeWei\":\"2000000000000000000\"}'",
+      "verification": "Autotune plan summary reflects the new minimum stake after execution."
+    }
+  ],
+  "ciGates": [
+    {
+      "name": "Demo CI",
+      "command": "npm run demo:sovereign-constellation:ci",
+      "description": "Runs contract tests, server schema validation, React build, and thermostat planning on every branch."
+    },
+    {
+      "name": "Owner Parameter Matrix",
+      "command": "npm run owner:parameters",
+      "description": "Confirms every adjustable parameter remains mapped to owner-only functions before promotion."
+    },
+    {
+      "name": "Branch Protection",
+      "command": "npm run ci:verify-branch-protection",
+      "description": "Verifies GitHub branch rules enforce constellation CI and owner governance checks."
+    }
+  ],
+  "telemetry": {
+    "overview": "Telemetry merges validator participation, commit/reveal cadence, and staking distribution from autotune.telemetry.json.",
+    "metrics": [
+      {
+        "metric": "averageParticipation",
+        "target": ">= 0.80",
+        "source": "autotune.telemetry.json › summary.averageParticipation",
+        "verification": "npm run demo:sovereign-constellation:plan outputs participation percentage."
+      },
+      {
+        "metric": "commitWindowSeconds",
+        "target": "adaptive",
+        "source": "autotune.telemetry.json › summary.commitWindowSeconds",
+        "verification": "Server GET /constellation/thermostat/plan returns recommended window."
+      },
+      {
+        "metric": "minStakeWei",
+        "target": ">= 1 ether",
+        "source": "autotune.telemetry.json › summary.minStakeWei",
+        "verification": "Autotune CLI displays Ether formatted minimum stake."
+      }
+    ]
+  },
+  "assurance": {
+    "unstoppable": "Victory plan keeps the constellation ready to relaunch instantly even after pauses by documenting restart scripts and telemetry baselines.",
+    "ownerSovereignty": "Every control step emphasises owner signatures; no automation holds private keys or bypasses wallet consent.",
+    "readiness": "CI gates and telemetry metrics provide objective readiness checks prior to mission escalation."
+  }
+}

--- a/demo/sovereign-constellation/server/index.ts
+++ b/demo/sovereign-constellation/server/index.ts
@@ -139,6 +139,52 @@ type AsiSystem = {
   assurance: string;
 };
 
+type AsiVictoryObjective = {
+  id: string;
+  title: string;
+  outcome: string;
+  verification: string;
+};
+
+type AsiVictoryOwnerControl = {
+  module: string;
+  action: string;
+  command: string;
+  verification: string;
+};
+
+type AsiVictoryGate = {
+  name: string;
+  command: string;
+  description: string;
+};
+
+type AsiVictoryMetric = {
+  metric: string;
+  target: string;
+  source: string;
+  verification: string;
+};
+
+type AsiVictoryPlan = {
+  id: string;
+  title: string;
+  summary: string;
+  operatorPromise: string;
+  objectives: AsiVictoryObjective[];
+  ownerControls: AsiVictoryOwnerControl[];
+  ciGates: AsiVictoryGate[];
+  telemetry: {
+    overview: string;
+    metrics: AsiVictoryMetric[];
+  };
+  assurance: {
+    unstoppable: string;
+    ownerSovereignty: string;
+    readiness: string;
+  };
+};
+
 const buildOwnerAtlas = untypedBuildOwnerAtlas as OwnerAtlasLib["buildOwnerAtlas"];
 const computeAutotunePlan = untypedComputeAutotunePlan as AutotuneLib["computeAutotunePlan"];
 type AutotuneTelemetry = Parameters<AutotuneLib["computeAutotunePlan"]>[0];
@@ -160,6 +206,7 @@ const actors = loadJson<any[]>("config/actors.json");
 const missionProfiles = loadJson<MissionProfile[]>("config/missionProfiles.json");
 const asiDeck = loadJson<AsiDeck>("config/asiTakesOffMatrix.json");
 const asiSystems = loadJson<AsiSystem[]>("config/asiTakesOffSystems.json");
+const asiVictoryPlan = loadJson<AsiVictoryPlan>("config/asiTakesOffVictoryPlan.json");
 
 type ConstellationContext = {
   uiConfig: UiConfig;
@@ -169,6 +216,7 @@ type ConstellationContext = {
   missionProfiles: MissionProfile[];
   asiDeck: AsiDeck;
   asiSystems: AsiSystem[];
+  asiVictoryPlan: AsiVictoryPlan;
 };
 
 const defaultContext: ConstellationContext = {
@@ -178,7 +226,8 @@ const defaultContext: ConstellationContext = {
   actors,
   missionProfiles,
   asiDeck,
-  asiSystems
+  asiSystems,
+  asiVictoryPlan
 };
 
 const jobAbi = [
@@ -253,9 +302,13 @@ export function createServer(ctx: ConstellationContext = defaultContext) {
       deck: ctx.asiDeck,
       ownerAtlas: atlas,
       autotunePlan: plan,
-      systems: ctx.asiSystems
+      systems: ctx.asiSystems,
+      victoryPlan: ctx.asiVictoryPlan
     });
   });
+  app.get("/constellation/asi-takes-off/victory-plan", (_req, res) =>
+    res.json({ plan: ctx.asiVictoryPlan })
+  );
   app.get("/constellation/asi-takes-off/systems", (_req, res) =>
     res.json({ systems: ctx.asiSystems })
   );

--- a/demo/sovereign-constellation/test/server/asiVictoryPlan.spec.js
+++ b/demo/sovereign-constellation/test/server/asiVictoryPlan.spec.js
@@ -1,0 +1,53 @@
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const root = path.join(__dirname, "..", "..");
+const planFile = path.join(root, "config/asiTakesOffVictoryPlan.json");
+const payload = JSON.parse(fs.readFileSync(planFile, "utf8"));
+
+assert.equal(payload.id, "asi-takes-off-victory", "Victory plan must be keyed to the flagship mission");
+assert.ok(payload.title && payload.summary, "Victory plan requires title and summary");
+assert.ok(Array.isArray(payload.objectives) && payload.objectives.length >= 3, "Victory plan needs at least three objectives");
+payload.objectives.forEach((objective) => {
+  assert.ok(objective.id, "Objectives require ids");
+  assert.ok(objective.title, `Objective ${objective.id} requires a title`);
+  assert.ok(objective.outcome, `Objective ${objective.id} needs an outcome description`);
+  assert.ok(objective.verification, `Objective ${objective.id} needs a verification step`);
+});
+
+assert.ok(Array.isArray(payload.ownerControls) && payload.ownerControls.length >= 3, "Victory plan must surface owner controls");
+payload.ownerControls.forEach((control) => {
+  assert.ok(control.module && control.action, "Owner controls must include module and action");
+  assert.ok(control.command, "Owner controls require executable command guidance");
+  assert.ok(control.verification, "Owner controls must cite verification narrative");
+});
+
+assert.ok(Array.isArray(payload.ciGates) && payload.ciGates.length >= 3, "Victory plan must document CI gates");
+payload.ciGates.forEach((gate) => {
+  assert.ok(gate.name && gate.command, "CI gates need names and commands");
+  assert.ok(gate.description, "CI gate entries must describe enforcement");
+});
+
+assert.ok(payload.telemetry?.overview, "Telemetry overview required for readiness");
+assert.ok(Array.isArray(payload.telemetry?.metrics) && payload.telemetry.metrics.length >= 3, "Telemetry metrics required");
+payload.telemetry.metrics.forEach((metric) => {
+  assert.ok(metric.metric, "Telemetry metric entries need identifiers");
+  assert.ok(metric.target, "Telemetry metric entries require targets");
+  assert.ok(metric.source, "Telemetry metric entries require source references");
+  assert.ok(metric.verification, "Telemetry metric entries require verification guidance");
+});
+
+assert.ok(payload.assurance?.unstoppable, "Assurance narrative must mention unstoppable readiness");
+assert.ok(payload.assurance?.ownerSovereignty, "Assurance narrative must mention owner sovereignty");
+assert.ok(payload.assurance?.readiness, "Assurance narrative must mention readiness criteria");
+
+const cliPath = path.join(root, "bin/asi-victory-plan.mjs");
+const result = spawnSync("node", [cliPath], { encoding: "utf8" });
+assert.equal(result.status, 0, `Victory CLI should exit cleanly. stderr: ${result.stderr}`);
+assert.ok(result.stdout.includes("Victory Assurance Plan"), "Victory CLI should include heading");
+assert.ok(result.stdout.includes("Unstoppable readiness"), "Victory CLI should surface unstoppable assurance");
+assert.ok(result.stdout.includes("CI Gates"), "Victory CLI should enumerate CI gates");
+
+console.log("✅ asiTakesOffVictoryPlan.json schema validated and CLI renders");

--- a/package.json
+++ b/package.json
@@ -185,11 +185,12 @@
     "demo:sovereign-constellation:app:install": "npm ci --prefix demo/sovereign-constellation/app",
     "demo:sovereign-constellation:app:build": "npm run build --prefix demo/sovereign-constellation/app",
     "demo:sovereign-constellation:test:contracts": "npx hardhat test demo/sovereign-constellation/test/*.t.ts",
-    "demo:sovereign-constellation:test:server": "node demo/sovereign-constellation/test/server/missionProfiles.spec.js && node demo/sovereign-constellation/test/server/asiTakesOffDeck.spec.js",
+    "demo:sovereign-constellation:test:server": "node demo/sovereign-constellation/test/server/missionProfiles.spec.js && node demo/sovereign-constellation/test/server/asiTakesOffDeck.spec.js && node demo/sovereign-constellation/test/server/asiVictoryPlan.spec.js",
     "demo:sovereign-constellation:test": "npm run demo:sovereign-constellation:test:contracts && npm run demo:sovereign-constellation:test:server",
     "demo:sovereign-constellation:ci": "npm run demo:sovereign-constellation:test && npm run demo:sovereign-constellation:server:install && npm run demo:sovereign-constellation:server:build && npm run demo:sovereign-constellation:app:install && npm run demo:sovereign-constellation:app:build && npm run demo:sovereign-constellation:plan",
     "demo:sovereign-constellation:local": "node demo/sovereign-constellation/bin/sovereign-constellation-local.mjs",
-    "demo:sovereign-constellation:asi-takes-off": "node demo/sovereign-constellation/bin/asi-takes-off.mjs"
+    "demo:sovereign-constellation:asi-takes-off": "node demo/sovereign-constellation/bin/asi-takes-off.mjs",
+    "demo:sovereign-constellation:victory": "node demo/sovereign-constellation/bin/asi-victory-plan.mjs"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add an ASI Takes Off victory assurance data set and expose it through the constellation server
- ship a CLI briefing that renders the victory plan for non-technical operators and document it in the demo README
- extend the demo server test suite to validate the new schema alongside the existing ASI orchestration assets

## Testing
- npm run demo:sovereign-constellation:test:server
- node demo/sovereign-constellation/bin/asi-victory-plan.mjs | head
- node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync('demo/sovereign-constellation/config/asiTakesOffVictoryPlan.json','utf8'));console.log(Object.keys(data.assurance));"

------
https://chatgpt.com/codex/tasks/task_e_68f3edb3d74483339f6ecfdefcb33e72