### PR TITLE
Add independent assurance weave to Meta-Agentic Program Synthesis demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -62,6 +62,16 @@ The verification stack now includes an explicit stress battery that intentionall
 
 Every evolved program must clear a configurable stress threshold (default `0.72`). The new CLI flag `--verification-stress-threshold` lets the contract owner ratchet this bar up or down without touching code.
 
+#### Independent assurance weave
+
+Triple verification now runs in lockstep with an **Independent Assurance Weave** – a second auditor that recomputes the sovereign's score using high-precision Decimal arithmetic, variance forensics, and a spectral leak detector. The weave refuses to sign off unless:
+
+* The Decimal replay stays within a configurable tolerance of the primary score.
+* Residual variance remains below an owner-set ceiling, protecting against unbounded drift.
+* Spectral energy across harmonics stays under a limit, preventing hidden oscillations or regime exploits.
+
+All three thresholds are owner-governed and surfaced through the CLI / JSON overrides, ensuring governance can harden or relax the assurance net instantly.
+
 ```mermaid
 stateDiagram-v2
     [*] --> SeedPopulation: bootstrap diverse codelets
@@ -134,12 +144,15 @@ knob – rewards, staking, evolution cadence, and pause state – can be adjuste
       --verification-confidence 0.975
       --verification-stress-threshold 0.74
       --verification-entropy 0.38
+      --verification-precision-tolerance 0.02
+      --verification-variance-ceiling 1.2
+      --verification-spectral-ceiling 0.5
 ```
 
 Use `--pause` to halt execution instantly. The orchestrator will refuse to launch jobs while paused and will explain the status
 in the CLI output. Re-run without `--pause` (or with a different override set) to resume operations.
 
-Verification overrides keep the sovereign architect honest: tighten holdout thresholds for ultra-conservative validation, raise MAE expectations for stricter fit, expand bootstrap iterations for deeper statistical certainty, or relax divergence tolerances when exploring frontier scenarios.
+Verification overrides keep the sovereign architect honest: tighten holdout thresholds for ultra-conservative validation, raise MAE expectations for stricter fit, expand bootstrap iterations for deeper statistical certainty, clamp precision tolerances for the Decimal replay, or harden variance/spectral ceilings when exploring frontier scenarios.
 
 ### Timelocked governance
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/__init__.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/__init__.py
@@ -1,6 +1,7 @@
 """Public package interface for the Meta-Agentic Program Synthesis demo."""
 
 from .admin import OwnerConsole, load_owner_overrides
+from .assurance import IndependentAuditor
 from .config import (
     DemoConfig,
     DemoScenario,
@@ -25,6 +26,7 @@ __all__ = [
     "StakePolicy",
     "VerificationPolicy",
     "OwnerConsole",
+    "IndependentAuditor",
     "SovereignArchitect",
     "generate_dataset",
     "export_report",

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/admin.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/admin.py
@@ -41,6 +41,9 @@ class OwnerConsole:
         "confidence_level",
         "stress_threshold",
         "entropy_floor",
+        "precision_replay_tolerance",
+        "variance_ratio_ceiling",
+        "spectral_energy_ceiling",
     }
 
     def __init__(self, config: DemoConfig) -> None:
@@ -222,6 +225,12 @@ class OwnerConsole:
             raise ValueError("stress_threshold must be between 0 and 1")
         if not 0 <= policy.entropy_floor <= 1:
             raise ValueError("entropy_floor must be between 0 and 1")
+        if policy.precision_replay_tolerance < 0:
+            raise ValueError("precision_replay_tolerance must be non-negative")
+        if policy.variance_ratio_ceiling <= 0:
+            raise ValueError("variance_ratio_ceiling must be positive")
+        if not 0 < policy.spectral_energy_ceiling <= 1:
+            raise ValueError("spectral_energy_ceiling must be within (0, 1]")
 
 
 def load_owner_overrides(path: Path) -> Mapping[str, Any]:

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/assurance.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/assurance.py
@@ -1,0 +1,121 @@
+"""Independent verification utilities for the Meta-Agentic Program Synthesis demo."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from decimal import Decimal, getcontext
+from statistics import pstdev
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    """Captures independent verification metrics."""
+
+    precision_score: float
+    variance_ratio: float
+    spectral_ratio: float
+    pass_precision: bool
+    pass_variance: bool
+    pass_spectral: bool
+
+
+class IndependentAuditor:
+    """Secondary verification engine that challenges the primary scorer."""
+
+    def __init__(
+        self,
+        *,
+        baseline_error: float,
+        precision_tolerance: float,
+        variance_ratio_ceiling: float,
+        spectral_energy_ceiling: float,
+        decimal_precision: int = 48,
+    ) -> None:
+        if baseline_error <= 0:
+            raise ValueError("baseline_error must be positive")
+        if precision_tolerance < 0:
+            raise ValueError("precision_tolerance must be non-negative")
+        if variance_ratio_ceiling <= 0:
+            raise ValueError("variance_ratio_ceiling must be positive")
+        if spectral_energy_ceiling <= 0:
+            raise ValueError("spectral_energy_ceiling must be positive")
+        self._baseline_error = baseline_error
+        self._precision_tolerance = precision_tolerance
+        self._variance_ratio_ceiling = variance_ratio_ceiling
+        self._spectral_energy_ceiling = spectral_energy_ceiling
+        self._decimal_precision = max(decimal_precision, 28)
+
+    def audit(
+        self,
+        *,
+        predictions: Sequence[float],
+        targets: Sequence[float],
+        primary_score: float,
+    ) -> AuditResult:
+        if len(predictions) != len(targets):
+            raise ValueError("predictions and targets must be aligned")
+        decimal_score = self._decimal_score(predictions, targets)
+        variance_ratio = self._variance_ratio(predictions, targets)
+        spectral_ratio = self._spectral_ratio(
+            residuals=(target - prediction for prediction, target in zip(predictions, targets))
+        )
+        return AuditResult(
+            precision_score=decimal_score,
+            variance_ratio=variance_ratio,
+            spectral_ratio=spectral_ratio,
+            pass_precision=abs(decimal_score - primary_score) <= self._precision_tolerance,
+            pass_variance=variance_ratio <= self._variance_ratio_ceiling,
+            pass_spectral=spectral_ratio <= self._spectral_energy_ceiling,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _decimal_score(self, predictions: Sequence[float], targets: Sequence[float]) -> float:
+        getcontext().prec = self._decimal_precision
+        baseline_error = Decimal(str(self._baseline_error))
+        total = Decimal("0")
+        count = Decimal("0")
+        for prediction, target in zip(predictions, targets):
+            diff = Decimal(str(prediction)) - Decimal(str(target))
+            total += diff * diff
+            count += Decimal(1)
+        if count == 0:
+            return 0.0
+        mse = total / count
+        normalised = Decimal("1") - min(mse / baseline_error, Decimal("1"))
+        score = max(normalised, Decimal("0")) ** Decimal("0.5")
+        return float(score)
+
+    def _variance_ratio(self, predictions: Sequence[float], targets: Sequence[float]) -> float:
+        if not predictions:
+            return 0.0
+        residuals = [target - prediction for prediction, target in zip(predictions, targets)]
+        if len(residuals) < 2:
+            return 0.0
+        signal_spread = pstdev(targets) or 1e-12
+        residual_spread = pstdev(residuals)
+        return float(max(residual_spread, 0.0) / signal_spread)
+
+    def _spectral_ratio(self, *, residuals: Iterable[float]) -> float:
+        values = list(residuals)
+        if not values:
+            return 0.0
+        total_energy = sum(value * value for value in values)
+        if total_energy <= 0:
+            return 0.0
+        n = len(values)
+        max_component = 0.0
+        for harmonic in range(1, min(6, n)):
+            cos_sum = 0.0
+            sin_sum = 0.0
+            for index, value in enumerate(values):
+                angle = 2 * math.pi * harmonic * index / n
+                cos_sum += value * math.cos(angle)
+                sin_sum += value * math.sin(angle)
+            component_energy = (cos_sum**2 + sin_sum**2) / n
+            max_component = max(max_component, component_energy)
+        if max_component <= 0:
+            return 0.0
+        return min(max_component / total_energy, 1.0)

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/config.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/config.py
@@ -75,6 +75,9 @@ class VerificationPolicy:
     confidence_level: float = 0.95
     stress_threshold: float = 0.72
     entropy_floor: float = 0.35
+    precision_replay_tolerance: float = 0.025
+    variance_ratio_ceiling: float = 1.25
+    spectral_energy_ceiling: float = 0.55
 
     def to_dict(self) -> Dict[str, float | int]:
         return {
@@ -88,6 +91,9 @@ class VerificationPolicy:
             "confidence_level": self.confidence_level,
             "stress_threshold": self.stress_threshold,
             "entropy_floor": self.entropy_floor,
+            "precision_replay_tolerance": self.precision_replay_tolerance,
+            "variance_ratio_ceiling": self.variance_ratio_ceiling,
+            "spectral_energy_ceiling": self.spectral_energy_ceiling,
         }
 
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
@@ -191,6 +191,12 @@ class VerificationDigest:
     entropy_score: float
     pass_entropy: bool
     entropy_floor: float
+    precision_replay_score: float
+    pass_precision_replay: bool
+    variance_ratio: float
+    pass_variance_ratio: bool
+    spectral_ratio: float
+    pass_spectral_ratio: bool
 
     @property
     def overall_pass(self) -> bool:
@@ -203,6 +209,9 @@ class VerificationDigest:
             and self.monotonic_pass
             and self.pass_stress
             and self.pass_entropy
+            and self.pass_precision_replay
+            and self.pass_variance_ratio
+            and self.pass_spectral_ratio
         )
 
     def to_dict(self) -> Dict[str, object]:
@@ -227,6 +236,12 @@ class VerificationDigest:
             "entropy_score": self.entropy_score,
             "pass_entropy": self.pass_entropy,
             "entropy_floor": self.entropy_floor,
+            "precision_replay_score": self.precision_replay_score,
+            "pass_precision_replay": self.pass_precision_replay,
+            "variance_ratio": self.variance_ratio,
+            "pass_variance_ratio": self.pass_variance_ratio,
+            "spectral_ratio": self.spectral_ratio,
+            "pass_spectral_ratio": self.pass_spectral_ratio,
             "overall_pass": self.overall_pass,
         }
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/report.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/report.py
@@ -377,6 +377,18 @@ def format_verification_cards(verification: VerificationDigest) -> str:
         f"  <h3>Entropy Shield</h3><p>{verification.entropy_score:.4f}</p>",
         f"  <p>Status: {'PASS' if verification.pass_entropy else 'ALERT'}</p>",
         "</div>",
+        "<div class=\"summary-card\">",
+        f"  <h3>Decimal Replay</h3><p>{verification.precision_replay_score:.4f}</p>",
+        f"  <p>Status: {'PASS' if verification.pass_precision_replay else 'ALERT'}</p>",
+        "</div>",
+        "<div class=\"summary-card\">",
+        f"  <h3>Variance Ratio</h3><p>{verification.variance_ratio:.4f}</p>",
+        f"  <p>Status: {'PASS' if verification.pass_variance_ratio else 'ALERT'}</p>",
+        "</div>",
+        "<div class=\"summary-card\">",
+        f"  <h3>Spectral Energy</h3><p>{verification.spectral_ratio:.4f}</p>",
+        f"  <p>Status: {'PASS' if verification.pass_spectral_ratio else 'ALERT'}</p>",
+        "</div>",
     ]
     return build_rows(cards)
 
@@ -398,6 +410,9 @@ def format_verification_table(verification: VerificationDigest) -> str:
             f"<tr><td>Bootstrap Interval</td><td>{verification.bootstrap_interval[0]:.4f} → {verification.bootstrap_interval[1]:.4f}</td><td>{'PASS' if verification.pass_confidence else 'ALERT'}</td></tr>",
             f"<tr><td>Monotonicity</td><td>{verification.monotonic_violations} violation(s)</td><td>{'PASS' if verification.monotonic_pass else 'ALERT'}</td></tr>",
             f"<tr><td>Entropy Shield</td><td>{verification.entropy_score:.4f} (floor {verification.entropy_floor:.2f})</td><td>{'PASS' if verification.pass_entropy else 'ALERT'}</td></tr>",
+            f"<tr><td>Decimal Replay</td><td>{verification.precision_replay_score:.4f} (Δ {verification.precision_replay_score - verification.primary_score:+.4f})</td><td>{'PASS' if verification.pass_precision_replay else 'ALERT'}</td></tr>",
+            f"<tr><td>Variance Ratio</td><td>{verification.variance_ratio:.4f}</td><td>{'PASS' if verification.pass_variance_ratio else 'ALERT'}</td></tr>",
+            f"<tr><td>Spectral Energy</td><td>{verification.spectral_ratio:.4f}</td><td>{'PASS' if verification.pass_spectral_ratio else 'ALERT'}</td></tr>",
         ]
     )
     return (
@@ -420,6 +435,9 @@ def build_verification_mermaid(verification: VerificationDigest) -> str:
             "    primary --> mae[MAE score]",
             "    primary --> stress[Stress battery]",
             "    primary --> entropy[Entropy shield]",
+            "    primary --> precision[Decimal replay]",
+            "    primary --> variance[Variance ratio]",
+            "    primary --> spectral[Spectral scan]",
             "    mae --> bootstrap[Bootstrap CI]",
             "    holdout --> monotonic[Monotonic audit]",
             f"    mae:::status -- {'PASS' if verification.pass_mae else 'ALERT'} --> bootstrap",
@@ -427,10 +445,13 @@ def build_verification_mermaid(verification: VerificationDigest) -> str:
             f"    holdout:::status -- {'PASS' if verification.pass_holdout else 'ALERT'} --> monotonic",
             f"    stress:::status -- {('≥' if verification.pass_stress else '<')} {verification.stress_threshold:.2f} --> verdict[Final verdict]",
             f"    entropy:::status -- {('≥' if verification.pass_entropy else '<')} {verification.entropy_floor:.2f} --> verdict",
+            f"    precision:::status -- {'PASS' if verification.pass_precision_replay else 'ALERT'} --> verdict",
+            f"    variance:::status -- {'PASS' if verification.pass_variance_ratio else 'ALERT'} --> verdict",
+            f"    spectral:::status -- {'PASS' if verification.pass_spectral_ratio else 'ALERT'} --> verdict",
             f"    bootstrap:::status -- {lower:.3f}→{upper:.3f} --> verdict[Final verdict]",
             f"    monotonic:::status -- {'PASS' if verification.monotonic_pass else 'ALERT'} --> verdict",
             "    classDef status fill:#0f172a,color:#f8fafc,stroke:#38bdf8,stroke-width:2px",
-            "    class primary,residual,holdout,mae,stress,entropy,bootstrap,monotonic,verdict status",
+            "    class primary,residual,holdout,mae,stress,entropy,precision,variance,spectral,bootstrap,monotonic,verdict status",
         ]
     )
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_admin.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_admin.py
@@ -80,6 +80,9 @@ def test_owner_console_updates_verification_policy() -> None:
         confidence_level=0.9,
         stress_threshold=0.73,
         entropy_floor=0.45,
+        precision_replay_tolerance=0.012,
+        variance_ratio_ceiling=1.1,
+        spectral_energy_ceiling=0.48,
     )
     policy = console.config.verification_policy
     assert pytest.approx(policy.holdout_threshold) == 0.85
@@ -92,6 +95,9 @@ def test_owner_console_updates_verification_policy() -> None:
     assert pytest.approx(policy.confidence_level) == 0.9
     assert pytest.approx(policy.stress_threshold) == 0.73
     assert pytest.approx(policy.entropy_floor) == 0.45
+    assert pytest.approx(policy.precision_replay_tolerance) == 0.012
+    assert pytest.approx(policy.variance_ratio_ceiling) == 1.1
+    assert pytest.approx(policy.spectral_energy_ceiling) == 0.48
     assert console.events[-1].action == "update_verification_policy"
 
 
@@ -115,6 +121,14 @@ def test_owner_console_rejects_invalid_verification_policy() -> None:
         console.update_verification_policy(entropy_floor=-0.1)
     with pytest.raises(ValueError):
         console.update_verification_policy(entropy_floor=1.5)
+    with pytest.raises(ValueError):
+        console.update_verification_policy(precision_replay_tolerance=-0.1)
+    with pytest.raises(ValueError):
+        console.update_verification_policy(variance_ratio_ceiling=0)
+    with pytest.raises(ValueError):
+        console.update_verification_policy(spectral_energy_ceiling=0)
+    with pytest.raises(ValueError):
+        console.update_verification_policy(spectral_energy_ceiling=1.5)
 
 
 def test_owner_console_apply_overrides_and_load(tmp_path: Path) -> None:
@@ -129,6 +143,9 @@ def test_owner_console_apply_overrides_and_load(tmp_path: Path) -> None:
             "bootstrap_iterations": 280,
             "stress_threshold": 0.69,
             "entropy_floor": 0.41,
+            "precision_replay_tolerance": 0.02,
+            "variance_ratio_ceiling": 1.3,
+            "spectral_energy_ceiling": 0.52,
         },
         "paused": True,
     }
@@ -146,6 +163,9 @@ def test_owner_console_apply_overrides_and_load(tmp_path: Path) -> None:
     assert verification_policy.bootstrap_iterations == 280
     assert pytest.approx(verification_policy.stress_threshold) == 0.69
     assert pytest.approx(verification_policy.entropy_floor) == 0.41
+    assert pytest.approx(verification_policy.precision_replay_tolerance) == 0.02
+    assert pytest.approx(verification_policy.variance_ratio_ceiling) == 1.3
+    assert pytest.approx(verification_policy.spectral_energy_ceiling) == 0.52
     assert any(event.action == "set_paused" for event in console.events)
 
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_assurance.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_assurance.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from meta_agentic_demo.assurance import IndependentAuditor
+
+
+def compute_primary_score(predictions: list[float], targets: list[float], baseline_error: float) -> float:
+    mse = sum((p - t) ** 2 for p, t in zip(predictions, targets)) / max(len(predictions), 1)
+    normalised = 1.0 - min(mse / max(baseline_error, 1e-9), 1.0)
+    return max(normalised, 0.0) ** 0.5
+
+
+def test_independent_auditor_validates_consistency() -> None:
+    targets = [1.0, 1.5, 2.0, 2.5, 3.0]
+    zero_predictions = [0.0] * len(targets)
+    baseline_error = sum((t - z) ** 2 for t, z in zip(targets, zero_predictions)) / len(targets)
+    predictions = [0.95, 1.55, 1.98, 2.48, 3.05]
+    primary_score = compute_primary_score(predictions, targets, baseline_error)
+    auditor = IndependentAuditor(
+        baseline_error=baseline_error,
+        precision_tolerance=0.02,
+        variance_ratio_ceiling=1.5,
+        spectral_energy_ceiling=0.8,
+    )
+    result = auditor.audit(predictions=predictions, targets=targets, primary_score=primary_score)
+    assert pytest.approx(result.precision_score, rel=1e-6) == primary_score
+    assert result.pass_precision
+    assert result.pass_variance
+    assert result.pass_spectral
+    assert 0 <= result.spectral_ratio <= 1
+
+
+def test_independent_auditor_flags_anomalies() -> None:
+    targets = [math.sin(i / 3.0) for i in range(24)]
+    zero_predictions = [0.0] * len(targets)
+    baseline_error = sum((t - z) ** 2 for t, z in zip(targets, zero_predictions)) / len(targets)
+    predictions = [0.0 for _ in targets]
+    primary_score = compute_primary_score(predictions, targets, baseline_error)
+    auditor = IndependentAuditor(
+        baseline_error=baseline_error,
+        precision_tolerance=0.001,
+        variance_ratio_ceiling=0.5,
+        spectral_energy_ceiling=0.2,
+    )
+    tampered_primary = primary_score + 0.05
+    result = auditor.audit(predictions=predictions, targets=targets, primary_score=tampered_primary)
+    assert not result.pass_precision
+    assert not result.pass_variance
+    assert not result.pass_spectral
+    assert result.variance_ratio >= 0.5
+    assert result.spectral_ratio >= 0.2

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
@@ -47,3 +47,9 @@ def test_orchestrator_generates_artifacts(tmp_path) -> None:
     assert 0 <= verification.entropy_score <= 1
     assert isinstance(verification.pass_entropy, bool)
     assert 0 <= verification.entropy_floor <= 1
+    assert verification.precision_replay_score >= 0
+    assert isinstance(verification.pass_precision_replay, bool)
+    assert verification.variance_ratio >= 0
+    assert isinstance(verification.pass_variance_ratio, bool)
+    assert 0 <= verification.spectral_ratio <= 1
+    assert isinstance(verification.pass_spectral_ratio, bool)

--- a/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
@@ -172,6 +172,21 @@ def parse_args() -> argparse.Namespace:
         type=float,
         help="Override minimum acceptable entropy score",
     )
+    verification_group.add_argument(
+        "--verification-precision-tolerance",
+        type=float,
+        help="Override tolerance for decimal replay consistency",
+    )
+    verification_group.add_argument(
+        "--verification-variance-ceiling",
+        type=float,
+        help="Override maximum acceptable variance ratio",
+    )
+    verification_group.add_argument(
+        "--verification-spectral-ceiling",
+        type=float,
+        help="Override maximum acceptable spectral energy ratio",
+    )
     governance_group = parser.add_argument_group("Governance timelock")
     governance_group.add_argument(
         "--timelock-delay",
@@ -283,6 +298,9 @@ def main() -> None:
                 "confidence_level": args.verification_confidence,
                 "stress_threshold": args.verification_stress_threshold,
                 "entropy_floor": args.verification_entropy,
+                "precision_replay_tolerance": args.verification_precision_tolerance,
+                "variance_ratio_ceiling": args.verification_variance_ceiling,
+                "spectral_energy_ceiling": args.verification_spectral_ceiling,
             }.items()
             if value is not None
         }
@@ -397,6 +415,19 @@ def main() -> None:
     lower, upper = verification.bootstrap_interval
     print(
         f"  • Bootstrap CI [{lower:.4f}, {upper:.4f}] | pass {verification.pass_confidence}"
+    )
+    print(
+        f"  • Decimal replay {verification.precision_replay_score:.4f}"
+        f" (Δ {verification.precision_replay_score - verification.primary_score:+.4f})"
+        f" | pass {verification.pass_precision_replay}"
+    )
+    print(
+        f"  • Variance ratio {verification.variance_ratio:.4f}"
+        f" | pass {verification.pass_variance_ratio}"
+    )
+    print(
+        f"  • Spectral ratio {verification.spectral_ratio:.4f}"
+        f" | pass {verification.pass_spectral_ratio}"
     )
     print(
         f"  • Monotonic violations {verification.monotonic_violations} | pass {verification.monotonic_pass}"


### PR DESCRIPTION
## Summary
- add an independent assurance auditor that recomputes program scores with decimal replay, variance forensics, and spectral leak detection
- expose new governance-controlled verification thresholds across the owner console, CLI, orchestrator, and HTML report
- extend the automated test suite with dedicated assurance coverage and updated policy override checks

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68f821fdf21083339471e195135e7418