### PR TITLE
Harden One-Box governance address validation

### DIFF
--- a/demo/One-Box/.env.example
+++ b/demo/One-Box/.env.example
@@ -3,7 +3,7 @@
 RPC_URL=https://sepolia.infura.io/v3/your-key
 # Deployed AGI Jobs job registry contract address
 JOB_REGISTRY_ADDRESS=0x0000000000000000000000000000000000000000
-# Optional: stake manager and system pause overrides (leave blank to reuse defaults)
+# Optional: stake manager and system pause overrides (leave blank to reuse network defaults, but set explicitly in demos so the owner can enforce guardrails and pause controls)
 STAKE_MANAGER_ADDRESS=
 SYSTEM_PAUSE_ADDRESS=
 # Optional: agent identity (EOA or ENS) monitored by the gateway utilities

--- a/demo/One-Box/bin/doctor.cjs
+++ b/demo/One-Box/bin/doctor.cjs
@@ -30,7 +30,9 @@ function describeContractStatus(probeEntry, { allowMissing = false } = {}) {
     case 'error':
       return `⚠️  RPC error while fetching bytecode${probeEntry.error ? `: ${probeEntry.error}` : ''}`;
     case 'missing':
-      return allowMissing ? '(not configured)' : '⚠️  Address not provided.';
+      return allowMissing
+        ? '⚠️  Address not configured. Configure it to keep owner pause controls active.'
+        : '⚠️  Address not provided.';
     default:
       return `⚠️  Unrecognised status: ${String(probeEntry.status)}`;
   }


### PR DESCRIPTION
## Summary
- enforce 0x address validation for One-Box governance controls and emit actionable warnings for missing owner guardrails
- highlight pause configuration gaps in the doctor output and document expectations in the demo environment file
- expand launcher tests to cover the stricter validation matrix

## Testing
- node --test demo/One-Box/test/launcher.test.cjs
- node --test demo/One-Box/test/rpc.test.cjs

------
https://chatgpt.com/codex/tasks/task_e_68f82cc921b48333b0e84861eab04e6a