### PR TITLE
Add schema-based cross validation to national supply chain demo

### DIFF
--- a/.github/workflows/demo-national-supply-chain.yml
+++ b/.github/workflows/demo-national-supply-chain.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Run national supply chain export
         run: npm run demo:national-supply-chain:export
 
+      - name: Cross-verify transcript with schema auditor
+        run: npm run demo:national-supply-chain:cross-verify
+
       - name: Validate supply chain transcript
         run: npm run demo:national-supply-chain:validate
 

--- a/demo/National-Supply-Chain-v0/README.md
+++ b/demo/National-Supply-Chain-v0/README.md
@@ -104,10 +104,13 @@ npm run demo:national-supply-chain
 # 2. Export a transcript for the mission control UI
 npm run demo:national-supply-chain:export
 
-# 3. Validate the transcript against unstoppable governance invariants
+# 3. Cross-verify the transcript with dual validation engines
+npm run demo:national-supply-chain:cross-verify
+
+# 4. Validate the transcript against unstoppable governance invariants
 npm run demo:national-supply-chain:validate
 
-# 4. Launch the static UI and autoreplay loop
+# 5. Launch the static UI and autoreplay loop
 npm run demo:national-supply-chain:control-room
 ```
 
@@ -144,6 +147,12 @@ and performs the following sequence end to end:
 The transcript (`demo/National-Supply-Chain-v0/ui/export/latest.json`) contains
 rich context for non-technical reviewers – every timeline event, owner action,
 scenario summary, minted credential, and treasury snapshot.
+
+[`scripts/v2/crossValidateNationalSupplyChainTranscript.ts`](../../scripts/v2/crossValidateNationalSupplyChainTranscript.ts)
+performs a second, schema-driven verification pass. It uses a Zod schema to
+assert structural guarantees, validates chronological ordering, and checks that
+every minted credential maps to a scenario. Cross-verifying with an entirely
+separate engine ensures no single validation approach can silently fail.
 
 [`scripts/v2/validateNationalSupplyChainTranscript.ts`](../../scripts/v2/validateNationalSupplyChainTranscript.ts)
 enforces the unstoppable transcript contract. It asserts timeline depth,
@@ -183,8 +192,10 @@ GitHub Actions workflow
 [`.github/workflows/demo-national-supply-chain.yml`](../../.github/workflows/demo-national-supply-chain.yml)
 replays the export on every pull request touching this demo. The job fails if
 any timeline, owner action, scenario, or telemetry array is empty, or if the UI
-JSON artefact is missing. This guarantees the demo never silently regresses and
-remains launchable by a single non-technical operator.
+JSON artefact is missing. It now runs both validation passes so the exported
+transcript must satisfy the imperative and schema-based auditors. This
+guarantees the demo never silently regresses and remains launchable by a single
+non-technical operator.
 
 ## Emergency controls and sovereignty
 

--- a/demo/National-Supply-Chain-v0/RUNBOOK.md
+++ b/demo/National-Supply-Chain-v0/RUNBOOK.md
@@ -46,6 +46,13 @@ npm run demo:national-supply-chain:export
 ```
 This writes `demo/National-Supply-Chain-v0/ui/export/latest.json`.
 
+Cross-check the export with both validation engines:
+```bash
+npm run demo:national-supply-chain:cross-verify
+```
+The cross-validator enforces the Zod schema, verifies chronological ordering,
+and confirms that every minted credential maps to an orchestrated scenario.
+
 Immediately validate the invariants that prove unstoppable governance:
 ```bash
 npm run demo:national-supply-chain:validate
@@ -80,8 +87,9 @@ npm run demo:national-supply-chain:control-room
 ## 6. Continuous verification (CI)
 
 The repository runs `.github/workflows/demo-national-supply-chain.yml` on every
-relevant pull request. The workflow executes the export command, validates that
-`timeline`, `ownerActions`, `scenarios`, `market.agentPortfolios`, and
+relevant pull request. The workflow executes the export command, runs both the
+cross-verifier and the imperative validator, checks that `timeline`,
+`ownerActions`, `scenarios`, `market.agentPortfolios`, and
 `ownerControl.baseline` are populated, and uploads the transcript artefact. A
 failed workflow blocks merges, ensuring the demo always remains executable.
 

--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
     "demo:national-supply-chain": "npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",
     "demo:national-supply-chain:export": "AGI_JOBS_DEMO_EXPORT=demo/National-Supply-Chain-v0/ui/export/latest.json npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",
     "demo:national-supply-chain:validate": "ts-node --transpile-only scripts/v2/validateNationalSupplyChainTranscript.ts",
+    "demo:national-supply-chain:cross-verify": "ts-node --transpile-only scripts/v2/crossValidateNationalSupplyChainTranscript.ts",
     "demo:national-supply-chain:control-room": "ts-node --transpile-only scripts/v2/launchNationalSupplyChainControlRoom.ts"
   },
   "keywords": [],

--- a/scripts/v2/crossValidateNationalSupplyChainTranscript.ts
+++ b/scripts/v2/crossValidateNationalSupplyChainTranscript.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env ts-node
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { validateTranscript } from './lib/nationalSupplyChainTranscript';
+import {
+  NationalSupplyChainTranscriptSchema,
+  parseNationalSupplyChainTranscript,
+  type NationalSupplyChainTranscriptParsed,
+} from './lib/nationalSupplyChainTranscriptSchema';
+
+function loadTranscript(pathOverride?: string): unknown {
+  const path = resolve(
+    process.cwd(),
+    pathOverride ??
+      process.env.AGI_JOBS_DEMO_EXPORT ??
+      'demo/National-Supply-Chain-v0/ui/export/latest.json'
+  );
+  const raw = readFileSync(path, 'utf8');
+  return JSON.parse(raw);
+}
+
+function ensureChronologicalOrder(
+  timeline: NationalSupplyChainTranscriptParsed['timeline']
+): void {
+  const violations: Array<{
+    index: number;
+    previous: string;
+    current: string;
+  }> = [];
+  for (let i = 1; i < timeline.length; i += 1) {
+    const previousTime = Date.parse(timeline[i - 1].at);
+    const currentTime = Date.parse(timeline[i].at);
+    if (Number.isNaN(previousTime) || Number.isNaN(currentTime)) {
+      continue;
+    }
+    if (currentTime < previousTime) {
+      violations.push({
+        index: i,
+        previous: timeline[i - 1].at,
+        current: timeline[i].at,
+      });
+    }
+  }
+
+  if (violations.length > 0) {
+    const detail = violations
+      .slice(0, 5)
+      .map(
+        (violation) =>
+          `index ${violation.index} (${violation.current}) < previous (${violation.previous})`
+      )
+      .join('; ');
+    throw new Error(`Timeline chronology violated: ${detail}`);
+  }
+}
+
+function ensureScenarioCoverage(
+  parsed: NationalSupplyChainTranscriptParsed
+): void {
+  const scenarioJobIds = new Set(
+    parsed.scenarios.map((scenario) => scenario.jobId)
+  );
+  const orphanCertificates = parsed.market.mintedCertificates.filter(
+    (certificate) => !scenarioJobIds.has(certificate.jobId)
+  );
+  if (orphanCertificates.length > 0) {
+    const detail = orphanCertificates
+      .map((certificate) => certificate.jobId)
+      .join(', ');
+    throw new Error(`Found certificate(s) without scenarios: ${detail}`);
+  }
+
+  parsed.scenarios.forEach((scenario) => {
+    const uniqueTimelineIndices = new Set(scenario.timelineIndices);
+    if (uniqueTimelineIndices.size !== scenario.timelineIndices.length) {
+      throw new Error(
+        `Scenario ${scenario.title} references duplicate timeline indices.`
+      );
+    }
+  });
+}
+
+function computeSummary(parsed: NationalSupplyChainTranscriptParsed) {
+  const ownerActionTimelineCount = parsed.timeline.filter(
+    (entry) => entry.kind === 'owner-action'
+  ).length;
+  const insightCategories = new Set(
+    parsed.insights.map((insight) => {
+      const record = insight as Record<string, unknown>;
+      const candidate = record.category;
+      return typeof candidate === 'string' && candidate.trim().length > 0
+        ? candidate
+        : 'unknown';
+    })
+  );
+  const validatorAddresses = parsed.market.validatorCouncil.map(
+    (validator) => validator.address
+  );
+
+  return {
+    ownerActionTimelineCount,
+    timelineLength: parsed.timeline.length,
+    insightCategories: insightCategories.size,
+    validatorAddresses: new Set(validatorAddresses).size,
+    unstoppableScore: parsed.automation.unstoppableScore,
+  };
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(
+    value
+  );
+}
+
+function main(): void {
+  const transcript = loadTranscript();
+
+  const zodResult = NationalSupplyChainTranscriptSchema.safeParse(transcript);
+  if (!zodResult.success) {
+    const issueSummary = zodResult.error.issues
+      .slice(0, 10)
+      .map((issue) => `${issue.path.join('.') || '(root)'} → ${issue.message}`)
+      .join('\n');
+    throw new Error(`Schema validation failed:\n${issueSummary}`);
+  }
+
+  const parsed = parseNationalSupplyChainTranscript(transcript);
+  ensureChronologicalOrder(parsed.timeline);
+  ensureScenarioCoverage(parsed);
+
+  const imperativeSummary = validateTranscript(transcript);
+  const derivedSummary = computeSummary(parsed);
+
+  if (imperativeSummary.timelineLength !== derivedSummary.timelineLength) {
+    throw new Error('Timeline length mismatch between validation passes.');
+  }
+  if (imperativeSummary.ownerActions !== parsed.ownerActions.length) {
+    throw new Error('Owner actions mismatch between validation passes.');
+  }
+  if (
+    imperativeSummary.mintedCertificates !==
+    parsed.market.mintedCertificates.length
+  ) {
+    throw new Error(
+      'Minted certificate count mismatch between validation passes.'
+    );
+  }
+  if (
+    Math.abs(
+      imperativeSummary.unstoppableScore - derivedSummary.unstoppableScore
+    ) > Number.EPSILON
+  ) {
+    throw new Error('Unstoppable score mismatch between validation passes.');
+  }
+
+  console.log(
+    '✅ National supply chain transcript cross-validated by dual engines.'
+  );
+  console.log(`   • Timeline entries: ${derivedSummary.timelineLength}`);
+  console.log(
+    `   • Owner actions (timeline / roster): ${derivedSummary.ownerActionTimelineCount} / ${parsed.ownerActions.length}`
+  );
+  console.log(
+    `   • Distinct insight channels: ${derivedSummary.insightCategories}`
+  );
+  console.log(
+    `   • Validator council members confirmed: ${derivedSummary.validatorAddresses}`
+  );
+  console.log(
+    `   • Unstoppable score: ${formatNumber(derivedSummary.unstoppableScore)}`
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error('❌ Cross-validation failed.');
+  if (error instanceof Error) {
+    console.error(`   → ${error.message}`);
+  } else {
+    console.error(error);
+  }
+  process.exitCode = 1;
+}

--- a/scripts/v2/lib/nationalSupplyChainTranscriptSchema.ts
+++ b/scripts/v2/lib/nationalSupplyChainTranscriptSchema.ts
@@ -1,0 +1,218 @@
+import { z } from 'zod';
+
+import type { NationalSupplyChainTranscript } from './nationalSupplyChainTranscript';
+
+const timelineEntrySchema = z.object({
+  kind: z.enum([
+    'section',
+    'step',
+    'job-summary',
+    'balance',
+    'owner-action',
+    'summary',
+    'insight',
+  ]),
+  label: z.string().min(1, 'timeline entry label required'),
+  at: z.string().min(1, 'timeline entry timestamp required'),
+  scenario: z.string().min(1).optional(),
+  meta: z.record(z.unknown()).optional(),
+});
+
+const ownerActionSchema = z.object({
+  label: z.string().min(1, 'owner action label required'),
+  contract: z.string().min(1, 'owner action contract required'),
+  method: z.string().min(1, 'owner action method required'),
+  at: z.string().min(1, 'owner action timestamp required'),
+  parameters: z.record(z.unknown()).optional(),
+});
+
+const scenarioEntrySchema = z.object({
+  title: z.string().min(1, 'scenario title required'),
+  jobId: z.string().min(1, 'scenario jobId required'),
+  timelineIndices: z
+    .array(z.number().int())
+    .min(5, 'scenario must reference at least five timeline entries'),
+});
+
+const mintedCertificateSchema = z.object({
+  jobId: z.string().min(1, 'certificate jobId required'),
+  owner: z.string().min(1).optional(),
+  uri: z.string().min(1).optional(),
+});
+
+const agentPortfolioSchema = z.object({
+  name: z.string().min(1, 'agent portfolio name required'),
+  address: z.string().min(1, 'agent portfolio address required'),
+  certificates: z.array(mintedCertificateSchema).min(0),
+});
+
+const validatorPortfolioSchema = z.object({
+  name: z.string().min(1, 'validator portfolio name required'),
+  address: z.string().min(1, 'validator portfolio address required'),
+});
+
+const marketSnapshotSchema = z.object({
+  totalJobs: z.string().min(1, 'market.totalJobs missing'),
+  totalBurned: z.string().min(1, 'market.totalBurned missing'),
+  finalSupply: z.string().min(1, 'market.finalSupply missing'),
+  feePct: z.number().finite('market.feePct missing'),
+  validatorRewardPct: z.number().finite('market.validatorRewardPct missing'),
+  pendingFees: z.string().min(1, 'market.pendingFees missing'),
+  totalAgentStake: z.string().min(1, 'market.totalAgentStake missing'),
+  totalValidatorStake: z.string().min(1, 'market.totalValidatorStake missing'),
+  mintedCertificates: z
+    .array(mintedCertificateSchema)
+    .min(2, 'at least two certificates required'),
+  agentPortfolios: z
+    .array(agentPortfolioSchema)
+    .min(2, 'need at least two agent portfolios'),
+  validatorCouncil: z
+    .array(validatorPortfolioSchema)
+    .min(3, 'validator council must have at least three members'),
+});
+
+const pauseMatrixSchema = z.object({
+  registry: z.boolean(),
+  stake: z.boolean(),
+  validation: z.boolean(),
+});
+
+const controlMatrixSchema = z
+  .object({
+    module: z.string().min(1, 'control matrix module required'),
+    address: z.string().min(1, 'control matrix address required'),
+    delegatedTo: z.string().min(1, 'control matrix delegatedTo required'),
+    capabilities: z
+      .array(z.unknown())
+      .min(1, 'control matrix capabilities required'),
+    status: z.string().min(1, 'control matrix status required'),
+  })
+  .array()
+  .min(6, 'owner control matrix must enumerate core modules');
+
+const ownerControlSchema = z.object({
+  ownerAddress: z.string().min(1, 'owner address missing'),
+  moderatorAddress: z.string().min(1, 'moderator address missing'),
+  baseline: z.record(z.unknown(), {
+    required_error: 'baseline controls missing',
+  }),
+  upgraded: z.record(z.unknown(), {
+    required_error: 'upgraded controls missing',
+  }),
+  restored: z.record(z.unknown(), {
+    required_error: 'restored controls missing',
+  }),
+  pauseDrill: z.object({
+    owner: pauseMatrixSchema,
+    moderator: pauseMatrixSchema,
+  }),
+  drillCompletedAt: z
+    .string()
+    .min(1, 'pause drill completion timestamp missing'),
+  controlMatrix: controlMatrixSchema,
+});
+
+const automationSchema = z.object({
+  unstoppableScore: z.number().min(95, 'unstoppable score must be at least 95'),
+  commands: z
+    .object({
+      replayDemo: z.string().min(1, 'replay command missing'),
+      exportTranscript: z.string().min(1, 'export command missing'),
+      launchControlRoom: z.string().min(1, 'control room command missing'),
+    })
+    .catchall(z.string().min(1)),
+});
+
+export const NationalSupplyChainTranscriptSchema = z
+  .object({
+    generatedAt: z.string().min(1, 'generatedAt timestamp missing'),
+    network: z.string().min(1, 'network metadata missing'),
+    actors: z.array(z.record(z.unknown())).min(1, 'actors roster missing'),
+    ownerActions: z
+      .array(ownerActionSchema)
+      .min(40, 'insufficient owner actions recorded'),
+    timeline: z
+      .array(timelineEntrySchema)
+      .min(150, 'timeline must contain at least 150 entries'),
+    scenarios: z
+      .array(scenarioEntrySchema)
+      .min(3, 'need at least three scenarios'),
+    market: marketSnapshotSchema,
+    ownerControl: ownerControlSchema,
+    insights: z
+      .array(z.record(z.unknown()))
+      .min(5, 'insights array must include strategic findings'),
+    automation: automationSchema,
+  })
+  .superRefine((data, ctx) => {
+    const ownerTimelineActions = data.timeline.filter(
+      (entry) => entry.kind === 'owner-action'
+    ).length;
+    if (ownerTimelineActions < 20) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'timeline must include at least 20 owner-action events',
+        path: ['timeline'],
+      });
+    }
+
+    const timelineLength = data.timeline.length;
+    data.scenarios.forEach((scenario, scenarioIndex) => {
+      scenario.timelineIndices.forEach((idx, indexWithinScenario) => {
+        if (idx < 0 || idx >= timelineLength) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `scenario ${scenario.title} references out-of-bounds timeline index ${idx}`,
+            path: [
+              'scenarios',
+              scenarioIndex,
+              'timelineIndices',
+              indexWithinScenario,
+            ],
+          });
+          return;
+        }
+        const timelineEntry = data.timeline[idx];
+        if (
+          timelineEntry.scenario &&
+          timelineEntry.scenario !== scenario.title
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `timeline entry ${idx} scenario mismatch; expected ${scenario.title}`,
+            path: [
+              'scenarios',
+              scenarioIndex,
+              'timelineIndices',
+              indexWithinScenario,
+            ],
+          });
+        }
+      });
+    });
+
+    const scenarioJobIds = new Set(
+      data.scenarios.map((scenario) => scenario.jobId)
+    );
+    data.market.mintedCertificates.forEach((certificate, index) => {
+      if (!scenarioJobIds.has(certificate.jobId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `certificate at index ${index} references unknown jobId ${certificate.jobId}`,
+          path: ['market', 'mintedCertificates', index, 'jobId'],
+        });
+      }
+    });
+  });
+
+export type NationalSupplyChainTranscriptParsed = z.infer<
+  typeof NationalSupplyChainTranscriptSchema
+>;
+
+export function parseNationalSupplyChainTranscript(
+  transcript: unknown
+): NationalSupplyChainTranscript & NationalSupplyChainTranscriptParsed {
+  const parsed = NationalSupplyChainTranscriptSchema.parse(transcript);
+  return parsed as NationalSupplyChainTranscript &
+    NationalSupplyChainTranscriptParsed;
+}


### PR DESCRIPTION
## Summary
- add a schema-driven transcript validator and CLI cross-check command so the national supply chain demo is verified by independent engines
- document the new workflow for operators and expose the command via package scripts
- extend the dedicated demo CI job to execute the schema auditor before running the existing transcript validator

## Testing
- npm run demo:national-supply-chain:cross-verify
- npm run demo:national-supply-chain:validate
- npx eslint scripts/v2/crossValidateNationalSupplyChainTranscript.ts scripts/v2/lib/nationalSupplyChainTranscriptSchema.ts

------
https://chatgpt.com/codex/tasks/task_e_68f68fb27a148333a4e26ac9e8fd0f8e