### PR TITLE
Enhance One-Box guardrails and diagnostics

### DIFF
--- a/demo/One-Box/.env.example
+++ b/demo/One-Box/.env.example
@@ -28,6 +28,12 @@ ONEBOX_EXPLORER_TX_BASE=https://sepolia.etherscan.io/tx/
 # UI default mode: guest (walletless) or expert.
 ONEBOX_UI_DEFAULT_MODE=guest
 
+# === Organisational guardrails ===
+# Maximum reward budget (AGIALPHA) a single job may allocate. Leave blank to disable the cap.
+ONEBOX_MAX_JOB_BUDGET_AGIA=
+# Maximum job duration in days enforced by the demo orchestrator. Leave blank to accept contract defaults.
+ONEBOX_MAX_JOB_DURATION_DAYS=
+
 # === IPFS + receipts (optional) ===
 # Configure a pinning gateway if you want the orchestrator to pin job specs/receipts.
 PINNER_HOST=

--- a/demo/One-Box/README.md
+++ b/demo/One-Box/README.md
@@ -50,7 +50,7 @@ The orchestrator keeps ownership controls in the loop at every stage—jobs are 
    ```sh
    npm run demo:onebox:doctor
    ```
-   The doctor checks required environment variables, pings your RPC to confirm the active chain, verifies that `JOB_REGISTRY_ADDRESS` points to live bytecode, prints the launch URL, and reminds the operator of the core owner-control commands.
+   The doctor checks required environment variables, pings your RPC to confirm the active chain, verifies that `JOB_REGISTRY_ADDRESS` points to live bytecode, surfaces active guardrail caps, prints the launch URL, and reminds the operator of the core owner-control commands.
 4. **Launch the One-Box:**
    ```sh
    npm run demo:onebox:launch
@@ -72,6 +72,8 @@ npm run demo:onebox:launch -- \
   --ui-host 0.0.0.0 \
   --ui-port 5050 \
   --orchestrator-port 9090 \
+  --max-budget 120 \
+  --max-duration 14 \
   --orchestrator-url http://demo.internal:9090/onebox \
   --prefix /mission \
   --token demo-api-token \
@@ -80,6 +82,8 @@ npm run demo:onebox:launch -- \
 ```
 
 Only the flags you specify are overridden; everything else continues to flow from `.env`. Invalid flag values (for example, a negative port) are rejected up front so operators catch mistakes before the orchestrator boots.
+
+`--max-budget` and `--max-duration` provide on-the-fly organisational guardrails, mirroring the `ONEBOX_MAX_JOB_BUDGET_AGIA` and `ONEBOX_MAX_JOB_DURATION_DAYS` environment variables. Use them to demo how the contract owner can ratchet limits without redeploying.
 
 ### Built-in safety rails
 
@@ -101,6 +105,8 @@ Only the flags you specify are overridden; everything else continues to flow fro
 | `ONEBOX_PUBLIC_ONEBOX_PREFIX` | Prefix inserted before planner/simulator endpoints (defaults to `/onebox`). |
 | `ONEBOX_PUBLIC_ORCHESTRATOR_URL` | Public base URL announced to the UI. Defaults to `http://127.0.0.1:${ONEBOX_PORT}`. |
 | `ONEBOX_UI_DEFAULT_MODE` | `guest` for relayer mode, `expert` for wallet calldata generation. |
+| `ONEBOX_MAX_JOB_BUDGET_AGIA` | Optional per-job reward ceiling enforced before execution. Blank disables the cap. |
+| `ONEBOX_MAX_JOB_DURATION_DAYS` | Optional lifecycle limit in days; jobs exceeding it are blocked before funding. |
 | `PINNER_*` | Optional IPFS pinning credentials to persist specs/receipts. |
 
 ## Owner control & observability

--- a/demo/One-Box/bin/doctor.cjs
+++ b/demo/One-Box/bin/doctor.cjs
@@ -73,6 +73,23 @@ function formatStatus(label, value) {
   }
   console.log('');
 
+  console.log('Organisational guardrails:');
+  formatStatus(
+    'Max job budget',
+    config.maxJobBudgetAgia ? `${config.maxJobBudgetAgia} AGIALPHA` : '(not configured)'
+  );
+  formatStatus(
+    'Max job duration',
+    config.maxJobDurationDays ? `${config.maxJobDurationDays} day(s)` : '(not configured)'
+  );
+  if (config.warnings.length > 0) {
+    console.log('   Guardrail warnings:');
+    for (const warning of config.warnings) {
+      console.log(`     • ${warning}`);
+    }
+  }
+  console.log('');
+
   console.log('Launch URL preview:');
   console.log(`   ${createDemoUrl(config)}`);
   console.log('');


### PR DESCRIPTION
## Summary
- add CLI and environment guardrail controls for maximum job budget and duration in the One-Box launcher
- surface guardrail configuration in the doctor output and README, including non-technical .env guidance
- extend launcher tests to cover new parsing logic and guardrail validation

## Testing
- node --test demo/One-Box/test/launcher.test.cjs
- node --test demo/One-Box/test/rpc.test.cjs

------
https://chatgpt.com/codex/tasks/task_e_68f804bac10483339b06c5fb887b0556