### PR TITLE
Align Stellar Kardashev demo pause directives with Safe payload names

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
@@ -1,6 +1,8 @@
 # AGI Jobs Platform at Kardashev II Scale — Demonstration Command Deck
 
 > **Thesis**: a non-technical steward can summon, audit, and steer a civilisation-scale AGI labour mesh – spanning Earth, Mars, and orbital habitats – using **AGI Jobs v0 (v2)** from a laptop. This demo ships the command surfaces, telemetry, calldata, and verification harness to make that real in minutes.
+>
+> **Operator’s note**: the hyper-augmented `k2-stellar-demo/` variant is bundled alongside this command deck. It mirrors every manifest entry, adds Titan/orbital orchestration, and exposes the unstoppable pause/resume levers exactly as encoded in the Safe payload so owners can prove universal control at a glance.
 
 ---
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/README.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/README.md
@@ -137,6 +137,7 @@ sequenceDiagram
 * **Sentinel coverage** — Each sentinel’s coverage seconds exceed guardian review window; deficits raise warnings in the ledger and UI.
 * **Self-improvement charter** — `selfImprovement.planHash` and `planURI` hashed + reflected in outputs; CLI validates `recordSelfImprovementExecution` cadence.
 * **Bridge sentries** — Telemetry tracks interplanetary bridge latency/bandwidth and flags breaches versus failsafe latency.
+* **Superintelligent kill-switch** — Pause/resume directives surface exactly as the Safe payload descriptions ("Pause all modules" / "Resume all modules"), so owners can trigger the unstoppable global halt or restart without decoding calldata.
 
 ---
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/config/k2-stellar.manifest.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/config/k2-stellar.manifest.json
@@ -76,15 +76,15 @@
       },
       {
         "id": "pause-all",
-        "title": "Stage global pause",
-        "description": "Encodes forwardPauseCall(pauseAll) for emergency stop",
+        "title": "Pause all modules",
+        "description": "Encodes forwardPauseCall(pauseAll) so the owner can halt the entire mesh instantly",
         "safeIndex": 48,
         "playbookURI": "ipfs://QmPlaybooksPause"
       },
       {
         "id": "resume-all",
-        "title": "Stage global resume",
-        "description": "Encodes forwardPauseCall(unpauseAll) to restart",
+        "title": "Resume all modules",
+        "description": "Encodes forwardPauseCall(unpauseAll) to restart planetary domains once safe",
         "safeIndex": 49,
         "playbookURI": "ipfs://QmPlaybooksResume"
       }

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/output/stellar-operator-briefing.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/output/stellar-operator-briefing.md
@@ -5,8 +5,8 @@
 - **Assign guardian council** (Safe step #1) — Updates guardian council multisig with fresh signers · Playbook: ipfs://QmPlaybooksGuardianCouncil
 - **Point to system pause** (Safe step #2) — Ensures SystemPause contract is owner controlled · Playbook: ipfs://QmPlaybooksSystemPause
 - **Install self-improvement charter** (Safe step #3) — Loads plan hash, cadence, and last execution marker · Playbook: ipfs://QmPlaybooksSelfImprovement
-- **Stage global pause** (Safe step #48) — Encodes forwardPauseCall(pauseAll) for emergency stop · Playbook: ipfs://QmPlaybooksPause
-- **Stage global resume** (Safe step #49) — Encodes forwardPauseCall(unpauseAll) to restart · Playbook: ipfs://QmPlaybooksResume
+- **Pause all modules** (Safe step #48) — Encodes forwardPauseCall(pauseAll) so the owner can halt the entire mesh instantly · Playbook: ipfs://QmPlaybooksPause
+- **Resume all modules** (Safe step #49) — Encodes forwardPauseCall(unpauseAll) to restart planetary domains once safe · Playbook: ipfs://QmPlaybooksResume
 
 ## Escalation pathways
 * Guardians: +1-415-555-2718 · Ops: +1-415-555-7741

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/output/stellar-orchestration-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/output/stellar-orchestration-report.md
@@ -1,6 +1,6 @@
 # Kardashev II Stellar Orchestration Runbook
 
-**Manifest hash**: 0xee8439327a43c913df73a2bf8621af5c664842d7da84100906f2416c002f863c
+**Manifest hash**: 0x39b4d76a35ffcdc6c67a0227e9f7f2f9d905ee9d05d040df13df51bd5ebec889
 **Dominance score**: 90.5 / 100
 
 ---

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/output/stellar-telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/output/stellar-telemetry.json
@@ -2,7 +2,7 @@
   "manifest": {
     "version": "agi-jobs.k2-stellar.demo.v1",
     "generatedAt": "2025-04-15T00:00:00Z",
-    "hash": "0xee8439327a43c913df73a2bf8621af5c664842d7da84100906f2416c002f863c",
+    "hash": "0x39b4d76a35ffcdc6c67a0227e9f7f2f9d905ee9d05d040df13df51bd5ebec889",
     "manifestoHash": "0x003e5745a210203b6e7badbead17047325e9308bd37888396d47c03bf9872fe3",
     "manifestoHashMatches": true,
     "planHash": "0xfcf6ec17dbeaaa17853e4ee4e5f37136dc4b288f841aaed2ea19ea9205ccb198",
@@ -476,15 +476,15 @@
       },
       {
         "id": "pause-all",
-        "title": "Stage global pause",
-        "description": "Encodes forwardPauseCall(pauseAll) for emergency stop",
+        "title": "Pause all modules",
+        "description": "Encodes forwardPauseCall(pauseAll) so the owner can halt the entire mesh instantly",
         "safeIndex": 48,
         "playbookURI": "ipfs://QmPlaybooksPause"
       },
       {
         "id": "resume-all",
-        "title": "Stage global resume",
-        "description": "Encodes forwardPauseCall(unpauseAll) to restart",
+        "title": "Resume all modules",
+        "description": "Encodes forwardPauseCall(unpauseAll) to restart planetary domains once safe",
         "safeIndex": 49,
         "playbookURI": "ipfs://QmPlaybooksResume"
       }

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/scripts/orchestrate.ts
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/scripts/orchestrate.ts
@@ -246,14 +246,10 @@ const missionDirectiveValidators: Record<
     normaliseForMatch(tx.description).includes("system pause"),
   "self-improvement": (_power, tx, _manifest) =>
     normaliseForMatch(tx.description).includes("self improvement plan"),
-  "pause-all": (_power, tx, _manifest) => {
-    const description = normaliseForMatch(tx.description);
-    return description.includes("pause") && description.includes("forwardpausecall");
-  },
-  "resume-all": (_power, tx, _manifest) => {
-    const description = normaliseForMatch(tx.description);
-    return description.includes("resume") && description.includes("forwardpausecall");
-  },
+  "pause-all": (power, tx, _manifest) =>
+    normaliseForMatch(tx.description) === normaliseForMatch(power.title),
+  "resume-all": (power, tx, _manifest) =>
+    normaliseForMatch(tx.description) === normaliseForMatch(power.title),
 };
 
 function directiveMatches(power: MissionPower, tx: SafeTransaction, manifest: Manifest): boolean {


### PR DESCRIPTION
## Summary
- align the k2-stellar manifest and owner briefing with the explicit "Pause all modules" / "Resume all modules" Safe calls so governors see identical wording across artefacts
- update the orchestrator validator to accept the harmonised directive titles and document the kill-switch clarity in the Stellar README and top-level guide
- regenerate telemetry and operator artefacts to carry the new manifest hash and fully green stability confidence

## Testing
- npm run demo:kardashev-ii-stellar:ci

------
https://chatgpt.com/codex/tasks/task_e_68fd36863d0883339b39476c0c608577