### PR TITLE
Add owner briefing outputs to meta-agentic program synthesis demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -26,6 +26,8 @@ The launcher performs:
    hashes them into a manifest.
 2. `npm run demo:meta-agentic-program-synthesis:full` – replays the run, verifies CI (v2) enforcement, runs owner diagnostics in
    offline mode, and compiles a full-run bundle.
+3. `npm run demo:meta-agentic-program-synthesis:briefing` – prints a console-native owner briefing while regenerating artefacts,
+   perfect for executive war rooms or quick remote updates.
 
 All artefacts land in `demo/Meta-Agentic-Program-Synthesis-v0/reports/` with deterministic SHA-256 fingerprints.
 
@@ -93,6 +95,7 @@ flowchart LR
 | `meta-agentic-program-synthesis-dashboard.html` | Executive UI with live Mermaid rendering and embedded JSON manifest. |
 | `meta-agentic-program-synthesis-triangulation.json` | Multi-perspective verification digest (consensus, confidences, per-perspective evidence). |
 | `meta-agentic-program-synthesis-manifest.json` | SHA-256 manifest of every artefact for audit trails. |
+| `meta-agentic-program-synthesis-briefing.md` | Two-page executive briefing with commands, task highlights, and triple-verification recap. |
 | `meta-agentic-program-synthesis-ci.json` | CI workflow verification report (lint/tests/foundry/coverage). |
 | `meta-agentic-program-synthesis-owner-diagnostics.{json,md}` | Owner readiness, command outputs, and sentinel status. |
 | `meta-agentic-program-synthesis-full.{json,md}` | Aggregate timeline of the run, CI verdict, diagnostics, and artefact index. |
@@ -139,6 +142,9 @@ The digest exported in `meta-agentic-program-synthesis-triangulation.json` lists
 ```bash
 # Regenerate synthesis dossier only
 npm run demo:meta-agentic-program-synthesis
+
+# Console-first owner briefing (regenerates artefacts if needed)
+npm run demo:meta-agentic-program-synthesis:briefing
 
 # Full pipeline with CI + owner diagnostics
 npm run demo:meta-agentic-program-synthesis:full

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-briefing.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-briefing.md
@@ -1,0 +1,61 @@
+# Owner Briefing – Meta-Agentic Program Synthesis Sovereign Mission
+
+This briefing distills the sovereign mission into an action-ready checklist for platform owners. Every metric originates from triple-verified artefacts generated during the latest run.
+
+## Instant Launch
+
+```bash
+./demo/Meta-Agentic-Program-Synthesis-v0/bin/launch.sh
+```
+
+Execute the command above to rerun evolutionary synthesis, CI enforcement, and owner diagnostics without manual configuration.
+
+## Mission Snapshot
+
+- **Mission:** Evolutionary Intelligence Forge
+- **Owner address:** 0x1111111111111111111111111111111111111111
+- **Treasury:** 0x2222222222222222222222222222222222222222
+- **Governance timelock:** 7.00 days
+- **Validator council:** sovereign.validator.eth, thermostat.guardian.eth, alpha.operator.eth
+- **Sentinel grid:** sentinel.quantum, sentinel.reward-engine, sentinel.timelock, sentinel.contract-size
+
+## System Health
+
+- **Accuracy:** 100.00% | **Novelty:** 77.76% | **Energy envelope:** 73.33
+- **Thermodynamic alignment:** 100.00% (Δ̄ 0.00 | Δmax 0.00)
+- **Verification consensus:** 1 confirmed • 0 attention • 2 rejected
+- **Owner controls readiness:** READY – satisfied: Emergency Pause, Thermostat, Upgrade, Treasury, Compliance
+- **Owner scripts:** All declared owner scripts are available and verified.
+
+## Task Highlights
+
+| Task | Mission | Score | Accuracy | Energy | Alignment | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- |
+| ARC Sentinel Edge Lift | Detect latent pixel edges, amplify discovery, and route high-confidence transformations back into the shared skill graph. | 140.38 | 100.00% | 88.00 | aligned | Deploy via job ARC-SYN-001 |
+| Ledger Harmonics Sequencer | Absorb asynchronous cash-flow deltas, stabilise them against the thermodynamic ledger, and emit rebalanced incentive curves for validator coalitions. | 133.04 | 100.00% | 64.00 | aligned | Deploy via job LEDGER-SYN-007 |
+| Nova Weave Sequence Optimiser | Elevate alpha sequences into deterministic blueprints that compile into on-chain production payloads with zero manual edits. | 136.05 | 100.00% | 68.00 | aligned | Deploy via job NOVA-SYN-009 |
+
+## Owner Control Panel
+
+| Category | Command | Status |
+| --- | --- | --- |
+| Emergency Pause | `npm run owner:system-pause -- --action pause` | ✅ |
+| Thermostat | `npm run thermostat:update -- --mission demo/Meta-Agentic-Program-Synthesis-v0/config/mission.meta-agentic-program-synthesis.json` | ✅ |
+| Upgrade | `npm run owner:upgrade -- --mission demo/Meta-Agentic-Program-Synthesis-v0/config/mission.meta-agentic-program-synthesis.json` | ✅ |
+| Treasury | `npm run reward-engine:update -- --mission demo/Meta-Agentic-Program-Synthesis-v0/config/mission.meta-agentic-program-synthesis.json` | ✅ |
+| Compliance | `npm run owner:compliance-report` | ✅ |
+
+## Immediate Next Actions
+
+1. Rerun the launch command to regenerate artefacts on the latest network snapshot.
+2. Review `meta-agentic-program-synthesis-dashboard.html` for live Mermaid dashboards and verification timelines.
+3. Resolve any ❌ owner commands, rerun the launch command, and confirm a ✅ status across controls.
+4. Share the manifest and this briefing with governance partners for compliance sign-off.
+
+## Triple-Verification Recap
+
+- **Deterministic replay:** 1 elite pipelines confirmed with zero drift.
+- **Baseline dominance:** 100.00% coverage across all mission tasks with evolved pipelines outperforming seeds.
+- **Governance sentinels:** 5/5 mandatory owner controls satisfied (pause, thermostat, upgrades, treasury, compliance).
+
+Distribute this briefing freely – it contains reproducible commands and hashed artefacts only, keeping operational keys offline while proving total owner control.

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html
@@ -218,16 +218,16 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for ARC Sentinel Edge Lift
-  2025-10-21T04:26:14.549Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
-  2025-10-21T04:26:14.551Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
-  2025-10-21T04:26:14.552Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
-  2025-10-21T04:26:14.552Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
-  2025-10-21T04:26:14.553Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
-  2025-10-21T04:26:14.555Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T04:26:14.556Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T04:26:14.557Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
-  2025-10-21T04:26:14.558Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
-  2025-10-21T04:26:14.558Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%</pre>
+  2025-10-21T12:18:34.762Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
+  2025-10-21T12:18:34.764Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
+  2025-10-21T12:18:34.765Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
+  2025-10-21T12:18:34.767Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
+  2025-10-21T12:18:34.768Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
+  2025-10-21T12:18:34.774Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T12:18:34.777Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T12:18:34.778Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
+  2025-10-21T12:18:34.780Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
+  2025-10-21T12:18:34.781Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%</pre>
   </details>
 </section>
 
@@ -330,16 +330,16 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for Ledger Harmonics Sequencer
-  2025-10-21T04:26:14.561Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
-  2025-10-21T04:26:14.561Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
-  2025-10-21T04:26:14.562Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
-  2025-10-21T04:26:14.563Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T04:26:14.564Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T04:26:14.565Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T04:26:14.570Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T04:26:14.571Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T04:26:14.572Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T04:26:14.572Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%</pre>
+  2025-10-21T12:18:34.784Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
+  2025-10-21T12:18:34.785Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
+  2025-10-21T12:18:34.786Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
+  2025-10-21T12:18:34.787Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T12:18:34.793Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T12:18:34.794Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T12:18:34.795Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T12:18:34.796Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T12:18:34.797Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T12:18:34.798Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%</pre>
   </details>
 </section>
 
@@ -442,16 +442,16 @@
     <summary>Evolution Timeline</summary>
     <pre class="mermaid">timeline
   title Evolutionary improvements for Nova Weave Sequence Optimiser
-  2025-10-21T04:26:14.573Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
-  2025-10-21T04:26:14.574Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
-  2025-10-21T04:26:14.575Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
-  2025-10-21T04:26:14.575Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
-  2025-10-21T04:26:14.576Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
-  2025-10-21T04:26:14.577Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
-  2025-10-21T04:26:14.577Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
-  2025-10-21T04:26:14.578Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
-  2025-10-21T04:26:14.578Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
-  2025-10-21T04:26:14.579Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%</pre>
+  2025-10-21T12:18:34.799Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
+  2025-10-21T12:18:34.800Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
+  2025-10-21T12:18:34.801Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
+  2025-10-21T12:18:34.802Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
+  2025-10-21T12:18:34.803Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
+  2025-10-21T12:18:34.804Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
+  2025-10-21T12:18:34.804Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
+  2025-10-21T12:18:34.805Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
+  2025-10-21T12:18:34.806Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T12:18:34.807Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%</pre>
   </details>
 </section>
     <section>
@@ -459,9 +459,9 @@
       <p>Workflow <code>ci (v2)</code> | Required jobs: Lint &amp; static checks, Tests, Foundry, Coverage thresholds</p>
       <p>Coverage ≥ 90% | Concurrency group <code>ci-${{ github.workflow }}-${{ github.ref }}</code></p>
     </section>
-    <footer>Generated 2025-10-21T04:26:14.545Z • JSON summary embedded below</footer>
+    <footer>Generated 2025-10-21T12:18:34.756Z • JSON summary embedded below</footer>
     <script id="meta-agentic-summary" type="application/json">{
-  &quot;generatedAt&quot;: &quot;2025-10-21T04:26:14.545Z&quot;,
+  &quot;generatedAt&quot;: &quot;2025-10-21T12:18:34.756Z&quot;,
   &quot;mission&quot;: {
     &quot;title&quot;: &quot;Meta-Agentic Program Synthesis Sovereign Mission&quot;,
     &quot;version&quot;: &quot;0.1.0&quot;,
@@ -756,7 +756,7 @@
           &quot;medianScore&quot;: 56.19020618556701,
           &quot;diversity&quot;: 0.9444444444444444,
           &quot;eliteScore&quot;: 110.36140657817333,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.549Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.762Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -765,7 +765,7 @@
           &quot;medianScore&quot;: 65.75277564301642,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 136.39087455307794,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.551Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.764Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -774,7 +774,7 @@
           &quot;medianScore&quot;: 73.64584551701412,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 138.12283331596453,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.552Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.765Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -783,7 +783,7 @@
           &quot;medianScore&quot;: 100.49230198051038,
           &quot;diversity&quot;: 0.8333333333333334,
           &quot;eliteScore&quot;: 138.41149310977895,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.552Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.767Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -792,7 +792,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.6944444444444444,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.553Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.768Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -801,7 +801,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.555Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.774Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -810,7 +810,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.556Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.777Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -819,7 +819,7 @@
           &quot;medianScore&quot;: 138.05804842234437,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.557Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.778Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -828,7 +828,7 @@
           &quot;medianScore&quot;: 116.57704853345733,
           &quot;diversity&quot;: 0.8055555555555556,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.558Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.780Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -837,7 +837,7 @@
           &quot;medianScore&quot;: 137.1920690409011,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 140.38164328854776,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.558Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.781Z&quot;
         }
       ],
       &quot;triangulation&quot;: {
@@ -1132,7 +1132,7 @@
           &quot;medianScore&quot;: 41.03751524896436,
           &quot;diversity&quot;: 0.9722222222222222,
           &quot;eliteScore&quot;: 96.0918022581709,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.561Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.784Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -1141,7 +1141,7 @@
           &quot;medianScore&quot;: 62.99975060567376,
           &quot;diversity&quot;: 0.9444444444444444,
           &quot;eliteScore&quot;: 98.43691088683215,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.561Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.785Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -1150,7 +1150,7 @@
           &quot;medianScore&quot;: 76.53115760829131,
           &quot;diversity&quot;: 0.75,
           &quot;eliteScore&quot;: 132.5084085000921,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.562Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.786Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -1159,7 +1159,7 @@
           &quot;medianScore&quot;: 77.95296283436663,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.563Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.787Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -1168,7 +1168,7 @@
           &quot;medianScore&quot;: 86.94000111220245,
           &quot;diversity&quot;: 0.7222222222222222,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.564Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.793Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -1177,7 +1177,7 @@
           &quot;medianScore&quot;: 88.99300139019402,
           &quot;diversity&quot;: 0.6111111111111112,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.565Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.794Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -1186,7 +1186,7 @@
           &quot;medianScore&quot;: 83.23985249780515,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.570Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.795Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -1195,7 +1195,7 @@
           &quot;medianScore&quot;: 82.9194778065494,
           &quot;diversity&quot;: 0.6111111111111112,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.571Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.796Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -1204,7 +1204,7 @@
           &quot;medianScore&quot;: 86.367830024997,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.572Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.797Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -1213,7 +1213,7 @@
           &quot;medianScore&quot;: 85.09002044220831,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 133.04138007631948,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.572Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.798Z&quot;
         }
       ],
       &quot;triangulation&quot;: {
@@ -1537,7 +1537,7 @@
           &quot;medianScore&quot;: 23.447749293641056,
           &quot;diversity&quot;: 1,
           &quot;eliteScore&quot;: 97.42746077012889,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.573Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.799Z&quot;
         },
         {
           &quot;generation&quot;: 1,
@@ -1546,7 +1546,7 @@
           &quot;medianScore&quot;: 33.23577114240753,
           &quot;diversity&quot;: 1,
           &quot;eliteScore&quot;: 101.68095349725729,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.574Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.800Z&quot;
         },
         {
           &quot;generation&quot;: 2,
@@ -1555,7 +1555,7 @@
           &quot;medianScore&quot;: 64.46743238768931,
           &quot;diversity&quot;: 0.8888888888888888,
           &quot;eliteScore&quot;: 125.76131787031291,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.575Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.801Z&quot;
         },
         {
           &quot;generation&quot;: 3,
@@ -1564,7 +1564,7 @@
           &quot;medianScore&quot;: 70.39942915911845,
           &quot;diversity&quot;: 0.8611111111111112,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.575Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.802Z&quot;
         },
         {
           &quot;generation&quot;: 4,
@@ -1573,7 +1573,7 @@
           &quot;medianScore&quot;: 71.05162669292856,
           &quot;diversity&quot;: 0.8333333333333334,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.576Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.803Z&quot;
         },
         {
           &quot;generation&quot;: 5,
@@ -1582,7 +1582,7 @@
           &quot;medianScore&quot;: 53.843889930604206,
           &quot;diversity&quot;: 0.7777777777777778,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.577Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.804Z&quot;
         },
         {
           &quot;generation&quot;: 6,
@@ -1591,7 +1591,7 @@
           &quot;medianScore&quot;: 78.25900854278035,
           &quot;diversity&quot;: 0.6666666666666666,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.577Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.804Z&quot;
         },
         {
           &quot;generation&quot;: 7,
@@ -1600,7 +1600,7 @@
           &quot;medianScore&quot;: 91.68021852282594,
           &quot;diversity&quot;: 0.5,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.578Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.805Z&quot;
         },
         {
           &quot;generation&quot;: 8,
@@ -1609,7 +1609,7 @@
           &quot;medianScore&quot;: 84.52984866490183,
           &quot;diversity&quot;: 0.6388888888888888,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.578Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.806Z&quot;
         },
         {
           &quot;generation&quot;: 9,
@@ -1618,7 +1618,7 @@
           &quot;medianScore&quot;: 90.34258929546631,
           &quot;diversity&quot;: 0.6388888888888888,
           &quot;eliteScore&quot;: 136.04606142636254,
-          &quot;timestamp&quot;: &quot;2025-10-21T04:26:14.579Z&quot;
+          &quot;timestamp&quot;: &quot;2025-10-21T12:18:34.807Z&quot;
         }
       ],
       &quot;triangulation&quot;: {
@@ -1755,7 +1755,7 @@
   }
 }</script>
     <script id="meta-agentic-triangulation" type="application/json">{
-  &quot;generatedAt&quot;: &quot;2025-10-21T04:26:14.545Z&quot;,
+  &quot;generatedAt&quot;: &quot;2025-10-21T12:18:34.756Z&quot;,
   &quot;confidence&quot;: 0.5333333333333333,
   &quot;consensus&quot;: {
     &quot;confirmed&quot;: 1,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-manifest.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-manifest.json
@@ -1,8 +1,13 @@
 {
-  "generatedAt": "2025-10-21T04:26:14.622Z",
+  "generatedAt": "2025-10-21T12:18:34.833Z",
   "root": "/workspace/AGIJobsv0",
-  "files": 9,
+  "files": 10,
   "entries": [
+    {
+      "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-briefing.md",
+      "sha256": "6f674051be79c9052f1b6d9603be1d1d81af34e525af4ea802db09179e62c641",
+      "bytes": 3741
+    },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-ci.json",
       "sha256": "cf7c86b71363271db89bd786f29a1c4fad913c49c9380e60cbcd94d4f8dcbdac",
@@ -10,7 +15,7 @@
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-dashboard.html",
-      "sha256": "7ea9cf7366feb0241e242ccc0b01ab8ab5439ee1f1ad8e8125f6970adb694897",
+      "sha256": "14fdb0c02e896775e2d1260804f80d1ad7bc6a4c5ab0d9f8ae7422b243c3ef10",
       "bytes": 73187
     },
     {
@@ -35,17 +40,17 @@
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md",
-      "sha256": "ed8d44ed936fc7f0684935ab725d50e9ffbf74bf342187fbe98e5b3e312d26e2",
+      "sha256": "6eb01613adcab58cd0e8131febc95f9abca44db2c3fb511c52bc24a1ccac193f",
       "bytes": 14195
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json",
-      "sha256": "847c973d3faf6b93899d2338e0a444ad5cd648ccb67192bebe4c5258f0bddfad",
+      "sha256": "6a1aabe210aec01e505283daa1d8a90d332cf0923d03ad68207b9e1a22ddd8b6",
       "bytes": 35281
     },
     {
       "path": "demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-triangulation.json",
-      "sha256": "c894788661ad4151480f4b1ea9a4df6ca1e31c086962c6e26b24428baf5807dc",
+      "sha256": "5310f77edead66fac2302c31a72c36d438cfa2b77acf76dfa7d408daad1e2030",
       "bytes": 5041
     }
   ]

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-report.md
@@ -161,16 +161,16 @@ pie title Verification consensus
 ```mermaid
 timeline
   title Evolutionary improvements for ARC Sentinel Edge Lift
-  2025-10-21T04:26:14.549Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
-  2025-10-21T04:26:14.551Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
-  2025-10-21T04:26:14.552Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
-  2025-10-21T04:26:14.552Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
-  2025-10-21T04:26:14.553Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
-  2025-10-21T04:26:14.555Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T04:26:14.556Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
-  2025-10-21T04:26:14.557Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
-  2025-10-21T04:26:14.558Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
-  2025-10-21T04:26:14.558Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%
+  2025-10-21T12:18:34.762Z : score 135.56 • elite 110.36 • diversity 0.94 • novelty 73.1%
+  2025-10-21T12:18:34.764Z : score 138.06 • elite 136.39 • diversity 0.75 • novelty 73.1%
+  2025-10-21T12:18:34.765Z : score 138.16 • elite 138.12 • diversity 0.75 • novelty 73.1%
+  2025-10-21T12:18:34.767Z : score 138.92 • elite 138.41 • diversity 0.83 • novelty 73.1%
+  2025-10-21T12:18:34.768Z : score 140.38 • elite 140.38 • diversity 0.69 • novelty 73.1%
+  2025-10-21T12:18:34.774Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T12:18:34.777Z : score 140.38 • elite 140.38 • diversity 0.78 • novelty 73.1%
+  2025-10-21T12:18:34.778Z : score 140.38 • elite 140.38 • diversity 0.72 • novelty 73.1%
+  2025-10-21T12:18:34.780Z : score 140.38 • elite 140.38 • diversity 0.81 • novelty 73.1%
+  2025-10-21T12:18:34.781Z : score 140.38 • elite 140.38 • diversity 0.75 • novelty 73.1%
 ```
 
 ## Ledger Harmonics Sequencer
@@ -240,16 +240,16 @@ pie title Verification consensus
 ```mermaid
 timeline
   title Evolutionary improvements for Ledger Harmonics Sequencer
-  2025-10-21T04:26:14.561Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
-  2025-10-21T04:26:14.561Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
-  2025-10-21T04:26:14.562Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
-  2025-10-21T04:26:14.563Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T04:26:14.564Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
-  2025-10-21T04:26:14.565Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T04:26:14.570Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T04:26:14.571Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
-  2025-10-21T04:26:14.572Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
-  2025-10-21T04:26:14.572Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T12:18:34.784Z : score 133.04 • elite 96.09 • diversity 0.97 • novelty 66.6%
+  2025-10-21T12:18:34.785Z : score 133.04 • elite 98.44 • diversity 0.94 • novelty 66.6%
+  2025-10-21T12:18:34.786Z : score 133.04 • elite 132.51 • diversity 0.75 • novelty 66.6%
+  2025-10-21T12:18:34.787Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T12:18:34.793Z : score 133.04 • elite 133.04 • diversity 0.72 • novelty 66.6%
+  2025-10-21T12:18:34.794Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T12:18:34.795Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T12:18:34.796Z : score 133.04 • elite 133.04 • diversity 0.61 • novelty 66.6%
+  2025-10-21T12:18:34.797Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
+  2025-10-21T12:18:34.798Z : score 133.04 • elite 133.04 • diversity 0.67 • novelty 66.6%
 ```
 
 ## Nova Weave Sequence Optimiser
@@ -319,16 +319,16 @@ pie title Verification consensus
 ```mermaid
 timeline
   title Evolutionary improvements for Nova Weave Sequence Optimiser
-  2025-10-21T04:26:14.573Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
-  2025-10-21T04:26:14.574Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
-  2025-10-21T04:26:14.575Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
-  2025-10-21T04:26:14.575Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
-  2025-10-21T04:26:14.576Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
-  2025-10-21T04:26:14.577Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
-  2025-10-21T04:26:14.577Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
-  2025-10-21T04:26:14.578Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
-  2025-10-21T04:26:14.578Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
-  2025-10-21T04:26:14.579Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T12:18:34.799Z : score 136.05 • elite 97.43 • diversity 1.00 • novelty 93.6%
+  2025-10-21T12:18:34.800Z : score 136.05 • elite 101.68 • diversity 1.00 • novelty 93.6%
+  2025-10-21T12:18:34.801Z : score 136.05 • elite 125.76 • diversity 0.89 • novelty 93.6%
+  2025-10-21T12:18:34.802Z : score 136.05 • elite 136.05 • diversity 0.86 • novelty 93.6%
+  2025-10-21T12:18:34.803Z : score 136.05 • elite 136.05 • diversity 0.83 • novelty 93.6%
+  2025-10-21T12:18:34.804Z : score 136.05 • elite 136.05 • diversity 0.78 • novelty 93.6%
+  2025-10-21T12:18:34.804Z : score 136.05 • elite 136.05 • diversity 0.67 • novelty 93.6%
+  2025-10-21T12:18:34.805Z : score 136.05 • elite 136.05 • diversity 0.50 • novelty 93.6%
+  2025-10-21T12:18:34.806Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
+  2025-10-21T12:18:34.807Z : score 136.05 • elite 136.05 • diversity 0.64 • novelty 93.6%
 ```
 
 ## CI Shield Alignment
@@ -338,4 +338,4 @@ timeline
 
 ## Generated At
 
-2025-10-21T04:26:14.545Z
+2025-10-21T12:18:34.756Z

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T04:26:14.545Z",
+  "generatedAt": "2025-10-21T12:18:34.756Z",
   "mission": {
     "title": "Meta-Agentic Program Synthesis Sovereign Mission",
     "version": "0.1.0",
@@ -294,7 +294,7 @@
           "medianScore": 56.19020618556701,
           "diversity": 0.9444444444444444,
           "eliteScore": 110.36140657817333,
-          "timestamp": "2025-10-21T04:26:14.549Z"
+          "timestamp": "2025-10-21T12:18:34.762Z"
         },
         {
           "generation": 1,
@@ -303,7 +303,7 @@
           "medianScore": 65.75277564301642,
           "diversity": 0.75,
           "eliteScore": 136.39087455307794,
-          "timestamp": "2025-10-21T04:26:14.551Z"
+          "timestamp": "2025-10-21T12:18:34.764Z"
         },
         {
           "generation": 2,
@@ -312,7 +312,7 @@
           "medianScore": 73.64584551701412,
           "diversity": 0.75,
           "eliteScore": 138.12283331596453,
-          "timestamp": "2025-10-21T04:26:14.552Z"
+          "timestamp": "2025-10-21T12:18:34.765Z"
         },
         {
           "generation": 3,
@@ -321,7 +321,7 @@
           "medianScore": 100.49230198051038,
           "diversity": 0.8333333333333334,
           "eliteScore": 138.41149310977895,
-          "timestamp": "2025-10-21T04:26:14.552Z"
+          "timestamp": "2025-10-21T12:18:34.767Z"
         },
         {
           "generation": 4,
@@ -330,7 +330,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.6944444444444444,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T04:26:14.553Z"
+          "timestamp": "2025-10-21T12:18:34.768Z"
         },
         {
           "generation": 5,
@@ -339,7 +339,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7777777777777778,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T04:26:14.555Z"
+          "timestamp": "2025-10-21T12:18:34.774Z"
         },
         {
           "generation": 6,
@@ -348,7 +348,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7777777777777778,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T04:26:14.556Z"
+          "timestamp": "2025-10-21T12:18:34.777Z"
         },
         {
           "generation": 7,
@@ -357,7 +357,7 @@
           "medianScore": 138.05804842234437,
           "diversity": 0.7222222222222222,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T04:26:14.557Z"
+          "timestamp": "2025-10-21T12:18:34.778Z"
         },
         {
           "generation": 8,
@@ -366,7 +366,7 @@
           "medianScore": 116.57704853345733,
           "diversity": 0.8055555555555556,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T04:26:14.558Z"
+          "timestamp": "2025-10-21T12:18:34.780Z"
         },
         {
           "generation": 9,
@@ -375,7 +375,7 @@
           "medianScore": 137.1920690409011,
           "diversity": 0.75,
           "eliteScore": 140.38164328854776,
-          "timestamp": "2025-10-21T04:26:14.558Z"
+          "timestamp": "2025-10-21T12:18:34.781Z"
         }
       ],
       "triangulation": {
@@ -670,7 +670,7 @@
           "medianScore": 41.03751524896436,
           "diversity": 0.9722222222222222,
           "eliteScore": 96.0918022581709,
-          "timestamp": "2025-10-21T04:26:14.561Z"
+          "timestamp": "2025-10-21T12:18:34.784Z"
         },
         {
           "generation": 1,
@@ -679,7 +679,7 @@
           "medianScore": 62.99975060567376,
           "diversity": 0.9444444444444444,
           "eliteScore": 98.43691088683215,
-          "timestamp": "2025-10-21T04:26:14.561Z"
+          "timestamp": "2025-10-21T12:18:34.785Z"
         },
         {
           "generation": 2,
@@ -688,7 +688,7 @@
           "medianScore": 76.53115760829131,
           "diversity": 0.75,
           "eliteScore": 132.5084085000921,
-          "timestamp": "2025-10-21T04:26:14.562Z"
+          "timestamp": "2025-10-21T12:18:34.786Z"
         },
         {
           "generation": 3,
@@ -697,7 +697,7 @@
           "medianScore": 77.95296283436663,
           "diversity": 0.7222222222222222,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T04:26:14.563Z"
+          "timestamp": "2025-10-21T12:18:34.787Z"
         },
         {
           "generation": 4,
@@ -706,7 +706,7 @@
           "medianScore": 86.94000111220245,
           "diversity": 0.7222222222222222,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T04:26:14.564Z"
+          "timestamp": "2025-10-21T12:18:34.793Z"
         },
         {
           "generation": 5,
@@ -715,7 +715,7 @@
           "medianScore": 88.99300139019402,
           "diversity": 0.6111111111111112,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T04:26:14.565Z"
+          "timestamp": "2025-10-21T12:18:34.794Z"
         },
         {
           "generation": 6,
@@ -724,7 +724,7 @@
           "medianScore": 83.23985249780515,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T04:26:14.570Z"
+          "timestamp": "2025-10-21T12:18:34.795Z"
         },
         {
           "generation": 7,
@@ -733,7 +733,7 @@
           "medianScore": 82.9194778065494,
           "diversity": 0.6111111111111112,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T04:26:14.571Z"
+          "timestamp": "2025-10-21T12:18:34.796Z"
         },
         {
           "generation": 8,
@@ -742,7 +742,7 @@
           "medianScore": 86.367830024997,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T04:26:14.572Z"
+          "timestamp": "2025-10-21T12:18:34.797Z"
         },
         {
           "generation": 9,
@@ -751,7 +751,7 @@
           "medianScore": 85.09002044220831,
           "diversity": 0.6666666666666666,
           "eliteScore": 133.04138007631948,
-          "timestamp": "2025-10-21T04:26:14.572Z"
+          "timestamp": "2025-10-21T12:18:34.798Z"
         }
       ],
       "triangulation": {
@@ -1075,7 +1075,7 @@
           "medianScore": 23.447749293641056,
           "diversity": 1,
           "eliteScore": 97.42746077012889,
-          "timestamp": "2025-10-21T04:26:14.573Z"
+          "timestamp": "2025-10-21T12:18:34.799Z"
         },
         {
           "generation": 1,
@@ -1084,7 +1084,7 @@
           "medianScore": 33.23577114240753,
           "diversity": 1,
           "eliteScore": 101.68095349725729,
-          "timestamp": "2025-10-21T04:26:14.574Z"
+          "timestamp": "2025-10-21T12:18:34.800Z"
         },
         {
           "generation": 2,
@@ -1093,7 +1093,7 @@
           "medianScore": 64.46743238768931,
           "diversity": 0.8888888888888888,
           "eliteScore": 125.76131787031291,
-          "timestamp": "2025-10-21T04:26:14.575Z"
+          "timestamp": "2025-10-21T12:18:34.801Z"
         },
         {
           "generation": 3,
@@ -1102,7 +1102,7 @@
           "medianScore": 70.39942915911845,
           "diversity": 0.8611111111111112,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T04:26:14.575Z"
+          "timestamp": "2025-10-21T12:18:34.802Z"
         },
         {
           "generation": 4,
@@ -1111,7 +1111,7 @@
           "medianScore": 71.05162669292856,
           "diversity": 0.8333333333333334,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T04:26:14.576Z"
+          "timestamp": "2025-10-21T12:18:34.803Z"
         },
         {
           "generation": 5,
@@ -1120,7 +1120,7 @@
           "medianScore": 53.843889930604206,
           "diversity": 0.7777777777777778,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T04:26:14.577Z"
+          "timestamp": "2025-10-21T12:18:34.804Z"
         },
         {
           "generation": 6,
@@ -1129,7 +1129,7 @@
           "medianScore": 78.25900854278035,
           "diversity": 0.6666666666666666,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T04:26:14.577Z"
+          "timestamp": "2025-10-21T12:18:34.804Z"
         },
         {
           "generation": 7,
@@ -1138,7 +1138,7 @@
           "medianScore": 91.68021852282594,
           "diversity": 0.5,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T04:26:14.578Z"
+          "timestamp": "2025-10-21T12:18:34.805Z"
         },
         {
           "generation": 8,
@@ -1147,7 +1147,7 @@
           "medianScore": 84.52984866490183,
           "diversity": 0.6388888888888888,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T04:26:14.578Z"
+          "timestamp": "2025-10-21T12:18:34.806Z"
         },
         {
           "generation": 9,
@@ -1156,7 +1156,7 @@
           "medianScore": 90.34258929546631,
           "diversity": 0.6388888888888888,
           "eliteScore": 136.04606142636254,
-          "timestamp": "2025-10-21T04:26:14.579Z"
+          "timestamp": "2025-10-21T12:18:34.807Z"
         }
       ],
       "triangulation": {

--- a/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-triangulation.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-triangulation.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-21T04:26:14.545Z",
+  "generatedAt": "2025-10-21T12:18:34.756Z",
   "confidence": 0.5333333333333333,
   "consensus": {
     "confirmed": 1,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/consoleBriefing.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/consoleBriefing.ts
@@ -1,0 +1,69 @@
+import { readFile } from "fs/promises";
+import { executeSynthesis, resolveRunOptions, type RunOptions } from "./runSynthesis";
+import { inspectCommand, loadPackageScripts } from "./commandValidation";
+
+function parseArgs(argv: string[]): RunOptions {
+  const options: RunOptions = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--mission" && index + 1 < argv.length) {
+      options.missionFile = argv[index + 1];
+      index += 1;
+    } else if (arg === "--report-dir" && index + 1 < argv.length) {
+      options.reportDir = argv[index + 1];
+      index += 1;
+    }
+  }
+  return options;
+}
+
+function printDivider(label: string): void {
+  const padding = Math.max(0, 72 - label.length - 2);
+  const line = `${"=".repeat(Math.floor(padding / 2))} ${label.toUpperCase()} ${"=".repeat(Math.ceil(padding / 2))}`;
+  console.log(line);
+}
+
+async function main(): Promise<void> {
+  const cliOptions = parseArgs(process.argv.slice(2));
+  const run = await executeSynthesis(cliOptions);
+  const resolved = resolveRunOptions(cliOptions);
+  const scripts = await loadPackageScripts();
+  printDivider("Meta-Agentic Program Synthesis");
+  console.log(`Mission: ${run.mission.meta.title}`);
+  console.log(`Generated at: ${run.generatedAt}`);
+  console.log(`Owner readiness: ${run.ownerCoverage.readiness}`);
+  console.log(`Accuracy: ${(run.aggregate.averageAccuracy * 100).toFixed(2)}% | Novelty: ${(run.aggregate.noveltyScore * 100).toFixed(2)}%`);
+  console.log(`Thermodynamic alignment: ${(run.aggregate.thermodynamics.averageAlignment * 100).toFixed(2)}%`);
+  console.log("");
+  printDivider("Owner Controls");
+  for (const capability of run.mission.ownerControls.capabilities) {
+    const status = inspectCommand(capability.command, scripts) ? "✅" : "❌";
+    console.log(`${status} ${capability.category} → ${capability.command}`);
+  }
+  console.log("");
+  printDivider("Task Highlights");
+  for (const task of run.tasks) {
+    const metrics = task.bestCandidate.metrics;
+    console.log(`• ${task.task.label}: score ${metrics.score.toFixed(2)}, accuracy ${(metrics.accuracy * 100).toFixed(2)}%, novelty ${(metrics.novelty * 100).toFixed(1)}%, energy ${metrics.energy.toFixed(2)} (status ${task.thermodynamics.status})`);
+  }
+  console.log("");
+  if (run.ownerBriefingPath) {
+    printDivider("Owner Briefing Snapshot");
+    const briefing = await readFile(run.ownerBriefingPath, "utf8");
+    const excerpt = briefing.split(/\n/).slice(0, 40).join("\n");
+    console.log(excerpt);
+    if (briefing.includes("##")) {
+      console.log("...");
+    }
+    console.log("");
+    console.log(`Full briefing: ${run.ownerBriefingPath}`);
+  }
+  console.log(`Manifest updated at ${resolved.manifestFile}`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("❌ Failed to render owner briefing:", error);
+    process.exitCode = 1;
+  });
+}

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/fullPipeline.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/fullPipeline.ts
@@ -381,7 +381,7 @@ export async function runFullPipeline(options: RunOptions = {}): Promise<void> {
     "utf8",
   );
 
-  const artifacts = {
+  const artifacts: Record<string, string> = {
     "Mission manifest": missionFile,
     "Markdown report": path.join(reportDir, "meta-agentic-program-synthesis-report.md"),
     "JSON summary": path.join(reportDir, "meta-agentic-program-synthesis-summary.json"),
@@ -393,9 +393,14 @@ export async function runFullPipeline(options: RunOptions = {}): Promise<void> {
     "Owner diagnostics (Markdown)": OWNER_MARKDOWN,
   };
 
+  if (run.ownerBriefingPath) {
+    artifacts["Owner briefing"] = run.ownerBriefingPath;
+  }
+
   const fullSummary = {
     generatedAt: new Date().toISOString(),
     aggregate: run.aggregate,
+    ownerBriefing: run.ownerBriefingPath ?? null,
     triangulation: {
       confidence: run.aggregate.triangulationConfidence,
       consensus: run.aggregate.consensus,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/types.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/types.ts
@@ -185,6 +185,7 @@ export interface SynthesisRun {
   tasks: TaskResult[];
   ownerCoverage: OwnerControlCoverage;
   ownerScriptsAudit: OwnerScriptAudit[];
+  ownerBriefingPath?: string;
   aggregate: {
     globalBestScore: number;
     averageAccuracy: number;

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
     "demo:alpha-meta:triangulate": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/triangulateMission.ts",
     "demo:alpha-meta:full": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/fullPipeline.ts",
     "demo:meta-agentic-program-synthesis": "ts-node --project demo/Meta-Agentic-Program-Synthesis-v0/tsconfig.json demo/Meta-Agentic-Program-Synthesis-v0/scripts/runSynthesis.ts",
+    "demo:meta-agentic-program-synthesis:briefing": "ts-node --project demo/Meta-Agentic-Program-Synthesis-v0/tsconfig.json demo/Meta-Agentic-Program-Synthesis-v0/scripts/consoleBriefing.ts",
     "demo:meta-agentic-program-synthesis:full": "ts-node --project demo/Meta-Agentic-Program-Synthesis-v0/tsconfig.json demo/Meta-Agentic-Program-Synthesis-v0/scripts/fullPipeline.ts",
     "demo:national-supply-chain": "npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",
     "demo:national-supply-chain:export": "AGI_JOBS_DEMO_EXPORT=demo/National-Supply-Chain-v0/ui/export/latest.json npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",


### PR DESCRIPTION
## Summary
- add a console-first owner briefing command that regenerates synthesis artefacts and streams the high-level results
- extend the reporting pipeline to generate a reusable owner briefing dossier and register it in the manifest/full bundle
- document the new workflow so non-technical operators can access the briefing from README guidance

## Testing
- npm run demo:meta-agentic-program-synthesis
- npm run demo:meta-agentic-program-synthesis:briefing
- npm run lint:check

------
https://chatgpt.com/codex/tasks/task_e_68f7784c753c8333b95f79e55d0eb1ef