### PR TITLE
fix: ensure CULTURE bootstrap scripts read deploy outputs

### DIFF
--- a/demo/CULTURE-v0/docker-compose.yml
+++ b/demo/CULTURE-v0/docker-compose.yml
@@ -73,6 +73,8 @@ services:
       bash -lc "set -euo pipefail && npm install --legacy-peer-deps &&
       npx hardhat compile &&
       npx hardhat run --network localhost demo/CULTURE-v0/scripts/deploy.culture.ts &&
+      export CULTURE_REGISTRY_ADDRESS=$(node -e 'const fs=require("fs"); const path=process.env.CULTURE_DEPLOY_OUTPUT || "/workspace/demo/CULTURE-v0/config/deployments.local.json"; const data=JSON.parse(fs.readFileSync(path, "utf8")); if(!data.cultureRegistry) throw new Error(`Missing cultureRegistry in ${path}`); process.stdout.write(data.cultureRegistry);') &&
+      export SELF_PLAY_ARENA_ADDRESS=$(node -e 'const fs=require("fs"); const path=process.env.CULTURE_DEPLOY_OUTPUT || "/workspace/demo/CULTURE-v0/config/deployments.local.json"; const data=JSON.parse(fs.readFileSync(path, "utf8")); if(!data.selfPlayArena) throw new Error(`Missing selfPlayArena in ${path}`); process.stdout.write(data.selfPlayArena);') &&
       npx hardhat run --network localhost demo/CULTURE-v0/scripts/owner.setParams.ts &&
       npx hardhat run --network localhost demo/CULTURE-v0/scripts/owner.setRoles.ts &&
       npx hardhat run --network localhost demo/CULTURE-v0/scripts/seed.culture.ts"


### PR DESCRIPTION
## Summary
- export the deployed CultureRegistry and SelfPlayArena addresses within the culture-contracts bootstrap command
- allow downstream owner and seeding scripts to read addresses without relying on stale environment variables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7feb6bba8833384ff97ac4a505e05