### PR TITLE
Add entropy shield resilience checks to Meta-Agentic Program Synthesis demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -38,13 +38,15 @@ flowchart TD
     Primary[Primary fitness score] --> Residual[Residual balance audit]
     Primary --> Holdouts[Noise-conditioned holdouts]
     Primary --> MAE[MAE consistency check]
+    Primary --> Entropy[Entropy shield]
     MAE --> Bootstrap[Bootstrap confidence band]
     Holdouts --> Monotonic[Monotonic trajectory scan]
     Residual --> Monotonic
+    Entropy --> Verdict
     Bootstrap --> Verdict[Final verdict]
     Monotonic --> Verdict
     classDef pass fill:#04364c,color:#d1f7ff,stroke:#38bdf8,stroke-width:2px
-    class Primary,Residual,Holdouts,MAE,Bootstrap,Monotonic,Verdict pass
+    class Primary,Residual,Holdouts,MAE,Bootstrap,Monotonic,Entropy,Verdict pass
 ```
 
 ### Evolutionary loop
@@ -56,6 +58,7 @@ The verification stack now includes an explicit stress battery that intentionall
 * **Regime shift** — applies structural trend and baseline shifts to mimic macroeconomic realignments.
 * **Volatility spike** — injects sharp noise bursts and transient outliers to test control under chaos.
 * **Signal dropout** — removes swathes of signal and damps cyclical structure to simulate degraded telemetry.
+* **Entropy shield** — enforces solver diversity by measuring the Shannon entropy of generated control kernels; if creativity collapses, the owner is alerted before capital is deployed.
 
 Every evolved program must clear a configurable stress threshold (default `0.72`). The new CLI flag `--verification-stress-threshold` lets the contract owner ratchet this bar up or down without touching code.
 
@@ -102,6 +105,7 @@ stateDiagram-v2
 
 The CLI narrates the process in natural language so the operator always understands what is happening.
 It now also prints a reward distribution digest summarising total payouts, architect retention, and the top solver/validator so executives can confirm value capture instantly. Immediately afterwards the CLI shares a triple-check verification digest (holdout scores, residual balance, divergence), flagging whether every gate passed.
+The digest now highlights the **entropy shield** so the owner can confirm that solver diversity stayed above the configurable floor – proving the sovereign architect remained creative and unstoppable while under explicit owner control.
 
 ---
 
@@ -129,6 +133,7 @@ knob – rewards, staking, evolution cadence, and pause state – can be adjuste
       --verification-bootstrap 400 \
       --verification-confidence 0.975
       --verification-stress-threshold 0.74
+      --verification-entropy 0.38
 ```
 
 Use `--pause` to halt execution instantly. The orchestrator will refuse to launch jobs while paused and will explain the status

--- a/demo/Meta-Agentic-Program-Synthesis-v0/config/owner-overrides.sample.json
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/config/owner-overrides.sample.json
@@ -25,7 +25,9 @@
     "mae_threshold": 0.74,
     "monotonic_tolerance": 0.02,
     "bootstrap_iterations": 320,
-    "confidence_level": 0.975
+    "confidence_level": 0.975,
+    "stress_threshold": 0.76,
+    "entropy_floor": 0.4
   },
   "paused": false
 }

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/admin.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/admin.py
@@ -40,6 +40,7 @@ class OwnerConsole:
         "bootstrap_iterations",
         "confidence_level",
         "stress_threshold",
+        "entropy_floor",
     }
 
     def __init__(self, config: DemoConfig) -> None:
@@ -219,6 +220,8 @@ class OwnerConsole:
             raise ValueError("confidence_level must be between 0 and 1")
         if not 0 <= policy.stress_threshold <= 1:
             raise ValueError("stress_threshold must be between 0 and 1")
+        if not 0 <= policy.entropy_floor <= 1:
+            raise ValueError("entropy_floor must be between 0 and 1")
 
 
 def load_owner_overrides(path: Path) -> Mapping[str, Any]:

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/config.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/config.py
@@ -74,6 +74,7 @@ class VerificationPolicy:
     bootstrap_iterations: int = 256
     confidence_level: float = 0.95
     stress_threshold: float = 0.72
+    entropy_floor: float = 0.35
 
     def to_dict(self) -> Dict[str, float | int]:
         return {
@@ -86,6 +87,7 @@ class VerificationPolicy:
             "bootstrap_iterations": self.bootstrap_iterations,
             "confidence_level": self.confidence_level,
             "stress_threshold": self.stress_threshold,
+            "entropy_floor": self.entropy_floor,
         }
 
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
@@ -188,6 +188,9 @@ class VerificationDigest:
     stress_scores: Dict[str, float]
     pass_stress: bool
     stress_threshold: float
+    entropy_score: float
+    pass_entropy: bool
+    entropy_floor: float
 
     @property
     def overall_pass(self) -> bool:
@@ -199,6 +202,7 @@ class VerificationDigest:
             and self.pass_confidence
             and self.monotonic_pass
             and self.pass_stress
+            and self.pass_entropy
         )
 
     def to_dict(self) -> Dict[str, object]:
@@ -220,6 +224,9 @@ class VerificationDigest:
             "stress_scores": dict(self.stress_scores),
             "pass_stress": self.pass_stress,
             "stress_threshold": self.stress_threshold,
+            "entropy_score": self.entropy_score,
+            "pass_entropy": self.pass_entropy,
+            "entropy_floor": self.entropy_floor,
             "overall_pass": self.overall_pass,
         }
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/report.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/report.py
@@ -373,6 +373,10 @@ def format_verification_cards(verification: VerificationDigest) -> str:
         f"  <h3>Stress Suite</h3><p>Min {(min(verification.stress_scores.values()) if verification.stress_scores else 0.0):.4f}</p>",
         f"  <p>Status: {'PASS' if verification.pass_stress else 'ALERT'}</p>",
         "</div>",
+        "<div class=\"summary-card\">",
+        f"  <h3>Entropy Shield</h3><p>{verification.entropy_score:.4f}</p>",
+        f"  <p>Status: {'PASS' if verification.pass_entropy else 'ALERT'}</p>",
+        "</div>",
     ]
     return build_rows(cards)
 
@@ -393,6 +397,7 @@ def format_verification_table(verification: VerificationDigest) -> str:
             f"<tr><td>MAE Consistency</td><td>{verification.mae_score:.4f}</td><td>{'PASS' if verification.pass_mae else 'ALERT'}</td></tr>",
             f"<tr><td>Bootstrap Interval</td><td>{verification.bootstrap_interval[0]:.4f} → {verification.bootstrap_interval[1]:.4f}</td><td>{'PASS' if verification.pass_confidence else 'ALERT'}</td></tr>",
             f"<tr><td>Monotonicity</td><td>{verification.monotonic_violations} violation(s)</td><td>{'PASS' if verification.monotonic_pass else 'ALERT'}</td></tr>",
+            f"<tr><td>Entropy Shield</td><td>{verification.entropy_score:.4f} (floor {verification.entropy_floor:.2f})</td><td>{'PASS' if verification.pass_entropy else 'ALERT'}</td></tr>",
         ]
     )
     return (
@@ -414,16 +419,18 @@ def build_verification_mermaid(verification: VerificationDigest) -> str:
             "    primary --> holdout[Holdout suite]",
             "    primary --> mae[MAE score]",
             "    primary --> stress[Stress battery]",
+            "    primary --> entropy[Entropy shield]",
             "    mae --> bootstrap[Bootstrap CI]",
             "    holdout --> monotonic[Monotonic audit]",
             f"    mae:::status -- {'PASS' if verification.pass_mae else 'ALERT'} --> bootstrap",
             f"    residual:::status -- {'PASS' if verification.pass_residual_balance else 'ALERT'} --> monotonic",
             f"    holdout:::status -- {'PASS' if verification.pass_holdout else 'ALERT'} --> monotonic",
             f"    stress:::status -- {('≥' if verification.pass_stress else '<')} {verification.stress_threshold:.2f} --> verdict[Final verdict]",
+            f"    entropy:::status -- {('≥' if verification.pass_entropy else '<')} {verification.entropy_floor:.2f} --> verdict",
             f"    bootstrap:::status -- {lower:.3f}→{upper:.3f} --> verdict[Final verdict]",
             f"    monotonic:::status -- {'PASS' if verification.monotonic_pass else 'ALERT'} --> verdict",
             "    classDef status fill:#0f172a,color:#f8fafc,stroke:#38bdf8,stroke-width:2px",
-            "    class primary,residual,holdout,mae,stress,bootstrap,monotonic,verdict status",
+            "    class primary,residual,holdout,mae,stress,entropy,bootstrap,monotonic,verdict status",
         ]
     )
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_admin.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_admin.py
@@ -79,6 +79,7 @@ def test_owner_console_updates_verification_policy() -> None:
         bootstrap_iterations=300,
         confidence_level=0.9,
         stress_threshold=0.73,
+        entropy_floor=0.45,
     )
     policy = console.config.verification_policy
     assert pytest.approx(policy.holdout_threshold) == 0.85
@@ -90,6 +91,7 @@ def test_owner_console_updates_verification_policy() -> None:
     assert policy.bootstrap_iterations == 300
     assert pytest.approx(policy.confidence_level) == 0.9
     assert pytest.approx(policy.stress_threshold) == 0.73
+    assert pytest.approx(policy.entropy_floor) == 0.45
     assert console.events[-1].action == "update_verification_policy"
 
 
@@ -109,6 +111,10 @@ def test_owner_console_rejects_invalid_verification_policy() -> None:
         console.update_verification_policy(stress_threshold=-0.2)
     with pytest.raises(ValueError):
         console.update_verification_policy(stress_threshold=1.2)
+    with pytest.raises(ValueError):
+        console.update_verification_policy(entropy_floor=-0.1)
+    with pytest.raises(ValueError):
+        console.update_verification_policy(entropy_floor=1.5)
 
 
 def test_owner_console_apply_overrides_and_load(tmp_path: Path) -> None:
@@ -122,6 +128,7 @@ def test_owner_console_apply_overrides_and_load(tmp_path: Path) -> None:
             "mae_threshold": 0.7,
             "bootstrap_iterations": 280,
             "stress_threshold": 0.69,
+            "entropy_floor": 0.41,
         },
         "paused": True,
     }
@@ -138,6 +145,7 @@ def test_owner_console_apply_overrides_and_load(tmp_path: Path) -> None:
     assert pytest.approx(verification_policy.mae_threshold) == 0.7
     assert verification_policy.bootstrap_iterations == 280
     assert pytest.approx(verification_policy.stress_threshold) == 0.69
+    assert pytest.approx(verification_policy.entropy_floor) == 0.41
     assert any(event.action == "set_paused" for event in console.events)
 
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
@@ -44,3 +44,6 @@ def test_orchestrator_generates_artifacts(tmp_path) -> None:
     assert isinstance(verification.stress_scores, dict)
     assert verification.stress_scores
     assert 0 <= verification.stress_threshold <= 1
+    assert 0 <= verification.entropy_score <= 1
+    assert isinstance(verification.pass_entropy, bool)
+    assert 0 <= verification.entropy_floor <= 1

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
@@ -40,6 +40,9 @@ def test_render_html_embeds_mermaid(tmp_path: Path) -> None:
     assert "Stress Suite" in html
     assert "Stress Scenario" in html
     assert "Holdout suite" in html
+    assert "Entropy Shield" in html
+    assert "Entropy shield" in html
+    assert "Entropy Shield Array" in html
     assert artefacts.final_program in html
 
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
@@ -167,6 +167,11 @@ def parse_args() -> argparse.Namespace:
         type=float,
         help="Override minimum acceptable stress test score",
     )
+    verification_group.add_argument(
+        "--verification-entropy",
+        type=float,
+        help="Override minimum acceptable entropy score",
+    )
     governance_group = parser.add_argument_group("Governance timelock")
     governance_group.add_argument(
         "--timelock-delay",
@@ -277,6 +282,7 @@ def main() -> None:
                 "bootstrap_iterations": args.verification_bootstrap,
                 "confidence_level": args.verification_confidence,
                 "stress_threshold": args.verification_stress_threshold,
+                "entropy_floor": args.verification_entropy,
             }.items()
             if value is not None
         }


### PR DESCRIPTION
## Summary
- add an entropy shield control to the demo configuration, owner console, and CLI so operators can enforce solver diversity thresholds
- extend sovereign orchestrator verification to compute entropy scores, surface the new opportunity narrative, and expose the metric in reports and documentation
- update automated tests, sample overrides, and docs to cover the entropy guardrail and refreshed governance flow

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests`


------
https://chatgpt.com/codex/tasks/task_e_68f8196225c4833398858d9357885b0c