### PR TITLE
Add CLI overrides for One-Box launcher

### DIFF
--- a/demo/One-Box/README.md
+++ b/demo/One-Box/README.md
@@ -62,6 +62,25 @@ The orchestrator keeps ownership controls in the loop at every stage—jobs are 
 
 That is all a non-technical operator needs: visit the chat, describe the job, confirm, and watch the receipt appear with an explorer link.
 
+#### Command-line overrides
+
+Need to tweak ports or skip automatically opening a browser tab? The launcher accepts friendly flags:
+
+```sh
+npm run demo:onebox:launch -- \
+  --no-browser \
+  --ui-host 0.0.0.0 \
+  --ui-port 5050 \
+  --orchestrator-port 9090 \
+  --orchestrator-url http://demo.internal:9090/onebox \
+  --prefix /mission \
+  --token demo-api-token \
+  --mode expert \
+  --explorer-base https://sepolia.etherscan.io/tx/
+```
+
+Only the flags you specify are overridden; everything else continues to flow from `.env`. Invalid flag values (for example, a negative port) are rejected up front so operators catch mistakes before the orchestrator boots.
+
 ### Built-in safety rails
 
 * **Walletless default.** Guest mode uses the relayer key supplied in `.env` to sponsor gas and escrow the reward. Expert mode can be toggled at any time to emit calldata for self-signing wallets.

--- a/demo/One-Box/bin/start-onebox.cjs
+++ b/demo/One-Box/bin/start-onebox.cjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-const { runDemo } = require('../lib/launcher.js');
+const { runDemo, parseCliArgs } = require('../lib/launcher.js');
 
 (async () => {
   try {
-    await runDemo();
+    const cliOptions = parseCliArgs(process.argv.slice(2));
+    await runDemo(cliOptions);
   } catch (error) {
     console.error('Failed to launch AGI Jobs One-Box demo:', error.message);
     if (process.env.DEBUG) {


### PR DESCRIPTION
## Summary
- add CLI flag parsing to the One-Box launcher so operators can override ports, prefixes, tokens, and browser behaviour without editing env files
- document the new flags in the One-Box demo README to highlight non-technical operator workflows
- extend the launcher test suite to cover CLI overrides and precedence handling

## Testing
- node --test demo/One-Box/test/launcher.test.cjs
- node --test demo/One-Box/test/rpc.test.cjs

------
https://chatgpt.com/codex/tasks/task_e_68f7fc0b26c48333bd79fa6e3ac9490c