### PR TITLE
Support Phase 6 domain sunsetting removal flows

### DIFF
--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/abi/Phase6ExpansionManager.json
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/abi/Phase6ExpansionManager.json
@@ -342,6 +342,25 @@
       },
       {
         "indexed": false,
+        "internalType": "string",
+        "name": "slug",
+        "type": "string"
+      }
+    ],
+    "name": "DomainRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
         "internalType": "uint32",
         "name": "resilienceBps",
         "type": "uint32"
@@ -691,6 +710,103 @@
         "name": "id",
         "type": "bytes32"
       },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "slug",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "validationModule",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "dataOracle",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2Gateway",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "subgraphEndpoint",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "executionRouter",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "heartbeatSeconds",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "active",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct Phase6ExpansionManager.Domain",
+        "name": "config",
+        "type": "tuple"
+      }
+    ],
+    "name": "updateDomain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "removeDomain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "domainExists",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
       {
         "internalType": "address",
         "name": "validationModule",
@@ -1667,6 +1783,38 @@
     "name": "updateDomain",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "removeDomain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "domainExists",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/subgraph/abis/Phase6ExpansionManager.json
+++ b/subgraph/abis/Phase6ExpansionManager.json
@@ -342,6 +342,25 @@
       },
       {
         "indexed": false,
+        "internalType": "string",
+        "name": "slug",
+        "type": "string"
+      }
+    ],
+    "name": "DomainRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
         "internalType": "uint32",
         "name": "resilienceBps",
         "type": "uint32"
@@ -691,6 +710,103 @@
         "name": "id",
         "type": "bytes32"
       },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "slug",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "validationModule",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "dataOracle",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2Gateway",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "subgraphEndpoint",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "executionRouter",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "heartbeatSeconds",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "active",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct Phase6ExpansionManager.Domain",
+        "name": "config",
+        "type": "tuple"
+      }
+    ],
+    "name": "updateDomain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "removeDomain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "domainExists",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
       {
         "internalType": "address",
         "name": "validationModule",
@@ -1667,6 +1783,38 @@
     "name": "updateDomain",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "removeDomain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "domainExists",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/test/scripts/phase6ApplyConfig.test.ts
+++ b/test/scripts/phase6ApplyConfig.test.ts
@@ -249,6 +249,7 @@ describe('Phase6 apply-config planner', function () {
           action: 'updateDomain',
           id: domainIdFromSlug('finance'),
           slug: 'finance',
+          lifecycle: 'active',
           diffs: ['metadataURI'],
           config: {
             slug: 'finance',
@@ -310,6 +311,7 @@ describe('Phase6 apply-config planner', function () {
           },
         },
       ],
+      domainInfrastructure: [],
       globalTelemetry: {
         action: 'setGlobalTelemetry',
         config: {
@@ -340,11 +342,19 @@ describe('Phase6 apply-config planner', function () {
     });
 
     expect(new Date(summary.generatedAt).getTime()).to.be.a('number');
-    expect(summary.counts).to.deep.equal({ global: 5, domains: 1, domainOperations: 1, domainTelemetry: 1, total: 8 });
+    expect(summary.counts).to.deep.equal({
+      global: 5,
+      domains: 1,
+      domainOperations: 1,
+      domainTelemetry: 1,
+      domainInfrastructure: 0,
+      total: 8,
+    });
     expect(summary.actions.domains[0].config.heartbeatSeconds).to.equal('120');
     expect(summary.actions.domainOperations[0].config.minStake).to.equal('1234567890000000000');
     expect(summary.actions.global?.config.l2SyncCadence).to.equal('180');
     expect(summary.actions.globalTelemetry?.config.resilienceFloorBps).to.equal(9300);
+    expect(summary.actions.domains[0].lifecycle).to.equal('active');
     expect(summary.filters.onlyDomains).to.deep.equal(['finance']);
     expect(summary.warnings).to.deep.equal(['review system pause escalation playbook']);
 
@@ -367,5 +377,222 @@ describe('Phase6 apply-config planner', function () {
     expect(filtered.actions.systemPause).to.be.undefined;
     expect(filtered.actions.escalationBridge).to.be.undefined;
     expect(filtered.counts.global).to.equal(2);
+  });
+
+  it('plans sunset removals without duplicate operations', async function () {
+    const [, governance] = await ethers.getSigners();
+    const manager = await deploy('Phase6ExpansionManager', governance.address);
+    const validation = await deploy('ValidationStub');
+    const pause = await deploy('Phase6MockSystemPause');
+    const escalation = await deploy('Phase6EscalationBridgeMock');
+    const router = await deploy('Phase6MockSystemPause');
+    const gateway = await deploy('Phase6MockSystemPause');
+    const treasury = await deploy('Phase6MockSystemPause');
+
+    const baseConfig: Phase6Config = {
+      global: {
+        manifestURI: 'ipfs://phase6/demo/global.json',
+        iotOracleRouter: router.target as string,
+        defaultL2Gateway: gateway.target as string,
+        didRegistry: validation.target as string,
+        treasuryBridge: treasury.target as string,
+        l2SyncCadence: 300,
+        systemPause: pause.target as string,
+        escalationBridge: escalation.target as string,
+        guards: {
+          treasuryBufferBps: 500,
+          circuitBreakerBps: 7200,
+          anomalyGracePeriod: 180,
+          autoPauseEnabled: true,
+          oversightCouncil: pause.target as string,
+        },
+        decentralizedInfra: [
+          {
+            name: 'EigenLayer Risk Shield AVS',
+            role: 'Telemetry attestations',
+            status: 'active',
+            endpoint: 'https://mesh.test/avs',
+          },
+          {
+            name: 'Filecoin Saturn Compute Mesh',
+            role: 'Burst compute layer',
+            status: 'ready',
+            endpoint: 'https://mesh.test/compute',
+          },
+          {
+            name: 'Arweave/IPFS Archive',
+            role: 'Manifest anchoring',
+            status: 'active',
+            endpoint: 'ar://phase6/demo',
+          },
+        ],
+        telemetry: {
+          manifestHash: ethers.id('phase6-global-manifest'),
+          metricsDigest: ethers.id('phase6-global-digest'),
+          resilienceFloorBps: 9100,
+          automationFloorBps: 8800,
+          oversightWeightBps: 6600,
+        },
+      },
+      domains: [
+        {
+          slug: 'logistics',
+          name: 'Autonomous Supply Lattice',
+          manifestURI: 'ipfs://phase6/domains/logistics.json',
+          subgraph: 'https://phase6.example/subgraphs/logistics',
+          validationModule: validation.target as string,
+          oracle: router.target as string,
+          l2Gateway: gateway.target as string,
+          executionRouter: validation.target as string,
+          heartbeatSeconds: 90,
+          active: true,
+          operations: {
+            maxActiveJobs: 64,
+            maxQueueDepth: 240,
+            minStake: ethers.parseEther('250').toString(),
+            treasuryShareBps: 240,
+            circuitBreakerBps: 6400,
+            requiresHumanValidation: false,
+          },
+          telemetry: {
+            resilienceBps: 9400,
+            automationBps: 9050,
+            complianceBps: 9200,
+            settlementLatencySeconds: 36,
+            usesL2Settlement: true,
+            sentinelOracle: validation.target as string,
+            settlementAsset: treasury.target as string,
+            metricsDigest: ethers.id('logistics-metrics'),
+            manifestHash: ethers.id('logistics-manifest'),
+          },
+          skillTags: ['logistics', 'iot'],
+          capabilities: {
+            routing: 4.2,
+            supply: 4.0,
+          },
+          priority: 88,
+          metadata: {
+            domain: 'Planetary logistics coordination',
+            l2: 'Base',
+            sentinel: 'Resilience-Index-Logistics',
+            resilienceIndex: 0.964,
+            uptime: '99.945%',
+            valueFlowMonthlyUSD: 12500000000,
+          },
+          infrastructure: [
+            {
+              layer: 'Settlement',
+              name: 'Ethereum Mainnet',
+              role: 'Final settlement',
+              status: 'anchor',
+            },
+            {
+              layer: 'Layer-2',
+              name: 'Base',
+              role: 'IoT event batching',
+              status: 'active',
+              endpoint: 'https://base.org',
+            },
+            {
+              layer: 'Oracle',
+              name: 'Chainlink CCIP',
+              role: 'Telemetry feeds',
+              status: 'active',
+              endpoint: 'https://chain.link',
+            },
+          ],
+          infrastructureControl: {
+            agentOps: router.target as string,
+            dataPipeline: gateway.target as string,
+            credentialVerifier: validation.target as string,
+            fallbackOperator: treasury.target as string,
+            controlPlaneURI: 'ipfs://phase6/domains/logistics/control.json',
+            autopilotCadence: 300,
+            autopilotEnabled: true,
+          },
+        },
+      ],
+    };
+
+    const stateBefore = await fetchPhase6State(manager);
+    const registrationPlan = planPhase6Changes(stateBefore, baseConfig);
+    const managerGov = manager.connect(governance);
+    await managerGov.setGlobalConfig(registrationPlan.global!.config);
+    await managerGov.setSystemPause(baseConfig.global.systemPause!);
+    await managerGov.setEscalationBridge(baseConfig.global.escalationBridge!);
+    await managerGov.setGlobalGuards(registrationPlan.globalGuards!.config);
+    if (registrationPlan.globalTelemetry) {
+      await managerGov.setGlobalTelemetry(registrationPlan.globalTelemetry.config);
+    }
+    await managerGov.registerDomain(registrationPlan.domains[0].config!);
+    await managerGov.setDomainOperations(
+      registrationPlan.domainOperations[0].id,
+      registrationPlan.domainOperations[0].config,
+    );
+    await managerGov.setDomainTelemetry(
+      registrationPlan.domainTelemetry[0].id,
+      registrationPlan.domainTelemetry[0].config,
+    );
+    await managerGov.setDomainInfrastructure(
+      registrationPlan.domainInfrastructure[0].id,
+      registrationPlan.domainInfrastructure[0].config,
+    );
+
+    const activeState = await fetchPhase6State(manager);
+
+    const sunsetConfig: Phase6Config = {
+      ...baseConfig,
+      domains: [
+        {
+          ...baseConfig.domains[0],
+          lifecycle: 'sunset',
+          sunsetPlan: {
+            reason: 'Logistics mesh merging into climate orchestration network',
+            retirementBlock: 21370000,
+            handoffDomains: ['finance', 'climate'],
+            notes: 'Agents migrate post resilience confirmation',
+          },
+        },
+      ],
+    };
+
+    const removalPlan = planPhase6Changes(activeState, sunsetConfig);
+    expect(removalPlan.domains).to.have.lengthOf(1);
+    const removal = removalPlan.domains[0];
+    expect(removal.action).to.equal('removeDomain');
+    expect(removal.lifecycle).to.equal('sunset');
+    expect(removal.sunsetPlan).to.deep.equal(sunsetConfig.domains[0].sunsetPlan);
+    expect(removalPlan.domainOperations).to.be.empty;
+    expect(removalPlan.domainTelemetry).to.be.empty;
+    expect(removalPlan.domainInfrastructure).to.be.empty;
+    expect(removalPlan.warnings).to.be.empty;
+
+    const managerAddress = await manager.getAddress();
+    const specVersion = await manager.SPEC_VERSION();
+    const network = await ethers.provider.getNetwork();
+    const summary = buildPlanSummary(removalPlan, {
+      manager: managerAddress,
+      governance: governance.address,
+      specVersion,
+      network: { name: network.name ?? 'hardhat', chainId: Number(network.chainId) },
+      configPath: 'sunset.json',
+      dryRun: true,
+      filters: {
+        skipGlobal: false,
+        skipSystemPause: false,
+        skipEscalation: false,
+        onlyDomains: [],
+      },
+    });
+
+    expect(summary.actions.domains).to.have.lengthOf(1);
+    expect(summary.actions.domains[0].action).to.equal('removeDomain');
+    expect(summary.actions.domains[0].lifecycle).to.equal('sunset');
+    expect(summary.actions.domains[0].sunsetPlan).to.deep.include({
+      reason: sunsetConfig.domains[0].sunsetPlan!.reason,
+    });
+    expect(summary.counts.domains).to.equal(1);
+    expect(summary.counts.domainOperations).to.equal(0);
+    expect(summary.warnings).to.be.empty;
   });
 });


### PR DESCRIPTION
## Summary
- allow the Phase 6 planner to understand lifecycle metadata, clone sunset plans, and emit removeDomain actions while enriching plan summaries
- extend the apply-config CLI validation/execution to cover lifecycle sunset scenarios and wire up removeDomain transactions
- sync the Phase6ExpansionManager ABI copies with the new view and removal methods and add a targeted Hardhat test for the sunsetting flow

## Testing
- npx hardhat compile
- npx hardhat test --no-compile test/scripts/phase6ApplyConfig.test.ts
- npx hardhat test --no-compile test/v2/Phase6ExpansionManager.test.js
- npm run demo:phase6:ci
- npm run lint:ci

------
https://chatgpt.com/codex/tasks/task_e_68fba2d97c908333a311b38a78b1be16