### PR TITLE
Add Phase 6 IoT simulator and non-technical walkthrough

### DIFF
--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
@@ -31,17 +31,25 @@
    * Layer-2 bridge plans synthesized from the config and the on-chain ABI.
    * A ready-to-copy mermaid system diagram and runtime routing commentary from the Python orchestrator.
    * Encoded `setSystemPause` / `setEscalationBridge` transactions so governance can pivot or halt instantly.
-3. **Produce a governance-ready Markdown runbook** (optional):
+3. **Simulate IoT + external system signals (hands-off preview)**:
+   ```bash
+   npm run demo:phase6:iot
+   ```
+   * Streams a console storyboard showing how the runtime routes finance, health, logistics, climate, and education events.
+   * Provides guard-rail summaries (staking floors, circuit breakers, human validation flags) per event.
+   * Outputs Layer-2 bridge plans and autopilot cadences; append `-- --json iot-report.json` for machine-readable export.
+   * Point to your own feed with `-- --events my-events.json` to dry-run enterprise telemetry without editing the repo.
+4. **Produce a governance-ready Markdown runbook** (optional):
    ```bash
    npm run demo:phase6:runbook -- --output phase6-runbook.md
    ```
    The output file bundles the executive summary, emergency calldata, per-domain guard rails, decentralized infra mesh, and the mermaid map for instant stakeholder distribution.
-4. **Verify readiness in CI** (runs automatically, can be triggered locally):
+5. **Verify readiness in CI** (runs automatically, can be triggered locally):
    ```bash
    npm run demo:phase6:ci
    ```
    The script validates JSON schema, address hygiene, ABI sync, and UI artifacts before the CI job signs off.
-5. **Push the manifest on-chain (dry-run by default)**:
+6. **Push the manifest on-chain (dry-run by default)**:
    ```bash
    npx hardhat run --no-compile scripts/phase6/apply-config.ts --network <network> -- --manager <Phase6ExpansionManager>
    ```

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-iot-simulator.ts
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-iot-simulator.ts
@@ -1,0 +1,378 @@
+#!/usr/bin/env ts-node
+/*
+ * Simulates IoT + external system events and produces actionable rollout guidance
+ * for the Phase 6 expansion plan. Designed for non-technical operators so they
+ * can preview how the platform responds across multiple domains.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  buildPhase6Blueprint,
+  loadPhase6Config,
+  Phase6Blueprint,
+  DomainBlueprint,
+} from './phase6-blueprint';
+
+interface EventPayload {
+  id: string;
+  domainHint?: string;
+  summary: string;
+  type: string;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  requiredSkills?: string[];
+  requiredCapabilities?: Record<string, number>;
+  metadata?: Record<string, unknown>;
+}
+
+interface CliOptions {
+  configPath: string;
+  eventPath?: string;
+  jsonOutput?: string;
+}
+
+interface EvaluatedEvent {
+  event: EventPayload;
+  recommendedDomain: DomainBlueprint;
+  rationale: string[];
+  scorecard: Array<{ domain: string; score: number; reasons: string[] }>;
+  bridgePlan: {
+    l2Gateway?: string | null;
+    settlementLayer: string;
+    autopilot: string;
+    requiresHumanValidation: boolean;
+  };
+  guardRails: {
+    minStakeEth: string;
+    treasuryShareBps: number;
+    circuitBreakerBps: number;
+  };
+}
+
+const DEFAULT_CONFIG_PATH = join(__dirname, '..', 'config', 'domains.phase6.json');
+const DEFAULT_EVENTS: EventPayload[] = [
+  {
+    id: 'finance-liquidity-shock',
+    domainHint: 'finance',
+    summary: 'High-volatility window detected by risk oracle – synthesize hedge routing and deploy treasury buffers.',
+    type: 'market.oracle.alert',
+    severity: 'critical',
+    requiredSkills: ['finance', 'risk', 'defi'],
+    requiredCapabilities: { treasury: 4, defi: 3 },
+    metadata: {
+      volatilityIndex: 0.87,
+      affectedMarkets: ['ETH', 'stables', 'fx-baskets'],
+    },
+  },
+  {
+    id: 'health-telemetry-escalation',
+    domainHint: 'health',
+    summary: 'Remote clinic telemetry flagged inconsistent vitals across 11 nodes – dispatch oversight + DID verification.',
+    type: 'iot.vitals.alert',
+    severity: 'high',
+    requiredSkills: ['health', 'compliance', 'regulation'],
+    requiredCapabilities: { compliance: 4 },
+    metadata: {
+      regions: ['Nairobi', 'Lagos'],
+      requiresHumanInLoop: true,
+    },
+  },
+  {
+    id: 'logistics-delay',
+    summary: 'Hyper-port sensor mesh reports 7-hour delay for a climate-sensitive shipment – reroute and notify operators.',
+    type: 'iot.logistics.delay',
+    severity: 'medium',
+    requiredSkills: ['logistics', 'climate', 'automation'],
+    requiredCapabilities: { logistics: 3 },
+    metadata: {
+      cargo: 'Biopharma cold-chain',
+      temperatureSpike: '2.3°C',
+      port: 'Singapore',
+    },
+  },
+  {
+    id: 'education-accreditation',
+    domainHint: 'education',
+    summary: 'Incoming cohort requests verifiable credential issuance mapped to DID wallet distribution.',
+    type: 'identity.credential.issue',
+    severity: 'low',
+    requiredSkills: ['education', 'identity', 'compliance'],
+    requiredCapabilities: { credentials: 3 },
+    metadata: {
+      cohortSize: 5400,
+      requiresOnChainProof: true,
+    },
+  },
+];
+
+function parseArgs(): CliOptions {
+  const argv = process.argv.slice(2);
+  const options: CliOptions = { configPath: DEFAULT_CONFIG_PATH };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--config') {
+      const next = argv[++i];
+      if (!next) {
+        throw new Error('--config expects a path');
+      }
+      options.configPath = next;
+      continue;
+    }
+    if (arg.startsWith('--config=')) {
+      options.configPath = arg.split('=', 2)[1] ?? DEFAULT_CONFIG_PATH;
+      continue;
+    }
+    if (arg === '--events') {
+      const next = argv[++i];
+      if (!next) {
+        throw new Error('--events expects a path to a JSON file.');
+      }
+      options.eventPath = next;
+      continue;
+    }
+    if (arg.startsWith('--events=')) {
+      options.eventPath = arg.split('=', 2)[1];
+      continue;
+    }
+    if (arg === '--json') {
+      const next = argv[i + 1];
+      if (!next || next.startsWith('--')) {
+        options.jsonOutput = '-';
+      } else {
+        options.jsonOutput = next;
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith('--json=')) {
+      const value = arg.split('=', 2)[1];
+      options.jsonOutput = value && value.length ? value : '-';
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+    console.warn(`Unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
+function printUsage(): void {
+  console.log(
+    `Phase 6 IoT simulator\n\n` +
+      `Usage: npm run demo:phase6:iot -- [options]\n\n` +
+      `Options:\n` +
+      `  --config <path>         Use a custom Phase 6 config file (default: ${DEFAULT_CONFIG_PATH})\n` +
+      `  --events <path>         Load events from a JSON file instead of built-in samples\n` +
+      `  --json [path|-]         Emit JSON output to <path>; use '-' for stdout\n` +
+      `  -h, --help              Show this message\n`,
+  );
+}
+
+function loadEvents(path?: string): EventPayload[] {
+  if (!path) {
+    return DEFAULT_EVENTS;
+  }
+  const raw = JSON.parse(readFileSync(path, 'utf-8'));
+  if (Array.isArray(raw)) {
+    return raw as EventPayload[];
+  }
+  throw new Error(`Events file must contain an array – received ${typeof raw}`);
+}
+
+function evaluateEvents(blueprint: Phase6Blueprint, events: EventPayload[]): EvaluatedEvent[] {
+  return events.map((event) => {
+    const scorecard = blueprint.domains
+      .map((domain) => ({
+        domain: domain.slug,
+        score: scoreDomain(domain, event),
+        reasons: buildReasons(domain, event),
+      }))
+      .sort((a, b) => b.score - a.score);
+
+    const top = scorecard[0];
+    const recommendedDomain = blueprint.domains.find((domain) => domain.slug === top.domain)!;
+
+    return {
+      event,
+      recommendedDomain,
+      rationale: scorecard[0].reasons,
+      scorecard,
+      bridgePlan: buildBridgePlan(blueprint, recommendedDomain),
+      guardRails: {
+        minStakeEth: recommendedDomain.operations.minStakeEth,
+        treasuryShareBps: recommendedDomain.operations.treasuryShareBps,
+        circuitBreakerBps: recommendedDomain.operations.circuitBreakerBps,
+      },
+    };
+  });
+}
+
+function normaliseSkills(skills?: string[]): string[] {
+  if (!skills) return [];
+  return skills.map((skill) => skill.toLowerCase().trim()).filter(Boolean);
+}
+
+function scoreDomain(domain: DomainBlueprint, event: EventPayload): number {
+  let score = domain.priority || 0;
+
+  if (event.domainHint && event.domainHint.toLowerCase() === domain.slug.toLowerCase()) {
+    score += 25;
+  }
+
+  const skills = normaliseSkills(event.requiredSkills);
+  const matchedSkills = skills.filter((skill) => domain.skillTags.includes(skill));
+  score += matchedSkills.length * 12;
+
+  const requiredCaps = event.requiredCapabilities ?? {};
+  const capabilityScore = Object.entries(requiredCaps).reduce((acc, [cap, weight]) => {
+    const domainCap = domain.capabilities[cap.toLowerCase()] ?? 0;
+    return acc + domainCap * Number(weight ?? 1);
+  }, 0);
+  score += capabilityScore * 6;
+
+  if (domain.telemetry.usesL2Settlement && event.type.startsWith('iot.')) {
+    score += 8;
+  }
+
+  if (domain.operations.requiresHumanValidation && event.metadata?.requiresHumanInLoop) {
+    score += 6;
+  }
+
+  if (!domain.operations.requiresHumanValidation && event.metadata?.requiresHumanInLoop) {
+    score -= 4;
+  }
+
+  if (domain.infrastructureControl.autopilotEnabled) {
+    score += 5;
+  }
+
+  if (event.severity === 'critical') {
+    score += 5;
+  }
+
+  if (event.severity === 'low') {
+    score -= 2;
+  }
+
+  return score;
+}
+
+function buildReasons(domain: DomainBlueprint, event: EventPayload): string[] {
+  const reasons: string[] = [];
+  if (event.domainHint && event.domainHint.toLowerCase() === domain.slug.toLowerCase()) {
+    reasons.push('Domain hint matches');
+  }
+  const skills = normaliseSkills(event.requiredSkills);
+  const matchedSkills = skills.filter((skill) => domain.skillTags.includes(skill));
+  if (matchedSkills.length) {
+    reasons.push(`Skill alignment: ${matchedSkills.join(', ')}`);
+  }
+  const requiredCaps = event.requiredCapabilities ?? {};
+  Object.entries(requiredCaps).forEach(([cap, weight]) => {
+    const domainCap = domain.capabilities[cap.toLowerCase()];
+    if (domainCap) {
+      reasons.push(`Capability ${cap}: ${domainCap.toFixed(1)} x weight ${Number(weight ?? 1).toFixed(1)}`);
+    }
+  });
+  if (domain.telemetry.usesL2Settlement && event.type.startsWith('iot.')) {
+    reasons.push('IoT-ready L2 settlement');
+  }
+  if (domain.operations.requiresHumanValidation) {
+    reasons.push('Human validation available');
+  }
+  if (domain.infrastructureControl.autopilotEnabled) {
+    reasons.push(`Autopilot cadence ${domain.infrastructureControl.autopilotCadenceSeconds || 0}s`);
+  }
+  return reasons;
+}
+
+function buildBridgePlan(blueprint: Phase6Blueprint, domain: DomainBlueprint) {
+  const autopilot = domain.infrastructureControl.autopilotEnabled
+    ? `autopilot enabled @ ${domain.infrastructureControl.autopilotCadenceSeconds || 0}s`
+    : 'autopilot standby';
+  return {
+    l2Gateway: domain.addresses.l2Gateway ?? blueprint.global.defaultL2Gateway,
+    settlementLayer: domain.telemetry.usesL2Settlement ? 'Layer-2 accelerated' : 'Layer-1 anchor',
+    autopilot,
+    requiresHumanValidation: domain.operations.requiresHumanValidation,
+  };
+}
+
+function summariseEvent(result: EvaluatedEvent) {
+  console.log(`\n\x1b[38;5;105mEvent: ${result.event.summary}\x1b[0m`);
+  console.log(`  id: ${result.event.id}`);
+  console.log(`  type: ${result.event.type}`);
+  console.log(`  severity: ${result.event.severity}`);
+  if (result.event.requiredSkills?.length) {
+    console.log(`  required skills: ${result.event.requiredSkills.join(', ')}`);
+  }
+  console.log(`\n  \x1b[32mRecommended domain:\x1b[0m ${result.recommendedDomain.name} (${result.recommendedDomain.slug})`);
+  console.log(`    manifest: ${result.recommendedDomain.manifestURI}`);
+  console.log(`    subgraph: ${result.recommendedDomain.subgraph}`);
+  console.log(`    guard rails: min stake ${result.guardRails.minStakeEth}, treasury share ${result.guardRails.treasuryShareBps} bps, circuit breaker ${result.guardRails.circuitBreakerBps} bps`);
+  console.log(`    bridge plan: ${result.bridgePlan.settlementLayer} via ${result.bridgePlan.l2Gateway ?? '—'} (${result.bridgePlan.autopilot})`);
+  if (result.bridgePlan.requiresHumanValidation) {
+    console.log('    ⚠ Requires human validation – route through credential verifier.');
+  }
+  console.log('    Rationale:');
+  result.rationale.forEach((reason) => {
+    console.log(`      • ${reason}`);
+  });
+  console.log('  Scorecard:');
+  result.scorecard.slice(0, 4).forEach((entry, idx) => {
+    const indicator = idx === 0 ? '★' : '•';
+    console.log(`    ${indicator} ${entry.domain.padEnd(12)} ${entry.score.toFixed(2)}`);
+  });
+}
+
+function emitJson(results: EvaluatedEvent[], path?: string) {
+  const payload = results.map((result) => ({
+    event: result.event,
+    recommendedDomain: {
+      slug: result.recommendedDomain.slug,
+      name: result.recommendedDomain.name,
+      manifestURI: result.recommendedDomain.manifestURI,
+      subgraph: result.recommendedDomain.subgraph,
+    },
+    rationale: result.rationale,
+    bridgePlan: result.bridgePlan,
+    guardRails: result.guardRails,
+    scorecard: result.scorecard,
+  }));
+
+  if (!path || path === '-') {
+    process.stdout.write(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  writeFileSync(path, JSON.stringify(payload, null, 2));
+  console.log(`\nJSON report written to ${path}`);
+}
+
+function main() {
+  const options = parseArgs();
+  const config = loadPhase6Config(options.configPath);
+  const blueprint = buildPhase6Blueprint(config, { configPath: options.configPath });
+  const events = loadEvents(options.eventPath);
+
+  console.log('\x1b[38;5;117mPhase 6 IoT & external signal simulator\x1b[0m');
+  console.log(`Spec version: ${blueprint.specVersion}`);
+  console.log(`Config hash: ${blueprint.configHash}`);
+  console.log(`Loaded ${events.length} event${events.length === 1 ? '' : 's'}.`);
+
+  const evaluations = evaluateEvents(blueprint, events);
+  evaluations.forEach(summariseEvent);
+
+  if (options.jsonOutput) {
+    emitJson(evaluations, options.jsonOutput);
+  }
+
+  console.log('\nAll events processed. Phase 6 routing plan ready for execution.');
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -257,6 +257,7 @@
     "demo:redenomination:guardian-drill": "node demo/REDENOMINATION/scripts/guardian-drill.mjs",
     "demo:phase6:orchestrate": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/run-phase6-demo.ts",
     "demo:phase6:ci": "node demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/ci-check.mjs",
+    "demo:phase6:iot": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-iot-simulator.ts",
     "demo:phase6:runbook": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/generate-phase6-runbook.ts",
     "demo:phase6:apply": "npx hardhat run --no-compile scripts/phase6/apply-config.ts",
     "demo:phase8:orchestrate": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-8-Universal-Value-Dominance/scripts/run-phase8-demo.ts",


### PR DESCRIPTION
## Summary
- add an interactive ts-node script that simulates IoT and external events, evaluates domain routing and outputs guard rails
- expose the simulator through the Phase 6 demo quickstart and update documentation for non-technical operators
- wire the new workflow into package.json so the command is available in CI and local tooling

## Testing
- npm run demo:phase6:iot -- --json -
- npm run demo:phase6:ci

------
https://chatgpt.com/codex/tasks/task_e_68fc36fefb848333ae95afbd2b357765