### PR TITLE
Add Phase 8 self-improvement governance surface

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/README.md
+++ b/demo/Phase-8-Universal-Value-Dominance/README.md
@@ -41,8 +41,8 @@
   control of domains, sentinel policies, capital streams, and emergency pause forwarding.
 * **Planetary telemetry in one command** – governance can read resilience, autonomy, value flow, and sentinel coverage from the
   CLI and UI without touching Solidity or Hardhat.
-* **Self-improving and self-checking** – playbooks and guardrails encoded in the manifest let the operator launch automated
-  retraining and adversarial stress-tests while ensuring autonomy stays bounded.
+* **Self-improving and self-checking** – an on-chain self-improvement charter (plan hash + cadence) plus manifest playbooks let
+  the operator launch automated retraining and adversarial stress-tests while ensuring autonomy stays bounded.
 * **Mermaid-first storytelling** – every run emits a rich diagram to explain how trillions in value flow through the
   superintelligent mesh.
 
@@ -62,6 +62,8 @@
 * **Domain dominion** – configure orchestration endpoints, vault limits, and autonomy bps per domain while guaranteeing slug
   uniqueness and heartbeat invariants. Domains, sentinels, and streams can also be removed entirely (`removeDomain`,
   `removeSentinel`, `removeCapitalStream`) with automatic pruning of bindings.
+* **Self-improvement charter** – `setSelfImprovementPlan` and `recordSelfImprovementExecution` keep the cadence, plan hash,
+  and audit trail of upgrades under direct governance control.
 
 The contract emits deterministic events so dashboards, subgraphs, and auditors can stream changes. All mutative calls remain
 `onlyGovernance`, satisfying the requirement that the owner can reconfigure everything – including pausing – at will.
@@ -70,10 +72,14 @@ The contract emits deterministic events so dashboards, subgraphs, and auditors c
 
 ## 🧠 Self-improvement kernel
 
-The manifest encodes a self-improvement plan:
+The manifest + contract encode a self-improvement plan:
 
-* **Playbooks** trigger weekly hyperparameter evolution and hourly stress-tests, each bound by cryptographic guardrails (checksums,
-  zk-proof-of-alignment, multi-agent cross-checks).
+* **Charter hash + cadence** – `setSelfImprovementPlan` writes the plan URI, cadence, and cryptographic hash on-chain so every
+  upgrade is pre-committed and auditable.
+* **Execution receipts** – `recordSelfImprovementExecution(executedAt, reportURI)` appends a tamper-evident log of each training
+  and evaluation cycle, binding it to an IPFS report.
+* **Playbooks** trigger weekly hyperparameter evolution and hourly stress-tests, each bound by cryptographic guardrails
+  (checksum verification, zk-proof-of-alignment, multi-agent cross-checks).
 * **Autonomy guard** enforces ≤8,000 bps autonomy, a 15-minute human override window, and escalations through guardian council,
   DAO emergency levers, and sentinel lockdown.
 * **Validator feedback loops** reward resilient domains (resilience >0.9) with higher capital allocation while surfacing low
@@ -91,7 +97,7 @@ Open [`index.html`](./index.html) to explore the fully client-side control room:
 * Domain cards with autonomy bps, resilience, heartbeat, and skill badges.
 * Sentinel lattice view with live coverage, sensitivity, and domain bindings (auto-highlighted when a domain loses coverage).
 * Capital stream portfolio with annual budgets, vault routing, and linked dominions.
-* Self-improvement playbooks and guardrails rendered with owner addresses.
+* Self-improvement plan (hash, cadence, report URI) plus playbooks and guardrails rendered with owner addresses.
 * An auto-generated Mermaid diagram illustrating governance, sentinels, and capital flow.
 
 ---

--- a/demo/Phase-8-Universal-Value-Dominance/config/universal.value.manifest.json
+++ b/demo/Phase-8-Universal-Value-Dominance/config/universal.value.manifest.json
@@ -203,6 +203,13 @@
     }
   ],
   "selfImprovement": {
+    "plan": {
+      "planURI": "ipfs://agi-jobs/phase8/self-improvement/plan.json",
+      "planHash": "0x7d2556f5ae0a7dd2e9c3c5e29377b7af168e2b2f42a3e08d96b9f8e32d4b9f10",
+      "cadenceSeconds": 7200,
+      "lastExecutedAt": 1700000400,
+      "lastReportURI": "ipfs://agi-jobs/phase8/self-improvement/reports/epoch-144.json"
+    },
     "playbooks": [
       {
         "name": "Hyperparameter Evolution",

--- a/demo/Phase-8-Universal-Value-Dominance/index.html
+++ b/demo/Phase-8-Universal-Value-Dominance/index.html
@@ -254,12 +254,20 @@
             : data.domains.reduce((acc, d) => acc + Number(d.resilienceIndex ?? 0), 0) / data.domains.length;
         const coverage = data.sentinels.reduce((acc, s) => acc + Number(s.coverageSeconds ?? 0), 0) / 60;
 
+        const plan = data.selfImprovement?.plan;
         const statItems = [
           { label: "Monthly value flow", value: formatUSD(totalMonthly) },
           { label: "Annual capital budget", value: formatUSD(annualBudget) },
           { label: "Average resilience", value: resilience.toFixed(3) },
           { label: "Sentinel coverage", value: `${coverage.toFixed(1)} min/cycle` },
         ];
+        if (plan?.cadenceSeconds) {
+          statItems.push({ label: "Improvement cadence", value: `${(plan.cadenceSeconds / 3600).toFixed(2)} h` });
+        }
+        if (plan?.lastExecutedAt) {
+          const executed = new Date(Number(plan.lastExecutedAt) * 1000).toISOString().replace("T", " · ");
+          statItems.push({ label: "Last improvement", value: executed });
+        }
         stats.innerHTML = statItems
           .map(
             (item) => `
@@ -356,7 +364,23 @@
           .join("");
 
         const playbooks = document.getElementById("playbooks");
+        const planCard = plan
+          ? `
+            <article class="playbook-item">
+              <strong>Strategic plan</strong>
+              <p>Cadence ${(plan.cadenceSeconds / 3600).toFixed(2)} h · Hash ${plan.planHash}</p>
+              <p>Manifest ${plan.planURI}${
+                plan.lastExecutedAt
+                  ? ` · Last execution ${new Date(Number(plan.lastExecutedAt) * 1000).toISOString()}`
+                  : ""
+              }</p>
+              <p>Latest report ${plan.lastReportURI || "—"}</p>
+            </article>
+          `
+          : "";
+
         playbooks.innerHTML = [
+          planCard,
           ...data.selfImprovement.playbooks.map(
             (playbook) => `
               <article class="playbook-item">
@@ -385,6 +409,8 @@
           <li>Install dependencies once: <code>npm ci</code></li>
           <li>Generate calldata + telemetry: <code>npm run demo:phase8:orchestrate</code></li>
           <li>Apply transactions via your governance Safe / Timelock</li>
+          <li>Update the self-improvement plan hash + cadence via <code>setSelfImprovementPlan</code></li>
+          <li>Record each improvement cycle with <code>recordSelfImprovementExecution</code> and archive the report URI</li>
           <li>Stream live telemetry from this console and the orchestrator runtime</li>
           <li>Trigger self-improvement playbooks as needed (see guardrails above)</li>
         `;


### PR DESCRIPTION
## Summary
- add on-chain self-improvement plan management to `Phase8UniversalValueManager` with new governance events and tests
- extend the Phase 8 manifest, CLI tooling, and UI to expose plan hash, cadence, and reporting guidance for operators
- tighten Phase 8 validation rules and documentation around the self-improvement charter

## Testing
- npm run demo:phase8:ci
- npx hardhat test test/v2/Phase8UniversalValueManager.test.ts *(did not finish locally; compiler run exceeded time limits)*

------
https://chatgpt.com/codex/tasks/task_e_68fa5a245f2083339e480fc5af4d7236