### PR TITLE
Enforce Phase 6 telemetry invariants

### DIFF
--- a/contracts/v2/Phase6ExpansionManager.sol
+++ b/contracts/v2/Phase6ExpansionManager.sol
@@ -74,6 +74,7 @@ contract Phase6ExpansionManager is Governable, ReentrancyGuard {
     error InvalidManifestURI();
     error InvalidMetadataURI();
     error InvalidPauseTarget(address target);
+    error InvalidSubgraphEndpoint();
 
     /// -----------------------------------------------------------------------
     /// Events
@@ -335,6 +336,7 @@ contract Phase6ExpansionManager is Governable, ReentrancyGuard {
         if (bytes(config.slug).length == 0) revert EmptySlug();
         if (bytes(config.name).length == 0) revert EmptyName();
         if (bytes(config.metadataURI).length == 0) revert InvalidMetadataURI();
+        if (bytes(config.subgraphEndpoint).length == 0) revert InvalidSubgraphEndpoint();
         if (config.heartbeatSeconds < 30) revert InvalidHeartbeat();
         _requireContract(config.validationModule, "validationModule");
         if (config.dataOracle != address(0)) {

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
@@ -51,6 +51,7 @@
 * `registerDomain`, `updateDomain`, `configureDomainConnectors`, `setDomainStatus`
 * `setGlobalConfig`, `setSystemPause`, `setEscalationBridge`, `forwardPauseCall`, `forwardEscalation`
 * Deterministic `domainId` helper & `listDomains()` enumeration for tooling.
+* Rejects missing telemetry targets – `subgraphEndpoint` is now mandatory on every domain mutation so dashboards never lose visibility.
 
 Emergency response: governance can forward any encoded call to the shared `SystemPause` contract or to an arbitrary escalation bridge. Pausing, routing, and redeployments remain one-click actions for the owner.
 

--- a/subgraph/abis/Phase6ExpansionManager.json
+++ b/subgraph/abis/Phase6ExpansionManager.json
@@ -1,18 +1,210 @@
 [
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "initialGovernance",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DuplicateDomain",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyName",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptySlug",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "needed",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "field",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "provided",
+        "type": "address"
+      }
+    ],
+    "name": "InvalidAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidHeartbeat",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidManifestURI",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidMetadataURI",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "InvalidPauseTarget",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidSubgraphEndpoint",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotGovernance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "UnknownDomain",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "bytes32", "name": "id", "type": "bytes32" },
-      { "indexed": false, "internalType": "string", "name": "slug", "type": "string" },
-      { "indexed": false, "internalType": "string", "name": "name", "type": "string" },
-      { "indexed": false, "internalType": "string", "name": "metadataURI", "type": "string" },
-      { "indexed": false, "internalType": "address", "name": "validationModule", "type": "address" },
-      { "indexed": false, "internalType": "address", "name": "dataOracle", "type": "address" },
-      { "indexed": false, "internalType": "address", "name": "l2Gateway", "type": "address" },
-      { "indexed": false, "internalType": "string", "name": "subgraphEndpoint", "type": "string" },
-      { "indexed": false, "internalType": "address", "name": "executionRouter", "type": "address" },
-      { "indexed": false, "internalType": "uint64", "name": "heartbeatSeconds", "type": "uint64" },
-      { "indexed": false, "internalType": "bool", "name": "active", "type": "bool" }
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "slug",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "metadataURI",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "validationModule",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "dataOracle",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "l2Gateway",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "subgraphEndpoint",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executionRouter",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "heartbeatSeconds",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "active",
+        "type": "bool"
+      }
     ],
     "name": "DomainRegistered",
     "type": "event"
@@ -20,26 +212,18 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "bytes32", "name": "id", "type": "bytes32" },
-      { "indexed": false, "internalType": "string", "name": "slug", "type": "string" },
-      { "indexed": false, "internalType": "string", "name": "name", "type": "string" },
-      { "indexed": false, "internalType": "string", "name": "metadataURI", "type": "string" },
-      { "indexed": false, "internalType": "address", "name": "validationModule", "type": "address" },
-      { "indexed": false, "internalType": "address", "name": "dataOracle", "type": "address" },
-      { "indexed": false, "internalType": "address", "name": "l2Gateway", "type": "address" },
-      { "indexed": false, "internalType": "string", "name": "subgraphEndpoint", "type": "string" },
-      { "indexed": false, "internalType": "address", "name": "executionRouter", "type": "address" },
-      { "indexed": false, "internalType": "uint64", "name": "heartbeatSeconds", "type": "uint64" },
-      { "indexed": false, "internalType": "bool", "name": "active", "type": "bool" }
-    ],
-    "name": "DomainUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "bytes32", "name": "id", "type": "bytes32" },
-      { "indexed": false, "internalType": "bool", "name": "active", "type": "bool" }
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "active",
+        "type": "bool"
+      }
     ],
     "name": "DomainStatusChanged",
     "type": "event"
@@ -47,28 +231,85 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "iotOracleRouter", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "defaultL2Gateway", "type": "address" },
-      { "indexed": false, "internalType": "address", "name": "didRegistry", "type": "address" },
-      { "indexed": false, "internalType": "address", "name": "treasuryBridge", "type": "address" },
-      { "indexed": false, "internalType": "uint64", "name": "l2SyncCadence", "type": "uint64" },
-      { "indexed": false, "internalType": "string", "name": "manifestURI", "type": "string" }
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "slug",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "metadataURI",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "validationModule",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "dataOracle",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "l2Gateway",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "subgraphEndpoint",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executionRouter",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "heartbeatSeconds",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "active",
+        "type": "bool"
+      }
     ],
-    "name": "GlobalConfigUpdated",
+    "name": "DomainUpdated",
     "type": "event"
   },
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "newSystemPause", "type": "address" }
-    ],
-    "name": "SystemPauseUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "newEscalationBridge", "type": "address" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newEscalationBridge",
+        "type": "address"
+      }
     ],
     "name": "EscalationBridgeUpdated",
     "type": "event"
@@ -76,31 +317,166 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "target", "type": "address" },
-      { "indexed": false, "internalType": "bytes", "name": "data", "type": "bytes" },
-      { "indexed": false, "internalType": "bytes", "name": "response", "type": "bytes" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "response",
+        "type": "bytes"
+      }
     ],
     "name": "EscalationForwarded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "iotOracleRouter",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "defaultL2Gateway",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "didRegistry",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "treasuryBridge",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "l2SyncCadence",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "manifestURI",
+        "type": "string"
+      }
+    ],
+    "name": "GlobalConfigUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newGovernance",
+        "type": "address"
+      }
+    ],
+    "name": "GovernanceUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newSystemPause",
+        "type": "address"
+      }
+    ],
+    "name": "SystemPauseUpdated",
     "type": "event"
   },
   {
     "inputs": [],
     "name": "SPEC_VERSION",
     "outputs": [
-      { "internalType": "string", "name": "", "type": "string" }
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
     ],
-    "stateMutability": "pure",
+    "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "bytes32", "name": "id", "type": "bytes32" },
-      { "internalType": "address", "name": "validationModule", "type": "address" },
-      { "internalType": "address", "name": "dataOracle", "type": "address" },
-      { "internalType": "address", "name": "l2Gateway", "type": "address" },
-      { "internalType": "string", "name": "subgraphEndpoint", "type": "string" },
-      { "internalType": "address", "name": "executionRouter", "type": "address" },
-      { "internalType": "uint64", "name": "heartbeatSeconds", "type": "uint64" }
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "validationModule",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "dataOracle",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "l2Gateway",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "subgraphEndpoint",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "executionRouter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "heartbeatSeconds",
+        "type": "uint64"
+      }
     ],
     "name": "configureDomainConnectors",
     "outputs": [],
@@ -108,12 +484,33 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "domainCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
-      { "internalType": "string", "name": "slug", "type": "string" }
+      {
+        "internalType": "string",
+        "name": "slug",
+        "type": "string"
+      }
     ],
     "name": "domainId",
     "outputs": [
-      { "internalType": "bytes32", "name": "", "type": "bytes32" }
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
     ],
     "stateMutability": "pure",
     "type": "function"
@@ -122,51 +519,115 @@
     "inputs": [],
     "name": "escalationBridge",
     "outputs": [
-      { "internalType": "address", "name": "", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "bytes", "name": "data", "type": "bytes" }
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
     ],
     "name": "forwardEscalation",
     "outputs": [
-      { "internalType": "bytes", "name": "", "type": "bytes" }
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
     ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "bytes", "name": "data", "type": "bytes" }
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
     ],
     "name": "forwardPauseCall",
     "outputs": [
-      { "internalType": "bytes", "name": "", "type": "bytes" }
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
     ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "bytes32", "name": "id", "type": "bytes32" }
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
     ],
     "name": "getDomain",
     "outputs": [
       {
         "components": [
-          { "internalType": "string", "name": "slug", "type": "string" },
-          { "internalType": "string", "name": "name", "type": "string" },
-          { "internalType": "string", "name": "metadataURI", "type": "string" },
-          { "internalType": "address", "name": "validationModule", "type": "address" },
-          { "internalType": "address", "name": "dataOracle", "type": "address" },
-          { "internalType": "address", "name": "l2Gateway", "type": "address" },
-          { "internalType": "string", "name": "subgraphEndpoint", "type": "string" },
-          { "internalType": "address", "name": "executionRouter", "type": "address" },
-          { "internalType": "uint64", "name": "heartbeatSeconds", "type": "uint64" },
-          { "internalType": "bool", "name": "active", "type": "bool" }
+          {
+            "internalType": "string",
+            "name": "slug",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "validationModule",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "dataOracle",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2Gateway",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "subgraphEndpoint",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "executionRouter",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "heartbeatSeconds",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "active",
+            "type": "bool"
+          }
         ],
         "internalType": "struct Phase6ExpansionManager.Domain",
         "name": "",
@@ -181,17 +642,47 @@
     "name": "globalConfig",
     "outputs": [
       {
-        "components": [
-          { "internalType": "address", "name": "iotOracleRouter", "type": "address" },
-          { "internalType": "address", "name": "defaultL2Gateway", "type": "address" },
-          { "internalType": "address", "name": "didRegistry", "type": "address" },
-          { "internalType": "address", "name": "treasuryBridge", "type": "address" },
-          { "internalType": "uint64", "name": "l2SyncCadence", "type": "uint64" },
-          { "internalType": "string", "name": "manifestURI", "type": "string" }
-        ],
-        "internalType": "struct Phase6ExpansionManager.GlobalConfig",
+        "internalType": "address",
+        "name": "iotOracleRouter",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "defaultL2Gateway",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "didRegistry",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "treasuryBridge",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "l2SyncCadence",
+        "type": "uint64"
+      },
+      {
+        "internalType": "string",
+        "name": "manifestURI",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "governance",
+    "outputs": [
+      {
+        "internalType": "contract TimelockController",
         "name": "",
-        "type": "tuple"
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -203,19 +694,63 @@
     "outputs": [
       {
         "components": [
-          { "internalType": "bytes32", "name": "id", "type": "bytes32" },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
           {
             "components": [
-              { "internalType": "string", "name": "slug", "type": "string" },
-              { "internalType": "string", "name": "name", "type": "string" },
-              { "internalType": "string", "name": "metadataURI", "type": "string" },
-              { "internalType": "address", "name": "validationModule", "type": "address" },
-              { "internalType": "address", "name": "dataOracle", "type": "address" },
-              { "internalType": "address", "name": "l2Gateway", "type": "address" },
-              { "internalType": "string", "name": "subgraphEndpoint", "type": "string" },
-              { "internalType": "address", "name": "executionRouter", "type": "address" },
-              { "internalType": "uint64", "name": "heartbeatSeconds", "type": "uint64" },
-              { "internalType": "bool", "name": "active", "type": "bool" }
+              {
+                "internalType": "string",
+                "name": "slug",
+                "type": "string"
+              },
+              {
+                "internalType": "string",
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "internalType": "string",
+                "name": "metadataURI",
+                "type": "string"
+              },
+              {
+                "internalType": "address",
+                "name": "validationModule",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "dataOracle",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "l2Gateway",
+                "type": "address"
+              },
+              {
+                "internalType": "string",
+                "name": "subgraphEndpoint",
+                "type": "string"
+              },
+              {
+                "internalType": "address",
+                "name": "executionRouter",
+                "type": "address"
+              },
+              {
+                "internalType": "uint64",
+                "name": "heartbeatSeconds",
+                "type": "uint64"
+              },
+              {
+                "internalType": "bool",
+                "name": "active",
+                "type": "bool"
+              }
             ],
             "internalType": "struct Phase6ExpansionManager.Domain",
             "name": "config",
@@ -231,19 +766,72 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "components": [
-          { "internalType": "string", "name": "slug", "type": "string" },
-          { "internalType": "string", "name": "name", "type": "string" },
-          { "internalType": "string", "name": "metadataURI", "type": "string" },
-          { "internalType": "address", "name": "validationModule", "type": "address" },
-          { "internalType": "address", "name": "dataOracle", "type": "address" },
-          { "internalType": "address", "name": "l2Gateway", "type": "address" },
-          { "internalType": "string", "name": "subgraphEndpoint", "type": "string" },
-          { "internalType": "address", "name": "executionRouter", "type": "address" },
-          { "internalType": "uint64", "name": "heartbeatSeconds", "type": "uint64" },
-          { "internalType": "bool", "name": "active", "type": "bool" }
+          {
+            "internalType": "string",
+            "name": "slug",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "validationModule",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "dataOracle",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2Gateway",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "subgraphEndpoint",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "executionRouter",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "heartbeatSeconds",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "active",
+            "type": "bool"
+          }
         ],
         "internalType": "struct Phase6ExpansionManager.Domain",
         "name": "config",
@@ -252,15 +840,27 @@
     ],
     "name": "registerDomain",
     "outputs": [
-      { "internalType": "bytes32", "name": "id", "type": "bytes32" }
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
     ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "bytes32", "name": "id", "type": "bytes32" },
-      { "internalType": "bool", "name": "active", "type": "bool" }
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "active",
+        "type": "bool"
+      }
     ],
     "name": "setDomainStatus",
     "outputs": [],
@@ -269,7 +869,11 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "newBridge", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "newBridge",
+        "type": "address"
+      }
     ],
     "name": "setEscalationBridge",
     "outputs": [],
@@ -280,12 +884,36 @@
     "inputs": [
       {
         "components": [
-          { "internalType": "address", "name": "iotOracleRouter", "type": "address" },
-          { "internalType": "address", "name": "defaultL2Gateway", "type": "address" },
-          { "internalType": "address", "name": "didRegistry", "type": "address" },
-          { "internalType": "address", "name": "treasuryBridge", "type": "address" },
-          { "internalType": "uint64", "name": "l2SyncCadence", "type": "uint64" },
-          { "internalType": "string", "name": "manifestURI", "type": "string" }
+          {
+            "internalType": "address",
+            "name": "iotOracleRouter",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "defaultL2Gateway",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "didRegistry",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "treasuryBridge",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "l2SyncCadence",
+            "type": "uint64"
+          },
+          {
+            "internalType": "string",
+            "name": "manifestURI",
+            "type": "string"
+          }
         ],
         "internalType": "struct Phase6ExpansionManager.GlobalConfig",
         "name": "config",
@@ -299,7 +927,24 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "newPause", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_governance",
+        "type": "address"
+      }
+    ],
+    "name": "setGovernance",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract SystemPause",
+        "name": "newPause",
+        "type": "address"
+      }
     ],
     "name": "setSystemPause",
     "outputs": [],
@@ -310,26 +955,87 @@
     "inputs": [],
     "name": "systemPause",
     "outputs": [
-      { "internalType": "address", "name": "", "type": "address" }
+      {
+        "internalType": "contract SystemPause",
+        "name": "",
+        "type": "address"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "bytes32", "name": "id", "type": "bytes32" },
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
       {
         "components": [
-          { "internalType": "string", "name": "slug", "type": "string" },
-          { "internalType": "string", "name": "name", "type": "string" },
-          { "internalType": "string", "name": "metadataURI", "type": "string" },
-          { "internalType": "address", "name": "validationModule", "type": "address" },
-          { "internalType": "address", "name": "dataOracle", "type": "address" },
-          { "internalType": "address", "name": "l2Gateway", "type": "address" },
-          { "internalType": "string", "name": "subgraphEndpoint", "type": "string" },
-          { "internalType": "address", "name": "executionRouter", "type": "address" },
-          { "internalType": "uint64", "name": "heartbeatSeconds", "type": "uint64" },
-          { "internalType": "bool", "name": "active", "type": "bool" }
+          {
+            "internalType": "string",
+            "name": "slug",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "validationModule",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "dataOracle",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2Gateway",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "subgraphEndpoint",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "executionRouter",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "heartbeatSeconds",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "active",
+            "type": "bool"
+          }
         ],
         "internalType": "struct Phase6ExpansionManager.Domain",
         "name": "config",

--- a/test/v2/Phase6ExpansionManager.test.js
+++ b/test/v2/Phase6ExpansionManager.test.js
@@ -244,6 +244,25 @@ describe("Phase6ExpansionManager", function () {
     ).to.be.revertedWithCustomError(manager, "InvalidAddress");
 
     await expect(
+      manager.connect(governance).registerDomain(
+        domainStruct({
+          subgraphEndpoint: "",
+          validationModule: validationStub.target,
+        }),
+      ),
+    ).to.be.revertedWithCustomError(manager, "InvalidSubgraphEndpoint");
+
+    const valid = domainStruct({ validationModule: validationStub.target });
+    await manager.connect(governance).registerDomain(valid);
+    const id = await manager.domainId(valid.slug);
+    await expect(
+      manager.connect(governance).updateDomain(id, {
+        ...valid,
+        subgraphEndpoint: "",
+      }),
+    ).to.be.revertedWithCustomError(manager, "InvalidSubgraphEndpoint");
+
+    await expect(
       manager.connect(governance).setGlobalConfig({
         iotOracleRouter: ethers.ZeroAddress,
         defaultL2Gateway: ethers.ZeroAddress,


### PR DESCRIPTION
## Summary
- ensure Phase6ExpansionManager rejects domain payloads without telemetry endpoints and surface the invariant in the demo guide
- extend coverage to assert register/update reverts when subgraph endpoints are omitted and refresh the exported ABI for tooling

## Testing
- npm run compile
- npx hardhat test --no-compile test/v2/Phase6ExpansionManager.test.js
- npm run demo:phase6:ci

------
https://chatgpt.com/codex/tasks/task_e_68fa2d4b1d3c8333af9b1001ff15499b