### PR TITLE
Enhance Phase 8 sentinel coverage guarantees

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/jest.config.cjs
+++ b/demo/Phase-8-Universal-Value-Dominance/jest.config.cjs
@@ -6,7 +6,7 @@ module.exports = {
   testMatch: ['<rootDir>/scripts/**/*.test.ts'],
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/../../tsconfig.json',
+      tsconfig: '<rootDir>/tsconfig.test.json',
       diagnostics: true,
     },
   },

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/__snapshots__/phase8-orchestrator.test.ts.snap
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/__snapshots__/phase8-orchestrator.test.ts.snap
@@ -11,6 +11,7 @@ Generated: <timestamp>
 - Universal dominance score: 96.9 / 100
 - Sentinel coverage per guardian cycle: 45.0 minutes
 - Domains covered by sentinels: 100.0%
+- Minimum sentinel coverage per domain: 900s (requirement 720s, adequacy 125.0%)
 - Maximum encoded autonomy: 7800 bps
 - Self-improvement cadence: every 2.00 hours
 - Last self-improvement execution: 2023-11-14T22:20:00.000Z

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/phase8-orchestrator.test.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/phase8-orchestrator.test.ts
@@ -56,7 +56,17 @@ describe("Phase 8 orchestration console", () => {
       coverageSeconds: 10,
     }));
     expect(() => parseManifest(coverageBreach)).toThrowError(
-      /sentinels: Total sentinel coverage 30s is below guardian review window 720s/, 
+      /sentinels: Total sentinel coverage 30s is below guardian review window 720s/,
+    );
+
+    const domainCoverageBreach = JSON.parse(JSON.stringify(config));
+    domainCoverageBreach.sentinels = domainCoverageBreach.sentinels.map((entry: any) =>
+      entry.slug === "solar-shield"
+        ? { ...entry, coverageSeconds: 600 }
+        : entry,
+    );
+    expect(() => parseManifest(domainCoverageBreach)).toThrowError(
+      /Domains below guardian window 720s: climate-harmonizer, infrastructure-synthesis/,
     );
   });
 
@@ -109,6 +119,9 @@ describe("Phase 8 orchestration console", () => {
     try {
       const outputs = writeArtifacts(config, metrics, data, env, { outputDir: tempDir });
       expect(outputs).toHaveLength(4);
+
+      expect(metrics.minDomainCoverageSeconds).toBeGreaterThan(0);
+      expect(metrics.minimumCoverageAdequacy).toBeGreaterThan(1);
 
       const telemetryPath = join(tempDir, "phase8-telemetry-report.md");
       const mermaidPath = join(tempDir, "phase8-mermaid-diagram.mmd");

--- a/demo/Phase-8-Universal-Value-Dominance/tsconfig.test.json
+++ b/demo/Phase-8-Universal-Value-Dominance/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- enforce per-domain sentinel coverage thresholds during manifest validation and orchestration parsing
- surface minimum sentinel coverage metrics across telemetry, CLI output, and generated governance artifacts
- add a Phase 8-specific Jest tsconfig so the updated coverage tests run without type collisions and verify the new guardrails

## Testing
- npm run demo:phase8:ci
- npx jest --config demo/Phase-8-Universal-Value-Dominance/jest.config.cjs --updateSnapshot


------
https://chatgpt.com/codex/tasks/task_e_68fb6935016c833381a805e45e52d708