### PR TITLE
Add direct registry view helpers for Phase 8 governance

### DIFF
--- a/contracts/v2/Phase8UniversalValueManager.sol
+++ b/contracts/v2/Phase8UniversalValueManager.sol
@@ -483,6 +483,13 @@ contract Phase8UniversalValueManager is Governable, ReentrancyGuard {
         return result;
     }
 
+    /// @notice Fetches a sentinel profile by its deterministic identifier.
+    /// @dev Reverts with {UnknownSentinel} when the sentinel is unregistered or removed.
+    function getSentinel(bytes32 id) external view returns (SentinelProfile memory) {
+        if (!_knownSentinel[id]) revert UnknownSentinel(id);
+        return _sentinels[id];
+    }
+
     /// @notice Returns the domains assigned to a sentinel identifier.
     /// @dev Reverts with {UnknownSentinel} to prevent leaking empty arrays for invalid IDs.
     function getSentinelDomains(bytes32 id) external view returns (bytes32[] memory) {
@@ -564,6 +571,13 @@ contract Phase8UniversalValueManager is Governable, ReentrancyGuard {
             result[i] = CapitalStreamView({id: id, stream: _capitalStreams[id]});
         }
         return result;
+    }
+
+    /// @notice Fetches a capital stream configuration by its deterministic identifier.
+    /// @dev Reverts with {UnknownStream} when the stream is unregistered or removed.
+    function getCapitalStream(bytes32 id) external view returns (CapitalStream memory) {
+        if (!_knownStream[id]) revert UnknownStream(id);
+        return _capitalStreams[id];
     }
 
     /// @notice Fetches the domain bindings for a capital stream identifier.

--- a/demo/Phase-8-Universal-Value-Dominance/README.md
+++ b/demo/Phase-8-Universal-Value-Dominance/README.md
@@ -85,9 +85,11 @@ latest run. Safe imports should always display the chain ID and manager address 
   vaults, knowledge graphs, and risk tolerances atomically.
 * **Sentinel lattice** – register, update, and toggle sentinels that monitor domains. Each sentinel enforces coverage windows
   and can be routed through the shared `SystemPause` via `forwardPauseCall`. Domain bindings are configured via
-  `setSentinelDomains` so every sentinel only monitors approved dominions.
+  `setSentinelDomains` so every sentinel only monitors approved dominions, and dashboards can query individual profiles with
+  `getSentinel`.
 * **Capital streams** – register autonomous treasury programs with annual budgets and expansion curves. Governance can pause,
-  re-target, or re-bind the domain list at any time with `setCapitalStreamDomains`.
+  re-target, or re-bind the domain list at any time with `setCapitalStreamDomains`, while analytics surfaces can fetch a
+  single stream’s configuration instantly through `getCapitalStream`.
 * **Domain dominion** – configure orchestration endpoints, vault limits, and autonomy bps per domain while guaranteeing slug
   uniqueness and heartbeat invariants. Domains, sentinels, and streams can also be removed entirely (`removeDomain`,
   `removeSentinel`, `removeCapitalStream`) with automatic pruning of bindings.

--- a/test/v2/Phase8UniversalValueManager.t.sol
+++ b/test/v2/Phase8UniversalValueManager.t.sol
@@ -141,6 +141,11 @@ contract Phase8UniversalValueManagerTest is Test {
         manager.setSentinelStatus(sentinelId, true);
         Phase8UniversalValueManager.SentinelProfile memory sentinelState = manager.listSentinels()[0].profile;
         assertTrue(sentinelState.active);
+        Phase8UniversalValueManager.SentinelProfile memory sentinelConfig = manager.getSentinel(sentinelId);
+        assertEq(sentinelConfig.uri, sentinel.uri);
+        bytes32 unknownSentinelId = keccak256(abi.encodePacked("unknown-sentinel"));
+        vm.expectRevert(abi.encodeWithSelector(Phase8UniversalValueManager.UnknownSentinel.selector, unknownSentinelId));
+        manager.getSentinel(unknownSentinelId);
 
         Phase8UniversalValueManager.CapitalStream memory stream = Phase8UniversalValueManager.CapitalStream({
             slug: "climate-stabilization",
@@ -186,6 +191,11 @@ contract Phase8UniversalValueManagerTest is Test {
         manager.setCapitalStreamStatus(streamId, true);
         Phase8UniversalValueManager.CapitalStream memory streamState = manager.listCapitalStreams()[0].stream;
         assertTrue(streamState.active);
+        Phase8UniversalValueManager.CapitalStream memory streamConfig = manager.getCapitalStream(streamId);
+        assertEq(streamConfig.uri, stream.uri);
+        bytes32 unknownStreamId = keccak256(abi.encodePacked("unknown-stream"));
+        vm.expectRevert(abi.encodeWithSelector(Phase8UniversalValueManager.UnknownStream.selector, unknownStreamId));
+        manager.getCapitalStream(unknownStreamId);
 
         vm.prank(GOVERNANCE);
         manager.removeDomain(domainId);

--- a/test/v2/Phase8UniversalValueManager.test.ts
+++ b/test/v2/Phase8UniversalValueManager.test.ts
@@ -147,6 +147,12 @@ describe("Phase8UniversalValueManager", function () {
     const sentinelListing = await manager.listSentinels();
     expect(sentinelListing).to.have.lengthOf(1);
     expect(sentinelListing[0].id).to.equal(sentinelId);
+    const sentinelView = await manager.getSentinel(sentinelId);
+    expect(sentinelView.uri).to.equal(sentinelProfile.uri);
+    await expect(manager.getSentinel(ethers.id("unknown-sentinel"))).to.be.revertedWithCustomError(
+      manager,
+      "UnknownSentinel",
+    );
 
     const stream = {
       slug: "climate-stabilization",
@@ -187,6 +193,12 @@ describe("Phase8UniversalValueManager", function () {
     const streams = await manager.listCapitalStreams();
     expect(streams).to.have.lengthOf(1);
     expect(streams[0].id).to.equal(streamId);
+    const streamView = await manager.getCapitalStream(streamId);
+    expect(streamView.uri).to.equal(stream.uri);
+    await expect(manager.getCapitalStream(ethers.id("unknown-stream"))).to.be.revertedWithCustomError(
+      manager,
+      "UnknownStream",
+    );
 
     await expect(manager.connect(governance).removeDomain(domainId)).to.emit(manager, "DomainRemoved");
     expect(await manager.listDomains()).to.have.lengthOf(0);


### PR DESCRIPTION
## Summary
- expose `getSentinel` and `getCapitalStream` view accessors on the Phase 8 manager so dashboards can inspect single records without iterating the registries
- extend the Hardhat and Foundry suites to exercise the new view helpers and their revert conditions for unregistered IDs
- document the additional read endpoints in the Phase 8 demo README so operators know the data is available for their control surfaces

## Testing
- npx hardhat test test/v2/Phase8UniversalValueManager.test.ts
- forge test --match-contract Phase8UniversalValueManagerTest
- npm run demo:phase8:ci

------
https://chatgpt.com/codex/tasks/task_e_68fb84ef30ec8333bf3564ab143150cb