### PR TITLE
Add opportunity intelligence analytics to meta-agentic demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -169,6 +169,18 @@ Run the demo with `python start_demo.py alpha --config-file config/owner-overrid
 
 ---
 
+## 🌌 Opportunity Intelligence Dashboard
+
+Every sovereign execution now concludes with a cinematic opportunity briefing distilled for non-technical leaders:
+
+* **Impact × Confidence analytics** – each opportunity blends evolutionary uplift, verification verdicts, and treasury responsiveness into headline percentages.
+* **Capital & energy allocations** – instantly see which fraction of the thermodynamic reward pool and energy budget an opportunity commands.
+* **Mermaid intelligence map** – a dark-mode flowchart showing how the Sovereign Architect routes capital into each opportunity node, annotating impact, confidence, and energy ratios.
+
+The CLI narrates these insights, and the HTML artefact renders them as interactive cards plus the strategy graph, so executives can redeploy capital or greenlight the next AGI campaign within seconds.
+
+---
+
 ## 🧪 Validation & CI
 
 * `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests` verifies the evolutionary loop, on-chain security primitives, and orchestration pipeline.

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/__init__.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/__init__.py
@@ -9,7 +9,7 @@ from .config import (
     StakePolicy,
     VerificationPolicy,
 )
-from .entities import DemoRunArtifacts, RewardSummary
+from .entities import DemoRunArtifacts, OpportunitySynopsis, RewardSummary
 from .governance import GovernanceTimelock, TimelockedAction
 from .orchestrator import SovereignArchitect, generate_dataset
 from .report import export_report, render_html
@@ -18,6 +18,7 @@ __all__ = [
     "DemoConfig",
     "DemoScenario",
     "DemoRunArtifacts",
+    "OpportunitySynopsis",
     "RewardSummary",
     "EvolutionPolicy",
     "RewardPolicy",

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
@@ -117,6 +117,28 @@ class RewardSummary:
 
 
 @dataclass
+class OpportunitySynopsis:
+    """High-level opportunity surfaced to the platform owner."""
+
+    name: str
+    impact_score: float
+    confidence: float
+    narrative: str
+    energy_ratio: float
+    capital_allocation: float
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "impact_score": self.impact_score,
+            "confidence": self.confidence,
+            "narrative": self.narrative,
+            "energy_ratio": self.energy_ratio,
+            "capital_allocation": self.capital_allocation,
+        }
+
+
+@dataclass
 class OwnerAction:
     """Structured record of privileged actions taken by the platform owner."""
 
@@ -210,6 +232,7 @@ class DemoRunArtifacts:
     verification: VerificationDigest
     owner_actions: List[OwnerAction]
     timelock_actions: List["TimelockedAction"]
+    opportunities: List[OpportunitySynopsis]
     improvement_over_first: float
     first_success_generation: int | None
     generated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
@@ -249,6 +272,7 @@ class DemoRunArtifacts:
             "verification": self.verification.to_dict(),
             "owner_actions": [action.to_dict() for action in self.owner_actions],
             "timelock_actions": [action.to_dict() for action in self.timelock_actions],
+            "opportunities": [opportunity.to_dict() for opportunity in self.opportunities],
             "improvement_over_first": self.improvement_over_first,
             "first_success_generation": self.first_success_generation,
             "generated_at": self.generated_at.isoformat(),

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
@@ -25,6 +25,13 @@ def test_orchestrator_generates_artifacts(tmp_path) -> None:
     assert artefacts.improvement_over_first >= 0
     assert artefacts.owner_actions == []
     assert artefacts.timelock_actions == []
+    assert artefacts.opportunities
+    for opportunity in artefacts.opportunities:
+        assert 0.0 <= opportunity.impact_score <= 1.0
+        assert 0.0 <= opportunity.confidence <= 1.0
+        assert 0.0 <= opportunity.energy_ratio <= 1.0
+        assert 0.0 <= opportunity.capital_allocation <= 1.0
+        assert opportunity.narrative
     verification = artefacts.verification
     assert isinstance(verification.holdout_scores, dict)
     assert verification.holdout_scores

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
@@ -31,6 +31,8 @@ def test_render_html_embeds_mermaid(tmp_path: Path) -> None:
     assert "Evolutionary Trajectory" in html
     assert "Total Rewards" in html
     assert "Multi-Angle Verification" in html
+    assert "Opportunity Intelligence" in html
+    assert "Alpha Streamliner" in html
     assert "Holdout" in html
     assert "MAE Consistency" in html
     assert "Bootstrap Interval" in html

--- a/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
@@ -382,6 +382,23 @@ def main() -> None:
         "  • Overall verification verdict:",
         "PASS" if verification.overall_pass else "ATTENTION REQUIRED",
     )
+    if artefacts.opportunities:
+        print("\n🌌 Opportunity intelligence:")
+        for opportunity in artefacts.opportunities:
+            print(
+                indent(
+                    (
+                        f"{opportunity.name} → impact {opportunity.impact_score * 100:.1f}% | "
+                        f"confidence {opportunity.confidence * 100:.1f}% | "
+                        f"capital {opportunity.capital_allocation * 100:.1f}% | "
+                        f"energy {opportunity.energy_ratio * 100:.1f}%"
+                    ),
+                    prefix="  • ",
+                )
+            )
+            print(indent(opportunity.narrative, prefix="      ↳ "))
+    else:
+        print("\n🌌 Opportunity intelligence: no actionable missions surfaced.")
     if owner_console.events:
         print("\n🛡️ Owner interventions during run:")
         for event in owner_console.events:


### PR DESCRIPTION
## Summary
- introduce an `OpportunitySynopsis` domain model and include opportunity telemetry within the meta-agentic demo artefacts
- derive opportunity intelligence from evolutionary, reward, and governance data and surface it in the orchestrator, CLI narration, and HTML report (including a new Mermaid graph)
- document the opportunity dashboard and extend regression tests to cover the new analytics

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests

------
https://chatgpt.com/codex/tasks/task_e_68f7dd55b08083339aa2db26d5ece74c