### PR TITLE
Add Kardashev-II stability ledger consensus surface

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
@@ -49,6 +49,7 @@
    * `output/kardashev-mermaid.mmd` – federated systems map (rendered automatically in the UI).
    * `output/kardashev-dyson.mmd` – Dyson Swarm expansion Gantt chart for timeline rehearsal.
    * `output/kardashev-operator-briefing.md` – concise owner & guardian directive pack with verification status.
+   * `output/kardashev-stability-ledger.json` – consensus ledger uniting deterministic, redundant, and thermodynamic checks.
    * Console output summarising dominance scores, delta checks, and incident alerts.
 3. **Launch the holographic control surface**
    ```bash
@@ -151,9 +152,19 @@ sequenceDiagram
 | `output/kardashev-orchestration-report.md` | Detailed runbook for non-technical operators (energy, bridges, checklist). |
 | `output/kardashev-dyson.mmd` | Dyson Swarm Gantt timeline rendered in the UI for programme rehearsals. |
 | `output/kardashev-operator-briefing.md` | Mission directives pack consolidating owner powers, escalation, and verification state. |
+| `output/kardashev-stability-ledger.json` | Composite consensus ledger blending deterministic, redundant, and thermodynamic verifications. |
 | `output/kardashev-safe-transaction-batch.json` | Safe payload bundling global parameters, sentinel bindings, capital streams, and pause toggles. |
 | `index.html` | Zero-build dashboard that renders telemetry, Mermaid diagrams, and operator controls in any static server. |
 | `ui/` | Assets powering the static dashboard (styles, JavaScript modules). |
+
+---
+
+## 🧬 Stability ledger & unstoppable consensus
+
+* **Composite quorum** – `kardashev-stability-ledger.json` scores governance, energy, compute, bridge, and pause levers with deterministic weights. The dashboard promotes the score, colour-coding it green only when ≥95% of weighted checks pass.
+* **Redundant verification vectors** – The ledger records independent confidence methods: boolean consensus, redundant telemetry agreement, and residual Dyson thermostat buffer. Operators can inspect divergences instantly.
+* **Alert surfacing** – Any failing check propagates into an `alerts` array consumed by the UI and CI. No Safe batch is marked deployable if a single high-severity invariant breaks.
+* **Owner lever audit** – Manager, guardian council, system pause, and pause/resume calldata inclusion are mirrored in the ledger so non-technical governors can assert absolute control before execution.
 
 ---
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -61,6 +61,21 @@
 
       <section class="card">
         <div class="section-title">
+          <h2>Stability ledger</h2>
+        </div>
+        <p id="ledger-summary" class="lede">…</p>
+        <p class="ledger-score">Composite confidence: <span id="ledger-score">…</span></p>
+        <ul id="ledger-checks" class="ledger-list"></ul>
+        <h3>Verification vectors</h3>
+        <ul id="ledger-methods" class="ledger-methods"></ul>
+        <div class="ledger-alerts">
+          <h3>Alerts</h3>
+          <ul id="ledger-alerts"></ul>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="section-title">
           <h2>Federated systems map</h2>
           <button id="reflect-button">Run reflection checklist</button>
         </div>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
@@ -1,0 +1,110 @@
+{
+  "generatedAt": "2025-03-01T00:00:00Z",
+  "manifestVersion": "agi-jobs.kardashev-ii.demo.v1",
+  "dominanceScore": 90,
+  "confidence": {
+    "compositeScore": 1,
+    "quorum": true,
+    "summary": "All Kardashev-II invariants satisfied. Safe batch ready for execution.",
+    "methods": [
+      {
+        "method": "deterministic-consensus",
+        "score": 1,
+        "explanation": "Weighted boolean consensus across critical governance, energy, and compute checks."
+      },
+      {
+        "method": "redundant-telemetry",
+        "score": 1,
+        "explanation": "Agreement ratio across energy triple-check, thermostat, compute, bridges, and guardian coverage."
+      },
+      {
+        "method": "energy-safety-buffer",
+        "score": 1,
+        "explanation": "Remaining Dyson thermostat buffer relative to configured safety margin."
+      }
+    ]
+  },
+  "checks": [
+    {
+      "id": "manifest-digest",
+      "title": "Manifest digests aligned",
+      "severity": "critical",
+      "status": true,
+      "weight": 1.2,
+      "evidence": "expected 0x620a4ecd9820a125ddf954a346556b7d6125c31dd93138e00491a4bf969e0033, observed 0x620a4ecd9820a125ddf954a346556b7d6125c31dd93138e00491a4bf969e0033"
+    },
+    {
+      "id": "self-improvement-digest",
+      "title": "Self-improvement charter verified",
+      "severity": "critical",
+      "status": true,
+      "weight": 1,
+      "evidence": "expected 0x08b94f37ebb5dfc4f564eb0dc97c407846355762f0596d8af89379ba6aec127d, observed 0x08b94f37ebb5dfc4f564eb0dc97c407846355762f0596d8af89379ba6aec127d"
+    },
+    {
+      "id": "owner-control",
+      "title": "Owner override levers encoded",
+      "severity": "high",
+      "status": true,
+      "weight": 0.9,
+      "evidence": "setGlobalParameters + pause/unpause transactions present"
+    },
+    {
+      "id": "guardian-coverage",
+      "title": "Guardian coverage >= review window",
+      "severity": "high",
+      "status": true,
+      "weight": 0.85,
+      "evidence": "minimum coverage 1800s vs 900s window"
+    },
+    {
+      "id": "energy-triple-check",
+      "title": "Energy models reconciled",
+      "severity": "critical",
+      "status": true,
+      "weight": 1.1,
+      "evidence": "regional 242,000 GW · Dyson 488,800 GW · thermostat 340,200 GW"
+    },
+    {
+      "id": "energy-margin",
+      "title": "Dyson thermostat buffer intact",
+      "severity": "medium",
+      "status": true,
+      "weight": 0.6,
+      "evidence": "utilisation 57.62% vs permitted 87.50%"
+    },
+    {
+      "id": "compute-alignment",
+      "title": "Compute deviation within tolerance",
+      "severity": "medium",
+      "status": true,
+      "weight": 0.7,
+      "evidence": "deviation 0.45% (≤ 0.75%)"
+    },
+    {
+      "id": "bridge-latency",
+      "title": "Bridge latency ≤ tolerance",
+      "severity": "high",
+      "status": true,
+      "weight": 0.75,
+      "evidence": "tolerance 120s · failsafe 120s"
+    }
+  ],
+  "alerts": [],
+  "ownerControls": {
+    "manager": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+    "systemPause": "0xb740e9e719f1a3f138ce7c36418495f5d9e6b4d2",
+    "guardianCouncil": "0x3ecb7d31b20d4a3bf59f7ae8894d42bee0b1a24b",
+    "transactionsEncoded": 23,
+    "pauseCallEncoded": true,
+    "resumeCallEncoded": true
+  },
+  "safety": {
+    "guardianReviewWindow": 900,
+    "minimumCoverageSeconds": 1800,
+    "coverageRatio": 1,
+    "bridgeFailsafeSeconds": 120,
+    "permittedUtilisation": 0.875,
+    "utilisation": 0.5761904761904761
+  }
+}

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/ci-validate.ts
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/ci-validate.ts
@@ -32,6 +32,7 @@ function validateReadme() {
     "## 🧱 Architecture overview",
     "## 🔌 Energy & compute governance",
     "## 🎛️ Mission directives & verification dashboards",
+    "## 🧬 Stability ledger & unstoppable consensus",
     "## 🛡️ Governance and safety levers",
     "## 📦 Artefacts in this directory",
     "## 🧪 Verification rituals",

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css
@@ -62,6 +62,12 @@ h1 {
   color: rgba(226, 232, 240, 0.85);
 }
 
+.card h3 {
+  margin: 16px 0 8px;
+  font-size: 1rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
 .tag {
   display: inline-flex;
   align-items: center;
@@ -84,6 +90,51 @@ h1 {
 .section-title h2 {
   margin: 0;
   font-size: 1.35rem;
+}
+
+.lede {
+  font-size: 1.05rem;
+  color: rgba(226, 232, 240, 0.92);
+  margin-bottom: 8px;
+}
+
+.ledger-score {
+  font-family: "IBM Plex Mono", "Fira Mono", monospace;
+  font-size: 0.95rem;
+  margin-bottom: 14px;
+}
+
+.ledger-list,
+.ledger-methods,
+.ledger-alerts ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ledger-list li,
+.ledger-methods li,
+.ledger-alerts li {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 12px;
+  padding: 12px 14px;
+  line-height: 1.5;
+}
+
+.ledger-evidence {
+  display: block;
+  font-family: "IBM Plex Mono", "Fira Mono", monospace;
+  font-size: 0.82rem;
+  color: rgba(148, 163, 184, 0.85);
+  margin-top: 4px;
+}
+
+.ledger-alerts h3 {
+  margin-top: 20px;
 }
 
 button {


### PR DESCRIPTION
## Summary
- generate a Kardashev-II stability ledger that blends deterministic, redundant, and thermodynamic checks for Safe review
- surface the ledger inside the static command deck with consensus scores, verification vectors, and alert surfacing for non-technical operators
- document the ledger workflow in the README, enforce it via CI, and commit the deterministic JSON artefact

## Testing
- npm run demo:kardashev-ii:orchestrate
- npm run demo:kardashev-ii:ci

------
https://chatgpt.com/codex/tasks/task_e_68fcec6e6bf483338e439c48d8e0a8d9