### PR TITLE
Add deterministic consistency audit to alpha-meta demo

### DIFF
--- a/demo/alpha-meta/README.md
+++ b/demo/alpha-meta/README.md
@@ -71,6 +71,9 @@ Modify either file to rehearse new constellations without touching TypeScript.
 # Regenerate dossier only
 npm run demo:alpha-meta
 
+# Deterministic invariants/manifest audit
+npm run demo:alpha-meta:consistency
+
 # Re-run validation/Jarzynski/owner coverage checks
 npm run demo:alpha-meta:validate
 

--- a/demo/alpha-meta/RUNBOOK.md
+++ b/demo/alpha-meta/RUNBOOK.md
@@ -152,6 +152,7 @@ npm run lint:check
 npm test
 npm run coverage:check
 npm run demo:alpha-meta:ci
+npm run demo:alpha-meta:consistency
 npm run demo:alpha-meta:triangulate
 npm run owner:verify-control
 npm run ci:verify-branch-protection

--- a/demo/alpha-meta/bin/launch.sh
+++ b/demo/alpha-meta/bin/launch.sh
@@ -17,7 +17,7 @@ cd "${ROOT_DIR}"
 # 1. Execute the first-class operating system drill with unstoppable owner supremacy.
 npm run demo:agi-os:first-class -- --auto-yes "$@"
 
-# 2. Generate the Alpha-Meta governance dossier, CI audit, owner diagnostics, and triangulation bundle.
+# 2. Generate the Alpha-Meta governance dossier, CI audit, owner diagnostics, deterministic consistency audit, and triangulation bundle.
 npm run demo:alpha-meta:full
 
 # 3. Replay the ASI take-off harness using the alpha-meta constellation mission plan.

--- a/demo/alpha-meta/reports/alpha-meta-consistency.json
+++ b/demo/alpha-meta/reports/alpha-meta-consistency.json
@@ -1,0 +1,149 @@
+{
+  "generatedAt": "2025-10-20T18:38:18.557Z",
+  "durationMs": 28700.754701000027,
+  "baseline": {
+    "gibbsFreeEnergyKJ": 222153.726,
+    "jarzynskiLogExpectation": -38.41439448414971,
+    "jarzynskiLogTheoretical": -37.911526076706544,
+    "equilibriumProfile": [
+      0.30667172100075735,
+      0.3328278999241852,
+      0.36050037907505755
+    ]
+  },
+  "iterations": [
+    {
+      "iteration": 1,
+      "gibbsFreeEnergyKJ": 222153.726,
+      "gibbsDelta": 0,
+      "jarzynskiLogExpectation": -38.41439448414971,
+      "jarzynskiExpectationDelta": 0,
+      "jarzynskiLogTheoretical": -37.911526076706544,
+      "jarzynskiTheoreticalDelta": 0,
+      "equilibriumProfile": [
+        0.30667172100075735,
+        0.3328278999241852,
+        0.36050037907505755
+      ],
+      "equilibriumDelta": 0,
+      "durationMs": 9717.991832
+    },
+    {
+      "iteration": 2,
+      "gibbsFreeEnergyKJ": 222153.726,
+      "gibbsDelta": 0,
+      "jarzynskiLogExpectation": -38.41439448414971,
+      "jarzynskiExpectationDelta": 0,
+      "jarzynskiLogTheoretical": -37.911526076706544,
+      "jarzynskiTheoreticalDelta": 0,
+      "equilibriumProfile": [
+        0.30667172100075735,
+        0.3328278999241852,
+        0.36050037907505755
+      ],
+      "equilibriumDelta": 0,
+      "durationMs": 9331.521796000015
+    },
+    {
+      "iteration": 3,
+      "gibbsFreeEnergyKJ": 222153.726,
+      "gibbsDelta": 0,
+      "jarzynskiLogExpectation": -38.41439448414971,
+      "jarzynskiExpectationDelta": 0,
+      "jarzynskiLogTheoretical": -37.911526076706544,
+      "jarzynskiTheoreticalDelta": 0,
+      "equilibriumProfile": [
+        0.30667172100075735,
+        0.3328278999241852,
+        0.36050037907505755
+      ],
+      "equilibriumDelta": 0,
+      "durationMs": 9650.901511000004
+    }
+  ],
+  "manifest": {
+    "checked": [
+      {
+        "path": "demo/alpha-meta/reports/alpha-meta-governance-summary.json",
+        "sha256Matches": true,
+        "bytesMatch": true,
+        "expectedSha256": "6510458b5968b08eb02a5f2a6df352d3e5d5a7c8215891ac0ada2d5c8e7da73c",
+        "actualSha256": "6510458b5968b08eb02a5f2a6df352d3e5d5a7c8215891ac0ada2d5c8e7da73c",
+        "expectedBytes": 21517,
+        "actualBytes": 21517
+      },
+      {
+        "path": "demo/alpha-meta/reports/alpha-meta-governance-report.md",
+        "sha256Matches": true,
+        "bytesMatch": true,
+        "expectedSha256": "f368708b6532e19f29b946ab7bdfc4cd0a4691c56fa378462042072facc3d432",
+        "actualSha256": "f368708b6532e19f29b946ab7bdfc4cd0a4691c56fa378462042072facc3d432",
+        "expectedBytes": 18066,
+        "actualBytes": 18066
+      },
+      {
+        "path": "demo/alpha-meta/reports/alpha-meta-governance-dashboard.html",
+        "sha256Matches": true,
+        "bytesMatch": true,
+        "expectedSha256": "889f7e88316fbe6e91b7195e1224db9df1ec4383154d16cae963bf0ed0a8900d",
+        "actualSha256": "889f7e88316fbe6e91b7195e1224db9df1ec4383154d16cae963bf0ed0a8900d",
+        "expectedBytes": 27078,
+        "actualBytes": 27078
+      },
+      {
+        "path": "demo/alpha-meta/reports/alpha-meta-owner-matrix.json",
+        "sha256Matches": true,
+        "bytesMatch": true,
+        "expectedSha256": "77ec0e5d13efaaebf00d6de6a49792ed7d9a0a8bf6637ad40c7f5cf4c8575047",
+        "actualSha256": "77ec0e5d13efaaebf00d6de6a49792ed7d9a0a8bf6637ad40c7f5cf4c8575047",
+        "expectedBytes": 5205,
+        "actualBytes": 5205
+      },
+      {
+        "path": "demo/alpha-meta/reports/alpha-meta-owner-matrix.md",
+        "sha256Matches": true,
+        "bytesMatch": true,
+        "expectedSha256": "c08ece43d8adbc20fe2a1882c912f51636a7d5e7d57fdb4fbdbf77cbc4c53889",
+        "actualSha256": "c08ece43d8adbc20fe2a1882c912f51636a7d5e7d57fdb4fbdbf77cbc4c53889",
+        "expectedBytes": 1814,
+        "actualBytes": 1814
+      },
+      {
+        "path": "demo/alpha-meta/reports/alpha-meta-consistency.json",
+        "sha256Matches": true,
+        "bytesMatch": true,
+        "expectedSha256": "3a2af7aee6ca0a5171269afbfd593be03d5c6cbe9fcbbef92b7dbf162b9f237a",
+        "actualSha256": "3a2af7aee6ca0a5171269afbfd593be03d5c6cbe9fcbbef92b7dbf162b9f237a",
+        "expectedBytes": 5098,
+        "actualBytes": 5098
+      },
+      {
+        "path": "demo/alpha-meta/reports/alpha-meta-consistency.md",
+        "sha256Matches": true,
+        "bytesMatch": true,
+        "expectedSha256": "4ab3a7a5e1e42f4891b9cf83cab564d7c4f33e88c2abbd664f4881d8000a3d66",
+        "actualSha256": "4ab3a7a5e1e42f4891b9cf83cab564d7c4f33e88c2abbd664f4881d8000a3d66",
+        "expectedBytes": 1140,
+        "actualBytes": 1140
+      }
+    ],
+    "missing": []
+  },
+  "tolerances": {
+    "gibbsFreeEnergyKJ": 0.000001,
+    "jarzynskiLog": 1e-9,
+    "equilibrium": 1e-9
+  },
+  "maxDeviation": {
+    "gibbsFreeEnergyKJ": 0,
+    "jarzynskiLogExpectation": 0,
+    "jarzynskiLogTheoretical": 0,
+    "equilibrium": 0
+  },
+  "success": true,
+  "warnings": [],
+  "outputs": {
+    "json": "/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-consistency.json",
+    "markdown": "/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-consistency.md"
+  }
+}

--- a/demo/alpha-meta/reports/alpha-meta-consistency.md
+++ b/demo/alpha-meta/reports/alpha-meta-consistency.md
@@ -1,0 +1,32 @@
+# Alpha-Meta Consistency Audit
+
+Generated at: 2025-10-20T18:38:18.557Z
+
+## Baseline invariants
+
+- Gibbs free energy (kJ): 222153.726000
+- Jarzynski expectation (log): -38.414394
+- Jarzynski theoretical (log): -37.911526
+- Equilibrium profile: 3.0667172e-1, 3.3282790e-1, 3.6050038e-1
+
+## Iteration comparisons
+
+| Iteration | Duration (ms) | Δ Gibbs (kJ) | Δ Jarzynski (expectation) | Δ Jarzynski (theoretical) | Δ Equilibrium (L∞) |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 9717.9918 | 0.00000e+0 | 0.00000e+0 | 0.00000e+0 | 0.00000e+0 |
+| 2 | 9331.5218 | 0.00000e+0 | 0.00000e+0 | 0.00000e+0 | 0.00000e+0 |
+| 3 | 9650.9015 | 0.00000e+0 | 0.00000e+0 | 0.00000e+0 | 0.00000e+0 |
+
+## Manifest verification
+
+All key artefacts are present with matching digests and byte lengths.
+
+## Verdict
+
+✅ Alpha-Meta invariants are deterministic across repeated computations and manifest integrity is intact.
+
+### Tolerances
+
+- Gibbs free energy Δ ≤ 1.00000e-6 kJ (observed 0.00000e+0)
+- Jarzynski log Δ ≤ 1.00000e-9 (observed max expectation Δ 0.00000e+0, theoretical Δ 0.00000e+0)
+- Equilibrium Δ ≤ 1.00000e-9 (observed 0.00000e+0)

--- a/demo/alpha-meta/reports/alpha-meta-full-run.json
+++ b/demo/alpha-meta/reports/alpha-meta-full-run.json
@@ -1,41 +1,48 @@
 {
-  "generatedAt": "2025-10-20T17:36:27.566Z",
-  "totalDurationMs": 205518.719063,
+  "generatedAt": "2025-10-20T18:37:38.457Z",
+  "totalDurationMs": 128409.689579,
   "steps": [
     {
       "id": "generate",
       "label": "Generate dossier",
       "status": "success",
-      "durationMs": 79943.433078,
+      "durationMs": 49772.425908,
       "details": "Free-energy margin 222153.73 kJ · Max method deviation 0.849374"
     },
     {
       "id": "validate",
       "label": "Validate physics",
       "status": "success",
-      "durationMs": 81602.23258800001,
+      "durationMs": 51142.637986999995,
       "details": "All 58 checks passed"
     },
     {
       "id": "ci",
       "label": "Audit CI shield",
       "status": "success",
-      "durationMs": 60.83084899999085,
+      "durationMs": 85.25785100000212,
       "details": "All enforcement guards locked."
     },
     {
       "id": "owner",
       "label": "Owner diagnostics",
       "status": "success",
-      "durationMs": 43911.428518,
+      "durationMs": 27408.835974999995,
       "details": "All owner automation commands executed successfully."
     },
     {
       "id": "triangulation",
       "label": "Triangulation cross-check",
       "status": "success",
-      "durationMs": 14363.258185999992,
+      "durationMs": 11264.906446000008,
       "details": "All checks satisfied (max Δ=0.693328)"
+    },
+    {
+      "id": "consistency",
+      "label": "Deterministic consistency audit",
+      "status": "success",
+      "durationMs": 28700.754701000027,
+      "details": "All invariants within tolerance (max Δ Gibbs=0.000e+0)"
     }
   ],
   "metrics": {
@@ -86,6 +93,8 @@
     "fullRunMarkdown": "/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-full-run.md",
     "manifest": "/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-manifest.json",
     "triangulationJson": "/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-triangulation.json",
-    "triangulationMarkdown": "/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-triangulation.md"
+    "triangulationMarkdown": "/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-triangulation.md",
+    "consistencyJson": "/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-consistency.json",
+    "consistencyMarkdown": "/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-consistency.md"
   }
 }

--- a/demo/alpha-meta/reports/alpha-meta-full-run.md
+++ b/demo/alpha-meta/reports/alpha-meta-full-run.md
@@ -1,6 +1,6 @@
 # Full Governance Demonstration Run
-*Generated at:* 2025-10-20T17:36:27.566Z
-*Total runtime:* 205.52 s
+*Generated at:* 2025-10-20T18:37:38.457Z
+*Total runtime:* 128.41 s
 
 ```mermaid
 graph LR
@@ -19,11 +19,12 @@ graph LR
 
 | Step | Status | Duration | Details |
 | --- | --- | --- | --- |
-| Generate dossier | ✅ | 79.94 s | \|F\|r\|e\|e\|-\|e\|n\|e\|r\|g\|y\| \|m\|a\|r\|g\|i\|n\| \|2\|2\|2\|1\|5\|3\|.\|7\|3\| \|k\|J\| \|·\| \|M\|a\|x\| \|m\|e\|t\|h\|o\|d\| \|d\|e\|v\|i\|a\|t\|i\|o\|n\| \|0\|.\|8\|4\|9\|3\|7\|4\| |
-| Validate physics | ✅ | 81.60 s | \|A\|l\|l\| \|5\|8\| \|c\|h\|e\|c\|k\|s\| \|p\|a\|s\|s\|e\|d\| |
-| Audit CI shield | ✅ | 0.06 s | \|A\|l\|l\| \|e\|n\|f\|o\|r\|c\|e\|m\|e\|n\|t\| \|g\|u\|a\|r\|d\|s\| \|l\|o\|c\|k\|e\|d\|.\| |
-| Owner diagnostics | ✅ | 43.91 s | \|A\|l\|l\| \|o\|w\|n\|e\|r\| \|a\|u\|t\|o\|m\|a\|t\|i\|o\|n\| \|c\|o\|m\|m\|a\|n\|d\|s\| \|e\|x\|e\|c\|u\|t\|e\|d\| \|s\|u\|c\|c\|e\|s\|s\|f\|u\|l\|l\|y\|.\| |
-| Triangulation cross-check | ✅ | 14.36 s | All checks satisfied (max Δ=0.693328) |
+| Generate dossier | ✅ | 49.77 s | \|F\|r\|e\|e\|-\|e\|n\|e\|r\|g\|y\| \|m\|a\|r\|g\|i\|n\| \|2\|2\|2\|1\|5\|3\|.\|7\|3\| \|k\|J\| \|·\| \|M\|a\|x\| \|m\|e\|t\|h\|o\|d\| \|d\|e\|v\|i\|a\|t\|i\|o\|n\| \|0\|.\|8\|4\|9\|3\|7\|4\| |
+| Validate physics | ✅ | 51.14 s | \|A\|l\|l\| \|5\|8\| \|c\|h\|e\|c\|k\|s\| \|p\|a\|s\|s\|e\|d\| |
+| Audit CI shield | ✅ | 0.09 s | \|A\|l\|l\| \|e\|n\|f\|o\|r\|c\|e\|m\|e\|n\|t\| \|g\|u\|a\|r\|d\|s\| \|l\|o\|c\|k\|e\|d\|.\| |
+| Owner diagnostics | ✅ | 27.41 s | \|A\|l\|l\| \|o\|w\|n\|e\|r\| \|a\|u\|t\|o\|m\|a\|t\|i\|o\|n\| \|c\|o\|m\|m\|a\|n\|d\|s\| \|e\|x\|e\|c\|u\|t\|e\|d\| \|s\|u\|c\|c\|e\|s\|s\|f\|u\|l\|l\|y\|.\| |
+| Deterministic consistency audit | ✅ | 28.70 s | All invariants within tolerance (max Δ Gibbs=0.000e+0) |
+| Triangulation cross-check | ✅ | 11.26 s | All checks satisfied (max Δ=0.693328) |
 
 ## Key Metrics
 - Gibbs free energy: 222153.73 kJ
@@ -66,6 +67,8 @@ graph LR
 - Full-run Markdown: `/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-full-run.md`
 - Triangulation JSON: `/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-triangulation.json`
 - Triangulation Markdown: `/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-triangulation.md`
+- Consistency JSON: `/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-consistency.json`
+- Consistency Markdown: `/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-consistency.md`
 - Manifest: `/workspace/AGIJobsv0/demo/alpha-meta/reports/alpha-meta-manifest.json`
 
 > ✅ CI shield verified with all guards active.

--- a/demo/alpha-meta/reports/alpha-meta-manifest.json
+++ b/demo/alpha-meta/reports/alpha-meta-manifest.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2025-10-20T17:36:42.010Z",
+  "generatedAt": "2025-10-20T18:39:35.984Z",
   "root": "/workspace/AGIJobsv0",
-  "files": 15,
+  "files": 17,
   "entries": [
     {
       "path": "demo/alpha-meta/config/mission@alpha-meta.json",
@@ -12,6 +12,16 @@
       "path": "demo/alpha-meta/reports/alpha-meta-ci-verification.json",
       "sha256": "96d62ca8c956d1bca25a42f8983072f0ce512e3d17fae4dac9f067f18442849f",
       "bytes": 1493
+    },
+    {
+      "path": "demo/alpha-meta/reports/alpha-meta-consistency.json",
+      "sha256": "ac86cb67b01f381fd5621da49e4deee598474d31920386747268f27a91d35ad9",
+      "bytes": 5100
+    },
+    {
+      "path": "demo/alpha-meta/reports/alpha-meta-consistency.md",
+      "sha256": "453114d6dea048568c682954b26ecc3c092e3ab6849a7bbc0eb2c209977be1e6",
+      "bytes": 1140
     },
     {
       "path": "demo/alpha-meta/reports/alpha-meta-full-run.json",

--- a/demo/alpha-meta/scripts/consistencyAudit.ts
+++ b/demo/alpha-meta/scripts/consistencyAudit.ts
@@ -1,0 +1,604 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { createHash } from "crypto";
+import path from "path";
+import { performance } from "perf_hooks";
+
+import {
+  loadMission,
+  computeThermodynamics,
+  computeStatisticalPhysics,
+  computeJarzynski,
+  computeEquilibrium,
+  type MissionConfig,
+} from "../../agi-governance/scripts/executeDemo";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const BASE_DIR = path.resolve(__dirname, "..");
+const REPORT_DIR = path.join(BASE_DIR, "reports");
+
+const DEFAULT_MISSION_FILE = path.join(BASE_DIR, "config", "mission@alpha-meta.json");
+const DEFAULT_SUMMARY_FILE = path.join(REPORT_DIR, "alpha-meta-governance-summary.json");
+const DEFAULT_JSON = path.join(REPORT_DIR, "alpha-meta-consistency.json");
+const DEFAULT_MARKDOWN = path.join(REPORT_DIR, "alpha-meta-consistency.md");
+const DEFAULT_MANIFEST = path.join(REPORT_DIR, "alpha-meta-manifest.json");
+
+const DEFAULT_ITERATIONS = 3;
+
+const DEFAULT_TOLERANCES = {
+  gibbsFreeEnergyKJ: 1e-6,
+  jarzynskiLog: 1e-9,
+  equilibrium: 1e-9,
+};
+
+const DEBUG = process.env.ALPHA_META_DEBUG === "1";
+
+function debugLog(...messages: unknown[]): void {
+  if (DEBUG) {
+    console.log("[alpha-meta:consistency]", ...messages);
+  }
+}
+
+const MANIFEST_KEY_FILES = [
+  path.join(BASE_DIR, "reports", "alpha-meta-governance-summary.json"),
+  path.join(BASE_DIR, "reports", "alpha-meta-governance-report.md"),
+  path.join(BASE_DIR, "reports", "alpha-meta-governance-dashboard.html"),
+  path.join(BASE_DIR, "reports", "alpha-meta-owner-matrix.json"),
+  path.join(BASE_DIR, "reports", "alpha-meta-owner-matrix.md"),
+  path.join(BASE_DIR, "reports", "alpha-meta-consistency.json"),
+  path.join(BASE_DIR, "reports", "alpha-meta-consistency.md"),
+];
+
+interface GovernanceSummary {
+  thermodynamics?: {
+    gibbsFreeEnergyKJ: number;
+  };
+  jarzynski?: {
+    logExpectation: number;
+    logTheoretical: number;
+    tolerance?: number;
+  };
+  equilibrium?: {
+    closedForm: number[];
+  };
+}
+
+interface ManifestDocument {
+  generatedAt: string;
+  root?: string;
+  files: number;
+  entries: Array<{
+    path: string;
+    sha256: string;
+    bytes: number;
+  }>;
+}
+
+interface ConsistencyIteration {
+  iteration: number;
+  gibbsFreeEnergyKJ: number;
+  gibbsDelta: number;
+  jarzynskiLogExpectation: number;
+  jarzynskiExpectationDelta: number;
+  jarzynskiLogTheoretical: number;
+  jarzynskiTheoreticalDelta: number;
+  equilibriumProfile: number[];
+  equilibriumDelta: number;
+  durationMs: number;
+}
+
+interface ManifestCheck {
+  checked: Array<{
+    path: string;
+    sha256Matches: boolean;
+    bytesMatch: boolean;
+    expectedSha256?: string;
+    actualSha256: string;
+    expectedBytes?: number;
+    actualBytes: number;
+  }>;
+  missing: string[];
+}
+
+export interface ConsistencyOptions {
+  missionFile?: string;
+  summaryFile?: string;
+  outputJson?: string;
+  outputMarkdown?: string;
+  manifestFile?: string;
+  iterations?: number;
+  tolerances?: Partial<typeof DEFAULT_TOLERANCES>;
+}
+
+export interface ConsistencyResult {
+  generatedAt: string;
+  durationMs: number;
+  baseline: {
+    gibbsFreeEnergyKJ: number;
+    jarzynskiLogExpectation: number;
+    jarzynskiLogTheoretical: number;
+    equilibriumProfile: number[];
+  };
+  iterations: ConsistencyIteration[];
+  manifest: ManifestCheck;
+  tolerances: typeof DEFAULT_TOLERANCES;
+  maxDeviation: {
+    gibbsFreeEnergyKJ: number;
+    jarzynskiLogExpectation: number;
+    jarzynskiLogTheoretical: number;
+    equilibrium: number;
+  };
+  success: boolean;
+  warnings: string[];
+  outputs: {
+    json: string;
+    markdown: string;
+  };
+}
+
+function normalisePath(filePath: string): string {
+  return path.relative(REPO_ROOT, filePath).replace(/\\/g, "/");
+}
+
+function formatNumber(value: number, digits = 6): string {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  if (Math.abs(value) >= 1) {
+    return value.toFixed(digits);
+  }
+  return value.toExponential(digits - 1);
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const raw = await readFile(filePath, "utf8");
+  return JSON.parse(raw) as T;
+}
+
+function maxAbsoluteDelta(a: number[], b: number[]): number {
+  const length = Math.max(a.length, b.length);
+  let maxDelta = 0;
+  for (let i = 0; i < length; i += 1) {
+    const delta = Math.abs((a[i] ?? 0) - (b[i] ?? 0));
+    if (delta > maxDelta) {
+      maxDelta = delta;
+    }
+  }
+  return maxDelta;
+}
+
+function collectManifestIssues(manifest: ManifestCheck): string[] {
+  return [
+    ...manifest.missing.map((pathValue) => `Missing manifest entry for ${pathValue}`),
+    ...manifest.checked
+      .filter((entry) => !entry.sha256Matches)
+      .map((entry) => `SHA-256 mismatch for ${entry.path}`),
+    ...manifest.checked
+      .filter((entry) => entry.sha256Matches && !entry.bytesMatch)
+      .map((entry) => `Byte-length mismatch for ${entry.path}`),
+  ];
+}
+
+function evaluateConsistency(
+  manifest: ManifestCheck,
+  maxDeviation: {
+    gibbsFreeEnergyKJ: number;
+    jarzynskiLogExpectation: number;
+    jarzynskiLogTheoretical: number;
+    equilibrium: number;
+  },
+  tolerances: typeof DEFAULT_TOLERANCES,
+): { success: boolean; warnings: string[]; manifestIssues: string[] } {
+  const manifestIssues = collectManifestIssues(manifest);
+  const success =
+    manifestIssues.length === 0 &&
+    maxDeviation.gibbsFreeEnergyKJ <= tolerances.gibbsFreeEnergyKJ &&
+    maxDeviation.jarzynskiLogExpectation <= tolerances.jarzynskiLog &&
+    maxDeviation.jarzynskiLogTheoretical <= tolerances.jarzynskiLog &&
+    maxDeviation.equilibrium <= tolerances.equilibrium;
+
+  const warnings: string[] = [];
+  if (!success && manifestIssues.length === 0) {
+    warnings.push("Physical invariants deviated beyond tolerance");
+  }
+  if (manifestIssues.length > 0) {
+    warnings.push(...manifestIssues);
+  }
+
+  return { success, warnings, manifestIssues };
+}
+
+function renderMarkdown(result: ConsistencyResult, manifestIssues: string[]): string {
+  const lines: string[] = [];
+  lines.push("# Alpha-Meta Consistency Audit");
+  lines.push("");
+  lines.push(`Generated at: ${result.generatedAt}`);
+  lines.push("");
+  lines.push("## Baseline invariants");
+  lines.push("");
+  lines.push(`- Gibbs free energy (kJ): ${formatNumber(result.baseline.gibbsFreeEnergyKJ)}`);
+  lines.push(`- Jarzynski expectation (log): ${formatNumber(result.baseline.jarzynskiLogExpectation)}`);
+  lines.push(`- Jarzynski theoretical (log): ${formatNumber(result.baseline.jarzynskiLogTheoretical)}`);
+  lines.push(
+    `- Equilibrium profile: ${result.baseline.equilibriumProfile
+      .map((value) => formatNumber(value, 8))
+      .join(", ")}`,
+  );
+  lines.push("");
+  lines.push("## Iteration comparisons");
+  lines.push("");
+  lines.push(
+    "| Iteration | Duration (ms) | Δ Gibbs (kJ) | Δ Jarzynski (expectation) | Δ Jarzynski (theoretical) | Δ Equilibrium (L∞) |",
+  );
+  lines.push("| --- | --- | --- | --- | --- | --- |");
+  for (const entry of result.iterations) {
+    lines.push(
+      `| ${entry.iteration} | ${formatNumber(entry.durationMs, 4)} | ${formatNumber(entry.gibbsDelta)} | ${formatNumber(
+        entry.jarzynskiExpectationDelta,
+      )} | ${formatNumber(entry.jarzynskiTheoreticalDelta)} | ${formatNumber(entry.equilibriumDelta)} |`,
+    );
+  }
+  lines.push("");
+  lines.push("## Manifest verification");
+  lines.push("");
+  if (manifestIssues.length === 0) {
+    lines.push("All key artefacts are present with matching digests and byte lengths.");
+  } else {
+    lines.push("Issues detected:");
+    for (const issue of manifestIssues) {
+      lines.push(`- ${issue}`);
+    }
+  }
+  lines.push("");
+  lines.push("## Verdict");
+  lines.push("");
+  if (result.success) {
+    lines.push(
+      "✅ Alpha-Meta invariants are deterministic across repeated computations and manifest integrity is intact.",
+    );
+  } else {
+    lines.push("❌ Deviations exceeded tolerance or manifest integrity checks failed.");
+  }
+  lines.push("");
+  lines.push("### Tolerances");
+  lines.push("");
+  lines.push(
+    `- Gibbs free energy Δ ≤ ${formatNumber(result.tolerances.gibbsFreeEnergyKJ)} kJ (observed ${formatNumber(
+      result.maxDeviation.gibbsFreeEnergyKJ,
+    )})`,
+  );
+  lines.push(
+    `- Jarzynski log Δ ≤ ${formatNumber(result.tolerances.jarzynskiLog)} (observed max expectation Δ ${formatNumber(
+      result.maxDeviation.jarzynskiLogExpectation,
+    )}, theoretical Δ ${formatNumber(result.maxDeviation.jarzynskiLogTheoretical)})`,
+  );
+  lines.push(
+    `- Equilibrium Δ ≤ ${formatNumber(result.tolerances.equilibrium)} (observed ${formatNumber(
+      result.maxDeviation.equilibrium,
+    )})`,
+  );
+
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+async function updateManifest(manifestPath: string, files: string[]): Promise<void> {
+  let document: ManifestDocument;
+  try {
+    document = await readJsonFile<ManifestDocument>(manifestPath);
+  } catch (error) {
+    document = {
+      generatedAt: new Date().toISOString(),
+      root: REPO_ROOT,
+      files: 0,
+      entries: [],
+    };
+  }
+
+  const entryMap = new Map<string, ManifestDocument["entries"][number]>(
+    (document.entries ?? []).map((entry) => [entry.path, entry]),
+  );
+
+  for (const file of files) {
+    const absolute = path.resolve(file);
+    const relative = normalisePath(absolute);
+    const buffer = await readFile(absolute);
+    const sha256 = createHash("sha256").update(buffer).digest("hex");
+    const entry = {
+      path: relative,
+      sha256,
+      bytes: buffer.length,
+    };
+    entryMap.set(relative, entry);
+  }
+
+  const entries = Array.from(entryMap.values()).sort((a, b) => a.path.localeCompare(b.path));
+  document.entries = entries;
+  document.files = entries.length;
+  document.root = document.root ?? REPO_ROOT;
+  document.generatedAt = new Date().toISOString();
+
+  await writeFile(manifestPath, JSON.stringify(document, null, 2), "utf8");
+}
+
+async function checkManifest(manifestPath: string): Promise<ManifestCheck> {
+  const manifest = await readJsonFile<ManifestDocument>(manifestPath);
+  const entryMap = new Map(manifest.entries.map((entry) => [entry.path, entry]));
+
+  const checked: ManifestCheck["checked"] = [];
+  const missing: string[] = [];
+
+  for (const absolute of MANIFEST_KEY_FILES) {
+    const relative = normalisePath(absolute);
+    const buffer = await readFile(absolute);
+    const sha256 = createHash("sha256").update(buffer).digest("hex");
+    const bytes = buffer.length;
+
+    const entry = entryMap.get(relative);
+    if (!entry) {
+      missing.push(relative);
+      continue;
+    }
+
+    checked.push({
+      path: relative,
+      sha256Matches: entry.sha256 === sha256,
+      bytesMatch: entry.bytes === bytes,
+      expectedSha256: entry.sha256,
+      actualSha256: sha256,
+      expectedBytes: entry.bytes,
+      actualBytes: bytes,
+    });
+  }
+
+  return { checked, missing };
+}
+
+async function computeBaseline(summaryFile: string): Promise<{
+  summary: GovernanceSummary;
+  gibbsFreeEnergyKJ: number;
+  jarzynskiLogExpectation: number;
+  jarzynskiLogTheoretical: number;
+  equilibriumProfile: number[];
+}> {
+  const summary = await readJsonFile<GovernanceSummary>(summaryFile);
+  if (!summary.thermodynamics || !Number.isFinite(summary.thermodynamics.gibbsFreeEnergyKJ)) {
+    throw new Error("Summary is missing thermodynamic Gibbs free energy");
+  }
+  if (!summary.jarzynski) {
+    throw new Error("Summary is missing Jarzynski data");
+  }
+  if (!summary.equilibrium || !Array.isArray(summary.equilibrium.closedForm)) {
+    throw new Error("Summary is missing equilibrium closed form");
+  }
+  return {
+    summary,
+    gibbsFreeEnergyKJ: summary.thermodynamics.gibbsFreeEnergyKJ,
+    jarzynskiLogExpectation: summary.jarzynski.logExpectation,
+    jarzynskiLogTheoretical: summary.jarzynski.logTheoretical,
+    equilibriumProfile: summary.equilibrium.closedForm,
+  };
+}
+
+function computeMissionIteration(mission: MissionConfig) {
+  const thermodynamics = computeThermodynamics(mission);
+  const statisticalPhysics = computeStatisticalPhysics(mission, thermodynamics);
+  const jarzynski = computeJarzynski(mission, thermodynamics, statisticalPhysics);
+  const equilibrium = computeEquilibrium(mission);
+
+  return {
+    gibbsFreeEnergyKJ: thermodynamics.gibbsFreeEnergyKJ,
+    jarzynskiLogExpectation: jarzynski.logExpectation,
+    jarzynskiLogTheoretical: jarzynski.logTheoretical,
+    equilibriumProfile: equilibrium.closedForm,
+  };
+}
+
+export async function executeConsistencyAudit(options: ConsistencyOptions = {}): Promise<ConsistencyResult> {
+  const missionFile = path.resolve(options.missionFile ?? DEFAULT_MISSION_FILE);
+  const summaryFile = path.resolve(options.summaryFile ?? DEFAULT_SUMMARY_FILE);
+  const outputJson = path.resolve(options.outputJson ?? DEFAULT_JSON);
+  const outputMarkdown = path.resolve(options.outputMarkdown ?? DEFAULT_MARKDOWN);
+  const manifestFile = path.resolve(options.manifestFile ?? DEFAULT_MANIFEST);
+  const iterations = Math.max(1, Math.floor(options.iterations ?? DEFAULT_ITERATIONS));
+  const tolerances = {
+    ...DEFAULT_TOLERANCES,
+    ...(options.tolerances ?? {}),
+  };
+
+  await mkdir(path.dirname(outputJson), { recursive: true });
+
+  const mission = await loadMission(missionFile);
+  const baseline = await computeBaseline(summaryFile);
+  debugLog("Mission and summary loaded");
+
+  const iterationResults: ConsistencyIteration[] = [];
+  let maxGibbsDelta = 0;
+  let maxJarzynskiExpectationDelta = 0;
+  let maxJarzynskiTheoreticalDelta = 0;
+  let maxEquilibriumDelta = 0;
+
+  const start = performance.now();
+  for (let index = 0; index < iterations; index += 1) {
+    const iterationStart = performance.now();
+    const result = computeMissionIteration(mission);
+    const iterationEnd = performance.now();
+
+    const gibbsDelta = Math.abs(result.gibbsFreeEnergyKJ - baseline.gibbsFreeEnergyKJ);
+    const jarzynskiExpectationDelta = Math.abs(
+      result.jarzynskiLogExpectation - baseline.jarzynskiLogExpectation,
+    );
+    const jarzynskiTheoreticalDelta = Math.abs(
+      result.jarzynskiLogTheoretical - baseline.jarzynskiLogTheoretical,
+    );
+    const equilibriumDelta = maxAbsoluteDelta(result.equilibriumProfile, baseline.equilibriumProfile);
+
+    maxGibbsDelta = Math.max(maxGibbsDelta, gibbsDelta);
+    maxJarzynskiExpectationDelta = Math.max(maxJarzynskiExpectationDelta, jarzynskiExpectationDelta);
+    maxJarzynskiTheoreticalDelta = Math.max(maxJarzynskiTheoreticalDelta, jarzynskiTheoreticalDelta);
+    maxEquilibriumDelta = Math.max(maxEquilibriumDelta, equilibriumDelta);
+
+    iterationResults.push({
+      iteration: index + 1,
+      gibbsFreeEnergyKJ: result.gibbsFreeEnergyKJ,
+      gibbsDelta,
+      jarzynskiLogExpectation: result.jarzynskiLogExpectation,
+      jarzynskiExpectationDelta,
+      jarzynskiLogTheoretical: result.jarzynskiLogTheoretical,
+      jarzynskiTheoreticalDelta,
+      equilibriumProfile: result.equilibriumProfile,
+      equilibriumDelta,
+      durationMs: iterationEnd - iterationStart,
+    });
+  }
+  const end = performance.now();
+
+  const maxDeviation = {
+    gibbsFreeEnergyKJ: maxGibbsDelta,
+    jarzynskiLogExpectation: maxJarzynskiExpectationDelta,
+    jarzynskiLogTheoretical: maxJarzynskiTheoreticalDelta,
+    equilibrium: maxEquilibriumDelta,
+  };
+  debugLog("Computed max deviations", maxDeviation);
+
+  const placeholderResult: ConsistencyResult = {
+    generatedAt: new Date().toISOString(),
+    durationMs: end - start,
+    baseline: {
+      gibbsFreeEnergyKJ: baseline.gibbsFreeEnergyKJ,
+      jarzynskiLogExpectation: baseline.jarzynskiLogExpectation,
+      jarzynskiLogTheoretical: baseline.jarzynskiLogTheoretical,
+      equilibriumProfile: baseline.equilibriumProfile,
+    },
+    iterations: iterationResults,
+    manifest: { checked: [], missing: [] },
+    tolerances,
+    maxDeviation,
+    success: false,
+    warnings: ["Manifest verification pending"],
+    outputs: {
+      json: outputJson,
+      markdown: outputMarkdown,
+    },
+  };
+
+  const placeholderMarkdown = [
+    "# Alpha-Meta Consistency Audit",
+    "",
+    `Generated at: ${placeholderResult.generatedAt}`,
+    "",
+    "Manifest verification pending — rerendering after digest checks...",
+  ].join("\n");
+
+  await writeFile(outputJson, JSON.stringify(placeholderResult, null, 2), "utf8");
+  await writeFile(outputMarkdown, placeholderMarkdown, "utf8");
+  debugLog("Wrote placeholder outputs");
+
+  await updateManifest(manifestFile, [outputJson, outputMarkdown]);
+  debugLog("Updated manifest with placeholder outputs");
+  let manifest = await checkManifest(manifestFile);
+  debugLog("Initial manifest check complete");
+  let evaluation = evaluateConsistency(manifest, maxDeviation, tolerances);
+
+  let result: ConsistencyResult = {
+    ...placeholderResult,
+    generatedAt: new Date().toISOString(),
+    manifest,
+    success: evaluation.success,
+    warnings: evaluation.warnings,
+  };
+
+  let markdown = renderMarkdown(result, evaluation.manifestIssues);
+
+  await writeFile(outputJson, JSON.stringify(result, null, 2), "utf8");
+  await writeFile(outputMarkdown, markdown, "utf8");
+  debugLog("Wrote first-pass outputs");
+
+  await updateManifest(manifestFile, [outputJson, outputMarkdown]);
+  debugLog("Updated manifest after first pass");
+  manifest = await checkManifest(manifestFile);
+  debugLog("Second manifest check complete");
+  evaluation = evaluateConsistency(manifest, maxDeviation, tolerances);
+
+  const finalResult: ConsistencyResult = {
+    ...result,
+    generatedAt: new Date().toISOString(),
+    manifest,
+    success: evaluation.success,
+    warnings: evaluation.warnings,
+  };
+
+  const finalMarkdown = renderMarkdown(finalResult, evaluation.manifestIssues);
+
+  const previousJson = JSON.stringify(result, null, 2);
+  const finalJson = JSON.stringify(finalResult, null, 2);
+
+  if (finalJson !== previousJson) {
+    await writeFile(outputJson, finalJson, "utf8");
+    debugLog("Applied final JSON output");
+  }
+  if (finalMarkdown !== markdown) {
+    await writeFile(outputMarkdown, finalMarkdown, "utf8");
+    debugLog("Applied final Markdown output");
+  }
+
+  if (finalJson !== previousJson || finalMarkdown !== markdown) {
+    await updateManifest(manifestFile, [outputJson, outputMarkdown]);
+    debugLog("Updated manifest after final outputs");
+    const postUpdateManifest = await checkManifest(manifestFile);
+    debugLog("Post-update manifest check complete");
+    const postEvaluation = evaluateConsistency(postUpdateManifest, maxDeviation, tolerances);
+    if (
+      postEvaluation.success !== finalResult.success ||
+      postEvaluation.warnings.join("\n") !== finalResult.warnings.join("\n") ||
+      collectManifestIssues(postUpdateManifest).join("\n") !==
+        collectManifestIssues(finalResult.manifest).join("\n")
+    ) {
+      const updatedResult: ConsistencyResult = {
+        ...finalResult,
+        generatedAt: new Date().toISOString(),
+        manifest: postUpdateManifest,
+        success: postEvaluation.success,
+        warnings: postEvaluation.warnings,
+      };
+      const updatedMarkdown = renderMarkdown(updatedResult, collectManifestIssues(postUpdateManifest));
+      await writeFile(outputJson, JSON.stringify(updatedResult, null, 2), "utf8");
+      await writeFile(outputMarkdown, updatedMarkdown, "utf8");
+      await updateManifest(manifestFile, [outputJson, outputMarkdown]);
+      debugLog("Updated manifest after reconciliation pass");
+      return updatedResult;
+    }
+  }
+
+  debugLog("Consistency audit completed successfully");
+  return finalResult;
+}
+
+async function main(): Promise<void> {
+  const result = await executeConsistencyAudit();
+
+  const manifestWarnings = result.warnings.filter((warning) => warning.startsWith("Missing manifest"));
+  if (!result.success) {
+    console.error("❌ Alpha-Meta consistency audit failed.");
+    if (result.warnings.length > 0) {
+      result.warnings.forEach((warning) => console.error(`   - ${warning}`));
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (manifestWarnings.length > 0) {
+    manifestWarnings.forEach((warning) => console.warn(`⚠️ ${warning}`));
+  }
+
+  console.log("✅ Alpha-Meta consistency audit complete.");
+  console.log(`   Consistency JSON: ${result.outputs.json}`);
+  console.log(`   Consistency Markdown: ${result.outputs.markdown}`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("❌ Failed to execute Alpha-Meta consistency audit:", error);
+    process.exitCode = 1;
+  });
+}

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "demo:alpha-meta:ci": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/verifyCi.ts",
     "demo:alpha-meta:owner": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/ownerDiagnostics.ts",
     "demo:alpha-meta:triangulate": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/triangulateMission.ts",
+    "demo:alpha-meta:consistency": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/consistencyAudit.ts",
     "demo:alpha-meta:full": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/fullPipeline.ts",
     "demo:national-supply-chain": "npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",
     "demo:national-supply-chain:export": "AGI_JOBS_DEMO_EXPORT=demo/National-Supply-Chain-v0/ui/export/latest.json npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",


### PR DESCRIPTION
## Summary
- add a dedicated alpha-meta consistency audit script that recomputes thermodynamic and equilibrium invariants, verifies manifest digests, and emits human-readable evidence artifacts
- wire the deterministic audit into the full alpha-meta pipeline, aggregated reports, and launch workflow while exposing a reusable npm script for direct execution
- document the new command in the alpha-meta README/RUNBOOK and extend the manifest plus full-run dossier to track the additional evidence bundle

## Testing
- npm run demo:alpha-meta:consistency
- npm run demo:alpha-meta:full


------
https://chatgpt.com/codex/tasks/task_e_68f67dd14ba88333b47b07772ab9b2a1