### PR TITLE
Phase 6 telemetry control surfaces and runtime integration

### DIFF
--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
@@ -8,10 +8,10 @@
 
 * **Instant global expansion** – governance can register, pause, or rewire entire industry stacks with a single `Phase6ExpansionManager` transaction.
 * **Non-technical empowerment** – a single command (`npm run demo:phase6:orchestrate`) emits pre-validated calldata, bridge plans, and AI orchestration summaries.
-* **Planetary telemetry** – the subgraph now indexes `Phase6Domain` & `Phase6GlobalConfig`, letting dashboards stream readiness, resilience indices, and upgrade intents in real time.
-* **Bullet-proof governance** – every parameter is updatable by the contract owner (timelock/multisig) including emergency pause delegates and cross-chain bridges.
+* **Planetary telemetry** – the subgraph now indexes `Phase6Domain`, `Phase6GlobalConfig`, and the new telemetry events so dashboards stream readiness, resilience, automation, compliance, and settlement posture in real time.
+* **Bullet-proof governance** – every parameter is updatable by the contract owner (timelock/multisig) including emergency pause delegates, cross-chain bridges, and per-domain telemetry digests.
 * **CI as a guardian** – the `ci (v2) / Phase 6 readiness` job enforces configuration drift detection on every PR and on `main`.
-* **Resilience telemetry** – the demo computes average/min/max resilience, sentinel coverage, and value flow across finance, health, logistics, climate, and the new education lattice.
+* **Resilience & automation telemetry** – the demo computes average/min/max resilience, automation/compliance BPS, settlement latency, sentinel coverage, and value flow across finance, health, logistics, climate, and the new education lattice.
 * **Mesh-level infrastructure clarity** – a new decentralized infra registry renders every Layer-2, storage, identity, oracle, and compute touchpoint for Phase 6 so governance can audit the rails instantly.
 
 ---
@@ -57,8 +57,9 @@
 `contracts/v2/Phase6ExpansionManager.sol` introduces a governance-only control plane that keeps the owner in absolute command:
 
 * `registerDomain`, `updateDomain`, `configureDomainConnectors`, `setDomainStatus`
-* `setGlobalConfig`, `setGlobalGuards`, `setSystemPause`, `setEscalationBridge`, `forwardPauseCall`, `forwardEscalation`
+* `setGlobalConfig`, `setGlobalGuards`, `setGlobalTelemetry`, `setSystemPause`, `setEscalationBridge`, `forwardPauseCall`, `forwardEscalation`
 * `setDomainOperations` locks in per-domain max concurrency, staking floors, revenue share, circuit breakers, and human validation toggles.
+* `setDomainTelemetry` publishes resilience/automation/compliance BPS, settlement latency, sentinel oracle, and manifest/metrics digests for every industry vertical.
 * Deterministic `domainId` helper & `listDomains()` enumeration for tooling.
 * Rejects missing telemetry targets – `subgraphEndpoint` is now mandatory on every domain mutation so dashboards never lose visibility.
 
@@ -90,11 +91,11 @@ flowchart TD
 
 The Graph mapping indexes the new events so dashboards, analytics, and governance tooling have live insight:
 
-* `Phase6Domain` entity tracks metadata, routing addresses, heartbeat SLAs, and pause status.
-* `Phase6GlobalConfig` entity exposes the canonical IoT router, L2 cadence, DID registry, manifest URI, and the active system pause & escalation bridges.
+* `Phase6Domain` entity tracks metadata, routing addresses, heartbeat SLAs, pause status **and** telemetry BPS/latency digests from `DomainTelemetryUpdated`.
+* `Phase6GlobalConfig` entity exposes the canonical IoT router, L2 cadence, DID registry, manifest URI, emergency bridges, and the telemetry floor signals emitted by `GlobalTelemetryUpdated`.
 * Every `EscalationForwarded` event is indexed with payload/response metadata so dashboards can surface the last emergency action and whether it targeted the pause contract or the escalation bridge.
-* Each event (`DomainRegistered`, `DomainUpdated`, `DomainStatusChanged`, `GlobalConfigUpdated`) updates the store instantly.
-* New handlers capture `DomainOperationsUpdated` & `GlobalGuardsUpdated` so analysts can graph staking floors, queue depth, treasury share, circuit breaker thresholds, and global auto-pause policy over time.
+* Each event (`DomainRegistered`, `DomainUpdated`, `DomainStatusChanged`, `GlobalConfigUpdated`, `DomainTelemetryUpdated`, `GlobalTelemetryUpdated`) updates the store instantly.
+* New handlers capture `DomainOperationsUpdated` & `GlobalGuardsUpdated` so analysts can graph staking floors, queue depth, treasury share, circuit breaker thresholds, global auto-pause policy, and telemetry floors over time.
 
 These additions power UI cards, CI validation, and off-chain monitoring (e.g., the Resilience Index).
 
@@ -103,7 +104,7 @@ These additions power UI cards, CI validation, and off-chain monitoring (e.g., t
 ## 🕸️ Decentralized infrastructure mesh
 
 * `config/domains.phase6.json` now includes a **global `decentralizedInfra` array** and per-domain `infrastructure` inventories. Each entry captures layer, provider, role, status, and optional endpoint.
-* `scripts/run-phase6-demo.ts` surfaces mesh telemetry – global integration counts, per-domain touchpoints, and copy-paste friendly summaries for multi-sig review.
+* `scripts/run-phase6-demo.ts` surfaces mesh + telemetry data – global integration counts, per-domain touchpoints, resilience/automation/compliance BPS, settlement latencies, and copy-paste friendly summaries for multi-sig review.
 * `index.html` renders the infra mesh alongside bridge plans so non-technical operators see exactly which L2s, storage rails, DID registries, and compute meshes come online.
 * `scripts/ci-check.mjs` enforces structural integrity: at least three integrations per domain and valid metadata for every mesh element.
 * `orchestrator/extensions/phase6.py` consumes the infra map to annotate runtime logs (`infra mesh: Layer-2:Linea(active)`) and to expose integration hints to IoT signal handlers.
@@ -150,7 +151,7 @@ Open `index.html` to explore:
 
 ## ✅ Deliverables included
 
-* Smart-contract upgrade: `Phase6ExpansionManager` + tests + mocks (global guard rails + domain operations control).
+* Smart-contract upgrade: `Phase6ExpansionManager` + tests + mocks (global guard rails, telemetry control, and domain operations control).
 * Python runtime extension with domain routing, IoT signal ingestion, guard-rail annotation, and bridge planning.
 * Subgraph schema & mapping updates for Phase 6 telemetry including guard/operations snapshots.
 * Static UI + JSON config + orchestration scripts for non-technical operators.

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json
@@ -40,7 +40,14 @@
         "status": "armed",
         "endpoint": "https://mesh.agi.jobs/lit-threshold"
       }
-    ]
+    ],
+    "telemetry": {
+      "manifestHash": "0x2613ea16baaa9a77b9aabab976b736dd81ebaeb5b209909b8aea66845a8314fa",
+      "metricsDigest": "0xc18fe72d328409449dcbf4defceb1d0e1497491f1c28e2c94290e689853e9de0",
+      "resilienceFloorBps": 9300,
+      "automationFloorBps": 9050,
+      "oversightWeightBps": 7200
+    }
   },
   "domains": [
     {
@@ -60,6 +67,17 @@
         "treasuryShareBps": 280,
         "circuitBreakerBps": 7200,
         "requiresHumanValidation": false
+      },
+      "telemetry": {
+        "resilienceBps": 9820,
+        "automationBps": 9475,
+        "complianceBps": 9650,
+        "settlementLatencySeconds": 32,
+        "usesL2Settlement": true,
+        "sentinelOracle": "0xc101010101010101010101010101010101010101",
+        "settlementAsset": "0xd202020202020202020202020202020202020202",
+        "metricsDigest": "0x2eebf13ed4594d4f83586ed0eb1d91c898861aa027d5fce841139f2cc4ff0d33",
+        "manifestHash": "0x2a3411c416ed4423c23e0e02d341ec8437d66c5385a83ee326a5524d222dfc17"
       },
       "skillTags": [
         "finance",
@@ -130,6 +148,17 @@
         "circuitBreakerBps": 6800,
         "requiresHumanValidation": true
       },
+      "telemetry": {
+        "resilienceBps": 9750,
+        "automationBps": 9310,
+        "complianceBps": 9890,
+        "settlementLatencySeconds": 44,
+        "usesL2Settlement": true,
+        "sentinelOracle": "0xc202020202020202020202020202020202020202",
+        "settlementAsset": "0xd303030303030303030303030303030303030303",
+        "metricsDigest": "0xc742f109b6ccb76e9e0da2b9a0066eaec70cd15247cd3d9d61ccd69174a0a57c",
+        "manifestHash": "0x1d5c15acbc09b4a0c1ff3a45be44b9016b78261ef652f480d89b5b281ac9f2dd"
+      },
       "skillTags": [
         "healthcare",
         "diagnostics",
@@ -197,6 +226,17 @@
         "treasuryShareBps": 300,
         "circuitBreakerBps": 7000,
         "requiresHumanValidation": false
+      },
+      "telemetry": {
+        "resilienceBps": 9680,
+        "automationBps": 9120,
+        "complianceBps": 9410,
+        "settlementLatencySeconds": 38,
+        "usesL2Settlement": true,
+        "sentinelOracle": "0xc303030303030303030303030303030303030303",
+        "settlementAsset": "0xd404040404040404040404040404040404040404",
+        "metricsDigest": "0x0f0730f130f09ec28a4f1979a06d6bc62cf2dd251af495f6ad953a8f8d3e562f",
+        "manifestHash": "0x112bebd20f5b4a430d951c1b7b3783d375dc72e71b9fb24df79aca77e2371a14"
       },
       "skillTags": [
         "logistics",
@@ -268,6 +308,17 @@
         "circuitBreakerBps": 6600,
         "requiresHumanValidation": true
       },
+      "telemetry": {
+        "resilienceBps": 9420,
+        "automationBps": 8840,
+        "complianceBps": 9125,
+        "settlementLatencySeconds": 56,
+        "usesL2Settlement": false,
+        "sentinelOracle": "0xc404040404040404040404040404040404040404",
+        "settlementAsset": "0xd505050505050505050505050505050505050505",
+        "metricsDigest": "0x545a606dc7a79eabf30db4432149a962decdf29b6cb5d3136b46ee87a3e020da",
+        "manifestHash": "0x5ab7ec8ed296a9fd0e30f8f6ac80de6026465593d4e823f9eb8e279d3d10bad8"
+      },
       "skillTags": [
         "climate",
         "sustainability",
@@ -336,6 +387,17 @@
         "treasuryShareBps": 240,
         "circuitBreakerBps": 6500,
         "requiresHumanValidation": true
+      },
+      "telemetry": {
+        "resilienceBps": 9570,
+        "automationBps": 9040,
+        "complianceBps": 9350,
+        "settlementLatencySeconds": 41,
+        "usesL2Settlement": true,
+        "sentinelOracle": "0xc505050505050505050505050505050505050505",
+        "settlementAsset": "0xd606060606060606060606060606060606060606",
+        "metricsDigest": "0xc7fead15d3fef8d6c5f63b8d2d5e53c583264a213178eea1fef3c23133507fc0",
+        "manifestHash": "0xfdbc03878183a69c2462afacd96eff4ee1ed3a7c6582e81550a3c05aa407aefc"
       },
       "skillTags": [
         "education",

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/index.html
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/index.html
@@ -254,6 +254,7 @@
 
     <script type="module">
       const zeroAddress = '0x0000000000000000000000000000000000000000';
+      const zeroBytes32 = '0x' + '0'.repeat(64);
       const configPath = './config/domains.phase6.json';
       const abi = await fetch('../subgraph/abis/Phase6ExpansionManager.json').then((res) => res.json());
       const { Interface, keccak256, toUtf8Bytes, formatEther } = await import('https://cdn.jsdelivr.net/npm/ethers@6.15.0/+esm');
@@ -293,13 +294,30 @@
           typeof minStakeRaw === 'string'
             ? BigInt(minStakeRaw)
             : BigInt(Math.trunc(Number(minStakeRaw)));
+      return [
+        BigInt(Math.trunc(Number(ops.maxActiveJobs ?? 0))),
+        BigInt(Math.trunc(Number(ops.maxQueueDepth ?? 0))),
+        minStake,
+        Number(ops.treasuryShareBps ?? 0),
+        Number(ops.circuitBreakerBps ?? 0),
+        Boolean(ops.requiresHumanValidation),
+      ];
+      }
+
+      function buildDomainTelemetryTuple(domain) {
+        const telemetry = domain.telemetry ?? {};
+        const toBytes32 = (value) =>
+          typeof value === 'string' && value.startsWith('0x') && value.length === 66 ? value : zeroBytes32;
         return [
-          BigInt(Math.trunc(Number(ops.maxActiveJobs ?? 0))),
-          BigInt(Math.trunc(Number(ops.maxQueueDepth ?? 0))),
-          minStake,
-          Number(ops.treasuryShareBps ?? 0),
-          Number(ops.circuitBreakerBps ?? 0),
-          Boolean(ops.requiresHumanValidation),
+          Number(telemetry.resilienceBps ?? 0),
+          Number(telemetry.automationBps ?? 0),
+          Number(telemetry.complianceBps ?? 0),
+          Number(telemetry.settlementLatencySeconds ?? 0),
+          Boolean(telemetry.usesL2Settlement ?? false),
+          telemetry.sentinelOracle ?? zeroAddress,
+          telemetry.settlementAsset ?? zeroAddress,
+          toBytes32(telemetry.metricsDigest),
+          toBytes32(telemetry.manifestHash),
         ];
       }
 
@@ -340,12 +358,34 @@
 
       function computeMetrics(config) {
         const resilience = [];
+        const automation = [];
+        const compliance = [];
+        const latency = [];
+        let l2Coverage = 0;
         const valueFlows = [];
         const sentinels = new Set();
         config.domains.forEach((domain) => {
           const idx = Number.parseFloat(domain.metadata?.resilienceIndex ?? '');
           if (!Number.isNaN(idx)) {
             resilience.push(idx);
+          }
+          if (domain.telemetry) {
+            const telemetry = domain.telemetry;
+            const auto = Number(telemetry.automationBps ?? NaN);
+            const comp = Number(telemetry.complianceBps ?? NaN);
+            const latencySeconds = Number(telemetry.settlementLatencySeconds ?? NaN);
+            if (!Number.isNaN(auto)) {
+              automation.push(auto);
+            }
+            if (!Number.isNaN(comp)) {
+              compliance.push(comp);
+            }
+            if (!Number.isNaN(latencySeconds)) {
+              latency.push(latencySeconds);
+            }
+            if (telemetry.usesL2Settlement) {
+              l2Coverage += 1;
+            }
           }
           const value = domain.metadata?.valueFlowMonthlyUSD;
           if (typeof value === 'number' && Number.isFinite(value)) {
@@ -366,12 +406,21 @@
           maxResilience,
           totalValueFlow,
           sentinelCount: sentinels.size,
+          averageAutomation: automation.length
+            ? automation.reduce((acc, cur) => acc + cur, 0) / automation.length
+            : null,
+          averageCompliance: compliance.length
+            ? compliance.reduce((acc, cur) => acc + cur, 0) / compliance.length
+            : null,
+          averageLatency: latency.length ? latency.reduce((acc, cur) => acc + cur, 0) / latency.length : null,
+          l2Coverage: config.domains.length ? l2Coverage / config.domains.length : 0,
         };
       }
 
       function renderGlobal(config) {
         const target = document.getElementById('global-summary');
         target.innerHTML = '';
+        const telemetry = config.global.telemetry || {};
         const items = [
           `Global manifest: ${config.global.manifestURI}`,
           `IoT oracle router: ${formatAddress(config.global.iotOracleRouter)}`,
@@ -385,13 +434,38 @@
           `Circuit breaker: ${formatBps(config.global.guards?.circuitBreakerBps)}`,
           `Anomaly grace: ${config.global.guards?.anomalyGracePeriod ?? '—'}s`,
           `Auto-pause: ${String(config.global.guards?.autoPauseEnabled ?? false)}`,
-          `Oversight council: ${formatAddress(config.global.guards?.oversightCouncil)}`
+          `Oversight council: ${formatAddress(config.global.guards?.oversightCouncil)}`,
+          `Telemetry manifest hash: ${telemetry.manifestHash ?? '—'}`,
+          `Telemetry metrics digest: ${telemetry.metricsDigest ?? '—'}`,
+          `Telemetry resilience floor: ${formatBps(telemetry.resilienceFloorBps)}`,
+          `Telemetry automation floor: ${formatBps(telemetry.automationFloorBps)}`,
+          `Telemetry oversight weight: ${formatBps(telemetry.oversightWeightBps)}`,
         ];
         if (state.metrics) {
-          const { averageResilience, minResilience, maxResilience, totalValueFlow, sentinelCount } = state.metrics;
+          const {
+            averageResilience,
+            minResilience,
+            maxResilience,
+            totalValueFlow,
+            sentinelCount,
+            averageAutomation,
+            averageCompliance,
+            averageLatency,
+            l2Coverage,
+          } = state.metrics;
           if (averageResilience !== null) {
             items.push(`Network resilience: avg ${averageResilience.toFixed(3)} (min ${minResilience?.toFixed(3)}, max ${maxResilience?.toFixed(3)})`);
           }
+          if (averageAutomation !== null) {
+            items.push(`Automation maturity: ${formatBps(averageAutomation)}`);
+          }
+          if (averageCompliance !== null) {
+            items.push(`Compliance assurance: ${formatBps(averageCompliance)}`);
+          }
+          if (averageLatency !== null) {
+            items.push(`Average settlement latency: ${averageLatency.toFixed(1)}s`);
+          }
+          items.push(`L2 settlement coverage: ${(l2Coverage * 100).toFixed(1)}% of domains`);
           if (totalValueFlow) {
             items.push(`Monthly value flow across domains: ${formatUSD(totalValueFlow)}`);
           }
@@ -428,6 +502,7 @@
           const metrics = document.createElement('div');
           metrics.className = 'metrics';
           const metadata = domain.metadata || {};
+          const telemetry = domain.telemetry || {};
           const resilience = metadata.resilienceIndex !== undefined ? Number(metadata.resilienceIndex).toFixed(3) : '—';
           metrics.innerHTML = `
             <span>Manifest URI: ${domain.manifestURI}</span>
@@ -440,6 +515,7 @@
             <span>Resilience index: ${resilience}</span>
             <span>Monthly value flow: ${metadata.valueFlowDisplay ?? formatUSD(metadata.valueFlowMonthlyUSD)}</span>
             <span>Domain sentinel: ${metadata.sentinel ?? '—'}</span>
+            <span>Sentinel oracle: ${formatAddress(telemetry.sentinelOracle)}</span>
             <span>Uptime: ${metadata.uptime ?? '—'}</span>
             <span>Max active jobs: ${domain.operations?.maxActiveJobs ?? '—'}</span>
             <span>Queue depth: ${domain.operations?.maxQueueDepth ?? '—'}</span>
@@ -447,6 +523,12 @@
             <span>Treasury share: ${formatBps(domain.operations?.treasuryShareBps)}</span>
             <span>Circuit breaker: ${formatBps(domain.operations?.circuitBreakerBps)}</span>
             <span>Requires human validation: ${domain.operations?.requiresHumanValidation ? 'Yes' : 'No'}</span>
+            <span>Telemetry resilience: ${formatBps(telemetry.resilienceBps)}</span>
+            <span>Telemetry automation: ${formatBps(telemetry.automationBps)}</span>
+            <span>Telemetry compliance: ${formatBps(telemetry.complianceBps)}</span>
+            <span>Settlement latency: ${telemetry.settlementLatencySeconds ?? '—'}s (L2 ${telemetry.usesL2Settlement ? 'enabled' : 'disabled'})</span>
+            <span>Telemetry metrics digest: ${telemetry.metricsDigest ?? '—'}</span>
+            <span>Telemetry manifest hash: ${telemetry.manifestHash ?? '—'}</span>
           `;
           card.appendChild(metrics);
           grid.appendChild(card);
@@ -460,6 +542,7 @@
           const div = document.createElement('div');
           div.className = 'domain-card';
           const metadata = domain.metadata || {};
+          const telemetry = domain.telemetry || {};
           const bridge = {
             domain: domain.slug,
             l2Gateway: domain.l2Gateway || config.global.defaultL2Gateway,
@@ -469,6 +552,11 @@
             cadence: heartbeatSummary(domain, config.global),
             sentinel: metadata.sentinel || '—',
             resilience: metadata.resilienceIndex !== undefined ? Number(metadata.resilienceIndex).toFixed(3) : '—',
+            telemetryResilience: telemetry.resilienceBps ?? null,
+            telemetryAutomation: telemetry.automationBps ?? null,
+            telemetryCompliance: telemetry.complianceBps ?? null,
+            settlementLatency: telemetry.settlementLatencySeconds ?? null,
+            usesL2: telemetry.usesL2Settlement ?? false,
           };
           div.innerHTML = `
             <h3>${domain.name}</h3>
@@ -483,6 +571,10 @@
               <span>Max active jobs: ${domain.operations?.maxActiveJobs ?? '—'}</span>
               <span>Min stake: ${formatStake(domain.operations?.minStake)}</span>
               <span>Treasury share: ${formatBps(domain.operations?.treasuryShareBps)}</span>
+              <span>Telemetry resilience: ${bridge.telemetryResilience !== null ? formatBps(Number(bridge.telemetryResilience)) : '—'}</span>
+              <span>Telemetry automation: ${bridge.telemetryAutomation !== null ? formatBps(Number(bridge.telemetryAutomation)) : '—'}</span>
+              <span>Telemetry compliance: ${bridge.telemetryCompliance !== null ? formatBps(Number(bridge.telemetryCompliance)) : '—'}</span>
+              <span>Settlement latency: ${bridge.settlementLatency ?? '—'}s (L2 ${bridge.usesL2 ? 'enabled' : 'disabled'})</span>
             </div>
           `;
           grid.appendChild(div);
@@ -522,6 +614,17 @@
           Boolean(config.global.guards?.autoPauseEnabled ?? false),
           config.global.guards?.oversightCouncil ?? zeroAddress,
         ];
+        const telemetryTuple = [
+          (config.global.telemetry?.manifestHash && config.global.telemetry.manifestHash.length === 66)
+            ? config.global.telemetry.manifestHash
+            : zeroBytes32,
+          (config.global.telemetry?.metricsDigest && config.global.telemetry.metricsDigest.length === 66)
+            ? config.global.telemetry.metricsDigest
+            : zeroBytes32,
+          Number(config.global.telemetry?.resilienceFloorBps ?? 0),
+          Number(config.global.telemetry?.automationFloorBps ?? 0),
+          Number(config.global.telemetry?.oversightWeightBps ?? 0),
+        ];
         calldata.push({
           label: 'setGlobalConfig(GlobalConfig)',
           data: iface.encodeFunctionData('setGlobalConfig', [globalTuple]),
@@ -529,6 +632,10 @@
         calldata.push({
           label: 'setGlobalGuards(GlobalGuards)',
           data: iface.encodeFunctionData('setGlobalGuards', [guardTuple]),
+        });
+        calldata.push({
+          label: 'setGlobalTelemetry(GlobalTelemetry)',
+          data: iface.encodeFunctionData('setGlobalTelemetry', [telemetryTuple]),
         });
         if (config.global.systemPause && config.global.systemPause !== zeroAddress) {
           calldata.push({
@@ -546,6 +653,7 @@
           const tuple = buildDomainTuple(domain);
           const domainId = keccak256(toUtf8Bytes(domain.slug.toLowerCase()));
           const opsTuple = buildDomainOperationsTuple(domain);
+          const telemetryTupleDomain = buildDomainTelemetryTuple(domain);
           calldata.push({
             label: `registerDomain(${domain.slug})`,
             data: iface.encodeFunctionData('registerDomain', [tuple]),
@@ -560,6 +668,10 @@
           calldata.push({
             label: `setDomainOperations(${domain.slug})`,
             data: iface.encodeFunctionData('setDomainOperations', [domainId, opsTuple]),
+          });
+          calldata.push({
+            label: `setDomainTelemetry(${domain.slug})`,
+            data: iface.encodeFunctionData('setDomainTelemetry', [domainId, telemetryTupleDomain]),
           });
         });
         state.calldata = calldata;

--- a/subgraph/abis/Phase6ExpansionManager.json
+++ b/subgraph/abis/Phase6ExpansionManager.json
@@ -101,6 +101,17 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "field",
+        "type": "string"
+      }
+    ],
+    "name": "InvalidDigest",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "InvalidHeartbeat",
     "type": "error"
@@ -140,6 +151,17 @@
   {
     "inputs": [],
     "name": "InvalidSubgraphEndpoint",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "field",
+        "type": "string"
+      }
+    ],
+    "name": "InvalidTelemetryValue",
     "type": "error"
   },
   {
@@ -307,6 +329,73 @@
       }
     ],
     "name": "DomainStatusChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "resilienceBps",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "automationBps",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "complianceBps",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "settlementLatencySeconds",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "usesL2Settlement",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sentinelOracle",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "settlementAsset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "metricsDigest",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "manifestHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DomainTelemetryUpdated",
     "type": "event"
   },
   {
@@ -498,6 +587,43 @@
       }
     ],
     "name": "GlobalGuardsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "manifestHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "metricsDigest",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "resilienceFloorBps",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "automationFloorBps",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "oversightWeightBps",
+        "type": "uint32"
+      }
+    ],
+    "name": "GlobalTelemetryUpdated",
     "type": "event"
   },
   {
@@ -807,6 +933,72 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getDomainTelemetry",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "resilienceBps",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "automationBps",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "complianceBps",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "settlementLatencySeconds",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bool",
+            "name": "usesL2Settlement",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "sentinelOracle",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "settlementAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metricsDigest",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "manifestHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct Phase6ExpansionManager.DomainTelemetry",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "globalConfig",
     "outputs": [
@@ -872,6 +1064,39 @@
         "internalType": "address",
         "name": "oversightCouncil",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "globalTelemetry",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "manifestHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "metricsDigest",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "resilienceFloorBps",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "automationFloorBps",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "oversightWeightBps",
+        "type": "uint32"
       }
     ],
     "stateMutability": "view",
@@ -1122,6 +1347,71 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "resilienceBps",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "automationBps",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "complianceBps",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "settlementLatencySeconds",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bool",
+            "name": "usesL2Settlement",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "sentinelOracle",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "settlementAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metricsDigest",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "manifestHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct Phase6ExpansionManager.DomainTelemetry",
+        "name": "telemetry",
+        "type": "tuple"
+      }
+    ],
+    "name": "setDomainTelemetry",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "newBridge",
         "type": "address"
@@ -1213,6 +1503,46 @@
       }
     ],
     "name": "setGlobalGuards",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "manifestHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metricsDigest",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "resilienceFloorBps",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "automationFloorBps",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "oversightWeightBps",
+            "type": "uint32"
+          }
+        ],
+        "internalType": "struct Phase6ExpansionManager.GlobalTelemetry",
+        "name": "telemetry",
+        "type": "tuple"
+      }
+    ],
+    "name": "setGlobalTelemetry",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -104,6 +104,15 @@ type Phase6Domain @entity {
   treasuryShareBps: Int!
   circuitBreakerBps: Int!
   requiresHumanValidation: Boolean!
+  telemetryResilienceBps: Int!
+  telemetryAutomationBps: Int!
+  telemetryComplianceBps: Int!
+  settlementLatencySeconds: Int!
+  usesL2Settlement: Boolean!
+  sentinelOracle: Bytes
+  settlementAsset: Bytes
+  telemetryMetricsDigest: Bytes
+  telemetryManifestHash: Bytes
 }
 
 type Phase6GlobalConfig @entity {
@@ -129,4 +138,9 @@ type Phase6GlobalConfig @entity {
   anomalyGracePeriod: Int!
   autoPauseEnabled: Boolean!
   oversightCouncil: Bytes
+  telemetryManifestHash: Bytes
+  telemetryMetricsDigest: Bytes
+  telemetryResilienceFloorBps: Int!
+  telemetryAutomationFloorBps: Int!
+  telemetryOversightWeightBps: Int!
 }

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -98,10 +98,14 @@ dataSources:
           handler: handlePhase6DomainStatusChanged
         - event: DomainOperationsUpdated(indexed bytes32,uint48,uint48,uint96,uint16,uint16,bool)
           handler: handlePhase6DomainOperationsUpdated
+        - event: DomainTelemetryUpdated(indexed bytes32,uint32,uint32,uint32,uint32,bool,address,address,bytes32,bytes32)
+          handler: handlePhase6DomainTelemetryUpdated
         - event: GlobalConfigUpdated(indexed address,indexed address,address,address,uint64,string)
           handler: handlePhase6GlobalConfigUpdated
         - event: GlobalGuardsUpdated(uint16,uint16,uint32,bool,address)
           handler: handlePhase6GlobalGuardsUpdated
+        - event: GlobalTelemetryUpdated(bytes32,bytes32,uint32,uint32,uint32)
+          handler: handlePhase6GlobalTelemetryUpdated
         - event: SystemPauseUpdated(indexed address)
           handler: handlePhase6SystemPauseUpdated
         - event: EscalationBridgeUpdated(indexed address)


### PR DESCRIPTION
## Summary
- extend Phase6ExpansionManager with governance-controlled telemetry structs, events, getters, and validation helpers
- surface the new telemetry data across config tooling, orchestrator runtime, demo UI, and subgraph to expose global and domain readiness metrics
- harden configuration assets, tests, and CI checks for bytes32 telemetry values and actionable planning output

## Testing
- `npx hardhat test test/v2/Phase6ExpansionManager.test.js --no-compile`
- `npm run demo:phase6:ci`
- `npm run lint:ci`


------
https://chatgpt.com/codex/tasks/task_e_68fa91aeda608333ad3646a76f25779c