### PR TITLE
feat: add Kardashev-II Monte Carlo safety checks

### DIFF
--- a/.github/workflows/demo-kardashev-ii.yml
+++ b/.github/workflows/demo-kardashev-ii.yml
@@ -1,0 +1,50 @@
+name: demo-kardashev-ii
+
+on:
+  pull_request:
+    paths:
+      - 'demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/**'
+      - '.github/workflows/demo-kardashev-ii.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  kardashev-demo:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: |
+            api.github.com
+            github.com
+            objects.githubusercontent.com
+            raw.githubusercontent.com
+            registry.npmjs.org
+            nodejs.org
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            **/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline --progress=false
+
+      - name: Kardashev-II CI validation
+        run: npm run demo:kardashev-ii:ci

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
@@ -169,6 +169,7 @@ flowchart TD
 * **Kelvin guardrails** – Reward temperature (Kelvin) must stay between 0.35 and 0.92; the orchestrator double checks the manifest and telemetry and aborts if the Thermostat would fall outside the band.
 * **Regional energy arbitration** – Earth, Mars, and Orbital clusters provide available GW, storage, and latency; the CLI sorts workloads accordingly and reports energy debt so operators can top-up storage before dispatching long-running swarms.
 * **Compute rollup** – All compute capacity is measured in exaFLOPs and agent counts. A reconciliation matrix confirms that per-region totals equal the Interstellar Council view and Dyson programme requirements.
+* **Probabilistic assurance** – Monte Carlo simulations (256 deterministic runs) estimate breach probability vs the 1% tolerance. Results surface in the UI and `output/kardashev-monte-carlo.json`; any breach probability above tolerance halts orchestration.
 
 ## 🎛️ Mission directives & verification dashboards
 
@@ -219,6 +220,7 @@ flowchart TD
 | `output/kardashev-dyson.mmd` | Dyson Swarm Gantt timeline rendered in the UI for programme rehearsals. |
 | `output/kardashev-operator-briefing.md` | Mission directives pack consolidating owner powers, escalation, and verification state. |
 | `output/kardashev-stability-ledger.json` | Composite consensus ledger blending deterministic, redundant, and thermodynamic verifications. |
+| `output/kardashev-monte-carlo.json` | Monte Carlo summary (runs, breach probability, percentiles) validating the energy thermostat tolerance. |
 | `output/kardashev-owner-proof.json` | Owner override proof deck with selector coverage, pause embeddings, target isolation, and unstoppable control score. |
 | `output/kardashev-safe-transaction-batch.json` | Safe payload bundling global parameters, sentinel bindings, capital streams, and pause toggles. |
 | `index.html` | Zero-build dashboard that renders telemetry, Mermaid diagrams, and operator controls in any static server. |
@@ -233,12 +235,13 @@ flowchart TD
 * **Alert surfacing** – Any failing check propagates into an `alerts` array consumed by the UI and CI. No Safe batch is marked deployable if a single high-severity invariant breaks.
 * **Owner lever audit** – Manager, guardian council, system pause, and pause/resume calldata inclusion are mirrored in the ledger so non-technical governors can assert absolute control before execution.
 * **Dual unstoppable verification** – A secondary decoder replays the Safe batch, recomputes selectors and pause embeddings, and records the corroborating unstoppable score next to the primary proof so drift is impossible to miss.
+* **Monte Carlo sentinel** – The ledger adds a dedicated check gating execution on the 1% breach tolerance, with confidence vectors publishing the simulated demand percentiles for guardian review.
 
 ---
 
 ## 🧪 Verification rituals
 
-1. **Local** – run `npm run demo:kardashev-ii:orchestrate` and confirm no warnings. Inspect `output/kardashev-telemetry.json` and ensure `energy.tripleCheck === true`, `verification.energyModels.withinMargin === true`, `governance.ownerOverridesReady === true`, `governance.ownerProof.secondary.matchesPrimaryScore === true`, and every entry in `scenarioSweep` reports `status !== "critical"`.
+1. **Local** – run `npm run demo:kardashev-ii:orchestrate` and confirm no warnings. Inspect `output/kardashev-telemetry.json` and ensure `energy.tripleCheck === true`, `verification.energyModels.withinMargin === true`, `verification.energyMonteCarlo.withinTolerance === true`, `governance.ownerOverridesReady === true`, `governance.ownerProof.secondary.matchesPrimaryScore === true`, and every entry in `scenarioSweep` reports `status !== "critical"`.
 2. **CI** – `npm run demo:kardashev-ii:ci` executes the orchestrator in check mode, validates README headings, ensures Mermaid code fences exist, and fails on drift.
 3. **Runtime** – Serve the UI and click “Trigger Pause Simulation” to confirm pause/unpause calldata toggles update the status badge, review the Dyson timeline, and verify each owner directive matches `kardashev-operator-briefing.md`.
 4. **Manual** – Operators copy/paste the Safe batch into a production Safe, verify the prefilled manager/system pause addresses, and stage the transaction.
@@ -253,6 +256,7 @@ Run `npm run demo:kardashev-ii:orchestrate -- --reflect` to receive:
 - ✅ Recomputed manifest hash vs `interstellarCouncil.manifestoHash`.
 - ✅ Confirmation that guardian coverage ≥ guardian review window.
 - ✅ Energy debt matrix (Earth, Mars, Orbital) all ≤ 0.
+- ✅ Monte Carlo breach probability ≤ 1% (see `kardashev-monte-carlo.json`).
 - ✅ Bridge latency vs Dyson failsafe latency.
 - ✅ Scenario stress sweep free of critical statuses (confidence badges ≥ 95%).
 - ✅ Pause bundle parity (pause/unpause both targeting configured SystemPause).

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -50,6 +50,11 @@
           <p id="energy-models">…</p>
         </article>
         <article class="card">
+          <h2>Energy Monte Carlo</h2>
+          <p id="energy-monte-carlo-summary">…</p>
+          <p>Status: <span id="energy-monte-carlo-status">…</span></p>
+        </article>
+        <article class="card">
           <h2>Compute delta</h2>
           <p id="compute-deviation">…</p>
         </article>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-monte-carlo.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-monte-carlo.json
@@ -1,0 +1,13 @@
+{
+  "runs": 256,
+  "breachProbability": 0,
+  "percentileGw": {
+    "p50": 237030.969218213,
+    "p95": 251695.495238463,
+    "p99": 255130.15072335023
+  },
+  "maxGw": 257220.62304422446,
+  "averageGw": 236494.16525702746,
+  "withinTolerance": true,
+  "tolerance": 0.01
+}

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
@@ -16,6 +16,7 @@
 
 ## Verification status
 * Energy models (regionalSum, dysonProjection, thermostatBudget) aligned: true
+* Monte Carlo breach 0.00% (≤ 1% tolerance): true
 * Compute deviation 0.45% (tolerance 0.75%): true
 * Bridge latency tolerance (120s): true
 * Owner override unstoppable score 100.00% (selectors true, pause true, resume true, secondary aligned @ 100.00%).

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
@@ -18,6 +18,8 @@
 * Captured GW (Dyson baseline): 420,000 GW.
 * Utilisation: 57.62% (margin 0.13%).
 * Regional availability: earth 82000 GW · mars 24000 GW · orbital 136000 GW.
+* Monte Carlo breach probability 0.00% (runs 256, tolerance 1.00%).
+* Demand percentiles: P95 251,695.495 GW · P99 255,130.151 GW.
 
 ---
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
@@ -1,12 +1,13 @@
 # Kardashev II Scale Control Dossier
 
-Generated: 2125-01-01T04:46:17.285Z
+Generated: 2125-01-01T08:19:21.838Z
 
 ## Executive Summary
 
 - **Universal Dominance Score:** 99.9/100 (targets met across all shards).
 - **Dyson Swarm Progress:** 2919/10000 satellites assembled (29.19% coverage).
 - **Captured Power:** 131,355 MW available for reallocation.
+- **Energy Monte Carlo:** 0.00% breach probability across 256 runs (tolerance 1.00%).
 - **Sentinel Status:** 1 advisories generated; all resolved within guardian SLA.
 
 ## Shard Operations

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
@@ -23,6 +23,11 @@
         "explanation": "Remaining Dyson thermostat buffer relative to configured safety margin."
       },
       {
+        "method": "monte-carlo",
+        "score": 1,
+        "explanation": "Energy breach probability 0.00% across 256 simulations (tolerance 1.00%)."
+      },
+      {
         "method": "scenario-sweep",
         "score": 0.7929052035435014,
         "explanation": "Average confidence across Kardashev-II surge, bridge, sentinel, compute, identity, and schedule stressors."
@@ -97,6 +102,14 @@
       "status": true,
       "weight": 1.1,
       "evidence": "regional 242,000 GW · Dyson 488,800 GW · thermostat 340,200 GW"
+    },
+    {
+      "id": "energy-monte-carlo",
+      "title": "Monte Carlo breach ≤ tolerance",
+      "severity": "critical",
+      "status": true,
+      "weight": 1,
+      "evidence": "breach 0.00% (runs 256)"
     },
     {
       "id": "energy-margin",
@@ -252,6 +265,8 @@
     "coverageRatio": 1,
     "bridgeFailsafeSeconds": 120,
     "permittedUtilisation": 0.875,
-    "utilisation": 0.5761904761904761
+    "utilisation": 0.5761904761904761,
+    "monteCarloBreachProbability": 0,
+    "monteCarloWithinTolerance": true
   }
 }

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
@@ -64,6 +64,19 @@
       "dysonProjectionGw": 488800,
       "thermostatBudgetGw": 340200,
       "withinMargin": true
+    },
+    "monteCarlo": {
+      "runs": 256,
+      "breachProbability": 0,
+      "percentileGw": {
+        "p50": 237030.969218213,
+        "p95": 251695.495238463,
+        "p99": 255130.15072335023
+      },
+      "maxGw": 257220.62304422446,
+      "averageGw": 236494.16525702746,
+      "withinTolerance": true,
+      "tolerance": 0.01
     }
   },
   "compute": {
@@ -504,6 +517,17 @@
         "thermostatBudgetGw": 340200
       },
       "withinMargin": true
+    },
+    "energyMonteCarlo": {
+      "runs": 256,
+      "breachProbability": 0,
+      "tolerance": 0.01,
+      "withinTolerance": true,
+      "percentileGw": {
+        "p50": 237030.969218213,
+        "p95": 251695.495238463,
+        "p99": 255130.15072335023
+      }
     },
     "compute": {
       "tolerancePct": 0.75,

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/telemetry.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2125-01-01T04:46:17.285Z",
+  "generatedAt": "2125-01-01T08:19:21.838Z",
   "dominanceScore": 99.9,
   "shards": [
     {
@@ -47,6 +47,21 @@
     "energyPerSatelliteMw": 45,
     "capturedMw": 131355,
     "coveragePercent": 29.19
+  },
+  "energyMonteCarlo": {
+    "runs": 256,
+    "breachProbability": 0,
+    "tolerance": 0.01,
+    "withinTolerance": true,
+    "capturedGw": 613,
+    "marginGw": 76.625,
+    "peakDemandGw": 497.31924606092264,
+    "averageDemandGw": 485.9969112264529,
+    "percentileGw": {
+      "p50": 486.2788814702444,
+      "p95": 494.3491990757454,
+      "p99": 496.096386420615
+    }
   },
   "configs": {
     "knowledgeGraph": "0x0000000000000000000000000000000000Kn0wG",

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -52,6 +52,12 @@ function renderMetrics(telemetry) {
       ? `Aligned — ${formatNumber(telemetry.energy.models.regionalSumGw)} vs ${formatNumber(telemetry.energy.models.dysonProjectionGw)} GW`
       : "Mismatch across energy models"
   );
+  const monteCarlo = telemetry.energy.monteCarlo;
+  document.querySelector("#energy-monte-carlo-summary").textContent = `Breach ${(monteCarlo.breachProbability * 100).toFixed(2)}% · P95 ${formatNumber(monteCarlo.percentileGw.p95)} GW · runs ${monteCarlo.runs}`;
+  setStatus(
+    document.querySelector("#energy-monte-carlo-status"),
+    monteCarlo.withinTolerance
+  );
   setStatusText(
     document.querySelector("#compute-deviation"),
     telemetry.verification.compute.withinTolerance,
@@ -87,6 +93,7 @@ function attachReflectionButton(telemetry) {
       { label: "Self-improvement plan hash", ok: telemetry.manifest.planHashMatches },
       { label: "Guardian coverage", ok: telemetry.governance.coverageOk },
       { label: "Energy triple check", ok: telemetry.energy.tripleCheck },
+      { label: "Energy Monte Carlo", ok: telemetry.energy.monteCarlo.withinTolerance },
       ...Object.entries(telemetry.bridges).map(([name, data]) => ({ label: `Bridge ${name}`, ok: data.withinFailsafe })),
     ];
     const list = document.querySelector("#reflection-checklist");


### PR DESCRIPTION
## Summary
- extend the Kardashev-II orchestrator to run deterministic energy Monte Carlo stress-tests, emit a new safety ledger signal, and publish `kardashev-monte-carlo.json`
- upgrade the static dashboard, README, and autopilot helper to surface Monte Carlo breach probability alongside existing telemetry and reflection routines
- wire a dedicated `demo-kardashev-ii` GitHub workflow so CI enforces the new readiness checks on pull requests

## Testing
- `npm run demo:kardashev-ii:orchestrate`
- `npm run demo:kardashev`
- `npm run demo:kardashev-ii:ci`


------
https://chatgpt.com/codex/tasks/task_e_68fd5749423883339f77fb581bd0e472