### PR TITLE
Add scenario verification workflow to REDENOMINATION demo

### DIFF
--- a/demo/REDENOMINATION/README.md
+++ b/demo/REDENOMINATION/README.md
@@ -29,7 +29,17 @@ a live ground truth.
    npm run compile
    ```
 
-2. Launch the **REDENOMINATION** mission transcript:
+2. Prove the artefacts are production-grade:
+
+   ```bash
+   npm run demo:redenomination:verify
+   ```
+
+   The verifier inspects `scenario.json`, validates referenced documentation paths, cross-checks automation commands against
+   `package.json`, and confirms the storyboard ships with a Mermaid orchestration graph and exportable control-room dataset. If
+   anything drifts, the script fails fast with explicit remediation guidance.
+
+3. Launch the **REDENOMINATION** mission transcript:
 
    ```bash
    npm run demo:redenomination
@@ -38,7 +48,7 @@ a live ground truth.
    This command prints the governed scenario using `scenario.json`, highlighting actors, phases, operational guardrails, and
    follow-up automation hooks that a non-technical operator can trigger verbatim.
 
-3. Open the immersive UI storyboard in any browser:
+4. Open the immersive UI storyboard in any browser:
 
    ```bash
    npx serve demo/REDENOMINATION
@@ -54,7 +64,7 @@ a live ground truth.
 | Component        | Description                                                                                                   |
 | ---------------- | ------------------------------------------------------------------------------------------------------------- |
 | `scenario.json`  | Canonical description of actors, lifecycle phases, operational metrics, and authoritative runbook references. |
-| `scripts/`       | Automation entry points. `run-demo.mjs` streams a narrated transcript that mirrors the real deployment plan.  |
+| `scripts/`       | Automation entry points. `verify-scenario.mjs` hardens artefacts, while `run-demo.mjs` streams a narrated transcript mirroring the real deployment plan.  |
 | `index.html`     | All-in-one web storyboard with mermaid diagrams, responsive cards, and actionable CTAs for stakeholders.      |
 
 The JSON file is intentionally minimal so that governance can amend parameters (stake requirements, committee size, audit
@@ -64,6 +74,8 @@ rate) without modifying scripts.
 
 ## Extend the mission
 
+- **Regenerate confidence:** run `npm run demo:redenomination:verify` after editing the scenario or UI assets to reconfirm every
+  reference remains production-safe.
 - **Connect to live infrastructure:** export `NETWORK=sepolia` and supply deployed contract addresses through `deployment-config/`
   before invoking the normal deployment scripts.
 - **Update policy controls:** run `npm run owner:command-center` to propose allow/deny list changes in the Policy Registry.

--- a/demo/REDENOMINATION/scenario.json
+++ b/demo/REDENOMINATION/scenario.json
@@ -70,11 +70,12 @@
   },
   "resources": {
     "docs": [
-      "docs/governance/overview.md",
-      "docs/operations/runbooks/system-pause.md",
-      "docs/observability/monitoring-playbook.md"
+      "docs/governance.md",
+      "docs/system-pause.md",
+      "docs/institutional-observability.md"
     ],
     "scripts": [
+      "npm run demo:redenomination:verify",
       "npm run deploy:oneclick:auto",
       "npm run owner:command-center",
       "npm run monitoring:validate"

--- a/demo/REDENOMINATION/scripts/run-demo.mjs
+++ b/demo/REDENOMINATION/scripts/run-demo.mjs
@@ -84,6 +84,7 @@ function printResources(resources) {
 }
 
 function printCallToAction() {
+  console.log(`${COLOR.bright}${COLOR.green}Preflight:${COLOR.reset} Confirm artefacts with ${COLOR.bright}npm run demo:redenomination:verify${COLOR.reset} before touching mainnet controls.`);
   console.log(`${COLOR.bright}${COLOR.green}Next Step:${COLOR.reset} Run ${COLOR.bright}npm run deploy:oneclick:auto${COLOR.reset} to materialize the full stack with governance defaults.`);
   console.log(`${COLOR.gray}The demo output is a guided transcript that mirrors the automated pipelines shipped with AGI Jobs v0 (v2).${COLOR.reset}`);
 }

--- a/demo/REDENOMINATION/scripts/verify-scenario.mjs
+++ b/demo/REDENOMINATION/scripts/verify-scenario.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const COLOR = {
+  reset: '\u001b[0m',
+  bright: '\u001b[1m',
+  green: '\u001b[32m',
+  red: '\u001b[31m',
+  yellow: '\u001b[33m',
+  cyan: '\u001b[36m',
+  magenta: '\u001b[35m'
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const demoRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+const scenarioPath = path.join(demoRoot, 'scenario.json');
+const packagePath = path.join(repoRoot, 'package.json');
+const storyboardPath = path.join(demoRoot, 'index.html');
+const uiStoryboardPath = path.join(demoRoot, 'ui', 'index.html');
+const exportPath = path.join(demoRoot, 'ui', 'export', 'latest.json');
+
+function readJson(filePath, label) {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    console.error(`${COLOR.red}${COLOR.bright}✗${COLOR.reset} Failed to parse ${label} (${filePath})`);
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+const scenario = readJson(scenarioPath, 'scenario.json');
+const packageJson = readJson(packagePath, 'package.json');
+const exportData = readJson(exportPath, 'ui/export/latest.json');
+
+const results = [];
+
+function record(status, message) {
+  results.push({ status, message });
+}
+
+function expect(condition, successMessage, failureMessage) {
+  if (condition) {
+    record('pass', successMessage);
+  } else {
+    record('fail', failureMessage);
+  }
+}
+
+function expectWarn(condition, successMessage, warningMessage) {
+  if (condition) {
+    record('pass', successMessage);
+  } else {
+    record('warn', warningMessage);
+  }
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+expect(isNonEmptyString(scenario.name), 'Scenario name present', 'Scenario name missing or empty');
+expect(isNonEmptyString(scenario.description), 'Scenario description present', 'Scenario description missing or empty');
+
+expect(Array.isArray(scenario.actors) && scenario.actors.length >= 3, 'Actors list populated', 'Actors list missing or too small');
+if (Array.isArray(scenario.actors)) {
+  scenario.actors.forEach((actor, index) => {
+    expect(
+      isNonEmptyString(actor.role) && isNonEmptyString(actor.label) && isNonEmptyString(actor.goal),
+      `Actor ${index + 1} complete`,
+      `Actor ${index + 1} missing required fields`
+    );
+  });
+}
+
+const expectedMetrics = [
+  'validationCommitteeSize',
+  'stakeRequirementAgent',
+  'stakeRequirementValidator',
+  'auditSampleRate',
+  'governanceTimelock'
+];
+
+expect(typeof scenario.metrics === 'object' && scenario.metrics !== null, 'Metrics block present', 'Metrics block missing');
+if (scenario.metrics) {
+  expectedMetrics.forEach((metricKey) => {
+    expect(
+      metricKey in scenario.metrics && isNonEmptyString(String(scenario.metrics[metricKey])),
+      `Metric “${metricKey}” provided`,
+      `Metric “${metricKey}” missing or empty`
+    );
+  });
+}
+
+expect(Array.isArray(scenario.flow) && scenario.flow.length > 0, 'Lifecycle phases defined', 'Lifecycle phases missing');
+if (Array.isArray(scenario.flow)) {
+  scenario.flow.forEach((phase, index) => {
+    expect(
+      isNonEmptyString(phase.phase),
+      `Phase ${index + 1} has a title`,
+      `Phase ${index + 1} missing title`
+    );
+    expect(
+      Array.isArray(phase.steps) && phase.steps.every(isNonEmptyString) && phase.steps.length > 0,
+      `Phase ${index + 1} steps populated`,
+      `Phase ${index + 1} steps missing`
+    );
+  });
+}
+
+expect(
+  Array.isArray(scenario.resources?.docs) && scenario.resources.docs.length > 0,
+  'Documentation references listed',
+  'Documentation references missing'
+);
+if (Array.isArray(scenario.resources?.docs)) {
+  scenario.resources.docs.forEach((docPath) => {
+    expect(
+      existsSync(path.join(repoRoot, docPath)),
+      `Doc available → ${docPath}`,
+      `Doc missing → ${docPath}`
+    );
+  });
+}
+
+expect(
+  Array.isArray(scenario.resources?.scripts) && scenario.resources.scripts.length > 0,
+  'Automation commands listed',
+  'Automation commands missing'
+);
+
+const packageScripts = packageJson.scripts ?? {};
+if (Array.isArray(scenario.resources?.scripts)) {
+  scenario.resources.scripts.forEach((command) => {
+    const match = /^npm run ([^\s]+)/.exec(command.trim());
+    if (match) {
+      const scriptName = match[1];
+      expect(
+        Object.prototype.hasOwnProperty.call(packageScripts, scriptName),
+        `Script registered → ${scriptName}`,
+        `Missing npm script → ${scriptName}`
+      );
+    } else {
+      expectWarn(false, '', `Unable to verify non-npm command: ${command}`);
+    }
+  });
+}
+
+const storyboard = readFileSync(storyboardPath, 'utf8');
+expect(
+  storyboard.includes('mermaid') && storyboard.includes('graph TD'),
+  'Storyboard contains Mermaid orchestration diagram',
+  'Storyboard missing Mermaid orchestration diagram'
+);
+
+const uiStoryboard = readFileSync(uiStoryboardPath, 'utf8');
+expect(
+  uiStoryboard.includes('export/latest.json'),
+  'UI control room references generated playbook',
+  'UI control room missing playbook reference'
+);
+
+expect(
+  Array.isArray(exportData.timeline) && exportData.timeline.length > 0,
+  'Exported playbook timeline populated',
+  'Exported playbook timeline missing or empty'
+);
+
+expect(
+  Array.isArray(exportData.invariants) && exportData.invariants.length > 0,
+  'Exported invariants recorded',
+  'Exported invariants missing or empty'
+);
+
+const failures = results.filter((entry) => entry.status === 'fail');
+const warnings = results.filter((entry) => entry.status === 'warn');
+const passes = results.filter((entry) => entry.status === 'pass');
+
+passes.forEach((entry) => {
+  console.log(`${COLOR.green}${COLOR.bright}✓${COLOR.reset} ${entry.message}`);
+});
+warnings.forEach((entry) => {
+  console.log(`${COLOR.yellow}${COLOR.bright}!${COLOR.reset} ${entry.message}`);
+});
+failures.forEach((entry) => {
+  console.log(`${COLOR.red}${COLOR.bright}✗${COLOR.reset} ${entry.message}`);
+});
+
+const summary = `${passes.length} pass${passes.length === 1 ? '' : 'es'}, ${warnings.length} warning${
+  warnings.length === 1 ? '' : 's'
+}, ${failures.length} failure${failures.length === 1 ? '' : 's'}`;
+
+if (failures.length > 0) {
+  console.log(`\n${COLOR.red}${COLOR.bright}Scenario verification failed${COLOR.reset} — ${summary}`);
+  process.exit(1);
+}
+
+console.log(`\n${COLOR.cyan}${COLOR.bright}Scenario verification succeeded${COLOR.reset} — ${summary}`);
+if (warnings.length > 0) {
+  console.log(
+    `${COLOR.magenta}Review warnings to decide if manual confirmation is required before production activation.${COLOR.reset}`,
+  );
+}

--- a/package.json
+++ b/package.json
@@ -245,7 +245,8 @@
     "demo:national-supply-chain:validate": "ts-node --transpile-only scripts/v2/validateNationalSupplyChainTranscript.ts",
     "demo:national-supply-chain:cross-verify": "ts-node --transpile-only scripts/v2/crossValidateNationalSupplyChainTranscript.ts",
     "demo:national-supply-chain:control-room": "ts-node --transpile-only scripts/v2/launchNationalSupplyChainControlRoom.ts",
-    "demo:redenomination": "node demo/REDENOMINATION/scripts/run-demo.mjs"
+    "demo:redenomination": "node demo/REDENOMINATION/scripts/run-demo.mjs",
+    "demo:redenomination:verify": "node demo/REDENOMINATION/scripts/verify-scenario.mjs"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a REDENOMINATION scenario verifier that validates documentation links, automation commands, and storyboard assets
- surface the verification workflow in the README, scenario resources, and transcript output so operators run it first
- register the npm command for the verifier and retarget scenario documentation references to existing guides

## Testing
- npm run demo:redenomination:verify

------
https://chatgpt.com/codex/tasks/task_e_68f6d391a7e88333a8fc6a423f5fcf15