### PR TITLE
feat: audit owner script readiness in meta-agentic demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -81,6 +81,8 @@ flowchart LR
   command and emit Markdown/JSON ready for regulators.
 - **Owner coverage sentinel** – mission loading now enforces Ethereum address formats, thermodynamic budgets, and 5/5 mandatory
   owner control categories (pause, thermostat, upgrade, treasury, compliance) before any synthesis can start.
+- **Owner script audit** – every mission-declared governance script is resolved against `package.json`, producing ✅/❌ tables in
+  the Markdown, JSON, and HTML artefacts so operators immediately spot missing tooling.
 
 ## Generated artefacts
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html
@@ -98,6 +98,24 @@
   <li><strong>Satisfied controls:</strong> Emergency Pause, Thermostat, Upgrade, Treasury, Compliance</li>
   <li><strong>Missing controls:</strong> None</li>
 </ul>
+      <h3>Owner Script Audit</h3>
+      
+<table class="owner-scripts">
+  <thead>
+    <tr>
+      <th>Script</th>
+      <th>Available</th>
+    </tr>
+  </thead>
+  <tbody>
+        <tr><td><code>npm run owner:command-center</code></td><td>✅</td></tr>
+        <tr><td><code>npm run owner:atlas</code></td><td>✅</td></tr>
+        <tr><td><code>npm run owner:system-pause</code></td><td>✅</td></tr>
+        <tr><td><code>npm run owner:upgrade-status</code></td><td>✅</td></tr>
+        <tr><td><code>npm run owner:change-ticket</code></td><td>✅</td></tr>
+  </tbody>
+</table>
+      <p>✅ all scripts available</p>
     </section>
     
 <section class="task">
@@ -200,16 +218,16 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for ARC Sentinel Edge Lift
-  2025-10-21T02:47:22.567Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
-  2025-10-21T02:47:22.568Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
-  2025-10-21T02:47:22.569Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
-  2025-10-21T02:47:22.570Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
-  2025-10-21T02:47:22.571Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
-  2025-10-21T02:47:22.573Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T02:47:22.574Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T02:47:22.574Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
-  2025-10-21T02:47:22.575Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
-  2025-10-21T02:47:22.576Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%</pre>
+  2025-10-21T04:26:14.549Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
+  2025-10-21T04:26:14.551Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
+  2025-10-21T04:26:14.552Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
+  2025-10-21T04:26:14.552Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
+  2025-10-21T04:26:14.553Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
+  2025-10-21T04:26:14.555Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T04:26:14.556Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T04:26:14.557Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
+  2025-10-21T04:26:14.558Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
+  2025-10-21T04:26:14.558Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%</pre>
   </details>
 </section>
 
@@ -312,16 +330,16 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for Ledger Harmonics Sequencer
-  2025-10-21T02:47:22.578Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
-  2025-10-21T02:47:22.579Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
-  2025-10-21T02:47:22.580Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
-  2025-10-21T02:47:22.581Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T02:47:22.581Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T02:47:22.582Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T02:47:22.583Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T02:47:22.584Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T02:47:22.585Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T02:47:22.585Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%</pre>
+  2025-10-21T04:26:14.561Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
+  2025-10-21T04:26:14.561Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
+  2025-10-21T04:26:14.562Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
+  2025-10-21T04:26:14.563Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T04:26:14.564Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T04:26:14.565Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T04:26:14.570Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T04:26:14.571Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T04:26:14.572Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T04:26:14.572Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%</pre>
   </details>
 </section>
 
@@ -424,16 +442,16 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for Nova Weave Sequence Optimiser
-  2025-10-21T02:47:22.586Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
-  2025-10-21T02:47:22.587Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
-  2025-10-21T02:47:22.587Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
-  2025-10-21T02:47:22.588Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
-  2025-10-21T02:47:22.589Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
-  2025-10-21T02:47:22.589Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
-  2025-10-21T02:47:22.597Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
-  2025-10-21T02:47:22.598Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
-  2025-10-21T02:47:22.598Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
-  2025-10-21T02:47:22.599Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%</pre>
+  2025-10-21T04:26:14.573Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
+  2025-10-21T04:26:14.574Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
+  2025-10-21T04:26:14.575Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
+  2025-10-21T04:26:14.575Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
+  2025-10-21T04:26:14.576Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
+  2025-10-21T04:26:14.577Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
+  2025-10-21T04:26:14.577Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
+  2025-10-21T04:26:14.578Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
+  2025-10-21T04:26:14.578Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T04:26:14.579Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%</pre>
   </details>
 </section>
     <section>
@@ -441,9 +459,9 @@
       <p>Workflow <code>ci (v2)</code> | Required jobs: Lint &amp; static checks, Tests, Foundry, Coverage thresholds</p>
       <p>Coverage ≥ 90% | Concurrency group <code>ci-${{ github.workflow }}-${{ github.ref }}</code></p>
     </section>
-    <footer>Generated 2025-10-21T02:47:22.562Z • JSON summary embedded below</footer>
+    <footer>Generated 2025-10-21T04:26:14.545Z • JSON summary embedded below</footer>
     <script id="meta-agentic-summary" type="application/json">{
-  &quot;generatedAt&quot;: &quot;2025-10-21T02:47:22.562Z&quot;,
+  &quot;generatedAt&quot;: &quot;2025-10-21T04:26:14.545Z&quot;,
   &quot;mission&quot;: {
     &quot;title&quot;: &quot;Meta-Agentic Program Synthesis Sovereign Mission&quot;,
     &quot;version&quot;: &quot;0.1.0&quot;,
@@ -738,7 +756,7 @@
           &quot;medianScore&quot;: 56.19020618556701,
           &quot;diversity&quot;: 0.9444444444444444,
           &quot;eliteScore&quot;: 110.36140657817333,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.567Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.549Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -747,7 +765,7 @@
           &quot;medianScore&quot;: 65.75277564301642,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 136.39087455307794,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.568Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.551Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -756,7 +774,7 @@
           &quot;medianScore&quot;: 73.64584551701412,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 138.12283331596453,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.569Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.552Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -765,7 +783,7 @@
           &quot;medianScore&quot;: 100.49230198051038,
           &quot;diversity&quot;: 0.8333333333333334,
           &quot;eliteScore&quot;: 138.41149310977895,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.570Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.552Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -774,7 +792,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.6944444444444444,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.571Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.553Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -783,7 +801,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.573Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.555Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -792,7 +810,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.574Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.556Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -801,7 +819,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.574Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.557Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -810,7 +828,7 @@
           &quot;medianScore&quot;: 116.57704853345733,
           &quot;diversity&quot;: 0.8055555555555556,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.575Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.558Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -819,7 +837,7 @@
           &quot;medianScore&quot;: 137.1920690409011,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.576Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.558Z&quot;
         }
       ],
       &quot;triangulation&quot;: {
@@ -1114,7 +1132,7 @@
           &quot;medianScore&quot;: 41.03751524896436,
           &quot;diversity&quot;: 0.9722222222222222,
           &quot;eliteScore&quot;: 96.0918022581709,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.578Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.561Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -1123,7 +1141,7 @@
           &quot;medianScore&quot;: 62.99975060567376,
           &quot;diversity&quot;: 0.9444444444444444,
           &quot;eliteScore&quot;: 98.43691088683215,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.579Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.561Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -1132,7 +1150,7 @@
           &quot;medianScore&quot;: 76.53115760829131,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 132.5084085000921,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.580Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.562Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -1141,7 +1159,7 @@
           &quot;medianScore&quot;: 77.95296283436663,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.581Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.563Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -1150,7 +1168,7 @@
           &quot;medianScore&quot;: 86.94000111220245,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.581Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.564Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -1159,7 +1177,7 @@
           &quot;medianScore&quot;: 88.99300139019402,
           &quot;diversity&quot;: 0.6111111111111112,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.582Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.565Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -1168,7 +1186,7 @@
           &quot;medianScore&quot;: 83.23985249780515,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.583Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.570Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -1177,7 +1195,7 @@
           &quot;medianScore&quot;: 82.9194778065494,
           &quot;diversity&quot;: 0.6111111111111112,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.584Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.571Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -1186,7 +1204,7 @@
           &quot;medianScore&quot;: 86.367830024997,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.585Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.572Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -1195,7 +1213,7 @@
           &quot;medianScore&quot;: 85.09002044220831,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.585Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.572Z&quot;
         }
       ],
       &quot;triangulation&quot;: {
@@ -1519,7 +1537,7 @@
           &quot;medianScore&quot;: 23.447749293641056,
           &quot;diversity&quot;: 1,
           &quot;eliteScore&quot;: 97.42746077012889,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.586Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.573Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -1528,7 +1546,7 @@
           &quot;medianScore&quot;: 33.23577114240753,
           &quot;diversity&quot;: 1,
           &quot;eliteScore&quot;: 101.68095349725729,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.587Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.574Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -1537,7 +1555,7 @@
           &quot;medianScore&quot;: 64.46743238768931,
           &quot;diversity&quot;: 0.8888888888888888,
           &quot;eliteScore&quot;: 125.76131787031291,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.587Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.575Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -1546,7 +1564,7 @@
           &quot;medianScore&quot;: 70.39942915911845,
           &quot;diversity&quot;: 0.8611111111111112,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.588Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.575Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -1555,7 +1573,7 @@
           &quot;medianScore&quot;: 71.05162669292856,
           &quot;diversity&quot;: 0.8333333333333334,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.589Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.576Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -1564,7 +1582,7 @@
           &quot;medianScore&quot;: 53.843889930604206,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.589Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.577Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -1573,7 +1591,7 @@
           &quot;medianScore&quot;: 78.25900854278035,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.597Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.577Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -1582,7 +1600,7 @@
           &quot;medianScore&quot;: 91.68021852282594,
           &quot;diversity&quot;: 0.5,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.598Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.578Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -1591,7 +1609,7 @@
           &quot;medianScore&quot;: 84.52984866490183,
           &quot;diversity&quot;: 0.6388888888888888,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.598Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.578Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -1600,7 +1618,7 @@
           &quot;medianScore&quot;: 90.34258929546631,
           &quot;diversity&quot;: 0.6388888888888888,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T02:47:22.599Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.579Z&quot;
         }
       ],
       &quot;triangulation&quot;: {
@@ -1708,10 +1726,36 @@
         &quot;verification&quot;: &quot;npm run owner:doctor&quot;
       }
     ]
+  },
+  &quot;ownerScripts&quot;: [
+    {
+      &quot;script&quot;: &quot;npm run owner:command-center&quot;,
+      &quot;available&quot;: true
+    },
+    {
+      &quot;script&quot;: &quot;npm run owner:atlas&quot;,
+      &quot;available&quot;: true
+    },
+    {
+      &quot;script&quot;: &quot;npm run owner:system-pause&quot;,
+      &quot;available&quot;: true
+    },
+    {
+      &quot;script&quot;: &quot;npm run owner:upgrade-status&quot;,
+      &quot;available&quot;: true
+    },
+    {
+      &quot;script&quot;: &quot;npm run owner:change-ticket&quot;,
+      &quot;available&quot;: true
+    }
+  ],
+  &quot;ownerScriptsVerdict&quot;: {
+    &quot;total&quot;: 5,
+    &quot;missing&quot;: []
   }
 }</script>
     <script id="meta-agentic-triangulation" type="application/json">{
-  &quot;generatedAt&quot;: &quot;2025-10-21T02:47:22.562Z&quot;,
+  &quot;generatedAt&quot;: &quot;2025-10-21T04:26:14.545Z&quot;,
   &quot;confidence&quot;: 0.5333333333333333,
   &quot;consensus&quot;: {
     &quot;confirmed&quot;: 1,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T02:47:22.635Z",
+  "generatedAt": "2025-10-21T04:26:14.620Z",
   "aggregate": {
     "globalBestScore": 140.38164328854776,
     "averageAccuracy": 1,
@@ -92,7 +92,7 @@
     "report": "/workspace/AGIJobsv0/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-ci.json"
   },
   "ownerDiagnostics": {
-    "generatedAt": "2025-10-21T02:47:22.634Z",
+    "generatedAt": "2025-10-21T04:26:14.619Z",
     "readiness": "ready",
     "commandReadiness": "ready",
     "coverage": {
@@ -164,7 +164,77 @@
         "commandAvailable": true,
         "verificationAvailable": true
       }
-    ]
+    ],
+    "scripts": [
+      {
+        "script": "npm run owner:command-center",
+        "available": true
+      },
+      {
+        "script": "npm run owner:atlas",
+        "available": true
+      },
+      {
+        "script": "npm run owner:system-pause",
+        "available": true
+      },
+      {
+        "script": "npm run owner:upgrade-status",
+        "available": true
+      },
+      {
+        "script": "npm run owner:change-ticket",
+        "available": true
+      }
+    ],
+    "scriptAudit": {
+      "matches": true,
+      "discrepancies": [],
+      "reported": [
+        {
+          "script": "npm run owner:atlas",
+          "available": true
+        },
+        {
+          "script": "npm run owner:change-ticket",
+          "available": true
+        },
+        {
+          "script": "npm run owner:command-center",
+          "available": true
+        },
+        {
+          "script": "npm run owner:system-pause",
+          "available": true
+        },
+        {
+          "script": "npm run owner:upgrade-status",
+          "available": true
+        }
+      ],
+      "assessed": [
+        {
+          "script": "npm run owner:atlas",
+          "available": true
+        },
+        {
+          "script": "npm run owner:change-ticket",
+          "available": true
+        },
+        {
+          "script": "npm run owner:command-center",
+          "available": true
+        },
+        {
+          "script": "npm run owner:system-pause",
+          "available": true
+        },
+        {
+          "script": "npm run owner:upgrade-status",
+          "available": true
+        }
+      ]
+    }
   },
   "ownerCoverage": {
     "requiredCategories": [
@@ -184,6 +254,28 @@
     "missingCategories": [],
     "readiness": "ready"
   },
+  "ownerScriptsAudit": [
+    {
+      "script": "npm run owner:atlas",
+      "available": true
+    },
+    {
+      "script": "npm run owner:change-ticket",
+      "available": true
+    },
+    {
+      "script": "npm run owner:command-center",
+      "available": true
+    },
+    {
+      "script": "npm run owner:system-pause",
+      "available": true
+    },
+    {
+      "script": "npm run owner:upgrade-status",
+      "available": true
+    }
+  ],
   "artifacts": {
     "Mission manifest": "/workspace/AGIJobsv0/demo/Meta-Agentic-Program-Synthesis-v0/config/mission.meta-agentic-program-synthesis.json",
     "Markdown report": "/workspace/AGIJobsv0/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md",

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.md
@@ -1,6 +1,6 @@
 # Meta-Agentic Program Synthesis – Full Run
 
-Generated: 2025-10-21T02:47:22.562Z
+Generated: 2025-10-21T04:26:14.545Z
 
 ## Aggregate Metrics
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-manifest.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T02:47:22.637Z",
+  "generatedAt": "2025-10-21T04:26:14.622Z",
   "root": "/workspace/AGIJobsv0",
   "files": 9,
   "entries": [
@@ -10,42 +10,42 @@
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html",
-      "sha256": "1276405e6930eeb35e9c4fcfee958933b7d9e42505ca9270ef895771d71c4bac",
-      "bytes": 71879
+      "sha256": "7ea9cf7366feb0241e242ccc0b01ab8ab5439ee1f1ad8e8125f6970adb694897",
+      "bytes": 73187
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.json",
-      "sha256": "a3a74f65118e95e4a40549031c10c09cf2d4c841d5b2e60a918f8fbec23cfae2",
-      "bytes": 6686
+      "sha256": "a66b6fb0e74860a3bc8385e3f8b7f5b51db89777c5dff04ff3b30ac8d0ee34db",
+      "bytes": 8723
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-full.md",
-      "sha256": "1c67c9019cce248d17587b6783cb1611bde03f746d2aa55f2a324015b5e679bf",
+      "sha256": "d4bb1dcc2334e1f37df2139cba707a82477e8428a372ee920900c45944f78586",
       "bytes": 1842
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.json",
-      "sha256": "153c98fc9ae97d7af1cdb24bc1bd3c3879fbf2942cbc0edcf3c5bbadf519b3f2",
-      "bytes": 2288
+      "sha256": "ec54824979c0d1ceb434761f1b42c0aa6446c4a894cd0b3bff5c1548540a3aec",
+      "bytes": 3743
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.md",
-      "sha256": "76b7c299831ec2bb72c8b76bc253697496874f1cdaec78e7011b8d7c10bc684a",
-      "bytes": 1100
+      "sha256": "eec9867c1e14626549ef945729ae2b49881a94d292d2422037cb8d93299f4ffc",
+      "bytes": 1431
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md",
-      "sha256": "d5d52c45583e803e976607ac8c724bba10ed49d16208cb87b27899ec1cc52355",
-      "bytes": 13826
+      "sha256": "ed8d44ed936fc7f0684935ab725d50e9ffbf74bf342187fbe98e5b3e312d26e2",
+      "bytes": 14195
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json",
-      "sha256": "1f6f506015040e6991bdf4a7aa02f3c2a1a99cfad326d0cca781cf6440325d23",
-      "bytes": 34778
+      "sha256": "847c973d3faf6b93899d2338e0a444ad5cd648ccb67192bebe4c5258f0bddfad",
+      "bytes": 35281
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-triangulation.json",
-      "sha256": "c62c762e1877d8a8bb15dfd3c121bf78aac8ec92e8d7279cc5be98a3a13fbe40",
+      "sha256": "c894788661ad4151480f4b1ea9a4df6ca1e31c086962c6e26b24428baf5807dc",
       "bytes": 5041
     }
   ]

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T02:47:22.634Z",
+  "generatedAt": "2025-10-21T04:26:14.619Z",
   "readiness": "ready",
   "commandReadiness": "ready",
   "coverage": {
@@ -71,5 +71,75 @@
       "commandAvailable": true,
       "verificationAvailable": true
     }
-  ]
+  ],
+  "scripts": [
+    {
+      "script": "npm run owner:command-center",
+      "available": true
+    },
+    {
+      "script": "npm run owner:atlas",
+      "available": true
+    },
+    {
+      "script": "npm run owner:system-pause",
+      "available": true
+    },
+    {
+      "script": "npm run owner:upgrade-status",
+      "available": true
+    },
+    {
+      "script": "npm run owner:change-ticket",
+      "available": true
+    }
+  ],
+  "scriptAudit": {
+    "matches": true,
+    "discrepancies": [],
+    "reported": [
+      {
+        "script": "npm run owner:atlas",
+        "available": true
+      },
+      {
+        "script": "npm run owner:change-ticket",
+        "available": true
+      },
+      {
+        "script": "npm run owner:command-center",
+        "available": true
+      },
+      {
+        "script": "npm run owner:system-pause",
+        "available": true
+      },
+      {
+        "script": "npm run owner:upgrade-status",
+        "available": true
+      }
+    ],
+    "assessed": [
+      {
+        "script": "npm run owner:atlas",
+        "available": true
+      },
+      {
+        "script": "npm run owner:change-ticket",
+        "available": true
+      },
+      {
+        "script": "npm run owner:command-center",
+        "available": true
+      },
+      {
+        "script": "npm run owner:system-pause",
+        "available": true
+      },
+      {
+        "script": "npm run owner:upgrade-status",
+        "available": true
+      }
+    ]
+  }
 }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-owner-diagnostics.md
@@ -11,3 +11,15 @@ Coverage readiness: ready (5/5 controls satisfied)
 | Queue sovereign upgrade | `npm run owner:upgrade -- --mission demo/Meta-Agentic-Program-Synthesis-v0/config/mission.meta-agentic-program-synthesis.json` (✅) | `npm run owner:upgrade-status` (✅) | Ready |
 | Mirror treasury share | `npm run reward-engine:update -- --mission demo/Meta-Agentic-Program-Synthesis-v0/config/mission.meta-agentic-program-synthesis.json` (✅) | `npm run reward-engine:report` (✅) | Ready |
 | Refresh compliance dossier | `npm run owner:compliance-report` (✅) | `npm run owner:doctor` (✅) | Ready |
+
+## Owner Script Audit
+
+| Script | Status |
+| --- | --- |
+| `npm run owner:command-center` | ✅ Available |
+| `npm run owner:atlas` | ✅ Available |
+| `npm run owner:system-pause` | ✅ Available |
+| `npm run owner:upgrade-status` | ✅ Available |
+| `npm run owner:change-ticket` | ✅ Available |
+
+Audit comparison: ✅ match.

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md
@@ -81,6 +81,18 @@ pie title System-wide verification consensus
 - **Satisfied controls:** Emergency Pause, Thermostat, Upgrade, Treasury, Compliance
 - **Missing controls:** None
 
+## Owner Script Audit
+
+| Script | Status |
+| --- | --- |
+| `npm run owner:command-center` | ✅ Available |
+| `npm run owner:atlas` | ✅ Available |
+| `npm run owner:system-pause` | ✅ Available |
+| `npm run owner:upgrade-status` | ✅ Available |
+| `npm run owner:change-ticket` | ✅ Available |
+
+Audit verdict: ✅ all declared scripts available in package.json.
+
 ## ARC Sentinel Edge Lift
 
 Detect latent pixel edges, amplify discovery, and route high-confidence transformations back into the shared skill graph.
@@ -149,16 +161,16 @@ pie title Verification consensus
 ```mermaid
 timeline
   title Evolutionary improvements for ARC Sentinel Edge Lift
-  2025-10-21T02:47:22.567Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
-  2025-10-21T02:47:22.568Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
-  2025-10-21T02:47:22.569Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
-  2025-10-21T02:47:22.570Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
-  2025-10-21T02:47:22.571Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
-  2025-10-21T02:47:22.573Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T02:47:22.574Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T02:47:22.574Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
-  2025-10-21T02:47:22.575Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
-  2025-10-21T02:47:22.576Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%
+  2025-10-21T04:26:14.549Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
+  2025-10-21T04:26:14.551Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
+  2025-10-21T04:26:14.552Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
+  2025-10-21T04:26:14.552Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
+  2025-10-21T04:26:14.553Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
+  2025-10-21T04:26:14.555Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T04:26:14.556Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T04:26:14.557Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
+  2025-10-21T04:26:14.558Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
+  2025-10-21T04:26:14.558Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%
 ```
 
 ## Ledger Harmonics Sequencer
@@ -228,16 +240,16 @@ pie title Verification consensus
 ```mermaid
 timeline
   title Evolutionary improvements for Ledger Harmonics Sequencer
-  2025-10-21T02:47:22.578Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
-  2025-10-21T02:47:22.579Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
-  2025-10-21T02:47:22.580Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
-  2025-10-21T02:47:22.581Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T02:47:22.581Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T02:47:22.582Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T02:47:22.583Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T02:47:22.584Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T02:47:22.585Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T02:47:22.585Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T04:26:14.561Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
+  2025-10-21T04:26:14.561Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
+  2025-10-21T04:26:14.562Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
+  2025-10-21T04:26:14.563Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T04:26:14.564Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T04:26:14.565Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T04:26:14.570Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T04:26:14.571Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T04:26:14.572Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T04:26:14.572Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
 ```
 
 ## Nova Weave Sequence Optimiser
@@ -307,16 +319,16 @@ pie title Verification consensus
 ```mermaid
 timeline
   title Evolutionary improvements for Nova Weave Sequence Optimiser
-  2025-10-21T02:47:22.586Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
-  2025-10-21T02:47:22.587Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
-  2025-10-21T02:47:22.587Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
-  2025-10-21T02:47:22.588Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
-  2025-10-21T02:47:22.589Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
-  2025-10-21T02:47:22.589Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
-  2025-10-21T02:47:22.597Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
-  2025-10-21T02:47:22.598Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
-  2025-10-21T02:47:22.598Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
-  2025-10-21T02:47:22.599Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T04:26:14.573Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
+  2025-10-21T04:26:14.574Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
+  2025-10-21T04:26:14.575Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
+  2025-10-21T04:26:14.575Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
+  2025-10-21T04:26:14.576Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
+  2025-10-21T04:26:14.577Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
+  2025-10-21T04:26:14.577Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
+  2025-10-21T04:26:14.578Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
+  2025-10-21T04:26:14.578Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T04:26:14.579Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
 ```
 
 ## CI Shield Alignment
@@ -326,4 +338,4 @@ timeline
 
 ## Generated At
 
-2025-10-21T02:47:22.562Z
+2025-10-21T04:26:14.545Z

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T02:47:22.562Z",
+  "generatedAt": "2025-10-21T04:26:14.545Z",
   "mission": {
     "title": "Meta-Agentic Program Synthesis Sovereign Mission",
     "version": "0.1.0",
@@ -294,7 +294,7 @@
           "medianScore": 56.19020618556701,
           "diversity": 0.9444444444444444,
           "eliteScore": 110.36140657817333,
-          "timestamp": "2025-10-21T02:47:22.567Z"
+          "timestamp": "2025-10-21T04:26:14.549Z"
         },
         {
           "generation": 1,
@@ -303,7 +303,7 @@
           "medianScore": 65.75277564301642,
           "diversity": 0.75,
           "eliteScore": 136.39087455307794,
-          "timestamp": "2025-10-21T02:47:22.568Z"
+          "timestamp": "2025-10-21T04:26:14.551Z"
         },
         {
           "generation": 2,
@@ -312,7 +312,7 @@
           "medianScore": 73.64584551701412,
           "diversity": 0.75,
           "eliteScore": 138.12283331596453,
-          "timestamp": "2025-10-21T02:47:22.569Z"
+          "timestamp": "2025-10-21T04:26:14.552Z"
         },
         {
           "generation": 3,
@@ -321,7 +321,7 @@
           "medianScore": 100.49230198051038,
           "diversity": 0.8333333333333334,
           "eliteScore": 138.41149310977895,
-          "timestamp": "2025-10-21T02:47:22.570Z"
+          "timestamp": "2025-10-21T04:26:14.552Z"
         },
         {
           "generation": 4,
@@ -330,7 +330,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.6944444444444444,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.571Z"
+          "timestamp": "2025-10-21T04:26:14.553Z"
         },
         {
           "generation": 5,
@@ -339,7 +339,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7777777777777778,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.573Z"
+          "timestamp": "2025-10-21T04:26:14.555Z"
         },
         {
           "generation": 6,
@@ -348,7 +348,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7777777777777778,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.574Z"
+          "timestamp": "2025-10-21T04:26:14.556Z"
         },
         {
           "generation": 7,
@@ -357,7 +357,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7222222222222222,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.574Z"
+          "timestamp": "2025-10-21T04:26:14.557Z"
         },
         {
           "generation": 8,
@@ -366,7 +366,7 @@
           "medianScore": 116.57704853345733,
           "diversity": 0.8055555555555556,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.575Z"
+          "timestamp": "2025-10-21T04:26:14.558Z"
         },
         {
           "generation": 9,
@@ -375,7 +375,7 @@
           "medianScore": 137.1920690409011,
           "diversity": 0.75,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T02:47:22.576Z"
+          "timestamp": "2025-10-21T04:26:14.558Z"
         }
       ],
       "triangulation": {
@@ -670,7 +670,7 @@
           "medianScore": 41.03751524896436,
           "diversity": 0.9722222222222222,
           "eliteScore": 96.0918022581709,
-          "timestamp": "2025-10-21T02:47:22.578Z"
+          "timestamp": "2025-10-21T04:26:14.561Z"
         },
         {
           "generation": 1,
@@ -679,7 +679,7 @@
           "medianScore": 62.99975060567376,
           "diversity": 0.9444444444444444,
           "eliteScore": 98.43691088683215,
-          "timestamp": "2025-10-21T02:47:22.579Z"
+          "timestamp": "2025-10-21T04:26:14.561Z"
         },
         {
           "generation": 2,
@@ -688,7 +688,7 @@
           "medianScore": 76.53115760829131,
           "diversity": 0.75,
           "eliteScore": 132.5084085000921,
-          "timestamp": "2025-10-21T02:47:22.580Z"
+          "timestamp": "2025-10-21T04:26:14.562Z"
         },
         {
           "generation": 3,
@@ -697,7 +697,7 @@
           "medianScore": 77.95296283436663,
           "diversity": 0.7222222222222222,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.581Z"
+          "timestamp": "2025-10-21T04:26:14.563Z"
         },
         {
           "generation": 4,
@@ -706,7 +706,7 @@
           "medianScore": 86.94000111220245,
           "diversity": 0.7222222222222222,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.581Z"
+          "timestamp": "2025-10-21T04:26:14.564Z"
         },
         {
           "generation": 5,
@@ -715,7 +715,7 @@
           "medianScore": 88.99300139019402,
           "diversity": 0.6111111111111112,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.582Z"
+          "timestamp": "2025-10-21T04:26:14.565Z"
         },
         {
           "generation": 6,
@@ -724,7 +724,7 @@
           "medianScore": 83.23985249780515,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.583Z"
+          "timestamp": "2025-10-21T04:26:14.570Z"
         },
         {
           "generation": 7,
@@ -733,7 +733,7 @@
           "medianScore": 82.9194778065494,
           "diversity": 0.6111111111111112,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.584Z"
+          "timestamp": "2025-10-21T04:26:14.571Z"
         },
         {
           "generation": 8,
@@ -742,7 +742,7 @@
           "medianScore": 86.367830024997,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.585Z"
+          "timestamp": "2025-10-21T04:26:14.572Z"
         },
         {
           "generation": 9,
@@ -751,7 +751,7 @@
           "medianScore": 85.09002044220831,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T02:47:22.585Z"
+          "timestamp": "2025-10-21T04:26:14.572Z"
         }
       ],
       "triangulation": {
@@ -1075,7 +1075,7 @@
           "medianScore": 23.447749293641056,
           "diversity": 1,
           "eliteScore": 97.42746077012889,
-          "timestamp": "2025-10-21T02:47:22.586Z"
+          "timestamp": "2025-10-21T04:26:14.573Z"
         },
         {
           "generation": 1,
@@ -1084,7 +1084,7 @@
           "medianScore": 33.23577114240753,
           "diversity": 1,
           "eliteScore": 101.68095349725729,
-          "timestamp": "2025-10-21T02:47:22.587Z"
+          "timestamp": "2025-10-21T04:26:14.574Z"
         },
         {
           "generation": 2,
@@ -1093,7 +1093,7 @@
           "medianScore": 64.46743238768931,
           "diversity": 0.8888888888888888,
           "eliteScore": 125.76131787031291,
-          "timestamp": "2025-10-21T02:47:22.587Z"
+          "timestamp": "2025-10-21T04:26:14.575Z"
         },
         {
           "generation": 3,
@@ -1102,7 +1102,7 @@
           "medianScore": 70.39942915911845,
           "diversity": 0.8611111111111112,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.588Z"
+          "timestamp": "2025-10-21T04:26:14.575Z"
         },
         {
           "generation": 4,
@@ -1111,7 +1111,7 @@
           "medianScore": 71.05162669292856,
           "diversity": 0.8333333333333334,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.589Z"
+          "timestamp": "2025-10-21T04:26:14.576Z"
         },
         {
           "generation": 5,
@@ -1120,7 +1120,7 @@
           "medianScore": 53.843889930604206,
           "diversity": 0.7777777777777778,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.589Z"
+          "timestamp": "2025-10-21T04:26:14.577Z"
         },
         {
           "generation": 6,
@@ -1129,7 +1129,7 @@
           "medianScore": 78.25900854278035,
           "diversity": 0.6666666666666666,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.597Z"
+          "timestamp": "2025-10-21T04:26:14.577Z"
         },
         {
           "generation": 7,
@@ -1138,7 +1138,7 @@
           "medianScore": 91.68021852282594,
           "diversity": 0.5,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.598Z"
+          "timestamp": "2025-10-21T04:26:14.578Z"
         },
         {
           "generation": 8,
@@ -1147,7 +1147,7 @@
           "medianScore": 84.52984866490183,
           "diversity": 0.6388888888888888,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.598Z"
+          "timestamp": "2025-10-21T04:26:14.578Z"
         },
         {
           "generation": 9,
@@ -1156,7 +1156,7 @@
           "medianScore": 90.34258929546631,
           "diversity": 0.6388888888888888,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T02:47:22.599Z"
+          "timestamp": "2025-10-21T04:26:14.579Z"
         }
       ],
       "triangulation": {
@@ -1264,5 +1264,31 @@
         "verification": "npm run owner:doctor"
       }
     ]
+  },
+  "ownerScripts": [
+    {
+      "script": "npm run owner:command-center",
+      "available": true
+    },
+    {
+      "script": "npm run owner:atlas",
+      "available": true
+    },
+    {
+      "script": "npm run owner:system-pause",
+      "available": true
+    },
+    {
+      "script": "npm run owner:upgrade-status",
+      "available": true
+    },
+    {
+      "script": "npm run owner:change-ticket",
+      "available": true
+    }
+  ],
+  "ownerScriptsVerdict": {
+    "total": 5,
+    "missing": []
   }
 }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-triangulation.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-triangulation.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T02:47:22.562Z",
+  "generatedAt": "2025-10-21T04:26:14.545Z",
   "confidence": 0.5333333333333333,
   "consensus": {
     "confirmed": 1,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/commandValidation.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/commandValidation.ts
@@ -1,0 +1,72 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import type { MissionConfig } from "./types";
+
+export type PackageScripts = Record<string, string | undefined>;
+
+export interface OwnerScriptStatus {
+  script: string;
+  available: boolean;
+}
+
+const DEFAULT_REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+async function loadPackageJson(repoRoot: string): Promise<{ scripts?: PackageScripts }> {
+  const packagePath = path.join(repoRoot, "package.json");
+  const raw = await readFile(packagePath, "utf8");
+  return JSON.parse(raw) as { scripts?: PackageScripts };
+}
+
+export async function loadPackageScripts(repoRoot: string = DEFAULT_REPO_ROOT): Promise<PackageScripts> {
+  const pkg = await loadPackageJson(repoRoot);
+  return pkg.scripts ?? {};
+}
+
+export function inspectCommand(command: string, scripts: PackageScripts): boolean {
+  const trimmed = command.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+
+  const tokens = trimmed.split(/\s+/).filter((token) => token.length > 0);
+  if (tokens.length === 0) {
+    return false;
+  }
+
+  if (tokens[0] === "npm" && tokens[1] === "run" && tokens.length >= 3) {
+    let index = 2;
+    while (index < tokens.length && tokens[index].startsWith("-") && tokens[index] !== "--") {
+      index += 1;
+    }
+    if (index < tokens.length && tokens[index] === "--") {
+      index += 1;
+    }
+    if (index >= tokens.length) {
+      return false;
+    }
+    const scriptName = tokens[index];
+    return Boolean(scriptName && scripts[scriptName]);
+  }
+
+  if (tokens[0] === "npx" || tokens[0] === "node" || tokens[0] === "ts-node") {
+    return true;
+  }
+
+  return true;
+}
+
+export function evaluateOwnerScripts(commands: string[], scripts: PackageScripts): OwnerScriptStatus[] {
+  return commands.map((command) => ({
+    script: command,
+    available: inspectCommand(command, scripts),
+  }));
+}
+
+export async function auditOwnerScripts(
+  mission: MissionConfig,
+  options: { repoRoot?: string; scripts?: PackageScripts } = {},
+): Promise<OwnerScriptStatus[]> {
+  const scripts = options.scripts ?? (await loadPackageScripts(options.repoRoot));
+  const commands = mission.meta.governance?.ownerScripts ?? [];
+  return evaluateOwnerScripts(commands, scripts);
+}

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/manifest.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/manifest.ts
@@ -40,7 +40,8 @@ export async function updateManifest(manifestPath: string, files: string[]): Pro
     }
   }
 
-  const root = document?.root ? path.resolve(document.root) : process.cwd();
+  const defaultRoot = path.dirname(absoluteManifest);
+  const root = document?.root ? path.resolve(document.root) : defaultRoot;
   const entries = new Map<string, ManifestEntry>();
 
   if (document) {

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/runSynthesis.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/runSynthesis.ts
@@ -39,13 +39,14 @@ export async function executeSynthesis(options: RunOptions = {}): Promise<Synthe
   const { mission, coverage }: { mission: MissionConfig; coverage: OwnerControlCoverage } =
     await loadMissionConfig(resolved.missionFile);
   const run = runMetaSynthesis(mission, coverage);
-  const { files } = await writeReports(run, {
+  const { files, ownerScripts } = await writeReports(run, {
     reportDir: resolved.reportDir,
     markdownFile: resolved.reportFile,
     jsonFile: resolved.summaryFile,
     htmlFile: resolved.dashboardFile,
     triangulationFile: resolved.triangulationFile,
   });
+  run.ownerScriptsAudit = ownerScripts;
   await updateManifest(resolved.manifestFile, files);
   return run;
 }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/synthesisEngine.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/synthesisEngine.ts
@@ -676,6 +676,7 @@ export function runMetaSynthesis(mission: MissionConfig, coverage?: OwnerControl
     parameters: mission.parameters,
     tasks,
     ownerCoverage,
+    ownerScriptsAudit: [],
     aggregate: {
       globalBestScore: globalBest,
       averageAccuracy,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/types.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/types.ts
@@ -98,6 +98,11 @@ export interface OwnerControlCoverage {
   readiness: "ready" | "attention" | "blocked";
 }
 
+export interface OwnerScriptAudit {
+  script: string;
+  available: boolean;
+}
+
 export interface MissionConfig {
   meta: MissionMeta;
   parameters: MissionParameters;
@@ -179,6 +184,7 @@ export interface SynthesisRun {
   parameters: MissionParameters;
   tasks: TaskResult[];
   ownerCoverage: OwnerControlCoverage;
+  ownerScriptsAudit: OwnerScriptAudit[];
   aggregate: {
     globalBestScore: number;
     averageAccuracy: number;


### PR DESCRIPTION
## Summary
- add a shared command validation utility that loads package scripts and audits mission-declared owner commands
- extend meta-agentic reporting, dashboard, and full pipeline diagnostics with owner script availability verdicts and consistency checks
- document the new owner script audit signal in the README and ensure manifests resolve relative paths deterministically

## Testing
- npm run demo:meta-agentic-program-synthesis --silent
- npm run demo:meta-agentic-program-synthesis:full --silent
- npx tsc --project demo/Meta-Agentic-Program-Synthesis-v0/tsconfig.json --noEmit # fails: tsconfig also includes sibling demo sources outside rootDir


------
https://chatgpt.com/codex/tasks/task_e_68f70967de2083338c762a4d7b6b08d1