### PR TITLE
Fix owner command detection in meta-agentic demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/fullPipeline.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/fullPipeline.ts
@@ -186,8 +186,19 @@ async function verifyCi(mission: MissionConfig): Promise<{
 
 function inspectCommand(command: string, scripts: Record<string, string | undefined>): boolean {
   const trimmed = command.trim();
-  if (trimmed.startsWith("npm run ")) {
-    const [, , scriptName] = trimmed.split(/\s+/, 3);
+  const tokens = trimmed.split(/\s+/).filter((token) => token.length > 0);
+  if (tokens.length >= 2 && tokens[0] === "npm" && tokens[1] === "run") {
+    let index = 2;
+    while (index < tokens.length && tokens[index].startsWith("-") && tokens[index] !== "--") {
+      index += 1;
+    }
+    if (index < tokens.length && tokens[index] === "--") {
+      index += 1;
+    }
+    if (index >= tokens.length) {
+      return false;
+    }
+    const scriptName = tokens[index];
     return Boolean(scriptName && scripts[scriptName]);
   }
   if (trimmed.startsWith("npx ")) {


### PR DESCRIPTION
## Summary
- improve the owner capability inspection in the meta-agentic program synthesis demo so `npm run` commands with flags/arguments are recognised
- keep owner readiness reporting aligned with the mission manifest by treating seeded scripts as available when present in package.json

## Testing
- npm run demo:meta-agentic-program-synthesis:full

------
https://chatgpt.com/codex/tasks/task_e_68f6ec5963988333b3b67892de311ce4