### PR TITLE
Add national supply chain demo orchestration kit

### DIFF
--- a/.github/workflows/demo-national-supply-chain-v0.yml
+++ b/.github/workflows/demo-national-supply-chain-v0.yml
@@ -1,0 +1,91 @@
+name: demo-national-supply-chain-v0
+
+on:
+  pull_request:
+    paths:
+      - 'demo/National-Supply-Chain-v0/**'
+      - 'scripts/v2/nationalSupplyChainDemo.ts'
+      - '.github/workflows/demo-national-supply-chain-v0.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  national-supply-chain:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: |
+            api.github.com
+            github.com
+            objects.githubusercontent.com
+            raw.githubusercontent.com
+            registry.npmjs.org
+            nodejs.org
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            **/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline --progress=false
+
+      - name: Render national supply chain intelligence kit
+        run: npm run demo:national-supply-chain:ci
+
+      - name: Validate manifest and export
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const manifestPath = 'reports/national-supply-chain/manifest.json';
+          const exportPath = 'demo/National-Supply-Chain-v0/ui/export/latest.json';
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+          const exportData = JSON.parse(fs.readFileSync(exportPath, 'utf8'));
+          if (!Array.isArray(manifest.files) || manifest.files.length < 5) {
+            throw new Error('Manifest missing required entries');
+          }
+          const required = [
+            'reports/national-supply-chain/dashboard.html',
+            'reports/national-supply-chain/summary.md',
+            'reports/national-supply-chain/mermaid.mmd',
+            'reports/national-supply-chain/mission-ledger.json',
+            'reports/national-supply-chain/owner-command-center.md'
+          ];
+          for (const file of required) {
+            if (!manifest.files.some((entry) => entry.path === file)) {
+              throw new Error(`Missing ${file} in manifest`);
+            }
+          }
+          if (!exportData || exportData.missionTag !== 'NATIONAL-SUPPLY-CHAIN-V0') {
+            throw new Error('Export missing missionTag NATIONAL-SUPPLY-CHAIN-V0');
+          }
+          if (!Array.isArray(exportData.jobs) || exportData.jobs.length === 0) {
+            throw new Error('Export jobs array empty');
+          }
+          console.log(`Validated manifest with ${manifest.files.length} files and export containing ${exportData.jobs.length} jobs.`);
+          NODE
+
+      - name: Upload intelligence kit
+        uses: actions/upload-artifact@v4
+        with:
+          name: national-supply-chain-kit
+          path: |
+            reports/national-supply-chain/
+            demo/National-Supply-Chain-v0/ui/export/latest.json

--- a/demo/National-Supply-Chain-v0/README.md
+++ b/demo/National-Supply-Chain-v0/README.md
@@ -1,0 +1,119 @@
+# National Supply Chain v0 Grand Demonstration
+
+The **National Supply Chain v0** demonstration proves that a non-technical steward can command an entire sovereign logistics grid with AGI Jobs v0 (v2). Launching a single script spins up the first-class AGI OS rehearsal, replays the ASI take-off harness with a national roster, and renders an intelligence kit with dashboards, manifests, and owner control drills. Every asset ships inside this repository—no bespoke contracts, forks, or external services are required.
+
+> ### Why it matters
+> - **Meta-agent orchestration at national scale.** The platform breaks down food, energy, medical, and infrastructure tasks into coordinated AI + human missions with validator-backed incentives.
+> - **Owner supremacy.** Every thermostat, treasury, and pause valve remains under sovereign control with timelocks, quadratic voting, and identity gating already wired.
+> - **Audit-grade evidence on demand.** The run outputs hash-signed manifests, mermaid system maps, and HTML command centres that regulators can verify without trusting a third party.
+
+## One-button launch
+
+```bash
+# from repository root
+chmod +x demo/National-Supply-Chain-v0/bin/launch.sh
+NATIONAL_SUPPLY_CHAIN_AUTO_YES=1 demo/National-Supply-Chain-v0/bin/launch.sh
+```
+
+The launcher:
+
+1. Runs `npm run demo:agi-os:first-class -- --auto-yes`, surfacing all sovereign control modules.
+2. Replays the ASI take-off harness with `ASI_TAKEOFF_PLAN_PATH=demo/National-Supply-Chain-v0/project-plan.national-supply-chain.json`, emitting validator receipts for the national roster.
+3. Executes `npm run demo:national-supply-chain:v0`, producing the intelligence kit under `reports/national-supply-chain/` and updating the interactive UI export.
+
+All artefacts are deterministic; rerunning the launcher reproduces identical manifests and hashes.
+
+## Mission atlas
+
+```mermaid
+flowchart LR
+  command(("Sovereign\nCommand")):::command
+  north_port[["Arctic Quantum Port"]]:::port
+  arctic_hub[["Permafrost Hub"]]:::hub
+  pacific_port[["Pacific Megaport"]]:::port
+  central_storage[["Strategic Reserve"]]:::storage
+  metro_grid[["Metro Microgrid"]]:::distribution
+  aid_cells[["Humanitarian Cells"]]:::relief
+  orbital_sensor(("Orbital Sentinel")):::sensor
+
+  command -->|Pause / Treasury / Thermostat| north_port
+  command -->|Quadratic governance| pacific_port
+  command -->|Reward engine, audits| central_storage
+  north_port -->|Icebreaker convoys| arctic_hub
+  pacific_port -->|Maglev spine| central_storage
+  central_storage -->|Electrified fleet| metro_grid
+  metro_grid -->|Drone drops| aid_cells
+  pacific_port -->|Orbital telemetry| orbital_sensor
+
+  classDef command fill:#0f172a,stroke:#38bdf8,stroke-width:2,color:#e2e8f0;
+  classDef port fill:#1e3a8a,stroke:#38bdf8,color:#f8fafc;
+  classDef hub fill:#312e81,stroke:#c084fc,color:#f5f3ff;
+  classDef storage fill:#064e3b,stroke:#34d399,color:#ecfdf5;
+  classDef distribution fill:#7c2d12,stroke:#fb923c,color:#ffedd5;
+  classDef relief fill:#7f1d1d,stroke:#fca5a5,color:#fee2e2;
+  classDef sensor fill:#3f3f46,stroke:#facc15,color:#fef9c3;
+```
+
+Every node in the atlas references concrete owner scripts from this repository (pause valves, thermostat adjustments, registry updates). The corridors are incentive-aware; validators monitor telemetry and can auto-trigger pause drills.
+
+## Surfaces for non-technical stewards
+
+| Surface | Path / URL | Purpose |
+| --- | --- | --- |
+| Launch script | `demo/National-Supply-Chain-v0/bin/launch.sh` | Full rehearsal (deploy/update, ASI take-off, intelligence kit). |
+| Interactive dashboard | `demo/National-Supply-Chain-v0/ui/index.html` | Visual supply chain cockpit, renders `ui/export/latest.json`. |
+| Owner Console (existing) | `npm --prefix apps/console run dev` | Treasury sliders, thermostat, pause toggles. |
+| Validator Dashboard (existing) | `docker compose up validator-ui` | Commit/reveal audits for corridors and relief missions. |
+| Enterprise Portal (existing) | `docker compose up enterprise-portal` | Post new supply chain missions with guided forms. |
+
+Open `demo/National-Supply-Chain-v0/ui/index.html` in a static server (for example `npx http-server demo/National-Supply-Chain-v0/ui`) and the dashboard will auto-load the latest export. Hover cards show corridor capacity, validator coverage, and owner commands relevant to each mission.
+
+## Reports generated on every run
+
+| File | Description |
+| --- | --- |
+| `reports/national-supply-chain/dashboard.html` | Rich HTML dossier with KPI grid, mermaid diagrams, and decision helpers. |
+| `reports/national-supply-chain/summary.md` | Markdown executive briefing with budgets, critical path, and owner drill results. |
+| `reports/national-supply-chain/mermaid.mmd` | Source mermaid definitions for supply atlas and Gantt timeline. |
+| `reports/national-supply-chain/mission-ledger.json` | Machine-readable ledger of jobs, dependencies, incentives, and corridor metrics. |
+| `reports/national-supply-chain/owner-command-center.md` | Checklist for pause, thermostat, reward engine, and registry updates. |
+| `reports/national-supply-chain/manifest.json` | SHA-256 hashes for every generated artefact; suitable for notarisation or IPFS pinning. |
+
+The launcher updates `demo/National-Supply-Chain-v0/ui/export/latest.json` so the UI remains in sync with the evidence bundle. No manual editing is required.
+
+## Owner control drills
+
+The demonstration assumes the contract owner is operating from the default Hardhat account (`0xf39f…`). The generated owner playbook instructs the steward to:
+
+1. Run pause toggles: `npm run owner:system-pause -- --action pause` then `--action unpause`.
+2. Tune incentives: `npm run owner:parameters` followed by `npm run thermostat:update`.
+3. Verify supremacy: `npm run owner:verify-control` and `npm run owner:command-center`.
+4. Rebalance treasuries: `npm run owner:mission-control` (prints allocations) then `npm run reward-engine:update` if adjustments are required.
+5. Inspect upgrade queue: `npm run owner:upgrade-status` to confirm timelocked governance integrity.
+
+Every command is referenced inside the generated `owner-command-center.md` with context, expected outputs, and rollback guidance.
+
+## Alignment with enforced v2 CI
+
+Branch protection already requires the v2 CI pipeline (`.github/workflows/ci.yml`). To validate locally before raising a PR:
+
+```bash
+npm run lint:check
+npm test
+npm run coverage:check
+npm run owner:verify-control
+npm run ci:verify-branch-protection
+npm run demo:national-supply-chain:v0
+```
+
+All GitHub PRs touching this demo also trigger `.github/workflows/demo-national-supply-chain-v0.yml`, which re-runs the intelligence kit generator and uploads the manifest so reviewers can verify hashes.
+
+## Next actions for operators
+
+- Share `reports/national-supply-chain/dashboard.html` with ministers and emergency responders.
+- Publish the `manifest.json` hash to IPFS or an internal registry for tamper-evident assurance.
+- Use `apps/console` to adjust thermostat temperatures or treasury splits in response to sensor data.
+- Extend `project-plan.national-supply-chain.json` with additional corridors or regional agencies; rerun the launcher to refresh every artefact.
+- Attach `ui/export/latest.json` to validation proposals so quadratic voters can audit incentives before approving changes.
+
+This demo packages a sovereign-scale logistics brain that humans can operate safely, transparently, and decisively.

--- a/demo/National-Supply-Chain-v0/RUNBOOK.md
+++ b/demo/National-Supply-Chain-v0/RUNBOOK.md
@@ -1,0 +1,129 @@
+# National Supply Chain v0 Runbook
+
+This runbook guides a non-technical steward through the full rehearsal. Every command is copy-paste ready and relies solely on tooling that ships with AGI Jobs v0 (v2).
+
+## 0. Environment checks
+
+1. Install Node `20.18.1` (run `nvm use` in the repo to reuse the checked-in `.nvmrc`).
+2. Install dependencies once: `npm ci --no-audit`.
+3. Optional but recommended: `docker compose pull` to cache dashboard containers.
+4. Ensure Hardhat Anvil is available (ships with `npm install`). The scripts automatically spawn/target `localhost`.
+
+## 1. Launch the demonstration
+
+```bash
+cd /path/to/AGIJobsv0
+chmod +x demo/National-Supply-Chain-v0/bin/launch.sh
+NATIONAL_SUPPLY_CHAIN_AUTO_YES=1 demo/National-Supply-Chain-v0/bin/launch.sh
+```
+
+Expected behaviour:
+
+- The first-class OS demo deploys/updates contracts, produces `reports/agi-os/*`, and surfaces owner control matrices.
+- The ASI take-off harness replays with the national plan, outputting receipts under `reports/asi-takeoff/`.
+- The national supply chain kit lands under `reports/national-supply-chain/` with dashboard, summary, mermaid, owner playbook, ledger, and manifest.
+
+The script is idempotent; rerun as many times as required.
+
+## 2. Spin up dashboards (optional but powerful)
+
+### Owner console & portals
+
+```bash
+# Terminal A
+npm --prefix apps/console run dev
+
+# Terminal B
+NODE_ENV=development docker compose up validator-ui enterprise-portal
+```
+
+Visit:
+
+- http://localhost:5173 — Owner Console (pause toggles, treasury sliders, thermostat controls).
+- http://localhost:3000 — Validator UI (commit/reveal flows, disputes, telemetry).
+- http://localhost:3001 — Enterprise Portal (guided mission authoring).
+
+### Static national cockpit
+
+```bash
+npx --yes http-server demo/National-Supply-Chain-v0/ui -p 4177
+```
+
+Open http://localhost:4177 to explore the generated dashboard using `ui/export/latest.json`.
+
+## 3. Owner drills (execute in order)
+
+1. **Pause rehearsal**
+   ```bash
+   npm run owner:system-pause -- --action pause
+   npm run owner:system-pause -- --action unpause
+   ```
+   Verify the dashboard updates within seconds.
+
+2. **Thermostat tuning**
+   ```bash
+   npm run owner:parameters
+   npm run thermostat:update
+   ```
+   Record the new values inside `reports/national-supply-chain/owner-command-center.md`.
+
+3. **Treasury rebalancing**
+   ```bash
+   npm run owner:mission-control
+   npm run reward-engine:update
+   ```
+
+4. **Identity / platform updates** (only if new participants were added)
+   ```bash
+   npm run identity:update
+   npm run platform:registry:update
+   ```
+
+5. **Governance verification**
+   ```bash
+   npm run owner:verify-control
+   npm run owner:upgrade-status
+   npm run ci:verify-branch-protection
+   ```
+
+## 4. Validate evidence bundle
+
+- Inspect `reports/national-supply-chain/summary.md` for the executive briefing.
+- Confirm `reports/national-supply-chain/manifest.json` lists SHA-256 hashes for every artefact.
+- Optional: notarise the manifest by uploading it to IPFS or anchoring the hash on-chain.
+- Share `demo/National-Supply-Chain-v0/ui/export/latest.json` with stakeholders who need an offline cockpit.
+
+## 5. Keep CI green
+
+Before opening a pull request or deploying to a new environment, run:
+
+```bash
+npm run lint:check
+npm test
+npm run coverage:check
+npm run owner:verify-control
+npm run ci:verify-branch-protection
+npm run demo:national-supply-chain:v0
+```
+
+GitHub automatically enforces the full v2 CI pipeline plus `demo-national-supply-chain-v0.yml` for any PR touching this demo. Upload artefacts from the Actions tab to share with reviewers.
+
+## 6. Extending the mission
+
+1. Edit `demo/National-Supply-Chain-v0/project-plan.national-supply-chain.json`.
+   - Add more `corridors`, `nodes`, or `jobs`.
+   - Update `ownerPlaybooks` if new scripts or controls are introduced.
+2. Rerun the launcher. All dashboards regenerate automatically.
+3. Use `apps/console` and the Validator UI to execute new missions live.
+
+## 7. Incident response
+
+If a disruption is detected:
+
+1. Trigger `npm run owner:system-pause -- --action pause`.
+2. Execute `npm run owner:emergency` for the emergency runbook (ships with the repo).
+3. Use `reports/national-supply-chain/mission-ledger.json` to identify impacted corridors.
+4. Post mitigation jobs via the Enterprise Portal or CLI.
+5. Resume operations once validators sign off: `npm run owner:system-pause -- --action unpause`.
+
+The combination of automation + human oversight keeps the nation resilient even in adversarial scenarios.

--- a/demo/National-Supply-Chain-v0/bin/launch.sh
+++ b/demo/National-Supply-Chain-v0/bin/launch.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PLAN_PATH="${SCRIPT_DIR}/project-plan.national-supply-chain.json"
+
+printf '\n🚛  National Supply Chain grand demonstration — ignition.\n\n'
+
+if [[ -z "${NODE_ENV:-}" ]]; then
+  export NODE_ENV=production
+fi
+
+export ASI_TAKEOFF_PLAN_PATH="${PLAN_PATH}"
+export NATIONAL_SUPPLY_CHAIN_PLAN_PATH="${PLAN_PATH}"
+
+cd "${ROOT_DIR}"
+
+# 1. Execute the first-class AGI OS rehearsal with sovereign controls surfaced.
+npm run demo:agi-os:first-class -- --auto-yes "$@"
+
+# 2. Re-run the ASI take-off harness with the national supply chain roster to emit mission receipts.
+npm run demo:asi-takeoff:local
+
+# 3. Render the national supply chain intelligence kit, dashboards, and manifest.
+npm run demo:national-supply-chain:v0
+
+printf '\n✅  National Supply Chain orchestration complete. Inspect reports/national-supply-chain/ for the intelligence kit.\n\n'

--- a/demo/National-Supply-Chain-v0/project-plan.national-supply-chain.json
+++ b/demo/National-Supply-Chain-v0/project-plan.national-supply-chain.json
@@ -1,0 +1,555 @@
+{
+  "initiative": "National Supply Chain Foresight Command",
+  "objective": "Demonstrate how AGI Jobs v0 (v2) autonomously orchestrates national logistics, humanitarian relief, energy flows, and strategic stockpiles while preserving sovereign owner control and quadratic governance levers.",
+  "metadata": {
+    "version": "v0.9.0",
+    "generatedAt": "2025-01-15T00:00:00.000Z",
+    "launchDate": "2025-04-01",
+    "timezone": "UTC",
+    "ownerEns": "national.supply.owner.agi.eth",
+    "missionTag": "NATIONAL-SUPPLY-CHAIN-V0"
+  },
+  "budget": {
+    "currency": "AGIALPHA",
+    "total": "1250000",
+    "operatorReserve": "275000",
+    "validatorPool": "210000"
+  },
+  "governance": {
+    "owner": "0xNATIONAL-SUPPLY-OWNER",
+    "pauseAuthority": "SystemPause",
+    "treasury": "0xTREASURY-NATIONAL-SUPPLY",
+    "thermostat": {
+      "initialTemperature": "0.18",
+      "surgeTemperature": "0.42",
+      "updateScript": "scripts/v2/updateThermostat.ts"
+    },
+    "ownerPlaybooks": [
+      "npm run owner:command-center",
+      "npm run owner:parameters",
+      "npm run owner:system-pause -- --action pause",
+      "npm run owner:system-pause -- --action unpause",
+      "npm run owner:upgrade-status",
+      "npm run owner:verify-control",
+      "npm run owner:mission-control"
+    ]
+  },
+  "participants": {
+    "agents": [
+      {
+        "handle": "aurora.supply.nation.agi.eth",
+        "role": "Northern Resilience Authority",
+        "capabilities": [
+          "Cryosphere logistics optimisation",
+          "Autonomous convoy routing",
+          "Quantum-secured telemetry"
+        ],
+        "wallet": "0xfA11eD000000000000000000000000000000A01",
+        "sovereign": "Aurora Coalition"
+      },
+      {
+        "handle": "pacific.logistics.nation.agi.eth",
+        "role": "Pacific Infrastructure Continuity Agency",
+        "capabilities": [
+          "Floating port assembly",
+          "Typhoon-adaptive routing",
+          "Dual-use port cyber defences"
+        ],
+        "wallet": "0xfA11eD000000000000000000000000000000A02",
+        "sovereign": "Pacific Alliance"
+      },
+      {
+        "handle": "continental.mesh.nation.agi.eth",
+        "role": "Continental Multi-Modal Mesh",
+        "capabilities": [
+          "AI rail corridor harmonisation",
+          "Supply-demand clearing market",
+          "National carbon-aware routing"
+        ],
+        "wallet": "0xfA11eD000000000000000000000000000000A03",
+        "sovereign": "Continental Union"
+      },
+      {
+        "handle": "healthshield.wallet.agi.eth",
+        "role": "HealthShield Humanitarian Collective",
+        "capabilities": [
+          "Rapid medical triage",
+          "Drone-based emergency delivery",
+          "On-chain citizen feedback"
+        ],
+        "wallet": "0xF9eD00000000000000000000000000000000B10",
+        "sovereign": "Community Treasury"
+      },
+      {
+        "handle": "railmesh.wallet.agi.eth",
+        "role": "RailMesh Cooperative Treasury",
+        "capabilities": [
+          "Rail hub automation",
+          "Predictive maintenance",
+          "Surge capacity hedging"
+        ],
+        "wallet": "0xF9eD00000000000000000000000000000000B11",
+        "sovereign": "Worker Consortium"
+      }
+    ],
+    "validators": [
+      {
+        "handle": "polaris.validator.agi.eth",
+        "stake": "160000",
+        "mandate": "Arctic supply assurance",
+        "wallet": "0xVAL1d0000000000000000000000000000000A1"
+      },
+      {
+        "handle": "trident.validator.agi.eth",
+        "stake": "145000",
+        "mandate": "Port security & customs compliance",
+        "wallet": "0xVAL1d0000000000000000000000000000000A2"
+      },
+      {
+        "handle": "helmsman.validator.agi.eth",
+        "stake": "132000",
+        "mandate": "Energy & medical supply telemetry",
+        "wallet": "0xVAL1d0000000000000000000000000000000A3"
+      }
+    ],
+    "humanOversight": [
+      {
+        "name": "National Logistics Command Council",
+        "responsibility": "Quadratic voting proposals, emergency pause authorisation"
+      },
+      {
+        "name": "Citizen Assurance Forum",
+        "responsibility": "Transparency, public communication, operator escalation"
+      }
+    ]
+  },
+  "supplyNetwork": {
+    "nodes": [
+      {
+        "id": "COMMAND",
+        "label": "Sovereign Command Centre",
+        "type": "command",
+        "region": "Capital",
+        "capacityTonnesPerDay": 0,
+        "controlSurfaces": ["owner:command-center", "owner:parameters", "owner:system-pause"],
+        "description": "Timelocked AGI Jobs owner console, treasury dashboards, pause valves."
+      },
+      {
+        "id": "NORTH_PORT",
+        "label": "Arctic Quantum Port",
+        "type": "port",
+        "region": "Aurora Coast",
+        "capacityTonnesPerDay": 4800,
+        "controlSurfaces": ["jobs/supply-routing", "thermostat"],
+        "description": "Icebreaker-ready modular port with AI berthing."
+      },
+      {
+        "id": "ARCTIC_HUB",
+        "label": "Permafrost Resilience Hub",
+        "type": "hub",
+        "region": "Polar Interior",
+        "capacityTonnesPerDay": 3600,
+        "controlSurfaces": ["inventory/oracle", "energy-oracle"],
+        "description": "Hybrid storage and additive manufacturing cluster for arctic communities."
+      },
+      {
+        "id": "PACIFIC_PORT",
+        "label": "Pacific Floating Megaport",
+        "type": "port",
+        "region": "Pacific Ocean",
+        "capacityTonnesPerDay": 5200,
+        "controlSurfaces": ["port/mesh", "quadratic-voting"],
+        "description": "Typhoon adaptive platform with autonomous cranes and customs."
+      },
+      {
+        "id": "CENTRAL_STORAGE",
+        "label": "National Strategic Reserve",
+        "type": "storage",
+        "region": "Central Corridor",
+        "capacityTonnesPerDay": 6400,
+        "controlSurfaces": ["treasury/rebalance", "owner:mission-control"],
+        "description": "Bi-directional energy, food, and medical stockpile with robotics."
+      },
+      {
+        "id": "METRO_GRID",
+        "label": "Metropolitan Microgrid",
+        "type": "distribution",
+        "region": "Capital",
+        "capacityTonnesPerDay": 2900,
+        "controlSurfaces": ["demand-response", "owner:parameters"],
+        "description": "AI-governed microgrids, desalination, and hospital supply pipelines."
+      },
+      {
+        "id": "AID_CELLS",
+        "label": "Humanitarian Field Cells",
+        "type": "relief",
+        "region": "National",
+        "capacityTonnesPerDay": 1800,
+        "controlSurfaces": ["community-wallet", "supplychain/agent"],
+        "description": "Distributed drone depots and mobile clinics activated via HealthShield."
+      },
+      {
+        "id": "ORBITAL_SENSOR",
+        "label": "Orbital Supply Sentinel",
+        "type": "sensor",
+        "region": "LEO",
+        "capacityTonnesPerDay": 0,
+        "controlSurfaces": ["telemetry", "owner:surface"],
+        "description": "Satellite mesh feeding weather, customs, and congestion signals."
+      }
+    ],
+    "corridors": [
+      {
+        "id": "ARCTIC-AIRBRIDGE",
+        "from": "NORTH_PORT",
+        "to": "ARCTIC_HUB",
+        "mode": "VTOL heavy lift",
+        "capacityTonnesPerDay": 900,
+        "latencyHours": 6,
+        "resilience": "Redundant thermal shielding & validator telemetry"
+      },
+      {
+        "id": "PORT-SPOKE-NORTH",
+        "from": "COMMAND",
+        "to": "NORTH_PORT",
+        "mode": "Icebreaker convoy",
+        "capacityTonnesPerDay": 2800,
+        "latencyHours": 12,
+        "resilience": "Quadratic validator quorum w/ automated replan"
+      },
+      {
+        "id": "PACIFIC-RAIL",
+        "from": "PACIFIC_PORT",
+        "to": "CENTRAL_STORAGE",
+        "mode": "Maglev & drone mesh",
+        "capacityTonnesPerDay": 2400,
+        "latencyHours": 9,
+        "resilience": "Dual stake guardrails + pause triggers"
+      },
+      {
+        "id": "CENTRAL-METRO",
+        "from": "CENTRAL_STORAGE",
+        "to": "METRO_GRID",
+        "mode": "Autonomous electric fleet",
+        "capacityTonnesPerDay": 1800,
+        "latencyHours": 4,
+        "resilience": "Thermostat-driven incentives"
+      },
+      {
+        "id": "METRO-RELIEF",
+        "from": "METRO_GRID",
+        "to": "AID_CELLS",
+        "mode": "Drone & amphibious",
+        "capacityTonnesPerDay": 600,
+        "latencyHours": 2,
+        "resilience": "Citizen validator quorum & DID gating"
+      },
+      {
+        "id": "PACIFIC-ORBITAL",
+        "from": "PACIFIC_PORT",
+        "to": "ORBITAL_SENSOR",
+        "mode": "Space elevator cargo",
+        "capacityTonnesPerDay": 50,
+        "latencyHours": 3,
+        "resilience": "Zero-trust telemetry encryption"
+      }
+    ],
+    "resilienceProfiles": [
+      {
+        "id": "ICEBREAKER-HARDENED",
+        "description": "Dual redundant convoys, thermal hulls, validator-signed navigation.",
+        "recommendedControls": ["owner:system-pause", "monitoring:sentinels", "thermostat:update"]
+      },
+      {
+        "id": "PACIFIC-REPLENISH",
+        "description": "Rapid modular pier deployment, quadratic voting for berth priority.",
+        "recommendedControls": ["owner:parameters", "owner:command-center", "reward-engine:update"]
+      },
+      {
+        "id": "CITIZEN-RESPONSE",
+        "description": "Community wallets, DID gating, validator-mediated payouts.",
+        "recommendedControls": ["identity:update", "owner:mission-control", "platform:registry:update"]
+      }
+    ]
+  },
+  "operations": {
+    "phases": [
+      {
+        "id": "STABILISE",
+        "title": "Stabilise critical lifelines",
+        "windowDays": 21,
+        "focus": ["Food", "Medical", "Energy"],
+        "ownerControls": ["owner:system-pause", "owner:command-center", "owner:parameters"],
+        "deliverables": [
+          "Deploy thermodynamic guardrails",
+          "Spin up rapid relief corridors",
+          "Publish sovereign command map"
+        ]
+      },
+      {
+        "id": "EXPAND",
+        "title": "Expand inter-regional capacity",
+        "windowDays": 45,
+        "focus": ["Infrastructure", "Energy storage", "Data fusion"],
+        "ownerControls": ["owner:mission-control", "owner:parameters", "thermostat:update"],
+        "deliverables": [
+          "Activate floating megaports",
+          "Commission orbital sentinel",
+          "Publish corridor capacity oracles"
+        ]
+      },
+      {
+        "id": "OPTIMISE",
+        "title": "Optimise incentives & market balance",
+        "windowDays": 60,
+        "focus": ["Dynamic pricing", "Validator incentives", "Quadratic votes"],
+        "ownerControls": ["owner:command-center", "reward-engine:update", "platform:registry:update"],
+        "deliverables": [
+          "Incentive thermostat tuned",
+          "Validator mesh calibrations",
+          "Citizen quadratic vote results"
+        ]
+      },
+      {
+        "id": "HARDEN",
+        "title": "Harden resilience & audit loops",
+        "windowDays": 30,
+        "focus": ["Pause drills", "Audit trails", "Sovereign reporting"],
+        "ownerControls": ["owner:verify-control", "owner:mission-control", "owner:upgrade-status"],
+        "deliverables": [
+          "System pause rehearsal",
+          "Grand manifest notarised",
+          "Stakeholder evidence bundle"
+        ]
+      }
+    ]
+  },
+  "jobs": [
+    {
+      "id": "ARCTIC-FOOD-RELAY",
+      "title": "Stabilise Arctic food and medicine relay",
+      "phase": "STABILISE",
+      "reward": "180000",
+      "deadlineDays": 35,
+      "durationDays": 21,
+      "dependencies": [],
+      "energyBudget": "72000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.17",
+        "adjustmentOnDelay": "raise-temperature"
+      },
+      "corridors": ["PORT-SPOKE-NORTH", "ARCTIC-AIRBRIDGE"],
+      "assigned": [
+        {
+          "agent": "aurora.supply.nation.agi.eth",
+          "responsibility": "Deploy icebreaker convoys and VTOL grid"
+        },
+        {
+          "agent": "healthshield.wallet.agi.eth",
+          "responsibility": "Coordinate field triage nodes"
+        }
+      ],
+      "validatorFocus": [
+        "polaris.validator.agi.eth",
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "AI convoys deliver 5,000 tonnes of food and medical supplies per week",
+        "Validator network signs real-time inventory snapshots",
+        "Owner thermostat calibrates incentives for sub-zero operations"
+      ]
+    },
+    {
+      "id": "PACIFIC-HUB-EXPANSION",
+      "title": "Deploy Pacific floating logistics mega-hub",
+      "phase": "EXPAND",
+      "reward": "220000",
+      "deadlineDays": 90,
+      "durationDays": 40,
+      "dependencies": ["ARCTIC-FOOD-RELAY"],
+      "energyBudget": "98000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.23",
+        "adjustmentOnDelay": "double-validator-bonus"
+      },
+      "corridors": ["PACIFIC-RAIL", "PACIFIC-ORBITAL"],
+      "assigned": [
+        {
+          "agent": "pacific.logistics.nation.agi.eth",
+          "responsibility": "Assemble modular piers"
+        },
+        {
+          "agent": "continental.mesh.nation.agi.eth",
+          "responsibility": "Synchronise inland maglev"
+        }
+      ],
+      "validatorFocus": [
+        "trident.validator.agi.eth"
+      ],
+      "brief": [
+        "Activate floating megaport with 200 autonomous cranes",
+        "Spin up orbital sentinel handshake for customs",
+        "Owner command centre verifies berth prioritisation via quadratic vote"
+      ]
+    },
+    {
+      "id": "CENTRAL-RESERVE-AUTOMATION",
+      "title": "Automate strategic reserve balancing",
+      "phase": "OPTIMISE",
+      "reward": "195000",
+      "deadlineDays": 110,
+      "durationDays": 30,
+      "dependencies": ["PACIFIC-HUB-EXPANSION"],
+      "energyBudget": "64000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.13",
+        "adjustmentOnDelay": "increase-agent-share"
+      },
+      "corridors": ["PACIFIC-RAIL", "CENTRAL-METRO"],
+      "assigned": [
+        {
+          "agent": "continental.mesh.nation.agi.eth",
+          "responsibility": "Optimise maglev + electric fleet"
+        },
+        {
+          "agent": "railmesh.wallet.agi.eth",
+          "responsibility": "Treasury automation and predictive maintenance"
+        }
+      ],
+      "validatorFocus": [
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Deploy reinforcement learning agents on stockpile hedging",
+        "Publish energy + nutrition coverage dashboards",
+        "Owner triggers reward engine update for fair share distribution"
+      ]
+    },
+    {
+      "id": "CITIZEN-RESPONSE-ACTIVATION",
+      "title": "Activate citizen humanitarian mesh",
+      "phase": "OPTIMISE",
+      "reward": "165000",
+      "deadlineDays": 105,
+      "durationDays": 25,
+      "dependencies": ["ARCTIC-FOOD-RELAY"],
+      "energyBudget": "54000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.19",
+        "adjustmentOnDelay": "trigger-pause-check"
+      },
+      "corridors": ["METRO-RELIEF"],
+      "assigned": [
+        {
+          "agent": "healthshield.wallet.agi.eth",
+          "responsibility": "Citizen DID onboarding"
+        },
+        {
+          "agent": "railmesh.wallet.agi.eth",
+          "responsibility": "Treasury payout automation"
+        }
+      ],
+      "validatorFocus": [
+        "polaris.validator.agi.eth",
+        "trident.validator.agi.eth"
+      ],
+      "brief": [
+        "Launch DID-gated citizen relief missions",
+        "Validators approve quadratic reward allocations",
+        "Owner monitors supply plan autop-run via CLI"
+      ]
+    },
+    {
+      "id": "VALIDATION-GRAND-AUDIT",
+      "title": "Validator coalition grand audit",
+      "phase": "HARDEN",
+      "reward": "155000",
+      "deadlineDays": 130,
+      "durationDays": 20,
+      "dependencies": [
+        "PACIFIC-HUB-EXPANSION",
+        "CENTRAL-RESERVE-AUTOMATION",
+        "CITIZEN-RESPONSE-ACTIVATION"
+      ],
+      "energyBudget": "41000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.08",
+        "adjustmentOnDelay": "raise-temperature"
+      },
+      "corridors": ["COMMAND"],
+      "assigned": [
+        {
+          "agent": "polaris.validator.agi.eth",
+          "responsibility": "Arctic logistic evidence"
+        },
+        {
+          "agent": "trident.validator.agi.eth",
+          "responsibility": "Port security attestations"
+        },
+        {
+          "agent": "helmsman.validator.agi.eth",
+          "responsibility": "Energy + medical telemetry assurance"
+        }
+      ],
+      "validatorFocus": [
+        "polaris.validator.agi.eth",
+        "trident.validator.agi.eth",
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Compile audit bundle for national senate",
+        "Verify owner pause + resume logs",
+        "Publish thermodynamic telemetry for all corridors"
+      ]
+    },
+    {
+      "id": "TREASURY-REBALANCING-DRILL",
+      "title": "Owner treasury rebalancing + pause drill",
+      "phase": "HARDEN",
+      "reward": "120000",
+      "deadlineDays": 140,
+      "durationDays": 12,
+      "dependencies": ["VALIDATION-GRAND-AUDIT"],
+      "energyBudget": "22000",
+      "thermodynamicProfile": {
+        "expectedEntropy": "0.05",
+        "adjustmentOnDelay": "trigger-pause-check"
+      },
+      "corridors": ["COMMAND", "CENTRAL-METRO"],
+      "assigned": [
+        {
+          "agent": "aurora.supply.nation.agi.eth",
+          "responsibility": "Execute owner commands via CLI"
+        },
+        {
+          "agent": "owner",
+          "responsibility": "Approve thermostat + treasury adjustments"
+        }
+      ],
+      "validatorFocus": [
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Run pause + resume using owner command centre",
+        "Rebalance treasury between validator and agent pools",
+        "Produce notarised manifest + hashed summary"
+      ]
+    }
+  ],
+  "reporting": {
+    "artifacts": {
+      "dashboard": "reports/national-supply-chain/dashboard.html",
+      "summary": "reports/national-supply-chain/summary.md",
+      "mermaid": "reports/national-supply-chain/mermaid.mmd",
+      "ledger": "reports/national-supply-chain/mission-ledger.json",
+      "ownerPlaybook": "reports/national-supply-chain/owner-command-center.md",
+      "manifest": "reports/national-supply-chain/manifest.json"
+    },
+    "dashboards": [
+      "demo/National-Supply-Chain-v0/ui/index.html",
+      "apps/console",
+      "docker compose validator-ui",
+      "enterprise portal"
+    ]
+  }
+}

--- a/demo/National-Supply-Chain-v0/ui/app.js
+++ b/demo/National-Supply-Chain-v0/ui/app.js
@@ -1,0 +1,332 @@
+const TRANSCRIPT_PATHS = ['export/latest.json', '../export/latest.json', 'sample.json'];
+
+const state = {
+  data: null,
+  phaseFilter: 'all',
+};
+
+const fmtNumber = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+
+const createCurrencyFormatter = (currency) => {
+  try {
+    const formatter = new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    });
+    return (value) => formatter.format(value);
+  } catch (error) {
+    console.warn(`Falling back to numeric formatting for currency ${currency}:`, error);
+    return (value) => `${fmtNumber.format(value)} ${currency}`.trim();
+  }
+};
+
+const fmtDate = (iso) =>
+  new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  });
+
+const fmtSlack = (days) => `${days} d`;
+
+async function loadData() {
+  for (const path of TRANSCRIPT_PATHS) {
+    try {
+      const res = await fetch(path, { cache: 'no-store' });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      return res.json();
+    } catch (error) {
+      console.warn(`Unable to load ${path}:`, error);
+    }
+  }
+  throw new Error('No national supply chain export found. Run npm run demo:national-supply-chain:v0.');
+}
+
+function clear(node) {
+  while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+function renderHeader(data) {
+  document.querySelector('[data-mission-title]').textContent = data.initiative;
+  document.querySelector('[data-mission-objective]').textContent = data.objective;
+  document.querySelector('[data-mission-tag]').textContent = data.missionTag || 'NATIONAL-SUPPLY-CHAIN';
+  document.querySelector('[data-generated-at]').textContent = data.generatedAt
+    ? new Date(data.generatedAt).toLocaleString()
+    : 'Unknown';
+  document.querySelector('[data-network]').textContent = data.network || '—';
+  document.querySelector('[data-owner-ens]').textContent = data.ownerEns || '—';
+}
+
+function renderMetrics(data) {
+  const container = document.querySelector('[data-metrics]');
+  clear(container);
+  const formatCurrency = createCurrencyFormatter(data.budget.currency);
+  const stats = [
+    { label: 'Jobs orchestrated', value: fmtNumber.format(data.metrics.jobCount) },
+    { label: 'Phases', value: fmtNumber.format(data.metrics.phaseCount) },
+    { label: 'Agents', value: fmtNumber.format(data.metrics.agentCount) },
+    { label: 'Validators', value: fmtNumber.format(data.metrics.validatorCount) },
+    { label: 'Total reward', value: formatCurrency(data.metrics.totalReward) },
+    { label: 'Operator reserve', value: formatCurrency(data.budget.operatorReserve) },
+    { label: 'Validator pool', value: formatCurrency(data.budget.validatorPool) },
+    { label: 'Critical path (days)', value: fmtNumber.format(data.metrics.criticalPathDays) },
+    { label: 'Max concurrency', value: fmtNumber.format(data.metrics.maxConcurrency) },
+    { label: 'Corridor capacity (t/day)', value: fmtNumber.format(data.metrics.corridorCapacity) },
+    { label: 'Validator stake', value: formatCurrency(data.metrics.validatorStake) },
+  ];
+
+  for (const stat of stats) {
+    const node = document.createElement('div');
+    node.className = 'stat';
+    const label = document.createElement('div');
+    label.className = 'stat__label';
+    label.textContent = stat.label;
+    const value = document.createElement('div');
+    value.className = 'stat__value';
+    value.textContent = stat.value;
+    node.appendChild(label);
+    node.appendChild(value);
+    container.appendChild(node);
+  }
+}
+
+function renderPhases(data) {
+  const container = document.querySelector('[data-phase-filters]');
+  clear(container);
+
+  const list = document.createElement('div');
+  list.className = 'pill-group';
+
+  const allButton = document.createElement('button');
+  allButton.type = 'button';
+  allButton.className = `btn ${state.phaseFilter === 'all' ? 'active' : ''}`;
+  allButton.textContent = 'All phases';
+  allButton.addEventListener('click', () => {
+    state.phaseFilter = 'all';
+    renderPhases(data);
+    renderJobs(data);
+  });
+  container.appendChild(allButton);
+
+  for (const phase of data.phases) {
+    const card = document.createElement('article');
+    card.className = `phase-card ${state.phaseFilter === phase.id ? 'active' : ''}`;
+    card.tabIndex = 0;
+
+    const title = document.createElement('h3');
+    title.textContent = `${phase.title}`;
+    card.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.className = 'phase-meta';
+    meta.textContent = `${phase.windowDays} day window · Focus: ${phase.focus.join(', ')}`;
+    card.appendChild(meta);
+
+    const controls = document.createElement('div');
+    controls.className = 'pill-group';
+    for (const control of phase.ownerControls) {
+      const pill = document.createElement('span');
+      pill.className = 'pill';
+      pill.textContent = control;
+      controls.appendChild(pill);
+    }
+    card.appendChild(controls);
+
+    const deliverables = document.createElement('div');
+    deliverables.className = 'phase-meta';
+    deliverables.textContent = `Deliverables: ${phase.deliverables.join('; ')}`;
+    card.appendChild(deliverables);
+
+    card.addEventListener('click', () => {
+      state.phaseFilter = phase.id;
+      renderPhases(data);
+      renderJobs(data);
+    });
+    card.addEventListener('keypress', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        state.phaseFilter = phase.id;
+        renderPhases(data);
+        renderJobs(data);
+      }
+    });
+
+    container.appendChild(card);
+  }
+}
+
+function renderJobs(data) {
+  const tbody = document.querySelector('[data-job-rows]');
+  clear(tbody);
+  const formatCurrency = createCurrencyFormatter(data.budget.currency);
+
+  const jobs = data.jobs.filter((job) => state.phaseFilter === 'all' || job.phase === state.phaseFilter);
+
+  if (jobs.length === 0) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 9;
+    cell.className = 'loading';
+    cell.textContent = 'No jobs in this phase filter.';
+    row.appendChild(cell);
+    tbody.appendChild(row);
+    return;
+  }
+
+  for (const job of jobs) {
+    const row = document.createElement('tr');
+    if (job.critical) row.classList.add('critical');
+
+    const idCell = document.createElement('td');
+    idCell.textContent = job.id;
+    row.appendChild(idCell);
+
+    const titleCell = document.createElement('td');
+    titleCell.textContent = job.title;
+    if (job.brief && job.brief.length) {
+      const hint = document.createElement('span');
+      hint.className = 'subtle';
+      hint.textContent = job.brief.join(' • ');
+      titleCell.appendChild(hint);
+    }
+    row.appendChild(titleCell);
+
+    const phaseCell = document.createElement('td');
+    phaseCell.textContent = job.phaseTitle || job.phase;
+    row.appendChild(phaseCell);
+
+    const windowCell = document.createElement('td');
+    windowCell.innerHTML = `${fmtDate(job.startDate)} → ${fmtDate(job.endDate)}<span class="subtle">Deadline ${fmtDate(job.deadlineDate)}</span>`;
+    row.appendChild(windowCell);
+
+    const rewardCell = document.createElement('td');
+    rewardCell.textContent = formatCurrency(job.reward);
+    row.appendChild(rewardCell);
+
+    const slackCell = document.createElement('td');
+    slackCell.textContent = fmtSlack(job.slackDays);
+    row.appendChild(slackCell);
+
+    const corridorCell = document.createElement('td');
+    corridorCell.textContent = job.corridors.join(', ');
+    row.appendChild(corridorCell);
+
+    const agentCell = document.createElement('td');
+    agentCell.innerHTML = job.assigned
+      .map((assignment) => `${assignment.agent}<span class="subtle">${assignment.responsibility}</span>`)
+      .join('<br/>');
+    row.appendChild(agentCell);
+
+    const validatorCell = document.createElement('td');
+    validatorCell.textContent = job.validators.join(', ');
+    row.appendChild(validatorCell);
+
+    tbody.appendChild(row);
+  }
+}
+
+function renderCorridors(data) {
+  const container = document.querySelector('[data-corridors]');
+  clear(container);
+
+  for (const corridor of data.corridors) {
+    const card = document.createElement('article');
+    card.className = 'corridor-card';
+
+    const title = document.createElement('h3');
+    title.textContent = corridor.id;
+    card.appendChild(title);
+
+    const mode = document.createElement('div');
+    mode.className = 'phase-meta';
+    mode.textContent = `${corridor.mode} · ${corridor.capacityTonnesPerDay} t/day · Latency ${corridor.latencyHours} h`;
+    card.appendChild(mode);
+
+    const resilience = document.createElement('div');
+    resilience.className = 'phase-meta';
+    resilience.textContent = corridor.resilience;
+    card.appendChild(resilience);
+
+    const ownership = document.createElement('div');
+    ownership.className = 'phase-meta';
+    ownership.textContent = `Owner controls: ${corridor.ownerControls.join(', ')}`;
+    card.appendChild(ownership);
+
+    container.appendChild(card);
+  }
+}
+
+function renderOwnerControls(data) {
+  const list = document.querySelector('[data-owner-controls]');
+  clear(list);
+  for (const command of data.ownerPlaybooks) {
+    const item = document.createElement('li');
+    item.textContent = command;
+    list.appendChild(item);
+  }
+}
+
+function renderValidators(data) {
+    const container = document.querySelector('[data-validators]');
+  clear(container);
+  const formatCurrency = createCurrencyFormatter(data.budget.currency);
+  for (const validator of data.validators) {
+    const card = document.createElement('article');
+    card.className = 'validator-card';
+
+    const title = document.createElement('h3');
+    title.textContent = validator.handle;
+    card.appendChild(title);
+
+    const stake = document.createElement('div');
+    stake.className = 'phase-meta';
+    stake.textContent = `Stake: ${formatCurrency(validator.stake)}`;
+    card.appendChild(stake);
+
+    const mandate = document.createElement('div');
+    mandate.className = 'phase-meta';
+    mandate.textContent = validator.mandate;
+    card.appendChild(mandate);
+
+    container.appendChild(card);
+  }
+}
+
+function renderMermaid(data) {
+  const network = document.querySelector('[data-mermaid-network]');
+  const gantt = document.querySelector('[data-mermaid-gantt]');
+  clear(network);
+  clear(gantt);
+  network.textContent = data.mermaid?.network || 'graph TD\n  A[No network diagram generated]\n  A --> B[Run npm run demo:national-supply-chain:v0]';
+  gantt.textContent = data.mermaid?.gantt || 'gantt\n  title Run npm run demo:national-supply-chain:v0 to generate timeline';
+  if (window.mermaid) {
+    window.mermaid.initialize(window.mermaidConfig || { startOnLoad: false, theme: 'dark' });
+    window.mermaid.run({ nodes: [network, gantt] });
+  }
+}
+
+async function init() {
+  try {
+    const data = await loadData();
+    state.data = data;
+    renderHeader(data);
+    renderMetrics(data);
+    renderPhases(data);
+    renderJobs(data);
+    renderCorridors(data);
+    renderOwnerControls(data);
+    renderValidators(data);
+    renderMermaid(data);
+    document.querySelector('[data-refresh-mermaid]').addEventListener('click', () => renderMermaid(state.data));
+  } catch (error) {
+    console.error(error);
+    const body = document.querySelector('body');
+    const notice = document.createElement('div');
+    notice.className = 'card';
+    notice.innerHTML = `<h2>Supply chain data missing</h2><p>${error.message}</p>`;
+    body.appendChild(notice);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/demo/National-Supply-Chain-v0/ui/export/latest.json
+++ b/demo/National-Supply-Chain-v0/ui/export/latest.json
@@ -1,0 +1,524 @@
+{
+  "initiative": "National Supply Chain Foresight Command",
+  "objective": "Demonstrate how AGI Jobs v0 (v2) autonomously orchestrates national logistics, humanitarian relief, energy flows, and strategic stockpiles while preserving sovereign owner control and quadratic governance levers.",
+  "missionTag": "NATIONAL-SUPPLY-CHAIN-V0",
+  "generatedAt": "2025-01-15T00:00:00.000Z",
+  "launchDate": "2025-04-01",
+  "network": "Hardhat localhost (31337)",
+  "ownerEns": "national.supply.owner.agi.eth",
+  "budget": {
+    "currency": "AGIALPHA",
+    "total": 1250000,
+    "operatorReserve": 275000,
+    "validatorPool": 210000
+  },
+  "metrics": {
+    "jobCount": 6,
+    "phaseCount": 4,
+    "agentCount": 5,
+    "validatorCount": 3,
+    "totalReward": 1035000,
+    "operatorReserve": 275000,
+    "validatorPool": 210000,
+    "criticalPathDays": 123,
+    "maxConcurrency": 2,
+    "corridorCapacity": 8550,
+    "validatorStake": 437000
+  },
+  "phases": [
+    {
+      "id": "STABILISE",
+      "title": "Stabilise critical lifelines",
+      "windowDays": 21,
+      "focus": [
+        "Food",
+        "Medical",
+        "Energy"
+      ],
+      "ownerControls": [
+        "owner:system-pause",
+        "owner:command-center",
+        "owner:parameters"
+      ],
+      "deliverables": [
+        "Deploy thermodynamic guardrails",
+        "Spin up rapid relief corridors",
+        "Publish sovereign command map"
+      ]
+    },
+    {
+      "id": "EXPAND",
+      "title": "Expand inter-regional capacity",
+      "windowDays": 45,
+      "focus": [
+        "Infrastructure",
+        "Energy storage",
+        "Data fusion"
+      ],
+      "ownerControls": [
+        "owner:mission-control",
+        "owner:parameters",
+        "thermostat:update"
+      ],
+      "deliverables": [
+        "Activate floating megaports",
+        "Commission orbital sentinel",
+        "Publish corridor capacity oracles"
+      ]
+    },
+    {
+      "id": "OPTIMISE",
+      "title": "Optimise incentives & market balance",
+      "windowDays": 60,
+      "focus": [
+        "Dynamic pricing",
+        "Validator incentives",
+        "Quadratic votes"
+      ],
+      "ownerControls": [
+        "owner:command-center",
+        "reward-engine:update",
+        "platform:registry:update"
+      ],
+      "deliverables": [
+        "Incentive thermostat tuned",
+        "Validator mesh calibrations",
+        "Citizen quadratic vote results"
+      ]
+    },
+    {
+      "id": "HARDEN",
+      "title": "Harden resilience & audit loops",
+      "windowDays": 30,
+      "focus": [
+        "Pause drills",
+        "Audit trails",
+        "Sovereign reporting"
+      ],
+      "ownerControls": [
+        "owner:verify-control",
+        "owner:mission-control",
+        "owner:upgrade-status"
+      ],
+      "deliverables": [
+        "System pause rehearsal",
+        "Grand manifest notarised",
+        "Stakeholder evidence bundle"
+      ]
+    }
+  ],
+  "jobs": [
+    {
+      "id": "ARCTIC-FOOD-RELAY",
+      "title": "Stabilise Arctic food and medicine relay",
+      "phase": "STABILISE",
+      "phaseTitle": "Stabilise critical lifelines",
+      "reward": 180000,
+      "startOffset": 0,
+      "endOffset": 21,
+      "startDate": "2025-04-01T00:00:00.000Z",
+      "endDate": "2025-04-22T00:00:00.000Z",
+      "deadlineDate": "2025-05-06T00:00:00.000Z",
+      "slackDays": 14,
+      "corridors": [
+        "PORT-SPOKE-NORTH",
+        "ARCTIC-AIRBRIDGE"
+      ],
+      "assigned": [
+        {
+          "agent": "aurora.supply.nation.agi.eth",
+          "responsibility": "Deploy icebreaker convoys and VTOL grid"
+        },
+        {
+          "agent": "healthshield.wallet.agi.eth",
+          "responsibility": "Coordinate field triage nodes"
+        }
+      ],
+      "validators": [
+        "polaris.validator.agi.eth",
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "AI convoys deliver 5,000 tonnes of food and medical supplies per week",
+        "Validator network signs real-time inventory snapshots",
+        "Owner thermostat calibrates incentives for sub-zero operations"
+      ],
+      "critical": true
+    },
+    {
+      "id": "PACIFIC-HUB-EXPANSION",
+      "title": "Deploy Pacific floating logistics mega-hub",
+      "phase": "EXPAND",
+      "phaseTitle": "Expand inter-regional capacity",
+      "reward": 220000,
+      "startOffset": 21,
+      "endOffset": 61,
+      "startDate": "2025-04-22T00:00:00.000Z",
+      "endDate": "2025-06-01T00:00:00.000Z",
+      "deadlineDate": "2025-06-30T00:00:00.000Z",
+      "slackDays": 29,
+      "corridors": [
+        "PACIFIC-RAIL",
+        "PACIFIC-ORBITAL"
+      ],
+      "assigned": [
+        {
+          "agent": "pacific.logistics.nation.agi.eth",
+          "responsibility": "Assemble modular piers"
+        },
+        {
+          "agent": "continental.mesh.nation.agi.eth",
+          "responsibility": "Synchronise inland maglev"
+        }
+      ],
+      "validators": [
+        "trident.validator.agi.eth"
+      ],
+      "brief": [
+        "Activate floating megaport with 200 autonomous cranes",
+        "Spin up orbital sentinel handshake for customs",
+        "Owner command centre verifies berth prioritisation via quadratic vote"
+      ],
+      "critical": true
+    },
+    {
+      "id": "CENTRAL-RESERVE-AUTOMATION",
+      "title": "Automate strategic reserve balancing",
+      "phase": "OPTIMISE",
+      "phaseTitle": "Optimise incentives & market balance",
+      "reward": 195000,
+      "startOffset": 61,
+      "endOffset": 91,
+      "startDate": "2025-06-01T00:00:00.000Z",
+      "endDate": "2025-07-01T00:00:00.000Z",
+      "deadlineDate": "2025-07-20T00:00:00.000Z",
+      "slackDays": 19,
+      "corridors": [
+        "PACIFIC-RAIL",
+        "CENTRAL-METRO"
+      ],
+      "assigned": [
+        {
+          "agent": "continental.mesh.nation.agi.eth",
+          "responsibility": "Optimise maglev + electric fleet"
+        },
+        {
+          "agent": "railmesh.wallet.agi.eth",
+          "responsibility": "Treasury automation and predictive maintenance"
+        }
+      ],
+      "validators": [
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Deploy reinforcement learning agents on stockpile hedging",
+        "Publish energy + nutrition coverage dashboards",
+        "Owner triggers reward engine update for fair share distribution"
+      ],
+      "critical": true
+    },
+    {
+      "id": "CITIZEN-RESPONSE-ACTIVATION",
+      "title": "Activate citizen humanitarian mesh",
+      "phase": "OPTIMISE",
+      "phaseTitle": "Optimise incentives & market balance",
+      "reward": 165000,
+      "startOffset": 21,
+      "endOffset": 46,
+      "startDate": "2025-04-22T00:00:00.000Z",
+      "endDate": "2025-05-17T00:00:00.000Z",
+      "deadlineDate": "2025-07-15T00:00:00.000Z",
+      "slackDays": 59,
+      "corridors": [
+        "METRO-RELIEF"
+      ],
+      "assigned": [
+        {
+          "agent": "healthshield.wallet.agi.eth",
+          "responsibility": "Citizen DID onboarding"
+        },
+        {
+          "agent": "railmesh.wallet.agi.eth",
+          "responsibility": "Treasury payout automation"
+        }
+      ],
+      "validators": [
+        "polaris.validator.agi.eth",
+        "trident.validator.agi.eth"
+      ],
+      "brief": [
+        "Launch DID-gated citizen relief missions",
+        "Validators approve quadratic reward allocations",
+        "Owner monitors supply plan autop-run via CLI"
+      ],
+      "critical": false
+    },
+    {
+      "id": "VALIDATION-GRAND-AUDIT",
+      "title": "Validator coalition grand audit",
+      "phase": "HARDEN",
+      "phaseTitle": "Harden resilience & audit loops",
+      "reward": 155000,
+      "startOffset": 91,
+      "endOffset": 111,
+      "startDate": "2025-07-01T00:00:00.000Z",
+      "endDate": "2025-07-21T00:00:00.000Z",
+      "deadlineDate": "2025-08-09T00:00:00.000Z",
+      "slackDays": 19,
+      "corridors": [
+        "COMMAND"
+      ],
+      "assigned": [
+        {
+          "agent": "polaris.validator.agi.eth",
+          "responsibility": "Arctic logistic evidence"
+        },
+        {
+          "agent": "trident.validator.agi.eth",
+          "responsibility": "Port security attestations"
+        },
+        {
+          "agent": "helmsman.validator.agi.eth",
+          "responsibility": "Energy + medical telemetry assurance"
+        }
+      ],
+      "validators": [
+        "polaris.validator.agi.eth",
+        "trident.validator.agi.eth",
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Compile audit bundle for national senate",
+        "Verify owner pause + resume logs",
+        "Publish thermodynamic telemetry for all corridors"
+      ],
+      "critical": true
+    },
+    {
+      "id": "TREASURY-REBALANCING-DRILL",
+      "title": "Owner treasury rebalancing + pause drill",
+      "phase": "HARDEN",
+      "phaseTitle": "Harden resilience & audit loops",
+      "reward": 120000,
+      "startOffset": 111,
+      "endOffset": 123,
+      "startDate": "2025-07-21T00:00:00.000Z",
+      "endDate": "2025-08-02T00:00:00.000Z",
+      "deadlineDate": "2025-08-19T00:00:00.000Z",
+      "slackDays": 17,
+      "corridors": [
+        "COMMAND",
+        "CENTRAL-METRO"
+      ],
+      "assigned": [
+        {
+          "agent": "aurora.supply.nation.agi.eth",
+          "responsibility": "Execute owner commands via CLI"
+        },
+        {
+          "agent": "owner",
+          "responsibility": "Approve thermostat + treasury adjustments"
+        }
+      ],
+      "validators": [
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Run pause + resume using owner command centre",
+        "Rebalance treasury between validator and agent pools",
+        "Produce notarised manifest + hashed summary"
+      ],
+      "critical": true
+    }
+  ],
+  "corridors": [
+    {
+      "id": "ARCTIC-AIRBRIDGE",
+      "from": "NORTH_PORT",
+      "to": "ARCTIC_HUB",
+      "mode": "VTOL heavy lift",
+      "capacityTonnesPerDay": 900,
+      "latencyHours": 6,
+      "resilience": "Redundant thermal shielding & validator telemetry",
+      "ownerControls": [
+        "jobs/supply-routing",
+        "thermostat",
+        "inventory/oracle",
+        "energy-oracle"
+      ]
+    },
+    {
+      "id": "PORT-SPOKE-NORTH",
+      "from": "COMMAND",
+      "to": "NORTH_PORT",
+      "mode": "Icebreaker convoy",
+      "capacityTonnesPerDay": 2800,
+      "latencyHours": 12,
+      "resilience": "Quadratic validator quorum w/ automated replan",
+      "ownerControls": [
+        "owner:command-center",
+        "owner:parameters",
+        "owner:system-pause",
+        "jobs/supply-routing",
+        "thermostat"
+      ]
+    },
+    {
+      "id": "PACIFIC-RAIL",
+      "from": "PACIFIC_PORT",
+      "to": "CENTRAL_STORAGE",
+      "mode": "Maglev & drone mesh",
+      "capacityTonnesPerDay": 2400,
+      "latencyHours": 9,
+      "resilience": "Dual stake guardrails + pause triggers",
+      "ownerControls": [
+        "port/mesh",
+        "quadratic-voting",
+        "treasury/rebalance",
+        "owner:mission-control"
+      ]
+    },
+    {
+      "id": "CENTRAL-METRO",
+      "from": "CENTRAL_STORAGE",
+      "to": "METRO_GRID",
+      "mode": "Autonomous electric fleet",
+      "capacityTonnesPerDay": 1800,
+      "latencyHours": 4,
+      "resilience": "Thermostat-driven incentives",
+      "ownerControls": [
+        "treasury/rebalance",
+        "owner:mission-control",
+        "demand-response",
+        "owner:parameters"
+      ]
+    },
+    {
+      "id": "METRO-RELIEF",
+      "from": "METRO_GRID",
+      "to": "AID_CELLS",
+      "mode": "Drone & amphibious",
+      "capacityTonnesPerDay": 600,
+      "latencyHours": 2,
+      "resilience": "Citizen validator quorum & DID gating",
+      "ownerControls": [
+        "demand-response",
+        "owner:parameters",
+        "community-wallet",
+        "supplychain/agent"
+      ]
+    },
+    {
+      "id": "PACIFIC-ORBITAL",
+      "from": "PACIFIC_PORT",
+      "to": "ORBITAL_SENSOR",
+      "mode": "Space elevator cargo",
+      "capacityTonnesPerDay": 50,
+      "latencyHours": 3,
+      "resilience": "Zero-trust telemetry encryption",
+      "ownerControls": [
+        "port/mesh",
+        "quadratic-voting",
+        "telemetry",
+        "owner:surface"
+      ]
+    }
+  ],
+  "validators": [
+    {
+      "handle": "polaris.validator.agi.eth",
+      "stake": 160000,
+      "mandate": "Arctic supply assurance",
+      "wallet": "0xVAL1d0000000000000000000000000000000A1"
+    },
+    {
+      "handle": "trident.validator.agi.eth",
+      "stake": 145000,
+      "mandate": "Port security & customs compliance",
+      "wallet": "0xVAL1d0000000000000000000000000000000A2"
+    },
+    {
+      "handle": "helmsman.validator.agi.eth",
+      "stake": 132000,
+      "mandate": "Energy & medical supply telemetry",
+      "wallet": "0xVAL1d0000000000000000000000000000000A3"
+    }
+  ],
+  "agents": [
+    {
+      "handle": "aurora.supply.nation.agi.eth",
+      "role": "Northern Resilience Authority",
+      "capabilities": [
+        "Cryosphere logistics optimisation",
+        "Autonomous convoy routing",
+        "Quantum-secured telemetry"
+      ],
+      "wallet": "0xfA11eD000000000000000000000000000000A01",
+      "sovereign": "Aurora Coalition"
+    },
+    {
+      "handle": "pacific.logistics.nation.agi.eth",
+      "role": "Pacific Infrastructure Continuity Agency",
+      "capabilities": [
+        "Floating port assembly",
+        "Typhoon-adaptive routing",
+        "Dual-use port cyber defences"
+      ],
+      "wallet": "0xfA11eD000000000000000000000000000000A02",
+      "sovereign": "Pacific Alliance"
+    },
+    {
+      "handle": "continental.mesh.nation.agi.eth",
+      "role": "Continental Multi-Modal Mesh",
+      "capabilities": [
+        "AI rail corridor harmonisation",
+        "Supply-demand clearing market",
+        "National carbon-aware routing"
+      ],
+      "wallet": "0xfA11eD000000000000000000000000000000A03",
+      "sovereign": "Continental Union"
+    },
+    {
+      "handle": "healthshield.wallet.agi.eth",
+      "role": "HealthShield Humanitarian Collective",
+      "capabilities": [
+        "Rapid medical triage",
+        "Drone-based emergency delivery",
+        "On-chain citizen feedback"
+      ],
+      "wallet": "0xF9eD00000000000000000000000000000000B10",
+      "sovereign": "Community Treasury"
+    },
+    {
+      "handle": "railmesh.wallet.agi.eth",
+      "role": "RailMesh Cooperative Treasury",
+      "capabilities": [
+        "Rail hub automation",
+        "Predictive maintenance",
+        "Surge capacity hedging"
+      ],
+      "wallet": "0xF9eD00000000000000000000000000000000B11",
+      "sovereign": "Worker Consortium"
+    }
+  ],
+  "ownerPlaybooks": [
+    "npm run owner:command-center",
+    "npm run owner:parameters",
+    "npm run owner:system-pause -- --action pause",
+    "npm run owner:system-pause -- --action unpause",
+    "npm run owner:upgrade-status",
+    "npm run owner:verify-control",
+    "npm run owner:mission-control"
+  ],
+  "mermaid": {
+    "network": "flowchart LR\n  COMMAND[\"Sovereign Command Centre\\nCapital\"]:::command\n  NORTH_PORT[\"Arctic Quantum Port\\nAurora Coast\"]:::port\n  ARCTIC_HUB[\"Permafrost Resilience Hub\\nPolar Interior\"]:::hub\n  PACIFIC_PORT[\"Pacific Floating Megaport\\nPacific Ocean\"]:::port\n  CENTRAL_STORAGE[\"National Strategic Reserve\\nCentral Corridor\"]:::storage\n  METRO_GRID[\"Metropolitan Microgrid\\nCapital\"]:::distribution\n  AID_CELLS[\"Humanitarian Field Cells\\nNational\"]:::relief\n  ORBITAL_SENSOR[\"Orbital Supply Sentinel\\nLEO\"]:::sensor\n  NORTH_PORT -->|VTOL heavy lift| ARCTIC_HUB\n  COMMAND -->|Icebreaker convoy| NORTH_PORT\n  PACIFIC_PORT -->|Maglev & drone mesh| CENTRAL_STORAGE\n  CENTRAL_STORAGE -->|Autonomous electric fleet| METRO_GRID\n  METRO_GRID -->|Drone & amphibious| AID_CELLS\n  PACIFIC_PORT -->|Space elevator cargo| ORBITAL_SENSOR\n  classDef command fill:#0f172a,stroke:#38bdf8,stroke-width:2,color:#e2e8f0;\n  classDef port fill:#1e3a8a,stroke:#38bdf8,color:#f8fafc;\n  classDef hub fill:#312e81,stroke:#c084fc,color:#f5f3ff;\n  classDef storage fill:#064e3b,stroke:#34d399,color:#ecfdf5;\n  classDef distribution fill:#7c2d12,stroke:#fb923c,color:#ffedd5;\n  classDef relief fill:#7f1d1d,stroke:#fca5a5,color:#fee2e2;\n  classDef sensor fill:#3f3f46,stroke:#facc15,color:#fef9c3;",
+    "gantt": "gantt\n  title National Supply Chain Critical Path\n  dateFormat  YYYY-MM-DD\n  axisFormat  %b %d\n  section Stabilise critical lifelines\n  Stabilise Arctic food and medicine relay: crit, arctic_food_relay, 2025-04-01, 2025-04-22\n  section Expand inter-regional capacity\n  Deploy Pacific floating logistics mega-hub: crit, pacific_hub_expansion, 2025-04-22, 2025-06-01\n  section Optimise incentives & market balance\n  Automate strategic reserve balancing: crit, central_reserve_automation, 2025-06-01, 2025-07-01\n  section Optimise incentives & market balance\n  Activate citizen humanitarian mesh:  citizen_response_activation, 2025-04-22, 2025-05-17\n  section Harden resilience & audit loops\n  Validator coalition grand audit: crit, validation_grand_audit, 2025-07-01, 2025-07-21\n  section Harden resilience & audit loops\n  Owner treasury rebalancing + pause drill: crit, treasury_rebalancing_drill, 2025-07-21, 2025-08-02"
+  },
+  "criticalJobs": [
+    "TREASURY-REBALANCING-DRILL",
+    "VALIDATION-GRAND-AUDIT",
+    "CENTRAL-RESERVE-AUTOMATION",
+    "PACIFIC-HUB-EXPANSION",
+    "ARCTIC-FOOD-RELAY"
+  ]
+}

--- a/demo/National-Supply-Chain-v0/ui/index.html
+++ b/demo/National-Supply-Chain-v0/ui/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>National Supply Chain v0 Intelligence Cockpit</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script>
+      window.mermaidConfig = { startOnLoad: false, theme: 'dark' };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js" defer></script>
+    <script type="module" src="app.js" defer></script>
+  </head>
+  <body>
+    <header class="hero">
+      <div>
+        <p class="tag" data-mission-tag>Mission Tag</p>
+        <h1 data-mission-title>National Supply Chain v0</h1>
+        <p class="objective" data-mission-objective>
+          Loading national intelligence kit…
+        </p>
+      </div>
+      <div class="meta-panel">
+        <dl>
+          <div>
+            <dt>Generated</dt>
+            <dd data-generated-at>—</dd>
+          </div>
+          <div>
+            <dt>Network</dt>
+            <dd data-network>—</dd>
+          </div>
+          <div>
+            <dt>Owner ENS</dt>
+            <dd data-owner-ens>—</dd>
+          </div>
+        </dl>
+        <div class="hero-actions">
+          <a class="btn" href="../RUNBOOK.md" target="_blank" rel="noopener">Open Runbook</a>
+          <a class="btn" href="../README.md" target="_blank" rel="noopener">View README</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="card" id="metrics">
+        <h2>Mission Metrics</h2>
+        <div class="stat-grid" data-metrics></div>
+      </section>
+
+      <section class="card" id="phase-filters">
+        <h2>Phases &amp; Controls</h2>
+        <div class="phase-grid" data-phase-filters></div>
+      </section>
+
+      <section class="card" id="jobs">
+        <div class="card-header">
+          <h2>Jobs &amp; Critical Path</h2>
+          <div class="pill legend-critical">Critical path</div>
+        </div>
+        <div class="table-responsive">
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Title</th>
+                <th>Phase</th>
+                <th>Window</th>
+                <th>Reward</th>
+                <th>Slack</th>
+                <th>Corridors</th>
+                <th>Agents</th>
+                <th>Validators</th>
+              </tr>
+            </thead>
+            <tbody data-job-rows>
+              <tr><td colspan="9" class="loading">Loading jobs…</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card" id="corridors">
+        <h2>Corridor Intelligence</h2>
+        <div class="corridor-grid" data-corridors></div>
+      </section>
+
+      <section class="card" id="owner-controls">
+        <h2>Owner Playbooks</h2>
+        <ul class="command-list" data-owner-controls></ul>
+      </section>
+
+      <section class="card" id="validators">
+        <h2>Validator Coalition</h2>
+        <div class="validator-grid" data-validators></div>
+      </section>
+
+      <section class="card" id="mermaid">
+        <div class="card-header">
+          <h2>Network Atlas (Mermaid)</h2>
+          <button class="btn" data-refresh-mermaid>Render diagrams</button>
+        </div>
+        <div class="mermaid" data-mermaid-network></div>
+        <div class="mermaid" data-mermaid-gantt></div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Generated entirely from repository-native tooling. Refresh the export by running
+        <code>npm run demo:national-supply-chain:v0</code>.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/demo/National-Supply-Chain-v0/ui/sample.json
+++ b/demo/National-Supply-Chain-v0/ui/sample.json
@@ -1,0 +1,524 @@
+{
+  "initiative": "National Supply Chain Foresight Command",
+  "objective": "Demonstrate how AGI Jobs v0 (v2) autonomously orchestrates national logistics, humanitarian relief, energy flows, and strategic stockpiles while preserving sovereign owner control and quadratic governance levers.",
+  "missionTag": "NATIONAL-SUPPLY-CHAIN-V0",
+  "generatedAt": "2025-01-15T00:00:00.000Z",
+  "launchDate": "2025-04-01",
+  "network": "Hardhat localhost (31337)",
+  "ownerEns": "national.supply.owner.agi.eth",
+  "budget": {
+    "currency": "AGIALPHA",
+    "total": 1250000,
+    "operatorReserve": 275000,
+    "validatorPool": 210000
+  },
+  "metrics": {
+    "jobCount": 6,
+    "phaseCount": 4,
+    "agentCount": 5,
+    "validatorCount": 3,
+    "totalReward": 1035000,
+    "operatorReserve": 275000,
+    "validatorPool": 210000,
+    "criticalPathDays": 123,
+    "maxConcurrency": 2,
+    "corridorCapacity": 8550,
+    "validatorStake": 437000
+  },
+  "phases": [
+    {
+      "id": "STABILISE",
+      "title": "Stabilise critical lifelines",
+      "windowDays": 21,
+      "focus": [
+        "Food",
+        "Medical",
+        "Energy"
+      ],
+      "ownerControls": [
+        "owner:system-pause",
+        "owner:command-center",
+        "owner:parameters"
+      ],
+      "deliverables": [
+        "Deploy thermodynamic guardrails",
+        "Spin up rapid relief corridors",
+        "Publish sovereign command map"
+      ]
+    },
+    {
+      "id": "EXPAND",
+      "title": "Expand inter-regional capacity",
+      "windowDays": 45,
+      "focus": [
+        "Infrastructure",
+        "Energy storage",
+        "Data fusion"
+      ],
+      "ownerControls": [
+        "owner:mission-control",
+        "owner:parameters",
+        "thermostat:update"
+      ],
+      "deliverables": [
+        "Activate floating megaports",
+        "Commission orbital sentinel",
+        "Publish corridor capacity oracles"
+      ]
+    },
+    {
+      "id": "OPTIMISE",
+      "title": "Optimise incentives & market balance",
+      "windowDays": 60,
+      "focus": [
+        "Dynamic pricing",
+        "Validator incentives",
+        "Quadratic votes"
+      ],
+      "ownerControls": [
+        "owner:command-center",
+        "reward-engine:update",
+        "platform:registry:update"
+      ],
+      "deliverables": [
+        "Incentive thermostat tuned",
+        "Validator mesh calibrations",
+        "Citizen quadratic vote results"
+      ]
+    },
+    {
+      "id": "HARDEN",
+      "title": "Harden resilience & audit loops",
+      "windowDays": 30,
+      "focus": [
+        "Pause drills",
+        "Audit trails",
+        "Sovereign reporting"
+      ],
+      "ownerControls": [
+        "owner:verify-control",
+        "owner:mission-control",
+        "owner:upgrade-status"
+      ],
+      "deliverables": [
+        "System pause rehearsal",
+        "Grand manifest notarised",
+        "Stakeholder evidence bundle"
+      ]
+    }
+  ],
+  "jobs": [
+    {
+      "id": "ARCTIC-FOOD-RELAY",
+      "title": "Stabilise Arctic food and medicine relay",
+      "phase": "STABILISE",
+      "phaseTitle": "Stabilise critical lifelines",
+      "reward": 180000,
+      "startOffset": 0,
+      "endOffset": 21,
+      "startDate": "2025-04-01T00:00:00.000Z",
+      "endDate": "2025-04-22T00:00:00.000Z",
+      "deadlineDate": "2025-05-06T00:00:00.000Z",
+      "slackDays": 14,
+      "corridors": [
+        "PORT-SPOKE-NORTH",
+        "ARCTIC-AIRBRIDGE"
+      ],
+      "assigned": [
+        {
+          "agent": "aurora.supply.nation.agi.eth",
+          "responsibility": "Deploy icebreaker convoys and VTOL grid"
+        },
+        {
+          "agent": "healthshield.wallet.agi.eth",
+          "responsibility": "Coordinate field triage nodes"
+        }
+      ],
+      "validators": [
+        "polaris.validator.agi.eth",
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "AI convoys deliver 5,000 tonnes of food and medical supplies per week",
+        "Validator network signs real-time inventory snapshots",
+        "Owner thermostat calibrates incentives for sub-zero operations"
+      ],
+      "critical": true
+    },
+    {
+      "id": "PACIFIC-HUB-EXPANSION",
+      "title": "Deploy Pacific floating logistics mega-hub",
+      "phase": "EXPAND",
+      "phaseTitle": "Expand inter-regional capacity",
+      "reward": 220000,
+      "startOffset": 21,
+      "endOffset": 61,
+      "startDate": "2025-04-22T00:00:00.000Z",
+      "endDate": "2025-06-01T00:00:00.000Z",
+      "deadlineDate": "2025-06-30T00:00:00.000Z",
+      "slackDays": 29,
+      "corridors": [
+        "PACIFIC-RAIL",
+        "PACIFIC-ORBITAL"
+      ],
+      "assigned": [
+        {
+          "agent": "pacific.logistics.nation.agi.eth",
+          "responsibility": "Assemble modular piers"
+        },
+        {
+          "agent": "continental.mesh.nation.agi.eth",
+          "responsibility": "Synchronise inland maglev"
+        }
+      ],
+      "validators": [
+        "trident.validator.agi.eth"
+      ],
+      "brief": [
+        "Activate floating megaport with 200 autonomous cranes",
+        "Spin up orbital sentinel handshake for customs",
+        "Owner command centre verifies berth prioritisation via quadratic vote"
+      ],
+      "critical": true
+    },
+    {
+      "id": "CENTRAL-RESERVE-AUTOMATION",
+      "title": "Automate strategic reserve balancing",
+      "phase": "OPTIMISE",
+      "phaseTitle": "Optimise incentives & market balance",
+      "reward": 195000,
+      "startOffset": 61,
+      "endOffset": 91,
+      "startDate": "2025-06-01T00:00:00.000Z",
+      "endDate": "2025-07-01T00:00:00.000Z",
+      "deadlineDate": "2025-07-20T00:00:00.000Z",
+      "slackDays": 19,
+      "corridors": [
+        "PACIFIC-RAIL",
+        "CENTRAL-METRO"
+      ],
+      "assigned": [
+        {
+          "agent": "continental.mesh.nation.agi.eth",
+          "responsibility": "Optimise maglev + electric fleet"
+        },
+        {
+          "agent": "railmesh.wallet.agi.eth",
+          "responsibility": "Treasury automation and predictive maintenance"
+        }
+      ],
+      "validators": [
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Deploy reinforcement learning agents on stockpile hedging",
+        "Publish energy + nutrition coverage dashboards",
+        "Owner triggers reward engine update for fair share distribution"
+      ],
+      "critical": true
+    },
+    {
+      "id": "CITIZEN-RESPONSE-ACTIVATION",
+      "title": "Activate citizen humanitarian mesh",
+      "phase": "OPTIMISE",
+      "phaseTitle": "Optimise incentives & market balance",
+      "reward": 165000,
+      "startOffset": 21,
+      "endOffset": 46,
+      "startDate": "2025-04-22T00:00:00.000Z",
+      "endDate": "2025-05-17T00:00:00.000Z",
+      "deadlineDate": "2025-07-15T00:00:00.000Z",
+      "slackDays": 59,
+      "corridors": [
+        "METRO-RELIEF"
+      ],
+      "assigned": [
+        {
+          "agent": "healthshield.wallet.agi.eth",
+          "responsibility": "Citizen DID onboarding"
+        },
+        {
+          "agent": "railmesh.wallet.agi.eth",
+          "responsibility": "Treasury payout automation"
+        }
+      ],
+      "validators": [
+        "polaris.validator.agi.eth",
+        "trident.validator.agi.eth"
+      ],
+      "brief": [
+        "Launch DID-gated citizen relief missions",
+        "Validators approve quadratic reward allocations",
+        "Owner monitors supply plan autop-run via CLI"
+      ],
+      "critical": false
+    },
+    {
+      "id": "VALIDATION-GRAND-AUDIT",
+      "title": "Validator coalition grand audit",
+      "phase": "HARDEN",
+      "phaseTitle": "Harden resilience & audit loops",
+      "reward": 155000,
+      "startOffset": 91,
+      "endOffset": 111,
+      "startDate": "2025-07-01T00:00:00.000Z",
+      "endDate": "2025-07-21T00:00:00.000Z",
+      "deadlineDate": "2025-08-09T00:00:00.000Z",
+      "slackDays": 19,
+      "corridors": [
+        "COMMAND"
+      ],
+      "assigned": [
+        {
+          "agent": "polaris.validator.agi.eth",
+          "responsibility": "Arctic logistic evidence"
+        },
+        {
+          "agent": "trident.validator.agi.eth",
+          "responsibility": "Port security attestations"
+        },
+        {
+          "agent": "helmsman.validator.agi.eth",
+          "responsibility": "Energy + medical telemetry assurance"
+        }
+      ],
+      "validators": [
+        "polaris.validator.agi.eth",
+        "trident.validator.agi.eth",
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Compile audit bundle for national senate",
+        "Verify owner pause + resume logs",
+        "Publish thermodynamic telemetry for all corridors"
+      ],
+      "critical": true
+    },
+    {
+      "id": "TREASURY-REBALANCING-DRILL",
+      "title": "Owner treasury rebalancing + pause drill",
+      "phase": "HARDEN",
+      "phaseTitle": "Harden resilience & audit loops",
+      "reward": 120000,
+      "startOffset": 111,
+      "endOffset": 123,
+      "startDate": "2025-07-21T00:00:00.000Z",
+      "endDate": "2025-08-02T00:00:00.000Z",
+      "deadlineDate": "2025-08-19T00:00:00.000Z",
+      "slackDays": 17,
+      "corridors": [
+        "COMMAND",
+        "CENTRAL-METRO"
+      ],
+      "assigned": [
+        {
+          "agent": "aurora.supply.nation.agi.eth",
+          "responsibility": "Execute owner commands via CLI"
+        },
+        {
+          "agent": "owner",
+          "responsibility": "Approve thermostat + treasury adjustments"
+        }
+      ],
+      "validators": [
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Run pause + resume using owner command centre",
+        "Rebalance treasury between validator and agent pools",
+        "Produce notarised manifest + hashed summary"
+      ],
+      "critical": true
+    }
+  ],
+  "corridors": [
+    {
+      "id": "ARCTIC-AIRBRIDGE",
+      "from": "NORTH_PORT",
+      "to": "ARCTIC_HUB",
+      "mode": "VTOL heavy lift",
+      "capacityTonnesPerDay": 900,
+      "latencyHours": 6,
+      "resilience": "Redundant thermal shielding & validator telemetry",
+      "ownerControls": [
+        "jobs/supply-routing",
+        "thermostat",
+        "inventory/oracle",
+        "energy-oracle"
+      ]
+    },
+    {
+      "id": "PORT-SPOKE-NORTH",
+      "from": "COMMAND",
+      "to": "NORTH_PORT",
+      "mode": "Icebreaker convoy",
+      "capacityTonnesPerDay": 2800,
+      "latencyHours": 12,
+      "resilience": "Quadratic validator quorum w/ automated replan",
+      "ownerControls": [
+        "owner:command-center",
+        "owner:parameters",
+        "owner:system-pause",
+        "jobs/supply-routing",
+        "thermostat"
+      ]
+    },
+    {
+      "id": "PACIFIC-RAIL",
+      "from": "PACIFIC_PORT",
+      "to": "CENTRAL_STORAGE",
+      "mode": "Maglev & drone mesh",
+      "capacityTonnesPerDay": 2400,
+      "latencyHours": 9,
+      "resilience": "Dual stake guardrails + pause triggers",
+      "ownerControls": [
+        "port/mesh",
+        "quadratic-voting",
+        "treasury/rebalance",
+        "owner:mission-control"
+      ]
+    },
+    {
+      "id": "CENTRAL-METRO",
+      "from": "CENTRAL_STORAGE",
+      "to": "METRO_GRID",
+      "mode": "Autonomous electric fleet",
+      "capacityTonnesPerDay": 1800,
+      "latencyHours": 4,
+      "resilience": "Thermostat-driven incentives",
+      "ownerControls": [
+        "treasury/rebalance",
+        "owner:mission-control",
+        "demand-response",
+        "owner:parameters"
+      ]
+    },
+    {
+      "id": "METRO-RELIEF",
+      "from": "METRO_GRID",
+      "to": "AID_CELLS",
+      "mode": "Drone & amphibious",
+      "capacityTonnesPerDay": 600,
+      "latencyHours": 2,
+      "resilience": "Citizen validator quorum & DID gating",
+      "ownerControls": [
+        "demand-response",
+        "owner:parameters",
+        "community-wallet",
+        "supplychain/agent"
+      ]
+    },
+    {
+      "id": "PACIFIC-ORBITAL",
+      "from": "PACIFIC_PORT",
+      "to": "ORBITAL_SENSOR",
+      "mode": "Space elevator cargo",
+      "capacityTonnesPerDay": 50,
+      "latencyHours": 3,
+      "resilience": "Zero-trust telemetry encryption",
+      "ownerControls": [
+        "port/mesh",
+        "quadratic-voting",
+        "telemetry",
+        "owner:surface"
+      ]
+    }
+  ],
+  "validators": [
+    {
+      "handle": "polaris.validator.agi.eth",
+      "stake": 160000,
+      "mandate": "Arctic supply assurance",
+      "wallet": "0xVAL1d0000000000000000000000000000000A1"
+    },
+    {
+      "handle": "trident.validator.agi.eth",
+      "stake": 145000,
+      "mandate": "Port security & customs compliance",
+      "wallet": "0xVAL1d0000000000000000000000000000000A2"
+    },
+    {
+      "handle": "helmsman.validator.agi.eth",
+      "stake": 132000,
+      "mandate": "Energy & medical supply telemetry",
+      "wallet": "0xVAL1d0000000000000000000000000000000A3"
+    }
+  ],
+  "agents": [
+    {
+      "handle": "aurora.supply.nation.agi.eth",
+      "role": "Northern Resilience Authority",
+      "capabilities": [
+        "Cryosphere logistics optimisation",
+        "Autonomous convoy routing",
+        "Quantum-secured telemetry"
+      ],
+      "wallet": "0xfA11eD000000000000000000000000000000A01",
+      "sovereign": "Aurora Coalition"
+    },
+    {
+      "handle": "pacific.logistics.nation.agi.eth",
+      "role": "Pacific Infrastructure Continuity Agency",
+      "capabilities": [
+        "Floating port assembly",
+        "Typhoon-adaptive routing",
+        "Dual-use port cyber defences"
+      ],
+      "wallet": "0xfA11eD000000000000000000000000000000A02",
+      "sovereign": "Pacific Alliance"
+    },
+    {
+      "handle": "continental.mesh.nation.agi.eth",
+      "role": "Continental Multi-Modal Mesh",
+      "capabilities": [
+        "AI rail corridor harmonisation",
+        "Supply-demand clearing market",
+        "National carbon-aware routing"
+      ],
+      "wallet": "0xfA11eD000000000000000000000000000000A03",
+      "sovereign": "Continental Union"
+    },
+    {
+      "handle": "healthshield.wallet.agi.eth",
+      "role": "HealthShield Humanitarian Collective",
+      "capabilities": [
+        "Rapid medical triage",
+        "Drone-based emergency delivery",
+        "On-chain citizen feedback"
+      ],
+      "wallet": "0xF9eD00000000000000000000000000000000B10",
+      "sovereign": "Community Treasury"
+    },
+    {
+      "handle": "railmesh.wallet.agi.eth",
+      "role": "RailMesh Cooperative Treasury",
+      "capabilities": [
+        "Rail hub automation",
+        "Predictive maintenance",
+        "Surge capacity hedging"
+      ],
+      "wallet": "0xF9eD00000000000000000000000000000000B11",
+      "sovereign": "Worker Consortium"
+    }
+  ],
+  "ownerPlaybooks": [
+    "npm run owner:command-center",
+    "npm run owner:parameters",
+    "npm run owner:system-pause -- --action pause",
+    "npm run owner:system-pause -- --action unpause",
+    "npm run owner:upgrade-status",
+    "npm run owner:verify-control",
+    "npm run owner:mission-control"
+  ],
+  "mermaid": {
+    "network": "flowchart LR\n  COMMAND[\"Sovereign Command Centre\\nCapital\"]:::command\n  NORTH_PORT[\"Arctic Quantum Port\\nAurora Coast\"]:::port\n  ARCTIC_HUB[\"Permafrost Resilience Hub\\nPolar Interior\"]:::hub\n  PACIFIC_PORT[\"Pacific Floating Megaport\\nPacific Ocean\"]:::port\n  CENTRAL_STORAGE[\"National Strategic Reserve\\nCentral Corridor\"]:::storage\n  METRO_GRID[\"Metropolitan Microgrid\\nCapital\"]:::distribution\n  AID_CELLS[\"Humanitarian Field Cells\\nNational\"]:::relief\n  ORBITAL_SENSOR[\"Orbital Supply Sentinel\\nLEO\"]:::sensor\n  NORTH_PORT -->|VTOL heavy lift| ARCTIC_HUB\n  COMMAND -->|Icebreaker convoy| NORTH_PORT\n  PACIFIC_PORT -->|Maglev & drone mesh| CENTRAL_STORAGE\n  CENTRAL_STORAGE -->|Autonomous electric fleet| METRO_GRID\n  METRO_GRID -->|Drone & amphibious| AID_CELLS\n  PACIFIC_PORT -->|Space elevator cargo| ORBITAL_SENSOR\n  classDef command fill:#0f172a,stroke:#38bdf8,stroke-width:2,color:#e2e8f0;\n  classDef port fill:#1e3a8a,stroke:#38bdf8,color:#f8fafc;\n  classDef hub fill:#312e81,stroke:#c084fc,color:#f5f3ff;\n  classDef storage fill:#064e3b,stroke:#34d399,color:#ecfdf5;\n  classDef distribution fill:#7c2d12,stroke:#fb923c,color:#ffedd5;\n  classDef relief fill:#7f1d1d,stroke:#fca5a5,color:#fee2e2;\n  classDef sensor fill:#3f3f46,stroke:#facc15,color:#fef9c3;",
+    "gantt": "gantt\n  title National Supply Chain Critical Path\n  dateFormat  YYYY-MM-DD\n  axisFormat  %b %d\n  section Stabilise critical lifelines\n  Stabilise Arctic food and medicine relay: crit, arctic_food_relay, 2025-04-01, 2025-04-22\n  section Expand inter-regional capacity\n  Deploy Pacific floating logistics mega-hub: crit, pacific_hub_expansion, 2025-04-22, 2025-06-01\n  section Optimise incentives & market balance\n  Automate strategic reserve balancing: crit, central_reserve_automation, 2025-06-01, 2025-07-01\n  section Optimise incentives & market balance\n  Activate citizen humanitarian mesh:  citizen_response_activation, 2025-04-22, 2025-05-17\n  section Harden resilience & audit loops\n  Validator coalition grand audit: crit, validation_grand_audit, 2025-07-01, 2025-07-21\n  section Harden resilience & audit loops\n  Owner treasury rebalancing + pause drill: crit, treasury_rebalancing_drill, 2025-07-21, 2025-08-02"
+  },
+  "criticalJobs": [
+    "TREASURY-REBALANCING-DRILL",
+    "VALIDATION-GRAND-AUDIT",
+    "CENTRAL-RESERVE-AUTOMATION",
+    "PACIFIC-HUB-EXPANSION",
+    "ARCTIC-FOOD-RELAY"
+  ]
+}

--- a/demo/National-Supply-Chain-v0/ui/styles.css
+++ b/demo/National-Supply-Chain-v0/ui/styles.css
@@ -1,0 +1,353 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  color-scheme: dark;
+  --bg-gradient: radial-gradient(circle at top left, #0f172a, #020617 55%);
+  --card-bg: rgba(15, 23, 42, 0.72);
+  --border: rgba(148, 163, 184, 0.3);
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.12);
+  --success: #34d399;
+  --warning: #facc15;
+  --danger: #f87171;
+  --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+  padding: 0 1.5rem 4rem;
+}
+
+.hero {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+  padding: 3rem 0 1.5rem;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 4vw, 3rem);
+}
+
+.hero .objective {
+  margin: 0.75rem 0 0;
+  max-width: 60ch;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+.meta-panel {
+  padding: 1.2rem 1.5rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid var(--border);
+  min-width: 260px;
+}
+
+.meta-panel dl {
+  margin: 0 0 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem 1rem;
+}
+
+.meta-panel dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.meta-panel dd {
+  margin: 0.2rem 0 0;
+  font-size: 0.95rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.75rem;
+  background: var(--accent);
+  color: #0f172a;
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(56, 189, 248, 0.35);
+}
+
+.btn.active {
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.5);
+}
+
+main {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 1.25rem;
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.4);
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.stat {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.stat__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.stat__value {
+  margin-top: 0.35rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.phase-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.phase-card {
+  padding: 1rem 1.2rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.55);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.phase-card.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.45);
+}
+
+.phase-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.phase-card .phase-meta {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.phase-card .pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-primary);
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.legend-critical {
+  background: rgba(236, 72, 153, 0.2);
+  color: #fbcfe8;
+  border: 1px solid rgba(236, 72, 153, 0.45);
+}
+
+.table-responsive {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+thead {
+  background: rgba(30, 41, 59, 0.75);
+}
+
+thead th {
+  padding: 0.75rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+tbody td {
+  padding: 0.85rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  vertical-align: top;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+tbody tr.critical {
+  background: rgba(236, 72, 153, 0.08);
+}
+
+td .subtle {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.loading {
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.corridor-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.corridor-card {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.command-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.command-list li {
+  line-height: 1.5;
+}
+
+.validator-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.validator-card {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.mermaid {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  overflow-x: auto;
+}
+
+.footer {
+  margin-top: 3rem;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.footer code {
+  background: rgba(15, 23, 42, 0.65);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 0 1rem 3rem;
+  }
+
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  table {
+    min-width: 100%;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -235,7 +235,9 @@
     "demo:alpha-meta:validate": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/validateMission.ts",
     "demo:alpha-meta:ci": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/verifyCi.ts",
     "demo:alpha-meta:owner": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/ownerDiagnostics.ts",
-    "demo:alpha-meta:full": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/fullPipeline.ts"
+    "demo:alpha-meta:full": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/fullPipeline.ts",
+    "demo:national-supply-chain:v0": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/v2/nationalSupplyChainDemo.ts",
+    "demo:national-supply-chain:ci": "npm run demo:national-supply-chain:v0 && npm run owner:verify-control && npm run ci:verify-branch-protection"
   },
   "keywords": [],
   "author": "",

--- a/reports/national-supply-chain/dashboard.html
+++ b/reports/national-supply-chain/dashboard.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>National Supply Chain Intelligence Kit</title>
+    <style>
+      :root { color-scheme: dark; font-family: 'Inter', system-ui, sans-serif; background:#020617; color:#e2e8f0; }
+      body { margin:0; background:radial-gradient(circle at top left,#0f172a,#020617 55%); padding:2.5rem; }
+      header { max-width:960px; margin:0 auto 2rem; }
+      h1 { font-size:2.8rem; margin:0; }
+      p.lede { color:#94a3b8; font-size:1.1rem; max-width:70ch; }
+      .grid { display:grid; gap:1.5rem; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); max-width:1200px; margin:0 auto; }
+      .card { background:rgba(15,23,42,0.72); border:1px solid rgba(148,163,184,0.3); border-radius:1.25rem; padding:1.5rem; box-shadow:0 20px 40px rgba(2,6,23,0.45); backdrop-filter:blur(18px); }
+      .card h2 { margin:0 0 1rem; font-size:1.4rem; }
+      .stats { display:grid; gap:1rem; grid-template-columns:repeat(auto-fit,minmax(140px,1fr)); }
+      .stat { background:rgba(15,23,42,0.6); border:1px solid rgba(148,163,184,0.2); border-radius:1rem; padding:1rem; }
+      .stat span { display:block; }
+      .stat .label { font-size:0.75rem; text-transform:uppercase; letter-spacing:0.08em; color:#94a3b8; }
+      .stat .value { font-size:1.25rem; margin-top:0.5rem; font-weight:600; }
+      table { width:100%; border-collapse:collapse; font-size:0.92rem; }
+      thead { background:rgba(30,41,59,0.75); }
+      thead th { text-transform:uppercase; letter-spacing:0.08em; font-size:0.72rem; padding:0.75rem; color:#94a3b8; }
+      tbody td { padding:0.85rem 0.75rem; border-bottom:1px solid rgba(148,163,184,0.15); vertical-align:top; }
+      tbody tr.critical { background:rgba(236,72,153,0.12); }
+      code { background:rgba(15,23,42,0.65); padding:0.25rem 0.45rem; border-radius:0.5rem; border:1px solid rgba(148,163,184,0.25); }
+      ul { margin:0; padding-left:1.2rem; display:grid; gap:0.5rem; }
+      .corridor-grid, .validator-grid { display:grid; gap:1rem; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); }
+      .corridor, .validator { background:rgba(15,23,42,0.55); border:1px solid rgba(148,163,184,0.25); border-radius:1rem; padding:1rem; }
+      .hint { color:#94a3b8; font-size:0.78rem; margin-top:0.35rem; }
+      .mermaid { background:rgba(15,23,42,0.65); border-radius:1rem; border:1px solid rgba(148,163,184,0.25); padding:1rem; overflow-x:auto; }
+      footer { max-width:960px; margin:2rem auto 0; text-align:center; color:#94a3b8; font-size:0.85rem; }
+      @media (max-width:720px) { body { padding:1.5rem; } }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>mermaid.initialize({ startOnLoad: true, theme: 'dark' });</script>
+  </head>
+  <body>
+    <header>
+      <span class="hint">NATIONAL-SUPPLY-CHAIN-V0</span>
+      <h1>National Supply Chain Foresight Command</h1>
+      <p class="lede">Demonstrate how AGI Jobs v0 (v2) autonomously orchestrates national logistics, humanitarian relief, energy flows, and strategic stockpiles while preserving sovereign owner control and quadratic governance levers.</p>
+    </header>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Mission Metrics</h2>
+      <div class="stats">
+        <div class="stat"><span class="label">Jobs orchestrated</span><span class="value">6</span></div>
+        <div class="stat"><span class="label">Phases</span><span class="value">4</span></div>
+        <div class="stat"><span class="label">Agents</span><span class="value">5</span></div>
+        <div class="stat"><span class="label">Validators</span><span class="value">3</span></div>
+        <div class="stat"><span class="label">Total reward</span><span class="value">1,035,000 AGIALPHA</span></div>
+        <div class="stat"><span class="label">Operator reserve</span><span class="value">275,000 AGIALPHA</span></div>
+        <div class="stat"><span class="label">Validator pool</span><span class="value">210,000 AGIALPHA</span></div>
+        <div class="stat"><span class="label">Critical path (days)</span><span class="value">123</span></div>
+        <div class="stat"><span class="label">Max concurrency</span><span class="value">2</span></div>
+        <div class="stat"><span class="label">Corridor capacity</span><span class="value">8,550 t/day</span></div>
+        <div class="stat"><span class="label">Validator stake</span><span class="value">437,000 AGIALPHA</span></div>
+      </div>
+    </section>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Jobs & Critical Path</h2>
+      <table>
+        <thead><tr><th>ID</th><th>Title</th><th>Phase</th><th>Window</th><th>Reward</th><th>Slack</th><th>Corridors</th><th>Agents</th><th>Validators</th></tr></thead>
+        <tbody><tr class="critical"><td>ARCTIC-FOOD-RELAY</td><td>Stabilise Arctic food and medicine relay</td><td>Stabilise critical lifelines</td><td>2025-04-01 → 2025-04-22</td><td>180,000 AGIALPHA</td><td>14 day(s)</td><td>PORT-SPOKE-NORTH, ARCTIC-AIRBRIDGE</td><td>aurora.supply.nation.agi.eth<div class="hint">Deploy icebreaker convoys and VTOL grid</div>healthshield.wallet.agi.eth<div class="hint">Coordinate field triage nodes</div></td><td>polaris.validator.agi.eth, helmsman.validator.agi.eth</td></tr>
+<tr class="critical"><td>PACIFIC-HUB-EXPANSION</td><td>Deploy Pacific floating logistics mega-hub</td><td>Expand inter-regional capacity</td><td>2025-04-22 → 2025-06-01</td><td>220,000 AGIALPHA</td><td>29 day(s)</td><td>PACIFIC-RAIL, PACIFIC-ORBITAL</td><td>pacific.logistics.nation.agi.eth<div class="hint">Assemble modular piers</div>continental.mesh.nation.agi.eth<div class="hint">Synchronise inland maglev</div></td><td>trident.validator.agi.eth</td></tr>
+<tr class="critical"><td>CENTRAL-RESERVE-AUTOMATION</td><td>Automate strategic reserve balancing</td><td>Optimise incentives &amp; market balance</td><td>2025-06-01 → 2025-07-01</td><td>195,000 AGIALPHA</td><td>19 day(s)</td><td>PACIFIC-RAIL, CENTRAL-METRO</td><td>continental.mesh.nation.agi.eth<div class="hint">Optimise maglev + electric fleet</div>railmesh.wallet.agi.eth<div class="hint">Treasury automation and predictive maintenance</div></td><td>helmsman.validator.agi.eth</td></tr>
+<tr class=""><td>CITIZEN-RESPONSE-ACTIVATION</td><td>Activate citizen humanitarian mesh</td><td>Optimise incentives &amp; market balance</td><td>2025-04-22 → 2025-05-17</td><td>165,000 AGIALPHA</td><td>59 day(s)</td><td>METRO-RELIEF</td><td>healthshield.wallet.agi.eth<div class="hint">Citizen DID onboarding</div>railmesh.wallet.agi.eth<div class="hint">Treasury payout automation</div></td><td>polaris.validator.agi.eth, trident.validator.agi.eth</td></tr>
+<tr class="critical"><td>VALIDATION-GRAND-AUDIT</td><td>Validator coalition grand audit</td><td>Harden resilience &amp; audit loops</td><td>2025-07-01 → 2025-07-21</td><td>155,000 AGIALPHA</td><td>19 day(s)</td><td>COMMAND</td><td>polaris.validator.agi.eth<div class="hint">Arctic logistic evidence</div>trident.validator.agi.eth<div class="hint">Port security attestations</div>helmsman.validator.agi.eth<div class="hint">Energy + medical telemetry assurance</div></td><td>polaris.validator.agi.eth, trident.validator.agi.eth, helmsman.validator.agi.eth</td></tr>
+<tr class="critical"><td>TREASURY-REBALANCING-DRILL</td><td>Owner treasury rebalancing + pause drill</td><td>Harden resilience &amp; audit loops</td><td>2025-07-21 → 2025-08-02</td><td>120,000 AGIALPHA</td><td>17 day(s)</td><td>COMMAND, CENTRAL-METRO</td><td>aurora.supply.nation.agi.eth<div class="hint">Execute owner commands via CLI</div>owner<div class="hint">Approve thermostat + treasury adjustments</div></td><td>helmsman.validator.agi.eth</td></tr></tbody>
+      </table>
+    </section>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Corridor Intelligence</h2>
+      <div class="corridor-grid"><article class="corridor"><h3>ARCTIC-AIRBRIDGE</h3><p>VTOL heavy lift</p><p>900 t/day · Latency 6 h</p><p>Redundant thermal shielding &amp; validator telemetry</p><p class="hint">Owner controls: jobs/supply-routing, thermostat, inventory/oracle, energy-oracle</p></article>
+<article class="corridor"><h3>PORT-SPOKE-NORTH</h3><p>Icebreaker convoy</p><p>2,800 t/day · Latency 12 h</p><p>Quadratic validator quorum w/ automated replan</p><p class="hint">Owner controls: owner:command-center, owner:parameters, owner:system-pause, jobs/supply-routing, thermostat</p></article>
+<article class="corridor"><h3>PACIFIC-RAIL</h3><p>Maglev &amp; drone mesh</p><p>2,400 t/day · Latency 9 h</p><p>Dual stake guardrails + pause triggers</p><p class="hint">Owner controls: port/mesh, quadratic-voting, treasury/rebalance, owner:mission-control</p></article>
+<article class="corridor"><h3>CENTRAL-METRO</h3><p>Autonomous electric fleet</p><p>1,800 t/day · Latency 4 h</p><p>Thermostat-driven incentives</p><p class="hint">Owner controls: treasury/rebalance, owner:mission-control, demand-response, owner:parameters</p></article>
+<article class="corridor"><h3>METRO-RELIEF</h3><p>Drone &amp; amphibious</p><p>600 t/day · Latency 2 h</p><p>Citizen validator quorum &amp; DID gating</p><p class="hint">Owner controls: demand-response, owner:parameters, community-wallet, supplychain/agent</p></article>
+<article class="corridor"><h3>PACIFIC-ORBITAL</h3><p>Space elevator cargo</p><p>50 t/day · Latency 3 h</p><p>Zero-trust telemetry encryption</p><p class="hint">Owner controls: port/mesh, quadratic-voting, telemetry, owner:surface</p></article></div>
+    </section>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Owner Playbooks</h2>
+      <ul><li><code>npm run owner:command-center</code></li>
+<li><code>npm run owner:parameters</code></li>
+<li><code>npm run owner:system-pause -- --action pause</code></li>
+<li><code>npm run owner:system-pause -- --action unpause</code></li>
+<li><code>npm run owner:upgrade-status</code></li>
+<li><code>npm run owner:verify-control</code></li>
+<li><code>npm run owner:mission-control</code></li></ul>
+    </section>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Validator Coalition</h2>
+      <div class="validator-grid"><article class="validator"><h3>polaris.validator.agi.eth</h3><p>Arctic supply assurance</p><p class="hint">Stake 160,000 AGIALPHA</p></article>
+<article class="validator"><h3>trident.validator.agi.eth</h3><p>Port security &amp; customs compliance</p><p class="hint">Stake 145,000 AGIALPHA</p></article>
+<article class="validator"><h3>helmsman.validator.agi.eth</h3><p>Energy &amp; medical supply telemetry</p><p class="hint">Stake 132,000 AGIALPHA</p></article></div>
+    </section>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Mermaid Atlas</h2>
+      <div class="mermaid">flowchart LR
+  COMMAND[&quot;Sovereign Command Centre\nCapital&quot;]:::command
+  NORTH_PORT[&quot;Arctic Quantum Port\nAurora Coast&quot;]:::port
+  ARCTIC_HUB[&quot;Permafrost Resilience Hub\nPolar Interior&quot;]:::hub
+  PACIFIC_PORT[&quot;Pacific Floating Megaport\nPacific Ocean&quot;]:::port
+  CENTRAL_STORAGE[&quot;National Strategic Reserve\nCentral Corridor&quot;]:::storage
+  METRO_GRID[&quot;Metropolitan Microgrid\nCapital&quot;]:::distribution
+  AID_CELLS[&quot;Humanitarian Field Cells\nNational&quot;]:::relief
+  ORBITAL_SENSOR[&quot;Orbital Supply Sentinel\nLEO&quot;]:::sensor
+  NORTH_PORT --&gt;|VTOL heavy lift| ARCTIC_HUB
+  COMMAND --&gt;|Icebreaker convoy| NORTH_PORT
+  PACIFIC_PORT --&gt;|Maglev &amp; drone mesh| CENTRAL_STORAGE
+  CENTRAL_STORAGE --&gt;|Autonomous electric fleet| METRO_GRID
+  METRO_GRID --&gt;|Drone &amp; amphibious| AID_CELLS
+  PACIFIC_PORT --&gt;|Space elevator cargo| ORBITAL_SENSOR
+  classDef command fill:#0f172a,stroke:#38bdf8,stroke-width:2,color:#e2e8f0;
+  classDef port fill:#1e3a8a,stroke:#38bdf8,color:#f8fafc;
+  classDef hub fill:#312e81,stroke:#c084fc,color:#f5f3ff;
+  classDef storage fill:#064e3b,stroke:#34d399,color:#ecfdf5;
+  classDef distribution fill:#7c2d12,stroke:#fb923c,color:#ffedd5;
+  classDef relief fill:#7f1d1d,stroke:#fca5a5,color:#fee2e2;
+  classDef sensor fill:#3f3f46,stroke:#facc15,color:#fef9c3;</div>
+      <div class="mermaid" style="margin-top:1rem;">gantt
+  title National Supply Chain Critical Path
+  dateFormat  YYYY-MM-DD
+  axisFormat  %b %d
+  section Stabilise critical lifelines
+  Stabilise Arctic food and medicine relay: crit, arctic_food_relay, 2025-04-01, 2025-04-22
+  section Expand inter-regional capacity
+  Deploy Pacific floating logistics mega-hub: crit, pacific_hub_expansion, 2025-04-22, 2025-06-01
+  section Optimise incentives &amp; market balance
+  Automate strategic reserve balancing: crit, central_reserve_automation, 2025-06-01, 2025-07-01
+  section Optimise incentives &amp; market balance
+  Activate citizen humanitarian mesh:  citizen_response_activation, 2025-04-22, 2025-05-17
+  section Harden resilience &amp; audit loops
+  Validator coalition grand audit: crit, validation_grand_audit, 2025-07-01, 2025-07-21
+  section Harden resilience &amp; audit loops
+  Owner treasury rebalancing + pause drill: crit, treasury_rebalancing_drill, 2025-07-21, 2025-08-02</div>
+    </section>
+    <footer>
+      Generated 2025-01-15T00:00:00.000Z · Plan version v0.9.0 · Owner national.supply.owner.agi.eth
+    </footer>
+  </body>
+</html>

--- a/reports/national-supply-chain/manifest.json
+++ b/reports/national-supply-chain/manifest.json
@@ -1,0 +1,36 @@
+{
+  "generatedAt": "2025-01-15T00:00:00.000Z",
+  "planVersion": "v0.9.0",
+  "files": [
+    {
+      "path": "reports/national-supply-chain/dashboard.html",
+      "sha256": "09e94929b7a2e2dd682358c48162c430984c2908b61d5f287533c6e8b48011b4",
+      "bytes": 13516
+    },
+    {
+      "path": "reports/national-supply-chain/summary.md",
+      "sha256": "c00f0858606420a8f9a4e96066c34396d1400330742f94c5cd94d37dd730dae0",
+      "bytes": 4555
+    },
+    {
+      "path": "reports/national-supply-chain/mermaid.mmd",
+      "sha256": "3c445f67adc20c13d111c124c4458205500c8ecbb7444ee594922b3722a22603",
+      "bytes": 2187
+    },
+    {
+      "path": "reports/national-supply-chain/mission-ledger.json",
+      "sha256": "c560b328ab90c91dc8024f77091789a88f98f9aefde3f9921688e988739d70d8",
+      "bytes": 17371
+    },
+    {
+      "path": "reports/national-supply-chain/owner-command-center.md",
+      "sha256": "9c2072d1bceba65df4f86b8664cabac2f8f895ffd76ab836e9c16392051e04db",
+      "bytes": 856
+    },
+    {
+      "path": "demo/National-Supply-Chain-v0/ui/export/latest.json",
+      "sha256": "c560b328ab90c91dc8024f77091789a88f98f9aefde3f9921688e988739d70d8",
+      "bytes": 17371
+    }
+  ]
+}

--- a/reports/national-supply-chain/mermaid.mmd
+++ b/reports/national-supply-chain/mermaid.mmd
@@ -1,0 +1,39 @@
+flowchart LR
+  COMMAND["Sovereign Command Centre\nCapital"]:::command
+  NORTH_PORT["Arctic Quantum Port\nAurora Coast"]:::port
+  ARCTIC_HUB["Permafrost Resilience Hub\nPolar Interior"]:::hub
+  PACIFIC_PORT["Pacific Floating Megaport\nPacific Ocean"]:::port
+  CENTRAL_STORAGE["National Strategic Reserve\nCentral Corridor"]:::storage
+  METRO_GRID["Metropolitan Microgrid\nCapital"]:::distribution
+  AID_CELLS["Humanitarian Field Cells\nNational"]:::relief
+  ORBITAL_SENSOR["Orbital Supply Sentinel\nLEO"]:::sensor
+  NORTH_PORT -->|VTOL heavy lift| ARCTIC_HUB
+  COMMAND -->|Icebreaker convoy| NORTH_PORT
+  PACIFIC_PORT -->|Maglev & drone mesh| CENTRAL_STORAGE
+  CENTRAL_STORAGE -->|Autonomous electric fleet| METRO_GRID
+  METRO_GRID -->|Drone & amphibious| AID_CELLS
+  PACIFIC_PORT -->|Space elevator cargo| ORBITAL_SENSOR
+  classDef command fill:#0f172a,stroke:#38bdf8,stroke-width:2,color:#e2e8f0;
+  classDef port fill:#1e3a8a,stroke:#38bdf8,color:#f8fafc;
+  classDef hub fill:#312e81,stroke:#c084fc,color:#f5f3ff;
+  classDef storage fill:#064e3b,stroke:#34d399,color:#ecfdf5;
+  classDef distribution fill:#7c2d12,stroke:#fb923c,color:#ffedd5;
+  classDef relief fill:#7f1d1d,stroke:#fca5a5,color:#fee2e2;
+  classDef sensor fill:#3f3f46,stroke:#facc15,color:#fef9c3;
+
+gantt
+  title National Supply Chain Critical Path
+  dateFormat  YYYY-MM-DD
+  axisFormat  %b %d
+  section Stabilise critical lifelines
+  Stabilise Arctic food and medicine relay: crit, arctic_food_relay, 2025-04-01, 2025-04-22
+  section Expand inter-regional capacity
+  Deploy Pacific floating logistics mega-hub: crit, pacific_hub_expansion, 2025-04-22, 2025-06-01
+  section Optimise incentives & market balance
+  Automate strategic reserve balancing: crit, central_reserve_automation, 2025-06-01, 2025-07-01
+  section Optimise incentives & market balance
+  Activate citizen humanitarian mesh:  citizen_response_activation, 2025-04-22, 2025-05-17
+  section Harden resilience & audit loops
+  Validator coalition grand audit: crit, validation_grand_audit, 2025-07-01, 2025-07-21
+  section Harden resilience & audit loops
+  Owner treasury rebalancing + pause drill: crit, treasury_rebalancing_drill, 2025-07-21, 2025-08-02

--- a/reports/national-supply-chain/mission-ledger.json
+++ b/reports/national-supply-chain/mission-ledger.json
@@ -1,0 +1,524 @@
+{
+  "initiative": "National Supply Chain Foresight Command",
+  "objective": "Demonstrate how AGI Jobs v0 (v2) autonomously orchestrates national logistics, humanitarian relief, energy flows, and strategic stockpiles while preserving sovereign owner control and quadratic governance levers.",
+  "missionTag": "NATIONAL-SUPPLY-CHAIN-V0",
+  "generatedAt": "2025-01-15T00:00:00.000Z",
+  "launchDate": "2025-04-01",
+  "network": "Hardhat localhost (31337)",
+  "ownerEns": "national.supply.owner.agi.eth",
+  "budget": {
+    "currency": "AGIALPHA",
+    "total": 1250000,
+    "operatorReserve": 275000,
+    "validatorPool": 210000
+  },
+  "metrics": {
+    "jobCount": 6,
+    "phaseCount": 4,
+    "agentCount": 5,
+    "validatorCount": 3,
+    "totalReward": 1035000,
+    "operatorReserve": 275000,
+    "validatorPool": 210000,
+    "criticalPathDays": 123,
+    "maxConcurrency": 2,
+    "corridorCapacity": 8550,
+    "validatorStake": 437000
+  },
+  "phases": [
+    {
+      "id": "STABILISE",
+      "title": "Stabilise critical lifelines",
+      "windowDays": 21,
+      "focus": [
+        "Food",
+        "Medical",
+        "Energy"
+      ],
+      "ownerControls": [
+        "owner:system-pause",
+        "owner:command-center",
+        "owner:parameters"
+      ],
+      "deliverables": [
+        "Deploy thermodynamic guardrails",
+        "Spin up rapid relief corridors",
+        "Publish sovereign command map"
+      ]
+    },
+    {
+      "id": "EXPAND",
+      "title": "Expand inter-regional capacity",
+      "windowDays": 45,
+      "focus": [
+        "Infrastructure",
+        "Energy storage",
+        "Data fusion"
+      ],
+      "ownerControls": [
+        "owner:mission-control",
+        "owner:parameters",
+        "thermostat:update"
+      ],
+      "deliverables": [
+        "Activate floating megaports",
+        "Commission orbital sentinel",
+        "Publish corridor capacity oracles"
+      ]
+    },
+    {
+      "id": "OPTIMISE",
+      "title": "Optimise incentives & market balance",
+      "windowDays": 60,
+      "focus": [
+        "Dynamic pricing",
+        "Validator incentives",
+        "Quadratic votes"
+      ],
+      "ownerControls": [
+        "owner:command-center",
+        "reward-engine:update",
+        "platform:registry:update"
+      ],
+      "deliverables": [
+        "Incentive thermostat tuned",
+        "Validator mesh calibrations",
+        "Citizen quadratic vote results"
+      ]
+    },
+    {
+      "id": "HARDEN",
+      "title": "Harden resilience & audit loops",
+      "windowDays": 30,
+      "focus": [
+        "Pause drills",
+        "Audit trails",
+        "Sovereign reporting"
+      ],
+      "ownerControls": [
+        "owner:verify-control",
+        "owner:mission-control",
+        "owner:upgrade-status"
+      ],
+      "deliverables": [
+        "System pause rehearsal",
+        "Grand manifest notarised",
+        "Stakeholder evidence bundle"
+      ]
+    }
+  ],
+  "jobs": [
+    {
+      "id": "ARCTIC-FOOD-RELAY",
+      "title": "Stabilise Arctic food and medicine relay",
+      "phase": "STABILISE",
+      "phaseTitle": "Stabilise critical lifelines",
+      "reward": 180000,
+      "startOffset": 0,
+      "endOffset": 21,
+      "startDate": "2025-04-01T00:00:00.000Z",
+      "endDate": "2025-04-22T00:00:00.000Z",
+      "deadlineDate": "2025-05-06T00:00:00.000Z",
+      "slackDays": 14,
+      "corridors": [
+        "PORT-SPOKE-NORTH",
+        "ARCTIC-AIRBRIDGE"
+      ],
+      "assigned": [
+        {
+          "agent": "aurora.supply.nation.agi.eth",
+          "responsibility": "Deploy icebreaker convoys and VTOL grid"
+        },
+        {
+          "agent": "healthshield.wallet.agi.eth",
+          "responsibility": "Coordinate field triage nodes"
+        }
+      ],
+      "validators": [
+        "polaris.validator.agi.eth",
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "AI convoys deliver 5,000 tonnes of food and medical supplies per week",
+        "Validator network signs real-time inventory snapshots",
+        "Owner thermostat calibrates incentives for sub-zero operations"
+      ],
+      "critical": true
+    },
+    {
+      "id": "PACIFIC-HUB-EXPANSION",
+      "title": "Deploy Pacific floating logistics mega-hub",
+      "phase": "EXPAND",
+      "phaseTitle": "Expand inter-regional capacity",
+      "reward": 220000,
+      "startOffset": 21,
+      "endOffset": 61,
+      "startDate": "2025-04-22T00:00:00.000Z",
+      "endDate": "2025-06-01T00:00:00.000Z",
+      "deadlineDate": "2025-06-30T00:00:00.000Z",
+      "slackDays": 29,
+      "corridors": [
+        "PACIFIC-RAIL",
+        "PACIFIC-ORBITAL"
+      ],
+      "assigned": [
+        {
+          "agent": "pacific.logistics.nation.agi.eth",
+          "responsibility": "Assemble modular piers"
+        },
+        {
+          "agent": "continental.mesh.nation.agi.eth",
+          "responsibility": "Synchronise inland maglev"
+        }
+      ],
+      "validators": [
+        "trident.validator.agi.eth"
+      ],
+      "brief": [
+        "Activate floating megaport with 200 autonomous cranes",
+        "Spin up orbital sentinel handshake for customs",
+        "Owner command centre verifies berth prioritisation via quadratic vote"
+      ],
+      "critical": true
+    },
+    {
+      "id": "CENTRAL-RESERVE-AUTOMATION",
+      "title": "Automate strategic reserve balancing",
+      "phase": "OPTIMISE",
+      "phaseTitle": "Optimise incentives & market balance",
+      "reward": 195000,
+      "startOffset": 61,
+      "endOffset": 91,
+      "startDate": "2025-06-01T00:00:00.000Z",
+      "endDate": "2025-07-01T00:00:00.000Z",
+      "deadlineDate": "2025-07-20T00:00:00.000Z",
+      "slackDays": 19,
+      "corridors": [
+        "PACIFIC-RAIL",
+        "CENTRAL-METRO"
+      ],
+      "assigned": [
+        {
+          "agent": "continental.mesh.nation.agi.eth",
+          "responsibility": "Optimise maglev + electric fleet"
+        },
+        {
+          "agent": "railmesh.wallet.agi.eth",
+          "responsibility": "Treasury automation and predictive maintenance"
+        }
+      ],
+      "validators": [
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Deploy reinforcement learning agents on stockpile hedging",
+        "Publish energy + nutrition coverage dashboards",
+        "Owner triggers reward engine update for fair share distribution"
+      ],
+      "critical": true
+    },
+    {
+      "id": "CITIZEN-RESPONSE-ACTIVATION",
+      "title": "Activate citizen humanitarian mesh",
+      "phase": "OPTIMISE",
+      "phaseTitle": "Optimise incentives & market balance",
+      "reward": 165000,
+      "startOffset": 21,
+      "endOffset": 46,
+      "startDate": "2025-04-22T00:00:00.000Z",
+      "endDate": "2025-05-17T00:00:00.000Z",
+      "deadlineDate": "2025-07-15T00:00:00.000Z",
+      "slackDays": 59,
+      "corridors": [
+        "METRO-RELIEF"
+      ],
+      "assigned": [
+        {
+          "agent": "healthshield.wallet.agi.eth",
+          "responsibility": "Citizen DID onboarding"
+        },
+        {
+          "agent": "railmesh.wallet.agi.eth",
+          "responsibility": "Treasury payout automation"
+        }
+      ],
+      "validators": [
+        "polaris.validator.agi.eth",
+        "trident.validator.agi.eth"
+      ],
+      "brief": [
+        "Launch DID-gated citizen relief missions",
+        "Validators approve quadratic reward allocations",
+        "Owner monitors supply plan autop-run via CLI"
+      ],
+      "critical": false
+    },
+    {
+      "id": "VALIDATION-GRAND-AUDIT",
+      "title": "Validator coalition grand audit",
+      "phase": "HARDEN",
+      "phaseTitle": "Harden resilience & audit loops",
+      "reward": 155000,
+      "startOffset": 91,
+      "endOffset": 111,
+      "startDate": "2025-07-01T00:00:00.000Z",
+      "endDate": "2025-07-21T00:00:00.000Z",
+      "deadlineDate": "2025-08-09T00:00:00.000Z",
+      "slackDays": 19,
+      "corridors": [
+        "COMMAND"
+      ],
+      "assigned": [
+        {
+          "agent": "polaris.validator.agi.eth",
+          "responsibility": "Arctic logistic evidence"
+        },
+        {
+          "agent": "trident.validator.agi.eth",
+          "responsibility": "Port security attestations"
+        },
+        {
+          "agent": "helmsman.validator.agi.eth",
+          "responsibility": "Energy + medical telemetry assurance"
+        }
+      ],
+      "validators": [
+        "polaris.validator.agi.eth",
+        "trident.validator.agi.eth",
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Compile audit bundle for national senate",
+        "Verify owner pause + resume logs",
+        "Publish thermodynamic telemetry for all corridors"
+      ],
+      "critical": true
+    },
+    {
+      "id": "TREASURY-REBALANCING-DRILL",
+      "title": "Owner treasury rebalancing + pause drill",
+      "phase": "HARDEN",
+      "phaseTitle": "Harden resilience & audit loops",
+      "reward": 120000,
+      "startOffset": 111,
+      "endOffset": 123,
+      "startDate": "2025-07-21T00:00:00.000Z",
+      "endDate": "2025-08-02T00:00:00.000Z",
+      "deadlineDate": "2025-08-19T00:00:00.000Z",
+      "slackDays": 17,
+      "corridors": [
+        "COMMAND",
+        "CENTRAL-METRO"
+      ],
+      "assigned": [
+        {
+          "agent": "aurora.supply.nation.agi.eth",
+          "responsibility": "Execute owner commands via CLI"
+        },
+        {
+          "agent": "owner",
+          "responsibility": "Approve thermostat + treasury adjustments"
+        }
+      ],
+      "validators": [
+        "helmsman.validator.agi.eth"
+      ],
+      "brief": [
+        "Run pause + resume using owner command centre",
+        "Rebalance treasury between validator and agent pools",
+        "Produce notarised manifest + hashed summary"
+      ],
+      "critical": true
+    }
+  ],
+  "corridors": [
+    {
+      "id": "ARCTIC-AIRBRIDGE",
+      "from": "NORTH_PORT",
+      "to": "ARCTIC_HUB",
+      "mode": "VTOL heavy lift",
+      "capacityTonnesPerDay": 900,
+      "latencyHours": 6,
+      "resilience": "Redundant thermal shielding & validator telemetry",
+      "ownerControls": [
+        "jobs/supply-routing",
+        "thermostat",
+        "inventory/oracle",
+        "energy-oracle"
+      ]
+    },
+    {
+      "id": "PORT-SPOKE-NORTH",
+      "from": "COMMAND",
+      "to": "NORTH_PORT",
+      "mode": "Icebreaker convoy",
+      "capacityTonnesPerDay": 2800,
+      "latencyHours": 12,
+      "resilience": "Quadratic validator quorum w/ automated replan",
+      "ownerControls": [
+        "owner:command-center",
+        "owner:parameters",
+        "owner:system-pause",
+        "jobs/supply-routing",
+        "thermostat"
+      ]
+    },
+    {
+      "id": "PACIFIC-RAIL",
+      "from": "PACIFIC_PORT",
+      "to": "CENTRAL_STORAGE",
+      "mode": "Maglev & drone mesh",
+      "capacityTonnesPerDay": 2400,
+      "latencyHours": 9,
+      "resilience": "Dual stake guardrails + pause triggers",
+      "ownerControls": [
+        "port/mesh",
+        "quadratic-voting",
+        "treasury/rebalance",
+        "owner:mission-control"
+      ]
+    },
+    {
+      "id": "CENTRAL-METRO",
+      "from": "CENTRAL_STORAGE",
+      "to": "METRO_GRID",
+      "mode": "Autonomous electric fleet",
+      "capacityTonnesPerDay": 1800,
+      "latencyHours": 4,
+      "resilience": "Thermostat-driven incentives",
+      "ownerControls": [
+        "treasury/rebalance",
+        "owner:mission-control",
+        "demand-response",
+        "owner:parameters"
+      ]
+    },
+    {
+      "id": "METRO-RELIEF",
+      "from": "METRO_GRID",
+      "to": "AID_CELLS",
+      "mode": "Drone & amphibious",
+      "capacityTonnesPerDay": 600,
+      "latencyHours": 2,
+      "resilience": "Citizen validator quorum & DID gating",
+      "ownerControls": [
+        "demand-response",
+        "owner:parameters",
+        "community-wallet",
+        "supplychain/agent"
+      ]
+    },
+    {
+      "id": "PACIFIC-ORBITAL",
+      "from": "PACIFIC_PORT",
+      "to": "ORBITAL_SENSOR",
+      "mode": "Space elevator cargo",
+      "capacityTonnesPerDay": 50,
+      "latencyHours": 3,
+      "resilience": "Zero-trust telemetry encryption",
+      "ownerControls": [
+        "port/mesh",
+        "quadratic-voting",
+        "telemetry",
+        "owner:surface"
+      ]
+    }
+  ],
+  "validators": [
+    {
+      "handle": "polaris.validator.agi.eth",
+      "stake": 160000,
+      "mandate": "Arctic supply assurance",
+      "wallet": "0xVAL1d0000000000000000000000000000000A1"
+    },
+    {
+      "handle": "trident.validator.agi.eth",
+      "stake": 145000,
+      "mandate": "Port security & customs compliance",
+      "wallet": "0xVAL1d0000000000000000000000000000000A2"
+    },
+    {
+      "handle": "helmsman.validator.agi.eth",
+      "stake": 132000,
+      "mandate": "Energy & medical supply telemetry",
+      "wallet": "0xVAL1d0000000000000000000000000000000A3"
+    }
+  ],
+  "agents": [
+    {
+      "handle": "aurora.supply.nation.agi.eth",
+      "role": "Northern Resilience Authority",
+      "capabilities": [
+        "Cryosphere logistics optimisation",
+        "Autonomous convoy routing",
+        "Quantum-secured telemetry"
+      ],
+      "wallet": "0xfA11eD000000000000000000000000000000A01",
+      "sovereign": "Aurora Coalition"
+    },
+    {
+      "handle": "pacific.logistics.nation.agi.eth",
+      "role": "Pacific Infrastructure Continuity Agency",
+      "capabilities": [
+        "Floating port assembly",
+        "Typhoon-adaptive routing",
+        "Dual-use port cyber defences"
+      ],
+      "wallet": "0xfA11eD000000000000000000000000000000A02",
+      "sovereign": "Pacific Alliance"
+    },
+    {
+      "handle": "continental.mesh.nation.agi.eth",
+      "role": "Continental Multi-Modal Mesh",
+      "capabilities": [
+        "AI rail corridor harmonisation",
+        "Supply-demand clearing market",
+        "National carbon-aware routing"
+      ],
+      "wallet": "0xfA11eD000000000000000000000000000000A03",
+      "sovereign": "Continental Union"
+    },
+    {
+      "handle": "healthshield.wallet.agi.eth",
+      "role": "HealthShield Humanitarian Collective",
+      "capabilities": [
+        "Rapid medical triage",
+        "Drone-based emergency delivery",
+        "On-chain citizen feedback"
+      ],
+      "wallet": "0xF9eD00000000000000000000000000000000B10",
+      "sovereign": "Community Treasury"
+    },
+    {
+      "handle": "railmesh.wallet.agi.eth",
+      "role": "RailMesh Cooperative Treasury",
+      "capabilities": [
+        "Rail hub automation",
+        "Predictive maintenance",
+        "Surge capacity hedging"
+      ],
+      "wallet": "0xF9eD00000000000000000000000000000000B11",
+      "sovereign": "Worker Consortium"
+    }
+  ],
+  "ownerPlaybooks": [
+    "npm run owner:command-center",
+    "npm run owner:parameters",
+    "npm run owner:system-pause -- --action pause",
+    "npm run owner:system-pause -- --action unpause",
+    "npm run owner:upgrade-status",
+    "npm run owner:verify-control",
+    "npm run owner:mission-control"
+  ],
+  "mermaid": {
+    "network": "flowchart LR\n  COMMAND[\"Sovereign Command Centre\\nCapital\"]:::command\n  NORTH_PORT[\"Arctic Quantum Port\\nAurora Coast\"]:::port\n  ARCTIC_HUB[\"Permafrost Resilience Hub\\nPolar Interior\"]:::hub\n  PACIFIC_PORT[\"Pacific Floating Megaport\\nPacific Ocean\"]:::port\n  CENTRAL_STORAGE[\"National Strategic Reserve\\nCentral Corridor\"]:::storage\n  METRO_GRID[\"Metropolitan Microgrid\\nCapital\"]:::distribution\n  AID_CELLS[\"Humanitarian Field Cells\\nNational\"]:::relief\n  ORBITAL_SENSOR[\"Orbital Supply Sentinel\\nLEO\"]:::sensor\n  NORTH_PORT -->|VTOL heavy lift| ARCTIC_HUB\n  COMMAND -->|Icebreaker convoy| NORTH_PORT\n  PACIFIC_PORT -->|Maglev & drone mesh| CENTRAL_STORAGE\n  CENTRAL_STORAGE -->|Autonomous electric fleet| METRO_GRID\n  METRO_GRID -->|Drone & amphibious| AID_CELLS\n  PACIFIC_PORT -->|Space elevator cargo| ORBITAL_SENSOR\n  classDef command fill:#0f172a,stroke:#38bdf8,stroke-width:2,color:#e2e8f0;\n  classDef port fill:#1e3a8a,stroke:#38bdf8,color:#f8fafc;\n  classDef hub fill:#312e81,stroke:#c084fc,color:#f5f3ff;\n  classDef storage fill:#064e3b,stroke:#34d399,color:#ecfdf5;\n  classDef distribution fill:#7c2d12,stroke:#fb923c,color:#ffedd5;\n  classDef relief fill:#7f1d1d,stroke:#fca5a5,color:#fee2e2;\n  classDef sensor fill:#3f3f46,stroke:#facc15,color:#fef9c3;",
+    "gantt": "gantt\n  title National Supply Chain Critical Path\n  dateFormat  YYYY-MM-DD\n  axisFormat  %b %d\n  section Stabilise critical lifelines\n  Stabilise Arctic food and medicine relay: crit, arctic_food_relay, 2025-04-01, 2025-04-22\n  section Expand inter-regional capacity\n  Deploy Pacific floating logistics mega-hub: crit, pacific_hub_expansion, 2025-04-22, 2025-06-01\n  section Optimise incentives & market balance\n  Automate strategic reserve balancing: crit, central_reserve_automation, 2025-06-01, 2025-07-01\n  section Optimise incentives & market balance\n  Activate citizen humanitarian mesh:  citizen_response_activation, 2025-04-22, 2025-05-17\n  section Harden resilience & audit loops\n  Validator coalition grand audit: crit, validation_grand_audit, 2025-07-01, 2025-07-21\n  section Harden resilience & audit loops\n  Owner treasury rebalancing + pause drill: crit, treasury_rebalancing_drill, 2025-07-21, 2025-08-02"
+  },
+  "criticalJobs": [
+    "TREASURY-REBALANCING-DRILL",
+    "VALIDATION-GRAND-AUDIT",
+    "CENTRAL-RESERVE-AUTOMATION",
+    "PACIFIC-HUB-EXPANSION",
+    "ARCTIC-FOOD-RELAY"
+  ]
+}

--- a/reports/national-supply-chain/owner-command-center.md
+++ b/reports/national-supply-chain/owner-command-center.md
@@ -1,0 +1,13 @@
+# Owner Command Centre Checklist
+
+Execute the following commands after each launch to assert sovereign control:
+
+- `npm run owner:command-center` — Render live state of every owner module.
+- `npm run owner:parameters` — Inspect configurable parameters (fees, stake thresholds, thermostat).
+- `npm run owner:system-pause -- --action pause` — Engage the global pause valve for drills or incidents.
+- `npm run owner:system-pause -- --action unpause` — Resume operations after validation.
+- `npm run owner:upgrade-status` — Review timelocked governance proposals before execution.
+- `npm run owner:verify-control` — Cryptographically verify owner supremacy across modules.
+- `npm run owner:mission-control` — Summarise treasury balances and mission spend.
+
+For emergency response run: `npm run owner:emergency` and follow the generated playbook.

--- a/reports/national-supply-chain/summary.md
+++ b/reports/national-supply-chain/summary.md
@@ -1,0 +1,101 @@
+# National Supply Chain Foresight Command
+
+**Objective:** Demonstrate how AGI Jobs v0 (v2) autonomously orchestrates national logistics, humanitarian relief, energy flows, and strategic stockpiles while preserving sovereign owner control and quadratic governance levers.
+
+## Mission metrics
+
+- Jobs orchestrated: 6
+- Critical path: 123 days
+- Max concurrency: 2
+- Total reward: 1,035,000 AGIALPHA
+- Validator stake: 437,000 AGIALPHA
+- Corridor capacity: 8550 tonnes/day
+
+## Jobs
+
+### Stabilise Arctic food and medicine relay
+- Phase: Stabilise critical lifelines
+- Schedule: 2025-04-01 → 2025-04-22 (deadline 2025-05-06)
+- Reward: 180,000 AGIALPHA · Slack: 14 days
+- Corridors: PORT-SPOKE-NORTH, ARCTIC-AIRBRIDGE
+- Agents: aurora.supply.nation.agi.eth (Deploy icebreaker convoys and VTOL grid); healthshield.wallet.agi.eth (Coordinate field triage nodes)
+- Validators: polaris.validator.agi.eth, helmsman.validator.agi.eth
+  - Brief:
+    - AI convoys deliver 5,000 tonnes of food and medical supplies per week
+    - Validator network signs real-time inventory snapshots
+    - Owner thermostat calibrates incentives for sub-zero operations
+  - **Critical path node**
+
+### Deploy Pacific floating logistics mega-hub
+- Phase: Expand inter-regional capacity
+- Schedule: 2025-04-22 → 2025-06-01 (deadline 2025-06-30)
+- Reward: 220,000 AGIALPHA · Slack: 29 days
+- Corridors: PACIFIC-RAIL, PACIFIC-ORBITAL
+- Agents: pacific.logistics.nation.agi.eth (Assemble modular piers); continental.mesh.nation.agi.eth (Synchronise inland maglev)
+- Validators: trident.validator.agi.eth
+  - Brief:
+    - Activate floating megaport with 200 autonomous cranes
+    - Spin up orbital sentinel handshake for customs
+    - Owner command centre verifies berth prioritisation via quadratic vote
+  - **Critical path node**
+
+### Automate strategic reserve balancing
+- Phase: Optimise incentives & market balance
+- Schedule: 2025-06-01 → 2025-07-01 (deadline 2025-07-20)
+- Reward: 195,000 AGIALPHA · Slack: 19 days
+- Corridors: PACIFIC-RAIL, CENTRAL-METRO
+- Agents: continental.mesh.nation.agi.eth (Optimise maglev + electric fleet); railmesh.wallet.agi.eth (Treasury automation and predictive maintenance)
+- Validators: helmsman.validator.agi.eth
+  - Brief:
+    - Deploy reinforcement learning agents on stockpile hedging
+    - Publish energy + nutrition coverage dashboards
+    - Owner triggers reward engine update for fair share distribution
+  - **Critical path node**
+
+### Activate citizen humanitarian mesh
+- Phase: Optimise incentives & market balance
+- Schedule: 2025-04-22 → 2025-05-17 (deadline 2025-07-15)
+- Reward: 165,000 AGIALPHA · Slack: 59 days
+- Corridors: METRO-RELIEF
+- Agents: healthshield.wallet.agi.eth (Citizen DID onboarding); railmesh.wallet.agi.eth (Treasury payout automation)
+- Validators: polaris.validator.agi.eth, trident.validator.agi.eth
+  - Brief:
+    - Launch DID-gated citizen relief missions
+    - Validators approve quadratic reward allocations
+    - Owner monitors supply plan autop-run via CLI
+
+### Validator coalition grand audit
+- Phase: Harden resilience & audit loops
+- Schedule: 2025-07-01 → 2025-07-21 (deadline 2025-08-09)
+- Reward: 155,000 AGIALPHA · Slack: 19 days
+- Corridors: COMMAND
+- Agents: polaris.validator.agi.eth (Arctic logistic evidence); trident.validator.agi.eth (Port security attestations); helmsman.validator.agi.eth (Energy + medical telemetry assurance)
+- Validators: polaris.validator.agi.eth, trident.validator.agi.eth, helmsman.validator.agi.eth
+  - Brief:
+    - Compile audit bundle for national senate
+    - Verify owner pause + resume logs
+    - Publish thermodynamic telemetry for all corridors
+  - **Critical path node**
+
+### Owner treasury rebalancing + pause drill
+- Phase: Harden resilience & audit loops
+- Schedule: 2025-07-21 → 2025-08-02 (deadline 2025-08-19)
+- Reward: 120,000 AGIALPHA · Slack: 17 days
+- Corridors: COMMAND, CENTRAL-METRO
+- Agents: aurora.supply.nation.agi.eth (Execute owner commands via CLI); owner (Approve thermostat + treasury adjustments)
+- Validators: helmsman.validator.agi.eth
+  - Brief:
+    - Run pause + resume using owner command centre
+    - Rebalance treasury between validator and agent pools
+    - Produce notarised manifest + hashed summary
+  - **Critical path node**
+
+## Owner playbooks
+
+- `npm run owner:command-center`
+- `npm run owner:parameters`
+- `npm run owner:system-pause -- --action pause`
+- `npm run owner:system-pause -- --action unpause`
+- `npm run owner:upgrade-status`
+- `npm run owner:verify-control`
+- `npm run owner:mission-control`

--- a/scripts/v2/nationalSupplyChainDemo.ts
+++ b/scripts/v2/nationalSupplyChainDemo.ts
@@ -1,0 +1,780 @@
+#!/usr/bin/env ts-node
+
+import { createHash } from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+interface PlanAgent {
+  handle: string;
+  role: string;
+  capabilities?: string[];
+  wallet?: string;
+  sovereign?: string;
+}
+
+interface PlanValidator {
+  handle: string;
+  stake: string;
+  mandate?: string;
+  wallet?: string;
+}
+
+interface PlanNode {
+  id: string;
+  label: string;
+  type: string;
+  region?: string;
+  capacityTonnesPerDay?: number;
+  controlSurfaces?: string[];
+  description?: string;
+}
+
+interface PlanCorridor {
+  id: string;
+  from: string;
+  to: string;
+  mode: string;
+  capacityTonnesPerDay: number;
+  latencyHours: number;
+  resilience: string;
+}
+
+interface PlanPhase {
+  id: string;
+  title: string;
+  windowDays: number;
+  focus: string[];
+  ownerControls: string[];
+  deliverables: string[];
+}
+
+interface PlanJobAssignment {
+  agent: string;
+  responsibility: string;
+}
+
+interface PlanJob {
+  id: string;
+  title: string;
+  phase: string;
+  reward: string;
+  deadlineDays: number;
+  durationDays: number;
+  dependencies: string[];
+  energyBudget: string;
+  thermodynamicProfile?: Record<string, unknown>;
+  corridors: string[];
+  assigned: PlanJobAssignment[];
+  validatorFocus: string[];
+  brief?: string[];
+}
+
+interface Plan {
+  initiative: string;
+  objective: string;
+  metadata: {
+    version: string;
+    generatedAt: string;
+    launchDate: string;
+    timezone?: string;
+    ownerEns?: string;
+    missionTag?: string;
+  };
+  budget: {
+    currency: string;
+    total: string;
+    operatorReserve?: string;
+    validatorPool?: string;
+  };
+  governance: {
+    owner: string;
+    pauseAuthority: string;
+    treasury: string;
+    thermostat?: Record<string, unknown>;
+    ownerPlaybooks?: string[];
+  };
+  participants: {
+    agents: PlanAgent[];
+    validators: PlanValidator[];
+    humanOversight?: Array<{ name: string; responsibility: string }>;
+  };
+  supplyNetwork: {
+    nodes: PlanNode[];
+    corridors: PlanCorridor[];
+    resilienceProfiles?: Array<{ id: string; description: string; recommendedControls: string[] }>;
+  };
+  operations: {
+    phases: PlanPhase[];
+  };
+  jobs: PlanJob[];
+  reporting?: Record<string, unknown>;
+}
+
+interface DerivedJob {
+  id: string;
+  title: string;
+  phase: string;
+  phaseTitle: string;
+  reward: number;
+  startOffset: number;
+  endOffset: number;
+  startDate: string;
+  endDate: string;
+  deadlineDate: string;
+  slackDays: number;
+  corridors: string[];
+  assigned: PlanJobAssignment[];
+  validators: string[];
+  brief: string[];
+  critical: boolean;
+}
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const DEFAULT_PLAN_PATH = path.join(ROOT, 'demo', 'National-Supply-Chain-v0', 'project-plan.national-supply-chain.json');
+const DEFAULT_REPORT_DIR = path.join(ROOT, 'reports', 'national-supply-chain');
+const DEFAULT_UI_EXPORT = path.join(ROOT, 'demo', 'National-Supply-Chain-v0', 'ui', 'export', 'latest.json');
+
+function resolvePath(envKey: string, defaultPath: string): string {
+  const override = process.env[envKey];
+  if (!override || override.trim().length === 0) {
+    return defaultPath;
+  }
+  const trimmed = override.trim();
+  if (path.isAbsolute(trimmed)) return trimmed;
+  return path.join(ROOT, trimmed);
+}
+
+function readJsonSync<T>(value: string): T {
+  return JSON.parse(value) as T;
+}
+
+function parsePlan(raw: string): Plan {
+  try {
+    return readJsonSync<Plan>(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse plan JSON: ${(error as Error).message}`);
+  }
+}
+
+function ensureUniqueIds(jobs: PlanJob[]): void {
+  const seen = new Set<string>();
+  for (const job of jobs) {
+    if (seen.has(job.id)) {
+      throw new Error(`Duplicate job id detected: ${job.id}`);
+    }
+    seen.add(job.id);
+  }
+}
+
+function detectCycles(jobs: PlanJob[]): void {
+  const jobMap = new Map<string, PlanJob>(jobs.map((job) => [job.id, job]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  function visit(id: string): void {
+    if (visited.has(id)) return;
+    if (visiting.has(id)) {
+      throw new Error(`Cyclic dependency detected at job ${id}`);
+    }
+    visiting.add(id);
+    const job = jobMap.get(id);
+    if (!job) {
+      throw new Error(`Missing job referenced in dependency graph: ${id}`);
+    }
+    for (const dep of job.dependencies) {
+      if (!jobMap.has(dep)) {
+        throw new Error(`Job ${job.id} references unknown dependency ${dep}`);
+      }
+      visit(dep);
+    }
+    visiting.delete(id);
+    visited.add(id);
+  }
+
+  for (const job of jobs) {
+    visit(job.id);
+  }
+}
+
+function toNumber(label: string, value: string | number | undefined): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`Invalid numeric value for ${label}: ${value}`);
+    }
+    return parsed;
+  }
+  throw new Error(`Missing numeric value for ${label}`);
+}
+
+function createCurrencyFormatter(currency: string): (value: number) => string {
+  try {
+    const formatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    });
+    return (value: number) => formatter.format(value);
+  } catch {
+    const fallback = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
+    return (value: number) => `${fallback.format(value)} ${currency}`.trim();
+  }
+}
+
+function computeSchedule(plan: Plan, launchDateIso: string): { jobs: DerivedJob[]; criticalPathDays: number; criticalJobIds: Set<string>; maxConcurrency: number } {
+  ensureUniqueIds(plan.jobs);
+  detectCycles(plan.jobs);
+
+  const phaseMap = new Map<string, PlanPhase>(plan.operations.phases.map((phase) => [phase.id, phase]));
+  const jobMap = new Map<string, PlanJob>(plan.jobs.map((job) => [job.id, job]));
+
+  const inDegree = new Map<string, number>();
+  const adjacency = new Map<string, string[]>();
+
+  for (const job of plan.jobs) {
+    inDegree.set(job.id, 0);
+    adjacency.set(job.id, []);
+  }
+
+  for (const job of plan.jobs) {
+    for (const dep of job.dependencies) {
+      adjacency.get(dep)?.push(job.id);
+      inDegree.set(job.id, (inDegree.get(job.id) || 0) + 1);
+    }
+  }
+
+  const queue: string[] = [];
+  for (const [id, degree] of inDegree.entries()) {
+    if (degree === 0) queue.push(id);
+  }
+
+  const ordered: string[] = [];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    ordered.push(id);
+    for (const next of adjacency.get(id) ?? []) {
+      const nextDegree = (inDegree.get(next) || 0) - 1;
+      inDegree.set(next, nextDegree);
+      if (nextDegree === 0) queue.push(next);
+    }
+  }
+
+  if (ordered.length !== plan.jobs.length) {
+    throw new Error('Failed to compute topological order; dependency graph malformed.');
+  }
+
+  const startDate = new Date(launchDateIso);
+  if (Number.isNaN(startDate.getTime())) {
+    throw new Error(`Invalid launchDate in plan metadata: ${launchDateIso}`);
+  }
+
+  const startOffsets = new Map<string, number>();
+  const endOffsets = new Map<string, number>();
+  const slackDays = new Map<string, number>();
+  const distance = new Map<string, number>();
+  const predecessor = new Map<string, string | null>();
+
+  for (const id of ordered) {
+    const job = jobMap.get(id);
+    if (!job) throw new Error(`Job not found during schedule computation: ${id}`);
+    const duration = toNumber(`${job.id}.durationDays`, job.durationDays);
+    const deadline = toNumber(`${job.id}.deadlineDays`, job.deadlineDays);
+
+    let earliestStart = 0;
+    let bestPred: string | null = null;
+    let bestDistance = 0;
+
+    for (const dep of job.dependencies) {
+      const depEnd = endOffsets.get(dep);
+      if (depEnd == null) {
+        throw new Error(`Dependency ${dep} missing end offset for job ${job.id}`);
+      }
+      if (depEnd > earliestStart) {
+        earliestStart = depEnd;
+      }
+      const depDistance = distance.get(dep) ?? 0;
+      if (depDistance > bestDistance) {
+        bestDistance = depDistance;
+        bestPred = dep;
+      }
+    }
+
+    const endOffset = earliestStart + duration;
+    const slack = deadline - endOffset;
+
+    startOffsets.set(id, earliestStart);
+    endOffsets.set(id, endOffset);
+    slackDays.set(id, slack);
+    distance.set(id, duration + bestDistance);
+    predecessor.set(id, bestPred);
+
+    if (slack < 0) {
+      console.warn(`⚠️  Job ${id} misses its deadline by ${Math.abs(slack)} day(s).`);
+    }
+  }
+
+  let criticalJobId: string | null = null;
+  let criticalDistance = -Infinity;
+  for (const [id, dist] of distance.entries()) {
+    if (dist > criticalDistance) {
+      criticalDistance = dist;
+      criticalJobId = id;
+    }
+  }
+
+  const criticalJobIds = new Set<string>();
+  while (criticalJobId) {
+    criticalJobIds.add(criticalJobId);
+    criticalJobId = predecessor.get(criticalJobId) ?? null;
+  }
+
+  const jobs: DerivedJob[] = [];
+  for (const job of plan.jobs) {
+    const phase = phaseMap.get(job.phase);
+    if (!phase) {
+      throw new Error(`Job ${job.id} references unknown phase ${job.phase}`);
+    }
+    const startOffset = startOffsets.get(job.id)!;
+    const endOffset = endOffsets.get(job.id)!;
+    const slack = slackDays.get(job.id)!;
+    const startDateIso = new Date(startDate.getTime() + startOffset * 24 * 60 * 60 * 1000).toISOString();
+    const endDateIso = new Date(startDate.getTime() + endOffset * 24 * 60 * 60 * 1000).toISOString();
+    const deadlineIso = new Date(startDate.getTime() + toNumber(`${job.id}.deadlineDays`, job.deadlineDays) * 24 * 60 * 60 * 1000).toISOString();
+
+    jobs.push({
+      id: job.id,
+      title: job.title,
+      phase: job.phase,
+      phaseTitle: phase.title,
+      reward: toNumber(`${job.id}.reward`, job.reward),
+      startOffset,
+      endOffset,
+      startDate: startDateIso,
+      endDate: endDateIso,
+      deadlineDate: deadlineIso,
+      slackDays: slack,
+      corridors: job.corridors,
+      assigned: job.assigned,
+      validators: job.validatorFocus,
+      brief: job.brief ?? [],
+      critical: criticalJobIds.has(job.id),
+    });
+  }
+
+  const events: Array<{ time: number; delta: number }> = [];
+  for (const job of jobs) {
+    events.push({ time: job.startOffset, delta: 1 });
+    events.push({ time: job.endOffset, delta: -1 });
+  }
+  events.sort((a, b) => (a.time === b.time ? a.delta - b.delta : a.time - b.time));
+
+  let current = 0;
+  let maxConcurrency = 0;
+  for (const event of events) {
+    current += event.delta;
+    if (current > maxConcurrency) maxConcurrency = current;
+  }
+
+  return {
+    jobs,
+    criticalPathDays: Math.round(criticalDistance),
+    criticalJobIds,
+    maxConcurrency,
+  };
+}
+
+function computeMermaid(plan: Plan, derived: DerivedJob[]): { network: string; gantt: string } {
+  const nodeClass: Record<string, string> = {
+    command: 'command',
+    port: 'port',
+    hub: 'hub',
+    storage: 'storage',
+    distribution: 'distribution',
+    relief: 'relief',
+    sensor: 'sensor',
+  };
+
+  const lines: string[] = ['flowchart LR'];
+  for (const node of plan.supplyNetwork.nodes) {
+    const klass = nodeClass[node.type] ?? 'command';
+    const label = `${node.label}${node.region ? `\\n${node.region}` : ''}`;
+    lines.push(`  ${node.id}["${label}"]:::${klass}`);
+  }
+
+  for (const corridor of plan.supplyNetwork.corridors) {
+    lines.push(`  ${corridor.from} -->|${corridor.mode}| ${corridor.to}`);
+  }
+
+  lines.push('  classDef command fill:#0f172a,stroke:#38bdf8,stroke-width:2,color:#e2e8f0;');
+  lines.push('  classDef port fill:#1e3a8a,stroke:#38bdf8,color:#f8fafc;');
+  lines.push('  classDef hub fill:#312e81,stroke:#c084fc,color:#f5f3ff;');
+  lines.push('  classDef storage fill:#064e3b,stroke:#34d399,color:#ecfdf5;');
+  lines.push('  classDef distribution fill:#7c2d12,stroke:#fb923c,color:#ffedd5;');
+  lines.push('  classDef relief fill:#7f1d1d,stroke:#fca5a5,color:#fee2e2;');
+  lines.push('  classDef sensor fill:#3f3f46,stroke:#facc15,color:#fef9c3;');
+
+  const ganttLines: string[] = [
+    'gantt',
+    '  title National Supply Chain Critical Path',
+    '  dateFormat  YYYY-MM-DD',
+    '  axisFormat  %b %d',
+  ];
+
+  const phases = new Map<string, PlanPhase>(plan.operations.phases.map((phase) => [phase.id, phase]));
+
+  for (const job of derived) {
+    const phase = phases.get(job.phase);
+    if (phase) {
+      ganttLines.push(`  section ${phase.title}`);
+    }
+    const start = job.startDate.slice(0, 10);
+    const end = job.endDate.slice(0, 10);
+    const slug = job.id.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const critFlag = job.critical ? 'crit,' : '';
+    ganttLines.push(`  ${job.title.replace(/:/g, '-')}: ${critFlag} ${slug}, ${start}, ${end}`);
+  }
+
+  return { network: lines.join('\n'), gantt: ganttLines.join('\n') };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderDashboard(plan: Plan, derived: DerivedJob[], metrics: Record<string, number>, mermaidDiagrams: { network: string; gantt: string }): string {
+  const currency = plan.budget.currency;
+  const formatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
+  const formatCurrency = createCurrencyFormatter(currency);
+
+  const jobRows = derived
+    .map((job) => {
+      const corridors = job.corridors.join(', ');
+      const agents = job.assigned
+        .map((assignment) => `${escapeHtml(assignment.agent)}<div class="hint">${escapeHtml(assignment.responsibility)}</div>`)
+        .join('');
+      const validators = job.validators.map(escapeHtml).join(', ');
+      const slack = `${job.slackDays} day(s)`;
+      return `<tr class="${job.critical ? 'critical' : ''}"><td>${escapeHtml(job.id)}</td><td>${escapeHtml(job.title)}</td><td>${escapeHtml(job.phaseTitle)}</td><td>${job.startDate.slice(0, 10)} → ${job.endDate.slice(0, 10)}</td><td>${formatCurrency(job.reward)}</td><td>${slack}</td><td>${escapeHtml(corridors)}</td><td>${agents}</td><td>${escapeHtml(validators)}</td></tr>`;
+    })
+    .join('\n');
+
+  const corridorCards = plan.supplyNetwork.corridors
+    .map((corridor) => {
+      const controls = new Set<string>();
+      const fromNode = plan.supplyNetwork.nodes.find((node) => node.id === corridor.from);
+      const toNode = plan.supplyNetwork.nodes.find((node) => node.id === corridor.to);
+      for (const control of fromNode?.controlSurfaces ?? []) controls.add(control);
+      for (const control of toNode?.controlSurfaces ?? []) controls.add(control);
+      return `<article class="corridor"><h3>${escapeHtml(corridor.id)}</h3><p>${escapeHtml(corridor.mode)}</p><p>${formatter.format(corridor.capacityTonnesPerDay)} t/day · Latency ${corridor.latencyHours} h</p><p>${escapeHtml(corridor.resilience)}</p><p class="hint">Owner controls: ${Array.from(controls).map(escapeHtml).join(', ') || '—'}</p></article>`;
+    })
+    .join('\n');
+
+  const ownerCommands = (plan.governance.ownerPlaybooks ?? [])
+    .map((command) => `<li><code>${escapeHtml(command)}</code></li>`)
+    .join('\n');
+
+  const validatorCards = plan.participants.validators
+    .map((validator) => {
+      const stake = formatCurrency(toNumber(`${validator.handle}.stake`, validator.stake));
+      return `<article class="validator"><h3>${escapeHtml(validator.handle)}</h3><p>${escapeHtml(validator.mandate ?? 'Validator')}</p><p class="hint">Stake ${stake}</p></article>`;
+    })
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>National Supply Chain Intelligence Kit</title>
+    <style>
+      :root { color-scheme: dark; font-family: 'Inter', system-ui, sans-serif; background:#020617; color:#e2e8f0; }
+      body { margin:0; background:radial-gradient(circle at top left,#0f172a,#020617 55%); padding:2.5rem; }
+      header { max-width:960px; margin:0 auto 2rem; }
+      h1 { font-size:2.8rem; margin:0; }
+      p.lede { color:#94a3b8; font-size:1.1rem; max-width:70ch; }
+      .grid { display:grid; gap:1.5rem; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); max-width:1200px; margin:0 auto; }
+      .card { background:rgba(15,23,42,0.72); border:1px solid rgba(148,163,184,0.3); border-radius:1.25rem; padding:1.5rem; box-shadow:0 20px 40px rgba(2,6,23,0.45); backdrop-filter:blur(18px); }
+      .card h2 { margin:0 0 1rem; font-size:1.4rem; }
+      .stats { display:grid; gap:1rem; grid-template-columns:repeat(auto-fit,minmax(140px,1fr)); }
+      .stat { background:rgba(15,23,42,0.6); border:1px solid rgba(148,163,184,0.2); border-radius:1rem; padding:1rem; }
+      .stat span { display:block; }
+      .stat .label { font-size:0.75rem; text-transform:uppercase; letter-spacing:0.08em; color:#94a3b8; }
+      .stat .value { font-size:1.25rem; margin-top:0.5rem; font-weight:600; }
+      table { width:100%; border-collapse:collapse; font-size:0.92rem; }
+      thead { background:rgba(30,41,59,0.75); }
+      thead th { text-transform:uppercase; letter-spacing:0.08em; font-size:0.72rem; padding:0.75rem; color:#94a3b8; }
+      tbody td { padding:0.85rem 0.75rem; border-bottom:1px solid rgba(148,163,184,0.15); vertical-align:top; }
+      tbody tr.critical { background:rgba(236,72,153,0.12); }
+      code { background:rgba(15,23,42,0.65); padding:0.25rem 0.45rem; border-radius:0.5rem; border:1px solid rgba(148,163,184,0.25); }
+      ul { margin:0; padding-left:1.2rem; display:grid; gap:0.5rem; }
+      .corridor-grid, .validator-grid { display:grid; gap:1rem; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); }
+      .corridor, .validator { background:rgba(15,23,42,0.55); border:1px solid rgba(148,163,184,0.25); border-radius:1rem; padding:1rem; }
+      .hint { color:#94a3b8; font-size:0.78rem; margin-top:0.35rem; }
+      .mermaid { background:rgba(15,23,42,0.65); border-radius:1rem; border:1px solid rgba(148,163,184,0.25); padding:1rem; overflow-x:auto; }
+      footer { max-width:960px; margin:2rem auto 0; text-align:center; color:#94a3b8; font-size:0.85rem; }
+      @media (max-width:720px) { body { padding:1.5rem; } }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>mermaid.initialize({ startOnLoad: true, theme: 'dark' });</script>
+  </head>
+  <body>
+    <header>
+      <span class="hint">${escapeHtml(plan.metadata.missionTag ?? 'NATIONAL-SUPPLY-CHAIN')}</span>
+      <h1>${escapeHtml(plan.initiative)}</h1>
+      <p class="lede">${escapeHtml(plan.objective)}</p>
+    </header>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Mission Metrics</h2>
+      <div class="stats">
+        <div class="stat"><span class="label">Jobs orchestrated</span><span class="value">${formatter.format(metrics.jobCount)}</span></div>
+        <div class="stat"><span class="label">Phases</span><span class="value">${formatter.format(metrics.phaseCount)}</span></div>
+        <div class="stat"><span class="label">Agents</span><span class="value">${formatter.format(metrics.agentCount)}</span></div>
+        <div class="stat"><span class="label">Validators</span><span class="value">${formatter.format(metrics.validatorCount)}</span></div>
+        <div class="stat"><span class="label">Total reward</span><span class="value">${formatCurrency(metrics.totalReward)}</span></div>
+        <div class="stat"><span class="label">Operator reserve</span><span class="value">${formatCurrency(metrics.operatorReserve)}</span></div>
+        <div class="stat"><span class="label">Validator pool</span><span class="value">${formatCurrency(metrics.validatorPool)}</span></div>
+        <div class="stat"><span class="label">Critical path (days)</span><span class="value">${formatter.format(metrics.criticalPathDays)}</span></div>
+        <div class="stat"><span class="label">Max concurrency</span><span class="value">${formatter.format(metrics.maxConcurrency)}</span></div>
+        <div class="stat"><span class="label">Corridor capacity</span><span class="value">${formatter.format(metrics.corridorCapacity)} t/day</span></div>
+        <div class="stat"><span class="label">Validator stake</span><span class="value">${formatCurrency(metrics.validatorStake)}</span></div>
+      </div>
+    </section>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Jobs & Critical Path</h2>
+      <table>
+        <thead><tr><th>ID</th><th>Title</th><th>Phase</th><th>Window</th><th>Reward</th><th>Slack</th><th>Corridors</th><th>Agents</th><th>Validators</th></tr></thead>
+        <tbody>${jobRows}</tbody>
+      </table>
+    </section>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Corridor Intelligence</h2>
+      <div class="corridor-grid">${corridorCards}</div>
+    </section>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Owner Playbooks</h2>
+      <ul>${ownerCommands}</ul>
+    </section>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Validator Coalition</h2>
+      <div class="validator-grid">${validatorCards}</div>
+    </section>
+    <section class="card" style="max-width:1200px;margin:0 auto 1.5rem;">
+      <h2>Mermaid Atlas</h2>
+      <div class="mermaid">${escapeHtml(mermaidDiagrams.network)}</div>
+      <div class="mermaid" style="margin-top:1rem;">${escapeHtml(mermaidDiagrams.gantt)}</div>
+    </section>
+    <footer>
+      Generated ${escapeHtml(plan.metadata.generatedAt)} · Plan version ${escapeHtml(plan.metadata.version)} · Owner ${escapeHtml(plan.metadata.ownerEns ?? 'N/A')}
+    </footer>
+  </body>
+</html>`;
+}
+
+function renderSummaryMarkdown(plan: Plan, metrics: Record<string, number>, derived: DerivedJob[], criticalJobIds: Set<string>): string {
+  const currency = plan.budget.currency;
+  const formatCurrency = createCurrencyFormatter(currency);
+  const lines: string[] = [];
+  lines.push(`# ${plan.initiative}`);
+  lines.push('');
+  lines.push(`**Objective:** ${plan.objective}`);
+  lines.push('');
+  lines.push('## Mission metrics');
+  lines.push('');
+  lines.push(`- Jobs orchestrated: ${metrics.jobCount}`);
+  lines.push(`- Critical path: ${metrics.criticalPathDays} days`);
+  lines.push(`- Max concurrency: ${metrics.maxConcurrency}`);
+  lines.push(`- Total reward: ${formatCurrency(metrics.totalReward)}`);
+  lines.push(`- Validator stake: ${formatCurrency(metrics.validatorStake)}`);
+  lines.push(`- Corridor capacity: ${metrics.corridorCapacity} tonnes/day`);
+  lines.push('');
+  lines.push('## Jobs');
+  lines.push('');
+  for (const job of derived) {
+    lines.push(`### ${job.title}`);
+    lines.push(`- Phase: ${job.phaseTitle}`);
+    lines.push(`- Schedule: ${job.startDate.slice(0, 10)} → ${job.endDate.slice(0, 10)} (deadline ${job.deadlineDate.slice(0, 10)})`);
+    lines.push(`- Reward: ${formatCurrency(job.reward)} · Slack: ${job.slackDays} days`);
+    lines.push(`- Corridors: ${job.corridors.join(', ') || '—'}`);
+    lines.push(`- Agents: ${job.assigned.map((assignment) => `${assignment.agent} (${assignment.responsibility})`).join('; ')}`);
+    lines.push(`- Validators: ${job.validators.join(', ') || '—'}`);
+    if (job.brief.length) {
+      lines.push('  - Brief:');
+      for (const item of job.brief) {
+        lines.push(`    - ${item}`);
+      }
+    }
+    if (criticalJobIds.has(job.id)) {
+      lines.push('  - **Critical path node**');
+    }
+    lines.push('');
+  }
+  lines.push('## Owner playbooks');
+  lines.push('');
+  for (const command of plan.governance.ownerPlaybooks ?? []) {
+    lines.push(`- \`${command}\``);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function renderOwnerPlaybook(plan: Plan): string {
+  const lines: string[] = [];
+  lines.push('# Owner Command Centre Checklist');
+  lines.push('');
+  lines.push('Execute the following commands after each launch to assert sovereign control:');
+  lines.push('');
+  const commands = plan.governance.ownerPlaybooks ?? [];
+  const annotated: Record<string, string> = {
+    'npm run owner:command-center': 'Render live state of every owner module.',
+    'npm run owner:parameters': 'Inspect configurable parameters (fees, stake thresholds, thermostat).',
+    'npm run owner:system-pause -- --action pause': 'Engage the global pause valve for drills or incidents.',
+    'npm run owner:system-pause -- --action unpause': 'Resume operations after validation.',
+    'npm run owner:upgrade-status': 'Review timelocked governance proposals before execution.',
+    'npm run owner:verify-control': 'Cryptographically verify owner supremacy across modules.',
+    'npm run owner:mission-control': 'Summarise treasury balances and mission spend.',
+    'npm run reward-engine:update': 'Apply incentive changes after `owner:mission-control` review.',
+    'npm run thermostat:update': 'Broadcast thermostat adjustments to the protocol.',
+  };
+  for (const command of commands) {
+    const description = annotated[command] ?? 'See CLI output for detailed guidance.';
+    lines.push(`- \`${command}\` — ${description}`);
+  }
+  lines.push('');
+  lines.push('For emergency response run: `npm run owner:emergency` and follow the generated playbook.');
+  return `${lines.join('\n')}\n`;
+}
+
+function computeMetrics(plan: Plan, derived: DerivedJob[], maxConcurrency: number): Record<string, number> {
+  const rewardSum = derived.reduce((sum, job) => sum + job.reward, 0);
+  const corridorCapacity = plan.supplyNetwork.corridors.reduce((sum, corridor) => sum + corridor.capacityTonnesPerDay, 0);
+  const validatorStake = plan.participants.validators.reduce(
+    (sum, validator) => sum + toNumber(`${validator.handle}.stake`, validator.stake),
+    0,
+  );
+  return {
+    jobCount: derived.length,
+    phaseCount: plan.operations.phases.length,
+    agentCount: plan.participants.agents.length,
+    validatorCount: plan.participants.validators.length,
+    totalReward: rewardSum,
+    operatorReserve: toNumber('budget.operatorReserve', plan.budget.operatorReserve ?? '0'),
+    validatorPool: toNumber('budget.validatorPool', plan.budget.validatorPool ?? '0'),
+    criticalPathDays: Math.max(...derived.map((job) => job.endOffset)),
+    maxConcurrency,
+    corridorCapacity,
+    validatorStake,
+  };
+}
+
+async function writeFileRelative(relPath: string, contents: string, outputs: Array<{ relPath: string; data: Buffer }>): Promise<void> {
+  const absolute = path.join(ROOT, relPath);
+  await fs.mkdir(path.dirname(absolute), { recursive: true });
+  const buffer = Buffer.from(contents);
+  await fs.writeFile(absolute, buffer);
+  outputs.push({ relPath, data: buffer });
+}
+
+async function main(): Promise<void> {
+  const planPath = resolvePath('NATIONAL_SUPPLY_CHAIN_PLAN_PATH', DEFAULT_PLAN_PATH);
+  const reportDir = resolvePath('NATIONAL_SUPPLY_CHAIN_REPORT_DIR', DEFAULT_REPORT_DIR);
+  const uiExportPath = resolvePath('NATIONAL_SUPPLY_CHAIN_UI_EXPORT', DEFAULT_UI_EXPORT);
+
+  const planRaw = await fs.readFile(planPath, 'utf8');
+  const plan = parsePlan(planRaw);
+
+  const schedule = computeSchedule(plan, plan.metadata.launchDate);
+  const metrics = computeMetrics(plan, schedule.jobs, schedule.maxConcurrency);
+  const mermaid = computeMermaid(plan, schedule.jobs);
+
+  const outputs: Array<{ relPath: string; data: Buffer }> = [];
+
+  const reportPrefix = path.relative(ROOT, reportDir) || 'reports/national-supply-chain';
+  await fs.mkdir(reportDir, { recursive: true });
+
+  const dashboardHtml = renderDashboard(plan, schedule.jobs, metrics, mermaid);
+  await writeFileRelative(path.join(reportPrefix, 'dashboard.html'), dashboardHtml, outputs);
+
+  const summaryMd = renderSummaryMarkdown(plan, metrics, schedule.jobs, schedule.criticalJobIds);
+  await writeFileRelative(path.join(reportPrefix, 'summary.md'), summaryMd, outputs);
+
+  await writeFileRelative(path.join(reportPrefix, 'mermaid.mmd'), `${mermaid.network}\n\n${mermaid.gantt}\n`, outputs);
+
+  const ledger = {
+    initiative: plan.initiative,
+    objective: plan.objective,
+    missionTag: plan.metadata.missionTag,
+    generatedAt: plan.metadata.generatedAt,
+    launchDate: plan.metadata.launchDate,
+    network: 'Hardhat localhost (31337)',
+    ownerEns: plan.metadata.ownerEns,
+    budget: {
+      currency: plan.budget.currency,
+      total: toNumber('budget.total', plan.budget.total),
+      operatorReserve: metrics.operatorReserve,
+      validatorPool: metrics.validatorPool,
+    },
+    metrics,
+    phases: plan.operations.phases,
+    jobs: schedule.jobs,
+    corridors: plan.supplyNetwork.corridors.map((corridor) => {
+      const fromNode = plan.supplyNetwork.nodes.find((node) => node.id === corridor.from);
+      const toNode = plan.supplyNetwork.nodes.find((node) => node.id === corridor.to);
+      const ownerControls = Array.from(
+        new Set([...(fromNode?.controlSurfaces ?? []), ...(toNode?.controlSurfaces ?? [])]),
+      );
+      return { ...corridor, ownerControls };
+    }),
+    validators: plan.participants.validators.map((validator) => ({
+      handle: validator.handle,
+      stake: toNumber(`${validator.handle}.stake`, validator.stake),
+      mandate: validator.mandate,
+      wallet: validator.wallet,
+    })),
+    agents: plan.participants.agents,
+    ownerPlaybooks: plan.governance.ownerPlaybooks ?? [],
+    mermaid,
+    criticalJobs: Array.from(schedule.criticalJobIds),
+  };
+  await writeFileRelative(
+    path.join(reportPrefix, 'mission-ledger.json'),
+    `${JSON.stringify(ledger, null, 2)}\n`,
+    outputs,
+  );
+
+  const ownerPlaybookMd = renderOwnerPlaybook(plan);
+  await writeFileRelative(path.join(reportPrefix, 'owner-command-center.md'), ownerPlaybookMd, outputs);
+
+  await writeFileRelative(
+    path.relative(ROOT, uiExportPath),
+    `${JSON.stringify({ ...ledger, mermaid }, null, 2)}\n`,
+    outputs,
+  );
+
+  const manifestEntries = outputs.map(({ relPath, data }) => ({
+    path: relPath,
+    sha256: createHash('sha256').update(data).digest('hex'),
+    bytes: data.byteLength,
+  }));
+  const manifest = {
+    generatedAt: plan.metadata.generatedAt,
+    planVersion: plan.metadata.version,
+    files: manifestEntries,
+  };
+  await writeFileRelative(path.join(reportPrefix, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, outputs);
+
+  console.log('National Supply Chain intelligence kit generated:');
+  for (const entry of manifestEntries) {
+    console.log(`  • ${entry.path} (${entry.bytes} bytes)`);
+  }
+  console.log(`Critical path length: ${metrics.criticalPathDays} days · Max concurrency ${metrics.maxConcurrency}`);
+}
+
+main().catch((error) => {
+  console.error(`National Supply Chain demo failed: ${(error as Error).message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add the National Supply Chain v0 demo with README, runbook, launch script, UI, and mission plan
- implement a TypeScript generator that validates the plan, computes schedules, and emits dashboard, ledger, manifest, and owner playbook assets
- wire npm scripts and a dedicated GitHub workflow so the demo runs in CI and publishes verifiable artefacts

## Testing
- npm run lint:check
- npm test
- npm run coverage:check
- npm run demo:national-supply-chain:v0

------
https://chatgpt.com/codex/tasks/task_e_68f6424d4d748333bef436faa68f2c62