### PR TITLE
Enhance One-Box governance diagnostics for readiness

### DIFF
--- a/demo/One-Box/.env.example
+++ b/demo/One-Box/.env.example
@@ -3,8 +3,10 @@
 RPC_URL=https://sepolia.infura.io/v3/your-key
 # Deployed AGI Jobs job registry contract address
 JOB_REGISTRY_ADDRESS=0x0000000000000000000000000000000000000000
-# Optional: stake manager and agent registry overrides (leave blank to reuse defaults)
+# Optional: stake manager and system pause overrides (leave blank to reuse defaults)
 STAKE_MANAGER_ADDRESS=
+SYSTEM_PAUSE_ADDRESS=
+# Optional: agent identity (EOA or ENS) monitored by the gateway utilities
 AGENT_ADDRESS=
 
 # === Relayer credentials ===

--- a/demo/One-Box/README.md
+++ b/demo/One-Box/README.md
@@ -50,7 +50,7 @@ The orchestrator keeps ownership controls in the loop at every stage—jobs are 
    ```sh
    npm run demo:onebox:doctor
    ```
-   The doctor checks required environment variables, pings your RPC to confirm the active chain, verifies that `JOB_REGISTRY_ADDRESS` points to live bytecode, inspects port availability before launch, surfaces active guardrail caps, prints the launch URL, and reminds the operator of the core owner-control commands.
+   The doctor checks required environment variables, pings your RPC to confirm the active chain, verifies that `JOB_REGISTRY_ADDRESS`, `STAKE_MANAGER_ADDRESS`, and `SYSTEM_PAUSE_ADDRESS` resolve to deployed bytecode, inspects port availability before launch, surfaces active guardrail caps, prints the launch URL, and reminds the operator of the core owner-control commands. It also classifies the configured agent identity (EOA or ENS) so operators know which wallet will auto-respond to jobs.
 4. **Launch the One-Box:**
    ```sh
    npm run demo:onebox:launch
@@ -114,6 +114,8 @@ The launcher merges CLI flags and environment variables, de-duplicates prompts, 
 | --- | --- |
 | `RPC_URL` | JSON-RPC endpoint used by the orchestrator provider. |
 | `JOB_REGISTRY_ADDRESS` | Address of the deployed AGI Jobs job registry. |
+| `STAKE_MANAGER_ADDRESS` | Address of the staking manager contract controlling agent collateral. |
+| `SYSTEM_PAUSE_ADDRESS` | Address of the `SystemPause` contract that can halt the platform. |
 | `ONEBOX_RELAYER_PRIVATE_KEY` | EOA key that signs transactions on the user’s behalf. Fund with ETH + AGIALPHA. |
 | `ONEBOX_API_TOKEN` | Optional bearer token protecting `/onebox/*`. Leave empty for local demos. |
 | `ONEBOX_PORT` / `ONEBOX_UI_PORT` | Ports for the orchestrator API and UI server. |
@@ -125,6 +127,7 @@ The launcher merges CLI flags and environment variables, de-duplicates prompts, 
 | `ONEBOX_MAX_JOB_BUDGET_AGIA` | Optional per-job reward ceiling enforced before execution. Blank disables the cap. |
 | `ONEBOX_MAX_JOB_DURATION_DAYS` | Optional lifecycle limit in days; jobs exceeding it are blocked before funding. |
 | `PINNER_*` | Optional IPFS pinning credentials to persist specs/receipts. |
+| `AGENT_ADDRESS` | Optional agent identity (EOA or ENS) monitored by the gateway utilities. |
 
 ## Owner control & observability
 

--- a/demo/One-Box/lib/launcher.js
+++ b/demo/One-Box/lib/launcher.js
@@ -318,6 +318,11 @@ function resolveConfig(env, options = {}) {
   const explorerBase = (options.explorerBase ?? env.ONEBOX_EXPLORER_TX_BASE ?? env.NEXT_PUBLIC_ONEBOX_EXPLORER_TX_BASE ?? '').trim();
   const welcomeMessage = (options.welcomeMessage ?? env.ONEBOX_UI_WELCOME ?? '').toString().trim();
 
+  const jobRegistryAddress = (env.JOB_REGISTRY_ADDRESS ?? '').trim();
+  const stakeManagerAddress = (env.STAKE_MANAGER_ADDRESS ?? '').trim();
+  const systemPauseAddress = (env.SYSTEM_PAUSE_ADDRESS ?? '').trim();
+  const agentAddress = (env.AGENT_ADDRESS ?? '').trim();
+
   const exampleSources = [];
   if (env.ONEBOX_UI_SHORTCUTS !== undefined) {
     exampleSources.push(env.ONEBOX_UI_SHORTCUTS);
@@ -406,6 +411,10 @@ function resolveConfig(env, options = {}) {
     maxJobDurationDays,
     welcomeMessage,
     shortcutExamples,
+    jobRegistryAddress,
+    stakeManagerAddress,
+    systemPauseAddress,
+    agentAddress,
   };
 }
 

--- a/demo/One-Box/test/launcher.test.cjs
+++ b/demo/One-Box/test/launcher.test.cjs
@@ -43,6 +43,9 @@ test('resolveConfig normalises prefix and derives defaults', () => {
     ONEBOX_UI_PORT: '4400',
     ONEBOX_PUBLIC_ONEBOX_PREFIX: 'mission-control/',
     ONEBOX_API_TOKEN: 'demo',
+    STAKE_MANAGER_ADDRESS: '0xabc',
+    SYSTEM_PAUSE_ADDRESS: '0xdef',
+    AGENT_ADDRESS: 'agent.example.eth',
   };
   const config = resolveConfig(env);
   assert.equal(config.orchestratorPort, 9010);
@@ -55,6 +58,10 @@ test('resolveConfig normalises prefix and derives defaults', () => {
   assert.equal(config.welcomeMessage, '');
   assert.deepEqual(config.shortcutExamples, []);
   assert.deepEqual(config.warnings, []);
+  assert.equal(config.jobRegistryAddress, '0x1234');
+  assert.equal(config.stakeManagerAddress, '0xabc');
+  assert.equal(config.systemPauseAddress, '0xdef');
+  assert.equal(config.agentAddress, 'agent.example.eth');
 });
 
 test('resolveConfig allows explicit CLI overrides to win over environment', () => {
@@ -106,6 +113,9 @@ test('resolveConfig parses guardrail environment variables', () => {
     RPC_URL: 'http://localhost:8545',
     JOB_REGISTRY_ADDRESS: '0x1234',
     ONEBOX_RELAYER_PRIVATE_KEY: '0xdead',
+    STAKE_MANAGER_ADDRESS: '   0x4567   ',
+    SYSTEM_PAUSE_ADDRESS: '   ',
+    AGENT_ADDRESS: ' 0x000000000000000000000000000000000000abcd ',
     ONEBOX_MAX_JOB_BUDGET_AGIA: '45.5',
     ONEBOX_MAX_JOB_DURATION_DAYS: '7',
     ONEBOX_UI_WELCOME: 'Hello operator',
@@ -117,6 +127,9 @@ test('resolveConfig parses guardrail environment variables', () => {
   assert.equal(config.welcomeMessage, 'Hello operator');
   assert.deepEqual(config.shortcutExamples, ['Research', 'Finalize job 12']);
   assert.deepEqual(config.warnings, []);
+  assert.equal(config.stakeManagerAddress, '0x4567');
+  assert.equal(config.systemPauseAddress, '');
+  assert.equal(config.agentAddress, '0x000000000000000000000000000000000000abcd');
 });
 
 test('resolveConfig merges CLI example overrides with environment shortcuts', () => {


### PR DESCRIPTION
## Summary
- extend the One-Box RPC probe to validate stake manager and SystemPause contracts while exposing reusable address helpers
- upgrade the doctor to surface contract status, agent identity guidance, and richer runtime diagnostics for operators
- document and template the new governance variables and cover them with launcher and RPC tests

## Testing
- node --test demo/One-Box/test/rpc.test.cjs
- node --test demo/One-Box/test/launcher.test.cjs
- npm run demo:onebox:doctor


------
https://chatgpt.com/codex/tasks/task_e_68f825bd22f883338156dc51666d475c