### PR TITLE
Enhance Phase 6 demo resilience telemetry

### DIFF
--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
@@ -11,6 +11,7 @@
 * **Planetary telemetry** – the subgraph now indexes `Phase6Domain` & `Phase6GlobalConfig`, letting dashboards stream readiness, resilience indices, and upgrade intents in real time.
 * **Bullet-proof governance** – every parameter is updatable by the contract owner (timelock/multisig) including emergency pause delegates and cross-chain bridges.
 * **CI as a guardian** – the `ci (v2) / Phase 6 readiness` job enforces configuration drift detection on every PR and on `main`.
+* **Resilience telemetry** – the demo computes average/min/max resilience, sentinel coverage, and value flow across finance, health, logistics, climate, and the new education lattice.
 
 ---
 
@@ -105,10 +106,10 @@ A new job in `.github/workflows/ci.yml` named **Phase 6 readiness** runs on ever
 
 Open `index.html` to explore:
 
-* Dynamic domain cards with L2 cadence, oracle routes, and skill matrices.
+* Dynamic domain cards with L2 cadence, oracle routes, resilience indices, and skill matrices.
 * Embedded mermaid system map.
 * Copyable calldata panes (auto-updated from the JSON config).
-* “One-click ready” states for finance, health, logistics, climate, plus global manifest metadata.
+* “One-click ready” states for finance, health, logistics, climate, education, plus global manifest metadata.
 
 ---
 

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json
@@ -23,7 +23,11 @@
       "metadata": {
         "domain": "Capital markets synthesis, real-time liquidity engineering",
         "l2": "Linea",
-        "sentinel": "Resilience-Index-Finance"
+        "sentinel": "Resilience-Index-Finance",
+        "resilienceIndex": 0.982,
+        "uptime": "99.982%",
+        "valueFlowMonthlyUSD": 28400000000,
+        "valueFlowDisplay": "$28.4B"
       }
     },
     {
@@ -41,7 +45,11 @@
       "metadata": {
         "domain": "Precision diagnostics, clinical validation, regulatory co-pilots",
         "l2": "Arbitrum",
-        "sentinel": "Resilience-Index-Health"
+        "sentinel": "Resilience-Index-Health",
+        "resilienceIndex": 0.975,
+        "uptime": "99.961%",
+        "valueFlowMonthlyUSD": 18600000000,
+        "valueFlowDisplay": "$18.6B"
       }
     },
     {
@@ -59,7 +67,11 @@
       "metadata": {
         "domain": "Planetary logistics, IoT coordination, smart city fulfillment",
         "l2": "Base",
-        "sentinel": "Resilience-Index-Logistics"
+        "sentinel": "Resilience-Index-Logistics",
+        "resilienceIndex": 0.968,
+        "uptime": "99.947%",
+        "valueFlowMonthlyUSD": 22400000000,
+        "valueFlowDisplay": "$22.4B"
       }
     },
     {
@@ -77,7 +89,33 @@
       "metadata": {
         "domain": "Global decarbonization, adaptive grid intelligence",
         "l2": "Polygon",
-        "sentinel": "Resilience-Index-Climate"
+        "sentinel": "Resilience-Index-Climate",
+        "resilienceIndex": 0.942,
+        "uptime": "99.923%",
+        "valueFlowMonthlyUSD": 11200000000,
+        "valueFlowDisplay": "$11.2B"
+      }
+    },
+    {
+      "slug": "education",
+      "name": "Omniversal Knowledge Cooperative",
+      "manifestURI": "ipfs://phase6/domains/education.json",
+      "subgraph": "https://phase6.montreal.ai/subgraphs/education",
+      "l2Gateway": "0x1357135713571357135713571357135713571357",
+      "oracle": "0x2468246824682468246824682468246824682468",
+      "executionRouter": "0x3579357935793579357935793579357935793579",
+      "heartbeatSeconds": 150,
+      "skillTags": ["education", "research", "training", "governance"],
+      "capabilities": { "curriculum": 4.1, "compliance": 3.9, "simulation": 4.2 },
+      "priority": 91,
+      "metadata": {
+        "domain": "Lifelong learning, institutional onboarding, policy education",
+        "l2": "Optimism",
+        "sentinel": "Resilience-Index-Education",
+        "resilienceIndex": 0.957,
+        "uptime": "99.938%",
+        "valueFlowMonthlyUSD": 9800000000,
+        "valueFlowDisplay": "$9.8B"
       }
     }
   ]

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/index.html
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/index.html
@@ -234,7 +234,7 @@
       const { Interface, keccak256, toUtf8Bytes } = await import('https://cdn.jsdelivr.net/npm/ethers@6.15.0/+esm');
       const iface = new Interface(abi);
 
-      const state = { config: null, mermaidSource: '', calldata: [] };
+      const state = { config: null, mermaidSource: '', calldata: [], metrics: null };
 
       function formatAddress(addr) {
         if (!addr || addr === zeroAddress) return '—';
@@ -261,6 +261,57 @@
         ];
       }
 
+      function formatUSD(value) {
+        if (value === undefined || value === null || Number.isNaN(Number(value))) {
+          return '—';
+        }
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) {
+          return '—';
+        }
+        if (numeric >= 1e12) {
+          return `$${(numeric / 1e12).toFixed(2)}T`;
+        }
+        if (numeric >= 1e9) {
+          return `$${(numeric / 1e9).toFixed(2)}B`;
+        }
+        if (numeric >= 1e6) {
+          return `$${(numeric / 1e6).toFixed(2)}M`;
+        }
+        return `$${numeric.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+      }
+
+      function computeMetrics(config) {
+        const resilience = [];
+        const valueFlows = [];
+        const sentinels = new Set();
+        config.domains.forEach((domain) => {
+          const idx = Number.parseFloat(domain.metadata?.resilienceIndex ?? '');
+          if (!Number.isNaN(idx)) {
+            resilience.push(idx);
+          }
+          const value = domain.metadata?.valueFlowMonthlyUSD;
+          if (typeof value === 'number' && Number.isFinite(value)) {
+            valueFlows.push(value);
+          }
+          if (domain.metadata?.sentinel) {
+            sentinels.add(String(domain.metadata.sentinel));
+          }
+        });
+        const averageResilience =
+          resilience.length > 0 ? resilience.reduce((acc, cur) => acc + cur, 0) / resilience.length : null;
+        const minResilience = resilience.length > 0 ? Math.min(...resilience) : null;
+        const maxResilience = resilience.length > 0 ? Math.max(...resilience) : null;
+        const totalValueFlow = valueFlows.reduce((acc, cur) => acc + cur, 0);
+        return {
+          averageResilience,
+          minResilience,
+          maxResilience,
+          totalValueFlow,
+          sentinelCount: sentinels.size,
+        };
+      }
+
       function renderGlobal(config) {
         const target = document.getElementById('global-summary');
         target.innerHTML = '';
@@ -272,6 +323,16 @@
           `DID registry: ${formatAddress(config.global.didRegistry)}`,
           `Network cadence baseline: ${config.global.l2SyncCadence}s`
         ];
+        if (state.metrics) {
+          const { averageResilience, minResilience, maxResilience, totalValueFlow, sentinelCount } = state.metrics;
+          if (averageResilience !== null) {
+            items.push(`Network resilience: avg ${averageResilience.toFixed(3)} (min ${minResilience?.toFixed(3)}, max ${maxResilience?.toFixed(3)})`);
+          }
+          if (totalValueFlow) {
+            items.push(`Monthly value flow across domains: ${formatUSD(totalValueFlow)}`);
+          }
+          items.push(`Active sentinels: ${sentinelCount}`);
+        }
         items.forEach((text) => {
           const span = document.createElement('span');
           span.textContent = `• ${text}`;
@@ -302,6 +363,8 @@
 
           const metrics = document.createElement('div');
           metrics.className = 'metrics';
+          const metadata = domain.metadata || {};
+          const resilience = metadata.resilienceIndex !== undefined ? Number(metadata.resilienceIndex).toFixed(3) : '—';
           metrics.innerHTML = `
             <span>Manifest URI: ${domain.manifestURI}</span>
             <span>Subgraph: ${domain.subgraph}</span>
@@ -310,6 +373,10 @@
             <span>Execution router: ${formatAddress(domain.executionRouter)}</span>
             <span>Heartbeat: ${heartbeatSummary(domain, config.global)}</span>
             <span>Skill tags: ${domain.skillTags.join(', ')}</span>
+            <span>Resilience index: ${resilience}</span>
+            <span>Monthly value flow: ${metadata.valueFlowDisplay ?? formatUSD(metadata.valueFlowMonthlyUSD)}</span>
+            <span>Domain sentinel: ${metadata.sentinel ?? '—'}</span>
+            <span>Uptime: ${metadata.uptime ?? '—'}</span>
           `;
           card.appendChild(metrics);
           grid.appendChild(card);
@@ -322,12 +389,15 @@
         config.domains.forEach((domain) => {
           const div = document.createElement('div');
           div.className = 'domain-card';
+          const metadata = domain.metadata || {};
           const bridge = {
             domain: domain.slug,
             l2Gateway: domain.l2Gateway || config.global.defaultL2Gateway,
             oracle: domain.oracle || config.global.iotOracleRouter,
             executionRouter: domain.executionRouter || zeroAddress,
             cadence: heartbeatSummary(domain, config.global),
+            sentinel: metadata.sentinel || '—',
+            resilience: metadata.resilienceIndex !== undefined ? Number(metadata.resilienceIndex).toFixed(3) : '—',
           };
           div.innerHTML = `
             <h3>${domain.name}</h3>
@@ -336,6 +406,8 @@
               <span>IoT oracle router: ${formatAddress(bridge.oracle)}</span>
               <span>Execution router: ${formatAddress(bridge.executionRouter)}</span>
               <span>${bridge.cadence}</span>
+              <span>Resilience index: ${bridge.resilience}</span>
+              <span>Sentinel coverage: ${bridge.sentinel}</span>
             </div>
           `;
           grid.appendChild(div);
@@ -393,6 +465,7 @@
         const response = await fetch(configPath);
         const cfg = await response.json();
         state.config = cfg;
+        state.metrics = computeMetrics(cfg);
         renderGlobal(cfg);
         renderDomains(cfg);
         renderBridgePlans(cfg);

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/ci-check.mjs
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/ci-check.mjs
@@ -71,6 +71,26 @@ config.domains.forEach((domain, idx) => {
   if (!Array.isArray(domain.skillTags) || domain.skillTags.length === 0) {
     fail(`${context}: skillTags must include at least one entry.`);
   }
+  const metadata = domain.metadata;
+  if (!metadata || typeof metadata !== 'object') {
+    fail(`${context}: metadata object is required.`);
+  }
+  ['domain', 'l2', 'sentinel', 'uptime'].forEach((key) => {
+    if (!metadata[key] || typeof metadata[key] !== 'string') {
+      fail(`${context}: metadata.${key} must be a non-empty string.`);
+    }
+  });
+  const resilienceIndex = Number.parseFloat(metadata.resilienceIndex);
+  if (!Number.isFinite(resilienceIndex) || resilienceIndex <= 0 || resilienceIndex > 1) {
+    fail(`${context}: metadata.resilienceIndex must be a number between 0 and 1.`);
+  }
+  const valueFlow = metadata.valueFlowMonthlyUSD;
+  if (typeof valueFlow !== 'number' || !Number.isFinite(valueFlow) || valueFlow < 0) {
+    fail(`${context}: metadata.valueFlowMonthlyUSD must be a positive number.`);
+  }
+  if (metadata.valueFlowDisplay && typeof metadata.valueFlowDisplay !== 'string') {
+    fail(`${context}: metadata.valueFlowDisplay must be a string when provided.`);
+  }
 });
 
 if (!html.includes('mermaid')) {


### PR DESCRIPTION
## Summary
- add resilience, uptime, and value-flow metadata for all Phase 6 domains and introduce the education lattice domain
- extend the orchestrator runtime, demo UI, and CLI blueprint script with network telemetry, sentinel context, and aggregated metrics
- harden the demo CI check to enforce the richer metadata contract

## Testing
- npm run demo:phase6:ci
- npm run demo:phase6:orchestrate
- npx hardhat test --no-compile test/v2/Phase6ExpansionManager.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f9945721a48333814d0e77498444a7