### PR TITLE
Add ledger orchestration to meta-agentic synthesis demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -68,6 +68,8 @@ flowchart LR
   mission manifest.
 - **Thermodynamic sentinel** – aggregate alignment telemetry quantifies per-task energy drift and surfaces green/yellow/red
   status directly in the Markdown dossier and executive dashboard.
+- **Commit–reveal ledger** – every task ships with a deterministic staking, validation, and reward transcript so owners can audit
+  slashing, treasury returns, and validator payouts.
 
 ## Owner supremacy proof points
 
@@ -94,6 +96,7 @@ flowchart LR
 | `meta-agentic-program-synthesis-ci.json` | CI workflow verification report (lint/tests/foundry/coverage). |
 | `meta-agentic-program-synthesis-owner-diagnostics.{json,md}` | Owner readiness, command outputs, and sentinel status. |
 | `meta-agentic-program-synthesis-full.{json,md}` | Aggregate timeline of the run, CI verdict, diagnostics, and artefact index. |
+| `meta-agentic-program-synthesis-summary.json` → `ledger` | Commit–reveal attempts, validator rewards, and treasury routing (embedded section). |
 
 ## Triple-verification sentinel
 
@@ -120,8 +123,34 @@ flowchart TD
 - **Baseline dominance** proves the evolved agent beats the deterministic mission seeds by a material margin.
 - **Adversarial jitter** injects bounded noise to ensure the pipeline remains stable under perturbations.
 - **Governance guard** enforces allowlisted operations, thermodynamic expectations, and elite peer dominance before the owner accepts the result.
+- **Ledger consensus** verifies validator-weighted commit–reveal paths and slashing outcomes before rewards move on-chain.
 
 The digest exported in `meta-agentic-program-synthesis-triangulation.json` lists every perspective, delta, and confidence score so auditors can replay the verdict independently.
+
+## Commit–reveal orchestration
+
+```mermaid
+flowchart LR
+  Owner((Owner)):::role --> JobRegistry{Job Registry}:::core
+  JobRegistry -->|Stake requirement| SolverA[Attempt 1 – legacy solver]:::warn
+  SolverA --> Validators[Validator Council]:::governance
+  Validators -->|Reject + slash| Slash[(Stake slashed)]:::warn
+  Slash --> JobRegistry
+  JobRegistry --> SolverB[Attempt 2 – evolved solver]:::core
+  SolverB --> Validators
+  Validators -->|Commit → reveal → approve| Consensus{{Consensus Finalised}}:::verify
+  Consensus --> Rewards[(Thermodynamic Rewards)]:::core
+  Rewards --> SolverB
+  Rewards --> Validators
+  Rewards --> Treasury[[Treasury return]]:::governance
+  classDef role fill:#0f172a,stroke:#38bdf8,stroke-width:2px,color:#f8fafc;
+  classDef core fill:#111827,stroke:#a855f7,stroke-width:2px,color:#f5f3ff;
+  classDef warn fill:#7f1d1d,stroke:#fecaca,stroke-width:2px,color:#fee2e2;
+  classDef governance fill:#1f2937,stroke:#22d3ee,stroke-width:2px,color:#e0f2fe;
+  classDef verify fill:#0b7285,stroke:#66d9e8,stroke-width:2px,color:#e6fcf5;
+```
+
+Every generated report embeds the ledger validator table, commit/reveal timeline, and reward breakdown so auditors can inspect stake movements without touching TypeScript.
 
 ## Power knobs for operators
 
@@ -140,6 +169,12 @@ npm run demo:meta-agentic-program-synthesis
 
 # Full pipeline with CI + owner diagnostics
 npm run demo:meta-agentic-program-synthesis:full
+
+# Validate ledger simulation invariants
+npm run demo:meta-agentic-program-synthesis:test
+
+# Inspect ledger section quickly
+jq '.tasks[0].ledger.summary' demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json
 ```
 
 Set `AGI_META_PROGRAM_MISSION=/path/to/custom.json` to target a modified mission file.

--- a/demo/Meta-Agentic-Program-Synthesis-v0/RUNBOOK.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/RUNBOOK.md
@@ -29,6 +29,7 @@ The launcher exports `AGI_META_PROGRAM_MISSION` and `AGI_OWNER_DIAGNOSTICS_OFFLI
 - Markdown dossier: `demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md`
 - Executive dashboard: `.../meta-agentic-program-synthesis-dashboard.html`
 - JSON summary: `.../meta-agentic-program-synthesis-summary.json`
+- Ledger transcript: `jq '.tasks[].ledger' .../meta-agentic-program-synthesis-summary.json`
 - Full-run bundle: `.../meta-agentic-program-synthesis-full.{json,md}`
 - CI verification: `.../meta-agentic-program-synthesis-ci.json`
 - Owner diagnostics: `.../meta-agentic-program-synthesis-owner-diagnostics.{json,md}`
@@ -66,10 +67,14 @@ All commands are idempotent offline. Point `HARDHAT_NETWORK` to a live network t
 npm run demo:meta-agentic-program-synthesis
 npm run demo:meta-agentic-program-synthesis:full
 jq '.' demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-ci.json
+npm run demo:meta-agentic-program-synthesis:test
+jq '.tasks[0].ledger.summary' demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json
 ```
 
 The CI report must confirm the workflow name `ci (v2)`, jobs `lint/tests/foundry/coverage`, `cancel-in-progress: true`, and
 coverage ≥90.
+
+The ledger test run asserts deterministic commit–reveal sequences, validator participation, and slashing behaviour before rewards move.
 
 ## 6. Custom missions
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html
@@ -31,6 +31,8 @@
       .owner-table { margin-top: 1rem; }
       ul.coverage { list-style: none; padding-left: 0; margin-top: 1rem; }
       ul.coverage li { margin-bottom: 0.35rem; }
+      ul.ledger-summary { list-style: disc; margin-left: 1.5rem; color: rgba(226, 232, 240, 0.9); }
+      ul.ledger-summary li { margin-bottom: 0.25rem; }
     </style>
   </head>
   <body>
@@ -45,6 +47,7 @@
         <div class="metric-card"><strong>Coverage</strong><br />100.00%</div>
         <div class="metric-card"><strong>Triangulation confidence</strong><br />53.33%</div>
         <div class="metric-card"><strong>Thermodynamic alignment</strong><br />100.00%<span class="metric-sub">Δ̄ 0.00 • Δmax 0.00 • 3 aligned / 0 monitor / 0 drift</span></div>
+        <div class="metric-card"><strong>Ledger rewards</strong><br />1,461,700<span class="metric-sub">Slashed 52,800 • Validators 186,600 • Treasury 93,300 • Participation 95.8%</span></div>
       </div>
     </header>
     <section>
@@ -81,6 +84,11 @@
   "Attention" : 0
   "Rejected" : 2
 </pre>
+    </section>
+    <section>
+      <h2>Ledger Economy</h2>
+      <p>Total rewards 1,461,700 • Slashed 52,800 • Validators 186,600 • Treasury 93,300</p>
+      <p>Average participation 95.8% • Average latency 250.2s • Consensus alerts 0</p>
     </section>
     <section>
       <h2>Owner Capabilities</h2>
@@ -200,16 +208,242 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for ARC Sentinel Edge Lift
-  2025-10-21T02:47:22.567Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
-  2025-10-21T02:47:22.568Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
-  2025-10-21T02:47:22.569Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
-  2025-10-21T02:47:22.570Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
-  2025-10-21T02:47:22.571Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
-  2025-10-21T02:47:22.573Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T02:47:22.574Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T02:47:22.574Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
-  2025-10-21T02:47:22.575Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
-  2025-10-21T02:47:22.576Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%</pre>
+  2025-10-21T03:23:20.682Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
+  2025-10-21T03:23:20.683Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
+  2025-10-21T03:23:20.684Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
+  2025-10-21T03:23:20.685Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
+  2025-10-21T03:23:20.686Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
+  2025-10-21T03:23:20.696Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T03:23:20.699Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T03:23:20.700Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
+  2025-10-21T03:23:20.704Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
+  2025-10-21T03:23:20.705Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%</pre>
+  </details>
+  <details>
+    <summary>On-chain Ledger</summary>
+    <ul class="ledger-summary"><li>Consensus: **ACCEPTED** across 2 attempts</li><li>Rewards paid: 394,800 (validators 50,400 | treasury 25,200)</li><li>Slashed stake: 14,400 | Participation 87.5%</li><li>Commit–reveal integrity: verified • Avg latency 247.0 seconds</li></ul>
+    <div class="table">
+<table class="ledger-validators">
+  <thead>
+    <tr>
+      <th>Validator</th>
+      <th>Stake (before)</th>
+      <th>Stake (after)</th>
+      <th>Rewards</th>
+      <th>Slashed</th>
+      <th>Participation</th>
+    </tr>
+  </thead>
+  <tbody>
+    
+        <tr>
+          <td>validator-195a5d4bfbdae573</td>
+          <td>52,687</td>
+          <td>65,287</td>
+          <td>12,600</td>
+          <td>0</td>
+          <td>100.0%</td>
+        </tr>
+      
+        <tr>
+          <td>validator-76bf560baa38ba87</td>
+          <td>53,186</td>
+          <td>65,786</td>
+          <td>12,600</td>
+          <td>0</td>
+          <td>100.0%</td>
+        </tr>
+      
+        <tr>
+          <td>validator-79c9d91afd1ddf92</td>
+          <td>60,772</td>
+          <td>73,372</td>
+          <td>12,600</td>
+          <td>0</td>
+          <td>100.0%</td>
+        </tr>
+      
+        <tr>
+          <td>validator-a93d1e2a9c0e3a2a</td>
+          <td>49,970</td>
+          <td>62,570</td>
+          <td>12,600</td>
+          <td>0</td>
+          <td>50.0%</td>
+        </tr>
+      
+  </tbody>
+</table></div>
+    <div class="table">
+<table class="ledger">
+  <thead>
+    <tr>
+      <th>Timestamp</th>
+      <th>Event</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    
+        <tr>
+          <td>2042-01-01T08:54:24.000Z</td>
+          <td>job_posted</td>
+          <td>jobId=ARC-SYN-001; reward=420,000; stakeRequired=120,000; description=Detect latent pixel edges, amplify discovery, and route high-confidence transformations back into the shared skill graph.</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:55:09.000Z</td>
+          <td>solver_selected</td>
+          <td>solverId=solver-834077d2c7cd0093; stakePosted=120,000</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:55:44.000Z</td>
+          <td>result_committed</td>
+          <td>solverId=solver-834077d2c7cd0093; commit=cdccfe1d1ecc488574b306b0afa622e76d4619196d444d00ed36bc17317dba16</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:55:54.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-195a5d4bfbdae573; commitment=6a13cc921e0d27d543a1f1a7b80eb4fa2b75c0525449b8f73a219358fdeb5116</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:56:09.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-195a5d4bfbdae573; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:56:20.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-76bf560baa38ba87; commitment=ff5cf0e04b2467375ef805362e542c143abea25b2bb7bb443515daa8dc3f1354</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:56:31.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-76bf560baa38ba87; vote=no</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:56:42.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-79c9d91afd1ddf92; commitment=95fe40173c0a29a739e2d0fa2d0105c755fb04b43e3532d8c310c35ce472c1d2</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:56:52.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-79c9d91afd1ddf92; vote=no</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:57:08.000Z</td>
+          <td>consensus_finalised</td>
+          <td>attempt=1; solverId=solver-834077d2c7cd0093; consensus=rejected; yesWeight=52,687</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:57:14.000Z</td>
+          <td>slash_applied</td>
+          <td>solverId=solver-834077d2c7cd0093; amount=14,400; reason=Failed consensus</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:57:26.000Z</td>
+          <td>requeue</td>
+          <td>solverId=solver-85b7571cb9684c4c; reason=Meta-architect escalated to evolved agent</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:57:30.000Z</td>
+          <td>solver_selected</td>
+          <td>solverId=solver-85b7571cb9684c4c; stakePosted=120,000</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:58:02.000Z</td>
+          <td>result_committed</td>
+          <td>solverId=solver-85b7571cb9684c4c; commit=a71fc6a4d27f9928547e7c9286a86675979d6854026355e0559ce8baf2e50211; operations=4</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:58:13.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-195a5d4bfbdae573; commitment=c0e7ac904a95f3b6b07a2d8458d1be1ea31b81714501555ef6da2be49ddaadce</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:58:24.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-195a5d4bfbdae573; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:58:33.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-76bf560baa38ba87; commitment=ba808148dada8a23c0977f5798f313954ad76c389605df96d26cab84f14ea32a</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:58:46.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-76bf560baa38ba87; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:58:55.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-79c9d91afd1ddf92; commitment=9d1ce6a17520b9b429f727eeb800908b5a13200a307782f3a8874baf70f96c11</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:59:08.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-79c9d91afd1ddf92; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:59:16.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-a93d1e2a9c0e3a2a; commitment=d112ff2b6d9545978359f988200e0c135e6b7c05e0812b51815198a85b53a97f</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:59:28.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-a93d1e2a9c0e3a2a; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:59:42.000Z</td>
+          <td>consensus_finalised</td>
+          <td>attempt=2; solverId=solver-85b7571cb9684c4c; consensus=accepted; yesWeight=216,615</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T08:59:54.000Z</td>
+          <td>reward_distributed</td>
+          <td>solverId=solver-85b7571cb9684c4c; solverReward=344,400; validatorRewards=50,400; treasuryReturn=25,200</td>
+        </tr>
+      
+  </tbody>
+</table></div>
+    <pre class="mermaid">flowchart LR
+  Job((Job ARC-SYN-001)):::core --> AttemptA[Attempt 1\nsolver-834077d2c7cd0093]:::warn
+  AttemptA -->|Consensus rejected| Slash[(Slash)]:::warn
+  AttemptA -->|Requeue| AttemptB[Attempt 2\nsolver-85b7571cb9684c4c]:::core
+  AttemptB -->|Validators| Consensus{Final consensus}:::verify
+  Consensus --> Reward[(Reward Distribution)]:::core
+  Reward --> Treasury[Treasury Return]:::governance
+  Reward --> Validators[Validator Rewards]:::governance
+  Reward --> Solver[Evolved Solver Payout]:::core
+  classDef core fill:#111827,stroke:#a855f7,stroke-width:2px,color:#f5f3ff;
+  classDef warn fill:#7f1d1d,stroke:#fecaca,stroke-width:2px,color:#fecaca;
+  classDef verify fill:#0b7285,stroke:#66d9e8,stroke-width:2px,color:#e6fcf5;
+  classDef governance fill:#1f2937,stroke:#22d3ee,stroke-width:2px,color:#e0f2fe;</pre>
   </details>
 </section>
 
@@ -312,16 +546,254 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for Ledger Harmonics Sequencer
-  2025-10-21T02:47:22.578Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
-  2025-10-21T02:47:22.579Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
-  2025-10-21T02:47:22.580Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
-  2025-10-21T02:47:22.581Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T02:47:22.581Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T02:47:22.582Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T02:47:22.583Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T02:47:22.584Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T02:47:22.585Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T02:47:22.585Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%</pre>
+  2025-10-21T03:23:20.716Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
+  2025-10-21T03:23:20.717Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
+  2025-10-21T03:23:20.718Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
+  2025-10-21T03:23:20.719Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T03:23:20.725Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T03:23:20.726Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T03:23:20.727Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T03:23:20.727Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T03:23:20.728Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T03:23:20.728Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%</pre>
+  </details>
+  <details>
+    <summary>On-chain Ledger</summary>
+    <ul class="ledger-summary"><li>Consensus: **ACCEPTED** across 2 attempts</li><li>Rewards paid: 493,500 (validators 63,000 | treasury 31,500)</li><li>Slashed stake: 18,600 | Participation 100.0%</li><li>Commit–reveal integrity: verified • Avg latency 270.0 seconds</li></ul>
+    <div class="table">
+<table class="ledger-validators">
+  <thead>
+    <tr>
+      <th>Validator</th>
+      <th>Stake (before)</th>
+      <th>Stake (after)</th>
+      <th>Rewards</th>
+      <th>Slashed</th>
+      <th>Participation</th>
+    </tr>
+  </thead>
+  <tbody>
+    
+        <tr>
+          <td>validator-02b303e331d093d1</td>
+          <td>60,555</td>
+          <td>76,305</td>
+          <td>15,750</td>
+          <td>0</td>
+          <td>100.0%</td>
+        </tr>
+      
+        <tr>
+          <td>validator-8fb387f22ab17dbb</td>
+          <td>77,689</td>
+          <td>93,439</td>
+          <td>15,750</td>
+          <td>0</td>
+          <td>100.0%</td>
+        </tr>
+      
+        <tr>
+          <td>validator-b48c4f3bd017c796</td>
+          <td>60,967</td>
+          <td>76,717</td>
+          <td>15,750</td>
+          <td>0</td>
+          <td>100.0%</td>
+        </tr>
+      
+        <tr>
+          <td>validator-f3cbd6e75978a4b6</td>
+          <td>78,620</td>
+          <td>94,370</td>
+          <td>15,750</td>
+          <td>0</td>
+          <td>100.0%</td>
+        </tr>
+      
+  </tbody>
+</table></div>
+    <div class="table">
+<table class="ledger">
+  <thead>
+    <tr>
+      <th>Timestamp</th>
+      <th>Event</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    
+        <tr>
+          <td>2042-01-01T13:16:24.000Z</td>
+          <td>job_posted</td>
+          <td>jobId=LEDGER-SYN-007; reward=525,000; stakeRequired=155,000; description=Absorb asynchronous cash-flow deltas, stabilise them against the thermodynamic ledger, and emit rebalanced incentive curves for validator coalitions.</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:17:09.000Z</td>
+          <td>solver_selected</td>
+          <td>solverId=solver-424046f71a035fe6; stakePosted=155,000</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:17:44.000Z</td>
+          <td>result_committed</td>
+          <td>solverId=solver-424046f71a035fe6; commit=3a489a39a4ac760eea4e21600c7db814fc7ef4e73499a6f0e7c200e447c856d5</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:17:55.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-02b303e331d093d1; commitment=386876e8b46f541afba7e9ba7981dc0e41940b840db1165200b4fc64be00fa49</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:18:08.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-02b303e331d093d1; vote=no</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:18:17.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-8fb387f22ab17dbb; commitment=d26aaf535bef21fa45371b67e612ecbf4724c3beceefe3b1a7c4771a699ff16c</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:18:31.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-8fb387f22ab17dbb; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:18:41.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-b48c4f3bd017c796; commitment=811943ed1d5afdf34e266be81f71f2fddee8d3426f4d5f4ae04b55056f5f3021</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:18:53.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-b48c4f3bd017c796; vote=no</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:19:05.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-f3cbd6e75978a4b6; commitment=df4080472bf5202c53c8cb11c5b947306a9a14c0bf8db697cf7d132e6fe4329d</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:19:17.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-f3cbd6e75978a4b6; vote=no</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:19:33.000Z</td>
+          <td>consensus_finalised</td>
+          <td>attempt=1; solverId=solver-424046f71a035fe6; consensus=rejected; yesWeight=77,689</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:19:39.000Z</td>
+          <td>slash_applied</td>
+          <td>solverId=solver-424046f71a035fe6; amount=18,600; reason=Failed consensus</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:19:51.000Z</td>
+          <td>requeue</td>
+          <td>solverId=solver-04c1f887eae22b1e; reason=Meta-architect escalated to evolved agent</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:19:55.000Z</td>
+          <td>solver_selected</td>
+          <td>solverId=solver-04c1f887eae22b1e; stakePosted=155,000</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:20:27.000Z</td>
+          <td>result_committed</td>
+          <td>solverId=solver-04c1f887eae22b1e; commit=ebda15b38d5047ceaade3779010231933171b8cdb316da86dbb9e61379be79fa; operations=3</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:20:37.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-02b303e331d093d1; commitment=a9ff81a696c9a6329240f07cca03b7d28a3d6b7674cf7706e5c465ec3e792d4e</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:20:50.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-02b303e331d093d1; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:21:01.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-8fb387f22ab17dbb; commitment=781a3ed0c6d16a9f5f6540199d91856aacd60d7ebbc832febf25e052a62f4f5c</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:21:10.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-8fb387f22ab17dbb; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:21:19.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-b48c4f3bd017c796; commitment=39593093be96192e274a31d636936a404d09f149af4366a54a2b4b2fd463bb23</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:21:28.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-b48c4f3bd017c796; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:21:38.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-f3cbd6e75978a4b6; commitment=a1ead23f0685e364f8d70ef43d00c2e91a83cfda9a907ba1fa0b75579202cc58</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:21:49.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-f3cbd6e75978a4b6; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:22:03.000Z</td>
+          <td>consensus_finalised</td>
+          <td>attempt=2; solverId=solver-04c1f887eae22b1e; consensus=accepted; yesWeight=277,831</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T13:22:15.000Z</td>
+          <td>reward_distributed</td>
+          <td>solverId=solver-04c1f887eae22b1e; solverReward=430,500; validatorRewards=63,000; treasuryReturn=31,500</td>
+        </tr>
+      
+  </tbody>
+</table></div>
+    <pre class="mermaid">flowchart LR
+  Job((Job LEDGER-SYN-007)):::core --> AttemptA[Attempt 1\nsolver-424046f71a035fe6]:::warn
+  AttemptA -->|Consensus rejected| Slash[(Slash)]:::warn
+  AttemptA -->|Requeue| AttemptB[Attempt 2\nsolver-04c1f887eae22b1e]:::core
+  AttemptB -->|Validators| Consensus{Final consensus}:::verify
+  Consensus --> Reward[(Reward Distribution)]:::core
+  Reward --> Treasury[Treasury Return]:::governance
+  Reward --> Validators[Validator Rewards]:::governance
+  Reward --> Solver[Evolved Solver Payout]:::core
+  classDef core fill:#111827,stroke:#a855f7,stroke-width:2px,color:#f5f3ff;
+  classDef warn fill:#7f1d1d,stroke:#fecaca,stroke-width:2px,color:#fecaca;
+  classDef verify fill:#0b7285,stroke:#66d9e8,stroke-width:2px,color:#e6fcf5;
+  classDef governance fill:#1f2937,stroke:#22d3ee,stroke-width:2px,color:#e0f2fe;</pre>
   </details>
 </section>
 
@@ -424,16 +896,221 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for Nova Weave Sequence Optimiser
-  2025-10-21T02:47:22.586Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
-  2025-10-21T02:47:22.587Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
-  2025-10-21T02:47:22.587Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
-  2025-10-21T02:47:22.588Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
-  2025-10-21T02:47:22.589Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
-  2025-10-21T02:47:22.589Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
-  2025-10-21T02:47:22.597Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
-  2025-10-21T02:47:22.598Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
-  2025-10-21T02:47:22.598Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
-  2025-10-21T02:47:22.599Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%</pre>
+  2025-10-21T03:23:20.730Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
+  2025-10-21T03:23:20.731Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
+  2025-10-21T03:23:20.731Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
+  2025-10-21T03:23:20.732Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
+  2025-10-21T03:23:20.733Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
+  2025-10-21T03:23:20.733Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
+  2025-10-21T03:23:20.734Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
+  2025-10-21T03:23:20.734Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
+  2025-10-21T03:23:20.735Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T03:23:20.736Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%</pre>
+  </details>
+  <details>
+    <summary>On-chain Ledger</summary>
+    <ul class="ledger-summary"><li>Consensus: **ACCEPTED** across 2 attempts</li><li>Rewards paid: 573,400 (validators 73,200 | treasury 36,600)</li><li>Slashed stake: 19,800 | Participation 100.0%</li><li>Commit–reveal integrity: verified • Avg latency 233.5 seconds</li></ul>
+    <div class="table">
+<table class="ledger-validators">
+  <thead>
+    <tr>
+      <th>Validator</th>
+      <th>Stake (before)</th>
+      <th>Stake (after)</th>
+      <th>Rewards</th>
+      <th>Slashed</th>
+      <th>Participation</th>
+    </tr>
+  </thead>
+  <tbody>
+    
+        <tr>
+          <td>validator-998a4f56b41c1653</td>
+          <td>85,872</td>
+          <td>110,272</td>
+          <td>24,400</td>
+          <td>0</td>
+          <td>100.0%</td>
+        </tr>
+      
+        <tr>
+          <td>validator-9d05a69084156cb4</td>
+          <td>68,211</td>
+          <td>92,611</td>
+          <td>24,400</td>
+          <td>0</td>
+          <td>100.0%</td>
+        </tr>
+      
+        <tr>
+          <td>validator-d3dc9de91651750d</td>
+          <td>58,085</td>
+          <td>82,485</td>
+          <td>24,400</td>
+          <td>0</td>
+          <td>100.0%</td>
+        </tr>
+      
+  </tbody>
+</table></div>
+    <div class="table">
+<table class="ledger">
+  <thead>
+    <tr>
+      <th>Timestamp</th>
+      <th>Event</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    
+        <tr>
+          <td>2042-01-01T07:29:20.000Z</td>
+          <td>job_posted</td>
+          <td>jobId=NOVA-SYN-009; reward=610,000; stakeRequired=165,000; description=Elevate alpha sequences into deterministic blueprints that compile into on-chain production payloads with zero manual edits.</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:30:05.000Z</td>
+          <td>solver_selected</td>
+          <td>solverId=solver-df8d72feae9e0558; stakePosted=165,000</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:30:40.000Z</td>
+          <td>result_committed</td>
+          <td>solverId=solver-df8d72feae9e0558; commit=53ccd0481295cff8b777e9e746537f782210d0d6634463a6ee45af55c9df399c</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:30:49.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-998a4f56b41c1653; commitment=b1c8d5fb8311d466fe88c58b0121b6c45662d842bf31bfe7485ceae3038ccd8c</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:31:00.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-998a4f56b41c1653; vote=no</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:31:10.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-9d05a69084156cb4; commitment=4657fd854d9a91e5f21ab296f043f3cb95e3e701e4a80fb5c7fc3a5bfef81729</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:31:23.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-9d05a69084156cb4; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:31:32.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-d3dc9de91651750d; commitment=b4affd948c6de5ef384077b29023dd77a88c6af547d1f8308a27ad6a0895ced4</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:31:47.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-d3dc9de91651750d; vote=no</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:32:03.000Z</td>
+          <td>consensus_finalised</td>
+          <td>attempt=1; solverId=solver-df8d72feae9e0558; consensus=rejected; yesWeight=68,211</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:32:09.000Z</td>
+          <td>slash_applied</td>
+          <td>solverId=solver-df8d72feae9e0558; amount=19,800; reason=Failed consensus</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:32:21.000Z</td>
+          <td>requeue</td>
+          <td>solverId=solver-b0ce6e46ec6aee31; reason=Meta-architect escalated to evolved agent</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:32:25.000Z</td>
+          <td>solver_selected</td>
+          <td>solverId=solver-b0ce6e46ec6aee31; stakePosted=165,000</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:32:57.000Z</td>
+          <td>result_committed</td>
+          <td>solverId=solver-b0ce6e46ec6aee31; commit=ec051e8ee05f18e96d72bcc879d6325db1bba43c808cc42dfbe7895eabdea108; operations=3</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:33:04.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-998a4f56b41c1653; commitment=76f6ee53383c2999cbe79913a5f6167c4ca686cdc3e266a2e28c96fea559c37a</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:33:15.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-998a4f56b41c1653; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:33:25.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-9d05a69084156cb4; commitment=8976703d78e5c6073ca9f883c7e6593a311201bf7e021cdfd02726cb0d218003</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:33:35.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-9d05a69084156cb4; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:33:46.000Z</td>
+          <td>vote_commit</td>
+          <td>validator=validator-d3dc9de91651750d; commitment=3cb52a63d7218a3eaa12727a77ed6b8e3c2261ed8db9007f22ec5ce0849c7d8d</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:33:58.000Z</td>
+          <td>vote_reveal</td>
+          <td>validator=validator-d3dc9de91651750d; vote=yes</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:34:12.000Z</td>
+          <td>consensus_finalised</td>
+          <td>attempt=2; solverId=solver-b0ce6e46ec6aee31; consensus=accepted; yesWeight=212,168</td>
+        </tr>
+      
+        <tr>
+          <td>2042-01-01T07:34:24.000Z</td>
+          <td>reward_distributed</td>
+          <td>solverId=solver-b0ce6e46ec6aee31; solverReward=500,200; validatorRewards=73,200; treasuryReturn=36,600</td>
+        </tr>
+      
+  </tbody>
+</table></div>
+    <pre class="mermaid">flowchart LR
+  Job((Job NOVA-SYN-009)):::core --> AttemptA[Attempt 1\nsolver-df8d72feae9e0558]:::warn
+  AttemptA -->|Consensus rejected| Slash[(Slash)]:::warn
+  AttemptA -->|Requeue| AttemptB[Attempt 2\nsolver-b0ce6e46ec6aee31]:::core
+  AttemptB -->|Validators| Consensus{Final consensus}:::verify
+  Consensus --> Reward[(Reward Distribution)]:::core
+  Reward --> Treasury[Treasury Return]:::governance
+  Reward --> Validators[Validator Rewards]:::governance
+  Reward --> Solver[Evolved Solver Payout]:::core
+  classDef core fill:#111827,stroke:#a855f7,stroke-width:2px,color:#f5f3ff;
+  classDef warn fill:#7f1d1d,stroke:#fecaca,stroke-width:2px,color:#fecaca;
+  classDef verify fill:#0b7285,stroke:#66d9e8,stroke-width:2px,color:#e6fcf5;
+  classDef governance fill:#1f2937,stroke:#22d3ee,stroke-width:2px,color:#e0f2fe;</pre>
   </details>
 </section>
     <section>
@@ -441,9 +1118,9 @@
       <p>Workflow <code>ci (v2)</code> | Required jobs: Lint &amp; static checks, Tests, Foundry, Coverage thresholds</p>
       <p>Coverage ≥ 90% | Concurrency group <code>ci-${{ github.workflow }}-${{ github.ref }}</code></p>
     </section>
-    <footer>Generated 2025-10-21T02:47:22.562Z • JSON summary embedded below</footer>
+    <footer>Generated 2025-10-21T03:23:20.678Z • JSON summary embedded below</footer>
     <script id="meta-agentic-summary" type="application/json">{
-  &quot;generatedAt&quot;: &quot;2025-10-21T02:47:22.562Z&quot;,
+  &quot;generatedAt&quot;: &quot;2025-10-21T03:23:20.678Z&quot;,
   &quot;mission&quot;: {
     &quot;title&quot;: &quot;Meta-Agentic Program Synthesis Sovereign Mission&quot;,
     &quot;version&quot;: &quot;0.1.0&quot;,
@@ -492,6 +1169,16 @@
         &quot;monitor&quot;: 0,
         &quot;drift&quot;: 0
       }
+    },
+    &quot;ledger&quot;: {
+      &quot;totalRewardPaid&quot;: 1461700,
+      &quot;totalSlashed&quot;: 52800,
+      &quot;validatorRewards&quot;: 186600,
+      &quot;treasuryReturn&quot;: 93300,
+      &quot;averageParticipationRate&quot;: 0.9583333333333334,
+      &quot;averageLatencySeconds&quot;: 250.16666666666666,
+      &quot;accepted&quot;: 3,
+      &quot;consensusAlerts&quot;: 0
     }
   },
   &quot;ownerCoverage&quot;: {
@@ -738,7 +1425,7 @@
           &quot;medianScore&quot;: 56.19020618556701,
           &quot;diversity&quot;: 0.9444444444444444,
           &quot;eliteScore&quot;: 110.36140657817333,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.567Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.682Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -747,7 +1434,7 @@
           &quot;medianScore&quot;: 65.75277564301642,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 136.39087455307794,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.568Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.683Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -756,7 +1443,7 @@
           &quot;medianScore&quot;: 73.64584551701412,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 138.12283331596453,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.569Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.684Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -765,7 +1452,7 @@
           &quot;medianScore&quot;: 100.49230198051038,
           &quot;diversity&quot;: 0.8333333333333334,
           &quot;eliteScore&quot;: 138.41149310977895,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.570Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.685Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -774,7 +1461,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.6944444444444444,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.571Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.686Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -783,7 +1470,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.573Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.696Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -792,7 +1479,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.574Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.699Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -801,7 +1488,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.574Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.700Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -810,7 +1497,7 @@
           &quot;medianScore&quot;: 116.57704853345733,
           &quot;diversity&quot;: 0.8055555555555556,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.575Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.704Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -819,7 +1506,7 @@
           &quot;medianScore&quot;: 137.1920690409011,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.576Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.705Z&quot;
         }
       ],
       &quot;triangulation&quot;: {
@@ -866,6 +1553,351 @@
             &quot;confidence&quot;: 0.2,
             &quot;energyDelta&quot;: 8,
             &quot;notes&quot;: &quot;Peer median 140.38 • energy delta 8.00 (≤ 33.60)&quot;
+          }
+        ]
+      },
+      &quot;ledger&quot;: {
+        &quot;summary&quot;: {
+          &quot;finalConsensus&quot;: &quot;accepted&quot;,
+          &quot;totalRewardPaid&quot;: 394800,
+          &quot;totalSlashed&quot;: 14400,
+          &quot;validatorRewards&quot;: 50400,
+          &quot;treasuryReturn&quot;: 25200,
+          &quot;averageLatencySeconds&quot;: 247,
+          &quot;participationRate&quot;: 0.875,
+          &quot;commitRevealIntegrity&quot;: &quot;verified&quot;,
+          &quot;attempts&quot;: 2
+        },
+        &quot;validators&quot;: [
+          {
+            &quot;validatorId&quot;: &quot;validator-195a5d4bfbdae573&quot;,
+            &quot;stakeBefore&quot;: 52687,
+            &quot;stakeAfter&quot;: 65287,
+            &quot;rewardEarned&quot;: 12600,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 1
+          },
+          {
+            &quot;validatorId&quot;: &quot;validator-76bf560baa38ba87&quot;,
+            &quot;stakeBefore&quot;: 53186,
+            &quot;stakeAfter&quot;: 65786,
+            &quot;rewardEarned&quot;: 12600,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 1
+          },
+          {
+            &quot;validatorId&quot;: &quot;validator-79c9d91afd1ddf92&quot;,
+            &quot;stakeBefore&quot;: 60772,
+            &quot;stakeAfter&quot;: 73372,
+            &quot;rewardEarned&quot;: 12600,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 1
+          },
+          {
+            &quot;validatorId&quot;: &quot;validator-a93d1e2a9c0e3a2a&quot;,
+            &quot;stakeBefore&quot;: 49970,
+            &quot;stakeAfter&quot;: 62570,
+            &quot;rewardEarned&quot;: 12600,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 0.5
+          }
+        ],
+        &quot;attempts&quot;: [
+          {
+            &quot;attemptId&quot;: &quot;arc-sentinel-attempt-1&quot;,
+            &quot;solverId&quot;: &quot;solver-834077d2c7cd0093&quot;,
+            &quot;status&quot;: &quot;slashed&quot;,
+            &quot;commitHash&quot;: &quot;cdccfe1d1ecc488574b306b0afa622e76d4619196d444d00ed36bc17317dba16&quot;,
+            &quot;reveal&quot;: &quot;insufficient-delta&quot;,
+            &quot;consensus&quot;: &quot;rejected&quot;,
+            &quot;rewardEarned&quot;: 0,
+            &quot;slashApplied&quot;: 14400,
+            &quot;latencySeconds&quot;: 164,
+            &quot;energyObserved&quot;: 70.4,
+            &quot;notes&quot;: &quot;Consensus rejected misaligned agent – stake partially slashed and job requeued.&quot;,
+            &quot;votes&quot;: [
+              {
+                &quot;validatorId&quot;: &quot;validator-195a5d4bfbdae573&quot;,
+                &quot;commitment&quot;: &quot;6a13cc921e0d27d543a1f1a7b80eb4fa2b75c0525449b8f73a219358fdeb5116&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 52687,
+                &quot;rewardEarned&quot;: 0,
+                &quot;slashed&quot;: 0
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-76bf560baa38ba87&quot;,
+                &quot;commitment&quot;: &quot;ff5cf0e04b2467375ef805362e542c143abea25b2bb7bb443515daa8dc3f1354&quot;,
+                &quot;revealed&quot;: &quot;no&quot;,
+                &quot;weight&quot;: 53186,
+                &quot;rewardEarned&quot;: 0,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Detected thermodynamic drift&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-79c9d91afd1ddf92&quot;,
+                &quot;commitment&quot;: &quot;95fe40173c0a29a739e2d0fa2d0105c755fb04b43e3532d8c310c35ce472c1d2&quot;,
+                &quot;revealed&quot;: &quot;no&quot;,
+                &quot;weight&quot;: 60772,
+                &quot;rewardEarned&quot;: 0,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Detected thermodynamic drift&quot;
+              }
+            ]
+          },
+          {
+            &quot;attemptId&quot;: &quot;arc-sentinel-attempt-2&quot;,
+            &quot;solverId&quot;: &quot;solver-85b7571cb9684c4c&quot;,
+            &quot;status&quot;: &quot;accepted&quot;,
+            &quot;commitHash&quot;: &quot;a71fc6a4d27f9928547e7c9286a86675979d6854026355e0559ce8baf2e50211&quot;,
+            &quot;reveal&quot;: &quot;arc-sentinel-g4-c166&quot;,
+            &quot;consensus&quot;: &quot;accepted&quot;,
+            &quot;rewardEarned&quot;: 344400,
+            &quot;slashApplied&quot;: 0,
+            &quot;latencySeconds&quot;: 330,
+            &quot;energyObserved&quot;: 88,
+            &quot;notes&quot;: &quot;Meta-agentic evolved solver achieved consensus and claimed rewards.&quot;,
+            &quot;votes&quot;: [
+              {
+                &quot;validatorId&quot;: &quot;validator-195a5d4bfbdae573&quot;,
+                &quot;commitment&quot;: &quot;c0e7ac904a95f3b6b07a2d8458d1be1ea31b81714501555ef6da2be49ddaadce&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 52687,
+                &quot;rewardEarned&quot;: 12600,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-76bf560baa38ba87&quot;,
+                &quot;commitment&quot;: &quot;ba808148dada8a23c0977f5798f313954ad76c389605df96d26cab84f14ea32a&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 53186,
+                &quot;rewardEarned&quot;: 12600,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-79c9d91afd1ddf92&quot;,
+                &quot;commitment&quot;: &quot;9d1ce6a17520b9b429f727eeb800908b5a13200a307782f3a8874baf70f96c11&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 60772,
+                &quot;rewardEarned&quot;: 12600,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-a93d1e2a9c0e3a2a&quot;,
+                &quot;commitment&quot;: &quot;d112ff2b6d9545978359f988200e0c135e6b7c05e0812b51815198a85b53a97f&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 49970,
+                &quot;rewardEarned&quot;: 12600,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              }
+            ]
+          }
+        ],
+        &quot;timeline&quot;: [
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:54:24.000Z&quot;,
+            &quot;type&quot;: &quot;job_posted&quot;,
+            &quot;details&quot;: {
+              &quot;jobId&quot;: &quot;ARC-SYN-001&quot;,
+              &quot;reward&quot;: 420000,
+              &quot;stakeRequired&quot;: 120000,
+              &quot;description&quot;: &quot;Detect latent pixel edges, amplify discovery, and route high-confidence transformations back into the shared skill graph.&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:55:09.000Z&quot;,
+            &quot;type&quot;: &quot;solver_selected&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-834077d2c7cd0093&quot;,
+              &quot;stakePosted&quot;: 120000
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:55:44.000Z&quot;,
+            &quot;type&quot;: &quot;result_committed&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-834077d2c7cd0093&quot;,
+              &quot;commit&quot;: &quot;cdccfe1d1ecc488574b306b0afa622e76d4619196d444d00ed36bc17317dba16&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:55:54.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-195a5d4bfbdae573&quot;,
+              &quot;commitment&quot;: &quot;6a13cc921e0d27d543a1f1a7b80eb4fa2b75c0525449b8f73a219358fdeb5116&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:56:09.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-195a5d4bfbdae573&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:56:20.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-76bf560baa38ba87&quot;,
+              &quot;commitment&quot;: &quot;ff5cf0e04b2467375ef805362e542c143abea25b2bb7bb443515daa8dc3f1354&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:56:31.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-76bf560baa38ba87&quot;,
+              &quot;vote&quot;: &quot;no&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:56:42.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-79c9d91afd1ddf92&quot;,
+              &quot;commitment&quot;: &quot;95fe40173c0a29a739e2d0fa2d0105c755fb04b43e3532d8c310c35ce472c1d2&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:56:52.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-79c9d91afd1ddf92&quot;,
+              &quot;vote&quot;: &quot;no&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:57:08.000Z&quot;,
+            &quot;type&quot;: &quot;consensus_finalised&quot;,
+            &quot;details&quot;: {
+              &quot;attempt&quot;: 1,
+              &quot;solverId&quot;: &quot;solver-834077d2c7cd0093&quot;,
+              &quot;consensus&quot;: &quot;rejected&quot;,
+              &quot;yesWeight&quot;: 52687
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:57:14.000Z&quot;,
+            &quot;type&quot;: &quot;slash_applied&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-834077d2c7cd0093&quot;,
+              &quot;amount&quot;: 14400,
+              &quot;reason&quot;: &quot;Failed consensus&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:57:26.000Z&quot;,
+            &quot;type&quot;: &quot;requeue&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-85b7571cb9684c4c&quot;,
+              &quot;reason&quot;: &quot;Meta-architect escalated to evolved agent&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:57:30.000Z&quot;,
+            &quot;type&quot;: &quot;solver_selected&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-85b7571cb9684c4c&quot;,
+              &quot;stakePosted&quot;: 120000
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:58:02.000Z&quot;,
+            &quot;type&quot;: &quot;result_committed&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-85b7571cb9684c4c&quot;,
+              &quot;commit&quot;: &quot;a71fc6a4d27f9928547e7c9286a86675979d6854026355e0559ce8baf2e50211&quot;,
+              &quot;operations&quot;: 4
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:58:13.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-195a5d4bfbdae573&quot;,
+              &quot;commitment&quot;: &quot;c0e7ac904a95f3b6b07a2d8458d1be1ea31b81714501555ef6da2be49ddaadce&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:58:24.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-195a5d4bfbdae573&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:58:33.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-76bf560baa38ba87&quot;,
+              &quot;commitment&quot;: &quot;ba808148dada8a23c0977f5798f313954ad76c389605df96d26cab84f14ea32a&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:58:46.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-76bf560baa38ba87&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:58:55.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-79c9d91afd1ddf92&quot;,
+              &quot;commitment&quot;: &quot;9d1ce6a17520b9b429f727eeb800908b5a13200a307782f3a8874baf70f96c11&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:59:08.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-79c9d91afd1ddf92&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:59:16.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-a93d1e2a9c0e3a2a&quot;,
+              &quot;commitment&quot;: &quot;d112ff2b6d9545978359f988200e0c135e6b7c05e0812b51815198a85b53a97f&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:59:28.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-a93d1e2a9c0e3a2a&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:59:42.000Z&quot;,
+            &quot;type&quot;: &quot;consensus_finalised&quot;,
+            &quot;details&quot;: {
+              &quot;attempt&quot;: 2,
+              &quot;solverId&quot;: &quot;solver-85b7571cb9684c4c&quot;,
+              &quot;consensus&quot;: &quot;accepted&quot;,
+              &quot;yesWeight&quot;: 216615
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T08:59:54.000Z&quot;,
+            &quot;type&quot;: &quot;reward_distributed&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-85b7571cb9684c4c&quot;,
+              &quot;solverReward&quot;: 344400,
+              &quot;validatorRewards&quot;: 50400,
+              &quot;treasuryReturn&quot;: 25200
+            }
           }
         ]
       }
@@ -1114,7 +2146,7 @@
           &quot;medianScore&quot;: 41.03751524896436,
           &quot;diversity&quot;: 0.9722222222222222,
           &quot;eliteScore&quot;: 96.0918022581709,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.578Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.716Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -1123,7 +2155,7 @@
           &quot;medianScore&quot;: 62.99975060567376,
           &quot;diversity&quot;: 0.9444444444444444,
           &quot;eliteScore&quot;: 98.43691088683215,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.579Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.717Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -1132,7 +2164,7 @@
           &quot;medianScore&quot;: 76.53115760829131,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 132.5084085000921,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.580Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.718Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -1141,7 +2173,7 @@
           &quot;medianScore&quot;: 77.95296283436663,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.581Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.719Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -1150,7 +2182,7 @@
           &quot;medianScore&quot;: 86.94000111220245,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.581Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.725Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -1159,7 +2191,7 @@
           &quot;medianScore&quot;: 88.99300139019402,
           &quot;diversity&quot;: 0.6111111111111112,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.582Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.726Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -1168,7 +2200,7 @@
           &quot;medianScore&quot;: 83.23985249780515,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.583Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.727Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -1177,7 +2209,7 @@
           &quot;medianScore&quot;: 82.9194778065494,
           &quot;diversity&quot;: 0.6111111111111112,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.584Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.727Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -1186,7 +2218,7 @@
           &quot;medianScore&quot;: 86.367830024997,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.585Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.728Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -1195,7 +2227,7 @@
           &quot;medianScore&quot;: 85.09002044220831,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.585Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.728Z&quot;
         }
       ],
       &quot;triangulation&quot;: {
@@ -1242,6 +2274,376 @@
             &quot;confidence&quot;: 0.2,
             &quot;energyDelta&quot;: 64,
             &quot;notes&quot;: &quot;Peer median 133.04 • energy delta 64.00 (≤ 44.80)&quot;
+          }
+        ]
+      },
+      &quot;ledger&quot;: {
+        &quot;summary&quot;: {
+          &quot;finalConsensus&quot;: &quot;accepted&quot;,
+          &quot;totalRewardPaid&quot;: 493500,
+          &quot;totalSlashed&quot;: 18600,
+          &quot;validatorRewards&quot;: 63000,
+          &quot;treasuryReturn&quot;: 31500,
+          &quot;averageLatencySeconds&quot;: 270,
+          &quot;participationRate&quot;: 1,
+          &quot;commitRevealIntegrity&quot;: &quot;verified&quot;,
+          &quot;attempts&quot;: 2
+        },
+        &quot;validators&quot;: [
+          {
+            &quot;validatorId&quot;: &quot;validator-02b303e331d093d1&quot;,
+            &quot;stakeBefore&quot;: 60555,
+            &quot;stakeAfter&quot;: 76305,
+            &quot;rewardEarned&quot;: 15750,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 1
+          },
+          {
+            &quot;validatorId&quot;: &quot;validator-8fb387f22ab17dbb&quot;,
+            &quot;stakeBefore&quot;: 77689,
+            &quot;stakeAfter&quot;: 93439,
+            &quot;rewardEarned&quot;: 15750,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 1
+          },
+          {
+            &quot;validatorId&quot;: &quot;validator-b48c4f3bd017c796&quot;,
+            &quot;stakeBefore&quot;: 60967,
+            &quot;stakeAfter&quot;: 76717,
+            &quot;rewardEarned&quot;: 15750,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 1
+          },
+          {
+            &quot;validatorId&quot;: &quot;validator-f3cbd6e75978a4b6&quot;,
+            &quot;stakeBefore&quot;: 78620,
+            &quot;stakeAfter&quot;: 94370,
+            &quot;rewardEarned&quot;: 15750,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 1
+          }
+        ],
+        &quot;attempts&quot;: [
+          {
+            &quot;attemptId&quot;: &quot;ledger-harmonics-attempt-1&quot;,
+            &quot;solverId&quot;: &quot;solver-424046f71a035fe6&quot;,
+            &quot;status&quot;: &quot;slashed&quot;,
+            &quot;commitHash&quot;: &quot;3a489a39a4ac760eea4e21600c7db814fc7ef4e73499a6f0e7c200e447c856d5&quot;,
+            &quot;reveal&quot;: &quot;insufficient-delta&quot;,
+            &quot;consensus&quot;: &quot;rejected&quot;,
+            &quot;rewardEarned&quot;: 0,
+            &quot;slashApplied&quot;: 18600,
+            &quot;latencySeconds&quot;: 189,
+            &quot;energyObserved&quot;: 51.2,
+            &quot;notes&quot;: &quot;Consensus rejected misaligned agent – stake partially slashed and job requeued.&quot;,
+            &quot;votes&quot;: [
+              {
+                &quot;validatorId&quot;: &quot;validator-02b303e331d093d1&quot;,
+                &quot;commitment&quot;: &quot;386876e8b46f541afba7e9ba7981dc0e41940b840db1165200b4fc64be00fa49&quot;,
+                &quot;revealed&quot;: &quot;no&quot;,
+                &quot;weight&quot;: 60555,
+                &quot;rewardEarned&quot;: 0,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Detected thermodynamic drift&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-8fb387f22ab17dbb&quot;,
+                &quot;commitment&quot;: &quot;d26aaf535bef21fa45371b67e612ecbf4724c3beceefe3b1a7c4771a699ff16c&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 77689,
+                &quot;rewardEarned&quot;: 0,
+                &quot;slashed&quot;: 0
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-b48c4f3bd017c796&quot;,
+                &quot;commitment&quot;: &quot;811943ed1d5afdf34e266be81f71f2fddee8d3426f4d5f4ae04b55056f5f3021&quot;,
+                &quot;revealed&quot;: &quot;no&quot;,
+                &quot;weight&quot;: 60967,
+                &quot;rewardEarned&quot;: 0,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Detected thermodynamic drift&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-f3cbd6e75978a4b6&quot;,
+                &quot;commitment&quot;: &quot;df4080472bf5202c53c8cb11c5b947306a9a14c0bf8db697cf7d132e6fe4329d&quot;,
+                &quot;revealed&quot;: &quot;no&quot;,
+                &quot;weight&quot;: 78620,
+                &quot;rewardEarned&quot;: 0,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Detected thermodynamic drift&quot;
+              }
+            ]
+          },
+          {
+            &quot;attemptId&quot;: &quot;ledger-harmonics-attempt-2&quot;,
+            &quot;solverId&quot;: &quot;solver-04c1f887eae22b1e&quot;,
+            &quot;status&quot;: &quot;accepted&quot;,
+            &quot;commitHash&quot;: &quot;ebda15b38d5047ceaade3779010231933171b8cdb316da86dbb9e61379be79fa&quot;,
+            &quot;reveal&quot;: &quot;ledger-harmonics-g0-c361&quot;,
+            &quot;consensus&quot;: &quot;accepted&quot;,
+            &quot;rewardEarned&quot;: 430500,
+            &quot;slashApplied&quot;: 0,
+            &quot;latencySeconds&quot;: 351,
+            &quot;energyObserved&quot;: 64,
+            &quot;notes&quot;: &quot;Meta-agentic evolved solver achieved consensus and claimed rewards.&quot;,
+            &quot;votes&quot;: [
+              {
+                &quot;validatorId&quot;: &quot;validator-02b303e331d093d1&quot;,
+                &quot;commitment&quot;: &quot;a9ff81a696c9a6329240f07cca03b7d28a3d6b7674cf7706e5c465ec3e792d4e&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 60555,
+                &quot;rewardEarned&quot;: 15750,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-8fb387f22ab17dbb&quot;,
+                &quot;commitment&quot;: &quot;781a3ed0c6d16a9f5f6540199d91856aacd60d7ebbc832febf25e052a62f4f5c&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 77689,
+                &quot;rewardEarned&quot;: 15750,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-b48c4f3bd017c796&quot;,
+                &quot;commitment&quot;: &quot;39593093be96192e274a31d636936a404d09f149af4366a54a2b4b2fd463bb23&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 60967,
+                &quot;rewardEarned&quot;: 15750,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-f3cbd6e75978a4b6&quot;,
+                &quot;commitment&quot;: &quot;a1ead23f0685e364f8d70ef43d00c2e91a83cfda9a907ba1fa0b75579202cc58&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 78620,
+                &quot;rewardEarned&quot;: 15750,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              }
+            ]
+          }
+        ],
+        &quot;timeline&quot;: [
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:16:24.000Z&quot;,
+            &quot;type&quot;: &quot;job_posted&quot;,
+            &quot;details&quot;: {
+              &quot;jobId&quot;: &quot;LEDGER-SYN-007&quot;,
+              &quot;reward&quot;: 525000,
+              &quot;stakeRequired&quot;: 155000,
+              &quot;description&quot;: &quot;Absorb asynchronous cash-flow deltas, stabilise them against the thermodynamic ledger, and emit rebalanced incentive curves for validator coalitions.&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:17:09.000Z&quot;,
+            &quot;type&quot;: &quot;solver_selected&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-424046f71a035fe6&quot;,
+              &quot;stakePosted&quot;: 155000
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:17:44.000Z&quot;,
+            &quot;type&quot;: &quot;result_committed&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-424046f71a035fe6&quot;,
+              &quot;commit&quot;: &quot;3a489a39a4ac760eea4e21600c7db814fc7ef4e73499a6f0e7c200e447c856d5&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:17:55.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-02b303e331d093d1&quot;,
+              &quot;commitment&quot;: &quot;386876e8b46f541afba7e9ba7981dc0e41940b840db1165200b4fc64be00fa49&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:18:08.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-02b303e331d093d1&quot;,
+              &quot;vote&quot;: &quot;no&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:18:17.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-8fb387f22ab17dbb&quot;,
+              &quot;commitment&quot;: &quot;d26aaf535bef21fa45371b67e612ecbf4724c3beceefe3b1a7c4771a699ff16c&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:18:31.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-8fb387f22ab17dbb&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:18:41.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-b48c4f3bd017c796&quot;,
+              &quot;commitment&quot;: &quot;811943ed1d5afdf34e266be81f71f2fddee8d3426f4d5f4ae04b55056f5f3021&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:18:53.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-b48c4f3bd017c796&quot;,
+              &quot;vote&quot;: &quot;no&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:19:05.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-f3cbd6e75978a4b6&quot;,
+              &quot;commitment&quot;: &quot;df4080472bf5202c53c8cb11c5b947306a9a14c0bf8db697cf7d132e6fe4329d&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:19:17.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-f3cbd6e75978a4b6&quot;,
+              &quot;vote&quot;: &quot;no&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:19:33.000Z&quot;,
+            &quot;type&quot;: &quot;consensus_finalised&quot;,
+            &quot;details&quot;: {
+              &quot;attempt&quot;: 1,
+              &quot;solverId&quot;: &quot;solver-424046f71a035fe6&quot;,
+              &quot;consensus&quot;: &quot;rejected&quot;,
+              &quot;yesWeight&quot;: 77689
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:19:39.000Z&quot;,
+            &quot;type&quot;: &quot;slash_applied&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-424046f71a035fe6&quot;,
+              &quot;amount&quot;: 18600,
+              &quot;reason&quot;: &quot;Failed consensus&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:19:51.000Z&quot;,
+            &quot;type&quot;: &quot;requeue&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-04c1f887eae22b1e&quot;,
+              &quot;reason&quot;: &quot;Meta-architect escalated to evolved agent&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:19:55.000Z&quot;,
+            &quot;type&quot;: &quot;solver_selected&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-04c1f887eae22b1e&quot;,
+              &quot;stakePosted&quot;: 155000
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:20:27.000Z&quot;,
+            &quot;type&quot;: &quot;result_committed&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-04c1f887eae22b1e&quot;,
+              &quot;commit&quot;: &quot;ebda15b38d5047ceaade3779010231933171b8cdb316da86dbb9e61379be79fa&quot;,
+              &quot;operations&quot;: 3
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:20:37.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-02b303e331d093d1&quot;,
+              &quot;commitment&quot;: &quot;a9ff81a696c9a6329240f07cca03b7d28a3d6b7674cf7706e5c465ec3e792d4e&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:20:50.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-02b303e331d093d1&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:21:01.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-8fb387f22ab17dbb&quot;,
+              &quot;commitment&quot;: &quot;781a3ed0c6d16a9f5f6540199d91856aacd60d7ebbc832febf25e052a62f4f5c&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:21:10.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-8fb387f22ab17dbb&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:21:19.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-b48c4f3bd017c796&quot;,
+              &quot;commitment&quot;: &quot;39593093be96192e274a31d636936a404d09f149af4366a54a2b4b2fd463bb23&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:21:28.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-b48c4f3bd017c796&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:21:38.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-f3cbd6e75978a4b6&quot;,
+              &quot;commitment&quot;: &quot;a1ead23f0685e364f8d70ef43d00c2e91a83cfda9a907ba1fa0b75579202cc58&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:21:49.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-f3cbd6e75978a4b6&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:22:03.000Z&quot;,
+            &quot;type&quot;: &quot;consensus_finalised&quot;,
+            &quot;details&quot;: {
+              &quot;attempt&quot;: 2,
+              &quot;solverId&quot;: &quot;solver-04c1f887eae22b1e&quot;,
+              &quot;consensus&quot;: &quot;accepted&quot;,
+              &quot;yesWeight&quot;: 277831
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T13:22:15.000Z&quot;,
+            &quot;type&quot;: &quot;reward_distributed&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-04c1f887eae22b1e&quot;,
+              &quot;solverReward&quot;: 430500,
+              &quot;validatorRewards&quot;: 63000,
+              &quot;treasuryReturn&quot;: 31500
+            }
           }
         ]
       }
@@ -1519,7 +2921,7 @@
           &quot;medianScore&quot;: 23.447749293641056,
           &quot;diversity&quot;: 1,
           &quot;eliteScore&quot;: 97.42746077012889,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.586Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.730Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -1528,7 +2930,7 @@
           &quot;medianScore&quot;: 33.23577114240753,
           &quot;diversity&quot;: 1,
           &quot;eliteScore&quot;: 101.68095349725729,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.587Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.731Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -1537,7 +2939,7 @@
           &quot;medianScore&quot;: 64.46743238768931,
           &quot;diversity&quot;: 0.8888888888888888,
           &quot;eliteScore&quot;: 125.76131787031291,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.587Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.731Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -1546,7 +2948,7 @@
           &quot;medianScore&quot;: 70.39942915911845,
           &quot;diversity&quot;: 0.8611111111111112,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.588Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.732Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -1555,7 +2957,7 @@
           &quot;medianScore&quot;: 71.05162669292856,
           &quot;diversity&quot;: 0.8333333333333334,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.589Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.733Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -1564,7 +2966,7 @@
           &quot;medianScore&quot;: 53.843889930604206,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.589Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.733Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -1573,7 +2975,7 @@
           &quot;medianScore&quot;: 78.25900854278035,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.597Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.734Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -1582,7 +2984,7 @@
           &quot;medianScore&quot;: 91.68021852282594,
           &quot;diversity&quot;: 0.5,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.598Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.734Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -1591,7 +2993,7 @@
           &quot;medianScore&quot;: 84.52984866490183,
           &quot;diversity&quot;: 0.6388888888888888,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.598Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.735Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -1600,7 +3002,7 @@
           &quot;medianScore&quot;: 90.34258929546631,
           &quot;diversity&quot;: 0.6388888888888888,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.599Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T03:23:20.736Z&quot;
         }
       ],
       &quot;triangulation&quot;: {
@@ -1647,6 +3049,318 @@
             &quot;confidence&quot;: 0.2,
             &quot;energyDelta&quot;: 76,
             &quot;notes&quot;: &quot;Peer median 136.05 • energy delta 76.00 (≤ 50.40)&quot;
+          }
+        ]
+      },
+      &quot;ledger&quot;: {
+        &quot;summary&quot;: {
+          &quot;finalConsensus&quot;: &quot;accepted&quot;,
+          &quot;totalRewardPaid&quot;: 573400,
+          &quot;totalSlashed&quot;: 19800,
+          &quot;validatorRewards&quot;: 73200,
+          &quot;treasuryReturn&quot;: 36600,
+          &quot;averageLatencySeconds&quot;: 233.5,
+          &quot;participationRate&quot;: 1,
+          &quot;commitRevealIntegrity&quot;: &quot;verified&quot;,
+          &quot;attempts&quot;: 2
+        },
+        &quot;validators&quot;: [
+          {
+            &quot;validatorId&quot;: &quot;validator-998a4f56b41c1653&quot;,
+            &quot;stakeBefore&quot;: 85872,
+            &quot;stakeAfter&quot;: 110272,
+            &quot;rewardEarned&quot;: 24400,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 1
+          },
+          {
+            &quot;validatorId&quot;: &quot;validator-9d05a69084156cb4&quot;,
+            &quot;stakeBefore&quot;: 68211,
+            &quot;stakeAfter&quot;: 92611,
+            &quot;rewardEarned&quot;: 24400,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 1
+          },
+          {
+            &quot;validatorId&quot;: &quot;validator-d3dc9de91651750d&quot;,
+            &quot;stakeBefore&quot;: 58085,
+            &quot;stakeAfter&quot;: 82485,
+            &quot;rewardEarned&quot;: 24400,
+            &quot;slashed&quot;: 0,
+            &quot;participationRate&quot;: 1
+          }
+        ],
+        &quot;attempts&quot;: [
+          {
+            &quot;attemptId&quot;: &quot;nova-weave-attempt-1&quot;,
+            &quot;solverId&quot;: &quot;solver-df8d72feae9e0558&quot;,
+            &quot;status&quot;: &quot;slashed&quot;,
+            &quot;commitHash&quot;: &quot;53ccd0481295cff8b777e9e746537f782210d0d6634463a6ee45af55c9df399c&quot;,
+            &quot;reveal&quot;: &quot;insufficient-delta&quot;,
+            &quot;consensus&quot;: &quot;rejected&quot;,
+            &quot;rewardEarned&quot;: 0,
+            &quot;slashApplied&quot;: 19800,
+            &quot;latencySeconds&quot;: 163,
+            &quot;energyObserved&quot;: 54.400000000000006,
+            &quot;notes&quot;: &quot;Consensus rejected misaligned agent – stake partially slashed and job requeued.&quot;,
+            &quot;votes&quot;: [
+              {
+                &quot;validatorId&quot;: &quot;validator-998a4f56b41c1653&quot;,
+                &quot;commitment&quot;: &quot;b1c8d5fb8311d466fe88c58b0121b6c45662d842bf31bfe7485ceae3038ccd8c&quot;,
+                &quot;revealed&quot;: &quot;no&quot;,
+                &quot;weight&quot;: 85872,
+                &quot;rewardEarned&quot;: 0,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Detected thermodynamic drift&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-9d05a69084156cb4&quot;,
+                &quot;commitment&quot;: &quot;4657fd854d9a91e5f21ab296f043f3cb95e3e701e4a80fb5c7fc3a5bfef81729&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 68211,
+                &quot;rewardEarned&quot;: 0,
+                &quot;slashed&quot;: 0
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-d3dc9de91651750d&quot;,
+                &quot;commitment&quot;: &quot;b4affd948c6de5ef384077b29023dd77a88c6af547d1f8308a27ad6a0895ced4&quot;,
+                &quot;revealed&quot;: &quot;no&quot;,
+                &quot;weight&quot;: 58085,
+                &quot;rewardEarned&quot;: 0,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Detected thermodynamic drift&quot;
+              }
+            ]
+          },
+          {
+            &quot;attemptId&quot;: &quot;nova-weave-attempt-2&quot;,
+            &quot;solverId&quot;: &quot;solver-b0ce6e46ec6aee31&quot;,
+            &quot;status&quot;: &quot;accepted&quot;,
+            &quot;commitHash&quot;: &quot;ec051e8ee05f18e96d72bcc879d6325db1bba43c808cc42dfbe7895eabdea108&quot;,
+            &quot;reveal&quot;: &quot;nova-weave-g0-c721&quot;,
+            &quot;consensus&quot;: &quot;accepted&quot;,
+            &quot;rewardEarned&quot;: 500200,
+            &quot;slashApplied&quot;: 0,
+            &quot;latencySeconds&quot;: 304,
+            &quot;energyObserved&quot;: 68,
+            &quot;notes&quot;: &quot;Meta-agentic evolved solver achieved consensus and claimed rewards.&quot;,
+            &quot;votes&quot;: [
+              {
+                &quot;validatorId&quot;: &quot;validator-998a4f56b41c1653&quot;,
+                &quot;commitment&quot;: &quot;76f6ee53383c2999cbe79913a5f6167c4ca686cdc3e266a2e28c96fea559c37a&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 85872,
+                &quot;rewardEarned&quot;: 24400,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-9d05a69084156cb4&quot;,
+                &quot;commitment&quot;: &quot;8976703d78e5c6073ca9f883c7e6593a311201bf7e021cdfd02726cb0d218003&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 68211,
+                &quot;rewardEarned&quot;: 24400,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              },
+              {
+                &quot;validatorId&quot;: &quot;validator-d3dc9de91651750d&quot;,
+                &quot;commitment&quot;: &quot;3cb52a63d7218a3eaa12727a77ed6b8e3c2261ed8db9007f22ec5ce0849c7d8d&quot;,
+                &quot;revealed&quot;: &quot;yes&quot;,
+                &quot;weight&quot;: 58085,
+                &quot;rewardEarned&quot;: 24400,
+                &quot;slashed&quot;: 0,
+                &quot;notes&quot;: &quot;Validated evolved solver output&quot;
+              }
+            ]
+          }
+        ],
+        &quot;timeline&quot;: [
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:29:20.000Z&quot;,
+            &quot;type&quot;: &quot;job_posted&quot;,
+            &quot;details&quot;: {
+              &quot;jobId&quot;: &quot;NOVA-SYN-009&quot;,
+              &quot;reward&quot;: 610000,
+              &quot;stakeRequired&quot;: 165000,
+              &quot;description&quot;: &quot;Elevate alpha sequences into deterministic blueprints that compile into on-chain production payloads with zero manual edits.&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:30:05.000Z&quot;,
+            &quot;type&quot;: &quot;solver_selected&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-df8d72feae9e0558&quot;,
+              &quot;stakePosted&quot;: 165000
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:30:40.000Z&quot;,
+            &quot;type&quot;: &quot;result_committed&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-df8d72feae9e0558&quot;,
+              &quot;commit&quot;: &quot;53ccd0481295cff8b777e9e746537f782210d0d6634463a6ee45af55c9df399c&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:30:49.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-998a4f56b41c1653&quot;,
+              &quot;commitment&quot;: &quot;b1c8d5fb8311d466fe88c58b0121b6c45662d842bf31bfe7485ceae3038ccd8c&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:31:00.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-998a4f56b41c1653&quot;,
+              &quot;vote&quot;: &quot;no&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:31:10.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-9d05a69084156cb4&quot;,
+              &quot;commitment&quot;: &quot;4657fd854d9a91e5f21ab296f043f3cb95e3e701e4a80fb5c7fc3a5bfef81729&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:31:23.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-9d05a69084156cb4&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:31:32.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-d3dc9de91651750d&quot;,
+              &quot;commitment&quot;: &quot;b4affd948c6de5ef384077b29023dd77a88c6af547d1f8308a27ad6a0895ced4&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:31:47.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-d3dc9de91651750d&quot;,
+              &quot;vote&quot;: &quot;no&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:32:03.000Z&quot;,
+            &quot;type&quot;: &quot;consensus_finalised&quot;,
+            &quot;details&quot;: {
+              &quot;attempt&quot;: 1,
+              &quot;solverId&quot;: &quot;solver-df8d72feae9e0558&quot;,
+              &quot;consensus&quot;: &quot;rejected&quot;,
+              &quot;yesWeight&quot;: 68211
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:32:09.000Z&quot;,
+            &quot;type&quot;: &quot;slash_applied&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-df8d72feae9e0558&quot;,
+              &quot;amount&quot;: 19800,
+              &quot;reason&quot;: &quot;Failed consensus&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:32:21.000Z&quot;,
+            &quot;type&quot;: &quot;requeue&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-b0ce6e46ec6aee31&quot;,
+              &quot;reason&quot;: &quot;Meta-architect escalated to evolved agent&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:32:25.000Z&quot;,
+            &quot;type&quot;: &quot;solver_selected&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-b0ce6e46ec6aee31&quot;,
+              &quot;stakePosted&quot;: 165000
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:32:57.000Z&quot;,
+            &quot;type&quot;: &quot;result_committed&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-b0ce6e46ec6aee31&quot;,
+              &quot;commit&quot;: &quot;ec051e8ee05f18e96d72bcc879d6325db1bba43c808cc42dfbe7895eabdea108&quot;,
+              &quot;operations&quot;: 3
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:33:04.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-998a4f56b41c1653&quot;,
+              &quot;commitment&quot;: &quot;76f6ee53383c2999cbe79913a5f6167c4ca686cdc3e266a2e28c96fea559c37a&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:33:15.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-998a4f56b41c1653&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:33:25.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-9d05a69084156cb4&quot;,
+              &quot;commitment&quot;: &quot;8976703d78e5c6073ca9f883c7e6593a311201bf7e021cdfd02726cb0d218003&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:33:35.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-9d05a69084156cb4&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:33:46.000Z&quot;,
+            &quot;type&quot;: &quot;vote_commit&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-d3dc9de91651750d&quot;,
+              &quot;commitment&quot;: &quot;3cb52a63d7218a3eaa12727a77ed6b8e3c2261ed8db9007f22ec5ce0849c7d8d&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:33:58.000Z&quot;,
+            &quot;type&quot;: &quot;vote_reveal&quot;,
+            &quot;details&quot;: {
+              &quot;validator&quot;: &quot;validator-d3dc9de91651750d&quot;,
+              &quot;vote&quot;: &quot;yes&quot;
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:34:12.000Z&quot;,
+            &quot;type&quot;: &quot;consensus_finalised&quot;,
+            &quot;details&quot;: {
+              &quot;attempt&quot;: 2,
+              &quot;solverId&quot;: &quot;solver-b0ce6e46ec6aee31&quot;,
+              &quot;consensus&quot;: &quot;accepted&quot;,
+              &quot;yesWeight&quot;: 212168
+            }
+          },
+          {
+            &quot;timestamp&quot;: &quot;2042-01-01T07:34:24.000Z&quot;,
+            &quot;type&quot;: &quot;reward_distributed&quot;,
+            &quot;details&quot;: {
+              &quot;solverId&quot;: &quot;solver-b0ce6e46ec6aee31&quot;,
+              &quot;solverReward&quot;: 500200,
+              &quot;validatorRewards&quot;: 73200,
+              &quot;treasuryReturn&quot;: 36600
+            }
           }
         ]
       }
@@ -1711,7 +3425,7 @@
   }
 }</script>
     <script id="meta-agentic-triangulation" type="application/json">{
-  &quot;generatedAt&quot;: &quot;2025-10-21T02:47:22.562Z&quot;,
+  &quot;generatedAt&quot;: &quot;2025-10-21T03:23:20.678Z&quot;,
   &quot;confidence&quot;: 0.5333333333333333,
   &quot;consensus&quot;: {
     &quot;confirmed&quot;: 1,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T02:47:22.635Z",
+  "generatedAt": "2025-10-21T03:23:20.777Z",
   "aggregate": {
     "globalBestScore": 140.38164328854776,
     "averageAccuracy": 1,
@@ -21,6 +21,16 @@
         "monitor": 0,
         "drift": 0
       }
+    },
+    "ledger": {
+      "totalRewardPaid": 1461700,
+      "totalSlashed": 52800,
+      "validatorRewards": 186600,
+      "treasuryReturn": 93300,
+      "averageParticipationRate": 0.9583333333333334,
+      "averageLatencySeconds": 250.16666666666666,
+      "accepted": 3,
+      "consensusAlerts": 0
     }
   },
   "triangulation": {
@@ -92,7 +102,7 @@
     "report": "/workspace/AGIJobsv0/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-ci.json"
   },
   "ownerDiagnostics": {
-    "generatedAt": "2025-10-21T02:47:22.634Z",
+    "generatedAt": "2025-10-21T03:23:20.776Z",
     "readiness": "ready",
     "commandReadiness": "ready",
     "coverage": {

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.md
@@ -1,6 +1,6 @@
 # Meta-Agentic Program Synthesis – Full Run
 
-Generated: 2025-10-21T02:47:22.562Z
+Generated: 2025-10-21T03:23:20.678Z
 
 ## Aggregate Metrics
 
@@ -11,6 +11,7 @@ Generated: 2025-10-21T02:47:22.562Z
 - Coverage: 100.00%
 - Triangulation confidence: 53.33% (1/0/2)
 - Thermodynamic alignment: 100.00% (mean Δ 0.00 | max Δ 0.00 | 3 aligned/0 monitor/0 drift)
+- Ledger economy: rewards 1,461,700 | slashed 52,800 | validator rewards 186,600 | treasury 93,300 | participation 95.8% | latency 250.2s | alerts 0
 
 ## Verification Consensus
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-manifest.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T02:47:22.637Z",
+  "generatedAt": "2025-10-21T03:23:20.779Z",
   "root": "/workspace/AGIJobsv0",
   "files": 9,
   "entries": [
@@ -10,22 +10,22 @@
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html",
-      "sha256": "1276405e6930eeb35e9c4fcfee958933b7d9e42505ca9270ef895771d71c4bac",
-      "bytes": 71879
+      "sha256": "df5ae5075aba8058bc9567f8912f20b15332ae6b0284bf2234e7befa1ad1d85b",
+      "bytes": 143365
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.json",
-      "sha256": "a3a74f65118e95e4a40549031c10c09cf2d4c841d5b2e60a918f8fbec23cfae2",
-      "bytes": 6686
+      "sha256": "c9b29d056e3f2225238d85ebc70244e72dadea59c1093aa25f7313a14d6b480b",
+      "bytes": 6990
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.md",
-      "sha256": "1c67c9019cce248d17587b6783cb1611bde03f746d2aa55f2a324015b5e679bf",
-      "bytes": 1842
+      "sha256": "fbb3adf6f3033ac490bdf5fd8ac55e1c6f3db66ef492037e3923a909c3664219",
+      "bytes": 1991
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.json",
-      "sha256": "153c98fc9ae97d7af1cdb24bc1bd3c3879fbf2942cbc0edcf3c5bbadf519b3f2",
+      "sha256": "1f81c9823e6d08f02634f5033f53c3edc52588e8a6aa0ce0b00d0243447e2d2b",
       "bytes": 2288
     },
     {
@@ -35,17 +35,17 @@
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md",
-      "sha256": "d5d52c45583e803e976607ac8c724bba10ed49d16208cb87b27899ec1cc52355",
-      "bytes": 13826
+      "sha256": "64cbda7cd3dbd119906357e2af5cd90630da914dbc1ec0caa449c5ea635cd0b0",
+      "bytes": 28295
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json",
-      "sha256": "1f6f506015040e6991bdf4a7aa02f3c2a1a99cfad326d0cca781cf6440325d23",
-      "bytes": 34778
+      "sha256": "8dd6646818722c44e14b31d869ecc8f560b5da6d94d803a358ef5ea92a13cbcf",
+      "bytes": 71318
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-triangulation.json",
-      "sha256": "c62c762e1877d8a8bb15dfd3c121bf78aac8ec92e8d7279cc5be98a3a13fbe40",
+      "sha256": "19aa146fa485ab7bdf423c6fc3ee6fc2c6006ae17de62b55be7aca5a4c8a14fe",
       "bytes": 5041
     }
   ]

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T02:47:22.634Z",
+  "generatedAt": "2025-10-21T03:23:20.776Z",
   "readiness": "ready",
   "commandReadiness": "ready",
   "coverage": {

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md
@@ -11,6 +11,7 @@ Deterministic rehearsal proving that AGI Jobs v0 (v2) lets a non-technical owner
 - **Coverage:** 100.00% task-level perfect matches.
 - **Triangulation confidence:** 53.33% consensus (1 confirmed / 0 attention / 2 flagged).
 - **Thermodynamic alignment:** 100.00% (mean Δ 0.00 | max Δ 0.00 | 3 aligned / 0 monitor / 0 drift).
+- **Ledger economy:** 1,461,700 rewards / 52,800 slashed / validators 186,600 / treasury 93,300 (participation 95.8% • latency 250.2s • alerts 0).
 - **Owner supremacy:** every control remains copy-paste accessible (pause, thermostat, upgrades, treasury mirrors, compliance dossier).
 - **Coverage readiness:** ready (5/5 controls satisfied).
 
@@ -149,16 +150,77 @@ pie title Verification consensus
 ```mermaid
 timeline
   title Evolutionary improvements for ARC Sentinel Edge Lift
-  2025-10-21T02:47:22.567Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
-  2025-10-21T02:47:22.568Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
-  2025-10-21T02:47:22.569Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
-  2025-10-21T02:47:22.570Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
-  2025-10-21T02:47:22.571Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
-  2025-10-21T02:47:22.573Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T02:47:22.574Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T02:47:22.574Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
-  2025-10-21T02:47:22.575Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
-  2025-10-21T02:47:22.576Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%
+  2025-10-21T03:23:20.682Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
+  2025-10-21T03:23:20.683Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
+  2025-10-21T03:23:20.684Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
+  2025-10-21T03:23:20.685Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
+  2025-10-21T03:23:20.686Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
+  2025-10-21T03:23:20.696Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T03:23:20.699Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T03:23:20.700Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
+  2025-10-21T03:23:20.704Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
+  2025-10-21T03:23:20.705Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%
+```
+
+### On-chain Ledger Synthesis
+
+- Consensus: **ACCEPTED** across 2 attempts
+- Rewards paid: 394,800 (validators 50,400 | treasury 25,200)
+- Slashed stake: 14,400 | Participation 87.5%
+- Commit–reveal integrity: verified • Avg latency 247.0 seconds
+
+#### Validator Performance
+
+| Validator | Stake (before) | Stake (after) | Rewards | Slashed | Participation |
+| --- | --- | --- | --- | --- | --- |
+| validator-195a5d4bfbdae573 | 52,687 | 65,287 | 12,600 | 0 | 100.0% |
+| validator-76bf560baa38ba87 | 53,186 | 65,786 | 12,600 | 0 | 100.0% |
+| validator-79c9d91afd1ddf92 | 60,772 | 73,372 | 12,600 | 0 | 100.0% |
+| validator-a93d1e2a9c0e3a2a | 49,970 | 62,570 | 12,600 | 0 | 50.0% |
+
+#### Timeline
+
+| Timestamp | Event | Details |
+| --- | --- | --- |
+| 2042-01-01T08:54:24.000Z | job_posted | jobId=ARC-SYN-001; reward=420,000; stakeRequired=120,000; description=Detect latent pixel edges, amplify discovery, and route high-confidence transformations back into the shared skill graph. |
+| 2042-01-01T08:55:09.000Z | solver_selected | solverId=solver-834077d2c7cd0093; stakePosted=120,000 |
+| 2042-01-01T08:55:44.000Z | result_committed | solverId=solver-834077d2c7cd0093; commit=cdccfe1d1ecc488574b306b0afa622e76d4619196d444d00ed36bc17317dba16 |
+| 2042-01-01T08:55:54.000Z | vote_commit | validator=validator-195a5d4bfbdae573; commitment=6a13cc921e0d27d543a1f1a7b80eb4fa2b75c0525449b8f73a219358fdeb5116 |
+| 2042-01-01T08:56:09.000Z | vote_reveal | validator=validator-195a5d4bfbdae573; vote=yes |
+| 2042-01-01T08:56:20.000Z | vote_commit | validator=validator-76bf560baa38ba87; commitment=ff5cf0e04b2467375ef805362e542c143abea25b2bb7bb443515daa8dc3f1354 |
+| 2042-01-01T08:56:31.000Z | vote_reveal | validator=validator-76bf560baa38ba87; vote=no |
+| 2042-01-01T08:56:42.000Z | vote_commit | validator=validator-79c9d91afd1ddf92; commitment=95fe40173c0a29a739e2d0fa2d0105c755fb04b43e3532d8c310c35ce472c1d2 |
+| 2042-01-01T08:56:52.000Z | vote_reveal | validator=validator-79c9d91afd1ddf92; vote=no |
+| 2042-01-01T08:57:08.000Z | consensus_finalised | attempt=1; solverId=solver-834077d2c7cd0093; consensus=rejected; yesWeight=52,687 |
+| 2042-01-01T08:57:14.000Z | slash_applied | solverId=solver-834077d2c7cd0093; amount=14,400; reason=Failed consensus |
+| 2042-01-01T08:57:26.000Z | requeue | solverId=solver-85b7571cb9684c4c; reason=Meta-architect escalated to evolved agent |
+| 2042-01-01T08:57:30.000Z | solver_selected | solverId=solver-85b7571cb9684c4c; stakePosted=120,000 |
+| 2042-01-01T08:58:02.000Z | result_committed | solverId=solver-85b7571cb9684c4c; commit=a71fc6a4d27f9928547e7c9286a86675979d6854026355e0559ce8baf2e50211; operations=4 |
+| 2042-01-01T08:58:13.000Z | vote_commit | validator=validator-195a5d4bfbdae573; commitment=c0e7ac904a95f3b6b07a2d8458d1be1ea31b81714501555ef6da2be49ddaadce |
+| 2042-01-01T08:58:24.000Z | vote_reveal | validator=validator-195a5d4bfbdae573; vote=yes |
+| 2042-01-01T08:58:33.000Z | vote_commit | validator=validator-76bf560baa38ba87; commitment=ba808148dada8a23c0977f5798f313954ad76c389605df96d26cab84f14ea32a |
+| 2042-01-01T08:58:46.000Z | vote_reveal | validator=validator-76bf560baa38ba87; vote=yes |
+| 2042-01-01T08:58:55.000Z | vote_commit | validator=validator-79c9d91afd1ddf92; commitment=9d1ce6a17520b9b429f727eeb800908b5a13200a307782f3a8874baf70f96c11 |
+| 2042-01-01T08:59:08.000Z | vote_reveal | validator=validator-79c9d91afd1ddf92; vote=yes |
+| 2042-01-01T08:59:16.000Z | vote_commit | validator=validator-a93d1e2a9c0e3a2a; commitment=d112ff2b6d9545978359f988200e0c135e6b7c05e0812b51815198a85b53a97f |
+| 2042-01-01T08:59:28.000Z | vote_reveal | validator=validator-a93d1e2a9c0e3a2a; vote=yes |
+| 2042-01-01T08:59:42.000Z | consensus_finalised | attempt=2; solverId=solver-85b7571cb9684c4c; consensus=accepted; yesWeight=216,615 |
+| 2042-01-01T08:59:54.000Z | reward_distributed | solverId=solver-85b7571cb9684c4c; solverReward=344,400; validatorRewards=50,400; treasuryReturn=25,200 |
+
+```mermaid
+flowchart LR
+  Job((Job ARC-SYN-001)):::core --> AttemptA[Attempt 1\nsolver-834077d2c7cd0093]:::warn
+  AttemptA -->|Consensus rejected| Slash[(Slash)]:::warn
+  AttemptA -->|Requeue| AttemptB[Attempt 2\nsolver-85b7571cb9684c4c]:::core
+  AttemptB -->|Validators| Consensus{Final consensus}:::verify
+  Consensus --> Reward[(Reward Distribution)]:::core
+  Reward --> Treasury[Treasury Return]:::governance
+  Reward --> Validators[Validator Rewards]:::governance
+  Reward --> Solver[Evolved Solver Payout]:::core
+  classDef core fill:#111827,stroke:#a855f7,stroke-width:2px,color:#f5f3ff;
+  classDef warn fill:#7f1d1d,stroke:#fecaca,stroke-width:2px,color:#fecaca;
+  classDef verify fill:#0b7285,stroke:#66d9e8,stroke-width:2px,color:#e6fcf5;
+  classDef governance fill:#1f2937,stroke:#22d3ee,stroke-width:2px,color:#e0f2fe;
 ```
 
 ## Ledger Harmonics Sequencer
@@ -228,16 +290,79 @@ pie title Verification consensus
 ```mermaid
 timeline
   title Evolutionary improvements for Ledger Harmonics Sequencer
-  2025-10-21T02:47:22.578Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
-  2025-10-21T02:47:22.579Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
-  2025-10-21T02:47:22.580Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
-  2025-10-21T02:47:22.581Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T02:47:22.581Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T02:47:22.582Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T02:47:22.583Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T02:47:22.584Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T02:47:22.585Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T02:47:22.585Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T03:23:20.716Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
+  2025-10-21T03:23:20.717Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
+  2025-10-21T03:23:20.718Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
+  2025-10-21T03:23:20.719Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T03:23:20.725Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T03:23:20.726Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T03:23:20.727Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T03:23:20.727Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T03:23:20.728Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T03:23:20.728Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+```
+
+### On-chain Ledger Synthesis
+
+- Consensus: **ACCEPTED** across 2 attempts
+- Rewards paid: 493,500 (validators 63,000 | treasury 31,500)
+- Slashed stake: 18,600 | Participation 100.0%
+- Commit–reveal integrity: verified • Avg latency 270.0 seconds
+
+#### Validator Performance
+
+| Validator | Stake (before) | Stake (after) | Rewards | Slashed | Participation |
+| --- | --- | --- | --- | --- | --- |
+| validator-02b303e331d093d1 | 60,555 | 76,305 | 15,750 | 0 | 100.0% |
+| validator-8fb387f22ab17dbb | 77,689 | 93,439 | 15,750 | 0 | 100.0% |
+| validator-b48c4f3bd017c796 | 60,967 | 76,717 | 15,750 | 0 | 100.0% |
+| validator-f3cbd6e75978a4b6 | 78,620 | 94,370 | 15,750 | 0 | 100.0% |
+
+#### Timeline
+
+| Timestamp | Event | Details |
+| --- | --- | --- |
+| 2042-01-01T13:16:24.000Z | job_posted | jobId=LEDGER-SYN-007; reward=525,000; stakeRequired=155,000; description=Absorb asynchronous cash-flow deltas, stabilise them against the thermodynamic ledger, and emit rebalanced incentive curves for validator coalitions. |
+| 2042-01-01T13:17:09.000Z | solver_selected | solverId=solver-424046f71a035fe6; stakePosted=155,000 |
+| 2042-01-01T13:17:44.000Z | result_committed | solverId=solver-424046f71a035fe6; commit=3a489a39a4ac760eea4e21600c7db814fc7ef4e73499a6f0e7c200e447c856d5 |
+| 2042-01-01T13:17:55.000Z | vote_commit | validator=validator-02b303e331d093d1; commitment=386876e8b46f541afba7e9ba7981dc0e41940b840db1165200b4fc64be00fa49 |
+| 2042-01-01T13:18:08.000Z | vote_reveal | validator=validator-02b303e331d093d1; vote=no |
+| 2042-01-01T13:18:17.000Z | vote_commit | validator=validator-8fb387f22ab17dbb; commitment=d26aaf535bef21fa45371b67e612ecbf4724c3beceefe3b1a7c4771a699ff16c |
+| 2042-01-01T13:18:31.000Z | vote_reveal | validator=validator-8fb387f22ab17dbb; vote=yes |
+| 2042-01-01T13:18:41.000Z | vote_commit | validator=validator-b48c4f3bd017c796; commitment=811943ed1d5afdf34e266be81f71f2fddee8d3426f4d5f4ae04b55056f5f3021 |
+| 2042-01-01T13:18:53.000Z | vote_reveal | validator=validator-b48c4f3bd017c796; vote=no |
+| 2042-01-01T13:19:05.000Z | vote_commit | validator=validator-f3cbd6e75978a4b6; commitment=df4080472bf5202c53c8cb11c5b947306a9a14c0bf8db697cf7d132e6fe4329d |
+| 2042-01-01T13:19:17.000Z | vote_reveal | validator=validator-f3cbd6e75978a4b6; vote=no |
+| 2042-01-01T13:19:33.000Z | consensus_finalised | attempt=1; solverId=solver-424046f71a035fe6; consensus=rejected; yesWeight=77,689 |
+| 2042-01-01T13:19:39.000Z | slash_applied | solverId=solver-424046f71a035fe6; amount=18,600; reason=Failed consensus |
+| 2042-01-01T13:19:51.000Z | requeue | solverId=solver-04c1f887eae22b1e; reason=Meta-architect escalated to evolved agent |
+| 2042-01-01T13:19:55.000Z | solver_selected | solverId=solver-04c1f887eae22b1e; stakePosted=155,000 |
+| 2042-01-01T13:20:27.000Z | result_committed | solverId=solver-04c1f887eae22b1e; commit=ebda15b38d5047ceaade3779010231933171b8cdb316da86dbb9e61379be79fa; operations=3 |
+| 2042-01-01T13:20:37.000Z | vote_commit | validator=validator-02b303e331d093d1; commitment=a9ff81a696c9a6329240f07cca03b7d28a3d6b7674cf7706e5c465ec3e792d4e |
+| 2042-01-01T13:20:50.000Z | vote_reveal | validator=validator-02b303e331d093d1; vote=yes |
+| 2042-01-01T13:21:01.000Z | vote_commit | validator=validator-8fb387f22ab17dbb; commitment=781a3ed0c6d16a9f5f6540199d91856aacd60d7ebbc832febf25e052a62f4f5c |
+| 2042-01-01T13:21:10.000Z | vote_reveal | validator=validator-8fb387f22ab17dbb; vote=yes |
+| 2042-01-01T13:21:19.000Z | vote_commit | validator=validator-b48c4f3bd017c796; commitment=39593093be96192e274a31d636936a404d09f149af4366a54a2b4b2fd463bb23 |
+| 2042-01-01T13:21:28.000Z | vote_reveal | validator=validator-b48c4f3bd017c796; vote=yes |
+| 2042-01-01T13:21:38.000Z | vote_commit | validator=validator-f3cbd6e75978a4b6; commitment=a1ead23f0685e364f8d70ef43d00c2e91a83cfda9a907ba1fa0b75579202cc58 |
+| 2042-01-01T13:21:49.000Z | vote_reveal | validator=validator-f3cbd6e75978a4b6; vote=yes |
+| 2042-01-01T13:22:03.000Z | consensus_finalised | attempt=2; solverId=solver-04c1f887eae22b1e; consensus=accepted; yesWeight=277,831 |
+| 2042-01-01T13:22:15.000Z | reward_distributed | solverId=solver-04c1f887eae22b1e; solverReward=430,500; validatorRewards=63,000; treasuryReturn=31,500 |
+
+```mermaid
+flowchart LR
+  Job((Job LEDGER-SYN-007)):::core --> AttemptA[Attempt 1\nsolver-424046f71a035fe6]:::warn
+  AttemptA -->|Consensus rejected| Slash[(Slash)]:::warn
+  AttemptA -->|Requeue| AttemptB[Attempt 2\nsolver-04c1f887eae22b1e]:::core
+  AttemptB -->|Validators| Consensus{Final consensus}:::verify
+  Consensus --> Reward[(Reward Distribution)]:::core
+  Reward --> Treasury[Treasury Return]:::governance
+  Reward --> Validators[Validator Rewards]:::governance
+  Reward --> Solver[Evolved Solver Payout]:::core
+  classDef core fill:#111827,stroke:#a855f7,stroke-width:2px,color:#f5f3ff;
+  classDef warn fill:#7f1d1d,stroke:#fecaca,stroke-width:2px,color:#fecaca;
+  classDef verify fill:#0b7285,stroke:#66d9e8,stroke-width:2px,color:#e6fcf5;
+  classDef governance fill:#1f2937,stroke:#22d3ee,stroke-width:2px,color:#e0f2fe;
 ```
 
 ## Nova Weave Sequence Optimiser
@@ -307,16 +432,74 @@ pie title Verification consensus
 ```mermaid
 timeline
   title Evolutionary improvements for Nova Weave Sequence Optimiser
-  2025-10-21T02:47:22.586Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
-  2025-10-21T02:47:22.587Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
-  2025-10-21T02:47:22.587Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
-  2025-10-21T02:47:22.588Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
-  2025-10-21T02:47:22.589Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
-  2025-10-21T02:47:22.589Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
-  2025-10-21T02:47:22.597Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
-  2025-10-21T02:47:22.598Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
-  2025-10-21T02:47:22.598Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
-  2025-10-21T02:47:22.599Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T03:23:20.730Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
+  2025-10-21T03:23:20.731Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
+  2025-10-21T03:23:20.731Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
+  2025-10-21T03:23:20.732Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
+  2025-10-21T03:23:20.733Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
+  2025-10-21T03:23:20.733Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
+  2025-10-21T03:23:20.734Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
+  2025-10-21T03:23:20.734Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
+  2025-10-21T03:23:20.735Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T03:23:20.736Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+```
+
+### On-chain Ledger Synthesis
+
+- Consensus: **ACCEPTED** across 2 attempts
+- Rewards paid: 573,400 (validators 73,200 | treasury 36,600)
+- Slashed stake: 19,800 | Participation 100.0%
+- Commit–reveal integrity: verified • Avg latency 233.5 seconds
+
+#### Validator Performance
+
+| Validator | Stake (before) | Stake (after) | Rewards | Slashed | Participation |
+| --- | --- | --- | --- | --- | --- |
+| validator-998a4f56b41c1653 | 85,872 | 110,272 | 24,400 | 0 | 100.0% |
+| validator-9d05a69084156cb4 | 68,211 | 92,611 | 24,400 | 0 | 100.0% |
+| validator-d3dc9de91651750d | 58,085 | 82,485 | 24,400 | 0 | 100.0% |
+
+#### Timeline
+
+| Timestamp | Event | Details |
+| --- | --- | --- |
+| 2042-01-01T07:29:20.000Z | job_posted | jobId=NOVA-SYN-009; reward=610,000; stakeRequired=165,000; description=Elevate alpha sequences into deterministic blueprints that compile into on-chain production payloads with zero manual edits. |
+| 2042-01-01T07:30:05.000Z | solver_selected | solverId=solver-df8d72feae9e0558; stakePosted=165,000 |
+| 2042-01-01T07:30:40.000Z | result_committed | solverId=solver-df8d72feae9e0558; commit=53ccd0481295cff8b777e9e746537f782210d0d6634463a6ee45af55c9df399c |
+| 2042-01-01T07:30:49.000Z | vote_commit | validator=validator-998a4f56b41c1653; commitment=b1c8d5fb8311d466fe88c58b0121b6c45662d842bf31bfe7485ceae3038ccd8c |
+| 2042-01-01T07:31:00.000Z | vote_reveal | validator=validator-998a4f56b41c1653; vote=no |
+| 2042-01-01T07:31:10.000Z | vote_commit | validator=validator-9d05a69084156cb4; commitment=4657fd854d9a91e5f21ab296f043f3cb95e3e701e4a80fb5c7fc3a5bfef81729 |
+| 2042-01-01T07:31:23.000Z | vote_reveal | validator=validator-9d05a69084156cb4; vote=yes |
+| 2042-01-01T07:31:32.000Z | vote_commit | validator=validator-d3dc9de91651750d; commitment=b4affd948c6de5ef384077b29023dd77a88c6af547d1f8308a27ad6a0895ced4 |
+| 2042-01-01T07:31:47.000Z | vote_reveal | validator=validator-d3dc9de91651750d; vote=no |
+| 2042-01-01T07:32:03.000Z | consensus_finalised | attempt=1; solverId=solver-df8d72feae9e0558; consensus=rejected; yesWeight=68,211 |
+| 2042-01-01T07:32:09.000Z | slash_applied | solverId=solver-df8d72feae9e0558; amount=19,800; reason=Failed consensus |
+| 2042-01-01T07:32:21.000Z | requeue | solverId=solver-b0ce6e46ec6aee31; reason=Meta-architect escalated to evolved agent |
+| 2042-01-01T07:32:25.000Z | solver_selected | solverId=solver-b0ce6e46ec6aee31; stakePosted=165,000 |
+| 2042-01-01T07:32:57.000Z | result_committed | solverId=solver-b0ce6e46ec6aee31; commit=ec051e8ee05f18e96d72bcc879d6325db1bba43c808cc42dfbe7895eabdea108; operations=3 |
+| 2042-01-01T07:33:04.000Z | vote_commit | validator=validator-998a4f56b41c1653; commitment=76f6ee53383c2999cbe79913a5f6167c4ca686cdc3e266a2e28c96fea559c37a |
+| 2042-01-01T07:33:15.000Z | vote_reveal | validator=validator-998a4f56b41c1653; vote=yes |
+| 2042-01-01T07:33:25.000Z | vote_commit | validator=validator-9d05a69084156cb4; commitment=8976703d78e5c6073ca9f883c7e6593a311201bf7e021cdfd02726cb0d218003 |
+| 2042-01-01T07:33:35.000Z | vote_reveal | validator=validator-9d05a69084156cb4; vote=yes |
+| 2042-01-01T07:33:46.000Z | vote_commit | validator=validator-d3dc9de91651750d; commitment=3cb52a63d7218a3eaa12727a77ed6b8e3c2261ed8db9007f22ec5ce0849c7d8d |
+| 2042-01-01T07:33:58.000Z | vote_reveal | validator=validator-d3dc9de91651750d; vote=yes |
+| 2042-01-01T07:34:12.000Z | consensus_finalised | attempt=2; solverId=solver-b0ce6e46ec6aee31; consensus=accepted; yesWeight=212,168 |
+| 2042-01-01T07:34:24.000Z | reward_distributed | solverId=solver-b0ce6e46ec6aee31; solverReward=500,200; validatorRewards=73,200; treasuryReturn=36,600 |
+
+```mermaid
+flowchart LR
+  Job((Job NOVA-SYN-009)):::core --> AttemptA[Attempt 1\nsolver-df8d72feae9e0558]:::warn
+  AttemptA -->|Consensus rejected| Slash[(Slash)]:::warn
+  AttemptA -->|Requeue| AttemptB[Attempt 2\nsolver-b0ce6e46ec6aee31]:::core
+  AttemptB -->|Validators| Consensus{Final consensus}:::verify
+  Consensus --> Reward[(Reward Distribution)]:::core
+  Reward --> Treasury[Treasury Return]:::governance
+  Reward --> Validators[Validator Rewards]:::governance
+  Reward --> Solver[Evolved Solver Payout]:::core
+  classDef core fill:#111827,stroke:#a855f7,stroke-width:2px,color:#f5f3ff;
+  classDef warn fill:#7f1d1d,stroke:#fecaca,stroke-width:2px,color:#fecaca;
+  classDef verify fill:#0b7285,stroke:#66d9e8,stroke-width:2px,color:#e6fcf5;
+  classDef governance fill:#1f2937,stroke:#22d3ee,stroke-width:2px,color:#e0f2fe;
 ```
 
 ## CI Shield Alignment
@@ -326,4 +509,4 @@ timeline
 
 ## Generated At
 
-2025-10-21T02:47:22.562Z
+2025-10-21T03:23:20.678Z

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T02:47:22.562Z",
+  "generatedAt": "2025-10-21T03:23:20.678Z",
   "mission": {
     "title": "Meta-Agentic Program Synthesis Sovereign Mission",
     "version": "0.1.0",
@@ -48,6 +48,16 @@
         "monitor": 0,
         "drift": 0
       }
+    },
+    "ledger": {
+      "totalRewardPaid": 1461700,
+      "totalSlashed": 52800,
+      "validatorRewards": 186600,
+      "treasuryReturn": 93300,
+      "averageParticipationRate": 0.9583333333333334,
+      "averageLatencySeconds": 250.16666666666666,
+      "accepted": 3,
+      "consensusAlerts": 0
     }
   },
   "ownerCoverage": {
@@ -294,7 +304,7 @@
           "medianScore": 56.19020618556701,
           "diversity": 0.9444444444444444,
           "eliteScore": 110.36140657817333,
-          "timestamp": "2025-10-21T02:47:22.567Z"
+          "timestamp": "2025-10-21T03:23:20.682Z"
         },
         {
           "generation": 1,
@@ -303,7 +313,7 @@
           "medianScore": 65.75277564301642,
           "diversity": 0.75,
           "eliteScore": 136.39087455307794,
-          "timestamp": "2025-10-21T02:47:22.568Z"
+          "timestamp": "2025-10-21T03:23:20.683Z"
         },
         {
           "generation": 2,
@@ -312,7 +322,7 @@
           "medianScore": 73.64584551701412,
           "diversity": 0.75,
           "eliteScore": 138.12283331596453,
-          "timestamp": "2025-10-21T02:47:22.569Z"
+          "timestamp": "2025-10-21T03:23:20.684Z"
         },
         {
           "generation": 3,
@@ -321,7 +331,7 @@
           "medianScore": 100.49230198051038,
           "diversity": 0.8333333333333334,
           "eliteScore": 138.41149310977895,
-          "timestamp": "2025-10-21T02:47:22.570Z"
+          "timestamp": "2025-10-21T03:23:20.685Z"
         },
         {
           "generation": 4,
@@ -330,7 +340,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.6944444444444444,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.571Z"
+          "timestamp": "2025-10-21T03:23:20.686Z"
         },
         {
           "generation": 5,
@@ -339,7 +349,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7777777777777778,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.573Z"
+          "timestamp": "2025-10-21T03:23:20.696Z"
         },
         {
           "generation": 6,
@@ -348,7 +358,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7777777777777778,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.574Z"
+          "timestamp": "2025-10-21T03:23:20.699Z"
         },
         {
           "generation": 7,
@@ -357,7 +367,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7222222222222222,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.574Z"
+          "timestamp": "2025-10-21T03:23:20.700Z"
         },
         {
           "generation": 8,
@@ -366,7 +376,7 @@
           "medianScore": 116.57704853345733,
           "diversity": 0.8055555555555556,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.575Z"
+          "timestamp": "2025-10-21T03:23:20.704Z"
         },
         {
           "generation": 9,
@@ -375,7 +385,7 @@
           "medianScore": 137.1920690409011,
           "diversity": 0.75,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.576Z"
+          "timestamp": "2025-10-21T03:23:20.705Z"
         }
       ],
       "triangulation": {
@@ -422,6 +432,351 @@
             "confidence": 0.2,
             "energyDelta": 8,
             "notes": "Peer median 140.38 • energy delta 8.00 (≤ 33.60)"
+          }
+        ]
+      },
+      "ledger": {
+        "summary": {
+          "finalConsensus": "accepted",
+          "totalRewardPaid": 394800,
+          "totalSlashed": 14400,
+          "validatorRewards": 50400,
+          "treasuryReturn": 25200,
+          "averageLatencySeconds": 247,
+          "participationRate": 0.875,
+          "commitRevealIntegrity": "verified",
+          "attempts": 2
+        },
+        "validators": [
+          {
+            "validatorId": "validator-195a5d4bfbdae573",
+            "stakeBefore": 52687,
+            "stakeAfter": 65287,
+            "rewardEarned": 12600,
+            "slashed": 0,
+            "participationRate": 1
+          },
+          {
+            "validatorId": "validator-76bf560baa38ba87",
+            "stakeBefore": 53186,
+            "stakeAfter": 65786,
+            "rewardEarned": 12600,
+            "slashed": 0,
+            "participationRate": 1
+          },
+          {
+            "validatorId": "validator-79c9d91afd1ddf92",
+            "stakeBefore": 60772,
+            "stakeAfter": 73372,
+            "rewardEarned": 12600,
+            "slashed": 0,
+            "participationRate": 1
+          },
+          {
+            "validatorId": "validator-a93d1e2a9c0e3a2a",
+            "stakeBefore": 49970,
+            "stakeAfter": 62570,
+            "rewardEarned": 12600,
+            "slashed": 0,
+            "participationRate": 0.5
+          }
+        ],
+        "attempts": [
+          {
+            "attemptId": "arc-sentinel-attempt-1",
+            "solverId": "solver-834077d2c7cd0093",
+            "status": "slashed",
+            "commitHash": "cdccfe1d1ecc488574b306b0afa622e76d4619196d444d00ed36bc17317dba16",
+            "reveal": "insufficient-delta",
+            "consensus": "rejected",
+            "rewardEarned": 0,
+            "slashApplied": 14400,
+            "latencySeconds": 164,
+            "energyObserved": 70.4,
+            "notes": "Consensus rejected misaligned agent – stake partially slashed and job requeued.",
+            "votes": [
+              {
+                "validatorId": "validator-195a5d4bfbdae573",
+                "commitment": "6a13cc921e0d27d543a1f1a7b80eb4fa2b75c0525449b8f73a219358fdeb5116",
+                "revealed": "yes",
+                "weight": 52687,
+                "rewardEarned": 0,
+                "slashed": 0
+              },
+              {
+                "validatorId": "validator-76bf560baa38ba87",
+                "commitment": "ff5cf0e04b2467375ef805362e542c143abea25b2bb7bb443515daa8dc3f1354",
+                "revealed": "no",
+                "weight": 53186,
+                "rewardEarned": 0,
+                "slashed": 0,
+                "notes": "Detected thermodynamic drift"
+              },
+              {
+                "validatorId": "validator-79c9d91afd1ddf92",
+                "commitment": "95fe40173c0a29a739e2d0fa2d0105c755fb04b43e3532d8c310c35ce472c1d2",
+                "revealed": "no",
+                "weight": 60772,
+                "rewardEarned": 0,
+                "slashed": 0,
+                "notes": "Detected thermodynamic drift"
+              }
+            ]
+          },
+          {
+            "attemptId": "arc-sentinel-attempt-2",
+            "solverId": "solver-85b7571cb9684c4c",
+            "status": "accepted",
+            "commitHash": "a71fc6a4d27f9928547e7c9286a86675979d6854026355e0559ce8baf2e50211",
+            "reveal": "arc-sentinel-g4-c166",
+            "consensus": "accepted",
+            "rewardEarned": 344400,
+            "slashApplied": 0,
+            "latencySeconds": 330,
+            "energyObserved": 88,
+            "notes": "Meta-agentic evolved solver achieved consensus and claimed rewards.",
+            "votes": [
+              {
+                "validatorId": "validator-195a5d4bfbdae573",
+                "commitment": "c0e7ac904a95f3b6b07a2d8458d1be1ea31b81714501555ef6da2be49ddaadce",
+                "revealed": "yes",
+                "weight": 52687,
+                "rewardEarned": 12600,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              },
+              {
+                "validatorId": "validator-76bf560baa38ba87",
+                "commitment": "ba808148dada8a23c0977f5798f313954ad76c389605df96d26cab84f14ea32a",
+                "revealed": "yes",
+                "weight": 53186,
+                "rewardEarned": 12600,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              },
+              {
+                "validatorId": "validator-79c9d91afd1ddf92",
+                "commitment": "9d1ce6a17520b9b429f727eeb800908b5a13200a307782f3a8874baf70f96c11",
+                "revealed": "yes",
+                "weight": 60772,
+                "rewardEarned": 12600,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              },
+              {
+                "validatorId": "validator-a93d1e2a9c0e3a2a",
+                "commitment": "d112ff2b6d9545978359f988200e0c135e6b7c05e0812b51815198a85b53a97f",
+                "revealed": "yes",
+                "weight": 49970,
+                "rewardEarned": 12600,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              }
+            ]
+          }
+        ],
+        "timeline": [
+          {
+            "timestamp": "2042-01-01T08:54:24.000Z",
+            "type": "job_posted",
+            "details": {
+              "jobId": "ARC-SYN-001",
+              "reward": 420000,
+              "stakeRequired": 120000,
+              "description": "Detect latent pixel edges, amplify discovery, and route high-confidence transformations back into the shared skill graph."
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:55:09.000Z",
+            "type": "solver_selected",
+            "details": {
+              "solverId": "solver-834077d2c7cd0093",
+              "stakePosted": 120000
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:55:44.000Z",
+            "type": "result_committed",
+            "details": {
+              "solverId": "solver-834077d2c7cd0093",
+              "commit": "cdccfe1d1ecc488574b306b0afa622e76d4619196d444d00ed36bc17317dba16"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:55:54.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-195a5d4bfbdae573",
+              "commitment": "6a13cc921e0d27d543a1f1a7b80eb4fa2b75c0525449b8f73a219358fdeb5116"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:56:09.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-195a5d4bfbdae573",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:56:20.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-76bf560baa38ba87",
+              "commitment": "ff5cf0e04b2467375ef805362e542c143abea25b2bb7bb443515daa8dc3f1354"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:56:31.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-76bf560baa38ba87",
+              "vote": "no"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:56:42.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-79c9d91afd1ddf92",
+              "commitment": "95fe40173c0a29a739e2d0fa2d0105c755fb04b43e3532d8c310c35ce472c1d2"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:56:52.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-79c9d91afd1ddf92",
+              "vote": "no"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:57:08.000Z",
+            "type": "consensus_finalised",
+            "details": {
+              "attempt": 1,
+              "solverId": "solver-834077d2c7cd0093",
+              "consensus": "rejected",
+              "yesWeight": 52687
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:57:14.000Z",
+            "type": "slash_applied",
+            "details": {
+              "solverId": "solver-834077d2c7cd0093",
+              "amount": 14400,
+              "reason": "Failed consensus"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:57:26.000Z",
+            "type": "requeue",
+            "details": {
+              "solverId": "solver-85b7571cb9684c4c",
+              "reason": "Meta-architect escalated to evolved agent"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:57:30.000Z",
+            "type": "solver_selected",
+            "details": {
+              "solverId": "solver-85b7571cb9684c4c",
+              "stakePosted": 120000
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:58:02.000Z",
+            "type": "result_committed",
+            "details": {
+              "solverId": "solver-85b7571cb9684c4c",
+              "commit": "a71fc6a4d27f9928547e7c9286a86675979d6854026355e0559ce8baf2e50211",
+              "operations": 4
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:58:13.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-195a5d4bfbdae573",
+              "commitment": "c0e7ac904a95f3b6b07a2d8458d1be1ea31b81714501555ef6da2be49ddaadce"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:58:24.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-195a5d4bfbdae573",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:58:33.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-76bf560baa38ba87",
+              "commitment": "ba808148dada8a23c0977f5798f313954ad76c389605df96d26cab84f14ea32a"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:58:46.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-76bf560baa38ba87",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:58:55.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-79c9d91afd1ddf92",
+              "commitment": "9d1ce6a17520b9b429f727eeb800908b5a13200a307782f3a8874baf70f96c11"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:59:08.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-79c9d91afd1ddf92",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:59:16.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-a93d1e2a9c0e3a2a",
+              "commitment": "d112ff2b6d9545978359f988200e0c135e6b7c05e0812b51815198a85b53a97f"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:59:28.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-a93d1e2a9c0e3a2a",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:59:42.000Z",
+            "type": "consensus_finalised",
+            "details": {
+              "attempt": 2,
+              "solverId": "solver-85b7571cb9684c4c",
+              "consensus": "accepted",
+              "yesWeight": 216615
+            }
+          },
+          {
+            "timestamp": "2042-01-01T08:59:54.000Z",
+            "type": "reward_distributed",
+            "details": {
+              "solverId": "solver-85b7571cb9684c4c",
+              "solverReward": 344400,
+              "validatorRewards": 50400,
+              "treasuryReturn": 25200
+            }
           }
         ]
       }
@@ -670,7 +1025,7 @@
           "medianScore": 41.03751524896436,
           "diversity": 0.9722222222222222,
           "eliteScore": 96.0918022581709,
-          "timestamp": "2025-10-21T02:47:22.578Z"
+          "timestamp": "2025-10-21T03:23:20.716Z"
         },
         {
           "generation": 1,
@@ -679,7 +1034,7 @@
           "medianScore": 62.99975060567376,
           "diversity": 0.9444444444444444,
           "eliteScore": 98.43691088683215,
-          "timestamp": "2025-10-21T02:47:22.579Z"
+          "timestamp": "2025-10-21T03:23:20.717Z"
         },
         {
           "generation": 2,
@@ -688,7 +1043,7 @@
           "medianScore": 76.53115760829131,
           "diversity": 0.75,
           "eliteScore": 132.5084085000921,
-          "timestamp": "2025-10-21T02:47:22.580Z"
+          "timestamp": "2025-10-21T03:23:20.718Z"
         },
         {
           "generation": 3,
@@ -697,7 +1052,7 @@
           "medianScore": 77.95296283436663,
           "diversity": 0.7222222222222222,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.581Z"
+          "timestamp": "2025-10-21T03:23:20.719Z"
         },
         {
           "generation": 4,
@@ -706,7 +1061,7 @@
           "medianScore": 86.94000111220245,
           "diversity": 0.7222222222222222,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.581Z"
+          "timestamp": "2025-10-21T03:23:20.725Z"
         },
         {
           "generation": 5,
@@ -715,7 +1070,7 @@
           "medianScore": 88.99300139019402,
           "diversity": 0.6111111111111112,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.582Z"
+          "timestamp": "2025-10-21T03:23:20.726Z"
         },
         {
           "generation": 6,
@@ -724,7 +1079,7 @@
           "medianScore": 83.23985249780515,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.583Z"
+          "timestamp": "2025-10-21T03:23:20.727Z"
         },
         {
           "generation": 7,
@@ -733,7 +1088,7 @@
           "medianScore": 82.9194778065494,
           "diversity": 0.6111111111111112,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.584Z"
+          "timestamp": "2025-10-21T03:23:20.727Z"
         },
         {
           "generation": 8,
@@ -742,7 +1097,7 @@
           "medianScore": 86.367830024997,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.585Z"
+          "timestamp": "2025-10-21T03:23:20.728Z"
         },
         {
           "generation": 9,
@@ -751,7 +1106,7 @@
           "medianScore": 85.09002044220831,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.585Z"
+          "timestamp": "2025-10-21T03:23:20.728Z"
         }
       ],
       "triangulation": {
@@ -798,6 +1153,376 @@
             "confidence": 0.2,
             "energyDelta": 64,
             "notes": "Peer median 133.04 • energy delta 64.00 (≤ 44.80)"
+          }
+        ]
+      },
+      "ledger": {
+        "summary": {
+          "finalConsensus": "accepted",
+          "totalRewardPaid": 493500,
+          "totalSlashed": 18600,
+          "validatorRewards": 63000,
+          "treasuryReturn": 31500,
+          "averageLatencySeconds": 270,
+          "participationRate": 1,
+          "commitRevealIntegrity": "verified",
+          "attempts": 2
+        },
+        "validators": [
+          {
+            "validatorId": "validator-02b303e331d093d1",
+            "stakeBefore": 60555,
+            "stakeAfter": 76305,
+            "rewardEarned": 15750,
+            "slashed": 0,
+            "participationRate": 1
+          },
+          {
+            "validatorId": "validator-8fb387f22ab17dbb",
+            "stakeBefore": 77689,
+            "stakeAfter": 93439,
+            "rewardEarned": 15750,
+            "slashed": 0,
+            "participationRate": 1
+          },
+          {
+            "validatorId": "validator-b48c4f3bd017c796",
+            "stakeBefore": 60967,
+            "stakeAfter": 76717,
+            "rewardEarned": 15750,
+            "slashed": 0,
+            "participationRate": 1
+          },
+          {
+            "validatorId": "validator-f3cbd6e75978a4b6",
+            "stakeBefore": 78620,
+            "stakeAfter": 94370,
+            "rewardEarned": 15750,
+            "slashed": 0,
+            "participationRate": 1
+          }
+        ],
+        "attempts": [
+          {
+            "attemptId": "ledger-harmonics-attempt-1",
+            "solverId": "solver-424046f71a035fe6",
+            "status": "slashed",
+            "commitHash": "3a489a39a4ac760eea4e21600c7db814fc7ef4e73499a6f0e7c200e447c856d5",
+            "reveal": "insufficient-delta",
+            "consensus": "rejected",
+            "rewardEarned": 0,
+            "slashApplied": 18600,
+            "latencySeconds": 189,
+            "energyObserved": 51.2,
+            "notes": "Consensus rejected misaligned agent – stake partially slashed and job requeued.",
+            "votes": [
+              {
+                "validatorId": "validator-02b303e331d093d1",
+                "commitment": "386876e8b46f541afba7e9ba7981dc0e41940b840db1165200b4fc64be00fa49",
+                "revealed": "no",
+                "weight": 60555,
+                "rewardEarned": 0,
+                "slashed": 0,
+                "notes": "Detected thermodynamic drift"
+              },
+              {
+                "validatorId": "validator-8fb387f22ab17dbb",
+                "commitment": "d26aaf535bef21fa45371b67e612ecbf4724c3beceefe3b1a7c4771a699ff16c",
+                "revealed": "yes",
+                "weight": 77689,
+                "rewardEarned": 0,
+                "slashed": 0
+              },
+              {
+                "validatorId": "validator-b48c4f3bd017c796",
+                "commitment": "811943ed1d5afdf34e266be81f71f2fddee8d3426f4d5f4ae04b55056f5f3021",
+                "revealed": "no",
+                "weight": 60967,
+                "rewardEarned": 0,
+                "slashed": 0,
+                "notes": "Detected thermodynamic drift"
+              },
+              {
+                "validatorId": "validator-f3cbd6e75978a4b6",
+                "commitment": "df4080472bf5202c53c8cb11c5b947306a9a14c0bf8db697cf7d132e6fe4329d",
+                "revealed": "no",
+                "weight": 78620,
+                "rewardEarned": 0,
+                "slashed": 0,
+                "notes": "Detected thermodynamic drift"
+              }
+            ]
+          },
+          {
+            "attemptId": "ledger-harmonics-attempt-2",
+            "solverId": "solver-04c1f887eae22b1e",
+            "status": "accepted",
+            "commitHash": "ebda15b38d5047ceaade3779010231933171b8cdb316da86dbb9e61379be79fa",
+            "reveal": "ledger-harmonics-g0-c361",
+            "consensus": "accepted",
+            "rewardEarned": 430500,
+            "slashApplied": 0,
+            "latencySeconds": 351,
+            "energyObserved": 64,
+            "notes": "Meta-agentic evolved solver achieved consensus and claimed rewards.",
+            "votes": [
+              {
+                "validatorId": "validator-02b303e331d093d1",
+                "commitment": "a9ff81a696c9a6329240f07cca03b7d28a3d6b7674cf7706e5c465ec3e792d4e",
+                "revealed": "yes",
+                "weight": 60555,
+                "rewardEarned": 15750,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              },
+              {
+                "validatorId": "validator-8fb387f22ab17dbb",
+                "commitment": "781a3ed0c6d16a9f5f6540199d91856aacd60d7ebbc832febf25e052a62f4f5c",
+                "revealed": "yes",
+                "weight": 77689,
+                "rewardEarned": 15750,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              },
+              {
+                "validatorId": "validator-b48c4f3bd017c796",
+                "commitment": "39593093be96192e274a31d636936a404d09f149af4366a54a2b4b2fd463bb23",
+                "revealed": "yes",
+                "weight": 60967,
+                "rewardEarned": 15750,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              },
+              {
+                "validatorId": "validator-f3cbd6e75978a4b6",
+                "commitment": "a1ead23f0685e364f8d70ef43d00c2e91a83cfda9a907ba1fa0b75579202cc58",
+                "revealed": "yes",
+                "weight": 78620,
+                "rewardEarned": 15750,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              }
+            ]
+          }
+        ],
+        "timeline": [
+          {
+            "timestamp": "2042-01-01T13:16:24.000Z",
+            "type": "job_posted",
+            "details": {
+              "jobId": "LEDGER-SYN-007",
+              "reward": 525000,
+              "stakeRequired": 155000,
+              "description": "Absorb asynchronous cash-flow deltas, stabilise them against the thermodynamic ledger, and emit rebalanced incentive curves for validator coalitions."
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:17:09.000Z",
+            "type": "solver_selected",
+            "details": {
+              "solverId": "solver-424046f71a035fe6",
+              "stakePosted": 155000
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:17:44.000Z",
+            "type": "result_committed",
+            "details": {
+              "solverId": "solver-424046f71a035fe6",
+              "commit": "3a489a39a4ac760eea4e21600c7db814fc7ef4e73499a6f0e7c200e447c856d5"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:17:55.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-02b303e331d093d1",
+              "commitment": "386876e8b46f541afba7e9ba7981dc0e41940b840db1165200b4fc64be00fa49"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:18:08.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-02b303e331d093d1",
+              "vote": "no"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:18:17.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-8fb387f22ab17dbb",
+              "commitment": "d26aaf535bef21fa45371b67e612ecbf4724c3beceefe3b1a7c4771a699ff16c"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:18:31.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-8fb387f22ab17dbb",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:18:41.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-b48c4f3bd017c796",
+              "commitment": "811943ed1d5afdf34e266be81f71f2fddee8d3426f4d5f4ae04b55056f5f3021"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:18:53.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-b48c4f3bd017c796",
+              "vote": "no"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:19:05.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-f3cbd6e75978a4b6",
+              "commitment": "df4080472bf5202c53c8cb11c5b947306a9a14c0bf8db697cf7d132e6fe4329d"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:19:17.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-f3cbd6e75978a4b6",
+              "vote": "no"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:19:33.000Z",
+            "type": "consensus_finalised",
+            "details": {
+              "attempt": 1,
+              "solverId": "solver-424046f71a035fe6",
+              "consensus": "rejected",
+              "yesWeight": 77689
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:19:39.000Z",
+            "type": "slash_applied",
+            "details": {
+              "solverId": "solver-424046f71a035fe6",
+              "amount": 18600,
+              "reason": "Failed consensus"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:19:51.000Z",
+            "type": "requeue",
+            "details": {
+              "solverId": "solver-04c1f887eae22b1e",
+              "reason": "Meta-architect escalated to evolved agent"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:19:55.000Z",
+            "type": "solver_selected",
+            "details": {
+              "solverId": "solver-04c1f887eae22b1e",
+              "stakePosted": 155000
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:20:27.000Z",
+            "type": "result_committed",
+            "details": {
+              "solverId": "solver-04c1f887eae22b1e",
+              "commit": "ebda15b38d5047ceaade3779010231933171b8cdb316da86dbb9e61379be79fa",
+              "operations": 3
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:20:37.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-02b303e331d093d1",
+              "commitment": "a9ff81a696c9a6329240f07cca03b7d28a3d6b7674cf7706e5c465ec3e792d4e"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:20:50.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-02b303e331d093d1",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:21:01.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-8fb387f22ab17dbb",
+              "commitment": "781a3ed0c6d16a9f5f6540199d91856aacd60d7ebbc832febf25e052a62f4f5c"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:21:10.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-8fb387f22ab17dbb",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:21:19.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-b48c4f3bd017c796",
+              "commitment": "39593093be96192e274a31d636936a404d09f149af4366a54a2b4b2fd463bb23"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:21:28.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-b48c4f3bd017c796",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:21:38.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-f3cbd6e75978a4b6",
+              "commitment": "a1ead23f0685e364f8d70ef43d00c2e91a83cfda9a907ba1fa0b75579202cc58"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:21:49.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-f3cbd6e75978a4b6",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:22:03.000Z",
+            "type": "consensus_finalised",
+            "details": {
+              "attempt": 2,
+              "solverId": "solver-04c1f887eae22b1e",
+              "consensus": "accepted",
+              "yesWeight": 277831
+            }
+          },
+          {
+            "timestamp": "2042-01-01T13:22:15.000Z",
+            "type": "reward_distributed",
+            "details": {
+              "solverId": "solver-04c1f887eae22b1e",
+              "solverReward": 430500,
+              "validatorRewards": 63000,
+              "treasuryReturn": 31500
+            }
           }
         ]
       }
@@ -1075,7 +1800,7 @@
           "medianScore": 23.447749293641056,
           "diversity": 1,
           "eliteScore": 97.42746077012889,
-          "timestamp": "2025-10-21T02:47:22.586Z"
+          "timestamp": "2025-10-21T03:23:20.730Z"
         },
         {
           "generation": 1,
@@ -1084,7 +1809,7 @@
           "medianScore": 33.23577114240753,
           "diversity": 1,
           "eliteScore": 101.68095349725729,
-          "timestamp": "2025-10-21T02:47:22.587Z"
+          "timestamp": "2025-10-21T03:23:20.731Z"
         },
         {
           "generation": 2,
@@ -1093,7 +1818,7 @@
           "medianScore": 64.46743238768931,
           "diversity": 0.8888888888888888,
           "eliteScore": 125.76131787031291,
-          "timestamp": "2025-10-21T02:47:22.587Z"
+          "timestamp": "2025-10-21T03:23:20.731Z"
         },
         {
           "generation": 3,
@@ -1102,7 +1827,7 @@
           "medianScore": 70.39942915911845,
           "diversity": 0.8611111111111112,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.588Z"
+          "timestamp": "2025-10-21T03:23:20.732Z"
         },
         {
           "generation": 4,
@@ -1111,7 +1836,7 @@
           "medianScore": 71.05162669292856,
           "diversity": 0.8333333333333334,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.589Z"
+          "timestamp": "2025-10-21T03:23:20.733Z"
         },
         {
           "generation": 5,
@@ -1120,7 +1845,7 @@
           "medianScore": 53.843889930604206,
           "diversity": 0.7777777777777778,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.589Z"
+          "timestamp": "2025-10-21T03:23:20.733Z"
         },
         {
           "generation": 6,
@@ -1129,7 +1854,7 @@
           "medianScore": 78.25900854278035,
           "diversity": 0.6666666666666666,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.597Z"
+          "timestamp": "2025-10-21T03:23:20.734Z"
         },
         {
           "generation": 7,
@@ -1138,7 +1863,7 @@
           "medianScore": 91.68021852282594,
           "diversity": 0.5,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.598Z"
+          "timestamp": "2025-10-21T03:23:20.734Z"
         },
         {
           "generation": 8,
@@ -1147,7 +1872,7 @@
           "medianScore": 84.52984866490183,
           "diversity": 0.6388888888888888,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.598Z"
+          "timestamp": "2025-10-21T03:23:20.735Z"
         },
         {
           "generation": 9,
@@ -1156,7 +1881,7 @@
           "medianScore": 90.34258929546631,
           "diversity": 0.6388888888888888,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.599Z"
+          "timestamp": "2025-10-21T03:23:20.736Z"
         }
       ],
       "triangulation": {
@@ -1203,6 +1928,318 @@
             "confidence": 0.2,
             "energyDelta": 76,
             "notes": "Peer median 136.05 • energy delta 76.00 (≤ 50.40)"
+          }
+        ]
+      },
+      "ledger": {
+        "summary": {
+          "finalConsensus": "accepted",
+          "totalRewardPaid": 573400,
+          "totalSlashed": 19800,
+          "validatorRewards": 73200,
+          "treasuryReturn": 36600,
+          "averageLatencySeconds": 233.5,
+          "participationRate": 1,
+          "commitRevealIntegrity": "verified",
+          "attempts": 2
+        },
+        "validators": [
+          {
+            "validatorId": "validator-998a4f56b41c1653",
+            "stakeBefore": 85872,
+            "stakeAfter": 110272,
+            "rewardEarned": 24400,
+            "slashed": 0,
+            "participationRate": 1
+          },
+          {
+            "validatorId": "validator-9d05a69084156cb4",
+            "stakeBefore": 68211,
+            "stakeAfter": 92611,
+            "rewardEarned": 24400,
+            "slashed": 0,
+            "participationRate": 1
+          },
+          {
+            "validatorId": "validator-d3dc9de91651750d",
+            "stakeBefore": 58085,
+            "stakeAfter": 82485,
+            "rewardEarned": 24400,
+            "slashed": 0,
+            "participationRate": 1
+          }
+        ],
+        "attempts": [
+          {
+            "attemptId": "nova-weave-attempt-1",
+            "solverId": "solver-df8d72feae9e0558",
+            "status": "slashed",
+            "commitHash": "53ccd0481295cff8b777e9e746537f782210d0d6634463a6ee45af55c9df399c",
+            "reveal": "insufficient-delta",
+            "consensus": "rejected",
+            "rewardEarned": 0,
+            "slashApplied": 19800,
+            "latencySeconds": 163,
+            "energyObserved": 54.400000000000006,
+            "notes": "Consensus rejected misaligned agent – stake partially slashed and job requeued.",
+            "votes": [
+              {
+                "validatorId": "validator-998a4f56b41c1653",
+                "commitment": "b1c8d5fb8311d466fe88c58b0121b6c45662d842bf31bfe7485ceae3038ccd8c",
+                "revealed": "no",
+                "weight": 85872,
+                "rewardEarned": 0,
+                "slashed": 0,
+                "notes": "Detected thermodynamic drift"
+              },
+              {
+                "validatorId": "validator-9d05a69084156cb4",
+                "commitment": "4657fd854d9a91e5f21ab296f043f3cb95e3e701e4a80fb5c7fc3a5bfef81729",
+                "revealed": "yes",
+                "weight": 68211,
+                "rewardEarned": 0,
+                "slashed": 0
+              },
+              {
+                "validatorId": "validator-d3dc9de91651750d",
+                "commitment": "b4affd948c6de5ef384077b29023dd77a88c6af547d1f8308a27ad6a0895ced4",
+                "revealed": "no",
+                "weight": 58085,
+                "rewardEarned": 0,
+                "slashed": 0,
+                "notes": "Detected thermodynamic drift"
+              }
+            ]
+          },
+          {
+            "attemptId": "nova-weave-attempt-2",
+            "solverId": "solver-b0ce6e46ec6aee31",
+            "status": "accepted",
+            "commitHash": "ec051e8ee05f18e96d72bcc879d6325db1bba43c808cc42dfbe7895eabdea108",
+            "reveal": "nova-weave-g0-c721",
+            "consensus": "accepted",
+            "rewardEarned": 500200,
+            "slashApplied": 0,
+            "latencySeconds": 304,
+            "energyObserved": 68,
+            "notes": "Meta-agentic evolved solver achieved consensus and claimed rewards.",
+            "votes": [
+              {
+                "validatorId": "validator-998a4f56b41c1653",
+                "commitment": "76f6ee53383c2999cbe79913a5f6167c4ca686cdc3e266a2e28c96fea559c37a",
+                "revealed": "yes",
+                "weight": 85872,
+                "rewardEarned": 24400,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              },
+              {
+                "validatorId": "validator-9d05a69084156cb4",
+                "commitment": "8976703d78e5c6073ca9f883c7e6593a311201bf7e021cdfd02726cb0d218003",
+                "revealed": "yes",
+                "weight": 68211,
+                "rewardEarned": 24400,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              },
+              {
+                "validatorId": "validator-d3dc9de91651750d",
+                "commitment": "3cb52a63d7218a3eaa12727a77ed6b8e3c2261ed8db9007f22ec5ce0849c7d8d",
+                "revealed": "yes",
+                "weight": 58085,
+                "rewardEarned": 24400,
+                "slashed": 0,
+                "notes": "Validated evolved solver output"
+              }
+            ]
+          }
+        ],
+        "timeline": [
+          {
+            "timestamp": "2042-01-01T07:29:20.000Z",
+            "type": "job_posted",
+            "details": {
+              "jobId": "NOVA-SYN-009",
+              "reward": 610000,
+              "stakeRequired": 165000,
+              "description": "Elevate alpha sequences into deterministic blueprints that compile into on-chain production payloads with zero manual edits."
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:30:05.000Z",
+            "type": "solver_selected",
+            "details": {
+              "solverId": "solver-df8d72feae9e0558",
+              "stakePosted": 165000
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:30:40.000Z",
+            "type": "result_committed",
+            "details": {
+              "solverId": "solver-df8d72feae9e0558",
+              "commit": "53ccd0481295cff8b777e9e746537f782210d0d6634463a6ee45af55c9df399c"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:30:49.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-998a4f56b41c1653",
+              "commitment": "b1c8d5fb8311d466fe88c58b0121b6c45662d842bf31bfe7485ceae3038ccd8c"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:31:00.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-998a4f56b41c1653",
+              "vote": "no"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:31:10.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-9d05a69084156cb4",
+              "commitment": "4657fd854d9a91e5f21ab296f043f3cb95e3e701e4a80fb5c7fc3a5bfef81729"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:31:23.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-9d05a69084156cb4",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:31:32.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-d3dc9de91651750d",
+              "commitment": "b4affd948c6de5ef384077b29023dd77a88c6af547d1f8308a27ad6a0895ced4"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:31:47.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-d3dc9de91651750d",
+              "vote": "no"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:32:03.000Z",
+            "type": "consensus_finalised",
+            "details": {
+              "attempt": 1,
+              "solverId": "solver-df8d72feae9e0558",
+              "consensus": "rejected",
+              "yesWeight": 68211
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:32:09.000Z",
+            "type": "slash_applied",
+            "details": {
+              "solverId": "solver-df8d72feae9e0558",
+              "amount": 19800,
+              "reason": "Failed consensus"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:32:21.000Z",
+            "type": "requeue",
+            "details": {
+              "solverId": "solver-b0ce6e46ec6aee31",
+              "reason": "Meta-architect escalated to evolved agent"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:32:25.000Z",
+            "type": "solver_selected",
+            "details": {
+              "solverId": "solver-b0ce6e46ec6aee31",
+              "stakePosted": 165000
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:32:57.000Z",
+            "type": "result_committed",
+            "details": {
+              "solverId": "solver-b0ce6e46ec6aee31",
+              "commit": "ec051e8ee05f18e96d72bcc879d6325db1bba43c808cc42dfbe7895eabdea108",
+              "operations": 3
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:33:04.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-998a4f56b41c1653",
+              "commitment": "76f6ee53383c2999cbe79913a5f6167c4ca686cdc3e266a2e28c96fea559c37a"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:33:15.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-998a4f56b41c1653",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:33:25.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-9d05a69084156cb4",
+              "commitment": "8976703d78e5c6073ca9f883c7e6593a311201bf7e021cdfd02726cb0d218003"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:33:35.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-9d05a69084156cb4",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:33:46.000Z",
+            "type": "vote_commit",
+            "details": {
+              "validator": "validator-d3dc9de91651750d",
+              "commitment": "3cb52a63d7218a3eaa12727a77ed6b8e3c2261ed8db9007f22ec5ce0849c7d8d"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:33:58.000Z",
+            "type": "vote_reveal",
+            "details": {
+              "validator": "validator-d3dc9de91651750d",
+              "vote": "yes"
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:34:12.000Z",
+            "type": "consensus_finalised",
+            "details": {
+              "attempt": 2,
+              "solverId": "solver-b0ce6e46ec6aee31",
+              "consensus": "accepted",
+              "yesWeight": 212168
+            }
+          },
+          {
+            "timestamp": "2042-01-01T07:34:24.000Z",
+            "type": "reward_distributed",
+            "details": {
+              "solverId": "solver-b0ce6e46ec6aee31",
+              "solverReward": 500200,
+              "validatorRewards": 73200,
+              "treasuryReturn": 36600
+            }
           }
         ]
       }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-triangulation.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-triangulation.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T02:47:22.562Z",
+  "generatedAt": "2025-10-21T03:23:20.678Z",
   "confidence": 0.5333333333333333,
   "consensus": {
     "confirmed": 1,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/__tests__/ledgerSimulation.test.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/__tests__/ledgerSimulation.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import { loadMissionConfig, runMetaSynthesis } from "../synthesisEngine";
+
+const MISSION_PATH = path.resolve(__dirname, "..", "..", "config", "mission.meta-agentic-program-synthesis.json");
+
+test("ledger summary reaches accepted consensus with slashing before rewards", async () => {
+  const { mission } = await loadMissionConfig(MISSION_PATH);
+  const run = runMetaSynthesis(mission);
+  const ledger = run.tasks[0]?.ledger;
+  assert.ok(ledger, "ledger data should be present");
+  assert.equal(ledger.summary.finalConsensus, "accepted");
+  assert.ok(ledger.summary.totalSlashed > 0, "expected at least one slashing event");
+  assert.ok(ledger.summary.validatorRewards > 0, "validator rewards should be positive");
+  const slashIndex = ledger.timeline.findIndex((event) => event.type === "slash_applied");
+  const rewardIndex = ledger.timeline.findIndex((event) => event.type === "reward_distributed");
+  assert.notEqual(slashIndex, -1, "slash event should exist");
+  assert.notEqual(rewardIndex, -1, "reward event should exist");
+  assert.ok(slashIndex < rewardIndex, "slash must precede reward distribution");
+});
+
+test("ledger simulation is deterministic for identical missions", async () => {
+  const { mission } = await loadMissionConfig(MISSION_PATH);
+  const first = runMetaSynthesis(mission);
+  const second = runMetaSynthesis(mission);
+  assert.deepEqual(first.aggregate.ledger, second.aggregate.ledger);
+  first.tasks.forEach((task, index) => {
+    assert.deepEqual(task.ledger.summary, second.tasks[index]?.ledger.summary);
+  });
+});
+
+test("ledger reward and slashing accounting is conserved", async () => {
+  const { mission } = await loadMissionConfig(MISSION_PATH);
+  const run = runMetaSynthesis(mission);
+  run.tasks.forEach((task) => {
+    const rewardFromAttempts = task.ledger.attempts.reduce((acc, attempt) => acc + attempt.rewardEarned, 0);
+    const rewardFromValidators = task.ledger.validators.reduce((acc, validator) => acc + validator.rewardEarned, 0);
+    assert.equal(
+      rewardFromAttempts + rewardFromValidators,
+      task.ledger.summary.totalRewardPaid,
+      "total rewards should equal solver + validator payouts",
+    );
+    const slashedFromAttempts = task.ledger.attempts.reduce((acc, attempt) => acc + attempt.slashApplied, 0);
+    assert.equal(
+      slashedFromAttempts,
+      task.ledger.summary.totalSlashed,
+      "summary slashed value should match attempt totals",
+    );
+  });
+});

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/fullPipeline.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/fullPipeline.ts
@@ -54,6 +54,9 @@ function renderMarkdown(
   lines.push(
     `- Thermodynamic alignment: ${formatPercent(run.aggregate.thermodynamics.averageAlignment)} (mean Δ ${formatNumber(run.aggregate.thermodynamics.meanDelta)} | max Δ ${formatNumber(run.aggregate.thermodynamics.maxDelta)} | ${formatThermoStatus(run.aggregate.thermodynamics.statusCounts)})`,
   );
+  lines.push(
+    `- Ledger economy: rewards ${run.aggregate.ledger.totalRewardPaid.toLocaleString()} | slashed ${run.aggregate.ledger.totalSlashed.toLocaleString()} | validator rewards ${run.aggregate.ledger.validatorRewards.toLocaleString()} | treasury ${run.aggregate.ledger.treasuryReturn.toLocaleString()} | participation ${(run.aggregate.ledger.averageParticipationRate * 100).toFixed(1)}% | latency ${run.aggregate.ledger.averageLatencySeconds.toFixed(1)}s | alerts ${run.aggregate.ledger.consensusAlerts}`,
+  );
   lines.push("");
   lines.push("## Verification Consensus");
   lines.push("");

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/ledgerSimulation.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/ledgerSimulation.ts
@@ -1,0 +1,361 @@
+import { createHash } from "crypto";
+import type {
+  CandidateRecord,
+  LedgerAttempt,
+  LedgerVote,
+  MissionConfig,
+  TaskDefinition,
+  TaskLedger,
+  TaskLedgerSummary,
+} from "./types";
+import { DeterministicRandom } from "./random";
+
+interface LedgerAgent {
+  id: string;
+  baseStake: number;
+  reputation: number;
+}
+
+interface LedgerValidator extends LedgerAgent {
+  reliability: number;
+}
+
+interface TimelineEvent {
+  offset: number;
+  type: "job_posted" | "solver_selected" | "result_committed" | "vote_commit" | "vote_reveal" | "consensus_finalised" | "reward_distributed" | "slash_applied" | "requeue";
+  details: Record<string, unknown>;
+}
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) % 2147483647;
+  }
+  return hash === 0 ? 1 : hash;
+}
+
+function deterministicId(prefix: string, seed: number, rng: DeterministicRandom): string {
+  const base = `${prefix}-${Math.abs(seed)}-${Math.floor(rng.next() * 10_000)}`;
+  return createHash("sha1").update(base).digest("hex").slice(0, 16);
+}
+
+function buildValidators(task: TaskDefinition, mission: MissionConfig, seed: number): LedgerValidator[] {
+  const rng = new DeterministicRandom(seed + 577);
+  const validatorCount = Math.max(3, Math.min(6, 3 + Math.floor(rng.next() * 3)));
+  const validators: LedgerValidator[] = [];
+  for (let index = 0; index < validatorCount; index += 1) {
+    validators.push({
+      id: `validator-${deterministicId(task.id, seed + index * 19, rng)}`,
+      baseStake: Math.floor(task.owner.stake * (0.35 + rng.next() * 0.2)),
+      reputation: 0.85 + rng.next() * 0.1,
+      reliability: 0.88 + rng.next() * 0.09,
+    });
+  }
+  // ensure deterministic ordering
+  validators.sort((a, b) => a.id.localeCompare(b.id));
+  return validators;
+}
+
+function buildSolverCandidates(task: TaskDefinition, seed: number): LedgerAgent[] {
+  const rng = new DeterministicRandom(seed + 113);
+  const agents: LedgerAgent[] = [];
+  const baseStake = Math.max(task.owner.stake, 120_000);
+  for (let index = 0; index < 2; index += 1) {
+    agents.push({
+      id: `solver-${deterministicId(task.id, seed + index * 97, rng)}`,
+      baseStake,
+      reputation: 0.75 + rng.next() * 0.15,
+    });
+  }
+  return agents;
+}
+
+function encodeCommitment(payload: string): string {
+  return createHash("sha256").update(payload).digest("hex");
+}
+
+function scheduleEvents(baseTimestamp: number, events: TimelineEvent[]): {
+  timeline: { timestamp: string; type: TimelineEvent["type"]; details: Record<string, unknown> }[];
+} {
+  const sorted = [...events].sort((a, b) => a.offset - b.offset);
+  return {
+    timeline: sorted.map((entry) => ({
+      timestamp: new Date(baseTimestamp + entry.offset * 1000).toISOString(),
+      type: entry.type,
+      details: entry.details,
+    })),
+  };
+}
+
+export function simulateLedger(
+  task: TaskDefinition,
+  mission: MissionConfig,
+  candidate: CandidateRecord,
+  seed: number,
+): TaskLedger {
+  const baseSeed = hashString(`${task.id}|${mission.meta.ownerAddress}|${mission.parameters.seed}`) + Math.abs(seed) * 13;
+  const rng = new DeterministicRandom(baseSeed);
+  const validators = buildValidators(task, mission, baseSeed);
+  const solvers = buildSolverCandidates(task, baseSeed);
+  const baseTimestamp = Date.UTC(2042, 0, 1) + Math.floor(rng.next() * 86_400) * 1000;
+
+  const attempts: LedgerAttempt[] = [];
+  const timeline: TimelineEvent[] = [];
+  const validatorSummaries = validators.map((validator) => ({
+    validatorId: validator.id,
+    stakeBefore: validator.baseStake,
+    stakeAfter: validator.baseStake,
+    rewardEarned: 0,
+    slashed: 0,
+    participationRate: 0,
+    participations: 0,
+  }));
+
+  const requiredStake = task.owner.stake;
+  const rewardPool = task.owner.reward;
+  const treasuryReturn = Math.floor(rewardPool * 0.06);
+
+  timeline.push({
+    offset: 0,
+    type: "job_posted",
+    details: {
+      jobId: task.owner.jobId,
+      reward: rewardPool,
+      stakeRequired: requiredStake,
+      description: task.narrative,
+    },
+  });
+
+  const failingSolver = solvers[0];
+  const successfulSolver = solvers[1] ?? solvers[0];
+
+  let offset = 45;
+  timeline.push({
+    offset,
+    type: "solver_selected",
+    details: { solverId: failingSolver.id, stakePosted: failingSolver.baseStake },
+  });
+
+  const failingCommit = encodeCommitment(`${failingSolver.id}|${baseSeed}|misaligned`);
+  offset += 35;
+  timeline.push({ offset, type: "result_committed", details: { solverId: failingSolver.id, commit: failingCommit } });
+
+  const failingVotes: LedgerVote[] = [];
+  let failYesVotes = 0;
+  validators.forEach((validator, index) => {
+    const participates = rng.next() <= validator.reliability;
+    if (!participates) {
+      return;
+    }
+    const commitment = encodeCommitment(`${validator.id}|${failingCommit}|attempt0`);
+    offset += 8 + Math.floor(rng.next() * 5);
+    timeline.push({ offset, type: "vote_commit", details: { validator: validator.id, commitment } });
+    const voteYes = index === 0 && rng.next() > 0.6 ? true : rng.next() > 0.65;
+    const vote = voteYes ? "yes" : "no";
+    failYesVotes += voteYes ? validator.baseStake : 0;
+    offset += 10 + Math.floor(rng.next() * 6);
+    timeline.push({ offset, type: "vote_reveal", details: { validator: validator.id, vote } });
+    const summary = validatorSummaries.find((entry) => entry.validatorId === validator.id);
+    if (summary) {
+      summary.participations += 1;
+    }
+    failingVotes.push({
+      validatorId: validator.id,
+      commitment,
+      revealed: vote,
+      weight: validator.baseStake,
+      rewardEarned: 0,
+      slashed: voteYes ? 0 : 0,
+      notes: vote === "no" ? "Detected thermodynamic drift" : undefined,
+    });
+  });
+
+  const failConsensus = failYesVotes > validators.reduce((acc, validator) => acc + validator.baseStake, 0) * 0.66;
+  const failSlash = Math.floor(requiredStake * 0.12);
+  offset += 16;
+  timeline.push({
+    offset,
+    type: "consensus_finalised",
+    details: {
+      attempt: 1,
+      solverId: failingSolver.id,
+      consensus: failConsensus ? "accepted" : "rejected",
+      yesWeight: failYesVotes,
+    },
+  });
+
+  if (!failConsensus) {
+    timeline.push({
+      offset: offset + 6,
+      type: "slash_applied",
+      details: { solverId: failingSolver.id, amount: failSlash, reason: "Failed consensus" },
+    });
+  }
+
+  attempts.push({
+    attemptId: `${task.id}-attempt-1`,
+    solverId: failingSolver.id,
+    status: failConsensus ? "accepted" : "slashed",
+    commitHash: failingCommit,
+    reveal: "insufficient-delta",
+    consensus: failConsensus ? "accepted" : "rejected",
+    rewardEarned: failConsensus ? Math.floor(rewardPool * 0.25) : 0,
+    slashApplied: failConsensus ? 0 : failSlash,
+    latencySeconds: offset,
+    energyObserved: candidate.metrics.energy * 0.8,
+    notes: failConsensus
+      ? "Legacy agent squeaked through but below thermodynamic target; improvement mandated."
+      : "Consensus rejected misaligned agent – stake partially slashed and job requeued.",
+    votes: failingVotes,
+  });
+
+  if (!failConsensus) {
+    timeline.push({
+      offset: offset + 18,
+      type: "requeue",
+      details: {
+        solverId: successfulSolver.id,
+        reason: "Meta-architect escalated to evolved agent",
+      },
+    });
+    offset += 22;
+  } else {
+    offset += 28;
+  }
+
+  timeline.push({
+    offset,
+    type: "solver_selected",
+    details: { solverId: successfulSolver.id, stakePosted: successfulSolver.baseStake },
+  });
+
+  const successCommit = encodeCommitment(`${successfulSolver.id}|${baseSeed}|${candidate.id}`);
+  offset += 32;
+  timeline.push({
+    offset,
+    type: "result_committed",
+    details: {
+      solverId: successfulSolver.id,
+      commit: successCommit,
+      operations: candidate.operations.length,
+    },
+  });
+
+  const successVotes: LedgerVote[] = [];
+  let yesWeight = 0;
+  validators.forEach((validator) => {
+    const commitment = encodeCommitment(`${validator.id}|${successCommit}|attempt1`);
+    offset += 7 + Math.floor(rng.next() * 5);
+    timeline.push({ offset, type: "vote_commit", details: { validator: validator.id, commitment } });
+    offset += 9 + Math.floor(rng.next() * 5);
+    timeline.push({ offset, type: "vote_reveal", details: { validator: validator.id, vote: "yes" } });
+    yesWeight += validator.baseStake;
+    const summary = validatorSummaries.find((entry) => entry.validatorId === validator.id);
+    if (summary) {
+      summary.participations += 1;
+    }
+    const rewardEarned = Math.floor((rewardPool * 0.12) / validators.length);
+    successVotes.push({
+      validatorId: validator.id,
+      commitment,
+      revealed: "yes",
+      weight: validator.baseStake,
+      rewardEarned,
+      slashed: 0,
+      notes: "Validated evolved solver output",
+    });
+  });
+
+  offset += 14;
+  timeline.push({
+    offset,
+    type: "consensus_finalised",
+    details: {
+      attempt: attempts.length + 1,
+      solverId: successfulSolver.id,
+      consensus: "accepted",
+      yesWeight,
+    },
+  });
+
+  const solverReward = rewardPool - treasuryReturn - successVotes.reduce((acc, vote) => acc + vote.rewardEarned, 0);
+  offset += 12;
+  timeline.push({
+    offset,
+    type: "reward_distributed",
+    details: {
+      solverId: successfulSolver.id,
+      solverReward,
+      validatorRewards: successVotes.reduce((acc, vote) => acc + vote.rewardEarned, 0),
+      treasuryReturn,
+    },
+  });
+
+  attempts.push({
+    attemptId: `${task.id}-attempt-2`,
+    solverId: successfulSolver.id,
+    status: "accepted",
+    commitHash: successCommit,
+    reveal: candidate.id,
+    consensus: "accepted",
+    rewardEarned: solverReward,
+    slashApplied: 0,
+    latencySeconds: offset,
+    energyObserved: candidate.metrics.energy,
+    notes: "Meta-agentic evolved solver achieved consensus and claimed rewards.",
+    votes: successVotes,
+  });
+
+  let totalParticipation = 0;
+  validatorSummaries.forEach((summary) => {
+    const totalVotes = attempts.reduce((acc, attempt) => acc + attempt.votes.filter((vote) => vote.validatorId === summary.validatorId).length, 0);
+    totalParticipation += totalVotes > 0 ? 1 : 0;
+    summary.rewardEarned = attempts.reduce(
+      (acc, attempt) =>
+        acc + attempt.votes.filter((vote) => vote.validatorId === summary.validatorId).reduce((sum, vote) => sum + vote.rewardEarned, 0),
+      0,
+    );
+    summary.slashed = attempts.reduce(
+      (acc, attempt) =>
+        acc + attempt.votes.filter((vote) => vote.validatorId === summary.validatorId).reduce((sum, vote) => sum + vote.slashed, 0),
+      0,
+    );
+    summary.stakeAfter = summary.stakeBefore + summary.rewardEarned - summary.slashed;
+    summary.participationRate = attempts.length > 0 ? summary.participations / attempts.length : 0;
+  });
+
+  const { timeline: resolvedTimeline } = scheduleEvents(baseTimestamp, timeline);
+
+  const totalRewardPaid = attempts.reduce((acc, attempt) => acc + attempt.rewardEarned, 0) + successVotes.reduce((acc, vote) => acc + vote.rewardEarned, 0);
+  const totalSlashed = attempts.reduce((acc, attempt) => acc + attempt.slashApplied, 0);
+  const validatorRewards = successVotes.reduce((acc, vote) => acc + vote.rewardEarned, 0);
+  const averageLatency = attempts.length === 0 ? 0 : attempts.reduce((acc, attempt) => acc + attempt.latencySeconds, 0) / attempts.length;
+  const participationRate = validatorSummaries.length === 0
+    ? 0
+    : validatorSummaries.reduce((acc, summary) => acc + summary.participationRate, 0) / validatorSummaries.length;
+
+  const summary: TaskLedgerSummary = {
+    finalConsensus: "accepted",
+    totalRewardPaid,
+    totalSlashed,
+    validatorRewards,
+    treasuryReturn,
+    averageLatencySeconds: averageLatency,
+    participationRate,
+    commitRevealIntegrity: totalSlashed > 0 ? "verified" : "attention",
+    attempts: attempts.length,
+  };
+
+  return {
+    jobId: task.owner.jobId,
+    missionSeed: baseSeed,
+    requiredStake,
+    reward: rewardPool,
+    attempts,
+    timeline: resolvedTimeline,
+    validators: validatorSummaries.map(({ participations, ...rest }) => rest),
+    summary,
+  };
+}
+
+export type { TaskLedger, TaskLedgerSummary } from "./types";

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/types.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/types.ts
@@ -53,6 +53,78 @@ export interface TaskOwnerMeta {
   thermodynamicTarget: number;
 }
 
+export interface LedgerVote {
+  validatorId: string;
+  commitment: string;
+  revealed: "yes" | "no";
+  weight: number;
+  rewardEarned: number;
+  slashed: number;
+  notes?: string;
+}
+
+export interface LedgerAttempt {
+  attemptId: string;
+  solverId: string;
+  status: "accepted" | "slashed";
+  commitHash: string;
+  reveal: string;
+  consensus: "accepted" | "rejected";
+  rewardEarned: number;
+  slashApplied: number;
+  latencySeconds: number;
+  energyObserved: number;
+  notes?: string;
+  votes: LedgerVote[];
+}
+
+export interface LedgerEvent {
+  timestamp: string;
+  type:
+    | "job_posted"
+    | "solver_selected"
+    | "result_committed"
+    | "vote_commit"
+    | "vote_reveal"
+    | "consensus_finalised"
+    | "reward_distributed"
+    | "slash_applied"
+    | "requeue";
+  details: Record<string, unknown>;
+}
+
+export interface LedgerValidatorSummary {
+  validatorId: string;
+  stakeBefore: number;
+  stakeAfter: number;
+  rewardEarned: number;
+  slashed: number;
+  participationRate: number;
+}
+
+export interface TaskLedgerSummary {
+  finalConsensus: "accepted" | "rejected";
+  totalRewardPaid: number;
+  totalSlashed: number;
+  validatorRewards: number;
+  treasuryReturn: number;
+  averageLatencySeconds: number;
+  participationRate: number;
+  commitRevealIntegrity: "verified" | "attention";
+  attempts: number;
+}
+
+export interface TaskLedger {
+  jobId: string;
+  missionSeed: number;
+  requiredStake: number;
+  reward: number;
+  attempts: LedgerAttempt[];
+  timeline: LedgerEvent[];
+  validators: LedgerValidatorSummary[];
+  summary: TaskLedgerSummary;
+}
+
 export interface TaskDefinition {
   id: string;
   label: string;
@@ -171,6 +243,7 @@ export interface TaskResult {
   archive: ArchiveCell[];
   triangulation: TriangulationReport;
   thermodynamics: TaskThermodynamics;
+  ledger: TaskLedger;
 }
 
 export interface SynthesisRun {
@@ -200,6 +273,16 @@ export interface SynthesisRun {
         monitor: number;
         drift: number;
       };
+    };
+    ledger: {
+      totalRewardPaid: number;
+      totalSlashed: number;
+      validatorRewards: number;
+      treasuryReturn: number;
+      averageParticipationRate: number;
+      averageLatencySeconds: number;
+      accepted: number;
+      consensusAlerts: number;
     };
   };
 }

--- a/package.json
+++ b/package.json
@@ -242,6 +242,7 @@
     "demo:alpha-meta:full": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/fullPipeline.ts",
     "demo:meta-agentic-program-synthesis": "ts-node --project demo/Meta-Agentic-Program-Synthesis-v0/tsconfig.json demo/Meta-Agentic-Program-Synthesis-v0/scripts/runSynthesis.ts",
     "demo:meta-agentic-program-synthesis:full": "ts-node --project demo/Meta-Agentic-Program-Synthesis-v0/tsconfig.json demo/Meta-Agentic-Program-Synthesis-v0/scripts/fullPipeline.ts",
+    "demo:meta-agentic-program-synthesis:test": "node --require ts-node/register --test demo/Meta-Agentic-Program-Synthesis-v0/scripts/__tests__/ledgerSimulation.test.ts",
     "demo:national-supply-chain": "npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",
     "demo:national-supply-chain:export": "AGI_JOBS_DEMO_EXPORT=demo/National-Supply-Chain-v0/ui/export/latest.json npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",
     "demo:national-supply-chain:validate": "ts-node --transpile-only scripts/v2/validateNationalSupplyChainTranscript.ts",


### PR DESCRIPTION
## Summary
- add a deterministic commit–reveal ledger simulator and expose its data through the synthesis engine
- extend markdown, HTML dashboards, README, and runbook with validator tables, timelines, and owner copy/paste commands
- introduce a scripted node:test suite and npm target that verify slashing, reward conservation, and ledger determinism

## Testing
- npm run demo:meta-agentic-program-synthesis
- npm run demo:meta-agentic-program-synthesis:full
- npm run demo:meta-agentic-program-synthesis:test

------
https://chatgpt.com/codex/tasks/task_e_68f6fa14189483339bb7309f02a12bcd