### PR TITLE
Enhance One-Box telemetry and guardrails

### DIFF
--- a/apps/onebox/src/app/globals.css
+++ b/apps/onebox/src/app/globals.css
@@ -175,6 +175,104 @@ button {
   background: linear-gradient(135deg, rgba(30, 64, 175, 0.18), rgba(14, 165, 233, 0.08));
 }
 
+.chat-pulse {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1rem 1.5rem 1.25rem;
+  border-bottom: 1px solid #1e293b;
+  background: rgba(2, 6, 23, 0.55);
+}
+
+.chat-pulse-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.chat-pulse-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.chat-pulse-subtitle {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.95);
+  line-height: 1.4;
+}
+
+.chat-pulse-grid {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.chat-pulse-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.85rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(15, 23, 42, 0.55);
+  min-height: 126px;
+}
+
+.chat-pulse-label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.chat-pulse-caption {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.chat-pulse-status {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.chat-pulse-status[data-state='active'] {
+  color: #38bdf8;
+}
+
+.chat-pulse-status[data-state='complete'] {
+  color: #34d399;
+}
+
+.chat-pulse-status[data-state='blocked'] {
+  color: #f87171;
+}
+
+.chat-pulse-detail {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(226, 232, 240, 0.88);
+  line-height: 1.45;
+}
+
+.chat-pulse-footer {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #93c5fd;
+  background: rgba(30, 64, 175, 0.18);
+  border-left: 3px solid rgba(14, 165, 233, 0.5);
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.5rem;
+}
+
 .chat-intro-copy {
   display: flex;
   flex-direction: column;

--- a/apps/onebox/src/components/ChatWindow.tsx
+++ b/apps/onebox/src/components/ChatWindow.tsx
@@ -16,6 +16,7 @@ import type {
   StatusResponse,
 } from '@agijobs/onebox-sdk';
 import { defaultMessages } from '../lib/defaultMessages';
+import { MissionPulse } from './MissionPulse';
 import { ReceiptsPanel } from './ReceiptsPanel';
 import type { ExecutionReceipt } from './receiptTypes';
 import {
@@ -65,7 +66,7 @@ type StatusMessage = {
 
 type ChatMessage = TextMessage | PlanMessage | SimulationMessage | StatusMessage;
 
-type ChatStage =
+export type ChatStage =
   | 'idle'
   | 'planning'
   | 'planned'
@@ -691,6 +692,8 @@ export function ChatWindow({
     return lines.join(' ');
   }, [runStatusMessage]);
 
+  const runState = runStatusMessage?.status.run.state ?? null;
+
   return (
     <div className="chat-wrapper">
       <div className="chat-shell">
@@ -724,6 +727,17 @@ export function ChatWindow({
             ))}
           </div>
         </div>
+        <MissionPulse
+          stage={stage}
+          orchestratorReady={orchestratorReady}
+          planError={planError}
+          simulateError={simulateError}
+          executeError={executeError}
+          hasPlan={Boolean(activePlan)}
+          hasSimulation={Boolean(activeSimulation)}
+          statusSummary={statusSummary}
+          runState={runState}
+        />
         <div className="chat-history" role="log" aria-live="polite">
           {messages.map((message) => {
             if (message.kind === 'plan') {

--- a/apps/onebox/src/components/MissionPulse.tsx
+++ b/apps/onebox/src/components/MissionPulse.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import type { ChatStage } from './ChatWindow';
+
+type MissionPulseProps = {
+  stage: ChatStage;
+  orchestratorReady: boolean;
+  planError: string | null;
+  simulateError: string | null;
+  executeError: string | null;
+  hasPlan: boolean;
+  hasSimulation: boolean;
+  statusSummary: string | null;
+  runState: string | null;
+};
+
+type PulseState = 'pending' | 'active' | 'complete' | 'blocked';
+
+type PulseCard = {
+  id: string;
+  title: string;
+  caption: string;
+  status: PulseState;
+  detail: string;
+};
+
+const statusIcon: Record<PulseState, string> = {
+  pending: '🌙',
+  active: '⚡',
+  complete: '🏁',
+  blocked: '⚠️',
+};
+
+const statusLabel: Record<PulseState, string> = {
+  pending: 'Standing by',
+  active: 'In flight',
+  complete: 'Complete',
+  blocked: 'Needs attention',
+};
+
+function computePlanCard({
+  stage,
+  orchestratorReady,
+  hasPlan,
+  planError,
+}: Pick<MissionPulseProps, 'stage' | 'orchestratorReady' | 'hasPlan' | 'planError'>): PulseCard {
+  if (planError) {
+    return {
+      id: 'planner',
+      title: 'Planner',
+      caption: 'LLM orchestrator',
+      status: 'blocked',
+      detail: planError,
+    };
+  }
+
+  if (stage === 'planning') {
+    return {
+      id: 'planner',
+      title: 'Planner',
+      caption: 'LLM orchestrator',
+      status: 'active',
+      detail: 'Synthesising the mission blueprint and policy guardrails.',
+    };
+  }
+
+  if (hasPlan) {
+    return {
+      id: 'planner',
+      title: 'Planner',
+      caption: 'LLM orchestrator',
+      status: 'complete',
+      detail: 'Blueprint ready. Proceed to simulation to validate economics.',
+    };
+  }
+
+  return {
+    id: 'planner',
+    title: 'Planner',
+    caption: 'LLM orchestrator',
+    status: orchestratorReady ? 'pending' : 'blocked',
+    detail: orchestratorReady
+      ? 'Awaiting your mission description to draft the on-chain workload.'
+      : 'Point the mission panel at a live orchestrator to unlock planning.',
+  };
+}
+
+function computeSimulationCard({
+  stage,
+  hasPlan,
+  hasSimulation,
+  simulateError,
+}: Pick<MissionPulseProps, 'stage' | 'hasPlan' | 'hasSimulation' | 'simulateError'>): PulseCard {
+  if (simulateError) {
+    return {
+      id: 'simulation',
+      title: 'Simulation',
+      caption: 'Risk + policy engine',
+      status: 'blocked',
+      detail: simulateError,
+    };
+  }
+
+  if (stage === 'simulating') {
+    return {
+      id: 'simulation',
+      title: 'Simulation',
+      caption: 'Risk + policy engine',
+      status: 'active',
+      detail: 'Stress-testing rewards, fees, and guardrails before any capital moves.',
+    };
+  }
+
+  if (hasSimulation) {
+    return {
+      id: 'simulation',
+      title: 'Simulation',
+      caption: 'Risk + policy engine',
+      status: 'complete',
+      detail: 'All guardrails satisfied. You can execute with one confirmation.',
+    };
+  }
+
+  return {
+    id: 'simulation',
+    title: 'Simulation',
+    caption: 'Risk + policy engine',
+    status: hasPlan ? 'pending' : 'blocked',
+    detail: hasPlan
+      ? 'Run the simulation to confirm budget sufficiency and compliance.'
+      : 'Draft a mission plan before running the policy simulator.',
+  };
+}
+
+function computeExecutionCard({
+  stage,
+  hasSimulation,
+  executeError,
+}: Pick<MissionPulseProps, 'stage' | 'hasSimulation' | 'executeError'>): PulseCard {
+  if (executeError) {
+    return {
+      id: 'execution',
+      title: 'Execution',
+      caption: 'Relayer + escrow',
+      status: 'blocked',
+      detail: executeError,
+    };
+  }
+
+  if (stage === 'executing') {
+    return {
+      id: 'execution',
+      title: 'Execution',
+      caption: 'Relayer + escrow',
+      status: 'active',
+      detail: 'Escrowing funds, posting job specs to IPFS, and broadcasting transactions.',
+    };
+  }
+
+  if (stage === 'completed') {
+    return {
+      id: 'execution',
+      title: 'Execution',
+      caption: 'Relayer + escrow',
+      status: 'complete',
+      detail: 'Mission live. Receipts archived and ready for auditors.',
+    };
+  }
+
+  return {
+    id: 'execution',
+    title: 'Execution',
+    caption: 'Relayer + escrow',
+    status: hasSimulation ? 'pending' : 'blocked',
+    detail: hasSimulation
+      ? 'Confirm once satisfied with the simulation to move capital trustlessly.'
+      : 'Complete the simulation first to unlock unstoppable execution.',
+  };
+}
+
+export function MissionPulse({
+  stage,
+  orchestratorReady,
+  planError,
+  simulateError,
+  executeError,
+  hasPlan,
+  hasSimulation,
+  statusSummary,
+  runState,
+}: MissionPulseProps) {
+  const cards: PulseCard[] = [
+    computePlanCard({ stage, orchestratorReady, hasPlan, planError }),
+    computeSimulationCard({ stage, hasPlan, hasSimulation, simulateError }),
+    computeExecutionCard({ stage, hasSimulation, executeError }),
+  ];
+
+  return (
+    <section className="chat-pulse" aria-live="polite">
+      <header className="chat-pulse-header">
+        <h3 className="chat-pulse-title">Intelligence pulse</h3>
+        <p className="chat-pulse-subtitle">
+          Real-time orchestration status across planning, policy simulation, and unstoppable execution.
+        </p>
+      </header>
+      <ul className="chat-pulse-grid" role="list">
+        {cards.map((card) => (
+          <li key={card.id} className="chat-pulse-item" role="listitem">
+            <div className="chat-pulse-label">
+              <span aria-hidden="true">{statusIcon[card.status]}</span>
+              <span>
+                {card.title}
+                <span className="chat-pulse-caption"> · {card.caption}</span>
+              </span>
+            </div>
+            <span className="chat-pulse-status" data-state={card.status}>
+              {statusLabel[card.status]}
+            </span>
+            <p className="chat-pulse-detail">{card.detail}</p>
+          </li>
+        ))}
+      </ul>
+      {statusSummary ? (
+        <p className="chat-pulse-footer">
+          <strong>Run telemetry:</strong> {statusSummary}
+        </p>
+      ) : runState ? (
+        <p className="chat-pulse-footer">
+          <strong>Run telemetry:</strong> Mission state {runState}. Awaiting orchestrator updates.
+        </p>
+      ) : null}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a live "Mission Pulse" status strip in the One-Box chat and supporting styling
- flag placeholder configuration, derive relayer diagnostics, and surface balance checks in the demo doctor
- expose reusable placeholder detection and RPC balance helpers with accompanying regression tests

## Testing
- node --test demo/One-Box/test/launcher.test.cjs
- node --test demo/One-Box/test/rpc.test.cjs

------
https://chatgpt.com/codex/tasks/task_e_68f7d94cebe48333a082d1a5ef92e4dd