### PR TITLE
feat: add offline owner diagnostics mode

### DIFF
--- a/demo/agi-governance/scripts/runFullDemo.ts
+++ b/demo/agi-governance/scripts/runFullDemo.ts
@@ -272,6 +272,7 @@ export async function runFullDemo(options: FullDemoOptions = {}): Promise<FullRu
     silent: options.owner?.silent ?? true,
     jsonFile: ownerJsonPath,
     markdownFile: ownerMarkdownPath,
+    missionFile: options.owner?.missionFile ?? demoOptions.missionFile,
   };
 
   const fullRunJsonPath = resolveWithDir(FULL_RUN_JSON, options.outputJson, demoOptions.reportDir);

--- a/demo/alpha-meta/scripts/fullPipeline.ts
+++ b/demo/alpha-meta/scripts/fullPipeline.ts
@@ -39,6 +39,8 @@ async function main(): Promise<void> {
       jsonFile: OWNER_JSON,
       markdownFile: OWNER_MARKDOWN,
       silent: true,
+      missionFile: MISSION_FILE,
+      offline: true,
     },
     outputJson: FULL_JSON,
     outputMarkdown: FULL_MARKDOWN,

--- a/demo/alpha-meta/scripts/ownerDiagnostics.ts
+++ b/demo/alpha-meta/scripts/ownerDiagnostics.ts
@@ -8,6 +8,7 @@ const BASE_DIR = path.resolve(__dirname, "..");
 const REPORT_DIR = path.join(BASE_DIR, "reports");
 const OUTPUT_JSON = path.join(REPORT_DIR, "alpha-meta-owner-diagnostics.json");
 const OUTPUT_MARKDOWN = path.join(REPORT_DIR, "alpha-meta-owner-diagnostics.md");
+const MISSION_FILE = path.join(BASE_DIR, "config", "mission@alpha-meta.json");
 
 async function main(): Promise<void> {
   const options: OwnerDiagnosticsOptions = {
@@ -15,6 +16,8 @@ async function main(): Promise<void> {
     reportDir: REPORT_DIR,
     jsonFile: OUTPUT_JSON,
     markdownFile: OUTPUT_MARKDOWN,
+    missionFile: MISSION_FILE,
+    offline: true,
   };
 
   const report = await collectOwnerDiagnostics(options);


### PR DESCRIPTION
## Summary
- add offline simulation support and env-driven detection to owner CLI diagnostics for Hamiltonian, reward engine, timelock, and compliance surfaces
- propagate mission-aware offline diagnostics through agi-governance orchestrator and alpha-meta demo wrappers
- ensure alpha-meta pipelines default to offline snapshots for non-interactive runs

## Testing
- npm run demo:alpha-meta:owner --silent
- npm run demo:alpha-meta:full --silent

------
https://chatgpt.com/codex/tasks/task_e_68f64080b930833392dbda26fce64f57