### PR TITLE
Document Phase 8 validation run and refresh generated artifacts

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/output/phase8-orchestration-report.txt
+++ b/demo/Phase-8-Universal-Value-Dominance/output/phase8-orchestration-report.txt
@@ -1,5 +1,5 @@
 PHASE 8 — UNIVERSAL VALUE DOMINANCE :: OPERATOR RUNBOOK
-Generated at 2025-10-24T15:30:45.042Z
+Generated at 2025-10-24T16:18:52.329Z
 
 Key telemetry snapshot:
 • Universal dominance score: 96.9 / 100

--- a/demo/Phase-8-Universal-Value-Dominance/output/phase8-self-improvement-plan.json
+++ b/demo/Phase-8-Universal-Value-Dominance/output/phase8-self-improvement-plan.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-24T15:30:45.042Z",
+  "generatedAt": "2025-10-24T16:18:52.329Z",
   "dominanceScore": 96.9,
   "sentinelCoverageMinutes": 45,
   "fundedDomainRatio": 100,

--- a/demo/Phase-8-Universal-Value-Dominance/phase8-validation-2025-10-24.md
+++ b/demo/Phase-8-Universal-Value-Dominance/phase8-validation-2025-10-24.md
@@ -1,0 +1,17 @@
+# Phase 8 validation report — 2025-10-24
+
+## Runtime + CI checks
+- `npm run demo:phase8:orchestrate` regenerated the Safe batch, telemetry brief, Mermaid map, runbook, and self-improvement payload directly from the manifest (`demo/Phase-8-Universal-Value-Dominance/config/universal.value.manifest.json`). Outputs now carry a 2025-10-24T16:18:52Z timestamp across the runbook and plan payload, and the telemetry report echoes the manifest governance addresses, coverage, and funding metrics. 
+- `npm run demo:phase8:ci` revalidated the manifest schema, confirming five domains, three sentinels, and three capital streams with 2,700s of total sentinel coverage and 7,200s cadence alignment.
+
+## Manifest alignment
+- Global governance addresses, domain caps/autonomy, sentinel bindings, and stream funding declared in the manifest mirror the regenerated telemetry briefing and Safe calldata payload.
+- The orchestrator continues to source every artifact from the shared manifest path, while the dashboard (`index.html`) resolves the same JSON for its data bindings.
+
+## Contract posture
+- `Phase8UniversalValueManager` keeps every mutating pathway gated behind `onlyGovernance`, including global parameter updates, pause forwarding, registry CRUD, and self-improvement logging. Events remain comprehensive for domains, sentinels, streams, and plan updates, and helper guards enforce address, heartbeat, coverage, and URI constraints.
+
+## Drift + follow-ups
+- The Safe batch metadata still records `createdFromSafeAddress` as `0x000…000` because the orchestrator defers to the `PHASE8_MANAGER_ADDRESS` environment variable; operators must inject the live Safe before execution.
+- Self-improvement artifacts report a 2025 generation timestamp while `lastExecutedAt` and next-run scheduling remain anchored to a 2023 epoch. Governance should reconcile the cadence anchor or update the manifest before deployment.
+


### PR DESCRIPTION
## Summary
- refresh the Phase 8 orchestration runbook and self-improvement payload with the 2025-10-24T16:18Z regeneration timestamp
- add a dated validation report capturing the latest runtime, CI, manifest alignment, contract posture, and known drift items

## Testing
- npm run demo:phase8:orchestrate
- npm run demo:phase8:ci

------
https://chatgpt.com/codex/tasks/task_e_68fba57b5da88333a5dea6ac9a68e075