### PR TITLE
Enhance AGI governance demo with incentive analytics

### DIFF
--- a/demo/agi-governance/README.md
+++ b/demo/agi-governance/README.md
@@ -31,11 +31,12 @@ npm run demo:agi-governance
 The command generates `reports/governance-demo-report.md` with:
 
 1. Thermodynamic energy accounting (Gibbs free energy, Hamiltonian convergence envelope, Landauer burn calibration).
-2. Five-way verified game-theory equilibrium (discrete replicator, RK4 continuous flow, closed-form solver, Perron eigenvector, Monte-Carlo stress sampling) with method-consistency scores.
-3. Analytic and numeric Jacobian comparison with Gershgorin, spectral radius, and max-delta checks plus antifragility curvature proving positive welfare response to adversarial shocks.
-4. Risk portfolio matrix with dual residual computations (direct and baseline-minus-mitigated) versus the board-mandated threshold.
-5. Owner control drilldown (pause/unpause, parameter upgrades, treasury manoeuvres, sentinel confirmations) with capability coverage matrix and npm-script command audit.
-6. Blockchain deployment checklist targeting Ethereum mainnet-level infrastructure, including pausable selectors and Safe module stack.
+2. Incentive free-energy flow (mint/burn/slash computation proving agent ↔ treasury parity and owner-tunable slashing curves).
+3. Five-way verified game-theory equilibrium (discrete replicator, RK4 continuous flow, closed-form solver, Perron eigenvector, Monte-Carlo stress sampling) with method-consistency scores.
+4. Analytic and numeric Jacobian comparison with Gershgorin, spectral radius, and max-delta checks plus antifragility curvature proving positive welfare response to adversarial shocks.
+5. Risk portfolio matrix with dual residual computations (direct and baseline-minus-mitigated) versus the board-mandated threshold.
+6. Owner control drilldown (pause/unpause, parameter upgrades, treasury manoeuvres, sentinel confirmations) with capability coverage matrix and npm-script command audit.
+7. Blockchain deployment checklist targeting Ethereum mainnet-level infrastructure, including pausable selectors and Safe module stack.
 
 Then run the CI verification layer:
 

--- a/demo/agi-governance/RUNBOOK.md
+++ b/demo/agi-governance/RUNBOOK.md
@@ -29,6 +29,7 @@ npm run demo:agi-governance
 
 Outputs `reports/governance-demo-report.md` with:
 - Thermodynamic energy margins (Gibbs free energy, Hamiltonian convergence envelope, Landauer limit calibration).
+- Incentive free-energy ledger (mint/burn/slash parity, treasury mirroring, owner-tunable slashing curves).
 - Five-method equilibrium confirmation (discrete replicator, RK4 continuous flow, Perron eigenvector, closed-form, Monte-Carlo) with maximum deviation score.
 - Analytic vs numeric Jacobian matrices (Gershgorin, spectral radius, max delta) and antifragility curvature plus welfare growth curve for adversarial shocks.
 - Risk audit portfolio with weighted mitigation coverage, dual residual calculations, and board threshold comparison.

--- a/demo/agi-governance/config/mission@v1.json
+++ b/demo/agi-governance/config/mission@v1.json
@@ -13,6 +13,57 @@
     "burnRatePerBlock": 0.0625,
     "stakeBoltzmann": 1.380649e-23
   },
+  "incentives": {
+    "mintRule": {
+      "eta": 0.94,
+      "deltaValue": 125000,
+      "treasuryMirrorShare": 0.65,
+      "tolerance": 0.01,
+      "rewardEngineShares": [
+        { "role": "Agent", "share": 0.65 },
+        { "role": "Validator", "share": 0.15 },
+        { "role": "Operator", "share": 0.15 },
+        { "role": "Employer", "share": 0.05 }
+      ]
+    },
+    "burnRule": {
+      "jobEscrow": 50000,
+      "burnBps": 600,
+      "treasuryBps": 200,
+      "employerBps": 200
+    },
+    "slashing": {
+      "stakeExample": 20000,
+      "minStake": {
+        "agent": 1200,
+        "validator": 4800,
+        "operator": 2600
+      },
+      "severities": [
+        {
+          "label": "Minor fault",
+          "description": "Performance lapse with limited downstream impact.",
+          "fraction": 0.05,
+          "treasuryShare": 0.6,
+          "employerShare": 0.3
+        },
+        {
+          "label": "Major fault",
+          "description": "Significant execution failure requiring restitution.",
+          "fraction": 0.25,
+          "treasuryShare": 0.75,
+          "employerShare": 0.25
+        },
+        {
+          "label": "Critical attack",
+          "description": "Malicious coordination breach triggering total slash.",
+          "fraction": 1.0,
+          "treasuryShare": 1.0,
+          "employerShare": 0.0
+        }
+      ]
+    }
+  },
   "hamiltonian": {
     "lambda": 0.94,
     "discountFactor": 0.92,


### PR DESCRIPTION
## Summary
- add incentive, burn, and slashing configuration to the governance mission manifest
- extend the TypeScript demo orchestrator to compute and render mint/burn parity, slashing distributions, and minimum stake tables alongside existing analytics
- refresh README and RUNBOOK guidance so non-technical operators know the dossier now includes the incentive free-energy ledger

## Testing
- npm run demo:agi-governance
- npm run demo:agi-governance:ci

------
https://chatgpt.com/codex/tasks/task_e_68f50db8618c83338277a41bb8e26dc4