### PR TITLE
Enhance Kardashev II demo with thermodynamic guardrails

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
@@ -169,6 +169,7 @@ flowchart TD
 * **Kelvin guardrails** – Reward temperature (Kelvin) must stay between 0.35 and 0.92; the orchestrator double checks the manifest and telemetry and aborts if the Thermostat would fall outside the band.
 * **Regional energy arbitration** – Earth, Mars, and Orbital clusters provide available GW, storage, and latency; the CLI sorts workloads accordingly and reports energy debt so operators can top-up storage before dispatching long-running swarms.
 * **Compute rollup** – All compute capacity is measured in exaFLOPs and agent counts. A reconciliation matrix confirms that per-region totals equal the Interstellar Council view and Dyson programme requirements.
+* **Free-energy surplus watchdog** – Deterministic thermodynamic accounting converts exaFLOPs into GW using the Dyson heuristics, nets out storage relief, and guarantees the civilisation-wide free-energy buffer stays above the thermostat margin. Both the stability ledger and dashboard flag any deficit in red, forcing owner review before launch.
 * **Probabilistic assurance** – Monte Carlo simulations (256 deterministic runs) estimate breach probability vs the 1% tolerance. Results surface in the UI and `output/kardashev-monte-carlo.json`; any breach probability above tolerance halts orchestration.
 
 ## 🎛️ Mission directives & verification dashboards
@@ -232,6 +233,7 @@ flowchart TD
 
 * **Composite quorum** – `kardashev-stability-ledger.json` scores governance, energy, compute, bridge, and pause levers with deterministic weights. The dashboard promotes the score, colour-coding it green only when ≥95% of weighted checks pass.
 * **Redundant verification vectors** – The ledger records independent confidence methods: boolean consensus, redundant telemetry agreement, and residual Dyson thermostat buffer. Operators can inspect divergences instantly.
+* **Thermodynamic sentry** – A dedicated “free energy buffer” invariant ensures the Dyson thermostat margin is respected; if civilisational free energy slips below target, the ledger raises a critical alert and the UI blocks “ready for launch” states.
 * **Alert surfacing** – Any failing check propagates into an `alerts` array consumed by the UI and CI. No Safe batch is marked deployable if a single high-severity invariant breaks.
 * **Owner lever audit** – Manager, guardian council, system pause, and pause/resume calldata inclusion are mirrored in the ledger so non-technical governors can assert absolute control before execution.
 * **Dual unstoppable verification** – A secondary decoder replays the Safe batch, recomputes selectors and pause embeddings, and records the corroborating unstoppable score next to the primary proof so drift is impossible to miss.
@@ -256,6 +258,7 @@ Run `npm run demo:kardashev-ii:orchestrate -- --reflect` to receive:
 - ✅ Recomputed manifest hash vs `interstellarCouncil.manifestoHash`.
 - ✅ Confirmation that guardian coverage ≥ guardian review window.
 - ✅ Energy debt matrix (Earth, Mars, Orbital) all ≤ 0.
+- ✅ Free energy buffer ≥ thermostat margin (see `kardashev-telemetry.json` → `energy.freeEnergy`).
 - ✅ Monte Carlo breach probability ≤ 1% (see `kardashev-monte-carlo.json`).
 - ✅ Bridge latency vs Dyson failsafe latency.
 - ✅ Scenario stress sweep free of critical statuses (confidence badges ≥ 95%).

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -55,6 +55,11 @@
           <p>Status: <span id="energy-monte-carlo-status">…</span></p>
         </article>
         <article class="card">
+          <h2>Free energy buffer</h2>
+          <p id="free-energy-buffer">…</p>
+          <p>Status: <span id="free-energy-status">…</span></p>
+        </article>
+        <article class="card">
           <h2>Compute delta</h2>
           <p id="compute-deviation">…</p>
         </article>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
@@ -17,6 +17,7 @@
 ## Verification status
 * Energy models (regionalSum, dysonProjection, thermostatBudget) aligned: true
 * Monte Carlo breach 0.00% (≤ 1% tolerance): true
+* Free energy buffer ≥ margin (52500.00 GW): true
 * Compute deviation 0.45% (tolerance 0.75%): true
 * Bridge latency tolerance (120s): true
 * Owner override unstoppable score 100.00% (selectors true, pause true, resume true, secondary aligned @ 100.00%).

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
@@ -17,7 +17,9 @@
 ## Energy telemetry
 * Captured GW (Dyson baseline): 420,000 GW.
 * Utilisation: 57.62% (margin 0.13%).
+* Free energy buffer: 419410.80 GW vs margin 52500.00 GW (heuristic 12 GW/EF).
 * Regional availability: earth 82000 GW · mars 24000 GW · orbital 136000 GW.
+* Regional free energy: earth 84029.20 GW · mars 24676.80 GW · orbital 141038.13 GW.
 * Monte Carlo breach probability 0.00% (runs 256, tolerance 1.00%).
 * Demand percentiles: P95 251,695.495 GW · P99 255,130.151 GW.
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
@@ -104,6 +104,14 @@
       "evidence": "regional 242,000 GW · Dyson 488,800 GW · thermostat 340,200 GW"
     },
     {
+      "id": "free-energy-buffer",
+      "title": "Free energy buffer ≥ thermostat margin",
+      "severity": "critical",
+      "status": true,
+      "weight": 0.95,
+      "evidence": "global free 419410.80 GW · margin 52500.00 GW"
+    },
+    {
       "id": "energy-monte-carlo",
       "title": "Monte Carlo breach ≤ tolerance",
       "severity": "critical",

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
@@ -37,25 +37,49 @@
     "dysonYield": 488800,
     "utilisationPct": 0.5761904761904761,
     "marginPct": 0.125,
+    "thermostatMarginGw": 52500,
+    "totalDemandGw": 589.2,
+    "globalFreeEnergyGw": 419410.8,
     "warnings": [],
     "regional": [
       {
         "slug": "earth",
+        "name": "Earth Sovereign Federation",
         "availableGw": 82000,
         "storageGwh": 54000,
-        "renewablePct": 0.87
+        "renewablePct": 0.87,
+        "latencyMs": 85,
+        "demandGw": 220.79999999999998,
+        "storageReliefGw": 2250,
+        "bufferedSupplyGw": 84250,
+        "freeEnergyGw": 84029.2,
+        "deficitGw": 0
       },
       {
         "slug": "mars",
+        "name": "Mars Terraforming Compact",
         "availableGw": 24000,
         "storageGwh": 18000,
-        "renewablePct": 0.93
+        "renewablePct": 0.93,
+        "latencyMs": 820,
+        "demandGw": 73.19999999999999,
+        "storageReliefGw": 750,
+        "bufferedSupplyGw": 24750,
+        "freeEnergyGw": 24676.8,
+        "deficitGw": 0
       },
       {
         "slug": "orbital",
+        "name": "Orbital Research Halo",
         "availableGw": 136000,
         "storageGwh": 128000,
-        "renewablePct": 0.99
+        "renewablePct": 0.99,
+        "latencyMs": 42,
+        "demandGw": 295.20000000000005,
+        "storageReliefGw": 5333.333333333333,
+        "bufferedSupplyGw": 141333.33333333334,
+        "freeEnergyGw": 141038.13333333333,
+        "deficitGw": 0
       }
     ],
     "tripleCheck": true,
@@ -64,6 +88,46 @@
       "dysonProjectionGw": 488800,
       "thermostatBudgetGw": 340200,
       "withinMargin": true
+    },
+    "freeEnergy": {
+      "heuristicGwPerExaflop": 12,
+      "totalDemandGw": 589.2,
+      "bufferedFreeEnergyGw": 249744.13333333333,
+      "globalFreeEnergyGw": 419410.8,
+      "thermostatMarginGw": 52500,
+      "withinMargin": true,
+      "regional": [
+        {
+          "slug": "earth",
+          "name": "Earth Sovereign Federation",
+          "availableGw": 82000,
+          "demandGw": 220.79999999999998,
+          "storageReliefGw": 2250,
+          "bufferedSupplyGw": 84250,
+          "freeEnergyGw": 84029.2,
+          "deficitGw": 0
+        },
+        {
+          "slug": "mars",
+          "name": "Mars Terraforming Compact",
+          "availableGw": 24000,
+          "demandGw": 73.19999999999999,
+          "storageReliefGw": 750,
+          "bufferedSupplyGw": 24750,
+          "freeEnergyGw": 24676.8,
+          "deficitGw": 0
+        },
+        {
+          "slug": "orbital",
+          "name": "Orbital Research Halo",
+          "availableGw": 136000,
+          "demandGw": 295.20000000000005,
+          "storageReliefGw": 5333.333333333333,
+          "bufferedSupplyGw": 141333.33333333334,
+          "freeEnergyGw": 141038.13333333333,
+          "deficitGw": 0
+        }
+      ]
     },
     "monteCarlo": {
       "runs": 256,
@@ -303,7 +367,11 @@
         "availableGw": 82000,
         "renewablePct": 0.87,
         "storageGwh": 54000,
-        "latencyMs": 85
+        "latencyMs": 85,
+        "demandGw": 220.79999999999998,
+        "freeEnergyGw": 84029.2,
+        "bufferedSupplyGw": 84250,
+        "deficitGw": 0
       },
       "compute": {
         "agents": 2800000000,
@@ -359,7 +427,11 @@
         "availableGw": 24000,
         "renewablePct": 0.93,
         "storageGwh": 18000,
-        "latencyMs": 820
+        "latencyMs": 820,
+        "demandGw": 73.19999999999999,
+        "freeEnergyGw": 24676.8,
+        "bufferedSupplyGw": 24750,
+        "deficitGw": 0
       },
       "compute": {
         "agents": 720000000,
@@ -406,7 +478,11 @@
         "availableGw": 136000,
         "renewablePct": 0.99,
         "storageGwh": 128000,
-        "latencyMs": 42
+        "latencyMs": 42,
+        "demandGw": 295.20000000000005,
+        "freeEnergyGw": 141038.13333333333,
+        "bufferedSupplyGw": 141333.33333333334,
+        "deficitGw": 0
       },
       "compute": {
         "agents": 960000000,
@@ -534,6 +610,13 @@
       "deviationPct": 0.45008183306055416,
       "dysonProjectionExaflops": 48.88,
       "withinTolerance": true
+    },
+    "thermodynamics": {
+      "withinMargin": true,
+      "globalFreeEnergyGw": 419410.8,
+      "thermostatMarginGw": 52500,
+      "totalDemandGw": 589.2,
+      "bufferedFreeEnergyGw": 249744.13333333333
     },
     "bridges": {
       "toleranceSeconds": 120,

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -37,6 +37,14 @@ function renderMetrics(telemetry) {
   document.querySelector("#coverage").textContent = `${Math.round(telemetry.governance.averageCoverageSeconds)}s coverage`;
   setStatus(document.querySelector("#coverage-status"), telemetry.governance.coverageOk);
   setStatus(document.querySelector("#energy-status"), telemetry.energy.tripleCheck && telemetry.energy.warnings.length === 0);
+  const freeEnergyText = `${formatNumber(telemetry.energy.globalFreeEnergyGw)} GW free · margin ${formatNumber(
+    telemetry.energy.thermostatMarginGw
+  )} GW`;
+  document.querySelector("#free-energy-buffer").textContent = freeEnergyText;
+  setStatus(
+    document.querySelector("#free-energy-status"),
+    telemetry.verification.thermodynamics.withinMargin
+  );
   const bridgeList = document.querySelector("#bridge-statuses");
   bridgeList.innerHTML = "";
   for (const [name, data] of Object.entries(telemetry.bridges)) {
@@ -93,6 +101,7 @@ function attachReflectionButton(telemetry) {
       { label: "Self-improvement plan hash", ok: telemetry.manifest.planHashMatches },
       { label: "Guardian coverage", ok: telemetry.governance.coverageOk },
       { label: "Energy triple check", ok: telemetry.energy.tripleCheck },
+      { label: "Free energy buffer", ok: telemetry.verification.thermodynamics.withinMargin },
       { label: "Energy Monte Carlo", ok: telemetry.energy.monteCarlo.withinTolerance },
       ...Object.entries(telemetry.bridges).map(([name, data]) => ({ label: `Bridge ${name}`, ok: data.withinFailsafe })),
     ];
@@ -143,6 +152,11 @@ function renderFederations(telemetry) {
       federation.energy.renewablePct * 100
     )}% renewable)`;
     card.appendChild(energy);
+
+    const freeEnergy = document.createElement("p");
+    const deficit = federation.energy.deficitGw > 0 ? ` · deficit ${formatNumber(federation.energy.deficitGw)} GW` : "";
+    freeEnergy.textContent = `Free energy ${formatNumber(federation.energy.freeEnergyGw)} GW${deficit}`;
+    card.appendChild(freeEnergy);
 
     const compute = document.createElement("p");
     compute.textContent = `Compute ${formatNumber(federation.compute.exaflops)} EF · Agents ${formatNumber(


### PR DESCRIPTION
## Summary
- add deterministic free-energy accounting to the Kardashev II orchestrator, telemetry, and stability ledger so owner control verifies the Dyson thermostat margin before launch
- surface the new thermodynamic buffer across the static UI, operator runbook, and briefing pack, keeping non-technical stewards informed about regional free-energy surpluses or deficits
- extend the README guidance and reflection checklist to document the new guardrails and ensure CI/owner rituals include the thermodynamic sentry

## Testing
- npm run demo:kardashev-ii:orchestrate
- npm run demo:kardashev-ii:ci

------
https://chatgpt.com/codex/tasks/task_e_68fd5ceb3dd8833382dad220f446d67f