### PR TITLE
Enhance meta-agentic demo verification controls

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -31,6 +31,22 @@ flowchart LR
     Telemetry --> User
 ```
 
+### Triple-verification lattice
+
+```mermaid
+flowchart TD
+    Primary[Primary fitness score] --> Residual[Residual balance audit]
+    Primary --> Holdouts[Noise-conditioned holdouts]
+    Primary --> MAE[MAE consistency check]
+    MAE --> Bootstrap[Bootstrap confidence band]
+    Holdouts --> Monotonic[Monotonic trajectory scan]
+    Residual --> Monotonic
+    Bootstrap --> Verdict[Final verdict]
+    Monotonic --> Verdict
+    classDef pass fill:#04364c,color:#d1f7ff,stroke:#38bdf8,stroke-width:2px
+    class Primary,Residual,Holdouts,MAE,Bootstrap,Monotonic,Verdict pass
+```
+
 ### Evolutionary loop
 
 ```mermaid
@@ -86,25 +102,28 @@ knob – rewards, staking, evolution cadence, and pause state – can be adjuste
 
 ### Command-line overrides
 
-```bash
-python start_demo.py alpha \
-  --reward-total 2500 \
-  --reward-temperature 0.8 \
-  --reward-validator-weight 0.25 \
+    ```bash
+    python start_demo.py alpha \
+      --reward-total 2500 \
+      --reward-temperature 0.8 \
+      --reward-validator-weight 0.25 \
   --stake-minimum 750 \
   --stake-timeout 120 \
   --evolution-generations 16 \
-  --verification-holdout-threshold 0.82 \
-  --verification-residual-mean 0.04 \
-  --verification-residual-std 0.02 \
-  --verification-divergence 0.15
+      --verification-holdout-threshold 0.82 \
+      --verification-residual-mean 0.04 \
+      --verification-residual-std 0.02 \
+      --verification-divergence 0.15 \
+      --verification-mae-threshold 0.76 \
+      --verification-monotonic 0.02 \
+      --verification-bootstrap 400 \
+      --verification-confidence 0.975
 ```
 
 Use `--pause` to halt execution instantly. The orchestrator will refuse to launch jobs while paused and will explain the status
 in the CLI output. Re-run without `--pause` (or with a different override set) to resume operations.
 
-Verification overrides keep the sovereign architect honest: tighten holdout thresholds for ultra-conservative validation or
-relax divergence tolerances when exploring frontier scenarios.
+Verification overrides keep the sovereign architect honest: tighten holdout thresholds for ultra-conservative validation, raise MAE expectations for stricter fit, expand bootstrap iterations for deeper statistical certainty, or relax divergence tolerances when exploring frontier scenarios.
 
 ### Timelocked governance
 
@@ -135,7 +154,11 @@ For executive operators, overrides can be pre-packaged in a JSON file:
     "holdout_threshold": 0.8,
     "residual_mean_tolerance": 0.05,
     "residual_std_minimum": 0.02,
-    "divergence_tolerance": 0.18
+    "divergence_tolerance": 0.18,
+    "mae_threshold": 0.75,
+    "monotonic_tolerance": 0.02,
+    "bootstrap_iterations": 320,
+    "confidence_level": 0.97
   },
   "paused": false
 }
@@ -151,7 +174,7 @@ Run the demo with `python start_demo.py alpha --config-file config/owner-overrid
 * `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests` verifies the evolutionary loop, on-chain security primitives, and orchestration pipeline.
 * `.github/workflows/demo-meta-agentic-program-synthesis.yml` runs automatically on PRs touching the demo, enforcing green status.
 * Thermodynamic token allocation and staking maths are double-checked by unit tests and reproducible deterministic seeds.
-* Multi-angle verification tests confirm holdout gating, residual balance, and divergence tolerances across independent datasets.
+* Multi-angle verification tests confirm holdout gating, residual balance, MAE thresholds, bootstrap confidence intervals, and monotonic consistency across independent datasets.
 
 ---
 
@@ -161,7 +184,7 @@ Run the demo with `python start_demo.py alpha --config-file config/owner-overrid
 * **ValidationModule** enforces commit–reveal with quorum-based approvals, preventing rogue agents from finalising unchecked results.
 * **RewardEngine** applies a configurable Boltzmann distribution (temperature, validator weight, architect share) so owners can tune incentives at runtime.
 * **GovernanceTimelock** simulates multi-sig, time-delayed policy enforcement so operators can queue, audit, fast-forward, or cancel overrides safely.
-* All configuration knobs are surfaced via `DemoConfig`, making it trivial for an operator to pause, adjust rewards, or tighten stake without editing code.
+* All configuration knobs – including MAE thresholds, monotonic tolerances, bootstrap iteration counts, and confidence levels – are surfaced via `DemoConfig`, making it trivial for an operator to pause, adjust rewards, or tighten verification gates without editing code.
 
 ---
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/config/owner-overrides.sample.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/config/owner-overrides.sample.json
@@ -21,7 +21,11 @@
     "holdout_threshold": 0.78,
     "residual_mean_tolerance": 0.04,
     "residual_std_minimum": 0.015,
-    "divergence_tolerance": 0.12
+    "divergence_tolerance": 0.12,
+    "mae_threshold": 0.74,
+    "monotonic_tolerance": 0.02,
+    "bootstrap_iterations": 320,
+    "confidence_level": 0.975
   },
   "paused": false
 }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/admin.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/admin.py
@@ -35,6 +35,10 @@ class OwnerConsole:
         "residual_mean_tolerance",
         "residual_std_minimum",
         "divergence_tolerance",
+        "mae_threshold",
+        "monotonic_tolerance",
+        "bootstrap_iterations",
+        "confidence_level",
     }
 
     def __init__(self, config: DemoConfig) -> None:
@@ -204,6 +208,14 @@ class OwnerConsole:
             raise ValueError("residual_std_minimum must be non-negative")
         if policy.divergence_tolerance < 0:
             raise ValueError("divergence_tolerance must be non-negative")
+        if not 0 <= policy.mae_threshold <= 1:
+            raise ValueError("mae_threshold must be between 0 and 1")
+        if policy.monotonic_tolerance < 0:
+            raise ValueError("monotonic_tolerance must be non-negative")
+        if policy.bootstrap_iterations < 1:
+            raise ValueError("bootstrap_iterations must be at least 1")
+        if not 0 < policy.confidence_level < 1:
+            raise ValueError("confidence_level must be between 0 and 1")
 
 
 def load_owner_overrides(path: Path) -> Mapping[str, Any]:

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/config.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/config.py
@@ -16,7 +16,7 @@ class RewardPolicy:
     validator_weight: float = 0.15
     architect_weight: float = 0.1
 
-    def to_dict(self) -> Dict[str, float]:
+    def to_dict(self) -> Dict[str, float | int]:
         return {
             "total_reward": self.total_reward,
             "temperature": self.temperature,
@@ -33,7 +33,7 @@ class StakePolicy:
     slash_fraction: float = 0.1
     inactivity_timeout: timedelta = timedelta(seconds=30)
 
-    def to_dict(self) -> Dict[str, float]:
+    def to_dict(self) -> Dict[str, float | int]:
         return {
             "minimum_stake": self.minimum_stake,
             "slash_fraction": self.slash_fraction,
@@ -51,7 +51,7 @@ class EvolutionPolicy:
     mutation_rate: float = 0.35
     crossover_rate: float = 0.4
 
-    def to_dict(self) -> Dict[str, float]:
+    def to_dict(self) -> Dict[str, float | int]:
         return {
             "generations": self.generations,
             "population_size": self.population_size,
@@ -69,13 +69,21 @@ class VerificationPolicy:
     residual_mean_tolerance: float = 0.05
     residual_std_minimum: float = 0.02
     divergence_tolerance: float = 0.2
+    mae_threshold: float = 0.7
+    monotonic_tolerance: float = 0.025
+    bootstrap_iterations: int = 256
+    confidence_level: float = 0.95
 
-    def to_dict(self) -> Dict[str, float]:
+    def to_dict(self) -> Dict[str, float | int]:
         return {
             "holdout_threshold": self.holdout_threshold,
             "residual_mean_tolerance": self.residual_mean_tolerance,
             "residual_std_minimum": self.residual_std_minimum,
             "divergence_tolerance": self.divergence_tolerance,
+            "mae_threshold": self.mae_threshold,
+            "monotonic_tolerance": self.monotonic_tolerance,
+            "bootstrap_iterations": self.bootstrap_iterations,
+            "confidence_level": self.confidence_level,
         }
 
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum, auto
 from hashlib import sha256
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:  # pragma: no cover - only for typing purposes
     from .governance import TimelockedAction
@@ -157,10 +157,23 @@ class VerificationDigest:
     pass_holdout: bool
     pass_residual_balance: bool
     pass_divergence: bool
+    mae_score: float
+    pass_mae: bool
+    bootstrap_interval: Tuple[float, float]
+    pass_confidence: bool
+    monotonic_pass: bool
+    monotonic_violations: int
 
     @property
     def overall_pass(self) -> bool:
-        return self.pass_holdout and self.pass_residual_balance and self.pass_divergence
+        return (
+            self.pass_holdout
+            and self.pass_residual_balance
+            and self.pass_divergence
+            and self.pass_mae
+            and self.pass_confidence
+            and self.monotonic_pass
+        )
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -172,6 +185,12 @@ class VerificationDigest:
             "pass_holdout": self.pass_holdout,
             "pass_residual_balance": self.pass_residual_balance,
             "pass_divergence": self.pass_divergence,
+            "mae_score": self.mae_score,
+            "pass_mae": self.pass_mae,
+            "bootstrap_interval": list(self.bootstrap_interval),
+            "pass_confidence": self.pass_confidence,
+            "monotonic_pass": self.monotonic_pass,
+            "monotonic_violations": self.monotonic_violations,
             "overall_pass": self.overall_pass,
         }
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
@@ -30,3 +30,7 @@ def test_orchestrator_generates_artifacts(tmp_path) -> None:
     assert verification.holdout_scores
     assert verification.residual_std >= 0
     assert verification.divergence >= 0
+    assert verification.mae_score >= 0
+    assert isinstance(verification.bootstrap_interval, tuple)
+    assert len(verification.bootstrap_interval) == 2
+    assert verification.monotonic_violations >= 0

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
@@ -25,13 +25,17 @@ def test_render_html_embeds_mermaid(tmp_path: Path) -> None:
     html = render_html(artefacts)
     assert "mermaid.initialize" in html
     assert "Architecture Atlas" in html
-    assert html.count("class=\"mermaid\"") >= 3
+    assert html.count("class=\"mermaid\"") >= 4
     assert "Owner Command Ledger" in html
     assert "Governance Timelock" in html
     assert "Evolutionary Trajectory" in html
     assert "Total Rewards" in html
     assert "Multi-Angle Verification" in html
     assert "Holdout" in html
+    assert "MAE Consistency" in html
+    assert "Bootstrap Interval" in html
+    assert "Monotonicity" in html
+    assert "Holdout suite" in html
     assert artefacts.final_program in html
 
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
@@ -142,6 +142,26 @@ def parse_args() -> argparse.Namespace:
         type=float,
         help="Override maximum allowed holdout divergence",
     )
+    verification_group.add_argument(
+        "--verification-mae-threshold",
+        type=float,
+        help="Override acceptable MAE-derived score threshold",
+    )
+    verification_group.add_argument(
+        "--verification-monotonic",
+        type=float,
+        help="Override tolerance for monotonic improvement checks",
+    )
+    verification_group.add_argument(
+        "--verification-bootstrap",
+        type=int,
+        help="Override bootstrap iteration count",
+    )
+    verification_group.add_argument(
+        "--verification-confidence",
+        type=float,
+        help="Override bootstrap confidence level (0-1)",
+    )
     governance_group = parser.add_argument_group("Governance timelock")
     governance_group.add_argument(
         "--timelock-delay",
@@ -247,6 +267,10 @@ def main() -> None:
                 "residual_mean_tolerance": args.verification_residual_mean,
                 "residual_std_minimum": args.verification_residual_std,
                 "divergence_tolerance": args.verification_divergence,
+                "mae_threshold": args.verification_mae_threshold,
+                "monotonic_tolerance": args.verification_monotonic,
+                "bootstrap_iterations": args.verification_bootstrap,
+                "confidence_level": args.verification_confidence,
             }.items()
             if value is not None
         }
@@ -343,6 +367,16 @@ def main() -> None:
         f"  • Holdout divergence {verification.divergence:.4f}"
         f" | pass gates: holdout={verification.pass_holdout}, residual={verification.pass_residual_balance},"
         f" divergence={verification.pass_divergence}"
+    )
+    print(
+        f"  • MAE score {verification.mae_score:.4f} | pass {verification.pass_mae}"
+    )
+    lower, upper = verification.bootstrap_interval
+    print(
+        f"  • Bootstrap CI [{lower:.4f}, {upper:.4f}] | pass {verification.pass_confidence}"
+    )
+    print(
+        f"  • Monotonic violations {verification.monotonic_violations} | pass {verification.monotonic_pass}"
     )
     print(
         "  • Overall verification verdict:",


### PR DESCRIPTION
## Summary
- extend the meta-agentic orchestrator with MAE scoring, bootstrap confidence intervals, and monotonicity auditing so every run is triple-verified
- expose the new verification thresholds and bootstrap settings through owner console APIs, CLI flags, and JSON overrides while expanding the HTML report with a verification lattice mermaid chart
- document the upgraded safety net in the README and refresh tests to cover the richer verification telemetry

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests`
- `python demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py alpha --timelock-fast-forward 0`


------
https://chatgpt.com/codex/tasks/task_e_68f7d558fc888333ace16a9187f9f16e