### PR TITLE
Add identity-gated artifact registry

### DIFF
--- a/contracts/v2/ArtifactRegistry.sol
+++ b/contracts/v2/ArtifactRegistry.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {IIdentityRegistry} from "./interfaces/IIdentityRegistry.sol";
+
+/// @title ArtifactRegistry
+/// @notice ERC721 registry that tracks cultural artifacts and their citation graph.
+contract ArtifactRegistry is ERC721, Ownable, AccessControl, Pausable, ReentrancyGuard {
+    /// @notice Author role recognised by the registry.
+    bytes32 public constant AUTHOR_ROLE = keccak256("AUTHOR_ROLE");
+
+    /// @notice Depth limit used when traversing the citation graph during minting.
+    uint256 public constant DFS_DEPTH_LIMIT = 64;
+
+    /// @notice Metadata describing a minted artifact.
+    struct Artifact {
+        string cid;
+        string kind;
+        uint256[] citations;
+        bytes32 lineageHash;
+        uint64 mintedAt;
+        uint256 influence;
+    }
+
+    /// @notice Maximum number of citations that can be recorded for a single artifact.
+    uint256 public maxCitations;
+
+    /// @notice External identity registry used for author verification.
+    IIdentityRegistry public identityRegistry;
+
+    /// @dev Incrementing token identifier (starts at 1).
+    uint256 private _nextTokenId;
+
+    /// @dev Storage for artifact metadata.
+    mapping(uint256 => Artifact) private _artifacts;
+
+    /// @dev Tracks lineage hashes to guarantee uniqueness.
+    mapping(bytes32 => uint256) private _lineageToToken;
+
+    event ArtifactMinted(uint256 indexed tokenId, address indexed author, string cid, string kind, bytes32 lineageHash);
+    event ArtifactCited(uint256 indexed tokenId, uint256 indexed citedTokenId);
+    event ArtifactInfluenceUpdated(uint256 indexed tokenId, uint256 newInfluence);
+    event ArtifactMetadataUpdated(uint256 indexed tokenId, string cid, string kind, bytes32 lineageHash);
+    event MaxCitationsUpdated(uint256 newMaxCitations);
+    event IdentityRegistryUpdated(address indexed previousRegistry, address indexed newRegistry);
+
+    error UnauthorizedAuthor(address account);
+    error InvalidIdentityRegistry();
+    error IdentityRegistryNotSet();
+    error InvalidSubdomain();
+    error EmptyCID();
+    error EmptyKind();
+    error UnknownArtifact(uint256 tokenId);
+    error DuplicateCitation(uint256 citedTokenId);
+    error CitationCycle(uint256 startTokenId, uint256 loopTokenId);
+    error CitationDepthExceeded(uint256 depthLimit);
+    error LineageHashInUse(bytes32 lineageHash, uint256 existingTokenId);
+    error MaxCitationsExceeded(uint256 attempted, uint256 maxAllowed);
+    error NotTokenOwnerOrApproved(uint256 tokenId, address caller);
+
+    constructor(string memory name_, string memory symbol_, uint256 maxCitations_)
+        ERC721(name_, symbol_)
+        Ownable(msg.sender)
+    {
+        if (maxCitations_ == 0) revert MaxCitationsExceeded(0, 0);
+
+        maxCitations = maxCitations_;
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(AUTHOR_ROLE, msg.sender);
+    }
+
+    /// @notice Mint a new artifact NFT and register its metadata.
+    /// @param cid IPFS or metadata content identifier for the artifact body.
+    /// @param kind Human readable artifact kind (e.g. "prompt", "model").
+    /// @param lineageHash Hash summarising the artifact's lineage to guarantee uniqueness.
+    /// @param citations List of artifact ids that this artifact cites.
+    /// @param subdomain ENS-like identifier supplied for IdentityRegistry attestation.
+    /// @param proof Merkle proof accompanying the IdentityRegistry verification.
+    /// @return tokenId Identifier of the newly minted artifact NFT.
+    function mintArtifact(
+        string calldata cid,
+        string calldata kind,
+        bytes32 lineageHash,
+        uint256[] calldata citations,
+        string calldata subdomain,
+        bytes32[] calldata proof
+    ) external whenNotPaused nonReentrant returns (uint256 tokenId) {
+        _assertAuthorised(msg.sender, subdomain, proof);
+        if (bytes(cid).length == 0) revert EmptyCID();
+        if (bytes(kind).length == 0) revert EmptyKind();
+
+        uint256 citationCount = citations.length;
+        if (citationCount > maxCitations) revert MaxCitationsExceeded(citationCount, maxCitations);
+
+        if (_lineageToToken[lineageHash] != 0) {
+            revert LineageHashInUse(lineageHash, _lineageToToken[lineageHash]);
+        }
+
+        tokenId = _nextTokenId + 1;
+        _enforceCitationInvariants(tokenId, citations);
+
+        _nextTokenId = tokenId;
+        Artifact storage artifact = _artifacts[tokenId];
+        artifact.cid = cid;
+        artifact.kind = kind;
+        artifact.lineageHash = lineageHash;
+        artifact.mintedAt = uint64(block.timestamp);
+
+        _storeCitations(tokenId, artifact, citations);
+        _lineageToToken[lineageHash] = tokenId;
+
+        _safeMint(msg.sender, tokenId);
+
+        emit ArtifactMinted(tokenId, msg.sender, cid, kind, lineageHash);
+    }
+
+    /// @notice Update mutable metadata for an artifact.
+    /// @dev Only token owner or approved operator may update metadata.
+    function updateArtifactMetadata(uint256 tokenId, string calldata cid, string calldata kind, bytes32 lineageHash)
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        address tokenOwner = _ownerOf(tokenId);
+        if (tokenOwner == address(0)) revert UnknownArtifact(tokenId);
+        if (msg.sender != tokenOwner && getApproved(tokenId) != msg.sender && !isApprovedForAll(tokenOwner, msg.sender))
+        {
+            revert NotTokenOwnerOrApproved(tokenId, msg.sender);
+        }
+        if (bytes(cid).length == 0) revert EmptyCID();
+        if (bytes(kind).length == 0) revert EmptyKind();
+
+        Artifact storage artifact = _artifacts[tokenId];
+        bytes32 previousHash = artifact.lineageHash;
+        if (lineageHash != previousHash) {
+            uint256 existing = _lineageToToken[lineageHash];
+            if (existing != 0 && existing != tokenId) {
+                revert LineageHashInUse(lineageHash, existing);
+            }
+            if (previousHash != bytes32(0)) {
+                _lineageToToken[previousHash] = 0;
+            }
+            _lineageToToken[lineageHash] = tokenId;
+            artifact.lineageHash = lineageHash;
+        }
+
+        artifact.cid = cid;
+        artifact.kind = kind;
+
+        emit ArtifactMetadataUpdated(tokenId, cid, kind, lineageHash);
+    }
+
+    /// @notice Retrieve immutable and mutable metadata for an artifact.
+    function getArtifact(uint256 tokenId) external view returns (Artifact memory) {
+        if (_ownerOf(tokenId) == address(0)) revert UnknownArtifact(tokenId);
+
+        Artifact storage stored = _artifacts[tokenId];
+        Artifact memory copy;
+        copy.cid = stored.cid;
+        copy.kind = stored.kind;
+        copy.lineageHash = stored.lineageHash;
+        copy.mintedAt = stored.mintedAt;
+        copy.influence = stored.influence;
+
+        uint256 length = stored.citations.length;
+        copy.citations = new uint256[](length);
+        for (uint256 i; i < length; ++i) {
+            copy.citations[i] = stored.citations[i];
+        }
+        return copy;
+    }
+
+    /// @notice Return the owner of a lineage hash if registered.
+    function lineageOwner(bytes32 lineageHash) external view returns (uint256 tokenId) {
+        return _lineageToToken[lineageHash];
+    }
+
+    /// @notice Update the maximum permitted citations per artifact.
+    function setMaxCitations(uint256 newMax) external onlyOwner {
+        if (newMax == 0) revert MaxCitationsExceeded(0, maxCitations);
+        maxCitations = newMax;
+        emit MaxCitationsUpdated(newMax);
+    }
+
+    /// @notice Pause mutating operations.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Resume minting and metadata updates.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /// @notice Configure the external IdentityRegistry used for author verification.
+    function setIdentityRegistry(IIdentityRegistry newRegistry) external onlyOwner {
+        if (address(newRegistry) == address(0)) revert InvalidIdentityRegistry();
+        if (newRegistry.version() != 2) revert InvalidIdentityRegistry();
+
+        address previous = address(identityRegistry);
+        identityRegistry = newRegistry;
+
+        emit IdentityRegistryUpdated(previous, address(newRegistry));
+    }
+
+    /// @notice Helper returning the next token identifier that will be assigned.
+    function nextTokenId() external view returns (uint256) {
+        return _nextTokenId + 1;
+    }
+
+    /// @inheritdoc ERC721
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        if (_ownerOf(tokenId) == address(0)) revert UnknownArtifact(tokenId);
+        return _artifacts[tokenId].cid;
+    }
+
+    /// @inheritdoc AccessControl
+    function supportsInterface(bytes4 interfaceId) public view override(ERC721, AccessControl) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function _storeCitations(uint256 tokenId, Artifact storage artifact, uint256[] calldata citations) internal {
+        uint256 length = citations.length;
+        for (uint256 i; i < length; ++i) {
+            uint256 citedId = citations[i];
+            artifact.citations.push(citedId);
+            Artifact storage cited = _artifacts[citedId];
+            cited.influence += 1;
+            emit ArtifactInfluenceUpdated(citedId, cited.influence);
+            emit ArtifactCited(tokenId, citedId);
+        }
+    }
+
+    function _assertAuthorised(address account, string calldata subdomain, bytes32[] calldata proof) internal view {
+        if (hasRole(AUTHOR_ROLE, account)) {
+            return;
+        }
+
+        IIdentityRegistry registry = identityRegistry;
+        if (address(registry) == address(0)) revert IdentityRegistryNotSet();
+        if (bytes(subdomain).length == 0) revert InvalidSubdomain();
+
+        bool ok = registry.isAuthorizedAgent(account, subdomain, proof);
+        if (!ok) revert UnauthorizedAuthor(account);
+    }
+
+    function _enforceCitationInvariants(uint256 tokenId, uint256[] calldata citations) internal view {
+        uint256 length = citations.length;
+        uint256[] memory path = new uint256[](DFS_DEPTH_LIMIT);
+        for (uint256 i; i < length; ++i) {
+            uint256 citedId = citations[i];
+            _assertArtifactExists(citedId);
+
+            for (uint256 j; j < i; ++j) {
+                if (citations[j] == citedId) revert DuplicateCitation(citedId);
+            }
+
+            _verifyAcyclic(tokenId, citedId, 0, path);
+        }
+    }
+
+    function _verifyAcyclic(uint256 originId, uint256 currentId, uint256 depth, uint256[] memory path) internal view {
+        if (depth >= DFS_DEPTH_LIMIT) revert CitationDepthExceeded(DFS_DEPTH_LIMIT);
+        path[depth] = currentId;
+
+        Artifact storage node = _artifacts[currentId];
+        uint256 length = node.citations.length;
+        for (uint256 i; i < length; ++i) {
+            uint256 nextId = node.citations[i];
+            if (nextId == originId) revert CitationCycle(originId, currentId);
+
+            for (uint256 j; j <= depth; ++j) {
+                if (path[j] == nextId) revert CitationCycle(originId, nextId);
+            }
+
+            _verifyAcyclic(originId, nextId, depth + 1, path);
+        }
+    }
+
+    function _assertArtifactExists(uint256 tokenId) internal view {
+        if (tokenId == 0 || _ownerOf(tokenId) == address(0)) revert UnknownArtifact(tokenId);
+    }
+}

--- a/test/v2/ArtifactRegistry.t.sol
+++ b/test/v2/ArtifactRegistry.t.sol
@@ -1,0 +1,531 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+import {ArtifactRegistry} from "../../contracts/v2/ArtifactRegistry.sol";
+import {IIdentityRegistry} from "../../contracts/v2/interfaces/IIdentityRegistry.sol";
+
+contract IdentityStub is IIdentityRegistry {
+    uint256 public constant version = 2;
+
+    mapping(address => bool) public authorised;
+
+    function setAuthorised(address account, bool allowed) external {
+        authorised[account] = allowed;
+    }
+
+    // --- IIdentityRegistry ---
+    function isAuthorizedAgent(address claimant, string calldata subdomain, bytes32[] calldata)
+        external
+        view
+        override
+        returns (bool)
+    {
+        if (bytes(subdomain).length == 0) {
+            return false;
+        }
+        return authorised[claimant];
+    }
+
+    function isAuthorizedValidator(address, string calldata, bytes32[] calldata) external pure override returns (bool) {
+        return false;
+    }
+
+    function verifyAgent(address claimant, string calldata subdomain, bytes32[] calldata)
+        external
+        view
+        override
+        returns (bool ok, bytes32 node, bool, bool)
+    {
+        ok = authorised[claimant] && bytes(subdomain).length > 0;
+        node = bytes32(0);
+    }
+
+    function verifyValidator(address, string calldata, bytes32[] calldata)
+        external
+        pure
+        override
+        returns (bool, bytes32, bool, bool)
+    {
+        return (false, bytes32(0), false, false);
+    }
+
+    function verifyNode(address, string calldata, bytes32[] calldata)
+        external
+        pure
+        override
+        returns (bool, bytes32, bool, bool)
+    {
+        return (false, bytes32(0), false, false);
+    }
+
+    function setENS(address) external override {}
+
+    function setNameWrapper(address) external override {}
+
+    function setReputationEngine(address) external override {}
+
+    function setAgentRootNode(bytes32) external override {}
+
+    function setClubRootNode(bytes32) external override {}
+
+    function setNodeRootNode(bytes32) external override {}
+
+    function setAgentMerkleRoot(bytes32) external override {}
+
+    function setValidatorMerkleRoot(bytes32) external override {}
+
+    function addAdditionalAgent(address account) external override {
+        authorised[account] = true;
+    }
+
+    function removeAdditionalAgent(address account) external override {
+        authorised[account] = false;
+    }
+
+    function addAdditionalValidator(address) external override {}
+
+    function removeAdditionalValidator(address) external override {}
+
+    function addAdditionalNodeOperator(address) external override {}
+
+    function removeAdditionalNodeOperator(address) external override {}
+
+    function setAgentType(address, AgentType) external override {}
+
+    function additionalAgents(address account) external view override returns (bool) {
+        return authorised[account];
+    }
+
+    function additionalValidators(address) external pure override returns (bool) {
+        return false;
+    }
+
+    function additionalNodeOperators(address) external pure override returns (bool) {
+        return false;
+    }
+
+    function getAgentType(address) external pure override returns (AgentType) {
+        return AgentType.Human;
+    }
+
+    function setAgentProfileURI(address, string calldata) external override {}
+
+    function updateAgentProfile(string calldata, bytes32[] calldata, string calldata) external override {}
+
+    function agentProfileURI(address) external pure override returns (string memory) {
+        return "";
+    }
+}
+
+contract ReentrantAuthor is IERC721Receiver {
+    ArtifactRegistry public immutable registry;
+    bytes32 public immutable lineageHash;
+
+    constructor(ArtifactRegistry registry_, bytes32 lineageHash_) {
+        registry = registry_;
+        lineageHash = lineageHash_;
+    }
+
+    function mint(string calldata cid, string calldata kind) external {
+        bytes32[] memory proof;
+        uint256[] memory cites;
+        registry.mintArtifact(cid, kind, lineageHash, cites, "author", proof);
+    }
+
+    function onERC721Received(address, address, uint256, bytes calldata) external override returns (bytes4) {
+        bytes32[] memory proof;
+        uint256[] memory cites;
+        // Attempt a re-entrant mint which should fail due to the guard.
+        try registry.mintArtifact("ipfs://reenter", "loop", bytes32("loop"), cites, "author", proof) {
+            revert("Reentrancy was not prevented");
+        } catch {}
+
+        return IERC721Receiver.onERC721Received.selector;
+    }
+}
+
+contract ArtifactRegistryTest is Test {
+    ArtifactRegistry internal registry;
+    IdentityStub internal identity;
+
+    address internal constant ADMIN = address(0xA11D);
+    address internal constant ALICE = address(0xA11CE);
+    address internal constant BOB = address(0xB0B);
+
+    function setUp() public {
+        identity = new IdentityStub();
+        vm.startPrank(ADMIN);
+        registry = new ArtifactRegistry("Artifacts", "ART", 8);
+        registry.setIdentityRegistry(identity);
+        registry.grantRole(registry.DEFAULT_ADMIN_ROLE(), address(this));
+        vm.stopPrank();
+        identity.setAuthorised(ALICE, true);
+    }
+
+    function testMintArtifactStoresMetadata() public {
+        bytes32[] memory proof;
+        uint256[] memory cites;
+
+        vm.prank(ALICE);
+        uint256 tokenId = registry.mintArtifact("ipfs://artifact-1", "model", bytes32("hash1"), cites, "alice", proof);
+
+        assertEq(tokenId, 1);
+        assertEq(registry.ownerOf(tokenId), ALICE);
+
+        ArtifactRegistry.Artifact memory data = registry.getArtifact(tokenId);
+        assertEq(data.cid, "ipfs://artifact-1");
+        assertEq(data.kind, "model");
+        assertEq(data.lineageHash, bytes32("hash1"));
+        assertEq(data.citations.length, 0);
+        assertGt(data.mintedAt, 0);
+        assertEq(data.influence, 0);
+    }
+
+    function testMintFanOutUpdatesInfluence() public {
+        bytes32[] memory proof;
+        uint256[] memory empty;
+
+        vm.prank(ADMIN);
+        uint256 baseA = registry.mintArtifact("ipfs://baseA", "dataset", bytes32("a"), empty, "owner", proof);
+        vm.prank(ADMIN);
+        uint256 baseB = registry.mintArtifact("ipfs://baseB", "dataset", bytes32("b"), empty, "owner", proof);
+
+        uint256[] memory cites = new uint256[](2);
+        cites[0] = baseA;
+        cites[1] = baseB;
+
+        vm.prank(ALICE);
+        uint256 fanOut = registry.mintArtifact("ipfs://fanout", "model", bytes32("fan"), cites, "alice", proof);
+        assertEq(fanOut, 3);
+
+        ArtifactRegistry.Artifact memory a = registry.getArtifact(baseA);
+        ArtifactRegistry.Artifact memory b = registry.getArtifact(baseB);
+        assertEq(a.influence, 1);
+        assertEq(b.influence, 1);
+
+        ArtifactRegistry.Artifact memory minted = registry.getArtifact(fanOut);
+        assertEq(minted.citations.length, 2);
+        assertEq(minted.citations[0], baseA);
+        assertEq(minted.citations[1], baseB);
+    }
+
+    function testMintRevertsForDuplicateCitations() public {
+        bytes32[] memory proof;
+        uint256[] memory empty;
+        vm.prank(ADMIN);
+        uint256 base = registry.mintArtifact("ipfs://base", "dataset", bytes32("base"), empty, "owner", proof);
+
+        uint256[] memory cites = new uint256[](2);
+        cites[0] = base;
+        cites[1] = base;
+
+        vm.startPrank(ALICE);
+        vm.expectRevert(abi.encodeWithSelector(ArtifactRegistry.DuplicateCitation.selector, base));
+        registry.mintArtifact("ipfs://dup", "model", bytes32("dup"), cites, "alice", proof);
+        vm.stopPrank();
+    }
+
+    function testMintRespectsDepthLimit() public {
+        bytes32[] memory proof;
+
+        uint256 previous;
+        for (uint256 i; i <= registry.DFS_DEPTH_LIMIT(); ++i) {
+            uint256[] memory cites;
+            if (previous != 0) {
+                cites = new uint256[](1);
+                cites[0] = previous;
+            }
+            vm.prank(ADMIN);
+            previous = registry.mintArtifact(
+                string.concat("ipfs://chain-", vm.toString(i)),
+                "dataset",
+                bytes32(uint256(i + 1)),
+                cites,
+                "owner",
+                proof
+            );
+        }
+
+        uint256[] memory citeRoot = new uint256[](1);
+        citeRoot[0] = previous;
+
+        vm.startPrank(ALICE);
+        vm.expectRevert(
+            abi.encodeWithSelector(ArtifactRegistry.CitationDepthExceeded.selector, registry.DFS_DEPTH_LIMIT())
+        );
+        registry.mintArtifact("ipfs://deep", "model", bytes32("deep"), citeRoot, "alice", proof);
+        vm.stopPrank();
+    }
+
+    function testMintRevertsWhenIdentityNotAuthorised() public {
+        bytes32[] memory proof;
+        uint256[] memory cites;
+
+        vm.startPrank(BOB);
+        vm.expectRevert(abi.encodeWithSelector(ArtifactRegistry.UnauthorizedAuthor.selector, BOB));
+        registry.mintArtifact("ipfs://bob", "model", bytes32("bob"), cites, "bob", proof);
+        vm.stopPrank();
+    }
+
+    function testGrantRoleBypassesIdentity() public {
+        bytes32[] memory proof;
+        uint256[] memory cites;
+
+        vm.prank(ADMIN);
+        registry.grantRole(registry.AUTHOR_ROLE(), BOB);
+
+        vm.prank(BOB);
+        uint256 tokenId = registry.mintArtifact("ipfs://bob", "model", bytes32("bob"), cites, "", proof);
+        assertEq(tokenId, 1);
+    }
+
+    function testUpdateArtifactMetadata() public {
+        bytes32[] memory proof;
+        uint256[] memory cites;
+        vm.prank(ALICE);
+        uint256 tokenId = registry.mintArtifact("ipfs://artifact", "prompt", bytes32("hash"), cites, "alice", proof);
+
+        vm.prank(ALICE);
+        registry.updateArtifactMetadata(tokenId, "ipfs://updated", "prompt-v2", bytes32("hash-new"));
+
+        ArtifactRegistry.Artifact memory data = registry.getArtifact(tokenId);
+        assertEq(data.cid, "ipfs://updated");
+        assertEq(data.lineageHash, bytes32("hash-new"));
+        assertEq(registry.lineageOwner(bytes32("hash-new")), tokenId);
+    }
+
+    function testUpdateMetadataRequiresOwnerOrApproved() public {
+        bytes32[] memory proof;
+        uint256[] memory cites;
+        vm.prank(ALICE);
+        uint256 tokenId = registry.mintArtifact("ipfs://artifact", "prompt", bytes32("hash"), cites, "alice", proof);
+
+        vm.startPrank(BOB);
+        vm.expectRevert(abi.encodeWithSelector(ArtifactRegistry.NotTokenOwnerOrApproved.selector, tokenId, BOB));
+        registry.updateArtifactMetadata(tokenId, "ipfs://other", "prompt", bytes32("hash2"));
+        vm.stopPrank();
+    }
+
+    function testPausePreventsMint() public {
+        vm.prank(ADMIN);
+        registry.pause();
+
+        bytes32[] memory proof;
+        uint256[] memory cites;
+        vm.startPrank(ALICE);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        registry.mintArtifact("ipfs://paused", "model", bytes32("p"), cites, "alice", proof);
+        vm.stopPrank();
+    }
+
+    function testSetMaxCitations() public {
+        vm.prank(ADMIN);
+        registry.setMaxCitations(16);
+        assertEq(registry.maxCitations(), 16);
+
+        vm.expectRevert(abi.encodeWithSelector(ArtifactRegistry.MaxCitationsExceeded.selector, 0, 16));
+        vm.prank(ADMIN);
+        registry.setMaxCitations(0);
+    }
+
+    function testIdentityRegistryVersionCheck() public {
+        BadIdentity bad = new BadIdentity();
+        vm.expectRevert(ArtifactRegistry.InvalidIdentityRegistry.selector);
+        vm.prank(ADMIN);
+        registry.setIdentityRegistry(bad);
+    }
+
+    function testReentrancyGuardBlocksNestedMint() public {
+        vm.prank(ADMIN);
+        registry.grantRole(registry.AUTHOR_ROLE(), address(this));
+
+        ReentrantAuthor attacker = new ReentrantAuthor(registry, bytes32("outer"));
+        vm.prank(ADMIN);
+        registry.grantRole(registry.AUTHOR_ROLE(), address(attacker));
+
+        attacker.mint("ipfs://outer", "loop");
+        assertEq(registry.ownerOf(1), address(attacker));
+    }
+
+    function testFuzzLineageHashUniqueness(bytes32 firstHash, bytes32 secondHash) public {
+        bytes32[] memory proof;
+        uint256[] memory cites;
+
+        vm.prank(ALICE);
+        registry.mintArtifact("ipfs://first", "kind", firstHash, cites, "alice", proof);
+
+        vm.assume(secondHash != firstHash);
+
+        vm.prank(ALICE);
+        registry.mintArtifact("ipfs://second", "kind", secondHash, cites, "alice", proof);
+    }
+
+    function testFuzzCitationCountCaps(uint8 citeCount, bytes32 seed) public {
+        bytes32[] memory proof;
+        uint256[] memory empty;
+
+        uint256 available = registry.maxCitations();
+        vm.assume(citeCount > available);
+
+        uint256[] memory mintedIds = new uint256[](available);
+        for (uint256 i; i < available; ++i) {
+            vm.prank(ADMIN);
+            mintedIds[i] = registry.mintArtifact(
+                string.concat("ipfs://base-", vm.toString(i)),
+                "kind",
+                keccak256(abi.encode(seed, i)),
+                empty,
+                "owner",
+                proof
+            );
+        }
+
+        uint256[] memory cites = new uint256[](citeCount);
+        for (uint256 i; i < citeCount; ++i) {
+            cites[i] = mintedIds[i % available];
+        }
+
+        vm.startPrank(ALICE);
+        vm.expectRevert(abi.encodeWithSelector(ArtifactRegistry.MaxCitationsExceeded.selector, citeCount, available));
+        registry.mintArtifact("ipfs://overflow", "kind", keccak256(abi.encode(seed, "overflow")), cites, "alice", proof);
+        vm.stopPrank();
+    }
+
+    function testFuzzCitationGraph(uint8 width, uint8 depth) public {
+        width = uint8(bound(width, 1, 3));
+        depth = uint8(bound(depth, 1, 4));
+        bytes32[] memory proof;
+
+        uint256[][] memory levels = new uint256[][](depth);
+        for (uint256 level; level < depth; ++level) {
+            levels[level] = new uint256[](width);
+            for (uint256 index; index < width; ++index) {
+                uint256[] memory cites;
+                if (level > 0) {
+                    cites = new uint256[](width);
+                    for (uint256 j; j < width; ++j) {
+                        cites[j] = levels[level - 1][j];
+                    }
+                }
+
+                vm.prank(ADMIN);
+                levels[level][index] = registry.mintArtifact(
+                    string.concat("ipfs://node-", vm.toString(level), "-", vm.toString(index)),
+                    "kind",
+                    keccak256(abi.encode(level, index)),
+                    cites,
+                    "owner",
+                    proof
+                );
+            }
+        }
+
+        uint256 target = levels[depth - 1][0];
+        ArtifactRegistry.Artifact memory data = registry.getArtifact(target);
+        if (depth > 1) {
+            assertEq(data.citations.length, width);
+        } else {
+            assertEq(data.citations.length, 0);
+        }
+    }
+}
+
+contract BadIdentity is IIdentityRegistry {
+    function version() external pure override returns (uint256) {
+        return 1;
+    }
+
+    function isAuthorizedAgent(address, string calldata, bytes32[] calldata) external pure override returns (bool) {
+        return false;
+    }
+
+    function isAuthorizedValidator(address, string calldata, bytes32[] calldata) external pure override returns (bool) {
+        return false;
+    }
+
+    function verifyAgent(address, string calldata, bytes32[] calldata)
+        external
+        pure
+        override
+        returns (bool, bytes32, bool, bool)
+    {
+        return (false, bytes32(0), false, false);
+    }
+
+    function verifyValidator(address, string calldata, bytes32[] calldata)
+        external
+        pure
+        override
+        returns (bool, bytes32, bool, bool)
+    {
+        return (false, bytes32(0), false, false);
+    }
+
+    function verifyNode(address, string calldata, bytes32[] calldata)
+        external
+        pure
+        override
+        returns (bool, bytes32, bool, bool)
+    {
+        return (false, bytes32(0), false, false);
+    }
+
+    function setENS(address) external pure override {}
+
+    function setNameWrapper(address) external pure override {}
+
+    function setReputationEngine(address) external pure override {}
+
+    function setAgentRootNode(bytes32) external pure override {}
+
+    function setClubRootNode(bytes32) external pure override {}
+
+    function setNodeRootNode(bytes32) external pure override {}
+
+    function setAgentMerkleRoot(bytes32) external pure override {}
+
+    function setValidatorMerkleRoot(bytes32) external pure override {}
+
+    function addAdditionalAgent(address) external pure override {}
+
+    function removeAdditionalAgent(address) external pure override {}
+
+    function addAdditionalValidator(address) external pure override {}
+
+    function removeAdditionalValidator(address) external pure override {}
+
+    function addAdditionalNodeOperator(address) external pure override {}
+
+    function removeAdditionalNodeOperator(address) external pure override {}
+
+    function setAgentType(address, AgentType) external pure override {}
+
+    function additionalAgents(address) external pure override returns (bool) {
+        return false;
+    }
+
+    function additionalValidators(address) external pure override returns (bool) {
+        return false;
+    }
+
+    function additionalNodeOperators(address) external pure override returns (bool) {
+        return false;
+    }
+
+    function getAgentType(address) external pure override returns (AgentType) {
+        return AgentType.Human;
+    }
+
+    function setAgentProfileURI(address, string calldata) external pure override {}
+
+    function updateAgentProfile(string calldata, bytes32[] calldata, string calldata) external pure override {}
+
+    function agentProfileURI(address) external pure override returns (string memory) {
+        return "";
+    }
+}

--- a/test/v2/ArtifactRegistry.test.js
+++ b/test/v2/ArtifactRegistry.test.js
@@ -1,0 +1,139 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('ArtifactRegistry', function () {
+  const AUTHOR_ROLE = ethers.id('AUTHOR_ROLE');
+
+  let registry;
+  let identity;
+  let owner;
+  let author;
+  let other;
+
+  beforeEach(async () => {
+    [owner, author, other] = await ethers.getSigners();
+
+    const Registry = await ethers.getContractFactory(
+      'contracts/v2/ArtifactRegistry.sol:ArtifactRegistry'
+    );
+    registry = await Registry.deploy('Artifacts', 'ART', 8);
+    await registry.waitForDeployment();
+
+    const IdentityMock = await ethers.getContractFactory(
+      'contracts/v2/mocks/IdentityRegistryMock.sol:IdentityRegistryMock'
+    );
+    identity = await IdentityMock.deploy();
+    await identity.waitForDeployment();
+  });
+
+  it('mints artifacts with citation fan-out and updates influence', async () => {
+    await registry.setIdentityRegistry(await identity.getAddress());
+
+    const baseA = await registry.nextTokenId();
+    await registry.mintArtifact('ipfs://baseA', 'dataset', ethers.id('baseA'), [], 'owner', []);
+
+    const baseB = await registry.nextTokenId();
+    await registry.mintArtifact('ipfs://baseB', 'dataset', ethers.id('baseB'), [], 'owner', []);
+
+    await identity.addAdditionalAgent(author.address);
+
+    const fanOutId = await registry.nextTokenId();
+
+    await expect(
+      registry
+        .connect(author)
+        .mintArtifact(
+          'ipfs://fan-out',
+          'model',
+          ethers.id('fan'),
+          [baseA, baseB],
+          'author',
+          []
+        )
+    )
+      .to.emit(registry, 'ArtifactMinted')
+      .withArgs(fanOutId, author.address, 'ipfs://fan-out', 'model', ethers.id('fan'));
+
+    const baseAInfo = await registry.getArtifact(baseA);
+    const baseBInfo = await registry.getArtifact(baseB);
+    expect(baseAInfo.influence).to.equal(1n);
+    expect(baseBInfo.influence).to.equal(1n);
+
+    const minted = await registry.getArtifact(fanOutId);
+    expect(minted.citations).to.deep.equal([baseA, baseB]);
+  });
+
+  it('updates metadata for token owners', async () => {
+    await registry.setIdentityRegistry(await identity.getAddress());
+    await identity.addAdditionalAgent(author.address);
+
+    const tokenId = await registry.nextTokenId();
+    await registry
+      .connect(author)
+      .mintArtifact('ipfs://orig', 'prompt', ethers.id('orig'), [], 'author', []);
+
+    await expect(
+      registry
+        .connect(author)
+        .updateArtifactMetadata(tokenId, 'ipfs://new', 'prompt-v2', ethers.id('new'))
+    )
+      .to.emit(registry, 'ArtifactMetadataUpdated')
+      .withArgs(tokenId, 'ipfs://new', 'prompt-v2', ethers.id('new'));
+
+    const updated = await registry.getArtifact(tokenId);
+    expect(updated.cid).to.equal('ipfs://new');
+    expect(updated.lineageHash).to.equal(ethers.id('new'));
+  });
+
+  it('reverts unauthorized minting when identity registry missing', async () => {
+    await expect(
+      registry
+        .connect(other)
+        .mintArtifact('ipfs://unauth', 'model', ethers.id('unauth'), [], 'other', [])
+    ).to.be.revertedWithCustomError(registry, 'IdentityRegistryNotSet');
+  });
+
+  it('enforces citation limits', async () => {
+    await registry.setMaxCitations(2);
+    await registry.setIdentityRegistry(await identity.getAddress());
+
+    await registry.mintArtifact('ipfs://a', 'kind', ethers.id('a'), [], 'owner', []);
+    await registry.mintArtifact('ipfs://b', 'kind', ethers.id('b'), [], 'owner', []);
+    await registry.mintArtifact('ipfs://c', 'kind', ethers.id('c'), [], 'owner', []);
+
+    await identity.addAdditionalAgent(author.address);
+
+    await expect(
+      registry
+        .connect(author)
+        .mintArtifact(
+          'ipfs://overflow',
+          'model',
+          ethers.id('overflow'),
+          [1, 2, 3],
+          'author',
+          []
+        )
+    ).to.be.revertedWithCustomError(registry, 'MaxCitationsExceeded');
+  });
+
+  it('pauses and resumes minting', async () => {
+    await registry.pause();
+
+    await expect(
+      registry.mintArtifact('ipfs://paused', 'kind', ethers.id('paused'), [], 'owner', [])
+    ).to.be.revertedWithCustomError(registry, 'EnforcedPause');
+
+    await registry.unpause();
+    await registry.mintArtifact('ipfs://live', 'kind', ethers.id('live'), [], 'owner', []);
+  });
+
+  it('allows admin to grant author role directly', async () => {
+    await registry.grantRole(AUTHOR_ROLE, author.address);
+
+    await registry
+      .connect(author)
+      .mintArtifact('ipfs://role', 'prompt', ethers.id('role'), [], '', []);
+    expect(await registry.ownerOf(1)).to.equal(author.address);
+  });
+});


### PR DESCRIPTION
## Summary
- add an ERC721-based `ArtifactRegistry` that enforces lineage hashing, identity checks, and acyclic citation graphs
- cover minting, DAG invariants, role enforcement, and reentrancy with a dedicated Foundry test suite
- add Hardhat tests for admin controls, citation fan-out, and pause behaviour

## Testing
- forge test --match-contract ArtifactRegistryTest
- pnpm hardhat test test/v2/ArtifactRegistry.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f8f50573088333ab8ea9f95d7803c3