### PR TITLE
Harden meta-agentic demo with mission validation and owner coverage telemetry

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -76,6 +76,8 @@ flowchart LR
   (`ci (v2)` with lint/tests/foundry/coverage gates and `cancel-in-progress: true`).
 - **Owner diagnostics bundle** – Hamiltonian audit, reward engine report, upgrade queue, and compliance health checks run in one
   command and emit Markdown/JSON ready for regulators.
+- **Owner coverage sentinel** – mission loading now enforces Ethereum address formats, thermodynamic budgets, and 5/5 mandatory
+  owner control categories (pause, thermostat, upgrade, treasury, compliance) before any synthesis can start.
 
 ## Generated artefacts
 
@@ -115,7 +117,8 @@ Set `AGI_META_PROGRAM_MISSION=/path/to/custom.json` to target a modified mission
 1. Run `npm run demo:meta-agentic-program-synthesis:full` – should finish green with CI and owner diagnostics.
 2. Review `meta-agentic-program-synthesis-dashboard.html` for the executive view.
 3. Share `meta-agentic-program-synthesis-manifest.json` + reports with partners/regulators.
-4. Exercise owner commands directly (pause, thermostat, upgrade) using the copy-paste scripts printed in the report.
+4. Exercise owner commands directly (pause, thermostat, upgrade) using the copy-paste scripts printed in the report and confirm the
+   **Coverage Readiness** panel reports 5/5 satisfied controls.
 
 With this demo, AGI Jobs v0 (v2) proves that a single non-technical steward can commission, audit, and redeploy a civilisation-scale
 program synthesis machine in minutes – fully instrumented, branch-protected, and economically aligned.

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html
@@ -28,6 +28,8 @@
       .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-top: 1rem; }
       .metric-card { padding: 1rem; border-radius: 0.75rem; background: rgba(15, 118, 110, 0.35); box-shadow: inset 0 0 0 1px rgba(45, 212, 191, 0.25); }
       .owner-table { margin-top: 1rem; }
+      ul.coverage { list-style: none; padding-left: 0; margin-top: 1rem; }
+      ul.coverage li { margin-bottom: 0.35rem; }
     </style>
   </head>
   <body>
@@ -77,6 +79,13 @@
 | Upgrade | `npm run owner:upgrade -- --mission demo/Meta-Agentic-Program-Synthesis-v0/config/mission.meta-agentic-program-synthesis.json` | `npm run owner:upgrade-status` |
 | Treasury | `npm run reward-engine:update -- --mission demo/Meta-Agentic-Program-Synthesis-v0/config/mission.meta-agentic-program-synthesis.json` | `npm run reward-engine:report` |
 | Compliance | `npm run owner:compliance-report` | `npm run owner:doctor` |</div>
+      <h3>Coverage Readiness</h3>
+      
+<ul class="coverage">
+  <li><strong>Readiness:</strong> ready</li>
+  <li><strong>Satisfied controls:</strong> Emergency Pause, Thermostat, Upgrade, Treasury, Compliance</li>
+  <li><strong>Missing controls:</strong> None</li>
+</ul>
     </section>
     
 <section class="task">
@@ -129,16 +138,16 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for ARC Sentinel Edge Lift
-  2025-10-21T00:37:12.031Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
-  2025-10-21T00:37:12.033Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
-  2025-10-21T00:37:12.035Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
-  2025-10-21T00:37:12.036Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
-  2025-10-21T00:37:12.037Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
-  2025-10-21T00:37:12.038Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T00:37:12.040Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T00:37:12.041Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
-  2025-10-21T00:37:12.042Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
-  2025-10-21T00:37:12.043Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%</pre>
+  2025-10-21T01:17:45.900Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
+  2025-10-21T01:17:45.902Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
+  2025-10-21T01:17:45.903Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
+  2025-10-21T01:17:45.904Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
+  2025-10-21T01:17:45.905Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
+  2025-10-21T01:17:45.905Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T01:17:45.912Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T01:17:45.913Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
+  2025-10-21T01:17:45.915Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
+  2025-10-21T01:17:45.916Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%</pre>
   </details>
 </section>
 
@@ -191,16 +200,16 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for Ledger Harmonics Sequencer
-  2025-10-21T00:37:12.045Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
-  2025-10-21T00:37:12.046Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
-  2025-10-21T00:37:12.047Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
-  2025-10-21T00:37:12.061Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T00:37:12.062Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T00:37:12.063Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T00:37:12.064Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T00:37:12.065Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T00:37:12.066Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T00:37:12.067Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%</pre>
+  2025-10-21T01:17:45.918Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
+  2025-10-21T01:17:45.919Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
+  2025-10-21T01:17:45.920Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
+  2025-10-21T01:17:45.921Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T01:17:45.921Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T01:17:45.922Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T01:17:45.923Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T01:17:45.923Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T01:17:45.924Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T01:17:45.924Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%</pre>
   </details>
 </section>
 
@@ -253,16 +262,16 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for Nova Weave Sequence Optimiser
-  2025-10-21T00:37:12.068Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
-  2025-10-21T00:37:12.069Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
-  2025-10-21T00:37:12.070Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
-  2025-10-21T00:37:12.071Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
-  2025-10-21T00:37:12.072Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
-  2025-10-21T00:37:12.073Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
-  2025-10-21T00:37:12.073Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
-  2025-10-21T00:37:12.074Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
-  2025-10-21T00:37:12.075Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
-  2025-10-21T00:37:12.076Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%</pre>
+  2025-10-21T01:17:45.925Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
+  2025-10-21T01:17:45.926Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
+  2025-10-21T01:17:45.926Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
+  2025-10-21T01:17:45.927Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
+  2025-10-21T01:17:45.928Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
+  2025-10-21T01:17:45.928Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
+  2025-10-21T01:17:45.929Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
+  2025-10-21T01:17:45.930Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
+  2025-10-21T01:17:45.930Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T01:17:45.931Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%</pre>
   </details>
 </section>
     <section>
@@ -270,9 +279,9 @@
       <p>Workflow <code>ci (v2)</code> | Required jobs: Lint &amp; static checks, Tests, Foundry, Coverage thresholds</p>
       <p>Coverage ≥ 90% | Concurrency group <code>ci-${{ github.workflow }}-${{ github.ref }}</code></p>
     </section>
-    <footer>Generated 2025-10-21T00:37:12.026Z • JSON summary embedded below</footer>
+    <footer>Generated 2025-10-21T01:17:45.896Z • JSON summary embedded below</footer>
     <script id="meta-agentic-summary" type="application/json">{
-  &quot;generatedAt&quot;: &quot;2025-10-21T00:37:12.026Z&quot;,
+  &quot;generatedAt&quot;: &quot;2025-10-21T01:17:45.896Z&quot;,
   &quot;mission&quot;: {
     &quot;title&quot;: &quot;Meta-Agentic Program Synthesis Sovereign Mission&quot;,
     &quot;version&quot;: &quot;0.1.0&quot;,
@@ -306,6 +315,24 @@
     &quot;energyUsage&quot;: 73.33333333333333,
     &quot;noveltyScore&quot;: 0.7776289047454377,
     &quot;coverageScore&quot;: 1
+  },
+  &quot;ownerCoverage&quot;: {
+    &quot;requiredCategories&quot;: [
+      &quot;Emergency Pause&quot;,
+      &quot;Thermostat&quot;,
+      &quot;Upgrade&quot;,
+      &quot;Treasury&quot;,
+      &quot;Compliance&quot;
+    ],
+    &quot;satisfiedCategories&quot;: [
+      &quot;Emergency Pause&quot;,
+      &quot;Thermostat&quot;,
+      &quot;Upgrade&quot;,
+      &quot;Treasury&quot;,
+      &quot;Compliance&quot;
+    ],
+    &quot;missingCategories&quot;: [],
+    &quot;readiness&quot;: &quot;ready&quot;
   },
   &quot;tasks&quot;: [
     {
@@ -525,7 +552,7 @@
           &quot;medianScore&quot;: 56.19020618556701,
           &quot;diversity&quot;: 0.9444444444444444,
           &quot;eliteScore&quot;: 110.36140657817333,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.031Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.900Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -534,7 +561,7 @@
           &quot;medianScore&quot;: 65.75277564301642,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 136.39087455307794,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.033Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.902Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -543,7 +570,7 @@
           &quot;medianScore&quot;: 73.64584551701412,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 138.12283331596453,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.035Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.903Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -552,7 +579,7 @@
           &quot;medianScore&quot;: 100.49230198051038,
           &quot;diversity&quot;: 0.8333333333333334,
           &quot;eliteScore&quot;: 138.41149310977895,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.036Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.904Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -561,7 +588,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.6944444444444444,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.037Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.905Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -570,7 +597,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.038Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.905Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -579,7 +606,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.040Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.912Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -588,7 +615,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.041Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.913Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -597,7 +624,7 @@
           &quot;medianScore&quot;: 116.57704853345733,
           &quot;diversity&quot;: 0.8055555555555556,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.042Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.915Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -606,7 +633,7 @@
           &quot;medianScore&quot;: 137.1920690409011,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.043Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.916Z&quot;
         }
       ]
     },
@@ -846,7 +873,7 @@
           &quot;medianScore&quot;: 41.03751524896436,
           &quot;diversity&quot;: 0.9722222222222222,
           &quot;eliteScore&quot;: 96.0918022581709,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.045Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.918Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -855,7 +882,7 @@
           &quot;medianScore&quot;: 62.99975060567376,
           &quot;diversity&quot;: 0.9444444444444444,
           &quot;eliteScore&quot;: 98.43691088683215,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.046Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.919Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -864,7 +891,7 @@
           &quot;medianScore&quot;: 76.53115760829131,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 132.5084085000921,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.047Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.920Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -873,7 +900,7 @@
           &quot;medianScore&quot;: 77.95296283436663,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.061Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.921Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -882,7 +909,7 @@
           &quot;medianScore&quot;: 86.94000111220245,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.062Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.921Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -891,7 +918,7 @@
           &quot;medianScore&quot;: 88.99300139019402,
           &quot;diversity&quot;: 0.6111111111111112,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.063Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.922Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -900,7 +927,7 @@
           &quot;medianScore&quot;: 83.23985249780515,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.064Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.923Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -909,7 +936,7 @@
           &quot;medianScore&quot;: 82.9194778065494,
           &quot;diversity&quot;: 0.6111111111111112,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.065Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.923Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -918,7 +945,7 @@
           &quot;medianScore&quot;: 86.367830024997,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.066Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.924Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -927,7 +954,7 @@
           &quot;medianScore&quot;: 85.09002044220831,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.067Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.924Z&quot;
         }
       ]
     },
@@ -1196,7 +1223,7 @@
           &quot;medianScore&quot;: 23.447749293641056,
           &quot;diversity&quot;: 1,
           &quot;eliteScore&quot;: 97.42746077012889,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.068Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.925Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -1205,7 +1232,7 @@
           &quot;medianScore&quot;: 33.23577114240753,
           &quot;diversity&quot;: 1,
           &quot;eliteScore&quot;: 101.68095349725729,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.069Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.926Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -1214,7 +1241,7 @@
           &quot;medianScore&quot;: 64.46743238768931,
           &quot;diversity&quot;: 0.8888888888888888,
           &quot;eliteScore&quot;: 125.76131787031291,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.070Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.926Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -1223,7 +1250,7 @@
           &quot;medianScore&quot;: 70.39942915911845,
           &quot;diversity&quot;: 0.8611111111111112,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.071Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.927Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -1232,7 +1259,7 @@
           &quot;medianScore&quot;: 71.05162669292856,
           &quot;diversity&quot;: 0.8333333333333334,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.072Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.928Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -1241,7 +1268,7 @@
           &quot;medianScore&quot;: 53.843889930604206,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.073Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.928Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -1250,7 +1277,7 @@
           &quot;medianScore&quot;: 78.25900854278035,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.073Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.929Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -1259,7 +1286,7 @@
           &quot;medianScore&quot;: 91.68021852282594,
           &quot;diversity&quot;: 0.5,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.074Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.930Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -1268,7 +1295,7 @@
           &quot;medianScore&quot;: 84.52984866490183,
           &quot;diversity&quot;: 0.6388888888888888,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.075Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.930Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -1277,7 +1304,7 @@
           &quot;medianScore&quot;: 90.34258929546631,
           &quot;diversity&quot;: 0.6388888888888888,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T00:37:12.076Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T01:17:45.931Z&quot;
         }
       ]
     }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T00:37:12.127Z",
+  "generatedAt": "2025-10-21T01:17:45.964Z",
   "aggregate": {
     "globalBestScore": 140.38164328854776,
     "averageAccuracy": 1,
@@ -42,8 +42,27 @@
     "report": "/workspace/AGIJobsv0/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-ci.json"
   },
   "ownerDiagnostics": {
-    "generatedAt": "2025-10-21T00:37:12.126Z",
+    "generatedAt": "2025-10-21T01:17:45.964Z",
     "readiness": "ready",
+    "commandReadiness": "ready",
+    "coverage": {
+      "requiredCategories": [
+        "Emergency Pause",
+        "Thermostat",
+        "Upgrade",
+        "Treasury",
+        "Compliance"
+      ],
+      "satisfiedCategories": [
+        "Emergency Pause",
+        "Thermostat",
+        "Upgrade",
+        "Treasury",
+        "Compliance"
+      ],
+      "missingCategories": [],
+      "readiness": "ready"
+    },
     "statuses": [
       {
         "capability": {
@@ -96,6 +115,24 @@
         "verificationAvailable": true
       }
     ]
+  },
+  "ownerCoverage": {
+    "requiredCategories": [
+      "Emergency Pause",
+      "Thermostat",
+      "Upgrade",
+      "Treasury",
+      "Compliance"
+    ],
+    "satisfiedCategories": [
+      "Emergency Pause",
+      "Thermostat",
+      "Upgrade",
+      "Treasury",
+      "Compliance"
+    ],
+    "missingCategories": [],
+    "readiness": "ready"
   },
   "artifacts": {
     "Mission manifest": "/workspace/AGIJobsv0/demo/Meta-Agentic-Program-Synthesis-v0/config/mission.meta-agentic-program-synthesis.json",

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.md
@@ -1,6 +1,6 @@
 # Meta-Agentic Program Synthesis – Full Run
 
-Generated: 2025-10-21T00:37:12.026Z
+Generated: 2025-10-21T01:17:45.896Z
 
 ## Aggregate Metrics
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-manifest.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T00:37:12.130Z",
+  "generatedAt": "2025-10-21T01:17:45.966Z",
   "root": "/workspace/AGIJobsv0",
   "files": 8,
   "entries": [
@@ -10,38 +10,38 @@
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html",
-      "sha256": "604507eaca53f1ba19134b7a9f07ea21d7626b5f6bddfd2d573c612c8a212afa",
-      "bytes": 51519
+      "sha256": "95150a24cba9d858ed2023df6e7bec383fa27338d59a8913d02e0590dd0eae45",
+      "bytes": 52424
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.json",
-      "sha256": "758003410be209879a6d37a32bfd884c9f8628dbc4798c4822aaa26c01ae096c",
-      "bytes": 4680
+      "sha256": "9d516dd30263b02567a5c1f7456078863fc8e080491becc20333481d0e83b07d",
+      "bytes": 5442
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.md",
-      "sha256": "88f4b4b76d532291b0e24e232b791d6074fb5d91a865d7a1f47e7f268bb3e02f",
+      "sha256": "9473c82f8b13652f2b0d31445919d41f5dda9e8151de96286039a863a04161d5",
       "bytes": 1486
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.json",
-      "sha256": "0d1f8b109dce4a9fb824123fce64b4fda9f10757cd1982d41f9591399ed9ecaf",
-      "bytes": 1913
+      "sha256": "7d0ca35c1f0de1e024c6afc6be23ea98331a2485bf626201558b5765569a63eb",
+      "bytes": 2288
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.md",
-      "sha256": "a51da540fe6dec779e0ec3a1fc2e209031ed57af5cc51592d17748df5a1dbb7f",
-      "bytes": 1048
+      "sha256": "76b7c299831ec2bb72c8b76bc253697496874f1cdaec78e7011b8d7c10bc684a",
+      "bytes": 1100
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md",
-      "sha256": "d004b9a7678effaa68dc887dff512b713eda3c9be7d1de246e435190d3912f3a",
-      "bytes": 11219
+      "sha256": "d5877a34c71f6d956767e756dd93dc3bfd686e8c8f3890bc99a3e41879223069",
+      "bytes": 11444
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json",
-      "sha256": "dedbfd0a209d90d41d117b4b31fb7cdf89586137fe23928e1f7819f17338163c",
-      "bytes": 28434
+      "sha256": "3ac044e8463b4e722a9636958d52a4299c8f10ff084a06dc2f44f2e664272ed3",
+      "bytes": 28783
     }
   ]
 }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.json
@@ -1,6 +1,25 @@
 {
-  "generatedAt": "2025-10-21T00:37:12.126Z",
+  "generatedAt": "2025-10-21T01:17:45.964Z",
   "readiness": "ready",
+  "commandReadiness": "ready",
+  "coverage": {
+    "requiredCategories": [
+      "Emergency Pause",
+      "Thermostat",
+      "Upgrade",
+      "Treasury",
+      "Compliance"
+    ],
+    "satisfiedCategories": [
+      "Emergency Pause",
+      "Thermostat",
+      "Upgrade",
+      "Treasury",
+      "Compliance"
+    ],
+    "missingCategories": [],
+    "readiness": "ready"
+  },
   "statuses": [
     {
       "capability": {

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.md
@@ -2,6 +2,8 @@
 
 Readiness: ready
 
+Coverage readiness: ready (5/5 controls satisfied)
+
 | Capability | Command | Verification | Status |
 | --- | --- | --- | --- |
 | Circuit breaker engage | `npm run owner:system-pause -- --action pause` (✅) | `npm run owner:system-pause -- --action status` (✅) | Ready |

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md
@@ -10,6 +10,7 @@ Deterministic rehearsal proving that AGI Jobs v0 (v2) lets a non-technical owner
 - **Novelty signal:** 77.76% average.
 - **Coverage:** 100.00% task-level perfect matches.
 - **Owner supremacy:** every control remains copy-paste accessible (pause, thermostat, upgrades, treasury mirrors, compliance dossier).
+- **Coverage readiness:** ready (5/5 controls satisfied).
 
 ## Mission Metadata
 
@@ -62,6 +63,12 @@ flowchart LR
 | Treasury | `npm run reward-engine:update -- --mission demo/Meta-Agentic-Program-Synthesis-v0/config/mission.meta-agentic-program-synthesis.json` | `npm run reward-engine:report` |
 | Compliance | `npm run owner:compliance-report` | `npm run owner:doctor` |
 
+## Owner Coverage Readiness
+
+- **Readiness:** ready
+- **Satisfied controls:** Emergency Pause, Thermostat, Upgrade, Treasury, Compliance
+- **Missing controls:** None
+
 ## ARC Sentinel Edge Lift
 
 Detect latent pixel edges, amplify discovery, and route high-confidence transformations back into the shared skill graph.
@@ -113,16 +120,16 @@ Detect latent pixel edges, amplify discovery, and route high-confidence transfor
 ```mermaid
 timeline
   title Evolutionary improvements for ARC Sentinel Edge Lift
-  2025-10-21T00:37:12.031Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
-  2025-10-21T00:37:12.033Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
-  2025-10-21T00:37:12.035Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
-  2025-10-21T00:37:12.036Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
-  2025-10-21T00:37:12.037Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
-  2025-10-21T00:37:12.038Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T00:37:12.040Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T00:37:12.041Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
-  2025-10-21T00:37:12.042Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
-  2025-10-21T00:37:12.043Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%
+  2025-10-21T01:17:45.900Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
+  2025-10-21T01:17:45.902Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
+  2025-10-21T01:17:45.903Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
+  2025-10-21T01:17:45.904Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
+  2025-10-21T01:17:45.905Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
+  2025-10-21T01:17:45.905Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T01:17:45.912Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T01:17:45.913Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
+  2025-10-21T01:17:45.915Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
+  2025-10-21T01:17:45.916Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%
 ```
 
 ## Ledger Harmonics Sequencer
@@ -175,16 +182,16 @@ Absorb asynchronous cash-flow deltas, stabilise them against the thermodynamic l
 ```mermaid
 timeline
   title Evolutionary improvements for Ledger Harmonics Sequencer
-  2025-10-21T00:37:12.045Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
-  2025-10-21T00:37:12.046Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
-  2025-10-21T00:37:12.047Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
-  2025-10-21T00:37:12.061Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T00:37:12.062Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T00:37:12.063Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T00:37:12.064Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T00:37:12.065Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T00:37:12.066Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T00:37:12.067Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T01:17:45.918Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
+  2025-10-21T01:17:45.919Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
+  2025-10-21T01:17:45.920Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
+  2025-10-21T01:17:45.921Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T01:17:45.921Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T01:17:45.922Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T01:17:45.923Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T01:17:45.923Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T01:17:45.924Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T01:17:45.924Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
 ```
 
 ## Nova Weave Sequence Optimiser
@@ -237,16 +244,16 @@ Elevate alpha sequences into deterministic blueprints that compile into on-chain
 ```mermaid
 timeline
   title Evolutionary improvements for Nova Weave Sequence Optimiser
-  2025-10-21T00:37:12.068Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
-  2025-10-21T00:37:12.069Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
-  2025-10-21T00:37:12.070Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
-  2025-10-21T00:37:12.071Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
-  2025-10-21T00:37:12.072Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
-  2025-10-21T00:37:12.073Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
-  2025-10-21T00:37:12.073Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
-  2025-10-21T00:37:12.074Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
-  2025-10-21T00:37:12.075Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
-  2025-10-21T00:37:12.076Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T01:17:45.925Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
+  2025-10-21T01:17:45.926Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
+  2025-10-21T01:17:45.926Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
+  2025-10-21T01:17:45.927Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
+  2025-10-21T01:17:45.928Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
+  2025-10-21T01:17:45.928Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
+  2025-10-21T01:17:45.929Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
+  2025-10-21T01:17:45.930Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
+  2025-10-21T01:17:45.930Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T01:17:45.931Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
 ```
 
 ## CI Shield Alignment
@@ -256,4 +263,4 @@ timeline
 
 ## Generated At
 
-2025-10-21T00:37:12.026Z
+2025-10-21T01:17:45.896Z

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T00:37:12.026Z",
+  "generatedAt": "2025-10-21T01:17:45.896Z",
   "mission": {
     "title": "Meta-Agentic Program Synthesis Sovereign Mission",
     "version": "0.1.0",
@@ -33,6 +33,24 @@
     "energyUsage": 73.33333333333333,
     "noveltyScore": 0.7776289047454377,
     "coverageScore": 1
+  },
+  "ownerCoverage": {
+    "requiredCategories": [
+      "Emergency Pause",
+      "Thermostat",
+      "Upgrade",
+      "Treasury",
+      "Compliance"
+    ],
+    "satisfiedCategories": [
+      "Emergency Pause",
+      "Thermostat",
+      "Upgrade",
+      "Treasury",
+      "Compliance"
+    ],
+    "missingCategories": [],
+    "readiness": "ready"
   },
   "tasks": [
     {
@@ -252,7 +270,7 @@
           "medianScore": 56.19020618556701,
           "diversity": 0.9444444444444444,
           "eliteScore": 110.36140657817333,
-          "timestamp": "2025-10-21T00:37:12.031Z"
+          "timestamp": "2025-10-21T01:17:45.900Z"
         },
         {
           "generation": 1,
@@ -261,7 +279,7 @@
           "medianScore": 65.75277564301642,
           "diversity": 0.75,
           "eliteScore": 136.39087455307794,
-          "timestamp": "2025-10-21T00:37:12.033Z"
+          "timestamp": "2025-10-21T01:17:45.902Z"
         },
         {
           "generation": 2,
@@ -270,7 +288,7 @@
           "medianScore": 73.64584551701412,
           "diversity": 0.75,
           "eliteScore": 138.12283331596453,
-          "timestamp": "2025-10-21T00:37:12.035Z"
+          "timestamp": "2025-10-21T01:17:45.903Z"
         },
         {
           "generation": 3,
@@ -279,7 +297,7 @@
           "medianScore": 100.49230198051038,
           "diversity": 0.8333333333333334,
           "eliteScore": 138.41149310977895,
-          "timestamp": "2025-10-21T00:37:12.036Z"
+          "timestamp": "2025-10-21T01:17:45.904Z"
         },
         {
           "generation": 4,
@@ -288,7 +306,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.6944444444444444,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T00:37:12.037Z"
+          "timestamp": "2025-10-21T01:17:45.905Z"
         },
         {
           "generation": 5,
@@ -297,7 +315,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7777777777777778,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T00:37:12.038Z"
+          "timestamp": "2025-10-21T01:17:45.905Z"
         },
         {
           "generation": 6,
@@ -306,7 +324,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7777777777777778,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T00:37:12.040Z"
+          "timestamp": "2025-10-21T01:17:45.912Z"
         },
         {
           "generation": 7,
@@ -315,7 +333,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7222222222222222,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T00:37:12.041Z"
+          "timestamp": "2025-10-21T01:17:45.913Z"
         },
         {
           "generation": 8,
@@ -324,7 +342,7 @@
           "medianScore": 116.57704853345733,
           "diversity": 0.8055555555555556,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T00:37:12.042Z"
+          "timestamp": "2025-10-21T01:17:45.915Z"
         },
         {
           "generation": 9,
@@ -333,7 +351,7 @@
           "medianScore": 137.1920690409011,
           "diversity": 0.75,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T00:37:12.043Z"
+          "timestamp": "2025-10-21T01:17:45.916Z"
         }
       ]
     },
@@ -573,7 +591,7 @@
           "medianScore": 41.03751524896436,
           "diversity": 0.9722222222222222,
           "eliteScore": 96.0918022581709,
-          "timestamp": "2025-10-21T00:37:12.045Z"
+          "timestamp": "2025-10-21T01:17:45.918Z"
         },
         {
           "generation": 1,
@@ -582,7 +600,7 @@
           "medianScore": 62.99975060567376,
           "diversity": 0.9444444444444444,
           "eliteScore": 98.43691088683215,
-          "timestamp": "2025-10-21T00:37:12.046Z"
+          "timestamp": "2025-10-21T01:17:45.919Z"
         },
         {
           "generation": 2,
@@ -591,7 +609,7 @@
           "medianScore": 76.53115760829131,
           "diversity": 0.75,
           "eliteScore": 132.5084085000921,
-          "timestamp": "2025-10-21T00:37:12.047Z"
+          "timestamp": "2025-10-21T01:17:45.920Z"
         },
         {
           "generation": 3,
@@ -600,7 +618,7 @@
           "medianScore": 77.95296283436663,
           "diversity": 0.7222222222222222,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T00:37:12.061Z"
+          "timestamp": "2025-10-21T01:17:45.921Z"
         },
         {
           "generation": 4,
@@ -609,7 +627,7 @@
           "medianScore": 86.94000111220245,
           "diversity": 0.7222222222222222,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T00:37:12.062Z"
+          "timestamp": "2025-10-21T01:17:45.921Z"
         },
         {
           "generation": 5,
@@ -618,7 +636,7 @@
           "medianScore": 88.99300139019402,
           "diversity": 0.6111111111111112,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T00:37:12.063Z"
+          "timestamp": "2025-10-21T01:17:45.922Z"
         },
         {
           "generation": 6,
@@ -627,7 +645,7 @@
           "medianScore": 83.23985249780515,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T00:37:12.064Z"
+          "timestamp": "2025-10-21T01:17:45.923Z"
         },
         {
           "generation": 7,
@@ -636,7 +654,7 @@
           "medianScore": 82.9194778065494,
           "diversity": 0.6111111111111112,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T00:37:12.065Z"
+          "timestamp": "2025-10-21T01:17:45.923Z"
         },
         {
           "generation": 8,
@@ -645,7 +663,7 @@
           "medianScore": 86.367830024997,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T00:37:12.066Z"
+          "timestamp": "2025-10-21T01:17:45.924Z"
         },
         {
           "generation": 9,
@@ -654,7 +672,7 @@
           "medianScore": 85.09002044220831,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T00:37:12.067Z"
+          "timestamp": "2025-10-21T01:17:45.924Z"
         }
       ]
     },
@@ -923,7 +941,7 @@
           "medianScore": 23.447749293641056,
           "diversity": 1,
           "eliteScore": 97.42746077012889,
-          "timestamp": "2025-10-21T00:37:12.068Z"
+          "timestamp": "2025-10-21T01:17:45.925Z"
         },
         {
           "generation": 1,
@@ -932,7 +950,7 @@
           "medianScore": 33.23577114240753,
           "diversity": 1,
           "eliteScore": 101.68095349725729,
-          "timestamp": "2025-10-21T00:37:12.069Z"
+          "timestamp": "2025-10-21T01:17:45.926Z"
         },
         {
           "generation": 2,
@@ -941,7 +959,7 @@
           "medianScore": 64.46743238768931,
           "diversity": 0.8888888888888888,
           "eliteScore": 125.76131787031291,
-          "timestamp": "2025-10-21T00:37:12.070Z"
+          "timestamp": "2025-10-21T01:17:45.926Z"
         },
         {
           "generation": 3,
@@ -950,7 +968,7 @@
           "medianScore": 70.39942915911845,
           "diversity": 0.8611111111111112,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T00:37:12.071Z"
+          "timestamp": "2025-10-21T01:17:45.927Z"
         },
         {
           "generation": 4,
@@ -959,7 +977,7 @@
           "medianScore": 71.05162669292856,
           "diversity": 0.8333333333333334,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T00:37:12.072Z"
+          "timestamp": "2025-10-21T01:17:45.928Z"
         },
         {
           "generation": 5,
@@ -968,7 +986,7 @@
           "medianScore": 53.843889930604206,
           "diversity": 0.7777777777777778,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T00:37:12.073Z"
+          "timestamp": "2025-10-21T01:17:45.928Z"
         },
         {
           "generation": 6,
@@ -977,7 +995,7 @@
           "medianScore": 78.25900854278035,
           "diversity": 0.6666666666666666,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T00:37:12.073Z"
+          "timestamp": "2025-10-21T01:17:45.929Z"
         },
         {
           "generation": 7,
@@ -986,7 +1004,7 @@
           "medianScore": 91.68021852282594,
           "diversity": 0.5,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T00:37:12.074Z"
+          "timestamp": "2025-10-21T01:17:45.930Z"
         },
         {
           "generation": 8,
@@ -995,7 +1013,7 @@
           "medianScore": 84.52984866490183,
           "diversity": 0.6388888888888888,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T00:37:12.075Z"
+          "timestamp": "2025-10-21T01:17:45.930Z"
         },
         {
           "generation": 9,
@@ -1004,7 +1022,7 @@
           "medianScore": 90.34258929546631,
           "diversity": 0.6388888888888888,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T00:37:12.076Z"
+          "timestamp": "2025-10-21T01:17:45.931Z"
         }
       ]
     }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/runSynthesis.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/runSynthesis.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { loadMissionConfig, runMetaSynthesis } from "./synthesisEngine";
 import { writeReports } from "./reporting";
 import { updateManifest } from "./manifest";
-import type { MissionConfig, SynthesisRun } from "./types";
+import type { MissionConfig, OwnerControlCoverage, SynthesisRun } from "./types";
 
 const BASE_DIR = path.resolve(__dirname, "..");
 const REPORT_DIR = path.join(BASE_DIR, "reports");
@@ -33,8 +33,9 @@ function resolveOptions(options: RunOptions = {}): Required<RunOptions> {
 
 export async function executeSynthesis(options: RunOptions = {}): Promise<SynthesisRun> {
   const resolved = resolveOptions(options);
-  const mission: MissionConfig = await loadMissionConfig(resolved.missionFile);
-  const run = runMetaSynthesis(mission);
+  const { mission, coverage }: { mission: MissionConfig; coverage: OwnerControlCoverage } =
+    await loadMissionConfig(resolved.missionFile);
+  const run = runMetaSynthesis(mission, coverage);
   const { files } = await writeReports(run, {
     reportDir: resolved.reportDir,
     markdownFile: resolved.reportFile,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/types.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/types.ts
@@ -82,6 +82,13 @@ export interface MissionOwnerControls {
   capabilities: OwnerCapability[];
 }
 
+export interface OwnerControlCoverage {
+  requiredCategories: string[];
+  satisfiedCategories: string[];
+  missingCategories: string[];
+  readiness: "ready" | "attention" | "blocked";
+}
+
 export interface MissionConfig {
   meta: MissionMeta;
   parameters: MissionParameters;
@@ -138,6 +145,7 @@ export interface SynthesisRun {
   generatedAt: string;
   parameters: MissionParameters;
   tasks: TaskResult[];
+  ownerCoverage: OwnerControlCoverage;
   aggregate: {
     globalBestScore: number;
     averageAccuracy: number;

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/validation.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/validation.ts
@@ -1,0 +1,156 @@
+import type { MissionConfig, MissionParameters, OwnerControlCoverage, TaskDefinition } from "./types";
+
+const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+const REQUIRED_OWNER_CATEGORIES = [
+  "Emergency Pause",
+  "Thermostat",
+  "Upgrade",
+  "Treasury",
+  "Compliance",
+] as const;
+
+type RequiredCategory = (typeof REQUIRED_OWNER_CATEGORIES)[number];
+
+function assertCondition(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`Mission validation failed: ${message}`);
+  }
+}
+
+function assertPositive(value: number, label: string): void {
+  assertCondition(Number.isFinite(value) && value > 0, `${label} must be a positive number.`);
+}
+
+function validateParameters(parameters: MissionParameters): void {
+  assertPositive(parameters.seed, "Seed");
+  assertPositive(parameters.generations, "Generations");
+  assertPositive(parameters.populationSize, "Population size");
+  assertPositive(parameters.eliteCount, "Elite count");
+  assertCondition(
+    parameters.eliteCount <= parameters.populationSize,
+    "Elite count cannot exceed population size.",
+  );
+  assertCondition(parameters.crossoverRate >= 0 && parameters.crossoverRate <= 1, "Crossover rate must be within [0,1].");
+  assertCondition(parameters.mutationRate >= 0 && parameters.mutationRate <= 1, "Mutation rate must be within [0,1].");
+  assertPositive(parameters.maxOperations, "Max operations");
+  assertPositive(parameters.energyBudget, "Energy budget");
+  assertCondition(
+    parameters.successThreshold > 0 && parameters.successThreshold <= 1,
+    "Success threshold must be within (0,1].",
+  );
+  assertCondition(
+    parameters.noveltyTarget >= 0 && parameters.noveltyTarget <= 1,
+    "Novelty target must be within [0,1].",
+  );
+}
+
+function normaliseCategory(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function computeOwnerCoverage(mission: MissionConfig): OwnerControlCoverage {
+  const declared = mission.ownerControls.capabilities ?? [];
+  const satisfied = new Set<RequiredCategory>();
+
+  for (const capability of declared) {
+    const normalised = normaliseCategory(capability.category);
+    for (const required of REQUIRED_OWNER_CATEGORIES) {
+      if (normaliseCategory(required) === normalised) {
+        satisfied.add(required);
+      }
+    }
+  }
+
+  const missing = REQUIRED_OWNER_CATEGORIES.filter((category) => !satisfied.has(category));
+
+  let readiness: OwnerControlCoverage["readiness"];
+  if (missing.length === 0) {
+    readiness = "ready";
+  } else if (missing.length <= 2) {
+    readiness = "attention";
+  } else {
+    readiness = "blocked";
+  }
+
+  return {
+    requiredCategories: [...REQUIRED_OWNER_CATEGORIES],
+    satisfiedCategories: [...satisfied],
+    missingCategories: missing,
+    readiness,
+  };
+}
+
+function validateTasks(tasks: TaskDefinition[], parameters: MissionParameters): void {
+  assertCondition(tasks.length > 0, "At least one task must be defined.");
+  const seenIds = new Set<string>();
+  for (const task of tasks) {
+    assertCondition(task.id.trim().length > 0, "Task IDs must not be empty.");
+    assertCondition(!seenIds.has(task.id), `Duplicate task id detected: ${task.id}`);
+    seenIds.add(task.id);
+    assertCondition(task.mode === "vector", `Unsupported task mode for ${task.id}; only 'vector' is supported.`);
+    assertCondition(task.examples.length > 0, `Task ${task.id} must include at least one example.`);
+    for (const example of task.examples) {
+      assertCondition(Array.isArray(example.input), `Task ${task.id} example inputs must be arrays.`);
+      assertCondition(Array.isArray(example.expected), `Task ${task.id} example expected values must be arrays.`);
+      assertCondition(example.input.length > 0, `Task ${task.id} example ${example.label} must not be empty.`);
+    }
+    assertPositive(task.owner.stake, `Task ${task.id} stake`);
+    assertPositive(task.owner.reward, `Task ${task.id} reward`);
+    assertCondition(
+      typeof task.owner.thermodynamicTarget === "number",
+      `Task ${task.id} thermodynamic target must be numeric.`,
+    );
+    if (task.constraints?.maxOperations !== undefined) {
+      assertCondition(
+        task.constraints.maxOperations > 0 && task.constraints.maxOperations <= parameters.maxOperations,
+        `Task ${task.id} maxOperations must be > 0 and ≤ mission maxOperations.`,
+      );
+    }
+  }
+}
+
+export function validateMission(mission: MissionConfig): OwnerControlCoverage {
+  assertCondition(
+    typeof mission.meta.title === "string" && mission.meta.title.trim().length > 0,
+    "Mission title must be provided.",
+  );
+  assertCondition(
+    typeof mission.meta.description === "string" && mission.meta.description.trim().length > 0,
+    "Mission description must be provided.",
+  );
+  assertCondition(ADDRESS_REGEX.test(mission.meta.ownerAddress), "Owner address must be a valid Ethereum address.");
+  assertCondition(ADDRESS_REGEX.test(mission.meta.treasuryAddress), "Treasury address must be a valid Ethereum address.");
+  assertPositive(mission.meta.timelockSeconds, "Timelock seconds");
+
+  validateParameters(mission.parameters);
+  validateTasks(mission.tasks, mission.parameters);
+
+  assertCondition(
+    mission.ownerControls.capabilities.length > 0,
+    "Owner capabilities must include at least one entry.",
+  );
+
+  const coverage = computeOwnerCoverage(mission);
+  assertCondition(
+    coverage.missingCategories.length === 0,
+    `Owner capabilities missing required categories: ${coverage.missingCategories.join(", ")}.`,
+  );
+
+  assertCondition(
+    typeof mission.ci.workflow === "string" && mission.ci.workflow.trim().length > 0,
+    "CI workflow name must be provided.",
+  );
+  assertCondition(Array.isArray(mission.ci.requiredJobs), "CI requiredJobs must be an array.");
+  assertPositive(mission.ci.minCoverage, "CI minimum coverage");
+  assertCondition(
+    typeof mission.ci.concurrency === "string" && mission.ci.concurrency.trim().length > 0,
+    "CI concurrency group must be provided.",
+  );
+
+  return coverage;
+}
+
+export function ensureMissionValidity(mission: MissionConfig): OwnerControlCoverage {
+  return validateMission(mission);
+}


### PR DESCRIPTION
## Summary
- add deterministic mission validation that enforces Ethereum address formatting, thermodynamic budgets, and mandatory owner control categories before synthesis
- propagate owner coverage telemetry through the synthesis engine, generated reports, and executive dashboard so non-technical stewards see readiness at a glance
- extend the full pipeline diagnostics to merge coverage readiness with command availability and document the guarantee in the README

## Testing
- npm run demo:meta-agentic-program-synthesis
- npm run demo:meta-agentic-program-synthesis:full
- node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync('demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json','utf8'));console.log({coverage:data.ownerCoverage});"

------
https://chatgpt.com/codex/tasks/task_e_68f6dd770c888333a5833c4407effd66