### PR TITLE
Harden Phase 6 config validation and tests

### DIFF
--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
@@ -143,6 +143,7 @@ Open `index.html` to explore:
 2. **Regenerate** plans with `npm run demo:phase6:orchestrate` (no build step needed).
 3. **Commit** the change. CI will block if a field is missing or malformed.
 4. **Dry-run or apply on-chain** with `npx hardhat run --no-compile scripts/phase6/apply-config.ts --network <network> -- --manager <Phase6ExpansionManager> [--apply]`.
+   * Hard-validates telemetry digests, decentralized infra coverage, metadata, and infrastructure maps before emitting any calldata.
 5. **Ship** – governance can copy the calldata into a multi-sig, or run through the existing owner scripts.
 
 > Tip: pair this demo with `npm run owner:mission-control` to script the actual transaction bundle from the same console.

--- a/scripts/phase6/apply-config-lib.ts
+++ b/scripts/phase6/apply-config-lib.ts
@@ -4,6 +4,34 @@ import { Contract } from 'ethers';
 import { keccak256, toUtf8Bytes } from 'ethers';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+
+export interface DecentralizedInfraEntry {
+  name: string;
+  role: string;
+  status: string;
+  endpoint?: string;
+}
+
+export interface InfrastructureEntry {
+  layer: string;
+  name: string;
+  role: string;
+  status: string;
+  endpoint?: string;
+  uri?: string;
+}
+
+export interface DomainMetadata {
+  domain: string;
+  l2: string;
+  sentinel: string;
+  resilienceIndex: number;
+  uptime: string;
+  valueFlowMonthlyUSD: number;
+  valueFlowDisplay?: string;
+  [key: string]: unknown;
+}
 
 export type GlobalConfigInput = {
   manifestURI: string;
@@ -14,6 +42,7 @@ export type GlobalConfigInput = {
   l2SyncCadence?: number;
   systemPause?: string;
   escalationBridge?: string;
+  decentralizedInfra?: DecentralizedInfraEntry[];
 };
 
 export type DomainConfigInput = {
@@ -29,6 +58,11 @@ export type DomainConfigInput = {
   active?: boolean;
   operations?: DomainOperationsInput;
   telemetry?: DomainTelemetryInput;
+  skillTags?: string[];
+  capabilities?: Record<string, number>;
+  priority?: number;
+  metadata?: DomainMetadata;
+  infrastructure?: InfrastructureEntry[];
 };
 
 export type DomainOperationsInput = {

--- a/test/scripts/phase6ApplyConfig.test.ts
+++ b/test/scripts/phase6ApplyConfig.test.ts
@@ -1,12 +1,6 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import {
-  domainIdFromSlug,
-  fetchPhase6State,
-  planPhase6Changes,
-  Phase6Config,
-  ZERO_ADDRESS,
-} from '../../scripts/phase6/apply-config-lib';
+import { domainIdFromSlug, fetchPhase6State, planPhase6Changes, Phase6Config } from '../../scripts/phase6/apply-config-lib';
 
 async function deploy(name: string, ...args: unknown[]) {
   const factory = await ethers.getContractFactory(name);
@@ -49,6 +43,33 @@ describe('Phase6 apply-config planner', function () {
           autoPauseEnabled: true,
           oversightCouncil: pause.target as string,
         },
+        decentralizedInfra: [
+          {
+            name: 'EigenLayer Risk Shield AVS',
+            role: 'Cross-domain telemetry attestation',
+            status: 'active',
+            endpoint: 'https://mesh.test/avs',
+          },
+          {
+            name: 'Filecoin Saturn Compute Mesh',
+            role: 'Burst compute layer',
+            status: 'ready',
+            endpoint: 'https://mesh.test/compute',
+          },
+          {
+            name: 'Arweave/IPFS Archive',
+            role: 'Manifest anchoring',
+            status: 'active',
+            endpoint: 'ar://phase6/demo',
+          },
+        ],
+        telemetry: {
+          manifestHash: ethers.id('phase6-global-manifest'),
+          metricsDigest: ethers.id('phase6-global-digest'),
+          resilienceFloorBps: 9000,
+          automationFloorBps: 8700,
+          oversightWeightBps: 6400,
+        },
       },
       domains: [
         {
@@ -57,9 +78,9 @@ describe('Phase6 apply-config planner', function () {
           manifestURI: 'ipfs://phase6/domains/finance.json',
           subgraph: 'https://phase6.example/subgraphs/finance',
           validationModule: validation.target as string,
-          oracle: ZERO_ADDRESS,
-          l2Gateway: ZERO_ADDRESS,
-          executionRouter: ZERO_ADDRESS,
+          oracle: router.target as string,
+          l2Gateway: gateway.target as string,
+          executionRouter: validation.target as string,
           heartbeatSeconds: 120,
           active: true,
           operations: {
@@ -70,6 +91,54 @@ describe('Phase6 apply-config planner', function () {
             circuitBreakerBps: 7200,
             requiresHumanValidation: false,
           },
+          telemetry: {
+            resilienceBps: 9200,
+            automationBps: 8800,
+            complianceBps: 9100,
+            settlementLatencySeconds: 45,
+            usesL2Settlement: true,
+            sentinelOracle: validation.target as string,
+            settlementAsset: treasury.target as string,
+            metricsDigest: ethers.id('finance-metrics'),
+            manifestHash: ethers.id('finance-manifest'),
+          },
+          skillTags: ['finance', 'risk'],
+          capabilities: {
+            credit: 4.0,
+            treasury: 3.5,
+          },
+          priority: 95,
+          metadata: {
+            domain: 'Capital markets synthesis',
+            l2: 'Linea',
+            sentinel: 'Resilience-Index-Finance',
+            resilienceIndex: 0.982,
+            uptime: '99.982%',
+            valueFlowMonthlyUSD: 1_200_000_000,
+            valueFlowDisplay: '$1.2B',
+          },
+          infrastructure: [
+            {
+              layer: 'Settlement',
+              name: 'Ethereum Mainnet',
+              role: 'Final settlement',
+              status: 'anchor',
+            },
+            {
+              layer: 'Layer-2',
+              name: 'Linea',
+              role: 'High-frequency execution',
+              status: 'active',
+              endpoint: 'https://linea.build',
+            },
+            {
+              layer: 'Storage',
+              name: 'Arweave',
+              role: 'Portfolio manifests',
+              status: 'active',
+              endpoint: 'ar://phase6/finance',
+            },
+          ],
         },
       ],
     };


### PR DESCRIPTION
## Summary
- tighten the Phase 6 apply-config validation to require non-zero routing addresses, telemetry, decentralized infrastructure, and per-domain metadata/infrastructure integrity
- extend the configuration types and tests to cover telemetry, infrastructure, and skills so a non-technical operator receives immediate feedback on malformed manifests
- document the new hard validations in the demo runbook for Phase 6 operators

## Testing
- npm run demo:phase6:ci
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fadb6d5d948333b2aafa669b43d6b5