### PR TITLE
Add culture registry and self-play arena modules

### DIFF
--- a/contracts/v2/CultureRegistry.sol
+++ b/contracts/v2/CultureRegistry.sol
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {IIdentityRegistry} from "./interfaces/IIdentityRegistry.sol";
+
+/// @title CultureRegistry
+/// @notice Registry for durable knowledge artifacts and their citation graph.
+/// @dev Invariants:
+/// - Artifact identifiers increment sequentially and are never reused.
+/// - `_artifacts[id].author != address(0)` is the sole indicator of artifact existence.
+/// - Citation arrays only contain unique, existing artifact identifiers.
+/// Emergency procedures:
+/// - The owner can call {pause} to freeze mints and citation updates and
+///   {setIdentityRegistry} to rotate compromised identity infrastructure.
+contract CultureRegistry is Ownable, Pausable, ReentrancyGuard {
+    /// @notice Metadata stored for each artifact entry.
+    struct Artifact {
+        address author;
+        string kind;
+        string uri;
+        uint64 createdAt;
+        uint256 parentId;
+        uint256[] citations;
+    }
+
+    /// @notice View helper that returns dynamic citation data in memory.
+    struct ArtifactView {
+        address author;
+        string kind;
+        string uri;
+        uint64 createdAt;
+        uint256 parentId;
+        uint256[] citations;
+    }
+
+    /// @notice External registry providing ENS backed role attestations.
+    IIdentityRegistry public identityRegistry;
+
+    /// @notice Maximum number of citations allowed per artifact.
+    uint256 public maxCitations;
+
+    /// @dev Incremental counter used to derive the next artifact identifier.
+    uint256 private _artifactIdCounter;
+
+    /// @dev Mapping of artifact identifier to metadata.
+    mapping(uint256 => Artifact) private _artifacts;
+
+    /// @dev Optional allow-list of artifact kinds hashed for efficient lookup.
+    mapping(bytes32 => bool) private _allowedKinds;
+
+    /// @dev Tracks whether at least one explicit kind has been configured.
+    bool private _kindsConfigured;
+
+    event ArtifactMinted(
+        uint256 indexed artifactId,
+        address indexed author,
+        string kind,
+        string uri,
+        uint256 parentId
+    );
+    event ArtifactCited(uint256 indexed artifactId, uint256 indexed citedArtifactId);
+    event AllowedKindUpdated(string indexed kind, bool allowed);
+    event MaxCitationsUpdated(uint256 newMax);
+    event IdentityRegistryUpdated(address indexed previousRegistry, address indexed newRegistry);
+
+    error InvalidKind();
+    error InvalidURI();
+    error InvalidParent(uint256 parentId);
+    error InvalidCitation(uint256 citedId);
+    error DuplicateCitation(uint256 citedId);
+    error SelfCitation(uint256 artifactId);
+    error TooManyCitations(uint256 attempted, uint256 maxAllowed);
+    error NotAuthorised(address caller);
+    error ZeroAddress();
+    error IdentityRegistryNotSet();
+
+    constructor(
+        address owner_,
+        address identityRegistry_,
+        string[] memory initialKinds,
+        uint256 maxCitations_
+    ) Ownable(owner_) {
+        if (maxCitations_ == 0) {
+            revert TooManyCitations(0, 0);
+        }
+        identityRegistry = IIdentityRegistry(identityRegistry_);
+        maxCitations = maxCitations_;
+
+        if (initialKinds.length > 0) {
+            _kindsConfigured = true;
+        }
+        for (uint256 i; i < initialKinds.length; ++i) {
+            bytes32 key = keccak256(bytes(initialKinds[i]));
+            _allowedKinds[key] = true;
+            emit AllowedKindUpdated(initialKinds[i], true);
+        }
+    }
+
+    /// @notice Returns the total number of minted artifacts.
+    function totalArtifacts() external view returns (uint256) {
+        return _artifactIdCounter;
+    }
+
+    /// @notice Checks if an artifact kind is authorised for minting.
+    function isAllowedKind(string memory kind) public view returns (bool) {
+        if (!_kindsConfigured) {
+            return true;
+        }
+        return _allowedKinds[keccak256(bytes(kind))];
+    }
+
+    /// @notice Fetch artifact metadata and citations.
+    function getArtifact(uint256 artifactId) external view returns (ArtifactView memory viewData) {
+        Artifact storage stored = _artifacts[artifactId];
+        if (stored.author == address(0)) {
+            revert InvalidParent(artifactId);
+        }
+        uint256 citationsLength = stored.citations.length;
+        uint256[] memory cites = new uint256[](citationsLength);
+        for (uint256 i; i < citationsLength; ++i) {
+            cites[i] = stored.citations[i];
+        }
+        viewData = ArtifactView({
+            author: stored.author,
+            kind: stored.kind,
+            uri: stored.uri,
+            createdAt: stored.createdAt,
+            parentId: stored.parentId,
+            citations: cites
+        });
+    }
+
+    /// @notice Mint a new artifact and optionally attach citations.
+    /// @param kind Classifier describing the artifact.
+    /// @param uri Off-chain URI (IPFS, HTTPS) that hosts the artifact payload.
+    /// @param parentId Optional parent artifact identifier (0 for none).
+    /// @param citations Array of cited artifact identifiers.
+    /// @param subdomain ENS label controlled by the caller for identity attestation.
+    /// @param proof Merkle proof attesting to the caller's membership in the author list.
+    function mintArtifact(
+        string calldata kind,
+        string calldata uri,
+        uint256 parentId,
+        uint256[] calldata citations,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external whenNotPaused nonReentrant returns (uint256 artifactId) {
+        _requireAuthorised(msg.sender, subdomain, proof);
+
+        if (bytes(kind).length == 0 || !isAllowedKind(kind)) {
+            revert InvalidKind();
+        }
+        if (bytes(uri).length == 0) {
+            revert InvalidURI();
+        }
+        if (citations.length > maxCitations) {
+            revert TooManyCitations(citations.length, maxCitations);
+        }
+
+        if (parentId != 0) {
+            _assertArtifactExists(parentId);
+        }
+
+        artifactId = ++_artifactIdCounter;
+        Artifact storage artifact = _artifacts[artifactId];
+        artifact.author = msg.sender;
+        artifact.kind = kind;
+        artifact.uri = uri;
+        artifact.createdAt = uint64(block.timestamp);
+        artifact.parentId = parentId;
+
+        if (citations.length != 0) {
+            _validateAndStoreCitations(artifactId, artifact, citations);
+        }
+
+        emit ArtifactMinted(artifactId, msg.sender, kind, uri, parentId);
+        for (uint256 i; i < citations.length; ++i) {
+            emit ArtifactCited(artifactId, citations[i]);
+        }
+    }
+
+    /// @notice Append an additional citation to an existing artifact.
+    /// @param artifactId Identifier of the artifact being updated.
+    /// @param citedArtifactId Identifier of the referenced artifact.
+    function cite(uint256 artifactId, uint256 citedArtifactId)
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        Artifact storage artifact = _artifacts[artifactId];
+        if (artifact.author == address(0)) {
+            revert InvalidParent(artifactId);
+        }
+        if (msg.sender != artifact.author && msg.sender != owner()) {
+            revert NotAuthorised(msg.sender);
+        }
+        if (artifact.citations.length >= maxCitations) {
+            revert TooManyCitations(artifact.citations.length + 1, maxCitations);
+        }
+        if (artifactId == citedArtifactId) {
+            revert SelfCitation(artifactId);
+        }
+        _assertArtifactExists(citedArtifactId);
+        uint256 length = artifact.citations.length;
+        for (uint256 i; i < length; ++i) {
+            if (artifact.citations[i] == citedArtifactId) {
+                revert DuplicateCitation(citedArtifactId);
+            }
+        }
+        artifact.citations.push(citedArtifactId);
+        emit ArtifactCited(artifactId, citedArtifactId);
+    }
+
+    /// @notice Owner can toggle specific artifact kinds.
+    function setAllowedKind(string calldata kind, bool allowed) external onlyOwner {
+        bytes32 key = keccak256(bytes(kind));
+        _allowedKinds[key] = allowed;
+        if (allowed) {
+            _kindsConfigured = true;
+        }
+        emit AllowedKindUpdated(kind, allowed);
+    }
+
+    /// @notice Update the maximum permitted citations per artifact.
+    function setMaxCitations(uint256 newMax) external onlyOwner {
+        if (newMax == 0) {
+            revert TooManyCitations(0, maxCitations);
+        }
+        maxCitations = newMax;
+        emit MaxCitationsUpdated(newMax);
+    }
+
+    /// @notice Update the external identity registry reference.
+    function setIdentityRegistry(address newRegistry) external onlyOwner {
+        if (newRegistry == address(0)) {
+            revert ZeroAddress();
+        }
+        address previous = address(identityRegistry);
+        identityRegistry = IIdentityRegistry(newRegistry);
+        emit IdentityRegistryUpdated(previous, newRegistry);
+    }
+
+    /// @notice Pause mutating operations in the registry.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Resume minting and citation updates.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    function _requireAuthorised(address account, string calldata subdomain, bytes32[] calldata proof)
+        internal
+        view
+    {
+        if (account == owner()) {
+            return;
+        }
+        IIdentityRegistry registry = identityRegistry;
+        if (address(registry) == address(0)) {
+            revert IdentityRegistryNotSet();
+        }
+        if (bytes(subdomain).length == 0) {
+            revert NotAuthorised(account);
+        }
+        bool ok = registry.isAuthorizedAgent(account, subdomain, proof);
+        if (!ok) {
+            revert NotAuthorised(account);
+        }
+    }
+
+    function _validateAndStoreCitations(
+        uint256 artifactId,
+        Artifact storage artifact,
+        uint256[] calldata citations
+    ) internal {
+        uint256 length = citations.length;
+        for (uint256 i; i < length; ++i) {
+            uint256 citedId = citations[i];
+            if (artifactId == citedId) {
+                revert SelfCitation(artifactId);
+            }
+            _assertArtifactExists(citedId);
+            for (uint256 j; j < i; ++j) {
+                if (citations[j] == citedId) {
+                    revert DuplicateCitation(citedId);
+                }
+            }
+            artifact.citations.push(citedId);
+        }
+    }
+
+    function _assertArtifactExists(uint256 artifactId) internal view {
+        if (artifactId == 0) {
+            revert InvalidCitation(artifactId);
+        }
+        Artifact storage candidate = _artifacts[artifactId];
+        if (candidate.author == address(0)) {
+            revert InvalidCitation(artifactId);
+        }
+    }
+}

--- a/contracts/v2/SelfPlayArena.sol
+++ b/contracts/v2/SelfPlayArena.sol
@@ -1,0 +1,496 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {IIdentityRegistry} from "./interfaces/IIdentityRegistry.sol";
+import {IJobRegistry} from "./interfaces/IJobRegistry.sol";
+import {IStakeManager} from "./interfaces/IStakeManager.sol";
+
+/// @title SelfPlayArena
+/// @notice Coordinates self-play rounds between teacher, student, and validator agents.
+/// @dev Invariants:
+/// - Round identifiers increment monotonically and each round can only be
+///   finalised once.
+/// - Once `closedAt` is set a round can no longer accept new participants.
+/// - Every registered participant must have passed IdentityRegistry attestation.
+/// Emergency procedures:
+/// - The owner can rotate orchestrators, update external module references,
+///   or call {pause} to halt all round mutations before invoking
+///   {reportValidatorMisconduct} or other follow-up remediations.
+contract SelfPlayArena is Ownable, Pausable, ReentrancyGuard {
+    struct Round {
+        uint32 difficulty;
+        uint64 startedAt;
+        uint64 closedAt;
+        bool finalised;
+        uint256 teacherJobId;
+        address teacher;
+        uint256[] studentJobIds;
+        address[] students;
+        uint256[] validatorJobIds;
+        address[] validators;
+        address[] winners;
+        int32 difficultyDelta;
+    }
+
+    struct RoundView {
+        uint256 id;
+        uint32 difficulty;
+        uint64 startedAt;
+        uint64 closedAt;
+        bool finalised;
+        uint256 teacherJobId;
+        address teacher;
+        uint256[] studentJobIds;
+        address[] students;
+        uint256[] validatorJobIds;
+        address[] validators;
+        address[] winners;
+        int32 difficultyDelta;
+    }
+
+    /// @notice Role gatekeepers via the IdentityRegistry.
+    IIdentityRegistry public identityRegistry;
+    /// @notice Job registry pointer used to validate referenced jobs.
+    IJobRegistry public jobRegistry;
+    /// @notice Stake manager utilised to slash misbehaving validators.
+    IStakeManager public stakeManager;
+
+    /// @notice Configured orchestrators allowed to manage rounds.
+    mapping(address => bool) public orchestrators;
+
+    /// @notice Economic parameters broadcast to off-chain services.
+    uint256 public baseTeacherReward;
+    uint256 public baseStudentReward;
+    uint256 public baseValidatorReward;
+    uint256 public committeeSize;
+    uint256 public validatorStake;
+    uint256 public targetSuccessRateBps;
+
+    uint256 private _roundIdCounter;
+    mapping(uint256 => Round) private _rounds;
+
+    event OrchestratorUpdated(address indexed orchestrator, bool allowed);
+    event IdentityRegistryUpdated(address indexed previousRegistry, address indexed newRegistry);
+    event JobRegistryUpdated(address indexed previousRegistry, address indexed newRegistry);
+    event StakeManagerUpdated(address indexed previousManager, address indexed newManager);
+    event RewardsUpdated(uint256 teacherReward, uint256 studentReward, uint256 validatorReward);
+    event CommitteeParametersUpdated(uint256 committeeSize, uint256 validatorStake);
+    event TargetSuccessRateUpdated(uint256 targetSuccessRateBps);
+    event RoundStarted(
+        uint256 indexed roundId,
+        uint32 difficulty,
+        uint256 indexed teacherJobId,
+        address indexed teacher,
+        string teacherSubdomain
+    );
+    event StudentRegistered(
+        uint256 indexed roundId,
+        uint256 indexed jobId,
+        address indexed student,
+        string subdomain
+    );
+    event ValidatorRegistered(
+        uint256 indexed roundId,
+        uint256 indexed jobId,
+        address indexed validator,
+        string subdomain
+    );
+    event RoundClosed(uint256 indexed roundId, uint64 closedAt);
+    event RoundFinalised(uint256 indexed roundId, address[] winners, int32 difficultyDelta);
+    event ValidatorMisconduct(
+        uint256 indexed roundId,
+        address indexed validator,
+        uint256 amount,
+        address indexed recipient,
+        string reason
+    );
+
+    error NotAuthorised();
+    error IdentityRegistryNotSet();
+    error InvalidAgent(address account);
+    error InvalidValidator(address account);
+    error InvalidJob(uint256 jobId);
+    error ZeroAddress();
+    error ZeroValue();
+    error RoundNotFound(uint256 roundId);
+    error RoundClosedAlready(uint256 roundId);
+    error RoundNotClosed(uint256 roundId);
+    error RoundFinalisedAlready(uint256 roundId);
+    error DuplicateParticipant(address account);
+    error CommitteeFull(uint256 roundId);
+    error StakeManagerNotConfigured();
+    error InvalidAmount();
+
+    modifier onlyOperator() {
+        if (msg.sender != owner() && !orchestrators[msg.sender]) {
+            revert NotAuthorised();
+        }
+        _;
+    }
+
+    constructor(
+        address owner_,
+        address identityRegistry_,
+        address jobRegistry_,
+        address stakeManager_,
+        uint256 teacherReward,
+        uint256 studentReward,
+        uint256 validatorReward,
+        uint256 committeeSize_,
+        uint256 validatorStake_,
+        uint256 targetSuccessRateBps_
+    ) Ownable(owner_) {
+        if (identityRegistry_ == address(0) || jobRegistry_ == address(0)) {
+            revert ZeroAddress();
+        }
+        if (
+            teacherReward == 0 ||
+            studentReward == 0 ||
+            validatorReward == 0 ||
+            committeeSize_ == 0 ||
+            validatorStake_ == 0 ||
+            targetSuccessRateBps_ == 0 ||
+            targetSuccessRateBps_ > 10_000
+        ) {
+            revert ZeroValue();
+        }
+        identityRegistry = IIdentityRegistry(identityRegistry_);
+        jobRegistry = IJobRegistry(jobRegistry_);
+        stakeManager = IStakeManager(stakeManager_);
+        baseTeacherReward = teacherReward;
+        baseStudentReward = studentReward;
+        baseValidatorReward = validatorReward;
+        committeeSize = committeeSize_;
+        validatorStake = validatorStake_;
+        targetSuccessRateBps = targetSuccessRateBps_;
+    }
+
+    /// @notice Configure or revoke an orchestrator address.
+    function setOrchestrator(address orchestrator, bool allowed) external onlyOwner {
+        if (orchestrator == address(0)) {
+            revert ZeroAddress();
+        }
+        orchestrators[orchestrator] = allowed;
+        emit OrchestratorUpdated(orchestrator, allowed);
+    }
+
+    /// @notice Rotate the IdentityRegistry reference.
+    function setIdentityRegistry(address newRegistry) external onlyOwner {
+        if (newRegistry == address(0)) {
+            revert ZeroAddress();
+        }
+        address previous = address(identityRegistry);
+        identityRegistry = IIdentityRegistry(newRegistry);
+        emit IdentityRegistryUpdated(previous, newRegistry);
+    }
+
+    /// @notice Update the JobRegistry hook.
+    function setJobRegistry(address newRegistry) external onlyOwner {
+        if (newRegistry == address(0)) {
+            revert ZeroAddress();
+        }
+        address previous = address(jobRegistry);
+        jobRegistry = IJobRegistry(newRegistry);
+        emit JobRegistryUpdated(previous, newRegistry);
+    }
+
+    /// @notice Update the StakeManager used for validator slashing.
+    function setStakeManager(address newManager) external onlyOwner {
+        address previous = address(stakeManager);
+        stakeManager = IStakeManager(newManager);
+        emit StakeManagerUpdated(previous, newManager);
+    }
+
+    /// @notice Update baseline rewards that downstream automation references.
+    function setRewards(uint256 teacherReward, uint256 studentReward, uint256 validatorReward)
+        external
+        onlyOwner
+    {
+        if (teacherReward == 0 || studentReward == 0 || validatorReward == 0) {
+            revert ZeroValue();
+        }
+        baseTeacherReward = teacherReward;
+        baseStudentReward = studentReward;
+        baseValidatorReward = validatorReward;
+        emit RewardsUpdated(teacherReward, studentReward, validatorReward);
+    }
+
+    /// @notice Update validator committee size and minimum stake signal.
+    function setCommitteeParameters(uint256 committeeSize_, uint256 validatorStake_)
+        external
+        onlyOwner
+    {
+        if (committeeSize_ == 0 || validatorStake_ == 0) {
+            revert ZeroValue();
+        }
+        committeeSize = committeeSize_;
+        validatorStake = validatorStake_;
+        emit CommitteeParametersUpdated(committeeSize_, validatorStake_);
+    }
+
+    /// @notice Update the target success rate used for adaptive difficulty.
+    function setTargetSuccessRateBps(uint256 targetSuccessRateBps_) external onlyOwner {
+        if (targetSuccessRateBps_ == 0 || targetSuccessRateBps_ > 10_000) {
+            revert ZeroValue();
+        }
+        targetSuccessRateBps = targetSuccessRateBps_;
+        emit TargetSuccessRateUpdated(targetSuccessRateBps_);
+    }
+
+    /// @notice Pause round lifecycle operations.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Resume round lifecycle operations.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /// @notice Start a new self-play round.
+    function startRound(
+        uint32 difficulty,
+        uint256 teacherJobId,
+        address teacher,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external whenNotPaused onlyOperator nonReentrant returns (uint256 roundId) {
+        _assertAgent(teacher, subdomain, proof);
+        _assertJobExists(teacherJobId);
+
+        roundId = ++_roundIdCounter;
+        Round storage round = _rounds[roundId];
+        round.difficulty = difficulty;
+        round.startedAt = uint64(block.timestamp);
+        round.teacherJobId = teacherJobId;
+        round.teacher = teacher;
+
+        emit RoundStarted(roundId, difficulty, teacherJobId, teacher, subdomain);
+    }
+
+    /// @notice Register a student job for an in-flight round.
+    function registerStudentJob(
+        uint256 roundId,
+        uint256 jobId,
+        address student,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external whenNotPaused onlyOperator {
+        Round storage round = _requireRound(roundId);
+        if (round.closedAt != 0) {
+            revert RoundClosedAlready(roundId);
+        }
+        _assertAgent(student, subdomain, proof);
+        _assertJobExists(jobId);
+        _ensureUnique(round.students, student);
+
+        round.studentJobIds.push(jobId);
+        round.students.push(student);
+
+        emit StudentRegistered(roundId, jobId, student, subdomain);
+    }
+
+    /// @notice Register a validator job for an in-flight round.
+    function registerValidatorJob(
+        uint256 roundId,
+        uint256 jobId,
+        address validator,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external whenNotPaused onlyOperator {
+        Round storage round = _requireRound(roundId);
+        if (round.closedAt != 0) {
+            revert RoundClosedAlready(roundId);
+        }
+        if (round.validators.length >= committeeSize) {
+            revert CommitteeFull(roundId);
+        }
+        _assertValidator(validator, subdomain, proof);
+        _assertJobExists(jobId);
+        _ensureUnique(round.validators, validator);
+
+        round.validatorJobIds.push(jobId);
+        round.validators.push(validator);
+
+        emit ValidatorRegistered(roundId, jobId, validator, subdomain);
+    }
+
+    /// @notice Prevent additional registrations and mark the round as closed.
+    function closeRound(uint256 roundId) external whenNotPaused onlyOperator {
+        Round storage round = _requireRound(roundId);
+        if (round.closedAt != 0) {
+            revert RoundClosedAlready(roundId);
+        }
+        round.closedAt = uint64(block.timestamp);
+        emit RoundClosed(roundId, round.closedAt);
+    }
+
+    /// @notice Finalise a round with outcome winners and difficulty delta.
+    function finaliseRound(
+        uint256 roundId,
+        address[] calldata winners,
+        int32 difficultyDelta
+    ) external whenNotPaused onlyOperator nonReentrant {
+        Round storage round = _requireRound(roundId);
+        if (round.closedAt == 0) {
+            revert RoundNotClosed(roundId);
+        }
+        if (round.finalised) {
+            revert RoundFinalisedAlready(roundId);
+        }
+        round.finalised = true;
+        round.difficultyDelta = difficultyDelta;
+        uint256 length = winners.length;
+        for (uint256 i; i < length; ++i) {
+            round.winners.push(winners[i]);
+        }
+        emit RoundFinalised(roundId, winners, difficultyDelta);
+    }
+
+    /// @notice Slash a validator involved in a round for misbehaviour.
+    /// @dev The arena must be configured as an authorised validator slasher in StakeManager.
+    function reportValidatorMisconduct(
+        uint256 roundId,
+        address validator,
+        uint256 amount,
+        address recipient,
+        string calldata reason
+    ) external whenNotPaused onlyOperator nonReentrant {
+        if (amount == 0) {
+            revert InvalidAmount();
+        }
+        if (recipient == address(0)) {
+            revert ZeroAddress();
+        }
+        Round storage round = _requireRound(roundId);
+        if (!_contains(round.validators, validator)) {
+            revert InvalidValidator(validator);
+        }
+        IStakeManager manager = stakeManager;
+        if (address(manager) == address(0)) {
+            revert StakeManagerNotConfigured();
+        }
+        manager.slash(validator, amount, recipient);
+        emit ValidatorMisconduct(roundId, validator, amount, recipient, reason);
+    }
+
+    /// @notice Retrieve round data including dynamic arrays in memory.
+    function getRound(uint256 roundId) external view returns (RoundView memory viewRound) {
+        Round storage round = _requireRound(roundId);
+        viewRound.id = roundId;
+        viewRound.difficulty = round.difficulty;
+        viewRound.startedAt = round.startedAt;
+        viewRound.closedAt = round.closedAt;
+        viewRound.finalised = round.finalised;
+        viewRound.teacherJobId = round.teacherJobId;
+        viewRound.teacher = round.teacher;
+        viewRound.difficultyDelta = round.difficultyDelta;
+        viewRound.studentJobIds = _copyUintArray(round.studentJobIds);
+        viewRound.students = _copyAddressArray(round.students);
+        viewRound.validatorJobIds = _copyUintArray(round.validatorJobIds);
+        viewRound.validators = _copyAddressArray(round.validators);
+        viewRound.winners = _copyAddressArray(round.winners);
+    }
+
+    /// @notice Total number of rounds ever started.
+    function totalRounds() external view returns (uint256) {
+        return _roundIdCounter;
+    }
+
+    function _assertAgent(address account, string calldata subdomain, bytes32[] calldata proof) internal view {
+        if (account == address(0)) {
+            revert InvalidAgent(account);
+        }
+        if (account == owner()) {
+            return;
+        }
+        IIdentityRegistry registry = identityRegistry;
+        if (address(registry) == address(0)) {
+            revert IdentityRegistryNotSet();
+        }
+        if (bytes(subdomain).length == 0) {
+            revert InvalidAgent(account);
+        }
+        if (!registry.isAuthorizedAgent(account, subdomain, proof)) {
+            revert InvalidAgent(account);
+        }
+    }
+
+    function _assertValidator(address account, string calldata subdomain, bytes32[] calldata proof)
+        internal
+        view
+    {
+        if (account == address(0)) {
+            revert InvalidValidator(account);
+        }
+        if (account == owner()) {
+            return;
+        }
+        IIdentityRegistry registry = identityRegistry;
+        if (address(registry) == address(0)) {
+            revert IdentityRegistryNotSet();
+        }
+        if (bytes(subdomain).length == 0) {
+            revert InvalidValidator(account);
+        }
+        if (!registry.isAuthorizedValidator(account, subdomain, proof)) {
+            revert InvalidValidator(account);
+        }
+    }
+
+    function _assertJobExists(uint256 jobId) internal view {
+        if (jobId == 0) {
+            revert InvalidJob(jobId);
+        }
+        IJobRegistry.Job memory job = jobRegistry.jobs(jobId);
+        if (job.employer == address(0)) {
+            revert InvalidJob(jobId);
+        }
+    }
+
+    function _requireRound(uint256 roundId) internal view returns (Round storage round) {
+        round = _rounds[roundId];
+        if (round.startedAt == 0) {
+            revert RoundNotFound(roundId);
+        }
+    }
+
+    function _ensureUnique(address[] storage list, address candidate) internal view {
+        uint256 length = list.length;
+        for (uint256 i; i < length; ++i) {
+            if (list[i] == candidate) {
+                revert DuplicateParticipant(candidate);
+            }
+        }
+    }
+
+    function _contains(address[] storage list, address candidate) internal view returns (bool) {
+        uint256 length = list.length;
+        for (uint256 i; i < length; ++i) {
+            if (list[i] == candidate) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function _copyUintArray(uint256[] storage source) internal view returns (uint256[] memory copy) {
+        uint256 length = source.length;
+        copy = new uint256[](length);
+        for (uint256 i; i < length; ++i) {
+            copy[i] = source[i];
+        }
+    }
+
+    function _copyAddressArray(address[] storage source) internal view returns (address[] memory copy) {
+        uint256 length = source.length;
+        copy = new address[](length);
+        for (uint256 i; i < length; ++i) {
+            copy[i] = source[i];
+        }
+    }
+}

--- a/test/v2/CultureRegistry.t.sol
+++ b/test/v2/CultureRegistry.t.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+
+import {CultureRegistry} from "../../contracts/v2/CultureRegistry.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+contract MockIdentityRegistry {
+    mapping(address => bool) public authorisedAgents;
+
+    function setAgent(address account, bool allowed) external {
+        authorisedAgents[account] = allowed;
+    }
+
+    function isAuthorizedAgent(address account, string calldata, bytes32[] calldata) external view returns (bool) {
+        return authorisedAgents[account];
+    }
+}
+
+contract CultureRegistryTest is Test {
+    CultureRegistry internal registry;
+    MockIdentityRegistry internal identity;
+
+    address internal owner = address(this);
+    address internal author = address(0xA11CE);
+    address internal other = address(0xBEEF);
+
+    string internal constant KIND_BOOK = "book";
+    string internal constant KIND_PROMPT = "prompt";
+    string internal constant SUBDOMAIN = "alice";
+
+    bytes32[] internal emptyProof;
+
+    function setUp() public {
+        identity = new MockIdentityRegistry();
+        identity.setAgent(author, true);
+
+        string[] memory kinds = new string[](2);
+        kinds[0] = KIND_BOOK;
+        kinds[1] = KIND_PROMPT;
+
+        registry = new CultureRegistry(owner, address(identity), kinds, 4);
+    }
+
+    function _mint(string memory kind, string memory uri) internal returns (uint256) {
+        vm.prank(author);
+        return registry.mintArtifact(kind, uri, 0, new uint256[](0), SUBDOMAIN, emptyProof);
+    }
+
+    function testMintArtifactHappyPath() public {
+        uint256 artifactId = _mint(KIND_BOOK, "ipfs://artifact-1");
+        assertEq(artifactId, 1);
+
+        CultureRegistry.ArtifactView memory viewData = registry.getArtifact(artifactId);
+        assertEq(viewData.author, author);
+        assertEq(viewData.kind, KIND_BOOK);
+        assertEq(viewData.uri, "ipfs://artifact-1");
+        assertEq(viewData.parentId, 0);
+        assertEq(viewData.citations.length, 0);
+    }
+
+    function testMintArtifactWithParentAndCitation() public {
+        uint256 parentId = _mint(KIND_BOOK, "ipfs://parent");
+
+        uint256[] memory cites = new uint256[](1);
+        cites[0] = parentId;
+
+        vm.prank(author);
+        uint256 childId = registry.mintArtifact(KIND_PROMPT, "ipfs://child", parentId, cites, SUBDOMAIN, emptyProof);
+
+        CultureRegistry.ArtifactView memory child = registry.getArtifact(childId);
+        assertEq(child.parentId, parentId);
+        assertEq(child.citations.length, 1);
+        assertEq(child.citations[0], parentId);
+    }
+
+    function testMintArtifactRejectsUnauthorisedAuthor() public {
+        vm.expectRevert(abi.encodeWithSelector(CultureRegistry.NotAuthorised.selector, other));
+        vm.prank(other);
+        registry.mintArtifact(KIND_BOOK, "ipfs://unauthorised", 0, new uint256[](0), SUBDOMAIN, emptyProof);
+    }
+
+    function testMintArtifactRejectsUnknownKind() public {
+        vm.prank(author);
+        vm.expectRevert(CultureRegistry.InvalidKind.selector);
+        registry.mintArtifact("dataset", "ipfs://dataset", 0, new uint256[](0), SUBDOMAIN, emptyProof);
+    }
+
+    function testMintArtifactRejectsMissingCitation() public {
+        _mint(KIND_BOOK, "ipfs://a");
+
+        uint256[] memory cites = new uint256[](1);
+        cites[0] = 42;
+
+        vm.prank(author);
+        vm.expectRevert(abi.encodeWithSelector(CultureRegistry.InvalidCitation.selector, 42));
+        registry.mintArtifact(KIND_PROMPT, "ipfs://b", 0, cites, SUBDOMAIN, emptyProof);
+    }
+
+    function testMintArtifactRejectsDuplicateCitations() public {
+        uint256 cited = _mint(KIND_BOOK, "ipfs://base");
+
+        uint256[] memory cites = new uint256[](2);
+        cites[0] = cited;
+        cites[1] = cited;
+
+        vm.prank(author);
+        vm.expectRevert(abi.encodeWithSelector(CultureRegistry.DuplicateCitation.selector, cited));
+        registry.mintArtifact(KIND_PROMPT, "ipfs://dup", 0, cites, SUBDOMAIN, emptyProof);
+    }
+
+    function testCiteRejectsSelfReference() public {
+        uint256 artifactId = _mint(KIND_BOOK, "ipfs://self");
+
+        vm.prank(author);
+        vm.expectRevert(abi.encodeWithSelector(CultureRegistry.SelfCitation.selector, artifactId));
+        registry.cite(artifactId, artifactId);
+    }
+
+    function testCiteRejectsDuplicate() public {
+        uint256 a = _mint(KIND_BOOK, "ipfs://a");
+        uint256 b = _mint(KIND_BOOK, "ipfs://b");
+
+        vm.prank(author);
+        registry.cite(b, a);
+
+        vm.prank(author);
+        vm.expectRevert(abi.encodeWithSelector(CultureRegistry.DuplicateCitation.selector, a));
+        registry.cite(b, a);
+    }
+
+    function testPauseBlocksMinting() public {
+        registry.pause();
+
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(author);
+        registry.mintArtifact(KIND_BOOK, "ipfs://paused", 0, new uint256[](0), SUBDOMAIN, emptyProof);
+    }
+
+    function testOwnerCanUpdateAllowedKind() public {
+        registry.setAllowedKind("dataset", true);
+
+        uint256[] memory cites;
+        vm.prank(author);
+        uint256 id = registry.mintArtifact("dataset", "ipfs://dataset", 0, cites, SUBDOMAIN, emptyProof);
+        assertEq(id, 1);
+    }
+
+    function testFuzzMintStoresUniqueCitations(uint256 saltA, uint256 saltB) public {
+        uint256 baseA = _mint(KIND_BOOK, "ipfs://baseA");
+        uint256 baseB = _mint(KIND_PROMPT, "ipfs://baseB");
+
+        uint256 citeA = (saltA % 2 == 0) ? baseA : baseB;
+        uint256 citeB = (saltB % 2 == 0) ? baseA : baseB;
+        vm.assume(citeA != citeB);
+
+        uint256[] memory cites = new uint256[](2);
+        cites[0] = citeA;
+        cites[1] = citeB;
+
+        vm.prank(author);
+        uint256 mintedId = registry.mintArtifact(KIND_BOOK, "ipfs://c", 0, cites, SUBDOMAIN, emptyProof);
+
+        CultureRegistry.ArtifactView memory viewData = registry.getArtifact(mintedId);
+        assertEq(viewData.citations.length, 2);
+        assertEq(viewData.citations[0], citeA);
+        assertEq(viewData.citations[1], citeB);
+    }
+}

--- a/test/v2/SelfPlayArena.t.sol
+++ b/test/v2/SelfPlayArena.t.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+
+import {SelfPlayArena} from "../../contracts/v2/SelfPlayArena.sol";
+import {IJobRegistry} from "../../contracts/v2/interfaces/IJobRegistry.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+contract MockIdentityRegistry {
+    mapping(address => bool) public authorisedAgents;
+    mapping(address => bool) public authorisedValidators;
+
+    function setAgent(address account, bool allowed) external {
+        authorisedAgents[account] = allowed;
+    }
+
+    function setValidator(address account, bool allowed) external {
+        authorisedValidators[account] = allowed;
+    }
+
+    function isAuthorizedAgent(address account, string calldata, bytes32[] calldata) external view returns (bool) {
+        return authorisedAgents[account];
+    }
+
+    function isAuthorizedValidator(address account, string calldata, bytes32[] calldata) external view returns (bool) {
+        return authorisedValidators[account];
+    }
+}
+
+contract MockJobRegistry {
+    mapping(uint256 => IJobRegistry.Job) internal _jobs;
+
+    function setJob(uint256 jobId, address employer, address agent) external {
+        _jobs[jobId] = IJobRegistry.Job({
+            employer: employer,
+            agent: agent,
+            reward: uint128(1),
+            stake: uint96(1),
+            burnReceiptAmount: uint128(0),
+            uriHash: bytes32(0),
+            resultHash: bytes32(0),
+            specHash: bytes32(0),
+            packedMetadata: 1
+        });
+    }
+
+    function jobs(uint256 jobId) external view returns (IJobRegistry.Job memory) {
+        return _jobs[jobId];
+    }
+}
+
+contract MockStakeManager {
+    mapping(address => uint256) public validatorStake;
+    uint256 public lastSlashAmount;
+    address public lastRecipient;
+
+    function setStake(address validator, uint256 amount) external {
+        validatorStake[validator] = amount;
+    }
+
+    function slash(address validator, uint256 amount, address recipient) external {
+        if (amount > validatorStake[validator]) revert("stake");
+        validatorStake[validator] -= amount;
+        lastSlashAmount = amount;
+        lastRecipient = recipient;
+    }
+}
+
+contract SelfPlayArenaTest is Test {
+    MockIdentityRegistry internal identity;
+    MockJobRegistry internal jobRegistry;
+    MockStakeManager internal stakeManager;
+    SelfPlayArena internal arena;
+
+    address internal owner = address(this);
+    address internal orchestrator = address(0xB0B);
+    address internal teacher = address(0xA11CE);
+    address internal student = address(0xC0DE);
+    address internal validator = address(0xF00D);
+    address internal employer = address(0xE1);
+
+    string internal constant TEACHER_SUBDOMAIN = "teacher";
+    string internal constant STUDENT_SUBDOMAIN = "student";
+    string internal constant VALIDATOR_SUBDOMAIN = "validator";
+
+    function setUp() public {
+        identity = new MockIdentityRegistry();
+        jobRegistry = new MockJobRegistry();
+        stakeManager = new MockStakeManager();
+
+        identity.setAgent(teacher, true);
+        identity.setAgent(student, true);
+        identity.setValidator(validator, true);
+
+        jobRegistry.setJob(1, employer, teacher);
+        jobRegistry.setJob(2, employer, student);
+        jobRegistry.setJob(3, employer, validator);
+
+        arena = new SelfPlayArena(
+            owner,
+            address(identity),
+            address(jobRegistry),
+            address(stakeManager),
+            100 ether,
+            50 ether,
+            25 ether,
+            3,
+            1 ether,
+            8_000
+        );
+
+        arena.setOrchestrator(orchestrator, true);
+    }
+
+    function _startRound() internal returns (uint256 roundId) {
+        vm.prank(orchestrator);
+        roundId = arena.startRound(1, 1, teacher, TEACHER_SUBDOMAIN, new bytes32[](0));
+    }
+
+    function testRoundLifecycleHappyPath() public {
+        uint256 roundId = _startRound();
+
+        vm.prank(orchestrator);
+        arena.registerStudentJob(roundId, 2, student, STUDENT_SUBDOMAIN, new bytes32[](0));
+
+        vm.prank(orchestrator);
+        arena.registerValidatorJob(roundId, 3, validator, VALIDATOR_SUBDOMAIN, new bytes32[](0));
+
+        vm.prank(orchestrator);
+        arena.closeRound(roundId);
+
+        address[] memory winners = new address[](1);
+        winners[0] = validator;
+        vm.prank(orchestrator);
+        arena.finaliseRound(roundId, winners, 1);
+
+        SelfPlayArena.RoundView memory viewData = arena.getRound(roundId);
+        assertEq(viewData.teacher, teacher);
+        assertEq(viewData.students.length, 1);
+        assertEq(viewData.validators.length, 1);
+        assertEq(viewData.winners.length, 1);
+        assertEq(viewData.finalised, true);
+    }
+
+    function testStartRoundRequiresIdentity() public {
+        identity.setAgent(teacher, false);
+
+        vm.prank(orchestrator);
+        vm.expectRevert(abi.encodeWithSelector(SelfPlayArena.InvalidAgent.selector, teacher));
+        arena.startRound(1, 1, teacher, TEACHER_SUBDOMAIN, new bytes32[](0));
+    }
+
+    function testRegisterStudentRejectsDuplicates() public {
+        uint256 roundId = _startRound();
+
+        vm.prank(orchestrator);
+        arena.registerStudentJob(roundId, 2, student, STUDENT_SUBDOMAIN, new bytes32[](0));
+
+        vm.prank(orchestrator);
+        vm.expectRevert(abi.encodeWithSelector(SelfPlayArena.DuplicateParticipant.selector, student));
+        arena.registerStudentJob(roundId, 2, student, STUDENT_SUBDOMAIN, new bytes32[](0));
+    }
+
+    function testRegisterValidatorRespectsCommitteeSize() public {
+        arena.setCommitteeParameters(1, 1 ether);
+        uint256 roundId = _startRound();
+
+        vm.prank(orchestrator);
+        arena.registerValidatorJob(roundId, 3, validator, VALIDATOR_SUBDOMAIN, new bytes32[](0));
+
+        address validator2 = address(0xF00E);
+        identity.setValidator(validator2, true);
+        jobRegistry.setJob(4, employer, validator2);
+
+        vm.prank(orchestrator);
+        vm.expectRevert(abi.encodeWithSelector(SelfPlayArena.CommitteeFull.selector, roundId));
+        arena.registerValidatorJob(roundId, 4, validator2, VALIDATOR_SUBDOMAIN, new bytes32[](0));
+    }
+
+    function testFinaliseRequiresClosedRound() public {
+        uint256 roundId = _startRound();
+
+        address[] memory winners;
+        vm.prank(orchestrator);
+        vm.expectRevert(abi.encodeWithSelector(SelfPlayArena.RoundNotClosed.selector, roundId));
+        arena.finaliseRound(roundId, winners, 0);
+    }
+
+    function testReportValidatorMisconductSlashesStake() public {
+        uint256 stakeAmount = 10 ether;
+        stakeManager.setStake(validator, stakeAmount);
+
+        uint256 roundId = _startRound();
+        vm.prank(orchestrator);
+        arena.registerValidatorJob(roundId, 3, validator, VALIDATOR_SUBDOMAIN, new bytes32[](0));
+
+        vm.prank(orchestrator);
+        arena.reportValidatorMisconduct(roundId, validator, 2 ether, owner, "slow reveal");
+
+        assertEq(stakeManager.validatorStake(validator), stakeAmount - 2 ether);
+        assertEq(stakeManager.lastRecipient(), owner);
+        assertEq(stakeManager.lastSlashAmount(), 2 ether);
+    }
+
+    function testReportValidatorMisconductRequiresStakeManager() public {
+        uint256 roundId = _startRound();
+        vm.prank(orchestrator);
+        arena.registerValidatorJob(roundId, 3, validator, VALIDATOR_SUBDOMAIN, new bytes32[](0));
+
+        arena.setStakeManager(address(0));
+        vm.prank(orchestrator);
+        vm.expectRevert(SelfPlayArena.StakeManagerNotConfigured.selector);
+        arena.reportValidatorMisconduct(roundId, validator, 1, owner, "missing manager");
+    }
+
+    function testPausePreventsStart() public {
+        arena.pause();
+        vm.prank(orchestrator);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        arena.startRound(1, 1, teacher, TEACHER_SUBDOMAIN, new bytes32[](0));
+    }
+
+    function testFuzzValidatorCannotRegisterTwice(address candidate) public {
+        vm.assume(candidate != address(0));
+        vm.assume(candidate != owner);
+        identity.setValidator(candidate, true);
+        jobRegistry.setJob(10, employer, candidate);
+
+        uint256 roundId = _startRound();
+
+        vm.prank(orchestrator);
+        arena.registerValidatorJob(roundId, 10, candidate, VALIDATOR_SUBDOMAIN, new bytes32[](0));
+
+        vm.prank(orchestrator);
+        vm.expectRevert(abi.encodeWithSelector(SelfPlayArena.DuplicateParticipant.selector, candidate));
+        arena.registerValidatorJob(roundId, 10, candidate, VALIDATOR_SUBDOMAIN, new bytes32[](0));
+    }
+}


### PR DESCRIPTION
## Summary
- implement a pausable, Ownable culture registry with identity-gated authorship, citation validation, and NatSpec emergency guidance
- add a self-play arena coordinating round lifecycle, job linkages, validator slashing integration, and owner-tunable parameters with documented safeguards
- introduce Foundry unit and fuzz tests that cover core flows, guardrails, citation graph integrity, and validator misconduct handling

## Testing
- forge test --match-path test/v2/CultureRegistry.t.sol *(compilation stalled in container; command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68f7ba8527b08333b7b21cb9cc72cfab