### PR TITLE
Add owner console controls to Meta-Agentic Program Synthesis demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -78,6 +78,44 @@ The CLI narrates the process in natural language so the operator always understa
 
 ---
 
+## 👑 Owner Command Console
+
+The demo now ships with an explicit owner console that mirrors the privileged controls of the on-chain deployment. Every policy
+knob – rewards, staking, evolution cadence, and pause state – can be adjusted at runtime without touching code.
+
+### Command-line overrides
+
+```bash
+python start_demo.py alpha \
+  --reward-total 2500 \
+  --reward-temperature 0.8 \
+  --reward-validator-weight 0.25 \
+  --stake-minimum 750 \
+  --stake-timeout 120 \
+  --evolution-generations 16
+```
+
+Use `--pause` to halt execution instantly. The orchestrator will refuse to launch jobs while paused and will explain the status
+in the CLI output. Re-run without `--pause` (or with a different override set) to resume operations.
+
+### JSON override files
+
+For executive operators, overrides can be pre-packaged in a JSON file:
+
+```json
+{
+  "reward_policy": {"total_reward": 3200, "temperature": 1.1},
+  "stake_policy": {"minimum_stake": 900, "slash_fraction": 0.15},
+  "evolution_policy": {"generations": 18, "mutation_rate": 0.28},
+  "paused": false
+}
+```
+
+Run the demo with `python start_demo.py alpha --config-file config/owner-overrides.sample.json` (a sample file is provided in
+`config/`). Invalid overrides are rejected gracefully with descriptive errors, guaranteeing the owner keeps uncompromised control.
+
+---
+
 ## 🧪 Validation & CI
 
 * `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests` verifies the evolutionary loop, on-chain security primitives, and orchestration pipeline.

--- a/demo/Meta-Agentic-Program-Synthesis-v0/config/owner-overrides.sample.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/config/owner-overrides.sample.json
@@ -1,0 +1,21 @@
+{
+  "reward_policy": {
+    "total_reward": 2800,
+    "temperature": 0.95,
+    "validator_weight": 0.22,
+    "architect_weight": 0.12
+  },
+  "stake_policy": {
+    "minimum_stake": 800,
+    "slash_fraction": 0.18,
+    "inactivity_timeout_seconds": 75
+  },
+  "evolution_policy": {
+    "generations": 14,
+    "population_size": 10,
+    "elite_count": 3,
+    "mutation_rate": 0.27,
+    "crossover_rate": 0.45
+  },
+  "paused": false
+}

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/__init__.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/__init__.py
@@ -1,5 +1,6 @@
 """Public package interface for the Meta-Agentic Program Synthesis demo."""
 
+from .admin import OwnerConsole, load_owner_overrides
 from .config import DemoConfig, DemoScenario, EvolutionPolicy, RewardPolicy, StakePolicy
 from .entities import DemoRunArtifacts
 from .orchestrator import SovereignArchitect, generate_dataset
@@ -12,8 +13,10 @@ __all__ = [
     "EvolutionPolicy",
     "RewardPolicy",
     "StakePolicy",
+    "OwnerConsole",
     "SovereignArchitect",
     "generate_dataset",
     "export_report",
     "render_html",
+    "load_owner_overrides",
 ]

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/admin.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/admin.py
@@ -1,0 +1,154 @@
+"""Owner control utilities for the Meta-Agentic Program Synthesis demo."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Mapping
+
+from .config import DemoConfig, EvolutionPolicy, RewardPolicy, StakePolicy
+
+
+class OwnerConsole:
+    """High-level administrative interface exposed to the platform owner."""
+
+    _REWARD_KEYS = {"total_reward", "temperature", "validator_weight", "architect_weight"}
+    _STAKE_KEYS = {"minimum_stake", "slash_fraction", "inactivity_timeout_seconds"}
+    _EVOLUTION_KEYS = {
+        "generations",
+        "population_size",
+        "elite_count",
+        "mutation_rate",
+        "crossover_rate",
+    }
+
+    def __init__(self, config: DemoConfig) -> None:
+        self._config = config
+        self._paused = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    @property
+    def config(self) -> DemoConfig:
+        return self._config
+
+    @property
+    def is_paused(self) -> bool:
+        return self._paused
+
+    def pause(self) -> None:
+        self._paused = True
+
+    def resume(self) -> None:
+        self._paused = False
+
+    def set_paused(self, value: bool) -> None:
+        self._paused = bool(value)
+
+    def require_active(self) -> None:
+        if self._paused:
+            raise RuntimeError("operations are paused by the contract owner")
+
+    def update_reward_policy(self, **kwargs: float) -> None:
+        overrides = self._validate_kwargs("reward_policy", kwargs, self._REWARD_KEYS)
+        if not overrides:
+            return
+        policy = replace(self._config.reward_policy, **overrides)
+        self._validate_reward_policy(policy)
+        self._config = replace(self._config, reward_policy=policy)
+
+    def update_stake_policy(self, **kwargs: float) -> None:
+        overrides = self._validate_kwargs("stake_policy", kwargs, self._STAKE_KEYS)
+        if not overrides:
+            return
+        mapped: dict[str, Any] = {}
+        if "minimum_stake" in overrides:
+            mapped["minimum_stake"] = overrides["minimum_stake"]
+        if "slash_fraction" in overrides:
+            mapped["slash_fraction"] = overrides["slash_fraction"]
+        if "inactivity_timeout_seconds" in overrides:
+            mapped["inactivity_timeout"] = timedelta(
+                seconds=overrides["inactivity_timeout_seconds"]
+            )
+        policy = replace(self._config.stake_policy, **mapped)
+        self._validate_stake_policy(policy)
+        self._config = replace(self._config, stake_policy=policy)
+
+    def update_evolution_policy(self, **kwargs: float) -> None:
+        overrides = self._validate_kwargs("evolution_policy", kwargs, self._EVOLUTION_KEYS)
+        if not overrides:
+            return
+        policy = replace(self._config.evolution_policy, **overrides)
+        self._validate_evolution_policy(policy)
+        self._config = replace(self._config, evolution_policy=policy)
+
+    def apply_overrides(self, overrides: Mapping[str, Any]) -> None:
+        """Apply overrides loaded from configuration files or CLI mappings."""
+
+        reward_overrides = overrides.get("reward_policy", {})
+        if reward_overrides:
+            self.update_reward_policy(**reward_overrides)
+        stake_overrides = overrides.get("stake_policy", {})
+        if stake_overrides:
+            self.update_stake_policy(**stake_overrides)
+        evolution_overrides = overrides.get("evolution_policy", {})
+        if evolution_overrides:
+            self.update_evolution_policy(**evolution_overrides)
+        if "paused" in overrides:
+            self.set_paused(bool(overrides["paused"]))
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    def _validate_kwargs(
+        self, namespace: str, provided: Mapping[str, Any], allowed: set[str]
+    ) -> dict[str, Any]:
+        unknown = set(provided) - allowed
+        if unknown:
+            raise ValueError(
+                f"unknown keys for {namespace}: {', '.join(sorted(unknown))}"
+            )
+        return {key: provided[key] for key in allowed & set(provided)}
+
+    def _validate_reward_policy(self, policy: RewardPolicy) -> None:
+        if policy.total_reward < 0:
+            raise ValueError("total_reward must be non-negative")
+        if policy.temperature <= 0:
+            raise ValueError("temperature must be positive")
+        if policy.validator_weight < 0 or policy.architect_weight < 0:
+            raise ValueError("reward weights must be non-negative")
+        if policy.validator_weight + policy.architect_weight > 1:
+            raise ValueError("reward weights exceed total allocation")
+
+    def _validate_stake_policy(self, policy: StakePolicy) -> None:
+        if policy.minimum_stake < 0:
+            raise ValueError("minimum_stake must be non-negative")
+        if not 0 <= policy.slash_fraction <= 1:
+            raise ValueError("slash_fraction must be between 0 and 1")
+        if policy.inactivity_timeout.total_seconds() <= 0:
+            raise ValueError("inactivity timeout must be positive")
+
+    def _validate_evolution_policy(self, policy: EvolutionPolicy) -> None:
+        if policy.generations < 1:
+            raise ValueError("generations must be at least 1")
+        if policy.population_size < 2:
+            raise ValueError("population_size must be at least 2")
+        if not 0 <= policy.elite_count < policy.population_size:
+            raise ValueError("elite_count must be less than population_size")
+        if not 0 <= policy.mutation_rate <= 1:
+            raise ValueError("mutation_rate must be between 0 and 1")
+        if not 0 <= policy.crossover_rate <= 1:
+            raise ValueError("crossover_rate must be between 0 and 1")
+
+
+def load_owner_overrides(path: Path) -> Mapping[str, Any]:
+    """Load overrides from a JSON file."""
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, Mapping):
+        raise ValueError("override file must contain a JSON object")
+    return data
+
+
+__all__ = ["OwnerConsole", "load_owner_overrides"]

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_admin.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_admin.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from meta_agentic_demo.admin import OwnerConsole, load_owner_overrides
+from meta_agentic_demo.config import DemoConfig, DemoScenario
+from meta_agentic_demo.orchestrator import SovereignArchitect
+
+
+def create_console() -> OwnerConsole:
+    scenario = DemoScenario(
+        identifier="alpha",
+        title="Alpha",
+        description="",
+        target_metric="score",
+        success_threshold=0.5,
+    )
+    return OwnerConsole(DemoConfig(scenarios=[scenario]))
+
+
+def test_owner_console_updates_reward_policy() -> None:
+    console = create_console()
+    console.update_reward_policy(total_reward=1500.0, validator_weight=0.2, architect_weight=0.1)
+    config = console.config
+    assert pytest.approx(config.reward_policy.total_reward) == 1500.0
+    assert pytest.approx(config.reward_policy.validator_weight) == 0.2
+    assert pytest.approx(config.reward_policy.architect_weight) == 0.1
+
+
+def test_owner_console_rejects_invalid_reward_policy() -> None:
+    console = create_console()
+    with pytest.raises(ValueError):
+        console.update_reward_policy(validator_weight=0.8, architect_weight=0.5)
+
+
+def test_owner_console_pause_and_resume_blocks_execution() -> None:
+    console = create_console()
+    architect = SovereignArchitect(config=console.config, owner_console=console)
+    console.pause()
+    with pytest.raises(RuntimeError):
+        architect.run(console.config.scenarios[0])
+    console.resume()
+    artefacts = architect.run(console.config.scenarios[0])
+    assert artefacts.final_score > 0
+
+
+def test_owner_console_updates_stake_and_evolution() -> None:
+    console = create_console()
+    console.update_stake_policy(minimum_stake=500.0, inactivity_timeout_seconds=45)
+    console.update_evolution_policy(generations=6, population_size=8, elite_count=2)
+    config = console.config
+    assert pytest.approx(config.stake_policy.minimum_stake) == 500.0
+    assert config.stake_policy.inactivity_timeout.total_seconds() == pytest.approx(45)
+    assert config.evolution_policy.generations == 6
+    assert config.evolution_policy.population_size == 8
+    assert config.evolution_policy.elite_count == 2
+
+
+def test_owner_console_apply_overrides_and_load(tmp_path: Path) -> None:
+    console = create_console()
+    overrides = {
+        "reward_policy": {"total_reward": 2000},
+        "stake_policy": {"slash_fraction": 0.2},
+        "evolution_policy": {"mutation_rate": 0.25},
+        "paused": True,
+    }
+    file_path = tmp_path / "overrides.json"
+    file_path.write_text(json.dumps(overrides), encoding="utf-8")
+    loaded = load_owner_overrides(file_path)
+    console.apply_overrides(loaded)
+    assert console.is_paused
+    assert pytest.approx(console.config.reward_policy.total_reward) == 2000
+    assert pytest.approx(console.config.stake_policy.slash_fraction) == 0.2
+    assert pytest.approx(console.config.evolution_policy.mutation_rate) == 0.25
+
+
+def test_owner_console_rejects_unknown_keys() -> None:
+    console = create_console()
+    with pytest.raises(ValueError):
+        console.update_reward_policy(nonexistent=1.0)  # type: ignore[arg-type]

--- a/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from textwrap import indent
 
+from meta_agentic_demo.admin import OwnerConsole, load_owner_overrides
 from meta_agentic_demo.config import DemoConfig, DemoScenario
 from meta_agentic_demo.orchestrator import SovereignArchitect
 from meta_agentic_demo.report import export_report
@@ -49,6 +50,74 @@ def parse_args() -> argparse.Namespace:
         default=Path("demo_output"),
         help="Directory where artefacts should be written",
     )
+    parser.add_argument(
+        "--config-file",
+        type=Path,
+        help="Optional JSON file containing owner overrides",
+    )
+
+    owner_group = parser.add_argument_group("Owner overrides")
+    owner_group.add_argument("--reward-total", type=float, help="Override total reward size")
+    owner_group.add_argument(
+        "--reward-temperature",
+        type=float,
+        help="Override thermodynamic temperature",
+    )
+    owner_group.add_argument(
+        "--reward-validator-weight",
+        type=float,
+        help="Portion of rewards dedicated to validators",
+    )
+    owner_group.add_argument(
+        "--reward-architect-weight",
+        type=float,
+        help="Portion of rewards retained by the architect",
+    )
+    owner_group.add_argument(
+        "--stake-minimum",
+        type=float,
+        help="Override minimum stake per agent",
+    )
+    owner_group.add_argument(
+        "--stake-slash-fraction",
+        type=float,
+        help="Override slashing fraction",
+    )
+    owner_group.add_argument(
+        "--stake-timeout",
+        type=float,
+        help="Override inactivity timeout in seconds",
+    )
+    owner_group.add_argument(
+        "--evolution-generations",
+        type=int,
+        help="Override number of generations",
+    )
+    owner_group.add_argument(
+        "--evolution-population",
+        type=int,
+        help="Override population size",
+    )
+    owner_group.add_argument(
+        "--evolution-elite",
+        type=int,
+        help="Override elite count",
+    )
+    owner_group.add_argument(
+        "--evolution-mutation",
+        type=float,
+        help="Override mutation rate",
+    )
+    owner_group.add_argument(
+        "--evolution-crossover",
+        type=float,
+        help="Override crossover rate",
+    )
+    owner_group.add_argument(
+        "--pause",
+        action="store_true",
+        help="Pause operations before they begin (no jobs executed)",
+    )
     return parser.parse_args()
 
 
@@ -60,12 +129,61 @@ def describe_config(config: DemoConfig) -> str:
 def main() -> None:
     args = parse_args()
     scenario = next(s for s in SCENARIOS if s.identifier == args.scenario)
-    config = DemoConfig(scenarios=SCENARIOS)
-    architect = SovereignArchitect(config=config)
+    owner_console = OwnerConsole(DemoConfig(scenarios=SCENARIOS))
+    try:
+        if args.config_file:
+            overrides = load_owner_overrides(args.config_file)
+            owner_console.apply_overrides(overrides)
+        reward_overrides = {
+            key: value
+            for key, value in {
+                "total_reward": args.reward_total,
+                "temperature": args.reward_temperature,
+                "validator_weight": args.reward_validator_weight,
+                "architect_weight": args.reward_architect_weight,
+            }.items()
+            if value is not None
+        }
+        if reward_overrides:
+            owner_console.update_reward_policy(**reward_overrides)
+        stake_overrides = {
+            key: value
+            for key, value in {
+                "minimum_stake": args.stake_minimum,
+                "slash_fraction": args.stake_slash_fraction,
+                "inactivity_timeout_seconds": args.stake_timeout,
+            }.items()
+            if value is not None
+        }
+        if stake_overrides:
+            owner_console.update_stake_policy(**stake_overrides)
+        evolution_overrides = {
+            key: value
+            for key, value in {
+                "generations": args.evolution_generations,
+                "population_size": args.evolution_population,
+                "elite_count": args.evolution_elite,
+                "mutation_rate": args.evolution_mutation,
+                "crossover_rate": args.evolution_crossover,
+            }.items()
+            if value is not None
+        }
+        if evolution_overrides:
+            owner_console.update_evolution_policy(**evolution_overrides)
+        if args.pause:
+            owner_console.pause()
+    except ValueError as error:
+        print("❌ Owner override error:", error)
+        return
+    config = owner_console.config
+    architect = SovereignArchitect(config=config, owner_console=owner_console)
     print("🚀 Initiating sovereign architect for scenario:", scenario.title)
     print(indent(scenario.description, prefix="  > "))
     print("\n🧭 Configuration:")
     print(indent(describe_config(config), prefix="  "))
+    if owner_console.is_paused:
+        print("\n⏸️ Operations paused by owner. Resume to execute jobs.")
+        return
     artefacts = architect.run(scenario)
     bundle = export_report(artefacts, args.output)
     print("\n✅ Demo complete. Artefacts written to:")


### PR DESCRIPTION
## Summary
- add an owner console module that governs reward, stake, and evolution policies with pause/resume controls
- extend the demo CLI and documentation with owner overrides plus ship a ready-made JSON configuration template
- wire the orchestrator into the new admin controls and cover the behaviour with dedicated tests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests

------
https://chatgpt.com/codex/tasks/task_e_68f7b59bf6c48333a22c9f399d01e3f6