### PR TITLE
Add Phase 6 decentralized infra mesh demo

### DIFF
--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
@@ -12,6 +12,7 @@
 * **Bullet-proof governance** – every parameter is updatable by the contract owner (timelock/multisig) including emergency pause delegates and cross-chain bridges.
 * **CI as a guardian** – the `ci (v2) / Phase 6 readiness` job enforces configuration drift detection on every PR and on `main`.
 * **Resilience telemetry** – the demo computes average/min/max resilience, sentinel coverage, and value flow across finance, health, logistics, climate, and the new education lattice.
+* **Mesh-level infrastructure clarity** – a new decentralized infra registry renders every Layer-2, storage, identity, oracle, and compute touchpoint for Phase 6 so governance can audit the rails instantly.
 
 ---
 
@@ -87,6 +88,16 @@ The Graph mapping indexes the new events so dashboards, analytics, and governanc
 * Each event (`DomainRegistered`, `DomainUpdated`, `DomainStatusChanged`, `GlobalConfigUpdated`) updates the store instantly.
 
 These additions power UI cards, CI validation, and off-chain monitoring (e.g., the Resilience Index).
+
+---
+
+## 🕸️ Decentralized infrastructure mesh
+
+* `config/domains.phase6.json` now includes a **global `decentralizedInfra` array** and per-domain `infrastructure` inventories. Each entry captures layer, provider, role, status, and optional endpoint.
+* `scripts/run-phase6-demo.ts` surfaces mesh telemetry – global integration counts, per-domain touchpoints, and copy-paste friendly summaries for multi-sig review.
+* `index.html` renders the infra mesh alongside bridge plans so non-technical operators see exactly which L2s, storage rails, DID registries, and compute meshes come online.
+* `scripts/ci-check.mjs` enforces structural integrity: at least three integrations per domain and valid metadata for every mesh element.
+* `orchestrator/extensions/phase6.py` consumes the infra map to annotate runtime logs (`infra mesh: Layer-2:Linea(active)`) and to expose integration hints to IoT signal handlers.
 
 ---
 

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json
@@ -7,7 +7,33 @@
     "treasuryBridge": "0x4444444444444444444444444444444444444444",
     "systemPause": "0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
     "escalationBridge": "0xb2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
-    "l2SyncCadence": 180
+    "l2SyncCadence": 180,
+    "decentralizedInfra": [
+      {
+        "name": "EigenLayer Risk Shield AVS",
+        "role": "Continuously scores cross-domain performance and streams slashable alerts to governance",
+        "status": "active",
+        "endpoint": "https://mesh.agi.jobs/eigenlayer-risk-shield"
+      },
+      {
+        "name": "Filecoin Saturn Compute Mesh",
+        "role": "Distributed compute and state channels for domain-specific AI copilots",
+        "status": "ready",
+        "endpoint": "https://mesh.agi.jobs/filecoin-saturn"
+      },
+      {
+        "name": "Arweave / IPFS Hybrid Archive",
+        "role": "Immutable manifest + verifiable credential anchor for Phase 6 manifests",
+        "status": "active",
+        "endpoint": "ar://phase6/manifest"
+      },
+      {
+        "name": "Lit Protocol Threshold Control",
+        "role": "Automated pause + escalation key ceremony synced with the Phase6ExpansionManager",
+        "status": "armed",
+        "endpoint": "https://mesh.agi.jobs/lit-threshold"
+      }
+    ]
   },
   "domains": [
     {
@@ -20,8 +46,17 @@
       "oracle": "0x6666666666666666666666666666666666666666",
       "executionRouter": "0x7777777777777777777777777777777777777777",
       "heartbeatSeconds": 90,
-      "skillTags": ["finance", "risk", "credit", "defi"],
-      "capabilities": { "credit": 4.0, "treasury": 3.5, "defi": 3.0 },
+      "skillTags": [
+        "finance",
+        "risk",
+        "credit",
+        "defi"
+      ],
+      "capabilities": {
+        "credit": 4.0,
+        "treasury": 3.5,
+        "defi": 3.0
+      },
       "priority": 95,
       "metadata": {
         "domain": "Capital markets synthesis, real-time liquidity engineering",
@@ -31,7 +66,36 @@
         "uptime": "99.982%",
         "valueFlowMonthlyUSD": 28400000000,
         "valueFlowDisplay": "$28.4B"
-      }
+      },
+      "infrastructure": [
+        {
+          "layer": "Settlement",
+          "name": "Ethereum Mainnet",
+          "role": "Final value settlement + treasury escrow",
+          "status": "anchor"
+        },
+        {
+          "layer": "Layer-2",
+          "name": "Linea",
+          "role": "High-frequency trade routing + compliance attestations",
+          "status": "active",
+          "endpoint": "https://linea.build"
+        },
+        {
+          "layer": "Storage",
+          "name": "Arweave",
+          "role": "Immutable portfolio manifests & pricing curves",
+          "status": "active",
+          "endpoint": "ar://phase6/finance"
+        },
+        {
+          "layer": "Compute",
+          "name": "EigenLayer AVS",
+          "role": "On-demand stress testing + liquidation sentinels",
+          "status": "ready",
+          "endpoint": "https://avs.agi.jobs/finance"
+        }
+      ]
     },
     {
       "slug": "health",
@@ -43,8 +107,16 @@
       "oracle": "0x9999999999999999999999999999999999999999",
       "executionRouter": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "heartbeatSeconds": 120,
-      "skillTags": ["healthcare", "diagnostics", "compliance", "bio"],
-      "capabilities": { "diagnostics": 4.5, "compliance": 4.0 },
+      "skillTags": [
+        "healthcare",
+        "diagnostics",
+        "compliance",
+        "bio"
+      ],
+      "capabilities": {
+        "diagnostics": 4.5,
+        "compliance": 4.0
+      },
       "priority": 92,
       "metadata": {
         "domain": "Precision diagnostics, clinical validation, regulatory co-pilots",
@@ -54,7 +126,36 @@
         "uptime": "99.961%",
         "valueFlowMonthlyUSD": 18600000000,
         "valueFlowDisplay": "$18.6B"
-      }
+      },
+      "infrastructure": [
+        {
+          "layer": "Settlement",
+          "name": "Ethereum Mainnet",
+          "role": "Clinical payout + credential settlement",
+          "status": "anchor"
+        },
+        {
+          "layer": "Layer-2",
+          "name": "Arbitrum One",
+          "role": "Low-latency care coordination and model fine-tuning",
+          "status": "active",
+          "endpoint": "https://arbitrum.foundation"
+        },
+        {
+          "layer": "Storage",
+          "name": "Ceramic DID Graph",
+          "role": "Encrypted patient DID wallets + verifiable credentials",
+          "status": "active",
+          "endpoint": "https://ceramic.network"
+        },
+        {
+          "layer": "Compute",
+          "name": "Filecoin Saturn",
+          "role": "Federated radiology model execution",
+          "status": "ready",
+          "endpoint": "https://saturn.tech/health"
+        }
+      ]
     },
     {
       "slug": "logistics",
@@ -66,8 +167,18 @@
       "oracle": "0xcccccccccccccccccccccccccccccccccccccccc",
       "executionRouter": "0xdddddddddddddddddddddddddddddddddddddddd",
       "heartbeatSeconds": 75,
-      "skillTags": ["logistics", "iot", "supply", "routing", "manufacturing"],
-      "capabilities": { "routing": 4.2, "supply": 4.0, "manufacturing": 3.8 },
+      "skillTags": [
+        "logistics",
+        "iot",
+        "supply",
+        "routing",
+        "manufacturing"
+      ],
+      "capabilities": {
+        "routing": 4.2,
+        "supply": 4.0,
+        "manufacturing": 3.8
+      },
       "priority": 94,
       "metadata": {
         "domain": "Planetary logistics, IoT coordination, smart city fulfillment",
@@ -77,7 +188,36 @@
         "uptime": "99.947%",
         "valueFlowMonthlyUSD": 22400000000,
         "valueFlowDisplay": "$22.4B"
-      }
+      },
+      "infrastructure": [
+        {
+          "layer": "Settlement",
+          "name": "Ethereum Mainnet",
+          "role": "Escrow for freight commitments",
+          "status": "anchor"
+        },
+        {
+          "layer": "Layer-2",
+          "name": "Base",
+          "role": "Route auctions + IoT event batching",
+          "status": "active",
+          "endpoint": "https://base.org"
+        },
+        {
+          "layer": "Oracle",
+          "name": "Chainlink CCIP",
+          "role": "Global shipment telemetry & compliance feeds",
+          "status": "active",
+          "endpoint": "https://chain.link"
+        },
+        {
+          "layer": "Compute",
+          "name": "EigenLayer AVS",
+          "role": "Autonomous dispatch heuristics + resilience scoring",
+          "status": "ready",
+          "endpoint": "https://avs.agi.jobs/logistics"
+        }
+      ]
     },
     {
       "slug": "climate",
@@ -89,8 +229,17 @@
       "oracle": "0xffffffffffffffffffffffffffffffffffffffff",
       "executionRouter": "0x1234567890123456789012345678901234567890",
       "heartbeatSeconds": 210,
-      "skillTags": ["climate", "sustainability", "energy", "carbon"],
-      "capabilities": { "carbon": 4.4, "energy": 4.1, "modeling": 3.9 },
+      "skillTags": [
+        "climate",
+        "sustainability",
+        "energy",
+        "carbon"
+      ],
+      "capabilities": {
+        "carbon": 4.4,
+        "energy": 4.1,
+        "modeling": 3.9
+      },
       "priority": 88,
       "metadata": {
         "domain": "Global decarbonization, adaptive grid intelligence",
@@ -100,7 +249,36 @@
         "uptime": "99.923%",
         "valueFlowMonthlyUSD": 11200000000,
         "valueFlowDisplay": "$11.2B"
-      }
+      },
+      "infrastructure": [
+        {
+          "layer": "Settlement",
+          "name": "Ethereum Mainnet",
+          "role": "Carbon credit issuance + retirement",
+          "status": "anchor"
+        },
+        {
+          "layer": "Layer-2",
+          "name": "Polygon zkEVM",
+          "role": "Climate derivative hedging + micro-escrow",
+          "status": "active",
+          "endpoint": "https://polygon.technology"
+        },
+        {
+          "layer": "Data Lake",
+          "name": "IPFS / Filecoin",
+          "role": "Satellite telemetry + climate oracle backing",
+          "status": "active",
+          "endpoint": "ipfs://phase6/climate"
+        },
+        {
+          "layer": "Compute",
+          "name": "Akash Network",
+          "role": "High-resolution climate simulation bursts",
+          "status": "ready",
+          "endpoint": "https://akash.network"
+        }
+      ]
     },
     {
       "slug": "education",
@@ -112,8 +290,17 @@
       "oracle": "0x2468246824682468246824682468246824682468",
       "executionRouter": "0x3579357935793579357935793579357935793579",
       "heartbeatSeconds": 150,
-      "skillTags": ["education", "research", "training", "governance"],
-      "capabilities": { "curriculum": 4.1, "compliance": 3.9, "simulation": 4.2 },
+      "skillTags": [
+        "education",
+        "research",
+        "training",
+        "governance"
+      ],
+      "capabilities": {
+        "curriculum": 4.1,
+        "compliance": 3.9,
+        "simulation": 4.2
+      },
       "priority": 91,
       "metadata": {
         "domain": "Lifelong learning, institutional onboarding, policy education",
@@ -123,7 +310,36 @@
         "uptime": "99.938%",
         "valueFlowMonthlyUSD": 9800000000,
         "valueFlowDisplay": "$9.8B"
-      }
+      },
+      "infrastructure": [
+        {
+          "layer": "Settlement",
+          "name": "Ethereum Mainnet",
+          "role": "Certification issuance + staking",
+          "status": "anchor"
+        },
+        {
+          "layer": "Layer-2",
+          "name": "Optimism",
+          "role": "Adaptive learning credit settlement",
+          "status": "active",
+          "endpoint": "https://optimism.io"
+        },
+        {
+          "layer": "Storage",
+          "name": "Arweave",
+          "role": "Curriculum manifest + credential audit logs",
+          "status": "active",
+          "endpoint": "ar://phase6/education"
+        },
+        {
+          "layer": "Identity",
+          "name": "Spruce DID Kit",
+          "role": "Verifiable credential issuance + KYC proofs",
+          "status": "ready",
+          "endpoint": "https://spruceid.com"
+        }
+      ]
     }
   ]
 }

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/index.html
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/index.html
@@ -131,6 +131,22 @@
         font-size: 0.95rem;
         color: var(--muted);
       }
+      ul.mesh-list {
+        list-style: none;
+        padding: 0;
+        margin: 12px 0 0 0;
+        display: grid;
+        gap: 8px;
+      }
+      ul.mesh-list li {
+        background: rgba(255, 255, 255, 0.03);
+        border-radius: 12px;
+        padding: 10px 14px;
+        border: 1px solid rgba(148, 163, 184, 0.15);
+        color: var(--muted);
+        font-size: 0.9rem;
+        line-height: 1.5;
+      }
       pre {
         background: rgba(15, 23, 42, 0.78);
         border-radius: 18px;
@@ -187,6 +203,15 @@
       <section class="card">
         <h2>Layer-2 bridge & oracle plan</h2>
         <div class="grid columns-2" id="bridge-grid"></div>
+      </section>
+
+      <section class="card">
+        <h2>Decentralized infrastructure mesh</h2>
+        <p style="color: var(--muted); margin-top: 0;">
+          Transparent view of the cross-chain, storage, identity, and compute rails the runtime activates per domain.
+          Every integration is pre-approved for automated governance overrides.
+        </p>
+        <div class="grid columns-2" id="infra-grid"></div>
       </section>
 
       <section class="card">
@@ -485,6 +510,7 @@
         renderGlobal(cfg);
         renderDomains(cfg);
         renderBridgePlans(cfg);
+        renderInfrastructure(cfg);
         buildCalldata(cfg);
         renderCalldata();
         updateMermaid();
@@ -507,6 +533,49 @@
         if (window.mermaid) {
           window.mermaid.run({ querySelector: '#mermaid-diagram' });
         }
+      }
+
+      function renderInfrastructure(config) {
+        const grid = document.getElementById('infra-grid');
+        grid.innerHTML = '';
+
+        const globalCard = document.createElement('div');
+        globalCard.className = 'domain-card';
+        const globalIntegrations = config.global.decentralizedInfra || [];
+        globalCard.innerHTML = `
+          <h3>Global control mesh</h3>
+          <div class="metrics">
+            <span>Total integrations: ${globalIntegrations.length}</span>
+            <span>Manifest anchor: ${config.global.manifestURI}</span>
+          </div>
+        `;
+        const globalList = document.createElement('ul');
+        globalList.className = 'mesh-list';
+        globalIntegrations.forEach((entry, idx) => {
+          const li = document.createElement('li');
+          const endpoint = entry.endpoint ? ` → ${entry.endpoint}` : '';
+          li.textContent = `[G${idx + 1}] ${entry.name} · ${entry.role} · status ${entry.status}${endpoint}`;
+          globalList.appendChild(li);
+        });
+        globalCard.appendChild(globalList);
+        grid.appendChild(globalCard);
+
+        config.domains.forEach((domain) => {
+          const card = document.createElement('div');
+          card.className = 'domain-card';
+          card.innerHTML = `<h3>${domain.name}</h3>`;
+          const list = document.createElement('ul');
+          list.className = 'mesh-list';
+          domain.infrastructure.forEach((entry, idx) => {
+            const endpoint = entry.endpoint || entry.uri;
+            const meta = endpoint ? ` → ${endpoint}` : '';
+            const item = document.createElement('li');
+            item.textContent = `[${idx + 1}] ${entry.layer}: ${entry.name} · ${entry.role} · status ${entry.status}${meta}`;
+            list.appendChild(item);
+          });
+          card.appendChild(list);
+          grid.appendChild(card);
+        });
       }
 
       document.getElementById('launch-demo').addEventListener('click', () => {

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/ci-check.mjs
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/ci-check.mjs
@@ -48,6 +48,25 @@ const addressPattern = /^0x[0-9a-fA-F]{40}$/;
   },
 );
 
+if (!Array.isArray(config.global.decentralizedInfra) || config.global.decentralizedInfra.length < 3) {
+  fail('Global decentralizedInfra must include at least three integrations.');
+}
+
+config.global.decentralizedInfra.forEach((entry, idx) => {
+  const context = `global.decentralizedInfra[${idx}]`;
+  if (!entry || typeof entry !== 'object') {
+    fail(`${context}: entry must be an object.`);
+  }
+  ['name', 'role', 'status'].forEach((key) => {
+    if (!entry[key] || typeof entry[key] !== 'string') {
+      fail(`${context}: ${key} must be a non-empty string.`);
+    }
+  });
+  if (entry.endpoint && typeof entry.endpoint !== 'string') {
+    fail(`${context}: endpoint must be a string when provided.`);
+  }
+});
+
 if (!Array.isArray(config.domains) || config.domains.length === 0) {
   fail('At least one domain must be configured.');
 }
@@ -106,6 +125,25 @@ config.domains.forEach((domain, idx) => {
   if (metadata.valueFlowDisplay && typeof metadata.valueFlowDisplay !== 'string') {
     fail(`${context}: metadata.valueFlowDisplay must be a string when provided.`);
   }
+  if (!Array.isArray(domain.infrastructure) || domain.infrastructure.length < 3) {
+    fail(`${context}: infrastructure must define at least three integrations.`);
+  }
+  domain.infrastructure.forEach((integration, infraIdx) => {
+    const infraContext = `${context}.infrastructure[${infraIdx}]`;
+    if (!integration || typeof integration !== 'object') {
+      fail(`${infraContext}: entry must be an object.`);
+    }
+    ['layer', 'name', 'role', 'status'].forEach((key) => {
+      if (!integration[key] || typeof integration[key] !== 'string') {
+        fail(`${infraContext}: ${key} must be a non-empty string.`);
+      }
+    });
+    ['endpoint', 'uri'].forEach((key) => {
+      if (integration[key] && typeof integration[key] !== 'string') {
+        fail(`${infraContext}: ${key} must be a string when provided.`);
+      }
+    });
+  });
 });
 
 if (!html.includes('mermaid')) {

--- a/test/orchestrator/test_phase6_runtime.py
+++ b/test/orchestrator/test_phase6_runtime.py
@@ -28,6 +28,21 @@ def sample_payload():
                 "skillTags": ["finance", "risk", "credit"],
                 "capabilities": {"credit": 3.0},
                 "priority": 50,
+                "infrastructure": [
+                    {
+                        "layer": "Layer-2",
+                        "name": "Linea",
+                        "role": "High frequency settlements",
+                        "status": "active",
+                        "endpoint": "https://linea.build",
+                    },
+                    {
+                        "layer": "Storage",
+                        "name": "Arweave",
+                        "role": "Portfolio manifest archive",
+                        "status": "active",
+                    },
+                ],
             },
             {
                 "slug": "health",
@@ -37,6 +52,14 @@ def sample_payload():
                 "heartbeatSeconds": 150,
                 "skillTags": ["healthcare", "compliance"],
                 "priority": 40,
+                "infrastructure": [
+                    {
+                        "layer": "Layer-2",
+                        "name": "Arbitrum",
+                        "role": "Clinical coordination",
+                        "status": "active",
+                    }
+                ],
             },
         ],
     }
@@ -60,11 +83,14 @@ def test_runtime_selects_domain_and_builds_bridge(sample_payload):
     step = make_step(params={"tags": ["credit", "analysis"]})
     logs = runtime.annotate_step(step)
     assert any("finance" in line for line in logs)
+    assert any("infra mesh" in line for line in logs)
     bridge_plan = runtime.build_bridge_plan("finance")
     assert bridge_plan["domain"] == "finance"
     assert bridge_plan["l2Gateway"].lower().endswith("3333")
     assert bridge_plan["iotOracle"].lower().endswith("4444")
     assert bridge_plan["syncCadenceSeconds"] == pytest.approx(180)
+    assert bridge_plan["infrastructure"]
+    assert bridge_plan["infrastructure"][0]["layer"] == "Layer-2"
 
 
 def test_runtime_hints_and_iot_signals(tmp_path: Path, sample_payload):
@@ -81,7 +107,15 @@ def test_runtime_hints_and_iot_signals(tmp_path: Path, sample_payload):
           "manifestURI": "ipfs://phase6/logistics.json",
           "subgraph": "https://phase6.montreal.ai/subgraphs/logistics",
           "skillTags": ["logistics", "iot", "supply"],
-          "priority": 55
+          "priority": 55,
+          "infrastructure": [
+            {
+              "layer": "Layer-2",
+              "name": "Base",
+              "role": "Logistics orchestration",
+              "status": "active"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- extend the Phase 6 demo config with global decentralized infrastructure inventory and per-domain integration meshes
- surface the new mesh in the CLI orchestrator output, static UI, CI validator, and runtime annotations/tests so non-technical operators see every rail in one place

## Testing
- npm run demo:phase6:ci
- npx hardhat test test/v2/Phase6ExpansionManager.test.js --no-compile
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/orchestrator/test_phase6_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68fa39f326748333a1f78363377a0358