### PR TITLE
Personalize One-Box demo welcome and shortcut prompts

### DIFF
--- a/apps/onebox/test/query-overrides.test.ts
+++ b/apps/onebox/test/query-overrides.test.ts
@@ -30,6 +30,8 @@ test('parseOverrideParams extracts orchestrator, prefix, token, and mode', () =>
   assert.equal(overrides.prefix, '/bridge');
   assert.equal(overrides.token, 'demo-key');
   assert.equal(overrides.mode, 'expert');
+  assert.equal(overrides.welcome, undefined);
+  assert.equal(overrides.examples, undefined);
   assert.deepEqual(overrides.appliedParams.sort(), ['mode', 'oneboxPrefix', 'orchestrator', 'token'].sort());
 });
 
@@ -38,4 +40,18 @@ test('parseOverrideParams handles demo reset and empty values', () => {
   assert.equal(overrides.orchestrator, '');
   assert.equal(overrides.prefix, '');
   assert.equal(overrides.token, '');
+});
+
+test('parseOverrideParams supports welcome and examples overrides', () => {
+  const encoded = encodeURIComponent(JSON.stringify(['Label 500 images, 5 AGIALPHA, 7 days', 'Finalize job 12']));
+  const overrides = parseOverrideParams(`https://demo.local/?welcome=Hello%20World&examples=${encoded}`);
+  assert.equal(overrides.welcome, 'Hello World');
+  assert.deepEqual(overrides.examples, ['Label 500 images, 5 AGIALPHA, 7 days', 'Finalize job 12']);
+  assert(overrides.appliedParams.includes('welcome'));
+  assert(overrides.appliedParams.includes('examples'));
+});
+
+test('parseOverrideParams falls back to delimiter parsing for examples', () => {
+  const overrides = parseOverrideParams('https://demo.local/?examples=Research%20mission%20|%20Finalize%20job%20123');
+  assert.deepEqual(overrides.examples, ['Research mission', 'Finalize job 123']);
 });

--- a/apps/onebox/url-overrides.js
+++ b/apps/onebox/url-overrides.js
@@ -47,6 +47,8 @@ export function parseOverrideParams(href) {
     prefix: undefined,
     token: undefined,
     mode: undefined,
+    welcome: undefined,
+    examples: undefined,
     appliedParams: [],
   };
   if (!href) {
@@ -78,6 +80,34 @@ export function parseOverrideParams(href) {
       result.appliedParams.push('mode');
       const rawMode = url.searchParams.get('mode');
       result.mode = rawMode ? rawMode.trim().toLowerCase() : '';
+    }
+    if (url.searchParams.has('welcome')) {
+      result.appliedParams.push('welcome');
+      const rawWelcome = url.searchParams.get('welcome');
+      result.welcome = rawWelcome ? rawWelcome.trim() : '';
+    }
+    if (url.searchParams.has('examples')) {
+      result.appliedParams.push('examples');
+      const rawExamples = url.searchParams.get('examples');
+      if (rawExamples) {
+        let parsedExamples = [];
+        try {
+          const parsed = JSON.parse(rawExamples);
+          if (Array.isArray(parsed)) {
+            parsedExamples = parsed.filter((value) => typeof value === 'string' && value.trim()).map((value) => value.trim());
+          } else if (typeof parsed === 'string' && parsed.trim()) {
+            parsedExamples = [parsed.trim()];
+          }
+        } catch (error) {
+          parsedExamples = rawExamples
+            .split(/[\n\r]+|\s*\|\s*/)
+            .map((segment) => segment.trim())
+            .filter(Boolean);
+        }
+        result.examples = [...new Set(parsedExamples)];
+      } else {
+        result.examples = [];
+      }
     }
   } catch (error) {
     // ignore malformed URLs but surface them for debugging in non-production contexts

--- a/demo/One-Box/.env.example
+++ b/demo/One-Box/.env.example
@@ -27,6 +27,10 @@ ONEBOX_PUBLIC_ORCHESTRATOR_URL=
 ONEBOX_EXPLORER_TX_BASE=https://sepolia.etherscan.io/tx/
 # UI default mode: guest (walletless) or expert.
 ONEBOX_UI_DEFAULT_MODE=guest
+# Optional: override the welcome banner inside the chat history.
+ONEBOX_UI_WELCOME=
+# Optional: pipe-separated, newline-separated, or JSON array of shortcut prompts.
+ONEBOX_UI_SHORTCUTS=
 
 # === Organisational guardrails ===
 # Maximum reward budget (AGIALPHA) a single job may allocate. Leave blank to disable the cap.

--- a/demo/One-Box/README.md
+++ b/demo/One-Box/README.md
@@ -78,12 +78,26 @@ npm run demo:onebox:launch -- \
   --prefix /mission \
   --token demo-api-token \
   --mode expert \
-  --explorer-base https://sepolia.etherscan.io/tx/
+  --explorer-base https://sepolia.etherscan.io/tx/ \
+  --welcome "Welcome to AGI Jobs Mission Control" \
+  --examples "Deploy data labeling | Finalize job 77"
 ```
 
 Only the flags you specify are overridden; everything else continues to flow from `.env`. Invalid flag values (for example, a negative port) are rejected up front so operators catch mistakes before the orchestrator boots.
 
 `--max-budget` and `--max-duration` provide on-the-fly organisational guardrails, mirroring the `ONEBOX_MAX_JOB_BUDGET_AGIA` and `ONEBOX_MAX_JOB_DURATION_DAYS` environment variables. Use them to demo how the contract owner can ratchet limits without redeploying.
+
+#### Personalise the assistant surface
+
+Set `ONEBOX_UI_WELCOME` to change the first assistant banner (for example `Welcome to AGI Jobs Mission Control`) and `ONEBOX_UI_SHORTCUTS` to seed ready-made prompts. Shortcuts accept pipe-separated strings, newline-delimited lists, or a JSON array, so operators can ship curated demos like:
+
+```sh
+ONEBOX_UI_WELCOME="Deploy your sovereign AGI workforce in one chat." \
+ONEBOX_UI_SHORTCUTS='["Spin up 500-image labeling run", "Finalize job 128", "Audit receipts for job 77"]' \
+npm run demo:onebox:launch -- --example "Schedule weekly research digest, 8 AGIALPHA" --welcome "Mission deck armed and ready."
+```
+
+The launcher merges CLI flags and environment variables, de-duplicates prompts, and forwards them to the static UI via query overrides so the non-technical operator lands on a perfectly staged experience every time.
 
 ### Built-in safety rails
 
@@ -106,6 +120,8 @@ Only the flags you specify are overridden; everything else continues to flow fro
 | `ONEBOX_PUBLIC_ONEBOX_PREFIX` | Prefix inserted before planner/simulator endpoints (defaults to `/onebox`). |
 | `ONEBOX_PUBLIC_ORCHESTRATOR_URL` | Public base URL announced to the UI. Defaults to `http://127.0.0.1:${ONEBOX_PORT}`. |
 | `ONEBOX_UI_DEFAULT_MODE` | `guest` for relayer mode, `expert` for wallet calldata generation. |
+| `ONEBOX_UI_WELCOME` | Optional welcome banner rendered as the first assistant message. |
+| `ONEBOX_UI_SHORTCUTS` | Optional shortcut prompts (`|`/newline separated or JSON array) rendered as preset pills. |
 | `ONEBOX_MAX_JOB_BUDGET_AGIA` | Optional per-job reward ceiling enforced before execution. Blank disables the cap. |
 | `ONEBOX_MAX_JOB_DURATION_DAYS` | Optional lifecycle limit in days; jobs exceeding it are blocked before funding. |
 | `PINNER_*` | Optional IPFS pinning credentials to persist specs/receipts. |

--- a/demo/One-Box/bin/doctor.cjs
+++ b/demo/One-Box/bin/doctor.cjs
@@ -61,6 +61,12 @@ function formatStatus(label, value) {
   formatStatus('Prefix', config.prefix || '(root)');
   formatStatus('Default mode', config.defaultMode);
   formatStatus('Public orchestrator', config.publicOrchestratorUrl);
+  if (config.welcomeMessage) {
+    formatStatus('Welcome prompt', config.welcomeMessage);
+  }
+  if (config.shortcutExamples.length > 0) {
+    formatStatus('Shortcuts', config.shortcutExamples.join(' | '));
+  }
   if (config.apiToken) {
     formatStatus('API token', 'provided');
   }


### PR DESCRIPTION
## Summary
- allow the One-Box launcher and CLI to inject a custom welcome banner and curated shortcut prompts
- render the configured prompts inside the chat UI with dynamic placeholders and event delegation
- document the new controls, surface them in the doctor output, and expand regression tests for config parsing

## Testing
- npm run pretest

------
https://chatgpt.com/codex/tasks/task_e_68f818feaa2483339fcd1b2979375514