### PR TITLE
Add Phase 6 blueprint export utilities

### DIFF
--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
@@ -26,7 +26,7 @@
    ```bash
    npm run demo:phase6:orchestrate
    ```
-   This prints:
+   Add `-- --json plan.json` to emit a machine-readable blueprint (use `-- --json -` to stream JSON to stdout). This prints:
    * Domain IDs and encoded `registerDomain` / `updateDomain` payloads.
    * Layer-2 bridge plans synthesized from the config and the on-chain ABI.
    * A ready-to-copy mermaid system diagram and runtime routing commentary from the Python orchestrator.

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-blueprint.ts
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-blueprint.ts
@@ -1,0 +1,571 @@
+#!/usr/bin/env ts-node
+import { readFileSync } from 'node:fs';
+import { Interface, formatEther, keccak256, toUtf8Bytes } from 'ethers';
+
+export interface DecentralizedInfraEntry {
+  name: string;
+  role: string;
+  status: string;
+  endpoint?: string;
+}
+
+export interface DomainInfrastructureEntry {
+  layer: string;
+  name: string;
+  role: string;
+  status: string;
+  endpoint?: string;
+  uri?: string;
+}
+
+export interface DomainOperationsConfig {
+  maxActiveJobs: number;
+  maxQueueDepth: number;
+  minStake: string | number;
+  treasuryShareBps: number;
+  circuitBreakerBps: number;
+  requiresHumanValidation?: boolean;
+}
+
+export interface DomainTelemetryConfig {
+  resilienceBps: number;
+  automationBps: number;
+  complianceBps: number;
+  settlementLatencySeconds: number;
+  usesL2Settlement: boolean;
+  sentinelOracle?: string;
+  settlementAsset?: string;
+  metricsDigest: string;
+  manifestHash: string;
+}
+
+export interface DomainMetadataConfig {
+  domain: string;
+  l2: string;
+  sentinel: string;
+  resilienceIndex: number;
+  uptime: string;
+  valueFlowMonthlyUSD: number;
+  valueFlowDisplay?: string;
+  [key: string]: unknown;
+}
+
+export interface Phase6DemoConfig {
+  global: {
+    manifestURI: string;
+    iotOracleRouter?: string;
+    defaultL2Gateway?: string;
+    didRegistry?: string;
+    treasuryBridge?: string;
+    systemPause?: string;
+    escalationBridge?: string;
+    l2SyncCadence?: number;
+    guards?: {
+      treasuryBufferBps: number;
+      circuitBreakerBps: number;
+      anomalyGracePeriod: number;
+      autoPauseEnabled: boolean;
+      oversightCouncil?: string;
+    };
+    decentralizedInfra?: DecentralizedInfraEntry[];
+    telemetry?: {
+      manifestHash: string;
+      metricsDigest: string;
+      resilienceFloorBps: number;
+      automationFloorBps: number;
+      oversightWeightBps: number;
+    };
+  };
+  domains: Array<{
+    slug: string;
+    name: string;
+    manifestURI: string;
+    subgraph: string;
+    validationModule: string;
+    oracle?: string;
+    l2Gateway?: string;
+    executionRouter?: string;
+    heartbeatSeconds?: number;
+    operations?: DomainOperationsConfig;
+    telemetry?: DomainTelemetryConfig;
+    skillTags?: string[];
+    capabilities?: Record<string, number>;
+    priority?: number;
+    metadata?: DomainMetadataConfig;
+    infrastructure?: DomainInfrastructureEntry[];
+  }>;
+}
+
+export interface DomainBlueprint {
+  slug: string;
+  name: string;
+  domainId: string;
+  manifestURI: string;
+  subgraph: string;
+  priority: number;
+  skillTags: string[];
+  capabilities: Record<string, number>;
+  heartbeatSeconds: number;
+  addresses: {
+    validationModule: string;
+    oracle: string | null;
+    l2Gateway: string | null;
+    executionRouter: string | null;
+  };
+  operations: {
+    maxActiveJobs: number;
+    maxQueueDepth: number;
+    minStakeWei: string;
+    minStakeEth: string;
+    treasuryShareBps: number;
+    circuitBreakerBps: number;
+    requiresHumanValidation: boolean;
+  };
+  telemetry: {
+    resilienceBps: number;
+    automationBps: number;
+    complianceBps: number;
+    settlementLatencySeconds: number;
+    usesL2Settlement: boolean;
+    sentinelOracle: string | null;
+    settlementAsset: string | null;
+    metricsDigest: string;
+    manifestHash: string;
+  };
+  metadata: {
+    resilienceIndex: number | null;
+    valueFlowMonthlyUSD: number | null;
+    valueFlowDisplay: string | null;
+    sentinel: string | null;
+    uptime: string | null;
+    raw: Record<string, unknown>;
+  };
+  infrastructure: DomainInfrastructureEntry[];
+  calldata: {
+    registerDomain: string;
+    updateDomain: string;
+    setDomainOperations: string;
+    setDomainTelemetry: string;
+  };
+}
+
+export interface Phase6Blueprint {
+  generatedAt: string;
+  configPath?: string;
+  configHash: string;
+  specVersion: string;
+  fragments: string[];
+  metrics: {
+    domainCount: number;
+    averageResilience?: number;
+    minResilience?: number;
+    maxResilience?: number;
+    averageAutomation?: number;
+    averageCompliance?: number;
+    averageLatency?: number;
+    l2SettlementCoverage: number;
+    totalValueFlowUSD: number;
+    sentinelFamilies: number;
+    globalInfraCount: number;
+    domainInfraCount: number;
+  };
+  global: {
+    manifestURI: string;
+    iotOracleRouter: string | null;
+    defaultL2Gateway: string | null;
+    didRegistry: string | null;
+    treasuryBridge: string | null;
+    systemPause: string | null;
+    escalationBridge: string | null;
+    l2SyncCadenceSeconds: number;
+  };
+  guards: {
+    treasuryBufferBps: number;
+    circuitBreakerBps: number;
+    anomalyGracePeriod: number;
+    autoPauseEnabled: boolean;
+    oversightCouncil: string | null;
+  };
+  telemetry: {
+    manifestHash: string | null;
+    metricsDigest: string | null;
+    resilienceFloorBps: number | null;
+    automationFloorBps: number | null;
+    oversightWeightBps: number | null;
+  };
+  infrastructure: {
+    global: DecentralizedInfraEntry[];
+    domains: Record<string, DomainInfrastructureEntry[]>;
+  };
+  calldata: {
+    globalConfig: string;
+    globalGuards: string;
+    globalTelemetry: string;
+    systemPause?: string;
+    escalationBridge?: string;
+  };
+  mermaid: string;
+  domains: DomainBlueprint[];
+}
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const ZERO_BYTES32 = '0x' + '0'.repeat(64);
+
+export const ABI_FRAGMENTS = [
+  'function setGlobalConfig((address,address,address,address,uint64,string) config)',
+  'function setGlobalGuards((uint16,uint16,uint32,bool,address) config)',
+  'function setGlobalTelemetry((bytes32,bytes32,uint32,uint32,uint32) telemetry)',
+  'function setSystemPause(address newPause)',
+  'function setEscalationBridge(address newBridge)',
+  'function registerDomain((string slug,string name,string metadataURI,address validationModule,address dataOracle,address l2Gateway,string subgraphEndpoint,address executionRouter,uint64 heartbeatSeconds,bool active) config)',
+  'function updateDomain(bytes32 id,(string slug,string name,string metadataURI,address validationModule,address dataOracle,address l2Gateway,string subgraphEndpoint,address executionRouter,uint64 heartbeatSeconds,bool active) config)',
+  'function setDomainOperations(bytes32 id,(uint48 maxActiveJobs,uint48 maxQueueDepth,uint96 minStake,uint16 treasuryShareBps,uint16 circuitBreakerBps,bool requiresHumanValidation) config)',
+  'function setDomainTelemetry(bytes32 id,(uint32,uint32,uint32,uint32,bool,address,address,bytes32,bytes32) telemetry)',
+];
+
+const ABI_INTERFACE = new Interface(ABI_FRAGMENTS);
+
+function ensureArray<T>(value: T[] | undefined | null): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normaliseAddress(value: string | undefined): string | null {
+  if (!value) return null;
+  if (value === ZERO_ADDRESS) return null;
+  return value;
+}
+
+function toNumber(value: unknown): number | null {
+  if (value === undefined || value === null) return null;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return numeric;
+}
+
+function toBigIntString(value: string | number | undefined): string {
+  if (value === undefined) return '0';
+  if (typeof value === 'number') return BigInt(Math.trunc(value)).toString();
+  return BigInt(value).toString();
+}
+
+function minStakeEth(valueWei: string): string {
+  try {
+    return `${formatEther(BigInt(valueWei))} ETH`;
+  } catch (error) {
+    return valueWei;
+  }
+}
+
+function computeMermaid(config: Phase6DemoConfig): string {
+  const lines = ['graph TD', '  Owner[[Governance]] --> Expansion(Phase6ExpansionManager)'];
+  for (const domain of config.domains) {
+    const id = domain.slug.replace(/[^a-z0-9]/gi, '');
+    lines.push(`  Expansion --> ${id}([${domain.name}])`);
+    lines.push(`  ${id} --> Runtime`);
+  }
+  lines.push('  Runtime[Phase6 Runtime] --> IoT[IoT & external oracles]');
+  lines.push('  Runtime --> L2[Layer-2 Executors]');
+  lines.push('  L2 --> Settlement[Ethereum Mainnet]');
+  return lines.join('\n');
+}
+
+function computeMetrics(config: Phase6DemoConfig) {
+  const resilience: number[] = [];
+  const automation: number[] = [];
+  const compliance: number[] = [];
+  const latency: number[] = [];
+  const sentinels = new Set<string>();
+  let l2Settlements = 0;
+  let totalValueFlow = 0;
+
+  for (const domain of config.domains) {
+    const metadata = domain.metadata;
+    if (metadata) {
+      const resilienceIndex = toNumber(metadata.resilienceIndex);
+      if (resilienceIndex !== null) {
+        resilience.push(resilienceIndex);
+      }
+      const valueFlow = toNumber(metadata.valueFlowMonthlyUSD);
+      if (valueFlow !== null) {
+        totalValueFlow += valueFlow;
+      }
+      const sentinel = metadata.sentinel;
+      if (typeof sentinel === 'string' && sentinel.length > 0) {
+        sentinels.add(sentinel);
+      }
+    }
+    const telemetry = domain.telemetry;
+    if (telemetry) {
+      const auto = toNumber(telemetry.automationBps);
+      if (auto !== null) {
+        automation.push(auto);
+      }
+      const comp = toNumber(telemetry.complianceBps);
+      if (comp !== null) {
+        compliance.push(comp);
+      }
+      const latencySeconds = toNumber(telemetry.settlementLatencySeconds);
+      if (latencySeconds !== null) {
+        latency.push(latencySeconds);
+      }
+      if (telemetry.usesL2Settlement) {
+        l2Settlements += 1;
+      }
+    }
+  }
+
+  const average = (values: number[]): number | undefined => {
+    if (!values.length) return undefined;
+    return values.reduce((acc, cur) => acc + cur, 0) / values.length;
+  };
+
+  return {
+    domainCount: config.domains.length,
+    averageResilience: average(resilience),
+    minResilience: resilience.length ? Math.min(...resilience) : undefined,
+    maxResilience: resilience.length ? Math.max(...resilience) : undefined,
+    averageAutomation: average(automation),
+    averageCompliance: average(compliance),
+    averageLatency: average(latency),
+    l2SettlementCoverage: config.domains.length ? l2Settlements / config.domains.length : 0,
+    totalValueFlowUSD: totalValueFlow,
+    sentinelFamilies: sentinels.size,
+    globalInfraCount: ensureArray(config.global.decentralizedInfra).length,
+    domainInfraCount: config.domains.reduce(
+      (acc, domain) => acc + ensureArray(domain.infrastructure).length,
+      0,
+    ),
+  };
+}
+
+function buildDomainTuples(domain: Phase6DemoConfig['domains'][number]) {
+  const tuple = [
+    domain.slug,
+    domain.name,
+    domain.manifestURI,
+    domain.validationModule ?? ZERO_ADDRESS,
+    domain.oracle ?? ZERO_ADDRESS,
+    domain.l2Gateway ?? ZERO_ADDRESS,
+    domain.subgraph,
+    domain.executionRouter ?? ZERO_ADDRESS,
+    BigInt(domain.heartbeatSeconds ?? 120),
+    true,
+  ];
+
+  const operations = domain.operations ?? {
+    maxActiveJobs: 0,
+    maxQueueDepth: 0,
+    minStake: 0,
+    treasuryShareBps: 0,
+    circuitBreakerBps: 0,
+    requiresHumanValidation: false,
+  };
+
+  const opsTuple = [
+    BigInt(Math.trunc(Number(operations.maxActiveJobs ?? 0))),
+    BigInt(Math.trunc(Number(operations.maxQueueDepth ?? 0))),
+    BigInt(toBigIntString(operations.minStake)),
+    Number(operations.treasuryShareBps ?? 0),
+    Number(operations.circuitBreakerBps ?? 0),
+    Boolean(operations.requiresHumanValidation),
+  ];
+
+  const telemetry = domain.telemetry ?? {
+    resilienceBps: 0,
+    automationBps: 0,
+    complianceBps: 0,
+    settlementLatencySeconds: 0,
+    usesL2Settlement: false,
+    metricsDigest: ZERO_BYTES32,
+    manifestHash: ZERO_BYTES32,
+  };
+
+  const telemetryTuple = [
+    Number(telemetry.resilienceBps ?? 0),
+    Number(telemetry.automationBps ?? 0),
+    Number(telemetry.complianceBps ?? 0),
+    Number(telemetry.settlementLatencySeconds ?? 0),
+    Boolean(telemetry.usesL2Settlement ?? false),
+    telemetry.sentinelOracle ?? ZERO_ADDRESS,
+    telemetry.settlementAsset ?? ZERO_ADDRESS,
+    typeof telemetry.metricsDigest === 'string' && telemetry.metricsDigest.startsWith('0x')
+      ? telemetry.metricsDigest
+      : ZERO_BYTES32,
+    typeof telemetry.manifestHash === 'string' && telemetry.manifestHash.startsWith('0x')
+      ? telemetry.manifestHash
+      : ZERO_BYTES32,
+  ];
+
+  return { tuple, opsTuple, telemetryTuple };
+}
+
+export function loadPhase6Config(path: string): Phase6DemoConfig {
+  const data = JSON.parse(readFileSync(path, 'utf-8'));
+  return data as Phase6DemoConfig;
+}
+
+export function buildPhase6Blueprint(
+  config: Phase6DemoConfig,
+  options: { configPath?: string } = {},
+): Phase6Blueprint {
+  const metrics = computeMetrics(config);
+
+  const configHash = keccak256(toUtf8Bytes(JSON.stringify(config)));
+  const mermaid = computeMermaid(config);
+
+  const globalGuards = config.global.guards ?? {
+    treasuryBufferBps: 0,
+    circuitBreakerBps: 0,
+    anomalyGracePeriod: 0,
+    autoPauseEnabled: false,
+  };
+
+  const globalTelemetry = config.global.telemetry ?? null;
+
+  const globalTuple = [
+    config.global.iotOracleRouter ?? ZERO_ADDRESS,
+    config.global.defaultL2Gateway ?? ZERO_ADDRESS,
+    config.global.didRegistry ?? ZERO_ADDRESS,
+    config.global.treasuryBridge ?? ZERO_ADDRESS,
+    BigInt(config.global.l2SyncCadence ?? 180),
+    config.global.manifestURI,
+  ];
+
+  const guardTuple = [
+    Number(globalGuards.treasuryBufferBps ?? 0),
+    Number(globalGuards.circuitBreakerBps ?? 0),
+    Number(globalGuards.anomalyGracePeriod ?? 0),
+    Boolean(globalGuards.autoPauseEnabled ?? false),
+    globalGuards.oversightCouncil ?? ZERO_ADDRESS,
+  ];
+
+  const telemetryTuple = [
+    globalTelemetry?.manifestHash ?? ZERO_BYTES32,
+    globalTelemetry?.metricsDigest ?? ZERO_BYTES32,
+    Number(globalTelemetry?.resilienceFloorBps ?? 0),
+    Number(globalTelemetry?.automationFloorBps ?? 0),
+    Number(globalTelemetry?.oversightWeightBps ?? 0),
+  ];
+
+  const domains: DomainBlueprint[] = config.domains.map((domain) => {
+    const domainId = keccak256(toUtf8Bytes(String(domain.slug).toLowerCase()));
+    const tuples = buildDomainTuples(domain);
+    const metadata = domain.metadata ?? ({} as DomainMetadataConfig);
+    const telemetry = domain.telemetry ?? ({} as DomainTelemetryConfig);
+    const operations = domain.operations ?? ({} as DomainOperationsConfig);
+
+    return {
+      slug: domain.slug,
+      name: domain.name,
+      domainId,
+      manifestURI: domain.manifestURI,
+      subgraph: domain.subgraph,
+      priority: Number(domain.priority ?? 0),
+      skillTags: ensureArray(domain.skillTags).map((tag) => tag.toLowerCase()),
+      capabilities: Object.fromEntries(
+        Object.entries(domain.capabilities ?? {}).map(([key, value]) => [key.toLowerCase(), Number(value)]),
+      ),
+      heartbeatSeconds: Number(domain.heartbeatSeconds ?? config.global.l2SyncCadence ?? 0),
+      addresses: {
+        validationModule: domain.validationModule,
+        oracle: normaliseAddress(domain.oracle),
+        l2Gateway: normaliseAddress(domain.l2Gateway),
+        executionRouter: normaliseAddress(domain.executionRouter),
+      },
+      operations: {
+        maxActiveJobs: Number(operations.maxActiveJobs ?? 0),
+        maxQueueDepth: Number(operations.maxQueueDepth ?? 0),
+        minStakeWei: toBigIntString(operations.minStake ?? '0'),
+        minStakeEth: minStakeEth(toBigIntString(operations.minStake ?? '0')),
+        treasuryShareBps: Number(operations.treasuryShareBps ?? 0),
+        circuitBreakerBps: Number(operations.circuitBreakerBps ?? 0),
+        requiresHumanValidation: Boolean(operations.requiresHumanValidation ?? false),
+      },
+      telemetry: {
+        resilienceBps: Number(telemetry.resilienceBps ?? 0),
+        automationBps: Number(telemetry.automationBps ?? 0),
+        complianceBps: Number(telemetry.complianceBps ?? 0),
+        settlementLatencySeconds: Number(telemetry.settlementLatencySeconds ?? 0),
+        usesL2Settlement: Boolean(telemetry.usesL2Settlement ?? false),
+        sentinelOracle: normaliseAddress(telemetry.sentinelOracle ?? undefined),
+        settlementAsset: normaliseAddress(telemetry.settlementAsset ?? undefined),
+        metricsDigest: telemetry.metricsDigest ?? ZERO_BYTES32,
+        manifestHash: telemetry.manifestHash ?? ZERO_BYTES32,
+      },
+      metadata: {
+        resilienceIndex: toNumber(metadata.resilienceIndex),
+        valueFlowMonthlyUSD: toNumber(metadata.valueFlowMonthlyUSD),
+        valueFlowDisplay: typeof metadata.valueFlowDisplay === 'string' ? metadata.valueFlowDisplay : null,
+        sentinel: typeof metadata.sentinel === 'string' ? metadata.sentinel : null,
+        uptime: typeof metadata.uptime === 'string' ? metadata.uptime : null,
+        raw: metadata as Record<string, unknown>,
+      },
+      infrastructure: ensureArray(domain.infrastructure),
+      calldata: {
+        registerDomain: ABI_INTERFACE.encodeFunctionData('registerDomain', [tuples.tuple]),
+        updateDomain: ABI_INTERFACE.encodeFunctionData('updateDomain', [domainId, tuples.tuple]),
+        setDomainOperations: ABI_INTERFACE.encodeFunctionData('setDomainOperations', [domainId, tuples.opsTuple]),
+        setDomainTelemetry: ABI_INTERFACE.encodeFunctionData('setDomainTelemetry', [domainId, tuples.telemetryTuple]),
+      },
+    };
+  });
+
+  const globalInfra = ensureArray(config.global.decentralizedInfra);
+  const domainInfra: Record<string, DomainInfrastructureEntry[]> = {};
+  for (const domain of config.domains) {
+    domainInfra[domain.slug] = ensureArray(domain.infrastructure);
+  }
+
+  const calldata = {
+    globalConfig: ABI_INTERFACE.encodeFunctionData('setGlobalConfig', [globalTuple]),
+    globalGuards: ABI_INTERFACE.encodeFunctionData('setGlobalGuards', [guardTuple]),
+    globalTelemetry: ABI_INTERFACE.encodeFunctionData('setGlobalTelemetry', [telemetryTuple]),
+    systemPause: config.global.systemPause
+      ? ABI_INTERFACE.encodeFunctionData('setSystemPause', [config.global.systemPause])
+      : undefined,
+    escalationBridge: config.global.escalationBridge
+      ? ABI_INTERFACE.encodeFunctionData('setEscalationBridge', [config.global.escalationBridge])
+      : undefined,
+  };
+
+  return {
+    generatedAt: new Date().toISOString(),
+    configPath: options.configPath,
+    configHash,
+    specVersion: 'phase6.expansion.v2',
+    fragments: [...ABI_FRAGMENTS],
+    metrics,
+    global: {
+      manifestURI: config.global.manifestURI,
+      iotOracleRouter: normaliseAddress(config.global.iotOracleRouter),
+      defaultL2Gateway: normaliseAddress(config.global.defaultL2Gateway),
+      didRegistry: normaliseAddress(config.global.didRegistry),
+      treasuryBridge: normaliseAddress(config.global.treasuryBridge),
+      systemPause: normaliseAddress(config.global.systemPause),
+      escalationBridge: normaliseAddress(config.global.escalationBridge),
+      l2SyncCadenceSeconds: Number(config.global.l2SyncCadence ?? 0),
+    },
+    guards: {
+      treasuryBufferBps: Number(globalGuards.treasuryBufferBps ?? 0),
+      circuitBreakerBps: Number(globalGuards.circuitBreakerBps ?? 0),
+      anomalyGracePeriod: Number(globalGuards.anomalyGracePeriod ?? 0),
+      autoPauseEnabled: Boolean(globalGuards.autoPauseEnabled ?? false),
+      oversightCouncil: normaliseAddress(globalGuards.oversightCouncil ?? undefined),
+    },
+    telemetry: {
+      manifestHash: globalTelemetry?.manifestHash ?? null,
+      metricsDigest: globalTelemetry?.metricsDigest ?? null,
+      resilienceFloorBps: globalTelemetry?.resilienceFloorBps ?? null,
+      automationFloorBps: globalTelemetry?.automationFloorBps ?? null,
+      oversightWeightBps: globalTelemetry?.oversightWeightBps ?? null,
+    },
+    infrastructure: {
+      global: globalInfra,
+      domains: domainInfra,
+    },
+    calldata,
+    mermaid,
+    domains,
+  };
+}
+

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/run-phase6-demo.ts
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/run-phase6-demo.ts
@@ -4,16 +4,78 @@
  * Outputs calldata, bridge plans, and orchestration guidance in a single run.
  */
 
-import { readFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { Interface, formatEther, keccak256, toUtf8Bytes } from 'ethers';
 
-const CONFIG_PATH = join(__dirname, '..', 'config', 'domains.phase6.json');
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
-const ZERO_BYTES32 = '0x' + '0'.repeat(64);
+import {
+  buildPhase6Blueprint,
+  loadPhase6Config,
+  Phase6Blueprint,
+  DomainBlueprint,
+  DecentralizedInfraEntry,
+  DomainInfrastructureEntry,
+} from './phase6-blueprint';
 
-function loadJson(path: string) {
-  return JSON.parse(readFileSync(path, 'utf-8'));
+const DEFAULT_CONFIG_PATH = join(__dirname, '..', 'config', 'domains.phase6.json');
+
+interface CliOptions {
+  configPath: string;
+  jsonOutput?: string;
+}
+
+function parseArgs(): CliOptions {
+  const argv = process.argv.slice(2);
+  const options: CliOptions = { configPath: DEFAULT_CONFIG_PATH };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--config') {
+      const next = argv[i + 1];
+      if (!next) {
+        throw new Error('--config expects a path');
+      }
+      options.configPath = next;
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--config=')) {
+      options.configPath = arg.split('=', 2)[1] ?? DEFAULT_CONFIG_PATH;
+      continue;
+    }
+    if (arg === '--json') {
+      const next = argv[i + 1];
+      if (!next || next.startsWith('--')) {
+        options.jsonOutput = '-';
+      } else {
+        options.jsonOutput = next;
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith('--json=')) {
+      const value = arg.split('=', 2)[1];
+      options.jsonOutput = value && value.length ? value : '-';
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+    console.warn(`Unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
+function printUsage(): void {
+  console.log(
+    `Phase 6 blueprint orchestrator\n\n` +
+      `Usage: npm run demo:phase6:orchestrate -- [options]\n\n` +
+      `Options:\n` +
+      `  --config <path>         Use a custom Phase 6 config file (default: ${DEFAULT_CONFIG_PATH})\n` +
+      `  --json [path|-]         Emit JSON blueprint to <path>; use '-' for stdout\n` +
+      `  -h, --help              Show this message\n`,
+  );
 }
 
 function banner(title: string) {
@@ -28,21 +90,6 @@ function summarizeAddress(label: string, addr?: string | null) {
   return `${label}: ${addr.slice(0, 6)}…${addr.slice(-4)}`;
 }
 
-function buildDomainTuple(domain: any) {
-  return [
-    domain.slug,
-    domain.name,
-    domain.manifestURI,
-    domain.validationModule ?? ZERO_ADDRESS,
-    domain.oracle ?? ZERO_ADDRESS,
-    domain.l2Gateway ?? ZERO_ADDRESS,
-    domain.subgraph,
-    domain.executionRouter ?? ZERO_ADDRESS,
-    BigInt(domain.heartbeatSeconds ?? 120),
-    true,
-  ];
-}
-
 function renderTable(rows: Array<[string, string]>) {
   const width = Math.max(...rows.map(([label]) => label.length)) + 3;
   rows.forEach(([label, value]) => {
@@ -51,69 +98,21 @@ function renderTable(rows: Array<[string, string]>) {
   });
 }
 
-function summariseInfra(entry: Record<string, string | undefined>) {
-  const layer = entry.layer ?? '—';
+function summariseInfra(entry: DecentralizedInfraEntry | DomainInfrastructureEntry) {
+  const layer = 'layer' in entry && entry.layer ? entry.layer : '—';
   const name = entry.name ?? '—';
   const role = entry.role ?? '—';
   const status = entry.status ? `status=${entry.status}` : '';
-  const endpoint = entry.endpoint || entry.uri;
+  const endpoint = entry.endpoint || ('uri' in entry ? entry.uri : undefined);
   const endpointSummary = endpoint ? ` @ ${endpoint}` : '';
   return `${layer}: ${name} — ${role} ${status}${endpointSummary}`.trim();
 }
 
-function formatStake(value: string | number | bigint | undefined): string {
-  try {
-    if (value === undefined) return '—';
-    const big = typeof value === 'bigint' ? value : BigInt(value);
-    return `${formatEther(big)} ETH`;
-  } catch (error) {
-    return String(value ?? '—');
-  }
-}
-
-function formatBps(value: number | undefined): string {
+function formatBps(value: number | undefined | null): string {
   if (typeof value !== 'number' || Number.isNaN(value)) {
     return '—';
   }
   return `${(value / 100).toFixed(2)}% (${value} bps)`;
-}
-
-function buildDomainOperationsTuple(domain: any) {
-  const ops = domain.operations ?? {};
-  const minStakeRaw = ops.minStake ?? 0;
-  const minStake =
-    typeof minStakeRaw === 'string'
-      ? BigInt(minStakeRaw)
-      : BigInt(Math.trunc(Number(minStakeRaw)));
-  return [
-    BigInt(Math.trunc(Number(ops.maxActiveJobs ?? 0))),
-    BigInt(Math.trunc(Number(ops.maxQueueDepth ?? 0))),
-    minStake,
-    Number(ops.treasuryShareBps ?? 0),
-    Number(ops.circuitBreakerBps ?? 0),
-    Boolean(ops.requiresHumanValidation),
-  ];
-}
-
-function buildDomainTelemetryTuple(domain: any) {
-  const telemetry = domain.telemetry ?? {};
-  const toBytes32 = (value: any) => {
-    if (typeof value === 'string' && value.startsWith('0x') && value.length === 66) {
-      return value;
-    }
-    return ZERO_BYTES32;
-  };
-  return [
-    Number(telemetry.resilienceBps ?? 0),
-    Number(telemetry.automationBps ?? 0),
-    Number(telemetry.complianceBps ?? 0),
-    Number(telemetry.settlementLatencySeconds ?? 0),
-    Boolean(telemetry.usesL2Settlement ?? false),
-    telemetry.sentinelOracle ?? ZERO_ADDRESS,
-    telemetry.settlementAsset ?? ZERO_ADDRESS,
-    toBytes32(telemetry.metricsDigest),
-    toBytes32(telemetry.manifestHash),
-  ];
 }
 
 function formatUSD(value?: number | null): string {
@@ -136,129 +135,21 @@ function formatUSD(value?: number | null): string {
   return `$${numeric.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
 }
 
-function toNumber(value: any): number | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : undefined;
+function heartbeatSummary(domain: DomainBlueprint, globalCadenceSeconds: number) {
+  const cadence = Math.max(domain.heartbeatSeconds, globalCadenceSeconds);
+  return `${cadence}s sync cadence (domain ${domain.heartbeatSeconds}s, global ${globalCadenceSeconds}s)`;
 }
 
-function computeNetworkMetrics(config: any) {
-  const resilience: number[] = [];
-  const automation: number[] = [];
-  const compliance: number[] = [];
-  const latency: number[] = [];
-  let l2Settlements = 0;
-  const valueFlows: number[] = [];
-  const sentinels = new Set<string>();
-  for (const domain of config.domains) {
-    const meta = domain.metadata ?? {};
-    const resilienceIndex = toNumber(meta.resilienceIndex);
-    if (resilienceIndex !== undefined) {
-      resilience.push(resilienceIndex);
-    }
-    if (domain.telemetry) {
-      const telemetry = domain.telemetry;
-      const auto = toNumber(telemetry.automationBps);
-      const comp = toNumber(telemetry.complianceBps);
-      const latencySeconds = toNumber(telemetry.settlementLatencySeconds);
-      if (auto !== undefined) {
-        automation.push(auto);
-      }
-      if (comp !== undefined) {
-        compliance.push(comp);
-      }
-      if (latencySeconds !== undefined) {
-        latency.push(latencySeconds);
-      }
-      if (telemetry.usesL2Settlement) {
-        l2Settlements += 1;
-      }
-    }
-    const valueFlow = toNumber(meta.valueFlowMonthlyUSD);
-    if (valueFlow !== undefined) {
-      valueFlows.push(valueFlow);
-    }
-    if (meta.sentinel) {
-      sentinels.add(String(meta.sentinel));
-    }
-  }
-  const averageResilience =
-    resilience.length > 0 ? resilience.reduce((acc, cur) => acc + cur, 0) / resilience.length : undefined;
-  const minResilience = resilience.length > 0 ? Math.min(...resilience) : undefined;
-  const maxResilience = resilience.length > 0 ? Math.max(...resilience) : undefined;
-  const totalValueFlow = valueFlows.reduce((acc, cur) => acc + cur, 0);
-  const averageAutomation = automation.length
-    ? automation.reduce((acc, cur) => acc + cur, 0) / automation.length
-    : undefined;
-  const averageCompliance = compliance.length
-    ? compliance.reduce((acc, cur) => acc + cur, 0) / compliance.length
-    : undefined;
-  const averageLatency = latency.length
-    ? latency.reduce((acc, cur) => acc + cur, 0) / latency.length
-    : undefined;
-  return {
-    averageResilience,
-    minResilience,
-    maxResilience,
-    totalValueFlow,
-    sentinelCount: sentinels.size,
-    averageAutomation,
-    averageCompliance,
-    averageLatency,
-    l2SettlementCoverage: config.domains.length ? l2Settlements / config.domains.length : 0,
-  };
-}
-
-function mermaid(config: any) {
-  const lines = ['graph TD', '  Owner[[Governance]] --> Expansion(Phase6ExpansionManager)'];
-  config.domains.forEach((domain: any) => {
-    const id = domain.slug.replace(/[^a-z0-9]/gi, '');
-    lines.push(`  Expansion --> ${id}([${domain.name}])`);
-    lines.push(`  ${id} --> Runtime`);
-  });
-  lines.push('  Runtime[Phase6 Runtime] --> IoT[IoT & external oracles]');
-  lines.push('  Runtime --> L2[Layer-2 Executors]');
-  lines.push('  L2 --> Settlement[Ethereum Mainnet]');
-  return lines.join('\n');
-}
-
-function heartbeatSummary(domain: any, global: any) {
-  const cadence = Math.max(domain.heartbeatSeconds ?? 0, global.l2SyncCadence ?? 0);
-  return `${cadence}s sync cadence (domain ${domain.heartbeatSeconds}s, global ${global.l2SyncCadence}s)`;
-}
-
-(async () => {
-  const config = loadJson(CONFIG_PATH);
-  const fragments = [
-    'function setGlobalConfig((address,address,address,address,uint64,string) config)',
-    'function setGlobalGuards((uint16,uint16,uint32,bool,address) config)',
-    'function setGlobalTelemetry((bytes32,bytes32,uint32,uint32,uint32) telemetry)',
-    'function setSystemPause(address newPause)',
-    'function setEscalationBridge(address newBridge)',
-    'function registerDomain((string slug,string name,string metadataURI,address validationModule,address dataOracle,address l2Gateway,string subgraphEndpoint,address executionRouter,uint64 heartbeatSeconds,bool active) config)',
-    'function updateDomain(bytes32 id,(string slug,string name,string metadataURI,address validationModule,address dataOracle,address l2Gateway,string subgraphEndpoint,address executionRouter,uint64 heartbeatSeconds,bool active) config)',
-    'function setDomainOperations(bytes32 id,(uint48 maxActiveJobs,uint48 maxQueueDepth,uint96 minStake,uint16 treasuryShareBps,uint16 circuitBreakerBps,bool requiresHumanValidation) config)',
-    'function setDomainTelemetry(bytes32 id,(uint32,uint32,uint32,uint32,bool,address,address,bytes32,bytes32) telemetry)'
-  ];
-  const iface = new Interface(fragments);
-
+function printBlueprint(blueprint: Phase6Blueprint, options: CliOptions) {
   banner('Phase 6 blueprint generated');
-  console.log('Configuration file:', CONFIG_PATH);
-  console.log('ABI fragments:', fragments.join(' | '));
+  if (options.configPath) {
+    console.log('Configuration file:', options.configPath);
+  }
+  console.log('Spec version:', blueprint.specVersion);
+  console.log('Configuration hash:', blueprint.configHash);
+  console.log('ABI fragments:', blueprint.fragments.join(' | '));
 
-  const metrics = computeNetworkMetrics(config);
-  const globalInfraCount = Array.isArray(config.global.decentralizedInfra)
-    ? config.global.decentralizedInfra.length
-    : 0;
-  const domainInfraCount = config.domains.reduce(
-    (acc: number, domain: any) => acc + (Array.isArray(domain.infrastructure) ? domain.infrastructure.length : 0),
-    0,
-  );
-
-  const guards = config.global.guards ?? {};
-
+  const metrics = blueprint.metrics;
   banner('Network telemetry');
   if (metrics.averageResilience !== undefined) {
     console.log(
@@ -276,172 +167,131 @@ function heartbeatSummary(domain: any, global: any) {
   if (metrics.averageLatency !== undefined) {
     console.log(`Settlement latency (avg): ${metrics.averageLatency.toFixed(1)}s`);
   }
+  console.log(`L2 settlement coverage: ${(metrics.l2SettlementCoverage * 100).toFixed(1)}% of domains`);
+  console.log(`Monthly value flow across domains: ${formatUSD(metrics.totalValueFlowUSD)}`);
+  console.log(`Active sentinel families: ${metrics.sentinelFamilies}`);
+  console.log(`Global infra integrations: ${metrics.globalInfraCount}`);
+  console.log(`Domain infra touchpoints: ${metrics.domainInfraCount}`);
   console.log(
-    `L2 settlement coverage: ${(metrics.l2SettlementCoverage * 100).toFixed(1)}% of domains`,
-  );
-  console.log(`Monthly value flow across domains: ${formatUSD(metrics.totalValueFlow)}`);
-  console.log(`Active sentinel families: ${metrics.sentinelCount}`);
-  console.log(`Global infra integrations: ${globalInfraCount}`);
-  console.log(`Domain infra touchpoints: ${domainInfraCount}`);
-  console.log(
-    `Guard rails: treasuryBuffer=${formatBps(guards.treasuryBufferBps)} | ` +
-      `circuitBreaker=${formatBps(guards.circuitBreakerBps)} | grace=${guards.anomalyGracePeriod ?? 0}s | ` +
-      `autoPause=${guards.autoPauseEnabled ? 'on' : 'off'}`,
+    `Guard rails: treasuryBuffer=${formatBps(blueprint.guards.treasuryBufferBps)} | ` +
+      `circuitBreaker=${formatBps(blueprint.guards.circuitBreakerBps)} | grace=${blueprint.guards.anomalyGracePeriod}s | ` +
+      `autoPause=${blueprint.guards.autoPauseEnabled ? 'on' : 'off'}`,
   );
 
   banner('Global controls');
-  const globalTelemetry = config.global.telemetry ?? {};
   renderTable([
-    ['Manifest URI', config.global.manifestURI],
-    summarizeAddress('IoT oracle router', config.global.iotOracleRouter).split(': '),
-    summarizeAddress('Default L2 gateway', config.global.defaultL2Gateway).split(': '),
-    summarizeAddress('Treasury bridge', config.global.treasuryBridge).split(': '),
-    summarizeAddress('DID registry', config.global.didRegistry).split(': '),
-    summarizeAddress('System pause', config.global.systemPause).split(': '),
-    summarizeAddress('Escalation bridge', config.global.escalationBridge).split(': '),
-    ['L2 sync cadence', `${config.global.l2SyncCadence}s`],
-    ['Treasury buffer', formatBps(guards.treasuryBufferBps)],
-    ['Circuit breaker', formatBps(guards.circuitBreakerBps)],
-    ['Anomaly grace', guards.anomalyGracePeriod ? `${guards.anomalyGracePeriod}s` : '—'],
-    ['Auto-pause enabled', String(guards.autoPauseEnabled ?? false)],
-    summarizeAddress('Oversight council', guards.oversightCouncil).split(': '),
-    ['Telemetry manifest hash', globalTelemetry.manifestHash ?? '—'],
-    ['Telemetry metrics digest', globalTelemetry.metricsDigest ?? '—'],
-    ['Telemetry resilience floor', formatBps(globalTelemetry.resilienceFloorBps)],
-    ['Telemetry automation floor', formatBps(globalTelemetry.automationFloorBps)],
-    ['Telemetry oversight weight', formatBps(globalTelemetry.oversightWeightBps)],
+    ['Manifest URI', blueprint.global.manifestURI],
+    summarizeAddress('IoT oracle router', blueprint.global.iotOracleRouter).split(': '),
+    summarizeAddress('Default L2 gateway', blueprint.global.defaultL2Gateway).split(': '),
+    summarizeAddress('Treasury bridge', blueprint.global.treasuryBridge).split(': '),
+    summarizeAddress('DID registry', blueprint.global.didRegistry).split(': '),
+    summarizeAddress('System pause', blueprint.global.systemPause).split(': '),
+    summarizeAddress('Escalation bridge', blueprint.global.escalationBridge).split(': '),
+    ['L2 sync cadence', `${blueprint.global.l2SyncCadenceSeconds}s`],
+    ['Treasury buffer', formatBps(blueprint.guards.treasuryBufferBps)],
+    ['Circuit breaker', formatBps(blueprint.guards.circuitBreakerBps)],
+    ['Anomaly grace', blueprint.guards.anomalyGracePeriod ? `${blueprint.guards.anomalyGracePeriod}s` : '—'],
+    ['Auto-pause enabled', String(blueprint.guards.autoPauseEnabled)],
+    summarizeAddress('Oversight council', blueprint.guards.oversightCouncil).split(': '),
+    ['Telemetry manifest hash', blueprint.telemetry.manifestHash ?? '—'],
+    ['Telemetry metrics digest', blueprint.telemetry.metricsDigest ?? '—'],
+    ['Telemetry resilience floor', formatBps(blueprint.telemetry.resilienceFloorBps)],
+    ['Telemetry automation floor', formatBps(blueprint.telemetry.automationFloorBps)],
+    ['Telemetry oversight weight', formatBps(blueprint.telemetry.oversightWeightBps)],
   ] as unknown as Array<[string, string]>);
 
   banner('Emergency levers');
-  if (config.global.systemPause) {
-    console.log(`System pause calldata: ${iface.encodeFunctionData('setSystemPause', [config.global.systemPause])}`);
-  } else {
-    console.log('System pause calldata: —');
-  }
-  if (config.global.escalationBridge) {
-    console.log(
-      `Escalation bridge calldata: ${iface.encodeFunctionData('setEscalationBridge', [config.global.escalationBridge])}`,
-    );
-  } else {
-    console.log('Escalation bridge calldata: —');
-  }
-
-  const globalTuple = [
-    config.global.iotOracleRouter ?? ZERO_ADDRESS,
-    config.global.defaultL2Gateway ?? ZERO_ADDRESS,
-    config.global.didRegistry ?? ZERO_ADDRESS,
-    config.global.treasuryBridge ?? ZERO_ADDRESS,
-    BigInt(config.global.l2SyncCadence ?? 180),
-    config.global.manifestURI,
-  ];
-  const guardTuple = [
-    Number(guards.treasuryBufferBps ?? 0),
-    Number(guards.circuitBreakerBps ?? 0),
-    Number(guards.anomalyGracePeriod ?? 0),
-    Boolean(guards.autoPauseEnabled ?? false),
-    guards.oversightCouncil ?? ZERO_ADDRESS,
-  ];
+  console.log(`System pause calldata: ${blueprint.calldata.systemPause ?? '—'}`);
+  console.log(`Escalation bridge calldata: ${blueprint.calldata.escalationBridge ?? '—'}`);
 
   console.log();
   console.log('setGlobalConfig calldata:');
-  console.log(iface.encodeFunctionData('setGlobalConfig', [globalTuple]));
+  console.log(blueprint.calldata.globalConfig);
   console.log('setGlobalGuards calldata:');
-  console.log(iface.encodeFunctionData('setGlobalGuards', [guardTuple]));
-  const telemetryTuple = [
-    globalTelemetry.manifestHash ?? ZERO_BYTES32,
-    globalTelemetry.metricsDigest ?? ZERO_BYTES32,
-    Number(globalTelemetry.resilienceFloorBps ?? 0),
-    Number(globalTelemetry.automationFloorBps ?? 0),
-    Number(globalTelemetry.oversightWeightBps ?? 0),
-  ];
+  console.log(blueprint.calldata.globalGuards);
   console.log('setGlobalTelemetry calldata:');
-  console.log(iface.encodeFunctionData('setGlobalTelemetry', [telemetryTuple]));
+  console.log(blueprint.calldata.globalTelemetry);
 
   banner('Decentralized infrastructure mesh');
-  const globalInfra = config.global.decentralizedInfra ?? [];
+  const globalInfra = blueprint.infrastructure.global;
   if (globalInfra.length) {
     console.log('Global mesh:');
-    globalInfra.forEach((entry: Record<string, string | undefined>, idx: number) => {
+    globalInfra.forEach((entry, idx) => {
       console.log(`  [G${idx + 1}] ${summariseInfra(entry)}`);
     });
   }
-  config.domains.forEach((domain: any) => {
-    const infra = domain.infrastructure ?? [];
+  for (const domain of blueprint.domains) {
+    const infra = blueprint.infrastructure.domains[domain.slug] ?? [];
     console.log(`Domain ${domain.name} (${domain.slug}) integrations:`);
-    infra.forEach((entry: Record<string, string | undefined>, idx: number) => {
+    infra.forEach((entry, idx) => {
       console.log(`  [${idx + 1}] ${summariseInfra(entry)}`);
     });
-  });
+  }
 
   banner('Domain registrations');
-  config.domains.forEach((domain: any) => {
-    const metadata = domain.metadata ?? {};
-    const resilienceIndex = toNumber(metadata.resilienceIndex);
-    const valueFlowUSD = toNumber(metadata.valueFlowMonthlyUSD);
-    const valueFlowDisplay = metadata.valueFlowDisplay ?? formatUSD(valueFlowUSD);
-    const domainId = keccak256(toUtf8Bytes(String(domain.slug).toLowerCase()));
+  blueprint.domains.forEach((domain) => {
+    const metadata = domain.metadata;
+    const valueFlowDisplay = metadata.valueFlowDisplay ?? formatUSD(metadata.valueFlowMonthlyUSD);
     console.log(`\n\x1b[35m${domain.name} (${domain.slug})\x1b[0m`);
     renderTable([
-      ['Domain ID', domainId],
+      ['Domain ID', domain.domainId],
       ['Manifest', domain.manifestURI],
       ['Subgraph', domain.subgraph],
-      ['Priority', String(domain.priority)],
-      ['Skill tags', domain.skillTags.join(', ')],
-      ['Capabilities', Object.entries(domain.capabilities || {}).map(([k, v]) => `${k}: ${v}`).join(', ') || '—'],
-      ['Heartbeat', heartbeatSummary(domain, config.global)],
-      summarizeAddress('Validation module', domain.validationModule).split(': '),
-      summarizeAddress('Oracle', domain.oracle).split(': '),
-      summarizeAddress('L2 gateway', domain.l2Gateway).split(': '),
-      summarizeAddress('Execution router', domain.executionRouter).split(': '),
-      ['Resilience index', resilienceIndex !== undefined ? resilienceIndex.toFixed(3) : '—'],
+      ['Priority', domain.priority.toString()],
+      ['Skill tags', domain.skillTags.join(', ') || '—'],
+      [
+        'Capabilities',
+        Object.entries(domain.capabilities)
+          .map(([key, value]) => `${key}: ${value}`)
+          .join(', ') || '—',
+      ],
+      ['Heartbeat', heartbeatSummary(domain, blueprint.global.l2SyncCadenceSeconds)],
+      summarizeAddress('Validation module', domain.addresses.validationModule).split(': '),
+      summarizeAddress('Oracle', domain.addresses.oracle).split(': '),
+      summarizeAddress('L2 gateway', domain.addresses.l2Gateway).split(': '),
+      summarizeAddress('Execution router', domain.addresses.executionRouter).split(': '),
+      [
+        'Resilience index',
+        metadata.resilienceIndex !== null && metadata.resilienceIndex !== undefined
+          ? metadata.resilienceIndex.toFixed(3)
+          : '—',
+      ],
       ['Monthly value flow', valueFlowDisplay],
       ['Domain sentinel', metadata.sentinel ?? '—'],
       ['Uptime', metadata.uptime ?? '—'],
-      ['Telemetry resilience', formatBps(domain.telemetry?.resilienceBps)],
-      ['Telemetry automation', formatBps(domain.telemetry?.automationBps)],
-      ['Telemetry compliance', formatBps(domain.telemetry?.complianceBps)],
+      ['Telemetry resilience', formatBps(domain.telemetry.resilienceBps)],
+      ['Telemetry automation', formatBps(domain.telemetry.automationBps)],
+      ['Telemetry compliance', formatBps(domain.telemetry.complianceBps)],
       [
         'Telemetry settlement latency',
-        domain.telemetry?.settlementLatencySeconds !== undefined
+        domain.telemetry.settlementLatencySeconds
           ? `${domain.telemetry.settlementLatencySeconds}s`
           : '—',
       ],
-      [
-        'Uses L2 settlement',
-        domain.telemetry?.usesL2Settlement === undefined
-          ? '—'
-          : domain.telemetry.usesL2Settlement
-            ? 'yes'
-            : 'no',
-      ],
-      ['Telemetry metrics digest', domain.telemetry?.metricsDigest ?? '—'],
-      ['Telemetry manifest hash', domain.telemetry?.manifestHash ?? '—'],
+      ['Uses L2 settlement', domain.telemetry.usesL2Settlement ? 'yes' : 'no'],
+      ['Telemetry metrics digest', domain.telemetry.metricsDigest],
+      ['Telemetry manifest hash', domain.telemetry.manifestHash],
     ] as unknown as Array<[string, string]>);
 
-    const tuple = buildDomainTuple(domain);
-    const opsTuple = buildDomainOperationsTuple(domain);
-    const telemetryTupleDomain = buildDomainTelemetryTuple(domain);
-    const ops = domain.operations ?? {};
     console.log('  registerDomain calldata:');
-    console.log(`    ${iface.encodeFunctionData('registerDomain', [tuple])}`);
+    console.log(`    ${domain.calldata.registerDomain}`);
     console.log('  updateDomain calldata:');
-    console.log(`    ${iface.encodeFunctionData('updateDomain', [domainId, tuple])}`);
+    console.log(`    ${domain.calldata.updateDomain}`);
     console.log('  Operations guard rails:');
     console.log(
-      `    maxActiveJobs=${ops.maxActiveJobs ?? '—'} | maxQueueDepth=${ops.maxQueueDepth ?? '—'} | minStake=${formatStake(ops.minStake)}`,
+      `    maxActiveJobs=${domain.operations.maxActiveJobs} | maxQueueDepth=${domain.operations.maxQueueDepth} | minStake=${domain.operations.minStakeEth}`,
     );
     console.log(
-      `    treasuryShare=${formatBps(ops.treasuryShareBps)} | circuitBreaker=${formatBps(ops.circuitBreakerBps)} | requiresHumanValidation=${ops.requiresHumanValidation ? 'yes' : 'no'}`,
+      `    treasuryShare=${formatBps(domain.operations.treasuryShareBps)} | circuitBreaker=${formatBps(domain.operations.circuitBreakerBps)} | requiresHumanValidation=${domain.operations.requiresHumanValidation ? 'yes' : 'no'}`,
     );
     console.log('  setDomainOperations calldata:');
-    console.log(`    ${iface.encodeFunctionData('setDomainOperations', [domainId, opsTuple])}`);
+    console.log(`    ${domain.calldata.setDomainOperations}`);
     console.log('  setDomainTelemetry calldata:');
-    console.log(`    ${iface.encodeFunctionData('setDomainTelemetry', [domainId, telemetryTupleDomain])}`);
+    console.log(`    ${domain.calldata.setDomainTelemetry}`);
   });
 
   banner('Mermaid system map (copy/paste into dashboards)');
-  const diagram = mermaid(config);
-  console.log(diagram);
+  console.log(blueprint.mermaid);
 
   banner('Runtime guidance');
   console.log('• Python orchestrator runtime (`orchestrator/extensions/phase6.py`) auto-selects domains using this config.');
@@ -453,4 +303,22 @@ function heartbeatSummary(domain: any, global: any) {
   console.log('1. Queue calldata (above) via multisig / timelock.');
   console.log('2. Monitor `Phase6Domain` entities in the subgraph to confirm readiness.');
   console.log('3. Use `npm run demo:phase6:ci` in CI to enforce manifest integrity.');
+}
+
+(async () => {
+  const options = parseArgs();
+  const config = loadPhase6Config(options.configPath);
+  const blueprint = buildPhase6Blueprint(config, { configPath: options.configPath });
+
+  if (options.jsonOutput === '-') {
+    console.log(JSON.stringify(blueprint, null, 2));
+    return;
+  }
+
+  printBlueprint(blueprint, options);
+
+  if (options.jsonOutput) {
+    writeFileSync(options.jsonOutput, JSON.stringify(blueprint, null, 2));
+    console.log(`\nBlueprint JSON saved to ${options.jsonOutput}`);
+  }
 })();

--- a/test/scripts/phase6Blueprint.test.ts
+++ b/test/scripts/phase6Blueprint.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { keccak256, toUtf8Bytes } from 'ethers';
+
+import {
+  buildPhase6Blueprint,
+  loadPhase6Config,
+} from '../../demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-blueprint';
+
+const CONFIG_PATH = 'demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json';
+
+describe('Phase 6 blueprint generator', function () {
+  it('produces aggregate metrics and global calldata', function () {
+    const config = loadPhase6Config(CONFIG_PATH);
+    const blueprint = buildPhase6Blueprint(config, { configPath: CONFIG_PATH });
+
+    expect(blueprint.metrics.domainCount).to.equal(config.domains.length);
+    expect(blueprint.calldata.globalConfig).to.match(/^0x[0-9a-fA-F]+$/);
+    expect(blueprint.fragments).to.include(
+      'function setGlobalConfig((address,address,address,address,uint64,string) config)',
+    );
+    expect(blueprint.configPath).to.equal(CONFIG_PATH);
+    expect(blueprint.mermaid).to.contain('Phase6ExpansionManager');
+  });
+
+  it('normalises domains and exposes deterministic ids', function () {
+    const config = loadPhase6Config(CONFIG_PATH);
+    const blueprint = buildPhase6Blueprint(config);
+    const finance = blueprint.domains.find((domain) => domain.slug === 'finance');
+
+    expect(finance).to.not.equal(undefined);
+    expect(finance!.domainId).to.equal(keccak256(toUtf8Bytes('finance')));
+    expect(finance!.operations.minStakeWei).to.match(/^[0-9]+$/);
+    expect(finance!.operations.minStakeEth).to.match(/ETH$/);
+    expect(finance!.calldata.registerDomain).to.match(/^0x[0-9a-fA-F]+$/);
+    expect(finance!.telemetry.metricsDigest).to.match(/^0x[0-9a-fA-F]{64}$/);
+  });
+
+  it('computes value flow and sentinel coverage totals', function () {
+    const config = loadPhase6Config(CONFIG_PATH);
+    const blueprint = buildPhase6Blueprint(config);
+
+    const expectedValue = config.domains.reduce((acc, domain) => {
+      const value = domain.metadata?.valueFlowMonthlyUSD ?? 0;
+      return acc + Number(value);
+    }, 0);
+
+    expect(blueprint.metrics.totalValueFlowUSD).to.equal(expectedValue);
+    expect(blueprint.metrics.sentinelFamilies).to.be.greaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable Phase 6 blueprint builder that encodes calldata, metrics, and infrastructure snapshots for governance review
- extend the orchestrate script with CLI options for JSON export/custom configs and refresh the README quickstart
- cover the new data pipeline with a focused Hardhat test to guard blueprint structure and aggregation logic

## Testing
- npm run demo:phase6:ci
- npx hardhat test --no-compile test/scripts/phase6Blueprint.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68faf1037dec8333a5f584057d0ed244