### PR TITLE
Add verification governance to Meta-Agentic Program Synthesis demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -71,11 +71,11 @@ stateDiagram-v2
    python start_demo.py alpha
    ```
 4. **Open the generated artefacts:**
-   * `demo_output/report.html` – cinematic dashboard with live Mermaid diagrams (architecture atlas, reward flows, evolution timeline), owner command ledger, telemetry, and the evolved program.
-   * `demo_output/report.json` – machine-readable export for downstream automation.
+   * `demo_output/report.html` – cinematic dashboard with live Mermaid diagrams (architecture atlas, reward flows, evolution timeline), multi-angle verification verdicts, owner command ledger, telemetry, and the evolved program.
+   * `demo_output/report.json` – machine-readable export for downstream automation (including verification metrics and pass/fail gates).
 
 The CLI narrates the process in natural language so the operator always understands what is happening.
-It now also prints a reward distribution digest summarising total payouts, architect retention, and the top solver/validator so executives can confirm value capture instantly.
+It now also prints a reward distribution digest summarising total payouts, architect retention, and the top solver/validator so executives can confirm value capture instantly. Immediately afterwards the CLI shares a triple-check verification digest (holdout scores, residual balance, divergence), flagging whether every gate passed.
 
 ---
 
@@ -93,11 +93,18 @@ python start_demo.py alpha \
   --reward-validator-weight 0.25 \
   --stake-minimum 750 \
   --stake-timeout 120 \
-  --evolution-generations 16
+  --evolution-generations 16 \
+  --verification-holdout-threshold 0.82 \
+  --verification-residual-mean 0.04 \
+  --verification-residual-std 0.02 \
+  --verification-divergence 0.15
 ```
 
 Use `--pause` to halt execution instantly. The orchestrator will refuse to launch jobs while paused and will explain the status
 in the CLI output. Re-run without `--pause` (or with a different override set) to resume operations.
+
+Verification overrides keep the sovereign architect honest: tighten holdout thresholds for ultra-conservative validation or
+relax divergence tolerances when exploring frontier scenarios.
 
 ### Timelocked governance
 
@@ -124,6 +131,12 @@ For executive operators, overrides can be pre-packaged in a JSON file:
   "reward_policy": {"total_reward": 3200, "temperature": 1.1},
   "stake_policy": {"minimum_stake": 900, "slash_fraction": 0.15},
   "evolution_policy": {"generations": 18, "mutation_rate": 0.28},
+  "verification_policy": {
+    "holdout_threshold": 0.8,
+    "residual_mean_tolerance": 0.05,
+    "residual_std_minimum": 0.02,
+    "divergence_tolerance": 0.18
+  },
   "paused": false
 }
 ```
@@ -138,6 +151,7 @@ Run the demo with `python start_demo.py alpha --config-file config/owner-overrid
 * `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests` verifies the evolutionary loop, on-chain security primitives, and orchestration pipeline.
 * `.github/workflows/demo-meta-agentic-program-synthesis.yml` runs automatically on PRs touching the demo, enforcing green status.
 * Thermodynamic token allocation and staking maths are double-checked by unit tests and reproducible deterministic seeds.
+* Multi-angle verification tests confirm holdout gating, residual balance, and divergence tolerances across independent datasets.
 
 ---
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/config/owner-overrides.sample.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/config/owner-overrides.sample.json
@@ -17,5 +17,11 @@
     "mutation_rate": 0.27,
     "crossover_rate": 0.45
   },
+  "verification_policy": {
+    "holdout_threshold": 0.78,
+    "residual_mean_tolerance": 0.04,
+    "residual_std_minimum": 0.015,
+    "divergence_tolerance": 0.12
+  },
   "paused": false
 }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/__init__.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/__init__.py
@@ -1,7 +1,14 @@
 """Public package interface for the Meta-Agentic Program Synthesis demo."""
 
 from .admin import OwnerConsole, load_owner_overrides
-from .config import DemoConfig, DemoScenario, EvolutionPolicy, RewardPolicy, StakePolicy
+from .config import (
+    DemoConfig,
+    DemoScenario,
+    EvolutionPolicy,
+    RewardPolicy,
+    StakePolicy,
+    VerificationPolicy,
+)
 from .entities import DemoRunArtifacts, RewardSummary
 from .governance import GovernanceTimelock, TimelockedAction
 from .orchestrator import SovereignArchitect, generate_dataset
@@ -15,6 +22,7 @@ __all__ = [
     "EvolutionPolicy",
     "RewardPolicy",
     "StakePolicy",
+    "VerificationPolicy",
     "OwnerConsole",
     "SovereignArchitect",
     "generate_dataset",

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/config.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/config.py
@@ -62,6 +62,24 @@ class EvolutionPolicy:
 
 
 @dataclass(frozen=True)
+class VerificationPolicy:
+    """Parameters driving multi-angle verification of evolved programs."""
+
+    holdout_threshold: float = 0.75
+    residual_mean_tolerance: float = 0.05
+    residual_std_minimum: float = 0.02
+    divergence_tolerance: float = 0.2
+
+    def to_dict(self) -> Dict[str, float]:
+        return {
+            "holdout_threshold": self.holdout_threshold,
+            "residual_mean_tolerance": self.residual_mean_tolerance,
+            "residual_std_minimum": self.residual_std_minimum,
+            "divergence_tolerance": self.divergence_tolerance,
+        }
+
+
+@dataclass(frozen=True)
 class DemoScenario:
     """Scenario definition surfaced to the non-technical user."""
 
@@ -79,6 +97,7 @@ class DemoConfig:
     reward_policy: RewardPolicy = field(default_factory=RewardPolicy)
     stake_policy: StakePolicy = field(default_factory=StakePolicy)
     evolution_policy: EvolutionPolicy = field(default_factory=EvolutionPolicy)
+    verification_policy: VerificationPolicy = field(default_factory=VerificationPolicy)
     scenarios: List[DemoScenario] = field(default_factory=list)
 
     def as_summary(self) -> Dict[str, object]:
@@ -86,5 +105,6 @@ class DemoConfig:
             "reward_policy": self.reward_policy.to_dict(),
             "stake_policy": self.stake_policy.to_dict(),
             "evolution_policy": self.evolution_policy.to_dict(),
+            "verification_policy": self.verification_policy.to_dict(),
             "scenarios": [scenario.__dict__ for scenario in self.scenarios],
         }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
@@ -146,6 +146,37 @@ class EvolutionRecord:
 
 
 @dataclass
+class VerificationDigest:
+    """Aggregates cross-checks validating the evolved program."""
+
+    primary_score: float
+    holdout_scores: Dict[str, float]
+    residual_mean: float
+    residual_std: float
+    divergence: float
+    pass_holdout: bool
+    pass_residual_balance: bool
+    pass_divergence: bool
+
+    @property
+    def overall_pass(self) -> bool:
+        return self.pass_holdout and self.pass_residual_balance and self.pass_divergence
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "primary_score": self.primary_score,
+            "holdout_scores": dict(self.holdout_scores),
+            "residual_mean": self.residual_mean,
+            "residual_std": self.residual_std,
+            "divergence": self.divergence,
+            "pass_holdout": self.pass_holdout,
+            "pass_residual_balance": self.pass_residual_balance,
+            "pass_divergence": self.pass_divergence,
+            "overall_pass": self.overall_pass,
+        }
+
+
+@dataclass
 class DemoRunArtifacts:
     """Aggregated trace produced at the end of a simulation."""
 
@@ -157,6 +188,7 @@ class DemoRunArtifacts:
     evolution: List[EvolutionRecord]
     final_program: str
     final_score: float
+    verification: VerificationDigest
     owner_actions: List[OwnerAction]
     timelock_actions: List["TimelockedAction"]
     improvement_over_first: float
@@ -195,6 +227,7 @@ class DemoRunArtifacts:
             ],
             "final_program": self.final_program,
             "final_score": self.final_score,
+            "verification": self.verification.to_dict(),
             "owner_actions": [action.to_dict() for action in self.owner_actions],
             "timelock_actions": [action.to_dict() for action in self.timelock_actions],
             "improvement_over_first": self.improvement_over_first,

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/governance.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/governance.py
@@ -50,6 +50,7 @@ class GovernanceTimelock:
         "update_reward_policy": lambda console, payload: console.update_reward_policy(**payload),
         "update_stake_policy": lambda console, payload: console.update_stake_policy(**payload),
         "update_evolution_policy": lambda console, payload: console.update_evolution_policy(**payload),
+        "update_verification_policy": lambda console, payload: console.update_verification_policy(**payload),
         "set_paused": lambda console, payload: console.set_paused(bool(payload["value"])),
         "pause": lambda console, payload: console.pause(),
         "resume": lambda console, payload: console.resume(),

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
@@ -25,3 +25,8 @@ def test_orchestrator_generates_artifacts(tmp_path) -> None:
     assert artefacts.improvement_over_first >= 0
     assert artefacts.owner_actions == []
     assert artefacts.timelock_actions == []
+    verification = artefacts.verification
+    assert isinstance(verification.holdout_scores, dict)
+    assert verification.holdout_scores
+    assert verification.residual_std >= 0
+    assert verification.divergence >= 0

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
@@ -30,6 +30,8 @@ def test_render_html_embeds_mermaid(tmp_path: Path) -> None:
     assert "Governance Timelock" in html
     assert "Evolutionary Trajectory" in html
     assert "Total Rewards" in html
+    assert "Multi-Angle Verification" in html
+    assert "Holdout" in html
     assert artefacts.final_program in html
 
 


### PR DESCRIPTION
## Summary
- add a dedicated verification policy model with owner controls, timelock support, and sample configuration overrides
- extend the orchestrator and report pipeline with holdout, residual, and divergence cross-checks surfaced in CLI and HTML outputs
- document the new controls and harden tests to assert verification behaviour across admin, governance, orchestrator, and report layers

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests`


------
https://chatgpt.com/codex/tasks/task_e_68f7cf01967483338d05c35ab043e06b