### PR TITLE
Add One-Box port availability guard rails

### DIFF
--- a/demo/One-Box/README.md
+++ b/demo/One-Box/README.md
@@ -50,7 +50,7 @@ The orchestrator keeps ownership controls in the loop at every stage—jobs are 
    ```sh
    npm run demo:onebox:doctor
    ```
-   The doctor checks required environment variables, pings your RPC to confirm the active chain, verifies that `JOB_REGISTRY_ADDRESS` points to live bytecode, surfaces active guardrail caps, prints the launch URL, and reminds the operator of the core owner-control commands.
+   The doctor checks required environment variables, pings your RPC to confirm the active chain, verifies that `JOB_REGISTRY_ADDRESS` points to live bytecode, inspects port availability before launch, surfaces active guardrail caps, prints the launch URL, and reminds the operator of the core owner-control commands.
 4. **Launch the One-Box:**
    ```sh
    npm run demo:onebox:launch
@@ -106,7 +106,7 @@ The launcher merges CLI flags and environment variables, de-duplicates prompts, 
 * **Resumable context.** Query parameters automatically persist the orchestrator URL, `/onebox` prefix, and mode. API tokens are applied for the current tab only so they are never written to storage.
 * **Audit artefacts.** Each execution stores a signed receipt CID. IPFS credentials in `.env` let the orchestrator pin specs and deliverables.
 * **Owner telemetry.** The One‑Box mission panel now calls `/onebox/governance/snapshot` to render live fee, stake, and identity guardrails so operators can confirm the owner surface is in control before releasing funds.
-* **Automatic hardening hints.** The launch kit flags unsafe configurations—such as sharing an HTTP endpoint or omitting an API token when the orchestrator is public—so operators correct them before a live demo.
+* **Automatic hardening hints.** The launch kit flags unsafe configurations—such as sharing an HTTP endpoint or omitting an API token when the orchestrator is public—and now blocks port collisions before the orchestrator boots so operators can correct issues in seconds.
 
 ## Configuration reference
 


### PR DESCRIPTION
## Summary
- add port availability diagnostics and enforcement to the One-Box launch workflow
- surface port status in the demo doctor output and documentation
- cover the new behaviour with dedicated node:test cases

## Testing
- node --test demo/One-Box/test/launcher.test.cjs
- node --test demo/One-Box/test/rpc.test.cjs

------
https://chatgpt.com/codex/tasks/task_e_68f81eb9b7188333beec67f674b1f87d