### PR TITLE
feat: add immersive governance dashboard

### DIFF
--- a/demo/agi-governance/README.md
+++ b/demo/agi-governance/README.md
@@ -21,6 +21,7 @@ The **AGI Governance Demonstration** compresses the entire AGI Jobs v0 (v2) stac
 | [`scripts/verifyCiStatus.ts`](scripts/verifyCiStatus.ts) | Audits `.github/workflows/ci.yml` to prove the v2 CI shield is intact (correct jobs, contexts, concurrency, and thresholds). |
 | [`scripts/validateReport.ts`](scripts/validateReport.ts) | Independent cross-check that recomputes physics, equilibrium, risk, and owner data from first principles and compares them with the generated summary. |
 | [`reports/`](reports) | Generated artefacts (`governance-demo-report.md`, `ci-verification.json`, etc.) are written here so they can be archived from CI. |
+| [`reports/governance-demo-dashboard.html`](reports/governance-demo-dashboard.html) | Immersive, mermaid-rich web console that renders the mission as an interactive UI for non-technical owners. |
 | [`RUNBOOK.md`](RUNBOOK.md) | Non-technical, step-by-step launch instructions with browser/Etherscan fallbacks. |
 
 ## Quick start
@@ -39,6 +40,7 @@ The command generates `reports/governance-demo-report.md` with:
 6. Risk portfolio matrix with dual residual computations (direct and baseline-minus-mitigated) versus the board-mandated threshold.
 7. Owner control drilldown (pause/unpause, parameter upgrades, treasury manoeuvres, sentinel confirmations) with capability coverage matrix and npm-script command audit.
 8. Blockchain deployment checklist targeting Ethereum mainnet-level infrastructure, including pausable selectors and Safe module stack.
+9. **Grandiose mermaid visualisations** (energy → governance flowchart, antifragility mindmap, owner command sequence, residual-risk pie) embedded directly in the Markdown dossier.
 
 Then confirm the dossier by replaying all analytics from scratch:
 
@@ -64,11 +66,20 @@ npm run demo:agi-governance:owner-diagnostics
 
 The aggregator executes the owner audit CLIs (`owner:audit-hamiltonian`, `reward-engine:report`, `owner:upgrade-status`, `owner:compliance-report`) with JSON output, normalises warnings (e.g., missing Hardhat artifacts or placeholder addresses), and writes both machine-readable and Markdown summaries to `reports/`. Non-technical operators can now forward a single dossier proving that every governance lever remains under the owner’s control.
 
+Finally, open the immersive HTML dashboard:
+
+```bash
+open reports/governance-demo-dashboard.html # or xdg-open on Linux
+```
+
+This UI renders all mermaid diagrams, antifragility charts, strategy tables, and CI shields in a cinematic control room the owner can navigate without touching source code.
+
 ## Empowering non-technical operators
 
 - **No manual math.** The orchestrator handles every computation—from Hamiltonian stability tests to discount factor tolerances—and explains the results plainly.
 - **Copy‑paste governance.** Ready-made command snippets let the owner update modules using `npm run owner:*` scripts, Etherscan transactions, or Safe batch actions.
 - **Evidence by default.** Every run produces timestamped artefacts that prove compliance with thermodynamic limits, governance divergence caps, antifragility curvature, residual risk bounds, and CI enforcement. Attach the files to board packets or regulator disclosures without extra work.
+- **Hyper-visual console.** Mermaid flowcharts, mindmaps, and pie charts—along with a responsive SVG antifragility curve—render straight into Markdown and the standalone dashboard so executives see the entire governance machine at a glance.
 
 ## Extending the mission
 

--- a/demo/agi-governance/RUNBOOK.md
+++ b/demo/agi-governance/RUNBOOK.md
@@ -83,7 +83,25 @@ This orchestrates `owner:audit-hamiltonian`, `reward-engine:report`, `owner:upgr
 
 ---
 
-## 5. Execute on-chain owner controls (optional live drill)
+## 5. Launch the grandiose governance console
+
+```bash
+open demo/agi-governance/reports/governance-demo-dashboard.html  # macOS
+# or
+xdg-open demo/agi-governance/reports/governance-demo-dashboard.html  # Linux
+```
+
+The dashboard renders the same mission data with:
+
+- Flowing mermaid diagrams (energy → incentives → owner loop, residual-risk pie, owner sequence, antifragility mindmap).
+- A live SVG antifragility curve driven by the recomputed welfare samples.
+- Responsive tables for strategies, risk vectors, pausable selectors, and CI shields.
+
+This gives non-technical owners a cinematic control room that mirrors the Markdown dossier without requiring terminal access.
+
+---
+
+## 6. Execute on-chain owner controls (optional live drill)
 
 Each command below can be run via the CLI, Safe transaction builder, or Etherscan write interface. Replace placeholder addresses with your deployment addresses.
 
@@ -126,7 +144,7 @@ Document transaction hashes in `reports/governance-demo-report.md` under the “
 
 ---
 
-## 6. Formal verification hooks
+## 7. Formal verification hooks
 
 1. **Coverage remapping audit:**
    ```bash
@@ -148,7 +166,7 @@ Archive the resulting artefacts inside `reports/` alongside the governance dossi
 
 ---
 
-## 7. Evidence of execution
+## 8. Evidence of execution
 
 After each run:
 1. Commit the generated artefacts to a dedicated evidence branch or upload them to immutable storage (e.g., IPFS, Arweave).

--- a/demo/agi-governance/reports/governance-demo-dashboard.html
+++ b/demo/agi-governance/reports/governance-demo-dashboard.html
@@ -1,0 +1,482 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Solving α-AGI Governance — Governance Dashboard</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #020617;
+        --card: rgba(15, 23, 42, 0.72);
+        --accent: #38bdf8;
+        --accent-strong: #f97316;
+        --text: #f8fafc;
+        --muted: #94a3b8;
+        --border: rgba(148, 163, 184, 0.3);
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+      }
+      body {
+        margin: 0;
+        background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 38%),
+          radial-gradient(circle at bottom right, rgba(249, 115, 22, 0.18), transparent 42%),
+          var(--bg);
+        color: var(--text);
+        line-height: 1.6;
+      }
+      header {
+        padding: 3.5rem 4vw 2rem;
+        text-align: center;
+      }
+      header h1 {
+        margin: 0;
+        font-size: clamp(2.5rem, 4vw, 3.5rem);
+        font-weight: 700;
+        letter-spacing: 0.04em;
+      }
+      header p.meta {
+        margin: 0.4rem 0 0;
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+      main {
+        padding: 0 4vw 4rem;
+        display: grid;
+        gap: 2.75rem;
+      }
+      section.card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 18px;
+        padding: 2.2rem;
+        box-shadow: 0 32px 64px rgba(15, 23, 42, 0.45);
+        backdrop-filter: blur(18px);
+      }
+      section.card h2 {
+        margin-top: 0;
+        font-size: 1.6rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+      section.card h3 {
+        margin-top: 2rem;
+        font-size: 1.1rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--muted);
+      }
+      .grid {
+        display: grid;
+        gap: 1.8rem;
+      }
+      @media (min-width: 1080px) {
+        .grid-columns-3 {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+        .grid-columns-2 {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+      ul.metric-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.75rem;
+      }
+      ul.metric-list li {
+        font-size: 1rem;
+        background: rgba(15, 23, 42, 0.65);
+        border-radius: 12px;
+        padding: 1rem 1.2rem;
+        border: 1px solid rgba(56, 189, 248, 0.12);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+        border: 1px solid var(--border);
+        font-size: 0.95rem;
+      }
+      table th,
+      table td {
+        padding: 0.7rem 0.9rem;
+        border-bottom: 1px solid var(--border);
+        text-align: left;
+      }
+      table th {
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.78rem;
+      }
+      pre.mermaid {
+        background: rgba(15, 23, 42, 0.6);
+        border-radius: 16px;
+        padding: 1.4rem;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        overflow-x: auto;
+      }
+      #antifragility-chart {
+        width: 100%;
+        height: 280px;
+        margin-top: 1.2rem;
+        border-radius: 16px;
+        border: 1px solid rgba(56, 189, 248, 0.25);
+        background: rgba(15, 23, 42, 0.6);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      footer {
+        padding: 3rem 4vw;
+        text-align: center;
+        color: var(--muted);
+        font-size: 0.85rem;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        background: rgba(56, 189, 248, 0.18);
+        color: var(--accent);
+        border-radius: 999px;
+        padding: 0.4rem 0.9rem;
+        font-size: 0.85rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="badge">AGI Jobs v0 (v2) Superintelligence Console</div>
+      <h1>Solving α-AGI Governance</h1>
+      <p class="meta">Generated 2025-10-19T18:25:12.965Z • Version 1.1.0</p>
+      <p class="meta">Hamiltonian-guided governance drill proving AGI Jobs v0 (v2) delivers superintelligent coordination under absolute owner control.</p>
+    </header>
+    <main>
+      <section class="card grid grid-columns-3">
+        <div>
+          <h2>Thermodynamics</h2>
+          <ul class="metric-list">
+            <li>Gibbs free energy: <strong>69.80k kJ</strong></li>
+            <li>Landauer limit: <strong>0.00 kJ</strong></li>
+            <li>Free-energy margin: <strong>69.80k kJ</strong></li>
+            <li>Burn energy per block: <strong>4.36k kJ</strong></li>
+            <li>β inverse temperature: <strong>0.0725</strong></li>
+            <li>Partition function Z: <strong>1.115e-18</strong></li>
+          </ul>
+        </div>
+        <div>
+          <h2>Hamiltonian</h2>
+          <ul class="metric-list">
+            <li>Kinetic term: <strong>34149.74M</strong></li>
+            <li>Potential term: <strong>302.02k</strong></li>
+            <li>Energy: <strong>34149.44M</strong></li>
+            <li>Δ check: <strong>0.000e+0</strong></li>
+          </ul>
+        </div>
+        <div>
+          <h2>Owner Control</h2>
+          <ul class="metric-list">
+            <li>Owner: <strong>0xA1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1</strong></li>
+            <li>Pauser: <strong>0xB2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2</strong></li>
+            <li>Treasury: <strong>0xC3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3</strong></li>
+            <li>Timelock: <strong>691200 seconds</strong></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Energy → Governance Flow</h2>
+        <pre class="mermaid">flowchart LR
+  subgraph Energy[Energy Intelligence Stack]
+    Thermo[Gibbs Free Energy 69.80k kJ]
+    Burn[Burn Envelope 4.36k kJ/block]
+    Thermo --> Burn
+  end
+  subgraph Incentives[Mint/Burn Governance]
+    Mint[Mint η=0.94]
+    BurnCurve[Burn Curve Δ Escrow]
+    Mint --> BurnCurve
+  end
+  subgraph Equilibrium[Macro Equilibrium]
+    StratA[Replicator Δ=1.34e-1]
+    Divergence[Divergence 2.22e-16]
+    Payoff[Payoff 1.00 tokens]
+    StratA --> Divergence
+    Divergence --> Payoff
+  end
+  subgraph Risk[Risk Engine]
+    Residual[Residual 0.214]
+  end
+  subgraph Control[Owner Command Surface]
+    Owner((Owner 0xA1A1…A1A1))
+    Pauser([Pauser 0xB2B2…B2B2])
+    Treasury([Treasury 0xC3C3…C3C3])
+    Owner --> Pauser
+    Owner --> Treasury
+  end
+  subgraph Chain[Mainnet Envelope]
+    Governor[AGIJobsGovernor]
+    Monitor[HamiltonianMonitor]
+    Governor --> Monitor
+  end
+  Thermo --> Mint
+  BurnCurve --> StratA
+  Payoff --> Residual
+  Residual --> Owner
+  Owner --> Governor</pre>
+      </section>
+
+      <section class="card grid grid-columns-2">
+        <div>
+          <h2>Mint Ledger</h2>
+          <p>Total minted per event: <strong>117.50k tokens</strong> • Treasury mirror share 65.00%</p>
+          <table>
+            <thead><tr><th>Role</th><th>Share</th><th>Minted</th></tr></thead>
+            <tbody><tr><td>Agent</td><td>65.00%</td><td>76.38k tokens</td></tr>
+<tr><td>Validator</td><td>15.00%</td><td>17.63k tokens</td></tr>
+<tr><td>Operator</td><td>15.00%</td><td>17.63k tokens</td></tr>
+<tr><td>Employer</td><td>5.00%</td><td>5.88k tokens</td></tr></tbody>
+          </table>
+        </div>
+        <div>
+          <h2>Game-Theoretic Equilibrium</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Strategy</th><th>Replicator</th><th>Closed</th><th>Monte-Carlo</th><th>Continuous</th><th>Eigenvector</th>
+              </tr>
+            </thead>
+            <tbody><tr><td>Pareto-Coop</td><td>40.75%</td><td>33.33%</td><td>33.44%</td><td>40.75%</td><td>33.33%</td></tr>
+<tr><td>Thermo-Titan</td><td>36.56%</td><td>33.33%</td><td>32.91%</td><td>36.56%</td><td>33.33%</td></tr>
+<tr><td>Sentinel-Tactician</td><td>22.70%</td><td>33.33%</td><td>33.64%</td><td>22.70%</td><td>33.33%</td></tr></tbody>
+          </table>
+          <p>Deviation Δmax: <strong>1.365e-1</strong> • Divergence 2.220e-16</p>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Antifragility Tensor</h2>
+        <pre class="mermaid">mindmap
+  root((Antifragility Tensor))
+    "Quadratic curvature":::core
+      "2a=6.98e-10":::core
+    "Sigma Scan":::core
+        "σ=0.00":::sigma --> "Welfare -4.64k":::welfare
+        "σ=0.10":::sigma --> "Welfare -4.64k":::welfare
+        "σ=0.20":::sigma --> "Welfare -4.64k":::welfare
+        "σ=0.30":::sigma --> "Welfare -4.64k":::welfare
+    "Owner Actions":::core
+      "Mint Mirror 65.00%"
+      "Residual Risk 0.214"
+  classDef core fill:#111827,stroke:#38bdf8,stroke-width:2px,color:#f9fafb,font-weight:600;
+  classDef sigma fill:#1f2937,stroke:#f97316,stroke-width:2px,color:#fef3c7;font-weight:600;
+  classDef welfare fill:#0f172a,stroke:#22d3ee,stroke-width:2px,color:#ecfeff;font-weight:600;</pre>
+        <div id="antifragility-chart">Rendering antifragility curve…</div>
+        <table>
+          <thead><tr><th>σ</th><th>Welfare</th><th>Average payoff</th><th>Divergence</th></tr></thead>
+          <tbody><tr><td>0.00</td><td>-4.64k</td><td>1.00</td><td>7.68e-2</td></tr>
+<tr><td>0.10</td><td>-4.64k</td><td>1.00</td><td>7.62e-2</td></tr>
+<tr><td>0.20</td><td>-4.64k</td><td>1.00</td><td>7.69e-2</td></tr>
+<tr><td>0.30</td><td>-4.64k</td><td>1.00</td><td>7.73e-2</td></tr></tbody>
+        </table>
+      </section>
+
+      <section class="card grid grid-columns-2">
+        <div>
+          <h2>Risk Portfolio</h2>
+          <p>Residual risk: <strong>0.214</strong> • Threshold 0.300</p>
+          <pre class="mermaid">pie showData
+  title Residual Risk Distribution ×10⁻³
+  "R0 Specification drift" : 72.1600
+  "R1 Economic exploit" : 27.2700
+  "R2 Protocol attack" : 12.6000
+  "R3 Model misbehaviour" : 53.6250
+  "R4 Societal externality" : 48.8000</pre>
+          <table>
+            <thead><tr><th>ID</th><th>Threat</th><th>Likelihood</th><th>Impact</th><th>Coverage</th><th>Residual</th></tr></thead>
+            <tbody><tr><td>R0</td><td>Specification drift</td><td>0.22</td><td>0.80</td><td>59.00%</td><td>0.072</td></tr>
+<tr><td>R1</td><td>Economic exploit</td><td>0.18</td><td>0.75</td><td>79.80%</td><td>0.027</td></tr>
+<tr><td>R2</td><td>Protocol attack</td><td>0.10</td><td>0.90</td><td>86.00%</td><td>0.013</td></tr>
+<tr><td>R3</td><td>Model misbehaviour</td><td>0.25</td><td>0.65</td><td>67.00%</td><td>0.054</td></tr>
+<tr><td>R4</td><td>Societal externality</td><td>0.08</td><td>1.00</td><td>39.00%</td><td>0.049</td></tr></tbody>
+          </table>
+        </div>
+        <div>
+          <h2>Owner Command Surface</h2>
+          <pre class="mermaid">sequenceDiagram
+  participant O as Owner
+  participant G as AGIJobsGovernor
+  participant T as Treasury
+  participant M as Mission AI Field
+  O->>G: Pause / Resume Commands
+  O->>T: Mirror Mint 117.50k tokens
+  G->>M: Reconfigure Hamiltonian λ
+  M-->>G: Updated Divergence Metrics
+  G-->>O: Deterministic State Report
+  T-->>O: Treasury Mirror Share 65.00%</pre>
+          <h3>Monitoring Sentinels</h3>
+          <ul><li>Grafana circuit-breakers watching governance divergence</li>
+<li>On-chain staking slash monitors</li>
+<li>Adaptive fuzz oracle with spectral drift alerts</li></ul>
+          <h3>Capabilities</h3>
+          <table>
+            <thead><tr><th>Capability</th><th>Category</th><th>Script</th><th>Status</th></tr></thead>
+            <tbody><tr><td>Global pause switch</td><td>pause</td><td>owner:system-pause</td><td>✅</td></tr>
+<tr><td>Resume operations</td><td>resume</td><td>owner:system-pause</td><td>✅</td></tr>
+<tr><td>Tune Hamiltonian parameters</td><td>parameter</td><td>owner:command-center</td><td>✅</td></tr>
+<tr><td>Reward engine burn curve</td><td>treasury</td><td>reward-engine:update</td><td>✅</td></tr>
+<tr><td>Sentinel rotation</td><td>sentinel</td><td>owner:rotate</td><td>✅</td></tr>
+<tr><td>Timelocked upgrade queue</td><td>upgrade</td><td>owner:upgrade</td><td>✅</td></tr>
+<tr><td>Regulatory disclosure</td><td>compliance</td><td>owner:update-all</td><td>✅</td></tr></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card grid grid-columns-2">
+        <div>
+          <h2>On-Chain Contracts</h2>
+          <p>Network: <strong>Ethereum Mainnet-grade</strong> • Gas target 24 gwei • Confirmations 3</p>
+          <table>
+            <thead><tr><th>Contract</th><th>Address</th><th>Role</th></tr></thead>
+            <tbody><tr><td>AGIJobsGovernor</td><td>0xD4D4D4D4D4D4D4D4D4D4D4D4D4D4D4D4D4D4D4D4</td><td>Primary governance module</td></tr>
+<tr><td>AGIJobsTreasury</td><td>0xE5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5</td><td>Treasury vault / emission controller</td></tr>
+<tr><td>HamiltonianMonitor</td><td>0xF6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6</td><td>Energy coupling supervisor</td></tr></tbody>
+          </table>
+          <h3>Pausable Functions</h3>
+          <table>
+            <thead><tr><th>Contract</th><th>Function</th><th>Selector</th><th>Description</th></tr></thead>
+            <tbody><tr><td>AGIJobsGovernor</td><td>pause</td><td>0x8456cb59</td><td>Global stop for task orchestration</td></tr>
+<tr><td>AGIJobsGovernor</td><td>unpause</td><td>0x3f4ba83a</td><td>Resume operations</td></tr>
+<tr><td>AGIJobsTreasury</td><td>updateEmissionCurve</td><td>0xa10204e9</td><td>Adjusts reward burn / mint ratios</td></tr></tbody>
+          </table>
+        </div>
+        <div>
+          <h2>CI Enforcement</h2>
+          <p>Workflow <strong>ci (v2)</strong> • Concurrency <code>ci-${{ github.workflow }}-${{ github.ref }}</code> • Coverage ≥ 90%</p>
+          <table>
+            <thead><tr><th>Job ID</th><th>Name</th></tr></thead>
+            <tbody><tr><td>lint</td><td>Lint &amp; static checks</td></tr>
+<tr><td>tests</td><td>Tests</td></tr>
+<tr><td>foundry</td><td>Foundry</td></tr>
+<tr><td>coverage</td><td>Coverage thresholds</td></tr>
+<tr><td>summary</td><td>CI summary</td></tr></tbody>
+          </table>
+          <h3>Jacobian Diagnostics</h3>
+          <ul class="metric-list">
+            <li>Gershgorin bound: <strong>3.333e-1</strong></li>
+            <li>Spectral radius: <strong>1.000e+0</strong></li>
+            <li>Analytic vs numeric Δ: <strong>3.333e-1</strong></li>
+          </ul>
+        </div>
+      </section>
+    </main>
+    <footer>
+      Solving α-AGI Governance — evidence that AGI Jobs v0 (v2) gives non-technical owners full-spectrum control over a
+      civilisation-scale intelligence engine.
+    </footer>
+    <script type="module">
+      import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+      mermaid.initialize({ startOnLoad: true, theme: 'forest' });
+
+      const antifragilityData = [{"sigma":0,"welfare":-4639.957446808511},{"sigma":0.1,"welfare":-4639.957446808511},{"sigma":0.2,"welfare":-4639.957446808511},{"sigma":0.3,"welfare":-4639.957446808511}];
+      const chart = document.querySelector('#antifragility-chart');
+      if (chart && Array.isArray(antifragilityData) && antifragilityData.length > 0) {
+        const width = 760;
+        const height = 260;
+        const padding = 42;
+        const min = Math.min(...antifragilityData.map((d) => d.welfare));
+        const max = Math.max(...antifragilityData.map((d) => d.welfare));
+        const svgNS = 'http://www.w3.org/2000/svg';
+        const svg = document.createElementNS(svgNS, 'svg');
+        svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+        svg.setAttribute('width', '100%');
+        svg.setAttribute('height', '100%');
+        svg.style.overflow = 'visible';
+
+        const axis = document.createElementNS(svgNS, 'line');
+        axis.setAttribute('x1', String(padding));
+        axis.setAttribute('y1', String(height - padding));
+        axis.setAttribute('x2', String(width - padding));
+        axis.setAttribute('y2', String(height - padding));
+        axis.setAttribute('stroke', 'rgba(148, 163, 184, 0.6)');
+        axis.setAttribute('stroke-width', '1.5');
+        svg.appendChild(axis);
+
+        const yAxis = document.createElementNS(svgNS, 'line');
+        yAxis.setAttribute('x1', String(padding));
+        yAxis.setAttribute('y1', String(padding));
+        yAxis.setAttribute('x2', String(padding));
+        yAxis.setAttribute('y2', String(height - padding));
+        yAxis.setAttribute('stroke', 'rgba(148, 163, 184, 0.6)');
+        yAxis.setAttribute('stroke-width', '1.5');
+        svg.appendChild(yAxis);
+
+        const points = antifragilityData
+          .map((point, index) => {
+            const x = padding + (index / Math.max(antifragilityData.length - 1, 1)) * (width - padding * 2);
+            const normalised = max === min ? 0.5 : (point.welfare - min) / (max - min);
+            const y = height - padding - normalised * (height - padding * 2);
+            return x + ',' + y;
+          })
+          .join(' ');
+
+        const polyline = document.createElementNS(svgNS, 'polyline');
+        polyline.setAttribute('points', points);
+        polyline.setAttribute('fill', 'none');
+        polyline.setAttribute('stroke', 'url(#gradient)');
+        polyline.setAttribute('stroke-width', '3');
+        polyline.setAttribute('stroke-linejoin', 'round');
+        polyline.setAttribute('stroke-linecap', 'round');
+        svg.appendChild(polyline);
+
+        const gradient = document.createElementNS(svgNS, 'linearGradient');
+        gradient.setAttribute('id', 'gradient');
+        gradient.setAttribute('x1', '0%');
+        gradient.setAttribute('y1', '0%');
+        gradient.setAttribute('x2', '100%');
+        gradient.setAttribute('y2', '0%');
+        const stop1 = document.createElementNS(svgNS, 'stop');
+        stop1.setAttribute('offset', '0%');
+        stop1.setAttribute('stop-color', '#38bdf8');
+        const stop2 = document.createElementNS(svgNS, 'stop');
+        stop2.setAttribute('offset', '100%');
+        stop2.setAttribute('stop-color', '#f97316');
+        gradient.appendChild(stop1);
+        gradient.appendChild(stop2);
+        const defs = document.createElementNS(svgNS, 'defs');
+        defs.appendChild(gradient);
+        svg.insertBefore(defs, svg.firstChild);
+
+        antifragilityData.forEach((point, index) => {
+          const x = padding + (index / Math.max(antifragilityData.length - 1, 1)) * (width - padding * 2);
+          const normalised = max === min ? 0.5 : (point.welfare - min) / (max - min);
+          const y = height - padding - normalised * (height - padding * 2);
+          const circle = document.createElementNS(svgNS, 'circle');
+          circle.setAttribute('cx', String(x));
+          circle.setAttribute('cy', String(y));
+          circle.setAttribute('r', '6');
+          circle.setAttribute('fill', '#0ea5e9');
+          circle.setAttribute('stroke', '#082f49');
+          circle.setAttribute('stroke-width', '2');
+          svg.appendChild(circle);
+
+          const label = document.createElementNS(svgNS, 'text');
+          label.setAttribute('x', String(x));
+          label.setAttribute('y', String(y - 12));
+          label.setAttribute('fill', '#bae6fd');
+          label.setAttribute('font-size', '12');
+          label.setAttribute('text-anchor', 'middle');
+          label.textContent = point.welfare.toFixed(3);
+          svg.appendChild(label);
+        });
+
+        chart.innerHTML = '';
+        chart.appendChild(svg);
+      }
+    </script>
+  </body>
+</html>

--- a/demo/agi-governance/reports/governance-demo-report.md
+++ b/demo/agi-governance/reports/governance-demo-report.md
@@ -1,5 +1,5 @@
 # Solving α-AGI Governance — Governance Demonstration Report
-*Generated at:* 2025-10-19T17:44:55.574Z
+*Generated at:* 2025-10-19T18:25:12.965Z
 *Version:* 1.1.0
 
 > Hamiltonian-guided governance drill proving AGI Jobs v0 (v2) delivers superintelligent coordination under absolute owner control.
@@ -73,6 +73,47 @@
 | Major fault | 25.00% | 5.00k tokens | 3.75k tokens | 1.25k tokens | 0.00 tokens |
 | Critical attack | 100.00% | 20.00k tokens | 20.00k tokens | 0.00 tokens | 0.00 tokens |
 
+```mermaid
+flowchart LR
+  subgraph Energy[Energy Intelligence Stack]
+    Thermo[Gibbs Free Energy 69.80k kJ]
+    Burn[Burn Envelope 4.36k kJ/block]
+    Thermo --> Burn
+  end
+  subgraph Incentives[Mint/Burn Governance]
+    Mint[Mint η=0.94]
+    BurnCurve[Burn Curve Δ Escrow]
+    Mint --> BurnCurve
+  end
+  subgraph Equilibrium[Macro Equilibrium]
+    StratA[Replicator Δ=1.34e-1]
+    Divergence[Divergence 2.22e-16]
+    Payoff[Payoff 1.00 tokens]
+    StratA --> Divergence
+    Divergence --> Payoff
+  end
+  subgraph Risk[Risk Engine]
+    Residual[Residual 0.214]
+  end
+  subgraph Control[Owner Command Surface]
+    Owner((Owner 0xA1A1…A1A1))
+    Pauser([Pauser 0xB2B2…B2B2])
+    Treasury([Treasury 0xC3C3…C3C3])
+    Owner --> Pauser
+    Owner --> Treasury
+  end
+  subgraph Chain[Mainnet Envelope]
+    Governor[AGIJobsGovernor]
+    Monitor[HamiltonianMonitor]
+    Governor --> Monitor
+  end
+  Thermo --> Mint
+  BurnCurve --> StratA
+  Payoff --> Residual
+  Residual --> Owner
+  Owner --> Governor
+```
+
 ## 5. Game-Theoretic Macro-Equilibrium
 
 - **Discount factor:** 0.92 (must exceed 0.80 for uniqueness)
@@ -121,6 +162,24 @@
 | 0.20 | -4.64k | 1.00 | 7.69e-2 |
 | 0.30 | -4.64k | 1.00 | 7.73e-2 |
 
+```mermaid
+mindmap
+  root((Antifragility Tensor))
+    "Quadratic curvature":::core
+      "2a=6.98e-10":::core
+    "Sigma Scan":::core
+        "σ=0.00":::sigma --> "Welfare -4.64k":::welfare
+        "σ=0.10":::sigma --> "Welfare -4.64k":::welfare
+        "σ=0.20":::sigma --> "Welfare -4.64k":::welfare
+        "σ=0.30":::sigma --> "Welfare -4.64k":::welfare
+    "Owner Actions":::core
+      "Mint Mirror 65.00%"
+      "Residual Risk 0.214"
+  classDef core fill:#111827,stroke:#38bdf8,stroke-width:2px,color:#f9fafb,font-weight:600;
+  classDef sigma fill:#1f2937,stroke:#f97316,stroke-width:2px,color:#fef3c7;font-weight:600;
+  classDef welfare fill:#0f172a,stroke:#22d3ee,stroke-width:2px,color:#ecfeff;font-weight:600;
+```
+
 ## 7. Risk & Safety Audit
 
 - **Coverage weights:** staking 40.00%, formal 40.00%, fuzz 20.00%
@@ -134,6 +193,16 @@
 | R2 | Protocol attack | 0.10 | 0.90 | 86.00% | 0.013 |
 | R3 | Model misbehaviour | 0.25 | 0.65 | 67.00% | 0.054 |
 | R4 | Societal externality | 0.08 | 1.00 | 39.00% | 0.049 |
+
+```mermaid
+pie showData
+  title Residual Risk Distribution ×10⁻³
+  "R0 Specification drift" : 72.1600
+  "R1 Economic exploit" : 27.2700
+  "R2 Protocol attack" : 12.6000
+  "R3 Model misbehaviour" : 53.6250
+  "R4 Societal externality" : 48.8000
+```
 
 ## 8. Owner Supremacy & Command Surface
 
@@ -174,6 +243,20 @@
 - Grafana circuit-breakers watching governance divergence
 - On-chain staking slash monitors
 - Adaptive fuzz oracle with spectral drift alerts
+
+```mermaid
+sequenceDiagram
+  participant O as Owner
+  participant G as AGIJobsGovernor
+  participant T as Treasury
+  participant M as Mission AI Field
+  O->>G: Pause / Resume Commands
+  O->>T: Mirror Mint 117.50k tokens
+  G->>M: Reconfigure Hamiltonian λ
+  M-->>G: Updated Divergence Metrics
+  G-->>O: Deterministic State Report
+  T-->>O: Treasury Mirror Share 65.00%
+```
 
 ### Command Audit
 | Category | npm script | Status |

--- a/demo/agi-governance/reports/governance-demo-summary.json
+++ b/demo/agi-governance/reports/governance-demo-summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-19T17:44:55.574Z",
+  "generatedAt": "2025-10-19T18:25:12.965Z",
   "version": "1.1.0",
   "thermodynamics": {
     "gibbsFreeEnergyKJ": 69800,

--- a/demo/agi-governance/reports/governance-demo-validation.json
+++ b/demo/agi-governance/reports/governance-demo-validation.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2025-10-19T17:46:07.725Z",
-  "summaryTimestamp": "2025-10-19T17:44:55.574Z",
+  "generatedAt": "2025-10-19T18:25:23.490Z",
+  "summaryTimestamp": "2025-10-19T18:25:12.965Z",
   "missionVersion": "1.1.0",
   "results": [
     {

--- a/demo/agi-governance/reports/governance-demo-validation.md
+++ b/demo/agi-governance/reports/governance-demo-validation.md
@@ -1,6 +1,6 @@
 # Governance Demo Validation
-*Generated at:* 2025-10-19T17:46:07.725Z
-*Summary timestamp:* 2025-10-19T17:44:55.574Z
+*Generated at:* 2025-10-19T18:25:23.490Z
+*Summary timestamp:* 2025-10-19T18:25:12.965Z
 *Mission version:* 1.1.0
 
 | Check | Status | Details |


### PR DESCRIPTION
## Summary
- generate mermaid-driven flow, risk, owner sequence, and antifragility mind map visuals inside the Solving α-AGI Governance demo
- emit a cinematic HTML dashboard alongside the Markdown dossier so non-technical owners can explore metrics and diagrams
- refresh demo documentation and runbook to highlight the new dashboard experience and visual evidence workflow

## Testing
- npm run demo:agi-governance
- npm run demo:agi-governance:validate
- npm run demo:agi-governance:ci

------
https://chatgpt.com/codex/tasks/task_e_68f52b53407883338096a9c8e91bd80c