### PR TITLE
Add credential governance UI and audits for Phase 6 demo

### DIFF
--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
@@ -44,12 +44,18 @@
    npm run demo:phase6:runbook -- --output phase6-runbook.md
    ```
    The output file bundles the executive summary, emergency calldata, per-domain guard rails, decentralized infra mesh, and the mermaid map for instant stakeholder distribution.
-5. **Verify readiness in CI** (runs automatically, can be triggered locally):
+5. **Audit DID & credential coverage**:
+   ```bash
+   npm run demo:phase6:did
+   ```
+   * Prints credential coverage, missing domains, and the active trust anchors/issuers.
+   * Append `-- --json did-audit.json` to produce a machine-readable report for governance archives.
+6. **Verify readiness in CI** (runs automatically, can be triggered locally):
    ```bash
    npm run demo:phase6:ci
    ```
    The script validates JSON schema, address hygiene, ABI sync, and UI artifacts before the CI job signs off.
-6. **Push the manifest on-chain (dry-run by default)**:
+7. **Push the manifest on-chain (dry-run by default)**:
    ```bash
    npx hardhat run --no-compile scripts/phase6/apply-config.ts --network <network> -- --manager <Phase6ExpansionManager>
    ```
@@ -57,7 +63,7 @@
    * Defaults to a dry-run – add `--apply` to execute transactions once reviewed.
    * Scope updates with `--domain finance,health` or skip globals via `--skip-global`.
    * Append `--export-plan plan.json` to emit a JSON manifest of the actions for multisig or council review.
-6. **Open the control surface UI**:
+8. **Open the control surface UI**:
    *Serve locally or open directly in the repo*
    ```bash
    npx serve demo/Phase-6-Scaling-Multi-Domain-Expansion
@@ -122,6 +128,16 @@ These additions power UI cards, CI validation, and off-chain monitoring (e.g., t
 * `index.html` renders the infra mesh alongside bridge plans so non-technical operators see exactly which L2s, storage rails, DID registries, and compute meshes come online.
 * `scripts/ci-check.mjs` enforces structural integrity: at least three integrations per domain and valid metadata for every mesh element.
 * `orchestrator/extensions/phase6.py` consumes the infra map to annotate runtime logs (`infra mesh: Layer-2:Linea(active)`) and to expose integration hints to IoT signal handlers.
+
+---
+
+## ✅ Credential governance mesh
+
+* Every domain in `config/domains.phase6.json` now declares explicit credential requirements (name, requirement, issuers, verifiers, registry, evidence).
+* Global trust anchors, issuers, policies, and the revocation registry are enforced by `scripts/ci-check.mjs` and surfaced throughout the blueprint, runtime, and UI.
+* `npm run demo:phase6:did` produces a credential coverage audit (and optional JSON) so governance can prove DID readiness before activating new industries.
+* The Python runtime annotates orchestrator logs with credential guard rails, and the IoT simulator reports issuer/verifier sets for every event.
+* The control-surface UI renders credential counts and requirement summaries on each domain card for non-technical operators.
 
 ---
 

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json
@@ -41,6 +41,57 @@
         "endpoint": "https://mesh.agi.jobs/lit-threshold"
       }
     ],
+    "credentials": {
+      "trustAnchors": [
+        {
+          "name": "AGI Jobs Oversight Council Multisig",
+          "did": "did:ens:agi.jobs.council",
+          "role": "Issues emergency oversight credentials and pause authorisations",
+          "policyURI": "ipfs://phase6/global/policies/oversight.json"
+        },
+        {
+          "name": "Global Neutrality Notary",
+          "did": "did:key:z6MkqGlobalNeutrality",
+          "role": "Attests to cross-jurisdictional compliance packages",
+          "policyURI": "ipfs://phase6/global/policies/compliance.json"
+        },
+        {
+          "name": "AI Alignment Guardians",
+          "did": "did:pkh:eip155:1:0x9090909090909090909090909090909090909090",
+          "role": "Provides mission-critical AI safety attestations for human-in-the-loop tasks",
+          "policyURI": "ipfs://phase6/global/policies/alignment.json"
+        }
+      ],
+      "issuers": [
+        {
+          "name": "Sovereign Identity Issuer",
+          "did": "did:ens:agi.jobs.identity",
+          "domains": ["finance", "health", "logistics", "climate", "education"],
+          "attestationType": "AGIJobsEmploymentCredential",
+          "registry": "did:ethr:0x5555aaAA5555aaAA5555aaAA5555aaAA5555aaAA"
+        },
+        {
+          "name": "Phase 6 Autonomous Validator Guild",
+          "did": "did:pkh:eip155:1:0x1212121212121212121212121212121212121212",
+          "domains": ["finance", "logistics"],
+          "attestationType": "ValidatorClearanceCredential",
+          "registry": "did:key:z6MkiValidatorClearance"
+        }
+      ],
+      "policies": [
+        {
+          "name": "Global Compliance Baseline",
+          "description": "Defines minimum DID + VC requirements for any human oversight or treasury interaction",
+          "uri": "ipfs://phase6/global/policies/compliance-baseline.md"
+        },
+        {
+          "name": "Autonomous Agent Safeguard",
+          "description": "Specifies verification cadence for autonomous agents participating in high-risk workflows",
+          "uri": "ipfs://phase6/global/policies/autonomous-safeguard.md"
+        }
+      ],
+      "revocationRegistry": "did:pkh:eip155:1:0xABCDabcdABCDabcdABCDabcdABCDabcdABCDabcd"
+    },
     "telemetry": {
       "manifestHash": "0x2613ea16baaa9a77b9aabab976b736dd81ebaeb5b209909b8aea66845a8314fa",
       "metricsDigest": "0xc18fe72d328409449dcbf4defceb1d0e1497491f1c28e2c94290e689853e9de0",
@@ -108,6 +159,40 @@
         "valueFlowMonthlyUSD": 28400000000,
         "valueFlowDisplay": "$28.4B"
       },
+      "credentials": [
+        {
+          "name": "Basel III Treasury Credential",
+          "requirement": "Mandatory for autonomous treasury actions above $50M notional",
+          "credentialType": "BaselIIIComplianceCredential",
+          "format": "EIP-712",
+          "issuers": [
+            "did:ens:agi.jobs.council",
+            "did:ens:agi.jobs.identity"
+          ],
+          "verifiers": [
+            "did:ens:agi.jobs.finance.verifier",
+            "did:pkh:eip155:1:0x4545454545454545454545454545454545454545"
+          ],
+          "registry": "did:ethr:0xf1F1f1F1f1F1f1F1f1F1f1F1f1F1f1F1f1F1f1F1",
+          "evidence": "ipfs://phase6/domains/finance/credentials/basel-iii.pdf",
+          "notes": "Gatekeeping autopilot overrides and emergency liquidity injections"
+        },
+        {
+          "name": "Cross-Border Settlement Passport",
+          "requirement": "Required to clear interjurisdictional cash flows or derivative settlements",
+          "credentialType": "ISO20022InterchangeCredential",
+          "format": "JSON-LD VC",
+          "issuers": [
+            "did:key:z6MkqGlobalNeutrality"
+          ],
+          "verifiers": [
+            "did:ens:agi.jobs.finance.verifier"
+          ],
+          "registry": "did:pkh:eip155:1:0x5656565656565656565656565656565656565656",
+          "evidence": "ipfs://phase6/domains/finance/credentials/iso20022.json",
+          "notes": "Ensures compliance desks can review real-time routes"
+        }
+      ],
       "infrastructure": [
         {
           "layer": "Settlement",
@@ -196,6 +281,40 @@
         "valueFlowMonthlyUSD": 18600000000,
         "valueFlowDisplay": "$18.6B"
       },
+      "credentials": [
+        {
+          "name": "HIPAA Verifier Credential",
+          "requirement": "Required for any human validator or agent accessing protected health information",
+          "credentialType": "HIPAAComplianceCredential",
+          "format": "JSON-LD VC",
+          "issuers": [
+            "did:ens:agi.jobs.identity",
+            "did:key:z6MkqGlobalNeutrality"
+          ],
+          "verifiers": [
+            "did:ens:agi.jobs.health.verifier",
+            "did:pkh:eip155:1:0x3131313131313131313131313131313131313131"
+          ],
+          "registry": "did:ethr:0x7777777777777777777777777777777777777777",
+          "evidence": "ipfs://phase6/domains/health/credentials/hipaa-checklist.json",
+          "notes": "Used to unlock diagnostics autopilot and escalate to human review"
+        },
+        {
+          "name": "Clinical Oversight Token",
+          "requirement": "Mandatory for high-risk telemedicine overrides or prescription issuance",
+          "credentialType": "ClinicalOversightCredential",
+          "format": "EIP-712",
+          "issuers": [
+            "did:pkh:eip155:1:0x9090909090909090909090909090909090909090"
+          ],
+          "verifiers": [
+            "did:ens:agi.jobs.health.verifier"
+          ],
+          "registry": "did:key:z6MkqClinicalOversight",
+          "evidence": "ipfs://phase6/domains/health/credentials/clinical-oversight.pdf",
+          "notes": "Expiring credential forcing rotation every 30 days"
+        }
+      ],
       "infrastructure": [
         {
           "layer": "Settlement",
@@ -286,6 +405,40 @@
         "valueFlowMonthlyUSD": 22400000000,
         "valueFlowDisplay": "$22.4B"
       },
+      "credentials": [
+        {
+          "name": "Critical Cargo Custody Credential",
+          "requirement": "Needed to authorize rerouting of climate-sensitive or sovereign cargo",
+          "credentialType": "CustodyChainCredential",
+          "format": "JSON-LD VC",
+          "issuers": [
+            "did:ens:agi.jobs.identity",
+            "did:pkh:eip155:1:0x1212121212121212121212121212121212121212"
+          ],
+          "verifiers": [
+            "did:ens:agi.jobs.logistics.verifier"
+          ],
+          "registry": "did:ethr:0x8888888888888888888888888888888888888888",
+          "evidence": "ipfs://phase6/domains/logistics/credentials/custody.json",
+          "notes": "Sensor mesh verifies credential before executing drone or fleet dispatch"
+        },
+        {
+          "name": "Port Authority Liaison Pass",
+          "requirement": "Enables agents to interact with human port authorities and customs APIs",
+          "credentialType": "PortAuthorityCredential",
+          "format": "EIP-712",
+          "issuers": [
+            "did:key:z6MkqGlobalNeutrality"
+          ],
+          "verifiers": [
+            "did:ens:agi.jobs.logistics.verifier",
+            "did:pkh:eip155:1:0x7878787878787878787878787878787878787878"
+          ],
+          "registry": "did:key:z6MkqPortAuthority",
+          "evidence": "ipfs://phase6/domains/logistics/credentials/port-pass.pdf",
+          "notes": "Mandatory for emergency rerouting or customs overrides"
+        }
+      ],
       "infrastructure": [
         {
           "layer": "Settlement",
@@ -375,6 +528,40 @@
         "valueFlowMonthlyUSD": 11200000000,
         "valueFlowDisplay": "$11.2B"
       },
+      "credentials": [
+        {
+          "name": "Climate Data Steward Credential",
+          "requirement": "Required for human sign-off on carbon accounting and resilience dashboards",
+          "credentialType": "ClimateStewardCredential",
+          "format": "JSON-LD VC",
+          "issuers": [
+            "did:ens:agi.jobs.identity",
+            "did:key:z6MkqGlobalNeutrality"
+          ],
+          "verifiers": [
+            "did:ens:agi.jobs.climate.verifier"
+          ],
+          "registry": "did:ethr:0x9999999999999999999999999999999999999999",
+          "evidence": "ipfs://phase6/domains/climate/credentials/steward.json",
+          "notes": "Enforced before publishing data to public markets or regulators"
+        },
+        {
+          "name": "Grid Emergency Override Pass",
+          "requirement": "Enables coordination with human grid operators during emergency demand response",
+          "credentialType": "GridOverrideCredential",
+          "format": "EIP-712",
+          "issuers": [
+            "did:pkh:eip155:1:0x9090909090909090909090909090909090909090"
+          ],
+          "verifiers": [
+            "did:ens:agi.jobs.climate.verifier",
+            "did:pkh:eip155:1:0x4545454545454545454545454545454545454545"
+          ],
+          "registry": "did:key:z6MkqGridOverride",
+          "evidence": "ipfs://phase6/domains/climate/credentials/grid-override.pdf",
+          "notes": "Short-lived credential with 6-hour expiry for safety"
+        }
+      ],
       "infrastructure": [
         {
           "layer": "Settlement",
@@ -464,6 +651,40 @@
         "valueFlowMonthlyUSD": 9800000000,
         "valueFlowDisplay": "$9.8B"
       },
+      "credentials": [
+        {
+          "name": "Accredited Mentor Credential",
+          "requirement": "Required for humans providing peer review or graduation approvals",
+          "credentialType": "MentorAccreditationCredential",
+          "format": "JSON-LD VC",
+          "issuers": [
+            "did:ens:agi.jobs.identity",
+            "did:pkh:eip155:1:0x1212121212121212121212121212121212121212"
+          ],
+          "verifiers": [
+            "did:ens:agi.jobs.education.verifier"
+          ],
+          "registry": "did:ethr:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+          "evidence": "ipfs://phase6/domains/education/credentials/mentor.json",
+          "notes": "Unlocks credential issuance autopilot for verified mentors"
+        },
+        {
+          "name": "Curriculum Integrity Token",
+          "requirement": "Needed to publish or update global course manifests across domains",
+          "credentialType": "CurriculumIntegrityCredential",
+          "format": "EIP-712",
+          "issuers": [
+            "did:key:z6MkqGlobalNeutrality"
+          ],
+          "verifiers": [
+            "did:ens:agi.jobs.education.verifier",
+            "did:pkh:eip155:1:0x5555777788889999aaaabbbbccccddddeeeeff00"
+          ],
+          "registry": "did:key:z6MkqCurriculumIntegrity",
+          "evidence": "ipfs://phase6/domains/education/credentials/curriculum.pdf",
+          "notes": "Enforces DID-based authorship trails and revocation support"
+        }
+      ],
       "infrastructure": [
         {
           "layer": "Settlement",

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/index.html
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/index.html
@@ -147,6 +147,20 @@
         font-size: 0.9rem;
         line-height: 1.5;
       }
+      ul.credential-list {
+        margin-top: 18px;
+      }
+      ul.credential-list li strong {
+        display: block;
+        color: var(--text);
+        font-weight: 600;
+        margin-bottom: 4px;
+      }
+      ul.credential-list li span {
+        display: block;
+        font-size: 0.82rem;
+        color: var(--muted);
+      }
       pre {
         background: rgba(15, 23, 42, 0.78);
         border-radius: 18px;
@@ -198,6 +212,12 @@
       <section class="card">
         <h2>Global readiness dashboard</h2>
         <div class="metrics" id="global-summary"></div>
+      </section>
+
+      <section class="card">
+        <h2>Credential governance</h2>
+        <div class="metrics" id="credential-summary"></div>
+        <div class="grid columns-2" id="credential-grid"></div>
       </section>
 
       <section class="card">
@@ -281,6 +301,32 @@
         const enabled = Boolean(control.autopilotEnabled);
         const cadence = formatCadence(control.autopilotCadence);
         return `${enabled ? 'enabled' : 'standby'} @ ${cadence}`;
+      }
+
+      function ensureArray(value) {
+        return Array.isArray(value) ? value : [];
+      }
+
+      function formatList(values, fallback = '—') {
+        if (!values || !values.length) {
+          return fallback;
+        }
+        return values.join(', ');
+      }
+
+      function appendCredentialItem(list, heading, lines = []) {
+        const li = document.createElement('li');
+        const title = document.createElement('strong');
+        title.textContent = heading;
+        li.appendChild(title);
+        lines
+          .filter((line) => typeof line === 'string' && line.length)
+          .forEach((line) => {
+            const span = document.createElement('span');
+            span.textContent = line;
+            li.appendChild(span);
+          });
+        list.appendChild(li);
       }
 
       function heartbeatSummary(domain, global) {
@@ -399,6 +445,22 @@
         const automationFloor = Number(config.global?.telemetry?.automationFloorBps ?? NaN);
         let resilienceFloorBreaches = 0;
         let automationFloorBreaches = 0;
+        const globalCredentials = config.global?.credentials ?? {};
+        const globalTrustAnchors = ensureArray(globalCredentials.trustAnchors);
+        const globalIssuers = ensureArray(globalCredentials.issuers);
+        const globalPolicies = ensureArray(globalCredentials.policies);
+        const issuerDomainCoverage = new Set();
+        globalIssuers.forEach((issuer) => {
+          ensureArray(issuer.domains).forEach((domain) => {
+            issuerDomainCoverage.add(String(domain).toLowerCase());
+          });
+        });
+        const globalRevocationRegistry =
+          typeof globalCredentials.revocationRegistry === 'string' && globalCredentials.revocationRegistry
+            ? globalCredentials.revocationRegistry
+            : null;
+        let credentialedDomains = 0;
+        let credentialRequirements = 0;
         config.domains.forEach((domain) => {
           const idx = Number.parseFloat(domain.metadata?.resilienceIndex ?? '');
           if (!Number.isNaN(idx)) {
@@ -428,6 +490,11 @@
             if (telemetry.usesL2Settlement) {
               l2Coverage += 1;
             }
+          }
+          const domainCredentials = ensureArray(domain.credentials);
+          if (domainCredentials.length) {
+            credentialedDomains += 1;
+            credentialRequirements += domainCredentials.length;
           }
           const value = domain.metadata?.valueFlowMonthlyUSD;
           if (typeof value === 'number' && Number.isFinite(value)) {
@@ -484,6 +551,14 @@
             (acc, domain) => (domain.infrastructureControl?.autopilotEnabled ? acc + 1 : acc),
             0,
           ),
+          credentialCoverage: config.domains.length ? credentialedDomains / config.domains.length : 0,
+          credentialedDomains,
+          credentialRequirements,
+          globalCredentialAnchors: globalTrustAnchors.length,
+          globalCredentialIssuers: globalIssuers.length,
+          globalCredentialPolicies: globalPolicies.length,
+          globalCredentialDomainCoverage: issuerDomainCoverage.size,
+          globalRevocationRegistry,
         };
       }
 
@@ -537,6 +612,14 @@
             resilienceFloorBreaches,
             automationFloorCoverage,
             automationFloorBreaches,
+            credentialCoverage,
+            credentialedDomains,
+            credentialRequirements,
+            globalCredentialAnchors,
+            globalCredentialIssuers,
+            globalCredentialPolicies,
+            globalCredentialDomainCoverage,
+            globalRevocationRegistry,
           } = state.metrics;
           if (averageResilience !== null) {
             items.push(`Network resilience: avg ${averageResilience.toFixed(3)} (min ${minResilience?.toFixed(3)}, max ${maxResilience?.toFixed(3)})`);
@@ -575,11 +658,184 @@
               ).toFixed(1)}% (${state.metrics.autopilotEnabled}/${config.domains.length} domains)`,
             );
           }
+          items.push(
+            `Credential coverage: ${(credentialCoverage * 100).toFixed(1)}% (${credentialedDomains}/${config.domains.length} domains, ${credentialRequirements} requirements)`,
+          );
+          items.push(
+            `Trust anchors: ${globalCredentialAnchors} | issuers: ${globalCredentialIssuers} | policies: ${globalCredentialPolicies}`,
+          );
+          items.push(
+            `Issuer footprint: ${globalCredentialDomainCoverage} domains | Revocation registry: ${
+              globalRevocationRegistry ?? '—'
+            }`,
+          );
         }
         items.forEach((text) => {
           const span = document.createElement('span');
           span.textContent = `• ${text}`;
           target.appendChild(span);
+        });
+      }
+
+      function renderCredentialGovernance(config) {
+        const summary = document.getElementById('credential-summary');
+        const grid = document.getElementById('credential-grid');
+        summary.innerHTML = '';
+        grid.innerHTML = '';
+
+        const metrics = state.metrics || {};
+        const coverage = Number(metrics.credentialCoverage ?? 0);
+        const credentialedDomains = Number(metrics.credentialedDomains ?? 0);
+        const requirements = Number(metrics.credentialRequirements ?? 0);
+        const trustAnchorsCount = Number(metrics.globalCredentialAnchors ?? 0);
+        const issuerCount = Number(metrics.globalCredentialIssuers ?? 0);
+        const policyCount = Number(metrics.globalCredentialPolicies ?? 0);
+        const issuerFootprint = Number(metrics.globalCredentialDomainCoverage ?? 0);
+        const configDomainCount = config.domains.length || 0;
+        const globalCredentials = config.global.credentials || {};
+        const revocationRegistry =
+          metrics.globalRevocationRegistry ?? globalCredentials.revocationRegistry ?? '—';
+        const summaryItems = [
+          `Global coverage: ${(coverage * 100).toFixed(1)}% (${credentialedDomains}/${configDomainCount} domains)`,
+          `Credential safeguards: ${requirements} total requirements`,
+          `Trust anchors: ${trustAnchorsCount} | issuers: ${issuerCount} | policies: ${policyCount}`,
+          `Issuer footprint: ${issuerFootprint} domains`,
+          `Revocation registry: ${revocationRegistry}`,
+        ];
+        summaryItems.forEach((text) => {
+          const span = document.createElement('span');
+          span.textContent = `• ${text}`;
+          summary.appendChild(span);
+        });
+
+        const trustAnchors = ensureArray(globalCredentials.trustAnchors);
+        const issuers = ensureArray(globalCredentials.issuers);
+        const policies = ensureArray(globalCredentials.policies);
+
+        const globalCard = document.createElement('div');
+        globalCard.className = 'domain-card';
+        const globalHeading = document.createElement('h3');
+        globalHeading.textContent = 'Global credential control';
+        globalCard.appendChild(globalHeading);
+
+        const globalMetrics = document.createElement('div');
+        globalMetrics.className = 'metrics';
+        globalMetrics.innerHTML = `
+          <span>Trust anchors: ${trustAnchors.length}</span>
+          <span>Issuers: ${issuers.length}</span>
+          <span>Policies: ${policies.length}</span>
+          <span>Issuer footprint: ${issuerFootprint} domains</span>
+          <span>Revocation registry: ${revocationRegistry}</span>
+        `;
+        globalCard.appendChild(globalMetrics);
+
+        const anchorList = document.createElement('ul');
+        anchorList.className = 'mesh-list credential-list';
+        if (trustAnchors.length) {
+          trustAnchors.forEach((anchor, idx) => {
+            appendCredentialItem(anchorList, `[Anchor ${idx + 1}] ${anchor.name}`, [
+              `DID: ${anchor.did}`,
+              anchor.role ? `Role: ${anchor.role}` : '',
+              anchor.policyURI ? `Policy: ${anchor.policyURI}` : '',
+            ]);
+          });
+        } else {
+          appendCredentialItem(anchorList, 'Trust anchors pending', [
+            'Define global oversight issuers to unlock credential automation.',
+          ]);
+        }
+        globalCard.appendChild(anchorList);
+
+        const issuerList = document.createElement('ul');
+        issuerList.className = 'mesh-list credential-list';
+        if (issuers.length) {
+          issuers.forEach((issuer, idx) => {
+            appendCredentialItem(issuerList, `[Issuer ${idx + 1}] ${issuer.name}`, [
+              `DID: ${issuer.did}`,
+              issuer.attestationType ? `Attestation: ${issuer.attestationType}` : '',
+              issuer.registry ? `Registry: ${issuer.registry}` : '',
+              issuer.domains?.length ? `Domains: ${formatList(issuer.domains)}` : '',
+            ]);
+          });
+        } else {
+          appendCredentialItem(issuerList, 'Issuers pending', [
+            'Register credential issuers to activate cross-domain access control.',
+          ]);
+        }
+        globalCard.appendChild(issuerList);
+
+        const policyList = document.createElement('ul');
+        policyList.className = 'mesh-list credential-list';
+        if (policies.length) {
+          policies.forEach((policy, idx) => {
+            appendCredentialItem(policyList, `[Policy ${idx + 1}] ${policy.name}`, [
+              policy.description || '',
+              policy.uri ? `URI: ${policy.uri}` : '',
+            ]);
+          });
+        } else {
+          appendCredentialItem(policyList, 'Policies pending', [
+            'Publish credential policies to guide human oversight enrollment.',
+          ]);
+        }
+        globalCard.appendChild(policyList);
+        grid.appendChild(globalCard);
+
+        config.domains.forEach((domain) => {
+          const domainCard = document.createElement('div');
+          domainCard.className = 'domain-card';
+          const heading = document.createElement('h3');
+          heading.textContent = domain.name;
+          domainCard.appendChild(heading);
+
+          const domainCredentials = ensureArray(domain.credentials);
+          const issuerSet = new Set();
+          const verifierSet = new Set();
+          const registrySet = new Set();
+          domainCredentials.forEach((credential) => {
+            ensureArray(credential.issuers).forEach((issuer) => issuerSet.add(issuer));
+            ensureArray(credential.verifiers).forEach((verifier) => verifierSet.add(verifier));
+            if (credential.registry) {
+              registrySet.add(credential.registry);
+            }
+          });
+
+          const domainMetrics = document.createElement('div');
+          domainMetrics.className = 'metrics';
+          domainMetrics.innerHTML = `
+            <span>Total requirements: ${domainCredentials.length}</span>
+            <span>Issuers in scope: ${issuerSet.size}</span>
+            <span>Verifiers active: ${verifierSet.size}</span>
+            <span>Registries referenced: ${registrySet.size}</span>
+          `;
+          domainCard.appendChild(domainMetrics);
+
+          const credentialList = document.createElement('ul');
+          credentialList.className = 'mesh-list credential-list';
+          if (domainCredentials.length) {
+            domainCredentials.forEach((credential, idx) => {
+              appendCredentialItem(credentialList, `[${idx + 1}] ${credential.name}`, [
+                credential.requirement,
+                credential.credentialType ? `Type: ${credential.credentialType}` : '',
+                credential.format ? `Format: ${credential.format}` : '',
+                credential.issuers?.length
+                  ? `Issuers: ${formatList(credential.issuers)}`
+                  : '',
+                credential.verifiers?.length
+                  ? `Verifiers: ${formatList(credential.verifiers)}`
+                  : '',
+                credential.registry ? `Registry: ${credential.registry}` : '',
+                credential.evidence ? `Evidence: ${credential.evidence}` : '',
+                credential.notes ? `Notes: ${credential.notes}` : '',
+              ]);
+            });
+          } else {
+            appendCredentialItem(credentialList, 'Credential plan pending', [
+              'Define verifiable credential guard rails before enabling autonomous operations.',
+            ]);
+          }
+          domainCard.appendChild(credentialList);
+          grid.appendChild(domainCard);
         });
       }
 
@@ -643,6 +899,25 @@
             <span>Autopilot posture: ${formatAutopilot(control)}</span>
           `;
           card.appendChild(metrics);
+
+          const credentialList = document.createElement('ul');
+          credentialList.className = 'mesh-list credential-list';
+          const domainCredentials = ensureArray(domain.credentials);
+          if (domainCredentials.length) {
+            domainCredentials.forEach((credential, idx) => {
+              appendCredentialItem(credentialList, `[${idx + 1}] ${credential.name}`, [
+                credential.requirement,
+                credential.issuers?.length ? `Issuers: ${formatList(credential.issuers)}` : '',
+                credential.verifiers?.length ? `Verifiers: ${formatList(credential.verifiers)}` : '',
+                credential.registry ? `Registry: ${credential.registry}` : '',
+              ]);
+            });
+          } else {
+            appendCredentialItem(credentialList, 'Credential guard rails', [
+              'No verifiable credentials configured yet — follow governance checklist before launch.',
+            ]);
+          }
+          card.appendChild(credentialList);
           grid.appendChild(card);
         });
       }
@@ -825,6 +1100,7 @@
         state.config = cfg;
         state.metrics = computeMetrics(cfg);
         renderGlobal(cfg);
+        renderCredentialGovernance(cfg);
         renderDomains(cfg);
         renderBridgePlans(cfg);
         renderInfrastructure(cfg);

--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-did-audit.ts
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-did-audit.ts
@@ -1,0 +1,196 @@
+#!/usr/bin/env ts-node
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  buildPhase6Blueprint,
+  loadPhase6Config,
+  Phase6Blueprint,
+  DomainBlueprint,
+} from './phase6-blueprint';
+
+const DEFAULT_CONFIG_PATH = join(__dirname, '..', 'config', 'domains.phase6.json');
+
+interface CliOptions {
+  configPath: string;
+  jsonOutput?: string;
+}
+
+export interface DidAuditReport {
+  generatedAt: string;
+  configPath?: string;
+  coverage: number;
+  credentialedDomains: number;
+  totalDomains: number;
+  totalRequirements: number;
+  globalTrustAnchors: number;
+  globalIssuers: number;
+  globalPolicies: number;
+  revocationRegistry?: string | null;
+  missingDomains: string[];
+  domainFindings: Array<{
+    slug: string;
+    name: string;
+    credentials: string[];
+    issuers: string[];
+    verifiers: string[];
+    gaps: string[];
+  }>;
+}
+
+function parseArgs(argv: string[] = process.argv.slice(2)): CliOptions {
+  const options: CliOptions = { configPath: DEFAULT_CONFIG_PATH };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    switch (arg) {
+      case '--config':
+        if (!next) {
+          throw new Error('--config expects a path');
+        }
+        options.configPath = next;
+        i += 1;
+        break;
+      case '--config=':
+        options.configPath = arg.split('=', 2)[1] ?? DEFAULT_CONFIG_PATH;
+        break;
+      case '--json':
+        if (!next || next.startsWith('--')) {
+          options.jsonOutput = '-';
+        } else {
+          options.jsonOutput = next;
+          i += 1;
+        }
+        break;
+      case '--json=':
+        options.jsonOutput = arg.split('=', 2)[1] ?? '-';
+        break;
+      case '--help':
+      case '-h':
+        printUsage();
+        process.exit(0);
+        break;
+      default:
+        console.warn(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function printUsage(): void {
+  console.log(
+    `Phase 6 DID & credential audit\n\n` +
+      `Usage: npm run demo:phase6:did -- [options]\n\n` +
+      `Options:\n` +
+      `  --config <path>   Use an alternate config file (default: ${DEFAULT_CONFIG_PATH})\n` +
+      `  --json [path|-]   Emit JSON to <path>; use '-' for stdout\n` +
+      `  -h, --help        Show this message\n`,
+  );
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values.filter((value) => value && value.length)));
+}
+
+function summarizeDomain(domain: DomainBlueprint): {
+  credentials: string[];
+  issuers: string[];
+  verifiers: string[];
+  gaps: string[];
+} {
+  const credentials = domain.credentials.map((credential) => credential.name);
+  const issuers = uniqueStrings(domain.credentials.flatMap((credential) => credential.issuers));
+  const verifiers = uniqueStrings(domain.credentials.flatMap((credential) => credential.verifiers));
+  const gaps: string[] = [];
+  if (credentials.length === 0) {
+    gaps.push('missing credentials');
+  }
+  if (issuers.length === 0) {
+    gaps.push('no issuers');
+  }
+  if (verifiers.length === 0) {
+    gaps.push('no verifiers');
+  }
+  return { credentials, issuers, verifiers, gaps };
+}
+
+export function createDidAuditReport(blueprint: Phase6Blueprint): DidAuditReport {
+  const missingDomains = blueprint.domains
+    .filter((domain) => domain.credentials.length === 0)
+    .map((domain) => domain.slug);
+  const domainFindings = blueprint.domains.map((domain) => {
+    const summary = summarizeDomain(domain);
+    return {
+      slug: domain.slug,
+      name: domain.name,
+      credentials: summary.credentials,
+      issuers: summary.issuers,
+      verifiers: summary.verifiers,
+      gaps: summary.gaps,
+    };
+  });
+  return {
+    generatedAt: new Date().toISOString(),
+    configPath: blueprint.configPath,
+    coverage: blueprint.metrics.credentialCoverage,
+    credentialedDomains: blueprint.metrics.credentialedDomainCount,
+    totalDomains: blueprint.metrics.domainCount,
+    totalRequirements: blueprint.metrics.credentialRequirementCount,
+    globalTrustAnchors: blueprint.credentials.global.trustAnchors.length,
+    globalIssuers: blueprint.credentials.global.issuers.length,
+    globalPolicies: blueprint.credentials.global.policies.length,
+    revocationRegistry: blueprint.credentials.global.revocationRegistry,
+    missingDomains,
+    domainFindings,
+  };
+}
+
+function renderReport(report: DidAuditReport, domains: DomainBlueprint[]): void {
+  console.log('\x1b[38;5;119mPhase 6 Credential & DID Audit\x1b[0m');
+  console.log(`Generated: ${report.generatedAt}`);
+  console.log(
+    `Coverage: ${(report.coverage * 100).toFixed(1)}% (${report.credentialedDomains}/${report.totalDomains} domains, ${report.totalRequirements} requirements)`,
+  );
+  console.log(`Trust anchors: ${report.globalTrustAnchors} | issuers: ${report.globalIssuers} | policies: ${report.globalPolicies}`);
+  console.log(`Revocation registry: ${report.revocationRegistry ?? '—'}`);
+  if (report.missingDomains.length) {
+    console.log(`⚠ Missing credential coverage for: ${report.missingDomains.join(', ')}`);
+  } else {
+    console.log('All domains include credential requirements.');
+  }
+  domains.forEach((domain) => {
+    const summary = summarizeDomain(domain);
+    console.log(`\n${domain.name} (${domain.slug})`);
+    console.log(`  Credentials: ${summary.credentials.length ? summary.credentials.join(', ') : '—'}`);
+    console.log(`  Issuers: ${summary.issuers.length ? summary.issuers.join(', ') : '—'}`);
+    console.log(`  Verifiers: ${summary.verifiers.length ? summary.verifiers.join(', ') : '—'}`);
+    if (summary.gaps.length) {
+      console.log(`  Gaps: ${summary.gaps.join(', ')}`);
+    }
+  });
+}
+
+export function runCli(argv: string[] = process.argv.slice(2)): void {
+  const options = parseArgs(argv);
+  const config = loadPhase6Config(options.configPath);
+  const blueprint = buildPhase6Blueprint(config, { configPath: options.configPath });
+  const report = createDidAuditReport(blueprint);
+
+  if (options.jsonOutput === '-') {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  renderReport(report, blueprint.domains);
+
+  if (options.jsonOutput) {
+    writeFileSync(options.jsonOutput, JSON.stringify(report, null, 2));
+    console.log(`\nDID audit JSON saved to ${options.jsonOutput}`);
+  }
+}
+
+if (require.main === module) {
+  runCli();
+}

--- a/package.json
+++ b/package.json
@@ -260,6 +260,7 @@
     "demo:phase6:iot": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-iot-simulator.ts",
     "demo:phase6:runbook": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/generate-phase6-runbook.ts",
     "demo:phase6:apply": "npx hardhat run --no-compile scripts/phase6/apply-config.ts",
+    "demo:phase6:did": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-did-audit.ts",
     "demo:phase8:orchestrate": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-8-Universal-Value-Dominance/scripts/run-phase8-demo.ts",
     "demo:phase8:ci": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-8-Universal-Value-Dominance/scripts/validate-phase8-config.ts",
     "culture:deploy": "npx hardhat run --no-compile scripts/deploy.culture.ts",

--- a/scripts/phase6/apply-config-lib.ts
+++ b/scripts/phase6/apply-config-lib.ts
@@ -22,6 +22,46 @@ export interface InfrastructureEntry {
   uri?: string;
 }
 
+export interface GlobalCredentialAnchorInput {
+  name: string;
+  did: string;
+  role: string;
+  policyURI?: string;
+}
+
+export interface GlobalCredentialIssuerInput {
+  name: string;
+  did: string;
+  attestationType: string;
+  registry: string;
+  domains: string[];
+}
+
+export interface GlobalCredentialPolicyInput {
+  name: string;
+  description: string;
+  uri: string;
+}
+
+export interface GlobalCredentialsInput {
+  trustAnchors: GlobalCredentialAnchorInput[];
+  issuers: GlobalCredentialIssuerInput[];
+  policies: GlobalCredentialPolicyInput[];
+  revocationRegistry: string;
+}
+
+export interface DomainCredentialRequirementInput {
+  name: string;
+  requirement: string;
+  credentialType: string;
+  format: string;
+  issuers: string[];
+  verifiers: string[];
+  registry: string;
+  evidence: string;
+  notes?: string;
+}
+
 export interface DomainMetadata {
   domain: string;
   l2: string;
@@ -43,6 +83,7 @@ export type GlobalConfigInput = {
   systemPause?: string;
   escalationBridge?: string;
   decentralizedInfra?: DecentralizedInfraEntry[];
+  credentials?: GlobalCredentialsInput;
 };
 
 export type DomainConfigInput = {
@@ -66,6 +107,7 @@ export type DomainConfigInput = {
   infrastructure?: InfrastructureEntry[];
   infrastructureControl?: DomainInfrastructureControlInput;
   sunsetPlan?: SunsetPlanInput;
+  credentials?: DomainCredentialRequirementInput[];
 };
 
 export type SunsetPlanInput = {

--- a/test/scripts/phase6Blueprint.test.ts
+++ b/test/scripts/phase6Blueprint.test.ts
@@ -25,6 +25,11 @@ describe('Phase 6 blueprint generator', function () {
     expect(blueprint.metrics.resilienceFloorCoverage).to.equal(1);
     expect(blueprint.metrics.automationFloorBreaches).to.equal(2);
     expect(blueprint.metrics.automationFloorCoverage).to.be.closeTo(0.6, 0.0001);
+    expect(blueprint.metrics.credentialedDomainCount).to.equal(config.domains.length);
+    expect(blueprint.metrics.credentialRequirementCount).to.equal(
+      config.domains.reduce((acc, domain) => acc + (domain.credentials?.length ?? 0), 0),
+    );
+    expect(blueprint.metrics.credentialCoverage).to.equal(1);
   });
 
   it('normalises domains and exposes deterministic ids', function () {

--- a/test/scripts/phase6DidAudit.test.ts
+++ b/test/scripts/phase6DidAudit.test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+
+import {
+  buildPhase6Blueprint,
+  loadPhase6Config,
+} from '../../demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-blueprint';
+import { createDidAuditReport } from '../../demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-did-audit';
+
+const CONFIG_PATH = 'demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json';
+
+describe('Phase 6 DID audit', function () {
+  it('summarises global credential coverage and domain findings', function () {
+    const config = loadPhase6Config(CONFIG_PATH);
+    const blueprint = buildPhase6Blueprint(config, { configPath: CONFIG_PATH });
+    const report = createDidAuditReport(blueprint);
+
+    expect(report.coverage).to.equal(blueprint.metrics.credentialCoverage);
+    expect(report.credentialedDomains).to.equal(blueprint.metrics.credentialedDomainCount);
+    expect(report.totalDomains).to.equal(config.domains.length);
+    expect(report.totalRequirements).to.equal(blueprint.metrics.credentialRequirementCount);
+    expect(report.globalTrustAnchors).to.equal(blueprint.credentials.global.trustAnchors.length);
+    expect(report.globalIssuers).to.equal(blueprint.credentials.global.issuers.length);
+    expect(report.globalPolicies).to.equal(blueprint.credentials.global.policies.length);
+    expect(report.domainFindings).to.have.length(blueprint.domains.length);
+    report.domainFindings.forEach((finding) => {
+      expect(finding.slug).to.be.a('string').and.not.empty;
+      expect(finding.credentials.length).to.be.greaterThan(0);
+      expect(finding.gaps).to.deep.equal([]);
+    });
+    expect(report.missingDomains).to.deep.equal([]);
+  });
+});

--- a/test/scripts/phase6Runbook.test.ts
+++ b/test/scripts/phase6Runbook.test.ts
@@ -19,5 +19,8 @@ describe('Phase 6 runbook generator', function () {
     expect(markdown).to.contain('registerDomain: 0x');
     expect(markdown).to.contain('Resilience Floor Coverage');
     expect(markdown).to.contain('Automation Floor Coverage');
+    expect(markdown).to.contain('Credential Governance Mesh');
+    expect(markdown).to.contain('Credential Coverage');
+    expect(markdown).to.contain('Trust Anchors');
   });
 });


### PR DESCRIPTION
## Summary
- extend the Phase 6 control surface to compute credential coverage metrics and render a dedicated governance section alongside per-domain credential summaries
- add a reusable Phase 6 DID audit CLI with associated npm script, runtime ingestion, and TypeScript/Python tests that exercise credential data paths
- document the credential workflow in the demo README and ensure CI/schema helpers enforce the new credential metadata

## Testing
- `npx hardhat test --no-compile test/scripts/phase6Blueprint.test.ts test/scripts/phase6Runbook.test.ts test/scripts/phase6DidAudit.test.ts`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/orchestrator/test_phase6_runtime.py`
- `npm run demo:phase6:ci`
- `npm run demo:phase6:did -- --json - --config demo/Phase-6-Scaling-Multi-Domain-Expansion/config/domains.phase6.json`


------
https://chatgpt.com/codex/tasks/task_e_68fcceaabdd88333b41298c70fb47c90