### PR TITLE
Enhance meta-agentic demo with reward summary analytics

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -75,6 +75,7 @@ stateDiagram-v2
    * `demo_output/report.json` – machine-readable export for downstream automation.
 
 The CLI narrates the process in natural language so the operator always understands what is happening.
+It now also prints a reward distribution digest summarising total payouts, architect retention, and the top solver/validator so executives can confirm value capture instantly.
 
 ---
 
@@ -162,6 +163,7 @@ The HTML report blends narrative storytelling with quantitative telemetry:
 * **Evolutionary trajectory** – per-generation improvements, score variance, and diversity notes.
 * **On-chain jobs** – each validation cycle with commitments and rewards.
 * **Thermodynamic rewards (Mermaid + tables)** – aggregated reward graph plus per-job energy footprints.
+* **Reward synthesis overview** – luminous cards highlighting total distribution, architect share, and top-performing solvers/validators.
 * **Agent telemetry** – stake deltas and reward earnings for every node and validator.
 
 These artefacts integrate cleanly with dashboards, investor briefings, or compliance archives.

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/__init__.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/__init__.py
@@ -2,7 +2,7 @@
 
 from .admin import OwnerConsole, load_owner_overrides
 from .config import DemoConfig, DemoScenario, EvolutionPolicy, RewardPolicy, StakePolicy
-from .entities import DemoRunArtifacts
+from .entities import DemoRunArtifacts, RewardSummary
 from .governance import GovernanceTimelock, TimelockedAction
 from .orchestrator import SovereignArchitect, generate_dataset
 from .report import export_report, render_html
@@ -11,6 +11,7 @@ __all__ = [
     "DemoConfig",
     "DemoScenario",
     "DemoRunArtifacts",
+    "RewardSummary",
     "EvolutionPolicy",
     "RewardPolicy",
     "StakePolicy",

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
@@ -95,6 +95,28 @@ class RewardBreakdown:
 
 
 @dataclass
+class RewardSummary:
+    """Aggregated reward telemetry across an entire demo run."""
+
+    total_reward: float
+    architect_total: float
+    solver_totals: Dict[str, float]
+    validator_totals: Dict[str, float]
+    top_solver: Optional[str] = None
+    top_validator: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "total_reward": self.total_reward,
+            "architect_total": self.architect_total,
+            "solver_totals": dict(self.solver_totals),
+            "validator_totals": dict(self.validator_totals),
+            "top_solver": self.top_solver,
+            "top_validator": self.top_validator,
+        }
+
+
+@dataclass
 class OwnerAction:
     """Structured record of privileged actions taken by the platform owner."""
 
@@ -131,6 +153,7 @@ class DemoRunArtifacts:
     jobs: List[Job]
     performances: List[AgentPerformance]
     rewards: List[RewardBreakdown]
+    reward_summary: RewardSummary
     evolution: List[EvolutionRecord]
     final_program: str
     final_score: float
@@ -157,6 +180,7 @@ class DemoRunArtifacts:
                 }
                 for breakdown in self.rewards
             ],
+            "reward_summary": self.reward_summary.to_dict(),
             "evolution": [
                 {
                     "generation": record.generation,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/orchestrator.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/orchestrator.py
@@ -23,6 +23,7 @@ from .ledger import (
     StakeManager,
     ValidationModule,
     aggregate_performance,
+    summarise_rewards,
 )
 
 
@@ -93,6 +94,7 @@ class SovereignArchitect:
             telemetry_hook=telemetry.append,
         )
         jobs, rewards = self._execute_on_chain(best_program, telemetry)
+        reward_summary = summarise_rewards(rewards)
         performances = aggregate_performance(rewards, self.stake_manager)
         final_score = self._score_program(best_program)
         improvement_over_first = (
@@ -107,6 +109,7 @@ class SovereignArchitect:
             jobs=jobs,
             performances=performances,
             rewards=rewards,
+            reward_summary=reward_summary,
             evolution=history,
             final_program=synthesizer.render_program(best_program),
             final_score=final_score,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
@@ -19,6 +19,9 @@ def test_orchestrator_generates_artifacts(tmp_path) -> None:
     assert len(artefacts.jobs) == config.evolution_policy.generations
     assert artefacts.rewards
     assert artefacts.performances
+    summary = artefacts.reward_summary
+    assert summary.total_reward > 0
+    assert summary.top_solver is not None
     assert artefacts.improvement_over_first >= 0
     assert artefacts.owner_actions == []
     assert artefacts.timelock_actions == []

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
@@ -29,6 +29,7 @@ def test_render_html_embeds_mermaid(tmp_path: Path) -> None:
     assert "Owner Command Ledger" in html
     assert "Governance Timelock" in html
     assert "Evolutionary Trajectory" in html
+    assert "Total Rewards" in html
     assert artefacts.final_program in html
 
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
@@ -274,6 +274,24 @@ def main() -> None:
         )
     else:
         print("Success threshold not reached within configured generations.")
+    summary = artefacts.reward_summary
+    print("\n💠 Reward distribution overview:")
+    print(f"  • Total disbursed: {summary.total_reward:.2f} $AGIα")
+    print(f"  • Architect retained: {summary.architect_total:.2f} $AGIα")
+    if summary.top_solver:
+        print(
+            f"  • Top solver: {summary.top_solver} "
+            f"({summary.solver_totals[summary.top_solver]:.2f} $AGIα)"
+        )
+    else:
+        print("  • Top solver: N/A")
+    if summary.top_validator:
+        print(
+            f"  • Top validator: {summary.top_validator} "
+            f"({summary.validator_totals[summary.top_validator]:.2f} $AGIα)"
+        )
+    else:
+        print("  • Top validator: N/A")
     if owner_console.events:
         print("\n🛡️ Owner interventions during run:")
         for event in owner_console.events:


### PR DESCRIPTION
## Summary
- add a RewardSummary aggregation layer to capture solver, validator, and architect payouts per sovereign run
- extend the HTML report and CLI narration with reward distribution cards and digest output for non-technical operators
- backfill documentation and tests covering the new telemetry and leaderboard insights

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests
- python demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py alpha --output /tmp/demo

------
https://chatgpt.com/codex/tasks/task_e_68f7c9c874a08333bf222ac08d750d2b