### PR TITLE
Add deterministic guardrails for Meta-Agentic Program Synthesis demo

### DIFF
--- a/.github/workflows/demo-meta-agentic-program-synthesis.yml
+++ b/.github/workflows/demo-meta-agentic-program-synthesis.yml
@@ -1,0 +1,59 @@
+name: demo-meta-agentic-program-synthesis
+
+on:
+  pull_request:
+    paths:
+      - 'demo/Meta-Agentic-Program-Synthesis-v0/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/demo-meta-agentic-program-synthesis.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  meta-agentic-demo:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: |
+            api.github.com
+            github.com
+            objects.githubusercontent.com
+            raw.githubusercontent.com
+            registry.npmjs.org
+            nodejs.org
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            **/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline --progress=false
+
+      - name: Run deterministic mission tests
+        run: npm run demo:meta-agentic-program-synthesis:test
+
+      - name: Generate full sovereign dossier
+        run: npm run demo:meta-agentic-program-synthesis:full
+
+      - name: Upload synthesis artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: meta-agentic-program-synthesis-reports
+          path: demo/Meta-Agentic-Program-Synthesis-v0/reports

--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -144,6 +144,17 @@ npm run demo:meta-agentic-program-synthesis
 npm run demo:meta-agentic-program-synthesis:full
 ```
 
+## Deterministic verification suite
+
+```bash
+npm run demo:meta-agentic-program-synthesis:test
+```
+
+The test harness imports the mission manifest, replays the seeded evolutionary run, and asserts that owner-control coverage,
+thermodynamic telemetry, consensus counts, and aggregate metrics match the published dossiers. The `demo-meta-agentic-program-
+synthesis` GitHub Actions workflow executes this test and the full pipeline on every pull request touching the demo, keeping
+the sovereign forge reproducible and audit-ready.
+
 Set `AGI_META_PROGRAM_MISSION=/path/to/custom.json` to target a modified mission file.
 
 ## Production readiness checklist

--- a/demo/Meta-Agentic-Program-Synthesis-v0/RUNBOOK.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/RUNBOOK.md
@@ -63,13 +63,16 @@ All commands are idempotent offline. Point `HARDHAT_NETWORK` to a live network t
 ## 5. Verify CI shield manually (optional)
 
 ```bash
+npm run demo:meta-agentic-program-synthesis:test
 npm run demo:meta-agentic-program-synthesis
 npm run demo:meta-agentic-program-synthesis:full
 jq '.' demo/Meta-Agentic-Program-Synthesis-v0/reports/meta-agentic-program-synthesis-ci.json
 ```
 
-The CI report must confirm the workflow name `ci (v2)`, jobs `lint/tests/foundry/coverage`, `cancel-in-progress: true`, and
-coverage ≥90.
+The deterministic test replays the seeded mission and fails fast if mission invariants or aggregate metrics drift. The CI
+report must confirm the workflow name `ci (v2)`, jobs `lint/tests/foundry/coverage`, `cancel-in-progress: true`, and coverage ≥90.
+The GitHub Actions workflow `demo-meta-agentic-program-synthesis` executes the same sequence on every pull request so owners can
+rely on reproducible dossiers.
 
 ## 6. Custom missions
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/scripts/__tests__/metaAgentic.test.ts
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/scripts/__tests__/metaAgentic.test.ts
@@ -1,0 +1,70 @@
+import path from "path";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadMissionConfig, runMetaSynthesis } from "../synthesisEngine";
+import { ensureMissionValidity } from "../validation";
+
+const missionPath = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "config",
+  "mission.meta-agentic-program-synthesis.json",
+);
+
+function within(actual: number, expected: number, tolerance = 1e-6): void {
+  assert.ok(Number.isFinite(actual), `Expected a finite value but received ${actual}`);
+  const delta = Math.abs(actual - expected);
+  assert.ok(
+    delta <= tolerance,
+    `Expected ${actual} to be within ±${tolerance} of ${expected} (delta ${delta}).`,
+  );
+}
+
+test("meta-agentic synthesis remains deterministic and mission-aligned", async () => {
+  const { mission, coverage } = await loadMissionConfig(missionPath);
+  assert.equal(coverage.readiness, "ready");
+  assert.deepEqual(
+    [...coverage.satisfiedCategories].sort(),
+    ["Compliance", "Emergency Pause", "Thermostat", "Treasury", "Upgrade"].sort(),
+  );
+  assert.equal(coverage.missingCategories.length, 0);
+
+  const run = runMetaSynthesis(mission, coverage);
+  assert.equal(run.tasks.length, mission.tasks.length);
+
+  within(run.aggregate.globalBestScore, 140.38164328854776);
+  within(run.aggregate.averageAccuracy, 1);
+  within(run.aggregate.energyUsage, 73.33333333333333);
+  within(run.aggregate.noveltyScore, 0.7776289047454377);
+  within(run.aggregate.coverageScore, 1);
+  within(run.aggregate.triangulationConfidence, 0.5333333333333333);
+
+  assert.equal(run.aggregate.consensus.confirmed, 1);
+  assert.equal(run.aggregate.consensus.attention, 0);
+  assert.equal(run.aggregate.consensus.rejected, 2);
+
+  const arc = run.tasks.find((task) => task.task.id === "arc-sentinel");
+  assert.ok(arc, "ARC Sentinel task missing from synthesis run");
+  within(arc.bestCandidate.metrics.score, 140.38164328854776);
+  within(arc.bestCandidate.metrics.accuracy, 1);
+  assert.equal(arc.triangulation.consensus, "confirmed");
+  assert.equal(arc.thermodynamics.status, "aligned");
+});
+
+test("mission validation enforces owner coverage and canonical addresses", async () => {
+  const { mission } = await loadMissionConfig(missionPath);
+
+  const missingCategoryMission = JSON.parse(JSON.stringify(mission));
+  missingCategoryMission.ownerControls.capabilities = mission.ownerControls.capabilities.filter(
+    (capability) => capability.category !== "Compliance",
+  );
+  assert.throws(
+    () => ensureMissionValidity(missingCategoryMission),
+    /Owner capabilities missing required categories/i,
+  );
+
+  const invalidAddressMission = JSON.parse(JSON.stringify(mission));
+  invalidAddressMission.meta.ownerAddress = "0x123";
+  assert.throws(() => ensureMissionValidity(invalidAddressMission), /Owner address must be a valid Ethereum address/i);
+});

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
     "demo:alpha-meta:triangulate": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/triangulateMission.ts",
     "demo:alpha-meta:full": "ts-node --project demo/alpha-meta/tsconfig.json demo/alpha-meta/scripts/fullPipeline.ts",
     "demo:meta-agentic-program-synthesis": "ts-node --project demo/Meta-Agentic-Program-Synthesis-v0/tsconfig.json demo/Meta-Agentic-Program-Synthesis-v0/scripts/runSynthesis.ts",
+    "demo:meta-agentic-program-synthesis:test": "node -r ts-node/register --test demo/Meta-Agentic-Program-Synthesis-v0/scripts/__tests__/metaAgentic.test.ts",
     "demo:meta-agentic-program-synthesis:full": "ts-node --project demo/Meta-Agentic-Program-Synthesis-v0/tsconfig.json demo/Meta-Agentic-Program-Synthesis-v0/scripts/fullPipeline.ts",
     "demo:national-supply-chain": "npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",
     "demo:national-supply-chain:export": "AGI_JOBS_DEMO_EXPORT=demo/National-Supply-Chain-v0/ui/export/latest.json npx hardhat run --no-compile --network hardhat scripts/v2/nationalSupplyChainGrandDemo.ts",


### PR DESCRIPTION
## Summary
- add a deterministic node:test suite that validates mission coverage, consensus counts, and aggregate metrics for the meta-agentic demo
- expose the test via npm scripts and document the workflow updates in the README and runbook
- introduce a dedicated GitHub Actions workflow that runs the deterministic test and the full dossier pipeline on every PR touching the demo

## Testing
- npm run demo:meta-agentic-program-synthesis:test
- npm run demo:meta-agentic-program-synthesis:full


------
https://chatgpt.com/codex/tasks/task_e_68f7784c753c8333b95f79e55d0eb1ef