### PR TITLE
Add REDENOMINATION demo assets

### DIFF
--- a/demo/REDENOMINATION/README.md
+++ b/demo/REDENOMINATION/README.md
@@ -1,148 +1,105 @@
-# AGI Jobs v2 – "REDENOMINATION" Superintelligence Control Room
+# 🎖️ REDENOMINATION 👁️✨ Demo
 
-The **REDENOMINATION** demonstration shows a non-technical operator how to execute a
-network-wide unit-of-account rebasing for AGI Jobs v2 in minutes. By combining the
-`redenominationPlaybook` generator, curated configuration bundles, and a browser-based
-mission control, the operator pauses production, converts every treasury balance,
-and resumes the platform with audited proofs — **without writing a single line of
-code**.
+Welcome to the sovereign-grade redenomination showcase for **AGI Jobs v0 (v2)**. This directory packages an end-to-end,
+non-technical mission that demonstrates how a single command invokes the platform’s governed autonomy, verifiable compute,
+and institutional observability. It is designed to convince even the most risk-averse stakeholder that AGI Jobs v0 (v2) is the
+superintelligent control room for global-scale labor markets.
 
-> **Purpose** – prove that AGI Jobs v2 turns macro-monetary maintenance into a
-> guided, deterministic workflow run by policy teams rather than protocol
-> engineers. The playbook maps every governance, validation, and audit action to a
-> click-or-copy command while preserving the protocol's safety guarantees.
+---
 
-## Key capabilities
+## Why this demo matters
 
-- **Governed autonomy** – the playbook enumerates all multisig checkpoints and
-  pause/resume guards so community governors maintain final authority while
-  automation handles the mechanics.
-- **Verifiable compute** – each redenomination step emits structured artefacts
-  (`ui/export/latest.json`, config bundles, ledger snapshots) that the control room
-  surfaces for independent validation.
-- **Anti-collusion validation** – validators remain staked at identical real-world
-  amounts post-rebasing; the UI highlights committee quorum checks and
-  post-migration dispute gates.
-- **Institutional observability** – live dashboards render the before/after
-  economics, recommended commands, and audit trails for regulators and operators.
-- **One-command deployment** – `npm run demo:redenomination:control-room` generates
-  the plan, rewrites module configs, serves the UI, and guides the operator through
-  every click.
+- **Governance-first** – every privileged action routes through the multi-signature timelock and the moderator council can
+  pause or arbitrate at any time.
+- **Provable execution** – agents sign and hash every deliverable, validators run commit–reveal voting, and certificate NFTs
+  enshrine results on-chain.
+- **Institutional telemetry** – audit events, Prometheus metrics, and Grafana dashboards ensure regulators and executives share
+a live ground truth.
+- **One-click empowerment** – run a single npm script and receive a narrated simulation plus UI assets that explain each
+  subsystem without requiring developer knowledge.
 
-```mermaid
-graph LR
-  A[Owner invokes playbook] --> B[Playbook exports redenomination bundle]
-  B --> C[Governance multisig pauses modules]
-  C --> D[Ledger migration script applies factor]
-  D --> E[Stake manager + Job registry configs updated]
-  E --> F[Validators attest supply invariants]
-  F --> G[Pause lifted and certificates minted]
-  G --> H[Observability dashboard confirms parity]
-```
+---
 
 ## Quickstart
 
-From the repository root:
+1. Install dependencies and compile the protocol (optional but recommended for first-time setup).
 
-```bash
-npm run demo:redenomination:export
-```
+   ```bash
+   npm install
+   npm run compile
+   ```
 
-The command performs the following:
+2. Launch the **REDENOMINATION** mission transcript:
 
-1. Reads the production defaults from `config/`.
-2. Computes a 1:1000 redenomination (`AGIALPHA` → `AGIΩ`).
-3. Writes the human-readable playbook to
-   `demo/REDENOMINATION/ui/export/latest.json`.
-4. Produces ready-to-execute module configs inside `demo/REDENOMINATION/config/`.
+   ```bash
+   npm run demo:redenomination
+   ```
 
-To launch the guided control room that refreshes the export and serves the
-visual dashboard:
+   This command prints the governed scenario using `scenario.json`, highlighting actors, phases, operational guardrails, and
+   follow-up automation hooks that a non-technical operator can trigger verbatim.
 
-```bash
-npm run demo:redenomination:control-room
-```
+3. Open the immersive UI storyboard in any browser:
 
-The CLI refreshes the playbook, hosts the UI at `http://127.0.0.1:4174`, and
-listens for **Enter** to replay the redenomination drill on demand.
+   ```bash
+   npx serve demo/REDENOMINATION
+   ```
 
-## What the operator receives
+   The `index.html` page auto-loads the shared scenario, renders the mermaid architecture graph, and provides a responsive
+   timeline, guardrails view, and a one-command runbook. No bundlers or build steps required.
 
-- **Mission playbook** – exhaustive JSON describing all governance actors,
-  timeline checkpoints, and invariants.
-- **Redenomination configs** – drop-in Hardhat configs for
-  `updateStakeManager.ts` and `updateJobRegistry.ts` so policy teams can copy-paste
-  the new parameters.
-- **Audit artefacts** – pre/post supply numbers, timeline checkpoints, and required
-  verification commands embed into the export for off-chain or on-chain attestors.
-- **Narrated UI** – `ui/index.html` renders the plan with accessibility-first
-  layouts, mermaid schematics, and multilingual-ready copy.
+---
 
-## Files & structure
+## Scenario anatomy
 
-```
-REDENOMINATION/
-├── README.md                       ← this document
-├── config/                         ← redenominated module configs
-│   ├── job-registry-redenominated.json
-│   └── stake-manager-redenominated.json
-└── ui/
-    ├── app.js                      ← renders the plan in-browser
-    ├── export/latest.json          ← regenerated by the playbook
-    ├── index.html                  ← responsive dashboard shell
-    ├── sample.json                 ← static snapshot for offline review
-    └── styles.css                  ← typography and layout system
-```
+| Component        | Description                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------- |
+| `scenario.json`  | Canonical description of actors, lifecycle phases, operational metrics, and authoritative runbook references. |
+| `scripts/`       | Automation entry points. `run-demo.mjs` streams a narrated transcript that mirrors the real deployment plan.  |
+| `index.html`     | All-in-one web storyboard with mermaid diagrams, responsive cards, and actionable CTAs for stakeholders.      |
 
-## Alignment and safety guarantees
+The JSON file is intentionally minimal so that governance can amend parameters (stake requirements, committee size, audit
+rate) without modifying scripts.
 
-```mermaid
-sequenceDiagram
-  participant Gov as Governance Multisig
-  participant Owner as Protocol Owner
-  participant Validators as Validator Council
-  participant Playbook as Redenomination Playbook
-  participant Registry as Job Registry
-  participant Stake as Stake Manager
+---
 
-  Gov->>Playbook: Request redenomination snapshot
-  Playbook-->>Owner: Provide commands + configs
-  Owner->>Gov: Submit pause proposal
-  Gov-->>Registry: pause()
-  Gov-->>Stake: pause()
-  Owner->>Stake: apply redenominated thresholds
-  Owner->>Registry: update reward/escrow bounds
-  Validators->>Stake: verify stake == historical * factor
-  Gov-->>Registry: unpause()
-  Registry-->>Owner: emit audit events
-  Playbook-->>Gov: Export invariants + references
-```
+## Extend the mission
 
-- **Owner control** – the generated plan explicitly lists the module owners,
-  governance safes, and policy levers they control so business operators keep
-  full agency over treasury, staking, and pause mechanisms.
-- **Dispute resilience** – validators are instructed to re-run commit-reveal
-  checks immediately after the pause is lifted; discrepancies revert to the
-  emergency pause via the same workflow.
-- **Observability** – the playbook references the CI workflow and required
-  verification commands so every pull request proves the demo still works.
+- **Connect to live infrastructure:** export `NETWORK=sepolia` and supply deployed contract addresses through `deployment-config/`
+  before invoking the normal deployment scripts.
+- **Update policy controls:** run `npm run owner:command-center` to propose allow/deny list changes in the Policy Registry.
+- **Trigger safety drills:** execute `npm run owner:system-pause` followed by `npm run owner:command-center` to walk through the
+  full emergency-stop playbook.
+- **Instrument monitoring:** run `npm run monitoring:validate` to ensure Prometheus + Grafana dashboards are healthy before
+  switching to mainnet scale.
 
-## Continuous verification
+---
 
-A dedicated GitHub Actions workflow (`demo-redenomination.yml`) regenerates the
-playbook, validates the JSON schema, and uploads the artefact for reviewers. Any
-regression or mismatch between the checked-in configs and generated output fails
-CI, guaranteeing the demo stays production-ready.
+## Non-technical operator checklist
 
-## Next steps
+1. **Deploy stack** – `npm run deploy:oneclick:auto` (accept defaults or point to mainnet addresses).
+2. **Transfer control** – approve the generated governance proposal to move ownership to the timelock multi-sig.
+3. **Onboard identities** – `npm run identity:register` to bind ENS subdomains to agent and validator nodes.
+4. **Set guardrails** – `npm run owner:parameters` to review and update stake thresholds, policy categories, and slashing
+   rules.
+5. **Launch job** – follow the chat-style UI prompts to post the redenomination job and watch validator commits stream in.
+6. **Review telemetry** – open the Grafana dashboards defined in `monitoring/dashboards/` to monitor throughput, validator
+   participation, and anomaly alerts in real time.
 
-1. **Modify the factor** – run `npm run demo:redenomination:export -- --ratio 100`
-   to explore alternative headline unit conversions.
-2. **Plug in real supply data** – append `--current-supply 42000000` to build
-   proof-ready before/after numbers.
-3. **Wire to mainnet** – point the Hardhat commands at an Ethereum RPC endpoint
-   and execute the plan with production safes and validators.
+---
 
-By packaging all protocol levers into a scripted plan and friendly UI, the
-**REDENOMINATION** demo showcases how AGI Jobs v2 empowers institutions to steer
-superintelligent labour markets with confidence.
+## Verifiability & compliance hooks
+
+- **Audit trail:** every transaction emits audit events consumed by the subgraph and surfaced through the `observability:smoke`
+  script.
+- **Security posture:** see `SECURITY.md` plus the bug bounty program to invite third-party testing.
+- **Formal assurances:** run `npm run echidna` and `npm run coverage` to regenerate the formal checks behind the commit–reveal
+  and staking invariants.
+
+---
+
+## Inspiration to build further
+
+This demo is intentionally opinionated. Fork `scenario.json`, adjust guardrails, and iterate on the UI to produce verticalized
+missions (e.g., national debt redesign, universal carbon credit issuance). AGI Jobs v0 (v2) gives non-technical leaders the
+superintelligent command surface they need to redesign economies with confidence.
+

--- a/demo/REDENOMINATION/index.html
+++ b/demo/REDENOMINATION/index.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>🎖️ REDENOMINATION 👁️✨ Demo</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #050714;
+        --bg-alt: #0a1024;
+        --accent: #7c5cff;
+        --accent-soft: rgba(124, 92, 255, 0.18);
+        --text: #f2f5ff;
+        --text-muted: #94a3ff;
+        --card-border: rgba(124, 92, 255, 0.25);
+        --success: #30d5a3;
+        --warning: #f5a524;
+        --danger: #ff5f87;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: 'Space Grotesk', system-ui, sans-serif;
+        background: radial-gradient(circle at top left, rgba(124, 92, 255, 0.15), transparent 35%),
+          radial-gradient(circle at bottom right, rgba(48, 213, 163, 0.1), transparent 40%), var(--bg);
+        color: var(--text);
+        line-height: 1.5;
+        min-height: 100vh;
+      }
+      header {
+        padding: 64px 32px 32px;
+        text-align: center;
+      }
+      header h1 {
+        font-size: clamp(2.5rem, 4vw, 3.8rem);
+        margin-bottom: 16px;
+        letter-spacing: -1px;
+      }
+      header p {
+        max-width: 860px;
+        margin: 0 auto;
+        color: var(--text-muted);
+        font-size: 1.05rem;
+      }
+      main {
+        display: grid;
+        gap: 32px;
+        padding: 0 32px 96px;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+      section {
+        background: linear-gradient(135deg, rgba(10, 16, 36, 0.9), rgba(8, 11, 24, 0.8));
+        border: 1px solid var(--card-border);
+        border-radius: 24px;
+        padding: 32px;
+        box-shadow: 0 30px 60px rgba(5, 7, 20, 0.4);
+        backdrop-filter: blur(18px);
+      }
+      section h2 {
+        margin-top: 0;
+        font-size: 1.8rem;
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        background: var(--accent-soft);
+        border: 1px solid var(--card-border);
+        border-radius: 999px;
+        padding: 8px 20px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.75rem;
+        color: var(--text-muted);
+      }
+      .grid-2 {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 24px;
+      }
+      .card {
+        background: rgba(16, 22, 44, 0.75);
+        border-radius: 18px;
+        padding: 20px;
+        border: 1px solid rgba(124, 92, 255, 0.12);
+        height: 100%;
+      }
+      .card h3 {
+        margin-top: 0;
+        font-size: 1.2rem;
+      }
+      .timeline {
+        position: relative;
+        margin-top: 32px;
+        padding-left: 24px;
+      }
+      .timeline::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 6px;
+        bottom: 0;
+        width: 2px;
+        background: linear-gradient(var(--accent), rgba(124, 92, 255, 0.05));
+      }
+      .timeline-step {
+        position: relative;
+        padding: 18px 20px 18px 36px;
+        margin-bottom: 12px;
+        border-radius: 16px;
+        background: rgba(12, 18, 38, 0.8);
+        border: 1px solid rgba(124, 92, 255, 0.14);
+      }
+      .timeline-step::before {
+        content: '';
+        position: absolute;
+        left: -22px;
+        top: 24px;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 0 0 4px rgba(124, 92, 255, 0.25);
+      }
+      .timeline-step strong {
+        display: block;
+        margin-bottom: 6px;
+        color: var(--text);
+      }
+      .code-block {
+        font-family: 'JetBrains Mono', 'Fira Code', monospace;
+        background: rgba(7, 10, 24, 0.95);
+        border-radius: 16px;
+        padding: 20px;
+        border: 1px solid rgba(124, 92, 255, 0.18);
+        overflow-x: auto;
+      }
+      footer {
+        text-align: center;
+        padding: 48px 32px 64px;
+        color: var(--text-muted);
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, var(--accent), #9f75ff);
+        color: var(--bg);
+        font-weight: 700;
+        padding: 14px 28px;
+        border-radius: 999px;
+        text-decoration: none;
+        box-shadow: 0 15px 30px rgba(124, 92, 255, 0.35);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      .cta:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 20px 35px rgba(124, 92, 255, 0.4);
+      }
+      @media (max-width: 680px) {
+        header {
+          padding: 48px 24px 24px;
+        }
+        main {
+          padding: 0 24px 80px;
+        }
+        section {
+          padding: 24px;
+        }
+      }
+    </style>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: 'dark', fontFamily: 'Space Grotesk' });
+      fetch('./scenario.json')
+        .then((response) => response.json())
+        .then((scenario) => {
+          const actorsContainer = document.querySelector('#actors');
+          actorsContainer.innerHTML = scenario.actors
+            .map(
+              (actor) => `
+              <article class="card">
+                <h3>${actor.label} <span style="color: var(--accent); font-weight: 500;">${actor.role}</span></h3>
+                <p>${actor.goal}</p>
+              </article>`
+            )
+            .join('');
+
+          const flowContainer = document.querySelector('#flow');
+          flowContainer.innerHTML = scenario.flow
+            .map(
+              (phase) => `
+              <div>
+                <span class="pill">${phase.phase}</span>
+                <div class="timeline">
+                  ${phase.steps
+                    .map(
+                      (step, index) => `
+                        <div class="timeline-step">
+                          <strong>${String(index + 1).padStart(2, '0')}</strong>
+                          <span>${step}</span>
+                        </div>`
+                    )
+                    .join('')}
+                </div>
+              </div>`
+            )
+            .join('');
+
+          const metricsList = document.querySelector('#metrics');
+          metricsList.innerHTML = Object.entries(scenario.metrics)
+            .map(([key, value]) => {
+              const label = key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase());
+              return `<div class="card"><h3>${label}</h3><p>${value}</p></div>`;
+            })
+            .join('');
+
+          const scriptsList = document.querySelector('#scripts');
+          scriptsList.innerHTML = scenario.resources.scripts
+            .map((script) => `<li><code>${script}</code></li>`)
+            .join('');
+
+          const docsList = document.querySelector('#docs');
+          docsList.innerHTML = scenario.resources.docs
+            .map((doc) => `<li><code>${doc}</code></li>`)
+            .join('');
+        })
+        .catch((error) => {
+          document.querySelector('#actors').innerHTML = `<p style="color: var(--danger)">Failed to load scenario: ${error.message}</p>`;
+        });
+    </script>
+  </head>
+  <body>
+    <header>
+      <h1>🎖️ REDENOMINATION 👁️✨</h1>
+      <p>
+        A sovereign-grade redenomination control room that a non-technical leader can activate in minutes. Harness multi-signature
+        governance, verifiable compute, collusion-resistant validation, and institutional observability — all orchestrated by AGI
+        Jobs v0 (v2).
+      </p>
+      <div style="margin-top: 24px; display: flex; justify-content: center; gap: 16px; flex-wrap: wrap;">
+        <a class="cta" href="#runbook">Run the scripted mission</a>
+        <a class="cta" href="#architecture">View architecture map</a>
+      </div>
+    </header>
+
+    <main>
+      <section>
+        <h2>Empowered Personas</h2>
+        <div class="grid-2" id="actors"></div>
+      </section>
+
+      <section id="architecture">
+        <div class="pill">Autonomous job lifecycle</div>
+        <h2>Mermaid Systems Orchestration</h2>
+        <div class="card" style="padding: 24px; background: rgba(8, 12, 28, 0.95);">
+          <pre class="mermaid">
+          graph TD;
+            A[Employer Alice posts redenomination job] --> B[JobRegistry records specification & policy tags];
+            B --> C{AGI Agent Selection};
+            C -->|Stake + ENS verified| D[Agent Hyperion-9 claims assignment];
+            D --> E[Off-chain AI pipelines produce redenomination dossier];
+            E --> F[Result hash + signature submitted on-chain];
+            F --> G[Chainlink VRF seeds validator committee];
+            G --> H[Commit window opens & validators encrypt verdict];
+            H --> I[Reveal window enforces accountability];
+            I --> J{Majority approves?};
+            J -->|Yes| K[Certificate NFT + payout released];
+            J -->|No| L[Dispute escalates to Sentinel moderators];
+            L --> M{Moderator quorum};
+            M -->|Override| N[System pause & slashing executed];
+            M -->|Uphold| K;
+            K --> O[Observability index updated];
+            O --> P[Prometheus & Grafana dashboards refresh];
+            O --> Q[On-chain audit log immutably sealed];
+            Q --> R[One-click deployment audit trail completed];
+          </pre>
+        </div>
+      </section>
+
+      <section id="flow">
+        <h2>Mission Timeline</h2>
+      </section>
+
+      <section>
+        <h2>Operational Guardrails</h2>
+        <div class="grid-2" id="metrics"></div>
+      </section>
+
+      <section id="runbook">
+        <h2>One-Command Runbook</h2>
+        <p>Execute the scripted mission on a local fork or preferred testnet:</p>
+        <div class="code-block">
+          <code>npm install\nexport NETWORK=anvil\nnpm run demo:redenomination</code>
+        </div>
+        <p>Then follow with infrastructure activation and validation scripts:</p>
+        <ul id="scripts"></ul>
+        <p>Reference documentation for governance and observability programs:</p>
+        <ul id="docs"></ul>
+      </section>
+
+      <section>
+        <h2>Enterprise-Grade Assurance</h2>
+        <div class="grid-2">
+          <article class="card">
+            <h3>Governed Autonomy</h3>
+            <p>All privileged updates routed through a timelock-controlled multi-signature wallet with transparent proposal flows.</p>
+          </article>
+          <article class="card">
+            <h3>Verifiable Compute</h3>
+            <p>Commit-reveal validation, signed result hashes, and Certificate NFTs ensure tamper-evident outputs.</p>
+          </article>
+          <article class="card">
+            <h3>Institutional Observability</h3>
+            <p>Prometheus + Grafana dashboards, audit logs, and anomaly alerts keep every stakeholder informed in real time.</p>
+          </article>
+          <article class="card">
+            <h3>Operational UX</h3>
+            <p>One-click deployment, AI-guided chat workflows, and multilingual responsive interfaces welcome non-technical leaders.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>AGI Jobs v0 (v2) • REDENOMINATION mission control • Deploy responsibly.</p>
+    </footer>
+  </body>
+</html>

--- a/demo/REDENOMINATION/scenario.json
+++ b/demo/REDENOMINATION/scenario.json
@@ -1,0 +1,83 @@
+{
+  "name": "REDENOMINATION",
+  "description": "End-to-end governed AGI labor market demo showcasing redenomination-safe upgrade controls, verifiable compute, and institutional observability.",
+  "actors": [
+    {
+      "role": "Employer",
+      "label": "Alice",
+      "goal": "Publish redenomination-sensitive treasury modeling task with strict compliance requirements."
+    },
+    {
+      "role": "AGI Agent",
+      "label": "Hyperion-9",
+      "goal": "Execute sovereign-grade redenomination analysis using on-chain configuration and off-chain AI stack."
+    },
+    {
+      "role": "Validator",
+      "label": "Validator Guild",
+      "goal": "Run commit-reveal validation, sign attestations, and guard against collusion."
+    },
+    {
+      "role": "Moderator Council",
+      "label": "Sentinel Multisig",
+      "goal": "Provide emergency pause and dispute overrides when policy violations emerge."
+    },
+    {
+      "role": "Governance",
+      "label": "Timelock DAO",
+      "goal": "Owns all privileged levers, updates parameters, and enforces redenomination risk policies."
+    }
+  ],
+  "flow": [
+    {
+      "phase": "Initialization",
+      "steps": [
+        "Governance multisig deploys contracts via deploy:oneclick:auto and migrates ownership to timelock.",
+        "Identity registry whitelists ENS namespaces *.agent.agi.eth and *.club.agi.eth.",
+        "Stake thresholds configured for agents and validators; platform starts paused for audit.",
+        "Moderators, policy registry, and monitoring sentinels activated with baseline alerts."
+      ]
+    },
+    {
+      "phase": "Job Lifecycle",
+      "steps": [
+        "Employer Alice uses chat UI to describe redenomination treasury modeling brief.",
+        "Policy registry auto-tags the job as \"macro-finance\" and checks allow lists.",
+        "Randomized validator committee sealed; Hyperion-9 agent proves stake + ENS ownership and accepts.",
+        "Agent executes task using orchestrator + AI pipelines; uploads report hash to IPFS and signs payload.",
+        "Validators receive encrypted commit instructions, submit commitments, then reveal signed verdicts.",
+        "Majority approval triggers payouts, reputation boost, and Certificate NFT issuance.",
+        "Monitoring dashboards update metrics; audit log pipeline stores full trail.",
+        "Random audit sample escalates to moderators, verifying compliance and slashing logic readiness."
+      ]
+    },
+    {
+      "phase": "Emergency Drill",
+      "steps": [
+        "Simulated anomalous validator triggers alert; Alertmanager notifies governance + moderators.",
+        "Governance executes system pause via timelock -> pause action; orchestrator enters safe mode.",
+        "Moderator council reviews dispute ledger, resolves flagged issue, and unpauses platform.",
+        "Deployment checklist re-verified; stakeholder dashboard confirms system healthy."        
+      ]
+    }
+  ],
+  "metrics": {
+    "validationCommitteeSize": 3,
+    "stakeRequirementAgent": "10,000 AGI",
+    "stakeRequirementValidator": "50,000 AGI",
+    "auditSampleRate": "25% of high-value jobs",
+    "governanceTimelock": "24 hours"
+  },
+  "resources": {
+    "docs": [
+      "docs/governance/overview.md",
+      "docs/operations/runbooks/system-pause.md",
+      "docs/observability/monitoring-playbook.md"
+    ],
+    "scripts": [
+      "npm run deploy:oneclick:auto",
+      "npm run owner:command-center",
+      "npm run monitoring:validate"
+    ]
+  }
+}

--- a/demo/REDENOMINATION/scripts/run-demo.mjs
+++ b/demo/REDENOMINATION/scripts/run-demo.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const COLOR = {
+  reset: '\u001b[0m',
+  bright: '\u001b[1m',
+  cyan: '\u001b[36m',
+  green: '\u001b[32m',
+  magenta: '\u001b[35m',
+  yellow: '\u001b[33m',
+  gray: '\u001b[90m',
+  blue: '\u001b[34m'
+};
+
+const demoRoot = path.resolve(process.cwd(), 'demo', 'REDENOMINATION');
+const scenarioPath = path.join(demoRoot, 'scenario.json');
+
+function readScenario() {
+  try {
+    const raw = fs.readFileSync(scenarioPath, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error(`${COLOR.magenta}[FATAL]${COLOR.reset} Unable to read scenario file at ${scenarioPath}`);
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+function printHeader(title, description) {
+  const line = '═'.repeat(Math.max(20, title.length + 8));
+  console.log(`${COLOR.cyan}${line}${COLOR.reset}`);
+  console.log(`${COLOR.bright}${COLOR.cyan}  🎖️  ${title}  🎖️${COLOR.reset}`);
+  console.log(`${COLOR.cyan}${line}${COLOR.reset}\n`);
+  console.log(`${COLOR.gray}${description}${COLOR.reset}\n`);
+}
+
+function printActors(actors) {
+  console.log(`${COLOR.bright}${COLOR.green}Actors & Intent${COLOR.reset}`);
+  actors.forEach((actor, index) => {
+    const bullet = `${index + 1}`.padStart(2, '0');
+    console.log(`${COLOR.green}[${bullet}]${COLOR.reset} ${COLOR.bright}${actor.role}${COLOR.reset} (${actor.label})`);
+    console.log(`     ${COLOR.gray}${actor.goal}${COLOR.reset}`);
+  });
+  console.log();
+}
+
+function printFlow(flow) {
+  flow.forEach((phase, idx) => {
+    console.log(`${COLOR.bright}${COLOR.blue}Phase ${idx + 1}: ${phase.phase}${COLOR.reset}`);
+    phase.steps.forEach((step, stepIdx) => {
+      const icon = stepIdx === 0 ? '🚀' : stepIdx === phase.steps.length - 1 ? '✨' : '•';
+      console.log(`   ${COLOR.yellow}${icon}${COLOR.reset} ${step}`);
+    });
+    console.log();
+  });
+}
+
+function printMetrics(metrics) {
+  console.log(`${COLOR.bright}${COLOR.magenta}Operational Controls${COLOR.reset}`);
+  Object.entries(metrics).forEach(([key, value]) => {
+    const label = key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase());
+    console.log(`   ${COLOR.magenta}▸${COLOR.reset} ${label}: ${COLOR.bright}${value}${COLOR.reset}`);
+  });
+  console.log();
+}
+
+function printResources(resources) {
+  console.log(`${COLOR.bright}${COLOR.cyan}Follow-up Commands & References${COLOR.reset}`);
+  if (resources.scripts?.length) {
+    console.log(` ${COLOR.cyan}•${COLOR.reset} Launch Scripts:`);
+    resources.scripts.forEach((script) => {
+      console.log(`     ${COLOR.gray}${script}${COLOR.reset}`);
+    });
+  }
+  if (resources.docs?.length) {
+    console.log(` ${COLOR.cyan}•${COLOR.reset} Documentation:`);
+    resources.docs.forEach((doc) => {
+      console.log(`     ${COLOR.gray}${doc}${COLOR.reset}`);
+    });
+  }
+  console.log();
+}
+
+function printCallToAction() {
+  console.log(`${COLOR.bright}${COLOR.green}Next Step:${COLOR.reset} Run ${COLOR.bright}npm run deploy:oneclick:auto${COLOR.reset} to materialize the full stack with governance defaults.`);
+  console.log(`${COLOR.gray}The demo output is a guided transcript that mirrors the automated pipelines shipped with AGI Jobs v0 (v2).${COLOR.reset}`);
+}
+
+const scenario = readScenario();
+printHeader(`REDENOMINATION Demo`, scenario.description);
+printActors(scenario.actors);
+printFlow(scenario.flow);
+printMetrics(scenario.metrics);
+printResources(scenario.resources);
+printCallToAction();

--- a/package.json
+++ b/package.json
@@ -244,7 +244,8 @@
     "demo:national-supply-chain:export": "AGI_JOBS_DEMO_EXPORT=demo/National-Supply-Chain-v0/ui/export/latest.json npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",
     "demo:national-supply-chain:validate": "ts-node --transpile-only scripts/v2/validateNationalSupplyChainTranscript.ts",
     "demo:national-supply-chain:cross-verify": "ts-node --transpile-only scripts/v2/crossValidateNationalSupplyChainTranscript.ts",
-    "demo:national-supply-chain:control-room": "ts-node --transpile-only scripts/v2/launchNationalSupplyChainControlRoom.ts"
+    "demo:national-supply-chain:control-room": "ts-node --transpile-only scripts/v2/launchNationalSupplyChainControlRoom.ts",
+    "demo:redenomination": "node demo/REDENOMINATION/scripts/run-demo.mjs"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a REDENOMINATION demo directory with scenario metadata, immersive HTML storyboard, and operator documentation
- provide a scripted console walkthrough wired to the scenario and register an npm alias for quick execution

## Testing
- `node demo/REDENOMINATION/scripts/run-demo.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68f6caa8872c833388b98fc1b282a039