### PR TITLE
Enforce Phase 8 readiness in CI and developer workflows

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+echo "[githook] Running Prettier check"
+npm run format:check
+
+echo "[githook] Running lint suite"
+npm run lint:ci

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+echo "[githook] Validating Phase 8 readiness"
+npm run demo:phase8:ci
+
+echo "[githook] Running dependency audit"
+npm run security:audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,26 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - &restore_npm_cache
+        name: Restore npm cache
+        id: npm-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - name: Dependency audit
+        run: npm run security:audit
+      - &save_npm_cache
+        name: Save npm cache
+        if: ${{ success() && steps.npm-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package-lock.json') }}
       - name: Verify toolchain locks
         run: npm run ci:verify-toolchain
       - name: Prettier formatting check
@@ -81,10 +95,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Cache Hardhat compilers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
@@ -94,6 +105,7 @@ jobs:
             hardhat-${{ runner.os }}-
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Compile contracts
         run: |
           npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
@@ -124,12 +136,10 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Regenerate constants for Foundry
         run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
       - name: Install Foundry
@@ -174,10 +184,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Cache Hardhat compilers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
@@ -187,6 +194,7 @@ jobs:
             hardhat-${{ runner.os }}-
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Regenerate constants for coverage
         run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
       - name: Generate coverage report
@@ -225,12 +233,10 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Validate Phase 6 manifest & UI
         run: npm run demo:phase6:ci
 
@@ -254,13 +260,11 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
-      - name: Validate Phase 8 manifest & UI
+      - *save_npm_cache
+      - name: Validate Phase 8 manifest, README, and UI assets
         run: npm run demo:phase8:ci
 
   asi_takeoff_demo:
@@ -281,10 +285,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Cache Hardhat compilers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
@@ -294,6 +295,7 @@ jobs:
             hardhat-${{ runner.os }}-
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Run ASI take-off demonstration
         run: npm run demo:asi-takeoff
       - name: Upload ASI take-off artifacts
@@ -322,10 +324,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Cache Hardhat compilers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
@@ -335,6 +334,7 @@ jobs:
             hardhat-${{ runner.os }}-
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Run Zenith Sapience deterministic kit
         run: npm run demo:zenith-sapience-initiative
       - name: Run Zenith Sapience local rehearsal
@@ -375,10 +375,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Cache Hardhat compilers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
@@ -388,6 +385,7 @@ jobs:
             hardhat-${{ runner.os }}-
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Run grand labour market simulation
         run: npm run demo:agi-labor-market:export
       - name: Upload labour market transcript
@@ -416,11 +414,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            demo/sovereign-mesh/server/package-lock.json
-            demo/sovereign-mesh/app/package-lock.json
+      - *restore_npm_cache
       - name: Install server dependencies
         working-directory: demo/sovereign-mesh/server
         run: npm ci --no-audit --prefer-offline --progress=false
@@ -430,6 +424,7 @@ jobs:
       - name: Install app dependencies
         working-directory: demo/sovereign-mesh/app
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Build React console
         working-directory: demo/sovereign-mesh/app
         run: npm run build
@@ -452,11 +447,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            demo/sovereign-constellation/server/package-lock.json
-            demo/sovereign-constellation/app/package-lock.json
+      - *restore_npm_cache
       - name: Install server dependencies
         working-directory: demo/sovereign-constellation/server
         run: npm ci --no-audit --prefer-offline --progress=false
@@ -466,6 +457,7 @@ jobs:
       - name: Install app dependencies
         working-directory: demo/sovereign-constellation/app
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Build React console
         working-directory: demo/sovereign-constellation/app
         run: npm run build
@@ -488,10 +480,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Cache Hardhat compilers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
@@ -501,6 +490,7 @@ jobs:
             hardhat-${{ runner.os }}-
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Run Celestial Archon deterministic kit
         run: npm run demo:zenith-sapience-celestial-archon
       - name: Run Celestial Archon local rehearsal
@@ -541,10 +531,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Cache Hardhat compilers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
@@ -554,6 +541,7 @@ jobs:
             hardhat-${{ runner.os }}-
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Run Hypernova deterministic kit
         run: npm run demo:zenith-hypernova
       - name: Run Hypernova local rehearsal
@@ -655,12 +643,10 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            **/package-lock.json
+      - *restore_npm_cache
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
+      - *save_npm_cache
       - name: Regenerate constants for invariants
         run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
       - name: Install Foundry

--- a/.github/workflows/culture-ci.yml
+++ b/.github/workflows/culture-ci.yml
@@ -211,7 +211,18 @@ jobs:
           --health-cmd "cast block-number" --health-interval 5s --health-timeout 5s --health-retries 12 --health-start-period 5s
         ports:
           - 8545:8545
-        command: ["anvil", "--host", "0.0.0.0", "--port", "8545", "--chain-id", "31337", "--block-time", "2"]
+        command:
+          [
+            'anvil',
+            '--host',
+            '0.0.0.0',
+            '--port',
+            '8545',
+            '--chain-id',
+            '31337',
+            '--block-time',
+            '2',
+          ]
       ipfs:
         image: ipfs/kubo:latest
         ports:

--- a/.github/workflows/demo-sovereign-constellation.yml
+++ b/.github/workflows/demo-sovereign-constellation.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - "release/**"
+      - 'release/**'
   pull_request:
     paths:
       - demo/sovereign-constellation/**
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: '20'
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci --no-audit --prefer-offline --progress=false
       - name: Sovereign Constellation CI

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ scripts/**/*.js
 !scripts/run-wire-verify.js
 !scripts/subgraph-e2e.js
 !scripts/docs/check-links.js
+!scripts/setup-git-hooks.js
 !scripts/observability-smoke-check.js
 !scripts/audit/check-freeze.js
 !scripts/release/generate-manifest.js

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -116,3 +116,44 @@ committee stakes or modifying fee distribution):
 Maintaining these procedures ensures rapid containment of slashing anomalies
 while keeping governance parameters aligned with production requirements.
 
+
+## 6. Phase 8 readiness validation
+
+The Phase 8 control room is now a required release gate. Use the CI harness to
+rerun the validations locally whenever Phase 8 files change or when CI
+reports a regression.
+
+1. **Execute the readiness suite.** From the repository root run:
+
+   ```bash
+   npm run demo:phase8:ci
+   ```
+
+   The script mirrors the `ci (v2) / Phase 8 readiness` job. It validates the
+   manifest schema, README heading order, UI markers in `index.html`, and the
+   exported plan/checksum artifacts under `demo/Phase-8-Universal-Value-
+   Dominance/output/`.
+
+2. **Interpret failures quickly.** The output highlights the failing guardrail:
+
+   * `README missing required heading` – the operator guide lost a mandated
+     section or the headings are out of order. Restore the canonical structure
+     so non-technical maintainers can follow the hand-off checklist.
+   * `index.html missing required UI marker` – the dashboard dropped a `data-
+     test-id` hook, orchestration download link, or the mermaid placeholder.
+     Reintroduce the markup to keep automated smoke tests stable.
+   * `Manifest planHash does not match exported plan JSON` (or cadence/URI
+     mismatches) – rerun `npm run demo:phase8:orchestrate` to regenerate the
+     plan export and commit the refreshed files so CI and on-call operators see
+     the same checksum.
+   * Schema errors (duplicate slugs, missing sentinel coverage) map directly to
+     the offending path in `config/universal.value.manifest.json`. Fix the data
+     and rerun the command until it reports ✅.
+
+3. **Escalate stubborn issues.** If the suite passes locally but fails in CI,
+   clear `~/.npm` (or rerun with `DEBUG=phase8`), then attach the transcript to
+   the incident log. The CI summary gate blocks merges until this job is green.
+
+Keeping this drill documented ensures responders can refresh the checks during
+incident response or after large merges without waiting for the remote
+workflow.

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/validate-phase8-config.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/validate-phase8-config.ts
@@ -1,11 +1,15 @@
 #!/usr/bin/env ts-node
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
 
 const ROOT = join(__dirname, "..", "config", "universal.value.manifest.json");
 const HTML = join(__dirname, "..", "index.html");
 const README = join(__dirname, "..", "README.md");
+const OUTPUT_DIR = join(__dirname, "..", "output");
+const PLAN_EXPORT = join(OUTPUT_DIR, "phase8-self-improvement-plan.json");
+const ORCHESTRATION_REPORT = join(OUTPUT_DIR, "phase8-orchestration-report.txt");
+const CYCLE_REPORT = join(OUTPUT_DIR, "phase8-cycle-report.csv");
 
 const address = z
   .string()
@@ -108,6 +112,51 @@ function main() {
   const configRaw = JSON.parse(readFileSync(ROOT, "utf-8"));
   const config = configSchema.parse(configRaw);
 
+  const requiredExports = [
+    { path: PLAN_EXPORT, label: "self-improvement plan export" },
+    { path: ORCHESTRATION_REPORT, label: "orchestration transcript" },
+    { path: CYCLE_REPORT, label: "cycle report" },
+  ] as const;
+  for (const artifact of requiredExports) {
+    if (!existsSync(artifact.path)) {
+      throw new Error(`Phase 8 ${artifact.label} missing at ${artifact.path}`);
+    }
+    if (statSync(artifact.path).size === 0) {
+      throw new Error(`Phase 8 ${artifact.label} at ${artifact.path} is empty`);
+    }
+  }
+
+  const planExportRaw = readFileSync(PLAN_EXPORT, "utf-8");
+  const planExport = JSON.parse(planExportRaw) as {
+    planURI?: string;
+    planHash?: string;
+    cadenceSeconds?: number;
+  };
+  const manifestPlan = config.selfImprovement.plan;
+  if (!planExport.planHash) {
+    throw new Error("Self-improvement plan export missing planHash");
+  }
+  if (planExport.planHash.toLowerCase() !== manifestPlan.planHash.toLowerCase()) {
+    throw new Error("Manifest planHash does not match exported plan JSON");
+  }
+  if (!planExport.planURI || planExport.planURI !== manifestPlan.planURI) {
+    throw new Error("Self-improvement plan export planURI misaligned with manifest");
+  }
+  if (typeof planExport.cadenceSeconds !== "number" || planExport.cadenceSeconds !== manifestPlan.cadenceSeconds) {
+    throw new Error("Self-improvement plan export cadence mismatch");
+  }
+
+  const cycleReportRaw = readFileSync(CYCLE_REPORT, "utf-8").trim();
+  const cycleLines = cycleReportRaw.split(/\r?\n/).filter((line) => line.length > 0);
+  if (cycleLines.length < 2) {
+    throw new Error("Phase 8 cycle report must include at least one execution entry");
+  }
+  const expectedHeader = ["cycle", "executedAt", "reportUri"];
+  const header = cycleLines[0].split(",");
+  if (expectedHeader.some((value, idx) => header[idx] !== value)) {
+    throw new Error(`Cycle report header mismatch — expected ${expectedHeader.join(", ")}`);
+  }
+
   const slugs = new Set<string>();
   for (const domain of config.domains) {
     const slug = domain.slug.toLowerCase();
@@ -158,12 +207,45 @@ function main() {
     throw new Error("index.html must embed a mermaid diagram placeholder");
   }
 
+  const uiMarkers = [
+    'data-test-id="stat-card"',
+    'data-test-id="sentinel-card"',
+    'data-test-id="stream-card"',
+    'data-test-id="runbook-step"',
+    'phase8-orchestration-report.txt',
+  ] as const;
+  for (const marker of uiMarkers) {
+    if (!html.includes(marker)) {
+      throw new Error(`index.html missing required UI marker: ${marker}`);
+    }
+  }
+
   const readme = readFileSync(README, "utf-8");
   const requiredSections = ["Quickstart", "Smart contract", "Mermaid", "Self-improvement"];
   for (const section of requiredSections) {
     if (!readme.toLowerCase().includes(section.toLowerCase())) {
       throw new Error(`README missing required section: ${section}`);
     }
+  }
+
+  const headingSequence = [
+    "## 🚀 Quickstart for operators",
+    "## ⚙️ Orchestration flow & troubleshooting",
+    "## 🧭 Why this demo matters",
+    "## 🧱 Smart contract control surface",
+    "## 🧠 Self-improvement kernel",
+    "## 🛰️ Demo control surface",
+  ] as const;
+  const headingPositions = headingSequence.map((heading) => {
+    const index = readme.indexOf(heading);
+    if (index === -1) {
+      throw new Error(`README missing required heading: ${heading}`);
+    }
+    return index;
+  });
+  const orderedHeadingPositions = [...headingPositions].sort((a, b) => a - b);
+  if (!headingPositions.every((pos, idx) => pos === orderedHeadingPositions[idx])) {
+    throw new Error("README headings out of canonical order");
   }
 
   const maxDomainAutonomy = Math.max(...config.domains.map((d) => d.autonomyLevelBps));
@@ -183,6 +265,10 @@ function main() {
   }
 
   console.log("Phase 8 manifest validated ✔");
+  console.log(`  README headings verified: ${headingSequence.length}`);
+  console.log(`  UI markers verified: ${uiMarkers.length}`);
+  console.log(`  Cycle report entries: ${cycleLines.length - 1}`);
+  console.log(`  Plan hash alignment: ${planExport.planHash}`);
   console.log(`  Domains: ${config.domains.length}`);
   console.log(`  Sentinels: ${config.sentinels.length}`);
   console.log(`  Capital streams: ${config.capitalStreams.length}`);

--- a/docs/ci-v2-branch-protection-checklist.md
+++ b/docs/ci-v2-branch-protection-checklist.md
@@ -10,14 +10,16 @@
 
 | Context | Source job | Why it matters |
 | --- | --- | --- |
-| `ci (v2) / Lint & static checks` | [`lint`](../.github/workflows/ci.yml) | Blocks merges when formatting, ESLint, or Solhint find issues before tests run.【F:.github/workflows/ci.yml†L28-L60】 |
-| `ci (v2) / Tests` | [`tests`](../.github/workflows/ci.yml) | Runs Hardhat compilation, the unit test suite, ABI drift detection, and constants regeneration.【F:.github/workflows/ci.yml†L62-L116】 |
-| `ci (v2) / Foundry` | [`foundry`](../.github/workflows/ci.yml) | Executes fuzz tests after unit tests, even when they fail, to expose property violations.【F:.github/workflows/ci.yml†L118-L165】 |
-| `ci (v2) / Coverage thresholds` | [`coverage`](../.github/workflows/ci.yml) | Enforces ≥90 % coverage and access-control reporting while publishing LCOV artifacts.【F:.github/workflows/ci.yml†L167-L216】 |
-| `ci (v2) / ASI Take-Off Demo` | [`asi_takeoff_demo`](../.github/workflows/ci.yml) | Exercises the ASI take-off rehearsal so mission automation never regresses.【F:.github/workflows/ci.yml†L208-L248】 |
-| `ci (v2) / Zenith Sapience Demonstration` | [`zenith_demo`](../.github/workflows/ci.yml) | Validates the flagship Zenith parameterisation with deterministic kit + local rehearsal.【F:.github/workflows/ci.yml†L249-L300】 |
-| `ci (v2) / Hypernova Governance Demonstration` | [`hypernova_demo`](../.github/workflows/ci.yml) | Runs the Supra-Sovereign Hypernova drill, proving the new governance configuration stays green end-to-end.【F:.github/workflows/ci.yml†L302-L353】 |
-| `ci (v2) / CI summary` | [`summary`](../.github/workflows/ci.yml) | Aggregates upstream job results into a single ✅/❌ indicator required by branch protection.【F:.github/workflows/ci.yml†L355-L401】 |
+| `ci (v2) / Lint & static checks` | [`lint`](../.github/workflows/ci.yml) | Blocks merges when formatting, ESLint, or Solhint find issues before tests run.【F:.github/workflows/ci.yml†L34-L79】 |
+| `ci (v2) / Tests` | [`tests`](../.github/workflows/ci.yml) | Runs Hardhat compilation, the unit test suite, ABI drift detection, and constants regeneration.【F:.github/workflows/ci.yml†L81-L118】 |
+| `ci (v2) / Foundry` | [`foundry`](../.github/workflows/ci.yml) | Executes fuzz tests after unit tests, even when they fail, to expose property violations.【F:.github/workflows/ci.yml†L120-L166】 |
+| `ci (v2) / Coverage thresholds` | [`coverage`](../.github/workflows/ci.yml) | Enforces ≥90 % coverage and access-control reporting while publishing LCOV artifacts.【F:.github/workflows/ci.yml†L168-L214】 |
+| `ci (v2) / Phase 6 readiness` | [`phase6`](../.github/workflows/ci.yml) | Validates the Phase 6 manifest & UI to keep the scaling demo deployable.【F:.github/workflows/ci.yml†L216-L241】 |
+| `ci (v2) / Phase 8 readiness` | [`phase8`](../.github/workflows/ci.yml) | Guards README headings, UI assets, and manifest checksum alignment via `npm run demo:phase8:ci`.【F:.github/workflows/ci.yml†L243-L268】 |
+| `ci (v2) / ASI Take-Off Demo` | [`asi_takeoff_demo`](../.github/workflows/ci.yml) | Exercises the ASI take-off rehearsal so mission automation never regresses.【F:.github/workflows/ci.yml†L270-L307】 |
+| `ci (v2) / Zenith Sapience Demonstration` | [`zenith_demo`](../.github/workflows/ci.yml) | Validates the flagship Zenith parameterisation with deterministic kit + local rehearsal.【F:.github/workflows/ci.yml†L309-L358】 |
+| `ci (v2) / Hypernova Governance Demonstration` | [`hypernova_demo`](../.github/workflows/ci.yml) | Runs the Supra-Sovereign Hypernova drill, proving the new governance configuration stays green end-to-end.【F:.github/workflows/ci.yml†L516-L559】 |
+| `ci (v2) / CI summary` | [`summary`](../.github/workflows/ci.yml) | Aggregates upstream job results into a single ✅/❌ indicator required by branch protection.【F:.github/workflows/ci.yml†L567-L625】 |
 | `static-analysis / Slither static analysis` | [`slither`](../.github/workflows/static-analysis.yml) | Fails the merge if Slither reports unapproved high-severity findings and uploads SARIF to the security tab.【F:.github/workflows/static-analysis.yml†L20-L106】 |
 | `static-analysis / CodeQL analysis` | [`codeql`](../.github/workflows/static-analysis.yml) | Ensures CodeQL JavaScript/TypeScript scans succeed with the hardened config and SARIF upload before merges land.【F:.github/workflows/static-analysis.yml†L108-L157】 |
 
@@ -31,7 +33,7 @@ The job display names in GitHub Actions must stay in sync with these contexts. A
 
 1. Navigate to **Settings → Branches**.
 2. Edit the rule that applies to `main`.
-3. Under **Require status checks to pass before merging**, verify the eight contexts above appear in the list, in order.
+3. Under **Require status checks to pass before merging**, verify the ten contexts above appear in the list, in order.
 4. Confirm **Require branches to be up to date before merging** and **Include administrators** are enabled. Both are required for audit compliance.
 5. Capture a screenshot or export the configuration for your change-control records.
 
@@ -55,7 +57,7 @@ gh api repos/:owner/:repo/branches/main/protection --jq '{required_status_checks
 gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled'
 ```
 
-- The first command must output the eight contexts exactly as listed in the table above.
+- The first command must output the ten contexts exactly as listed in the table above.
 - The second must print `true`, proving administrators cannot bypass the checks.
 - Record the command output (copy/paste or redirect to a dated text file) for auditors.
 

--- a/docs/v2-ci-operations.md
+++ b/docs/v2-ci-operations.md
@@ -45,9 +45,11 @@ Enable branch protection on `main` with these required status checks (copy the c
 | `ci (v2) / Tests` | `tests` job | Runs Hardhat compilation and the main test suite. |
 | `ci (v2) / Foundry` | `foundry` job | Always runs after the `tests` job, even when it fails, to expose fuzz failures. |
 | `ci (v2) / Coverage thresholds` | `coverage` job | Enforces `COVERAGE_MIN` and access-control coverage. |
+| `ci (v2) / Phase 6 readiness` | `phase6` job | Re-validates the Phase 6 manifest and UI so intermediate operators stay guarded. |
+| `ci (v2) / Phase 8 readiness` | `phase8` job | Runs `npm run demo:phase8:ci` to verify README structure, UI markers, and manifest checksum alignment. |
 | `ci (v2) / CI summary` | `summary` job | Fails when any dependency job fails so the PR badge stays red. |
 
-> ✅ **Tip:** In GitHub branch protection, mark `Require branches to be up to date` to guarantee pull requests re-run the workflow when `main` advances.
+> ✅ **Tip:** In GitHub branch protection, mark `Require branches to be up to date` to guarantee pull requests re-run the workflow when `main` advances and reviews stay current.
 
 ### Quick verification from the command line
 
@@ -66,7 +68,7 @@ gh api repos/:owner/:repo/branches/main/protection --jq '{required_status_checks
 gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled'
 ```
 
-The first command should list the five required contexts above in order. The second confirms admins are also blocked when the pipeline is red.
+The first command should list the seven required contexts above in order. The second confirms admins are also blocked when the pipeline is red.
 
 ### Companion workflow checks
 
@@ -83,7 +85,7 @@ Keep the rest of the release surface visible by marking the following workflows 
 
 ## Pull request hygiene checklist
 
-1. Confirm that the **Checks** tab shows all five required `ci (v2)` contexts above plus the companion workflows you have marked as required.
+1. Confirm that the **Checks** tab shows all seven required `ci (v2)` contexts above plus the companion workflows you have marked as required.
 2. Inspect the **Artifacts** section for `coverage-lcov` when coverage needs auditing.
 3. Review the `CI summary` job output for a condensed Markdown table of job results.
 4. When re-running failed jobs, choose **Re-run failed jobs** to keep historical logs.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml?query=branch%3Amain)",
   "main": "index.js",
   "scripts": {
+    "prepare": "node scripts/setup-git-hooks.js",
     "build": "truffle compile",
     "compile": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/generate-constants.ts && hardhat compile",
     "compile:mainnet": "npm run compile -- --network mainnet",

--- a/scripts/setup-git-hooks.js
+++ b/scripts/setup-git-hooks.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+const { chmodSync, existsSync } = require('node:fs');
+const { join } = require('node:path');
+const { execSync } = require('node:child_process');
+
+const hooksDir = join(__dirname, '..', '.githooks');
+
+function ensureExecutable(file) {
+  if (existsSync(file)) {
+    chmodSync(file, 0o755);
+  }
+}
+
+function main() {
+  try {
+    execSync('git rev-parse --is-inside-work-tree', { stdio: 'ignore' });
+  } catch (error) {
+    console.warn('[hooks] Skipping installation (not a git repository).');
+    return;
+  }
+
+  if (!existsSync(hooksDir)) {
+    console.warn('[hooks] Skipping installation (.githooks directory missing).');
+    return;
+  }
+
+  try {
+    execSync(`git config core.hooksPath ${hooksDir}`);
+  } catch (error) {
+    console.warn('[hooks] Failed to set core.hooksPath:', error.message);
+    return;
+  }
+
+  ensureExecutable(join(hooksDir, 'pre-commit'));
+  ensureExecutable(join(hooksDir, 'pre-push'));
+  console.log('[hooks] Git hooks configured at .githooks');
+}
+
+main();


### PR DESCRIPTION
## Summary
- replace ad-hoc npm caching with reusable restore/save steps, add an audit-ci gate, and keep the Phase 8 readiness job explicit in the main workflow
- expand the Phase 8 validator to check README structure, UI markers, and exported checksum alignment while documenting the rerun procedure for maintainers
- introduce git hooks plus a prepare script so local pushes run the formatting, lint, readiness, and dependency audit checks before hitting CI; refresh documentation to require the Phase 6/8 contexts
- format existing workflows that Prettier flagged so the lint suite stays green

## Testing
- npm run format:check
- npm run lint:ci
- npm run demo:phase8:ci
- npm run security:audit *(fails: current dependencies contain known advisories; see audit output)*

------
https://chatgpt.com/codex/tasks/task_e_68fae9ba59448333ae597e9ed8179304