### PR TITLE
Add triangulated verification to meta-agentic synthesis demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -5,6 +5,7 @@ owner launches a single command and receives:
 
 - An evolutionary program synthesis loop that breeds agent code for ARC-style perception, ledger equilibria, and on-chain payload
   weaving – all governed by thermodynamic budgets and quality-diversity archives.
+- A multi-angle verification lattice that replay-scores, baseline-compares, stress-jitters, and governance-audits every elite pipeline so owners see a consensus verdict rather than a single unchecked metric.
 - A governance dossier proving that the owner retains absolute command: pause switches, thermostat calibrations, upgrade queues,
   treasury mirrors, and compliance beacons are exported with copy-paste commands.
 - CI v2 branch-protection verification and owner diagnostics so that the generated machine matches production branch policies and
@@ -86,10 +87,39 @@ flowchart LR
 | `meta-agentic-program-synthesis-report.md` | Narrative dossier with Mermaid diagrams, tables, and mission metadata. |
 | `meta-agentic-program-synthesis-summary.json` | Machine-readable synthesis metrics, pipelines, and archive excerpts. |
 | `meta-agentic-program-synthesis-dashboard.html` | Executive UI with live Mermaid rendering and embedded JSON manifest. |
+| `meta-agentic-program-synthesis-triangulation.json` | Multi-perspective verification digest (consensus, confidences, per-perspective evidence). |
 | `meta-agentic-program-synthesis-manifest.json` | SHA-256 manifest of every artefact for audit trails. |
 | `meta-agentic-program-synthesis-ci.json` | CI workflow verification report (lint/tests/foundry/coverage). |
 | `meta-agentic-program-synthesis-owner-diagnostics.{json,md}` | Owner readiness, command outputs, and sentinel status. |
 | `meta-agentic-program-synthesis-full.{json,md}` | Aggregate timeline of the run, CI verdict, diagnostics, and artefact index. |
+
+## Triple-verification sentinel
+
+```mermaid
+flowchart TD
+  Candidate[[Elite Agent Pipeline]]:::core --> Replay[Deterministic Replay]:::verify
+  Candidate --> Baseline[Baseline Dominance]:::verify
+  Candidate --> Stability[Adversarial Jitter]:::verify
+  Candidate --> Governance[Governance & Thermodynamics]:::verify
+  Replay --> Verdict{Consensus Engine}:::decision
+  Baseline --> Verdict
+  Stability --> Verdict
+  Governance --> Verdict
+  Verdict -->|Confidence & alerts| Owner((Owner Command Surface)):::role
+  Verdict --> Archive[[Triangulation Digest]]:::archive
+  classDef core fill:#111827,stroke:#a855f7,stroke-width:2px,color:#f5f3ff;
+  classDef verify fill:#0b7285,stroke:#66d9e8,stroke-width:2px,color:#e6fcf5;
+  classDef decision fill:#1f2933,stroke:#fcd34d,stroke-width:2px,color:#fef08a;
+  classDef role fill:#0f172a,stroke:#38bdf8,stroke-width:2px,color:#f8fafc;
+  classDef archive fill:#1e3a8a,stroke:#f59e0b,stroke-width:2px,color:#fef3c7;
+```
+
+- **Replay** checks for deterministic agreement with the scoring engine and exposes hidden state drift.
+- **Baseline dominance** proves the evolved agent beats the deterministic mission seeds by a material margin.
+- **Adversarial jitter** injects bounded noise to ensure the pipeline remains stable under perturbations.
+- **Governance guard** enforces allowlisted operations, thermodynamic expectations, and elite peer dominance before the owner accepts the result.
+
+The digest exported in `meta-agentic-program-synthesis-triangulation.json` lists every perspective, delta, and confidence score so auditors can replay the verdict independently.
 
 ## Power knobs for operators
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/runSynthesis.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/runSynthesis.ts
@@ -11,6 +11,7 @@ const REPORT_FILE = path.join(REPORT_DIR, "meta-agentic-program-synthesis-report
 const SUMMARY_FILE = path.join(REPORT_DIR, "meta-agentic-program-synthesis-summary.json");
 const DASHBOARD_FILE = path.join(REPORT_DIR, "meta-agentic-program-synthesis-dashboard.html");
 const MANIFEST_FILE = path.join(REPORT_DIR, "meta-agentic-program-synthesis-manifest.json");
+const TRIANGULATION_FILE = path.join(REPORT_DIR, "meta-agentic-program-synthesis-triangulation.json");
 
 export interface RunOptions {
   missionFile?: string;
@@ -19,6 +20,7 @@ export interface RunOptions {
   summaryFile?: string;
   dashboardFile?: string;
   manifestFile?: string;
+  triangulationFile?: string;
 }
 
 function resolveOptions(options: RunOptions = {}): Required<RunOptions> {
@@ -28,7 +30,8 @@ function resolveOptions(options: RunOptions = {}): Required<RunOptions> {
   const summaryFile = path.resolve(options.summaryFile ?? SUMMARY_FILE);
   const dashboardFile = path.resolve(options.dashboardFile ?? DASHBOARD_FILE);
   const manifestFile = path.resolve(options.manifestFile ?? MANIFEST_FILE);
-  return { missionFile, reportDir, reportFile, summaryFile, dashboardFile, manifestFile };
+  const triangulationFile = path.resolve(options.triangulationFile ?? TRIANGULATION_FILE);
+  return { missionFile, reportDir, reportFile, summaryFile, dashboardFile, manifestFile, triangulationFile };
 }
 
 export async function executeSynthesis(options: RunOptions = {}): Promise<SynthesisRun> {
@@ -41,6 +44,7 @@ export async function executeSynthesis(options: RunOptions = {}): Promise<Synthe
     markdownFile: resolved.reportFile,
     jsonFile: resolved.summaryFile,
     htmlFile: resolved.dashboardFile,
+    triangulationFile: resolved.triangulationFile,
   });
   await updateManifest(resolved.manifestFile, files);
   return run;
@@ -72,6 +76,7 @@ async function main(): Promise<void> {
   console.log(`   Markdown report: ${resolveOptions(cliOptions).reportFile}`);
   console.log(`   JSON summary: ${resolveOptions(cliOptions).summaryFile}`);
   console.log(`   Dashboard: ${resolveOptions(cliOptions).dashboardFile}`);
+  console.log(`   Triangulation digest: ${resolveOptions(cliOptions).triangulationFile}`);
   console.log(`   Manifest: ${resolveOptions(cliOptions).manifestFile}`);
   console.log(
     `   Aggregate → score ${run.aggregate.globalBestScore.toFixed(2)}, accuracy ${(run.aggregate.averageAccuracy * 100).toFixed(2)}%, novelty ${(run.aggregate.noveltyScore * 100).toFixed(1)}%`,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/types.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/types.ts
@@ -116,6 +116,28 @@ export interface CandidateRecord {
   generation: number;
 }
 
+export interface VerificationPerspective {
+  id: string;
+  label: string;
+  method: string;
+  passed: boolean;
+  confidence: number;
+  scoreDelta?: number;
+  accuracyDelta?: number;
+  noveltyDelta?: number;
+  energyDelta?: number;
+  notes?: string;
+}
+
+export interface TriangulationReport {
+  candidateId: string;
+  consensus: "confirmed" | "attention" | "rejected";
+  confidence: number;
+  passed: number;
+  total: number;
+  perspectives: VerificationPerspective[];
+}
+
 export interface GenerationSnapshot {
   generation: number;
   bestScore: number;
@@ -138,6 +160,7 @@ export interface TaskResult {
   elites: CandidateRecord[];
   history: GenerationSnapshot[];
   archive: ArchiveCell[];
+  triangulation: TriangulationReport;
 }
 
 export interface SynthesisRun {
@@ -152,5 +175,11 @@ export interface SynthesisRun {
     energyUsage: number;
     noveltyScore: number;
     coverageScore: number;
+    triangulationConfidence: number;
+    consensus: {
+      confirmed: number;
+      attention: number;
+      rejected: number;
+    };
   };
 }


### PR DESCRIPTION
## Summary
- add multi-perspective triangulation reporting and consensus tracking to the meta-agentic synthesis engine
- surface the new verification evidence across markdown, HTML dashboards, manifest outputs, and the full pipeline summary
- document the triple-verification workflow and updated artefacts in the demo readme for non-technical users

## Testing
- npm run demo:meta-agentic-program-synthesis
- npm run demo:meta-agentic-program-synthesis:full
- npm run format:check *(fails: repository has pre-existing prettier warnings outside touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68f6e565bc8883339f9b29a2cec6ebb2