### PR TITLE
Enhance Phase 8 runtime coverage messaging

### DIFF
--- a/orchestrator/extensions/phase8.py
+++ b/orchestrator/extensions/phase8.py
@@ -259,6 +259,8 @@ class Phase8DominionRuntime:
         ]
         if sentinel_links:
             notes.append("• sentinel coverage: " + " | ".join(sentinel_links))
+        else:
+            notes.append("• sentinel coverage: none — configure sentinel lattice for this dominion")
         stream_links = [
             stream.describe()
             for stream in self._streams.values()
@@ -266,6 +268,8 @@ class Phase8DominionRuntime:
         ]
         if stream_links:
             notes.append("• capital streams: " + " | ".join(stream_links))
+        else:
+            notes.append("• capital streams: none mapped — review capital allocation for this dominion")
         notes.append("• guardian summary: " + self.guardian_summary())
         if self._source:
             notes.append(f"• manifest source: {self._source}")


### PR DESCRIPTION
## Summary
- highlight when a Phase 8 dominion lacks sentinel coverage in Python runtime annotations
- flag domains that have no mapped capital streams so operators can correct allocations

## Testing
- python -m py_compile orchestrator/extensions/phase8.py
- npm run demo:phase8:ci

------
https://chatgpt.com/codex/tasks/task_e_68fa64e9e10483338bf81cd3c6c14cd4