### PR TITLE
Add stress battery verification to Meta-Agentic Program Synthesis demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -49,6 +49,16 @@ flowchart TD
 
 ### Evolutionary loop
 
+#### Adversarial stress battery
+
+The verification stack now includes an explicit stress battery that intentionally perturbs the sovereign's data environment:
+
+* **Regime shift** — applies structural trend and baseline shifts to mimic macroeconomic realignments.
+* **Volatility spike** — injects sharp noise bursts and transient outliers to test control under chaos.
+* **Signal dropout** — removes swathes of signal and damps cyclical structure to simulate degraded telemetry.
+
+Every evolved program must clear a configurable stress threshold (default `0.72`). The new CLI flag `--verification-stress-threshold` lets the contract owner ratchet this bar up or down without touching code.
+
 ```mermaid
 stateDiagram-v2
     [*] --> SeedPopulation: bootstrap diverse codelets
@@ -118,6 +128,7 @@ knob – rewards, staking, evolution cadence, and pause state – can be adjuste
       --verification-monotonic 0.02 \
       --verification-bootstrap 400 \
       --verification-confidence 0.975
+      --verification-stress-threshold 0.74
 ```
 
 Use `--pause` to halt execution instantly. The orchestrator will refuse to launch jobs while paused and will explain the status

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/admin.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/admin.py
@@ -39,6 +39,7 @@ class OwnerConsole:
         "monotonic_tolerance",
         "bootstrap_iterations",
         "confidence_level",
+        "stress_threshold",
     }
 
     def __init__(self, config: DemoConfig) -> None:
@@ -216,6 +217,8 @@ class OwnerConsole:
             raise ValueError("bootstrap_iterations must be at least 1")
         if not 0 < policy.confidence_level < 1:
             raise ValueError("confidence_level must be between 0 and 1")
+        if not 0 <= policy.stress_threshold <= 1:
+            raise ValueError("stress_threshold must be between 0 and 1")
 
 
 def load_owner_overrides(path: Path) -> Mapping[str, Any]:

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/config.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/config.py
@@ -73,6 +73,7 @@ class VerificationPolicy:
     monotonic_tolerance: float = 0.025
     bootstrap_iterations: int = 256
     confidence_level: float = 0.95
+    stress_threshold: float = 0.72
 
     def to_dict(self) -> Dict[str, float | int]:
         return {
@@ -84,6 +85,7 @@ class VerificationPolicy:
             "monotonic_tolerance": self.monotonic_tolerance,
             "bootstrap_iterations": self.bootstrap_iterations,
             "confidence_level": self.confidence_level,
+            "stress_threshold": self.stress_threshold,
         }
 
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
@@ -185,6 +185,9 @@ class VerificationDigest:
     pass_confidence: bool
     monotonic_pass: bool
     monotonic_violations: int
+    stress_scores: Dict[str, float]
+    pass_stress: bool
+    stress_threshold: float
 
     @property
     def overall_pass(self) -> bool:
@@ -195,6 +198,7 @@ class VerificationDigest:
             and self.pass_mae
             and self.pass_confidence
             and self.monotonic_pass
+            and self.pass_stress
         )
 
     def to_dict(self) -> Dict[str, object]:
@@ -213,6 +217,9 @@ class VerificationDigest:
             "pass_confidence": self.pass_confidence,
             "monotonic_pass": self.monotonic_pass,
             "monotonic_violations": self.monotonic_violations,
+            "stress_scores": dict(self.stress_scores),
+            "pass_stress": self.pass_stress,
+            "stress_threshold": self.stress_threshold,
             "overall_pass": self.overall_pass,
         }
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_admin.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_admin.py
@@ -78,6 +78,7 @@ def test_owner_console_updates_verification_policy() -> None:
         monotonic_tolerance=0.015,
         bootstrap_iterations=300,
         confidence_level=0.9,
+        stress_threshold=0.73,
     )
     policy = console.config.verification_policy
     assert pytest.approx(policy.holdout_threshold) == 0.85
@@ -88,6 +89,7 @@ def test_owner_console_updates_verification_policy() -> None:
     assert pytest.approx(policy.monotonic_tolerance) == 0.015
     assert policy.bootstrap_iterations == 300
     assert pytest.approx(policy.confidence_level) == 0.9
+    assert pytest.approx(policy.stress_threshold) == 0.73
     assert console.events[-1].action == "update_verification_policy"
 
 
@@ -103,6 +105,10 @@ def test_owner_console_rejects_invalid_verification_policy() -> None:
         console.update_verification_policy(bootstrap_iterations=0)
     with pytest.raises(ValueError):
         console.update_verification_policy(confidence_level=1.2)
+    with pytest.raises(ValueError):
+        console.update_verification_policy(stress_threshold=-0.2)
+    with pytest.raises(ValueError):
+        console.update_verification_policy(stress_threshold=1.2)
 
 
 def test_owner_console_apply_overrides_and_load(tmp_path: Path) -> None:
@@ -115,6 +121,7 @@ def test_owner_console_apply_overrides_and_load(tmp_path: Path) -> None:
             "divergence_tolerance": 0.14,
             "mae_threshold": 0.7,
             "bootstrap_iterations": 280,
+            "stress_threshold": 0.69,
         },
         "paused": True,
     }
@@ -130,6 +137,7 @@ def test_owner_console_apply_overrides_and_load(tmp_path: Path) -> None:
     assert pytest.approx(verification_policy.divergence_tolerance) == 0.14
     assert pytest.approx(verification_policy.mae_threshold) == 0.7
     assert verification_policy.bootstrap_iterations == 280
+    assert pytest.approx(verification_policy.stress_threshold) == 0.69
     assert any(event.action == "set_paused" for event in console.events)
 
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
@@ -41,3 +41,6 @@ def test_orchestrator_generates_artifacts(tmp_path) -> None:
     assert isinstance(verification.bootstrap_interval, tuple)
     assert len(verification.bootstrap_interval) == 2
     assert verification.monotonic_violations >= 0
+    assert isinstance(verification.stress_scores, dict)
+    assert verification.stress_scores
+    assert 0 <= verification.stress_threshold <= 1

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
@@ -37,6 +37,8 @@ def test_render_html_embeds_mermaid(tmp_path: Path) -> None:
     assert "MAE Consistency" in html
     assert "Bootstrap Interval" in html
     assert "Monotonicity" in html
+    assert "Stress Suite" in html
+    assert "Stress Scenario" in html
     assert "Holdout suite" in html
     assert artefacts.final_program in html
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
@@ -162,6 +162,11 @@ def parse_args() -> argparse.Namespace:
         type=float,
         help="Override bootstrap confidence level (0-1)",
     )
+    verification_group.add_argument(
+        "--verification-stress-threshold",
+        type=float,
+        help="Override minimum acceptable stress test score",
+    )
     governance_group = parser.add_argument_group("Governance timelock")
     governance_group.add_argument(
         "--timelock-delay",
@@ -271,6 +276,7 @@ def main() -> None:
                 "monotonic_tolerance": args.verification_monotonic,
                 "bootstrap_iterations": args.verification_bootstrap,
                 "confidence_level": args.verification_confidence,
+                "stress_threshold": args.verification_stress_threshold,
             }.items()
             if value is not None
         }
@@ -360,6 +366,17 @@ def main() -> None:
     print("\n🔍 Multi-angle verification checks:")
     for name, score in sorted(verification.holdout_scores.items()):
         print(f"  • {name}: {score:.4f}")
+    if verification.stress_scores:
+        print(
+            f"  • Stress threshold {verification.stress_threshold:.2f} | pass {verification.pass_stress}"
+        )
+        for name, score in sorted(verification.stress_scores.items()):
+            status = "PASS" if score >= verification.stress_threshold else "ALERT"
+            print(
+                f"      - {name}: {score:.4f} ({status})"
+            )
+    else:
+        print("  • Stress suite: no adversarial scenarios executed")
     print(
         f"  • Residual mean {verification.residual_mean:+.4f} | std {verification.residual_std:.4f}"
     )


### PR DESCRIPTION
## Summary
- extend the meta-agentic verification pipeline with adversarial stress scenarios and owner-governable thresholds
- expose the new controls through the owner console, CLI, generated reports, and narrative documentation
- broaden automated tests to cover stress metrics while updating the interactive demo output

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests -q`
- `python demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py alpha --output demo/Meta-Agentic-Program-Synthesis-v0/.ci-artifacts`


------
https://chatgpt.com/codex/tasks/task_e_68f7f84ae1888333945dc619de8d2bc6