### PR TITLE
Add validation and tests for Phase 8 orchestration console

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/README.md
+++ b/demo/Phase-8-Universal-Value-Dominance/README.md
@@ -42,6 +42,25 @@
 
 ---
 
+## ⚙️ Orchestration flow & troubleshooting
+
+1. **Load + validate** – the CLI parses `config/universal.value.manifest.json` through a strict Zod schema. Any missing slug,
+   malformed address, or negative cadence halts execution with a red `Phase 8 orchestration failed` banner and a bullet list of
+   the offending paths. Fix the manifest and rerun.
+2. **Encode governance calls** – calldata is generated with deterministic `ethers.Interface` encoders. If you see an encoding
+   failure, double-check that every address is a 20-byte hex string and that large integers (for TVL or budgets) are expressed
+   as base-10 strings or safe integers.
+3. **Export artifacts** – the script writes Safe templates, telemetry, and Mermaid diagrams into `output/`. Override
+   destinations via `PHASE8_MANAGER_ADDRESS` / `PHASE8_CHAIN_ID`; invalid overrides trigger validation errors instead of
+   silently falling back to defaults.
+4. **Troubleshoot quickly** – rerun with `DEBUG=*` to inspect encoded calldata, or delete the generated `output/` directory to
+   force a clean regeneration if filesystem permissions or stale files cause issues.
+
+> **Tip**: When copying telemetry into wikis, reference the timestamped header in `phase8-telemetry-report.md` to confirm the
+latest run. Safe imports should always display the chain ID and manager address injected by the environment variables above.
+
+---
+
 ## 🧭 Why this demo matters
 
 * **Universal authority with hard guardrails** – the new `Phase8UniversalValueManager` contract keeps the owner in absolute

--- a/demo/Phase-8-Universal-Value-Dominance/jest.config.cjs
+++ b/demo/Phase-8-Universal-Value-Dominance/jest.config.cjs
@@ -1,0 +1,16 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: __dirname,
+  testMatch: ['<rootDir>/scripts/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/../../tsconfig.json',
+      diagnostics: true,
+    },
+  },
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
+};

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/__snapshots__/phase8-orchestrator.test.ts.snap
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/__snapshots__/phase8-orchestrator.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Phase 8 orchestration console writes artifact kit with telemetry and mermaid snapshots 1`] = `
+"# Phase 8 — Universal Value Dominance Telemetry
+Generated: <timestamp>
+
+## Global Metrics
+- Total monthly value flow: $688.00B
+- Annual capital allocation: $1.97T
+- Average resilience index: 0.925
+- Sentinel coverage per guardian cycle: 18.0 minutes
+- Domains covered by sentinels: 100.0%
+- Maximum encoded autonomy: 7800 bps
+- Self-improvement cadence: every 2.00 hours
+- Last self-improvement execution: 2023-11-14T22:20:00.000Z
+
+## Governance Control Surface
+- Treasury: 0x8a1f8f5e3b9d9b2a7b6c5e4f3d2c1b0a9f8e7d6c
+- Universal vault: 0xb5c7fe65f0c84a22330a3e913450b1214cc0a8f9
+- Upgrade coordinator: 0x3e8b71da4c5e981a2d4facfe97b53bd2736d1d10
+- Validator registry: 0x21f49cff41f9e69a13a3d6cef7b1a92d9c4e0d8e
+- Mission control: 0xe9a6b9b6c6a53382e5e7d1b8e0f93c5f4a32e1a4
+- Knowledge graph: 0x9b2b5f9c4d4e58a63e934f52aa4c3f62f6c4b672
+- Guardian council: 0x4c3ab8173d97d58b0daa9f73a2e3e87a4fe98c87
+- System pause: 0xdd1f26bcb5d0faa1a69729db849bb4c276c74e5c
+- Manifest URI: ipfs://agi-jobs/phase8/manifest.json
+- Max drawdown guard: 3200 bps
+
+## Domains
+| Domain | Autonomy (bps) | Resilience | Heartbeat (s) | TVL cap | Monthly value | Sentinels | Capital streams |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Planetary Finance Mesh | 7800 | 0.960 | 300 | 420… (10^24) | $245.00B | Capital Watch Exocomptroller | Planetary Resilience Fund |
+| Climate Harmonizer Array | 7400 | 0.940 | 180 | 185… (10^24) | $128.00B | Solar Shield Guardian | Climate Stabilization Endowment |
+| Health Sovereign Continuum | 7000 | 0.910 | 240 | 920… (10^23) | $94.00B | Bio Sentinel Continuity | Planetary Resilience Fund |
+| Infrastructure Synthesis Grid | 7600 | 0.915 | 210 | 215… (10^24) | $167.00B | Solar Shield Guardian | Climate Stabilization Endowment, Innovation Thrust Catalyst |
+| Knowledge Lattice Nexus | 6900 | 0.902 | 150 | 680… (10^23) | $54.00B | Capital Watch Exocomptroller | Planetary Resilience Fund, Innovation Thrust Catalyst |
+
+## Sentinel Lattice
+- Solar Shield Guardian · coverage 420s · sensitivity 450 bps · guarding climate-harmonizer, infrastructure-synthesis
+- Capital Watch Exocomptroller · coverage 360s · sensitivity 380 bps · guarding planetary-finance, knowledge-lattice
+- Bio Sentinel Continuity · coverage 300s · sensitivity 420 bps · guarding health-sovereign
+
+## Capital Streams
+- Climate Stabilization Endowment · $720.00B/yr · expansion 1300 bps · targets climate-harmonizer, infrastructure-synthesis
+- Planetary Resilience Fund · $890.00B/yr · expansion 1250 bps · targets planetary-finance, health-sovereign, knowledge-lattice
+- Innovation Thrust Catalyst · $360.00B/yr · expansion 1600 bps · targets knowledge-lattice, infrastructure-synthesis
+
+## Self-Improvement Kernel
+- Strategic plan: cadence 7200s (2.00 h) · hash 0x7d2556f5ae0a7dd2e9c3c5e29377b7af168e2b2f42a3e08d96b9f8e32d4b9f10 · last report ipfs://agi-jobs/phase8/self-improvement/reports/epoch-144.json
+- Playbook Hyperparameter Evolution (weekly) · owner 0x4c3ab8173d97d58b0daa9f73a2e3e87a4fe98c87 · guardrails checksum-verification, zk-proof-of-alignment
+- Playbook Universal Value Mesh Stress Tests (hourly) · owner 0x3e8b71da4c5e981a2d4facfe97b53bd2736d1d10 · guardrails branch-protected-ci, multi-agent-cross-check
+- Autonomy guard: ≤8000 bps · override window 15 minutes · escalation guardian-council → dao-emergency → sentinel-lockdown"
+`;
+
+exports[`Phase 8 orchestration console writes artifact kit with telemetry and mermaid snapshots 2`] = `
+"graph TD
+  Governance[[Guardian DAO]] --> Manager(Phase8UniversalValueManager)
+  Manager --> planetaryfinance([Planetary Finance Mesh])
+  Manager --> climateharmonizer([Climate Harmonizer Array])
+  Manager --> healthsovereign([Health Sovereign Continuum])
+  Manager --> infrastructuresynthesis([Infrastructure Synthesis Grid])
+  Manager --> knowledgelattice([Knowledge Lattice Nexus])
+  Manager --> Treasury[[Universal Treasury]]
+  Manager --> Sentinels{Sentinel lattice}
+  Sentinels --> Pause[System pause]
+  Manager --> Streams[[Capital Streams]]
+  Streams --> climatestabilizationStream([Climate Stabilization Endowment])
+  Streams --> planetaryresilienceStream([Planetary Resilience Fund])
+  Streams --> innovationthrustStream([Innovation Thrust Catalyst])
+  Streams --> Domains([Autonomous domains])"
+`;

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/phase8-orchestrator.test.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/phase8-orchestrator.test.ts
@@ -1,0 +1,105 @@
+import { describe, beforeAll, expect, it } from "@jest/globals";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildSafeTransactions,
+  calldata,
+  computeMetrics,
+  flattenCalldataEntries,
+  loadConfig,
+  parseManifest,
+  resolveEnvironment,
+  telemetryMarkdown,
+  mermaid,
+  writeArtifacts,
+  type Phase8Config,
+} from "../run-phase8-demo";
+
+describe("Phase 8 orchestration console", () => {
+  let config: Phase8Config;
+
+  beforeAll(() => {
+    config = loadConfig();
+  });
+
+  it("parses the manifest with strict validation", () => {
+    expect(config.domains).toHaveLength(5);
+    expect(config.sentinels).toHaveLength(3);
+    expect(config.capitalStreams).toHaveLength(3);
+
+    const broken = JSON.parse(JSON.stringify(config));
+    broken.domains[0].slug = "";
+    expect(() => parseManifest(broken)).toThrowError(/domains\.0\.slug: Domain slug is required/);
+  });
+
+  it("encodes calldata and flattens manifests deterministically", () => {
+    const calls = calldata(config);
+    expect(calls.setGlobalParameters).toMatch(/^0x[0-9a-f]+$/i);
+    expect(calls.registerDomains).toHaveLength(config.domains.length);
+
+    const flattened = flattenCalldataEntries(calls);
+    const registerDomain = flattened.find((entry) => entry.label === "registerDomain");
+    expect(registerDomain).toBeDefined();
+    expect(registerDomain?.data).toMatch(/^0x[0-9a-f]+$/i);
+    expect(flattened.length).toBeGreaterThan(config.domains.length + config.sentinels.length + config.capitalStreams.length);
+
+    const safeTransactions = buildSafeTransactions(flattened, "0x1234567890abcdef1234567890abcdef12345678");
+    expect(safeTransactions[0]).toMatchObject({ to: "0x1234567890abcdef1234567890abcdef12345678", value: "0" });
+    expect(new Set(safeTransactions.map((tx) => tx.data)).size).toBeGreaterThan(0);
+  });
+
+  it("resolves environment overrides with validation", () => {
+    expect(resolveEnvironment({} as NodeJS.ProcessEnv)).toEqual({
+      chainId: 1,
+      managerAddress: "0x0000000000000000000000000000000000000000",
+    });
+
+    expect(
+      resolveEnvironment({
+        PHASE8_CHAIN_ID: "777",
+        PHASE8_MANAGER_ADDRESS: "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefabcd",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({
+      chainId: 777,
+      managerAddress: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    });
+
+    expect(() =>
+      resolveEnvironment({
+        PHASE8_CHAIN_ID: "-5",
+        PHASE8_MANAGER_ADDRESS: "not-an-address",
+      } as NodeJS.ProcessEnv),
+    ).toThrowError(/Environment validation failed:[\s\S]*chainId: Chain ID must be positive/);
+  });
+
+  it("writes artifact kit with telemetry and mermaid snapshots", () => {
+    const metrics = computeMetrics(config);
+    const data = calldata(config);
+    const env = { chainId: 8453, managerAddress: "0x9999999999999999999999999999999999999999" } as const;
+    const tempDir = mkdtempSync(join(tmpdir(), "phase8-test-"));
+
+    try {
+      const outputs = writeArtifacts(config, metrics, data, env, { outputDir: tempDir });
+      expect(outputs).toHaveLength(4);
+
+      const telemetryPath = join(tempDir, "phase8-telemetry-report.md");
+      const mermaidPath = join(tempDir, "phase8-mermaid-diagram.mmd");
+      const telemetry = readFileSync(telemetryPath, "utf-8");
+      const diagram = readFileSync(mermaidPath, "utf-8");
+
+      expect(telemetryMarkdown(config, metrics)).toContain("Phase 8 — Universal Value Dominance Telemetry");
+      const stableTelemetry = telemetry.replace(/Generated: .*/u, "Generated: <timestamp>");
+      expect(stableTelemetry).toMatchSnapshot();
+      expect(mermaid(config)).toEqual(diagram);
+      expect(diagram).toMatchSnapshot();
+
+      const safeBatch = JSON.parse(readFileSync(join(tempDir, "phase8-safe-transaction-batch.json"), "utf-8"));
+      expect(safeBatch.chainId).toBe(String(env.chainId));
+      expect(safeBatch.meta.createdFromSafeAddress).toBe(env.managerAddress);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- replace the Phase 8 demo orchestrator with strict Zod validation, environment parsing, and export helpers
- generate Safe bundles, telemetry, and mermaid diagrams through a reusable API with explicit error reporting
- add Jest unit tests, snapshots, and documentation covering orchestration flow and troubleshooting

## Testing
- `npx jest --config demo/Phase-8-Universal-Value-Dominance/jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68faa1d6162c8333a27ae89662332b6e