### PR TITLE
Enhance Phase 8 governance control surfaces

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/README.md
+++ b/demo/Phase-8-Universal-Value-Dominance/README.md
@@ -55,11 +55,13 @@
 * **Global parameters** – `setGlobalParameters`, `updateManifesto`, and `updateRiskParameters` let the owner reshape treasury,
   vaults, knowledge graphs, and risk tolerances atomically.
 * **Sentinel lattice** – register, update, and toggle sentinels that monitor domains. Each sentinel enforces coverage windows
-  and can be routed through the shared `SystemPause` via `forwardPauseCall`.
-* **Capital streams** – register autonomous treasury programs with annual budgets and expansion curves. Governance can pause or
-  re-target any stream instantly.
+  and can be routed through the shared `SystemPause` via `forwardPauseCall`. Domain bindings are configured via
+  `setSentinelDomains` so every sentinel only monitors approved dominions.
+* **Capital streams** – register autonomous treasury programs with annual budgets and expansion curves. Governance can pause,
+  re-target, or re-bind the domain list at any time with `setCapitalStreamDomains`.
 * **Domain dominion** – configure orchestration endpoints, vault limits, and autonomy bps per domain while guaranteeing slug
-  uniqueness and heartbeat invariants.
+  uniqueness and heartbeat invariants. Domains, sentinels, and streams can also be removed entirely (`removeDomain`,
+  `removeSentinel`, `removeCapitalStream`) with automatic pruning of bindings.
 
 The contract emits deterministic events so dashboards, subgraphs, and auditors can stream changes. All mutative calls remain
 `onlyGovernance`, satisfying the requirement that the owner can reconfigure everything – including pausing – at will.
@@ -87,8 +89,8 @@ Open [`index.html`](./index.html) to explore the fully client-side control room:
 
 * Planetary stats (value flow, budget, resilience, sentinel coverage).
 * Domain cards with autonomy bps, resilience, heartbeat, and skill badges.
-* Sentinel lattice view with live coverage, sensitivity, and domain bindings.
-* Capital stream portfolio with annual budgets and vault routing.
+* Sentinel lattice view with live coverage, sensitivity, and domain bindings (auto-highlighted when a domain loses coverage).
+* Capital stream portfolio with annual budgets, vault routing, and linked dominions.
 * Self-improvement playbooks and guardrails rendered with owner addresses.
 * An auto-generated Mermaid diagram illustrating governance, sentinels, and capital flow.
 
@@ -128,7 +130,8 @@ graph TD
 ## 📚 Related orchestration hooks
 
 * [`demo/Phase-8-Universal-Value-Dominance/scripts/run-phase8-demo.ts`](./scripts/run-phase8-demo.ts) – generates calldata,
-  telemetry, and the mermaid diagram.
+  telemetry, and the mermaid diagram. Outputs include per-sentinel and per-stream domain binding calls plus deterministic
+  removal calldata so governors can rehearse reconfigurations.
 * [`demo/Phase-8-Universal-Value-Dominance/scripts/validate-phase8-config.ts`](./scripts/validate-phase8-config.ts) – schema
   validation enforced by CI.
 * [`orchestrator/extensions/phase8.py`](../../orchestrator/extensions/phase8.py) – runtime adapter so Python orchestrators can

--- a/demo/Phase-8-Universal-Value-Dominance/index.html
+++ b/demo/Phase-8-Universal-Value-Dominance/index.html
@@ -101,6 +101,21 @@
         padding: 1.75rem;
         background: linear-gradient(135deg, rgba(16, 40, 76, 0.8), rgba(7, 14, 24, 0.92));
       }
+      .domain-card.no-coverage {
+        border-color: rgba(255, 96, 110, 0.6);
+        box-shadow: 0 0 0 1px rgba(255, 96, 110, 0.35);
+      }
+      .domain-card.no-coverage::after {
+        content: "Sentinel coverage required";
+        display: inline-block;
+        margin-top: 0.8rem;
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        background: rgba(255, 96, 110, 0.18);
+        border: 1px solid rgba(255, 96, 110, 0.5);
+        color: #ffccd3;
+      }
       .domain-card h3 {
         margin: 0;
         font-size: 1.35rem;
@@ -285,12 +300,20 @@
           </div>
         `;
 
+        const coverageMap = new Map();
+        data.sentinels.forEach((sentinel) => {
+          (sentinel.domains || []).forEach((slug) => {
+            coverageMap.set(String(slug).toLowerCase(), true);
+          });
+        });
+
         const domains = document.getElementById("domains");
         domains.innerHTML = data.domains
           .map((domain) => {
             const tags = (domain.skillTags || []).map((tag) => `<span class="chip">${tag}</span>`).join(" ");
+            const covered = coverageMap.has(String(domain.slug).toLowerCase());
             return `
-              <article class="domain-card">
+              <article class="domain-card${covered ? "" : " no-coverage"}">
                 <h3>${domain.name}</h3>
                 <p>${domain.autonomyNarrative || "Autonomy narrative pending."}</p>
                 <div class="domain-meta">

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/validate-phase8-config.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/validate-phase8-config.ts
@@ -104,6 +104,26 @@ function main() {
     slugs.add(slug);
   }
 
+  const sentinelDomains = new Set<string>();
+  for (const sentinel of config.sentinels) {
+    for (const domain of sentinel.domains ?? []) {
+      const normalized = domain.toLowerCase();
+      if (!slugs.has(normalized)) {
+        throw new Error(`Sentinel ${sentinel.slug} references unknown domain ${domain}`);
+      }
+      sentinelDomains.add(normalized);
+    }
+  }
+
+  for (const stream of config.capitalStreams) {
+    for (const domain of stream.domains ?? []) {
+      const normalized = domain.toLowerCase();
+      if (!slugs.has(normalized)) {
+        throw new Error(`Capital stream ${stream.slug} references unknown domain ${domain}`);
+      }
+    }
+  }
+
   const sentinelCoverage = config.sentinels.reduce((acc, s) => acc + s.coverageSeconds, 0);
   if (sentinelCoverage < config.global.guardianReviewWindow) {
     throw new Error(
@@ -137,6 +157,7 @@ function main() {
   console.log(`  Sentinels: ${config.sentinels.length}`);
   console.log(`  Capital streams: ${config.capitalStreams.length}`);
   console.log(`  Total sentinel coverage: ${sentinelCoverage}s`);
+  console.log(`  Domains with sentinel coverage: ${sentinelDomains.size}`);
 }
 
 main();


### PR DESCRIPTION
## Summary
- extend `Phase8UniversalValueManager` with domain removal hooks plus binding controls for sentinels and capital streams
- surface the new capabilities in the Phase 8 demo README, UI dashboard, and orchestration CLI outputs
- harden config validation and automated tests to guard domain coverage and governance workflows

## Testing
- `npx hardhat test test/v2/Phase8UniversalValueManager.test.ts`
- `npm run demo:phase8:ci`
- `npm run demo:phase8:orchestrate`

------
https://chatgpt.com/codex/tasks/task_e_68fa4f3cb348833386411bd5ecc79799