### PR TITLE
Enhance Phase 6 metrics coverage and reporting

### DIFF
--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/index.html
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/index.html
@@ -395,6 +395,10 @@
         let l2Coverage = 0;
         const valueFlows = [];
         const sentinels = new Set();
+        const resilienceFloor = Number(config.global?.telemetry?.resilienceFloorBps ?? NaN);
+        const automationFloor = Number(config.global?.telemetry?.automationFloorBps ?? NaN);
+        let resilienceFloorBreaches = 0;
+        let automationFloorBreaches = 0;
         config.domains.forEach((domain) => {
           const idx = Number.parseFloat(domain.metadata?.resilienceIndex ?? '');
           if (!Number.isNaN(idx)) {
@@ -402,11 +406,18 @@
           }
           if (domain.telemetry) {
             const telemetry = domain.telemetry;
+            const resilienceBps = Number(telemetry.resilienceBps ?? NaN);
+            if (!Number.isNaN(resilienceBps) && !Number.isNaN(resilienceFloor) && resilienceBps < resilienceFloor) {
+              resilienceFloorBreaches += 1;
+            }
             const auto = Number(telemetry.automationBps ?? NaN);
             const comp = Number(telemetry.complianceBps ?? NaN);
             const latencySeconds = Number(telemetry.settlementLatencySeconds ?? NaN);
             if (!Number.isNaN(auto)) {
               automation.push(auto);
+              if (!Number.isNaN(automationFloor) && auto < automationFloor) {
+                automationFloorBreaches += 1;
+              }
             }
             if (!Number.isNaN(comp)) {
               compliance.push(comp);
@@ -430,11 +441,31 @@
           resilience.length > 0 ? resilience.reduce((acc, cur) => acc + cur, 0) / resilience.length : null;
         const minResilience = resilience.length > 0 ? Math.min(...resilience) : null;
         const maxResilience = resilience.length > 0 ? Math.max(...resilience) : null;
+        const resilienceStdDev =
+          resilience.length > 0 && averageResilience !== null
+            ? Math.sqrt(
+                resilience.reduce((acc, cur) => {
+                  const diff = cur - averageResilience;
+                  return acc + diff * diff;
+                }, 0) / resilience.length,
+              )
+            : null;
         const totalValueFlow = valueFlows.reduce((acc, cur) => acc + cur, 0);
+        const domainCount = config.domains.length || 0;
+        const computeCoverage = (breaches, floor) => {
+          if (Number.isNaN(floor)) {
+            return null;
+          }
+          if (!domainCount) {
+            return 1;
+          }
+          return (domainCount - breaches) / domainCount;
+        };
         return {
           averageResilience,
           minResilience,
           maxResilience,
+          resilienceStdDev,
           totalValueFlow,
           sentinelCount: sentinels.size,
           averageAutomation: automation.length
@@ -445,6 +476,10 @@
             : null,
           averageLatency: latency.length ? latency.reduce((acc, cur) => acc + cur, 0) / latency.length : null,
           l2Coverage: config.domains.length ? l2Coverage / config.domains.length : 0,
+          resilienceFloorCoverage: computeCoverage(resilienceFloorBreaches, resilienceFloor),
+          resilienceFloorBreaches,
+          automationFloorCoverage: computeCoverage(automationFloorBreaches, automationFloor),
+          automationFloorBreaches,
           autopilotEnabled: config.domains.reduce(
             (acc, domain) => (domain.infrastructureControl?.autopilotEnabled ? acc + 1 : acc),
             0,
@@ -497,9 +532,17 @@
             averageCompliance,
             averageLatency,
             l2Coverage,
+            resilienceStdDev,
+            resilienceFloorCoverage,
+            resilienceFloorBreaches,
+            automationFloorCoverage,
+            automationFloorBreaches,
           } = state.metrics;
           if (averageResilience !== null) {
             items.push(`Network resilience: avg ${averageResilience.toFixed(3)} (min ${minResilience?.toFixed(3)}, max ${maxResilience?.toFixed(3)})`);
+          }
+          if (resilienceStdDev !== null) {
+            items.push(`Resilience deviation: ±${resilienceStdDev.toFixed(4)}`);
           }
           if (averageAutomation !== null) {
             items.push(`Automation maturity: ${formatBps(averageAutomation)}`);
@@ -515,6 +558,16 @@
             items.push(`Monthly value flow across domains: ${formatUSD(totalValueFlow)}`);
           }
           items.push(`Active sentinels: ${sentinelCount}`);
+          if (resilienceFloorCoverage !== null) {
+            items.push(
+              `Resilience floor coverage: ${(resilienceFloorCoverage * 100).toFixed(1)}% (breaches ${resilienceFloorBreaches})`,
+            );
+          }
+          if (automationFloorCoverage !== null) {
+            items.push(
+              `Automation floor coverage: ${(automationFloorCoverage * 100).toFixed(1)}% (breaches ${automationFloorBreaches})`,
+            );
+          }
           if (config.domains.length) {
             items.push(
               `Autopilot coverage: ${(

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-runbook.ts
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-runbook.ts
@@ -136,6 +136,21 @@ export function createPhase6Runbook(blueprint: Phase6Blueprint): string {
   if (typeof blueprint.metrics.averageCompliance === 'number') {
     lines.push(`- Compliance (avg): ${formatBps(blueprint.metrics.averageCompliance)}`);
   }
+  if (typeof blueprint.metrics.resilienceStdDev === 'number') {
+    lines.push(`- Resilience Deviation: ±${blueprint.metrics.resilienceStdDev.toFixed(4)}`);
+  }
+  if (typeof blueprint.metrics.resilienceFloorCoverage === 'number') {
+    lines.push(
+      `- Resilience Floor Coverage: ${(blueprint.metrics.resilienceFloorCoverage * 100).toFixed(1)}% ` +
+        `(breaches ${blueprint.metrics.resilienceFloorBreaches ?? 0})`,
+    );
+  }
+  if (typeof blueprint.metrics.automationFloorCoverage === 'number') {
+    lines.push(
+      `- Automation Floor Coverage: ${(blueprint.metrics.automationFloorCoverage * 100).toFixed(1)}% ` +
+        `(breaches ${blueprint.metrics.automationFloorBreaches ?? 0})`,
+    );
+  }
   lines.push(`- L2 Settlement Coverage: ${(blueprint.metrics.l2SettlementCoverage * 100).toFixed(1)}%`);
   lines.push(`- Sentinel Families: ${blueprint.metrics.sentinelFamilies}`);
   lines.push(`- Global Infra Touchpoints: ${blueprint.metrics.globalInfraCount}`);

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/run-phase6-demo.ts
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/run-phase6-demo.ts
@@ -191,6 +191,21 @@ function printBlueprint(blueprint: Phase6Blueprint, options: CliOptions) {
     `Autopilot coverage: ${(metrics.autopilotCoverage * 100).toFixed(1)}% ` +
       `(${metrics.autopilotEnabledCount}/${metrics.domainCount} domains)`,
   );
+  if (metrics.resilienceStdDev !== undefined) {
+    console.log(`Resilience deviation: ±${metrics.resilienceStdDev.toFixed(4)}`);
+  }
+  if (metrics.resilienceFloorCoverage !== undefined) {
+    console.log(
+      `Resilience floor coverage: ${(metrics.resilienceFloorCoverage * 100).toFixed(1)}% ` +
+        `(breaches ${metrics.resilienceFloorBreaches ?? 0})`,
+    );
+  }
+  if (metrics.automationFloorCoverage !== undefined) {
+    console.log(
+      `Automation floor coverage: ${(metrics.automationFloorCoverage * 100).toFixed(1)}% ` +
+        `(breaches ${metrics.automationFloorBreaches ?? 0})`,
+    );
+  }
   console.log(
     `Guard rails: treasuryBuffer=${formatBps(blueprint.guards.treasuryBufferBps)} | ` +
       `circuitBreaker=${formatBps(blueprint.guards.circuitBreakerBps)} | grace=${blueprint.guards.anomalyGracePeriod}s | ` +

--- a/test/scripts/phase6Blueprint.test.ts
+++ b/test/scripts/phase6Blueprint.test.ts
@@ -20,6 +20,11 @@ describe('Phase 6 blueprint generator', function () {
     );
     expect(blueprint.configPath).to.equal(CONFIG_PATH);
     expect(blueprint.mermaid).to.contain('Phase6ExpansionManager');
+    expect(blueprint.metrics.resilienceStdDev).to.be.a('number');
+    expect(blueprint.metrics.resilienceFloorBreaches).to.equal(0);
+    expect(blueprint.metrics.resilienceFloorCoverage).to.equal(1);
+    expect(blueprint.metrics.automationFloorBreaches).to.equal(2);
+    expect(blueprint.metrics.automationFloorCoverage).to.be.closeTo(0.6, 0.0001);
   });
 
   it('normalises domains and exposes deterministic ids', function () {

--- a/test/scripts/phase6Runbook.test.ts
+++ b/test/scripts/phase6Runbook.test.ts
@@ -17,5 +17,7 @@ describe('Phase 6 runbook generator', function () {
     expect(markdown).to.contain('## Domain: Sovereign Finance Hypergrid');
     expect(markdown).to.contain('setGlobalConfig');
     expect(markdown).to.contain('registerDomain: 0x');
+    expect(markdown).to.contain('Resilience Floor Coverage');
+    expect(markdown).to.contain('Automation Floor Coverage');
   });
 });


### PR DESCRIPTION
## Summary
- extend the Phase 6 blueprint metrics with resilience deviation plus automation/resilience floor coverage tracking and propagate the values through generated calldata and manifests
- surface the new coverage insights in the CLI blueprint output, the HTML control surface, and the runbook so non-technical operators can audit guard-rail readiness at a glance
- expand unit tests to assert the new metric fields and runbook content

## Testing
- npm run demo:phase6:ci
- npx ts-node demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/run-phase6-demo.ts --json - > /tmp/phase6.json

------
https://chatgpt.com/codex/tasks/task_e_68fbb5e3a1ec83339ba8854e4f83553d