### PR TITLE
Add physics-aware diagnostics to AGI governance demo

### DIFF
--- a/demo/agi-governance/README.md
+++ b/demo/agi-governance/README.md
@@ -33,6 +33,7 @@ The command generates `reports/governance-demo-report.md` with:
 2. Triple-verified game-theory equilibrium analysis (replicator dynamics simulation + closed-form solver + Monte-Carlo stress sampling).
 3. Owner control drilldown (pause/unpause, parameter upgrades, treasury manoeuvres, sentinel confirmations).
 4. Blockchain deployment checklist targeting Ethereum mainnet-level infrastructure.
+5. Assurance diagnostics (Landauer adequacy ratios, symmetrised payoff eigenvalues, and automated owner authority assertions).
 
 Then run the CI verification layer:
 
@@ -47,6 +48,7 @@ This command checks that the repository’s v2 CI workflow still enforces the ma
 - **No manual math.** The orchestrator handles every computation—from Hamiltonian stability tests to discount factor tolerances—and explains the results plainly.
 - **Copy‑paste governance.** Ready-made command snippets let the owner update modules using `npm run owner:*` scripts, Etherscan transactions, or Safe batch actions.
 - **Evidence by default.** Every run produces timestamped artefacts that prove compliance with thermodynamic limits, governance divergence caps, and CI enforcement. Attach the files to board packets or regulator disclosures without extra work.
+- **Automatic diagnostics.** The dossier now embeds Landauer adequacy ratios, eigenvalue condition numbers, and owner assertion checks so non-technical operators can certify control without bespoke analysis.
 
 ## Extending the mission
 

--- a/demo/agi-governance/RUNBOOK.md
+++ b/demo/agi-governance/RUNBOOK.md
@@ -32,6 +32,7 @@ Outputs `reports/governance-demo-report.md` with:
 - Triple-verified game-theory equilibrium (replicator simulation, closed-form solver, Monte-Carlo stress test).
 - Owner command surface (pause/unpause, parameter upgrades, treasury manoeuvres, sentinel verifications).
 - CI enforcement proof (required contexts, concurrency, access-control coverage).
+- Assurance diagnostics (Landauer adequacy ratios, payoff eigenvalue condition number, automated owner authority assertions).
 
 Review the report. It references exact commands to execute each owner action on Ethereum or via AGI Jobs automation scripts.
 

--- a/demo/agi-governance/reports/governance-demo-report.md
+++ b/demo/agi-governance/reports/governance-demo-report.md
@@ -1,5 +1,5 @@
 # Solving α-AGI Governance — Governance Demonstration Report
-*Generated at:* 2025-10-19T12:57:39.892Z
+*Generated at:* 2025-10-19T13:50:47.593Z
 *Version:* 1.0.0
 
 > Hamiltonian-guided governance drill proving AGI Jobs v0 (v2) delivers superintelligent coordination under absolute owner control.
@@ -11,17 +11,16 @@
 - **Free-energy safety margin:** 69.80k kJ
 - **Energy dissipated per block (burn):** 4.36k kJ
 - **Cross-check delta:** 0.000e+0 kJ (≤ 1e-6 required)
-
+- **Gibbs-to-Landauer ratio:** 1.307e+19
+- **Burn/Landauer ratio:** 8.169e+17
+- **Stake Boltzmann energy:** 2.967e-21 J (2.967e-24 kJ)
 ## 2. Hamiltonian Control Plane
-
 - **Kinetic term:** 34149.74M units
 - **Potential term (scaled by λ):** 302.02k units
 - **Hamiltonian energy:** 34149.44M units
 - **Alternate computation check:** 34149.44M units
 - **Difference:** 0.000e+0 (≤ 1e-3 target)
-
 ## 3. Game-Theoretic Macro-Equilibrium
-
 - **Discount factor:** 0.92 (must exceed 0.80 for uniqueness)
 - **Replicator iterations to convergence:** 50000
 - **Replicator vs closed-form deviation:** 1.101e-1
@@ -34,9 +33,9 @@
 | Pareto-Coop | 32.36% | 33.33% | 33.91% |
 | Thermo-Titan | 41.56% | 33.33% | 33.11% |
 | Sentinel-Tactician | 26.09% | 33.33% | 32.98% |
-
+- **Average divergence (Monte-Carlo):** 6.820e-2
+- **Average payoff (Monte-Carlo):** 1.00 tokens
 ## 4. Owner Supremacy & Command Surface
-
 - **Owner:** 0xA1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1
 - **Pauser:** 0xB2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2
 - **Treasury:** 0xC3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3
@@ -51,9 +50,7 @@
   └─ <code>$ npm run owner:rotate -- --network mainnet --role Sentinel --count 3</code>
 - **Update tax policy disclosure.** Publishes the latest regulatory acknowledgement without touching business logic.
   └─ <code>$ npm run owner:update-all -- --network mainnet --module TaxPolicy --acknowledgement "Participants accept AGI Jobs v2 tax terms."</code>
-
 ## 5. CI Enforcement Ledger
-
 - **Workflow name:** ci (v2)
 - **Concurrency guard:** <code>ci-${{ github.workflow }}-${{ github.ref }}</code>
 - **Minimum coverage:** 90%
@@ -67,9 +64,30 @@
 | summary | CI summary |
 
 Run <code>npm run demo:agi-governance:ci</code> to assert the workflow still exports these shields.
+## 6. Diagnostics & Assurance
+- **Landauer adequacy:** Gibbs free energy exceeds Landauer minimum by 1.307e+19x
+- **Replicator vs Monte-Carlo deviation:** 1.101e-1
+- **Replicator vs closed-form deviation:** 1.101e-1
+- **Monte-Carlo average divergence:** 6.820e-2
 
-## 6. Owner Execution Log (fill during live ops)
+### Owner assertions
+- ✅ **Owner address format:** 0xA1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1 is a valid EOA/multisig format
+- ✅ **Pauser address format:** 0xB2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2 is a valid controller format
+- ✅ **Treasury address format:** 0xC3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3 is a valid treasury format
+- ✅ **Timelock horizon:** Timelock is 691200 seconds (8.00 days)
+- ✅ **Upgrade action: Recalibrate Hamiltonian monitor:** npm run owner:command-center -- --network mainnet --target HamiltonianMonitor --set-lambda 0.94 --set-inertia 1.08
+- ✅ **Upgrade action: Adjust reward engine burn curve:** npm run reward-engine:update -- --network mainnet --burn-bps 600 --treasury-bps 200
+- ✅ **Upgrade action: Rotate governance sentinels:** npm run owner:rotate -- --network mainnet --role Sentinel --count 3
+- ✅ **Upgrade action: Update tax policy disclosure:** npm run owner:update-all -- --network mainnet --module TaxPolicy --acknowledgement "Participants accept AGI Jobs v2 tax terms."
 
+### Symmetrised payoff eigenvalues
+| Eigenvalue | Magnitude |
+| --- | --- |
+| λ1 | 3.0000 |
+| λ2 | 0.0000 |
+| λ3 | -0.0000 |
+- **Condition number:** 1.000e+0 (lower is more stable)
+## 7. Owner Execution Log (fill during live ops)
 | Timestamp | Action | Tx hash | Operator | Notes |
 | --- | --- | --- | --- | --- |
 | _pending_ |  |  |  |  |

--- a/demo/agi-governance/reports/governance-demo-summary.json
+++ b/demo/agi-governance/reports/governance-demo-summary.json
@@ -1,13 +1,18 @@
 {
-  "generatedAt": "2025-10-19T12:57:39.892Z",
+  "generatedAt": "2025-10-19T13:50:47.593Z",
   "version": "1.0.0",
   "thermodynamics": {
     "gibbsFreeEnergyKJ": 69800,
     "gibbsFreeEnergyJ": 69800000,
     "landauerKJ": 5.3400207262464265e-15,
+    "landauerJ": 5.340020726246426e-12,
     "freeEnergyMarginKJ": 69800,
     "burnEnergyPerBlockKJ": 4362.5,
-    "gibbsAgreementDelta": 0
+    "gibbsAgreementDelta": 0,
+    "gibbsToLandauerRatio": 13071110315533058000,
+    "burnToLandauerRatio": 816944394720816100,
+    "stakeBoltzmannEnergyJ": 2.9666781812480147e-21,
+    "stakeBoltzmannEnergyKJ": 2.966678181248015e-24
   },
   "hamiltonian": {
     "kineticTerm": 34149742376.26085,
@@ -42,7 +47,9 @@
     "payoffAtEquilibrium": 1,
     "divergenceAtEquilibrium": 0,
     "discountFactor": 0.92,
-    "replicatorDeviation": 0.11005256345802282
+    "replicatorDeviation": 0.11005256345802282,
+    "monteCarloAverageDivergence": 0.06820361080231813,
+    "monteCarloAveragePayoff": 1
   },
   "owner": {
     "owner": "0xA1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1",
@@ -98,5 +105,59 @@
     ],
     "minCoverage": 90,
     "concurrency": "ci-${{ github.workflow }}-${{ github.ref }}"
+  },
+  "diagnostics": {
+    "landauerAdequacy": "Gibbs free energy exceeds Landauer minimum by 1.307e+19x",
+    "ownerAssertions": [
+      {
+        "check": "Owner address format",
+        "passed": true,
+        "detail": "0xA1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1 is a valid EOA/multisig format"
+      },
+      {
+        "check": "Pauser address format",
+        "passed": true,
+        "detail": "0xB2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2 is a valid controller format"
+      },
+      {
+        "check": "Treasury address format",
+        "passed": true,
+        "detail": "0xC3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3 is a valid treasury format"
+      },
+      {
+        "check": "Timelock horizon",
+        "passed": true,
+        "detail": "Timelock is 691200 seconds (8.00 days)"
+      },
+      {
+        "check": "Upgrade action: Recalibrate Hamiltonian monitor",
+        "passed": true,
+        "detail": "npm run owner:command-center -- --network mainnet --target HamiltonianMonitor --set-lambda 0.94 --set-inertia 1.08"
+      },
+      {
+        "check": "Upgrade action: Adjust reward engine burn curve",
+        "passed": true,
+        "detail": "npm run reward-engine:update -- --network mainnet --burn-bps 600 --treasury-bps 200"
+      },
+      {
+        "check": "Upgrade action: Rotate governance sentinels",
+        "passed": true,
+        "detail": "npm run owner:rotate -- --network mainnet --role Sentinel --count 3"
+      },
+      {
+        "check": "Upgrade action: Update tax policy disclosure",
+        "passed": true,
+        "detail": "npm run owner:update-all -- --network mainnet --module TaxPolicy --acknowledgement \"Participants accept AGI Jobs v2 tax terms.\""
+      }
+    ],
+    "eigenvalues": [
+      3,
+      4.440892098500626e-16,
+      -8.881784197001252e-16
+    ],
+    "eigenvalueCondition": 1,
+    "replicatorVsMonteCarlo": 0.11010278111938565,
+    "replicatorVsClosedForm": 0.11005256345802282,
+    "monteCarloAverageDivergence": 0.06820361080231813
   }
 }


### PR DESCRIPTION
## Summary
- extend the governance demo orchestrator with thermodynamic ratios, eigenvalue diagnostics, and automated owner control assertions that feed both the markdown dossier and JSON summary
- surface the new diagnostics and assurance steps in the README and RUNBOOK so non-technical operators understand the additional evidence they receive
- refresh the reference dossier outputs to showcase the added analytics

## Testing
- npm run demo:agi-governance
- npm run demo:agi-governance:ci

------
https://chatgpt.com/codex/tasks/task_e_68f4ea41c0c88333a0a30791d6eaa0ae