### PR TITLE
Add resilience index telemetry to Meta-Agentic demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/README.md
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/README.md
@@ -72,6 +72,10 @@ Triple verification now runs in lockstep with an **Independent Assurance Weave**
 
 All three thresholds are owner-governed and surfaced through the CLI / JSON overrides, ensuring governance can harden or relax the assurance net instantly.
 
+#### Resilience index
+
+Every sovereign cycle now reports a **Resilience Index** – a bounded \[0,1] signal that fuses four orthogonal safety rails: the primary composite score, the harshest stress battery outcome, the entropy shield, and the bootstrap confidence centre. The index quantifies how unstoppable-yet-controllable the meta-architecture is, surfacing to owners whenever resilience slips below the configured stress threshold. Batch constellations aggregate this statistic to highlight the most unshakeable mission and the fleet's average resilience so non-technical leaders can judge when the machine is ready to deploy live capital.
+
 ```mermaid
 stateDiagram-v2
     [*] --> SeedPopulation: bootstrap diverse codelets

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/entities.py
@@ -197,6 +197,7 @@ class VerificationDigest:
     pass_variance_ratio: bool
     spectral_ratio: float
     pass_spectral_ratio: bool
+    resilience_index: float
 
     @property
     def overall_pass(self) -> bool:
@@ -242,6 +243,7 @@ class VerificationDigest:
             "pass_variance_ratio": self.pass_variance_ratio,
             "spectral_ratio": self.spectral_ratio,
             "pass_spectral_ratio": self.pass_spectral_ratio,
+            "resilience_index": self.resilience_index,
             "overall_pass": self.overall_pass,
         }
 

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/orchestrator.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/orchestrator.py
@@ -272,6 +272,18 @@ class SovereignArchitect:
         monotonic_pass, violations = self._assess_monotonicity(
             [record.best_score for record in telemetry], policy.monotonic_tolerance
         )
+        stress_anchor = (
+            min(stress_scores.values()) if stress_scores else primary_score
+        )
+        confidence_centre = sum(bootstrap_interval) / 2.0
+        resilience_components = (
+            0.4 * primary_score,
+            0.3 * stress_anchor,
+            0.2 * entropy_score,
+            0.1 * confidence_centre,
+        )
+        resilience_index = max(0.0, min(sum(resilience_components), 1.0))
+
         return VerificationDigest(
             primary_score=primary_score,
             holdout_scores=holdout_scores,
@@ -299,6 +311,7 @@ class SovereignArchitect:
             pass_variance_ratio=audit.pass_variance,
             spectral_ratio=audit.spectral_ratio,
             pass_spectral_ratio=audit.pass_spectral,
+            resilience_index=resilience_index,
         )
 
     def _stress_test_program(self, program: Program) -> Dict[str, float]:

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_orchestrator.py
@@ -55,6 +55,7 @@ def test_orchestrator_generates_artifacts(tmp_path) -> None:
     assert isinstance(verification.pass_variance_ratio, bool)
     assert 0 <= verification.spectral_ratio <= 1
     assert isinstance(verification.pass_spectral_ratio, bool)
+    assert 0 <= verification.resilience_index <= 1
 
 
 def test_orchestrator_respects_dataset_profile() -> None:

--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_report.py
@@ -50,6 +50,7 @@ def test_render_html_embeds_mermaid(tmp_path: Path) -> None:
     assert "Entropy Shield" in html
     assert "Entropy shield" in html
     assert "Entropy Shield Array" in html
+    assert "Resilience Index" in html
     assert artefacts.final_program in html
 
 
@@ -75,10 +76,13 @@ def test_export_batch_report_includes_constellation_dashboard(tmp_path: Path) ->
     payload = json.loads(batch_bundle.json_path.read_text(encoding="utf-8"))
     assert payload["summary"]["completed"] == 1
     assert payload["summary"]["best_identifier"] == scenario.identifier
+    assert payload["summary"]["resilience_identifier"] == scenario.identifier
+    assert "average_resilience" in payload["summary"]
     html = batch_bundle.html_path.read_text(encoding="utf-8")
     assert "Mission Constellation" in html
     assert scenario.title in html
     assert "Meridian Flow" in html
+    assert "Resilience" in html
     inline_html = render_batch_html(
         {scenario.identifier: artefacts},
         payload["summary"],
@@ -87,3 +91,4 @@ def test_export_batch_report_includes_constellation_dashboard(tmp_path: Path) ->
         {scenario.identifier: scenario},
     )
     assert "Pass rate" in inline_html
+    assert "Average Resilience" in inline_html

--- a/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/start_demo.py
@@ -451,6 +451,9 @@ def main() -> None:
             f"  • Stress battery: {json.dumps(digest.stress_scores)} (threshold={digest.stress_threshold:.2f}, pass={digest.pass_stress})"
         )
         print(
+            f"  • Resilience index: {digest.resilience_index:.4f} (harmonised stress/entropy/confidence)"
+        )
+        print(
             f"  • Entropy shield: score={digest.entropy_score:.4f} (floor={digest.entropy_floor:.2f}, pass={digest.pass_entropy})"
         )
         print(


### PR DESCRIPTION
## Summary
- add a resilience index to the verification digest so the orchestrator and CLI surface harmonised stress, entropy, and confidence telemetry
- extend the HTML and batch reports with resilience badges, tables, and averages so mission constellations highlight the strongest runs
- document the new resilience index signal for non-technical operators inside the demo README

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68f835a984d48333a1c5653babe81564