### PR TITLE
Harden One-Box demo exposure checks

### DIFF
--- a/demo/One-Box/README.md
+++ b/demo/One-Box/README.md
@@ -92,6 +92,7 @@ Only the flags you specify are overridden; everything else continues to flow fro
 * **Resumable context.** Query parameters automatically persist the orchestrator URL, `/onebox` prefix, and mode. API tokens are applied for the current tab only so they are never written to storage.
 * **Audit artefacts.** Each execution stores a signed receipt CID. IPFS credentials in `.env` let the orchestrator pin specs and deliverables.
 * **Owner telemetry.** The One‑Box mission panel now calls `/onebox/governance/snapshot` to render live fee, stake, and identity guardrails so operators can confirm the owner surface is in control before releasing funds.
+* **Automatic hardening hints.** The launch kit flags unsafe configurations—such as sharing an HTTP endpoint or omitting an API token when the orchestrator is public—so operators correct them before a live demo.
 
 ## Configuration reference
 

--- a/demo/One-Box/bin/doctor.cjs
+++ b/demo/One-Box/bin/doctor.cjs
@@ -83,7 +83,7 @@ function formatStatus(label, value) {
     config.maxJobDurationDays ? `${config.maxJobDurationDays} day(s)` : '(not configured)'
   );
   if (config.warnings.length > 0) {
-    console.log('   Guardrail warnings:');
+    console.log('   Configuration warnings:');
     for (const warning of config.warnings) {
       console.log(`     • ${warning}`);
     }


### PR DESCRIPTION
## Summary
- add security heuristics to the One-Box launcher to warn about insecure public orchestrator exposure
- surface configuration warnings in the doctor script and document the new hardening hints
- expand launcher unit tests to cover the new warning pathways

## Testing
- node --test demo/One-Box/test/launcher.test.cjs
- node --test demo/One-Box/test/rpc.test.cjs

------
https://chatgpt.com/codex/tasks/task_e_68f80ed24f0c833385d1f26c117ba7b7