### PR TITLE
Add owner supremacy graph to Alpha-Meta control matrix

### DIFF
--- a/demo/alpha-meta/README.md
+++ b/demo/alpha-meta/README.md
@@ -84,7 +84,7 @@ Every branch is delivered through the generated dossier, dashboard, JSON summari
 | `alpha-meta-governance-validation.{json,md}` | Deterministic recomputation of every metric with Jarzynski, Hamiltonian, Jacobian, and owner coverage checks. |
 | `alpha-meta-ci-verification.json` | CI parity proof showing lint, tests, foundry, coverage, and summary guards enforced on `main`. |
 | `alpha-meta-owner-diagnostics.{json,md}` | Results from automated owner command scripts (Hamiltonian audit, reward engine report, upgrade queue status, compliance disclosure). |
-| `alpha-meta-owner-matrix.{json,md}` | Authoritative owner control matrix detailing every governance capability, script availability, and verification hook. |
+| `alpha-meta-owner-matrix.{json,md}` | Authoritative owner control matrix detailing every governance capability, script availability, verification hook, and a Mermaid "owner supremacy" graph highlighting category health. |
 | `alpha-meta-triangulation.{json,md}` | Independent cross-check (replicator, eigenvector, thermodynamics, Jarzynski) verifying the mission dossier with redundant solvers. |
 | `alpha-meta-full-run.{json,md}` | Timeline of the full pipeline with Mermaid timeline, metrics, triangulation status, and aggregated health verdict. |
 | `alpha-meta-manifest.json` | SHA-256 manifest covering the mission config and every dossier artefact produced by the run. |

--- a/demo/alpha-meta/RUNBOOK.md
+++ b/demo/alpha-meta/RUNBOOK.md
@@ -84,6 +84,8 @@ npm run demo:alpha-meta:owner
 
 The generated diagnostics Markdown lists each automation command, exit code, and JSON payload. Any warning or error is highlighted.
 
+The owner matrix Markdown now embeds an "Owner Supremacy" Mermaid graph that visualises which control categories are fully automated, manual, or require remediation. Treat any orange or red nodes as action items before approving production changes.
+
 ## 4. Submit a civilisation-scale mission
 
 From the Enterprise Portal:

--- a/demo/alpha-meta/reports/alpha-meta-owner-matrix.md
+++ b/demo/alpha-meta/reports/alpha-meta-owner-matrix.md
@@ -1,9 +1,30 @@
 # Owner Control Matrix
-*Generated at:* 2025-10-20T17:34:21.964Z
+*Generated at:* 2025-10-20T20:00:15.390Z
 *Owner:* 0xAAAABBBBCCCCDDDDEEEEFFFF0000111122223333
 *Pauser:* 0xBBBBCCCCDDDDEEEEFFFF00001111222233334444
 *Treasury:* 0xCCCCDDDDEEEEFFFF000011112222333344445555
 *Timelock:* 604800 seconds (168.00 hours)
+
+## Owner Supremacy Graph
+```mermaid
+graph TD
+  OWNER[Owner Supremacy\n0xAAAABBBBCCCCDDDDEEEEFFFF0000111122223333]:::owner
+  OWNER --> C0[pause\n✅ ready]:::available
+  OWNER --> C1[resume\n✅ ready]:::available
+  OWNER --> C2[parameter\n✅ ready]:::available
+  OWNER --> C3[governance\n✅ ready]:::available
+  OWNER --> C4[treasury\n✅ ready]:::available
+  OWNER --> C5[sentinel\n✅ ready]:::available
+  OWNER --> C6[upgrade\n✅ ready]:::available
+  OWNER --> C7[compliance\n✅ ready]:::available
+  OWNER --> C8[plan\n✅ ready]:::available
+  OWNER --> C9[monitoring\n✅ ready]:::available
+  classDef owner fill:#0f172a,stroke:#a855f7,stroke-width:3px,color:#f8fafc;
+  classDef available fill:#14532d,stroke:#22c55e,stroke-width:2px,color:#f0fdf4;
+  classDef manual fill:#1e293b,stroke:#f59e0b,stroke-width:2px,color:#fef3c7;
+  classDef gap fill:#3b0764,stroke:#f97316,stroke-width:2px,color:#fde68a;
+  classDef critical fill:#450a0a,stroke:#ef4444,stroke-width:2px,color:#fee2e2;
+```
 
 ## Coverage
 - Full coverage: ✅


### PR DESCRIPTION
## Summary
- augment the governance demo generator with status ranking utilities that project owner coverage into a Mermaid "Owner Supremacy" graph
- embed the new graph in the generated Alpha-Meta owner matrix markdown and document the visualization in the README and runbook
- refresh the tracked owner matrix example to showcase the rendered control lattice

## Testing
- npm run demo:alpha-meta
- npm run lint -- --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68f693147dc883338e30fd519d114109