### PR TITLE
Add owner control matrix artifacts to alpha-meta governance demo

### DIFF
--- a/demo/agi-governance/scripts/runFullDemo.ts
+++ b/demo/agi-governance/scripts/runFullDemo.ts
@@ -8,6 +8,8 @@ import {
   REPORT_FILE as GOVERNANCE_REPORT_FILE,
   SUMMARY_FILE as GOVERNANCE_SUMMARY_FILE,
   DASHBOARD_FILE as GOVERNANCE_DASHBOARD_FILE,
+  OWNER_MATRIX_JSON_FILE,
+  OWNER_MATRIX_MARKDOWN_FILE,
   type GovernanceDemoOptions,
   type ReportBundle,
 } from "./executeDemo";
@@ -97,6 +99,8 @@ type FullRunSummary = {
     report: string;
     summary: string;
     dashboard: string;
+    ownerMatrixJson: string;
+    ownerMatrixMarkdown: string;
     validationJson: string;
     validationMarkdown: string;
     ciReport: string;
@@ -217,6 +221,16 @@ export async function runFullDemo(options: FullDemoOptions = {}): Promise<FullRu
   const reportFile = resolveWithDir(GOVERNANCE_REPORT_FILE, demoOptions.reportFile, demoOptions.reportDir);
   const summaryFile = resolveWithDir(GOVERNANCE_SUMMARY_FILE, demoOptions.summaryFile, demoOptions.reportDir);
   const dashboardFile = resolveWithDir(GOVERNANCE_DASHBOARD_FILE, demoOptions.dashboardFile, demoOptions.reportDir);
+  const ownerMatrixJsonPath = resolveWithDir(
+    OWNER_MATRIX_JSON_FILE,
+    demoOptions.ownerMatrixJsonFile,
+    demoOptions.reportDir,
+  );
+  const ownerMatrixMarkdownPath = resolveWithDir(
+    OWNER_MATRIX_MARKDOWN_FILE,
+    demoOptions.ownerMatrixMarkdownFile,
+    demoOptions.reportDir,
+  );
 
   const generationOptions: GovernanceDemoOptions = {
     ...demoOptions,
@@ -224,6 +238,8 @@ export async function runFullDemo(options: FullDemoOptions = {}): Promise<FullRu
     reportFile,
     summaryFile,
     dashboardFile,
+    ownerMatrixJsonFile: ownerMatrixJsonPath,
+    ownerMatrixMarkdownFile: ownerMatrixMarkdownPath,
   };
 
   const validationSummaryPath = resolveWithDir(
@@ -377,6 +393,8 @@ export async function runFullDemo(options: FullDemoOptions = {}): Promise<FullRu
       report: reportFile,
       summary: summaryFile,
       dashboard: dashboardFile,
+      ownerMatrixJson: ownerMatrixJsonPath,
+      ownerMatrixMarkdown: ownerMatrixMarkdownPath,
       validationJson: validationJsonPath,
       validationMarkdown: validationMarkdownPath,
       ciReport: ciOutputPath,
@@ -441,6 +459,8 @@ export async function runFullDemo(options: FullDemoOptions = {}): Promise<FullRu
     `- Governance dossier: \`${summary.artifacts.report}\``,
     `- Physics summary: \`${summary.artifacts.summary}\``,
     `- Interactive dashboard: \`${summary.artifacts.dashboard}\``,
+    `- Owner matrix JSON: \`${summary.artifacts.ownerMatrixJson}\``,
+    `- Owner matrix Markdown: \`${summary.artifacts.ownerMatrixMarkdown}\``,
     `- Validation JSON: \`${summary.artifacts.validationJson}\``,
     `- Validation Markdown: \`${summary.artifacts.validationMarkdown}\``,
     `- CI verification: \`${summary.artifacts.ciReport}\``,

--- a/demo/alpha-meta/README.md
+++ b/demo/alpha-meta/README.md
@@ -50,6 +50,7 @@ flowchart LR
 | `alpha-meta-governance-validation.{json,md}` | Deterministic recomputation of every metric with Jarzynski, Hamiltonian, Jacobian, and owner coverage checks. |
 | `alpha-meta-ci-verification.json` | CI parity proof showing lint, tests, foundry, coverage, and summary guards enforced on `main`. |
 | `alpha-meta-owner-diagnostics.{json,md}` | Results from automated owner command scripts (Hamiltonian audit, reward engine report, upgrade queue status, compliance disclosure). |
+| `alpha-meta-owner-matrix.{json,md}` | Authoritative owner control matrix detailing every governance capability, script availability, and verification hook. |
 | `alpha-meta-full-run.{json,md}` | Timeline of the full pipeline with Mermaid timeline, metrics, and aggregated health verdict. |
 
 ## Mission manifest and plan

--- a/demo/alpha-meta/RUNBOOK.md
+++ b/demo/alpha-meta/RUNBOOK.md
@@ -38,6 +38,8 @@ Verify the bundle:
 - `demo/alpha-meta/reports/alpha-meta-governance-report.md`
 - `demo/alpha-meta/reports/alpha-meta-governance-dashboard.html`
 - `demo/alpha-meta/reports/alpha-meta-owner-diagnostics.json`
+- `demo/alpha-meta/reports/alpha-meta-owner-matrix.md`
+- `demo/alpha-meta/reports/alpha-meta-owner-matrix.json`
 - `reports/agi-os/grand-summary.html`
 - `reports/asi-takeoff/mission-bundle/mission.json`
 

--- a/demo/alpha-meta/reports/alpha-meta-governance-dashboard.html
+++ b/demo/alpha-meta/reports/alpha-meta-governance-dashboard.html
@@ -152,7 +152,7 @@
     <header>
       <div class="badge">AGI Jobs v0 (v2) Superintelligence Console</div>
       <h1>Meta-Agentic α-AGI — Alpha-Meta Sovereign Hypergraph</h1>
-      <p class="meta">Generated 2025-10-20T13:36:19.247Z • Version 2.0.0</p>
+      <p class="meta">Generated 2025-10-20T15:57:10.273Z • Version 2.0.0</p>
       <p class="meta">Alpha-Meta proves that AGI Jobs v0 (v2) empowers a non-technical owner to choreograph a civilisation-scale meta-agent that governs subordinate swarms, physics guarantees, and unstoppable blockchain levers in one deterministic command.</p>
     </header>
     <main>

--- a/demo/alpha-meta/reports/alpha-meta-governance-report.md
+++ b/demo/alpha-meta/reports/alpha-meta-governance-report.md
@@ -1,5 +1,5 @@
 # Meta-Agentic α-AGI — Alpha-Meta Sovereign Hypergraph — Governance Demonstration Report
-*Generated at:* 2025-10-20T13:36:19.247Z
+*Generated at:* 2025-10-20T15:57:10.273Z
 *Version:* 2.0.0
 
 > Alpha-Meta proves that AGI Jobs v0 (v2) empowers a non-technical owner to choreograph a civilisation-scale meta-agent that governs subordinate swarms, physics guarantees, and unstoppable blockchain levers in one deterministic command.

--- a/demo/alpha-meta/reports/alpha-meta-governance-summary.json
+++ b/demo/alpha-meta/reports/alpha-meta-governance-summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-20T13:36:19.247Z",
+  "generatedAt": "2025-10-20T15:57:10.273Z",
   "version": "2.0.0",
   "thermodynamics": {
     "gibbsFreeEnergyKJ": 222153.726,

--- a/demo/alpha-meta/reports/alpha-meta-governance-validation.json
+++ b/demo/alpha-meta/reports/alpha-meta-governance-validation.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2025-10-20T13:37:08.440Z",
-  "summaryTimestamp": "2025-10-20T13:36:19.247Z",
+  "generatedAt": "2025-10-20T15:56:20.102Z",
+  "summaryTimestamp": "2025-10-20T15:55:49.477Z",
   "missionVersion": "2.0.0",
   "results": [
     {

--- a/demo/alpha-meta/reports/alpha-meta-governance-validation.md
+++ b/demo/alpha-meta/reports/alpha-meta-governance-validation.md
@@ -1,6 +1,6 @@
 # Governance Demo Validation
-*Generated at:* 2025-10-20T13:37:08.440Z
-*Summary timestamp:* 2025-10-20T13:36:19.247Z
+*Generated at:* 2025-10-20T15:56:20.102Z
+*Summary timestamp:* 2025-10-20T15:55:49.477Z
 *Mission version:* 2.0.0
 
 | Check | Status | Details |

--- a/demo/alpha-meta/reports/alpha-meta-owner-matrix.json
+++ b/demo/alpha-meta/reports/alpha-meta-owner-matrix.json
@@ -1,0 +1,145 @@
+{
+  "generatedAt": "2025-10-20T15:57:10.273Z",
+  "owner": "0xAAAABBBBCCCCDDDDEEEEFFFF0000111122223333",
+  "pauser": "0xBBBBCCCCDDDDEEEEFFFF00001111222233334444",
+  "treasury": "0xCCCCDDDDEEEEFFFF000011112222333344445555",
+  "timelockSeconds": 604800,
+  "timelockHours": 168,
+  "coverage": {
+    "fullCoverage": true,
+    "allCommandsPresent": true,
+    "allVerificationsPresent": true,
+    "satisfiedCategories": [
+      "pause",
+      "resume",
+      "parameter",
+      "governance",
+      "treasury",
+      "sentinel",
+      "upgrade",
+      "compliance",
+      "plan",
+      "monitoring"
+    ],
+    "missingCategories": []
+  },
+  "capabilities": [
+    {
+      "category": "pause",
+      "label": "Pause orchestrator",
+      "description": "Instantly halt AGI Jobs orchestration if divergence spikes.",
+      "command": "npm run owner:system-pause",
+      "commandScript": "owner:system-pause",
+      "commandStatus": "available",
+      "verification": "npm run owner:verify-control",
+      "verificationScript": "owner:verify-control",
+      "verificationStatus": "available"
+    },
+    {
+      "category": "resume",
+      "label": "Resume orchestrator",
+      "description": "Restart execution after antifragility recovery.",
+      "command": "npm run owner:system-pause -- --action unpause",
+      "commandScript": "owner:system-pause",
+      "commandStatus": "available",
+      "verification": "npm run owner:verify-control",
+      "verificationScript": "owner:verify-control",
+      "verificationStatus": "available"
+    },
+    {
+      "category": "parameter",
+      "label": "Thermostat update",
+      "description": "Adjust the macro temperature to stabilise energy flux.",
+      "command": "npm run thermostat:update",
+      "commandScript": "thermostat:update",
+      "commandStatus": "available",
+      "verification": "npm run reward-engine:report",
+      "verificationScript": "reward-engine:report",
+      "verificationStatus": "available"
+    },
+    {
+      "category": "governance",
+      "label": "Hamiltonian rewrite",
+      "description": "Push updated λ/inertia parameters from physics computation.",
+      "command": "npm run owner:command-center",
+      "commandScript": "owner:command-center",
+      "commandStatus": "available",
+      "verification": "npm run owner:audit-hamiltonian",
+      "verificationScript": "owner:audit-hamiltonian",
+      "verificationStatus": "available"
+    },
+    {
+      "category": "treasury",
+      "label": "Treasury surge router",
+      "description": "Route treasury flows via owner-specified channels.",
+      "command": "npm run owner:dashboard -- --focus treasury",
+      "commandScript": "owner:dashboard",
+      "commandStatus": "available",
+      "verification": "npm run owner:compliance-report",
+      "verificationScript": "owner:compliance-report",
+      "verificationStatus": "available"
+    },
+    {
+      "category": "sentinel",
+      "label": "Sentinel refresh",
+      "description": "Rotate enforcement guardians before antifragility decay.",
+      "command": "npm run owner:rotate -- --role Sentinel --count 16",
+      "commandScript": "owner:rotate",
+      "commandStatus": "available",
+      "verification": "npm run monitoring:sentinels",
+      "verificationScript": "monitoring:sentinels",
+      "verificationStatus": "available"
+    },
+    {
+      "category": "upgrade",
+      "label": "Upgrade queue",
+      "description": "Submit unstoppable upgrade bundles to the timelock queue.",
+      "command": "npm run owner:upgrade",
+      "commandScript": "owner:upgrade",
+      "commandStatus": "available",
+      "verification": "npm run owner:upgrade-status",
+      "verificationScript": "owner:upgrade-status",
+      "verificationStatus": "available"
+    },
+    {
+      "category": "compliance",
+      "label": "Compliance broadcast",
+      "description": "Publish policy acknowledgements with evidence.",
+      "command": "npm run owner:compliance-report",
+      "commandScript": "owner:compliance-report",
+      "commandStatus": "available",
+      "verification": "npm run owner:doctor",
+      "verificationScript": "owner:doctor",
+      "verificationStatus": "available"
+    },
+    {
+      "category": "plan",
+      "label": "Mission plan",
+      "description": "Deploy new labour missions via owner plan tooling.",
+      "command": "npm run owner:plan",
+      "commandScript": "owner:plan",
+      "commandStatus": "available",
+      "verification": "npm run owner:plan:safe",
+      "verificationScript": "owner:plan:safe",
+      "verificationStatus": "available"
+    },
+    {
+      "category": "monitoring",
+      "label": "Sentinel validation",
+      "description": "Validate monitoring sentinels and hooks.",
+      "command": "npm run monitoring:validate",
+      "commandScript": "monitoring:validate",
+      "commandStatus": "available",
+      "verification": "npm run monitoring:sentinels",
+      "verificationScript": "monitoring:sentinels",
+      "verificationStatus": "available"
+    }
+  ],
+  "monitoringSentinels": [
+    "sentinel://alpha-meta/thermostat",
+    "sentinel://alpha-meta/treasury",
+    "sentinel://alpha-meta/quantum",
+    "sentinel://alpha-meta/owner",
+    "sentinel://alpha-meta/antifragility"
+  ]
+}

--- a/demo/alpha-meta/reports/alpha-meta-owner-matrix.md
+++ b/demo/alpha-meta/reports/alpha-meta-owner-matrix.md
@@ -1,0 +1,33 @@
+# Owner Control Matrix
+*Generated at:* 2025-10-20T15:57:10.273Z
+*Owner:* 0xAAAABBBBCCCCDDDDEEEEFFFF0000111122223333
+*Pauser:* 0xBBBBCCCCDDDDEEEEFFFF00001111222233334444
+*Treasury:* 0xCCCCDDDDEEEEFFFF000011112222333344445555
+*Timelock:* 604800 seconds (168.00 hours)
+
+## Coverage
+- Full coverage: ✅
+- Command scripts present: ✅
+- Verification scripts present: ✅
+- Satisfied categories: pause, resume, parameter, governance, treasury, sentinel, upgrade, compliance, plan, monitoring
+
+## Capabilities
+| Category | Capability | Command | Command status | Verification | Verification status |
+| --- | --- | --- | --- | --- | --- |
+| pause | Pause orchestrator | owner:system-pause | ✅ ready | owner:verify-control | ✅ ready |
+| resume | Resume orchestrator | owner:system-pause | ✅ ready | owner:verify-control | ✅ ready |
+| parameter | Thermostat update | thermostat:update | ✅ ready | reward-engine:report | ✅ ready |
+| governance | Hamiltonian rewrite | owner:command-center | ✅ ready | owner:audit-hamiltonian | ✅ ready |
+| treasury | Treasury surge router | owner:dashboard | ✅ ready | owner:compliance-report | ✅ ready |
+| sentinel | Sentinel refresh | owner:rotate | ✅ ready | monitoring:sentinels | ✅ ready |
+| upgrade | Upgrade queue | owner:upgrade | ✅ ready | owner:upgrade-status | ✅ ready |
+| compliance | Compliance broadcast | owner:compliance-report | ✅ ready | owner:doctor | ✅ ready |
+| plan | Mission plan | owner:plan | ✅ ready | owner:plan:safe | ✅ ready |
+| monitoring | Sentinel validation | monitoring:validate | ✅ ready | monitoring:sentinels | ✅ ready |
+
+## Monitoring Sentinels
+- sentinel://alpha-meta/thermostat
+- sentinel://alpha-meta/treasury
+- sentinel://alpha-meta/quantum
+- sentinel://alpha-meta/owner
+- sentinel://alpha-meta/antifragility

--- a/demo/alpha-meta/scripts/fullPipeline.ts
+++ b/demo/alpha-meta/scripts/fullPipeline.ts
@@ -8,6 +8,8 @@ const MISSION_FILE = path.join(BASE_DIR, "config", "mission@alpha-meta.json");
 const REPORT_FILE = path.join(REPORT_DIR, "alpha-meta-governance-report.md");
 const SUMMARY_FILE = path.join(REPORT_DIR, "alpha-meta-governance-summary.json");
 const DASHBOARD_FILE = path.join(REPORT_DIR, "alpha-meta-governance-dashboard.html");
+const OWNER_MATRIX_JSON = path.join(REPORT_DIR, "alpha-meta-owner-matrix.json");
+const OWNER_MATRIX_MARKDOWN = path.join(REPORT_DIR, "alpha-meta-owner-matrix.md");
 const VALIDATION_JSON = path.join(REPORT_DIR, "alpha-meta-governance-validation.json");
 const VALIDATION_MARKDOWN = path.join(REPORT_DIR, "alpha-meta-governance-validation.md");
 const CI_REPORT = path.join(REPORT_DIR, "alpha-meta-ci-verification.json");
@@ -24,6 +26,8 @@ async function main(): Promise<void> {
       reportFile: REPORT_FILE,
       summaryFile: SUMMARY_FILE,
       dashboardFile: DASHBOARD_FILE,
+      ownerMatrixJsonFile: OWNER_MATRIX_JSON,
+      ownerMatrixMarkdownFile: OWNER_MATRIX_MARKDOWN,
     },
     validation: {
       missionFile: MISSION_FILE,

--- a/demo/alpha-meta/scripts/runMission.ts
+++ b/demo/alpha-meta/scripts/runMission.ts
@@ -1,5 +1,8 @@
 import path from "path";
-import { generateGovernanceDemo, type GovernanceDemoOptions } from "../../agi-governance/scripts/executeDemo";
+import {
+  generateGovernanceDemo,
+  type GovernanceDemoOptions,
+} from "../../agi-governance/scripts/executeDemo";
 
 const BASE_DIR = path.resolve(__dirname, "..");
 const REPORT_DIR = path.join(BASE_DIR, "reports");
@@ -7,6 +10,8 @@ const MISSION_FILE = path.join(BASE_DIR, "config", "mission@alpha-meta.json");
 const REPORT_FILE = path.join(REPORT_DIR, "alpha-meta-governance-report.md");
 const SUMMARY_FILE = path.join(REPORT_DIR, "alpha-meta-governance-summary.json");
 const DASHBOARD_FILE = path.join(REPORT_DIR, "alpha-meta-governance-dashboard.html");
+const OWNER_MATRIX_JSON = path.join(REPORT_DIR, "alpha-meta-owner-matrix.json");
+const OWNER_MATRIX_MARKDOWN = path.join(REPORT_DIR, "alpha-meta-owner-matrix.md");
 
 async function main(): Promise<void> {
   const options: GovernanceDemoOptions = {
@@ -15,6 +20,8 @@ async function main(): Promise<void> {
     reportFile: REPORT_FILE,
     summaryFile: SUMMARY_FILE,
     dashboardFile: DASHBOARD_FILE,
+    ownerMatrixJsonFile: OWNER_MATRIX_JSON,
+    ownerMatrixMarkdownFile: OWNER_MATRIX_MARKDOWN,
   };
 
   await generateGovernanceDemo(options);
@@ -24,6 +31,8 @@ async function main(): Promise<void> {
   console.log(`   Markdown report: ${REPORT_FILE}`);
   console.log(`   JSON summary: ${SUMMARY_FILE}`);
   console.log(`   Interactive dashboard: ${DASHBOARD_FILE}`);
+  console.log(`   Owner matrix JSON: ${OWNER_MATRIX_JSON}`);
+  console.log(`   Owner matrix Markdown: ${OWNER_MATRIX_MARKDOWN}`);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- add owner control matrix generation to the shared governance demo tooling and emit dedicated JSON/Markdown artefacts
- wire the alpha-meta pipelines to produce and reference the owner matrix outputs, and document them for non-technical operators
- commit the refreshed alpha-meta evidence bundle including the new owner matrix files

## Testing
- npm run lint:check
- npm run demo:alpha-meta
- npm run demo:alpha-meta:validate
- npm run demo:alpha-meta:ci

------
https://chatgpt.com/codex/tasks/task_e_68f659d513e48333809fc6e9acf246d4